### PR TITLE
fix(docker): correct registry default, image names, ports, and missing env vars

### DIFF
--- a/.github/workflows/docker-frontend.yml
+++ b/.github/workflows/docker-frontend.yml
@@ -33,7 +33,7 @@ jobs:
         include:
           - target: ppt-web
             dockerfile: docker/frontend/ppt-web.Dockerfile
-          - target: reality-web
+          - target: ppt-reality-web
             dockerfile: docker/frontend/reality-web.Dockerfile
 
     steps:

--- a/docker-compose.synology.yml
+++ b/docker-compose.synology.yml
@@ -106,6 +106,8 @@ services:
       DATABASE_URL: postgres://${POSTGRES_USER:-ppt}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-ppt}
       REDIS_URL: redis://redis:6379
       JWT_SECRET: ${JWT_SECRET:?JWT secret required}
+      TOTP_ENCRYPTION_KEY: ${TOTP_ENCRYPTION_KEY:?TOTP encryption key required (64-char hex, 32 bytes)}
+      INTEGRATION_ENCRYPTION_KEY: ${INTEGRATION_ENCRYPTION_KEY:?Integration encryption key required (64-char hex, 32 bytes)}
       RUST_LOG: ${RUST_LOG:-warn}
       S3_ENDPOINT: ${S3_ENDPOINT}
       S3_ACCESS_KEY: ${S3_ACCESS_KEY}
@@ -147,6 +149,9 @@ services:
       DATABASE_URL: postgres://${POSTGRES_USER:-ppt}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-ppt}
       REDIS_URL: redis://redis:6379
       JWT_SECRET: ${JWT_SECRET}
+      PM_CLIENT_SECRET: ${PM_CLIENT_SECRET:?PM_CLIENT_SECRET required for OAuth client}
+      PM_API_URL: ${PM_API_URL:-http://api-server:8080}
+      PM_API_HEALTH_URL: ${PM_API_HEALTH_URL:-http://api-server:8080/health}
       RUST_LOG: ${RUST_LOG:-warn}
       S3_ENDPOINT: ${S3_ENDPOINT}
       S3_ACCESS_KEY: ${S3_ACCESS_KEY}
@@ -190,9 +195,9 @@ services:
     environment:
       <<: *common-env
     ports:
-      - "3000:80"
+      - "3000:8080"
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:80/health"]
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]
       interval: 60s
       timeout: 10s
       retries: 3

--- a/docker-compose.synology.yml
+++ b/docker-compose.synology.yml
@@ -98,7 +98,7 @@ services:
   # ==========================================================================
 
   api-server:
-    image: ${REGISTRY:-ghcr.io/hanibalsk}/ppt-api-server:${VERSION:-latest}
+    image: ${REGISTRY:-ghcr.io/martin-janci}/ppt-api-server:${VERSION:-latest}
     container_name: ppt-api-server
     restart: unless-stopped
     environment:
@@ -139,7 +139,7 @@ services:
       - ppt-network
 
   reality-server:
-    image: ${REGISTRY:-ghcr.io/hanibalsk}/ppt-reality-server:${VERSION:-latest}
+    image: ${REGISTRY:-ghcr.io/martin-janci}/ppt-reality-server:${VERSION:-latest}
     container_name: ppt-reality-server
     restart: unless-stopped
     environment:
@@ -184,7 +184,7 @@ services:
   # ==========================================================================
 
   ppt-web:
-    image: ${REGISTRY:-ghcr.io/hanibalsk}/ppt-web:${VERSION:-latest}
+    image: ${REGISTRY:-ghcr.io/martin-janci}/ppt-web:${VERSION:-latest}
     container_name: ppt-web
     restart: unless-stopped
     environment:
@@ -206,7 +206,7 @@ services:
       - ppt-network
 
   reality-web:
-    image: ${REGISTRY:-ghcr.io/hanibalsk}/ppt-reality-web:${VERSION:-latest}
+    image: ${REGISTRY:-ghcr.io/martin-janci}/ppt-reality-web:${VERSION:-latest}
     container_name: ppt-reality-web
     restart: unless-stopped
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-ppt}
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./backend/scripts/init-db.sql:/docker-entrypoint-initdb.d/00-init.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-ppt} -d ${POSTGRES_DB:-ppt}"]
       interval: 30s
@@ -65,13 +66,15 @@ services:
   # ==========================================================================
 
   api-server:
-    image: ${REGISTRY:-ghcr.io/hanibalsk}/ppt-api-server:${VERSION:-latest}
+    image: ${REGISTRY:-ghcr.io/martin-janci}/ppt-api-server:${VERSION:-latest}
     container_name: ppt-api-server
     restart: unless-stopped
     environment:
       DATABASE_URL: postgres://${POSTGRES_USER:-ppt}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-ppt}
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379
       JWT_SECRET: ${JWT_SECRET:?JWT secret required}
