### PR TITLE
fix(ci): version-bump creates PR instead of pushing directly to main

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -19,6 +19,7 @@ jobs:
 
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +45,9 @@ jobs:
       - name: Bump patch version
         run: ./scripts/bump-version.sh patch
 
-      - name: Commit and push version bump
+      - name: Create PR with version bump
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION=$(cat VERSION | tr -d '[:space:]')
           git add VERSION
@@ -55,5 +58,23 @@ jobs:
           git add mobile-native/gradle.properties 2>/dev/null || true
           git add docs/api/typespec/main.tsp 2>/dev/null || true
           git diff --cached --quiet && echo "No version files changed" && exit 0
+
+          BRANCH="chore/version-${VERSION}"
+          git checkout -b "$BRANCH"
           git commit -m "chore(version): bump to $VERSION"
-          git push
+          git push origin "$BRANCH"
+
+          PR_NUMBER=$(gh pr create \
+            --title "chore(version): bump to $VERSION" \
+            --body "Automated patch version bump triggered by merge to \`main\`." \
+            --base main \
+            --head "$BRANCH" \
+            --json number \
+            --jq '.number')
+
+          echo "Created PR #$PR_NUMBER"
+
+          # Enable auto-merge — merges automatically once approval conditions are met
+          gh pr merge "$PR_NUMBER" --auto --squash \
+            && echo "Auto-merge enabled on PR #$PR_NUMBER" \
+            || echo "Note: auto-merge not available in repo settings — PR #$PR_NUMBER needs manual merge"


### PR DESCRIPTION
## Problem

After merging #189, the `version-bump` CI job failed with:

```
remote: - Changes must be made through a pull request.
```

`main` is protected by a branch ruleset that blocks direct pushes.

## Fix

Instead of pushing directly to `main`, the workflow now:
1. Creates a short-lived `chore/version-X.Y.Z` branch
2. Commits the version bump there
3. Opens a PR against `main`
4. Enables auto-merge — the existing auto-approve workflow will approve and merge it once Copilot reviews it