### PR TITLE
fix(ppt-web): dark-mode-aware nav + landing, auth-gate ConnectionStatus, favicon

### DIFF
--- a/frontend/apps/ppt-web/index.html
+++ b/frontend/apps/ppt-web/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Property Management</title>
   </head>
   <body>

--- a/frontend/apps/ppt-web/public/favicon.svg
+++ b/frontend/apps/ppt-web/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#2563eb"/>
+  <path d="M16 48V20l16-8 16 8v28h-8V32H24v16h-8z" fill="#ffffff"/>
+  <rect x="28" y="20" width="8" height="6" fill="#2563eb"/>
+</svg>

--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -221,6 +221,7 @@ function WebSocketWrapper({ children }: { children: ReactNode }) {
 
 function AppNavigation() {
   const { t } = useTranslation();
+  const { isAuthenticated } = useAuth();
   return (
     <nav className="app-nav" aria-label="Main navigation">
       <Link to="/">{t('nav.home')}</Link>
@@ -231,8 +232,10 @@ function AppNavigation() {
       <Link to="/outages">{t('nav.outages')}</Link>
       <Link to="/settings/accessibility">{t('nav.accessibility')}</Link>
       <Link to="/settings/privacy">{t('nav.privacy')}</Link>
-      <ConnectionStatus />
-      <LanguageSwitcher />
+      <div className="ml-auto flex items-center gap-3">
+        {isAuthenticated && <ConnectionStatus />}
+        <LanguageSwitcher />
+      </div>
     </nav>
   );
 }
@@ -1669,10 +1672,79 @@ function BudgetManagementPageRoute() {
 
 function Home() {
   const { t } = useTranslation();
+  const { isAuthenticated, user } = useAuth();
+  const navigate = useNavigate();
+
   return (
-    <div>
-      <h1>{t('home.title')}</h1>
-      <p>{t('home.welcome')}</p>
+    <div className="space-y-10">
+      <section className="text-center py-10">
+        <h1 className="text-3xl md:text-4xl font-bold mb-3">{t('home.title')}</h1>
+        <p className="text-lg max-w-2xl mx-auto" style={{ color: 'var(--color-text-secondary)' }}>
+          {t('home.welcome')}
+        </p>
+        {!isAuthenticated && (
+          <div className="mt-6 flex flex-wrap justify-center gap-3">
+            <button
+              type="button"
+              onClick={() => navigate('/login')}
+              className="px-5 py-2.5 rounded-lg font-medium text-white"
+              style={{ backgroundColor: 'var(--color-primary, #2563eb)' }}
+            >
+              {t('auth.signIn')}
+            </button>
+            <button
+              type="button"
+              onClick={() => navigate('/register')}
+              className="px-5 py-2.5 rounded-lg font-medium"
+              style={{
+                color: 'var(--color-primary, #2563eb)',
+                border: '1px solid var(--color-primary, #2563eb)',
+              }}
+            >
+              {t('auth.register', { defaultValue: 'Register' })}
+            </button>
+          </div>
+        )}
+        {isAuthenticated && (
+          <div className="mt-6">
+            <button
+              type="button"
+              onClick={() =>
+                navigate(user?.role === 'manager' ? '/dashboard/manager' : '/dashboard/resident')
+              }
+              className="px-5 py-2.5 rounded-lg font-medium text-white"
+              style={{ backgroundColor: 'var(--color-primary, #2563eb)' }}
+            >
+              {t('nav.dashboard', { defaultValue: 'Open dashboard' })}
+            </button>
+          </div>
+        )}
+      </section>
+
+      <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {[
+          { to: '/documents', titleKey: 'nav.documents' },
+          { to: '/news', titleKey: 'nav.news' },
+          { to: '/disputes', titleKey: 'nav.disputes' },
+          { to: '/outages', titleKey: 'nav.outages' },
+          { to: '/emergency', titleKey: 'nav.emergency' },
+          { to: '/settings/accessibility', titleKey: 'nav.accessibility' },
+        ].map((card) => (
+          <Link
+            key={card.to}
+            to={card.to}
+            className="block p-5 rounded-xl"
+            style={{
+              backgroundColor: 'var(--color-surface)',
+              border: '1px solid var(--color-border)',
+            }}
+          >
+            <span className="font-semibold" style={{ color: 'var(--color-text)' }}>
+              {t(card.titleKey)}
+            </span>
+          </Link>
+        ))}
+      </section>
     </div>
   );
 }

--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -1687,19 +1687,14 @@ function Home() {
             <button
               type="button"
               onClick={() => navigate('/login')}
-              className="px-5 py-2.5 rounded-lg font-medium text-white"
-              style={{ backgroundColor: 'var(--color-primary, #2563eb)' }}
+              className="btn-primary-token px-5 py-2.5 rounded-lg font-medium"
             >
               {t('auth.signIn')}
             </button>
             <button
               type="button"
               onClick={() => navigate('/register')}
-              className="px-5 py-2.5 rounded-lg font-medium"
-              style={{
-                color: 'var(--color-primary, #2563eb)',
-                border: '1px solid var(--color-primary, #2563eb)',
-              }}
+              className="btn-outline-token px-5 py-2.5 rounded-lg font-medium"
             >
               {t('auth.register', { defaultValue: 'Register' })}
             </button>
@@ -1712,8 +1707,7 @@ function Home() {
               onClick={() =>
                 navigate(user?.role === 'manager' ? '/dashboard/manager' : '/dashboard/resident')
               }
-              className="px-5 py-2.5 rounded-lg font-medium text-white"
-              style={{ backgroundColor: 'var(--color-primary, #2563eb)' }}
+              className="btn-primary-token px-5 py-2.5 rounded-lg font-medium"
             >
               {t('nav.dashboard', { defaultValue: 'Open dashboard' })}
             </button>

--- a/frontend/apps/ppt-web/src/index.css
+++ b/frontend/apps/ppt-web/src/index.css
@@ -30,31 +30,6 @@
     @apply min-h-screen flex flex-col;
   }
 
-  .app-nav {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    padding: 0.75rem 1.5rem;
-    background-color: var(--color-surface, #ffffff);
-    border-bottom: 1px solid var(--color-border, #e5e7eb);
-    box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-  }
-
-  .app-nav a {
-    color: var(--color-text-secondary, #4b5563);
-    font-weight: 500;
-    font-size: 0.875rem;
-    text-decoration: none;
-  }
-
-  .app-nav a:hover {
-    color: var(--color-primary, #2563eb);
-  }
-
-  .app-nav a[aria-current="page"] {
-    color: var(--color-primary, #2563eb);
-  }
-
   main#main-content {
     @apply flex-1 px-6 py-6 max-w-7xl w-full mx-auto;
   }
@@ -63,32 +38,94 @@
     @apply max-w-2xl mx-auto px-6 py-16 text-center;
   }
 
-  .error-page h1 {
-    @apply text-2xl font-semibold mb-3;
-    color: var(--color-text, #111827);
-  }
-
-  .error-page p {
-    @apply mb-4;
-    color: var(--color-text-secondary, #6b7280);
-  }
-
-  .error-page a {
-    color: var(--color-primary, #2563eb);
-    text-decoration: underline;
-  }
-
-  .error-page a:hover {
-    color: var(--color-primary-hover, #1d4ed8);
-  }
-
   .loading-page {
     @apply max-w-2xl mx-auto px-6 py-16 text-center;
-    color: var(--color-text-secondary, #6b7280);
   }
 
   .dispute-detail-page,
   .dispute-detail-page > * {
     @apply max-w-4xl mx-auto;
   }
+}
+
+/*
+ * Unlayered overrides — these need to win over the unlayered global
+ * rules in features/settings/styles/accessibility.css
+ * (`a { color: var(--color-primary); }` and `button, a { ... }`).
+ * Tailwind @layer rules always lose to unlayered ones in the cascade,
+ * so component-level theming for the nav and error pages lives here.
+ */
+.app-nav {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1.5rem;
+  background-color: var(--color-surface, #ffffff);
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+}
+
+.app-nav a {
+  color: var(--color-text-secondary, #4b5563);
+  font-weight: 500;
+  font-size: 0.875rem;
+  text-decoration: none;
+}
+
+.app-nav a:hover {
+  color: var(--color-primary, #2563eb);
+}
+
+.app-nav a[aria-current="page"] {
+  color: var(--color-primary, #2563eb);
+}
+
+.error-page h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  color: var(--color-text, #111827);
+}
+
+.error-page p {
+  margin-bottom: 1rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.error-page a {
+  color: var(--color-primary, #2563eb);
+  text-decoration: underline;
+}
+
+.error-page a:hover {
+  color: var(--color-primary-hover, #1d4ed8);
+}
+
+.loading-page {
+  color: var(--color-text-secondary, #6b7280);
+}
+
+/*
+ * Buttons styled inline with --color-primary background must keep
+ * their explicit text color even though the global rule
+ * `button, a { color: var(--color-primary) }` would otherwise paint
+ * them blue-on-blue.
+ */
+.btn-primary-token {
+  color: #ffffff;
+  background-color: var(--color-primary, #2563eb);
+}
+
+.btn-primary-token:hover {
+  background-color: var(--color-primary-hover, #1d4ed8);
+}
+
+.btn-outline-token {
+  color: var(--color-primary, #2563eb);
+  background-color: transparent;
+  border: 1px solid var(--color-primary, #2563eb);
+}
+
+.btn-outline-token:hover {
+  background-color: var(--color-surface-hover, #f3f4f6);
 }

--- a/frontend/apps/ppt-web/src/index.css
+++ b/frontend/apps/ppt-web/src/index.css
@@ -4,7 +4,7 @@
 
 @layer base {
   body {
-    @apply bg-white text-gray-900 antialiased;
+    @apply antialiased;
     font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
   }
 
@@ -31,15 +31,28 @@
   }
 
   .app-nav {
-    @apply flex items-center gap-4 px-6 py-3 bg-white border-b border-gray-200 shadow-sm;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.75rem 1.5rem;
+    background-color: var(--color-surface, #ffffff);
+    border-bottom: 1px solid var(--color-border, #e5e7eb);
+    box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   }
 
   .app-nav a {
-    @apply text-gray-700 hover:text-blue-600 no-underline font-medium text-sm;
+    color: var(--color-text-secondary, #4b5563);
+    font-weight: 500;
+    font-size: 0.875rem;
+    text-decoration: none;
+  }
+
+  .app-nav a:hover {
+    color: var(--color-primary, #2563eb);
   }
 
   .app-nav a[aria-current="page"] {
-    @apply text-blue-600;
+    color: var(--color-primary, #2563eb);
   }
 
   main#main-content {
@@ -51,19 +64,27 @@
   }
 
   .error-page h1 {
-    @apply text-2xl font-semibold text-gray-900 mb-3;
+    @apply text-2xl font-semibold mb-3;
+    color: var(--color-text, #111827);
   }
 
   .error-page p {
-    @apply text-gray-600 mb-4;
+    @apply mb-4;
+    color: var(--color-text-secondary, #6b7280);
   }
 
   .error-page a {
-    @apply text-blue-600 hover:text-blue-800 underline;
+    color: var(--color-primary, #2563eb);
+    text-decoration: underline;
+  }
+
+  .error-page a:hover {
+    color: var(--color-primary-hover, #1d4ed8);
   }
 
   .loading-page {
-    @apply max-w-2xl mx-auto px-6 py-16 text-center text-gray-600;
+    @apply max-w-2xl mx-auto px-6 py-16 text-center;
+    color: var(--color-text-secondary, #6b7280);
   }
 
   .dispute-detail-page,


### PR DESCRIPTION
## Summary

Audit pass on prod surfaced four UX polish issues — all rooted in \`index.css\` pinning Tailwind palette colours instead of using the existing design-token CSS vars. Anything not explicitly themed by a child component broke in dark colour scheme.

### Changes
- **\`index.css\`** — replace Tailwind-palette colors with \`var(--color-surface)\`/\`var(--color-text)\`/etc. These vars are already defined for light/dark/high-contrast modes.
- **\`App.tsx\` AppNavigation** — hide \`ConnectionStatus\` when not authenticated. Right-align status + LanguageSwitcher.
- **\`App.tsx\` Home** — replace bare h1+p with hero + Sign In / Register CTAs and a 6-card grid.
- **\`public/favicon.svg\`** + \`<link rel=\"icon\">\`. Removes /favicon.ico 404.

## Test plan
- [x] \`pnpm --filter @ppt/web build\` passes
- [x] vite preview light mode: clean nav, hero, cards, favicon serves
- [x] vite preview dark mode: nav blends, "Authentication Required" h1 now readable
- [ ] After merge: deploy + re-verify on prod