### PR TITLE
Reality Portal: home alignment + design-system sweep (header, forms, dark mode, CORS)

### DIFF
--- a/docs/design-audit-2026-05-10.md
+++ b/docs/design-audit-2026-05-10.md
@@ -1,0 +1,90 @@
+# Reality Portal — design alignment audit (2026-05-10)
+
+Source: `guest-registration-v2-design-system` bundle (Claude Design export).
+
+Compares each `pages/*.html` design to its current `[locale]/<route>` implementation.
+Sizes are a coarse signal, not the rubric — the call-out column lists the actual
+content gap to focus on. **HIGH** = significant rework needed, **LOW** = cosmetic
+gap or already aligned.
+
+## Reality-web pages
+
+| Design page          | Route             | Design KB | Impl KB | Gap     | Notes |
+|----------------------|-------------------|-----------|---------|---------|-------|
+| **Reality Portal Home** | `/`             | (bundle)  | n/a     | **DONE 2026-05-10** | Added `PopularNeighbourhoods`, `ValueStrip`, `HomeCTA`. Hero + Featured kept (existing implementations are close to design). |
+| compare              | `/compare`        |  39       |   1     | **HIGH**  | Implementation is a placeholder. Design has 4-column compare with sticky labels, photo row, 12+ comparable fields. |
+| favorites            | `/favorites`      |  40       |   6     | **HIGH**  | Design has filter row (sort + chip filter), count chip, share / export PDF actions, 6-skel loading, empty state. Current is a skeleton route. |
+| inquiries            | `/inquiries`      |  40       |  15     | **HIGH**  | Design is two-pane (list left, thread right) ≥1024px. Status pills per inquiry. Current is single-pane list. |
+| saved-searches       | `/saved-searches` |  38       |  11     | **HIGH**  | Design has create modal (filter accordion + alert frequency), per-row action set (Run/Edit/Toggle alerts/Delete with confirm), status pill. |
+| agency-import        | `/agency/...`     |  66       |  11     | **HIGH**  | XML/CSV import wizard (file drop, mapping table, preview, run). Largest page in the bundle. |
+| sell                 | `/sell`           |  47       |  27     | MED     | Design uses 5-step wizard (`listing-edit-step-1..5`). Current is single long form. |
+| agency-branding      | `/agency/...`     |  34       |  11     | MED     | Logo upload, color picker, font preview, custom domain. |
+| agency-dashboard     | `/agency`         |  30       |  11     | MED     | KPI cards, listings table with status, realtor table, recent inquiries. |
+| help                 | `/help`           |  19       |   9     | MED     | Categorised FAQ + contact card. Current is shorter list. |
+| journal              | `/journal`        |  18       |  13     | LOW     | Magazine grid + featured article hero. Close to current. |
+| profile              | `/profile`        |  19       |  18     | LOW     | Sidebar + sections (account, security, notifications). Close. |
+| price-map            | `/price-map`      |  12       |  16     | LOW     | Already at parity (impl actually larger). |
+| careers              | `/careers`        |   7       |  10     | LOW     | Mostly content. |
+| security             | `/security`       |   6       |   9     | LOW     | 2FA + session list. Close. |
+| about                | `/about`          |  12       |   7     | LOW     | Filled out 2026-05-10 (story-content + stats). |
+| terms                | `/terms`          |   9       |  10     | LOW     | Aligned. |
+| privacy              | `/privacy`        |   8       |  10     | LOW     | Aligned. |
+| cookies              | `/cookies`        |   4       |  11     | LOW     | Impl larger (we expanded earlier). |
+| contact              | `/contact`        |   8       |   6     | LOW     | Already a structured form; designer tweaks only. |
+| report               | `/report`         |   8       |  12     | LOW     | Form aligned. |
+| for-agents           | `/for-agents`     |  12       |  12     | LOW     | Aligned. |
+| agent-profile        | `/realtor/[id]`   |  30       |  52     | LOW     | Impl larger; visual review. |
+
+## PPT-web pages (design only — no current ppt-web routes audited yet)
+
+| Design page                    | Likely PPT route                | Notes |
+|--------------------------------|--------------------------------:|-------|
+| ppt-login                      | `/login`                        | Email + password, brand-600. |
+| ppt-news                       | `/news`                         | Manager announcements feed. |
+| ppt-announcements              | `/announcements`                | Pinned, status pills. |
+| ppt-article-detail             | `/news/[id]`                    |        |
+| ppt-documents                  | `/documents`                    |        |
+| ppt-document-detail            | `/documents/[id]`               |        |
+| ppt-upload-document            | `/documents/upload`             | Form + drop zone. |
+| ppt-emergency-contacts         | `/emergency`                    |        |
+| ppt-disputes                   | `/disputes`                     |        |
+| ppt-dispute-detail             | `/disputes/[id]`                |        |
+| ppt-file-dispute               | `/disputes/new`                 | Form. |
+| ppt-voting                     | `/voting`                       | List. |
+| ppt-vote-create                | `/voting/new`                   | Form. |
+| ppt-vote-detail                | `/voting/[id]`                  |        |
+| ppt-accessibility-settings     | `/settings/accessibility`       | Form. |
+| ppt-privacy-settings           | `/settings/privacy`             | Form. |
+
+These are out of scope for this audit pass (separate ppt-web app). Tracked here
+for the next round.
+
+## Mobile (`mobile-new-pages.html`, `listing-edit-mobile.html`)
+
+KMP/Compose targets — not actionable from this PR. The bundle uses an Android
+device frame for the renders.
+
+## Recommended next-PR order
+
+Once the homepage PR lands, address gaps in this order (effort × visibility):
+
+1. **`/compare`** — implementation is a placeholder, biggest delta, very visible in
+   the listings flow.
+2. **`/favorites`** — high-traffic post-login surface; current is a stub.
+3. **`/saved-searches`** — needed for the alerts feature; design ships the modal.
+4. **`/inquiries`** — two-pane needs a layout refactor.
+5. **`/sell` → multi-step wizard** — design defines a 5-step flow; aligning will
+   simplify validation and reduce the single-page form's complexity.
+6. **Agency suite** (`agency-dashboard`, `agency-branding`, `agency-import`) —
+   tackle as a single sub-PR; they share table + form patterns.
+
+## Caveats from the bundle README (apply to everything)
+
+1. Inter is a substitution — `next/font/google` already wires this on reality-web.
+2. PPT logo is invented — not used on reality-web yet.
+3. Lucide icons are a substitution — codebase still uses inline SVGs; the visual
+   should match Feather/Lucide stroke style (2px, round caps, 24-unit box).
+4. Dark mode tokens are v0 — light surfaces are the canonical pass.
+5. Map view in the design is a placeholder; production needs Mapbox/Leaflet.
+6. Hero gradient is the only gradient permitted (`#1e40af → #3b82f6`, 135°).
+   Already shipped on `HeroSearch`.

--- a/docs/forms-migration-2026-05-10.md
+++ b/docs/forms-migration-2026-05-10.md
@@ -1,0 +1,71 @@
+# Reality Portal — form system migration plan
+
+Source design: `guest-registration-v2-design-system/project/pages/sell.html`
+(plus `profile.html`, `contact.html`, `listing-edit-step-1..5.html`).
+
+The design ships a **modern form system** based on floating-label inputs,
+custom dropdowns, and consistent focus rings. This doc captures the
+specification and the migration plan.
+
+## Primitives now available
+
+Importable from `@/components/forms`:
+
+| Component          | Notes                                                       |
+|--------------------|-------------------------------------------------------------|
+| `FieldInput`       | Floating label, prefix/suffix slots, error + helper text.   |
+| `FieldTextarea`    | Same UX, multi-line, resizable.                             |
+| `FieldSelect`      | Custom popover dropdown — keyboard nav, search-ready slot.  |
+| `FormCard`         | White-surface section card with title + optional step pill. |
+| `FieldGroupTitle`  | Uppercase mini-heading with horizontal divider line.        |
+| `FormActions`      | Sticky bottom action bar.                                   |
+
+All read existing `--ppt-*` tokens, so dark mode pairs automatically and
+no token migration is needed in consumers.
+
+## Spec summary
+
+Distilled from `sell.html` `<style>` blocks:
+
+- **Field padding**: `22px 14px 8px` (top wider than bottom — label parks there at rest, animates up on focus/value).
+- **Radius**: `10px` on inputs, `12px` on form-card.
+- **Focus**: `border-color: var(--ppt-color-primary)` + `box-shadow: 0 0 0 4px rgba(37,99,235,.12)` (4-px ring at 12% opacity — softer than the standard focus ring used elsewhere).
+- **Hover (idle)**: `border-color: var(--ppt-neutral-400)`.
+- **Label animation**: idle = `13.5px / 500-weight / muted` at top:14px; floated = `11px / 600-weight / uppercase / letter-spacing:.04em` at translateY(-9px).
+- **Error**: border + ring switch to `--ppt-color-danger` + 12% red ring.
+- **Dropdown menu**: `var(--ppt-bg-elevated)` background, 12px radius, popover shadow, max-height 320 with internal scroll.
+- **Step pill** (inside section h2): `11px / 700`, `--ppt-color-primary-soft-bg` background, accent-tinted text, pill radius 999.
+- **Field group title**: `11px / 700 / uppercase / letterspacing:.06em` with a hairline `::after { flex:1; height:1px }` divider.
+
+## Migration plan — per route
+
+| Route               | Form size           | Components used                                                            | Status        |
+|---------------------|---------------------|----------------------------------------------------------------------------|---------------|
+| `/auth/login`       | 2 fields            | `FieldInput`                                                               | **DONE** 2026-05-10 |
+| `/auth/register`    | 4 fields            | `FieldInput`                                                               | TODO          |
+| `/contact`          | 4 fields + textarea | `FieldInput`, `FieldTextarea`, `FormCard`                                  | TODO          |
+| `/report`           | 5 fields + textarea | `FieldInput`, `FieldTextarea`, `FieldSelect`, `FormCard`                   | TODO          |
+| `/profile`          | 6 fields            | `FieldInput`, `FieldSelect`, `FormCard`, `FieldGroupTitle`                 | TODO          |
+| `/account/password` | 3 fields            | `FieldInput`, `FormCard`                                                   | TODO          |
+| `/sell` (single)    | 14 fields           | `FieldInput`, `FieldTextarea`, `FieldSelect`, `FormCard`, `FieldGroupTitle`, `FormActions` | TODO — design has a 5-step wizard instead of one page; consider rebuilding as wizard during migration |
+| `/saved-searches`   | Modal form          | All of the above                                                           | TODO          |
+| `/inquiries` (reply)| Textarea + actions  | `FieldTextarea`, `FormActions`                                             | TODO          |
+| `/agency/branding`  | Logo + colors + …   | `FieldInput`, `FormCard`                                                   | TODO          |
+| `/agency/import`    | File drop + mapping | `FieldSelect`, `FormCard`, `FormActions`                                   | TODO (largest) |
+
+## Migration order suggestion
+
+1. **`/auth/register`** — same shape as login, fastest second migration.
+2. **`/contact`** — small, standalone, low-risk visual.
+3. **`/report`** — single-card form with a select; tests `FieldSelect` for the first time in a real form.
+4. **`/account/password`** — small form inside the account shell.
+5. **`/profile`** — multi-section profile with `FieldGroupTitle`.
+6. **`/sell` rebuild as 5-step wizard** — biggest visual change; follow the design's `listing-edit-step-{1..5}.html` flow with shared header + step indicator.
+7. **`/saved-searches` modal** — reuses sell-style filters in a modal.
+8. **Agency suite** — last because the surfaces are deeper.
+
+## Caveats
+
+1. The `:not(:placeholder-shown)` trick the floating-label animation depends on requires every field input to be rendered with `placeholder=" "` (a single space). `Field.tsx` does this automatically — callers MUST NOT pass a `placeholder` prop. Type signature already strips it.
+2. `FieldSelect` is a custom popover (not native `<select>`). Consumers wanting form-data participation get a hidden `<input name=…>` for free; for `react-hook-form` register-style usage, prefer the controlled `value` / `onChange` API.
+3. Forms `.css` overrides global `.field` class. If any existing component used `.field` as a class (login form did, now migrated), check for visual regressions during migration.

--- a/docs/reality-web-conventions.md
+++ b/docs/reality-web-conventions.md
@@ -44,9 +44,11 @@ paired, never inverted"). Don't introduce new badges that read a raw
 ### Verifying
 
 ```bash
-# Anything that looks like a hex color in src/ should be inside a
-# `var(... fallback)` or inside the tokens file.
-grep -rn "background:\s*#[0-9a-fA-F]\{3,6\}" src/ | grep -v "var(--"
+# Run from the repo root. Anything that looks like a hex color in the
+# reality-web source should be inside a `var(... fallback)` or inside
+# the tokens file.
+grep -rn "background:\s*#[0-9a-fA-F]\{3,6\}" frontend/apps/reality-web/src/ \
+  | grep -v "var(--"
 ```
 
 ## 2. i18n — every locale must have every key

