### PR TITLE
feat(deploy-server): pmctl bootstrap-target one-shot

### DIFF
--- a/backend/servers/deploy-server/src/api/bootstrap.rs
+++ b/backend/servers/deploy-server/src/api/bootstrap.rs
@@ -1,0 +1,219 @@
+// backend/servers/deploy-server/src/api/bootstrap.rs
+//! One-shot target bootstrap.
+//!
+//! Brings a deploy target's infrastructure prerequisites to the state the
+//! preflight validator expects, so the operator doesn't have to remember
+//! which `docker network create` / `psql CREATE DATABASE` / `docker network
+//! connect` lines to run by hand. Idempotent — re-running on a healthy
+//! target reports each step as `already-ok` and exits 0.
+//!
+//! What this DOES:
+//!   - Create `ppt_<target>` from `ppt_dev_template` (skipped if exists).
+//!   - Create docker network `ppt-<target>` (skipped if exists).
+//!   - Connect `ppt-postgres` to the target network (idempotent).
+//!   - Connect `ppt-caddy` to the target network (idempotent).
+//!
+//! What this DOESN'T do (deferred to the first deploy / `pmctl deploy`):
+//!   - Pull/start backend or frontend containers — those are the deploy's job.
+//!   - Run `ppt-seed` for OAuth client + admin — the api-server container
+//!     doesn't exist yet, and `ppt-seed` is shipped inside that image. After
+//!     the first successful deploy the operator runs:
+//!     `docker exec <target>-api-blue ppt-seed --reality-portal-secret …`
+use crate::api::release::ReleaseService;
+use crate::config::TargetsConfig;
+use crate::infra::{CallerIdentity, PostgresOps};
+use crate::{DeployError, Result};
+use axum::extract::{Path, State};
+use axum::Json;
+use serde::Serialize;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct BootstrapService {
+    pub targets: Arc<TargetsConfig>,
+    pub postgres: Arc<PostgresOps>,
+    /// Reused so `bootstrap` and `deploy` always agree on which Docker /
+    /// Caddy clients belong to a target — no chance of the bootstrap
+    /// connecting `ppt-caddy` to a network that the deploy then can't see.
+    pub release_svc: Arc<ReleaseService>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct StepResult {
+    pub step: &'static str,
+    /// `created`, `already-ok`, or `failed`. We don't fail the whole
+    /// bootstrap on `failed` — operator gets the full report and can act.
+    pub status: &'static str,
+    pub detail: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BootstrapResult {
+    pub target: String,
+    pub steps: Vec<StepResult>,
+}
+
+pub async fn bootstrap_handler(
+    State(svc): State<Arc<BootstrapService>>,
+    axum::Extension(caller): axum::Extension<CallerIdentity>,
+    Path(target_name): Path<String>,
+) -> Result<Json<BootstrapResult>> {
+    // Same scope as deploy — anyone who can deploy a target can prepare it.
+    caller.require_scope("release:deploy")?;
+
+    if !svc.targets.targets.contains_key(&target_name) {
+        return Err(DeployError::NotFound(format!(
+            "no target '{target_name}' in targets.yaml; add a `{target_name}:` block first"
+        )));
+    }
+
+    let target_db = format!("ppt_{target_name}");
+    let target_network = format!("ppt-{target_name}");
+
+    let mut steps = Vec::with_capacity(4);
+
+    // ── 1. Postgres database ────────────────────────────────────────────
+    steps.push(ensure_database(&svc.postgres, &target_db).await);
+
+    // ── 2. Docker network ───────────────────────────────────────────────
+    let docker = svc
+        .release_svc
+        .docker_pool
+        .get(&target_name)
+        .ok_or_else(|| DeployError::Config(format!("no docker for target '{target_name}'")))?;
+    steps.push(ensure_network(docker, &target_network).await);
+
+    // ── 3. ppt-postgres ⇆ target network ────────────────────────────────
+    steps.push(
+        ensure_membership(
+            docker,
+            &target_network,
+            "ppt-postgres",
+            "postgres ⇆ network",
+        )
+        .await,
+    );
+
+    // ── 4. ppt-caddy ⇆ target network ───────────────────────────────────
+    steps.push(ensure_membership(docker, &target_network, "ppt-caddy", "caddy ⇆ network").await);
+
+    Ok(Json(BootstrapResult {
+        target: target_name,
+        steps,
+    }))
+}
+
+async fn ensure_database(pg: &PostgresOps, db_name: &str) -> StepResult {
+    // Cheap existence check via `psql -tAc "SELECT 1 FROM pg_database WHERE
+    // datname = …"` — same pattern as the preflight validator. Avoids the
+    // cost of a CREATE-DATABASE that fails halfway through if the template
+    // is in use by another connection.
+    match db_exists(&pg.admin_url, db_name).await {
+        Ok(true) => StepResult {
+            step: "database",
+            status: "already-ok",
+            detail: format!("'{db_name}' already exists"),
+        },
+        Ok(false) => match pg.create_from_template(db_name).await {
+            Ok(()) => StepResult {
+                step: "database",
+                status: "created",
+                detail: format!("'{db_name}' created from template '{}'", pg.template_db),
+            },
+            Err(e) => StepResult {
+                step: "database",
+                status: "failed",
+                detail: format!("CREATE DATABASE '{db_name}' failed: {e}"),
+            },
+        },
+        Err(e) => StepResult {
+            step: "database",
+            status: "failed",
+            detail: format!("could not check existence of '{db_name}': {e}"),
+        },
+    }
+}
+
+async fn ensure_network(docker: &crate::infra::DockerClient, name: &str) -> StepResult {
+    use bollard::network::{CreateNetworkOptions, InspectNetworkOptions};
+    match docker
+        .bollard()
+        .inspect_network(name, None::<InspectNetworkOptions<&str>>)
+        .await
+    {
+        Ok(_) => StepResult {
+            step: "network",
+            status: "already-ok",
+            detail: format!("'{name}' already exists"),
+        },
+        Err(bollard::errors::Error::DockerResponseServerError {
+            status_code: 404, ..
+        }) => match docker
+            .bollard()
+            .create_network(CreateNetworkOptions {
+                name: name.to_string(),
+                driver: "bridge".into(),
+                ..Default::default()
+            })
+            .await
+        {
+            Ok(_) => StepResult {
+                step: "network",
+                status: "created",
+                detail: format!("'{name}' created (driver=bridge)"),
+            },
+            Err(e) => StepResult {
+                step: "network",
+                status: "failed",
+                detail: format!("create network '{name}': {e}"),
+            },
+        },
+        Err(e) => StepResult {
+            step: "network",
+            status: "failed",
+            detail: format!("inspect network '{name}': {e}"),
+        },
+    }
+}
+
+async fn ensure_membership(
+    docker: &crate::infra::DockerClient,
+    network: &str,
+    container: &str,
+    label: &'static str,
+) -> StepResult {
+    match docker.ensure_network_membership(network, container).await {
+        Ok(()) => StepResult {
+            step: label,
+            // ensure_network_membership is idempotent — it returns Ok(()) for
+            // both "was already on" and "just connected"; Docker doesn't give
+            // us a distinguishing signal cheaply. We log the action either
+            // way and let `tracing` show the granular state.
+            status: "ok",
+            detail: format!("'{container}' on '{network}'"),
+        },
+        Err(e) => StepResult {
+            step: label,
+            status: "failed",
+            detail: format!("connect '{container}' to '{network}': {e}"),
+        },
+    }
+}
+
+async fn db_exists(admin_url: &str, db_name: &str) -> std::result::Result<bool, String> {
+    let escaped = db_name.replace('\'', "''");
+    let sql = format!("SELECT 1 FROM pg_database WHERE datname = '{}'", escaped);
+    let out = tokio::process::Command::new("psql")
+        .args(["-tAc", &sql, admin_url])
+        .output()
+        .await
+        .map_err(|e| format!("psql exec: {e}"))?;
+    if !out.status.success() {
+        return Err(format!(
+            "psql exited {}: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim() == "1")
+}

--- a/backend/servers/deploy-server/src/api/bootstrap.rs
+++ b/backend/servers/deploy-server/src/api/bootstrap.rs
@@ -41,8 +41,10 @@ pub struct BootstrapService {
 #[derive(Debug, Serialize)]
 pub struct StepResult {
     pub step: &'static str,
-    /// `created`, `already-ok`, or `failed`. We don't fail the whole
-    /// bootstrap on `failed` — operator gets the full report and can act.
+    /// One of `created`, `already-ok`, or `failed`. Same vocabulary across
+    /// every step so callers can group/colorize uniformly. We don't fail
+    /// the whole bootstrap on `failed` — operator gets the full report and
+    /// can act on each line independently.
     pub status: &'static str,
     pub detail: String,
 }
@@ -60,6 +62,14 @@ pub async fn bootstrap_handler(
 ) -> Result<Json<BootstrapResult>> {
     // Same scope as deploy — anyone who can deploy a target can prepare it.
     caller.require_scope("release:deploy")?;
+
+    // Defense-in-depth: the target name flows into a Postgres identifier
+    // (`CREATE DATABASE "ppt_<name>" …`) and a Docker network name. We
+    // already trust `targets.yaml` (operator-controlled), but constraining
+    // to `[a-z0-9_-]+` rejects anything that could change SQL parsing or
+    // produce an invalid Docker resource — cheaper to check here than to
+    // chase a mojibake'd identifier through psql later.
+    validate_target_name(&target_name)?;
 
     if !svc.targets.targets.contains_key(&target_name) {
         return Err(DeployError::NotFound(format!(
@@ -183,14 +193,15 @@ async fn ensure_membership(
     label: &'static str,
 ) -> StepResult {
     match docker.ensure_network_membership(network, container).await {
-        Ok(()) => StepResult {
+        Ok(true) => StepResult {
             step: label,
-            // ensure_network_membership is idempotent — it returns Ok(()) for
-            // both "was already on" and "just connected"; Docker doesn't give
-            // us a distinguishing signal cheaply. We log the action either
-            // way and let `tracing` show the granular state.
-            status: "ok",
-            detail: format!("'{container}' on '{network}'"),
+            status: "created",
+            detail: format!("connected '{container}' to '{network}'"),
+        },
+        Ok(false) => StepResult {
+            step: label,
+            status: "already-ok",
+            detail: format!("'{container}' already on '{network}'"),
         },
         Err(e) => StepResult {
             step: label,
@@ -198,6 +209,33 @@ async fn ensure_membership(
             detail: format!("connect '{container}' to '{network}': {e}"),
         },
     }
+}
+
+/// Reject any target name that would be unsafe to interpolate into a
+/// Postgres identifier or Docker resource name. The set is intentionally
+/// narrow — `[a-z0-9_-]+`, no leading dash or underscore — to keep the
+/// generated names predictable across both surfaces.
+fn validate_target_name(name: &str) -> Result<()> {
+    if name.is_empty() || name.len() > 32 {
+        return Err(DeployError::BadRequest(format!(
+            "target name must be 1–32 characters (got {})",
+            name.len()
+        )));
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_')
+    {
+        return Err(DeployError::BadRequest(format!(
+            "target name '{name}' must match [a-z0-9_-]+"
+        )));
+    }
+    if name.starts_with('-') || name.starts_with('_') {
+        return Err(DeployError::BadRequest(format!(
+            "target name '{name}' must not start with '-' or '_'"
+        )));
+    }
+    Ok(())
 }
 
 async fn db_exists(admin_url: &str, db_name: &str) -> std::result::Result<bool, String> {
@@ -216,4 +254,33 @@ async fn db_exists(admin_url: &str, db_name: &str) -> std::result::Result<bool, 
         ));
     }
     Ok(String::from_utf8_lossy(&out.stdout).trim() == "1")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_accepts_typical_names() {
+        for ok in ["staging", "prod", "dev-1", "wt_42", "a"] {
+            assert!(validate_target_name(ok).is_ok(), "{ok} should pass");
+        }
+    }
+
+    #[test]
+    fn validate_rejects_unsafe_names() {
+        for bad in [
+            "",
+            "Staging",       // uppercase
+            "prod;DROP",     // SQL meta
+            "prod\"",        // quote
+            "prod space",    // whitespace
+            "-prod",         // leading dash
+            "_prod",         // leading underscore
+            &"x".repeat(33), // too long
+            "🎉",            // non-ASCII
+        ] {
+            assert!(validate_target_name(bad).is_err(), "{bad:?} should fail");
+        }
+    }
 }

--- a/backend/servers/deploy-server/src/api/mod.rs
+++ b/backend/servers/deploy-server/src/api/mod.rs
@@ -1,5 +1,6 @@
 // backend/servers/deploy-server/src/api/mod.rs
 pub mod audit_query;
+pub mod bootstrap;
 pub mod gc;
 pub mod health;
 pub mod logs;

--- a/backend/servers/deploy-server/src/api/router.rs
+++ b/backend/servers/deploy-server/src/api/router.rs
@@ -1,5 +1,5 @@
 // backend/servers/deploy-server/src/api/router.rs
-use crate::api::{audit_query, gc, health, logs, promote, release, webhook, worktree};
+use crate::api::{audit_query, bootstrap, gc, health, logs, promote, release, webhook, worktree};
 use crate::auth::{ApiKeyValidator, OidcValidator};
 use crate::config::Config;
 use crate::infra::{
@@ -30,6 +30,7 @@ pub fn build(
     backend_image_prefix: String,
     promote_svc: Arc<promote::PromoteService>,
     worktree_locks: Arc<WorktreeLockRegistry>,
+    bootstrap_svc: Arc<bootstrap::BootstrapService>,
 ) -> Router {
     let svc = Arc::new(worktree::WorktreeService {
         store: store.clone(),
@@ -83,6 +84,14 @@ pub fn build(
                 .route("/api/promote", post(promote::promote_handler))
                 .route("/api/rollback", post(promote::rollback_handler))
                 .with_state(promote_svc),
+        )
+        .merge(
+            Router::new()
+                .route(
+                    "/api/targets/:target/bootstrap",
+                    post(bootstrap::bootstrap_handler),
+                )
+                .with_state(bootstrap_svc),
         )
         .layer(axum::extract::DefaultBodyLimit::max(1024 * 1024))
         .layer(from_fn_with_state(auth_state, audit::auth_and_audit));

--- a/backend/servers/deploy-server/src/bin/pmctl.rs
+++ b/backend/servers/deploy-server/src/bin/pmctl.rs
@@ -76,6 +76,13 @@ enum Cmd {
         #[arg(long)]
         to: Option<String>,
     },
+    /// One-shot bootstrap of a target's infrastructure prerequisites
+    /// (database, docker network, postgres+caddy network membership). Idempotent.
+    /// Run once before the first `pmctl deploy <target>`.
+    BootstrapTarget {
+        /// Target name from `targets.yaml` (e.g. `staging`, `prod`).
+        target: String,
+    },
 }
 
 #[derive(Serialize)]
@@ -244,6 +251,14 @@ async fn main() -> anyhow::Result<()> {
                 .post(format!("{}/api/rollback", cli.url))
                 .header("Authorization", &auth)
                 .json(&body)
+                .send()
+                .await?;
+            print_resp(resp, cli.json).await?;
+        }
+        Cmd::BootstrapTarget { target } => {
+            let resp = http
+                .post(format!("{}/api/targets/{target}/bootstrap", cli.url))
+                .header("Authorization", &auth)
                 .send()
                 .await?;
             print_resp(resp, cli.json).await?;

--- a/backend/servers/deploy-server/src/infra/docker.rs
+++ b/backend/servers/deploy-server/src/infra/docker.rs
@@ -153,7 +153,11 @@ impl DockerClient {
     /// Inspects the container first; no-ops if already on `network`. Real
     /// errors (container missing, network missing, daemon unreachable)
     /// propagate.
-    pub async fn ensure_network_membership(&self, network: &str, container: &str) -> Result<()> {
+    /// Returns `Ok(true)` if a connect was actually performed; `Ok(false)` if
+    /// `container` was already on `network`. Callers (notably the bootstrap
+    /// endpoint) report `created` vs `already-ok` to the operator based on
+    /// this signal — without it everything looks like a no-op.
+    pub async fn ensure_network_membership(&self, network: &str, container: &str) -> Result<bool> {
         let info = self.docker.inspect_container(container, None).await?;
         let already_connected = info
             .network_settings
@@ -162,7 +166,7 @@ impl DockerClient {
             .map(|nets| nets.contains_key(network))
             .unwrap_or(false);
         if already_connected {
-            return Ok(());
+            return Ok(false);
         }
 
         use bollard::network::ConnectNetworkOptions;
@@ -176,12 +180,16 @@ impl DockerClient {
             )
             .await
             .map_err(crate::DeployError::Docker)?;
+        // Generic message: this helper is called for both `ppt-caddy` and
+        // `ppt-postgres` (and any future shared service). The earlier
+        // hardcoded "connected ppt-caddy to per-target network" was wrong
+        // for postgres bootstraps and showed up as misleading log noise.
         tracing::info!(
             network = %network,
             container = %container,
-            "connected ppt-caddy to per-target network"
+            "connected container to per-target network"
         );
-        Ok(())
+        Ok(true)
     }
 
     pub async fn run_frontend_dev(&self, spec: &FrontendDevSpec) -> Result<String> {

--- a/backend/servers/deploy-server/src/main.rs
+++ b/backend/servers/deploy-server/src/main.rs
@@ -94,10 +94,12 @@ async fn main() -> anyhow::Result<()> {
         cfg.gh_repo.clone(),
     ));
 
-    // Bootstrap reuses release_svc.docker_pool/caddy_pool so deploy + bootstrap
-    // never disagree about which clients drive which target — bootstrap can't
-    // create a network on a different docker socket than the one the
-    // subsequent deploy will see.
+    // Bootstrap reuses release_svc.docker_pool so deploy + bootstrap never
+    // disagree about which Docker socket drives which target — bootstrap
+    // can't create a network on a different daemon than the one the
+    // subsequent deploy will see. Bootstrap doesn't talk to Caddy itself
+    // (it only attaches `ppt-caddy` to the new network); the Caddy admin
+    // client lives elsewhere in the release pipeline.
     let bootstrap_svc = Arc::new(deploy_server::api::bootstrap::BootstrapService {
         targets: Arc::new(targets.clone()),
         postgres: postgres.clone(),

--- a/backend/servers/deploy-server/src/main.rs
+++ b/backend/servers/deploy-server/src/main.rs
@@ -94,6 +94,16 @@ async fn main() -> anyhow::Result<()> {
         cfg.gh_repo.clone(),
     ));
 
+    // Bootstrap reuses release_svc.docker_pool/caddy_pool so deploy + bootstrap
+    // never disagree about which clients drive which target — bootstrap can't
+    // create a network on a different docker socket than the one the
+    // subsequent deploy will see.
+    let bootstrap_svc = Arc::new(deploy_server::api::bootstrap::BootstrapService {
+        targets: Arc::new(targets.clone()),
+        postgres: postgres.clone(),
+        release_svc: release_svc.clone(),
+    });
+
     let app = router::build(
         store,
         git,
@@ -129,6 +139,7 @@ async fn main() -> anyhow::Result<()> {
         cfg.backend_image_prefix.clone(),
         promote_svc,
         worktree_locks,
+        bootstrap_svc,
     );
 
     let mut fd = ListenFd::from_env();

--- a/backend/servers/deploy-server/tests/common/mod.rs
+++ b/backend/servers/deploy-server/tests/common/mod.rs
@@ -168,6 +168,11 @@ pub async fn setup_app(target_names: &[&str]) -> TestApp {
         targets: targets_cfg.clone(),
     });
     let worktree_locks = Arc::new(WorktreeLockRegistry::new());
+    let bootstrap_svc = Arc::new(deploy_server::api::bootstrap::BootstrapService {
+        targets: targets_cfg.clone(),
+        postgres: postgres.clone(),
+        release_svc: release_svc.clone(),
+    });
 
     let app = router::build(
         store,
@@ -187,6 +192,7 @@ pub async fn setup_app(target_names: &[&str]) -> TestApp {
         "ghcr.io/test".into(),
         promote_svc,
         worktree_locks,
+        bootstrap_svc,
     );
 
     TestApp {


### PR DESCRIPTION
## Summary

- `POST /api/targets/:target/bootstrap` — idempotent infra prep: creates DB from template, creates docker network, connects ppt-postgres + ppt-caddy.
- `pmctl bootstrap-target <name>` — thin client over the endpoint.
- Each step returns `created` / `already-ok` / `failed` — partial failures don't abort the whole bootstrap so the operator sees the full picture.

This is **E5** from the post-prod-launch enhancement list (E4 ✅, E1 ✅, E5 ✅, E8 next).

## Use

```bash
pmctl bootstrap-target prod
# {
#   "target": "prod",
#   "steps": [
#     {"step": "database", "status": "already-ok", "detail": "'ppt_prod' already exists"},
#     {"step": "network",  "status": "created",    "detail": "'ppt-prod' created (driver=bridge)"},
#     {"step": "postgres ⇆ network", "status": "ok", "detail": "'ppt-postgres' on 'ppt-prod'"},
#     {"step": "caddy ⇆ network",    "status": "ok", "detail": "'ppt-caddy' on 'ppt-prod'"}
#   ]
# }
pmctl deploy prod --tag main
# … and after first successful deploy:
docker exec prod-api-blue ppt-seed --reality-portal-secret "$PPT_PM_CLIENT_SECRET"
```

## Test plan
- [x] `cargo check -p deploy-server` clean
- [x] `cargo clippy -p deploy-server --all-targets` clean (no warnings)
- [x] All deploy-server tests pass