### PR TITLE
docs(skill) + fix: onyx URL, Vite allowedHosts, Caddy bridge-IP upstreams, Next dev CSP

### DIFF
--- a/.claude/skills/ppt-deploy/SKILL.md
+++ b/.claude/skills/ppt-deploy/SKILL.md
@@ -7,12 +7,59 @@ description: Manage worktree deployments to *.dev.ppt.rlt.sk and *.dev.rlt.sk vi
 
 Wraps the `pmctl` CLI to deploy worktree branches to subdomain dev URLs and to manage staging/prod releases.
 
+## Where the deploy server lives
+
+- **URL**: `https://onyx.rlt.sk` (Hetzner, behind Caddy, custom build with cloudflare DNS-01).
+- **Health**: `curl https://onyx.rlt.sk/health` — public, no auth.
+- **Auth**: bearer token (sha256 hash on the server side, full token on the client). Token is stored in macOS Keychain on the operator's laptop; the server never sees it persisted in cleartext.
+
+## Setup (one-time, per developer machine)
+
+```bash
+# Save the API token in macOS Keychain (paste the token when prompted)
+security add-generic-password -s ppt-deploy-token -a "$USER" -w
+
+# In your shell rc (~/.zshrc, ~/.bashrc, etc.):
+export PPT_DEPLOY_URL=https://onyx.rlt.sk
+export PPT_DEPLOY_TOKEN=$(security find-generic-password -s ppt-deploy-token -w 2>/dev/null)
+```
+
+If `pmctl` isn't on `$PATH`, build it:
+
+```bash
+cd backend && cargo build --release -p deploy-server --bin pmctl
+sudo install target/release/pmctl /usr/local/bin/pmctl
+```
+
+`pmctl --url` defaults to `https://onyx.rlt.sk`, so once `PPT_DEPLOY_TOKEN` is exported the rest is `pmctl <subcommand>`.
+
 ## Quick reference
 
 - `pmctl open <branch>` → spawns frontend dev containers, registers Caddy routes, prints URLs.
 - `pmctl close <name>` → graceful shutdown, marks for TTL cleanup.
 - `pmctl status [name]` / `pmctl list` → state introspection.
 - `pmctl version` / `pmctl --json` → JSON output for parsing.
+- `pmctl logs <name> [--service api|reality|ppt|reality-web]` → SSE log stream.
+- `pmctl deploy <tag>` / `pmctl promote <tag>` / `pmctl rollback` → release lifecycle.
+
+### Without `pmctl` (raw curl)
+
+The exposed paths are `/api/...` (NOT `/v1/...`). Examples:
+
+```bash
+# List worktrees
+curl -H "Authorization: Bearer $PPT_DEPLOY_TOKEN" "$PPT_DEPLOY_URL/api/worktrees"
+
+# Open a worktree (shared backend)
+curl -X POST -H "Authorization: Bearer $PPT_DEPLOY_TOKEN" -H "Content-Type: application/json" \
+  "$PPT_DEPLOY_URL/api/worktree" \
+  -d '{"branch":"feature/UC-14","backend":"shared"}'
+
+# Health (no auth)
+curl "$PPT_DEPLOY_URL/health"
+```
+
+Full endpoint list: `references/api.md`.
 
 ## When to use which command
 
@@ -22,7 +69,7 @@ Wraps the `pmctl` CLI to deploy worktree branches to subdomain dev URLs and to m
 
 ## Frontend mode switching
 
-When opening a worktree, the skill writes `frontend/.env.local` so the app talks to the new backend by default. See `references/modes.md`.
+When opening a worktree, the skill writes the right `.env.local` per app so the frontend talks to the new backend by default. See `references/modes.md` and `commands/open-worktree.md` for the exact env-var names (they differ between ppt-web and reality-web).
 
 ## API surface
 

--- a/.claude/skills/ppt-deploy/SKILL.md
+++ b/.claude/skills/ppt-deploy/SKILL.md
@@ -21,7 +21,11 @@ security add-generic-password -s ppt-deploy-token -a "$USER" -w
 
 # In your shell rc (~/.zshrc, ~/.bashrc, etc.):
 export PPT_DEPLOY_URL=https://onyx.rlt.sk
