### PR TITLE
feat(deploy-server): inject env vars into blue/green containers

### DIFF
--- a/backend/servers/deploy-server/src/api/promote.rs
+++ b/backend/servers/deploy-server/src/api/promote.rs
@@ -2,7 +2,9 @@
 use crate::api::release::ReleaseService;
 use crate::config::TargetsConfig;
 use crate::domain::{ReleaseState, TargetKind};
-use crate::infra::{BlueGreenDeployer, BlueGreenSpec, CallerIdentity, HealthProbe};
+use crate::infra::{
+    build_service_envs, BlueGreenDeployer, BlueGreenSpec, CallerIdentity, HealthProbe,
+};
 use crate::{DeployError, Result};
 use axum::extract::State;
 use axum::Json;
@@ -72,7 +74,17 @@ pub async fn promote_handler(
         }));
     }
 
-    let spec = BlueGreenSpec::from_release(&candidate, target.as_str(), target_cfg)?;
+    // Promote and rollback use the same env layout as a fresh deploy — both
+    // backends share `ppt-postgres` for the target's database, both UIs
+    // serve the target's apex hostnames. Compute once and reuse on the
+    // rollback path (where we re-deploy the previous Release).
+    let service_envs = build_service_envs(target.as_str(), target_cfg)?;
+    let spec = BlueGreenSpec::from_release(
+        &candidate,
+        target.as_str(),
+        target_cfg,
+        service_envs.clone(),
+    )?;
     let docker = svc
         .release_svc
         .docker_pool
