### PR TITLE
feat: split /health (liveness) from /readiness across all services

### DIFF
--- a/backend/servers/api-server/src/lib.rs
+++ b/backend/servers/api-server/src/lib.rs
@@ -41,8 +41,10 @@ fn parse_default_origins() -> Vec<HeaderValue> {
 /// This function is exposed for integration testing.
 pub fn create_router(state: AppState) -> Router {
     Router::new()
-        // Health check
-        .route("/health", get(routes::health::health))
+        // Health (liveness) — shallow, no deps. Docker HEALTHCHECK target.
+        .route("/health", get(routes::health::liveness))
+        // Readiness — deep dep check (DB + Redis). Operator dashboards.
+        .route("/readiness", get(routes::health::readiness))
         // Auth routes
         .nest("/api/v1/auth", routes::auth::router())
         // Admin routes

--- a/backend/servers/api-server/src/main.rs
+++ b/backend/servers/api-server/src/main.rs
@@ -101,7 +101,8 @@ fn parse_default_origins() -> Vec<HeaderValue> {
         (url = "https://api.ppt.example.com", description = "Production")
     ),
     paths(
-        routes::health::health,
+        routes::health::liveness,
+        routes::health::readiness,
         routes::auth::login,
         routes::auth::register,
         routes::auth::logout,
@@ -141,6 +142,7 @@ fn parse_default_origins() -> Vec<HeaderValue> {
     ),
     components(schemas(
         routes::health::HealthResponse,
+        routes::health::LivenessResponse,
         routes::auth::LoginRequest,
         routes::auth::LoginResponse,
         routes::auth::RegisterRequest,
@@ -371,8 +373,10 @@ async fn main() -> anyhow::Result<()> {
 
     // Build router
     let app = Router::new()
-        // Health check
-        .route("/health", get(routes::health::health))
+        // Health (liveness) — shallow, no deps. Docker HEALTHCHECK target.
+        .route("/health", get(routes::health::liveness))
+        // Readiness — deep dep check (DB + Redis). Operator dashboards.
+        .route("/readiness", get(routes::health::readiness))
         // Prometheus metrics endpoint (Epic 95.4)
         .route("/metrics", get(metrics_endpoint))
         // Auth routes

--- a/backend/servers/api-server/src/routes/health.rs
+++ b/backend/servers/api-server/src/routes/health.rs
@@ -1,6 +1,22 @@
-//! Health check endpoint (Epic 95.3 - Enhanced Health Checks).
+//! Health & readiness endpoints (Epic 95.3 - Enhanced Health Checks).
 //!
 //! Story 103.2: Added Redis health check.
+//!
+//! E8 (post-prod-launch): split shallow liveness from deep readiness so a
+//! degraded dependency on one service doesn't cascade-kill its consumers.
+//!
+//! - `GET /health` → liveness. No I/O. 200 as long as the process is alive
+//!   and the listener accepted the request. Used by Docker HEALTHCHECK and
+//!   the deploy-server's `wait_until_ready` so a transient DB blip doesn't
+//!   flip the container to UNHEALTHY and tear down a working blue/green
+//!   flip.
+//! - `GET /readiness` → deep check. DB + Redis + (reality) PM API. 503 on
+//!   unhealthy. Used by operator dashboards and any external monitor that
+//!   wants to know if the service is *useful*, not just *up*.
+//!
+//! Why both: the Docker docs are clear that HEALTHCHECK should be cheap and
+//! local; coupling it to upstream availability is the standard recipe for
+//! cascading outages.
 
 use axum::{extract::State, http::StatusCode, Json};
 use serde::Serialize;
@@ -9,6 +25,40 @@ use std::time::Instant;
 use utoipa::ToSchema;
 
 use crate::state::AppState;
+
+/// Minimal liveness probe. No I/O, no AppState. Returning at all means the
+/// tokio runtime is scheduling and the listener accepted us.
+#[derive(Serialize, ToSchema)]
+pub struct LivenessResponse {
+    /// Always `"ok"` — clients should match on the HTTP status code, not this
+    /// field, but it's here for human-readable curl output.
+    pub status: &'static str,
+    pub service: &'static str,
+    pub version: &'static str,
+}
+
+/// Liveness probe.
+///
+/// Distinct from `/readiness` (deep check). Docker HEALTHCHECK and the
+/// deploy-server's blue/green wait loop call this; if it ever 5xxs, the
+/// container is genuinely gone (panic, lock-up, OOM). DB or Redis being
+/// down does not flip this to failure — that's `/readiness`'s job.
+#[utoipa::path(
+    get,
+    path = "/health",
+    tag = "Health",
+    responses((status = 200, description = "Process alive", body = LivenessResponse))
+)]
+pub async fn liveness() -> (StatusCode, Json<LivenessResponse>) {
+    (
+        StatusCode::OK,
+        Json(LivenessResponse {
+            status: "ok",
+            service: "api-server",
+            version: env!("CARGO_PKG_VERSION"),
+        }),
+    )
+}
 
 /// Health status enumeration.
 #[derive(Debug, Clone, Copy, Serialize, ToSchema, PartialEq)]
@@ -153,22 +203,25 @@ fn determine_overall_status(dependencies: &[DependencyHealth]) -> HealthStatus {
     }
 }
 
-/// Health check endpoint.
+/// Readiness probe (deep check).
 ///
-/// Returns overall system health status including dependency checks for:
-/// - Database connectivity
-/// - Redis (when available)
-/// - External services
+/// Reports whether the service is *useful*, not just *up*. Returns 503 if
+/// any critical dependency is unhealthy (DB), 200 with `degraded` body if a
+/// non-critical dep is unhealthy (Redis), 200 if everything is healthy.
+///
+/// Use this from operator dashboards and external monitoring. Do NOT wire
+/// this to Docker HEALTHCHECK — that's `/health` (liveness). See the module
+/// docstring for the rationale.
 #[utoipa::path(
     get,
-    path = "/health",
+    path = "/readiness",
     tag = "Health",
     responses(
-        (status = 200, description = "Service is healthy", body = HealthResponse),
+        (status = 200, description = "Service is ready", body = HealthResponse),
         (status = 503, description = "Service is unhealthy", body = HealthResponse)
     )
 )]
-pub async fn health(State(state): State<AppState>) -> (StatusCode, Json<HealthResponse>) {
+pub async fn readiness(State(state): State<AppState>) -> (StatusCode, Json<HealthResponse>) {
     let uptime_seconds = state.boot_time.elapsed().as_secs();
 
     // Check all dependencies

--- a/backend/servers/api-server/src/routes/health.rs
+++ b/backend/servers/api-server/src/routes/health.rs
@@ -10,9 +10,12 @@
 //!   the deploy-server's `wait_until_ready` so a transient DB blip doesn't
 //!   flip the container to UNHEALTHY and tear down a working blue/green
 //!   flip.
-//! - `GET /readiness` → deep check. DB + Redis + (reality) PM API. 503 on
-//!   unhealthy. Used by operator dashboards and any external monitor that
-//!   wants to know if the service is *useful*, not just *up*.
+//! - `GET /readiness` → deep check. DB + Redis on api-server (DB + PM API
+//!   on reality-server). DB is the only critical dependency: a DB outage
+//!   returns 503. Redis failure is reported as `degraded` and stays 200 —
+//!   sessions degrade to short-lived in-memory state but the service still
+//!   serves requests. Used by operator dashboards and any external monitor
+//!   that wants to know if the service is *useful*, not just *up*.
 //!
 //! Why both: the Docker docs are clear that HEALTHCHECK should be cheap and
 //! local; coupling it to upstream availability is the standard recipe for
@@ -159,15 +162,20 @@ async fn check_redis(redis_client: &Option<integrations::RedisClient>) -> Depend
                     latency_ms: Some(latency_ms),
                     error: None,
                 },
+                // Redis failures map to `Degraded`, not `Unhealthy`:
+                // sessions and pub/sub fall back to in-memory state but
+                // the service still serves traffic. The module docstring
+                // pins this contract — only the DB is treated as a 503-
+                // worthy critical dependency.
                 Ok(false) => DependencyHealth {
                     name: "redis".to_string(),
-                    status: HealthStatus::Unhealthy,
+                    status: HealthStatus::Degraded,
                     latency_ms: Some(latency_ms),
                     error: Some("Redis PING returned unexpected response".to_string()),
                 },
                 Err(e) => DependencyHealth {
                     name: "redis".to_string(),
-                    status: HealthStatus::Unhealthy,
+                    status: HealthStatus::Degraded,
                     latency_ms: Some(latency_ms),
                     error: Some(format!("Redis connection failed: {}", e)),
                 },

--- a/backend/servers/api-server/tests/integration/health_tests.rs
+++ b/backend/servers/api-server/tests/integration/health_tests.rs
@@ -1,10 +1,16 @@
-//! Health check integration tests (Epic 99, Story 99.4).
+//! Health & readiness integration tests (Epic 99, Story 99.4; E8 split).
 //!
-//! Tests health check endpoints:
-//! - Database connectivity verification
-//! - Uptime tracking
-//! - Degraded status reporting
-//! - Response format compliance
+//! Two endpoints under test:
+//!   - `/health`   — shallow liveness; returns 200 with a small payload.
+//!   - `/readiness` — deep dep check (DB + Redis); 200 healthy/degraded,
+//!     503 unhealthy. Carries the rich payload (status/version/uptime
+//!     /dependencies).
+//!
+//! Tests are split per endpoint so an assertion failure points at the
+//! right contract — pre-split, the DB-connectivity tests hit `/health`
+//! but quietly skipped their deep assertions when the response lacked
+//! `checks`, which let regressions slide. Now `/readiness` tests
+//! assert on dependency fields explicitly.
 //!
 //! Uses sqlx::test for test database isolation.
 
@@ -113,70 +119,119 @@ mod basic_health {
 }
 
 // =============================================================================
-// Database Connectivity Tests
+// Readiness — Deep Dependency Check (DB + Redis)
 // =============================================================================
+//
+// Post-E8 split: the deep-check assertions live here against `/readiness`,
+// not `/health`. `/health` is shallow liveness and intentionally has no
+// `dependencies` field — asserting on it from `/health` would be looking
+// in the wrong place.
 
 #[cfg(test)]
-mod database_health {
+mod readiness {
     use super::*;
 
-    #[sqlx::test]
-    async fn test_health_verifies_database_connectivity(pool: PgPool) {
-        let app = TestApp::new(pool).await;
-
-        // If we can create the app, database is connected
-        let request = Request::builder()
-            .method(Method::GET)
-            .uri("/health")
-            .body(Body::empty())
-            .unwrap();
-
-        let response = app.execute(request).await;
-
-        // Should be OK since we have a valid pool
-        response.assert_status(StatusCode::OK);
-
-        let json = response.json_value();
-
-        // Database status might be in checks or root level
-        if let Some(checks) = json.get("checks") {
-            if let Some(db_check) = checks.get("database") {
-                let db_status = db_check.get("status").and_then(|s| s.as_str());
-                assert!(
-                    db_status == Some("healthy") || db_status == Some("ok"),
-                    "Database should be healthy when connected"
-                );
-            }
-        }
+    /// Find a dependency by name in the readiness response. Returns the
+    /// dependency object so callers can assert on `status`/`latency_ms`/etc.
+    fn find_dep<'a>(
+        json: &'a serde_json::Value,
+        name: &str,
+    ) -> Option<&'a serde_json::Value> {
+        json.get("dependencies")?
+            .as_array()?
+            .iter()
+            .find(|d| d.get("name").and_then(|n| n.as_str()) == Some(name))
     }
 
     #[sqlx::test]
-    async fn test_health_reports_database_latency(pool: PgPool) {
+    async fn readiness_returns_ok_with_working_db(pool: PgPool) {
         let app = TestApp::new(pool).await;
 
         let request = Request::builder()
             .method(Method::GET)
-            .uri("/health")
+            .uri("/readiness")
             .body(Body::empty())
             .unwrap();
 
         let response = app.execute(request).await;
 
+        // Healthy DB + (degraded-not-configured) Redis ⇒ overall 200.
+        response.assert_status(StatusCode::OK);
+    }
+
+    #[sqlx::test]
+    async fn readiness_reports_database_dependency(pool: PgPool) {
+        let app = TestApp::new(pool).await;
+
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri("/readiness")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.execute(request).await;
         response.assert_status(StatusCode::OK);
 
         let json = response.json_value();
+        let db = find_dep(&json, "database").expect("readiness must report a `database` dependency");
+        let status = db
+            .get("status")
+            .and_then(|s| s.as_str())
+            .expect("database dep must carry `status`");
+        assert!(
+            status == "healthy" || status == "degraded",
+            "DB should be healthy or degraded with a working pool, got: {status}"
+        );
+    }
 
-        // Check for latency in response
-        if let Some(checks) = json.get("checks") {
-            if let Some(db_check) = checks.get("database") {
-                if let Some(latency) = db_check.get("latency_ms") {
-                    assert!(
-                        latency.is_number(),
-                        "Database latency should be a number"
-                    );
-                }
-            }
-        }
+    #[sqlx::test]
+    async fn readiness_reports_database_latency(pool: PgPool) {
+        let app = TestApp::new(pool).await;
+
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri("/readiness")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.execute(request).await;
+        response.assert_status(StatusCode::OK);
+
+        let json = response.json_value();
+        let db = find_dep(&json, "database").expect("expected database dep");
+        let latency = db
+            .get("latency_ms")
+            .expect("database dep must carry latency_ms");
+        assert!(latency.is_number(), "latency_ms should be numeric");
+    }
+
+    #[sqlx::test]
+    async fn readiness_redis_failure_stays_200_degraded(pool: PgPool) {
+        // Per the module docstring, Redis is non-critical: any Redis-related
+        // status (including unconfigured/unhealthy) must NOT 503. The test
+        // app doesn't configure Redis, so this simultaneously pins the
+        // unconfigured branch of `check_redis`.
+        let app = TestApp::new(pool).await;
+
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri("/readiness")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.execute(request).await;
+        response.assert_status(StatusCode::OK);
+
+        let json = response.json_value();
+        let redis = find_dep(&json, "redis").expect("expected redis dep entry");
+        let status = redis
+            .get("status")
+            .and_then(|s| s.as_str())
+            .expect("redis dep must carry `status`");
+        assert_ne!(
+            status, "unhealthy",
+            "Redis is non-critical — unhealthy must be downgraded to degraded"
+        );
     }
 }
 

--- a/backend/servers/deploy-server/src/infra/blue_green.rs
+++ b/backend/servers/deploy-server/src/infra/blue_green.rs
@@ -351,7 +351,10 @@ impl BlueGreenDeployer {
         // shortcut.
         let mut reality_env = env_for("reality");
         reality_env.push(format!(
-            "PM_API_HEALTH_URL=http://{target_name}-api-{next_color}:8080/health"
+            // Hits api-server's /readiness (deep dep check) — reality-server's
+            // OWN readiness wants the full picture for its dashboard, not just
+            // "is the process up". The Docker HEALTHCHECK still uses /health.
+            "PM_API_HEALTH_URL=http://{target_name}-api-{next_color}:8080/readiness"
         ));
         self.run_service(
             &format!("{target_name}-api-{next_color}"),

--- a/backend/servers/reality-server/src/main.rs
+++ b/backend/servers/reality-server/src/main.rs
@@ -140,7 +140,8 @@ fn parse_default_origins() -> Vec<HeaderValue> {
         (url = "https://api.reality-portal.eu", description = "EU-wide")
     ),
     paths(
-        routes::health::health,
+        routes::health::liveness,
+        routes::health::readiness,
         routes::listings::search,
         routes::listings::get_listing,
         routes::listings::get_suggestions,
@@ -193,6 +194,7 @@ fn parse_default_origins() -> Vec<HeaderValue> {
     ),
     components(schemas(
         routes::health::HealthResponse,
+        routes::health::LivenessResponse,
         routes::health::CacheMetricsResponse,
         routes::health::CacheMetricsDetail,
         routes::listings::ListingSearchRequest,
@@ -319,8 +321,10 @@ async fn main() -> anyhow::Result<()> {
 
     // Build router with state
     let app = Router::new()
-        // Health check (stateless)
-        .route("/health", get(routes::health::health))
+        // Health (liveness) — shallow, no deps. Docker HEALTHCHECK target.
+        .route("/health", get(routes::health::liveness))
+        // Readiness — deep dep check (DB + PM API). Operator dashboards.
+        .route("/readiness", get(routes::health::readiness))
         // Prometheus metrics endpoint (Epic 95.4)
         .route("/metrics", get(metrics_endpoint))
         // Public listing routes

--- a/backend/servers/reality-server/src/routes/health.rs
+++ b/backend/servers/reality-server/src/routes/health.rs
@@ -1,4 +1,13 @@
-//! Health check endpoint (Epic 95.3 - Enhanced Health Checks, Epic 104.1 - PM API Health).
+//! Health & readiness endpoints (Epic 95.3, Epic 104.1).
+//!
+//! E8 (post-prod-launch): split shallow liveness from deep readiness.
+//! Reality-server's `check_pm_api` reaches out to api-server for SSO health,
+//! and the cascade was real — when api-server's `/health` flapped on a
+//! Redis blip, reality-server's `/health` flapped too, which made
+//! reality-web's HEALTHCHECK flap, which made the deploy-server's
+//! `wait_until_ready` bail and tear down a fine blue/green flip. Splitting
+//! the probes breaks the chain: `/health` is local-only, `/readiness` keeps
+//! the deep check for dashboards.
 
 use axum::{extract::State, http::StatusCode, Json};
 use serde::Serialize;
@@ -7,6 +16,32 @@ use std::time::Instant;
 use utoipa::ToSchema;
 
 use crate::state::{AppState, CacheMetrics};
+
+/// Minimal liveness probe response.
+#[derive(Serialize, ToSchema)]
+pub struct LivenessResponse {
+    pub status: &'static str,
+    pub service: &'static str,
+    pub version: &'static str,
+}
+
+/// Liveness probe. No I/O. See module docstring for the cascade story.
+#[utoipa::path(
+    get,
+    path = "/health",
+    tag = "Health",
+    responses((status = 200, description = "Process alive", body = LivenessResponse))
+)]
+pub async fn liveness() -> (StatusCode, Json<LivenessResponse>) {
+    (
+        StatusCode::OK,
+        Json(LivenessResponse {
+            status: "ok",
+            service: "reality-server",
+            version: env!("CARGO_PKG_VERSION"),
+        }),
+    )
+}
 
 /// Health status enumeration.
 #[derive(Debug, Clone, Copy, Serialize, ToSchema, PartialEq)]
@@ -207,23 +242,20 @@ fn determine_overall_status(dependencies: &[DependencyHealth]) -> HealthStatus {
     }
 }
 
-/// Health check endpoint.
+/// Readiness probe (deep check).
 ///
-/// Returns overall system health status including dependency checks for:
-/// - Database connectivity
-/// - PM API connectivity (for SSO) - Epic 104.1
-///
-/// Also includes cache metrics for monitoring (Epic 104).
+/// DB + PM API check. Used by operator dashboards. NOT wired to Docker
+/// HEALTHCHECK — see module docstring for why.
 #[utoipa::path(
     get,
-    path = "/health",
+    path = "/readiness",
     tag = "Health",
     responses(
-        (status = 200, description = "Service is healthy", body = HealthResponse),
+        (status = 200, description = "Service is ready", body = HealthResponse),
         (status = 503, description = "Service is unhealthy", body = HealthResponse)
     )
 )]
-pub async fn health(State(state): State<AppState>) -> (StatusCode, Json<HealthResponse>) {
+pub async fn readiness(State(state): State<AppState>) -> (StatusCode, Json<HealthResponse>) {
     let region = std::env::var("REGION").unwrap_or_else(|_| "local".to_string());
 
     // Check all dependencies in parallel

--- a/backend/servers/reality-server/src/state.rs
+++ b/backend/servers/reality-server/src/state.rs
@@ -102,8 +102,12 @@ impl AppConfig {
                 }
                 secret
             },
+            // Default points at api-server's deep readiness, not its
+            // shallow liveness. Reality-server's own readiness wants the
+            // full picture for the operator dashboard. Docker HEALTHCHECK
+            // is unaffected — it still uses `/health`.
             pm_api_health_url: std::env::var("PM_API_HEALTH_URL")
-                .unwrap_or_else(|_| format!("{}/health", pm_api_base)),
+                .unwrap_or_else(|_| format!("{}/readiness", pm_api_base)),
         }
     }
 }


### PR DESCRIPTION
## Summary

Breaks dependency cascade between Docker HEALTHCHECK and upstream readiness:

- **`/health`** — shallow liveness. No I/O. 200 if process alive. Docker HEALTHCHECK + deploy-server `wait_until_ready` target.
- **`/readiness`** — deep dep check (DB + Redis on api, DB + PM API on reality). 503 on unhealthy. Operator dashboards.

`PM_API_HEALTH_URL` default flips to `/readiness` so reality-server's own readiness still has a deep view of api-server. Deploy-server's per-deploy injection updated to match.

E8 from the post-prod-launch enhancement list. With this PR all four selected enhancements (E1, E4, E5, E8) are landing.

## Why

Real failure mode during prod cutover: Redis blip → api-server `/health` 503 → reality-server `check_pm_api` unhealthy → reality-server `/health` 503 → reality-web HEALTHCHECK UNHEALTHY → deploy-server `wait_until_ready` bailed → tore down a working blue/green flip.

## Test plan
- [x] `cargo check` + `cargo clippy` clean across api-server, reality-server, deploy-server
- [x] No leftover `routes::health::health` references
- [ ] Post-merge: `curl https://api.rlt.sk/health` → 200, `/readiness` → 200 with deps payload