+      TOTP_ENCRYPTION_KEY: ${TOTP_ENCRYPTION_KEY:?TOTP encryption key required (64-char hex, 32 bytes)}
+      INTEGRATION_ENCRYPTION_KEY: ${INTEGRATION_ENCRYPTION_KEY:?Integration encryption key required (64-char hex, 32 bytes)}
       RUST_LOG: ${RUST_LOG:-info}
       S3_ENDPOINT: ${S3_ENDPOINT}
       S3_ACCESS_KEY: ${S3_ACCESS_KEY}
@@ -105,13 +108,16 @@ services:
       - ppt-external
 
   reality-server:
-    image: ${REGISTRY:-ghcr.io/hanibalsk}/ppt-reality-server:${VERSION:-latest}
+    image: ${REGISTRY:-ghcr.io/martin-janci}/ppt-reality-server:${VERSION:-latest}
     container_name: ppt-reality-server
     restart: unless-stopped
     environment:
       DATABASE_URL: postgres://${POSTGRES_USER:-ppt}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-ppt}
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379
       JWT_SECRET: ${JWT_SECRET}
+      PM_CLIENT_SECRET: ${PM_CLIENT_SECRET:?PM_CLIENT_SECRET required for OAuth client}
+      PM_API_URL: ${PM_API_URL:-http://api-server:8080}
+      PM_API_HEALTH_URL: ${PM_API_HEALTH_URL:-http://api-server:8080/health}
       RUST_LOG: ${RUST_LOG:-info}
       S3_ENDPOINT: ${S3_ENDPOINT}
       S3_ACCESS_KEY: ${S3_ACCESS_KEY}
@@ -149,13 +155,13 @@ services:
   # ==========================================================================
 
   ppt-web:
-    image: ${REGISTRY:-ghcr.io/hanibalsk}/ppt-web:${VERSION:-latest}
+    image: ${REGISTRY:-ghcr.io/martin-janci}/ppt-web:${VERSION:-latest}
     container_name: ppt-web
     restart: unless-stopped
     ports:
-      - "3000:80"
+      - "3000:8080"
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:80/health"]
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -170,7 +176,7 @@ services:
       - ppt-external
 
   reality-web:
-    image: ${REGISTRY:-ghcr.io/hanibalsk}/ppt-reality-web:${VERSION:-latest}
+    image: ${REGISTRY:-ghcr.io/martin-janci}/ppt-reality-web:${VERSION:-latest}
     container_name: ppt-reality-web
     restart: unless-stopped
     environment:

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -21,9 +21,39 @@ REDIS_PASSWORD=change-this-redis-password
 # =============================================================================
 # Security
 # =============================================================================
-# JWT secret for token signing (minimum 32 characters)
-# Generate with: openssl rand -base64 32
-JWT_SECRET=change-this-to-a-secure-random-string-minimum-32-chars
+# JWT secret for token signing (minimum 64 characters recommended)
+# Generate with: openssl rand -base64 48
+JWT_SECRET=change-this-to-a-secure-random-string-minimum-64-chars
+
+# TOTP encryption key - REQUIRED in production
+# 64-character hex string (32 bytes) for AES-256 encryption
+# Generate with: openssl rand -hex 32
+TOTP_ENCRYPTION_KEY=change-this-to-64-hex-chars
+
+# Integration encryption key - REQUIRED in production
+# Used to encrypt OAuth tokens and webhook secrets at rest
+# 64-character hex string (32 bytes) for AES-256 encryption
+# Generate with: openssl rand -hex 32
+INTEGRATION_ENCRYPTION_KEY=change-this-to-64-hex-chars
+
+# =============================================================================
+# Property Management <-> Reality Portal SSO
+# =============================================================================
+# OAuth client secret used by reality-server to authenticate to api-server
+# Generate with: openssl rand -base64 36
+PM_CLIENT_SECRET=change-this-pm-client-secret
+
+# Optional - override defaults if you reverse-proxy or run on different hosts
+# PM_API_URL=http://api-server:8080
+# PM_API_HEALTH_URL=http://api-server:8080/health
+
+# Optional - for full SSO flow (OAuth client must be registered in api-server)
+# PM_CLIENT_ID=
+# PM_OAUTH_AUTHORIZE_URL=
+# PM_OAUTH_TOKEN_URL=
+# PM_USERINFO_URL=
+# PM_INTROSPECT_URL=
+# SSO_CALLBACK_URL=
 
 # =============================================================================
 # S3-Compatible Storage (MinIO / AWS S3 / Synology C2)
@@ -59,7 +89,7 @@ RUST_LOG=info
 # =============================================================================
 # Container Registry (for production)
 # =============================================================================
-REGISTRY=ghcr.io/hanibalsk
+REGISTRY=ghcr.io/martin-janci
 VERSION=latest
 
 # =============================================================================

--- a/docker/.env.synology.example
+++ b/docker/.env.synology.example
@@ -64,5 +64,5 @@ RUST_LOG=warn
 # =============================================================================
 # Container Registry
 # =============================================================================
-REGISTRY=ghcr.io/hanibalsk
+REGISTRY=ghcr.io/martin-janci
 VERSION=latest

--- a/docker/.env.synology.example
+++ b/docker/.env.synology.example
@@ -23,9 +23,39 @@ POSTGRES_DB=ppt
 # =============================================================================
 # Security
 # =============================================================================
-# JWT secret for token signing (minimum 32 characters)
-# Generate with: openssl rand -base64 32
-JWT_SECRET=your-secure-jwt-secret-minimum-32-characters
+# JWT secret for token signing (minimum 64 characters recommended)
+# Generate with: openssl rand -base64 48
+JWT_SECRET=your-secure-jwt-secret-minimum-64-characters
+
+# TOTP encryption key - REQUIRED in production
+# 64-character hex string (32 bytes) for AES-256 encryption
+# Generate with: openssl rand -hex 32
+TOTP_ENCRYPTION_KEY=your-64-hex-char-totp-encryption-key
+
+# Integration encryption key - REQUIRED in production
+# Used to encrypt OAuth tokens and webhook secrets at rest
+# 64-character hex string (32 bytes) for AES-256 encryption
+# Generate with: openssl rand -hex 32
+INTEGRATION_ENCRYPTION_KEY=your-64-hex-char-integration-encryption-key
+
+# =============================================================================
+# Property Management <-> Reality Portal SSO
+# =============================================================================
+# OAuth client secret used by reality-server to authenticate to api-server
+# Generate with: openssl rand -base64 36
+PM_CLIENT_SECRET=your-pm-client-secret
+
+# Optional - override defaults if you reverse-proxy or run on different hosts
+# PM_API_URL=http://api-server:8080
+# PM_API_HEALTH_URL=http://api-server:8080/health
+
+# Optional - for full SSO flow (OAuth client must be registered in api-server)
+# PM_CLIENT_ID=
+# PM_OAUTH_AUTHORIZE_URL=
+# PM_OAUTH_TOKEN_URL=
+# PM_USERINFO_URL=
+# PM_INTROSPECT_URL=
+# SSO_CALLBACK_URL=
 
 # =============================================================================
 # S3-Compatible Storage


### PR DESCRIPTION
## Summary
Multiple deployment-blocking issues encountered when deploying to a fresh Hetzner Cloud server with `docker compose up`. All changes are backwards-compatible (overrideable via env) but make the default deploy path actually work.

## Bugs fixed

### `docker-compose.yml`
- **REGISTRY default** changed from `ghcr.io/hanibalsk` (no longer publishes images) → `ghcr.io/martin-janci` (matches what `docker-build.yml`/`docker-frontend.yml` actually push to).
- **`ppt-web` port mismatch** — container nginx listens on `8080`, but compose mapped host `3000:80` → caused 502 from any reverse proxy. Now `3000:8080` (and healthcheck path).
- **Missing env vars on `api-server`** — `TOTP_ENCRYPTION_KEY` (panic) and `INTEGRATION_ENCRYPTION_KEY` (warning) are required by the binary but were never passed through. Added with `:?` enforcement so missing values fail fast at compose-up rather than panic at runtime.
- **Missing env vars on `reality-server`** — `PM_CLIENT_SECRET` is required (panic) and `PM_API_URL` defaults inside the binary to `localhost:8080`, which is wrong inside Docker. Added all three with sensible defaults pointing at the in-network `api-server` service.
- **`init-db.sql` never ran** — `backend/scripts/init-db.sql` is now mounted to `/docker-entrypoint-initdb.d/`, so extensions and helper functions are created on first postgres init.

### `docker-compose.synology.yml`
- Same REGISTRY default fix.

### `.github/workflows/docker-frontend.yml`
- Matrix target `reality-web` was producing image `ghcr.io/martin-janci/reality-web`, but `docker-compose.yml` consumed `ghcr.io/martin-janci/ppt-reality-web`. Target renamed so published name matches.

### `docker/.env.example`, `docker/.env.synology.example`
- Document new required env vars (`TOTP_ENCRYPTION_KEY`, `INTEGRATION_ENCRYPTION_KEY`, `PM_CLIENT_SECRET`) with generation hints.
- Document optional `PM_*` and `SSO_CALLBACK_URL` for full SSO setup.
- Bumped `JWT_SECRET` recommendation from 32 → 64 chars (api-server warns below 64).
- `REGISTRY` default changed to `ghcr.io/martin-janci`.

## Known follow-ups (not in this PR)
SQLx migrations are not run automatically. The 103 `.sql` files in `backend/crates/db/migrations/` have to be applied manually after first start (this PR makes the failure mode obvious — you'll see `function clear_request_context() does not exist` and similar errors).

Recommended next step: either
- (a) call `sqlx::migrate!().run(&pool).await?` from `api-server`'s `main.rs` so migrations run on every startup; or
- (b) add a one-shot `migrator` service to compose that runs `sqlx migrate run` before `api-server` starts.

## Test plan
- [x] `docker compose --env-file <fresh .env> config` validates without errors
- [x] `docker compose --env-file <fresh .env> up -d` starts successfully on fresh Hetzner server
- [x] All 4 expected hostnames (PPT web/API, Reality web/API) reachable through reverse proxy
- [x] Both `/health` endpoints return 200 after migrations are applied