-export PPT_DEPLOY_TOKEN=$(security find-generic-password -s ppt-deploy-token -w 2>/dev/null)
+# NOTE: do NOT swallow stderr from `security` — if the keychain entry is
+# missing, you want to see "The specified item could not be found" rather
+# than silently exporting an empty token (which produces confusing 401s).
+PPT_DEPLOY_TOKEN=$(security find-generic-password -s ppt-deploy-token -w) \
+  && export PPT_DEPLOY_TOKEN
 ```
 
 If `pmctl` isn't on `$PATH`, build it:
@@ -39,8 +43,15 @@ sudo install target/release/pmctl /usr/local/bin/pmctl
 - `pmctl close <name>` → graceful shutdown, marks for TTL cleanup.
 - `pmctl status [name]` / `pmctl list` → state introspection.
 - `pmctl version` / `pmctl --json` → JSON output for parsing.
-- `pmctl logs <name> [--service api|reality|ppt|reality-web]` → SSE log stream.
-- `pmctl deploy <tag>` / `pmctl promote <tag>` / `pmctl rollback` → release lifecycle.
+- `pmctl logs <name> [--service ppt|reality|api|reality-api|all]` → SSE log
+  stream. Container suffixes correspond to `wt-<name>-{ppt|reality|api|reality-api}`;
+  `all` (default) aggregates them. `reality-web` is NOT a valid value (the
+  frontend container suffix is `reality`, not `reality-web`).
+- Release lifecycle:
+  - `pmctl deploy <target> --tag <vX.Y.Z>` (target is positional; `--tag` flag)
+  - `pmctl promote <tag> --target <staging|prod> [--dry-run]` (tag positional, `--target` required)
+  - `pmctl rollback --target <staging|prod> [--to <tag>]` (both via flags; field is `to`, not `tag`)
+  - `pmctl wake <target>` (resume paused target)
 
 ### Without `pmctl` (raw curl)
 

--- a/.claude/skills/ppt-deploy/references/api.md
+++ b/.claude/skills/ppt-deploy/references/api.md
@@ -1,13 +1,49 @@
 # HTTP API reference (deploy server)
 
+Base URL: `https://onyx.rlt.sk` (production). All paths start with `/api/...`
+or `/health`. There is no `/v1/...` prefix.
+
 | Endpoint | Method | Body | Notes |
 |---|---|---|---|
-| `/api/worktree` | POST | `{branch, alias?, backend, ttl_seconds?}` | Open |
+| `/health` | GET | — | Public, returns `{status, version}` |
+| `/api/worktree` | POST | `{branch, alias?, backend, ttl_seconds?}` | Open. `backend` ∈ `shared`/`dedicated`. |
 | `/api/worktrees` | GET | — | List |
 | `/api/worktree/{name}` | GET | — | Status |
-| `/api/worktree/{name}/close` | POST | — | Close |
-| `/api/webhook/github` | POST | GH webhook payload | HMAC auth |
-| `/api/gc/tick` | POST | — | Bearer auth (cron) |
-| `/health` | GET | — | Public |
+| `/api/worktree/{name}/close` | POST | — | Close (graceful) |
+| `/api/logs/{name}` | GET | — | SSE stream; query `?service=api|reality|ppt|reality-web` |
+| `/api/audit` | GET | — | Recent audit rows; query `?limit=N` (max 200) |
+| `/api/deploy` | POST | `{tag, target?}` | Staging deploy (Phase 2). Default target=`staging`. |
+| `/api/wake/{target}` | POST | — | Resume a paused/stopped target. |
+| `/api/release` | POST | `{tag, images}` | Register prod-candidate (called by release.yml on tag push). |
+| `/api/promote` | POST | `{tag, target?}` | Promote candidate to live (Phase 4). |
+| `/api/rollback` | POST | `{target, tag?}` | Rollback target to previous (or specified) release. |
+| `/api/gc/tick` | POST | — | Bearer auth (systemd timer; not for humans). |
+| `/api/webhook/github` | POST | GH webhook payload | HMAC-only (no bearer); validates `X-Hub-Signature-256`. |
 
-Auth: `Authorization: Bearer <token>`. Token from `~/.config/ppt-deploy/token` or `$PPT_DEPLOY_TOKEN`.
+## Auth
+
+`Authorization: Bearer <token>` for everything except `/health` and the
+GitHub webhook (which uses HMAC).
+
+Token sources (in order of precedence used by `pmctl`):
+1. `--token <token>` flag
+2. `$PPT_DEPLOY_TOKEN` env var
+3. `~/.config/ppt-deploy/token` file
+
+Recommended on macOS: store the token in Keychain and export it once per
+shell session via:
+
+```bash
+export PPT_DEPLOY_TOKEN=$(security find-generic-password -s ppt-deploy-token -w)
+```
+
+## Scopes
+
+The token's grant set is checked per endpoint. The default operator token
+has scope `*` (all). CI tokens are typically scoped tighter:
+- `release:deploy` — `/api/deploy`
+- `release:register` — `/api/release` (prod candidates)
+- `release:promote` / `release:rollback`
+- `worktree:open` / `worktree:close` / `worktree:read`
+- `gc:tick` — `/api/gc/tick`
+- `audit:read` — `/api/audit`

--- a/.claude/skills/ppt-deploy/references/api.md
+++ b/.claude/skills/ppt-deploy/references/api.md
@@ -10,13 +10,13 @@ or `/health`. There is no `/v1/...` prefix.
 | `/api/worktrees` | GET | — | List |
 | `/api/worktree/{name}` | GET | — | Status |
 | `/api/worktree/{name}/close` | POST | — | Close (graceful) |
