### PR TITLE
Audit fixes: SEO, i18n, mobile UX, sell-wizard validation, GDPR terms

### DIFF
--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -811,7 +811,6 @@ function DisputeDetailRoute() {
  * Manages filter state and navigation callbacks.
  */
 function OutagesPageRoute() {
-  const { t } = useTranslation();
   const navigate = useNavigate();
   const { user } = useAuth();
   const [queryParams, setQueryParams] = useState<OutageListQuery>({ limit: 10, offset: 0 });

--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -37,6 +37,7 @@ import {
 import {
   AnnouncerProvider,
   ConnectionStatus,
+  AuthRequiredGate,
   LanguageSwitcher,
   OfflineIndicator,
   ProtectedRoute,
@@ -518,13 +519,7 @@ function DisputesPageRoute() {
 
   // Require organization context for disputes
   if (!user?.organizationId) {
-    return (
-      <div className="error-page">
-        <h1>{t('errors.authenticationRequired')}</h1>
-        <p>{t('errors.missingOrgContext')}</p>
-        <Link to="/login">{t('auth.signIn')}</Link>
-      </div>
-    );
+    return <AuthRequiredGate />;
   }
 
   const organizationId = user.organizationId;
@@ -618,13 +613,7 @@ function FileDisputePageRoute() {
 
   // Require organization context for filing disputes
   if (!user?.organizationId) {
-    return (
-      <div className="error-page">
-        <h1>{t('errors.authenticationRequired')}</h1>
-        <p>{t('errors.missingOrgContext')}</p>
-        <Link to="/login">{t('auth.signIn')}</Link>
-      </div>
-    );
+    return <AuthRequiredGate />;
   }
 
   const organizationId = user.organizationId;
@@ -830,13 +819,7 @@ function OutagesPageRoute() {
   const { data, isLoading } = useOutages(queryParams);
 
   if (!user?.organizationId) {
-    return (
-      <div className="error-page">
-        <h1>{t('errors.authenticationRequired')}</h1>
-        <p>{t('errors.missingOrgContext')}</p>
-        <Link to="/login">{t('auth.signIn')}</Link>
-      </div>
-    );
+    return <AuthRequiredGate />;
   }
 
   const outages: ApiOutageSummary[] = data?.outages ?? [];
@@ -882,13 +865,7 @@ function CreateOutagePageRoute() {
   const { data: buildingsData, isLoading: isLoadingBuildings } = useBuildings();
 
   if (!user?.organizationId) {
-    return (
-      <div className="error-page">
-        <h1>{t('errors.authenticationRequired')}</h1>
-        <p>{t('errors.missingOrgContext')}</p>
-        <Link to="/login">{t('auth.signIn')}</Link>
-      </div>
-    );
+    return <AuthRequiredGate />;
   }
 
   // Transform API buildings to UI format

--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -25,7 +25,15 @@ import {
 import { AccessibilityProvider, SkipNavigation } from '@ppt/ui-kit';
 import { type ReactNode, Suspense, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { BrowserRouter, Link, Route, Routes, useNavigate, useParams } from 'react-router-dom';
+import {
+  BrowserRouter,
+  Link,
+  Navigate,
+  Route,
+  Routes,
+  useNavigate,
+  useParams,
+} from 'react-router-dom';
 import {
   AnnouncerProvider,
   ConnectionStatus,
@@ -298,7 +306,16 @@ function App() {
                               <Route path="/settings/password" element={<ChangePasswordPage />} />
                               <Route path="/settings/two-factor" element={<TwoFactorAuthPage />} />
                               <Route path="/settings/profile" element={<ProfileEditPage />} />
-                              {/* Dashboard routes (Epic 124) */}
+                              {/* Dashboard routes (Epic 124).
+                                  Bare /dashboard 404'd previously — redirect
+                                  it to the manager dashboard so users typing
+                                  the obvious URL get something useful (the
+                                  ProtectedRoute / role check on the target
+                                  page handles auth + role-based fan-out). */}
+                              <Route
+                                path="/dashboard"
+                                element={<Navigate to="/dashboard/manager" replace />}
+                              />
                               <Route path="/dashboard/manager" element={<ManagerDashboardPage />} />
                               <Route
                                 path="/dashboard/resident"

--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -36,8 +36,8 @@ import {
 } from 'react-router-dom';
 import {
   AnnouncerProvider,
-  ConnectionStatus,
   AuthRequiredGate,
+  ConnectionStatus,
   LanguageSwitcher,
   OfflineIndicator,
   ProtectedRoute,

--- a/frontend/apps/ppt-web/src/components/AuthRequiredGate.tsx
+++ b/frontend/apps/ppt-web/src/components/AuthRequiredGate.tsx
@@ -1,0 +1,26 @@
+/**
+ * Inline auth-required gate.
+ *
+ * Used by routes that require an authenticated user with an active
+ * `organizationId`. Centralises a JSX block that was repeated inline
+ * across DisputesPageRoute, OutagesPageRoute, FaultsPageRoute and
+ * AnnouncementsPageRoute (4 copies of the same eight lines, all using
+ * the same translation keys).
+ *
+ * For routes that need full SPA-style auth + redirect, use
+ * `<ProtectedRoute>` instead.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+
+export function AuthRequiredGate() {
+  const { t } = useTranslation();
+  return (
+    <div className="error-page" role="alert">
+      <h1>{t('errors.authenticationRequired')}</h1>
+      <p>{t('errors.missingOrgContext')}</p>
+      <Link to="/login">{t('auth.signIn')}</Link>
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/components/index.ts
+++ b/frontend/apps/ppt-web/src/components/index.ts
@@ -3,6 +3,7 @@
  */
 
 export { AnnouncerProvider, useAnnouncer } from './Announcer';
+export { AuthRequiredGate } from './AuthRequiredGate';
 export type { ConfirmationDialogProps } from './ConfirmationDialog';
 export { ConfirmationDialog } from './ConfirmationDialog';
 export type { ConnectionStatusProps } from './ConnectionStatus';

--- a/frontend/apps/ppt-web/src/index.css
+++ b/frontend/apps/ppt-web/src/index.css
@@ -57,11 +57,39 @@
 .app-nav {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  padding: 0.75rem 1.5rem;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  padding: 0.75rem 1rem;
   background-color: var(--color-surface, #ffffff);
   border-bottom: 1px solid var(--color-border, #e5e7eb);
   box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+}
+
+.app-nav > .ml-auto {
+  margin-left: auto;
+}
+
+@media (max-width: 640px) {
+  .app-nav {
+    gap: 0.5rem 0.75rem;
+    padding: 0.5rem 0.75rem;
+  }
+  .app-nav a {
+    /* Larger tap target than the body-text 0.875rem the desktop nav uses;
+       WCAG 2.5.5 recommends ≥24×24 CSS px for touch targets. With the
+       0.5rem column-gap this keeps adjacent links comfortably apart. */
+    padding: 0.25rem 0;
+    min-height: 1.75rem;
+    display: inline-flex;
+    align-items: center;
+  }
+  .app-nav > .ml-auto {
+    /* On phones the action cluster wraps to its own row below the links
+       instead of being pushed off-screen by the auto margin. */
+    margin-left: 0;
+    width: 100%;
+    justify-content: flex-end;
+  }
 }
 
 .app-nav a {

--- a/frontend/apps/reality-web/messages/cs.json
+++ b/frontend/apps/reality-web/messages/cs.json
@@ -505,15 +505,48 @@
       "termsLabel": "I agree to the {termsLink} and the {privacyLink}.",
       "termsRequired": "You must accept the Terms of Service and Privacy Policy to register.",
       "termsLinkText": "Terms of Service",
-      "privacyLinkText": "Privacy Policy"
+      "privacyLinkText": "Privacy Policy",
+      "checkInbox": "Check your inbox",
+      "checkInboxBody": "We sent a verification email to {email}. Click the link to activate your account.",
+      "backToSignIn": "Back to sign in",
+      "creating": "Creating account…",
+      "submit": "Create account"
     },
     "forgotPassword": {
       "title": "Reset your password",
-      "description": "We'll send you a reset link by email."
+      "description": "Enter your email and we'll send you a reset link.",
+      "emailLabel": "Email",
+      "emailRequired": "Email is required",
+      "emailInvalid": "Enter a valid email address",
+      "submit": "Send reset link",
+      "submitting": "Sending…",
+      "checkInbox": "Check your inbox",
+      "checkInboxBody": "If an account exists for {email}, we've sent instructions to reset your password.",
+      "backToSignIn": "Back to sign in",
+      "remembered": "Remembered your password?",
+      "signIn": "Sign in",
+      "networkError": "Network error. Please check your connection and try again.",
+      "serverError": "Server error. Please try again later.",
+      "genericError": "Could not send reset email. Please try again."
     },
     "resetPassword": {
       "title": "Set a new password",
-      "description": "Choose a strong password for your account."
+      "description": "Choose a strong password you haven't used before.",
+      "invalidTitle": "Invalid link",
+      "invalidBody": "This reset link is invalid or has expired. Request a new one.",
+      "successTitle": "Password updated",
+      "successBody": "You can now sign in with your new password.",
+      "passwordLabel": "New password",
+      "confirmLabel": "Confirm password",
+      "passwordHint": "At least 8 characters.",
+      "passwordRequired": "Password is required",
+      "passwordTooShort": "Password must be at least 8 characters",
+      "passwordsMismatch": "Passwords do not match",
+      "submit": "Update password",
+      "submitting": "Saving…",
+      "requestNew": "Request a new reset link",
+      "goToSignIn": "Go to sign in",
+      "genericError": "Could not reset password. Please try again."
     }
   },
   "search": {

--- a/frontend/apps/reality-web/messages/cs.json
+++ b/frontend/apps/reality-web/messages/cs.json
@@ -363,14 +363,17 @@
     },
     "report": {
       "submit": "Odeslat nahlášení",
-      "subtitle": "Pomozte nám udržovat portál bezpečným.",
+      "subtitle": "Help us keep the portal trustworthy — tell us what's wrong.",
       "success": "Nahlášení bylo odesláno",
-      "title": "Nahlásit inzerát"
+      "title": "Report a listing",
+      "h1": "Report a listing"
     },
     "security": {
       "reportCta": "Nahlásit inzerát",
-      "subtitle": "Vaše bezpečnost je naší prioritou",
-      "title": "Bezpečnost"
+      "subtitle": "How we keep listings, payments and your data safe — and what to watch out for.",
+      "title": "Security",
+      "h1": "Your security is our priority",
+      "scenariosHeading": "Common fraud scenarios"
     },
     "sell": {
       "steps": {

--- a/frontend/apps/reality-web/messages/cs.json
+++ b/frontend/apps/reality-web/messages/cs.json
@@ -465,6 +465,22 @@
         "label": "I agree to the {termsLink} and the {privacyLink}.",
         "termsLink": "terms of use",
         "privacyLink": "privacy policy"
+      },
+      "validation": {
+        "required": "Required",
+        "addressRequired": "Address is required",
+        "cityRequired": "City is required",
+        "areaRequired": "Area is required",
+        "areaPositive": "Area must be greater than 0",
+        "roomsRequired": "Number of rooms is required",
+        "priceRequired": "Price is required",
+        "pricePositive": "Price must be greater than 0",
+        "nameRequired": "Name is required",
+        "phoneRequired": "Phone is required",
+        "phoneFormat": "Please enter a valid phone number",
+        "emailRequired": "E-mail is required",
+        "emailFormat": "Please enter a valid e-mail address",
+        "termsRequired": "You must agree to the terms of use to publish"
       }
     },
     "terms": {
@@ -485,7 +501,11 @@
     },
     "register": {
       "title": "Create your account",
-      "description": "Save listings, set alerts and contact agents."
+      "description": "Save listings, set alerts and contact agents.",
+      "termsLabel": "I agree to the {termsLink} and the {privacyLink}.",
+      "termsRequired": "You must accept the Terms of Service and Privacy Policy to register.",
+      "termsLinkText": "Terms of Service",
+      "privacyLinkText": "Privacy Policy"
     },
     "forgotPassword": {
       "title": "Reset your password",

--- a/frontend/apps/reality-web/messages/cs.json
+++ b/frontend/apps/reality-web/messages/cs.json
@@ -291,7 +291,8 @@
         "subtitle": "Připojte se k našemu týmu.",
         "title": "Pojďme budovat realitní trh, který dává smysl."
       },
-      "title": "Kariéra"
+      "title": "Kariéra",
+      "h1": "Let's build a real estate market that makes sense."
     },
     "contact": {
       "description": "Pro podporu nebo obchodní dotazy nás kontaktujte na",
@@ -300,19 +301,26 @@
     },
     "cookies": {
       "reopen": "Znovu otevřít nastavení cookies",
-      "title": "Zásady používání cookies"
+      "title": "Zásady používání cookies",
+      "subtitle": "Cookie policy",
+      "lastUpdated": "Last updated: 1 January 2025"
     },
     "forAgents": {
       "features": "Co získáte",
       "pricing": "Cenové plány",
       "subtitle": "Prodávejte více s Reality Portálem",
-      "title": "Pro makléře a agentury"
+      "title": "Pro makléře a agentury",
+      "heroTitle": "Sell more with Reality Portal",
+      "heroBadge": "For agents & agencies",
+      "heroIntro": "Tools, analytics and reach across millions of buyers and renters in one place."
     },
     "help": {
       "categories": "Kategorie",
       "faq": "Často kladené otázky",
       "searchPlaceholder": "Vyhledávejte v centru nápovědy...",
-      "title": "Centrum nápovědy"
+      "title": "Centrum nápovědy",
+      "subtitle": "How can we help?",
+      "intro": "Search our help centre or contact us directly."
     },
     "journal": {
       "editorsPicks": "Výběr redakce",
@@ -321,7 +329,13 @@
       "mostRead": "Nejvíce čtené",
       "newsletter": "Odběr novinek",
       "subtitle": "Analýzy, tipy a novinky ze světa nemovitostí.",
-      "title": "Reality Žurnál"
+      "title": "Reality Žurnál",
+      "readingTime": "{min} min read",
+      "newsletterIntro": "Get the latest analyses and tips delivered to your inbox.",
+      "newsletterSuccess": "✅ You're subscribed!",
+      "newsletterEmailPlaceholder": "you@email.com",
+      "newsletterSubmit": "Subscribe",
+      "newsletterTitle": "Newsletter signup"
     },
     "listingEdit": {
       "save": "Uložit změny",
@@ -331,7 +345,8 @@
     "priceMap": {
       "clickHint": "Klikněte na čtvrť pro detailní statistiky.",
       "subtitle": "Bratislava – přehled",
-      "title": "Mapa cen"
+      "title": "Mapa cen",
+      "h1": "Price map"
     },
     "privacy": {
       "description": "Zavazujeme se chránit vaše osobní údaje v souladu s GDPR a platnými zákony. Úplné podmínky ochrany osobních údajů budou zveřejněny zde.",

--- a/frontend/apps/reality-web/messages/cs.json
+++ b/frontend/apps/reality-web/messages/cs.json
@@ -371,6 +371,14 @@
     "terms": {
       "description": "Používáním Reality Portálu souhlasíte s našimi obchodními podmínkami. Úplné podmínky používání budou zveřejněny zde.",
       "title": "Podmínky používání"
+    },
+    "listings": {
+      "title": "Všechny nemovitosti",
+      "description": "Prohledejte všechny nabídky nemovitostí v České republice, na Slovensku a dále."
+    },
+    "favorites": {
+      "title": "Moje oblíbené",
+      "description": "Nemovitosti, které jste si uložili."
     }
   },
   "search": {

--- a/frontend/apps/reality-web/messages/cs.json
+++ b/frontend/apps/reality-web/messages/cs.json
@@ -478,6 +478,22 @@
     "favorites": {
       "title": "Moje oblíbené",
       "description": "Nemovitosti, které jste si uložili."
+    },
+    "login": {
+      "title": "Sign in",
+      "description": "Sign in to your Reality Portal account."
+    },
+    "register": {
+      "title": "Create your account",
+      "description": "Save listings, set alerts and contact agents."
+    },
+    "forgotPassword": {
+      "title": "Reset your password",
+      "description": "We'll send you a reset link by email."
+    },
+    "resetPassword": {
+      "title": "Set a new password",
+      "description": "Choose a strong password for your account."
     }
   },
   "search": {

--- a/frontend/apps/reality-web/messages/cs.json
+++ b/frontend/apps/reality-web/messages/cs.json
@@ -483,7 +483,8 @@
         "phoneFormat": "Please enter a valid phone number",
         "emailRequired": "E-mail is required",
         "emailFormat": "Please enter a valid e-mail address",
-        "termsRequired": "You must agree to the terms of use to publish"
+        "termsRequired": "You must agree to the terms of use to publish",
+        "roomsPositive": "Number of rooms must be greater than 0"
       }
     },
     "terms": {
@@ -513,7 +514,22 @@
       "checkInboxBody": "We sent a verification email to {email}. Click the link to activate your account.",
       "backToSignIn": "Back to sign in",
       "creating": "Creating account…",
-      "submit": "Create account"
+      "submit": "Create account",
+      "displayNameRequired": "Display name is required",
+      "emailRequired": "Email is required",
+      "emailInvalid": "Enter a valid email address",
+      "passwordRequired": "Password is required",
+      "passwordTooShort": "Password must be at least {min} characters",
+      "passwordsMismatch": "Passwords do not match",
+      "emailTaken": "An account with this email already exists.",
+      "genericError": "Registration failed. Please try again.",
+      "displayNameLabel": "Display name",
+      "emailLabel": "Email",
+      "passwordLabel": "Password",
+      "confirmPasswordLabel": "Confirm password",
+      "passwordHint": "At least {min} characters.",
+      "haveAccount": "Already have an account?",
+      "signInLink": "Sign in"
     },
     "forgotPassword": {
       "title": "Reset your password",

--- a/frontend/apps/reality-web/messages/cs.json
+++ b/frontend/apps/reality-web/messages/cs.json
@@ -359,14 +359,98 @@
     },
     "sell": {
       "steps": {
-        "details": "Detaily",
-        "photos": "Fotografie",
-        "price": "Cena",
-        "summary": "Kontakt & shrnutí",
-        "typeLocation": "Typ a poloha"
+        "type": {
+          "title": "Type & location",
+          "description": "Choose a property type and enter the address"
+        },
+        "details": {
+          "title": "Details",
+          "description": "Area, rooms, floor, year built"
+        },
+        "photos": {
+          "title": "Photos",
+          "description": "Add high-quality photos"
+        },
+        "price": {
+          "title": "Price",
+          "description": "Set the asking price"
+        },
+        "contact": {
+          "title": "Contact & summary",
+          "description": "Verify details and publish"
+        }
       },
       "submit": "Zveřejnit inzerát",
-      "title": "Přidat inzerát"
+      "title": "Add listing",
+      "stepLabel": "Step {step} of {total}: {stepTitle}",
+      "asideTitle": "Steps",
+      "back": "← Back",
+      "next": "Next →",
+      "publish": "Publish listing",
+      "submittedTitle": "Your listing has been submitted!",
+      "submittedBody": "After review it will be published within 2 hours.",
+      "submittedCta": "Add another listing",
+      "fields": {
+        "transactionType": "Transaction type",
+        "propertyType": "Property type",
+        "address": "Address",
+        "addressPlaceholder": "Street and number",
+        "city": "City / Town",
+        "cityPlaceholder": "e.g. Bratislava",
+        "area": "Area (m²)",
+        "areaPlaceholder": "e.g. 65",
+        "rooms": "Number of rooms",
+        "roomsPlaceholder": "e.g. 3",
+        "floor": "Floor",
+        "floorPlaceholder": "e.g. 2",
+        "totalFloors": "Total floors",
+        "totalFloorsPlaceholder": "e.g. 7",
+        "yearBuilt": "Year built",
+        "yearBuiltPlaceholder": "e.g. 1995",
+        "description": "Property description",
+        "descriptionPlaceholder": "Describe the property, its features and amenities…",
+        "price": "Asking price (€)",
+        "priceSalePlaceholder": "e.g. 250000",
+        "priceRentPlaceholder": "Monthly rent, e.g. 800",
+        "priceNegotiable": "Price is negotiable",
+        "contactName": "Name",
+        "contactNamePlaceholder": "Your full name",
+        "contactPhone": "Phone",
+        "contactPhonePlaceholder": "+421 9XX XXX XXX",
+        "contactEmail": "E-mail",
+        "contactEmailPlaceholder": "you@email.com"
+      },
+      "transactionOptions": {
+        "sale": "Sale",
+        "rent": "Rent"
+      },
+      "propertyOptions": {
+        "apartment": "Apartment",
+        "house": "House",
+        "land": "Land",
+        "commercial": "Commercial"
+      },
+      "photos": {
+        "intro": "Upload photos (5 minimum, 30 maximum recommended).",
+        "cta": "Click or drag photos here",
+        "formats": "JPG, PNG, WEBP · up to 10 MB each",
+        "selected_one": "✓ {count} photo selected",
+        "selected_other": "✓ {count} photos selected"
+      },
+      "summary": {
+        "type": "Type",
+        "location": "Location",
+        "area": "Area",
+        "rooms": "Rooms",
+        "price": "Price",
+        "photos": "Photos",
+        "negotiable": "(negotiable)"
+      },
+      "terms": {
+        "label": "I agree to the {termsLink} and the {privacyLink}.",
+        "termsLink": "terms of use",
+        "privacyLink": "privacy policy"
+      }
     },
     "terms": {
       "description": "Používáním Reality Portálu souhlasíte s našimi obchodními podmínkami. Úplné podmínky používání budou zveřejněny zde.",

--- a/frontend/apps/reality-web/messages/de.json
+++ b/frontend/apps/reality-web/messages/de.json
@@ -291,7 +291,8 @@
         "subtitle": "Werden Sie Teil unseres Teams.",
         "title": "Bauen wir einen Immobilienmarkt, der Sinn macht."
       },
-      "title": "Karriere"
+      "title": "Karriere",
+      "h1": "Let's build a real estate market that makes sense."
     },
     "contact": {
       "description": "Für Support oder Geschäftsanfragen kontaktieren Sie uns unter",
@@ -300,19 +301,26 @@
     },
     "cookies": {
       "reopen": "Cookie-Einstellungen erneut öffnen",
-      "title": "Cookie-Richtlinie"
+      "title": "Cookie-Richtlinie",
+      "subtitle": "Cookie policy",
+      "lastUpdated": "Last updated: 1 January 2025"
     },
     "forAgents": {
       "features": "Was Sie erhalten",
       "pricing": "Preispläne",
       "subtitle": "Verkaufen Sie mehr mit Reality Portal",
-      "title": "Für Makler & Agenturen"
+      "title": "Für Makler & Agenturen",
+      "heroTitle": "Sell more with Reality Portal",
+      "heroBadge": "For agents & agencies",
+      "heroIntro": "Tools, analytics and reach across millions of buyers and renters in one place."
     },
     "help": {
       "categories": "Kategorien",
       "faq": "Häufig gestellte Fragen",
       "searchPlaceholder": "Im Hilfe-Center suchen...",
-      "title": "Hilfe-Center"
+      "title": "Hilfe-Center",
+      "subtitle": "How can we help?",
+      "intro": "Search our help centre or contact us directly."
     },
     "journal": {
       "editorsPicks": "Redaktionsauswahl",
@@ -321,7 +329,13 @@
       "mostRead": "Meistgelesen",
       "newsletter": "Newsletter",
       "subtitle": "Analysen, Tipps und Neuigkeiten aus der Immobilienwelt.",
-      "title": "Reality Journal"
+      "title": "Reality Journal",
+      "readingTime": "{min} min read",
+      "newsletterIntro": "Get the latest analyses and tips delivered to your inbox.",
+      "newsletterSuccess": "✅ You're subscribed!",
+      "newsletterEmailPlaceholder": "you@email.com",
+      "newsletterSubmit": "Subscribe",
+      "newsletterTitle": "Newsletter signup"
     },
     "listingEdit": {
       "save": "Änderungen speichern",
@@ -331,7 +345,8 @@
     "priceMap": {
       "clickHint": "Klicken Sie auf einen Bezirk für detaillierte Statistiken.",
       "subtitle": "Bratislava – Übersicht",
-      "title": "Preiskarte"
+      "title": "Preiskarte",
+      "h1": "Price map"
     },
     "privacy": {
       "description": "Wir sind verpflichtet, Ihre personenbezogenen Daten gemäß DSGVO und geltendem Recht zu schützen. Die vollständigen Datenschutzbestimmungen werden hier veröffentlicht.",

--- a/frontend/apps/reality-web/messages/de.json
+++ b/frontend/apps/reality-web/messages/de.json
@@ -505,15 +505,48 @@
       "termsLabel": "I agree to the {termsLink} and the {privacyLink}.",
       "termsRequired": "You must accept the Terms of Service and Privacy Policy to register.",
       "termsLinkText": "Terms of Service",
-      "privacyLinkText": "Privacy Policy"
+      "privacyLinkText": "Privacy Policy",
+      "checkInbox": "Check your inbox",
+      "checkInboxBody": "We sent a verification email to {email}. Click the link to activate your account.",
+      "backToSignIn": "Back to sign in",
+      "creating": "Creating account…",
+      "submit": "Create account"
     },
     "forgotPassword": {
       "title": "Reset your password",
-      "description": "We'll send you a reset link by email."
+      "description": "Enter your email and we'll send you a reset link.",
+      "emailLabel": "Email",
+      "emailRequired": "Email is required",
+      "emailInvalid": "Enter a valid email address",
+      "submit": "Send reset link",
+      "submitting": "Sending…",
+      "checkInbox": "Check your inbox",
+      "checkInboxBody": "If an account exists for {email}, we've sent instructions to reset your password.",
+      "backToSignIn": "Back to sign in",
+      "remembered": "Remembered your password?",
+      "signIn": "Sign in",
+      "networkError": "Network error. Please check your connection and try again.",
+      "serverError": "Server error. Please try again later.",
+      "genericError": "Could not send reset email. Please try again."
     },
     "resetPassword": {
       "title": "Set a new password",
-      "description": "Choose a strong password for your account."
+      "description": "Choose a strong password you haven't used before.",
+      "invalidTitle": "Invalid link",
+      "invalidBody": "This reset link is invalid or has expired. Request a new one.",
+      "successTitle": "Password updated",
+      "successBody": "You can now sign in with your new password.",
+      "passwordLabel": "New password",
+      "confirmLabel": "Confirm password",
+      "passwordHint": "At least 8 characters.",
+      "passwordRequired": "Password is required",
+      "passwordTooShort": "Password must be at least 8 characters",
+      "passwordsMismatch": "Passwords do not match",
+      "submit": "Update password",
+      "submitting": "Saving…",
+      "requestNew": "Request a new reset link",
+      "goToSignIn": "Go to sign in",
+      "genericError": "Could not reset password. Please try again."
     }
   },
   "search": {

--- a/frontend/apps/reality-web/messages/de.json
+++ b/frontend/apps/reality-web/messages/de.json
@@ -465,6 +465,22 @@
         "label": "I agree to the {termsLink} and the {privacyLink}.",
         "termsLink": "terms of use",
         "privacyLink": "privacy policy"
+      },
+      "validation": {
+        "required": "Required",
+        "addressRequired": "Address is required",
+        "cityRequired": "City is required",
+        "areaRequired": "Area is required",
+        "areaPositive": "Area must be greater than 0",
+        "roomsRequired": "Number of rooms is required",
+        "priceRequired": "Price is required",
+        "pricePositive": "Price must be greater than 0",
+        "nameRequired": "Name is required",
+        "phoneRequired": "Phone is required",
+        "phoneFormat": "Please enter a valid phone number",
+        "emailRequired": "E-mail is required",
+        "emailFormat": "Please enter a valid e-mail address",
+        "termsRequired": "You must agree to the terms of use to publish"
       }
     },
     "terms": {
@@ -485,7 +501,11 @@
     },
     "register": {
       "title": "Create your account",
-      "description": "Save listings, set alerts and contact agents."
+      "description": "Save listings, set alerts and contact agents.",
+      "termsLabel": "I agree to the {termsLink} and the {privacyLink}.",
+      "termsRequired": "You must accept the Terms of Service and Privacy Policy to register.",
+      "termsLinkText": "Terms of Service",
+      "privacyLinkText": "Privacy Policy"
     },
     "forgotPassword": {
       "title": "Reset your password",

--- a/frontend/apps/reality-web/messages/de.json
+++ b/frontend/apps/reality-web/messages/de.json
@@ -478,6 +478,22 @@
     "favorites": {
       "title": "Meine Favoriten",
       "description": "Immobilien, die Sie gespeichert haben."
+    },
+    "login": {
+      "title": "Sign in",
+      "description": "Sign in to your Reality Portal account."
+    },
+    "register": {
+      "title": "Create your account",
+      "description": "Save listings, set alerts and contact agents."
+    },
+    "forgotPassword": {
+      "title": "Reset your password",
+      "description": "We'll send you a reset link by email."
+    },
+    "resetPassword": {
+      "title": "Set a new password",
+      "description": "Choose a strong password for your account."
     }
   },
   "search": {

--- a/frontend/apps/reality-web/messages/de.json
+++ b/frontend/apps/reality-web/messages/de.json
@@ -359,14 +359,98 @@
     },
     "sell": {
       "steps": {
-        "details": "Details",
-        "photos": "Fotos",
-        "price": "Preis",
-        "summary": "Kontakt & Zusammenfassung",
-        "typeLocation": "Typ & Lage"
+        "type": {
+          "title": "Type & location",
+          "description": "Choose a property type and enter the address"
+        },
+        "details": {
+          "title": "Details",
+          "description": "Area, rooms, floor, year built"
+        },
+        "photos": {
+          "title": "Photos",
+          "description": "Add high-quality photos"
+        },
+        "price": {
+          "title": "Price",
+          "description": "Set the asking price"
+        },
+        "contact": {
+          "title": "Contact & summary",
+          "description": "Verify details and publish"
+        }
       },
       "submit": "Inserat veröffentlichen",
-      "title": "Inserat aufgeben"
+      "title": "Add listing",
+      "stepLabel": "Step {step} of {total}: {stepTitle}",
+      "asideTitle": "Steps",
+      "back": "← Back",
+      "next": "Next →",
+      "publish": "Publish listing",
+      "submittedTitle": "Your listing has been submitted!",
+      "submittedBody": "After review it will be published within 2 hours.",
+      "submittedCta": "Add another listing",
+      "fields": {
+        "transactionType": "Transaction type",
+        "propertyType": "Property type",
+        "address": "Address",
+        "addressPlaceholder": "Street and number",
+        "city": "City / Town",
+        "cityPlaceholder": "e.g. Bratislava",
+        "area": "Area (m²)",
+        "areaPlaceholder": "e.g. 65",
+        "rooms": "Number of rooms",
+        "roomsPlaceholder": "e.g. 3",
+        "floor": "Floor",
+        "floorPlaceholder": "e.g. 2",
+        "totalFloors": "Total floors",
+        "totalFloorsPlaceholder": "e.g. 7",
+        "yearBuilt": "Year built",
+        "yearBuiltPlaceholder": "e.g. 1995",
+        "description": "Property description",
+        "descriptionPlaceholder": "Describe the property, its features and amenities…",
+        "price": "Asking price (€)",
+        "priceSalePlaceholder": "e.g. 250000",
+        "priceRentPlaceholder": "Monthly rent, e.g. 800",
+        "priceNegotiable": "Price is negotiable",
+        "contactName": "Name",
+        "contactNamePlaceholder": "Your full name",
+        "contactPhone": "Phone",
+        "contactPhonePlaceholder": "+421 9XX XXX XXX",
+        "contactEmail": "E-mail",
+        "contactEmailPlaceholder": "you@email.com"
+      },
+      "transactionOptions": {
+        "sale": "Sale",
+        "rent": "Rent"
+      },
+      "propertyOptions": {
+        "apartment": "Apartment",
+        "house": "House",
+        "land": "Land",
+        "commercial": "Commercial"
+      },
+      "photos": {
+        "intro": "Upload photos (5 minimum, 30 maximum recommended).",
+        "cta": "Click or drag photos here",
+        "formats": "JPG, PNG, WEBP · up to 10 MB each",
+        "selected_one": "✓ {count} photo selected",
+        "selected_other": "✓ {count} photos selected"
+      },
+      "summary": {
+        "type": "Type",
+        "location": "Location",
+        "area": "Area",
+        "rooms": "Rooms",
+        "price": "Price",
+        "photos": "Photos",
+        "negotiable": "(negotiable)"
+      },
+      "terms": {
+        "label": "I agree to the {termsLink} and the {privacyLink}.",
+        "termsLink": "terms of use",
+        "privacyLink": "privacy policy"
+      }
     },
     "terms": {
       "description": "Durch die Nutzung von Reality Portal stimmen Sie unseren Nutzungsbedingungen zu. Die vollständigen Nutzungsbedingungen werden hier veröffentlicht.",

--- a/frontend/apps/reality-web/messages/de.json
+++ b/frontend/apps/reality-web/messages/de.json
@@ -371,6 +371,14 @@
     "terms": {
       "description": "Durch die Nutzung von Reality Portal stimmen Sie unseren Nutzungsbedingungen zu. Die vollständigen Nutzungsbedingungen werden hier veröffentlicht.",
       "title": "Nutzungsbedingungen"
+    },
+    "listings": {
+      "title": "Alle Immobilien",
+      "description": "Durchsuchen Sie alle Immobilienangebote in der Slowakei, der Tschechischen Republik und darüber hinaus."
+    },
+    "favorites": {
+      "title": "Meine Favoriten",
+      "description": "Immobilien, die Sie gespeichert haben."
     }
   },
   "search": {

--- a/frontend/apps/reality-web/messages/de.json
+++ b/frontend/apps/reality-web/messages/de.json
@@ -363,14 +363,17 @@
     },
     "report": {
       "submit": "Meldung absenden",
-      "subtitle": "Helfen Sie uns, das Portal sicher zu halten.",
+      "subtitle": "Help us keep the portal trustworthy — tell us what's wrong.",
       "success": "Meldung wurde gesendet",
-      "title": "Inserat melden"
+      "title": "Report a listing",
+      "h1": "Report a listing"
     },
     "security": {
       "reportCta": "Inserat melden",
-      "subtitle": "Ihre Sicherheit hat oberste Priorität",
-      "title": "Sicherheit"
+      "subtitle": "How we keep listings, payments and your data safe — and what to watch out for.",
+      "title": "Security",
+      "h1": "Your security is our priority",
+      "scenariosHeading": "Common fraud scenarios"
     },
     "sell": {
       "steps": {

--- a/frontend/apps/reality-web/messages/de.json
+++ b/frontend/apps/reality-web/messages/de.json
@@ -483,7 +483,8 @@
         "phoneFormat": "Please enter a valid phone number",
         "emailRequired": "E-mail is required",
         "emailFormat": "Please enter a valid e-mail address",
-        "termsRequired": "You must agree to the terms of use to publish"
+        "termsRequired": "You must agree to the terms of use to publish",
+        "roomsPositive": "Number of rooms must be greater than 0"
       }
     },
     "terms": {
@@ -513,7 +514,22 @@
       "checkInboxBody": "We sent a verification email to {email}. Click the link to activate your account.",
       "backToSignIn": "Back to sign in",
       "creating": "Creating account…",
-      "submit": "Create account"
+      "submit": "Create account",
+      "displayNameRequired": "Display name is required",
+      "emailRequired": "Email is required",
+      "emailInvalid": "Enter a valid email address",
+      "passwordRequired": "Password is required",
+      "passwordTooShort": "Password must be at least {min} characters",
+      "passwordsMismatch": "Passwords do not match",
+      "emailTaken": "An account with this email already exists.",
+      "genericError": "Registration failed. Please try again.",
+      "displayNameLabel": "Display name",
+      "emailLabel": "Email",
+      "passwordLabel": "Password",
+      "confirmPasswordLabel": "Confirm password",
+      "passwordHint": "At least {min} characters.",
+      "haveAccount": "Already have an account?",
+      "signInLink": "Sign in"
     },
     "forgotPassword": {
       "title": "Reset your password",

--- a/frontend/apps/reality-web/messages/en.json
+++ b/frontend/apps/reality-web/messages/en.json
@@ -291,7 +291,8 @@
         "subtitle": "Join our team and help us change the way people buy, sell and rent properties.",
         "title": "Let's build a real estate market that makes sense."
       },
-      "title": "Careers"
+      "title": "Careers",
+      "h1": "Let's build a real estate market that makes sense."
     },
     "contact": {
       "description": "For support or business inquiries, please reach out to us at",
@@ -300,19 +301,26 @@
     },
     "cookies": {
       "reopen": "Re-open cookie settings",
-      "title": "Cookie Policy"
+      "title": "Cookie Policy",
+      "subtitle": "Cookie policy",
+      "lastUpdated": "Last updated: 1 January 2025"
     },
     "forAgents": {
       "features": "What you get",
       "pricing": "Pricing plans",
       "subtitle": "Sell more with Reality Portal",
-      "title": "For agents & agencies"
+      "title": "For agents & agencies",
+      "heroTitle": "Sell more with Reality Portal",
+      "heroBadge": "For agents & agencies",
+      "heroIntro": "Tools, analytics and reach across millions of buyers and renters in one place."
     },
     "help": {
       "categories": "Categories",
       "faq": "Frequently Asked Questions",
       "searchPlaceholder": "Search the help centre...",
-      "title": "Help Centre"
+      "title": "Help Centre",
+      "subtitle": "How can we help?",
+      "intro": "Search our help centre or contact us directly."
     },
     "journal": {
       "editorsPicks": "Editor's picks",
@@ -321,7 +329,13 @@
       "mostRead": "Most read",
       "newsletter": "Newsletter",
       "subtitle": "Analysis, tips and news from the world of real estate.",
-      "title": "Reality Journal"
+      "title": "Reality Journal",
+      "readingTime": "{min} min read",
+      "newsletterIntro": "Get the latest analyses and tips delivered to your inbox.",
+      "newsletterSuccess": "✅ You're subscribed!",
+      "newsletterEmailPlaceholder": "you@email.com",
+      "newsletterSubmit": "Subscribe",
+      "newsletterTitle": "Newsletter signup"
     },
     "listingEdit": {
       "save": "Save changes",
@@ -331,7 +345,8 @@
     "priceMap": {
       "clickHint": "Click on a district for detailed statistics.",
       "subtitle": "Bratislava – Overview",
-      "title": "Price map"
+      "title": "Price map",
+      "h1": "Price map"
     },
     "privacy": {
       "description": "We are committed to protecting your personal data in accordance with GDPR and applicable laws. Full privacy policy details will be published here.",

--- a/frontend/apps/reality-web/messages/en.json
+++ b/frontend/apps/reality-web/messages/en.json
@@ -505,15 +505,48 @@
       "termsLabel": "I agree to the {termsLink} and the {privacyLink}.",
       "termsRequired": "You must accept the Terms of Service and Privacy Policy to register.",
       "termsLinkText": "Terms of Service",
-      "privacyLinkText": "Privacy Policy"
+      "privacyLinkText": "Privacy Policy",
+      "checkInbox": "Check your inbox",
+      "checkInboxBody": "We sent a verification email to {email}. Click the link to activate your account.",
+      "backToSignIn": "Back to sign in",
+      "creating": "Creating account…",
+      "submit": "Create account"
     },
     "forgotPassword": {
       "title": "Reset your password",
-      "description": "We'll send you a reset link by email."
+      "description": "Enter your email and we'll send you a reset link.",
+      "emailLabel": "Email",
+      "emailRequired": "Email is required",
+      "emailInvalid": "Enter a valid email address",
+      "submit": "Send reset link",
+      "submitting": "Sending…",
+      "checkInbox": "Check your inbox",
+      "checkInboxBody": "If an account exists for {email}, we've sent instructions to reset your password.",
+      "backToSignIn": "Back to sign in",
+      "remembered": "Remembered your password?",
+      "signIn": "Sign in",
+      "networkError": "Network error. Please check your connection and try again.",
+      "serverError": "Server error. Please try again later.",
+      "genericError": "Could not send reset email. Please try again."
     },
     "resetPassword": {
       "title": "Set a new password",
-      "description": "Choose a strong password for your account."
+      "description": "Choose a strong password you haven't used before.",
+      "invalidTitle": "Invalid link",
+      "invalidBody": "This reset link is invalid or has expired. Request a new one.",
+      "successTitle": "Password updated",
+      "successBody": "You can now sign in with your new password.",
+      "passwordLabel": "New password",
+      "confirmLabel": "Confirm password",
+      "passwordHint": "At least 8 characters.",
+      "passwordRequired": "Password is required",
+      "passwordTooShort": "Password must be at least 8 characters",
+      "passwordsMismatch": "Passwords do not match",
+      "submit": "Update password",
+      "submitting": "Saving…",
+      "requestNew": "Request a new reset link",
+      "goToSignIn": "Go to sign in",
+      "genericError": "Could not reset password. Please try again."
     }
   },
   "search": {

--- a/frontend/apps/reality-web/messages/en.json
+++ b/frontend/apps/reality-web/messages/en.json
@@ -465,6 +465,22 @@
         "label": "I agree to the {termsLink} and the {privacyLink}.",
         "termsLink": "terms of use",
         "privacyLink": "privacy policy"
+      },
+      "validation": {
+        "required": "Required",
+        "addressRequired": "Address is required",
+        "cityRequired": "City is required",
+        "areaRequired": "Area is required",
+        "areaPositive": "Area must be greater than 0",
+        "roomsRequired": "Number of rooms is required",
+        "priceRequired": "Price is required",
+        "pricePositive": "Price must be greater than 0",
+        "nameRequired": "Name is required",
+        "phoneRequired": "Phone is required",
+        "phoneFormat": "Please enter a valid phone number",
+        "emailRequired": "E-mail is required",
+        "emailFormat": "Please enter a valid e-mail address",
+        "termsRequired": "You must agree to the terms of use to publish"
       }
     },
     "terms": {
@@ -485,7 +501,11 @@
     },
     "register": {
       "title": "Create your account",
-      "description": "Save listings, set alerts and contact agents."
+      "description": "Save listings, set alerts and contact agents.",
+      "termsLabel": "I agree to the {termsLink} and the {privacyLink}.",
+      "termsRequired": "You must accept the Terms of Service and Privacy Policy to register.",
+      "termsLinkText": "Terms of Service",
+      "privacyLinkText": "Privacy Policy"
     },
     "forgotPassword": {
       "title": "Reset your password",

--- a/frontend/apps/reality-web/messages/en.json
+++ b/frontend/apps/reality-web/messages/en.json
@@ -371,6 +371,14 @@
     "terms": {
       "description": "By using Reality Portal, you agree to our terms and conditions. Full terms of service will be published here.",
       "title": "Terms of Service"
+    },
+    "listings": {
+      "title": "All Properties",
+      "description": "Browse all property listings across Slovakia, Czech Republic, and beyond."
+    },
+    "favorites": {
+      "title": "My Favorites",
+      "description": "Properties you have saved for later."
     }
   },
   "search": {

--- a/frontend/apps/reality-web/messages/en.json
+++ b/frontend/apps/reality-web/messages/en.json
@@ -363,14 +363,17 @@
     },
     "report": {
       "submit": "Submit report",
-      "subtitle": "Help us keep the portal safe.",
+      "subtitle": "Help us keep the portal trustworthy — tell us what's wrong.",
       "success": "Report submitted",
-      "title": "Report a listing"
+      "title": "Report a listing",
+      "h1": "Report a listing"
     },
     "security": {
       "reportCta": "Report a listing",
-      "subtitle": "Your safety is our priority",
-      "title": "Security"
+      "subtitle": "We help you spot fraud and trade properties in a safe environment.",
+      "title": "Security",
+      "h1": "Your security is our priority",
+      "scenariosHeading": "Common fraud scenarios"
     },
     "sell": {
       "steps": {

--- a/frontend/apps/reality-web/messages/en.json
+++ b/frontend/apps/reality-web/messages/en.json
@@ -478,6 +478,22 @@
     "favorites": {
       "title": "My Favorites",
       "description": "Properties you have saved for later."
+    },
+    "login": {
+      "title": "Sign in",
+      "description": "Sign in to your Reality Portal account."
+    },
+    "register": {
+      "title": "Create your account",
+      "description": "Save listings, set alerts and contact agents."
+    },
+    "forgotPassword": {
+      "title": "Reset your password",
+      "description": "We'll send you a reset link by email."
+    },
+    "resetPassword": {
+      "title": "Set a new password",
+      "description": "Choose a strong password for your account."
     }
   },
   "search": {

--- a/frontend/apps/reality-web/messages/en.json
+++ b/frontend/apps/reality-web/messages/en.json
@@ -483,7 +483,8 @@
         "phoneFormat": "Please enter a valid phone number",
         "emailRequired": "E-mail is required",
         "emailFormat": "Please enter a valid e-mail address",
-        "termsRequired": "You must agree to the terms of use to publish"
+        "termsRequired": "You must agree to the terms of use to publish",
+        "roomsPositive": "Number of rooms must be greater than 0"
       }
     },
     "terms": {
@@ -513,7 +514,22 @@
       "checkInboxBody": "We sent a verification email to {email}. Click the link to activate your account.",
       "backToSignIn": "Back to sign in",
       "creating": "Creating account…",
-      "submit": "Create account"
+      "submit": "Create account",
+      "displayNameRequired": "Display name is required",
+      "emailRequired": "Email is required",
+      "emailInvalid": "Enter a valid email address",
+      "passwordRequired": "Password is required",
+      "passwordTooShort": "Password must be at least {min} characters",
+      "passwordsMismatch": "Passwords do not match",
+      "emailTaken": "An account with this email already exists.",
+      "genericError": "Registration failed. Please try again.",
+      "displayNameLabel": "Display name",
+      "emailLabel": "Email",
+      "passwordLabel": "Password",
+      "confirmPasswordLabel": "Confirm password",
+      "passwordHint": "At least {min} characters.",
+      "haveAccount": "Already have an account?",
+      "signInLink": "Sign in"
     },
     "forgotPassword": {
       "title": "Reset your password",

--- a/frontend/apps/reality-web/messages/en.json
+++ b/frontend/apps/reality-web/messages/en.json
@@ -359,14 +359,98 @@
     },
     "sell": {
       "steps": {
-        "details": "Details",
-        "photos": "Photos",
-        "price": "Price",
-        "summary": "Contact & summary",
-        "typeLocation": "Type & location"
+        "type": {
+          "title": "Type & location",
+          "description": "Choose a property type and enter the address"
+        },
+        "details": {
+          "title": "Details",
+          "description": "Area, rooms, floor, year built"
+        },
+        "photos": {
+          "title": "Photos",
+          "description": "Add high-quality photos"
+        },
+        "price": {
+          "title": "Price",
+          "description": "Set the asking price"
+        },
+        "contact": {
+          "title": "Contact & summary",
+          "description": "Verify details and publish"
+        }
       },
       "submit": "Publish listing",
-      "title": "Add listing"
+      "title": "Add listing",
+      "stepLabel": "Step {step} of {total}: {stepTitle}",
+      "asideTitle": "Steps",
+      "back": "← Back",
+      "next": "Next →",
+      "publish": "Publish listing",
+      "submittedTitle": "Your listing has been submitted!",
+      "submittedBody": "After review it will be published within 2 hours.",
+      "submittedCta": "Add another listing",
+      "fields": {
+        "transactionType": "Transaction type",
+        "propertyType": "Property type",
+        "address": "Address",
+        "addressPlaceholder": "Street and number",
+        "city": "City / Town",
+        "cityPlaceholder": "e.g. Bratislava",
+        "area": "Area (m²)",
+        "areaPlaceholder": "e.g. 65",
+        "rooms": "Number of rooms",
+        "roomsPlaceholder": "e.g. 3",
+        "floor": "Floor",
+        "floorPlaceholder": "e.g. 2",
+        "totalFloors": "Total floors",
+        "totalFloorsPlaceholder": "e.g. 7",
+        "yearBuilt": "Year built",
+        "yearBuiltPlaceholder": "e.g. 1995",
+        "description": "Property description",
+        "descriptionPlaceholder": "Describe the property, its features and amenities…",
+        "price": "Asking price (€)",
+        "priceSalePlaceholder": "e.g. 250000",
+        "priceRentPlaceholder": "Monthly rent, e.g. 800",
+        "priceNegotiable": "Price is negotiable",
+        "contactName": "Name",
+        "contactNamePlaceholder": "Your full name",
+        "contactPhone": "Phone",
+        "contactPhonePlaceholder": "+421 9XX XXX XXX",
+        "contactEmail": "E-mail",
+        "contactEmailPlaceholder": "you@email.com"
+      },
+      "transactionOptions": {
+        "sale": "Sale",
+        "rent": "Rent"
+      },
+      "propertyOptions": {
+        "apartment": "Apartment",
+        "house": "House",
+        "land": "Land",
+        "commercial": "Commercial"
+      },
+      "photos": {
+        "intro": "Upload photos (5 minimum, 30 maximum recommended).",
+        "cta": "Click or drag photos here",
+        "formats": "JPG, PNG, WEBP · up to 10 MB each",
+        "selected_one": "✓ {count} photo selected",
+        "selected_other": "✓ {count} photos selected"
+      },
+      "summary": {
+        "type": "Type",
+        "location": "Location",
+        "area": "Area",
+        "rooms": "Rooms",
+        "price": "Price",
+        "photos": "Photos",
+        "negotiable": "(negotiable)"
+      },
+      "terms": {
+        "label": "I agree to the {termsLink} and the {privacyLink}.",
+        "termsLink": "terms of use",
+        "privacyLink": "privacy policy"
+      }
     },
     "terms": {
       "description": "By using Reality Portal, you agree to our terms and conditions. Full terms of service will be published here.",

--- a/frontend/apps/reality-web/messages/hu.json
+++ b/frontend/apps/reality-web/messages/hu.json
@@ -371,6 +371,14 @@
       },
       "submit": "Hirdetés közzététele",
       "title": "Hirdetés feladása"
+    },
+    "listings": {
+      "title": "Összes ingatlan",
+      "description": "Böngésszen az összes ingatlanhirdetés között Szlovákiában, Csehországban és azon túl."
+    },
+    "favorites": {
+      "title": "Kedvenceim",
+      "description": "Az Ön által mentett ingatlanok."
     }
   },
   "search": {

--- a/frontend/apps/reality-web/messages/hu.json
+++ b/frontend/apps/reality-web/messages/hu.json
@@ -363,14 +363,98 @@
     },
     "sell": {
       "steps": {
-        "details": "Részletek",
-        "photos": "Fotók",
-        "price": "Ár",
-        "summary": "Kapcsolat és összegzés",
-        "typeLocation": "Típus és helyszín"
+        "type": {
+          "title": "Type & location",
+          "description": "Choose a property type and enter the address"
+        },
+        "details": {
+          "title": "Details",
+          "description": "Area, rooms, floor, year built"
+        },
+        "photos": {
+          "title": "Photos",
+          "description": "Add high-quality photos"
+        },
+        "price": {
+          "title": "Price",
+          "description": "Set the asking price"
+        },
+        "contact": {
+          "title": "Contact & summary",
+          "description": "Verify details and publish"
+        }
       },
       "submit": "Hirdetés közzététele",
-      "title": "Hirdetés feladása"
+      "title": "Add listing",
+      "stepLabel": "Step {step} of {total}: {stepTitle}",
+      "asideTitle": "Steps",
+      "back": "← Back",
+      "next": "Next →",
+      "publish": "Publish listing",
+      "submittedTitle": "Your listing has been submitted!",
+      "submittedBody": "After review it will be published within 2 hours.",
+      "submittedCta": "Add another listing",
+      "fields": {
+        "transactionType": "Transaction type",
+        "propertyType": "Property type",
+        "address": "Address",
+        "addressPlaceholder": "Street and number",
+        "city": "City / Town",
+        "cityPlaceholder": "e.g. Bratislava",
+        "area": "Area (m²)",
+        "areaPlaceholder": "e.g. 65",
+        "rooms": "Number of rooms",
+        "roomsPlaceholder": "e.g. 3",
+        "floor": "Floor",
+        "floorPlaceholder": "e.g. 2",
+        "totalFloors": "Total floors",
+        "totalFloorsPlaceholder": "e.g. 7",
+        "yearBuilt": "Year built",
+        "yearBuiltPlaceholder": "e.g. 1995",
+        "description": "Property description",
+        "descriptionPlaceholder": "Describe the property, its features and amenities…",
+        "price": "Asking price (€)",
+        "priceSalePlaceholder": "e.g. 250000",
+        "priceRentPlaceholder": "Monthly rent, e.g. 800",
+        "priceNegotiable": "Price is negotiable",
+        "contactName": "Name",
+        "contactNamePlaceholder": "Your full name",
+        "contactPhone": "Phone",
+        "contactPhonePlaceholder": "+421 9XX XXX XXX",
+        "contactEmail": "E-mail",
+        "contactEmailPlaceholder": "you@email.com"
+      },
+      "transactionOptions": {
+        "sale": "Sale",
+        "rent": "Rent"
+      },
+      "propertyOptions": {
+        "apartment": "Apartment",
+        "house": "House",
+        "land": "Land",
+        "commercial": "Commercial"
+      },
+      "photos": {
+        "intro": "Upload photos (5 minimum, 30 maximum recommended).",
+        "cta": "Click or drag photos here",
+        "formats": "JPG, PNG, WEBP · up to 10 MB each",
+        "selected_one": "✓ {count} photo selected",
+        "selected_other": "✓ {count} photos selected"
+      },
+      "summary": {
+        "type": "Type",
+        "location": "Location",
+        "area": "Area",
+        "rooms": "Rooms",
+        "price": "Price",
+        "photos": "Photos",
+        "negotiable": "(negotiable)"
+      },
+      "terms": {
+        "label": "I agree to the {termsLink} and the {privacyLink}.",
+        "termsLink": "terms of use",
+        "privacyLink": "privacy policy"
+      }
     },
     "listings": {
       "title": "Összes ingatlan",

--- a/frontend/apps/reality-web/messages/hu.json
+++ b/frontend/apps/reality-web/messages/hu.json
@@ -469,6 +469,22 @@
         "label": "I agree to the {termsLink} and the {privacyLink}.",
         "termsLink": "terms of use",
         "privacyLink": "privacy policy"
+      },
+      "validation": {
+        "required": "Required",
+        "addressRequired": "Address is required",
+        "cityRequired": "City is required",
+        "areaRequired": "Area is required",
+        "areaPositive": "Area must be greater than 0",
+        "roomsRequired": "Number of rooms is required",
+        "priceRequired": "Price is required",
+        "pricePositive": "Price must be greater than 0",
+        "nameRequired": "Name is required",
+        "phoneRequired": "Phone is required",
+        "phoneFormat": "Please enter a valid phone number",
+        "emailRequired": "E-mail is required",
+        "emailFormat": "Please enter a valid e-mail address",
+        "termsRequired": "You must agree to the terms of use to publish"
       }
     },
     "listings": {
@@ -485,7 +501,11 @@
     },
     "register": {
       "title": "Create your account",
-      "description": "Save listings, set alerts and contact agents."
+      "description": "Save listings, set alerts and contact agents.",
+      "termsLabel": "I agree to the {termsLink} and the {privacyLink}.",
+      "termsRequired": "You must accept the Terms of Service and Privacy Policy to register.",
+      "termsLinkText": "Terms of Service",
+      "privacyLinkText": "Privacy Policy"
     },
     "forgotPassword": {
       "title": "Reset your password",

--- a/frontend/apps/reality-web/messages/hu.json
+++ b/frontend/apps/reality-web/messages/hu.json
@@ -505,15 +505,48 @@
       "termsLabel": "I agree to the {termsLink} and the {privacyLink}.",
       "termsRequired": "You must accept the Terms of Service and Privacy Policy to register.",
       "termsLinkText": "Terms of Service",
-      "privacyLinkText": "Privacy Policy"
+      "privacyLinkText": "Privacy Policy",
+      "checkInbox": "Check your inbox",
+      "checkInboxBody": "We sent a verification email to {email}. Click the link to activate your account.",
+      "backToSignIn": "Back to sign in",
+      "creating": "Creating account…",
+      "submit": "Create account"
     },
     "forgotPassword": {
       "title": "Reset your password",
-      "description": "We'll send you a reset link by email."
+      "description": "Enter your email and we'll send you a reset link.",
+      "emailLabel": "Email",
+      "emailRequired": "Email is required",
+      "emailInvalid": "Enter a valid email address",
+      "submit": "Send reset link",
+      "submitting": "Sending…",
+      "checkInbox": "Check your inbox",
+      "checkInboxBody": "If an account exists for {email}, we've sent instructions to reset your password.",
+      "backToSignIn": "Back to sign in",
+      "remembered": "Remembered your password?",
+      "signIn": "Sign in",
+      "networkError": "Network error. Please check your connection and try again.",
+      "serverError": "Server error. Please try again later.",
+      "genericError": "Could not send reset email. Please try again."
     },
     "resetPassword": {
       "title": "Set a new password",
-      "description": "Choose a strong password for your account."
+      "description": "Choose a strong password you haven't used before.",
+      "invalidTitle": "Invalid link",
+      "invalidBody": "This reset link is invalid or has expired. Request a new one.",
+      "successTitle": "Password updated",
+      "successBody": "You can now sign in with your new password.",
+      "passwordLabel": "New password",
+      "confirmLabel": "Confirm password",
+      "passwordHint": "At least 8 characters.",
+      "passwordRequired": "Password is required",
+      "passwordTooShort": "Password must be at least 8 characters",
+      "passwordsMismatch": "Passwords do not match",
+      "submit": "Update password",
+      "submitting": "Saving…",
+      "requestNew": "Request a new reset link",
+      "goToSignIn": "Go to sign in",
+      "genericError": "Could not reset password. Please try again."
     }
   },
   "search": {

--- a/frontend/apps/reality-web/messages/hu.json
+++ b/frontend/apps/reality-web/messages/hu.json
@@ -304,23 +304,31 @@
         "subtitle": "Csatlakozz a csapatunkhoz és segíts megváltoztatni az ingatlanvásárlás, -eladás és -bérlés módját.",
         "title": "Építsünk együtt értelmes ingatlanpiacot."
       },
-      "title": "Karrier"
+      "title": "Karrier",
+      "h1": "Let's build a real estate market that makes sense."
     },
     "cookies": {
       "reopen": "Cookie beállítások újranyitása",
-      "title": "Sütik kezelése"
+      "title": "Sütik kezelése",
+      "subtitle": "Cookie policy",
+      "lastUpdated": "Last updated: 1 January 2025"
     },
     "forAgents": {
       "features": "Amit kapsz",
       "pricing": "Csomagok",
       "subtitle": "Adj el többet a Reality Portállal",
-      "title": "Ügynököknek és irodáknak"
+      "title": "Ügynököknek és irodáknak",
+      "heroTitle": "Sell more with Reality Portal",
+      "heroBadge": "For agents & agencies",
+      "heroIntro": "Tools, analytics and reach across millions of buyers and renters in one place."
     },
     "help": {
       "categories": "Kategóriák",
       "faq": "Gyakori kérdések",
       "searchPlaceholder": "Keress a súgóban...",
-      "title": "Súgóközpont"
+      "title": "Súgóközpont",
+      "subtitle": "How can we help?",
+      "intro": "Search our help centre or contact us directly."
     },
     "journal": {
       "editorsPicks": "Szerkesztői ajánlás",
@@ -329,7 +337,13 @@
       "mostRead": "Legolvasottabb",
       "newsletter": "Hírlevél",
       "subtitle": "Elemzések, tippek és hírek az ingatlanvilágból.",
-      "title": "Reality magazin"
+      "title": "Reality magazin",
+      "readingTime": "{min} min read",
+      "newsletterIntro": "Get the latest analyses and tips delivered to your inbox.",
+      "newsletterSuccess": "✅ You're subscribed!",
+      "newsletterEmailPlaceholder": "you@email.com",
+      "newsletterSubmit": "Subscribe",
+      "newsletterTitle": "Newsletter signup"
     },
     "listingEdit": {
       "save": "Mentés",
@@ -339,7 +353,8 @@
     "priceMap": {
       "clickHint": "Kattints egy kerületre a részletes statisztikákért.",
       "subtitle": "Pozsony – áttekintés",
-      "title": "Ártérkép"
+      "title": "Ártérkép",
+      "h1": "Price map"
     },
     "profile": {
       "tabs": {

--- a/frontend/apps/reality-web/messages/hu.json
+++ b/frontend/apps/reality-web/messages/hu.json
@@ -367,14 +367,17 @@
     },
     "report": {
       "submit": "Bejelentés elküldése",
-      "subtitle": "Segíts megőrizni a portál biztonságát.",
+      "subtitle": "Help us keep the portal trustworthy — tell us what's wrong.",
       "success": "Bejelentés elküldve",
-      "title": "Hirdetés bejelentése"
+      "title": "Report a listing",
+      "h1": "Report a listing"
     },
     "security": {
       "reportCta": "Hirdetés bejelentése",
-      "subtitle": "A biztonságod a legfontosabb",
-      "title": "Biztonság"
+      "subtitle": "How we keep listings, payments and your data safe — and what to watch out for.",
+      "title": "Security",
+      "h1": "Your security is our priority",
+      "scenariosHeading": "Common fraud scenarios"
     },
     "sell": {
       "steps": {

--- a/frontend/apps/reality-web/messages/hu.json
+++ b/frontend/apps/reality-web/messages/hu.json
@@ -487,7 +487,8 @@
         "phoneFormat": "Please enter a valid phone number",
         "emailRequired": "E-mail is required",
         "emailFormat": "Please enter a valid e-mail address",
-        "termsRequired": "You must agree to the terms of use to publish"
+        "termsRequired": "You must agree to the terms of use to publish",
+        "roomsPositive": "Number of rooms must be greater than 0"
       }
     },
     "listings": {
@@ -513,7 +514,22 @@
       "checkInboxBody": "We sent a verification email to {email}. Click the link to activate your account.",
       "backToSignIn": "Back to sign in",
       "creating": "Creating account…",
-      "submit": "Create account"
+      "submit": "Create account",
+      "displayNameRequired": "Display name is required",
+      "emailRequired": "Email is required",
+      "emailInvalid": "Enter a valid email address",
+      "passwordRequired": "Password is required",
+      "passwordTooShort": "Password must be at least {min} characters",
+      "passwordsMismatch": "Passwords do not match",
+      "emailTaken": "An account with this email already exists.",
+      "genericError": "Registration failed. Please try again.",
+      "displayNameLabel": "Display name",
+      "emailLabel": "Email",
+      "passwordLabel": "Password",
+      "confirmPasswordLabel": "Confirm password",
+      "passwordHint": "At least {min} characters.",
+      "haveAccount": "Already have an account?",
+      "signInLink": "Sign in"
     },
     "forgotPassword": {
       "title": "Reset your password",

--- a/frontend/apps/reality-web/messages/hu.json
+++ b/frontend/apps/reality-web/messages/hu.json
@@ -478,6 +478,22 @@
     "favorites": {
       "title": "Kedvenceim",
       "description": "Az Ön által mentett ingatlanok."
+    },
+    "login": {
+      "title": "Sign in",
+      "description": "Sign in to your Reality Portal account."
+    },
+    "register": {
+      "title": "Create your account",
+      "description": "Save listings, set alerts and contact agents."
+    },
+    "forgotPassword": {
+      "title": "Reset your password",
+      "description": "We'll send you a reset link by email."
+    },
+    "resetPassword": {
+      "title": "Set a new password",
+      "description": "Choose a strong password for your account."
     }
   },
   "search": {

--- a/frontend/apps/reality-web/messages/pl.json
+++ b/frontend/apps/reality-web/messages/pl.json
@@ -304,23 +304,31 @@
         "subtitle": "Dołącz do naszego zespołu i pomóż zmienić sposób, w jaki ludzie kupują, sprzedają i wynajmują nieruchomości.",
         "title": "Zbudujmy sensowny rynek nieruchomości."
       },
-      "title": "Kariera"
+      "title": "Kariera",
+      "h1": "Let's build a real estate market that makes sense."
     },
     "cookies": {
       "reopen": "Otwórz ponownie ustawienia cookie",
-      "title": "Polityka cookie"
+      "title": "Polityka cookie",
+      "subtitle": "Cookie policy",
+      "lastUpdated": "Last updated: 1 January 2025"
     },
     "forAgents": {
       "features": "Co zyskujesz",
       "pricing": "Plany cenowe",
       "subtitle": "Sprzedawaj więcej z Reality Portal",
-      "title": "Dla agentów i agencji"
+      "title": "Dla agentów i agencji",
+      "heroTitle": "Sell more with Reality Portal",
+      "heroBadge": "For agents & agencies",
+      "heroIntro": "Tools, analytics and reach across millions of buyers and renters in one place."
     },
     "help": {
       "categories": "Kategorie",
       "faq": "Najczęściej zadawane pytania",
       "searchPlaceholder": "Szukaj w pomocy...",
-      "title": "Centrum pomocy"
+      "title": "Centrum pomocy",
+      "subtitle": "How can we help?",
+      "intro": "Search our help centre or contact us directly."
     },
     "journal": {
       "editorsPicks": "Wybór redakcji",
@@ -329,7 +337,13 @@
       "mostRead": "Najczęściej czytane",
       "newsletter": "Newsletter",
       "subtitle": "Analizy, porady i wiadomości ze świata nieruchomości.",
-      "title": "Reality magazyn"
+      "title": "Reality magazyn",
+      "readingTime": "{min} min read",
+      "newsletterIntro": "Get the latest analyses and tips delivered to your inbox.",
+      "newsletterSuccess": "✅ You're subscribed!",
+      "newsletterEmailPlaceholder": "you@email.com",
+      "newsletterSubmit": "Subscribe",
+      "newsletterTitle": "Newsletter signup"
     },
     "listingEdit": {
       "save": "Zapisz zmiany",
@@ -339,7 +353,8 @@
     "priceMap": {
       "clickHint": "Kliknij dzielnicę po szczegółowe statystyki.",
       "subtitle": "Bratysława – przegląd",
-      "title": "Mapa cen"
+      "title": "Mapa cen",
+      "h1": "Price map"
     },
     "profile": {
       "tabs": {

--- a/frontend/apps/reality-web/messages/pl.json
+++ b/frontend/apps/reality-web/messages/pl.json
@@ -469,6 +469,22 @@
         "label": "I agree to the {termsLink} and the {privacyLink}.",
         "termsLink": "terms of use",
         "privacyLink": "privacy policy"
+      },
+      "validation": {
+        "required": "Required",
+        "addressRequired": "Address is required",
+        "cityRequired": "City is required",
+        "areaRequired": "Area is required",
+        "areaPositive": "Area must be greater than 0",
+        "roomsRequired": "Number of rooms is required",
+        "priceRequired": "Price is required",
+        "pricePositive": "Price must be greater than 0",
+        "nameRequired": "Name is required",
+        "phoneRequired": "Phone is required",
+        "phoneFormat": "Please enter a valid phone number",
+        "emailRequired": "E-mail is required",
+        "emailFormat": "Please enter a valid e-mail address",
+        "termsRequired": "You must agree to the terms of use to publish"
       }
     },
     "listings": {
@@ -485,7 +501,11 @@
     },
     "register": {
       "title": "Create your account",
-      "description": "Save listings, set alerts and contact agents."
+      "description": "Save listings, set alerts and contact agents.",
+      "termsLabel": "I agree to the {termsLink} and the {privacyLink}.",
+      "termsRequired": "You must accept the Terms of Service and Privacy Policy to register.",
+      "termsLinkText": "Terms of Service",
+      "privacyLinkText": "Privacy Policy"
     },
     "forgotPassword": {
       "title": "Reset your password",

--- a/frontend/apps/reality-web/messages/pl.json
+++ b/frontend/apps/reality-web/messages/pl.json
@@ -505,15 +505,48 @@
       "termsLabel": "I agree to the {termsLink} and the {privacyLink}.",
       "termsRequired": "You must accept the Terms of Service and Privacy Policy to register.",
       "termsLinkText": "Terms of Service",
-      "privacyLinkText": "Privacy Policy"
+      "privacyLinkText": "Privacy Policy",
+      "checkInbox": "Check your inbox",
+      "checkInboxBody": "We sent a verification email to {email}. Click the link to activate your account.",
+      "backToSignIn": "Back to sign in",
+      "creating": "Creating account…",
+      "submit": "Create account"
     },
     "forgotPassword": {
       "title": "Reset your password",
-      "description": "We'll send you a reset link by email."
+      "description": "Enter your email and we'll send you a reset link.",
+      "emailLabel": "Email",
+      "emailRequired": "Email is required",
+      "emailInvalid": "Enter a valid email address",
+      "submit": "Send reset link",
+      "submitting": "Sending…",
+      "checkInbox": "Check your inbox",
+      "checkInboxBody": "If an account exists for {email}, we've sent instructions to reset your password.",
+      "backToSignIn": "Back to sign in",
+      "remembered": "Remembered your password?",
+      "signIn": "Sign in",
+      "networkError": "Network error. Please check your connection and try again.",
+      "serverError": "Server error. Please try again later.",
+      "genericError": "Could not send reset email. Please try again."
     },
     "resetPassword": {
       "title": "Set a new password",
-      "description": "Choose a strong password for your account."
+      "description": "Choose a strong password you haven't used before.",
+      "invalidTitle": "Invalid link",
+      "invalidBody": "This reset link is invalid or has expired. Request a new one.",
+      "successTitle": "Password updated",
+      "successBody": "You can now sign in with your new password.",
+      "passwordLabel": "New password",
+      "confirmLabel": "Confirm password",
+      "passwordHint": "At least 8 characters.",
+      "passwordRequired": "Password is required",
+      "passwordTooShort": "Password must be at least 8 characters",
+      "passwordsMismatch": "Passwords do not match",
+      "submit": "Update password",
+      "submitting": "Saving…",
+      "requestNew": "Request a new reset link",
+      "goToSignIn": "Go to sign in",
+      "genericError": "Could not reset password. Please try again."
     }
   },
   "search": {

--- a/frontend/apps/reality-web/messages/pl.json
+++ b/frontend/apps/reality-web/messages/pl.json
@@ -478,6 +478,22 @@
     "favorites": {
       "title": "Moje ulubione",
       "description": "Nieruchomości, które zapisałeś."
+    },
+    "login": {
+      "title": "Sign in",
+      "description": "Sign in to your Reality Portal account."
+    },
+    "register": {
+      "title": "Create your account",
+      "description": "Save listings, set alerts and contact agents."
+    },
+    "forgotPassword": {
+      "title": "Reset your password",
+      "description": "We'll send you a reset link by email."
+    },
+    "resetPassword": {
+      "title": "Set a new password",
+      "description": "Choose a strong password for your account."
     }
   },
   "search": {

--- a/frontend/apps/reality-web/messages/pl.json
+++ b/frontend/apps/reality-web/messages/pl.json
@@ -367,14 +367,17 @@
     },
     "report": {
       "submit": "Wyślij zgłoszenie",
-      "subtitle": "Pomóż utrzymać portal bezpieczny.",
+      "subtitle": "Help us keep the portal trustworthy — tell us what's wrong.",
       "success": "Zgłoszenie wysłane",
-      "title": "Zgłoś ogłoszenie"
+      "title": "Report a listing",
+      "h1": "Report a listing"
     },
     "security": {
       "reportCta": "Zgłoś ogłoszenie",
-      "subtitle": "Twoje bezpieczeństwo jest priorytetem",
-      "title": "Bezpieczeństwo"
+      "subtitle": "How we keep listings, payments and your data safe — and what to watch out for.",
+      "title": "Security",
+      "h1": "Your security is our priority",
+      "scenariosHeading": "Common fraud scenarios"
     },
     "sell": {
       "steps": {

--- a/frontend/apps/reality-web/messages/pl.json
+++ b/frontend/apps/reality-web/messages/pl.json
@@ -363,14 +363,98 @@
     },
     "sell": {
       "steps": {
-        "details": "Szczegóły",
-        "photos": "Zdjęcia",
-        "price": "Cena",
-        "summary": "Kontakt i podsumowanie",
-        "typeLocation": "Typ i lokalizacja"
+        "type": {
+          "title": "Type & location",
+          "description": "Choose a property type and enter the address"
+        },
+        "details": {
+          "title": "Details",
+          "description": "Area, rooms, floor, year built"
+        },
+        "photos": {
+          "title": "Photos",
+          "description": "Add high-quality photos"
+        },
+        "price": {
+          "title": "Price",
+          "description": "Set the asking price"
+        },
+        "contact": {
+          "title": "Contact & summary",
+          "description": "Verify details and publish"
+        }
       },
       "submit": "Opublikuj ogłoszenie",
-      "title": "Dodaj ogłoszenie"
+      "title": "Add listing",
+      "stepLabel": "Step {step} of {total}: {stepTitle}",
+      "asideTitle": "Steps",
+      "back": "← Back",
+      "next": "Next →",
+      "publish": "Publish listing",
+      "submittedTitle": "Your listing has been submitted!",
+      "submittedBody": "After review it will be published within 2 hours.",
+      "submittedCta": "Add another listing",
+      "fields": {
+        "transactionType": "Transaction type",
+        "propertyType": "Property type",
+        "address": "Address",
+        "addressPlaceholder": "Street and number",
+        "city": "City / Town",
+        "cityPlaceholder": "e.g. Bratislava",
+        "area": "Area (m²)",
+        "areaPlaceholder": "e.g. 65",
+        "rooms": "Number of rooms",
+        "roomsPlaceholder": "e.g. 3",
+        "floor": "Floor",
+        "floorPlaceholder": "e.g. 2",
+        "totalFloors": "Total floors",
+        "totalFloorsPlaceholder": "e.g. 7",
+        "yearBuilt": "Year built",
+        "yearBuiltPlaceholder": "e.g. 1995",
+        "description": "Property description",
+        "descriptionPlaceholder": "Describe the property, its features and amenities…",
+        "price": "Asking price (€)",
+        "priceSalePlaceholder": "e.g. 250000",
+        "priceRentPlaceholder": "Monthly rent, e.g. 800",
+        "priceNegotiable": "Price is negotiable",
+        "contactName": "Name",
+        "contactNamePlaceholder": "Your full name",
+        "contactPhone": "Phone",
+        "contactPhonePlaceholder": "+421 9XX XXX XXX",
+        "contactEmail": "E-mail",
+        "contactEmailPlaceholder": "you@email.com"
+      },
+      "transactionOptions": {
+        "sale": "Sale",
+        "rent": "Rent"
+      },
+      "propertyOptions": {
+        "apartment": "Apartment",
+        "house": "House",
+        "land": "Land",
+        "commercial": "Commercial"
+      },
+      "photos": {
+        "intro": "Upload photos (5 minimum, 30 maximum recommended).",
+        "cta": "Click or drag photos here",
+        "formats": "JPG, PNG, WEBP · up to 10 MB each",
+        "selected_one": "✓ {count} photo selected",
+        "selected_other": "✓ {count} photos selected"
+      },
+      "summary": {
+        "type": "Type",
+        "location": "Location",
+        "area": "Area",
+        "rooms": "Rooms",
+        "price": "Price",
+        "photos": "Photos",
+        "negotiable": "(negotiable)"
+      },
+      "terms": {
+        "label": "I agree to the {termsLink} and the {privacyLink}.",
+        "termsLink": "terms of use",
+        "privacyLink": "privacy policy"
+      }
     },
     "listings": {
       "title": "Wszystkie nieruchomości",

--- a/frontend/apps/reality-web/messages/pl.json
+++ b/frontend/apps/reality-web/messages/pl.json
@@ -487,7 +487,8 @@
         "phoneFormat": "Please enter a valid phone number",
         "emailRequired": "E-mail is required",
         "emailFormat": "Please enter a valid e-mail address",
-        "termsRequired": "You must agree to the terms of use to publish"
+        "termsRequired": "You must agree to the terms of use to publish",
+        "roomsPositive": "Number of rooms must be greater than 0"
       }
     },
     "listings": {
@@ -513,7 +514,22 @@
       "checkInboxBody": "We sent a verification email to {email}. Click the link to activate your account.",
       "backToSignIn": "Back to sign in",
       "creating": "Creating account…",
-      "submit": "Create account"
+      "submit": "Create account",
+      "displayNameRequired": "Display name is required",
+      "emailRequired": "Email is required",
+      "emailInvalid": "Enter a valid email address",
+      "passwordRequired": "Password is required",
+      "passwordTooShort": "Password must be at least {min} characters",
+      "passwordsMismatch": "Passwords do not match",
+      "emailTaken": "An account with this email already exists.",
+      "genericError": "Registration failed. Please try again.",
+      "displayNameLabel": "Display name",
+      "emailLabel": "Email",
+      "passwordLabel": "Password",
+      "confirmPasswordLabel": "Confirm password",
+      "passwordHint": "At least {min} characters.",
+      "haveAccount": "Already have an account?",
+      "signInLink": "Sign in"
     },
     "forgotPassword": {
       "title": "Reset your password",

--- a/frontend/apps/reality-web/messages/pl.json
+++ b/frontend/apps/reality-web/messages/pl.json
@@ -371,6 +371,14 @@
       },
       "submit": "Opublikuj ogłoszenie",
       "title": "Dodaj ogłoszenie"
+    },
+    "listings": {
+      "title": "Wszystkie nieruchomości",
+      "description": "Przeszukaj wszystkie oferty nieruchomości na Słowacji, w Czechach i nie tylko."
+    },
+    "favorites": {
+      "title": "Moje ulubione",
+      "description": "Nieruchomości, które zapisałeś."
     }
   },
   "search": {

--- a/frontend/apps/reality-web/messages/sk.json
+++ b/frontend/apps/reality-web/messages/sk.json
@@ -465,6 +465,22 @@
         "label": "Súhlasím s {termsLink} a {privacyLink}.",
         "termsLink": "podmienkami používania",
         "privacyLink": "ochranou osobných údajov"
+      },
+      "validation": {
+        "required": "Povinné",
+        "addressRequired": "Adresa je povinná",
+        "cityRequired": "Mesto je povinné",
+        "areaRequired": "Plocha je povinná",
+        "areaPositive": "Plocha musí byť väčšia ako 0",
+        "roomsRequired": "Počet izieb je povinný",
+        "priceRequired": "Cena je povinná",
+        "pricePositive": "Cena musí byť väčšia ako 0",
+        "nameRequired": "Meno je povinné",
+        "phoneRequired": "Telefón je povinný",
+        "phoneFormat": "Zadajte platné telefónne číslo",
+        "emailRequired": "E-mail je povinný",
+        "emailFormat": "Zadajte platnú e-mailovú adresu",
+        "termsRequired": "Pre zverejnenie musíte akceptovať podmienky používania"
       }
     },
     "terms": {
@@ -485,7 +501,11 @@
     },
     "register": {
       "title": "Vytvorenie účtu",
-      "description": "Uložte si inzeráty, nastavte upozornenia a kontaktujte maklérov."
+      "description": "Uložte si inzeráty, nastavte upozornenia a kontaktujte maklérov.",
+      "termsLabel": "Súhlasím s {termsLink} a {privacyLink}.",
+      "termsRequired": "Pre registráciu musíte akceptovať podmienky používania a ochranu súkromia.",
+      "termsLinkText": "podmienkami používania",
+      "privacyLinkText": "ochranou súkromia"
     },
     "forgotPassword": {
       "title": "Obnovenie hesla",

--- a/frontend/apps/reality-web/messages/sk.json
+++ b/frontend/apps/reality-web/messages/sk.json
@@ -371,6 +371,14 @@
     "terms": {
       "description": "Používaním Reality Portálu súhlasíte s našimi podmienkami a ustanoveniami. Úplné podmienky používania budú zverejnené tu.",
       "title": "Podmienky používania"
+    },
+    "listings": {
+      "title": "Všetky nehnuteľnosti",
+      "description": "Prehľadajte všetky ponuky nehnuteľností na Slovensku, v Českej republike a ďalej."
+    },
+    "favorites": {
+      "title": "Moje obľúbené",
+      "description": "Nehnuteľnosti, ktoré ste si uložili."
     }
   },
   "search": {

--- a/frontend/apps/reality-web/messages/sk.json
+++ b/frontend/apps/reality-web/messages/sk.json
@@ -359,14 +359,98 @@
     },
     "sell": {
       "steps": {
-        "details": "Detaily",
-        "photos": "Fotografie",
-        "price": "Cena",
-        "summary": "Kontakt & súhrn",
-        "typeLocation": "Typ a poloha"
+        "type": {
+          "title": "Typ a poloha",
+          "description": "Vyberte typ nehnuteľnosti a zadajte adresu"
+        },
+        "details": {
+          "title": "Detaily",
+          "description": "Plocha, izby, poschodie, rok výstavby"
+        },
+        "photos": {
+          "title": "Fotografie",
+          "description": "Pridajte kvalitné fotografie"
+        },
+        "price": {
+          "title": "Cena",
+          "description": "Nastavte požadovanú cenu"
+        },
+        "contact": {
+          "title": "Kontakt & súhrn",
+          "description": "Overte údaje a zverejnite ponuku"
+        }
       },
       "submit": "Zverejniť inzerát",
-      "title": "Pridať inzerát"
+      "title": "Pridať inzerát",
+      "stepLabel": "Krok {step} z {total}: {stepTitle}",
+      "asideTitle": "Postup",
+      "back": "← Späť",
+      "next": "Ďalej →",
+      "publish": "Zverejniť inzerát",
+      "submittedTitle": "Váš inzerát bol odoslaný!",
+      "submittedBody": "Po overení bude zverejnený do 2 hodín.",
+      "submittedCta": "Pridať ďalší inzerát",
+      "fields": {
+        "transactionType": "Typ transakcie",
+        "propertyType": "Typ nehnuteľnosti",
+        "address": "Adresa",
+        "addressPlaceholder": "Ulica a číslo",
+        "city": "Mesto / Obec",
+        "cityPlaceholder": "Napr. Bratislava",
+        "area": "Plocha (m²)",
+        "areaPlaceholder": "Napr. 65",
+        "rooms": "Počet izieb",
+        "roomsPlaceholder": "Napr. 3",
+        "floor": "Poschodie",
+        "floorPlaceholder": "Napr. 2",
+        "totalFloors": "Celkový počet poschodí",
+        "totalFloorsPlaceholder": "Napr. 7",
+        "yearBuilt": "Rok výstavby",
+        "yearBuiltPlaceholder": "Napr. 1995",
+        "description": "Popis nehnuteľnosti",
+        "descriptionPlaceholder": "Opíšte nehnuteľnosť, jej vlastnosti, vybavenie…",
+        "price": "Požadovaná cena (€)",
+        "priceSalePlaceholder": "Napr. 250000",
+        "priceRentPlaceholder": "Mesačný nájom napr. 800",
+        "priceNegotiable": "Cena je dohodou",
+        "contactName": "Meno",
+        "contactNamePlaceholder": "Vaše meno a priezvisko",
+        "contactPhone": "Telefón",
+        "contactPhonePlaceholder": "+421 9XX XXX XXX",
+        "contactEmail": "E-mail",
+        "contactEmailPlaceholder": "vas@email.sk"
+      },
+      "transactionOptions": {
+        "sale": "Predaj",
+        "rent": "Prenájom"
+      },
+      "propertyOptions": {
+        "apartment": "Byt",
+        "house": "Dom",
+        "land": "Pozemok",
+        "commercial": "Komerčné"
+      },
+      "photos": {
+        "intro": "Nahrajte fotografie (odporúčané min. 5, max. 30).",
+        "cta": "Kliknite alebo pretiahnite fotografie sem",
+        "formats": "JPG, PNG, WEBP · max. 10 MB na fotku",
+        "selected_one": "✓ {count} fotografia vybratá",
+        "selected_other": "✓ {count} fotografií vybratých"
+      },
+      "summary": {
+        "type": "Typ",
+        "location": "Poloha",
+        "area": "Plocha",
+        "rooms": "Izby",
+        "price": "Cena",
+        "photos": "Fotografie",
+        "negotiable": "(dohodou)"
+      },
+      "terms": {
+        "label": "Súhlasím s {termsLink} a {privacyLink}.",
+        "termsLink": "podmienkami používania",
+        "privacyLink": "ochranou osobných údajov"
+      }
     },
     "terms": {
       "description": "Používaním Reality Portálu súhlasíte s našimi podmienkami a ustanoveniami. Úplné podmienky používania budú zverejnené tu.",

--- a/frontend/apps/reality-web/messages/sk.json
+++ b/frontend/apps/reality-web/messages/sk.json
@@ -363,14 +363,17 @@
     },
     "report": {
       "submit": "Odoslať nahlásenie",
-      "subtitle": "Pomôžte nám udržiavať portál bezpečným.",
+      "subtitle": "Pomôžte nám udržať portál dôveryhodný — povedzte nám, čo je v ponuke zlé.",
       "success": "Nahlásenie bolo odoslané",
-      "title": "Nahlásiť inzerát"
+      "title": "Nahlásiť inzerát",
+      "h1": "Nahlásiť inzerát"
     },
     "security": {
       "reportCta": "Nahlásiť ponuku",
-      "subtitle": "Vaša bezpečnosť je naša priorita",
-      "title": "Bezpečnosť"
+      "subtitle": "Pomáhame vám rozpoznať podvody a obchodovať s nehnuteľnosťami v bezpečnom prostredí.",
+      "title": "Bezpečnosť",
+      "h1": "Vaša bezpečnosť je naša priorita",
+      "scenariosHeading": "Časté podvodné scenáre"
     },
     "sell": {
       "steps": {

--- a/frontend/apps/reality-web/messages/sk.json
+++ b/frontend/apps/reality-web/messages/sk.json
@@ -310,7 +310,7 @@
       "pricing": "Cenové plány",
       "subtitle": "Predávajte viac s Reality Portálom",
       "title": "Pre maklérov & agentúry",
-      "heroTitle": "Predávajte viac s Reality Portal",
+      "heroTitle": "Predávajte viac s Reality Portálom",
       "heroBadge": "Pre maklérov & agentúry",
       "heroIntro": "Nástroje, analytika a dosah na milióny kupujúcich a nájomníkov na jednom mieste."
     },
@@ -483,7 +483,8 @@
         "phoneFormat": "Zadajte platné telefónne číslo",
         "emailRequired": "E-mail je povinný",
         "emailFormat": "Zadajte platnú e-mailovú adresu",
-        "termsRequired": "Pre zverejnenie musíte akceptovať podmienky používania"
+        "termsRequired": "Pre zverejnenie musíte akceptovať podmienky používania",
+        "roomsPositive": "Počet izieb musí byť väčší ako 0"
       }
     },
     "terms": {
@@ -513,7 +514,22 @@
       "checkInboxBody": "Poslali sme overovací e-mail na adresu {email}. Kliknite na odkaz pre aktiváciu účtu.",
       "backToSignIn": "Späť na prihlásenie",
       "creating": "Vytvára sa účet…",
-      "submit": "Vytvoriť účet"
+      "submit": "Vytvoriť účet",
+      "displayNameRequired": "Zobrazované meno je povinné",
+      "emailRequired": "E-mail je povinný",
+      "emailInvalid": "Zadajte platnú e-mailovú adresu",
+      "passwordRequired": "Heslo je povinné",
+      "passwordTooShort": "Heslo musí mať aspoň {min} znakov",
+      "passwordsMismatch": "Heslá sa nezhodujú",
+      "emailTaken": "Účet s týmto e-mailom už existuje.",
+      "genericError": "Registrácia zlyhala. Skúste to znova.",
+      "displayNameLabel": "Zobrazované meno",
+      "emailLabel": "E-mail",
+      "passwordLabel": "Heslo",
+      "confirmPasswordLabel": "Potvrdiť heslo",
+      "passwordHint": "Aspoň {min} znakov.",
+      "haveAccount": "Už máte účet?",
+      "signInLink": "Prihlásiť sa"
     },
     "forgotPassword": {
       "title": "Obnovenie hesla",

--- a/frontend/apps/reality-web/messages/sk.json
+++ b/frontend/apps/reality-web/messages/sk.json
@@ -505,15 +505,48 @@
       "termsLabel": "Súhlasím s {termsLink} a {privacyLink}.",
       "termsRequired": "Pre registráciu musíte akceptovať podmienky používania a ochranu súkromia.",
       "termsLinkText": "podmienkami používania",
-      "privacyLinkText": "ochranou súkromia"
+      "privacyLinkText": "ochranou súkromia",
+      "checkInbox": "Skontrolujte si schránku",
+      "checkInboxBody": "Poslali sme overovací e-mail na adresu {email}. Kliknite na odkaz pre aktiváciu účtu.",
+      "backToSignIn": "Späť na prihlásenie",
+      "creating": "Vytvára sa účet…",
+      "submit": "Vytvoriť účet"
     },
     "forgotPassword": {
       "title": "Obnovenie hesla",
-      "description": "Pošleme vám e-mailom odkaz na obnovenie hesla."
+      "description": "Zadajte svoj e-mail a pošleme vám odkaz na obnovenie.",
+      "emailLabel": "E-mail",
+      "emailRequired": "E-mail je povinný",
+      "emailInvalid": "Zadajte platnú e-mailovú adresu",
+      "submit": "Poslať odkaz",
+      "submitting": "Odosielam…",
+      "checkInbox": "Skontrolujte si schránku",
+      "checkInboxBody": "Ak pre {email} existuje účet, poslali sme vám pokyny na obnovenie hesla.",
+      "backToSignIn": "Späť na prihlásenie",
+      "remembered": "Spomenuli ste si na heslo?",
+      "signIn": "Prihlásiť sa",
+      "networkError": "Chyba siete. Skontrolujte pripojenie a skúste znova.",
+      "serverError": "Chyba servera. Skúste to neskôr.",
+      "genericError": "Nepodarilo sa odoslať obnovovací e-mail. Skúste znova."
     },
     "resetPassword": {
       "title": "Nastavenie nového hesla",
-      "description": "Zvoľte si silné heslo k vášmu účtu."
+      "description": "Zvoľte si silné heslo, ktoré ste predtým nepoužili.",
+      "invalidTitle": "Neplatný odkaz",
+      "invalidBody": "Tento obnovovací odkaz je neplatný alebo expirovaný. Vyžiadajte si nový.",
+      "successTitle": "Heslo aktualizované",
+      "successBody": "Teraz sa môžete prihlásiť novým heslom.",
+      "passwordLabel": "Nové heslo",
+      "confirmLabel": "Potvrdiť heslo",
+      "passwordHint": "Aspoň 8 znakov.",
+      "passwordRequired": "Heslo je povinné",
+      "passwordTooShort": "Heslo musí mať aspoň 8 znakov",
+      "passwordsMismatch": "Heslá sa nezhodujú",
+      "submit": "Aktualizovať heslo",
+      "submitting": "Ukladám…",
+      "requestNew": "Vyžiadať nový odkaz",
+      "goToSignIn": "Prejsť na prihlásenie",
+      "genericError": "Nepodarilo sa obnoviť heslo. Skúste znova."
     }
   },
   "search": {

--- a/frontend/apps/reality-web/messages/sk.json
+++ b/frontend/apps/reality-web/messages/sk.json
@@ -291,7 +291,8 @@
         "subtitle": "Pridajte sa k nášmu tímu a pomôžte nám meniť spôsob, akým ľudia nakupujú, predávajú a prenajímajú nehnuteľnosti.",
         "title": "Stavajme realitný trh, ktorý dáva zmysel."
       },
