### PR TITLE
feat(deploy-server): inject URL defaults (APP_BASE_URL, API_BASE_URL, SSO_CALLBACK_URL)

### DIFF
--- a/backend/servers/deploy-server/src/infra/blue_green.rs
+++ b/backend/servers/deploy-server/src/infra/blue_green.rs
@@ -171,10 +171,28 @@ pub fn build_service_envs(
     // Shared baseline both backends need. Per-service additions are made
     // below where they differ (api-server has TOTP+INTEGRATION encryption
     // keys; reality-server has the PM OAuth client secret).
+    //
+    // Several URL-shaped vars (BASE_URL / APP_BASE_URL / API_BASE_URL) are
+    // read by individual modules with localhost defaults that break in
+    // prod (e.g. signed email links pointing at http://localhost:3000).
+    // We inject the right per-target apexes so those modules don't have
+    // to know about the deploy topology.
+    let app_base_url = format!("https://{}", target.ppt_apex);
+    let api_base_url = format!("https://api.{}", target.ppt_apex);
     let mut backend_env = vec![
         format!("DATABASE_URL={database_url}"),
         format!("JWT_SECRET={jwt_secret}"),
         format!("CORS_ALLOWED_ORIGINS={cors}"),
+        // `APP_BASE_URL` is consumed by api-server's EmailService for
+        // verification links; `BASE_URL` is read by routes/agencies and
+        // signatures::DEFAULT_BASE_URL falls back to localhost without it.
+        // Setting both to the PM UI's apex covers both code paths.
+        format!("APP_BASE_URL={app_base_url}"),
+        format!("BASE_URL={app_base_url}"),
+        // `API_BASE_URL` is used by integrations callbacks (e.g. webhook
+        // URLs we hand out to Adobe Sign / DocuSign) and must point at the
+        // public api.<ppt_apex> host the third party can reach.
+        format!("API_BASE_URL={api_base_url}"),
         "RUST_LOG=info".into(),
     ];
 
@@ -194,7 +212,17 @@ pub fn build_service_envs(
     // round-trip flows through Caddy, which already proxies to the active
     // blue/green color — simpler than threading the active-color name into
     // env config.
-    reality_env.push(format!("PM_API_URL=https://api.{}", target.ppt_apex));
+    reality_env.push(format!("PM_API_URL={api_base_url}"));
+    // `SSO_CALLBACK_URL` defaults to `http://localhost:8081/api/v1/sso/callback`
+    // — that endpoint is on reality-server itself, exposed publicly at
+    // `<reality_apex>/api/v1/sso/callback` so the user's browser can reach
+    // it after the OAuth redirect from api-server. Without overriding the
+    // default, the redirect from PM SSO would point at localhost in the
+    // user's browser → broken login.
+    reality_env.push(format!(
+        "SSO_CALLBACK_URL=https://{}/api/v1/sso/callback",
+        target.reality_apex
+    ));
 
     let mut envs = std::collections::HashMap::new();
     envs.insert("api".into(), api_env);


### PR DESCRIPTION
## Summary

Stacked on top of #212. After encryption keys + `PM_CLIENT_SECRET` got the backends past their startup panics, the next layer of breakage is URL-shaped env vars whose defaults point at localhost / placeholders:

| Container var | Default that breaks in prod | Used by |
|---|---|---|
| `APP_BASE_URL` | `http://localhost:3000` | api-server `EmailService` verification links |
| `BASE_URL` | `http://localhost:3000` | api-server `routes/agencies` + `signatures::DEFAULT_BASE_URL` |
| `API_BASE_URL` | `https://api.ppt.example.com` | api-server `routes/integrations` webhook callback URLs |
| `SSO_CALLBACK_URL` | `http://localhost:8081/api/v1/sso/callback` | reality-server OAuth redirect URL — without this, PM SSO redirects the user's browser to localhost |

Set per target (using the existing `reality_apex` + `ppt_apex`):

- `APP_BASE_URL` = `BASE_URL` = `https://<ppt_apex>` (PM UI host)
- `API_BASE_URL` = `https://api.<ppt_apex>`
- `SSO_CALLBACK_URL` = `https://<reality_apex>/api/v1/sso/callback`

## Stacked-PR notes

- Base branch: `feature/blue-green-prod-secrets` (PR #212).
- When #212 merges, this PR's base auto-resets to `main` and the diff collapses to ~30 lines in `blue_green.rs`.
- No new secrets needed on onyx — these are derived from `Target` config the deploy-server already has.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p deploy-server --all-targets -- -D warnings` clean
- [x] `cargo test -p deploy-server --lib` — 40 passed / 1 ignored
- [ ] Post-merge: rebuild + redeploy on onyx, then `POST /api/deploy {target:prod, tag:main}` should produce containers that start without further crash-loops on URL-default env panics.

## Roadmap to "main → live actually serves traffic"

- ✅ #211: env injection skeleton (DATABASE_URL, JWT_SECRET, CORS, NEXT_PUBLIC_*)
- ✅ #212: encryption keys + PM_CLIENT_SECRET
- 👉 **#213 (this): URL defaults**
- ⏳ #214: ppt-web nginx proxy `/api/*` → api-server (cross-origin fix)
- ⏳ #215: api-server runs `sqlx::migrate!()` on startup
- ⏳ ops: seed `oauth_clients(reality-portal, hash(PM_CLIENT_SECRET))` + bootstrap admin user