### PR TITLE
fix(docker): reality-web HEALTHCHECK uses 127.0.0.1 + ship ppt-seed/ppt-features in api-server image

### DIFF
--- a/backend/servers/api-server/src/bin/seed.rs
+++ b/backend/servers/api-server/src/bin/seed.rs
@@ -370,7 +370,7 @@ async fn main() -> anyhow::Result<()> {
                 };
                 println!("Seeding `reality-portal` OAuth client...");
                 println!("  redirect_uris: {:?}", redirect_uris);
-                upsert_reality_portal_client(&runner.pool(), secret, &redirect_uris).await?;
+                upsert_reality_portal_client(runner.pool(), secret, &redirect_uris).await?;
                 println!("  ✓ reality-portal client UPSERT complete");
                 println!();
             }

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -85,19 +85,30 @@ COPY backend/servers ./servers
 COPY frontend/packages/sitemap/src/json/sitemap.json /frontend/packages/sitemap/src/json/sitemap.json
 
 # Build the applications
-# Build both binaries in a single cargo invocation so the matrix workflow
-# can share a single GHA cache scope (see .github/workflows/docker-build.yml).
+# Build server binaries plus the api-server-side helper bins (`ppt-seed`
+# bootstraps OAuth clients + admin user; `ppt-features` toggles feature
+# flags) in a single cargo invocation so the matrix workflow can share a
+# single GHA cache scope (see .github/workflows/docker-build.yml). The
+# helper bins are needed at runtime — operators run them via
+# `docker exec <api-container> ppt-seed ...` post-deploy — so they must
+# ship in the api-server image, not just exist in the build stage.
 ENV SQLX_OFFLINE=true
 RUN RUST_TARGET=$(cat /tmp/rust-target) && \
     if [ "$TARGETARCH" = "arm64" ]; then \
     export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc && \
     export PKG_CONFIG_SYSROOT_DIR=/usr/aarch64-linux-gnu && \
-    cargo build --release --target $RUST_TARGET --bin api-server --bin reality-server && \
+    cargo build --release --target $RUST_TARGET \
+        --bin api-server --bin reality-server \
+        --bin ppt-seed --bin ppt-features && \
     mkdir -p target/release && \
     cp target/$RUST_TARGET/release/api-server target/release/api-server && \
-    cp target/$RUST_TARGET/release/reality-server target/release/reality-server; \
+    cp target/$RUST_TARGET/release/reality-server target/release/reality-server && \
+    cp target/$RUST_TARGET/release/ppt-seed target/release/ppt-seed && \
+    cp target/$RUST_TARGET/release/ppt-features target/release/ppt-features; \
     else \
-    cargo build --release --bin api-server --bin reality-server; \
+    cargo build --release \
+        --bin api-server --bin reality-server \
+        --bin ppt-seed --bin ppt-features; \
     fi
 
 # =============================================================================
@@ -123,6 +134,13 @@ WORKDIR /app
 FROM runtime-base AS api-server
 
 COPY --from=builder /app/target/release/api-server /app/api-server
+# Helper bins shipped alongside `api-server` so operators can run them via
+# `docker exec <container> ppt-seed --reality-portal-secret "$SECRET"`
+# (bootstraps OAuth clients + admin) and `ppt-features` (toggles feature
+# flags). They share the same image so they read the same DATABASE_URL +
+# secrets the running api-server has.
+COPY --from=builder /app/target/release/ppt-seed /usr/local/bin/ppt-seed
+COPY --from=builder /app/target/release/ppt-features /usr/local/bin/ppt-features
 RUN chown -R ppt:ppt /app
 USER ppt
 

--- a/docker/frontend/reality-web.Dockerfile
+++ b/docker/frontend/reality-web.Dockerfile
@@ -92,7 +92,14 @@ ENV HOSTNAME="0.0.0.0"
 USER nextjs
 EXPOSE 3000
 
+# `127.0.0.1` not `localhost`: Alpine's BusyBox wget tries IPv6 first per
+# RFC 6724 ordering, and `localhost` resolves to BOTH `127.0.0.1` and
+# `::1`. Next.js standalone with `HOSTNAME=0.0.0.0` binds IPv4 only, so the
+# IPv6 connect refused and the healthcheck flapped to UNHEALTHY despite
+# the server actually serving on `127.0.0.1:3000`. The deploy-server's
+# wait_until_ready (post-#218) treats UNHEALTHY as a hard fail and bailed
+# every blue/green flip without registering Caddy routes for the new color.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD wget -q --spider http://localhost:3000/api/health || exit 1
+    CMD wget -q --spider http://127.0.0.1:3000/api/health || exit 1
 
 CMD ["node", "apps/reality-web/server.js"]


### PR DESCRIPTION
Two Dockerfile bugs surfaced during the first prod deploy after #218 + #219 landed.

## A. reality-web HEALTHCHECK refused under IPv6

`HEALTHCHECK ... wget http://localhost:3000/api/health` against Alpine BusyBox wget. `localhost` resolves to BOTH `127.0.0.1` AND `::1`. BusyBox wget tries IPv6 first (RFC 6724). Next.js standalone with `HOSTNAME=0.0.0.0` binds IPv4 only — the IPv6 connect refused and the healthcheck flapped to UNHEALTHY despite the server actually serving on `127.0.0.1:3000`. Verified manually on onyx:

```
docker exec prod-reality-web-green wget -q --spider http://[::1]:3000/        # refused
docker exec prod-reality-web-green wget -q --spider http://127.0.0.1:3000/    # OK
```

The deploy-server's wait_until_ready (post-#218) treats UNHEALTHY as a hard fail and aborted every blue/green flip without registering Caddy routes for the new color. Fix: pin the healthcheck URL to `127.0.0.1`.

ppt-web's nginx config does `listen [::]:8080` explicitly so it isn't affected — kept localhost there.

## B. api-server image was missing ppt-seed and ppt-features

`api-server/Cargo.toml` declares three bins — `api-server`, `ppt-seed`, `ppt-features` — but the runtime image only `COPY`d `api-server`. So `docker exec prod-api-blue ppt-seed --reality-portal-secret …` (PR #218's whole point) returned "executable file not found in $PATH":

```
$ docker exec prod-api-green ppt-seed --help
OCI runtime exec failed: ... exec: "ppt-seed": executable file not found in $PATH
```

Build stage now `cargo build --bin ppt-seed --bin ppt-features` alongside the servers (single cargo invocation keeps the GHA cache scope shared); api-server runtime stage `COPY`s both into `/usr/local/bin/` so they're on `$PATH` for any operator-run docker exec. Both share the same DATABASE_URL + secrets the api-server container has, so they Just Work without re-supplying credentials.

## Verified

- `docker buildx build` builds clean locally for both stages.
- The reality-web fix is verified end-to-end on onyx via the manual reproduction noted above (IPv6 refused vs. IPv4 200).

## Rollout

Both image rebuilds + push happen automatically on this PR's merge to main via `docker-build.yml` and `docker-frontend.yml`. Auto-deploy fires when both images are pushed; the new wait_until_ready (post-#218) sees HEALTHY for reality-web this time and Caddy routes flip cleanly. After that, `docker exec prod-api-blue ppt-seed --reality-portal-secret "$PPT_PM_CLIENT_SECRET"` succeeds and finalizes the OAuth client bootstrap.