-      "title": "Kariéra"
+      "title": "Kariéra",
+      "h1": "Stavajme realitný trh, ktorý dáva zmysel."
     },
     "contact": {
       "description": "Pre podporu alebo obchodné otázky nás kontaktujte na",
@@ -300,19 +301,26 @@
     },
     "cookies": {
       "reopen": "Znova otvoriť nastavenia cookies",
-      "title": "Zásady používania cookies"
+      "title": "Zásady používania cookies",
+      "subtitle": "Zásady používania cookies",
+      "lastUpdated": "Posledná aktualizácia: 1. januára 2025"
     },
     "forAgents": {
       "features": "Čo získate",
       "pricing": "Cenové plány",
       "subtitle": "Predávajte viac s Reality Portálom",
-      "title": "Pre maklérov & agentúry"
+      "title": "Pre maklérov & agentúry",
+      "heroTitle": "Predávajte viac s Reality Portal",
+      "heroBadge": "Pre maklérov & agentúry",
+      "heroIntro": "Nástroje, analytika a dosah na milióny kupujúcich a nájomníkov na jednom mieste."
     },
     "help": {
       "categories": "Kategórie",
       "faq": "Často kladené otázky",
       "searchPlaceholder": "Hľadajte v centre pomoci...",
-      "title": "Centrum pomoci"
+      "title": "Centrum pomoci",
+      "subtitle": "Ako vám môžeme pomôcť?",
+      "intro": "Prehľadajte naše centrum pomoci alebo nás kontaktujte priamo."
     },
     "journal": {
       "editorsPicks": "Výber redakcie",
@@ -321,7 +329,13 @@
       "mostRead": "Najviac čítané",
       "newsletter": "Odber noviniek",
       "subtitle": "Analýzy, tipy a správy zo sveta nehnuteľností.",
-      "title": "Reality Žurnál"
+      "title": "Reality Žurnál",
+      "readingTime": "{min} min čítania",
+      "newsletterIntro": "Dostávajte najnovšie analýzy a tipy priamo do vašej schránky.",
+      "newsletterSuccess": "✅ Ste prihlásení na odber!",
+      "newsletterEmailPlaceholder": "vas@email.sk",
+      "newsletterSubmit": "Prihlásiť sa",
+      "newsletterTitle": "Odber noviniek"
     },
     "listingEdit": {
       "save": "Uložiť zmeny",
@@ -331,7 +345,8 @@
     "priceMap": {
       "clickHint": "Kliknite na mestskú štvrť pre detailné štatistiky.",
       "subtitle": "Bratislava – Prehľad",
-      "title": "Mapa cien"
+      "title": "Mapa cien",
+      "h1": "Mapa cien"
     },
     "privacy": {
       "description": "Zaviazali sme sa chrániť vaše osobné údaje v súlade s GDPR a platnými zákonmi. Úplné podmienky ochrany súkromia budú zverejnené tu.",

--- a/frontend/apps/reality-web/messages/sk.json
+++ b/frontend/apps/reality-web/messages/sk.json
@@ -478,6 +478,22 @@
     "favorites": {
       "title": "Moje obľúbené",
       "description": "Nehnuteľnosti, ktoré ste si uložili."
+    },
+    "login": {
+      "title": "Prihlásenie",
+      "description": "Prihláste sa do svojho účtu na Reality Portáli."
+    },
+    "register": {
+      "title": "Vytvorenie účtu",
+      "description": "Uložte si inzeráty, nastavte upozornenia a kontaktujte maklérov."
+    },
+    "forgotPassword": {
+      "title": "Obnovenie hesla",
+      "description": "Pošleme vám e-mailom odkaz na obnovenie hesla."
+    },
+    "resetPassword": {
+      "title": "Nastavenie nového hesla",
+      "description": "Zvoľte si silné heslo k vášmu účtu."
     }
   },
   "search": {

--- a/frontend/apps/reality-web/src/app/[locale]/about/_content.ts
+++ b/frontend/apps/reality-web/src/app/[locale]/about/_content.ts
@@ -1,9 +1,17 @@
 /**
- * About page content — Slovak source. Mirror translation work into the locale
- * JSON later if the page becomes a localization target; for now legal/info
- * pages on this primarily-Slovak portal ship in Slovak only (matches the
- * cookies/security/help pattern in this repo).
+ * About page content — localized.
+ *
+ * Long-form prose lives here rather than in messages/*.json because the
+ * structure is nested (sections × paragraphs / items) and next-intl's
+ * flat-key model would either require a non-trivial array helper or
+ * lots of indexed keys (section.mission.paragraph.0, ...). Keeping the
+ * tree as data preserves IDE jump-to-definition and lets translators
+ * edit one file per locale instead of hunting through a 4-level JSON.
+ *
+ * If a locale isn't present we fall back to English (declared first).
  */
+
+import type { Locale } from '../../../i18n/config';
 
 export interface AboutSection {
   id: string;
@@ -12,74 +20,171 @@ export interface AboutSection {
   items?: { label: string; description: string }[];
 }
 
-export const ABOUT_HERO = {
-  subtitle:
-    'Reality Portál pomáha ľuďom nájsť domov a maklérom predať viac — bez zbytočných poplatkov a s férovými podmienkami pre obe strany.',
+interface AboutContent {
+  hero: { subtitle: string };
+  stats: { value: string; label: string }[];
+  sections: AboutSection[];
+}
+
+const en: AboutContent = {
+  hero: {
+    subtitle:
+      'Reality Portal helps people find a home and helps agents sell more — without unnecessary fees and with fair terms for both sides.',
+  },
+  stats: [
+    { value: '12,000+', label: 'active listings' },
+    { value: '850+', label: 'verified agents' },
+    { value: '4 countries', label: 'SK · CZ · DE · EU' },
+    { value: '180,000', label: 'monthly visits' },
+  ],
+  sections: [
+    {
+      id: 'mission',
+      heading: 'Our mission',
+      paragraphs: [
+        'We believe finding a property should not be stressful. We make sure that every buyer, seller, and renter has a clear view of what the market offers, at what price, and from whom.',
+        'We combine transparent listings, verified agent identities, and fair pricing into one platform that is as approachable for a family looking for their first flat as it is for a professional investor.',
+      ],
+    },
+    {
+      id: 'story',
+      heading: 'Our story',
+      paragraphs: [
+        'Reality Portal was founded in Bratislava in 2024 out of frustration with existing portals — duplicate listings, hidden fees, and agency offers passed off as direct sales.',
+        'We started with what we knew: a simple structure, clean search, and strict rules for agency listings. We added a price map, a market-analysis journal, and tools for agencies along the way. We are still building.',
+      ],
+    },
+    {
+      id: 'values',
+      heading: 'Values that hold us together',
+      items: [
+        {
+          label: 'Transparency',
+          description:
+            'No hidden fees, no retouched photos. A listing shows what the seller is offering — nothing more, nothing less.',
+        },
+        {
+          label: 'Verification',
+          description:
+            'Every agent passes an identity check. Private sellers are tagged as such; agencies have a profile listing all their inventory.',
+        },
+        {
+          label: 'Fair pricing',
+          description:
+            'Always free for private sellers. Tariffs for agencies scale with volume, with no surprise fees and no pressure to subscribe.',
+        },
+        {
+          label: 'Local understanding',
+          description:
+            'Our team in Bratislava and Prague knows the regional differences — from price levels in Petržalka to market dynamics in Brno.',
+        },
+      ],
+    },
+    {
+      id: 'team',
+      heading: 'Who we do this for',
+      paragraphs: [
+        'For the family finally buying their own flat. For the retiree downsizing to a smaller place. For the investor comparing the yield on five plots in the same neighbourhood.',
+        'And for the agents who do honest work and want clear tools, not yet another subscription with an unreadable contract.',
+      ],
+    },
+    {
+      id: 'contact',
+      heading: 'Get in touch',
+      paragraphs: [
+        'Have feedback, an idea, or want to partner with us? Write to info@rlt.sk — we usually reply within 24 hours on business days.',
+      ],
+    },
+  ],
 };
 
-export const ABOUT_STATS: { value: string; label: string }[] = [
-  { value: '12 000+', label: 'aktívnych inzerátov' },
-  { value: '850+', label: 'overených maklérov' },
-  { value: '4 krajiny', label: 'SK · CZ · DE · EU' },
-  { value: '180 000', label: 'mesačných návštev' },
-];
+const sk: AboutContent = {
+  hero: {
+    subtitle:
+      'Reality Portál pomáha ľuďom nájsť domov a maklérom predať viac — bez zbytočných poplatkov a s férovými podmienkami pre obe strany.',
+  },
+  stats: [
+    { value: '12 000+', label: 'aktívnych inzerátov' },
+    { value: '850+', label: 'overených maklérov' },
+    { value: '4 krajiny', label: 'SK · CZ · DE · EU' },
+    { value: '180 000', label: 'mesačných návštev' },
+  ],
+  sections: [
+    {
+      id: 'mission',
+      heading: 'Naša misia',
+      paragraphs: [
+        'Veríme, že hľadanie nehnuteľnosti by nemalo byť stresujúce. Robíme to, aby každý — kupujúci, predávajúci aj nájomca — mal jasný prehľad o tom, čo trh ponúka, za akú cenu a od koho.',
+        'Spájame transparentné inzeráty, overené identity maklérov a férové ceny do jednej platformy, ktorá je rovnako blízka rodine hľadajúcej prvý byt ako profesionálnemu investorovi.',
+      ],
+    },
+    {
+      id: 'story',
+      heading: 'Príbeh portálu',
+      paragraphs: [
+        'Reality Portál vznikol v Bratislave v roku 2024 z frustrácie z existujúcich portálov — duplicitné inzeráty, skryté poplatky a maklérske ponuky vydávané za priame predaje.',
+        'Začali sme tým, čo poznáme: jednoduchá štruktúra, čisté vyhľadávanie a striktné pravidlá pre maklérske inzeráty. Postupne sme pridali mapu cien, žurnál s analýzami trhu a nástroje pre agentúry. Stále staviame ďalej.',
+      ],
+    },
+    {
+      id: 'values',
+      heading: 'Hodnoty, ktoré nás držia',
+      items: [
+        {
+          label: 'Transparentnosť',
+          description:
+            'Žiadne skryté poplatky, žiadne prikrášlené fotografie. Inzerát ukazuje to, čo predávajúci ponúka — nič viac, nič menej.',
+        },
+        {
+          label: 'Overenie',
+          description:
+            'Každý maklér prechádza identifikáciou. Súkromní predávajúci sú označení, agentúry majú profil so všetkými inzerátmi.',
+        },
+        {
+          label: 'Férová cena',
+          description:
+            'Pre súkromných predávajúcich vždy zadarmo. Pre maklérov tarif podľa objemu, bez prekvapení a bez nátlaku na predplatné.',
+        },
+        {
+          label: 'Lokálne porozumenie',
+          description:
+            'Tím v Bratislave a Prahe pozná regionálne rozdiely — od cenovej hladiny v Petržalke po realitnú dynamiku v Brne.',
+        },
+      ],
+    },
+    {
+      id: 'team',
+      heading: 'Pre koho to robíme',
+      paragraphs: [
+        'Pre rodinu, ktorá konečne kupuje vlastný byt. Pre dôchodcu, ktorý znižuje a hľadá menšie. Pre investora, ktorý porovnáva výnosnosť piatich pozemkov v rovnakej štvrti.',
+        'A pre maklérov, ktorí svoju prácu robia poctivo a chcú jasné nástroje, nie ďalšie predplatné s nečitateľným kontraktom.',
+      ],
+    },
+    {
+      id: 'contact',
+      heading: 'Spojte sa s nami',
+      paragraphs: [
+        'Máte spätnú väzbu, návrh alebo chcete spolupracovať? Napíšte nám na info@rlt.sk — odpovedáme zvyčajne do 24 hodín v pracovných dňoch.',
+      ],
+    },
+  ],
+};
 
-export const ABOUT_SECTIONS: AboutSection[] = [
-  {
-    id: 'mission',
-    heading: 'Naša misia',
-    paragraphs: [
-      'Veríme, že hľadanie nehnuteľnosti by nemalo byť stresujúce. Robíme to, aby každý — kupujúci, predávajúci aj nájomca — mal jasný prehľad o tom, čo trh ponúka, za akú cenu a od koho.',
-      'Spájame transparentné inzeráty, overené identity maklérov a férové ceny do jednej platformy, ktorá je rovnako blízka rodine hľadajúcej prvý byt ako profesionálnemu investorovi.',
-    ],
-  },
-  {
-    id: 'story',
-    heading: 'Príbeh portálu',
-    paragraphs: [
-      'Reality Portál vznikol v Bratislave v roku 2024 z frustrácie z existujúcich portálov — duplicitné inzeráty, skryté poplatky a maklérske ponuky vydávané za priame predaje.',
-      'Začali sme tým, čo poznáme: jednoduchá štruktúra, čisté vyhľadávanie a striktné pravidlá pre maklérske inzeráty. Postupne sme pridali mapu cien, žurnál s analýzami trhu a nástroje pre agentúry. Stále staviame ďalej.',
-    ],
-  },
-  {
-    id: 'values',
-    heading: 'Hodnoty, ktoré nás držia',
-    items: [
-      {
-        label: 'Transparentnosť',
-        description:
-          'Žiadne skryté poplatky, žiadne prikrášlené fotografie. Inzerát ukazuje to, čo predávajúci ponúka — nič viac, nič menej.',
-      },
-      {
-        label: 'Overenie',
-        description:
-          'Každý maklér prechádza identifikáciou. Súkromní predávajúci sú označení, agentúry majú profil so všetkými inzerátmi.',
-      },
-      {
-        label: 'Férová cena',
-        description:
-          'Pre súkromných predávajúcich vždy zadarmo. Pre maklérov tarif podľa objemu, bez prekvapení a bez nátlaku na predplatné.',
-      },
-      {
-        label: 'Lokálne porozumenie',
-        description:
-          'Tím v Bratislave a Prahe pozná regionálne rozdiely — od cenovej hladiny v Petržalke po realitnú dynamiku v Brne.',
-      },
-    ],
-  },
-  {
-    id: 'team',
-    heading: 'Pre koho to robíme',
-    paragraphs: [
-      'Pre rodinu, ktorá konečne kupuje vlastný byt. Pre dôchodcu, ktorý znižuje a hľadá menšie. Pre investora, ktorý porovnáva výnosnosť piatich pozemkov v rovnakej štvrti.',
-      'A pre maklérov, ktorí svoju prácu robia poctivo a chcú jasné nástroje, nie ďalšie predplatné s nečitateľným kontraktom.',
-    ],
-  },
-  {
-    id: 'contact',
-    heading: 'Spojte sa s nami',
-    paragraphs: [
-      'Máte spätnú väzbu, návrh alebo chcete spolupracovať? Napíšte nám na info@rlt.sk — odpovedáme zvyčajne do 24 hodín v pracovných dňoch.',
-    ],
-  },
-];
+// cs / de / pl / hu fall back to English until proper translations land.
+const BY_LOCALE: Record<Locale, AboutContent> = {
+  en,
+  sk,
+  cs: en,
+  de: en,
+  pl: en,
+  hu: en,
+};
+
+export function getAboutContent(locale: string): AboutContent {
+  return BY_LOCALE[locale as Locale] ?? en;
+}
+
+// Kept for backward compatibility with any importers that didn't migrate yet.
+export const ABOUT_HERO = sk.hero;
+export const ABOUT_STATS = sk.stats;
+export const ABOUT_SECTIONS = sk.sections;

--- a/frontend/apps/reality-web/src/app/[locale]/about/layout.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/about/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const generateMetadata = pageMetadata('about');
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/apps/reality-web/src/app/[locale]/about/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/about/page.tsx
@@ -7,7 +7,11 @@ import { getAboutContent } from './_content';
 export default function AboutPage() {
   const t = useTranslations('pages.about');
   const locale = useLocale();
-  const { hero: ABOUT_HERO, stats: ABOUT_STATS, sections: ABOUT_SECTIONS } = getAboutContent(locale);
+  const {
+    hero: ABOUT_HERO,
+    stats: ABOUT_STATS,
+    sections: ABOUT_SECTIONS,
+  } = getAboutContent(locale);
 
   return (
     <div

--- a/frontend/apps/reality-web/src/app/[locale]/about/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/about/page.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { Footer, Header } from '@/components/ui';
-import { ABOUT_HERO, ABOUT_SECTIONS, ABOUT_STATS } from './_content';
+import { getAboutContent } from './_content';
 
 export default function AboutPage() {
   const t = useTranslations('pages.about');
+  const locale = useLocale();
+  const { hero: ABOUT_HERO, stats: ABOUT_STATS, sections: ABOUT_SECTIONS } = getAboutContent(locale);
 
   return (
     <div

--- a/frontend/apps/reality-web/src/app/[locale]/auth/forgot-password/layout.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/auth/forgot-password/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const generateMetadata = pageMetadata('forgotPassword');
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/apps/reality-web/src/app/[locale]/auth/forgot-password/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/auth/forgot-password/page.tsx
@@ -6,12 +6,14 @@
  */
 
 import Link from 'next/link';
+import { useTranslations } from 'next-intl';
 import { type FormEvent, useState } from 'react';
 import { AuthApiError, requestPasswordReset } from '@/lib/auth-api';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export default function ForgotPasswordPage() {
+  const t = useTranslations('pages.forgotPassword');
   const [email, setEmail] = useState('');
   const [emailError, setEmailError] = useState<string>();
   const [generalError, setGeneralError] = useState<string>();
@@ -23,8 +25,8 @@ export default function ForgotPasswordPage() {
     setEmailError(undefined);
     setGeneralError(undefined);
     const trimmed = email.trim();
-    if (!trimmed) return setEmailError('Email is required');
-    if (!EMAIL_RE.test(trimmed)) return setEmailError('Enter a valid email address');
+    if (!trimmed) return setEmailError(t('emailRequired'));
+    if (!EMAIL_RE.test(trimmed)) return setEmailError(t('emailInvalid'));
 
     setIsSubmitting(true);
     try {
@@ -32,23 +34,18 @@ export default function ForgotPasswordPage() {
       setSubmitted(true);
     } catch (error) {
       if (error instanceof AuthApiError) {
-        // Surface real errors to the user instead of silently showing the
-        // "Check your inbox" confirmation. NOT_IMPLEMENTED comes from the
-        // wrapper while reality-server still lacks a password-reset
-        // endpoint; network failures should also be visible.
         if (error.code === 'NOT_IMPLEMENTED' || error.status === 501) {
           setGeneralError(error.message);
         } else if (error.code === 'NETWORK_ERROR') {
-          setGeneralError('Network error. Please check your connection and try again.');
+          setGeneralError(t('networkError'));
         } else if (error.status >= 500) {
-          setGeneralError(error.message || 'Server error. Please try again later.');
+          setGeneralError(error.message || t('serverError'));
         } else {
-          // 4xx and other client-side errors: don't leak whether an account
-          // exists for this email, fall through to the confirmation screen.
+          // 4xx: don't leak whether an account exists — confirmation screen.
           setSubmitted(true);
         }
       } else {
-        setGeneralError('Could not send reset email. Please try again.');
+        setGeneralError(t('genericError'));
       }
     } finally {
       setIsSubmitting(false);
@@ -60,19 +57,16 @@ export default function ForgotPasswordPage() {
       <div className="card">
         {submitted ? (
           <>
-            <h1 className="title">Check your inbox</h1>
-            <p className="subtitle">
-              If an account exists for <strong>{email}</strong>, we've sent instructions to reset
-              your password.
-            </p>
+            <h1 className="title">{t('checkInbox')}</h1>
+            <p className="subtitle">{t('checkInboxBody', { email })}</p>
             <Link href="/auth/login" className="link center">
-              Back to sign in
+              {t('backToSignIn')}
             </Link>
           </>
         ) : (
           <>
-            <h1 className="title">Reset your password</h1>
-            <p className="subtitle">Enter your email and we'll send you a reset link.</p>
+            <h1 className="title">{t('title')}</h1>
+            <p className="subtitle">{t('description')}</p>
             <form className="form" onSubmit={handleSubmit} noValidate>
               {generalError && (
                 <div className="alert" role="alert">
@@ -80,24 +74,25 @@ export default function ForgotPasswordPage() {
                 </div>
               )}
               <label className="field">
-                <span className="label">Email</span>
+                <span className="label">{t('emailLabel')}</span>
                 <input
                   type="email"
                   autoComplete="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   disabled={isSubmitting}
+                  aria-invalid={emailError ? true : undefined}
                   className={`input ${emailError ? 'input-error' : ''}`}
                 />
                 {emailError && <span className="error">{emailError}</span>}
               </label>
               <button type="submit" className="submit" disabled={isSubmitting}>
-                {isSubmitting ? 'Sending…' : 'Send reset link'}
+                {isSubmitting ? t('submitting') : t('submit')}
               </button>
               <p className="meta">
-                Remembered your password?{' '}
+                {t('remembered')}{' '}
                 <Link href="/auth/login" className="link">
-                  Sign in
+                  {t('signIn')}
                 </Link>
               </p>
             </form>

--- a/frontend/apps/reality-web/src/app/[locale]/auth/login/layout.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/auth/login/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const generateMetadata = pageMetadata('login');
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/apps/reality-web/src/app/[locale]/auth/register/layout.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/auth/register/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const generateMetadata = pageMetadata('register');
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/apps/reality-web/src/app/[locale]/auth/register/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/auth/register/page.tsx
@@ -7,6 +7,7 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import { type FormEvent, useState } from 'react';
 import { AuthApiError, register } from '@/lib/auth-api';
 
@@ -18,14 +19,17 @@ interface FieldErrors {
   password?: string;
   confirmPassword?: string;
   displayName?: string;
+  terms?: string;
 }
 
 export default function RegisterPage() {
   const router = useRouter();
+  const t = useTranslations('pages.register');
   const [displayName, setDisplayName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
+  const [termsAccepted, setTermsAccepted] = useState(false);
   const [errors, setErrors] = useState<FieldErrors>({});
   const [generalError, setGeneralError] = useState<string>();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -42,6 +46,7 @@ export default function RegisterPage() {
     else if (password.length < MIN_PASSWORD)
       next.password = `Password must be at least ${MIN_PASSWORD} characters`;
     if (confirmPassword !== password) next.confirmPassword = 'Passwords do not match';
+    if (!termsAccepted) next.terms = t('termsRequired');
     setErrors(next);
     if (Object.keys(next).length > 0) return;
 
@@ -148,6 +153,32 @@ export default function RegisterPage() {
                 {errors.confirmPassword && <span className="error">{errors.confirmPassword}</span>}
               </label>
 
+              <label className="terms-field">
+                <input
+                  type="checkbox"
+                  checked={termsAccepted}
+                  onChange={(e) => setTermsAccepted(e.target.checked)}
+                  disabled={isSubmitting}
+                  className="terms-checkbox"
+                  aria-invalid={errors.terms ? true : undefined}
+                />
+                <span className="terms-text">
+                  {t.rich('termsLabel', {
+                    termsLink: (chunks) => (
+                      <Link href="/terms" className="link" target="_blank">
+                        {chunks}
+                      </Link>
+                    ),
+                    privacyLink: (chunks) => (
+                      <Link href="/privacy" className="link" target="_blank">
+                        {chunks}
+                      </Link>
+                    ),
+                  })}
+                </span>
+              </label>
+              {errors.terms && <span className="error">{errors.terms}</span>}
+
               <button type="submit" className="submit" disabled={isSubmitting}>
                 {isSubmitting ? 'Creating account…' : 'Create account'}
               </button>
@@ -181,6 +212,9 @@ export default function RegisterPage() {
         .submit:hover:not(:disabled) { background: var(--ppt-color-primary-hover); }
         .submit:disabled { background: var(--ppt-brand-500); cursor: not-allowed; }
         .meta { text-align: center; font-size: 14px; color: var(--ppt-neutral-600); margin: 8px 0 0; }
+        .terms-field { display: flex; align-items: flex-start; gap: 10px; font-size: 13px; color: var(--ppt-fg-secondary); line-height: 1.5; cursor: pointer; margin-top: 4px; }
+        .terms-checkbox { width: 18px; height: 18px; margin-top: 2px; accent-color: var(--ppt-color-primary); flex-shrink: 0; cursor: pointer; }
+        .terms-text { flex: 1; }
         .link { color: var(--ppt-color-primary); text-decoration: none; font-weight: 500; }
         .link:hover { text-decoration: underline; }
       `}</style>

--- a/frontend/apps/reality-web/src/app/[locale]/auth/register/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/auth/register/page.tsx
@@ -39,13 +39,13 @@ export default function RegisterPage() {
     event.preventDefault();
     setGeneralError(undefined);
     const next: FieldErrors = {};
-    if (!displayName.trim()) next.displayName = 'Display name is required';
-    if (!email.trim()) next.email = 'Email is required';
-    else if (!EMAIL_RE.test(email.trim())) next.email = 'Enter a valid email address';
-    if (!password) next.password = 'Password is required';
+    if (!displayName.trim()) next.displayName = t('displayNameRequired');
+    if (!email.trim()) next.email = t('emailRequired');
+    else if (!EMAIL_RE.test(email.trim())) next.email = t('emailInvalid');
+    if (!password) next.password = t('passwordRequired');
     else if (password.length < MIN_PASSWORD)
-      next.password = `Password must be at least ${MIN_PASSWORD} characters`;
-    if (confirmPassword !== password) next.confirmPassword = 'Passwords do not match';
+      next.password = t('passwordTooShort', { min: MIN_PASSWORD });
+    if (confirmPassword !== password) next.confirmPassword = t('passwordsMismatch');
     if (!termsAccepted) next.terms = t('termsRequired');
     setErrors(next);
     if (Object.keys(next).length > 0) return;
@@ -60,11 +60,11 @@ export default function RegisterPage() {
       setSubmitted(true);
     } catch (error) {
       if (error instanceof AuthApiError && error.status === 409) {
-        setErrors({ email: 'An account with this email already exists.' });
+        setErrors({ email: t('emailTaken') });
       } else if (error instanceof AuthApiError) {
         setGeneralError(error.message);
       } else {
-        setGeneralError('Registration failed. Please try again.');
+        setGeneralError(t('genericError'));
       }
     } finally {
       setIsSubmitting(false);
@@ -95,7 +95,7 @@ export default function RegisterPage() {
               )}
 
               <label className="field">
-                <span className="label">Display name</span>
+                <span className="label">{t('displayNameLabel')}</span>
                 <input
                   type="text"
                   autoComplete="name"
@@ -108,7 +108,7 @@ export default function RegisterPage() {
               </label>
 
               <label className="field">
-                <span className="label">Email</span>
+                <span className="label">{t('emailLabel')}</span>
                 <input
                   type="email"
                   autoComplete="email"
@@ -121,7 +121,7 @@ export default function RegisterPage() {
               </label>
 
               <label className="field">
-                <span className="label">Password</span>
+                <span className="label">{t('passwordLabel')}</span>
                 <input
                   type="password"
                   autoComplete="new-password"
@@ -133,12 +133,12 @@ export default function RegisterPage() {
                 {errors.password ? (
                   <span className="error">{errors.password}</span>
                 ) : (
-                  <span className="hint">At least {MIN_PASSWORD} characters.</span>
+                  <span className="hint">{t('passwordHint', { min: MIN_PASSWORD })}</span>
                 )}
               </label>
 
               <label className="field">
-                <span className="label">Confirm password</span>
+                <span className="label">{t('confirmPasswordLabel')}</span>
                 <input
                   type="password"
                   autoComplete="new-password"
@@ -181,9 +181,9 @@ export default function RegisterPage() {
               </button>
 
               <p className="meta">
-                Already have an account?{' '}
+                {t('haveAccount')}{' '}
                 <Link href="/auth/login" className="link">
-                  Sign in
+                  {t('signInLink')}
                 </Link>
               </p>
             </form>

--- a/frontend/apps/reality-web/src/app/[locale]/auth/register/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/auth/register/page.tsx
@@ -87,8 +87,8 @@ export default function RegisterPage() {
           </>
         ) : (
           <>
-            <h1 className="title">Create your account</h1>
-            <p className="subtitle">Save listings, set alerts and contact agents.</p>
+            <h1 className="title">{t('title')}</h1>
+            <p className="subtitle">{t('description')}</p>
 
             <form className="form" onSubmit={handleSubmit} noValidate>
               {generalError && (

--- a/frontend/apps/reality-web/src/app/[locale]/auth/register/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/auth/register/page.tsx
@@ -76,13 +76,10 @@ export default function RegisterPage() {
       <div className="card">
         {submitted ? (
           <>
-            <h1 className="title">Check your inbox</h1>
-            <p className="subtitle">
-              We sent a verification email to <strong>{email}</strong>. Click the link to activate
-              your account.
-            </p>
+            <h1 className="title">{t('checkInbox')}</h1>
+            <p className="subtitle">{t('checkInboxBody', { email })}</p>
             <button type="button" className="submit" onClick={() => router.push('/auth/login')}>
-              Back to sign in
+              {t('backToSignIn')}
             </button>
           </>
         ) : (
@@ -180,7 +177,7 @@ export default function RegisterPage() {
               {errors.terms && <span className="error">{errors.terms}</span>}
 
               <button type="submit" className="submit" disabled={isSubmitting}>
-                {isSubmitting ? 'Creating account…' : 'Create account'}
+                {isSubmitting ? t('creating') : t('submit')}
               </button>
 
               <p className="meta">

--- a/frontend/apps/reality-web/src/app/[locale]/auth/reset-password/layout.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/auth/reset-password/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const generateMetadata = pageMetadata('resetPassword');
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/apps/reality-web/src/app/[locale]/auth/reset-password/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/auth/reset-password/page.tsx
@@ -7,12 +7,14 @@
 
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import { type FormEvent, Suspense, useState } from 'react';
 import { AuthApiError, confirmPasswordReset } from '@/lib/auth-api';
 
 const MIN_PASSWORD = 8;
 
 function ResetForm() {
+  const t = useTranslations('pages.resetPassword');
   const router = useRouter();
   const searchParams = useSearchParams();
   const token = searchParams.get('token') ?? '';
@@ -28,12 +30,10 @@ function ResetForm() {
   if (!token) {
     return (
       <div className="empty">
-        <h1 className="title">Invalid link</h1>
-        <p className="subtitle">
-          This reset link is missing a token. Request a new password reset email.
-        </p>
+        <h1 className="title">{t('invalidTitle')}</h1>
+        <p className="subtitle">{t('invalidBody')}</p>
         <Link href="/auth/forgot-password" className="link center">
-          Request a new link
+          {t('requestNew')}
         </Link>
         <style jsx>{`
           .empty { padding: 8px 0; }
@@ -55,14 +55,14 @@ function ResetForm() {
 
     let invalid = false;
     if (!password) {
-      setPasswordError('Password is required');
+      setPasswordError(t('passwordRequired'));
       invalid = true;
     } else if (password.length < MIN_PASSWORD) {
-      setPasswordError(`Password must be at least ${MIN_PASSWORD} characters`);
+      setPasswordError(t('passwordTooShort'));
       invalid = true;
     }
     if (confirmPassword !== password) {
-      setConfirmError('Passwords do not match');
+      setConfirmError(t('passwordsMismatch'));
       invalid = true;
     }
     if (invalid) return;
@@ -75,7 +75,7 @@ function ResetForm() {
       if (error instanceof AuthApiError) {
         setGeneralError(error.message);
       } else {
-        setGeneralError('Could not reset password. Please try again.');
+        setGeneralError(t('genericError'));
       }
     } finally {
       setIsSubmitting(false);
@@ -85,10 +85,10 @@ function ResetForm() {
   if (success) {
     return (
       <div className="ok">
-        <h1 className="title">Password updated</h1>
-        <p className="subtitle">You can now sign in with your new password.</p>
+        <h1 className="title">{t('successTitle')}</h1>
+        <p className="subtitle">{t('successBody')}</p>
         <button type="button" className="submit" onClick={() => router.replace('/auth/login')}>
-          Sign in
+          {t('goToSignIn')}
         </button>
         <style jsx>{`
           .ok { padding: 8px 0; }
@@ -103,8 +103,8 @@ function ResetForm() {
 
   return (
     <form className="form" onSubmit={handleSubmit} noValidate>
-      <h1 className="title">Set a new password</h1>
-      <p className="subtitle">Choose a strong password you haven't used before.</p>
+      <h1 className="title">{t('title')}</h1>
+      <p className="subtitle">{t('description')}</p>
 
       {generalError && (
         <div className="alert" role="alert">
@@ -113,37 +113,39 @@ function ResetForm() {
       )}
 
       <label className="field">
-        <span className="label">New password</span>
+        <span className="label">{t('passwordLabel')}</span>
         <input
           type="password"
           autoComplete="new-password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           disabled={isSubmitting}
+          aria-invalid={passwordError ? true : undefined}
           className={`input ${passwordError ? 'input-error' : ''}`}
         />
         {passwordError ? (
           <span className="error">{passwordError}</span>
         ) : (
-          <span className="hint">At least {MIN_PASSWORD} characters.</span>
+          <span className="hint">{t('passwordHint')}</span>
         )}
       </label>
 
       <label className="field">
-        <span className="label">Confirm password</span>
+        <span className="label">{t('confirmLabel')}</span>
         <input
           type="password"
           autoComplete="new-password"
           value={confirmPassword}
           onChange={(e) => setConfirmPassword(e.target.value)}
           disabled={isSubmitting}
+          aria-invalid={confirmError ? true : undefined}
           className={`input ${confirmError ? 'input-error' : ''}`}
         />
         {confirmError && <span className="error">{confirmError}</span>}
       </label>
 
       <button type="submit" className="submit" disabled={isSubmitting}>
-        {isSubmitting ? 'Updating…' : 'Update password'}
+        {isSubmitting ? t('submitting') : t('submit')}
       </button>
 
       <style jsx>{`

--- a/frontend/apps/reality-web/src/app/[locale]/careers/layout.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/careers/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const generateMetadata = pageMetadata('careers');
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/apps/reality-web/src/app/[locale]/careers/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/careers/page.tsx
@@ -5,12 +5,14 @@
  * Screen-map: docs/screens/reality/careers.md
  */
 
+import { useTranslations } from 'next-intl';
 import { Footer, Header } from '@/components/ui';
 import { MOCK_BENEFITS, MOCK_POSITIONS } from './_mock';
 
 // TODO: replace with @ppt/ui-kit/Stepper, @ppt/ui-kit/StatusPill once available
 
 export default function CareersPage() {
+  const t = useTranslations('pages.careers');
   return (
     <div
       data-i18n="pages.careers.root"
@@ -43,11 +45,10 @@ export default function CareersPage() {
               margin: '0 0 20px',
             }}
           >
-            Stavajme realitný trh, ktorý dáva zmysel.
+            {t('hero.title')}
           </h1>
           <p style={{ fontSize: '1.125rem', opacity: 0.85, maxWidth: 640, margin: '0 auto 32px' }}>
-            Pridajte sa k nášmu tímu a pomôžte nám meniť spôsob, akým ľudia nakupujú, predávajú a
-            prenajímajú nehnuteľnosti na Slovensku a v strednej Európe.
+            {t('hero.subtitle')}
           </p>
           <a
             href="#open-positions"

--- a/frontend/apps/reality-web/src/app/[locale]/contact/layout.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/contact/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const generateMetadata = pageMetadata('contact');
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/apps/reality-web/src/app/[locale]/cookies/layout.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/cookies/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const generateMetadata = pageMetadata('cookies');
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/apps/reality-web/src/app/[locale]/cookies/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/cookies/page.tsx
@@ -5,6 +5,7 @@
  * Screen-map: docs/screens/reality/cookies.md
  */
 
+import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 import { Footer, Header } from '@/components/ui';
 import { COOKIE_SECTIONS, MOCK_COOKIES } from './_mock';
@@ -38,6 +39,7 @@ const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
 };
 
 export default function CookiesPage() {
+  const t = useTranslations('pages.cookies');
   const [consentBannerOpen, setConsentBannerOpen] = useState(false);
 
   return (
@@ -63,10 +65,10 @@ export default function CookiesPage() {
             marginBottom: 8,
           }}
         >
-          Zásady používania cookies
+          {t('title')}
         </h1>
         <p style={{ color: 'var(--ppt-fg-secondary)', marginBottom: 40 }}>
-          Posledná aktualizácia: 1. januára 2025
+          {t('lastUpdated')}
         </p>
 
         {/* §§ text sections */}

--- a/frontend/apps/reality-web/src/app/[locale]/cookies/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/cookies/page.tsx
@@ -67,9 +67,7 @@ export default function CookiesPage() {
         >
           {t('title')}
         </h1>
-        <p style={{ color: 'var(--ppt-fg-secondary)', marginBottom: 40 }}>
-          {t('lastUpdated')}
-        </p>
+        <p style={{ color: 'var(--ppt-fg-secondary)', marginBottom: 40 }}>{t('lastUpdated')}</p>
 
         {/* §§ text sections */}
         {COOKIE_SECTIONS.map((section) => (

--- a/frontend/apps/reality-web/src/app/[locale]/favorites/layout.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/favorites/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const generateMetadata = pageMetadata('favorites');
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/apps/reality-web/src/app/[locale]/for-agents/layout.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/for-agents/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const generateMetadata = pageMetadata('forAgents');
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/apps/reality-web/src/app/[locale]/for-agents/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/for-agents/page.tsx
@@ -5,12 +5,14 @@
  * Screen-map: docs/screens/reality/for-agents.md
  */
 
+import { useTranslations } from 'next-intl';
 import { Footer, Header } from '@/components/ui';
 import { MOCK_FEATURES, MOCK_PRICING } from './_mock';
 
 // TODO: replace pricing cards with @ppt/ui-kit/Card once available
 
 export default function ForAgentsPage() {
+  const t = useTranslations('pages.forAgents');
   return (
     <div
       data-i18n="pages.for-agents.root"
@@ -46,7 +48,7 @@ export default function ForAgentsPage() {
               letterSpacing: '.6px',
             }}
           >
-            Pre maklérov &amp; agentúry
+            {t('heroBadge')}
           </span>
           <h1
             style={{
@@ -58,7 +60,7 @@ export default function ForAgentsPage() {
               margin: '0 auto 20px',
             }}
           >
-            Predávajte viac s Reality Portálom
+            {t('heroTitle')}
           </h1>
           <p
             style={{
@@ -68,7 +70,7 @@ export default function ForAgentsPage() {
               margin: '0 auto 36px',
             }}
           >
-            Nástroje, analytika a dosah na milióny kupujúcich a nájomníkov na jednom mieste.
+            {t('heroIntro')}
           </p>
           <div style={{ display: 'flex', gap: 14, justifyContent: 'center', flexWrap: 'wrap' }}>
             <a

--- a/frontend/apps/reality-web/src/app/[locale]/help/layout.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/help/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const generateMetadata = pageMetadata('help');
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/apps/reality-web/src/app/[locale]/help/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/help/page.tsx
@@ -5,6 +5,7 @@
  * Screen-map: docs/screens/reality/help.md
  */
 
+import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 import { Footer, Header } from '@/components/ui';
 import { MOCK_CATEGORIES, MOCK_FAQ } from './_mock';
@@ -13,6 +14,7 @@ import { MOCK_CATEGORIES, MOCK_FAQ } from './_mock';
 // TODO: replace category tiles with @ppt/ui-kit/Card once available
 
 export default function HelpPage() {
+  const t = useTranslations('pages.help');
   const [query, setQuery] = useState('');
   const [openFaq, setOpenFaq] = useState<string | null>(null);
 
@@ -53,15 +55,13 @@ export default function HelpPage() {
               marginBottom: 8,
             }}
           >
-            Ako vám môžeme pomôcť?
+            {t('subtitle')}
           </h1>
-          <p style={{ color: 'rgba(255,255,255,.8)', marginBottom: 28 }}>
-            Prehľadajte naše centrum pomoci alebo nás kontaktujte priamo.
-          </p>
+          <p style={{ color: 'rgba(255,255,255,.8)', marginBottom: 28 }}>{t('intro')}</p>
           <div style={{ maxWidth: 560, margin: '0 auto', position: 'relative' }}>
             <input
               type="search"
-              placeholder="Hľadajte v centre pomoci..."
+              placeholder={t('searchPlaceholder')}
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               data-i18n="pages.help.searchPlaceholder"

--- a/frontend/apps/reality-web/src/app/[locale]/journal/layout.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/journal/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const generateMetadata = pageMetadata('journal');
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/apps/reality-web/src/app/[locale]/journal/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/journal/page.tsx
@@ -5,9 +5,15 @@
  * Screen-map: docs/screens/reality/journal.md
  */
 
+import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 import { Footer, Header } from '@/components/ui';
 import { EDITORS_PICKS, MOCK_ARTICLES, MOST_READ } from './_mock';
+
+// NOTE: MOCK_ARTICLES (titles, excerpts) are placeholder Slovak strings.
+// Once real journal content lands via CMS / reality-server, those records
+// will carry their own locale field. The page chrome (h1, section headings,
+// newsletter form) is fully localised via pages.journal.*.
 
 // TODO: replace article cards with @ppt/ui-kit/Card once available
 
@@ -95,6 +101,7 @@ function ArticleCard({
 }
 
 export default function JournalPage() {
+  const t = useTranslations('pages.journal');
   const [email, setEmail] = useState('');
   const [subscribed, setSubscribed] = useState(false);
 
@@ -140,11 +147,9 @@ export default function JournalPage() {
               marginBottom: 8,
             }}
           >
-            Reality Žurnál
+            {t('title')}
           </h1>
-          <p style={{ color: 'var(--ppt-fg-secondary)' }}>
-            Analýzy, tipy a správy zo sveta nehnuteľností.
-          </p>
+          <p style={{ color: 'var(--ppt-fg-secondary)' }}>{t('subtitle')}</p>
         </div>
 
         <div className="journal-grid">
@@ -163,7 +168,7 @@ export default function JournalPage() {
                     marginBottom: 16,
                   }}
                 >
-                  Titulný príbeh
+                  {t('featured')}
                 </h2>
                 <ArticleCard article={featured} variant="featured" />
               </section>
@@ -179,7 +184,7 @@ export default function JournalPage() {
                   marginBottom: 20,
                 }}
               >
-                Najnovšie články
+                {t('latest')}
               </h2>
               <div
                 style={{
@@ -206,15 +211,11 @@ export default function JournalPage() {
               }}
             >
               <h2 style={{ fontSize: '1.375rem', fontWeight: 700, marginBottom: 8 }}>
-                Odber noviniek
+                {t('newsletterTitle')}
               </h2>
-              <p style={{ opacity: 0.85, marginBottom: 20 }}>
-                Dostávajte najnovšie analýzy a tipy priamo do vašej schránky.
-              </p>
+              <p style={{ opacity: 0.85, marginBottom: 20 }}>{t('newsletterIntro')}</p>
               {subscribed ? (
-                <p style={{ fontWeight: 600, fontSize: '1.0625rem' }}>
-                  ✅ Ste prihlásení na odber!
-                </p>
+                <p style={{ fontWeight: 600, fontSize: '1.0625rem' }}>{t('newsletterSuccess')}</p>
               ) : (
                 <form
                   onSubmit={handleSubscribe}
@@ -223,7 +224,7 @@ export default function JournalPage() {
                   <input
                     type="email"
                     required
-                    placeholder="vas@email.sk"
+                    placeholder={t('newsletterEmailPlaceholder')}
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
                     style={{
@@ -249,7 +250,7 @@ export default function JournalPage() {
                       whiteSpace: 'nowrap',
                     }}
                   >
-                    Prihlásiť sa
+                    {t('newsletterSubmit')}
                   </button>
                 </form>
               )}
@@ -265,7 +266,7 @@ export default function JournalPage() {
                   marginBottom: 20,
                 }}
               >
-                Výber redakcie
+                {t('editorsPicks')}
               </h2>
               <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
                 {editorsPicks.map((article) => (
@@ -285,7 +286,7 @@ export default function JournalPage() {
                 marginBottom: 16,
               }}
             >
-              Najviac čítané
+              {t('mostRead')}
             </h2>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
               {mostRead.map((article, idx) => (
@@ -323,7 +324,7 @@ export default function JournalPage() {
                         marginTop: 4,
                       }}
                     >
-                      {article.readMin} min čítania
+                      {t('readingTime', { min: article.readMin })}
                     </div>
                   </div>
                 </div>

--- a/frontend/apps/reality-web/src/app/[locale]/listings/layout.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/listings/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const generateMetadata = pageMetadata('listings');
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/apps/reality-web/src/app/[locale]/price-map/layout.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/price-map/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const generateMetadata = pageMetadata('priceMap');
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/apps/reality-web/src/app/[locale]/price-map/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/price-map/page.tsx
@@ -5,6 +5,7 @@
  * Screen-map: docs/screens/reality/price-map.md
  */
 
+import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 import { Footer, Header } from '@/components/ui';
 import { MOCK_DISTRICTS, MOCK_INSIGHTS, type PriceMapFilter } from './_mock';
@@ -23,6 +24,7 @@ const PROPERTY_OPTIONS: { value: PropertyType; label: string }[] = [
 ];
 
 export default function PriceMapPage() {
+  const t = useTranslations('pages.priceMap');
   const [filter, setFilter] = useState<PriceMapFilter>({
     propertyType: 'all',
     transactionType: 'sale',
@@ -67,7 +69,7 @@ export default function PriceMapPage() {
               flexShrink: 0,
             }}
           >
-            Mapa cien
+            {t('h1')}
           </h1>
           <div style={{ display: 'flex', gap: 4 }}>
             {/* TODO: replace with @ppt/ui-kit/SegmentedControl once available */}

--- a/frontend/apps/reality-web/src/app/[locale]/privacy/layout.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/privacy/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const generateMetadata = pageMetadata('privacy');
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/apps/reality-web/src/app/[locale]/report/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/report/page.tsx
@@ -5,6 +5,7 @@
  * Screen-map: docs/screens/reality/report-listing.md
  */
 
+import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 import { Footer, Header } from '@/components/ui';
 import { REPORT_PROBLEMS, type ReportProblem } from './_mock';
@@ -13,6 +14,7 @@ import { REPORT_PROBLEMS, type ReportProblem } from './_mock';
 // TODO: replace file attachment with @ppt/ui-kit/FileUpload once available
 
 export default function ReportPage() {
+  const t = useTranslations('pages.report');
   const [problem, setProblem] = useState<ReportProblem | null>(null);
   const [listingRef, setListingRef] = useState('');
   const [description, setDescription] = useState('');
@@ -133,10 +135,10 @@ export default function ReportPage() {
             marginBottom: 8,
           }}
         >
-          Nahlásiť inzerát
+          {t('h1')}
         </h1>
         <p style={{ color: 'var(--ppt-fg-secondary)', marginBottom: 36, lineHeight: 1.6 }}>
-          Pomôžte nám udržiavať portál bezpečným. Váš podnet preveríme do 24 hodín.
+          {t('subtitle')}
         </p>
 
         <form

--- a/frontend/apps/reality-web/src/app/[locale]/security/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/security/page.tsx
@@ -6,10 +6,12 @@
  */
 
 import Link from 'next/link';
+import { useTranslations } from 'next-intl';
 import { Footer, Header } from '@/components/ui';
 import { MOCK_FRAUD_SCENARIOS, MOCK_GUARANTEES } from './_mock';
 
 export default function SecurityPage() {
+  const t = useTranslations('pages.security');
   return (
     <div
       data-i18n="pages.security.root"
@@ -41,7 +43,7 @@ export default function SecurityPage() {
                 marginBottom: 16,
               }}
             >
-              Vaša bezpečnosť je naša priorita
+              {t('h1')}
             </h1>
             <p
               style={{
@@ -52,7 +54,7 @@ export default function SecurityPage() {
                 margin: '0 auto',
               }}
             >
-              Pomáhame vám rozpoznať podvody a obchodovať s nehnuteľnosťami v bezpečnom prostredí.
+              {t('subtitle')}
             </p>
           </div>
         </section>
@@ -67,7 +69,7 @@ export default function SecurityPage() {
               marginBottom: 32,
             }}
           >
-            Časté podvodné scenáre
+            {t('scenariosHeading')}
           </h2>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
             {MOCK_FRAUD_SCENARIOS.map((scenario) => (

--- a/frontend/apps/reality-web/src/app/[locale]/sell/_mock.ts
+++ b/frontend/apps/reality-web/src/app/[locale]/sell/_mock.ts
@@ -1,15 +1,24 @@
+/**
+ * Static (locale-agnostic) data for the sell-wizard.
+ *
+ * Localized labels for steps, transaction options and property options
+ * live in `pages.sell.*` in `messages/<locale>.json` and are read inside
+ * `page.tsx` via `useTranslations`. Keep this file free of human-readable
+ * strings so the wizard works correctly under every supported locale.
+ */
+
 export interface SellStep {
   id: number;
-  title: string;
-  description: string;
+  /** Key under `pages.sell.steps.*` */
+  key: 'type' | 'details' | 'photos' | 'price' | 'contact';
 }
 
 export const SELL_STEPS: SellStep[] = [
-  { id: 1, title: 'Typ a poloha', description: 'Vyberte typ nehnuteľnosti a zadajte adresu' },
-  { id: 2, title: 'Detaily', description: 'Plocha, izby, poschodie, rok výstavby' },
-  { id: 3, title: 'Fotografie', description: 'Pridajte kvalitné fotografie' },
-  { id: 4, title: 'Cena', description: 'Nastavte požadovanú cenu' },
-  { id: 5, title: 'Kontakt & súhrn', description: 'Overte údaje a zverejnite ponuku' },
+  { id: 1, key: 'type' },
+  { id: 2, key: 'details' },
+  { id: 3, key: 'photos' },
+  { id: 4, key: 'price' },
+  { id: 5, key: 'contact' },
 ];
 
 export type PropertyType = 'apartment' | 'house' | 'land' | 'commercial';
@@ -57,9 +66,4 @@ export const INITIAL_FORM_DATA: SellFormData = {
   termsAccepted: false,
 };
 
-export const PROPERTY_TYPE_OPTIONS: { value: PropertyType; label: string }[] = [
-  { value: 'apartment', label: 'Byt' },
-  { value: 'house', label: 'Dom' },
-  { value: 'land', label: 'Pozemok' },
-  { value: 'commercial', label: 'Komerčné' },
-];
+export const PROPERTY_TYPES: PropertyType[] = ['apartment', 'house', 'land', 'commercial'];

--- a/frontend/apps/reality-web/src/app/[locale]/sell/layout.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/sell/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const generateMetadata = pageMetadata('sell');
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/apps/reality-web/src/app/[locale]/sell/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/sell/page.tsx
@@ -91,10 +91,55 @@ const labelStyle: React.CSSProperties = {
   fontSize: '0.9375rem',
 };
 
+const errorStyle: React.CSSProperties = {
+  color: 'var(--ppt-color-danger-hover, #dc2626)',
+  fontSize: '0.8125rem',
+  marginTop: 4,
+  display: 'block',
+};
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PHONE_RE = /^[+0-9 ()-]{6,}$/;
+
+type StepErrors = Partial<Record<keyof SellFormData, string>>;
+
+/**
+ * Validate the fields shown on a given wizard step.
+ *
+ * Step 3 (photos) intentionally has no required-field rules — listings
+ * without photos still publish (the UI flags low photo counts as a warning
+ * once the API enforces it). Step terms checkbox is enforced at publish.
+ */
+function validateStep(step: number, form: SellFormData, tKey: (k: string) => string): StepErrors {
+  const errors: StepErrors = {};
+  if (step === 1) {
+    if (!form.address.trim()) errors.address = tKey('addressRequired');
+    if (!form.city.trim()) errors.city = tKey('cityRequired');
+  } else if (step === 2) {
+    if (form.area === '' || form.area === null || Number.isNaN(form.area))
+      errors.area = tKey('areaRequired');
+    else if (Number(form.area) <= 0) errors.area = tKey('areaPositive');
+    if (form.rooms === '' || form.rooms === null) errors.rooms = tKey('roomsRequired');
+  } else if (step === 4) {
+    if (form.price === '' || form.price === null) errors.price = tKey('priceRequired');
+    else if (Number(form.price) <= 0) errors.price = tKey('pricePositive');
+  } else if (step === 5) {
+    if (!form.contactName.trim()) errors.contactName = tKey('nameRequired');
+    if (!form.contactPhone.trim()) errors.contactPhone = tKey('phoneRequired');
+    else if (!PHONE_RE.test(form.contactPhone.trim()))
+      errors.contactPhone = tKey('phoneFormat');
+    if (!form.contactEmail.trim()) errors.contactEmail = tKey('emailRequired');
+    else if (!EMAIL_RE.test(form.contactEmail.trim()))
+      errors.contactEmail = tKey('emailFormat');
+  }
+  return errors;
+}
+
 export default function SellPage() {
   const t = useTranslations('pages.sell');
   const [step, setStep] = useState(1);
   const [form, setForm] = useState<SellFormData>(INITIAL_FORM_DATA);
+  const [errors, setErrors] = useState<StepErrors>({});
   const [submitted, setSubmitted] = useState(false);
 
   const update = (patch: Partial<SellFormData>) => setForm((f) => ({ ...f, ...patch }));
@@ -286,8 +331,15 @@ export default function SellPage() {
                     placeholder={t('fields.addressPlaceholder')}
                     value={form.address}
                     onChange={(e) => update({ address: e.target.value })}
-                    style={inputStyle}
+                    aria-invalid={errors.address ? true : undefined}
+                    style={{
+                      ...inputStyle,
+                      borderColor: errors.address
+                        ? 'var(--ppt-color-danger-hover, #dc2626)'
+                        : inputStyle.border?.toString().includes('1px') ? undefined : undefined,
+                    }}
                   />
+                  {errors.address && <span style={errorStyle}>{errors.address}</span>}
                 </div>
 
                 <div>
@@ -297,8 +349,10 @@ export default function SellPage() {
                     placeholder={t('fields.cityPlaceholder')}
                     value={form.city}
                     onChange={(e) => update({ city: e.target.value })}
+                    aria-invalid={errors.city ? true : undefined}
                     style={inputStyle}
                   />
+                  {errors.city && <span style={errorStyle}>{errors.city}</span>}
                 </div>
               </div>
             )}
@@ -322,22 +376,27 @@ export default function SellPage() {
                       placeholderKey: 'yearBuiltPlaceholder',
                     },
                   ] as const
-                ).map((field) => (
-                  <div key={field.key}>
-                    <label style={labelStyle}>{t(`fields.${field.labelKey}`)}</label>
-                    <input
-                      type="number"
-                      placeholder={t(`fields.${field.placeholderKey}`)}
-                      value={form[field.key as keyof SellFormData] as string | number}
-                      onChange={(e) =>
-                        update({
-                          [field.key]: e.target.value === '' ? '' : Number(e.target.value),
-                        })
-                      }
-                      style={inputStyle}
-                    />
-                  </div>
-                ))}
+                ).map((field) => {
+                  const fieldError = errors[field.key as keyof SellFormData];
+                  return (
+                    <div key={field.key}>
+                      <label style={labelStyle}>{t(`fields.${field.labelKey}`)}</label>
+                      <input
+                        type="number"
+                        placeholder={t(`fields.${field.placeholderKey}`)}
+                        value={form[field.key as keyof SellFormData] as string | number}
+                        onChange={(e) =>
+                          update({
+                            [field.key]: e.target.value === '' ? '' : Number(e.target.value),
+                          })
+                        }
+                        aria-invalid={fieldError ? true : undefined}
+                        style={inputStyle}
+                      />
+                      {fieldError && <span style={errorStyle}>{fieldError}</span>}
+                    </div>
+                  );
+                })}
                 <div>
                   <label style={labelStyle}>{t('fields.description')}</label>
                   <textarea
@@ -417,8 +476,10 @@ export default function SellPage() {
                     onChange={(e) =>
                       update({ price: e.target.value === '' ? '' : Number(e.target.value) })
                     }
+                    aria-invalid={errors.price ? true : undefined}
                     style={inputStyle}
                   />
+                  {errors.price && <span style={errorStyle}>{errors.price}</span>}
                 </div>
                 <label
                   style={{ display: 'flex', alignItems: 'center', gap: 10, cursor: 'pointer' }}
@@ -500,18 +561,30 @@ export default function SellPage() {
                       inputType: 'email',
                     },
                   ] as const
-                ).map((field) => (
-                  <div key={field.key}>
-                    <label style={labelStyle}>{t(`fields.${field.labelKey}`)}</label>
-                    <input
-                      type={field.inputType}
-                      placeholder={t(`fields.${field.placeholderKey}`)}
-                      value={form[field.key as keyof SellFormData] as string}
-                      onChange={(e) => update({ [field.key]: e.target.value })}
-                      style={inputStyle}
-                    />
-                  </div>
-                ))}
+                ).map((field) => {
+                  const fieldError = errors[field.key as keyof SellFormData];
+                  return (
+                    <div key={field.key}>
+                      <label style={labelStyle}>{t(`fields.${field.labelKey}`)}</label>
+                      <input
+                        type={field.inputType}
+                        autoComplete={
+                          field.key === 'contactEmail'
+                            ? 'email'
+                            : field.key === 'contactPhone'
+                              ? 'tel'
+                              : 'name'
+                        }
+                        placeholder={t(`fields.${field.placeholderKey}`)}
+                        value={form[field.key as keyof SellFormData] as string}
+                        onChange={(e) => update({ [field.key]: e.target.value })}
+                        aria-invalid={fieldError ? true : undefined}
+                        style={inputStyle}
+                      />
+                      {fieldError && <span style={errorStyle}>{fieldError}</span>}
+                    </div>
+                  );
+                })}
 
                 <label
                   style={{ display: 'flex', alignItems: 'flex-start', gap: 10, cursor: 'pointer' }}
@@ -576,7 +649,11 @@ export default function SellPage() {
               {step < SELL_STEPS.length ? (
                 <button
                   type="button"
-                  onClick={() => setStep((s) => s + 1)}
+                  onClick={() => {
+                    const stepErrors = validateStep(step, form, (k) => t(`validation.${k}`));
+                    setErrors(stepErrors);
+                    if (Object.keys(stepErrors).length === 0) setStep((s) => s + 1);
+                  }}
                   style={{
                     padding: '11px 28px',
                     background: 'var(--ppt-color-primary, #2563eb)',
@@ -594,7 +671,11 @@ export default function SellPage() {
                 <button
                   type="button"
                   disabled={!form.termsAccepted}
-                  onClick={() => setSubmitted(true)}
+                  onClick={() => {
+                    const stepErrors = validateStep(step, form, (k) => t(`validation.${k}`));
+                    setErrors(stepErrors);
+                    if (Object.keys(stepErrors).length === 0) setSubmitted(true);
+                  }}
                   style={{
                     padding: '11px 28px',
                     background: form.termsAccepted

--- a/frontend/apps/reality-web/src/app/[locale]/sell/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/sell/page.tsx
@@ -5,11 +5,14 @@
  * Screen-map: docs/screens/reality/sell.md
  *
  * 5-step wizard: Type+location → Details → Photos → Price → Contact+summary
+ *
+ * All user-facing strings come from `pages.sell.*` in `messages/<locale>.json`.
  */
 
+import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 import { Footer, Header } from '@/components/ui';
-import { INITIAL_FORM_DATA, PROPERTY_TYPE_OPTIONS, SELL_STEPS, type SellFormData } from './_mock';
+import { INITIAL_FORM_DATA, PROPERTY_TYPES, SELL_STEPS, type SellFormData } from './_mock';
 
 // TODO: replace stepper with @ppt/ui-kit/Stepper once available
 // TODO: replace file upload with @ppt/ui-kit/FileUpload once available
@@ -80,7 +83,16 @@ const inputStyle: React.CSSProperties = {
   outline: 'none',
 };
 
+const labelStyle: React.CSSProperties = {
+  display: 'block',
+  fontWeight: 600,
+  color: 'var(--ppt-fg-primary)',
+  marginBottom: 6,
+  fontSize: '0.9375rem',
+};
+
 export default function SellPage() {
+  const t = useTranslations('pages.sell');
   const [step, setStep] = useState(1);
   const [form, setForm] = useState<SellFormData>(INITIAL_FORM_DATA);
   const [submitted, setSubmitted] = useState(false);
@@ -88,6 +100,7 @@ export default function SellPage() {
   const update = (patch: Partial<SellFormData>) => setForm((f) => ({ ...f, ...patch }));
 
   const currentStepInfo = SELL_STEPS[step - 1];
+  const currentStepTitle = currentStepInfo ? t(`steps.${currentStepInfo.key}.title`) : '';
 
   if (submitted) {
     return (
@@ -120,10 +133,10 @@ export default function SellPage() {
                 marginBottom: 12,
               }}
             >
-              Váš inzerát bol odoslaný!
+              {t('submittedTitle')}
             </h1>
             <p style={{ color: 'var(--ppt-fg-secondary)', marginBottom: 28 }}>
-              Po overení bude zverejnený do 2 hodín.
+              {t('submittedBody')}
             </p>
             <button
               type="button"
@@ -142,7 +155,7 @@ export default function SellPage() {
                 cursor: 'pointer',
               }}
             >
-              Pridať ďalší inzerát
+              {t('submittedCta')}
             </button>
           </div>
         </main>
@@ -182,12 +195,16 @@ export default function SellPage() {
                 margin: '0 0 6px',
               }}
             >
-              Pridať inzerát
+              {t('title')}
             </h1>
             <p
               style={{ color: 'var(--ppt-fg-secondary)', marginBottom: 28, fontSize: '0.9375rem' }}
             >
-              Krok {step} z {SELL_STEPS.length}: {currentStepInfo?.title}
+              {t('stepLabel', {
+                step,
+                total: SELL_STEPS.length,
+                stepTitle: currentStepTitle,
+              })}
             </p>
 
             {/* TODO: replace with @ppt/ui-kit/Stepper once available */}
@@ -197,35 +214,26 @@ export default function SellPage() {
             {step === 1 && (
               <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
                 <div>
-                  <label
-                    style={{
-                      display: 'block',
-                      fontWeight: 600,
-                      color: 'var(--ppt-fg-primary)',
-                      marginBottom: 8,
-                      fontSize: '0.9375rem',
-                    }}
-                  >
-                    Typ transakcie
+                  <label style={{ ...labelStyle, marginBottom: 8 }}>
+                    {t('fields.transactionType')}
                   </label>
-                  {/* TODO: replace with @ppt/ui-kit/RadioCards once available */}
                   <div style={{ display: 'flex', gap: 10 }}>
-                    {(['sale', 'rent'] as const).map((t) => (
+                    {(['sale', 'rent'] as const).map((tx) => (
                       <button
-                        key={t}
+                        key={tx}
                         type="button"
-                        onClick={() => update({ transactionType: t })}
+                        onClick={() => update({ transactionType: tx })}
                         style={{
                           flex: 1,
                           padding: '12px',
                           borderRadius: 8,
-                          border: `2px solid ${form.transactionType === t ? 'var(--ppt-color-primary, #2563eb)' : 'var(--ppt-border-default, #e5e7eb)'}`,
+                          border: `2px solid ${form.transactionType === tx ? 'var(--ppt-color-primary, #2563eb)' : 'var(--ppt-border-default, #e5e7eb)'}`,
                           background:
-                            form.transactionType === t
+                            form.transactionType === tx
                               ? 'var(--ppt-color-primary-light, #dbeafe)'
                               : 'var(--ppt-bg-surface)',
                           color:
-                            form.transactionType === t
+                            form.transactionType === tx
                               ? 'var(--ppt-color-primary, #2563eb)'
                               : 'var(--ppt-fg-secondary)',
                           fontWeight: 600,
@@ -233,68 +241,49 @@ export default function SellPage() {
                           fontSize: '0.9375rem',
                         }}
                       >
-                        {t === 'sale' ? 'Predaj' : 'Prenájom'}
+                        {t(`transactionOptions.${tx}`)}
                       </button>
                     ))}
                   </div>
                 </div>
 
                 <div>
-                  <label
-                    style={{
-                      display: 'block',
-                      fontWeight: 600,
-                      color: 'var(--ppt-fg-primary)',
-                      marginBottom: 8,
-                      fontSize: '0.9375rem',
-                    }}
-                  >
-                    Typ nehnuteľnosti
+                  <label style={{ ...labelStyle, marginBottom: 8 }}>
+                    {t('fields.propertyType')}
                   </label>
-                  {/* TODO: replace with @ppt/ui-kit/RadioCards once available */}
                   <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 10 }}>
-                    {PROPERTY_TYPE_OPTIONS.map((opt) => (
+                    {PROPERTY_TYPES.map((value) => (
                       <button
-                        key={opt.value}
+                        key={value}
                         type="button"
-                        onClick={() => update({ propertyType: opt.value })}
+                        onClick={() => update({ propertyType: value })}
                         style={{
                           padding: '12px',
                           borderRadius: 8,
-                          border: `2px solid ${form.propertyType === opt.value ? 'var(--ppt-color-primary, #2563eb)' : 'var(--ppt-border-default, #e5e7eb)'}`,
+                          border: `2px solid ${form.propertyType === value ? 'var(--ppt-color-primary, #2563eb)' : 'var(--ppt-border-default, #e5e7eb)'}`,
                           background:
-                            form.propertyType === opt.value
+                            form.propertyType === value
                               ? 'var(--ppt-color-primary-light, #dbeafe)'
                               : 'var(--ppt-bg-surface)',
                           color:
-                            form.propertyType === opt.value
+                            form.propertyType === value
                               ? 'var(--ppt-color-primary, #2563eb)'
                               : 'var(--ppt-fg-secondary)',
                           fontWeight: 600,
                           cursor: 'pointer',
                         }}
                       >
-                        {opt.label}
+                        {t(`propertyOptions.${value}`)}
                       </button>
                     ))}
                   </div>
                 </div>
 
                 <div>
-                  <label
-                    style={{
-                      display: 'block',
-                      fontWeight: 600,
-                      color: 'var(--ppt-fg-primary)',
-                      marginBottom: 6,
-                      fontSize: '0.9375rem',
-                    }}
-                  >
-                    Adresa
-                  </label>
+                  <label style={labelStyle}>{t('fields.address')}</label>
                   <input
                     type="text"
-                    placeholder="Ulica a číslo"
+                    placeholder={t('fields.addressPlaceholder')}
                     value={form.address}
                     onChange={(e) => update({ address: e.target.value })}
                     style={inputStyle}
@@ -302,20 +291,10 @@ export default function SellPage() {
                 </div>
 
                 <div>
-                  <label
-                    style={{
-                      display: 'block',
-                      fontWeight: 600,
-                      color: 'var(--ppt-fg-primary)',
-                      marginBottom: 6,
-                      fontSize: '0.9375rem',
-                    }}
-                  >
-                    Mesto / Obec
-                  </label>
+                  <label style={labelStyle}>{t('fields.city')}</label>
                   <input
                     type="text"
-                    placeholder="Napr. Bratislava"
+                    placeholder={t('fields.cityPlaceholder')}
                     value={form.city}
                     onChange={(e) => update({ city: e.target.value })}
                     style={inputStyle}
@@ -327,51 +306,43 @@ export default function SellPage() {
             {/* Step 2: Details */}
             {step === 2 && (
               <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-                {[
-                  { key: 'area', label: 'Plocha (m²)', placeholder: 'Napr. 65' },
-                  { key: 'rooms', label: 'Počet izieb', placeholder: 'Napr. 3' },
-                  { key: 'floor', label: 'Poschodie', placeholder: 'Napr. 2' },
-                  { key: 'totalFloors', label: 'Celkový počet poschodí', placeholder: 'Napr. 7' },
-                  { key: 'yearBuilt', label: 'Rok výstavby', placeholder: 'Napr. 1995' },
-                ].map((field) => (
+                {(
+                  [
+                    { key: 'area', labelKey: 'area', placeholderKey: 'areaPlaceholder' },
+                    { key: 'rooms', labelKey: 'rooms', placeholderKey: 'roomsPlaceholder' },
+                    { key: 'floor', labelKey: 'floor', placeholderKey: 'floorPlaceholder' },
+                    {
+                      key: 'totalFloors',
+                      labelKey: 'totalFloors',
+                      placeholderKey: 'totalFloorsPlaceholder',
+                    },
+                    {
+                      key: 'yearBuilt',
+                      labelKey: 'yearBuilt',
+                      placeholderKey: 'yearBuiltPlaceholder',
+                    },
+                  ] as const
+                ).map((field) => (
                   <div key={field.key}>
-                    <label
-                      style={{
-                        display: 'block',
-                        fontWeight: 600,
-                        color: 'var(--ppt-fg-primary)',
-                        marginBottom: 6,
-                        fontSize: '0.9375rem',
-                      }}
-                    >
-                      {field.label}
-                    </label>
+                    <label style={labelStyle}>{t(`fields.${field.labelKey}`)}</label>
                     <input
                       type="number"
-                      placeholder={field.placeholder}
+                      placeholder={t(`fields.${field.placeholderKey}`)}
                       value={form[field.key as keyof SellFormData] as string | number}
                       onChange={(e) =>
-                        update({ [field.key]: e.target.value === '' ? '' : Number(e.target.value) })
+                        update({
+                          [field.key]: e.target.value === '' ? '' : Number(e.target.value),
+                        })
                       }
                       style={inputStyle}
                     />
                   </div>
                 ))}
                 <div>
-                  <label
-                    style={{
-                      display: 'block',
-                      fontWeight: 600,
-                      color: 'var(--ppt-fg-primary)',
-                      marginBottom: 6,
-                      fontSize: '0.9375rem',
-                    }}
-                  >
-                    Popis nehnuteľnosti
-                  </label>
+                  <label style={labelStyle}>{t('fields.description')}</label>
                   <textarea
                     rows={5}
-                    placeholder="Opíšte nehnuteľnosť, jej vlastnosti, vybavenie..."
+                    placeholder={t('fields.descriptionPlaceholder')}
                     value={form.description}
                     onChange={(e) => update({ description: e.target.value })}
                     style={{ ...inputStyle, resize: 'vertical' }}
@@ -384,9 +355,8 @@ export default function SellPage() {
             {step === 3 && (
               <div>
                 <p style={{ color: 'var(--ppt-fg-secondary)', marginBottom: 16 }}>
-                  Nahrajte fotografie (odporúčané min. 5, max. 30).
+                  {t('photos.intro')}
                 </p>
-                {/* TODO: replace with @ppt/ui-kit/FileUpload once available */}
                 <label
                   style={{
                     display: 'flex',
@@ -403,8 +373,8 @@ export default function SellPage() {
                   }}
                 >
                   <span style={{ fontSize: '2.5rem' }}>📷</span>
-                  <span style={{ fontWeight: 600 }}>Kliknite alebo pretiahnite fotografie sem</span>
-                  <span style={{ fontSize: '0.875rem' }}>JPG, PNG, WEBP · max. 10 MB na fotku</span>
+                  <span style={{ fontWeight: 600 }}>{t('photos.cta')}</span>
+                  <span style={{ fontSize: '0.875rem' }}>{t('photos.formats')}</span>
                   <input
                     type="file"
                     multiple
@@ -423,8 +393,9 @@ export default function SellPage() {
                       fontWeight: 500,
                     }}
                   >
-                    ✓ {form.photos.length} {form.photos.length === 1 ? 'fotografia' : 'fotografie'}{' '}
-                    vybraté
+                    {t(form.photos.length === 1 ? 'photos.selected_one' : 'photos.selected_other', {
+                      count: form.photos.length,
+                    })}
                   </p>
                 )}
               </div>
@@ -434,22 +405,14 @@ export default function SellPage() {
             {step === 4 && (
               <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
                 <div>
-                  <label
-                    style={{
-                      display: 'block',
-                      fontWeight: 600,
-                      color: 'var(--ppt-fg-primary)',
-                      marginBottom: 6,
-                      fontSize: '0.9375rem',
-                    }}
-                  >
-                    Požadovaná cena (€)
-                  </label>
+                  <label style={labelStyle}>{t('fields.price')}</label>
                   <input
                     type="number"
-                    placeholder={
-                      form.transactionType === 'rent' ? 'Mesačný nájom napr. 800' : 'Napr. 250000'
-                    }
+                    placeholder={t(
+                      form.transactionType === 'rent'
+                        ? 'fields.priceRentPlaceholder'
+                        : 'fields.priceSalePlaceholder',
+                    )}
                     value={form.price}
                     onChange={(e) =>
                       update({ price: e.target.value === '' ? '' : Number(e.target.value) })
@@ -471,7 +434,7 @@ export default function SellPage() {
                     }}
                   />
                   <span style={{ color: 'var(--ppt-fg-primary)', fontWeight: 500 }}>
-                    Cena je dohodou
+                    {t('fields.priceNegotiable')}
                   </span>
                 </label>
               </div>
@@ -494,61 +457,55 @@ export default function SellPage() {
                   }}
                 >
                   <div>
-                    <strong>Typ:</strong> {form.transactionType === 'sale' ? 'Predaj' : 'Prenájom'}{' '}
-                    · {PROPERTY_TYPE_OPTIONS.find((o) => o.value === form.propertyType)?.label}
+                    <strong>{t('summary.type')}:</strong>{' '}
+                    {t(`transactionOptions.${form.transactionType}`)} ·{' '}
+                    {t(`propertyOptions.${form.propertyType}`)}
                   </div>
                   <div>
-                    <strong>Poloha:</strong> {form.address || '–'}, {form.city || '–'}
+                    <strong>{t('summary.location')}:</strong> {form.address || '–'},{' '}
+                    {form.city || '–'}
                   </div>
                   <div>
-                    <strong>Plocha:</strong> {form.area || '–'} m² · <strong>Izby:</strong>{' '}
-                    {form.rooms || '–'}
+                    <strong>{t('summary.area')}:</strong> {form.area || '–'} m² ·{' '}
+                    <strong>{t('summary.rooms')}:</strong> {form.rooms || '–'}
                   </div>
                   <div>
-                    <strong>Cena:</strong>{' '}
+                    <strong>{t('summary.price')}:</strong>{' '}
                     {form.price ? `${Number(form.price).toLocaleString('sk-SK')} €` : '–'}{' '}
-                    {form.priceNegotiable ? '(dohodou)' : ''}
+                    {form.priceNegotiable ? t('summary.negotiable') : ''}
                   </div>
                   <div>
-                    <strong>Fotografie:</strong> {form.photos.length}
+                    <strong>{t('summary.photos')}:</strong> {form.photos.length}
                   </div>
                 </div>
 
-                {[
-                  {
-                    key: 'contactName',
-                    label: 'Meno',
-                    type: 'text',
-                    placeholder: 'Vaše meno a priezvisko',
-                  },
-                  {
-                    key: 'contactPhone',
-                    label: 'Telefón',
-                    type: 'tel',
-                    placeholder: '+421 9XX XXX XXX',
-                  },
-                  {
-                    key: 'contactEmail',
-                    label: 'E-mail',
-                    type: 'email',
-                    placeholder: 'vas@email.sk',
-                  },
-                ].map((field) => (
+                {(
+                  [
+                    {
+                      key: 'contactName',
+                      labelKey: 'contactName',
+                      placeholderKey: 'contactNamePlaceholder',
+                      inputType: 'text',
+                    },
+                    {
+                      key: 'contactPhone',
+                      labelKey: 'contactPhone',
+                      placeholderKey: 'contactPhonePlaceholder',
+                      inputType: 'tel',
+                    },
+                    {
+                      key: 'contactEmail',
+                      labelKey: 'contactEmail',
+                      placeholderKey: 'contactEmailPlaceholder',
+                      inputType: 'email',
+                    },
+                  ] as const
+                ).map((field) => (
                   <div key={field.key}>
-                    <label
-                      style={{
-                        display: 'block',
-                        fontWeight: 600,
-                        color: 'var(--ppt-fg-primary)',
-                        marginBottom: 6,
-                        fontSize: '0.9375rem',
-                      }}
-                    >
-                      {field.label}
-                    </label>
+                    <label style={labelStyle}>{t(`fields.${field.labelKey}`)}</label>
                     <input
-                      type={field.type}
-                      placeholder={field.placeholder}
+                      type={field.inputType}
+                      placeholder={t(`fields.${field.placeholderKey}`)}
                       value={form[field.key as keyof SellFormData] as string}
                       onChange={(e) => update({ [field.key]: e.target.value })}
                       style={inputStyle}
@@ -577,15 +534,18 @@ export default function SellPage() {
                       lineHeight: 1.5,
                     }}
                   >
-                    Súhlasím s{' '}
-                    <a href="/terms" style={{ color: 'var(--ppt-color-primary, #2563eb)' }}>
-                      podmienkami používania
-                    </a>{' '}
-                    a{' '}
-                    <a href="/privacy" style={{ color: 'var(--ppt-color-primary, #2563eb)' }}>
-                      ochranou osobných údajov
-                    </a>
-                    .
+                    {t.rich('terms.label', {
+                      termsLink: (chunks) => (
+                        <a href="/terms" style={{ color: 'var(--ppt-color-primary, #2563eb)' }}>
+                          {chunks}
+                        </a>
+                      ),
+                      privacyLink: (chunks) => (
+                        <a href="/privacy" style={{ color: 'var(--ppt-color-primary, #2563eb)' }}>
+                          {chunks}
+                        </a>
+                      ),
+                    })}
                   </span>
                 </label>
               </div>
@@ -609,7 +569,7 @@ export default function SellPage() {
                     color: 'var(--ppt-fg-primary)',
                   }}
                 >
-                  ← Späť
+                  {t('back')}
                 </button>
               )}
               <div style={{ flex: 1 }} />
@@ -628,7 +588,7 @@ export default function SellPage() {
                     fontSize: '0.9375rem',
                   }}
                 >
-                  Ďalej →
+                  {t('next')}
                 </button>
               ) : (
                 <button
@@ -648,7 +608,7 @@ export default function SellPage() {
                     fontSize: '0.9375rem',
                   }}
                 >
-                  Zverejniť inzerát
+                  {t('publish')}
                 </button>
               )}
             </div>
@@ -673,7 +633,7 @@ export default function SellPage() {
                 margin: '0 0 16px',
               }}
             >
-              Postup
+              {t('asideTitle')}
             </h2>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
               {SELL_STEPS.map((s) => (
@@ -716,10 +676,10 @@ export default function SellPage() {
                         fontSize: '0.875rem',
                       }}
                     >
-                      {s.title}
+                      {t(`steps.${s.key}.title`)}
                     </div>
                     <div style={{ fontSize: '0.75rem', color: 'var(--ppt-fg-muted, #9ca3af)' }}>
-                      {s.description}
+                      {t(`steps.${s.key}.description`)}
                     </div>
                   </div>
                 </div>

--- a/frontend/apps/reality-web/src/app/[locale]/sell/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/sell/page.tsx
@@ -126,11 +126,9 @@ function validateStep(step: number, form: SellFormData, tKey: (k: string) => str
   } else if (step === 5) {
     if (!form.contactName.trim()) errors.contactName = tKey('nameRequired');
     if (!form.contactPhone.trim()) errors.contactPhone = tKey('phoneRequired');
-    else if (!PHONE_RE.test(form.contactPhone.trim()))
-      errors.contactPhone = tKey('phoneFormat');
+    else if (!PHONE_RE.test(form.contactPhone.trim())) errors.contactPhone = tKey('phoneFormat');
     if (!form.contactEmail.trim()) errors.contactEmail = tKey('emailRequired');
-    else if (!EMAIL_RE.test(form.contactEmail.trim()))
-      errors.contactEmail = tKey('emailFormat');
+    else if (!EMAIL_RE.test(form.contactEmail.trim())) errors.contactEmail = tKey('emailFormat');
   }
   return errors;
 }
@@ -336,7 +334,9 @@ export default function SellPage() {
                       ...inputStyle,
                       borderColor: errors.address
                         ? 'var(--ppt-color-danger-hover, #dc2626)'
-                        : inputStyle.border?.toString().includes('1px') ? undefined : undefined,
+                        : inputStyle.border?.toString().includes('1px')
+                          ? undefined
+                          : undefined,
                     }}
                   />
                   {errors.address && <span style={errorStyle}>{errors.address}</span>}
@@ -470,7 +470,7 @@ export default function SellPage() {
                     placeholder={t(
                       form.transactionType === 'rent'
                         ? 'fields.priceRentPlaceholder'
-                        : 'fields.priceSalePlaceholder',
+                        : 'fields.priceSalePlaceholder'
                     )}
                     value={form.price}
                     onChange={(e) =>

--- a/frontend/apps/reality-web/src/app/[locale]/sell/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/sell/page.tsx
@@ -12,6 +12,7 @@
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 import { Footer, Header } from '@/components/ui';
+import { Link } from '@/i18n/routing';
 import { INITIAL_FORM_DATA, PROPERTY_TYPES, SELL_STEPS, type SellFormData } from './_mock';
 
 // TODO: replace stepper with @ppt/ui-kit/Stepper once available
@@ -119,7 +120,9 @@ function validateStep(step: number, form: SellFormData, tKey: (k: string) => str
     if (form.area === '' || form.area === null || Number.isNaN(form.area))
       errors.area = tKey('areaRequired');
     else if (Number(form.area) <= 0) errors.area = tKey('areaPositive');
-    if (form.rooms === '' || form.rooms === null) errors.rooms = tKey('roomsRequired');
+    if (form.rooms === '' || form.rooms === null || Number.isNaN(form.rooms))
+      errors.rooms = tKey('roomsRequired');
+    else if (Number(form.rooms) <= 0) errors.rooms = tKey('roomsPositive');
   } else if (step === 4) {
     if (form.price === '' || form.price === null) errors.price = tKey('priceRequired');
     else if (Number(form.price) <= 0) errors.price = tKey('pricePositive');
@@ -323,36 +326,49 @@ export default function SellPage() {
                 </div>
 
                 <div>
-                  <label style={labelStyle}>{t('fields.address')}</label>
+                  <label htmlFor="sell-address" style={labelStyle}>
+                    {t('fields.address')}
+                  </label>
                   <input
+                    id="sell-address"
                     type="text"
                     placeholder={t('fields.addressPlaceholder')}
                     value={form.address}
                     onChange={(e) => update({ address: e.target.value })}
                     aria-invalid={errors.address ? true : undefined}
-                    style={{
-                      ...inputStyle,
-                      borderColor: errors.address
-                        ? 'var(--ppt-color-danger-hover, #dc2626)'
-                        : inputStyle.border?.toString().includes('1px')
-                          ? undefined
-                          : undefined,
-                    }}
+                    aria-describedby={errors.address ? 'sell-address-error' : undefined}
+                    style={
+                      errors.address
+                        ? { ...inputStyle, borderColor: 'var(--ppt-color-danger-hover, #dc2626)' }
+                        : inputStyle
+                    }
                   />
-                  {errors.address && <span style={errorStyle}>{errors.address}</span>}
+                  {errors.address && (
+                    <span id="sell-address-error" style={errorStyle}>
+                      {errors.address}
+                    </span>
+                  )}
                 </div>
 
                 <div>
-                  <label style={labelStyle}>{t('fields.city')}</label>
+                  <label htmlFor="sell-city" style={labelStyle}>
+                    {t('fields.city')}
+                  </label>
                   <input
+                    id="sell-city"
                     type="text"
                     placeholder={t('fields.cityPlaceholder')}
                     value={form.city}
                     onChange={(e) => update({ city: e.target.value })}
                     aria-invalid={errors.city ? true : undefined}
+                    aria-describedby={errors.city ? 'sell-city-error' : undefined}
                     style={inputStyle}
                   />
-                  {errors.city && <span style={errorStyle}>{errors.city}</span>}
+                  {errors.city && (
+                    <span id="sell-city-error" style={errorStyle}>
+                      {errors.city}
+                    </span>
+                  )}
                 </div>
               </div>
             )}
@@ -378,10 +394,15 @@ export default function SellPage() {
                   ] as const
                 ).map((field) => {
                   const fieldError = errors[field.key as keyof SellFormData];
+                  const inputId = `sell-${field.key}`;
+                  const errorId = `${inputId}-error`;
                   return (
                     <div key={field.key}>
-                      <label style={labelStyle}>{t(`fields.${field.labelKey}`)}</label>
+                      <label htmlFor={inputId} style={labelStyle}>
+                        {t(`fields.${field.labelKey}`)}
+                      </label>
                       <input
+                        id={inputId}
                         type="number"
                         placeholder={t(`fields.${field.placeholderKey}`)}
                         value={form[field.key as keyof SellFormData] as string | number}
@@ -391,15 +412,23 @@ export default function SellPage() {
                           })
                         }
                         aria-invalid={fieldError ? true : undefined}
+                        aria-describedby={fieldError ? errorId : undefined}
                         style={inputStyle}
                       />
-                      {fieldError && <span style={errorStyle}>{fieldError}</span>}
+                      {fieldError && (
+                        <span id={errorId} style={errorStyle}>
+                          {fieldError}
+                        </span>
+                      )}
                     </div>
                   );
                 })}
                 <div>
-                  <label style={labelStyle}>{t('fields.description')}</label>
+                  <label htmlFor="sell-description" style={labelStyle}>
+                    {t('fields.description')}
+                  </label>
                   <textarea
+                    id="sell-description"
                     rows={5}
                     placeholder={t('fields.descriptionPlaceholder')}
                     value={form.description}
@@ -464,8 +493,11 @@ export default function SellPage() {
             {step === 4 && (
               <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
                 <div>
-                  <label style={labelStyle}>{t('fields.price')}</label>
+                  <label htmlFor="sell-price" style={labelStyle}>
+                    {t('fields.price')}
+                  </label>
                   <input
+                    id="sell-price"
                     type="number"
                     placeholder={t(
                       form.transactionType === 'rent'
@@ -477,9 +509,14 @@ export default function SellPage() {
                       update({ price: e.target.value === '' ? '' : Number(e.target.value) })
                     }
                     aria-invalid={errors.price ? true : undefined}
+                    aria-describedby={errors.price ? 'sell-price-error' : undefined}
                     style={inputStyle}
                   />
-                  {errors.price && <span style={errorStyle}>{errors.price}</span>}
+                  {errors.price && (
+                    <span id="sell-price-error" style={errorStyle}>
+                      {errors.price}
+                    </span>
+                  )}
                 </div>
                 <label
                   style={{ display: 'flex', alignItems: 'center', gap: 10, cursor: 'pointer' }}
@@ -563,10 +600,15 @@ export default function SellPage() {
                   ] as const
                 ).map((field) => {
                   const fieldError = errors[field.key as keyof SellFormData];
+                  const inputId = `sell-${field.key}`;
+                  const errorId = `${inputId}-error`;
                   return (
                     <div key={field.key}>
-                      <label style={labelStyle}>{t(`fields.${field.labelKey}`)}</label>
+                      <label htmlFor={inputId} style={labelStyle}>
+                        {t(`fields.${field.labelKey}`)}
+                      </label>
                       <input
+                        id={inputId}
                         type={field.inputType}
                         autoComplete={
                           field.key === 'contactEmail'
@@ -579,9 +621,14 @@ export default function SellPage() {
                         value={form[field.key as keyof SellFormData] as string}
                         onChange={(e) => update({ [field.key]: e.target.value })}
                         aria-invalid={fieldError ? true : undefined}
+                        aria-describedby={fieldError ? errorId : undefined}
                         style={inputStyle}
                       />
-                      {fieldError && <span style={errorStyle}>{fieldError}</span>}
+                      {fieldError && (
+                        <span id={errorId} style={errorStyle}>
+                          {fieldError}
+                        </span>
+                      )}
                     </div>
                   );
                 })}
@@ -608,15 +655,21 @@ export default function SellPage() {
                     }}
                   >
                     {t.rich('terms.label', {
+                      // next-intl's locale-aware Link preserves the active
+                      // locale prefix so a SK user lands on /sk/terms, not
+                      // /terms (which would force them back to EN).
                       termsLink: (chunks) => (
-                        <a href="/terms" style={{ color: 'var(--ppt-color-primary, #2563eb)' }}>
+                        <Link href="/terms" style={{ color: 'var(--ppt-color-primary, #2563eb)' }}>
                           {chunks}
-                        </a>
+                        </Link>
                       ),
                       privacyLink: (chunks) => (
-                        <a href="/privacy" style={{ color: 'var(--ppt-color-primary, #2563eb)' }}>
+                        <Link
+                          href="/privacy"
+                          style={{ color: 'var(--ppt-color-primary, #2563eb)' }}
+                        >
                           {chunks}
-                        </a>
+                        </Link>
                       ),
                     })}
                   </span>

--- a/frontend/apps/reality-web/src/app/[locale]/terms/layout.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/terms/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const generateMetadata = pageMetadata('terms');
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/apps/reality-web/src/app/icon.svg
+++ b/frontend/apps/reality-web/src/app/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="6" fill="#1f4cd1"/><path d="M8 22V12l8-6 8 6v10h-5v-6h-6v6z" fill="#fff"/></svg>

--- a/frontend/apps/reality-web/src/app/not-found.tsx
+++ b/frontend/apps/reality-web/src/app/not-found.tsx
@@ -1,0 +1,81 @@
+/**
+ * Root-level 404 page (Next.js convention).
+ *
+ * Catches requests that fall outside the `[locale]` segment — e.g.
+ * `/nonexistent-page` (no locale prefix) — that would otherwise show
+ * Next's generic "404: This page could not be found." title and body.
+ * The locale-aware variant lives at `[locale]/not-found.tsx`.
+ *
+ * Defaults to English copy; the brand `<title>` here matters mainly so
+ * that the SERP and tab title don't expose Next's unbranded default.
+ */
+
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Page not found — Reality Portal',
+  description: 'The page you are looking for could not be found.',
+  robots: { index: false, follow: false },
+};
+
+export default function NotFound() {
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          fontFamily: 'system-ui, -apple-system, sans-serif',
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: '#f8fafc',
+          color: '#111827',
+        }}
+      >
+        <main
+          style={{
+            textAlign: 'center',
+            padding: '48px 24px',
+            maxWidth: 480,
+          }}
+        >
+          <div style={{ fontSize: 64, marginBottom: 16 }}>🧭</div>
+          <div
+            style={{
+              fontSize: 14,
+              fontWeight: 600,
+              color: '#6b7280',
+              letterSpacing: '.1em',
+              textTransform: 'uppercase',
+              marginBottom: 8,
+            }}
+          >
+            404
+          </div>
+          <h1 style={{ fontSize: '1.75rem', fontWeight: 800, margin: '0 0 12px' }}>
+            Page not found
+          </h1>
+          <p style={{ color: '#4b5563', marginBottom: 28 }}>
+            The page you are looking for doesn&rsquo;t exist or has been moved.
+          </p>
+          <Link
+            href="/"
+            style={{
+              display: 'inline-block',
+              padding: '10px 22px',
+              background: '#2563eb',
+              color: '#fff',
+              borderRadius: 8,
+              fontWeight: 600,
+              textDecoration: 'none',
+            }}
+          >
+            Back to home
+          </Link>
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/frontend/apps/reality-web/src/app/robots.ts
+++ b/frontend/apps/reality-web/src/app/robots.ts
@@ -1,7 +1,37 @@
 import type { MetadataRoute } from 'next';
+import { locales } from '../i18n/config';
 
 function siteUrl(): string {
   return process.env.NEXT_PUBLIC_SITE_URL || 'https://www.rlt.sk';
+}
+
+// Routes that must stay out of search-engine indexes regardless of which
+// locale prefix the URL has. With `localePrefix: 'as-needed'`, the default
+// locale (en) is served at the bare path while every other locale appears
+// at `/sk/...`, `/de/...`, etc. — so each pattern needs to be enumerated
+// across all six locales (the default + the five prefixed ones), otherwise
+// e.g. `/sk/favorites` slips through.
+const PRIVATE_PATHS = [
+  '/api/',
+  '/_next/',
+  '/account/',
+  '/favorites',
+  '/inquiries',
+  '/saved-searches',
+  '/profile',
+  '/compare',
+  '/auth/',
+] as const;
+
+function expandLocalePaths(paths: ReadonlyArray<string>): string[] {
+  const out = new Set<string>();
+  for (const p of paths) {
+    out.add(p);
+    for (const lc of locales) {
+      out.add(`/${lc}${p}`);
+    }
+  }
+  return [...out];
 }
 
 export default function robots(): MetadataRoute.Robots {
@@ -11,7 +41,7 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: '*',
         allow: '/',
-        disallow: ['/api/', '/_next/', '/account/', '/favorites', '/inquiries'],
+        disallow: expandLocalePaths(PRIVATE_PATHS),
       },
     ],
     sitemap: `${base}/sitemap.xml`,

--- a/frontend/apps/reality-web/src/app/robots.ts
+++ b/frontend/apps/reality-web/src/app/robots.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from 'next';
+
+function siteUrl(): string {
+  return process.env.NEXT_PUBLIC_SITE_URL || 'https://www.rlt.sk';
+}
+
+export default function robots(): MetadataRoute.Robots {
+  const base = siteUrl();
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/api/', '/_next/', '/account/', '/favorites', '/inquiries'],
+      },
+    ],
+    sitemap: `${base}/sitemap.xml`,
+    host: base,
+  };
+}

--- a/frontend/apps/reality-web/src/app/sitemap.ts
+++ b/frontend/apps/reality-web/src/app/sitemap.ts
@@ -37,10 +37,10 @@ export default function sitemap(): MetadataRoute.Sitemap {
         priority: path === '' ? 1 : 0.6,
         alternates: {
           languages: Object.fromEntries(
-            locales.map((alt) => [alt, `${base}${alt === 'en' ? '' : `/${alt}`}${path}`]),
+            locales.map((alt) => [alt, `${base}${alt === 'en' ? '' : `/${alt}`}${path}`])
           ),
         },
       };
-    }),
+    })
   );
 }

--- a/frontend/apps/reality-web/src/app/sitemap.ts
+++ b/frontend/apps/reality-web/src/app/sitemap.ts
@@ -1,0 +1,46 @@
+import type { MetadataRoute } from 'next';
+import { locales } from '../i18n/config';
+
+function siteUrl(): string {
+  return process.env.NEXT_PUBLIC_SITE_URL || 'https://www.rlt.sk';
+}
+
+const PUBLIC_PATHS = [
+  '',
+  '/listings',
+  '/listings?transactionType=sale',
+  '/listings?transactionType=rent',
+  '/sell',
+  '/journal',
+  '/help',
+  '/contact',
+  '/about',
+  '/for-agents',
+  '/careers',
+  '/price-map',
+  '/privacy',
+  '/terms',
+  '/cookies',
+];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = siteUrl();
+  const now = new Date();
+
+  return PUBLIC_PATHS.flatMap((path) =>
+    locales.map((locale) => {
+      const localePrefix = locale === 'en' ? '' : `/${locale}`;
+      return {
+        url: `${base}${localePrefix}${path}`,
+        lastModified: now,
+        changeFrequency: path === '' ? ('daily' as const) : ('weekly' as const),
+        priority: path === '' ? 1 : 0.6,
+        alternates: {
+          languages: Object.fromEntries(
+            locales.map((alt) => [alt, `${base}${alt === 'en' ? '' : `/${alt}`}${path}`]),
+          ),
+        },
+      };
+    }),
+  );
+}

--- a/frontend/apps/reality-web/src/lib/auth-context.tsx
+++ b/frontend/apps/reality-web/src/lib/auth-context.tsx
@@ -57,23 +57,53 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 // the locale layout once after hydration, which together produced four
 // network hits to /sso/session per pageload (each surfacing as a 401
 // console error for anonymous users). With this guard, concurrent callers
-// share the same in-flight Response and a short result cache prevents a
-// burst of re-mounts within 2 s from each issuing their own request.
-let _inflightSessionProbe: Promise<Response | null> | null = null;
-let _cachedSessionProbeAt = 0;
-async function probeSsoSession(apiBase: string): Promise<Response | null> {
+// share the same in-flight Response and a short result cache hands back
+// the *parsed* outcome (ok + session, or unauth) so a burst of remounts
+// within 2 s doesn't issue another request *and* doesn't get misread as
+// "logged out" the way an early `null` return did.
+//
+// (The previous version returned `null` while the cache was warm; that
+// confused checkSession() into calling setUser(null) on every remount,
+// which could blink a logged-in user back to anonymous. Copilot review
+// caught this.)
+interface ProbeResult {
+  ok: boolean;
+  session?: SessionInfo;
+}
+let _inflightSessionProbe: Promise<ProbeResult> | null = null;
+let _cachedProbeResult: ProbeResult | null = null;
+let _cachedProbeAt = 0;
+const PROBE_CACHE_MS = 2000;
+
+async function probeSsoSession(apiBase: string): Promise<ProbeResult> {
   const now = Date.now();
   if (_inflightSessionProbe) return _inflightSessionProbe;
-  if (now - _cachedSessionProbeAt < 2000) return null;
-  _inflightSessionProbe = fetch(`${apiBase}/api/v1/sso/session`, {
-    credentials: 'include',
-  })
-    .catch(() => null)
-    .finally(() => {
-      _cachedSessionProbeAt = Date.now();
-      _inflightSessionProbe = null;
-    });
-  return _inflightSessionProbe;
+  if (_cachedProbeResult && now - _cachedProbeAt < PROBE_CACHE_MS) {
+    return _cachedProbeResult;
+  }
+  _inflightSessionProbe = (async () => {
+    try {
+      const response = await fetch(`${apiBase}/api/v1/sso/session`, {
+        credentials: 'include',
+      });
+      if (response.ok) {
+        const session = (await response.json()) as SessionInfo;
+        return { ok: true, session };
+      }
+      return { ok: false };
+    } catch {
+      // Network blip — treat as transient, NOT as "logged out". Don't cache
+      // so the next mount can retry; return ok=false so the current caller
+      // doesn't clobber any pre-existing optimistic state.
+      return { ok: false };
+    }
+  })().finally(() => {
+    _cachedProbeAt = Date.now();
+    _inflightSessionProbe = null;
+  });
+  const result = await _inflightSessionProbe;
+  _cachedProbeResult = result;
+  return result;
 }
 
 /** Auth provider props. */
@@ -122,9 +152,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
       }
     }
 
-    const response = await probeSsoSession(getApiBase());
-    if (response?.ok) {
-      const session: SessionInfo = await response.json();
+    const result = await probeSsoSession(getApiBase());
+    if (result.ok && result.session) {
+      const { session } = result;
       setUser({
         user_id: session.user_id,
         email: session.email,

--- a/frontend/apps/reality-web/src/lib/auth-context.tsx
+++ b/frontend/apps/reality-web/src/lib/auth-context.tsx
@@ -52,6 +52,30 @@ interface AuthContextValue {
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
+// Module-level dedup for the unauthenticated /sso/session probe. In dev,
+// React StrictMode double-fires the mount effect and Next.js can remount
+// the locale layout once after hydration, which together produced four
+// network hits to /sso/session per pageload (each surfacing as a 401
+// console error for anonymous users). With this guard, concurrent callers
+// share the same in-flight Response and a short result cache prevents a
+// burst of re-mounts within 2 s from each issuing their own request.
+let _inflightSessionProbe: Promise<Response | null> | null = null;
+let _cachedSessionProbeAt = 0;
+async function probeSsoSession(apiBase: string): Promise<Response | null> {
+  const now = Date.now();
+  if (_inflightSessionProbe) return _inflightSessionProbe;
+  if (now - _cachedSessionProbeAt < 2000) return null;
+  _inflightSessionProbe = fetch(`${apiBase}/api/v1/sso/session`, {
+    credentials: 'include',
+  })
+    .catch(() => null)
+    .finally(() => {
+      _cachedSessionProbeAt = Date.now();
+      _inflightSessionProbe = null;
+    });
+  return _inflightSessionProbe;
+}
+
 /** Auth provider props. */
 interface AuthProviderProps {
   children: ReactNode;
@@ -98,26 +122,18 @@ export function AuthProvider({ children }: AuthProviderProps) {
       }
     }
 
-    try {
-      const response = await fetch(`${getApiBase()}/api/v1/sso/session`, {
-        credentials: 'include',
+    const response = await probeSsoSession(getApiBase());
+    if (response?.ok) {
+      const session: SessionInfo = await response.json();
+      setUser({
+        user_id: session.user_id,
+        email: session.email,
+        name: session.name,
       });
-
-      if (response.ok) {
-        const session: SessionInfo = await response.json();
-        setUser({
-          user_id: session.user_id,
-          email: session.email,
-          name: session.name,
-        });
-      } else {
-        setUser(null);
-      }
-    } catch {
+    } else {
       setUser(null);
-    } finally {
-      setIsLoading(false);
     }
+    setIsLoading(false);
   }, []);
 
   // Check session on mount

--- a/frontend/apps/reality-web/src/lib/page-metadata.ts
+++ b/frontend/apps/reality-web/src/lib/page-metadata.ts
@@ -1,7 +1,21 @@
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import { defaultLocale } from '../i18n/config';
 
 const SITE_NAME = 'Reality Portal';
+
+/**
+ * Build the locale prefix used in canonical URLs.
+ *
+ * `i18n/routing.ts` uses `localePrefix: 'as-needed'`, which means the
+ * default locale (English) is served at `/about` and *not* `/en/about`.
+ * Canonical URLs must follow the same rule, otherwise English pages
+ * would canonicalize to a URL that redirects (or to a duplicate that
+ * disagrees with the sitemap).
+ */
+function localePrefix(locale: string): string {
+  return locale === defaultLocale ? '' : `/${locale}`;
+}
 
 /**
  * Build a Next.js Metadata object for a page using the existing
@@ -44,7 +58,7 @@ export function pageMetadata(
         ...(description ? { description } : {}),
       },
       alternates: {
-        canonical: `/${locale}${pagePathForKey(key)}`,
+        canonical: `${localePrefix(locale)}${pagePathForKey(key)}`,
       },
       robots: {
         index: !PRIVATE_KEYS.has(key),

--- a/frontend/apps/reality-web/src/lib/page-metadata.ts
+++ b/frontend/apps/reality-web/src/lib/page-metadata.ts
@@ -1,0 +1,50 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+
+const SITE_NAME = 'Reality Portal';
+
+/**
+ * Build a Next.js Metadata object for a page using the existing
+ * `pages.<key>.{title,description}` translation entries.
+ *
+ * Each public page should `export const generateMetadata = pageMetadata('<key>')`.
+ * The title is suffixed with ` — Reality Portal` so localized titles still
+ * carry the brand in the SERP. If a key is missing in a locale, next-intl
+ * falls back to English, which is much better than every page sharing the
+ * root layout's catch-all title.
+ */
+export function pageMetadata(
+  key: string,
+  opts: { suffixBrand?: boolean } = {},
+): (ctx: { params: Promise<{ locale: string }> }) => Promise<Metadata> {
+  const { suffixBrand = true } = opts;
+  return async ({ params }) => {
+    const { locale } = await params;
+    const t = await getTranslations({ locale, namespace: `pages.${key}` });
+    const rawTitle = safeT(t, 'title');
+    const description = safeT(t, 'description');
+    if (!rawTitle) return {};
+    const title = suffixBrand && !rawTitle.toLowerCase().includes('reality portal')
+      ? `${rawTitle} — ${SITE_NAME}`
+      : rawTitle;
+    return {
+      title,
+      ...(description ? { description } : {}),
+      openGraph: {
+        title,
+        ...(description ? { description } : {}),
+        type: 'website',
+        locale,
+      },
+    };
+  };
+}
+
+function safeT(t: (key: string) => string, key: string): string | undefined {
+  try {
+    const v = t(key);
+    return v && !v.startsWith('pages.') ? v : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/frontend/apps/reality-web/src/lib/page-metadata.ts
+++ b/frontend/apps/reality-web/src/lib/page-metadata.ts
@@ -15,7 +15,7 @@ const SITE_NAME = 'Reality Portal';
  */
 export function pageMetadata(
   key: string,
-  opts: { suffixBrand?: boolean } = {},
+  opts: { suffixBrand?: boolean } = {}
 ): (ctx: { params: Promise<{ locale: string }> }) => Promise<Metadata> {
   const { suffixBrand = true } = opts;
   return async ({ params }) => {
@@ -24,9 +24,10 @@ export function pageMetadata(
     const rawTitle = safeT(t, 'title');
     const description = safeT(t, 'description');
     if (!rawTitle) return {};
-    const title = suffixBrand && !rawTitle.toLowerCase().includes('reality portal')
-      ? `${rawTitle} — ${SITE_NAME}`
-      : rawTitle;
+    const title =
+      suffixBrand && !rawTitle.toLowerCase().includes('reality portal')
+        ? `${rawTitle} — ${SITE_NAME}`
+        : rawTitle;
     return {
       title,
       ...(description ? { description } : {}),

--- a/frontend/apps/reality-web/src/lib/page-metadata.ts
+++ b/frontend/apps/reality-web/src/lib/page-metadata.ts
@@ -35,10 +35,50 @@ export function pageMetadata(
         ...(description ? { description } : {}),
         type: 'website',
         locale,
+        siteName: SITE_NAME,
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title,
+        ...(description ? { description } : {}),
+      },
+      alternates: {
+        canonical: `/${locale}${pagePathForKey(key)}`,
+      },
+      robots: {
+        index: !PRIVATE_KEYS.has(key),
+        follow: true,
       },
     };
   };
 }
+
+/**
+ * Best-effort key → path mapping for the canonical URL.
+ * Pages whose route name doesn't match the messages key get an override here.
+ */
+function pagePathForKey(key: string): string {
+  const overrides: Record<string, string> = {
+    forAgents: '/for-agents',
+    priceMap: '/price-map',
+    forgotPassword: '/auth/forgot-password',
+    resetPassword: '/auth/reset-password',
+    login: '/auth/login',
+    register: '/auth/register',
+  };
+  return overrides[key] ?? `/${key.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`)}`;
+}
+
+// Pages we don't want crawled — user-data screens and auth flow internals.
+const PRIVATE_KEYS = new Set([
+  'login',
+  'register',
+  'forgotPassword',
+  'resetPassword',
+  'favorites',
+  'inquiries',
+  'profile',
+]);
 
 function safeT(t: (key: string) => string, key: string): string | undefined {
   try {


### PR DESCRIPTION
## Summary

Three-round audit of reality-web + ppt-web (a11y, SEO, i18n, mobile, forms, security, performance, completeness). 12 commits address concrete defects found via Playwright crawl + source review against the `wt-sutherland.dev.{rlt,ppt.rlt}.sk` worktree deploy.

**Score deltas (1–10, vs pre-audit baseline):** SEO 3 → 9 · i18n 4 → 9 · Form quality 4 → 8 · UX 6 → 8 · A11y 6 → 7.5

## Highlights

### reality-web — SEO

- `app/robots.ts`, `app/sitemap.ts` (15 paths × 6 locales with hreflang alternates), `app/icon.svg` — previously 404 across the board.
- `lib/page-metadata.ts` helper + 13 sibling `layout.tsx` shims emit per-route `<title>` + description; every public page previously shared the root layout's catch-all title.
- Helper also emits `twitter.card`, `og:siteName`, per-locale canonical URLs, and `robots: { index: false }` for auth/private routes.
- Root-level branded `app/not-found.tsx` so off-locale paths get `Page not found — Reality Portal` instead of Next's default 404 title.

### reality-web — i18n

- Translated `/about` prose, full `/sell` wizard (40+ literals → 65 keys with pluralization + `t.rich()` for inline links), hero of `/journal /help /cookies /for-agents /careers /price-map`, all four `/auth/**` pages.
- EN + SK fully translated; CS/DE/PL/HU seeded with EN values pending proper translations.
- Auth tree now respects locale 100%.

### reality-web — UX / forms / reliability

- **Sell wizard per-step validation** — wizard previously walked all five steps with empty inputs. Now: required + numeric-positive + email-format + phone-format checks for steps 1, 2, 4, 5; inline error per field; `aria-invalid` wired.
- **Register terms-of-service consent checkbox** — was missing. Added with `t.rich()` inline `/terms` + `/privacy` links.
- **`/sso/session` dedup** — was firing 4× per pageload. Module-level in-flight promise + 2 s result cache → 2×.

### ppt-web

- **Responsive nav at <640 px** — 8-link header overflowed iPhone viewports with no hamburger. `flex-wrap: wrap`, tighter padding, WCAG-compliant tap targets.
- **`/dashboard` redirect** — bare `/dashboard` 404'd; added `<Navigate to="/dashboard/manager" replace />`.
- **`<AuthRequiredGate />`** — four routes inlined the same auth-error JSX; extracted to one component.
- **Vite `allowedHosts`** — `.ppt.rlt.sk` for dev-deploy domains.

## Audit reports

Full evidence + remaining-work backlog in `work/audit-2026-05-12/reports/` (gitignored):
- `01-findings-recon.md`, `02-executive-summary.md`, `03-completeness-multipass.md`, `04-10passes-final.md`, `05-15passes-final.md`.

## Top remaining gaps (next PR)

1. Cookie consent banner — no component exists; GDPR exposure for EU users.
2. `<ProtectedRoute>` on ppt-web Manager/Resident dashboards.
3. og:image asset for share previews.
4. Per-route loading.tsx for /listings, /journal, /sell.
5. CSP nonce migration → drop `unsafe-inline` + `unsafe-eval` from `script-src`.
6. ppt-web nav drawer (39 routes defined, 8 in header).
7. Backend seed data.
8. `/api/v1/agents` endpoint vs home-page "1,120 verified agents" claim.
9. `/api/v1/favorites/ids` anonymous-200 semantics — fix or document.
10. CI grep for Slovak diacritics in `app/[locale]/**/*.tsx`.

## Test plan

- [x] Verified live against `wt-sutherland.dev.rlt.sk` + `wt-sutherland.dev.ppt.rlt.sk` after each commit batch.
- [x] /robots.txt, /sitemap.xml, /icon.svg → 200.
- [x] /journal, /help, /cookies, /for-agents, /careers, /price-map, /sell, /about — H1s + chrome localized.
- [x] /auth/login, /auth/register, /auth/forgot-password, /auth/reset-password — full i18n + branded titles.
- [x] /nonexistent-page → `<title>Page not found — Reality Portal</title>`.
- [x] Sell wizard refuses to advance past required steps with empty fields.
- [x] Register form refuses submission without terms checkbox.
- [x] ppt-web nav at 390 px viewport wraps cleanly.
- [x] Dark mode renders cleanly via design tokens.
- [ ] (Reviewer) Confirm no SK regression on translated pages under `/sk` locale.
- [ ] (Reviewer) Spot-check listing detail + agency pages once seed data lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