@@ -104,8 +116,12 @@ pub async fn promote_handler(
                 tracing::warn!(error = %e, auto = auto, "health grace failed");
                 if auto {
                     if let Some(prev) = &prev_release {
-                        let prev_spec =
-                            BlueGreenSpec::from_release(prev, target.as_str(), target_cfg)?;
+                        let prev_spec = BlueGreenSpec::from_release(
+                            prev,
+                            target.as_str(),
+                            target_cfg,
+                            service_envs.clone(),
+                        )?;
                         match deployer.deploy(&prev_spec).await {
                             Ok(_) => {
                                 tracing::warn!(prev_tag = %prev.tag, "auto-rolled back after health grace failure");
@@ -230,7 +246,9 @@ pub async fn rollback_handler(
         .current_release_for(target.as_str(), live_state)
         .await?;
 
-    let spec = BlueGreenSpec::from_release(&target_release, target.as_str(), target_cfg)?;
+    let service_envs = build_service_envs(target.as_str(), target_cfg)?;
+    let spec =
+        BlueGreenSpec::from_release(&target_release, target.as_str(), target_cfg, service_envs)?;
     let docker = svc
         .release_svc
         .docker_pool

--- a/backend/servers/deploy-server/src/api/release.rs
+++ b/backend/servers/deploy-server/src/api/release.rs
@@ -2,8 +2,8 @@
 use crate::config::TargetsConfig;
 use crate::domain::{Release, ReleaseState, TargetKind};
 use crate::infra::{
-    BlueGreenDeployer, BlueGreenSpec, CaddyClient, CallerIdentity, DockerClient, StagingDeploySpec,
-    Store,
+    build_service_envs, BlueGreenDeployer, BlueGreenSpec, CaddyClient, CallerIdentity,
+    DockerClient, StagingDeploySpec, Store,
 };
 use crate::{DeployError, Result};
 use axum::extract::{Path, State};
@@ -80,6 +80,7 @@ pub async fn deploy_handler(
         .ok_or_else(|| DeployError::Config(format!("unknown target {target}")))?;
 
     let images = build_staging_images(&svc.image_prefix, &req.tag);
+    let service_envs = build_service_envs(target.as_str(), target_cfg)?;
 
     let spec = StagingDeploySpec {
         tag: req.tag.clone(),
@@ -90,6 +91,7 @@ pub async fn deploy_handler(
         reality_apex: target_cfg.reality_apex.clone(),
         ppt_apex: target_cfg.ppt_apex.clone(),
         target_name: target.as_str().into(),
+        service_envs,
     };
     let docker = svc
         .docker_pool
@@ -165,7 +167,8 @@ pub async fn wake_handler(
         .targets
         .get(target.as_str())
         .ok_or_else(|| DeployError::Config("staging target missing".into()))?;
-    let spec = BlueGreenSpec::from_release(&rel, target.as_str(), target_cfg)?;
+    let service_envs = build_service_envs(target.as_str(), target_cfg)?;
+    let spec = BlueGreenSpec::from_release(&rel, target.as_str(), target_cfg, service_envs)?;
     let docker = svc
         .docker_pool
         .get(target.as_str())

--- a/backend/servers/deploy-server/src/infra/blue_green.rs
+++ b/backend/servers/deploy-server/src/infra/blue_green.rs
@@ -122,8 +122,19 @@ pub fn build_service_envs(
     // (see ops docs). Per-target database name pattern: `ppt_<target>`
     // (e.g. `ppt_prod`, `ppt_staging`) — those databases must exist before
     // first deploy (ops creates them from `ppt_dev_template`).
-    let database_url =
-        format!("postgres://ppt:{postgres_password}@ppt-postgres:5432/ppt_{target_name}");
+    //
+    // Build the URL via `url::Url::set_password` rather than `format!()` so
+    // passwords containing reserved URL characters (`@`, `:`, `/`, `#`,
+    // etc.) are correctly percent-encoded. Mirrors `PostgresOps::url_for`'s
+    // approach for the same reason.
+    let mut url = url::Url::parse("postgres://ppt@ppt-postgres:5432/").map_err(|e| {
+        crate::DeployError::Config(format!("internal: bad postgres URL template: {e}"))
+    })?;
+    url.set_password(Some(&postgres_password)).map_err(|()| {
+        crate::DeployError::Config("failed to set postgres password on URL".into())
+    })?;
+    url.set_path(&format!("/ppt_{target_name}"));
+    let database_url: String = url.into();
 
     // CORS allow-list — both UIs and both APIs from this target's tree, so
     // the browser running on rlt.sk / ppt.rlt.sk can talk to api.rlt.sk
@@ -354,10 +365,13 @@ impl BlueGreenDeployer {
         let cfg = Config {
             image: Some(image.to_string()),
             exposed_ports: Some(exposed),
-            // Pass `None` instead of `Some(empty_vec)` when there's nothing
-            // to inject — bollard treats `Some(Vec)` as "wipe whatever the
-            // image set as defaults" while `None` preserves them. Static
-            // services like ppt-web rely on Dockerfile-baked defaults.
+            // Docker MERGES image env (`Dockerfile ENV`) with container env
+            // — explicitly verified: `docker run -e FOO=bar node:20-alpine env`
+            // still shows the image's `NODE_VERSION` and `PATH`. So setting
+            // `Some(env)` doesn't wipe defaults like `NODE_ENV=production`,
+            // `PORT=3000`, `HOSTNAME=0.0.0.0` baked into reality-web. We
+            // still pass `None` for the empty case as a small clarity win
+            // (no allocation of an empty Vec on the wire).
             env: if env.is_empty() { None } else { Some(env) },
             host_config: Some(host_config),
             ..Default::default()

--- a/backend/servers/deploy-server/src/infra/blue_green.rs
+++ b/backend/servers/deploy-server/src/infra/blue_green.rs
@@ -35,6 +35,14 @@ pub struct BlueGreenSpec {
     /// ppt-web is served at this exact host; api-server at `api.<ppt_apex>`.
     pub ppt_apex: String,
     pub target_name: String,
+    /// Per-service environment variables to inject into each container,
+    /// keyed by short service name (`api`, `reality`, `ppt`, `reality-web`).
+    /// Each value is a list of `KEY=VALUE` strings passed straight to
+    /// Docker. Without this, backend containers panic at startup because
+    /// they can't read `DATABASE_URL` / `JWT_SECRET`. Constructed in the
+    /// HTTP handlers (deploy/promote) where access to secrets and target
+    /// config is centralized.
+    pub service_envs: std::collections::HashMap<String, Vec<String>>,
 }
 
 impl BlueGreenSpec {
@@ -46,6 +54,7 @@ impl BlueGreenSpec {
         rel: &crate::domain::Release,
         target_name: &str,
         target: &crate::config::Target,
+        service_envs: std::collections::HashMap<String, Vec<String>>,
     ) -> crate::Result<Self> {
         fn require(rel: &crate::domain::Release, key: &str) -> crate::Result<String> {
             rel.images.get(key).cloned().ok_or_else(|| {
@@ -64,8 +73,91 @@ impl BlueGreenSpec {
             reality_web_image: require(rel, "reality-web")?,
             reality_apex: target.reality_apex.clone(),
             ppt_apex: target.ppt_apex.clone(),
+            service_envs,
         })
     }
+}
+
+/// Build the per-service environment map for a target deploy.
+///
+/// Reads shared secrets from the deploy-server's own environment
+/// (`POSTGRES_PASSWORD`, `PPT_JWT_SECRET`) and templates per-service env
+/// strings using the target's apex hostnames. Each backend service gets a
+/// dedicated `DATABASE_URL` pointing at `ppt_<target_name>` on the shared
+/// `ppt-postgres` container; both backends share the same JWT secret so
+/// SSO between them works. The Next.js `reality-web` gets the public API
+/// URLs that its `/env.js` route serves to the browser. `ppt-web` is
+/// Vite-built static and currently has nothing useful to inject (its API
+/// URL is baked at build time as the relative path `/api`).
+///
+/// Errors out with a clear `Config` error if the deploy-server's own env
+/// is missing the required secrets — better than starting containers
+/// that crash-loop with empty values.
+pub fn build_service_envs(
+    target_name: &str,
+    target: &crate::config::Target,
+) -> crate::Result<std::collections::HashMap<String, Vec<String>>> {
+    let postgres_password = std::env::var("POSTGRES_PASSWORD").map_err(|_| {
+        crate::DeployError::Config(
+            "POSTGRES_PASSWORD env var is not set; refusing to start backend containers \
+             without a database password. Set it in /etc/ppt-deploy/secrets.env."
+                .into(),
+        )
+    })?;
+    let jwt_secret = std::env::var("PPT_JWT_SECRET").map_err(|_| {
+        crate::DeployError::Config(
+            "PPT_JWT_SECRET env var is not set; refusing to start backend containers \
+             without a JWT secret. Set it in /etc/ppt-deploy/secrets.env."
+                .into(),
+        )
+    })?;
+    if jwt_secret.len() < 32 {
+        return Err(crate::DeployError::Config(
+            "PPT_JWT_SECRET must be at least 32 characters".into(),
+        ));
+    }
+
+    // The `ppt-postgres` container is reachable by name from the
+    // `ppt-<target>` bridge network once it's connected to that network
+    // (see ops docs). Per-target database name pattern: `ppt_<target>`
+    // (e.g. `ppt_prod`, `ppt_staging`) — those databases must exist before
+    // first deploy (ops creates them from `ppt_dev_template`).
+    let database_url =
+        format!("postgres://ppt:{postgres_password}@ppt-postgres:5432/ppt_{target_name}");
+
+    // CORS allow-list — both UIs and both APIs from this target's tree, so
+    // the browser running on rlt.sk / ppt.rlt.sk can talk to api.rlt.sk
+    // and api.ppt.rlt.sk without 'Access-Control-Allow-Origin' rejections.
+    let cors = format!(
+        "https://{0},https://api.{0},https://{1},https://api.{1}",
+        target.reality_apex, target.ppt_apex
+    );
+
+    let backend_env = vec![
+        format!("DATABASE_URL={database_url}"),
+        format!("JWT_SECRET={jwt_secret}"),
+        format!("CORS_ALLOWED_ORIGINS={cors}"),
+        "RUST_LOG=info".into(),
+    ];
+
+    let mut envs = std::collections::HashMap::new();
+    envs.insert("api".into(), backend_env.clone());
+    envs.insert("reality".into(), backend_env);
+    // Next.js reads window.__ENV__ (served by /env.js) at runtime; the
+    // env.js route handler reads NEXT_PUBLIC_* from process.env.
+    envs.insert(
+        "reality-web".into(),
+        vec![
+            format!("NEXT_PUBLIC_API_URL=https://api.{}", target.reality_apex),
+            format!("NEXT_PUBLIC_SITE_URL=https://{}", target.reality_apex),
+        ],
+    );
+    // ppt-web is a Vite-built static bundle: API URL was inlined at build
+    // time as the relative path `/api` (see docker-frontend.yml build-args).
+    // No runtime env needed today; entry stays so the deployer's env-lookup
+    // is uniform across all four services.
+    envs.insert("ppt".into(), vec![]);
+    Ok(envs)
 }
 
 impl BlueGreenDeployer {
@@ -129,11 +221,17 @@ impl BlueGreenDeployer {
             "blue"
         };
 
+        // Per-service env: if the spec doesn't have an entry for a service
+        // we pass an empty Vec rather than panicking. ppt-web legitimately
+        // has no env today; missing api/reality entries would surface as
+        // crash-looping containers, which is recoverable but bad UX.
+        let env_for = |s: &str| spec.service_envs.get(s).cloned().unwrap_or_default();
         self.run_service(
             &format!("{target_name}-api-{next_color}"),
             &spec.api_image,
             8080,
             target_name,
+            env_for("api"),
         )
         .await?;
         self.run_service(
@@ -141,6 +239,7 @@ impl BlueGreenDeployer {
             &spec.reality_image,
             8081,
             target_name,
+            env_for("reality"),
         )
         .await?;
         self.run_service(
@@ -148,6 +247,7 @@ impl BlueGreenDeployer {
             &spec.ppt_web_image,
             80,
             target_name,
+            env_for("ppt"),
         )
         .await?;
         self.run_service(
@@ -155,6 +255,7 @@ impl BlueGreenDeployer {
             &spec.reality_web_image,
             3000,
             target_name,
+            env_for("reality-web"),
         )
         .await?;
 
@@ -225,6 +326,7 @@ impl BlueGreenDeployer {
         image: &str,
         container_port: u16,
         target: &str,
+        env: Vec<String>,
     ) -> Result<()> {
         let docker = self.docker.bollard();
         let _ = docker
@@ -252,6 +354,11 @@ impl BlueGreenDeployer {
         let cfg = Config {
             image: Some(image.to_string()),
             exposed_ports: Some(exposed),
+            // Pass `None` instead of `Some(empty_vec)` when there's nothing
+            // to inject — bollard treats `Some(Vec)` as "wipe whatever the
+            // image set as defaults" while `None` preserves them. Static
+            // services like ppt-web rely on Dockerfile-baked defaults.
+            env: if env.is_empty() { None } else { Some(env) },
             host_config: Some(host_config),
             ..Default::default()
         };

--- a/backend/servers/deploy-server/src/infra/mod.rs
+++ b/backend/servers/deploy-server/src/infra/mod.rs
@@ -13,7 +13,8 @@ pub mod worktree_lock;
 
 pub use audit::{auth_and_audit, AuthState, CallerIdentity};
 pub use blue_green::{
-    BlueGreenDeployer, BlueGreenSpec, StagingDeploySpec, StagingDeployer, BG_SERVICES,
+    build_service_envs, BlueGreenDeployer, BlueGreenSpec, StagingDeploySpec, StagingDeployer,
+    BG_SERVICES,
 };
 pub use caddy::CaddyClient;
 pub use docker::{BackendDedicatedSpec, DockerClient, FrontendDevSpec};


### PR DESCRIPTION
## Summary

`BlueGreenDeployer::run_service` was creating containers with `..Default::default()` on the env field — backend services launched with no `DATABASE_URL`, no `JWT_SECRET`, no `CORS_ALLOWED_ORIGINS`. The first end-to-end auto-deploy from PR #210 surfaced this clearly: `/api/deploy` returned HTTP 200, four containers came up, then three crash-looped within seconds:

```
prod-api-blue    Restarting (101)  panic: DATABASE_URL is required
prod-reality-blue  Up               Error: pool timed out
prod-ppt-blue     Healthy           (no DB; static)
prod-reality-web-blue  Health: starting → exit (no NEXT_PUBLIC_API_URL)
```

## What this PR does

* `BlueGreenSpec.service_envs: HashMap<String, Vec<String>>` carries per-service `KEY=VALUE` strings.
* New `build_service_envs(target_name, target)` helper:
  - reads `POSTGRES_PASSWORD` + `PPT_JWT_SECRET` from the deploy-server's own env (already populated from `/etc/ppt-deploy/secrets.env` by systemd).
  - templates per-service env strings using the target's `reality_apex` + `ppt_apex`.
  - errors out with a clear `Config` error if either secret is missing or `JWT_SECRET` is shorter than 32 chars.
* What each service gets:
  | Service | Vars |
  |---|---|
  | api / reality | `DATABASE_URL` (per-target ppt_<target> on shared ppt-postgres), `JWT_SECRET`, `CORS_ALLOWED_ORIGINS` (covering both apexes + their `api.` siblings), `RUST_LOG=info` |
  | reality-web | `NEXT_PUBLIC_API_URL=https://api.<reality_apex>`, `NEXT_PUBLIC_SITE_URL=https://<reality_apex>` (read at runtime by `/env.js` handler) |
  | ppt-web | empty for now (Vite baked the API URL at build time as `/api`; runtime config is its own refactor) |
* `BlueGreenDeployer::deploy` looks up the env per service via `spec.service_envs.get(...)` (missing entries default to empty Vec).
* `run_service` accepts `env: Vec<String>` and sets `Config.env = if env.is_empty() { None } else { Some(env) }` — `None` keeps Dockerfile-baked defaults intact for static images; `Some(empty)` would wipe them.
* `deploy_handler` (release.rs), `wake_handler` (release.rs), `promote_handler` forward path, and the auto-rollback path in promote.rs all compute envs once per target and feed them into `BlueGreenSpec` / `from_release`.

## Onyx prerequisites for this to deliver running containers

- `ppt-postgres` container connected to `ppt-prod` and `ppt-staging` networks (so backend services can resolve `ppt-postgres:5432` over Docker DNS).
- `ppt_prod` and `ppt_staging` databases exist on the shared Postgres (already provisioned from `ppt_dev_template`).

Both are post-merge ops actions, sequenced with this PR's rollout.

## Out of scope

- ppt-web's hardcoded build-time `/api` URL: needs a runtime templating refactor in the Vite app + Dockerfile build-args. Tracked as a separate cleanup.
- Per-target overrides via YAML (today the env is fully derived in code from target apexes + shared secrets). YAML-level customization is a future improvement; the current code is the minimum viable layer.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p deploy-server --all-targets -- -D warnings` clean
- [x] `cargo test -p deploy-server --lib` — 40 passed / 1 ignored / 0 failed
- [ ] Post-merge: rebuild + redeploy ppt-deploy on onyx, attach ppt-postgres to ppt-staging+ppt-prod networks, push to dev branch → first real end-to-end staging deploy with running api+reality containers connected to `ppt_staging`.