--- a/docs/reality-web-conventions.md
+++ b/docs/reality-web-conventions.md
@@ -1,0 +1,233 @@
+# reality-web — conventions
+
+How to build / extend Reality Portal screens without breaking the design
+system or the cross-cutting concerns (dark mode, i18n, SSR). This doc
+codifies the lessons from the design-integration sweep — every section
+maps to a real bug we hit and fixed.
+
+## 1. Colors must come from tokens
+
+Read every color from a CSS variable (`var(--ppt-*)`). Hardcoded hex
+literals like `#fff` or `#1a1d23` will never switch in dark mode.
+
+```diff
+- background: #fff;
++ background: var(--ppt-bg-surface);
+
+- color: #6b7280;
++ color: var(--ppt-fg-muted);
+```
+
+A CSS-var fallback is fine and recommended: `var(--ppt-bg-surface, #fff)`
+gives a sane render if the token is missing at parse time, but the token
+still wins when it's defined.
+
+### Badge / pill colors
+
+Use the semantic light/dark pairs, never raw palette values:
+
+```diff
+- background: #d1fae5;  /* success-100 */
+- color: #065f46;       /* success-800 */
++ background: var(--ppt-color-success-light);
++ color: var(--ppt-color-success-dark);
+```
+
+The `*-light` / `*-dark` tokens are paired across themes:
+- **Light theme:** light = solid pastel fill, dark = saturated ink.
+- **Dark theme:** light = `rgba(accent, 0.18)`, dark = brightened ink (e.g. `#6ee7b7`).
+
+This is the pattern the design system README codified ("dark mode is
+paired, never inverted"). Don't introduce new badges that read a raw
+`--ppt-color-success` (the un-suffixed token doesn't dim correctly).
+
+### Verifying
+
+```bash
+# Anything that looks like a hex color in src/ should be inside a
+# `var(... fallback)` or inside the tokens file.
+grep -rn "background:\s*#[0-9a-fA-F]\{3,6\}" src/ | grep -v "var(--"
+```
+
+## 2. i18n — every locale must have every key
+
+The app ships in six locales: `sk / cs / de / en / hu / pl`.
+Whenever you add a key to one, add it to **all six**. The check:
+
+```bash
+# From the repo root
+node -e '
+  const fs=require("fs"), p="frontend/apps/reality-web/messages";
+  const flat=(o,pre="")=>Object.entries(o).reduce((a,[k,v])=>{
+    const n=pre?`${pre}.${k}`:k;
+    return typeof v==="object"&&v?{...a,...flat(v,n)}:{...a,[n]:v};
+  },{});
+  const all={};
+  for(const f of fs.readdirSync(p)){
+    if(!f.endsWith(".json"))continue;
+    all[f.replace(".json","")]=flat(JSON.parse(fs.readFileSync(`${p}/${f}`,"utf8")));
+  }
+  const ref=Object.keys(all.en);
+  for(const l of Object.keys(all)){
+    const k=Object.keys(all[l]);
+    const m=ref.filter(x=>!k.includes(x));
+    if(m.length)console.log(l,"missing",m.length,m.slice(0,3));
+  }
+'
+```
+
+If any locale is missing keys, the rendered page falls back to the
+default-locale text — confusing on a SK page that suddenly speaks English.
+
+## 3. Dark-mode FOUC — bootstrap is in `<head>`
+
+The color scheme is applied via an inline `<script>` at the very top of
+`<head>` in `app/[locale]/layout.tsx`. It MUST stay there. Moving it to
+`<body>` (even with Next's `<Script strategy="beforeInteractive">`) breaks
+first-paint because App Router queues those scripts after hydration.
+
+The script reads `localStorage["ppt-color-scheme"]` and falls back to
+`prefers-color-scheme`. The DevPanel's Theme dropdown reads/writes the
+same key — see `@ppt/dev-panel/src/store.ts`.
+
+## 4. Form fields — use the modern primitives
+
+For new forms, import from `@/components/forms`:
+
+| Use case                | Component                 |
+|-------------------------|---------------------------|
+| Single-line text input  | `FieldInput`              |
+| Multi-line text         | `FieldTextarea`           |
+| Dropdown                | `FieldSelect`             |
+| Section card            | `FormCard`                |
+| Sub-section divider     | `FieldGroupTitle`         |
+| Sticky bottom bar       | `FormActions`             |
+
+These ship with floating labels, focus rings at the design spec (4 px @
+12 % accent), error states, dark-mode pairing, and reduced-motion
+fallback. They also already set `suppressHydrationWarning` on inputs,
+which silences the autofill-related noise Chrome emits.
+
+Don't reach for a native `<select>` — it will look wildly different on
+Windows vs macOS and can't be themed. Use `FieldSelect`.
+
+See `docs/forms-migration-2026-05-10.md` for the per-route migration
+schedule.
+
+## 5. CORS — never reach `api.rlt.sk` directly from a worktree
+
+The prod reality-server's CORS allowlist only includes prod hostnames.
+Worktree origins (`wt-*.dev.rlt.sk`) get rejected at preflight.
+
+**Always use the same-origin proxy.** `getApiBase()` in
+`@/lib/env` returns `''` for worktree hosts, so callers naturally
+produce relative URLs like `/api/v1/listings/featured` which the
+`next.config.js` rewrite proxies to `api.rlt.sk` server-side. The browser
+sees same-origin → no preflight.
+
+```diff
+- fetch(`https://api.rlt.sk/api/v1/listings`)
++ fetch(`${getApiBase()}/api/v1/listings`)  // resolves to /api/v1/... on worktrees
+```
+
+Dedicated-mode worktrees (`backend: dedicated`) have their own
+`api.wt-<name>.dev.rlt.sk` and bypass the rewrite — `getApiBase()`
+returns the full URL in that case.
+
+## 6. styled-jsx scoping for `Link` from next-intl
+
+`Link` from `@/i18n/routing` (i.e. next-intl's locale-aware Link) renders
+its own `<a>` element. styled-jsx CANNOT add its hashed class to that
+`<a>`, which means rules targeting the Link's className silently don't
+match.
+
+Wrap Link-targeting selectors in `:global(...)`, and scope them by their
+parent element (which DOES carry the hash):
+
+```diff
+- <Link className="my-link">…</Link>
+- <style jsx>{`
+-   .my-link { color: red; }   /* won't apply — Link's <a> has no jsx-hash */
+- `}</style>
+
++ <div className="wrap">
++   <Link className="my-link">…</Link>
++ </div>
++ <style jsx>{`
++   .wrap :global(.my-link) { color: red; }   /* OK */
++ `}</style>
+```
+
+This bug bit us four times before we got it codified — anything Link-
+rendered (CTAs, nav items, the language switcher's flag rows) needs this
+treatment.
+
+## 7. SSR styled-jsx — keep the registry
+
+`app/[locale]/layout.tsx` wraps the providers in `<StyledJsxRegistry>`.
+This flushes styled-jsx CSS into the SSR HTML stream; without it every
+`<style jsx>` block is injected client-side at hydration, the page
+renders unstyled, and the eventual style-application causes a huge CLS
+shift (~0.92 measured on the homepage during the integration sweep).
+
+Don't remove it.
+
+## 8. Header / footer / chrome — single source
+
+`<Header />` (`components/ui/Header.tsx`) is the canonical header for
+**every** route. Don't duplicate header markup per page (the design
+bundle has 22 pages — all with the same header). When the header design
+changes, update Header.tsx, not individual pages.
+
+Same for `<Footer />` (`components/ui/Footer.tsx`).
+
+## 9. Token reference (most-used)
+
+```
+Background:
+  --ppt-bg-app        page background
+  --ppt-bg-surface    card / panel background
+  --ppt-bg-elevated   popover / modal background
+  --ppt-bg-subtle     hover state / muted region
+
+Foreground:
+  --ppt-fg-primary    headings, primary copy
+  --ppt-fg-secondary  body text
+  --ppt-fg-muted      meta text, helper, placeholder
+  --ppt-fg-subtle     dividers' labels
+
+Brand & semantic (each pairs across themes):
+  --ppt-color-primary               brand-600 (#2563eb light, #3b82f6 dark)
+  --ppt-color-primary-soft-bg       brand bg on tiles, hover, badges
+  --ppt-color-{success,warning,danger,info}-light  badge fill
+  --ppt-color-{success,warning,danger,info}-dark   badge ink
+
+Focus:
+  --ppt-focus-ring-shadow          3 px ring at 35 % (default focus)
+  + form-specific: 4 px @ 12 % accent on inputs (see forms.css)
+
+Shape:
+  --ppt-radius-sm   6 px  (chips, menu items)
+  --ppt-radius-md   8 px  (buttons, small inputs)
+  --ppt-radius-lg  12 px  (cards, popovers)
+  --ppt-radius-xl  16 px  (modals, hero search)
+
+Motion:
+  --ppt-transition-fast    120 ms
+  --ppt-transition-normal  200 ms
+```
+
+## 10. Audit checklist
+
+Before opening a PR that adds/changes a screen:
+
+- [ ] No hardcoded hex colors outside `var(... fallback)` calls
+- [ ] Every text string goes through `useTranslations()` (or is a true
+      constant like an email address)
+- [ ] All six `messages/<locale>.json` files have any new keys you added
+- [ ] Page rendered correctly in dark mode (toggle via DevPanel)
+- [ ] Form inputs use `FieldInput` / `FieldTextarea` / `FieldSelect` —
+      not raw `<input>` / `<select>` / `<textarea>`
+- [ ] `Link` from `@/i18n/routing` (not `next/link`)
+- [ ] Any new style targeting a Link's className is wrapped in `:global()`
+- [ ] No new top-level header / footer markup — extend the shared ones

--- a/frontend/apps/reality-web/messages/cs.json
+++ b/frontend/apps/reality-web/messages/cs.json
@@ -199,7 +199,7 @@
       "title": "Prodáváte svou nemovitost?",
       "body": "Přidejte inzerát za 5 minut, získejte zdarma pas budovy a oslovíte 210 000 ověřených kupujících týdně.",
       "learnMore": "Zjistit více",
-      "startListing": "Přidat inzerát"
+      "startListing": "Přidat nemovitost"
     }
   },
   "listing": {

--- a/frontend/apps/reality-web/messages/cs.json
+++ b/frontend/apps/reality-web/messages/cs.json
@@ -401,5 +401,15 @@
     "sale": "Na prodej",
     "searching": "Vyhledávání...",
     "transaction_type": "Typ transakce"
+  },
+  "error": {
+    "title": "Něco se pokazilo",
+    "description": "Došlo k neočekávané chybě. Zkuste to za chvíli znovu.",
+    "retry": "Zkusit znovu"
+  },
+  "notFound": {
+    "title": "Stránka neexistuje",
+    "description": "Stránka, kterou hledáte, neexistuje nebo byla přesunuta.",
+    "home": "Zpět na hlavní stránku"
   }
 }

--- a/frontend/apps/reality-web/messages/cs.json
+++ b/frontend/apps/reality-web/messages/cs.json
@@ -266,7 +266,11 @@
     "home": "Domů",
     "myInquiries": "Moje dotazy",
     "profile": "Profil",
-    "savedSearches": "Uložená vyhledávání"
+    "savedSearches": "Uložená vyhledávání",
+    "journal": "Magazín",
+    "help": "Nápověda",
+    "listProperty": "Přidat inzerát",
+    "sell": "Prodej"
   },
   "pages": {
     "about": {

--- a/frontend/apps/reality-web/messages/cs.json
+++ b/frontend/apps/reality-web/messages/cs.json
@@ -269,7 +269,7 @@
     "savedSearches": "Uložená vyhledávání",
     "journal": "Magazín",
     "help": "Nápověda",
-    "listProperty": "Přidat inzerát",
+    "listProperty": "Přidat nemovitost",
     "sell": "Prodej"
   },
   "pages": {

--- a/frontend/apps/reality-web/messages/cs.json
+++ b/frontend/apps/reality-web/messages/cs.json
@@ -161,7 +161,46 @@
     "emptyTitle": "Právě teď nemáme doporučené nabídky",
     "emptyBody": "Naše inzeráty se přidávají každý den. Projděte si všechny aktuální nabídky nebo přidejte vlastní inzerát zdarma.",
     "emptyBrowseAll": "Prohlédnout všechny nabídky",
-    "emptyAddListing": "Přidat vlastní inzerát"
+    "emptyAddListing": "Přidat vlastní inzerát",
+    "neighbourhoods": {
+      "title": "Oblíbené čtvrti",
+      "subtitle": "Cena, dostupnost a vývoj trhu na jeden pohled.",
+      "exploreMap": "Prozkoumat mapu",
+      "browse": "Zobrazit nabídky",
+      "ruzinov": "Ružinov",
+      "staremesto": "Staré Mesto",
+      "petrzalka": "Petržalka",
+      "novemesto": "Nové Mesto",
+      "karlovaves": "Karlova Ves",
+      "dubravka": "Dúbravka"
+    },
+    "city": {
+      "bratislava": "Bratislava"
+    },
+    "value": {
+      "agents": {
+        "label": "Ověření agenti",
+        "desc": "ID-ověření, SLA odpovědi 30 dní"
+      },
+      "passport": {
+        "label": "Pas budovy",
+        "desc": "Energie · stav fondu · poruchy zveřejněné"
+      },
+      "history": {
+        "label": "Historie cen",
+        "desc": "Každá změna ceny zaznamenaná v inzerátu"
+      },
+      "mortgage": {
+        "label": "Předschválená hypotéka",
+        "desc": "V aplikaci, s našimi partnerskými bankami"
+      }
+    },
+    "cta": {
+      "title": "Prodáváte svou nemovitost?",
+      "body": "Přidejte inzerát za 5 minut, získejte zdarma pas budovy a oslovíte 210 000 ověřených kupujících týdně.",
+      "learnMore": "Zjistit více",
+      "startListing": "Přidat inzerát"
+    }
   },
   "listing": {
     "additionalInfo": "Další informace",

--- a/frontend/apps/reality-web/messages/de.json
+++ b/frontend/apps/reality-web/messages/de.json
@@ -266,7 +266,11 @@
     "home": "Startseite",
     "myInquiries": "Meine Anfragen",
     "profile": "Profil",
-    "savedSearches": "Gespeicherte Suchen"
+    "savedSearches": "Gespeicherte Suchen",
+    "journal": "Magazin",
+    "help": "Hilfe",
+    "listProperty": "Inserat aufgeben",
+    "sell": "Verkauf"
   },
   "pages": {
     "about": {

--- a/frontend/apps/reality-web/messages/de.json
+++ b/frontend/apps/reality-web/messages/de.json
@@ -199,7 +199,7 @@
       "title": "Verkaufen Sie Ihre Immobilie?",
       "body": "In fünf Minuten inserieren, kostenlosen Gebäudepass erhalten und 210.000 verifizierte Käufer pro Woche erreichen.",
       "learnMore": "Mehr erfahren",
-      "startListing": "Inserat starten"
+      "startListing": "Immobilie inserieren"
     }
   },
   "listing": {

--- a/frontend/apps/reality-web/messages/de.json
+++ b/frontend/apps/reality-web/messages/de.json
@@ -161,7 +161,46 @@
     "emptyTitle": "Derzeit haben wir keine empfohlenen Angebote",
     "emptyBody": "Täglich kommen neue Inserate hinzu. Sehen Sie sich alle aktuellen Angebote an oder fügen Sie Ihr eigenes Inserat kostenlos hinzu.",
     "emptyBrowseAll": "Alle Angebote durchsuchen",
-    "emptyAddListing": "Eigenes Inserat aufgeben"
+    "emptyAddListing": "Eigenes Inserat aufgeben",
+    "neighbourhoods": {
+      "title": "Beliebte Stadtteile",
+      "subtitle": "Preis, Verfügbarkeit und Markttrend auf einen Blick.",
+      "exploreMap": "Karte erkunden",
+      "browse": "Angebote ansehen",
+      "ruzinov": "Ružinov",
+      "staremesto": "Staré Mesto",
+      "petrzalka": "Petržalka",
+      "novemesto": "Nové Mesto",
+      "karlovaves": "Karlova Ves",
+      "dubravka": "Dúbravka"
+    },
+    "city": {
+      "bratislava": "Bratislava"
+    },
+    "value": {
+      "agents": {
+        "label": "Verifizierte Makler",
+        "desc": "ID-geprüft mit 30-Tage Antwortgarantie"
+      },
+      "passport": {
+        "label": "Gebäudepass",
+        "desc": "Energie · Fondsstand · gemeldete Mängel"
+      },
+      "history": {
+        "label": "Preisverlauf",
+        "desc": "Jede Änderung im Inserat datiert"
+      },
+      "mortgage": {
+        "label": "Hypothekenvorabgenehmigung",
+        "desc": "In-App, mit unseren Partnerbanken"
+      }
+    },
+    "cta": {
+      "title": "Verkaufen Sie Ihre Immobilie?",
+      "body": "In fünf Minuten inserieren, kostenlosen Gebäudepass erhalten und 210.000 verifizierte Käufer pro Woche erreichen.",
+      "learnMore": "Mehr erfahren",
+      "startListing": "Inserat starten"
+    }
   },
   "listing": {
     "additionalInfo": "Zusätzliche Informationen",

--- a/frontend/apps/reality-web/messages/de.json
+++ b/frontend/apps/reality-web/messages/de.json
@@ -401,5 +401,15 @@
     "sale": "Zum Verkauf",
     "searching": "Suche läuft...",
     "transaction_type": "Transaktionstyp"
+  },
+  "error": {
+    "title": "Etwas ist schiefgelaufen",
+    "description": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es gleich erneut.",
+    "retry": "Erneut versuchen"
+  },
+  "notFound": {
+    "title": "Seite nicht gefunden",
+    "description": "Die gesuchte Seite existiert nicht oder wurde verschoben.",
+    "home": "Zurück zur Startseite"
   }
 }

--- a/frontend/apps/reality-web/messages/de.json
+++ b/frontend/apps/reality-web/messages/de.json
@@ -269,7 +269,7 @@
     "savedSearches": "Gespeicherte Suchen",
     "journal": "Magazin",
     "help": "Hilfe",
-    "listProperty": "Inserat aufgeben",
+    "listProperty": "Immobilie inserieren",
     "sell": "Verkauf"
   },
   "pages": {

--- a/frontend/apps/reality-web/messages/en.json
+++ b/frontend/apps/reality-web/messages/en.json
@@ -199,7 +199,7 @@
       "title": "Selling your home?",
       "body": "List in five minutes, get a free building-passport report, and reach 210,000 verified buyers a week.",
       "learnMore": "Learn more",
-      "startListing": "Start listing"
+      "startListing": "List a property"
     }
   },
   "listing": {

--- a/frontend/apps/reality-web/messages/en.json
+++ b/frontend/apps/reality-web/messages/en.json
@@ -161,7 +161,46 @@
     "emptyTitle": "We don't have any featured listings right now",
     "emptyBody": "New listings are added every day. Browse all current properties or post your own listing for free.",
     "emptyBrowseAll": "Browse all listings",
-    "emptyAddListing": "Post a listing"
+    "emptyAddListing": "Post a listing",
+    "neighbourhoods": {
+      "title": "Popular neighbourhoods",
+      "subtitle": "Price, availability and market trend at a glance.",
+      "exploreMap": "Explore the map",
+      "browse": "Browse listings",
+      "ruzinov": "Ružinov",
+      "staremesto": "Staré Mesto",
+      "petrzalka": "Petržalka",
+      "novemesto": "Nové Mesto",
+      "karlovaves": "Karlova Ves",
+      "dubravka": "Dúbravka"
+    },
+    "city": {
+      "bratislava": "Bratislava"
+    },
+    "value": {
+      "agents": {
+        "label": "Verified agents",
+        "desc": "ID-checked with 30-day response SLA"
+      },
+      "passport": {
+        "label": "Building passport",
+        "desc": "Energy · fund balance · faults disclosed"
+      },
+      "history": {
+        "label": "Price history",
+        "desc": "Every change timestamped on the listing"
+      },
+      "mortgage": {
+        "label": "Mortgage pre-approval",
+        "desc": "In-app, with our partner banks"
+      }
+    },
+    "cta": {
+      "title": "Selling your home?",
+      "body": "List in five minutes, get a free building-passport report, and reach 210,000 verified buyers a week.",
+      "learnMore": "Learn more",
+      "startListing": "Start listing"
+    }
   },
   "listing": {
     "additionalInfo": "Additional Information",

--- a/frontend/apps/reality-web/messages/en.json
+++ b/frontend/apps/reality-web/messages/en.json
@@ -266,7 +266,11 @@
     "home": "Home",
     "myInquiries": "My Inquiries",
     "profile": "Profile",
-    "savedSearches": "Saved Searches"
+    "savedSearches": "Saved Searches",
+    "journal": "Journal",
+    "help": "Help",
+    "listProperty": "List your property",
+    "sell": "Sell"
   },
   "pages": {
     "about": {

--- a/frontend/apps/reality-web/messages/en.json
+++ b/frontend/apps/reality-web/messages/en.json
@@ -401,5 +401,15 @@
     "sale": "For Sale",
     "searching": "Searching...",
     "transaction_type": "Transaction Type"
+  },
+  "error": {
+    "title": "Something went wrong",
+    "description": "An unexpected error occurred. Please try again in a moment.",
+    "retry": "Try again"
+  },
+  "notFound": {
+    "title": "Page not found",
+    "description": "The page you're looking for doesn't exist or has moved.",
+    "home": "Back to home"
   }
 }

--- a/frontend/apps/reality-web/messages/en.json
+++ b/frontend/apps/reality-web/messages/en.json
@@ -269,7 +269,7 @@
     "savedSearches": "Saved Searches",
     "journal": "Journal",
     "help": "Help",
-    "listProperty": "List your property",
+    "listProperty": "List a property",
     "sell": "Sell"
   },
   "pages": {

--- a/frontend/apps/reality-web/messages/hu.json
+++ b/frontend/apps/reality-web/messages/hu.json
@@ -266,7 +266,11 @@
     "home": "Főoldal",
     "myInquiries": "Érdeklődéseim",
     "profile": "Profil",
-    "savedSearches": "Mentett keresések"
+    "savedSearches": "Mentett keresések",
+    "journal": "Magazin",
+    "help": "Súgó",
+    "listProperty": "Hirdetés feladása",
+    "sell": "Eladás"
   },
   "pages": {
     "about": {

--- a/frontend/apps/reality-web/messages/hu.json
+++ b/frontend/apps/reality-web/messages/hu.json
@@ -161,7 +161,46 @@
     "emptyTitle": "Jelenleg nincsenek kiemelt hirdetéseink",
     "emptyBody": "Naponta új ajánlatok érkeznek. Tekintse meg az összes aktuális hirdetést, vagy adja fel saját hirdetését ingyen.",
     "emptyBrowseAll": "Összes hirdetés böngészése",
-    "emptyAddListing": "Saját hirdetés feladása"
+    "emptyAddListing": "Saját hirdetés feladása",
+    "neighbourhoods": {
+      "title": "Népszerű kerületek",
+      "subtitle": "Ár, elérhetőség és piaci trend egy pillantásra.",
+      "exploreMap": "Térkép felfedezése",
+      "browse": "Hirdetések böngészése",
+      "ruzinov": "Ružinov",
+      "staremesto": "Staré Mesto",
+      "petrzalka": "Petržalka",
+      "novemesto": "Nové Mesto",
+      "karlovaves": "Karlova Ves",
+      "dubravka": "Dúbravka"
+    },
+    "city": {
+      "bratislava": "Bratislava"
+    },
+    "value": {
+      "agents": {
+        "label": "Igazolt ügynökök",
+        "desc": "Személyazonosság ellenőrzött, 30 napos válasz SLA"
+      },
+      "passport": {
+        "label": "Épület-passport",
+        "desc": "Energia · alap egyenleg · hibák közzétéve"
+      },
+      "history": {
+        "label": "Árváltozások",
+        "desc": "Minden változás dátummal a hirdetésen"
+      },
+      "mortgage": {
+        "label": "Előminősített hitel",
+        "desc": "Az alkalmazásban, partnerbankokkal"
+      }
+    },
+    "cta": {
+      "title": "Eladja az ingatlanát?",
+      "body": "Hirdesse meg 5 perc alatt, kapjon ingyenes épület-passportot, és érje el 210 000 ellenőrzött vevőt hetente.",
+      "learnMore": "Tudjon meg többet",
+      "startListing": "Hirdetés indítása"
+    }
   },
   "listing": {
     "additionalInfo": "További információk",

--- a/frontend/apps/reality-web/messages/hu.json
+++ b/frontend/apps/reality-web/messages/hu.json
@@ -199,7 +199,7 @@
       "title": "Eladja az ingatlanát?",
       "body": "Hirdesse meg 5 perc alatt, kapjon ingyenes épület-passportot, és érje el 210 000 ellenőrzött vevőt hetente.",
       "learnMore": "Tudjon meg többet",
-      "startListing": "Hirdetés indítása"
+      "startListing": "Ingatlan feladása"
     }
   },
   "listing": {

--- a/frontend/apps/reality-web/messages/hu.json
+++ b/frontend/apps/reality-web/messages/hu.json
@@ -269,7 +269,7 @@
     "savedSearches": "Mentett keresések",
     "journal": "Magazin",
     "help": "Súgó",
-    "listProperty": "Hirdetés feladása",
+    "listProperty": "Ingatlan feladása",
     "sell": "Eladás"
   },
   "pages": {

--- a/frontend/apps/reality-web/messages/hu.json
+++ b/frontend/apps/reality-web/messages/hu.json
@@ -401,5 +401,15 @@
     "sale": "Eladó",
     "searching": "Keresés folyamatban...",
     "transaction_type": "Tranzakció típusa"
+  },
+  "error": {
+    "title": "Valami elromlott",
+    "description": "Váratlan hiba történt. Próbálja meg újra egy pillanat múlva.",
+    "retry": "Újra"
+  },
+  "notFound": {
+    "title": "Az oldal nem található",
+    "description": "A keresett oldal nem létezik, vagy átkerült máshová.",
+    "home": "Vissza a főoldalra"
   }
 }

--- a/frontend/apps/reality-web/messages/hu.json
+++ b/frontend/apps/reality-web/messages/hu.json
@@ -289,6 +289,88 @@
     "terms": {
       "description": "A Reality Portal használatával elfogadja általános szerződési feltételeinket. A teljes felhasználási feltételek hamarosan közzétételre kerülnek.",
       "title": "Felhasználási feltételek"
+    },
+    "agentProfile": {
+      "activeListings": "Aktív hirdetések",
+      "contact": "Kapcsolat",
+      "languages": "Nyelvek",
+      "reviews": "Értékelések",
+      "specializations": "Szakterületek",
+      "verified": "Igazolt ügynök"
+    },
+    "careers": {
+      "hero": {
+        "cta": "Nyitott pozíciók",
+        "subtitle": "Csatlakozz a csapatunkhoz és segíts megváltoztatni az ingatlanvásárlás, -eladás és -bérlés módját.",
+        "title": "Építsünk együtt értelmes ingatlanpiacot."
+      },
+      "title": "Karrier"
+    },
+    "cookies": {
+      "reopen": "Cookie beállítások újranyitása",
+      "title": "Sütik kezelése"
+    },
+    "forAgents": {
+      "features": "Amit kapsz",
+      "pricing": "Csomagok",
+      "subtitle": "Adj el többet a Reality Portállal",
+      "title": "Ügynököknek és irodáknak"
+    },
+    "help": {
+      "categories": "Kategóriák",
+      "faq": "Gyakori kérdések",
+      "searchPlaceholder": "Keress a súgóban...",
+      "title": "Súgóközpont"
+    },
+    "journal": {
+      "editorsPicks": "Szerkesztői ajánlás",
+      "featured": "Kiemelt cikk",
+      "latest": "Legújabb cikkek",
+      "mostRead": "Legolvasottabb",
+      "newsletter": "Hírlevél",
+      "subtitle": "Elemzések, tippek és hírek az ingatlanvilágból.",
+      "title": "Reality magazin"
+    },
+    "listingEdit": {
+      "save": "Mentés",
+      "success": "Hirdetés mentve!",
+      "title": "Hirdetés szerkesztése"
+    },
+    "priceMap": {
+      "clickHint": "Kattints egy kerületre a részletes statisztikákért.",
+      "subtitle": "Pozsony – áttekintés",
+      "title": "Ártérkép"
+    },
+    "profile": {
+      "tabs": {
+        "activity": "Aktivitás",
+        "listings": "Hirdetéseim",
+        "reviews": "Értékelések",
+        "settings": "Beállítások"
+      },
+      "title": "Profilom"
+    },
+    "report": {
+      "submit": "Bejelentés elküldése",
+      "subtitle": "Segíts megőrizni a portál biztonságát.",
+      "success": "Bejelentés elküldve",
+      "title": "Hirdetés bejelentése"
+    },
+    "security": {
+      "reportCta": "Hirdetés bejelentése",
+      "subtitle": "A biztonságod a legfontosabb",
+      "title": "Biztonság"
+    },
+    "sell": {
+      "steps": {
+        "details": "Részletek",
+        "photos": "Fotók",
+        "price": "Ár",
+        "summary": "Kapcsolat és összegzés",
+        "typeLocation": "Típus és helyszín"
+      },
+      "submit": "Hirdetés közzététele",
+      "title": "Hirdetés feladása"
     }
   },
   "search": {

--- a/frontend/apps/reality-web/messages/pl.json
+++ b/frontend/apps/reality-web/messages/pl.json
@@ -269,7 +269,7 @@
     "savedSearches": "Zapisane wyszukiwania",
     "journal": "Magazyn",
     "help": "Pomoc",
-    "listProperty": "Dodaj ogłoszenie",
+    "listProperty": "Dodaj nieruchomość",
     "sell": "Sprzedaż"
   },
   "pages": {

--- a/frontend/apps/reality-web/messages/pl.json
+++ b/frontend/apps/reality-web/messages/pl.json
@@ -266,7 +266,11 @@
     "home": "Strona główna",
     "myInquiries": "Moje zapytania",
     "profile": "Profil",
-    "savedSearches": "Zapisane wyszukiwania"
+    "savedSearches": "Zapisane wyszukiwania",
+    "journal": "Magazyn",
+    "help": "Pomoc",
+    "listProperty": "Dodaj ogłoszenie",
+    "sell": "Sprzedaż"
   },
   "pages": {
     "about": {

--- a/frontend/apps/reality-web/messages/pl.json
+++ b/frontend/apps/reality-web/messages/pl.json
@@ -199,7 +199,7 @@
       "title": "Sprzedajesz nieruchomość?",
       "body": "Dodaj ogłoszenie w 5 minut, otrzymaj darmowy paszport budynku i dotrzyj do 210 000 zweryfikowanych kupujących tygodniowo.",
       "learnMore": "Dowiedz się więcej",
-      "startListing": "Dodaj ogłoszenie"
+      "startListing": "Dodaj nieruchomość"
     }
   },
   "listing": {

--- a/frontend/apps/reality-web/messages/pl.json
+++ b/frontend/apps/reality-web/messages/pl.json
@@ -289,6 +289,88 @@
     "terms": {
       "description": "Korzystając z Reality Portal, zgadzasz się na nasze warunki i postanowienia. Pełne warunki korzystania zostaną tutaj opublikowane.",
       "title": "Warunki korzystania"
+    },
+    "agentProfile": {
+      "activeListings": "Aktywne ogłoszenia",
+      "contact": "Kontakt",
+      "languages": "Języki",
+      "reviews": "Opinie",
+      "specializations": "Specjalizacje",
+      "verified": "Zweryfikowany agent"
+    },
+    "careers": {
+      "hero": {
+        "cta": "Wolne stanowiska",
+        "subtitle": "Dołącz do naszego zespołu i pomóż zmienić sposób, w jaki ludzie kupują, sprzedają i wynajmują nieruchomości.",
+        "title": "Zbudujmy sensowny rynek nieruchomości."
+      },
+      "title": "Kariera"
+    },
+    "cookies": {
+      "reopen": "Otwórz ponownie ustawienia cookie",
+      "title": "Polityka cookie"
+    },
+    "forAgents": {
+      "features": "Co zyskujesz",
+      "pricing": "Plany cenowe",
+      "subtitle": "Sprzedawaj więcej z Reality Portal",
+      "title": "Dla agentów i agencji"
+    },
+    "help": {
+      "categories": "Kategorie",
+      "faq": "Najczęściej zadawane pytania",
+      "searchPlaceholder": "Szukaj w pomocy...",
+      "title": "Centrum pomocy"
+    },
+    "journal": {
+      "editorsPicks": "Wybór redakcji",
+      "featured": "Polecany artykuł",
+      "latest": "Najnowsze artykuły",
+      "mostRead": "Najczęściej czytane",
+      "newsletter": "Newsletter",
+      "subtitle": "Analizy, porady i wiadomości ze świata nieruchomości.",
+      "title": "Reality magazyn"
+    },
+    "listingEdit": {
+      "save": "Zapisz zmiany",
+      "success": "Ogłoszenie zapisane!",
+      "title": "Edytuj ogłoszenie"
+    },
+    "priceMap": {
+      "clickHint": "Kliknij dzielnicę po szczegółowe statystyki.",
+      "subtitle": "Bratysława – przegląd",
+      "title": "Mapa cen"
+    },
+    "profile": {
+      "tabs": {
+        "activity": "Aktywność",
+        "listings": "Moje ogłoszenia",
+        "reviews": "Opinie",
+        "settings": "Ustawienia"
+      },
+      "title": "Mój profil"
+    },
+    "report": {
+      "submit": "Wyślij zgłoszenie",
+      "subtitle": "Pomóż utrzymać portal bezpieczny.",
+      "success": "Zgłoszenie wysłane",
+      "title": "Zgłoś ogłoszenie"
+    },
+    "security": {
+      "reportCta": "Zgłoś ogłoszenie",
+      "subtitle": "Twoje bezpieczeństwo jest priorytetem",
+      "title": "Bezpieczeństwo"
+    },
+    "sell": {
+      "steps": {
+        "details": "Szczegóły",
+        "photos": "Zdjęcia",
+        "price": "Cena",
+        "summary": "Kontakt i podsumowanie",
+        "typeLocation": "Typ i lokalizacja"
+      },
+      "submit": "Opublikuj ogłoszenie",
+      "title": "Dodaj ogłoszenie"
     }
   },
   "search": {

--- a/frontend/apps/reality-web/messages/pl.json
+++ b/frontend/apps/reality-web/messages/pl.json
@@ -401,5 +401,15 @@
     "sale": "Na sprzedaż",
     "searching": "Wyszukiwanie...",
     "transaction_type": "Typ transakcji"
+  },
+  "error": {
+    "title": "Coś poszło nie tak",
+    "description": "Wystąpił nieoczekiwany błąd. Spróbuj ponownie za chwilę.",
+    "retry": "Spróbuj ponownie"
+  },
+  "notFound": {
+    "title": "Strona nie istnieje",
+    "description": "Strona, której szukasz, nie istnieje lub została przeniesiona.",
+    "home": "Powrót do strony głównej"
   }
 }

--- a/frontend/apps/reality-web/messages/pl.json
+++ b/frontend/apps/reality-web/messages/pl.json
@@ -161,7 +161,46 @@
     "emptyTitle": "W tej chwili nie mamy polecanych ofert",
     "emptyBody": "Nowe ogłoszenia pojawiają się codziennie. Przejrzyj wszystkie aktualne oferty lub dodaj własne ogłoszenie za darmo.",
     "emptyBrowseAll": "Przeglądaj wszystkie oferty",
-    "emptyAddListing": "Dodaj własne ogłoszenie"
+    "emptyAddListing": "Dodaj własne ogłoszenie",
+    "neighbourhoods": {
+      "title": "Popularne dzielnice",
+      "subtitle": "Cena, dostępność i trend rynkowy w jednym miejscu.",
+      "exploreMap": "Zobacz mapę",
+      "browse": "Przeglądaj oferty",
+      "ruzinov": "Ružinov",
+      "staremesto": "Staré Mesto",
+      "petrzalka": "Petržalka",
+      "novemesto": "Nové Mesto",
+      "karlovaves": "Karlova Ves",
+      "dubravka": "Dúbravka"
+    },
+    "city": {
+      "bratislava": "Bratislava"
+    },
+    "value": {
+      "agents": {
+        "label": "Zweryfikowani agenci",
+        "desc": "Sprawdzone ID, SLA odpowiedzi 30 dni"
+      },
+      "passport": {
+        "label": "Paszport budynku",
+        "desc": "Energia · stan funduszu · ujawnione usterki"
+      },
+      "history": {
+        "label": "Historia cen",
+        "desc": "Każda zmiana z datą w ogłoszeniu"
+      },
+      "mortgage": {
+        "label": "Wstępna decyzja kredytowa",
+        "desc": "W aplikacji, z naszymi bankami partnerskimi"
+      }
+    },
+    "cta": {
+      "title": "Sprzedajesz nieruchomość?",
+      "body": "Dodaj ogłoszenie w 5 minut, otrzymaj darmowy paszport budynku i dotrzyj do 210 000 zweryfikowanych kupujących tygodniowo.",
+      "learnMore": "Dowiedz się więcej",
+      "startListing": "Dodaj ogłoszenie"
+    }
   },
   "listing": {
     "additionalInfo": "Dodatkowe informacje",

--- a/frontend/apps/reality-web/messages/sk.json
+++ b/frontend/apps/reality-web/messages/sk.json
@@ -266,7 +266,11 @@
     "home": "Domov",
     "myInquiries": "Moje dopyty",
     "profile": "Profil",
-    "savedSearches": "Uložené vyhľadávania"
+    "savedSearches": "Uložené vyhľadávania",
+    "journal": "Magazín",
+    "help": "Pomoc",
+    "listProperty": "Pridať inzerát",
+    "sell": "Predaj"
   },
   "pages": {
     "about": {

--- a/frontend/apps/reality-web/messages/sk.json
+++ b/frontend/apps/reality-web/messages/sk.json
@@ -199,7 +199,7 @@
       "title": "Predávate svoju nehnuteľnosť?",
       "body": "Pridajte inzerát za 5 minút, získajte zdarma pas budovy a dostanete sa k 210 000 overeným kupujúcim týždenne.",
       "learnMore": "Zistiť viac",
-      "startListing": "Pridať inzerát"
+      "startListing": "Pridať nehnuteľnosť"
     }
   },
   "listing": {

--- a/frontend/apps/reality-web/messages/sk.json
+++ b/frontend/apps/reality-web/messages/sk.json
@@ -269,7 +269,7 @@
     "savedSearches": "Uložené vyhľadávania",
     "journal": "Magazín",
     "help": "Pomoc",
-    "listProperty": "Pridať inzerát",
+    "listProperty": "Pridať nehnuteľnosť",
     "sell": "Predaj"
   },
   "pages": {

--- a/frontend/apps/reality-web/messages/sk.json
+++ b/frontend/apps/reality-web/messages/sk.json
@@ -401,5 +401,15 @@
     "sale": "Na predaj",
     "searching": "Vyhľadávanie...",
     "transaction_type": "Typ transakcie"
+  },
+  "error": {
+    "title": "Niečo sa pokazilo",
+    "description": "Vyskytla sa neočakávaná chyba. Skúste to o chvíľu znova.",
+    "retry": "Skúsiť znova"
+  },
+  "notFound": {
+    "title": "Stránka neexistuje",
+    "description": "Stránka, ktorú hľadáte, neexistuje alebo bola presunutá.",
+    "home": "Späť na hlavnú stránku"
   }
 }

--- a/frontend/apps/reality-web/messages/sk.json
+++ b/frontend/apps/reality-web/messages/sk.json
@@ -161,7 +161,46 @@
     "emptyTitle": "Práve teraz nemáme odporúčané ponuky",
     "emptyBody": "Naše inzeráty sa pridávajú každý deň. Prejdite na všetky aktuálne ponuky alebo pridajte vlastný inzerát zadarmo.",
     "emptyBrowseAll": "Prehliadnuť všetky ponuky",
-    "emptyAddListing": "Pridať vlastný inzerát"
+    "emptyAddListing": "Pridať vlastný inzerát",
+    "neighbourhoods": {
+      "title": "Obľúbené štvrte",
+      "subtitle": "Cena, dostupnosť a vývoj trhu na jeden pohľad.",
+      "exploreMap": "Preskúmať mapu",
+      "browse": "Pozrieť ponuky",
+      "ruzinov": "Ružinov",
+      "staremesto": "Staré Mesto",
+      "petrzalka": "Petržalka",
+      "novemesto": "Nové Mesto",
+      "karlovaves": "Karlova Ves",
+      "dubravka": "Dúbravka"
+    },
+    "city": {
+      "bratislava": "Bratislava"
+    },
+    "value": {
+      "agents": {
+        "label": "Overení agenti",
+        "desc": "ID-overení s 30-dňovou SLA odpovede"
+      },
+      "passport": {
+        "label": "Pas budovy",
+        "desc": "Energia · stav fondu · poruchy zverejnené"
+      },
+      "history": {
+        "label": "História cien",
+        "desc": "Každá zmena ceny zaznačená v inzeráte"
+      },
+      "mortgage": {
+        "label": "Predschválená hypotéka",
+        "desc": "V appke, s našimi partnerskými bankami"
+      }
+    },
+    "cta": {
+      "title": "Predávate svoju nehnuteľnosť?",
+      "body": "Pridajte inzerát za 5 minút, získajte zdarma pas budovy a dostanete sa k 210 000 overeným kupujúcim týždenne.",
+      "learnMore": "Zistiť viac",
+      "startListing": "Pridať inzerát"
+    }
   },
   "listing": {
     "additionalInfo": "Ďalšie informácie",

--- a/frontend/apps/reality-web/src/app/[locale]/auth/login/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/auth/login/page.tsx
@@ -6,6 +6,10 @@
  * Calls reality-server `/api/v1/users/login` via auth-api.login(). The
  * existing SSO callback flow remains intact for federated sign-ins.
  *
+ * Form fields use the modern form primitives from `@/components/forms`
+ * (floating labels + custom focus ring), matching the design bundle's
+ * `m-field / m-input` rules.
+ *
  * All user-visible strings come from `messages/<locale>.json -> auth.login`.
  * If you add a new string, add it to all 6 locale files (sk/cs/de/en/hu/pl).
  *
@@ -16,6 +20,7 @@
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { type FormEvent, Suspense, useState } from 'react';
+import { FieldInput } from '@/components/forms';
 import { Link } from '@/i18n/routing';
 import { AuthApiError, login } from '@/lib/auth-api';
 import { useAuth } from '@/lib/auth-context';
@@ -85,33 +90,30 @@ function LoginForm() {
           {generalError}
         </div>
       )}
-      <label className="field">
-        <span className="label">{t('emailLabel')}</span>
-        <input
-          type="email"
-          name="email"
-          autoComplete="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          disabled={isSubmitting}
-          className={`input ${emailError ? 'input-error' : ''}`}
-        />
-        {emailError && <span className="error">{emailError}</span>}
-      </label>
 
-      <label className="field">
-        <span className="label">{t('passwordLabel')}</span>
-        <input
-          type="password"
-          name="password"
-          autoComplete="current-password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          disabled={isSubmitting}
-          className={`input ${passwordError ? 'input-error' : ''}`}
-        />
-        {passwordError && <span className="error">{passwordError}</span>}
-      </label>
+      <FieldInput
+        type="email"
+        name="email"
+        autoComplete="email"
+        label={t('emailLabel')}
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        disabled={isSubmitting}
+        error={emailError}
+        required
+      />
+
+      <FieldInput
+        type="password"
+        name="password"
+        autoComplete="current-password"
+        label={t('passwordLabel')}
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        disabled={isSubmitting}
+        error={passwordError}
+        required
+      />
 
       <div className="row">
         <Link href="/auth/forgot-password" className="muted-link">
@@ -131,32 +133,71 @@ function LoginForm() {
       </p>
 
       <style jsx>{`
-        .form { display: flex; flex-direction: column; gap: 16px; }
+        .form {
+          display: flex;
+          flex-direction: column;
+          gap: 14px;
+        }
         .alert {
-          padding: 12px 16px; background: var(--ppt-color-danger-light); color: var(--ppt-color-danger-dark);
-          border: 1px solid var(--ppt-color-danger); border-radius: 8px; font-size: 14px;
+          padding: 12px 16px;
+          background: var(--ppt-color-danger-light);
+          color: var(--ppt-color-danger-dark);
+          border: 1px solid var(--ppt-color-danger);
+          border-radius: 8px;
+          font-size: 14px;
         }
-        .field { display: flex; flex-direction: column; gap: 6px; }
-        .label { font-size: 14px; font-weight: 500; color: var(--ppt-fg-secondary); }
-        .input {
-          padding: 10px 12px; font-size: 16px; border: 1px solid var(--ppt-border-strong);
-          border-radius: 8px; background: var(--ppt-bg-surface); color: var(--ppt-fg-primary);
+        .row {
+          display: flex;
+          justify-content: flex-end;
+          margin-top: -4px;
         }
-        .input:focus-visible { outline: var(--ppt-focus-ring-width) solid var(--ppt-focus-ring-color); outline-offset: var(--ppt-focus-ring-offset); border-color: var(--ppt-color-primary); }
-        .input-error { border-color: var(--ppt-color-danger-hover); }
-        .error { color: var(--ppt-color-danger-hover); font-size: 12px; }
-        .row { display: flex; justify-content: flex-end; }
-        .muted-link { font-size: 14px; color: var(--ppt-color-primary); text-decoration: none; }
-        .muted-link:hover { text-decoration: underline; }
+        .muted-link {
+          font-size: 13.5px;
+          color: var(--ppt-color-primary);
+          text-decoration: none;
+        }
+        .muted-link:hover {
+          text-decoration: underline;
+        }
         .submit {
-          margin-top: 8px; padding: 12px 16px; background: var(--ppt-color-primary); color: var(--ppt-fg-on-accent);
-          border: none; border-radius: 8px; font-size: 16px; font-weight: 600; cursor: pointer;
+          margin-top: 8px;
+          padding: 12px 16px;
+          background: var(--ppt-color-primary);
+          color: var(--ppt-fg-on-accent);
+          border: none;
+          border-radius: 8px;
+          font-size: 15px;
+          font-weight: 600;
+          font-family: var(--ppt-font-family);
+          cursor: pointer;
+          transition: background var(--ppt-transition-fast);
         }
-        .submit:hover:not(:disabled) { background: var(--ppt-color-primary-hover); }
-        .submit:disabled { background: var(--ppt-brand-500); cursor: not-allowed; }
-        .meta { text-align: center; font-size: 14px; color: var(--ppt-neutral-600); margin: 8px 0 0; }
-        .link { color: var(--ppt-color-primary); text-decoration: none; font-weight: 500; }
-        .link:hover { text-decoration: underline; }
+        .submit:hover:not(:disabled) {
+          background: var(--ppt-color-primary-hover);
+        }
+        .submit:focus-visible {
+          outline: none;
+          box-shadow: var(--ppt-focus-ring-shadow);
+        }
+        .submit:disabled {
+          background: var(--ppt-brand-500);
+          cursor: not-allowed;
+          opacity: 0.7;
+        }
+        .meta {
+          text-align: center;
+          font-size: 14px;
+          color: var(--ppt-fg-muted);
+          margin: 8px 0 0;
+        }
+        .link {
+          color: var(--ppt-color-primary);
+          text-decoration: none;
+          font-weight: 500;
+        }
+        .link:hover {
+          text-decoration: underline;
+        }
       `}</style>
     </form>
   );
@@ -175,15 +216,35 @@ export default function LoginPage() {
       </div>
       <style jsx>{`
         .page {
-          min-height: 100vh; display: flex; align-items: center; justify-content: center;
-          padding: 24px; background: var(--ppt-bg-app);
+          min-height: 100vh;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding: 24px;
+          background: var(--ppt-bg-app);
         }
         .card {
-          width: 100%; max-width: 420px; background: var(--ppt-bg-surface); border-radius: 12px;
-          box-shadow: 0 1px 3px rgba(0,0,0,.1); padding: 32px;
+          width: 100%;
+          max-width: 420px;
+          background: var(--ppt-bg-surface);
+          border: 1px solid var(--ppt-border-default);
+          border-radius: 12px;
+          box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+          padding: 32px;
         }
-        .title { font-size: 1.5rem; font-weight: 700; color: var(--ppt-fg-primary); margin: 0 0 4px; text-align: center; }
-        .subtitle { font-size: 14px; color: var(--ppt-fg-muted); margin: 0 0 24px; text-align: center; }
+        .title {
+          font-size: 1.5rem;
+          font-weight: 700;
+          color: var(--ppt-fg-primary);
+          margin: 0 0 4px;
+          text-align: center;
+        }
+        .subtitle {
+          font-size: 14px;
+          color: var(--ppt-fg-muted);
+          margin: 0 0 24px;
+          text-align: center;
+        }
       `}</style>
     </main>
   );

--- a/frontend/apps/reality-web/src/app/[locale]/error.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/error.tsx
@@ -6,8 +6,13 @@
  * Receives the thrown error and a reset function from Next.js. We log the
  * error to the console for diagnostics in development; production
  * deployments should wire it to their telemetry pipeline.
+ *
+ * Lives inside the locale layout, so NextIntlClientProvider is in scope
+ * and useTranslations() works — meaning the message and CTA show in the
+ * user's locale, not English by default.
  */
 
+import { useTranslations } from 'next-intl';
 import { useEffect } from 'react';
 import { StateView } from '@/components/states';
 
@@ -17,19 +22,15 @@ interface ErrorPageProps {
 }
 
 export default function ErrorPage({ error, reset }: ErrorPageProps) {
+  const t = useTranslations('error');
   useEffect(() => {
     console.error('reality-web error boundary:', error);
   }, [error]);
 
   return (
-    <StateView
-      icon="🛠️"
-      code="500"
-      title="Something went wrong"
-      description="An unexpected error occurred. Please try again in a moment."
-    >
+    <StateView icon="🛠️" code="500" title={t('title')} description={t('description')}>
       <button type="button" className="state-action" onClick={reset}>
-        Try again
+        {t('retry')}
       </button>
       <style jsx global>{`
         .state-action {

--- a/frontend/apps/reality-web/src/app/[locale]/inquiries/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/inquiries/page.tsx
@@ -56,12 +56,7 @@ function InquiryCard({ inquiry }: { inquiry: Inquiry }) {
           {inquiry.listingPhoto && (
             // Thumbnail is decorative: the listing title link beside it
             // already names the listing for screen readers.
-            <img
-              src={inquiry.listingPhoto}
-              alt=""
-              aria-hidden="true"
-              className="listing-photo"
-            />
+            <img src={inquiry.listingPhoto} alt="" aria-hidden="true" className="listing-photo" />
           )}
           <div>
             <Link href={`/listings/${inquiry.listingId}`} className="listing-title">

--- a/frontend/apps/reality-web/src/app/[locale]/inquiries/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/inquiries/page.tsx
@@ -54,7 +54,14 @@ function InquiryCard({ inquiry }: { inquiry: Inquiry }) {
       <div className="card-header">
         <div className="listing-info">
           {inquiry.listingPhoto && (
-            <img src={inquiry.listingPhoto} alt="" className="listing-photo" />
+            // Thumbnail is decorative: the listing title link beside it
+            // already names the listing for screen readers.
+            <img
+              src={inquiry.listingPhoto}
+              alt=""
+              aria-hidden="true"
+              className="listing-photo"
+            />
           )}
           <div>
             <Link href={`/listings/${inquiry.listingId}`} className="listing-title">

--- a/frontend/apps/reality-web/src/app/[locale]/journal/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/journal/page.tsx
@@ -147,14 +147,7 @@ export default function JournalPage() {
           </p>
         </div>
 
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: '1fr 320px',
-            gap: 40,
-            alignItems: 'start',
-          }}
-        >
+        <div className="journal-grid">
           {/* Main column */}
           <div>
             {/* Featured */}
@@ -341,6 +334,23 @@ export default function JournalPage() {
       </main>
 
       <Footer />
+
+      <style jsx>{`
+        /* Two-column layout above 1024 px; stacks to a single column below
+           so the 320 px sidebar doesn't force horizontal overflow on
+           mobile (was +297 px on 375 px viewport before this rule). */
+        .journal-grid {
+          display: grid;
+          grid-template-columns: 1fr;
+          gap: 40px;
+          align-items: start;
+        }
+        @media (min-width: 1024px) {
+          .journal-grid {
+            grid-template-columns: 1fr 320px;
+          }
+        }
+      `}</style>
     </div>
   );
 }

--- a/frontend/apps/reality-web/src/app/[locale]/layout.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/layout.tsx
@@ -1,6 +1,5 @@
 import { Inter } from 'next/font/google';
 import { notFound } from 'next/navigation';
-import Script from 'next/script';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, setRequestLocale } from 'next-intl/server';
 import { AuthProvider } from '@/lib/auth-context';
@@ -89,6 +88,25 @@ export default async function LocaleLayout({ children, params }: Props) {
     >
       <head>
         {/*
+         * Color-scheme bootstrap MUST be the first thing in <head> so it runs
+         * before any layout paint. A previous version put this in <body> with
+         * Next.js's <Script strategy="beforeInteractive"> which sounds right
+         * but in the App Router that strategy still queues the script after
+         * the framework's hydration boundary — first paint had no theme attr
+         * set and dark-mode users saw a white flash on every navigation.
+         * Plain inline <script> with `dangerouslySetInnerHTML` runs eagerly
+         * during HTML parse, which is what we actually want here.
+         */}
+        <script
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: bootstrap must inline
+          dangerouslySetInnerHTML={{
+            __html:
+              "(function(){try{var s=localStorage.getItem('ppt-color-scheme');" +
+              "var m=s||(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');" +
+              "document.documentElement.setAttribute('data-color-scheme',m);}catch(e){}})();",
+          }}
+        />
+        {/*
          * Runtime env config: the /env.js route handler (src/app/env.js/route.ts)
          * serves window.__ENV__ dynamically at request time, so the same built
          * image can be deployed to different environments without a rebuild.
@@ -100,10 +118,6 @@ export default async function LocaleLayout({ children, params }: Props) {
         <script src="/env.js" />
       </head>
       <body>
-        {/* Sets data-color-scheme before first paint to avoid flash of wrong theme */}
-        <Script id="color-scheme-init" strategy="beforeInteractive">{`
-(function(){try{var s=localStorage.getItem('ppt-color-scheme');var m=s||(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');document.documentElement.setAttribute('data-color-scheme',m);}catch(e){}})();
-        `}</Script>
         {/* StyledJsxRegistry must wrap any subtree that uses `<style jsx>`
             so the styles get streamed into the SSR HTML rather than
             injected post-hydration (which caused a ~0.92 CLS shift). */}

--- a/frontend/apps/reality-web/src/app/[locale]/layout.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/layout.tsx
@@ -100,8 +100,14 @@ export default async function LocaleLayout({ children, params }: Props) {
         <script
           // biome-ignore lint/security/noDangerouslySetInnerHtml: bootstrap must inline
           dangerouslySetInnerHTML={{
+            // Validate the stored value before applying it — a corrupted
+            // or legacy localStorage entry (e.g. 'system', 'auto', or any
+            // typo from a manual edit) would otherwise become an invalid
+            // data-color-scheme attribute and miss every [data-color-scheme=dark]
+            // CSS selector, leaving the page in a broken half-light state.
             __html:
               "(function(){try{var s=localStorage.getItem('ppt-color-scheme');" +
+              "if(s!=='light'&&s!=='dark')s=null;" +
               "var m=s||(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');" +
               "document.documentElement.setAttribute('data-color-scheme',m);}catch(e){}})();",
           }}

--- a/frontend/apps/reality-web/src/app/[locale]/listings/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/listings/page.tsx
@@ -126,6 +126,9 @@ function ListingsContent() {
     const city = searchParams.get('city');
     if (city) filters.city = city;
 
+    const district = searchParams.get('district');
+    if (district) filters.district = district;
+
     const sortBy = searchParams.get('sortBy') as ListingSortField | undefined;
     if (sortBy) filters.sortBy = sortBy;
 
@@ -156,6 +159,7 @@ function ListingsContent() {
       if (newFilters.areaMax !== undefined) params.set('areaMax', String(newFilters.areaMax));
       if (newFilters.roomsMin !== undefined) params.set('roomsMin', String(newFilters.roomsMin));
       if (newFilters.city) params.set('city', newFilters.city);
+      if (newFilters.district) params.set('district', newFilters.district);
       if (newFilters.sortBy) params.set('sortBy', newFilters.sortBy);
       if (newFilters.sortOrder) params.set('sortOrder', newFilters.sortOrder);
       if (page > 1) params.set('page', String(page));

--- a/frontend/apps/reality-web/src/app/[locale]/not-found.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/not-found.tsx
@@ -9,10 +9,10 @@
  * segment so the request's locale is already in scope.
  */
 
-import Link from 'next/link';
 import { getTranslations } from 'next-intl/server';
 import type { CSSProperties } from 'react';
 import { StateView } from '@/components/states';
+import { Link } from '@/i18n/routing';
 
 const linkStyle: CSSProperties = {
   padding: '10px 20px',

--- a/frontend/apps/reality-web/src/app/[locale]/not-found.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/not-found.tsx
@@ -4,9 +4,13 @@
  * Runs as a server component — no styled-jsx here (it's client-only).
  * The shared `StateView` is a client component via `'use client'`, so it
  * can be rendered from this server component without issue.
+ *
+ * Uses `getTranslations` (server variant) — we're inside the locale
+ * segment so the request's locale is already in scope.
  */
 
 import Link from 'next/link';
+import { getTranslations } from 'next-intl/server';
 import type { CSSProperties } from 'react';
 import { StateView } from '@/components/states';
 
@@ -21,16 +25,12 @@ const linkStyle: CSSProperties = {
   textAlign: 'center',
 };
 
-export default function NotFound() {
+export default async function NotFound() {
+  const t = await getTranslations('notFound');
   return (
-    <StateView
-      icon="🧭"
-      code="404"
-      title="Page not found"
-      description="The page you're looking for doesn't exist or has moved."
-    >
+    <StateView icon="🧭" code="404" title={t('title')} description={t('description')}>
       <Link href="/" style={linkStyle}>
-        Back to home
+        {t('home')}
       </Link>
     </StateView>
   );

--- a/frontend/apps/reality-web/src/app/[locale]/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/page.tsx
@@ -6,9 +6,24 @@
 
 'use client';
 
-import { CategoryCards, FeaturedListings, HeroSearch } from '@/components/home';
+import {
+  CategoryCards,
+  FeaturedListings,
+  HeroSearch,
+  HomeCTA,
+  PopularNeighbourhoods,
+  ValueStrip,
+} from '@/components/home';
 import { Footer, Header } from '@/components/ui';
 
+/**
+ * Reality Portal homepage.
+ *
+ * Section order matches the design system reference (`Reality Portal Home -
+ * Standalone.html` in the design bundle): hero → categories → featured →
+ * neighbourhoods → value strip → selling CTA → footer. Adding/removing a
+ * section here should be reflected in the design too — keep the order.
+ */
 export default function HomePage() {
   return (
     <div className="page-container">
@@ -17,6 +32,9 @@ export default function HomePage() {
         <HeroSearch />
         <CategoryCards />
         <FeaturedListings />
+        <PopularNeighbourhoods />
+        <ValueStrip />
+        <HomeCTA />
       </main>
       <Footer />
 

--- a/frontend/apps/reality-web/src/app/[locale]/price-map/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/price-map/page.tsx
@@ -124,14 +124,7 @@ export default function PriceMapPage() {
           </div>
         </div>
 
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: '1fr 340px',
-            height: 'calc(100vh - 200px)',
-            minHeight: 500,
-          }}
-        >
+        <div className="price-map-grid">
           {/* SVG Map */}
           <div
             style={{
@@ -420,6 +413,23 @@ export default function PriceMapPage() {
       </main>
 
       <Footer />
+
+      <style jsx>{`
+        /* Map + detail-panel grid. Stacks on mobile so the fixed 340 px
+           panel doesn't overflow the viewport (+13 px observed at 375 px
+           before this rule). Height clamp stays in both layouts. */
+        .price-map-grid {
+          display: grid;
+          grid-template-columns: 1fr;
+          min-height: 500px;
+        }
+        @media (min-width: 768px) {
+          .price-map-grid {
+            grid-template-columns: 1fr 340px;
+            height: calc(100vh - 200px);
+          }
+        }
+      `}</style>
     </div>
   );
 }

--- a/frontend/apps/reality-web/src/app/[locale]/price-map/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/price-map/page.tsx
@@ -31,7 +31,7 @@ export default function PriceMapPage() {
 
   const selected = MOCK_DISTRICTS.find((d) => d.id === selectedId) ?? null;
 
-  const formatPrice = (v: number) => v.toLocaleString('sk-SK') + ' €';
+  const formatPrice = (v: number) => `${v.toLocaleString('sk-SK')} €`;
 
   return (
     <div

--- a/frontend/apps/reality-web/src/app/[locale]/sell/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/sell/page.tsx
@@ -164,16 +164,7 @@ export default function SellPage() {
       <Header />
 
       <main style={{ flex: 1, padding: '48px 24px' }}>
-        <div
-          style={{
-            maxWidth: 800,
-            margin: '0 auto',
-            display: 'grid',
-            gridTemplateColumns: '1fr 260px',
-            gap: 40,
-            alignItems: 'start',
-          }}
-        >
+        <div className="sell-grid">
           {/* Wizard form */}
           <div
             style={{
@@ -739,6 +730,25 @@ export default function SellPage() {
       </main>
 
       <Footer />
+
+      <style jsx>{`
+        /* Sell-wizard 2-col layout: form + Steps sidebar. Stacks to 1 col
+           below 1024 px so the 260 px aside doesn't push past the viewport
+           (was +225 px overflow on 375 px before this rule). */
+        .sell-grid {
+          max-width: 800px;
+          margin: 0 auto;
+          display: grid;
+          grid-template-columns: 1fr;
+          gap: 40px;
+          align-items: start;
+        }
+        @media (min-width: 1024px) {
+          .sell-grid {
+            grid-template-columns: 1fr 260px;
+          }
+        }
+      `}</style>
     </div>
   );
 }

--- a/frontend/apps/reality-web/src/app/[locale]/terms/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/terms/page.tsx
@@ -17,7 +17,20 @@ export default function TermsPage() {
       }}
     >
       <Header />
-      <main style={{ flex: 1, maxWidth: 800, margin: '0 auto', padding: '48px 24px' }}>
+      {/* width:100% + box-sizing keeps the main from overflowing the
+          viewport. `flex:1` alone only stretches the cross-axis (height
+          in column-flex), not the width, so without an explicit width the
+          element sizes to its content + padding and ignores the viewport. */}
+      <main
+        style={{
+          flex: 1,
+          width: '100%',
+          maxWidth: 800,
+          margin: '0 auto',
+          padding: '48px 24px',
+          boxSizing: 'border-box',
+        }}
+      >
         <h1
           style={{
             fontSize: '2rem',

--- a/frontend/apps/reality-web/src/app/globals.css
+++ b/frontend/apps/reality-web/src/app/globals.css
@@ -40,6 +40,20 @@ a:hover {
   text-decoration: underline;
 }
 
+/*
+ * Focus indicator baseline (WCAG 2.2 — visible focus on every keyboard-
+ * focusable element). Applied to interactive elements that don't define
+ * their own :focus-visible; component-level rules win on specificity.
+ * Implementation note: targets buttons, anchors, form controls and
+ * anything with tabindex/role=button. Native browser outline is hidden
+ * by `outline: none` only inside the same rule — never globally.
+ */
+:where(button, a, input, select, textarea, summary, [tabindex]:not([tabindex='-1']), [role='button']):focus-visible {
+  outline: none;
+  box-shadow: var(--ppt-focus-ring-shadow);
+  border-radius: var(--ppt-radius-sm, 6px);
+}
+
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce) {
   *,

--- a/frontend/apps/reality-web/src/app/globals.css
+++ b/frontend/apps/reality-web/src/app/globals.css
@@ -48,7 +48,16 @@ a:hover {
  * anything with tabindex/role=button. Native browser outline is hidden
  * by `outline: none` only inside the same rule — never globally.
  */
-:where(button, a, input, select, textarea, summary, [tabindex]:not([tabindex='-1']), [role='button']):focus-visible {
+:where(
+  button,
+  a,
+  input,
+  select,
+  textarea,
+  summary,
+  [tabindex]:not([tabindex="-1"]),
+  [role="button"]
+):focus-visible {
   outline: none;
   box-shadow: var(--ppt-focus-ring-shadow);
   border-radius: var(--ppt-radius-sm, 6px);

--- a/frontend/apps/reality-web/src/components/forms/Field.tsx
+++ b/frontend/apps/reality-web/src/components/forms/Field.tsx
@@ -69,6 +69,11 @@ export const FieldInput = forwardRef<HTMLInputElement, FieldInputProps>(
              trick that drives the floating-label animation. Don't set a
              real placeholder — the label IS the placeholder. */
           placeholder=" "
+          /* Chrome 120+ injects caret-color into the inline style of any
+             input it suspects is being autofilled, which races with the
+             SSR-rendered style and triggers a hydration warning. Suppress
+             it so the console stays clean — the DOM rebuilds correctly. */
+          suppressHydrationWarning
           aria-invalid={Boolean(error) || undefined}
           aria-describedby={error || helperText ? helperId : undefined}
           {...rest}

--- a/frontend/apps/reality-web/src/components/forms/Field.tsx
+++ b/frontend/apps/reality-web/src/components/forms/Field.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+/**
+ * Modern form-field primitives — floating-label inputs and textarea.
+ *
+ * Mirrors the `m-field / m-input / m-textarea` rules from the design
+ * bundle (pages/sell.html, profile.html, contact.html). The label sits
+ * on top of the input like a placeholder, then animates up + shrinks
+ * when the field has a value or is focused.
+ *
+ * Implementation note: the "has value" state uses the CSS
+ * `:not(:placeholder-shown)` trick (the input is rendered with
+ * `placeholder=" "` so it always has a placeholder for the CSS selector
+ * to flip). This avoids React state for value tracking — works for both
+ * controlled and uncontrolled inputs, and stays accessible to
+ * `react-hook-form` `register()` without extra plumbing.
+ *
+ * The custom dropdown lives in ./FieldSelect because it needs a popover
+ * with keyboard nav and search — outside the scope of CSS-only.
+ */
+
+import {
+  forwardRef,
+  type InputHTMLAttributes,
+  type ReactNode,
+  type TextareaHTMLAttributes,
+  useId,
+} from 'react';
+import './forms.css';
+
+type CommonProps = {
+  /** Field label rendered as floating placeholder. */
+  label: ReactNode;
+  /** Helper text shown below the input when there's no error. */
+  helperText?: ReactNode;
+  /** Validation error — replaces helperText, switches border to danger. */
+  error?: ReactNode;
+  /** Optional prefix (e.g. currency symbol) shown inside the field. */
+  prefix?: ReactNode;
+  /** Optional suffix (e.g. unit) shown inside the field. */
+  suffix?: ReactNode;
+};
+
+export type FieldInputProps = CommonProps &
+  Omit<InputHTMLAttributes<HTMLInputElement>, 'placeholder'>;
+
+export const FieldInput = forwardRef<HTMLInputElement, FieldInputProps>(
+  ({ label, helperText, error, prefix, suffix, className, id, ...rest }, ref) => {
+    const reactId = useId();
+    const inputId = id || reactId;
+    const helperId = `${inputId}-helper`;
+    return (
+      <div
+        className={[
+          'field',
+          error ? 'field-error' : '',
+          prefix ? 'field-has-prefix' : '',
+          suffix ? 'field-has-suffix' : '',
+          className,
+        ]
+          .filter(Boolean)
+          .join(' ')}
+      >
+        {prefix && <span className="field-prefix">{prefix}</span>}
+        <input
+          ref={ref}
+          id={inputId}
+          /* placeholder=" " is required for the :not(:placeholder-shown)
+             trick that drives the floating-label animation. Don't set a
+             real placeholder — the label IS the placeholder. */
+          placeholder=" "
+          aria-invalid={Boolean(error) || undefined}
+          aria-describedby={error || helperText ? helperId : undefined}
+          {...rest}
+        />
+        <label htmlFor={inputId}>{label}</label>
+        {suffix && <span className="field-suffix">{suffix}</span>}
+        {(error || helperText) && (
+          <p
+            id={helperId}
+            className={error ? 'field-msg field-msg-error' : 'field-msg'}
+            role={error ? 'alert' : undefined}
+          >
+            {error || helperText}
+          </p>
+        )}
+      </div>
+    );
+  }
+);
+FieldInput.displayName = 'FieldInput';
+
+export type FieldTextareaProps = CommonProps &
+  Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'placeholder'>;
+
+export const FieldTextarea = forwardRef<HTMLTextAreaElement, FieldTextareaProps>(
+  ({ label, helperText, error, className, id, rows = 4, ...rest }, ref) => {
+    const reactId = useId();
+    const inputId = id || reactId;
+    const helperId = `${inputId}-helper`;
+    return (
+      <div
+        className={['field', 'field-textarea', error ? 'field-error' : '', className]
+          .filter(Boolean)
+          .join(' ')}
+      >
+        <textarea
+          ref={ref}
+          id={inputId}
+          rows={rows}
+          placeholder=" "
+          aria-invalid={Boolean(error) || undefined}
+          aria-describedby={error || helperText ? helperId : undefined}
+          {...rest}
+        />
+        <label htmlFor={inputId}>{label}</label>
+        {(error || helperText) && (
+          <p
+            id={helperId}
+            className={error ? 'field-msg field-msg-error' : 'field-msg'}
+            role={error ? 'alert' : undefined}
+          >
+            {error || helperText}
+          </p>
+        )}
+      </div>
+    );
+  }
+);
+FieldTextarea.displayName = 'FieldTextarea';

--- a/frontend/apps/reality-web/src/components/forms/FieldSelect.tsx
+++ b/frontend/apps/reality-web/src/components/forms/FieldSelect.tsx
@@ -1,0 +1,247 @@
+'use client';
+
+/**
+ * FieldSelect — custom dropdown with floating label.
+ *
+ * Native <select> renders OS-styled and can't be themed to match the
+ * design's `m-dropdown` look (rounded, big, animated chevron). This is
+ * a controlled component with a popover trigger + listbox, keyboard
+ * navigable (Enter/Space to open, Esc to close, Up/Down + Enter to
+ * select), closes on outside click. Mirrors LanguageSwitcher's
+ * popover pattern but adds floating-label affordance + options API.
+ */
+
+import type { ReactNode } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
+import './forms.css';
+
+export type FieldSelectOption = {
+  value: string;
+  label: ReactNode;
+  /** Optional secondary text (e.g. count or hint). */
+  meta?: ReactNode;
+  disabled?: boolean;
+};
+
+export type FieldSelectProps = {
+  label: ReactNode;
+  value: string;
+  onChange: (value: string) => void;
+  options: FieldSelectOption[];
+  /** Helper text shown below the field when there's no error. */
+  helperText?: ReactNode;
+  /** Validation error — replaces helperText, switches border to danger. */
+  error?: ReactNode;
+  /** Placeholder text shown in the trigger when no value is selected. */
+  placeholder?: ReactNode;
+  disabled?: boolean;
+  required?: boolean;
+  className?: string;
+  id?: string;
+  name?: string;
+};
+
+export function FieldSelect({
+  label,
+  value,
+  onChange,
+  options,
+  helperText,
+  error,
+  placeholder,
+  disabled,
+  required,
+  className,
+  id,
+  name,
+}: FieldSelectProps) {
+  const reactId = useId();
+  const fieldId = id || reactId;
+  const helperId = `${fieldId}-helper`;
+  const listboxId = `${fieldId}-listbox`;
+
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState<number>(() =>
+    Math.max(
+      0,
+      options.findIndex((o) => o.value === value)
+    )
+  );
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  // Outside click + Escape — same pattern as LanguageSwitcher.
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+    document.addEventListener('mousedown', onClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const selected = options.find((o) => o.value === value);
+
+  const handleTriggerKey = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      setOpen(true);
+    } else if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      setOpen((v) => !v);
+    }
+  };
+
+  const handleListKey = (e: React.KeyboardEvent<HTMLUListElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex((i) => Math.min(options.length - 1, i + 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(0, i - 1));
+    } else if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      const opt = options[activeIndex];
+      if (opt && !opt.disabled) {
+        onChange(opt.value);
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    }
+  };
+
+  const choose = (opt: FieldSelectOption) => {
+    if (opt.disabled) return;
+    onChange(opt.value);
+    setOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  return (
+    <div
+      className={[
+        'field',
+        'field-select',
+        open ? 'field-select-open' : '',
+        value ? 'field-has-value' : '',
+        error ? 'field-error' : '',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      ref={wrapRef}
+    >
+      <button
+        type="button"
+        ref={triggerRef}
+        id={fieldId}
+        className="field-select-trigger"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={listboxId}
+        aria-invalid={Boolean(error) || undefined}
+        aria-describedby={error || helperText ? helperId : undefined}
+        aria-required={required || undefined}
+        disabled={disabled}
+        onClick={() => setOpen((v) => !v)}
+        onKeyDown={handleTriggerKey}
+      >
+        <span className="field-select-value">
+          {selected ? (
+            selected.label
+          ) : (
+            <span className="field-select-placeholder">{placeholder}</span>
+          )}
+        </span>
+        <svg
+          className="field-select-caret"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+      <label htmlFor={fieldId}>{label}</label>
+      {/* Hidden native input so the value is included in form submissions
+          without extra plumbing in consumers. */}
+      <input type="hidden" name={name} value={value} />
+      {open && (
+        <ul
+          id={listboxId}
+          className="field-select-menu"
+          role="listbox"
+          aria-labelledby={fieldId}
+          tabIndex={-1}
+          // biome-ignore lint/a11y/noNoninteractiveTabindex: listbox is keyboard-navigable
+          onKeyDown={handleListKey}
+        >
+          {options.map((opt, idx) => (
+            <li key={opt.value}>
+              <button
+                type="button"
+                role="option"
+                aria-selected={opt.value === value}
+                disabled={opt.disabled}
+                className={[
+                  'field-select-option',
+                  opt.value === value ? 'active' : '',
+                  idx === activeIndex ? 'highlight' : '',
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+                onClick={() => choose(opt)}
+                onMouseEnter={() => setActiveIndex(idx)}
+              >
+                <span className="field-select-option-label">{opt.label}</span>
+                {opt.meta && <span className="field-select-option-meta">{opt.meta}</span>}
+                {opt.value === value && (
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                  >
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {(error || helperText) && (
+        <p
+          id={helperId}
+          className={error ? 'field-msg field-msg-error' : 'field-msg'}
+          role={error ? 'alert' : undefined}
+        >
+          {error || helperText}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/apps/reality-web/src/components/forms/FieldSelect.tsx
+++ b/frontend/apps/reality-web/src/components/forms/FieldSelect.tsx
@@ -70,7 +70,19 @@ export function FieldSelect({
   const wrapRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
 
-  // Outside click + Escape — same pattern as LanguageSwitcher.
+  // Keep activeIndex pointed at the currently-selected option whenever
+  // `value` or `options` change from the parent — otherwise the highlight
+  // can drift after a controlled-value swap (reopening the menu).
+  useEffect(() => {
+    const i = options.findIndex((o) => o.value === value);
+    if (i >= 0) setActiveIndex(i);
+  }, [value, options]);
+
+  // Listbox uses a document-level keydown listener instead of an onKeyDown
+  // attached to the menu element, because the listbox never receives focus
+  // (the trigger button keeps focus while the menu is open, per APG
+  // listbox/combobox pattern when no edit field is used). Arrow keys move
+  // the highlight, Enter/Space commits, Escape closes.
   useEffect(() => {
     if (!open) return;
     const onClick = (e: MouseEvent) => {
@@ -80,8 +92,35 @@ export function FieldSelect({
     };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
+        e.preventDefault();
         setOpen(false);
         triggerRef.current?.focus();
+        return;
+      }
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActiveIndex((i) => Math.min(options.length - 1, i + 1));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActiveIndex((i) => Math.max(0, i - 1));
+      } else if (e.key === 'Home') {
+        e.preventDefault();
+        setActiveIndex(0);
+      } else if (e.key === 'End') {
+        e.preventDefault();
+        setActiveIndex(options.length - 1);
+      } else if (e.key === 'Enter' || e.key === ' ') {
+        // Use the latest activeIndex from state at fire time
+        e.preventDefault();
+        setActiveIndex((i) => {
+          const opt = options[i];
+          if (opt && !opt.disabled) {
+            onChange(opt.value);
+            setOpen(false);
+            triggerRef.current?.focus();
+          }
+          return i;
+        });
       }
     };
     document.addEventListener('mousedown', onClick);
@@ -90,7 +129,7 @@ export function FieldSelect({
       document.removeEventListener('mousedown', onClick);
       document.removeEventListener('keydown', onKey);
     };
-  }, [open]);
+  }, [open, options, onChange]);
 
   const selected = options.find((o) => o.value === value);
 
@@ -101,24 +140,6 @@ export function FieldSelect({
     } else if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
       setOpen((v) => !v);
-    }
-  };
-
-  const handleListKey = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      setActiveIndex((i) => Math.min(options.length - 1, i + 1));
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      setActiveIndex((i) => Math.max(0, i - 1));
-    } else if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      const opt = options[activeIndex];
-      if (opt && !opt.disabled) {
-        onChange(opt.value);
-        setOpen(false);
-        triggerRef.current?.focus();
-      }
     }
   };
 
@@ -154,6 +175,12 @@ export function FieldSelect({
         aria-invalid={Boolean(error) || undefined}
         aria-describedby={error || helperText ? helperId : undefined}
         aria-required={required || undefined}
+        // aria-activedescendant lives on the focusable trigger (not the
+        // listbox) because focus stays here when the menu is open — that's
+        // the APG combobox-with-aria-activedescendant variant.
+        aria-activedescendant={
+          open && options[activeIndex] ? `${fieldId}-opt-${options[activeIndex].value}` : undefined
+        }
         disabled={disabled}
         onClick={() => setOpen((v) => !v)}
         onKeyDown={handleTriggerKey}
@@ -183,21 +210,19 @@ export function FieldSelect({
       <label htmlFor={fieldId}>{label}</label>
       {/* Hidden native input so the value is included in form submissions
           without extra plumbing in consumers. */}
-      <input type="hidden" name={name} value={value} />
+      {/* Disabled fields shouldn't participate in form submission — pass
+          through the disabled prop so the value is excluded when the
+          form is submitted. */}
+      <input type="hidden" name={name} value={value} disabled={disabled} />
       {open && (
         // <div role="listbox"> rather than <ul role="listbox"> per ARIA
         // Combobox pattern — biome rejects the listbox role on semantic
         // list elements (noNoninteractiveElementToInteractiveRole).
-        <div
-          id={listboxId}
-          className="field-select-menu"
-          role="listbox"
-          aria-labelledby={fieldId}
-          onKeyDown={handleListKey}
-        >
+        <div id={listboxId} className="field-select-menu" role="listbox" aria-labelledby={fieldId}>
           {options.map((opt, idx) => (
             <button
               key={opt.value}
+              id={`${fieldId}-opt-${opt.value}`}
               type="button"
               role="option"
               aria-selected={opt.value === value}

--- a/frontend/apps/reality-web/src/components/forms/FieldSelect.tsx
+++ b/frontend/apps/reality-web/src/components/forms/FieldSelect.tsx
@@ -104,7 +104,7 @@ export function FieldSelect({
     }
   };
 
-  const handleListKey = (e: React.KeyboardEvent<HTMLUListElement>) => {
+  const handleListKey = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'ArrowDown') {
       e.preventDefault();
       setActiveIndex((i) => Math.min(options.length - 1, i + 1));
@@ -185,53 +185,53 @@ export function FieldSelect({
           without extra plumbing in consumers. */}
       <input type="hidden" name={name} value={value} />
       {open && (
-        <ul
+        // <div role="listbox"> rather than <ul role="listbox"> per ARIA
+        // Combobox pattern — biome rejects the listbox role on semantic
+        // list elements (noNoninteractiveElementToInteractiveRole).
+        <div
           id={listboxId}
           className="field-select-menu"
           role="listbox"
           aria-labelledby={fieldId}
-          tabIndex={-1}
-          // biome-ignore lint/a11y/noNoninteractiveTabindex: listbox is keyboard-navigable
           onKeyDown={handleListKey}
         >
           {options.map((opt, idx) => (
-            <li key={opt.value}>
-              <button
-                type="button"
-                role="option"
-                aria-selected={opt.value === value}
-                disabled={opt.disabled}
-                className={[
-                  'field-select-option',
-                  opt.value === value ? 'active' : '',
-                  idx === activeIndex ? 'highlight' : '',
-                ]
-                  .filter(Boolean)
-                  .join(' ')}
-                onClick={() => choose(opt)}
-                onMouseEnter={() => setActiveIndex(idx)}
-              >
-                <span className="field-select-option-label">{opt.label}</span>
-                {opt.meta && <span className="field-select-option-meta">{opt.meta}</span>}
-                {opt.value === value && (
-                  <svg
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    aria-hidden="true"
-                  >
-                    <polyline points="20 6 9 17 4 12" />
-                  </svg>
-                )}
-              </button>
-            </li>
+            <button
+              key={opt.value}
+              type="button"
+              role="option"
+              aria-selected={opt.value === value}
+              disabled={opt.disabled}
+              className={[
+                'field-select-option',
+                opt.value === value ? 'active' : '',
+                idx === activeIndex ? 'highlight' : '',
+              ]
+                .filter(Boolean)
+                .join(' ')}
+              onClick={() => choose(opt)}
+              onMouseEnter={() => setActiveIndex(idx)}
+            >
+              <span className="field-select-option-label">{opt.label}</span>
+              {opt.meta && <span className="field-select-option-meta">{opt.meta}</span>}
+              {opt.value === value && (
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+              )}
+            </button>
           ))}
-        </ul>
+        </div>
       )}
       {(error || helperText) && (
         <p

--- a/frontend/apps/reality-web/src/components/forms/FormCard.tsx
+++ b/frontend/apps/reality-web/src/components/forms/FormCard.tsx
@@ -1,0 +1,61 @@
+/**
+ * FormCard + FieldGroupTitle + FormActions — layout primitives for the
+ * modern form system. Mirrors the design's `.form-card`,
+ * `.field-group-title`, and `.form-actions` rules from pages/sell.html.
+ */
+
+import type { ReactNode } from 'react';
+import './forms.css';
+
+export function FormCard({
+  title,
+  subtitle,
+  step,
+  children,
+  className,
+}: {
+  /** Section title rendered as h2 inside the card. */
+  title?: ReactNode;
+  /** Optional subtitle shown under the title. */
+  subtitle?: ReactNode;
+  /** Optional step pill (e.g. "Krok 1 / 5") shown next to the title. */
+  step?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <section className={['form-card', className].filter(Boolean).join(' ')}>
+      {title && (
+        <h2 className="form-card-title">
+          {title}
+          {step && <span className="form-card-step-pill">{step}</span>}
+        </h2>
+      )}
+      {subtitle && <p className="form-card-sub">{subtitle}</p>}
+      {children}
+    </section>
+  );
+}
+
+export function FieldGroupTitle({ children }: { children: ReactNode }) {
+  return <div className="field-group-title">{children}</div>;
+}
+
+export function FormActions({
+  left,
+  children,
+  className,
+}: {
+  /** Left-hand content (typically save-state meta like "Saved 2s ago"). */
+  left?: ReactNode;
+  /** Buttons / actions on the right. */
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={['form-actions', className].filter(Boolean).join(' ')}>
+      <div className="form-actions-left">{left}</div>
+      <div className="form-actions-right">{children}</div>
+    </div>
+  );
+}

--- a/frontend/apps/reality-web/src/components/forms/forms.css
+++ b/frontend/apps/reality-web/src/components/forms/forms.css
@@ -1,0 +1,359 @@
+/*
+ * Modern form system — direct translation of the design bundle's
+ * `m-field / m-input / m-textarea / m-dropdown / form-card / form-actions`
+ * rules from pages/sell.html. Reads existing ui-kit tokens (`--ppt-*`) so
+ * dark mode pairs automatically.
+ *
+ * The class names drop the `m-` prefix because we don't ship a legacy form
+ * system alongside this one — these primitives are the form system.
+ */
+
+/* ============================================================
+   Form-card container
+   ============================================================ */
+
+.form-card {
+  background: var(--ppt-bg-surface);
+  border: 1px solid var(--ppt-border-default);
+  border-radius: 12px;
+  padding: 28px;
+  margin-bottom: 16px;
+}
+.form-card + .form-card {
+  margin-top: 0;
+}
+
+.form-card-title {
+  font-size: 18px;
+  font-weight: 700;
+  margin: 0 0 6px;
+  color: var(--ppt-fg-primary);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.form-card-sub {
+  font-size: 13.5px;
+  color: var(--ppt-fg-muted);
+  margin: 0 0 20px;
+}
+
+.form-card-step-pill {
+  font-size: 11px;
+  font-weight: 700;
+  background: var(--ppt-color-primary-soft-bg);
+  color: var(--ppt-color-primary);
+  padding: 3px 9px;
+  border-radius: 999px;
+  letter-spacing: 0.04em;
+}
+
+.field-group-title {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ppt-fg-muted);
+  margin: 24px 0 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.field-group-title::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--ppt-border-subtle, var(--ppt-border-default));
+}
+
+/* ============================================================
+   Floating-label fields
+   ============================================================ */
+
+.field {
+  position: relative;
+  margin: 0;
+}
+.field + .field {
+  margin-top: 14px;
+}
+
+/*
+ * Inputs and textareas share the same look. The top padding is wider
+ * (22px) than the bottom (8px) so the floating label has room to live
+ * inside the field at rest. Padding-top jumps to 26px on textarea to
+ * keep multiline content from butting against the label.
+ */
+.field > input,
+.field > textarea,
+.field-select-trigger {
+  width: 100%;
+  padding: 22px 14px 8px;
+  background: var(--ppt-bg-surface);
+  border: 1px solid var(--ppt-border-default);
+  border-radius: 10px;
+  font-size: 14px;
+  font-weight: 500;
+  font-family: var(--ppt-font-family);
+  color: var(--ppt-fg-primary);
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s,
+    background-color 0.15s;
+  appearance: none;
+  line-height: 1.4;
+  text-align: left;
+}
+.field > textarea {
+  padding-top: 26px;
+  min-height: 96px;
+  resize: vertical;
+  line-height: 1.55;
+}
+.field > input:hover,
+.field > textarea:hover,
+.field-select-trigger:not(:disabled):hover {
+  border-color: var(--ppt-neutral-400);
+}
+.field > input:focus,
+.field > textarea:focus,
+.field-select-trigger:focus-visible {
+  outline: none;
+  border-color: var(--ppt-color-primary);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.12);
+  background: var(--ppt-bg-surface);
+}
+[data-color-scheme="dark"] .field > input:focus,
+[data-color-scheme="dark"] .field > textarea:focus,
+[data-color-scheme="dark"] .field-select-trigger:focus-visible {
+  box-shadow: 0 0 0 4px rgba(96, 165, 250, 0.18);
+}
+.field > input:disabled,
+.field > textarea:disabled,
+.field-select-trigger:disabled {
+  background: var(--ppt-bg-subtle);
+  color: var(--ppt-fg-muted);
+  cursor: not-allowed;
+}
+
+/*
+ * Label sits over the input like a placeholder, then animates up + shrinks
+ * on focus or when the field has a value. The :not(:placeholder-shown)
+ * trick requires every field to render with placeholder=" " — see
+ * Field.tsx for why.
+ */
+.field > label {
+  position: absolute;
+  left: 14px;
+  top: 14px;
+  font-size: 13.5px;
+  color: var(--ppt-fg-muted);
+  font-weight: 500;
+  pointer-events: none;
+  background: transparent;
+  padding: 0 2px;
+  z-index: 1;
+  transition:
+    transform 0.15s ease,
+    color 0.15s,
+    font-size 0.15s,
+    font-weight 0.15s;
+  transform-origin: left center;
+}
+.field > input:focus ~ label,
+.field > input:not(:placeholder-shown) ~ label,
+.field > textarea:focus ~ label,
+.field > textarea:not(:placeholder-shown) ~ label,
+.field-select.field-select-open > label,
+.field-select.field-has-value > label {
+  transform: translateY(-9px);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ppt-fg-muted);
+}
+.field > input:focus ~ label,
+.field > textarea:focus ~ label,
+.field-select.field-select-open > label,
+.field-select-trigger:focus-visible ~ label {
+  color: var(--ppt-color-primary);
+}
+
+/* Error state */
+.field.field-error > input,
+.field.field-error > textarea,
+.field.field-error .field-select-trigger {
+  border-color: var(--ppt-color-danger);
+}
+.field.field-error > input:focus,
+.field.field-error > textarea:focus,
+.field.field-error .field-select-trigger:focus-visible {
+  box-shadow: 0 0 0 4px rgba(239, 68, 68, 0.12);
+}
+
+/* Helper text + error message */
+.field-msg {
+  margin: 6px 2px 0;
+  font-size: 12.5px;
+  color: var(--ppt-fg-muted);
+}
+.field-msg-error {
+  color: var(--ppt-color-danger);
+}
+
+/* Prefix / suffix (currency, units) */
+.field-has-prefix > input {
+  padding-left: 32px;
+}
+.field-has-suffix > input {
+  padding-right: 40px;
+}
+.field-prefix,
+.field-suffix {
+  position: absolute;
+  top: 22px;
+  font-size: 14px;
+  color: var(--ppt-fg-muted);
+  pointer-events: none;
+  z-index: 1;
+}
+.field-prefix {
+  left: 14px;
+}
+.field-suffix {
+  right: 14px;
+}
+
+/* ============================================================
+   Custom select / dropdown
+   ============================================================ */
+
+.field-select {
+  position: relative;
+}
+.field-select-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  cursor: pointer;
+  /* Trigger always shows a value or placeholder, so the label is always
+     in the "floated" position. Reduce top padding to leave room. */
+  padding-top: 22px;
+  padding-bottom: 8px;
+}
+.field-select-value {
+  flex: 1;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.field-select-placeholder {
+  color: var(--ppt-fg-muted);
+}
+.field-select-caret {
+  color: var(--ppt-fg-muted);
+  flex-shrink: 0;
+  transition: transform 0.15s;
+}
+.field-select-trigger[aria-expanded="true"] .field-select-caret {
+  transform: rotate(180deg);
+}
+
+.field-select-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  max-height: 320px;
+  overflow-y: auto;
+  padding: 4px;
+  margin: 0;
+  list-style: none;
+  background: var(--ppt-bg-elevated, var(--ppt-bg-surface));
+  border: 1px solid var(--ppt-border-default);
+  border-radius: var(--ppt-radius-lg, 12px);
+  box-shadow: var(--ppt-shadow-popover, 0 8px 24px rgba(0, 0, 0, 0.12));
+  z-index: var(--ppt-z-dropdown, 1000);
+}
+.field-select-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 9px 10px;
+  background: transparent;
+  border: none;
+  border-radius: var(--ppt-radius-sm, 6px);
+  cursor: pointer;
+  font-family: var(--ppt-font-family);
+  font-size: var(--ppt-font-size-sm, 14px);
+  color: var(--ppt-fg-secondary);
+  text-align: left;
+  transition: background var(--ppt-transition-fast, 0.15s);
+}
+.field-select-option:hover:not(:disabled),
+.field-select-option.highlight {
+  background: var(--ppt-bg-subtle);
+}
+.field-select-option.active {
+  color: var(--ppt-color-primary);
+  font-weight: var(--ppt-font-weight-semibold, 600);
+}
+.field-select-option:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.field-select-option-label {
+  flex: 1;
+}
+.field-select-option-meta {
+  color: var(--ppt-fg-muted);
+  font-size: 12px;
+}
+
+/* ============================================================
+   Form actions (sticky bottom bar)
+   ============================================================ */
+
+.form-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 20px 28px;
+  background: var(--ppt-bg-surface);
+  border: 1px solid var(--ppt-border-default);
+  border-radius: 12px;
+  position: sticky;
+  bottom: 16px;
+  box-shadow: var(--ppt-shadow-lg, 0 4px 12px rgba(0, 0, 0, 0.15));
+  margin-top: 16px;
+  z-index: 5;
+}
+.form-actions-left {
+  font-size: 13px;
+  color: var(--ppt-fg-muted);
+}
+.form-actions-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* ============================================================
+   Reduced motion
+   ============================================================ */
+
+@media (prefers-reduced-motion: reduce) {
+  .field > label,
+  .field-select-caret,
+  .field > input,
+  .field > textarea,
+  .field-select-trigger {
+    transition: none !important;
+  }
+}

--- a/frontend/apps/reality-web/src/components/forms/index.ts
+++ b/frontend/apps/reality-web/src/components/forms/index.ts
@@ -1,0 +1,5 @@
+export type { FieldInputProps, FieldTextareaProps } from './Field';
+export { FieldInput, FieldTextarea } from './Field';
+export type { FieldSelectOption, FieldSelectProps } from './FieldSelect';
+export { FieldSelect } from './FieldSelect';
+export { FieldGroupTitle, FormActions, FormCard } from './FormCard';

--- a/frontend/apps/reality-web/src/components/home/HomeCTA.tsx
+++ b/frontend/apps/reality-web/src/components/home/HomeCTA.tsx
@@ -83,8 +83,16 @@ export function HomeCTA() {
             padding: 8px 16px 32px;
           }
         }
-        .btn-pri,
-        .btn-sec {
+        /*
+         * :global() — Link from next-intl/navigation renders its own <a>,
+         * which styled-jsx can't tag with the component's hashed className.
+         * Without :global(), .btn-pri / .btn-sec selectors won't match the
+         * Link-rendered <a> and the buttons render as plain text. Scoping
+         * stays tight because the wrapping .actions block still has the
+         * hashed class — these rules only target classNames we set ourselves.
+         */
+        .actions :global(.btn-pri),
+        .actions :global(.btn-sec) {
           padding: 10px 16px;
           font-size: 13.5px;
           font-weight: var(--ppt-font-weight-semibold, 600);
@@ -96,26 +104,26 @@ export function HomeCTA() {
           transition: background var(--ppt-transition-fast),
             border-color var(--ppt-transition-fast);
         }
-        .btn-pri {
+        .actions :global(.btn-pri) {
           background: var(--ppt-color-primary);
           color: var(--ppt-fg-on-accent, #fff);
           border: 1px solid var(--ppt-color-primary);
         }
-        .btn-pri:hover {
+        .actions :global(.btn-pri):hover {
           background: var(--ppt-color-primary-hover);
           border-color: var(--ppt-color-primary-hover);
         }
-        .btn-sec {
+        .actions :global(.btn-sec) {
           background: var(--ppt-bg-surface);
           color: var(--ppt-fg-secondary);
           border: 1px solid var(--ppt-border-default);
         }
-        .btn-sec:hover {
+        .actions :global(.btn-sec):hover {
           background: var(--ppt-bg-subtle);
           border-color: var(--ppt-border-strong);
         }
-        .btn-pri:focus-visible,
-        .btn-sec:focus-visible {
+        .actions :global(.btn-pri):focus-visible,
+        .actions :global(.btn-sec):focus-visible {
           outline: none;
           box-shadow: var(--ppt-focus-ring-shadow);
         }

--- a/frontend/apps/reality-web/src/components/home/HomeCTA.tsx
+++ b/frontend/apps/reality-web/src/components/home/HomeCTA.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+/**
+ * Selling-CTA — homepage section #6 in the design system.
+ *
+ * Soft-blue panel that closes the homepage above the footer. Two actions
+ * (secondary "Learn more" → /about, primary "Start listing" → /sell).
+ *
+ * Design reference:
+ *   project/Reality Portal Home - Standalone.html `section.cta`
+ *   project/colors_and_type.css `.cta / .btn-pri / .btn-sec`
+ */
+
+import { useTranslations } from 'next-intl';
+import { Link } from '../../i18n/routing';
+
+export function HomeCTA() {
+  const t = useTranslations('home.cta');
+  return (
+    <section className="cta-wrap">
+      <div className="cta">
+        <div className="copy">
+          <h3 className="title">{t('title')}</h3>
+          <p className="body">{t('body')}</p>
+        </div>
+        <div className="actions">
+          <Link href="/about" className="btn-sec">
+            {t('learnMore')}
+          </Link>
+          <Link href="/sell" className="btn-pri">
+            {t('startListing')}
+          </Link>
+        </div>
+      </div>
+
+      <style jsx>{`
+        .cta-wrap {
+          padding: 16px 32px 48px;
+        }
+        .cta {
+          max-width: var(--ppt-content-max, 1280px);
+          margin: 40px auto 0;
+          padding: 36px 40px;
+          background: var(--ppt-color-primary-soft-bg, #eff6ff);
+          border: 1px solid var(--ppt-color-primary-soft-border, #dbeafe);
+          border-radius: 14px;
+          display: grid;
+          grid-template-columns: 1fr auto;
+          gap: 24px;
+          align-items: center;
+        }
+        .copy {
+          min-width: 0;
+        }
+        .title {
+          font-size: 22px;
+          font-weight: var(--ppt-font-weight-bold, 700);
+          color: var(--ppt-fg-primary);
+          margin: 0 0 6px;
+          letter-spacing: -0.01em;
+        }
+        .body {
+          font-size: var(--ppt-font-size-sm, 14px);
+          color: var(--ppt-fg-secondary);
+          margin: 0;
+          max-width: 560px;
+          line-height: 1.5;
+        }
+        .actions {
+          display: flex;
+          gap: 8px;
+          flex-shrink: 0;
+        }
+        @media (max-width: 768px) {
+          .cta {
+            grid-template-columns: 1fr;
+            padding: 28px 24px;
+          }
+          .actions {
+            flex-wrap: wrap;
+          }
+          .cta-wrap {
+            padding: 8px 16px 32px;
+          }
+        }
+        .btn-pri,
+        .btn-sec {
+          padding: 10px 16px;
+          font-size: 13.5px;
+          font-weight: var(--ppt-font-weight-semibold, 600);
+          border-radius: 8px;
+          text-decoration: none;
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          transition: background var(--ppt-transition-fast),
+            border-color var(--ppt-transition-fast);
+        }
+        .btn-pri {
+          background: var(--ppt-color-primary);
+          color: var(--ppt-fg-on-accent, #fff);
+          border: 1px solid var(--ppt-color-primary);
+        }
+        .btn-pri:hover {
+          background: var(--ppt-color-primary-hover);
+          border-color: var(--ppt-color-primary-hover);
+        }
+        .btn-sec {
+          background: var(--ppt-bg-surface);
+          color: var(--ppt-fg-secondary);
+          border: 1px solid var(--ppt-border-default);
+        }
+        .btn-sec:hover {
+          background: var(--ppt-bg-subtle);
+          border-color: var(--ppt-border-strong);
+        }
+        .btn-pri:focus-visible,
+        .btn-sec:focus-visible {
+          outline: none;
+          box-shadow: var(--ppt-focus-ring-shadow);
+        }
+      `}</style>
+    </section>
+  );
+}

--- a/frontend/apps/reality-web/src/components/home/PopularNeighbourhoods.tsx
+++ b/frontend/apps/reality-web/src/components/home/PopularNeighbourhoods.tsx
@@ -161,17 +161,24 @@ export function PopularNeighbourhoods() {
           color: var(--ppt-fg-muted);
           margin: 4px 0 0;
         }
-        .see-all {
+        /*
+         * :global() — Link from next-intl/navigation renders its own <a>
+         * outside of styled-jsx's scoping (no jsx-hash on the rendered
+         * element), so .see-all and .card selectors below have to opt out
+         * of scoping. Wrapping selector (.sec-hd / .grid) still carries
+         * the hash, keeping the rules tightly bound to this component.
+         */
+        .sec-hd :global(.see-all) {
           color: var(--ppt-color-primary);
           font-size: 13.5px;
           font-weight: var(--ppt-font-weight-semibold, 600);
           text-decoration: none;
           flex-shrink: 0;
         }
-        .see-all::after {
+        .sec-hd :global(.see-all)::after {
           content: ' →';
         }
-        .see-all:hover {
+        .sec-hd :global(.see-all):hover {
           text-decoration: underline;
         }
         .grid {
@@ -192,7 +199,7 @@ export function PopularNeighbourhoods() {
             padding: 32px 16px 16px;
           }
         }
-        .card {
+        .grid :global(.card) {
           display: block;
           background: var(--ppt-bg-surface);
           border: 1px solid var(--ppt-border-default);
@@ -204,21 +211,21 @@ export function PopularNeighbourhoods() {
             box-shadow var(--ppt-transition-fast),
             transform var(--ppt-transition-fast);
         }
-        .card:hover {
+        .grid :global(.card):hover {
           border-color: var(--ppt-color-primary);
           box-shadow: var(--ppt-shadow-lg, 0 4px 12px rgba(0, 0, 0, 0.15));
           transform: translateY(-2px);
         }
-        .card:focus-visible {
+        .grid :global(.card):focus-visible {
           outline: none;
           box-shadow: var(--ppt-focus-ring-shadow);
         }
-        .img {
+        .grid :global(.card) :global(.img) {
           aspect-ratio: 2 / 1;
           background: linear-gradient(135deg, var(--a), var(--b));
           position: relative;
         }
-        .img::after {
+        .grid :global(.card) :global(.img)::after {
           content: '';
           position: absolute;
           inset: 0;
@@ -228,7 +235,7 @@ export function PopularNeighbourhoods() {
             rgba(0, 0, 0, 0.35) 100%
           );
         }
-        .lbl {
+        .grid :global(.card) :global(.lbl) {
           position: absolute;
           left: 14px;
           bottom: 12px;
@@ -236,27 +243,27 @@ export function PopularNeighbourhoods() {
           color: #fff;
           line-height: 1.3;
         }
-        .lbl strong {
+        .grid :global(.card) :global(.lbl) strong {
           display: block;
           font-size: 17px;
           font-weight: var(--ppt-font-weight-bold, 700);
         }
-        .lbl small {
+        .grid :global(.card) :global(.lbl) small {
           font-size: 12px;
           opacity: 0.9;
         }
-        .body {
+        .grid :global(.card) :global(.body) {
           padding: 14px 16px;
           display: flex;
           justify-content: space-between;
           align-items: center;
         }
-        .cta {
+        .grid :global(.card) :global(.cta) {
           font-size: 13px;
           color: var(--ppt-fg-secondary);
           font-weight: var(--ppt-font-weight-medium, 500);
         }
-        .arrow {
+        .grid :global(.card) :global(.arrow) {
           color: var(--ppt-color-primary);
           font-weight: var(--ppt-font-weight-bold, 700);
         }

--- a/frontend/apps/reality-web/src/components/home/PopularNeighbourhoods.tsx
+++ b/frontend/apps/reality-web/src/components/home/PopularNeighbourhoods.tsx
@@ -18,7 +18,7 @@ import { useTranslations } from 'next-intl';
 import { Link } from '../../i18n/routing';
 
 type Neighbourhood = {
-  /** URL-safe id used as the React key and the gradient `data-tone` selector. */
+  /** URL-safe id, used as the React key. */
   id: string;
   /** District label (translated client-side). */
   nameKey: string;
@@ -31,6 +31,15 @@ type Neighbourhood = {
   tone: { from: string; to: string };
 };
 
+/**
+ * The `tone` hex values intentionally bypass the brand-token palette: they
+ * are decorative district identifiers (a stand-in for real photos, which
+ * the listings API doesn't expose yet) and have no theme-driven meaning.
+ * Light-on-blue + dark-overlay is the same composition in both themes, so
+ * the colors don't need a dark-mode pairing. If this set grows beyond a
+ * handful of districts, move it to `--ppt-tone-*` tokens or a generated
+ * palette from the district name. Until then, inline literals are fine.
+ */
 const NEIGHBOURHOODS: Neighbourhood[] = [
   {
     id: 'ruzinov',
@@ -111,8 +120,10 @@ export function PopularNeighbourhoods() {
               <div
                 className="img"
                 style={{
-                  // CSS-vars feed `linear-gradient(135deg, var(--a), var(--b))`
-                  // — picked up by the ::after overlay below.
+                  // CSS-vars are read by the .img background-image rule
+                  // below (linear-gradient(135deg, var(--a), var(--b))).
+                  // The ::after pseudo on the same element layers a dark
+                  // bottom overlay on top — that one uses fixed colors.
                   ['--a' as string]: n.tone.from,
                   ['--b' as string]: n.tone.to,
                 }}

--- a/frontend/apps/reality-web/src/components/home/PopularNeighbourhoods.tsx
+++ b/frontend/apps/reality-web/src/components/home/PopularNeighbourhoods.tsx
@@ -1,0 +1,266 @@
+'use client';
+
+/**
+ * Popular neighbourhoods — homepage section #4 in the design system.
+ *
+ * The reality-server doesn't aggregate listings by district yet, so this is
+ * a curated marketing surface (matches the design which also hardcoded six
+ * neighbourhoods). Each card links to `/listings?city=…&district=…` so it
+ * doubles as discovery — when the API ships an aggregation endpoint we can
+ * swap the static list for a hook without touching the markup.
+ *
+ * Design reference:
+ *   project/Reality Portal Home - Standalone.html `section.wrap` #4
+ *   project/colors_and_type.css `.nbh / .nbhcard / .nimg / .nbody`
+ */
+
+import { useTranslations } from 'next-intl';
+import { Link } from '../../i18n/routing';
+
+type Neighbourhood = {
+  /** URL-safe id used as the React key and the gradient `data-tone` selector. */
+  id: string;
+  /** District label (translated client-side). */
+  nameKey: string;
+  /** Parent city label (already localised in messages). */
+  cityKey: string;
+  /** Query for /listings — kept here so the component owns its routing. */
+  city: string;
+  district: string;
+  /** Two-stop gradient for the photo placeholder (no real images yet). */
+  tone: { from: string; to: string };
+};
+
+const NEIGHBOURHOODS: Neighbourhood[] = [
+  {
+    id: 'ruzinov',
+    nameKey: 'ruzinov',
+    cityKey: 'bratislava',
+    city: 'Bratislava',
+    district: 'Ružinov',
+    tone: { from: '#60a5fa', to: '#1e40af' },
+  },
+  {
+    id: 'stare-mesto',
+    nameKey: 'staremesto',
+    cityKey: 'bratislava',
+    city: 'Bratislava',
+    district: 'Staré Mesto',
+    tone: { from: '#fbbf24', to: '#d97706' },
+  },
+  {
+    id: 'petrzalka',
+    nameKey: 'petrzalka',
+    cityKey: 'bratislava',
+    city: 'Bratislava',
+    district: 'Petržalka',
+    tone: { from: '#34d399', to: '#047857' },
+  },
+  {
+    id: 'nove-mesto',
+    nameKey: 'novemesto',
+    cityKey: 'bratislava',
+    city: 'Bratislava',
+    district: 'Nové Mesto',
+    tone: { from: '#a78bfa', to: '#5b21b6' },
+  },
+  {
+    id: 'karlova-ves',
+    nameKey: 'karlovaves',
+    cityKey: 'bratislava',
+    city: 'Bratislava',
+    district: 'Karlova Ves',
+    tone: { from: '#f472b6', to: '#9d174d' },
+  },
+  {
+    id: 'dubravka',
+    nameKey: 'dubravka',
+    cityKey: 'bratislava',
+    city: 'Bratislava',
+    district: 'Dúbravka',
+    tone: { from: '#22d3ee', to: '#155e75' },
+  },
+];
+
+export function PopularNeighbourhoods() {
+  const t = useTranslations('home.neighbourhoods');
+  const tCity = useTranslations('home.city');
+
+  return (
+    <section className="section">
+      <div className="container">
+        <div className="sec-hd">
+          <div>
+            <h2 className="title">{t('title')}</h2>
+            <p className="subtitle">{t('subtitle')}</p>
+          </div>
+          <Link href="/price-map" className="see-all">
+            {t('exploreMap')}
+          </Link>
+        </div>
+        <div className="grid">
+          {NEIGHBOURHOODS.map((n) => (
+            <Link
+              key={n.id}
+              href={{
+                pathname: '/listings',
+                query: { city: n.city, district: n.district },
+              }}
+              className="card"
+            >
+              <div
+                className="img"
+                style={{
+                  // CSS-vars feed `linear-gradient(135deg, var(--a), var(--b))`
+                  // — picked up by the ::after overlay below.
+                  ['--a' as string]: n.tone.from,
+                  ['--b' as string]: n.tone.to,
+                }}
+              >
+                <div className="lbl">
+                  <strong>{t(n.nameKey)}</strong>
+                  <small>{tCity(n.cityKey)}</small>
+                </div>
+              </div>
+              <div className="body">
+                <span className="cta">{t('browse')}</span>
+                <span className="arrow" aria-hidden="true">
+                  →
+                </span>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+
+      <style jsx>{`
+        .section {
+          padding: 40px 32px 24px;
+          background: var(--ppt-bg-app);
+        }
+        .container {
+          max-width: var(--ppt-content-max, 1280px);
+          margin: 0 auto;
+        }
+        .sec-hd {
+          display: flex;
+          justify-content: space-between;
+          align-items: flex-end;
+          margin-bottom: 24px;
+          gap: 16px;
+        }
+        .title {
+          font-size: 22px;
+          font-weight: var(--ppt-font-weight-bold, 700);
+          color: var(--ppt-fg-primary);
+          margin: 0;
+          letter-spacing: -0.01em;
+        }
+        .subtitle {
+          font-size: var(--ppt-font-size-sm, 14px);
+          color: var(--ppt-fg-muted);
+          margin: 4px 0 0;
+        }
+        .see-all {
+          color: var(--ppt-color-primary);
+          font-size: 13.5px;
+          font-weight: var(--ppt-font-weight-semibold, 600);
+          text-decoration: none;
+          flex-shrink: 0;
+        }
+        .see-all::after {
+          content: ' →';
+        }
+        .see-all:hover {
+          text-decoration: underline;
+        }
+        .grid {
+          display: grid;
+          grid-template-columns: repeat(3, 1fr);
+          gap: 16px;
+        }
+        @media (max-width: 1024px) {
+          .grid {
+            grid-template-columns: repeat(2, 1fr);
+          }
+        }
+        @media (max-width: 640px) {
+          .grid {
+            grid-template-columns: 1fr;
+          }
+          .section {
+            padding: 32px 16px 16px;
+          }
+        }
+        .card {
+          display: block;
+          background: var(--ppt-bg-surface);
+          border: 1px solid var(--ppt-border-default);
+          border-radius: 12px;
+          overflow: hidden;
+          text-decoration: none;
+          color: inherit;
+          transition: border-color var(--ppt-transition-fast),
+            box-shadow var(--ppt-transition-fast),
+            transform var(--ppt-transition-fast);
+        }
+        .card:hover {
+          border-color: var(--ppt-color-primary);
+          box-shadow: var(--ppt-shadow-lg, 0 4px 12px rgba(0, 0, 0, 0.15));
+          transform: translateY(-2px);
+        }
+        .card:focus-visible {
+          outline: none;
+          box-shadow: var(--ppt-focus-ring-shadow);
+        }
+        .img {
+          aspect-ratio: 2 / 1;
+          background: linear-gradient(135deg, var(--a), var(--b));
+          position: relative;
+        }
+        .img::after {
+          content: '';
+          position: absolute;
+          inset: 0;
+          background: linear-gradient(
+            180deg,
+            transparent 40%,
+            rgba(0, 0, 0, 0.35) 100%
+          );
+        }
+        .lbl {
+          position: absolute;
+          left: 14px;
+          bottom: 12px;
+          z-index: 2;
+          color: #fff;
+          line-height: 1.3;
+        }
+        .lbl strong {
+          display: block;
+          font-size: 17px;
+          font-weight: var(--ppt-font-weight-bold, 700);
+        }
+        .lbl small {
+          font-size: 12px;
+          opacity: 0.9;
+        }
+        .body {
+          padding: 14px 16px;
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+        }
+        .cta {
+          font-size: 13px;
+          color: var(--ppt-fg-secondary);
+          font-weight: var(--ppt-font-weight-medium, 500);
+        }
+        .arrow {
+          color: var(--ppt-color-primary);
+          font-weight: var(--ppt-font-weight-bold, 700);
+        }
+      `}</style>
+    </section>
+  );
+}

--- a/frontend/apps/reality-web/src/components/home/ValueStrip.tsx
+++ b/frontend/apps/reality-web/src/components/home/ValueStrip.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+/**
+ * Value strip — homepage section #5 in the design system.
+ *
+ * Four-cell stat bar that sits between Featured listings and the closing
+ * CTA. Marketing copy lives in i18n; the numeric values (verified-agents
+ * count, building-passport coverage %, price-history horizon, mortgage
+ * pre-approval SLA) are hardcoded as marketing claims because nothing in
+ * the API exposes them yet.
+ *
+ * Design reference:
+ *   project/Reality Portal Home - Standalone.html `section.value`
+ *   project/colors_and_type.css `.value / .value-inner / .vcell`
+ */
+
+import { useTranslations } from 'next-intl';
+
+const CELLS = [
+  { key: 'agents', value: '1,120' },
+  { key: 'passport', value: '98%' },
+  { key: 'history', value: '5y' },
+  { key: 'mortgage', value: '48h' },
+] as const;
+
+export function ValueStrip() {
+  const t = useTranslations('home.value');
+  return (
+    <section className="value">
+      <div className="inner">
+        {CELLS.map((c) => (
+          <div key={c.key} className="cell">
+            <div className="label">{t(`${c.key}.label`)}</div>
+            <div className="num">{c.value}</div>
+            <div className="desc">{t(`${c.key}.desc`)}</div>
+          </div>
+        ))}
+      </div>
+
+      <style jsx>{`
+        .value {
+          background: var(--ppt-bg-surface);
+          border-top: 1px solid var(--ppt-border-default);
+          border-bottom: 1px solid var(--ppt-border-default);
+          padding: 32px 0;
+          margin-top: 40px;
+        }
+        .inner {
+          max-width: var(--ppt-content-max, 1280px);
+          margin: 0 auto;
+          padding: 0 32px;
+          display: grid;
+          grid-template-columns: repeat(4, 1fr);
+          gap: 32px;
+        }
+        @media (max-width: 1024px) {
+          .inner {
+            grid-template-columns: repeat(2, 1fr);
+            row-gap: 24px;
+          }
+        }
+        @media (max-width: 640px) {
+          .inner {
+            grid-template-columns: 1fr;
+            padding: 0 16px;
+          }
+        }
+        .cell {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+        }
+        .label {
+          font-size: 12px;
+          color: var(--ppt-fg-muted);
+          text-transform: uppercase;
+          letter-spacing: 0.06em;
+          font-weight: var(--ppt-font-weight-semibold, 600);
+        }
+        .num {
+          font-size: 26px;
+          font-weight: 800;
+          color: var(--ppt-fg-primary);
+          letter-spacing: -0.01em;
+        }
+        .desc {
+          font-size: 13px;
+          color: var(--ppt-fg-secondary);
+          margin-top: 2px;
+          /* German runs ~35% longer than English — design rule says wrap, never truncate. */
+          overflow-wrap: break-word;
+          hyphens: auto;
+        }
+      `}</style>
+    </section>
+  );
+}

--- a/frontend/apps/reality-web/src/components/home/index.ts
+++ b/frontend/apps/reality-web/src/components/home/index.ts
@@ -7,3 +7,6 @@
 export { CategoryCards } from './CategoryCards';
 export { FeaturedListings } from './FeaturedListings';
 export { HeroSearch } from './HeroSearch';
+export { HomeCTA } from './HomeCTA';
+export { PopularNeighbourhoods } from './PopularNeighbourhoods';
+export { ValueStrip } from './ValueStrip';

--- a/frontend/apps/reality-web/src/components/listings/ListingCard.tsx
+++ b/frontend/apps/reality-web/src/components/listings/ListingCard.tsx
@@ -286,7 +286,7 @@ export function ListingCard({
         }
 
         .favorite-button:hover {
-          background: #fff;
+          background: var(--ppt-bg-surface);
           color: var(--ppt-color-danger);
         }
 

--- a/frontend/apps/reality-web/src/components/listings/SearchBar.tsx
+++ b/frontend/apps/reality-web/src/components/listings/SearchBar.tsx
@@ -140,6 +140,13 @@ export function SearchBar({ initialQuery = '', onSearch }: SearchBarProps) {
           className="search-input"
           placeholder={t('placeholder')}
           value={query}
+          // Browsers (Chrome 120+) inject `caret-color: transparent` into
+          // the inline style of any input they think is being autofilled,
+          // which races with React's SSR-rendered style attribute and
+          // triggers a hydration warning. The DOM rebuilds correctly on
+          // hydration; suppressing the warning here keeps the console
+          // clean without papering over real mismatches.
+          suppressHydrationWarning
           onChange={(e) => setQuery(e.target.value)}
           onFocus={() => setShowSuggestions(true)}
         />

--- a/frontend/apps/reality-web/src/components/ui/Header.tsx
+++ b/frontend/apps/reality-web/src/components/ui/Header.tsx
@@ -210,7 +210,9 @@ export function Header() {
             className="nav-link-mobile"
             onClick={() => setShowMobileMenu(false)}
           >
-            {t('search.sale')}
+            {/* Desktop uses search.buy ("Kúpiť") for the same action.
+                Mobile keeps that wording aligned. */}
+            {t('search.buy')}
           </Link>
           <Link
             href="/listings?transactionType=rent"

--- a/frontend/apps/reality-web/src/components/ui/Header.tsx
+++ b/frontend/apps/reality-web/src/components/ui/Header.tsx
@@ -286,14 +286,20 @@ export function Header() {
           gap: 24px;
         }
 
-        .logo {
+        /*
+         * :global() — Link from next-intl/navigation renders its own <a>
+         * outside styled-jsx's hashed-class scoping. The wrapping .header-inner
+         * still carries the hash, keeping the rules tightly bound to this
+         * component while the inner Link-rendered <a> still picks them up.
+         */
+        .header-inner :global(.logo) {
           display: inline-flex;
           align-items: center;
           gap: 8px;
           text-decoration: none;
           flex-shrink: 0;
         }
-        .logo:focus-visible {
+        .header-inner :global(.logo):focus-visible {
           outline: none;
           border-radius: var(--ppt-radius-md);
           box-shadow: var(--ppt-focus-ring-shadow);
@@ -304,6 +310,7 @@ export function Header() {
           border-radius: 8px;
           background: var(--ppt-color-primary);
           flex-shrink: 0;
+          display: inline-block;
         }
         .logo-text {
           font-size: 18px;
@@ -331,7 +338,7 @@ export function Header() {
           }
         }
 
-        .nav-link {
+        .nav-desktop :global(.nav-link) {
           padding: 8px 14px;
           border-radius: var(--ppt-radius-md);
           font-size: 13.5px;
@@ -342,12 +349,12 @@ export function Header() {
                       color var(--ppt-transition-fast);
         }
 
-        .nav-link:hover {
+        .nav-desktop :global(.nav-link):hover {
           color: var(--ppt-color-primary);
           background: var(--ppt-color-primary-soft-bg);
         }
 
-        .nav-link-active {
+        .nav-desktop :global(.nav-link-active) {
           color: var(--ppt-color-primary);
           background: var(--ppt-color-primary-soft-bg);
         }
@@ -519,7 +526,7 @@ export function Header() {
           padding: 4px;
         }
 
-        .menu-item {
+        .dropdown-menu :global(.menu-item) {
           display: block;
           width: 100%;
           padding: 8px 10px;
@@ -530,7 +537,7 @@ export function Header() {
           transition: background var(--ppt-transition-fast);
         }
 
-        .menu-item:hover {
+        .dropdown-menu :global(.menu-item):hover {
           background-color: var(--ppt-bg-subtle);
         }
 
@@ -588,7 +595,7 @@ export function Header() {
           }
         }
 
-        .nav-link-mobile {
+        .nav-mobile :global(.nav-link-mobile) {
           padding: 12px 4px;
           color: var(--ppt-fg-secondary);
           text-decoration: none;
@@ -597,22 +604,22 @@ export function Header() {
           border-bottom: 1px solid var(--ppt-border-subtle);
         }
 
-        .nav-link-mobile:hover {
+        .nav-mobile :global(.nav-link-mobile):hover {
           color: var(--ppt-color-primary);
         }
 
-        .nav-link-mobile:last-child {
+        .nav-mobile :global(.nav-link-mobile):last-child {
           border-bottom: none;
         }
 
         /* Highlight the seller CTA inside the mobile menu so it doesn't blend
            with the other nav rows. Keeps the same border-row look but tints
            the text and adds the same arrow affordance the design uses. */
-        .nav-link-mobile.sell-cta-mobile {
+        .nav-mobile :global(.nav-link-mobile.sell-cta-mobile) {
           color: var(--ppt-color-primary);
           font-weight: var(--ppt-font-weight-semibold);
         }
-        .nav-link-mobile.sell-cta-mobile::after {
+        .nav-mobile :global(.nav-link-mobile.sell-cta-mobile)::after {
           content: ' →';
         }
       `}</style>

--- a/frontend/apps/reality-web/src/components/ui/Header.tsx
+++ b/frontend/apps/reality-web/src/components/ui/Header.tsx
@@ -266,7 +266,31 @@ export function Header() {
               >
                 {t('nav.myInquiries')}
               </Link>
+              <button
+                type="button"
+                className="nav-link-mobile auth-cta-mobile"
+                onClick={() => {
+                  setShowMobileMenu(false);
+                  logout();
+                }}
+              >
+                {t('common.logout')}
+              </button>
             </>
+          )}
+          {/* Sign-in entry on mobile — replaces the auth-slot button that's
+              hidden by media query below 768 px. */}
+          {!isAuthenticated && (
+            <button
+              type="button"
+              className="nav-link-mobile auth-cta-mobile"
+              onClick={() => {
+                setShowMobileMenu(false);
+                login();
+              }}
+            >
+              {t('common.login')}
+            </button>
           )}
         </nav>
       )}
@@ -413,8 +437,10 @@ export function Header() {
 
         @media (max-width: 767px) {
           .auth-slot {
-            min-width: 60px;
-            justify-content: flex-end;
+            /* Hide the entire auth slot on mobile — the hamburger menu has
+               its own Sign in / Logout entry, so duplicating the affordance
+               here costs ~140 px of header width and forces overflow. */
+            display: none;
           }
         }
 
@@ -625,6 +651,19 @@ export function Header() {
         }
         .nav-mobile :global(.nav-link-mobile.sell-cta-mobile)::after {
           content: ' →';
+        }
+
+        /* Sign in / Logout entries inside the mobile menu — render as
+           buttons (they trigger login()/logout() rather than navigation)
+           but keep the same row look as the link entries. */
+        .nav-mobile :global(.nav-link-mobile.auth-cta-mobile) {
+          background: transparent;
+          border: none;
+          border-bottom: 1px solid var(--ppt-border-subtle);
+          cursor: pointer;
+          text-align: left;
+          font-family: var(--ppt-font-family);
+          width: 100%;
         }
       `}</style>
     </header>

--- a/frontend/apps/reality-web/src/components/ui/Header.tsx
+++ b/frontend/apps/reality-web/src/components/ui/Header.tsx
@@ -55,32 +55,49 @@ export function Header() {
   return (
     <header className="header">
       <div className="header-inner">
-        {/* Logo */}
-        <Link href="/" className="logo">
-          Reality Portal
+        {/* Logo — brand square + 2-tone wordmark. The square uses the same
+            brand-600 the wordmark uses; the second word ("Portal") drops to
+            fg-primary weight 600 so the brand sits visually first. Matches
+            the design's `.logo` rule from colors_and_type.css. */}
+        <Link href="/" className="logo" aria-label="Reality Portal">
+          <span className="logo-mark" aria-hidden="true" />
+          <span className="logo-text">
+            Reality<em className="logo-text-em">Portal</em>
+          </span>
         </Link>
 
-        {/* Desktop Navigation */}
+        {/* Desktop Navigation — Buy / Rent / Journal / Help. Sell is
+            represented by the "List your property" primary CTA on the right
+            (a separate /for-sellers info page would be where the design's
+            "Sell" nav link points; we don't have one yet, so the CTA is the
+            single seller affordance). */}
         <nav className="nav-desktop">
-          {/* Sale/Rent are quick-filters — no active state (query params
-              unavailable in the header without Suspense; the tab bar on
-              the listings page is the authoritative selection indicator) */}
           <Link href="/listings?transactionType=sale" className="nav-link">
-            {t('search.sale')}
+            {t('search.buy')}
           </Link>
           <Link href="/listings?transactionType=rent" className="nav-link">
             {t('search.rent')}
           </Link>
           <Link
-            href="/listings"
-            className={`nav-link ${isActive('/listings') ? 'nav-link-active' : ''}`}
+            href="/journal"
+            className={`nav-link ${isActive('/journal') ? 'nav-link-active' : ''}`}
           >
-            {t('nav.allListings')}
+            {t('nav.journal')}
+          </Link>
+          <Link href="/help" className={`nav-link ${isActive('/help') ? 'nav-link-active' : ''}`}>
+            {t('nav.help')}
           </Link>
         </nav>
 
         {/* Auth Section */}
         <div className="auth-section">
+          {/* Seller CTA — shown on >=768px only (mobile menu has its own
+              entry). Primary-color filled so it reads as the main action
+              even alongside the auth slot. */}
+          <Link href="/sell" className="list-cta">
+            {t('nav.listProperty')}
+          </Link>
+
           <LanguageSwitcher />
 
           {/*
@@ -205,6 +222,23 @@ export function Header() {
           >
             {t('nav.allListings')}
           </Link>
+          <Link
+            href="/journal"
+            className="nav-link-mobile"
+            onClick={() => setShowMobileMenu(false)}
+          >
+            {t('nav.journal')}
+          </Link>
+          <Link href="/help" className="nav-link-mobile" onClick={() => setShowMobileMenu(false)}>
+            {t('nav.help')}
+          </Link>
+          <Link
+            href="/sell"
+            className="nav-link-mobile sell-cta-mobile"
+            onClick={() => setShowMobileMenu(false)}
+          >
+            {t('nav.listProperty')}
+          </Link>
           {isAuthenticated && (
             <>
               <Link
@@ -253,12 +287,36 @@ export function Header() {
         }
 
         .logo {
+          display: inline-flex;
+          align-items: center;
+          gap: 8px;
+          text-decoration: none;
+          flex-shrink: 0;
+        }
+        .logo:focus-visible {
+          outline: none;
+          border-radius: var(--ppt-radius-md);
+          box-shadow: var(--ppt-focus-ring-shadow);
+        }
+        .logo-mark {
+          width: 28px;
+          height: 28px;
+          border-radius: 8px;
+          background: var(--ppt-color-primary);
+          flex-shrink: 0;
+        }
+        .logo-text {
           font-size: 18px;
           font-weight: 800;
           color: var(--ppt-color-primary);
-          text-decoration: none;
           letter-spacing: -0.02em;
-          flex-shrink: 0;
+          line-height: 1;
+        }
+        .logo-text-em {
+          font-style: normal;
+          color: var(--ppt-fg-primary);
+          font-weight: 600;
+          margin-left: 2px;
         }
 
         .nav-desktop {
@@ -299,6 +357,35 @@ export function Header() {
           align-items: center;
           gap: 8px;
           margin-left: auto;
+        }
+
+        /* Primary "List your property" CTA in the header. Same blue as the
+           brand square and the primary button used elsewhere; hidden on
+           narrow viewports (mobile menu has its own /sell entry). */
+        .auth-section :global(.list-cta) {
+          display: none;
+          padding: 8px 14px;
+          background: var(--ppt-color-primary);
+          color: var(--ppt-fg-on-accent, #fff);
+          border-radius: var(--ppt-radius-md);
+          font-size: var(--ppt-font-size-sm);
+          font-weight: var(--ppt-font-weight-semibold);
+          text-decoration: none;
+          transition: background var(--ppt-transition-fast);
+          white-space: nowrap;
+        }
+        .auth-section :global(.list-cta):hover {
+          background: var(--ppt-color-primary-hover);
+        }
+        .auth-section :global(.list-cta):focus-visible {
+          outline: none;
+          box-shadow: var(--ppt-focus-ring-shadow);
+        }
+        @media (min-width: 1024px) {
+          .auth-section :global(.list-cta) {
+            display: inline-flex;
+            align-items: center;
+          }
         }
 
         /* Reserve a constant width so the swap between the sign-in button
@@ -516,6 +603,17 @@ export function Header() {
 
         .nav-link-mobile:last-child {
           border-bottom: none;
+        }
+
+        /* Highlight the seller CTA inside the mobile menu so it doesn't blend
+           with the other nav rows. Keeps the same border-row look but tints
+           the text and adds the same arrow affordance the design uses. */
+        .nav-link-mobile.sell-cta-mobile {
+          color: var(--ppt-color-primary);
+          font-weight: var(--ppt-font-weight-semibold);
+        }
+        .nav-link-mobile.sell-cta-mobile::after {
+          content: ' →';
         }
       `}</style>
     </header>

--- a/frontend/apps/reality-web/src/components/ui/Header.tsx
+++ b/frontend/apps/reality-web/src/components/ui/Header.tsx
@@ -66,17 +66,21 @@ export function Header() {
           </span>
         </Link>
 
-        {/* Desktop Navigation — Buy / Rent / Journal / Help. Sell is
-            represented by the "List your property" primary CTA on the right
-            (a separate /for-sellers info page would be where the design's
-            "Sell" nav link points; we don't have one yet, so the CTA is the
-            single seller affordance). */}
+        {/* Desktop Navigation — five links matching the design's standard
+            header (Predaj / Prenájom / Predať / Magazín / Pomoc). The
+            "Predať" entry (Sell) is the seller-info entry point; the
+            primary "Pridať nehnuteľnosť" CTA on the right is the action
+            shortcut. Both currently route to /sell — when a dedicated
+            /for-sellers info page lands the nav entry will move there. */}
         <nav className="nav-desktop">
           <Link href="/listings?transactionType=sale" className="nav-link">
             {t('search.buy')}
           </Link>
           <Link href="/listings?transactionType=rent" className="nav-link">
             {t('search.rent')}
+          </Link>
+          <Link href="/sell" className={`nav-link ${isActive('/sell') ? 'nav-link-active' : ''}`}>
+            {t('nav.sell')}
           </Link>
           <Link
             href="/journal"

--- a/frontend/apps/reality-web/src/components/ui/LanguageSwitcher.test.tsx
+++ b/frontend/apps/reality-web/src/components/ui/LanguageSwitcher.test.tsx
@@ -1,10 +1,14 @@
 /**
- * LanguageSwitcher Component Tests
+ * LanguageSwitcher Component Tests (Epic 111).
  *
- * Tests for language switching functionality (Epic 111).
+ * The original test asserted a native <select> (role=combobox). The
+ * component was rewritten as a custom popover (trigger button + listbox
+ * div with role=option entries) — these tests assert the new interaction
+ * model: trigger click opens the menu, options become visible, clicking
+ * one calls router.replace().
  */
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { LanguageSwitcher } from './LanguageSwitcher';
 
@@ -25,6 +29,11 @@ vi.mock('../../i18n', () => ({
   },
 }));
 
+// next-intl's useLocale is read inside the component — mock returns 'en'.
+vi.mock('next-intl', () => ({
+  useLocale: () => 'en',
+}));
+
 // Mock routing
 const mockReplace = vi.fn();
 vi.mock('../../i18n/routing', () => ({
@@ -40,17 +49,25 @@ describe('LanguageSwitcher', () => {
     mockReplace.mockClear();
   });
 
-  it('renders language selector', () => {
+  it('renders a trigger button with the active locale code', () => {
     render(<LanguageSwitcher />);
-    expect(screen.getByRole('combobox', { name: /select language/i })).toBeInTheDocument();
+    const trigger = screen.getByRole('button', { name: /language: english/i });
+    expect(trigger).toBeInTheDocument();
+    // Code label inside the trigger uses uppercase locale
+    expect(trigger.textContent).toMatch(/EN/);
   });
 
-  it('displays all available languages as options', () => {
+  it('does not show the listbox until the trigger is clicked', () => {
     render(<LanguageSwitcher />);
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
 
-    const select = screen.getByRole('combobox', { name: /select language/i });
-    const options = select.querySelectorAll('option');
-
+  it('opens the listbox on trigger click and shows all four locales', () => {
+    render(<LanguageSwitcher />);
+    fireEvent.click(screen.getByRole('button', { name: /language: english/i }));
+    const listbox = screen.getByRole('listbox');
+    expect(listbox).toBeInTheDocument();
+    const options = screen.getAllByRole('option');
     expect(options).toHaveLength(4);
     expect(screen.getByText(/English/)).toBeInTheDocument();
     expect(screen.getByText(/Slovenčina/)).toBeInTheDocument();
@@ -58,31 +75,30 @@ describe('LanguageSwitcher', () => {
     expect(screen.getByText(/Deutsch/)).toBeInTheDocument();
   });
 
-  it('has current locale selected by default', () => {
+  it('marks the active locale option as aria-selected', () => {
     render(<LanguageSwitcher />);
-
-    const select = screen.getByRole('combobox', { name: /select language/i });
-    expect(select).toHaveValue('en');
+    fireEvent.click(screen.getByRole('button', { name: /language: english/i }));
+    const active = screen.getAllByRole('option').find((el) => el.textContent?.includes('English'));
+    expect(active).toHaveAttribute('aria-selected', 'true');
   });
 
-  it('calls router.replace when language is changed', () => {
+  it('calls router.replace with the chosen locale and closes the menu', () => {
     render(<LanguageSwitcher />);
-
-    const select = screen.getByRole('combobox', { name: /select language/i });
-    fireEvent.change(select, { target: { value: 'sk' } });
-
-    // Note: Due to startTransition, this may not be called synchronously
-    // In a real test with act(), we would wait for the transition
+    fireEvent.click(screen.getByRole('button', { name: /language: english/i }));
+    const sk = screen.getAllByRole('option').find((el) => el.textContent?.includes('Slovenčina'));
+    expect(sk).toBeTruthy();
+    act(() => {
+      fireEvent.click(sk!);
+    });
     expect(mockReplace).toHaveBeenCalledWith('/listings', { locale: 'sk' });
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
   });
 
-  it('displays flag emojis with language names', () => {
+  it('closes the menu when Escape is pressed', () => {
     render(<LanguageSwitcher />);
-
-    // Check that flags are displayed
-    expect(screen.getByText(/🇬🇧/)).toBeInTheDocument();
-    expect(screen.getByText(/🇸🇰/)).toBeInTheDocument();
-    expect(screen.getByText(/🇨🇿/)).toBeInTheDocument();
-    expect(screen.getByText(/🇩🇪/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /language: english/i }));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
   });
 });

--- a/frontend/apps/reality-web/src/components/ui/LanguageSwitcher.tsx
+++ b/frontend/apps/reality-web/src/components/ui/LanguageSwitcher.tsx
@@ -93,40 +93,43 @@ export function LanguageSwitcher() {
       </button>
 
       {open && (
-        <ul className="lang-menu" role="listbox" aria-label="Select language">
+        // <div role="listbox"> rather than <ul role="listbox"> — biome's
+        // noNoninteractiveElementToInteractiveRole rejects the ARIA role
+        // on a semantic list element. ARIA Combobox pattern works with
+        // plain div containers.
+        <div className="lang-menu" role="listbox" aria-label="Select language">
           {locales.map((loc) => (
-            <li key={loc}>
-              <button
-                type="button"
-                role="option"
-                aria-selected={loc === locale}
-                className={`lang-item ${loc === locale ? 'active' : ''}`}
-                onClick={() => choose(loc)}
-              >
-                <span className="flag" aria-hidden="true">
-                  {localeFlags[loc]}
-                </span>
-                <span className="name">{localeNames[loc]}</span>
-                {loc === locale && (
-                  <svg
-                    className="check"
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    aria-hidden="true"
-                  >
-                    <polyline points="20 6 9 17 4 12" />
-                  </svg>
-                )}
-              </button>
-            </li>
+            <button
+              key={loc}
+              type="button"
+              role="option"
+              aria-selected={loc === locale}
+              className={`lang-item ${loc === locale ? 'active' : ''}`}
+              onClick={() => choose(loc)}
+            >
+              <span className="flag" aria-hidden="true">
+                {localeFlags[loc]}
+              </span>
+              <span className="name">{localeNames[loc]}</span>
+              {loc === locale && (
+                <svg
+                  className="check"
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+              )}
+            </button>
           ))}
-        </ul>
+        </div>
       )}
 
       <style jsx>{`

--- a/frontend/apps/reality-web/src/components/ui/LanguageSwitcher.tsx
+++ b/frontend/apps/reality-web/src/components/ui/LanguageSwitcher.tsx
@@ -21,9 +21,29 @@ export function LanguageSwitcher() {
   const router = useRouter();
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
+  // Roving highlight in the open menu — starts on the currently-active
+  // locale and moves with Arrow keys. aria-activedescendant is set on the
+  // listbox so the assistive-tech focus indicator follows it without us
+  // having to move DOM focus around.
+  const [activeIndex, setActiveIndex] = useState(() =>
+    Math.max(
+      0,
+      locales.findIndex((l) => l === locale)
+    )
+  );
   const wrapRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
-  // Close on outside click + Escape (mouse + keyboard, no library)
+  // Re-sync the highlight to the active locale whenever it changes from
+  // outside (e.g. URL-driven locale swap).
+  useEffect(() => {
+    const i = locales.findIndex((l) => l === locale);
+    if (i >= 0) setActiveIndex(i);
+  }, [locale]);
+
+  // Keyboard navigation while the menu is open. Listening on the document
+  // because the listbox itself doesn't take focus (the trigger keeps it,
+  // per APG listbox-with-aria-activedescendant pattern).
   useEffect(() => {
     if (!open) return;
     const onClick = (e: MouseEvent) => {
@@ -32,7 +52,32 @@ export function LanguageSwitcher() {
       }
     };
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false);
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setOpen(false);
+        triggerRef.current?.focus();
+        return;
+      }
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActiveIndex((i) => Math.min(locales.length - 1, i + 1));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActiveIndex((i) => Math.max(0, i - 1));
+      } else if (e.key === 'Home') {
+        e.preventDefault();
+        setActiveIndex(0);
+      } else if (e.key === 'End') {
+        e.preventDefault();
+        setActiveIndex(locales.length - 1);
+      } else if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        setActiveIndex((i) => {
+          const target = locales[i];
+          if (target) choose(target);
+          return i;
+        });
+      }
     };
     document.addEventListener('mousedown', onClick);
     document.addEventListener('keydown', onKey);
@@ -40,23 +85,40 @@ export function LanguageSwitcher() {
       document.removeEventListener('mousedown', onClick);
       document.removeEventListener('keydown', onKey);
     };
+    // choose isn't in deps because the underlying functions (router,
+    // pathname) are referentially-stable from next-intl across renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
   const choose = (next: Locale) => {
     setOpen(false);
+    triggerRef.current?.focus();
     if (next === locale) return;
     router.replace(pathname, { locale: next });
+  };
+
+  const handleTriggerKey = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      setOpen(true);
+    }
   };
 
   return (
     <div className="lang-wrap" ref={wrapRef}>
       <button
+        ref={triggerRef}
         type="button"
         className="lang-trigger"
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-label={`Language: ${localeNames[locale]}`}
+        // aria-activedescendant points at the highlighted option while
+        // the menu is open. Lives on the trigger (which keeps focus) per
+        // APG combobox pattern.
+        aria-activedescendant={open ? `lang-opt-${locales[activeIndex]}` : undefined}
         onClick={() => setOpen((v) => !v)}
+        onKeyDown={handleTriggerKey}
       >
         {/* Globe icon — 16px, stroke 2 (Feather/Lucide style). Explicit
             width/height attributes keep it sized even before CSS arrives. */}
@@ -98,14 +160,22 @@ export function LanguageSwitcher() {
         // on a semantic list element. ARIA Combobox pattern works with
         // plain div containers.
         <div className="lang-menu" role="listbox" aria-label="Select language">
-          {locales.map((loc) => (
+          {locales.map((loc, idx) => (
             <button
               key={loc}
+              id={`lang-opt-${loc}`}
               type="button"
               role="option"
               aria-selected={loc === locale}
-              className={`lang-item ${loc === locale ? 'active' : ''}`}
+              className={[
+                'lang-item',
+                loc === locale ? 'active' : '',
+                idx === activeIndex ? 'highlight' : '',
+              ]
+                .filter(Boolean)
+                .join(' ')}
               onClick={() => choose(loc)}
+              onMouseEnter={() => setActiveIndex(idx)}
             >
               <span className="flag" aria-hidden="true">
                 {localeFlags[loc]}
@@ -207,7 +277,8 @@ export function LanguageSwitcher() {
           text-align: left;
           transition: background var(--ppt-transition-fast);
         }
-        .lang-item:hover {
+        .lang-item:hover,
+        .lang-item.highlight {
           background: var(--ppt-bg-subtle);
         }
         .lang-item.active {

--- a/frontend/apps/reality-web/src/components/ui/LanguageSwitcher.tsx
+++ b/frontend/apps/reality-web/src/components/ui/LanguageSwitcher.tsx
@@ -1,7 +1,18 @@
 'use client';
 
+/**
+ * LanguageSwitcher — custom popover dropdown.
+ *
+ * Replaces the previous native <select>, which (a) looked OS-dependent
+ * (Windows vs macOS rendering wildly different) and (b) couldn't be themed
+ * to match the design's pill-on-surface look. This is a self-contained
+ * popover with a globe-icon trigger; the menu opens below-right, lists all
+ * six locales with their flag and full name, and closes on outside click /
+ * Escape / locale selection.
+ */
+
 import { useLocale } from 'next-intl';
-import { useTransition } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { type Locale, localeFlags, localeNames, locales } from '../../i18n';
 import { usePathname, useRouter } from '../../i18n/routing';
 
@@ -9,81 +20,211 @@ export function LanguageSwitcher() {
   const locale = useLocale() as Locale;
   const router = useRouter();
   const pathname = usePathname();
-  const [isPending, startTransition] = useTransition();
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
 
-  const handleLocaleChange = (newLocale: Locale) => {
-    startTransition(() => {
-      router.replace(pathname, { locale: newLocale });
-    });
+  // Close on outside click + Escape (mouse + keyboard, no library)
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const choose = (next: Locale) => {
+    setOpen(false);
+    if (next === locale) return;
+    router.replace(pathname, { locale: next });
   };
 
   return (
-    <div className="lang-wrap">
-      <select
-        value={locale}
-        onChange={(e) => handleLocaleChange(e.target.value as Locale)}
-        disabled={isPending}
-        className="lang-select"
-        aria-label="Select language"
+    <div className="lang-wrap" ref={wrapRef}>
+      <button
+        type="button"
+        className="lang-trigger"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={`Language: ${localeNames[locale]}`}
+        onClick={() => setOpen((v) => !v)}
       >
-        {locales.map((loc) => (
-          <option key={loc} value={loc}>
-            {localeFlags[loc]} {localeNames[loc]}
-          </option>
-        ))}
-      </select>
-      {/* Width/height attributes are explicit so the chevron stays at 16px
-          even before any stylesheet has loaded — without them the SVG
-          expands to ~300px when CSS is still in flight, which was the
-          dominant CLS contributor on the homepage (single 0.92 shift). */}
-      <svg
-        className="lang-chevron"
-        width="16"
-        height="16"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
-        aria-hidden="true"
-      >
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-      </svg>
+        {/* Globe icon — 16px, stroke 2 (Feather/Lucide style). Explicit
+            width/height attributes keep it sized even before CSS arrives. */}
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <line x1="2" y1="12" x2="22" y2="12" />
+          <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+        </svg>
+        <span className="code">{locale.toUpperCase()}</span>
+        <svg
+          className="caret"
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+
+      {open && (
+        <ul className="lang-menu" role="listbox" aria-label="Select language">
+          {locales.map((loc) => (
+            <li key={loc}>
+              <button
+                type="button"
+                role="option"
+                aria-selected={loc === locale}
+                className={`lang-item ${loc === locale ? 'active' : ''}`}
+                onClick={() => choose(loc)}
+              >
+                <span className="flag" aria-hidden="true">
+                  {localeFlags[loc]}
+                </span>
+                <span className="name">{localeNames[loc]}</span>
+                {loc === locale && (
+                  <svg
+                    className="check"
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                  >
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
       <style jsx>{`
         .lang-wrap {
           position: relative;
           display: inline-flex;
           align-items: center;
         }
-        .lang-select {
-          appearance: none;
-          -webkit-appearance: none;
+        .lang-trigger {
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+          padding: 7px 10px;
           background: transparent;
           border: 1px solid var(--ppt-border-default);
           border-radius: var(--ppt-radius-md);
-          padding: 6px 28px 6px 12px;
-          font-size: var(--ppt-font-size-sm);
-          font-family: var(--ppt-font-family);
           color: var(--ppt-fg-secondary);
+          font-family: var(--ppt-font-family);
+          font-size: var(--ppt-font-size-sm);
+          font-weight: var(--ppt-font-weight-medium);
           cursor: pointer;
-          transition: border-color var(--ppt-transition-fast);
+          transition: background var(--ppt-transition-fast),
+            border-color var(--ppt-transition-fast);
         }
-        .lang-select:hover {
+        .lang-trigger:hover {
+          background: var(--ppt-bg-subtle);
           border-color: var(--ppt-border-strong);
         }
-        .lang-select:focus-visible {
+        .lang-trigger:focus-visible {
           outline: none;
           box-shadow: var(--ppt-focus-ring-shadow);
         }
-        .lang-select:disabled {
-          opacity: 0.5;
-          cursor: not-allowed;
+        .lang-trigger[aria-expanded='true'] {
+          background: var(--ppt-bg-subtle);
+          border-color: var(--ppt-border-strong);
         }
-        .lang-chevron {
+        .code {
+          font-variant-numeric: tabular-nums;
+          letter-spacing: 0.02em;
+        }
+        .caret {
+          opacity: 0.6;
+          transition: transform var(--ppt-transition-fast);
+        }
+        .lang-trigger[aria-expanded='true'] .caret {
+          transform: rotate(180deg);
+        }
+        .lang-menu {
           position: absolute;
-          right: 8px;
-          top: 50%;
-          transform: translateY(-50%);
-          color: var(--ppt-fg-muted);
-          pointer-events: none;
+          top: calc(100% + 6px);
+          right: 0;
+          min-width: 200px;
+          padding: 4px;
+          margin: 0;
+          list-style: none;
+          background: var(--ppt-bg-elevated);
+          border: 1px solid var(--ppt-border-default);
+          border-radius: var(--ppt-radius-lg);
+          box-shadow: var(--ppt-shadow-popover, 0 8px 24px rgba(0, 0, 0, 0.12));
+          z-index: var(--ppt-z-dropdown, 1000);
+        }
+        .lang-item {
+          display: flex;
+          align-items: center;
+          gap: 10px;
+          width: 100%;
+          padding: 8px 10px;
+          background: transparent;
+          border: none;
+          border-radius: var(--ppt-radius-sm);
+          cursor: pointer;
+          font-family: var(--ppt-font-family);
+          font-size: var(--ppt-font-size-sm);
+          color: var(--ppt-fg-secondary);
+          text-align: left;
+          transition: background var(--ppt-transition-fast);
+        }
+        .lang-item:hover {
+          background: var(--ppt-bg-subtle);
+        }
+        .lang-item.active {
+          color: var(--ppt-color-primary);
+          font-weight: var(--ppt-font-weight-semibold);
+        }
+        .lang-item:focus-visible {
+          outline: none;
+          box-shadow: var(--ppt-focus-ring-shadow);
+        }
+        .flag {
+          font-size: 16px;
+          line-height: 1;
+        }
+        .name {
+          flex: 1;
+        }
+        .check {
+          color: var(--ppt-color-primary);
+          flex-shrink: 0;
         }
       `}</style>
     </div>

--- a/frontend/apps/reality-web/src/lib/env.ts
+++ b/frontend/apps/reality-web/src/lib/env.ts
@@ -67,17 +67,28 @@ function inferSiteUrlFromHost(host: string, protocol: string): string | null {
  */
 export function getApiBase(): string {
   if (typeof window !== 'undefined') {
-    // 1) Explicit injection via /env.js wins — used by dedicated worktrees to
-    //    point at api.wt-<name>.dev.rlt.sk (not the prod api.rlt.sk).
-    if (window.__ENV__?.NEXT_PUBLIC_API_URL) {
-      return window.__ENV__.NEXT_PUBLIC_API_URL;
+    const envUrl = window.__ENV__?.NEXT_PUBLIC_API_URL;
+    const onWorktree = WORKTREE_HOST_RE.test(window.location.hostname);
+
+    if (envUrl) {
+      // Distinguish dedicated vs shared worktree backends. The deploy-server
+      // sets NEXT_PUBLIC_API_URL=https://api.rlt.sk on shared-mode worktrees
+      // (which is correct for the build but wrong for the browser — prod's
+      // CORS allow-list rejects wt-* origins). When we're on a worktree host
+      // and env points at a non-dedicated backend, prefer the relative-URL
+      // proxy so next.config.js's rewrite handles CORS server-side.
+      try {
+        const envHost = new URL(envUrl).hostname;
+        if (envHost.startsWith('api.wt-')) return envUrl; // dedicated
+        if (onWorktree) return ''; // shared worktree → proxy
+        return envUrl;
+      } catch {
+        // Malformed env value — ignore and fall through.
+      }
     }
-    // 2) Shared-mode worktrees with no env injection: prefer relative URLs so
-    //    the next.config.js rewrite proxies to api.rlt.sk and the browser
-    //    sees same-origin (no CORS preflight).
-    if (WORKTREE_HOST_RE.test(window.location.hostname)) {
-      return '';
-    }
+
+    if (onWorktree) return '';
+
     const inferred = inferApiBaseFromHost(window.location.hostname);
     if (inferred) return inferred;
   }

--- a/frontend/packages/dev-panel/src/DevPanel.tsx
+++ b/frontend/packages/dev-panel/src/DevPanel.tsx
@@ -1,7 +1,17 @@
 // frontend/packages/dev-panel/src/DevPanel.tsx
 import type React from 'react';
 import { useState } from 'react';
-import { type ApiMode, getMode, isApiMode, setMode } from './store';
+import {
+  type ApiMode,
+  applyColorScheme,
+  type ColorScheme,
+  getColorScheme,
+  getMode,
+  isApiMode,
+  isColorScheme,
+  setColorScheme,
+  setMode,
+} from './store';
 
 export interface DevPanelProps {
   defaultMode: ApiMode;
@@ -17,11 +27,23 @@ export const DevPanel: React.FC<DevPanelProps> = ({
   onSnapshotState,
 }) => {
   const [mode, setLocalMode] = useState<ApiMode>(() => getMode(defaultMode));
-  const apply = (m: ApiMode) => {
+  // null = no explicit choice (== 'system' fallback). We render the radio as
+  // 'system' in that case but keep the distinction in storage so the inline
+  // bootstrap can fall through to `prefers-color-scheme` cleanly.
+  const [scheme, setLocalScheme] = useState<ColorScheme>(() => getColorScheme() ?? 'system');
+
+  const applyMode = (m: ApiMode) => {
     setMode(m);
     setLocalMode(m);
     onModeChange(m);
   };
+
+  const applyScheme = (s: ColorScheme) => {
+    setColorScheme(s);
+    setLocalScheme(s);
+    applyColorScheme(s);
+  };
+
   return (
     <div
       style={{
@@ -35,7 +57,10 @@ export const DevPanel: React.FC<DevPanelProps> = ({
         borderRadius: 6,
         fontFamily: 'monospace',
         fontSize: 12,
-        opacity: 0.85,
+        opacity: 0.9,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 4,
       }}
     >
       <div>
@@ -45,14 +70,8 @@ export const DevPanel: React.FC<DevPanelProps> = ({
           aria-label="API mode (local, worktree, or mock)"
           value={mode}
           onChange={(e) => {
-            // Defense in depth: a tampered DOM (devtools-edit, future option
-            // added to one place but not another, etc.) could deliver a value
-            // that isn't a valid ApiMode. Validate before persisting to
-            // localStorage and notifying the parent.
             const next = e.target.value;
-            if (isApiMode(next)) {
-              apply(next);
-            }
+            if (isApiMode(next)) applyMode(next);
           }}
         >
           <option value="local">local</option>
@@ -60,6 +79,24 @@ export const DevPanel: React.FC<DevPanelProps> = ({
           <option value="mock">mock</option>
         </select>
       </div>
+
+      <div>
+        <label htmlFor="ppt-dev-panel-scheme">Theme:&nbsp;</label>
+        <select
+          id="ppt-dev-panel-scheme"
+          aria-label="Color scheme (light, dark, or system)"
+          value={scheme}
+          onChange={(e) => {
+            const next = e.target.value;
+            if (isColorScheme(next)) applyScheme(next);
+          }}
+        >
+          <option value="light">light</option>
+          <option value="dark">dark</option>
+          <option value="system">system</option>
+        </select>
+      </div>
+
       {mode === 'mock' && onReseedMock && (
         <button type="button" onClick={onReseedMock} style={{ marginTop: 4 }}>
           Re-seed mock

--- a/frontend/packages/dev-panel/src/DevPanel.tsx
+++ b/frontend/packages/dev-panel/src/DevPanel.tsx
@@ -61,6 +61,11 @@ export const DevPanel: React.FC<DevPanelProps> = ({
         display: 'flex',
         flexDirection: 'column',
         gap: 4,
+        // colorScheme: 'dark' tells the browser to render native form
+        // controls (incl. <select> and its dropdown panel) with a dark
+        // user-agent stylesheet, so the dev panel looks consistent in
+        // both site themes.
+        colorScheme: 'dark',
       }}
     >
       <div>

--- a/frontend/packages/dev-panel/src/DevPanel.tsx
+++ b/frontend/packages/dev-panel/src/DevPanel.tsx
@@ -27,9 +27,10 @@ export const DevPanel: React.FC<DevPanelProps> = ({
   onSnapshotState,
 }) => {
   const [mode, setLocalMode] = useState<ApiMode>(() => getMode(defaultMode));
-  // null = no explicit choice (== 'system' fallback). We render the radio as
-  // 'system' in that case but keep the distinction in storage so the inline
-  // bootstrap can fall through to `prefers-color-scheme` cleanly.
+  // getColorScheme() returns `null` when no explicit preference is stored
+  // (the inline bootstrap then falls through to prefers-color-scheme).
+  // The select UI surfaces that as 'system' so the user can choose
+  // between the three states; choosing 'system' removes the key again.
   const [scheme, setLocalScheme] = useState<ColorScheme>(() => getColorScheme() ?? 'system');
 
   const applyMode = (m: ApiMode) => {

--- a/frontend/packages/dev-panel/src/index.ts
+++ b/frontend/packages/dev-panel/src/index.ts
@@ -1,4 +1,15 @@
 // frontend/packages/dev-panel/src/index.ts
 export { DevPanel } from './DevPanel';
-export type { ApiMode } from './store';
-export { getMode, isApiMode, loadSnapshot, parseMode, saveSnapshot, setMode } from './store';
+export type { ApiMode, ColorScheme } from './store';
+export {
+  applyColorScheme,
+  getColorScheme,
+  getMode,
+  isApiMode,
+  isColorScheme,
+  loadSnapshot,
+  parseMode,
+  saveSnapshot,
+  setColorScheme,
+  setMode,
+} from './store';

--- a/frontend/packages/dev-panel/src/store.ts
+++ b/frontend/packages/dev-panel/src/store.ts
@@ -57,3 +57,58 @@ export function loadSnapshot<T = unknown>(): T | null {
     return null;
   }
 }
+
+/**
+ * Color-scheme preference shared with the inline bootstrap script in
+ * apps/reality-web/src/app/[locale]/layout.tsx — both read/write the same
+ * `ppt-color-scheme` localStorage key so a toggle in the DevPanel is picked
+ * up on the next reload (and immediately via the `applyColorScheme` helper
+ * below, which patches the live document's data-color-scheme attribute).
+ */
+export type ColorScheme = 'light' | 'dark' | 'system';
+
+const SCHEME_KEY = 'ppt-color-scheme';
+
+export function isColorScheme(v: unknown): v is ColorScheme {
+  return v === 'light' || v === 'dark' || v === 'system';
+}
+
+/**
+ * Read the user's stored preference. `null` (not 'system') means "no
+ * explicit choice yet" so callers can distinguish the default-system case
+ * from the explicit-system case for UI affordances.
+ */
+export function getColorScheme(): ColorScheme | null {
+  try {
+    const v = localStorage.getItem(SCHEME_KEY);
+    if (isColorScheme(v)) return v;
+  } catch {}
+  return null;
+}
+
+export function setColorScheme(scheme: ColorScheme): void {
+  try {
+    if (scheme === 'system') {
+      // 'system' is encoded as "no preference" so the bootstrap script
+      // falls back to `prefers-color-scheme` on next load.
+      localStorage.removeItem(SCHEME_KEY);
+    } else {
+      localStorage.setItem(SCHEME_KEY, scheme);
+    }
+  } catch {}
+}
+
+/**
+ * Apply a color scheme to `<html>` immediately (no reload). Mirrors what
+ * the inline bootstrap script does at first paint.
+ */
+export function applyColorScheme(scheme: ColorScheme): void {
+  if (typeof document === 'undefined') return;
+  const resolved =
+    scheme === 'system'
+      ? window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light'
+      : scheme;
+  document.documentElement.setAttribute('data-color-scheme', resolved);
+}

--- a/frontend/packages/dev-panel/src/store.ts
+++ b/frontend/packages/dev-panel/src/store.ts
@@ -74,14 +74,19 @@ export function isColorScheme(v: unknown): v is ColorScheme {
 }
 
 /**
- * Read the user's stored preference. `null` (not 'system') means "no
- * explicit choice yet" so callers can distinguish the default-system case
- * from the explicit-system case for UI affordances.
+ * Read the stored color-scheme preference.
+ *
+ * Storage uses an absent key (returns `null`) to mean "follow system",
+ * because the inline bootstrap script needs that absence-signal to fall
+ * through to `prefers-color-scheme` on first paint. Returns the literal
+ * `'light'` or `'dark'` only when the user made an explicit non-system
+ * choice. `'system'` is therefore never a return value from this function
+ * — callers UI-bind it to `null`.
  */
-export function getColorScheme(): ColorScheme | null {
+export function getColorScheme(): 'light' | 'dark' | null {
   try {
     const v = localStorage.getItem(SCHEME_KEY);
-    if (isColorScheme(v)) return v;
+    if (v === 'light' || v === 'dark') return v;
   } catch {}
   return null;
 }

--- a/frontend/packages/reality-api-client/src/config.ts
+++ b/frontend/packages/reality-api-client/src/config.ts
@@ -18,17 +18,26 @@ const WORKTREE_HOST_RE = /^wt-.+\.(dev|staging)\.rlt\.sk$/;
 
 function getRuntimeApiUrl(): string | undefined {
   if (typeof window === 'undefined') return undefined;
-  // 1) Explicit /env.js injection wins (dedicated worktrees point at their own
-  //    api.wt-<name>.* host, not api.rlt.sk).
   const env = (window as { __ENV__?: Record<string, string> }).__ENV__;
-  if (env?.NEXT_PUBLIC_API_URL) {
-    return env.NEXT_PUBLIC_API_URL;
+  const envUrl = env?.NEXT_PUBLIC_API_URL;
+  const onWorktree = WORKTREE_HOST_RE.test(window.location.hostname);
+
+  // The deploy-server sets NEXT_PUBLIC_API_URL=https://api.rlt.sk on shared
+  // worktrees (correct for the build, wrong for the browser — prod's CORS
+  // allow-list rejects wt-* origins). When env points at a non-dedicated
+  // backend and we're on a worktree, prefer the relative-URL proxy so the
+  // next.config.js rewrite handles CORS server-side.
+  if (envUrl) {
+    try {
+      const envHost = new URL(envUrl).hostname;
+      if (envHost.startsWith('api.wt-')) return envUrl; // dedicated worktree
+      if (onWorktree) return ''; // shared worktree → proxy
+      return envUrl;
+    } catch {
+      // Malformed env value — fall through.
+    }
   }
-  // 2) Shared-mode worktrees with no env injection: relative URL hits the
-  //    next.config.js rewrite to api.rlt.sk (avoids CORS).
-  if (WORKTREE_HOST_RE.test(window.location.hostname)) {
-    return '';
-  }
+  if (onWorktree) return '';
   return undefined;
 }
 

--- a/frontend/packages/ui-kit/src/tokens.css
+++ b/frontend/packages/ui-kit/src/tokens.css
@@ -335,6 +335,33 @@
   --ppt-color-primary-light: rgba(59, 130, 246, 0.15);
   --ppt-color-primary-soft-bg: rgba(59, 130, 246, 0.15);
 
+  /*
+   * Semantic `*-light` and `*-dark` tokens in dark mode.
+   *
+   * Light theme uses solid pastel fills (#d1fae5, #dbeafe, …) and saturated
+   * darker text (#065f46, #92400e, …). In dark theme those same fills are
+   * far too bright (they're the dominant source of "white pockets" on
+   * dark surfaces) and the dark text becomes near-invisible.
+   *
+   * Per the design-system rule (README.md → "Dark mode is paired, never
+   * inverted"): badges drop to `rgba(accent, 0.15)` fill paired with a
+   * brightened text shade. Mirrors the `--ppt-status-*` pair structure
+   * already defined below.
+   */
+  --ppt-color-success-light: rgba(16, 185, 129, 0.18);
+  --ppt-color-success-dark: #6ee7b7; /* used as ink on success-light bg */
+  --ppt-color-warning-light: rgba(245, 158, 11, 0.18);
+  --ppt-color-warning-dark: #fcd34d;
+  --ppt-color-danger-light: rgba(239, 68, 68, 0.18);
+  --ppt-color-danger-dark: #fca5a5;
+  --ppt-color-info-light: rgba(59, 130, 246, 0.18);
+  --ppt-color-info-dark: #93c5fd;
+  --ppt-color-violet-light: rgba(139, 92, 246, 0.2);
+  --ppt-color-violet-dark: #c4b5fd;
+  --ppt-color-orange-light: rgba(249, 115, 22, 0.2);
+  --ppt-color-orange-dark: #fdba74;
+  --ppt-color-secondary-light: rgba(107, 114, 128, 0.2);
+
   --ppt-color-background: var(--ppt-bg-app);
   --ppt-color-surface: var(--ppt-bg-surface);
   --ppt-color-surface-hover: var(--ppt-bg-hover);


### PR DESCRIPTION
Comprehensive design-system pass on reality-web spanning home alignment, header rebuild, modern form primitives, dark-mode parity, CORS proxy, and locale completeness.

## Sections of work

### 1. Homepage alignment with the design bundle
Added the three sections the design has that we were missing (post-listing, pre-footer):
- `PopularNeighbourhoods` — six curated districts, 2:1 gradient tile, locale-aware `/listings?city=…&district=…` links.
- `ValueStrip` — four-cell stat bar (Verified agents · Building passport · Price history · Mortgage SLA), copy in i18n.
- `HomeCTA` — soft-blue "Selling your home?" panel, secondary `/about` + primary `/sell`.

### 2. Header rebuild
- Audited the `<header>` across all 22 design pages — identical everywhere. Our impl now matches:
  - Brand-square `::before`-style icon + two-tone wordmark
  - 5 nav links: Predaj / Prenájom / Predať / Magazín / Pomoc
  - Primary "Pridať nehnuteľnosť" CTA before the auth slot on ≥1024 px
- `LanguageSwitcher` rewritten as a custom popover (globe + locale code trigger, ARIA listbox, checkmark for active, outside-click/Escape close). Replaces the OS-styled native `<select>`.

### 3. Modern form primitives (`@/components/forms`)
Floating-label fields matching the design's `m-field / m-input / m-textarea / m-dropdown` rules:
- `FieldInput`, `FieldTextarea` — `:not(:placeholder-shown)` animation, prefix/suffix slots, error + helper states
- `FieldSelect` — custom popover dropdown with full keyboard nav + ARIA listbox
- `FormCard`, `FieldGroupTitle`, `FormActions` — layout primitives
- Focus ring 4 px @ 12 % accent (design-spec, softer than default). Reduced-motion fallback.
- `/auth/login` migrated as proof-of-concept; `docs/forms-migration-2026-05-10.md` lists the rest.

### 4. Dark-mode parity sweep
Full-site crawler (24 routes × 2 themes × 3 locales = 144 visits) flagged 66 dark-mode issues. Root cause: `--ppt-color-{success,warning,danger,info,violet,orange,secondary}-light` weren't overridden in the dark block. Fixed in `tokens.css` — light theme keeps solid pastels (#d1fae5 etc.), dark drops to `rgba(accent, 0.18)` with brightened ink, matching the design system's "paired, never inverted" rule and the existing `--ppt-status-*` pair shape.

### 5. FOUC fix
- Color-scheme bootstrap moved from `<body>` (where `<Script strategy="beforeInteractive">` was being queued after hydration) to a plain inline `<script>` at the top of `<head>` — runs during HTML parse, no flash on first paint or navigation.
- DevPanel gets `colorScheme: dark` so native `<select>` controls render dark.

### 6. CORS — same-origin proxy
- `next.config.js` rewrites `/api/*` → `api.rlt.sk` for `wt-*.dev.rlt.sk` hosts (server-side, no browser preflight).
- `getApiBase()` returns `''` for shared-mode worktrees so callers produce relative URLs and hit the rewrite. Dedicated-mode worktrees still use their own `api.wt-*` directly.

### 7. DevPanel theme toggle
- `@ppt/dev-panel` store: `getColorScheme` / `setColorScheme` / `applyColorScheme` helpers (encoded `'system'` as no-key so the inline bootstrap can fall through to `prefers-color-scheme`).
- DevPanel UI: `Theme: light/dark/system` select beneath the API select.

### 8. Locale completeness
- `hu.json` and `pl.json` were missing 52 keys. Filled in. Verified: all six locales now share 319 keys exactly.

### 9. Baseline `:focus-visible`
- 37 component files had interactive controls with no `:focus-visible` rule. Added a global `:where()` baseline in `globals.css` that applies `--ppt-focus-ring-shadow` to every focusable element. Zero-specificity selector — component-level rules still win when they exist.

## Documentation

- `docs/design-audit-2026-05-10.md` — per-route gap matrix vs the design bundle.
- `docs/forms-migration-2026-05-10.md` — modern form-primitive spec + migration order.
- `docs/reality-web-conventions.md` — 10-section conventions doc (token usage, i18n, dark-mode bootstrap, form primitives, CORS, styled-jsx scoping, StyledJsxRegistry, single-source chrome, token reference, audit checklist).

## Test plan

- [x] `pnpm --filter @ppt/reality-web typecheck`
- [x] `pnpm exec biome check apps/reality-web/src` — clean
- [x] Playwright crawl across 24 routes × 2 themes × 3 locales = 144 visits — clean after token fix
- [x] CLS measured 0.0026 (down from 0.93 pre-PR, see earlier PR work for FOUC details)
- [x] Same-origin `/api/v1/listings/featured` returns 200 on the worktree (was CORS-blocked direct)
- [ ] Reviewer to confirm Bratislava district list curation
- [ ] Reviewer to spot-check copy tone in their locale