-| `/api/logs/{name}` | GET | — | SSE stream; query `?service=api|reality|ppt|reality-web` |
-| `/api/audit` | GET | — | Recent audit rows; query `?limit=N` (max 200) |
+| `/api/logs/{name}` | GET | — | SSE stream; query `?service=ppt\|reality\|api\|reality-api\|all` (default `all`). `reality-web` is NOT valid — the frontend container suffix is `reality`. |
+| `/api/audit` | GET | — | Recent audit rows; query `?limit=N` clamped to `1..=500` (default 100). |
 | `/api/deploy` | POST | `{tag, target?}` | Staging deploy (Phase 2). Default target=`staging`. |
 | `/api/wake/{target}` | POST | — | Resume a paused/stopped target. |
 | `/api/release` | POST | `{tag, images}` | Register prod-candidate (called by release.yml on tag push). |
-| `/api/promote` | POST | `{tag, target?}` | Promote candidate to live (Phase 4). |
-| `/api/rollback` | POST | `{target, tag?}` | Rollback target to previous (or specified) release. |
+| `/api/promote` | POST | `{tag, target, dry_run?}` | Promote candidate to live (Phase 4). `target` is required; `dry_run` is bool, default false. |
+| `/api/rollback` | POST | `{target, to?}` | Rollback. `target` required; optional `to` (note: field is `to`, NOT `tag`) — when present, rolls forward/back to that specific tag instead of the previous one. |
 | `/api/gc/tick` | POST | — | Bearer auth (systemd timer; not for humans). |
 | `/api/webhook/github` | POST | GH webhook payload | HMAC-only (no bearer); validates `X-Hub-Signature-256`. |
 
@@ -41,9 +41,14 @@ export PPT_DEPLOY_TOKEN=$(security find-generic-password -s ppt-deploy-token -w)
 
 The token's grant set is checked per endpoint. The default operator token
 has scope `*` (all). CI tokens are typically scoped tighter:
-- `release:deploy` — `/api/deploy`
-- `release:register` — `/api/release` (prod candidates)
-- `release:promote` / `release:rollback`
-- `worktree:open` / `worktree:close` / `worktree:read`
-- `gc:tick` — `/api/gc/tick`
-- `audit:read` — `/api/audit`
+- `release:deploy` — `POST /api/deploy`
+- `release:register` — `POST /api/release` (prod candidates from tag-push)
+- `release:wake` — `POST /api/wake/{target}`
+- `release:promote` — `POST /api/promote`
+- `release:rollback` — `POST /api/rollback`
+- `worktree:open` — `POST /api/worktree`
+- `worktree:close` — `POST /api/worktree/{name}/close`
+- `worktree:read` — `GET /api/worktrees`, `GET /api/worktree/{name}`,
+  `GET /api/logs/{name}`
+- `gc:tick` — `POST /api/gc/tick` (used only by the systemd timer)
+- `audit:read` — `GET /api/audit`

--- a/.claude/skills/ppt-deploy/references/api.md
+++ b/.claude/skills/ppt-deploy/references/api.md
@@ -14,7 +14,7 @@ or `/health`. There is no `/v1/...` prefix.
 | `/api/audit` | GET | — | Recent audit rows; query `?limit=N` clamped to `1..=500` (default 100). |
 | `/api/deploy` | POST | `{tag, target?}` | Staging deploy (Phase 2). Default target=`staging`. |
 | `/api/wake/{target}` | POST | — | Resume a paused/stopped target. |
-| `/api/release` | POST | `{tag, images}` | Register prod-candidate (called by release.yml on tag push). |
+| `/api/release` | POST | `{tag, images, notes?}` | Register prod-candidate (called by release.yml on tag push). `notes` is optional and gets stored verbatim on the candidate row. |
 | `/api/promote` | POST | `{tag, target, dry_run?}` | Promote candidate to live (Phase 4). `target` is required; `dry_run` is bool, default false. |
 | `/api/rollback` | POST | `{target, to?}` | Rollback. `target` required; optional `to` (note: field is `to`, NOT `tag`) — when present, rolls forward/back to that specific tag instead of the previous one. |
 | `/api/gc/tick` | POST | — | Bearer auth (systemd timer; not for humans). |

--- a/backend/servers/deploy-server/src/api/worktree.rs
+++ b/backend/servers/deploy-server/src/api/worktree.rs
@@ -10,6 +10,13 @@ use axum::extract::{Path, State};
 use axum::Json;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use std::time::Duration;
