### PR TITLE
feat(deploy-server): per-target dual-apex URL routing (prod = rlt.sk + ppt.rlt.sk)

### DIFF
--- a/backend/servers/deploy-server/src/api/promote.rs
+++ b/backend/servers/deploy-server/src/api/promote.rs
@@ -72,7 +72,7 @@ pub async fn promote_handler(
         }));
     }
 
-    let spec = BlueGreenSpec::from_release(&candidate, target.as_str(), &target_cfg.domain_suffix)?;
+    let spec = BlueGreenSpec::from_release(&candidate, target.as_str(), target_cfg)?;
     let docker = svc
         .release_svc
         .docker_pool
@@ -91,7 +91,12 @@ pub async fn promote_handler(
     let new_state = target.live_release_state();
     let health_grace_passed = if let Some(grace) = &target_cfg.health_grace {
         let secs = parse_duration_secs(grace).unwrap_or(60);
-        let url = format!("https://api.{}/health", target_cfg.domain_suffix);
+        // Probe api-server health (PM API). Reality-server health is at
+        // `api.<reality_apex>/health`; we pick PM API as the canonical signal
+        // because both backends share the same Postgres + secrets path, so a
+        // failure in one is highly correlated with the other. Cheap to probe
+        // both later if needed.
+        let url = format!("https://api.{}/health", target_cfg.ppt_apex);
         match svc.health.grace_check(&url, 5, secs).await {
             Ok(()) => true,
             Err(e) => {
@@ -99,11 +104,8 @@ pub async fn promote_handler(
                 tracing::warn!(error = %e, auto = auto, "health grace failed");
                 if auto {
                     if let Some(prev) = &prev_release {
-                        let prev_spec = BlueGreenSpec::from_release(
-                            prev,
-                            target.as_str(),
-                            &target_cfg.domain_suffix,
-                        )?;
+                        let prev_spec =
+                            BlueGreenSpec::from_release(prev, target.as_str(), target_cfg)?;
                         match deployer.deploy(&prev_spec).await {
                             Ok(_) => {
                                 tracing::warn!(prev_tag = %prev.tag, "auto-rolled back after health grace failure");
@@ -228,8 +230,7 @@ pub async fn rollback_handler(
         .current_release_for(target.as_str(), live_state)
         .await?;
 
-    let spec =
-        BlueGreenSpec::from_release(&target_release, target.as_str(), &target_cfg.domain_suffix)?;
+    let spec = BlueGreenSpec::from_release(&target_release, target.as_str(), target_cfg)?;
     let docker = svc
         .release_svc
         .docker_pool

--- a/backend/servers/deploy-server/src/api/release.rs
+++ b/backend/servers/deploy-server/src/api/release.rs
@@ -86,7 +86,8 @@ pub async fn deploy_handler(
         reality_image: images["reality-server"].clone(),
         ppt_web_image: images["ppt-web"].clone(),
         reality_web_image: images["reality-web"].clone(),
-        domain_suffix: target_cfg.domain_suffix.clone(),
+        reality_apex: target_cfg.reality_apex.clone(),
+        ppt_apex: target_cfg.ppt_apex.clone(),
         target_name: target.as_str().into(),
     };
     let docker = svc
@@ -163,7 +164,7 @@ pub async fn wake_handler(
         .targets
         .get(target.as_str())
         .ok_or_else(|| DeployError::Config("staging target missing".into()))?;
-    let spec = BlueGreenSpec::from_release(&rel, target.as_str(), &target_cfg.domain_suffix)?;
+    let spec = BlueGreenSpec::from_release(&rel, target.as_str(), target_cfg)?;
     let docker = svc
         .docker_pool
         .get(target.as_str())

--- a/backend/servers/deploy-server/src/config.rs
+++ b/backend/servers/deploy-server/src/config.rs
@@ -59,7 +59,16 @@ pub struct TargetsConfig {
 pub struct Target {
     pub docker_socket: String,
     pub caddy_url: String,
-    pub domain_suffix: String,
+    /// Apex hostname for the Reality Portal subtree at this target. The Caddy
+    /// route for `reality-web` (Next.js UI) is registered at this exact host;
+    /// `reality-server` (the Reality API) at `api.<reality_apex>`.
+    /// Examples: "rlt.sk" (prod), "staging.rlt.sk" (staging).
+    pub reality_apex: String,
+    /// Apex hostname for the Property Management subtree at this target. The
+    /// Caddy route for `ppt-web` (Vite/React UI) is registered at this exact
+    /// host; `api-server` (the PM API) at `api.<ppt_apex>`.
+    /// Examples: "ppt.rlt.sk" (prod), "staging.ppt.rlt.sk" (staging).
+    pub ppt_apex: String,
     #[serde(default)]
     pub idle_timeout: Option<String>,
     #[serde(default)]

--- a/backend/servers/deploy-server/src/infra/blue_green.rs
+++ b/backend/servers/deploy-server/src/infra/blue_green.rs
@@ -28,7 +28,12 @@ pub struct BlueGreenSpec {
     pub reality_image: String,
     pub ppt_web_image: String,
     pub reality_web_image: String,
-    pub domain_suffix: String,
+    /// Reality Portal apex (e.g. `rlt.sk`, `staging.rlt.sk`). reality-web is
+    /// served at this exact host; reality-server at `api.<reality_apex>`.
+    pub reality_apex: String,
+    /// Property Management apex (e.g. `ppt.rlt.sk`, `staging.ppt.rlt.sk`).
+    /// ppt-web is served at this exact host; api-server at `api.<ppt_apex>`.
+    pub ppt_apex: String,
     pub target_name: String,
 }
 
@@ -40,7 +45,7 @@ impl BlueGreenSpec {
     pub fn from_release(
         rel: &crate::domain::Release,
         target_name: &str,
-        domain_suffix: &str,
+        target: &crate::config::Target,
     ) -> crate::Result<Self> {
         fn require(rel: &crate::domain::Release, key: &str) -> crate::Result<String> {
             rel.images.get(key).cloned().ok_or_else(|| {
@@ -57,7 +62,8 @@ impl BlueGreenSpec {
             reality_image: require(rel, "reality-server")?,
             ppt_web_image: require(rel, "ppt-web")?,
             reality_web_image: require(rel, "reality-web")?,
-            domain_suffix: domain_suffix.to_string(),
+            reality_apex: target.reality_apex.clone(),
+            ppt_apex: target.ppt_apex.clone(),
         })
     }
 }
@@ -162,28 +168,33 @@ impl BlueGreenDeployer {
         self.wait_until_ready(&format!("{target_name}-reality-web-{next_color}"), 3000, 30)
             .await?;
 
-        let suffix = &spec.domain_suffix;
+        // Per-service Caddy routes use the dual-apex layout:
+        //   <reality_apex>           → reality-web   (Reality Portal UI, bare apex)
+        //   api.<reality_apex>       → reality-server (Reality public API)
+        //   <ppt_apex>               → ppt-web       (Property Management UI)
+        //   api.<ppt_apex>           → api-server    (PM API)
+        // For prod with reality_apex="rlt.sk" + ppt_apex="ppt.rlt.sk" this gives
+        // rlt.sk / api.rlt.sk / ppt.rlt.sk / api.ppt.rlt.sk respectively.
+        let reality_apex = &spec.reality_apex;
+        let ppt_apex = &spec.ppt_apex;
         self.caddy
             .register_route(
-                &format!("api.{suffix}"),
+                &format!("api.{ppt_apex}"),
                 &format!("{target_name}-api-{next_color}:8080"),
             )
             .await?;
         self.caddy
             .register_route(
-                &format!("reality-api.{suffix}"),
+                &format!("api.{reality_apex}"),
                 &format!("{target_name}-reality-{next_color}:8081"),
             )
             .await?;
         self.caddy
-            .register_route(
-                &format!("ppt.{suffix}"),
-                &format!("{target_name}-ppt-{next_color}:80"),
-            )
+            .register_route(ppt_apex, &format!("{target_name}-ppt-{next_color}:80"))
             .await?;
         self.caddy
             .register_route(
-                &format!("reality.{suffix}"),
+                reality_apex,
                 &format!("{target_name}-reality-web-{next_color}:3000"),
             )
             .await?;

--- a/backend/servers/deploy-server/src/main.rs
+++ b/backend/servers/deploy-server/src/main.rs
@@ -102,13 +102,24 @@ async fn main() -> anyhow::Result<()> {
         api_keys,
         oidc,
         std::env::var("PPT_FRONTEND_IMAGE").unwrap_or_else(|_| "ppt-frontend-dev:local".into()),
+        // Worktree dev hosts (`wt-<name>.dev.ppt.rlt.sk`, `wt-<name>.dev.rlt.sk`)
+        // mirror the staging apex with `staging.` swapped for `dev.`. Example:
+        // staging.ppt_apex="staging.ppt.rlt.sk" → "dev.ppt.rlt.sk".
+        // Future improvement: make these explicit fields on the staging
+        // target (or top-level config) instead of derived from staging.*.
         format!(
-            "dev.ppt.{}",
-            staging.domain_suffix.trim_start_matches("staging.")
+            "dev.{}",
+            staging
+                .ppt_apex
+                .strip_prefix("staging.")
+                .unwrap_or(&staging.ppt_apex)
         ),
         format!(
             "dev.{}",
-            staging.domain_suffix.trim_start_matches("staging.")
+            staging
+                .reality_apex
+                .strip_prefix("staging.")
+                .unwrap_or(&staging.reality_apex)
         ),
         webhook_cfg,
         cfg_arc,

--- a/backend/servers/deploy-server/tests/common/mod.rs
+++ b/backend/servers/deploy-server/tests/common/mod.rs
@@ -103,7 +103,14 @@ pub async fn setup_app(target_names: &[&str]) -> TestApp {
         let target = Target {
             docker_socket: "unix:///var/run/docker.sock".into(),
             caddy_url: caddy_mock.base_url(),
-            domain_suffix: format!("{name}.rlt.sk"),
+            // Test apexes mirror the conventions used on onyx:
+            //   staging → reality_apex="staging.rlt.sk", ppt_apex="staging.ppt.rlt.sk"
+            //   prod    → reality_apex="prod.rlt.sk",    ppt_apex="prod.ppt.rlt.sk"
+            // (prod uses a "prod." prefix in tests to keep target names
+            // distinguishable; real onyx prod target uses bare "rlt.sk" /
+            // "ppt.rlt.sk".)
+            reality_apex: format!("{name}.rlt.sk"),
+            ppt_apex: format!("{name}.ppt.rlt.sk"),
             idle_timeout: Some("8h".into()),
             promote_strategy: Some("blue-green".into()),
             rollback_mode: "manual".into(),


### PR DESCRIPTION
## Summary

Replaces the single `domain_suffix` per-target config with two explicit apex hostnames so prod can serve Reality Portal at the **bare `rlt.sk` apex** (not `reality.rlt.sk`) and Property Management at `ppt.rlt.sk`, while staging mirrors the same shape under a `staging.` subtree.

| target  | reality_apex      | ppt_apex                |
|---------|-------------------|-------------------------|
| prod    | `rlt.sk`          | `ppt.rlt.sk`            |
| staging | `staging.rlt.sk`  | `staging.ppt.rlt.sk`    |

The blue/green Caddy routes register accordingly:

| Service          | Hostname              | prod                  | staging                       |
|------------------|-----------------------|-----------------------|-------------------------------|
| reality-web      | `<reality_apex>`      | `rlt.sk`              | `staging.rlt.sk`              |
| reality-server   | `api.<reality_apex>`  | `api.rlt.sk`          | `api.staging.rlt.sk`          |
| ppt-web          | `<ppt_apex>`          | `ppt.rlt.sk`          | `staging.ppt.rlt.sk`          |
| api-server       | `api.<ppt_apex>`      | `api.ppt.rlt.sk`      | `api.staging.ppt.rlt.sk`      |

The previous hardcoded layout (`api.<suffix>`, `reality-api.<suffix>`, `ppt.<suffix>`, `reality.<suffix>`) couldn't serve a bare apex at all and didn't put the Reality API at `api.<reality_apex>` — both blockers for the planned prod URL scheme.

## Changes

* `config::Target` — drop `domain_suffix`, add required `reality_apex` + `ppt_apex` (with module-level docs explaining the convention).
* `BlueGreenSpec` + `BlueGreenSpec::from_release` — same field swap; `from_release` now takes `&Target` instead of a single `&str` so callers don't need to thread two strings around.
* `BlueGreenDeployer::deploy` — register the four routes from the dual apexes per the table above.
* `promote_handler` — health probe now hits `api.<ppt_apex>/health` (api-server health is the canonical signal; reality-server can be added later if both should be checked).
* `release_handler` (`/api/deploy`) — populate the new fields.
* `main.rs` — derive the worktree dev domains from `staging.ppt_apex` / `staging.reality_apex` by replacing `staging.` → `dev.` (e.g. `staging.ppt.rlt.sk` → `dev.ppt.rlt.sk`).
* `tests/common/mod.rs` — fixture builds Target with both apex fields.

## Breaking change

`/etc/ppt-deploy/targets.yaml` schema changed. After this lands, the running deploy-server's config must rename `domain_suffix:` to `reality_apex:` + `ppt_apex:` per target before the new binary is started. Sequenced with the onyx update — staging and prod targets get migrated together.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p deploy-server --all-targets -- -D warnings` clean
- [x] `cargo test -p deploy-server --lib` — 40 passed / 1 ignored
- [x] `cargo test -p deploy-server --tests` — 40 passed / 3 ignored (smoke tests need Docker)
- [ ] Onyx config migrated + binary redeployed (post-merge, manual)
- [ ] Cloudflare DNS for the 6 apex/api hostnames pointed at onyx (post-merge, manual)
- [ ] First successful staging deploy via `pmctl deploy staging --tag <sha>` after migration

## Out of scope

- The GitHub-Actions workflows for **main → prod / dev → staging auto-deploy** ship in a follow-up PR; that PR depends on this one because the workflows assume the new URL scheme is already running on onyx.
- `dev.ppt.rlt.sk` / `dev.rlt.sk` worktree apexes are still derived from the staging target. A future cleanup can move them to top-level config fields so they're not implicitly `staging.` → `dev.` substitutions.