### PR TITLE
ci: branch-keyed auto-deploy — main → prod, dev → staging

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -116,12 +116,22 @@ jobs:
       - name: POST /api/deploy
         env:
           DEPLOY_URL: https://onyx.rlt.sk
-          FULL_SHA: ${{ github.sha }}
+          # We deploy by BRANCH tag (e.g. `main`, `dev`), not by short SHA.
+          # docker-build.yml and docker-frontend.yml are paths-filtered, so a
+          # backend-only push on main only updates `ppt-api-server:main` and
+          # `ppt-reality-server:main`; `ppt-web:<sha>` and `ppt-reality-web:<sha>`
+          # for the same SHA never exist, and a SHA-based deploy would 404 on
+          # those pulls. The branch tag is rewritten by every successful build
+          # of either workflow, so `:main` (or `:dev`) on each of the four
+          # service images always points at the most recent successful build of
+          # that service for that branch — independent of which workflow last
+          # ran. Side effect: per-commit precision is lost in the auto-deploy
+          # path; tag-based releases (release.yml → /api/release with vX.Y.Z)
+          # keep their commit-specific semantics.
+          BRANCH_TAG: ${{ steps.target.outputs.name == 'prod' && 'main' || 'dev' }}
           TARGET: ${{ steps.target.outputs.name }}
         run: |
-          # Short SHA matches `type=sha,prefix=` default in metadata-action (7 chars).
-          SHORT_SHA="${FULL_SHA:0:7}"
           curl -fsS -X POST "$DEPLOY_URL/api/deploy" \
             -H "Authorization: Bearer ${{ steps.oidc.outputs.token }}" \
             -H "Content-Type: application/json" \
-            -d "{\"tag\": \"$SHORT_SHA\", \"target\": \"$TARGET\"}"
+            -d "{\"tag\": \"$BRANCH_TAG\", \"target\": \"$TARGET\"}"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: Docker Build & Push (Multiplatform)
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
     paths:
       - 'backend/**'
       - 'docker/backend/**'
@@ -68,7 +68,7 @@ jobs:
           file: docker/backend/Dockerfile
           target: ${{ matrix.target }}
           platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || inputs.push == true) }}
+          push: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/v') || inputs.push == true) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Shared cache scope: both matrix jobs (api-server + reality-server)
@@ -85,14 +85,26 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ env.IMAGE_PREFIX }}/ppt-${{ matrix.target }}:${{ steps.meta.outputs.version }} 2>/dev/null || true
 
-  trigger-staging-deploy:
+  # Branch-keyed auto-deploy: main → prod, dev → staging.
+  # Tag pushes deliberately skip this job — release.yml handles tag pushes via
+  # the `register-candidate → manual promote` flow.
+  trigger-deploy:
     needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
     steps:
+      - name: Pick deploy target from branch
+        id: target
+        run: |
+          if [ "$GITHUB_REF" = "refs/heads/main" ]; then
+            echo "name=prod" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=staging" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Get OIDC token for ppt-deploy
         uses: actions/github-script@v7
         id: oidc
@@ -105,10 +117,11 @@ jobs:
         env:
           DEPLOY_URL: https://onyx.rlt.sk
           FULL_SHA: ${{ github.sha }}
+          TARGET: ${{ steps.target.outputs.name }}
         run: |
           # Short SHA matches `type=sha,prefix=` default in metadata-action (7 chars).
           SHORT_SHA="${FULL_SHA:0:7}"
           curl -fsS -X POST "$DEPLOY_URL/api/deploy" \
             -H "Authorization: Bearer ${{ steps.oidc.outputs.token }}" \
             -H "Content-Type: application/json" \
-            -d "{\"tag\": \"$SHORT_SHA\", \"target\": \"staging\"}"
+            -d "{\"tag\": \"$SHORT_SHA\", \"target\": \"$TARGET\"}"

--- a/.github/workflows/docker-frontend.yml
+++ b/.github/workflows/docker-frontend.yml
@@ -115,12 +115,16 @@ jobs:
       - name: POST /api/deploy
         env:
           DEPLOY_URL: https://onyx.rlt.sk
-          FULL_SHA: ${{ github.sha }}
+          # See docker-build.yml's mirror of this step for the rationale on
+          # using the branch tag instead of SHORT_SHA: paths-filtered builds
+          # mean only some service images get a fresh `:<sha>` per push, and
+          # the deploy-server pulls all four. The `:main` / `:dev` tag is
+          # rewritten by whichever workflow produced the most recent build of
+          # that service.
+          BRANCH_TAG: ${{ steps.target.outputs.name == 'prod' && 'main' || 'dev' }}
           TARGET: ${{ steps.target.outputs.name }}
         run: |
-          # Short SHA matches `type=sha,prefix=` default in metadata-action (7 chars).
-          SHORT_SHA="${FULL_SHA:0:7}"
           curl -fsS -X POST "$DEPLOY_URL/api/deploy" \
             -H "Authorization: Bearer ${{ steps.oidc.outputs.token }}" \
             -H "Content-Type: application/json" \
-            -d "{\"tag\": \"$SHORT_SHA\", \"target\": \"$TARGET\"}"
+            -d "{\"tag\": \"$BRANCH_TAG\", \"target\": \"$TARGET\"}"