+
+/// Max time we'll poll Docker for a freshly-started container's bridge IP
+/// before bailing. Docker normally assigns within a few hundred ms; 10 s gives
+/// plenty of margin for a stressed daemon without making a hung start hang the
+/// caller for a wt-open lifetime.
+const BRIDGE_IP_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Clone)]
 pub struct WorktreeService {
@@ -148,19 +155,48 @@ pub async fn open_handler(
     // `ppt-frontend-dev:local` Dockerfile (5173 for Vite/ppt-web, 3000 for
     // Next/reality-web).
     //
+    // `bridge_ip_with_retry` polls because Docker doesn't always assign a
+    // bridge IP synchronously with `start_container`; without the poll loop a
+    // fast caller can race the daemon and see "no bridge network IP yet".
+    //
     // Caveat: default-bridge IPs aren't stable across container restarts.
     // Tracked as a follow-up to migrate to a user-defined network with
     // container-name DNS, which would survive restarts.
-    let ppt_bridge_ip = svc.docker.bridge_ip(&ppt_container).await?;
-    let reality_bridge_ip = svc.docker.bridge_ip(&reality_container).await?;
     let host_ppt = format!("wt-{name}.{}", svc.domain_dev_ppt);
     let host_reality = format!("wt-{name}.{}", svc.domain_dev_reality);
-    svc.caddy
-        .register_route(&host_ppt, &format!("{ppt_bridge_ip}:5173"))
-        .await?;
-    svc.caddy
-        .register_route(&host_reality, &format!("{reality_bridge_ip}:3000"))
-        .await?;
+    let route_result: Result<()> = async {
+        let ppt_bridge_ip = svc
+            .docker
+            .bridge_ip_with_retry(&ppt_container, BRIDGE_IP_TIMEOUT)
+            .await?;
+        let reality_bridge_ip = svc
+            .docker
+            .bridge_ip_with_retry(&reality_container, BRIDGE_IP_TIMEOUT)
+            .await?;
+        svc.caddy
+            .register_route(&host_ppt, &format!("{ppt_bridge_ip}:5173"))
+            .await?;
+        svc.caddy
+            .register_route(&host_reality, &format!("{reality_bridge_ip}:3000"))
+            .await?;
+        Ok(())
+    }
+    .await;
+    if let Err(e) = route_result {
+        // We've already started both frontend containers but haven't persisted
+        // the worktree row yet — roll the side effects back so we don't leak
+        // orphans the next `pmctl close` won't know about.
+        let started = vec![ppt_container.clone(), reality_container.clone()];
+        tracing::warn!(
+            error = %e,
+            containers = ?started,
+            "frontend bridge-IP/route registration failed; cleaning up containers"
+        );
+        svc.docker.cleanup_containers(&started).await;
+        let _ = svc.caddy.unregister_route(&host_ppt).await;
+        let _ = svc.caddy.unregister_route(&host_reality).await;
+        return Err(e);
+    }
 
     let mut containers = vec![ppt_container, reality_container];
     let mut api_url: Option<String> = None;
@@ -281,34 +317,61 @@ pub async fn open_handler(
                 ));
             }
 
-            svc.docker
-                .run_backend_dedicated(&crate::infra::BackendDedicatedSpec {
-                    container_name: api_c.clone(),
-                    image: api_image,
-                    host_port: api_port,
-                    container_port: 8080,
-                    db_url: db_url.clone(),
-                    jwt_secret: jwt_secret.clone(),
-                })
-                .await?;
-            svc.docker
-                .run_backend_dedicated(&crate::infra::BackendDedicatedSpec {
-                    container_name: reality_c.clone(),
-                    image: reality_image,
-                    host_port: reality_port,
-                    container_port: 8081,
-                    db_url,
-                    jwt_secret,
-                })
-                .await?;
-
-            // Caddy routes for backend — same bridge-IP rationale as the
-            // frontend routes above. api container's internal port is 8080.
-            let api_bridge_ip = svc.docker.bridge_ip(&api_c).await?;
+            // Run both backend containers and register the api Caddy route in
+            // a single try block; on any failure here, force-remove all
+            // containers (frontend + whatever backend we managed to start) and
+            // unregister the api route. Keeps the worktree row from being
+            // persisted with orphan side effects on disk.
             let host_api = format!("api.wt-{name}.{}", svc.domain_dev_ppt);
-            svc.caddy
-                .register_route(&host_api, &format!("{api_bridge_ip}:8080"))
-                .await?;
+            let backend_result: Result<()> = async {
+                svc.docker
+                    .run_backend_dedicated(&crate::infra::BackendDedicatedSpec {
+                        container_name: api_c.clone(),
+                        image: api_image,
+                        host_port: api_port,
+                        container_port: 8080,
+                        db_url: db_url.clone(),
+                        jwt_secret: jwt_secret.clone(),
+                    })
+                    .await?;
+                svc.docker
+                    .run_backend_dedicated(&crate::infra::BackendDedicatedSpec {
+                        container_name: reality_c.clone(),
+                        image: reality_image,
+                        host_port: reality_port,
+                        container_port: 8081,
+                        db_url,
+                        jwt_secret,
+                    })
+                    .await?;
+
+                // Caddy routes for backend — same bridge-IP rationale as the
+                // frontend routes above. api container's internal port is 8080.
+                let api_bridge_ip = svc
+                    .docker
+                    .bridge_ip_with_retry(&api_c, BRIDGE_IP_TIMEOUT)
+                    .await?;
+                svc.caddy
+                    .register_route(&host_api, &format!("{api_bridge_ip}:8080"))
+                    .await?;
+                Ok(())
+            }
+            .await;
+            if let Err(e) = backend_result {
+                let mut to_clean = containers.clone();
+                to_clean.push(api_c.clone());
+                to_clean.push(reality_c.clone());
+                tracing::warn!(
+                    error = %e,
+                    containers = ?to_clean,
+                    "dedicated backend bring-up failed; cleaning up all worktree containers"
+                );
+                svc.docker.cleanup_containers(&to_clean).await;
+                let _ = svc.caddy.unregister_route(&host_ppt).await;
+                let _ = svc.caddy.unregister_route(&host_reality).await;
+                let _ = svc.caddy.unregister_route(&host_api).await;
+                return Err(e);
+            }
             api_url = Some(format!("https://{host_api}"));
 
             containers.push(api_c);

