### PR TITLE
fix(ci): parse PR number from URL, not --json flag

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -64,15 +64,14 @@ jobs:
           git commit -m "chore(version): bump to $VERSION"
           git push origin "$BRANCH"
 
-          PR_NUMBER=$(gh pr create \
+          PR_URL=$(gh pr create \
             --title "chore(version): bump to $VERSION" \
             --body "Automated patch version bump triggered by merge to \`main\`." \
             --base main \
-            --head "$BRANCH" \
-            --json number \
-            --jq '.number')
+            --head "$BRANCH")
 
-          echo "Created PR #$PR_NUMBER"
+          PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+          echo "Created PR #$PR_NUMBER: $PR_URL"
 
           # Enable auto-merge — merges automatically once approval conditions are met
           gh pr merge "$PR_NUMBER" --auto --squash \


### PR DESCRIPTION
## Problem

`gh pr create` does not support `--json`/`--jq` for output formatting — only read commands like `gh pr view` and `gh pr list` do. The workflow failed with `unknown flag: --json`.

## Fix

Parse the PR number from the URL that `gh pr create` returns by default:

```bash
PR_URL=$(gh pr create ...)
PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
```