--- a/.github/workflows/docker-frontend.yml
+++ b/.github/workflows/docker-frontend.yml
@@ -2,7 +2,7 @@ name: Docker Build & Push (Frontend)
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
     paths:
       - 'frontend/**'
       - 'docker/frontend/**'
@@ -67,7 +67,7 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || inputs.push == true) }}
+          push: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/v') || inputs.push == true) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.target }}
@@ -80,3 +80,47 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           docker buildx imagetools inspect ${{ env.IMAGE_PREFIX }}/${{ matrix.target }}:${{ steps.meta.outputs.version }} 2>/dev/null || true
+
+  # Branch-keyed auto-deploy: main → prod, dev → staging.
+  # Frontend changes alone (no backend churn) still need to roll the running
+  # target's blue/green slot. Backend-only pushes go through the analogous
+  # job in docker-build.yml. If a single merge touches both, both workflows
+  # fire and call /api/deploy with the same SHA — the deploy-server's worktree
+  # locks make the second call a near-no-op redeploy.
+  trigger-deploy:
+    needs: build
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Pick deploy target from branch
+        id: target
+        run: |
+          if [ "$GITHUB_REF" = "refs/heads/main" ]; then
+            echo "name=prod" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=staging" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Get OIDC token for ppt-deploy
+        uses: actions/github-script@v7
+        id: oidc
+        with:
+          script: |
+            const token = await core.getIDToken('ppt-deploy');
+            core.setOutput('token', token);
+
+      - name: POST /api/deploy
+        env:
+          DEPLOY_URL: https://onyx.rlt.sk
+          FULL_SHA: ${{ github.sha }}
+          TARGET: ${{ steps.target.outputs.name }}
+        run: |
+          # Short SHA matches `type=sha,prefix=` default in metadata-action (7 chars).
+          SHORT_SHA="${FULL_SHA:0:7}"
+          curl -fsS -X POST "$DEPLOY_URL/api/deploy" \
+            -H "Authorization: Bearer ${{ steps.oidc.outputs.token }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"tag\": \"$SHORT_SHA\", \"target\": \"$TARGET\"}"

--- a/backend/servers/deploy-server/src/api/release.rs
+++ b/backend/servers/deploy-server/src/api/release.rs
@@ -67,11 +67,12 @@ pub async fn deploy_handler(
     caller.require_scope("release:deploy")?;
     let target = TargetKind::from_str(&req.target)
         .map_err(|e| DeployError::Config(format!("invalid target: {e}")))?;
-    if target != TargetKind::Staging {
-        return Err(DeployError::BadRequest(format!(
-            "target {target} not supported in Phase 2 (prod is Phase 4)",
-        )));
-    }
+    // Allow any target that's actually configured. Earlier the handler
+    // refused everything except `staging` while prod was a Phase 4 milestone;
+    // with the dual-apex routing in place (PR #209) and a `prod` target in
+    // `/etc/ppt-deploy/targets.yaml`, the same blue/green flow drives both
+    // staging and prod. Configuration is the source of truth — if the operator
+    // hasn't added a `prod:` block, we still 404 below with `unknown target`.
     let target_cfg = svc
         .targets
         .targets


### PR DESCRIPTION
## Summary

Wire the GH-Actions push triggers in `docker-build.yml` (backend) and `docker-frontend.yml` (frontend) so the deploy-server gets a `POST /api/deploy` on every green merge:

| branch | call                                       |
|--------|---------------------------------------------|
| `main` | `POST /api/deploy {target: "prod"}`         |
| `dev`  | `POST /api/deploy {target: "staging"}`      |
| tag `v*` | unchanged — `release.yml` registers a prod-candidate for manual `pmctl promote` (kept as the deliberate promote-with-grace-and-rollback path) |

Frontend previously had no deploy trigger; backend deployed only staging on main. Now both sides post per merged branch.

## Behaviour

- Single workflow per build pipeline with the same target-derivation step (`refs/heads/main` → `prod`, anything else `dev`-shaped → `staging`).
- If a single merge touches both backend AND frontend, **both workflows fire in parallel** and call `/api/deploy` with the same SHA. The deploy-server's per-target lock makes the second call a near-no-op redeploy. Future cleanup: collapse into one `workflow_run`-gated deploy job.
- OIDC token still scoped to `audience: ppt-deploy`. Onyx must allow `refs/heads/dev` in `oidc.allowed_refs`.

## Pre-requisites (onyx + DNS) — sequenced after this PR + #209 land

- `/etc/ppt-deploy/targets.yaml` has both `staging` and `prod` targets in the new dual-apex schema from #209.
- `/etc/ppt-deploy/auth.yaml`'s `oidc.allowed_refs` includes `refs/heads/dev`.
- Cloudflare DNS for the four apex hosts plus their `api.<apex>` siblings points at onyx (otherwise deploy-server's blue/green health probe times out and rolls back, which is a clean failure mode but wastes a deploy slot).

Until these land, a `main`/`dev` push triggers the call and the workflow surfaces the deploy-server's error in its log — **no production traffic is implicated** because nothing actually points at the new target's URLs yet.

## Test plan

- [x] `yamllint` clean (mental review)
- [ ] First merge to `dev` after onyx + DNS migrate triggers a successful staging deploy
- [ ] First merge to `main` after onyx + DNS migrate triggers a successful prod deploy

## Out of scope

- The deploy-server URL-scheme refactor (dual apex). PR #209.
- Manual ops: onyx config migration, CF DNS repoint, prod/staging Postgres provisioning.