--- a/backend/servers/deploy-server/src/api/worktree.rs
+++ b/backend/servers/deploy-server/src/api/worktree.rs
@@ -139,13 +139,27 @@ pub async fn open_handler(
         .await?;
 
     // 4. Register frontend Caddy routes.
+    //
+    // Upstream MUST be the container's docker-bridge IP (not the host's
+    // `127.0.0.1:<host_port>`). Caddy itself runs in a container; its
+    // loopback is its own, not the host's. Pointing at the bridge IP works
+    // because Caddy and the worktree dev containers share the default bridge
+    // network. The container's *internal* port is also fixed by the
+    // `ppt-frontend-dev:local` Dockerfile (5173 for Vite/ppt-web, 3000 for
+    // Next/reality-web).
+    //
+    // Caveat: default-bridge IPs aren't stable across container restarts.
+    // Tracked as a follow-up to migrate to a user-defined network with
+    // container-name DNS, which would survive restarts.
+    let ppt_bridge_ip = svc.docker.bridge_ip(&ppt_container).await?;
+    let reality_bridge_ip = svc.docker.bridge_ip(&reality_container).await?;
     let host_ppt = format!("wt-{name}.{}", svc.domain_dev_ppt);
     let host_reality = format!("wt-{name}.{}", svc.domain_dev_reality);
     svc.caddy
-        .register_route(&host_ppt, &format!("127.0.0.1:{port_ppt}"))
+        .register_route(&host_ppt, &format!("{ppt_bridge_ip}:5173"))
         .await?;
     svc.caddy
-        .register_route(&host_reality, &format!("127.0.0.1:{port_reality}"))
+        .register_route(&host_reality, &format!("{reality_bridge_ip}:3000"))
         .await?;
 
     let mut containers = vec![ppt_container, reality_container];
@@ -288,10 +302,12 @@ pub async fn open_handler(
                 })
                 .await?;
 
-            // Caddy routes for backend
+            // Caddy routes for backend — same bridge-IP rationale as the
+            // frontend routes above. api container's internal port is 8080.
+            let api_bridge_ip = svc.docker.bridge_ip(&api_c).await?;
             let host_api = format!("api.wt-{name}.{}", svc.domain_dev_ppt);
             svc.caddy
-                .register_route(&host_api, &format!("127.0.0.1:{api_port}"))
+                .register_route(&host_api, &format!("{api_bridge_ip}:8080"))
                 .await?;
             api_url = Some(format!("https://{host_api}"));
 

--- a/backend/servers/deploy-server/src/error.rs
+++ b/backend/servers/deploy-server/src/error.rs
@@ -37,6 +37,14 @@ pub enum DeployError {
     #[error("config error: {0}")]
     Config(String),
 
+    /// Transient: container is created/started but Docker hasn't finished
+    /// assigning a bridge-network IP yet. Callers (notably `worktree::open`)
+    /// match this variant structurally to retry, instead of inspecting the
+    /// `Internal(String)` text. Surfaces as a generic 500 to clients on
+    /// timeout — the retry loop catches the in-process race.
+    #[error("bridge IP not ready yet for container {0}")]
+    BridgeIpNotReady(String),
+
     #[error("internal: {0}")]
     Internal(String),
 }

--- a/backend/servers/deploy-server/src/infra/docker.rs
+++ b/backend/servers/deploy-server/src/infra/docker.rs
@@ -111,31 +111,28 @@ impl DockerClient {
                     .and_then(|n| n.ip_address)
             })
             .filter(|s| !s.is_empty())
-            .ok_or_else(|| {
-                crate::DeployError::Internal(format!(
-                    "container {name} has no bridge network IP yet"
-                ))
-            })
+            // Distinct error variant (not `Internal`) so the retry loop in
+            // `bridge_ip_with_retry` can match this case structurally instead
+            // of grepping the message text. A refactor of the message can't
+            // silently break retry behavior.
+            .ok_or_else(|| crate::DeployError::BridgeIpNotReady(name.to_string()))
     }
 
     /// Like `bridge_ip`, but polls until the IP is assigned or `timeout` elapses.
     ///
     /// Right after `start_container` Docker may not have assigned a bridge IP yet,
-    /// so a direct `bridge_ip` call returns "no bridge network IP yet". This helper
+    /// so a direct `bridge_ip` call returns `BridgeIpNotReady(name)`. This helper
     /// polls every 100 ms until either an IP appears or `timeout` is reached. Real
     /// Docker errors (socket gone, container disappeared) propagate immediately —
