### PR TITLE
feat: api-server + reality-server run sqlx::migrate!() on startup

### DIFF
--- a/backend/crates/db/src/lib.rs
+++ b/backend/crates/db/src/lib.rs
@@ -55,6 +55,27 @@ pub use rls_pool::{PublicConnection, RlsGuard, RlsPool};
 // Re-export repositories for direct import
 pub use repositories::FormRepository;
 
+/// Run all pending SQL migrations against the given pool.
+///
+/// Applies the 100+ migrations under `backend/crates/db/migrations/` in
+/// numeric order. The migrator embeds every file in the binary at compile
+/// time via `sqlx::migrate!`, so the running container doesn't need disk
+/// access to `crates/db/migrations`.
+///
+/// Idempotent and concurrency-safe: sqlx tracks applied versions in a
+/// `_sqlx_migrations` table and uses a Postgres advisory lock around the
+/// run, so two backends starting at the same time (api-server +
+/// reality-server in the same blue/green color) won't race — the second
+/// caller waits and then sees zero pending migrations.
+///
+/// Call this once on each server's startup, after creating the pool and
+/// before serving traffic. The first deploy of a target turns its empty
+/// `ppt_<target>` database into the full schema; subsequent deploys
+/// no-op as long as no new migrations are added.
+pub async fn run_migrations(pool: &DbPool) -> Result<(), sqlx::migrate::MigrateError> {
+    sqlx::migrate!("./migrations").run(pool).await
+}
+
 /// Create database connection pool.
 ///
 /// This creates a standard pool without RLS cleanup hooks.

--- a/backend/servers/api-server/src/main.rs
+++ b/backend/servers/api-server/src/main.rs
@@ -283,6 +283,19 @@ async fn main() -> anyhow::Result<()> {
     let db_pool = db::create_rls_safe_pool(&database_url).await?;
     tracing::info!("Connected to database with RLS-safe pool");
 
+    // Apply any pending migrations from `backend/crates/db/migrations/`. The
+    // sqlx migrator is idempotent and uses a Postgres advisory lock, so a
+    // concurrent `reality-server` startup against the same DB is safe — the
+    // second caller blocks until the first finishes, then sees zero pending.
+    // Critical on first deploy of a fresh target: `ppt_prod` / `ppt_staging`
+    // are empty databases (created from `ppt_dev_template` which is also
+    // empty); without this call the first request would fail with
+    // `relation "users" does not exist`.
+    db::run_migrations(&db_pool)
+        .await
+        .map_err(|e| anyhow::anyhow!("DB migration failed: {e}"))?;
+    tracing::info!("Database migrations applied (or already current)");
+
     // Create email service (development mode by default)
     let email_enabled = std::env::var("EMAIL_ENABLED")
         .map(|v| v == "true" || v == "1")

--- a/backend/servers/reality-server/src/main.rs
+++ b/backend/servers/reality-server/src/main.rs
@@ -298,6 +298,17 @@ async fn main() -> anyhow::Result<()> {
     let db = db::create_rls_safe_pool(&database_url).await?;
     tracing::info!("Connected to database with RLS-safe pool");
 
+    // Apply any pending migrations. Same migration set as api-server (both
+    // share the per-target Postgres database). Concurrency-safe via sqlx's
+    // advisory lock — if api-server happens to be migrating in parallel
+    // (typical blue/green spin-up), this call blocks then sees zero pending.
+    // Required on first deploy of a fresh target where the database was
+    // created empty from `ppt_dev_template`.
+    db::run_migrations(&db)
+        .await
+        .map_err(|e| anyhow::anyhow!("DB migration failed: {e}"))?;
+    tracing::info!("Database migrations applied (or already current)");
+
     // Create application state
     let state = AppState::new(db);
 


### PR DESCRIPTION
## Summary

Closes the last "container starts but DB is empty" gap surfaced during the auto-deploy rollout. The 104 SQL migrations under `backend/crates/db/migrations/` had no entry point — only the deploy-server itself ran its OWN sqlite migrations; api-server and reality-server skipped straight to opening their connection pool against the empty `ppt_prod` / `ppt_staging` databases (created from `ppt_dev_template` which is also empty).

First request today fails with `relation "users" does not exist`. After this PR, the schema is materialized on first boot.

## Changes

| File | Change |
|---|---|
| `crates/db/src/lib.rs` | New `pub async fn run_migrations(pool)` wrapping `sqlx::migrate!("./migrations").run(pool)` |
| `servers/api-server/src/main.rs` | Call `db::run_migrations(&db_pool)` after pool creation |
| `servers/reality-server/src/main.rs` | Same |

## Concurrency

Blue/green spins up `<target>-api-<color>` and `<target>-reality-<color>` in parallel against the same Postgres DB. sqlx's migrator uses a `_sqlx_migrations` tracking table plus a Postgres advisory lock — second caller blocks until the first finishes, then sees zero pending and exits cleanly. No extra coordination needed.

## Idempotency

Each migration is recorded with a checksum on success. Subsequent boots see recorded versions and skip them. Adding a new sequenced file applies it on the next deploy without restarting all migrations.

## Test plan

- [x] `cargo check -p api-server -p reality-server -p db` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] CI clippy gate (full workspace clippy was slow locally, relying on CI)
- [ ] Post-merge: redeploy prod target. Container logs should show `Database migrations applied (or already current)` on first boot, and api-server's startup should NOT panic on missing schema. `psql ppt_prod -c '\dt' | wc -l` should jump from 0 → ~100 tables after first boot.

## Roadmap

- ✅ #211/#212/#213/#214: env injection, encryption keys, OAuth client, URL defaults, ppt-web cross-origin shim
- 👉 **#215 (this): migrations on startup**
- ⏳ Ops one-time on first prod deploy: `docker exec prod-api-blue ppt-seed --admin-email ... --admin-password ... --reality-portal-secret <PPT_PM_CLIENT_SECRET from secrets.env>` to seed the OAuth client + bootstrap admin. (`ppt-seed` binary already ships in the api-server image; needs a `--reality-portal-secret` flag added — separate small PR if we want it scripted.)