### PR TITLE
fix(ppt-web): Suspense boundary around Routes (React #426)

### DIFF
--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -238,6 +238,7 @@ function AppNavigation() {
 }
 
 function RouteLoading() {
+  const { t } = useTranslation();
   return (
     <div
       className="flex items-center justify-center py-16"
@@ -245,7 +246,11 @@ function RouteLoading() {
       aria-live="polite"
       aria-busy="true"
     >
-      <div className="h-8 w-8 animate-spin rounded-full border-2 border-blue-600 border-t-transparent" />
+      <div
+        className="h-8 w-8 animate-spin rounded-full border-2 border-blue-600 border-t-transparent"
+        aria-hidden="true"
+      />
+      <span className="sr-only">{t('common.loading')}</span>
     </div>
   );
 }

--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -23,7 +23,7 @@ import type {
   OutageListQuery,
 } from '@ppt/api-client';
 import { AccessibilityProvider, SkipNavigation } from '@ppt/ui-kit';
-import { type ReactNode, useEffect, useState } from 'react';
+import { type ReactNode, Suspense, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BrowserRouter, Link, Route, Routes, useNavigate, useParams } from 'react-router-dom';
 import {
@@ -237,6 +237,19 @@ function AppNavigation() {
   );
 }
 
+function RouteLoading() {
+  return (
+    <div
+      className="flex items-center justify-center py-16"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <div className="h-8 w-8 animate-spin rounded-full border-2 border-blue-600 border-t-transparent" />
+    </div>
+  );
+}
+
 /**
  * Command Palette wrapper that registers navigation commands.
  * Must be rendered inside BrowserRouter for useNavigate to work.
@@ -267,148 +280,159 @@ function App() {
                       <div className="app">
                         <AppNavigation />
                         <main id="main-content">
-                          <Routes>
-                            <Route path="/" element={<Home />} />
-                            <Route path="/login" element={<LoginPage />} />
-                            <Route path="/register" element={<RegisterPage />} />
-                            <Route path="/forgot-password" element={<ForgotPasswordPage />} />
-                            <Route path="/reset-password" element={<ResetPasswordPage />} />
-                            <Route path="/settings/password" element={<ChangePasswordPage />} />
-                            <Route path="/settings/two-factor" element={<TwoFactorAuthPage />} />
-                            <Route path="/settings/profile" element={<ProfileEditPage />} />
-                            {/* Dashboard routes (Epic 124) */}
-                            <Route path="/dashboard/manager" element={<ManagerDashboardPage />} />
-                            <Route path="/dashboard/resident" element={<ResidentDashboardPage />} />
-                            {/* Document Intelligence routes (Epic 39) */}
-                            <Route
-                              path="/documents"
-                              element={
-                                <ProtectedRoute>
-                                  <DocumentsPageRoute />
-                                </ProtectedRoute>
-                              }
-                            />
-                            <Route
-                              path="/documents/upload"
-                              element={
-                                <ProtectedRoute>
-                                  <DocumentUploadPage />
-                                </ProtectedRoute>
-                              }
-                            />
-                            <Route
-                              path="/documents/:documentId"
-                              element={
-                                <ProtectedRoute>
-                                  <DocumentDetailRoute />
-                                </ProtectedRoute>
-                              }
-                            />
-                            {/* News routes (Epic 59) */}
-                            <Route
-                              path="/news"
-                              element={
-                                <ProtectedRoute>
-                                  <NewsListPage />
-                                </ProtectedRoute>
-                              }
-                            />
-                            <Route
-                              path="/news/:articleId"
-                              element={
-                                <ProtectedRoute>
-                                  <ArticleDetailRoute />
-                                </ProtectedRoute>
-                              }
-                            />
-                            {/* Emergency contacts route (Epic 62) */}
-                            <Route
-                              path="/emergency"
-                              element={
-                                <ProtectedRoute>
-                                  <EmergencyContactDirectoryPage />
-                                </ProtectedRoute>
-                              }
-                            />
-                            {/* Accessibility settings route (Epic 60) */}
-                            <Route
-                              path="/settings/accessibility"
-                              element={<AccessibilitySettingsPage />}
-                            />
-                            {/* Privacy settings route (Epic 63) */}
-                            <Route path="/settings/privacy" element={<PrivacySettingsPage />} />
-                            {/* Dispute Resolution routes (Epic 77) */}
-                            <Route path="/disputes" element={<DisputesPageRoute />} />
-                            <Route path="/disputes/new" element={<FileDisputePageRoute />} />
-                            <Route path="/disputes/:disputeId" element={<DisputeDetailRoute />} />
-                            {/* Outages routes (UC-12) */}
-                            <Route path="/outages" element={<OutagesPageRoute />} />
-                            <Route path="/outages/new" element={<CreateOutagePageRoute />} />
-                            <Route path="/outages/:outageId" element={<ViewOutagePageRoute />} />
-                            <Route
-                              path="/outages/:outageId/edit"
-                              element={<EditOutagePageRoute />}
-                            />
-                            {/* Announcements routes (UC-06) */}
-                            <Route path="/announcements" element={<AnnouncementsPageRoute />} />
-                            <Route
-                              path="/announcements/new"
-                              element={<CreateAnnouncementPageRoute />}
-                            />
-                            <Route
-                              path="/announcements/:announcementId"
-                              element={<ViewAnnouncementPageRoute />}
-                            />
-                            <Route
-                              path="/announcements/:announcementId/edit"
-                              element={<EditAnnouncementPageRoute />}
-                            />
-                            {/* Messaging routes (UC-07) */}
-                            <Route path="/messages" element={<MessagesPageRoute />} />
-                            <Route path="/messages/new" element={<NewMessagePageRoute />} />
-                            <Route path="/messages/:threadId" element={<ThreadDetailPageRoute />} />
-                            {/* Faults routes (UC-03) */}
-                            <Route path="/faults" element={<FaultsPageRoute />} />
-                            <Route path="/faults/new" element={<CreateFaultPageRoute />} />
-                            <Route path="/faults/:faultId" element={<FaultDetailPageRoute />} />
-                            <Route path="/faults/:faultId/edit" element={<EditFaultPageRoute />} />
-                            {/* Community routes (Epic 42) */}
-                            <Route path="/community" element={<FeedPageRoute />} />
-                            <Route path="/community/groups" element={<GroupsPageRoute />} />
-                            <Route
-                              path="/community/groups/new"
-                              element={<CreateGroupPageRoute />}
-                            />
-                            <Route
-                              path="/community/groups/:groupId"
-                              element={<GroupDetailPageRoute />}
-                            />
-                            <Route path="/community/events" element={<EventsPageRoute />} />
-                            <Route
-                              path="/community/marketplace"
-                              element={<MarketplacePageRoute />}
-                            />
-                            {/* Financial routes (Epic 52) */}
-                            <Route path="/financial" element={<FinancialDashboardPageRoute />} />
-                            <Route
-                              path="/financial/invoices"
-                              element={<InvoiceManagementPageRoute />}
-                            />
-                            <Route
-                              path="/financial/payments"
-                              element={<PaymentManagementPageRoute />}
-                            />
-                            <Route
-                              path="/financial/budgets"
-                              element={<BudgetManagementPageRoute />}
-                            />
+                          <Suspense fallback={<RouteLoading />}>
+                            <Routes>
+                              <Route path="/" element={<Home />} />
+                              <Route path="/login" element={<LoginPage />} />
+                              <Route path="/register" element={<RegisterPage />} />
+                              <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+                              <Route path="/reset-password" element={<ResetPasswordPage />} />
+                              <Route path="/settings/password" element={<ChangePasswordPage />} />
+                              <Route path="/settings/two-factor" element={<TwoFactorAuthPage />} />
+                              <Route path="/settings/profile" element={<ProfileEditPage />} />
+                              {/* Dashboard routes (Epic 124) */}
+                              <Route path="/dashboard/manager" element={<ManagerDashboardPage />} />
+                              <Route
+                                path="/dashboard/resident"
+                                element={<ResidentDashboardPage />}
+                              />
+                              {/* Document Intelligence routes (Epic 39) */}
+                              <Route
+                                path="/documents"
+                                element={
+                                  <ProtectedRoute>
+                                    <DocumentsPageRoute />
+                                  </ProtectedRoute>
+                                }
+                              />
+                              <Route
+                                path="/documents/upload"
+                                element={
+                                  <ProtectedRoute>
+                                    <DocumentUploadPage />
+                                  </ProtectedRoute>
+                                }
+                              />
+                              <Route
+                                path="/documents/:documentId"
+                                element={
+                                  <ProtectedRoute>
+                                    <DocumentDetailRoute />
+                                  </ProtectedRoute>
+                                }
+                              />
+                              {/* News routes (Epic 59) */}
+                              <Route
+                                path="/news"
+                                element={
+                                  <ProtectedRoute>
+                                    <NewsListPage />
+                                  </ProtectedRoute>
+                                }
+                              />
+                              <Route
+                                path="/news/:articleId"
+                                element={
+                                  <ProtectedRoute>
+                                    <ArticleDetailRoute />
+                                  </ProtectedRoute>
+                                }
+                              />
+                              {/* Emergency contacts route (Epic 62) */}
+                              <Route
+                                path="/emergency"
+                                element={
+                                  <ProtectedRoute>
+                                    <EmergencyContactDirectoryPage />
+                                  </ProtectedRoute>
+                                }
+                              />
+                              {/* Accessibility settings route (Epic 60) */}
+                              <Route
+                                path="/settings/accessibility"
+                                element={<AccessibilitySettingsPage />}
+                              />
+                              {/* Privacy settings route (Epic 63) */}
+                              <Route path="/settings/privacy" element={<PrivacySettingsPage />} />
+                              {/* Dispute Resolution routes (Epic 77) */}
+                              <Route path="/disputes" element={<DisputesPageRoute />} />
+                              <Route path="/disputes/new" element={<FileDisputePageRoute />} />
+                              <Route path="/disputes/:disputeId" element={<DisputeDetailRoute />} />
+                              {/* Outages routes (UC-12) */}
+                              <Route path="/outages" element={<OutagesPageRoute />} />
+                              <Route path="/outages/new" element={<CreateOutagePageRoute />} />
+                              <Route path="/outages/:outageId" element={<ViewOutagePageRoute />} />
+                              <Route
+                                path="/outages/:outageId/edit"
+                                element={<EditOutagePageRoute />}
+                              />
+                              {/* Announcements routes (UC-06) */}
+                              <Route path="/announcements" element={<AnnouncementsPageRoute />} />
+                              <Route
+                                path="/announcements/new"
+                                element={<CreateAnnouncementPageRoute />}
+                              />
+                              <Route
+                                path="/announcements/:announcementId"
+                                element={<ViewAnnouncementPageRoute />}
+                              />
+                              <Route
+                                path="/announcements/:announcementId/edit"
+                                element={<EditAnnouncementPageRoute />}
+                              />
+                              {/* Messaging routes (UC-07) */}
+                              <Route path="/messages" element={<MessagesPageRoute />} />
+                              <Route path="/messages/new" element={<NewMessagePageRoute />} />
+                              <Route
+                                path="/messages/:threadId"
+                                element={<ThreadDetailPageRoute />}
+                              />
+                              {/* Faults routes (UC-03) */}
+                              <Route path="/faults" element={<FaultsPageRoute />} />
+                              <Route path="/faults/new" element={<CreateFaultPageRoute />} />
+                              <Route path="/faults/:faultId" element={<FaultDetailPageRoute />} />
+                              <Route
+                                path="/faults/:faultId/edit"
+                                element={<EditFaultPageRoute />}
+                              />
+                              {/* Community routes (Epic 42) */}
+                              <Route path="/community" element={<FeedPageRoute />} />
+                              <Route path="/community/groups" element={<GroupsPageRoute />} />
+                              <Route
+                                path="/community/groups/new"
+                                element={<CreateGroupPageRoute />}
+                              />
+                              <Route
+                                path="/community/groups/:groupId"
+                                element={<GroupDetailPageRoute />}
+                              />
+                              <Route path="/community/events" element={<EventsPageRoute />} />
+                              <Route
+                                path="/community/marketplace"
+                                element={<MarketplacePageRoute />}
+                              />
+                              {/* Financial routes (Epic 52) */}
+                              <Route path="/financial" element={<FinancialDashboardPageRoute />} />
+                              <Route
+                                path="/financial/invoices"
+                                element={<InvoiceManagementPageRoute />}
+                              />
+                              <Route
+                                path="/financial/payments"
+                                element={<PaymentManagementPageRoute />}
+                              />
+                              <Route
+                                path="/financial/budgets"
+                                element={<BudgetManagementPageRoute />}
+                              />
 
-                            {/* Error / state surfaces */}
-                            <Route path="/forbidden" element={<ForbiddenPage />} />
-                            <Route path="/server-error" element={<ServerErrorPage />} />
-                            <Route path="/session-expired" element={<SessionExpiredPage />} />
-                            <Route path="*" element={<NotFoundPage />} />
-                          </Routes>
+                              {/* Error / state surfaces */}
+                              <Route path="/forbidden" element={<ForbiddenPage />} />
+                              <Route path="/server-error" element={<ServerErrorPage />} />
+                              <Route path="/session-expired" element={<SessionExpiredPage />} />
+                              <Route path="*" element={<NotFoundPage />} />
+                            </Routes>
+                          </Suspense>
                         </main>
                       </div>
                     </CommandPaletteWrapper>


### PR DESCRIPTION
## Summary

React error #426 (\"This Suspense boundary received an update before it finished hydrating\") fired on the first navigation to lazy-loaded routes on prod (e.g. \`/dashboard/manager\`). The app uses React.lazy() for code splitting but App.tsx had no explicit \`<Suspense>\` boundary around \`<Routes>\`, so the implicit root boundary handled the suspension. State updates from AuthProvider/OrganizationProvider during chunk loading caused the boundary to tear, ErrorBoundary caught it, user saw \"Something went wrong\".

Wrap \`<Routes>\` with \`<Suspense fallback={<RouteLoading />}>\`. The fallback is a small Tailwind-styled spinner. Subsequent state updates while a chunk is loading now render the spinner instead of throwing.

## Test plan
- [x] \`pnpm --filter @ppt/web build\` passes
- [x] Local \`vite preview\`:
  - \`/dashboard/manager\` two consecutive loads: 0 errors both times
  - \`/news\` → redirect to /login: 0 errors
  - \`/documents\` → redirect to /login: 0 errors
- [ ] After merge: deploy + re-verify on prod

## Notes
- i18n fallbackLng is already set to \`en\`, so the cs/de/hu/pl gap discovered in PR #185 is already covered by the fallback chain (missing keys in non-English locales fall back to English).