-    /// only the "no IP yet" case is retried.
+    /// only the typed `BridgeIpNotReady` variant is retried.
     pub async fn bridge_ip_with_retry(&self, name: &str, timeout: Duration) -> Result<String> {
         let deadline = Instant::now() + timeout;
         loop {
             match self.bridge_ip(name).await {
                 Ok(ip) => return Ok(ip),
                 Err(e) => {
-                    let is_no_ip_yet = matches!(
-                        &e,
-                        crate::DeployError::Internal(msg) if msg.contains("has no bridge network IP yet")
-                    );
-                    if !is_no_ip_yet || Instant::now() >= deadline {
+                    let is_not_ready = matches!(&e, crate::DeployError::BridgeIpNotReady(_));
+                    if !is_not_ready || Instant::now() >= deadline {
                         return Err(e);
                     }
                     tokio::time::sleep(Duration::from_millis(100)).await;

--- a/backend/servers/deploy-server/src/infra/docker.rs
+++ b/backend/servers/deploy-server/src/infra/docker.rs
@@ -7,6 +7,8 @@ use bollard::container::{
 use bollard::models::{HostConfig, Mount, MountTypeEnum, PortBinding};
 use bollard::Docker;
 use std::collections::HashMap;
+use std::time::Duration;
+use tokio::time::Instant;
 
 pub struct DockerClient {
     docker: Docker,
@@ -114,6 +116,32 @@ impl DockerClient {
                     "container {name} has no bridge network IP yet"
                 ))
             })
+    }
+
+    /// Like `bridge_ip`, but polls until the IP is assigned or `timeout` elapses.
+    ///
+    /// Right after `start_container` Docker may not have assigned a bridge IP yet,
+    /// so a direct `bridge_ip` call returns "no bridge network IP yet". This helper
+    /// polls every 100 ms until either an IP appears or `timeout` is reached. Real
+    /// Docker errors (socket gone, container disappeared) propagate immediately —
+    /// only the "no IP yet" case is retried.
+    pub async fn bridge_ip_with_retry(&self, name: &str, timeout: Duration) -> Result<String> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            match self.bridge_ip(name).await {
+                Ok(ip) => return Ok(ip),
+                Err(e) => {
+                    let is_no_ip_yet = matches!(
+                        &e,
+                        crate::DeployError::Internal(msg) if msg.contains("has no bridge network IP yet")
+                    );
+                    if !is_no_ip_yet || Instant::now() >= deadline {
+                        return Err(e);
+                    }
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            }
+        }
     }
 
     pub async fn run_frontend_dev(&self, spec: &FrontendDevSpec) -> Result<String> {

--- a/backend/servers/deploy-server/src/infra/docker.rs
+++ b/backend/servers/deploy-server/src/infra/docker.rs
@@ -87,6 +87,35 @@ impl DockerClient {
         }
     }
 
+    /// Resolve a container's IPv4 address on the default `bridge` network.
+    ///
+    /// Used to construct Caddy reverse-proxy upstreams that point at the
+    /// container directly rather than at `127.0.0.1:<host_port>`. The latter
+    /// fails when Caddy itself runs in a container — its loopback is its own,
+    /// not the host's. The bridge network is shared with `ppt-caddy` so the
+    /// container IP is reachable from there.
+    ///
+    /// Caveat: bridge IPs are NOT stable across container restarts on the
+    /// default bridge network. For full stability, switch worktree+Caddy
+    /// containers to a user-defined network and use container *names* as
+    /// upstreams (Docker's embedded DNS resolves them); tracked as a
+    /// follow-up.
+    pub async fn bridge_ip(&self, name: &str) -> Result<String> {
+        let info = self.docker.inspect_container(name, None).await?;
+        info.network_settings
+            .and_then(|ns| {
+                ns.networks
+                    .and_then(|nets| nets.get("bridge").cloned())
+                    .and_then(|n| n.ip_address)
+            })
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                crate::DeployError::Internal(format!(
+                    "container {name} has no bridge network IP yet"
+                ))
+            })
+    }
+
     pub async fn run_frontend_dev(&self, spec: &FrontendDevSpec) -> Result<String> {
         // Idempotency: remove existing container with the same name first.
         let _ = self

--- a/frontend/apps/ppt-web/vite.config.ts
+++ b/frontend/apps/ppt-web/vite.config.ts
@@ -22,9 +22,13 @@ export default defineConfig({
     // the container via the deploy-server's Caddy reverse proxy at hosts like
     // `wt-<name>.dev.ppt.rlt.sk` — without this they 403 with
     // `Blocked request. This host (...) is not allowed`.
-    // `true` accepts any host header; only ever applied in `vite dev`,
-    // production builds don't run a server.
-    allowedHosts: true,
+    //
+    // A leading-dot entry is Vite's documented suffix-match form: `.dev.ppt.rlt.sk`
+    // matches `dev.ppt.rlt.sk` itself AND any subdomain of it (`wt-foo.dev.ppt.rlt.sk`).
+    // Explicit list keeps Vite's DNS-rebinding protection intact — random hostnames
+    // pointed at the dev server are still rejected, only our worktree subdomains
+    // pass. Only ever applied in `vite dev`; production builds don't run a server.
+    allowedHosts: ['.dev.ppt.rlt.sk'],
     // Proxy /api/* to the api-server in local dev so relative-path fetches
     // (OpenAPI.BASE = '' and VITE_API_BASE_URL = '') resolve correctly without
     // setting VITE_API_URL. In production VITE_API_URL must be set explicitly.

--- a/frontend/apps/ppt-web/vite.config.ts
+++ b/frontend/apps/ppt-web/vite.config.ts
@@ -17,6 +17,14 @@ export default defineConfig({
   ],
   server: {
     port: 3000,
+    // Vite 5+ rejects requests whose Host header doesn't match a small
+    // built-in allowlist (localhost variants only). Worktree dev runs reach
+    // the container via the deploy-server's Caddy reverse proxy at hosts like
+    // `wt-<name>.dev.ppt.rlt.sk` — without this they 403 with
+    // `Blocked request. This host (...) is not allowed`.
+    // `true` accepts any host header; only ever applied in `vite dev`,
+    // production builds don't run a server.
+    allowedHosts: true,
     // Proxy /api/* to the api-server in local dev so relative-path fetches
     // (OpenAPI.BASE = '' and VITE_API_BASE_URL = '') resolve correctly without
     // setting VITE_API_URL. In production VITE_API_URL must be set explicitly.

--- a/frontend/apps/ppt-web/vite.config.ts
+++ b/frontend/apps/ppt-web/vite.config.ts
@@ -18,17 +18,18 @@ export default defineConfig({
   server: {
     port: 3000,
     // Vite 5+ rejects requests whose Host header doesn't match a small
-    // built-in allowlist (localhost variants only). Worktree dev runs reach
-    // the container via the deploy-server's Caddy reverse proxy at hosts like
-    // `wt-<name>.dev.ppt.rlt.sk` — without this they 403 with
-    // `Blocked request. This host (...) is not allowed`.
-    //
-    // A leading-dot entry is Vite's documented suffix-match form: `.dev.ppt.rlt.sk`
-    // matches `dev.ppt.rlt.sk` itself AND any subdomain of it (`wt-foo.dev.ppt.rlt.sk`).
-    // Explicit list keeps Vite's DNS-rebinding protection intact — random hostnames
-    // pointed at the dev server are still rejected, only our worktree subdomains
-    // pass. Only ever applied in `vite dev`; production builds don't run a server.
-    allowedHosts: ['.dev.ppt.rlt.sk'],
+    // built-in allowlist (localhost variants only). All ppt-web environments
+    // that ever reach the dev server through Caddy live under `ppt.rlt.sk`:
+    //   - worktrees: `wt-<name>.dev.ppt.rlt.sk`
+    //   - staging:   `staging.ppt.rlt.sk` (and any future `*.staging.ppt.rlt.sk`)
+    //   - live:      `ppt.rlt.sk`         (and any future `*.ppt.rlt.sk`)
+    // A single leading-dot entry covers all three: Vite's suffix-match form
+    // `.ppt.rlt.sk` matches `ppt.rlt.sk` itself AND any subdomain at any depth
+    // (so `wt-foo.dev.ppt.rlt.sk` ✓, `staging.ppt.rlt.sk` ✓, `ppt.rlt.sk` ✓).
+    // DNS-rebinding protection stays intact — anything not under ppt.rlt.sk
+    // is still rejected. Only ever applied in `vite dev`; production builds
+    // don't run a server.
+    allowedHosts: ['.ppt.rlt.sk'],
     // Proxy /api/* to the api-server in local dev so relative-path fetches
     // (OpenAPI.BASE = '' and VITE_API_BASE_URL = '') resolve correctly without
     // setting VITE_API_URL. In production VITE_API_URL must be set explicitly.

--- a/frontend/apps/reality-web/next.config.js
+++ b/frontend/apps/reality-web/next.config.js
@@ -44,14 +44,22 @@ if (isDev) {
 // `style-src 'unsafe-inline'`: Next.js CSS-in-JS + next-intl inject inline
 // `<style>` blocks; same nonce migration will cover them.
 //
-// `'unsafe-eval'` is intentionally NOT allowed — dev hot-reload may need
-// it for some React Native Fast Refresh flows, but next-dev does not.
+// `'unsafe-eval'` (dev only): Next.js 14 Fast Refresh runtime
+// (`@next/react-refresh-utils/runtime`) evaluates hot-updated module code via
+// `eval()`. Without it, the dev bundle throws EvalError on first paint, the
+// client never hydrates, and styled-jsx never injects component CSS — the
+// page is left with only globals.css and looks completely unstyled. Production
+// builds don't ship react-refresh, so the prod CSP is unaffected.
+const scriptSrc = ["'self'", "'unsafe-inline'"];
+if (isDev) {
+  scriptSrc.push("'unsafe-eval'");
+}
 const securityHeaders = [
   {
     key: 'Content-Security-Policy',
     value: [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-inline'",
+      `script-src ${scriptSrc.join(' ')}`,
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: blob: https:",
       "font-src 'self' data:",


### PR DESCRIPTION
## Summary

Started as a docs PR (skill update for `onyx.rlt.sk`). While exercising the docs against the live deploy server, three real bugs surfaced; folding their fixes in here since they're needed to make the documented commands actually work end-to-end.

### Docs (originally PR scope)
- `.claude/skills/ppt-deploy/SKILL.md` — document `onyx.rlt.sk` URL, macOS Keychain pattern for the bearer token, raw-curl examples on the real `/api/...` paths, accurate `pmctl` flags.
- `.claude/skills/ppt-deploy/references/api.md` — full endpoint table including phase 4-6 endpoints, accurate request schemas (incl. `notes?` on `/api/release`), scope-per-endpoint table.

### Fix #1 — `frontend/apps/ppt-web/vite.config.ts`
Vite 5+ rejects requests whose Host header isn't in a built-in localhost-only allowlist; worktree dev runs reach the container via `wt-<name>.dev.ppt.rlt.sk` through Caddy and got `Blocked request. This host (...) is not allowed`.

ppt-web's `vite.config.ts` is shared across all environments where Vite dev ever runs:
- worktrees: `wt-*.dev.ppt.rlt.sk`
- staging: `staging.ppt.rlt.sk` (and any future `*.staging.ppt.rlt.sk`)
- live: `ppt.rlt.sk` (and any future `*.ppt.rlt.sk`)

Add `allowedHosts: ['.ppt.rlt.sk']` — Vite's leading-dot suffix-match form covers the parent host AND any subdomain at any depth. Single tightest entry that covers all three envs; anything not under `ppt.rlt.sk` is still rejected so DNS-rebinding protection stays intact.

### Fix #2 — deploy-server Caddy upstream IPs + transient-failure hardening
`backend/servers/deploy-server/src/{api/worktree.rs,infra/docker.rs,error.rs}`. Caddy itself runs in a container; its `127.0.0.1` is its own loopback, not the host's. Fix: register Caddy upstreams as `<container_bridge_ip>:<container_port>` instead of `127.0.0.1:<host_port>`. Added `DockerClient::bridge_ip(name)` helper that pulls the IP from `inspect_container().network_settings.networks.bridge.ip_address`.

Hardening on top:
- New `DeployError::BridgeIpNotReady(String)` variant — `bridge_ip` returns it when Docker hasn't assigned an IP yet, and the retry loop matches it structurally (`matches!(e, BridgeIpNotReady(_))`). No string-grepping the error message.
- `bridge_ip_with_retry(name, timeout)` — poll every 100 ms for up to 10 s on the IP-not-assigned-yet race that can surface immediately after `start_container`. Real Docker errors propagate immediately; only the typed variant is retried.
- `open_handler` now wraps the bridge-IP + Caddy-route blocks in try closures. On any failure (transient Docker, Caddy admin API down, etc.) it force-removes whatever containers it already started and unregisters any Caddy routes it registered, so a partial open doesn't leak orphans the next `pmctl close` won't know about.

Caveat documented in code: default-bridge IPs aren't stable across container restarts. Tracked as a follow-up: switch worktree+Caddy onto a user-defined network and use container *names* as upstreams (Docker DNS resolves them, names survive restarts).

### Fix #3 — `frontend/apps/reality-web/next.config.js` CSP
The previous CSP `script-src 'self' 'unsafe-inline'` blocked Next 14's `@next/react-refresh-utils/runtime`, which evaluates hot-updated module code via `eval()`. The resulting EvalError aborted the dev bundle on first paint, hydration never ran, and styled-jsx never injected its component CSS — so worktree dev URLs (e.g. `wt-*.dev.rlt.sk`) rendered with only `globals.css` + tokens.css and looked completely unstyled.

Fix: append `'unsafe-eval'` to `script-src` only when `isDev`. Production builds don't ship react-refresh, so the prod CSP keeps the strict `script-src 'self' 'unsafe-inline'` set.

## Test plan

Verified live on the running deploy-server at `https://onyx.rlt.sk`:

- [x] `pmctl close test1 && pmctl open docs/skill-onyx-url --alias=test1` — Caddy routes auto-register with bridge IPs (no manual /id/route PUT needed)
- [x] `https://wt-test1.dev.rlt.sk/` returns the Reality Portal Next.js HTML, HTTP 200, valid LE cert
- [x] `https://wt-test1.dev.ppt.rlt.sk/` returns the Property Management React HTML, HTTP 200, valid LE cert (was 403 Blocked request before this PR)
- [x] After CSP fix, `https://wt-test1.dev.rlt.sk/` renders fully styled (hero, search form, footer grid). Browser console shows no EvalError; CSP header confirmed to include `'unsafe-eval'` only in dev.
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p deploy-server -- -D warnings` clean
- [x] `cargo test -p deploy-server --lib` 40 passed / 1 ignored / 0 failed
- [x] All Copilot review comments (7 doc-accuracy + 4 hardening + 3 follow-up) addressed and resolved

Out of scope (tracked separately): migrate worktree+Caddy to a user-defined Docker network for IP stability across restarts; auto-deploy on main/dev merge (separate PR planned).