### PR TITLE
fix(mobile-native): wire navigation gaps found in emulator walkthrough

### DIFF
--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/navigation/Navigation.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/navigation/Navigation.kt
@@ -1,6 +1,18 @@
 package three.two.bit.ppt.reality.navigation
 
 import android.net.Uri
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -8,18 +20,24 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import kotlinx.coroutines.launch
+import three.two.bit.ppt.reality.R
 import three.two.bit.ppt.reality.auth.SsoService
 import three.two.bit.ppt.reality.favorites.FavoritesRepository
 import three.two.bit.ppt.reality.favorites.SavedSearch as ApiSavedSearch
 import three.two.bit.ppt.reality.inquiry.InquiryRepository
 import three.two.bit.ppt.reality.listing.ListingRepository
+import three.two.bit.ppt.reality.listing.ListingType
+import three.two.bit.ppt.reality.listing.PropertyCategory
 import three.two.bit.ppt.reality.ui.account.AccountScreen
 import three.two.bit.ppt.reality.ui.agency.AgencyHubScreen
 import three.two.bit.ppt.reality.ui.agency.AgencyInquiriesScreen
@@ -47,7 +65,18 @@ import three.two.bit.ppt.reality.ui.search.SearchScreen
 sealed class Screen(val route: String) {
     data object Home : Screen("home")
 
-    data object Search : Screen("search")
+    data object Search : Screen("search?type={type}&category={category}") {
+        fun createRoute(
+            type: ListingType? = null,
+            category: PropertyCategory? = null,
+        ): String {
+            val params = buildList {
+                type?.let { add("type=${it.name.lowercase()}") }
+                category?.let { add("category=${it.name.lowercase()}") }
+            }
+            return if (params.isEmpty()) "search" else "search?${params.joinToString("&")}"
+        }
+    }
 
     data object ListingDetail : Screen("listing/{listingId}") {
         fun createRoute(listingId: String) = "listing/$listingId"
@@ -102,258 +131,383 @@ fun RealityNavHost(
     inquiryRepository: InquiryRepository,
     startDestination: String = Screen.Home.route,
 ) {
-    NavHost(navController = navController, startDestination = startDestination) {
-        composable(Screen.Home.route) {
-            HomeScreen(
-                repository = listingRepository,
-                ssoService = ssoService,
-                onSearchClick = { navController.navigate(Screen.Search.route) },
-                onListingClick = { id ->
-                    navController.navigate(Screen.ListingDetail.createRoute(id))
-                },
-                onFavoritesClick = { navController.navigate(Screen.Favorites.route) },
-                onAccountClick = { navController.navigate(Screen.Account.route) },
-                onInquiriesClick = { navController.navigate(Screen.Inquiries.route) }
-            )
-        }
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route
+    val onSignInClick: () -> Unit = { navController.navigate(Screen.Login.route) }
 
-        composable(Screen.Search.route) {
-            SearchScreen(
-                repository = listingRepository,
-                onListingClick = { id ->
-                    navController.navigate(Screen.ListingDetail.createRoute(id))
-                },
-                onBackClick = { navController.popBackStack() }
-            )
+    val tabNavigate: (String) -> Unit = { route ->
+        navController.navigate(route) {
+            popUpTo(Screen.Home.route) { saveState = true }
+            launchSingleTop = true
+            restoreState = true
         }
+    }
 
-        composable(
-            route = Screen.ListingDetail.route,
-            arguments = listOf(navArgument("listingId") { type = NavType.StringType })
-        ) { backStackEntry ->
-            val listingId = backStackEntry.arguments?.getString("listingId") ?: return@composable
-            ListingDetailScreen(
-                listingId = listingId,
-                repository = listingRepository,
-                ssoService = ssoService,
-                onBackClick = { navController.popBackStack() },
-                onInquirySuccess = { navController.navigate(Screen.Inquiries.route) }
-            )
-        }
+    Scaffold(
+        bottomBar = {
+            if (currentRoute in TOP_LEVEL_ROUTES) {
+                RealityBottomBar(
+                    currentRoute = currentRoute,
+                    onHomeClick = { tabNavigate(Screen.Home.route) },
+                    onSearchClick = { tabNavigate(Screen.Search.createRoute()) },
+                    onFavoritesClick = { tabNavigate(Screen.Favorites.route) },
+                    onInquiriesClick = { tabNavigate(Screen.Inquiries.route) },
+                    onAccountClick = { tabNavigate(Screen.Account.route) },
+                )
+            }
+        },
+    ) { innerPadding ->
+        NavHost(
+            navController = navController,
+            startDestination = startDestination,
+            modifier = Modifier.padding(innerPadding),
+        ) {
+            composable(Screen.Home.route) {
+                HomeScreen(
+                    repository = listingRepository,
+                    ssoService = ssoService,
+                    onSearchClick = { type, category ->
+                        navController.navigate(Screen.Search.createRoute(type, category))
+                    },
+                    onListingClick = { id ->
+                        navController.navigate(Screen.ListingDetail.createRoute(id))
+                    },
+                    onFavoritesClick = { navController.navigate(Screen.Favorites.route) },
+                    onAccountClick = { navController.navigate(Screen.Account.route) },
+                    onInquiriesClick = { navController.navigate(Screen.Inquiries.route) },
+                )
+            }
 
-        composable(Screen.Favorites.route) {
-            FavoritesScreen(
-                repository = listingRepository,
-                ssoService = ssoService,
-                onListingClick = { id ->
-                    navController.navigate(Screen.ListingDetail.createRoute(id))
-                },
-                onBackClick = { navController.popBackStack() }
-            )
-        }
+            composable(
+                route = Screen.Search.route,
+                arguments =
+                    listOf(
+                        navArgument("type") {
+                            type = NavType.StringType
+                            nullable = true
+                            defaultValue = null
+                        },
+                        navArgument("category") {
+                            type = NavType.StringType
+                            nullable = true
+                            defaultValue = null
+                        },
+                    ),
+            ) { entry ->
+                val initialType =
+                    entry.arguments?.getString("type")?.let { raw ->
+                        runCatching { ListingType.valueOf(raw.uppercase()) }.getOrNull()
+                    }
+                val initialCategory =
+                    entry.arguments?.getString("category")?.let { raw ->
+                        runCatching { PropertyCategory.valueOf(raw.uppercase()) }.getOrNull()
+                    }
+                SearchScreen(
+                    repository = listingRepository,
+                    onListingClick = { id ->
+                        navController.navigate(Screen.ListingDetail.createRoute(id))
+                    },
+                    onBackClick = { navController.popBackStack() },
+                    initialType = initialType,
+                    initialCategory = initialCategory,
+                )
+            }
 
-        composable(Screen.Account.route) {
-            AccountScreen(
-                ssoService = ssoService,
-                onBackClick = { navController.popBackStack() },
-                onLogout = {
-                    ssoService.logout()
-                    navController.popBackStack(Screen.Home.route, inclusive = false)
+            composable(
+                route = Screen.ListingDetail.route,
+                arguments = listOf(navArgument("listingId") { type = NavType.StringType })
+            ) { backStackEntry ->
+                val listingId =
+                    backStackEntry.arguments?.getString("listingId") ?: return@composable
+                ListingDetailScreen(
+                    listingId = listingId,
+                    repository = listingRepository,
+                    ssoService = ssoService,
+                    onBackClick = { navController.popBackStack() },
+                    onInquirySuccess = { navController.navigate(Screen.Inquiries.route) }
+                )
+            }
+
+            composable(Screen.Favorites.route) {
+                FavoritesScreen(
+                    repository = listingRepository,
+                    ssoService = ssoService,
+                    onListingClick = { id ->
+                        navController.navigate(Screen.ListingDetail.createRoute(id))
+                    },
+                    onBackClick = { navController.popBackStack() },
+                    onSignInClick = onSignInClick,
+                )
+            }
+
+            composable(Screen.Account.route) {
+                AccountScreen(
+                    ssoService = ssoService,
+                    onBackClick = { navController.popBackStack() },
+                    onLogout = {
+                        ssoService.logout()
+                        navController.popBackStack(Screen.Home.route, inclusive = false)
+                    },
+                    onProfileEditClick = { navController.navigate(Screen.ProfileEdit.route) },
+                    onSavedSearchesClick = { navController.navigate(Screen.SavedSearches.route) },
+                    onSignInClick = onSignInClick,
+                )
+            }
+
+            composable(Screen.Inquiries.route) {
+                InquiriesScreen(
+                    repository = listingRepository,
+                    ssoService = ssoService,
+                    onListingClick = { id ->
+                        navController.navigate(Screen.ListingDetail.createRoute(id))
+                    },
+                    onBackClick = { navController.popBackStack() },
+                    onSignInClick = onSignInClick,
+                )
+            }
+
+            // Auth & profile (UC-47).
+            composable(Screen.Login.route) {
+                LoginScreen(
+                    onBackClick = { navController.popBackStack() },
+                    onSubmit = { email, password ->
+                        ssoService.loginWithPassword(email, password).map {}
+                    },
+                    onForgotPasswordClick = { navController.navigate(Screen.ForgotPassword.route) },
+                    onRegisterClick = { navController.navigate(Screen.Register.route) },
+                )
+            }
+            composable(Screen.Register.route) {
+                RegisterScreen(
+                    onBackClick = { navController.popBackStack() },
+                    onSubmit = { displayName, email, password ->
+                        ssoService.register(email, password, displayName)
+                    },
+                    onSignInClick = { navController.popBackStack(Screen.Login.route, false) },
+                )
+            }
+            composable(Screen.ForgotPassword.route) {
+                ForgotPasswordScreen(
+                    onBackClick = { navController.popBackStack() },
+                    onSubmit = { email -> ssoService.requestPasswordReset(email) },
+                    onSignInClick = { navController.popBackStack(Screen.Login.route, false) },
+                )
+            }
+            composable(
+                route = Screen.ResetPassword.route,
+                arguments =
+                    listOf(
+                        navArgument("token") {
+                            type = NavType.StringType
+                            defaultValue = ""
+                        }
+                    ),
+            ) { backStackEntry ->
+                val token = backStackEntry.arguments?.getString("token") ?: ""
+                ResetPasswordScreen(
+                    token = token,
+                    onBackClick = { navController.popBackStack() },
+                    onSubmit = { resetToken, newPassword ->
+                        ssoService.confirmPasswordReset(resetToken, newPassword)
+                    },
+                    onSuccess = { navController.popBackStack(Screen.Login.route, false) },
+                )
+            }
+            composable(Screen.TwoFactor.route) {
+                TwoFactorScreen(
+                    onBackClick = { navController.popBackStack() },
+                    onDone = { navController.popBackStack() },
+                )
+            }
+            composable(Screen.ProfileEdit.route) {
+                ProfileEditScreen(
+                    ssoService = ssoService,
+                    onBackClick = { navController.popBackStack() },
+                    onSubmit = { displayName -> ssoService.updateProfile(displayName).map {} },
+                )
+            }
+
+            // Saved searches & agency/realtor surfaces (UC-45, UC-49, UC-51).
+            // Data sources will plug in once the mobile-native API client exposes
+            // the corresponding endpoints; for now the screens render with empty
+            // collections so the navigation graph is complete.
+            composable(Screen.SavedSearches.route) {
+                // Load saved searches via FavoritesRepository on first
+                // composition, then expose toggle/delete callbacks that call
+                // the repo and update local state on success.
+                val scope = rememberCoroutineScope()
+                var searches by remember { mutableStateOf<List<ApiSavedSearch>>(emptyList()) }
+                var isLoading by remember { mutableStateOf(true) }
+
+                LaunchedEffect(Unit) {
+                    isLoading = true
+                    favoritesRepository
+                        .getSavedSearches()
+                        .onSuccess { searches = it.searches }
+                        .onFailure { searches = emptyList() }
+                    isLoading = false
                 }
-            )
-        }
 
-        composable(Screen.Inquiries.route) {
-            InquiriesScreen(
-                repository = listingRepository,
-                ssoService = ssoService,
-                onListingClick = { id ->
-                    navController.navigate(Screen.ListingDetail.createRoute(id))
-                },
-                onBackClick = { navController.popBackStack() }
-            )
-        }
-
-        // Auth & profile (UC-47).
-        composable(Screen.Login.route) {
-            LoginScreen(
-                onBackClick = { navController.popBackStack() },
-                onSubmit = { email, password ->
-                    ssoService.loginWithPassword(email, password).map {}
-                },
-                onForgotPasswordClick = { navController.navigate(Screen.ForgotPassword.route) },
-                onRegisterClick = { navController.navigate(Screen.Register.route) },
-            )
-        }
-        composable(Screen.Register.route) {
-            RegisterScreen(
-                onBackClick = { navController.popBackStack() },
-                onSubmit = { displayName, email, password ->
-                    ssoService.register(email, password, displayName)
-                },
-                onSignInClick = { navController.popBackStack(Screen.Login.route, false) },
-            )
-        }
-        composable(Screen.ForgotPassword.route) {
-            ForgotPasswordScreen(
-                onBackClick = { navController.popBackStack() },
-                onSubmit = { email -> ssoService.requestPasswordReset(email) },
-                onSignInClick = { navController.popBackStack(Screen.Login.route, false) },
-            )
-        }
-        composable(
-            route = Screen.ResetPassword.route,
-            arguments =
-                listOf(
-                    navArgument("token") {
-                        type = NavType.StringType
-                        defaultValue = ""
-                    }
-                ),
-        ) { backStackEntry ->
-            val token = backStackEntry.arguments?.getString("token") ?: ""
-            ResetPasswordScreen(
-                token = token,
-                onBackClick = { navController.popBackStack() },
-                onSubmit = { resetToken, newPassword ->
-                    ssoService.confirmPasswordReset(resetToken, newPassword)
-                },
-                onSuccess = { navController.popBackStack(Screen.Login.route, false) },
-            )
-        }
-        composable(Screen.TwoFactor.route) {
-            TwoFactorScreen(
-                onBackClick = { navController.popBackStack() },
-                onDone = { navController.popBackStack() },
-            )
-        }
-        composable(Screen.ProfileEdit.route) {
-            ProfileEditScreen(
-                ssoService = ssoService,
-                onBackClick = { navController.popBackStack() },
-                onSubmit = { displayName -> ssoService.updateProfile(displayName).map {} },
-            )
-        }
-
-        // Saved searches & agency/realtor surfaces (UC-45, UC-49, UC-51).
-        // Data sources will plug in once the mobile-native API client exposes
-        // the corresponding endpoints; for now the screens render with empty
-        // collections so the navigation graph is complete.
-        composable(Screen.SavedSearches.route) {
-            // Load saved searches via FavoritesRepository on first
-            // composition, then expose toggle/delete callbacks that call
-            // the repo and update local state on success.
-            val scope = rememberCoroutineScope()
-            var searches by remember { mutableStateOf<List<ApiSavedSearch>>(emptyList()) }
-            var isLoading by remember { mutableStateOf(true) }
-
-            LaunchedEffect(Unit) {
-                isLoading = true
-                favoritesRepository
-                    .getSavedSearches()
-                    .onSuccess { searches = it.searches }
-                    .onFailure { searches = emptyList() }
-                isLoading = false
-            }
-
-            SavedSearchesScreen(
-                searches = searches.map { it.toUiModel() },
-                isLoading = isLoading,
-                onBackClick = { navController.popBackStack() },
-                onSearchClick = { _ ->
-                    // The Search route doesn't yet accept saved-search
-                    // parameters; navigate without filters as a baseline.
-                    navController.navigate(Screen.Search.route)
-                },
-                onToggleAlerts = { id, enabled ->
-                    scope.launch {
-                        favoritesRepository.toggleSearchAlert(id, enabled).onSuccess { updated ->
-                            searches = searches.map { if (it.id == id) updated else it }
-                        }
-                    }
-                },
-                onDelete = { id ->
-                    scope.launch {
-                        favoritesRepository.deleteSavedSearch(id).onSuccess {
-                            searches = searches.filterNot { it.id == id }
-                        }
-                    }
-                },
-            )
-        }
-        composable(Screen.AgencyHub.route) {
-            AgencyHubScreen(
-                onBackClick = { navController.popBackStack() },
-                onInquiriesClick = { navController.navigate(Screen.AgencyInquiries.route) },
-                onMyListingsClick = { navController.navigate(Screen.MyListings.route) },
-                onCreateListingClick = { navController.navigate(Screen.CreateListing.route) },
-                onAnalyticsClick = { navController.navigate(Screen.ListingAnalytics.route) },
-            )
-        }
-        composable(Screen.AgencyInquiries.route) {
-            // Load the realtor's inbox via /realtors/inquiries — that's the
-            // agency-side dataset. `getInquiries()` would return the
-            // signed-in user's own outbound (resident-side) inquiries
-            // instead. Tapping a row drops into `Screen.Inquiries` for now;
-            // a dedicated realtor-side detail screen is a separate task.
-            var inquiries by remember {
-                mutableStateOf<List<three.two.bit.ppt.reality.ui.agency.AgencyInquiry>>(emptyList())
-            }
-            var isLoading by remember { mutableStateOf(true) }
-
-            LaunchedEffect(Unit) {
-                isLoading = true
-                inquiryRepository
-                    .getRealtorInquiries()
-                    .onSuccess { resp ->
-                        inquiries =
-                            resp.inquiries.map { i ->
-                                three.two.bit.ppt.reality.ui.agency.AgencyInquiry(
-                                    id = i.id,
-                                    listingTitle = i.listing?.title ?: "Listing #${i.listingId}",
-                                    contactName = "",
-                                    contactEmail = "",
-                                    message = i.message,
-                                    status = i.status.name.lowercase(),
-                                )
+                SavedSearchesScreen(
+                    searches = searches.map { it.toUiModel() },
+                    isLoading = isLoading,
+                    onBackClick = { navController.popBackStack() },
+                    onSearchClick = { _ ->
+                        // The Search route doesn't yet accept saved-search
+                        // parameters; navigate without filters as a baseline.
+                        navController.navigate(Screen.Search.route)
+                    },
+                    onToggleAlerts = { id, enabled ->
+                        scope.launch {
+                            favoritesRepository.toggleSearchAlert(id, enabled).onSuccess { updated
+                                ->
+                                searches = searches.map { if (it.id == id) updated else it }
                             }
-                    }
-                    .onFailure { inquiries = emptyList() }
-                isLoading = false
+                        }
+                    },
+                    onDelete = { id ->
+                        scope.launch {
+                            favoritesRepository.deleteSavedSearch(id).onSuccess {
+                                searches = searches.filterNot { it.id == id }
+                            }
+                        }
+                    },
+                )
             }
+            composable(Screen.AgencyHub.route) {
+                AgencyHubScreen(
+                    onBackClick = { navController.popBackStack() },
+                    onInquiriesClick = { navController.navigate(Screen.AgencyInquiries.route) },
+                    onMyListingsClick = { navController.navigate(Screen.MyListings.route) },
+                    onCreateListingClick = { navController.navigate(Screen.CreateListing.route) },
+                    onAnalyticsClick = { navController.navigate(Screen.ListingAnalytics.route) },
+                )
+            }
+            composable(Screen.AgencyInquiries.route) {
+                // Load the realtor's inbox via /realtors/inquiries — that's the
+                // agency-side dataset. `getInquiries()` would return the
+                // signed-in user's own outbound (resident-side) inquiries
+                // instead. Tapping a row drops into `Screen.Inquiries` for now;
+                // a dedicated realtor-side detail screen is a separate task.
+                var inquiries by remember {
+                    mutableStateOf<List<three.two.bit.ppt.reality.ui.agency.AgencyInquiry>>(
+                        emptyList()
+                    )
+                }
+                var isLoading by remember { mutableStateOf(true) }
 
-            AgencyInquiriesScreen(
-                inquiries = inquiries,
-                isLoading = isLoading,
-                onBackClick = { navController.popBackStack() },
-                onInquiryClick = { _ -> navController.navigate(Screen.Inquiries.route) },
-            )
+                LaunchedEffect(Unit) {
+                    isLoading = true
+                    inquiryRepository
+                        .getRealtorInquiries()
+                        .onSuccess { resp ->
+                            inquiries =
+                                resp.inquiries.map { i ->
+                                    three.two.bit.ppt.reality.ui.agency.AgencyInquiry(
+                                        id = i.id,
+                                        listingTitle =
+                                            i.listing?.title ?: "Listing #${i.listingId}",
+                                        contactName = "",
+                                        contactEmail = "",
+                                        message = i.message,
+                                        status = i.status.name.lowercase(),
+                                    )
+                                }
+                        }
+                        .onFailure { inquiries = emptyList() }
+                    isLoading = false
+                }
+
+                AgencyInquiriesScreen(
+                    inquiries = inquiries,
+                    isLoading = isLoading,
+                    onBackClick = { navController.popBackStack() },
+                    onInquiryClick = { _ -> navController.navigate(Screen.Inquiries.route) },
+                )
+            }
+            composable(Screen.MyListings.route) {
+                MyListingsScreen(
+                    listings = emptyList(),
+                    isLoading = false,
+                    onBackClick = { navController.popBackStack() },
+                    onCreateClick = { navController.navigate(Screen.CreateListing.route) },
+                    onListingClick = { id ->
+                        navController.navigate(Screen.ListingDetail.createRoute(id))
+                    },
+                )
+            }
+            composable(Screen.CreateListing.route) {
+                CreateListingScreen(
+                    onBackClick = { navController.popBackStack() },
+                    onSubmit = { _ -> Result.failure(NotImplementedError("Wire to listing API")) },
+                    onCreated = { navController.popBackStack(Screen.MyListings.route, false) },
+                )
+            }
+            composable(Screen.ListingAnalytics.route) {
+                ListingAnalyticsScreen(
+                    metrics = emptyList(),
+                    isLoading = false,
+                    onBackClick = { navController.popBackStack() },
+                )
+            }
         }
-        composable(Screen.MyListings.route) {
-            MyListingsScreen(
-                listings = emptyList(),
-                isLoading = false,
-                onBackClick = { navController.popBackStack() },
-                onCreateClick = { navController.navigate(Screen.CreateListing.route) },
-                onListingClick = { id ->
-                    navController.navigate(Screen.ListingDetail.createRoute(id))
-                },
-            )
-        }
-        composable(Screen.CreateListing.route) {
-            CreateListingScreen(
-                onBackClick = { navController.popBackStack() },
-                onSubmit = { _ -> Result.failure(NotImplementedError("Wire to listing API")) },
-                onCreated = { navController.popBackStack(Screen.MyListings.route, false) },
-            )
-        }
-        composable(Screen.ListingAnalytics.route) {
-            ListingAnalyticsScreen(
-                metrics = emptyList(),
-                isLoading = false,
-                onBackClick = { navController.popBackStack() },
-            )
-        }
+    }
+}
+
+/**
+ * The five tab destinations that show the persistent bottom navigation bar. Any route outside this
+ * set (auth flows, listing detail, realtor surfaces) hides the bar so the screen can own its full
+ * top-to-bottom layout.
+ */
+private val TOP_LEVEL_ROUTES =
+    setOf(
+        Screen.Home.route,
+        Screen.Search.route,
+        Screen.Favorites.route,
+        Screen.Inquiries.route,
+        Screen.Account.route,
+    )
+
+@Composable
+private fun RealityBottomBar(
+    currentRoute: String?,
+    onHomeClick: () -> Unit,
+    onSearchClick: () -> Unit,
+    onFavoritesClick: () -> Unit,
+    onInquiriesClick: () -> Unit,
+    onAccountClick: () -> Unit,
+) {
+    NavigationBar {
+        NavigationBarItem(
+            selected = currentRoute == Screen.Home.route,
+            onClick = onHomeClick,
+            icon = { Icon(Icons.Default.Home, contentDescription = null) },
+            label = { Text(stringResource(R.string.tab_home)) },
+        )
+        NavigationBarItem(
+            selected = currentRoute == Screen.Search.route,
+            onClick = onSearchClick,
+            icon = { Icon(Icons.Default.Search, contentDescription = null) },
+            label = { Text(stringResource(R.string.tab_search)) },
+        )
+        NavigationBarItem(
+            selected = currentRoute == Screen.Favorites.route,
+            onClick = onFavoritesClick,
+            icon = { Icon(Icons.Default.FavoriteBorder, contentDescription = null) },
+            label = { Text(stringResource(R.string.tab_favorites)) },
+        )
+        NavigationBarItem(
+            selected = currentRoute == Screen.Inquiries.route,
+            onClick = onInquiriesClick,
+            icon = { Icon(Icons.Default.Email, contentDescription = null) },
+            label = { Text(stringResource(R.string.tab_inquiries)) },
+        )
+        NavigationBarItem(
+            selected = currentRoute == Screen.Account.route,
+            onClick = onAccountClick,
+            icon = { Icon(Icons.Default.Person, contentDescription = null) },
+            label = { Text(stringResource(R.string.tab_account)) },
+        )
     }
 }
 

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/account/AccountScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/account/AccountScreen.kt
@@ -67,7 +67,14 @@ private const val TAG = "AccountScreen"
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AccountScreen(ssoService: SsoService, onBackClick: () -> Unit, onLogout: () -> Unit) {
+fun AccountScreen(
+    ssoService: SsoService,
+    onBackClick: () -> Unit,
+    onLogout: () -> Unit,
+    onProfileEditClick: () -> Unit = {},
+    onSavedSearchesClick: () -> Unit = {},
+    onSignInClick: () -> Unit = {},
+) {
     val scope = rememberCoroutineScope()
     val authState by ssoService.authState.collectAsState()
 
@@ -101,7 +108,7 @@ fun AccountScreen(ssoService: SsoService, onBackClick: () -> Unit, onLogout: () 
         when (val state = authState) {
             is AuthState.Unauthenticated,
             is AuthState.Error -> {
-                NotSignedInContent(onSignInClick = { /* Open SSO login via PM app */})
+                NotSignedInContent(onSignInClick = onSignInClick)
             }
             is AuthState.Loading -> {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -113,10 +120,13 @@ fun AccountScreen(ssoService: SsoService, onBackClick: () -> Unit, onLogout: () 
                     modifier = Modifier.fillMaxSize(),
                     contentPadding = PaddingValues(bottom = 100.dp),
                 ) {
-                    item { ProfileTopBar() }
+                    item { ProfileTopBar(onEditProfileClick = onProfileEditClick) }
                     item { ProfileHero(user = state.user) }
                     item { Spacer(modifier = Modifier.height(8.dp)) }
-                    item { StatsRow() }
+                    // Stats counts will come from /me/stats once the endpoint exists.
+                    // Until then we pass nulls — StatCard renders an em-dash to
+                    // signal "unknown" rather than a fake number.
+                    item { StatsRow(favorites = null, searches = null, inquiries = null) }
                     item { Spacer(modifier = Modifier.height(24.dp)) }
                     item {
                         SectionList(
@@ -132,6 +142,7 @@ fun AccountScreen(ssoService: SsoService, onBackClick: () -> Unit, onLogout: () 
                                 notificationsExpanded = !notificationsExpanded
                             },
                             notificationsExpanded = notificationsExpanded,
+                            onSavedSearchesClick = onSavedSearchesClick,
                         )
                     }
                     if (notificationsExpanded && notificationPrefs != null) {
@@ -200,7 +211,7 @@ fun AccountScreen(ssoService: SsoService, onBackClick: () -> Unit, onLogout: () 
 // ─── Top bar ────────────────────────────────────────────────────────────────
 
 @Composable
-private fun ProfileTopBar() {
+private fun ProfileTopBar(onEditProfileClick: () -> Unit) {
     Row(
         modifier =
             Modifier.fillMaxWidth().padding(start = 16.dp, end = 8.dp, top = 14.dp, bottom = 12.dp),
@@ -213,10 +224,10 @@ private fun ProfileTopBar() {
             color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.weight(1f),
         )
-        IconButton(onClick = { /* settings */}) {
+        IconButton(onClick = onEditProfileClick) {
             Icon(
-                Icons.Default.Settings,
-                contentDescription = stringResource(R.string.settings),
+                Icons.Default.Edit,
+                contentDescription = stringResource(R.string.edit_profile),
                 tint = MaterialTheme.colorScheme.onSurface,
             )
         }
@@ -331,25 +342,25 @@ private fun VerifiedPill() {
 // ─── Stats row ──────────────────────────────────────────────────────────────
 
 @Composable
-private fun StatsRow() {
+private fun StatsRow(favorites: Int?, searches: Int?, inquiries: Int?) {
     Row(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
         horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
         StatCard(
-            value = "4",
+            value = favorites?.toString() ?: "—",
             label = stringResource(R.string.profile_stat_favorites),
-            modifier = Modifier.weight(1f)
+            modifier = Modifier.weight(1f),
         )
         StatCard(
-            value = "3",
+            value = searches?.toString() ?: "—",
             label = stringResource(R.string.profile_stat_searches),
-            modifier = Modifier.weight(1f)
+            modifier = Modifier.weight(1f),
         )
         StatCard(
-            value = "7",
+            value = inquiries?.toString() ?: "—",
             label = stringResource(R.string.profile_stat_inquiries),
-            modifier = Modifier.weight(1f)
+            modifier = Modifier.weight(1f),
         )
     }
 }
@@ -393,6 +404,7 @@ private fun SectionList(
     notificationsEnabled: Boolean,
     onNotificationsToggle: () -> Unit,
     notificationsExpanded: Boolean,
+    onSavedSearchesClick: () -> Unit,
 ) {
     Card(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
@@ -406,7 +418,7 @@ private fun SectionList(
                 title = stringResource(R.string.profile_section_searches),
                 subtitle = stringResource(R.string.profile_section_searches_sub),
                 trailing = SectionTrailing.Chevron,
-                onClick = { /* nav to saved searches */},
+                onClick = onSavedSearchesClick,
             )
             SectionDivider()
             SectionRow(

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/favorites/FavoritesScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/favorites/FavoritesScreen.kt
@@ -67,6 +67,7 @@ fun FavoritesScreen(
     ssoService: SsoService,
     onListingClick: (String) -> Unit,
     onBackClick: () -> Unit,
+    onSignInClick: () -> Unit = {},
 ) {
     val scope = rememberCoroutineScope()
     val authState by ssoService.authState.collectAsState()
@@ -113,7 +114,7 @@ fun FavoritesScreen(
     ) {
         when (authState) {
             is AuthState.Unauthenticated,
-            is AuthState.Error -> NotSignedInContent()
+            is AuthState.Error -> NotSignedInContent(onSignInClick = onSignInClick)
             is AuthState.Loading -> {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                     CircularProgressIndicator()
@@ -705,7 +706,7 @@ private fun SavedSearchCard(
 // ─── Shared state views ─────────────────────────────────────────────────────
 
 @Composable
-private fun NotSignedInContent() {
+private fun NotSignedInContent(onSignInClick: () -> Unit) {
     Column(
         modifier = Modifier.fillMaxSize().padding(32.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -729,6 +730,14 @@ private fun NotSignedInContent() {
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+        Spacer(modifier = Modifier.height(24.dp))
+        Button(
+            onClick = onSignInClick,
+            shape = RoundedCornerShape(14.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(stringResource(R.string.sign_in))
+        }
     }
 }
 

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/home/HomeScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/home/HomeScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.filled.Apartment
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.DirectionsCar
 import androidx.compose.material.icons.filled.Domain
+import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.Forest
 import androidx.compose.material.icons.filled.House
 import androidx.compose.material.icons.filled.Landscape
@@ -74,7 +75,7 @@ import three.two.bit.ppt.reality.util.FormatUtils
 fun HomeScreen(
     repository: ListingRepository,
     ssoService: SsoService,
-    onSearchClick: () -> Unit,
+    onSearchClick: (type: ListingType?, category: PropertyCategory?) -> Unit,
     onListingClick: (String) -> Unit,
     onFavoritesClick: () -> Unit,
     onAccountClick: () -> Unit,
@@ -113,14 +114,15 @@ fun HomeScreen(
                 HomeTopBar(
                     authState = authState,
                     onBellClick = onInquiriesClick,
+                    onFavoritesClick = onFavoritesClick,
                     onAvatarClick = onAccountClick,
                 )
             }
 
             item {
                 HeroCard(
-                    onSearchClick = onSearchClick,
-                    onTabClick = onSearchClick,
+                    onSearchClick = { onSearchClick(null, null) },
+                    onTabClick = { type -> onSearchClick(type, null) },
                 )
             }
 
@@ -130,17 +132,36 @@ fun HomeScreen(
             // hero already gives the user a visible affordance while
             // featured loads, so a separate skeleton isn't needed here.
             if (featuredListings.isNotEmpty()) {
-                item { SectionHeader(stringResource(R.string.featured_properties), onSearchClick) }
+                item {
+                    SectionHeader(
+                        title = stringResource(R.string.featured_properties),
+                        onSeeAllClick = { onSearchClick(null, null) },
+                    )
+                }
                 item { FeaturedRow(featuredListings, onListingClick) }
             } else if (isLoading) {
                 item { FeaturedSkeleton() }
             }
 
-            item { SectionHeader(stringResource(R.string.categories), onSearchClick) }
-            item { CategoryGrid(onCategoryClick = { onSearchClick() }) }
+            item {
+                SectionHeader(
+                    title = stringResource(R.string.categories),
+                    onSeeAllClick = { onSearchClick(null, null) },
+                )
+            }
+            item {
+                CategoryGrid(
+                    onCategoryClick = { category -> onSearchClick(null, category) },
+                )
+            }
 
             if (recentListings.isNotEmpty()) {
-                item { SectionHeader(stringResource(R.string.recently_added), onSearchClick) }
+                item {
+                    SectionHeader(
+                        title = stringResource(R.string.recently_added),
+                        onSeeAllClick = { onSearchClick(null, null) },
+                    )
+                }
                 items(recentListings.take(5)) { listing ->
                     RecentRow(listing = listing, onClick = { onListingClick(listing.id) })
                 }
@@ -160,6 +181,7 @@ fun HomeScreen(
 private fun HomeTopBar(
     authState: AuthState,
     onBellClick: () -> Unit,
+    onFavoritesClick: () -> Unit,
     onAvatarClick: () -> Unit,
 ) {
     Row(
@@ -173,6 +195,13 @@ private fun HomeTopBar(
             color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.weight(1f),
         )
+        IconButton(onClick = onFavoritesClick) {
+            Icon(
+                imageVector = Icons.Default.FavoriteBorder,
+                contentDescription = stringResource(R.string.tab_favorites),
+                tint = MaterialTheme.colorScheme.onSurface,
+            )
+        }
         IconButton(onClick = onBellClick) {
             Box {
                 Icon(
@@ -241,7 +270,7 @@ private fun HomeTopBar(
 @Composable
 private fun HeroCard(
     onSearchClick: () -> Unit,
-    onTabClick: () -> Unit,
+    onTabClick: (ListingType?) -> Unit,
 ) {
     Box(
         modifier =
@@ -310,14 +339,17 @@ private fun HeroCard(
             }
             Spacer(modifier = Modifier.height(12.dp))
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                // "New builds" maps to no type (it would need a separate filter once
+                // newly-built inventory is tagged in the backend; until then we just
+                // open Search without a type preselect).
                 listOf(
-                        R.string.home_hero_tab_sale,
-                        R.string.home_hero_tab_rent,
-                        R.string.home_hero_tab_new,
+                        R.string.home_hero_tab_sale to ListingType.SALE,
+                        R.string.home_hero_tab_rent to ListingType.RENT,
+                        R.string.home_hero_tab_new to null,
                     )
-                    .forEach { labelRes ->
+                    .forEach { (labelRes, type) ->
                         Surface(
-                            onClick = onTabClick,
+                            onClick = { onTabClick(type) },
                             shape = RoundedCornerShape(999.dp),
                             color = Color.White.copy(alpha = 0.18f),
                         ) {
@@ -501,7 +533,7 @@ private data class HomeCategory(
     val icon: ImageVector,
     val iconTint: Color,
     val iconBg: Color,
-    val countPlaceholder: Int,
+    val category: PropertyCategory?,
 )
 
 private val CATEGORIES: List<HomeCategory> =
@@ -511,47 +543,49 @@ private val CATEGORIES: List<HomeCategory> =
             Icons.Default.Apartment,
             Color(0xFF1E40AF),
             Color(0xFFDBEAFE),
-            842
+            PropertyCategory.APARTMENT,
         ),
         HomeCategory(
             R.string.cat_houses,
             Icons.Default.House,
             Color(0xFF92400E),
             Color(0xFFFEF3C7),
-            212
+            PropertyCategory.HOUSE,
         ),
         HomeCategory(
             R.string.cat_commercial,
             Icons.Default.Domain,
             Color(0xFF065F46),
             Color(0xFFD1FAE5),
-            128
+            PropertyCategory.COMMERCIAL,
         ),
         HomeCategory(
             R.string.cat_land,
             Icons.Default.Landscape,
             Color(0xFF5B21B6),
             Color(0xFFEDE9FE),
-            64
+            PropertyCategory.LAND,
         ),
+        // No PropertyCategory match for "recreation" yet — tapping opens
+        // Search without preselection, same as today.
         HomeCategory(
             R.string.cat_recreation,
             Icons.Default.Forest,
             Color(0xFF155E75),
             Color(0xFFCFFAFE),
-            42
+            null,
         ),
         HomeCategory(
             R.string.cat_parking,
             Icons.Default.DirectionsCar,
             Color(0xFF991B1B),
             Color(0xFFFEE2E2),
-            28
+            PropertyCategory.GARAGE,
         ),
     )
 
 @Composable
-private fun CategoryGrid(onCategoryClick: (Int) -> Unit) {
+private fun CategoryGrid(onCategoryClick: (PropertyCategory?) -> Unit) {
     // LazyVerticalGrid can't be nested inside LazyColumn so we use a
     // fixed-height non-lazy alternative: two Rows of three Cards each.
     Column(
@@ -564,7 +598,7 @@ private fun CategoryGrid(onCategoryClick: (Int) -> Unit) {
                     CategoryCard(
                         category = cat,
                         modifier = Modifier.weight(1f),
-                        onClick = { onCategoryClick(cat.labelRes) },
+                        onClick = { onCategoryClick(cat.category) },
                     )
                 }
             }
@@ -609,12 +643,9 @@ private fun CategoryCard(
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurface,
             )
-            Spacer(modifier = Modifier.height(2.dp))
-            Text(
-                text = category.countPlaceholder.toString(),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+            // Per-category listing counts removed — the previous values were
+            // hardcoded placeholders. Re-introduce once a /listings/counts
+            // endpoint exposes real numbers.
         }
     }
 }

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/inquiries/InquiriesScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/inquiries/InquiriesScreen.kt
@@ -75,6 +75,7 @@ fun InquiriesScreen(
     ssoService: SsoService,
     onListingClick: (String) -> Unit,
     onBackClick: () -> Unit,
+    onSignInClick: () -> Unit = {},
 ) {
     val scope = rememberCoroutineScope()
     val authState by ssoService.authState.collectAsState()
@@ -120,7 +121,7 @@ fun InquiriesScreen(
     ) {
         when (authState) {
             is AuthState.Unauthenticated,
-            is AuthState.Error -> NotSignedInContent()
+            is AuthState.Error -> NotSignedInContent(onSignInClick = onSignInClick)
             is AuthState.Loading ->
                 Box(
                     modifier = Modifier.fillMaxSize(),
@@ -654,7 +655,7 @@ private fun ViewingStatusPill(status: ViewingStatus) {
 // ─── Empty / error / unauth states ──────────────────────────────────────────
 
 @Composable
-private fun NotSignedInContent() {
+private fun NotSignedInContent(onSignInClick: () -> Unit) {
     Column(
         modifier = Modifier.fillMaxSize().padding(32.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -678,6 +679,14 @@ private fun NotSignedInContent() {
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+        Spacer(modifier = Modifier.height(24.dp))
+        Button(
+            onClick = onSignInClick,
+            shape = RoundedCornerShape(14.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(stringResource(R.string.sign_in))
+        }
     }
 }
 

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/search/SearchScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/search/SearchScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.ViewList
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -71,6 +70,8 @@ fun SearchScreen(
     repository: ListingRepository,
     onListingClick: (String) -> Unit,
     onBackClick: () -> Unit,
+    initialType: ListingType? = null,
+    initialCategory: PropertyCategory? = null,
 ) {
     val scope = rememberCoroutineScope()
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -82,11 +83,14 @@ fun SearchScreen(
     var currentPage by remember { mutableStateOf(1) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
     var showFilters by remember { mutableStateOf(false) }
-    var viewMode by remember { mutableStateOf(ViewMode.LIST) }
+    // ViewMode kept as state since list/map switch is wired in many call-sites,
+    // but the segmented toggle is hidden from the UI until a real map view ships.
+    val viewMode = ViewMode.LIST
 
-    // Filter state
-    var selectedType by remember { mutableStateOf<ListingType?>(null) }
-    var selectedCategory by remember { mutableStateOf<PropertyCategory?>(null) }
+    // Filter state. Initial filter values may come from Home (tab/category tap)
+    // — those are read from the route args and seed `selectedType` / `selectedCategory`.
+    var selectedType by remember { mutableStateOf<ListingType?>(initialType) }
+    var selectedCategory by remember { mutableStateOf<PropertyCategory?>(initialCategory) }
     var minPrice by remember { mutableStateOf("") }
     var maxPrice by remember { mutableStateOf("") }
     var minRooms by remember { mutableStateOf<Int?>(null) }
@@ -144,10 +148,8 @@ fun SearchScreen(
             Column(modifier = Modifier.fillMaxSize()) {
                 ListingsTopBar(
                     activeFilterCount = activeFilterCount,
-                    viewMode = viewMode,
                     onBackClick = onBackClick,
                     onFiltersClick = { showFilters = !showFilters },
-                    onViewModeChange = { viewMode = it },
                 )
 
                 // Search input row — single line, inline with chips per design hint
@@ -210,6 +212,10 @@ fun SearchScreen(
                             CircularProgressIndicator()
                         }
                     }
+                    // Suppress the "No results found / try adjusting filters" empty
+                    // state when the search failed — the error banner above already
+                    // explains why; the empty-state copy is misleading in that case.
+                    errorMessage != null && searchResults.isEmpty() -> Unit
                     searchResults.isEmpty() -> EmptySearchResults()
                     viewMode == ViewMode.LIST -> {
                         LazyColumn(
@@ -282,10 +288,8 @@ private enum class ViewMode {
 @Composable
 private fun ListingsTopBar(
     activeFilterCount: Int,
-    viewMode: ViewMode,
     onBackClick: () -> Unit,
     onFiltersClick: () -> Unit,
-    onViewModeChange: (ViewMode) -> Unit,
 ) {
     Row(
         modifier =
@@ -339,26 +343,9 @@ private fun ListingsTopBar(
             }
         }
         Spacer(modifier = Modifier.weight(1f))
-        // View switcher (segmented control)
-        Surface(
-            shape = RoundedCornerShape(999.dp),
-            color = MaterialTheme.colorScheme.surfaceVariant,
-        ) {
-            Row(modifier = Modifier.padding(3.dp)) {
-                SegmentChip(
-                    icon = Icons.AutoMirrored.Filled.ViewList,
-                    label = stringResource(R.string.view_list),
-                    selected = viewMode == ViewMode.LIST,
-                    onClick = { onViewModeChange(ViewMode.LIST) },
-                )
-                SegmentChip(
-                    icon = Icons.Default.Map,
-                    label = stringResource(R.string.view_map),
-                    selected = viewMode == ViewMode.MAP,
-                    onClick = { onViewModeChange(ViewMode.MAP) },
-                )
-            }
-        }
+        // View switcher hidden until a real map view ships — the toggle was a no-op
+        // and read as a broken control. ViewMode state stays so the underlying
+        // branch keeps working once map integration lands.
     }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #240. An ADB walkthrough of the redesigned KMP screens on an emulator surfaced a set of navigation/wiring gaps — screens that compiled and looked right but were unreachable or had dead controls. This PR wires them up.

### Fixes

- **Bottom navigation bar** — adds a persistent `NavigationBar` (Home / Search / Favorites / Inquiries / Account) in a Scaffold around the NavHost, shown only on top-level routes. **Favorites was previously unreachable from any screen.**
- **Sign-in path wired** — `Account`, `Favorites`, and `Inquiries` unauthenticated empty states now route to the `Login` screen. The Account "Sign In via PM App" button was a `/* stub */`; Favorites/Inquiries had no CTA at all. This unblocks the entire auth surface (Login/Register/ForgotPassword/ResetPassword/ProfileEdit), which had no reachable entry point.
- **Home → Search filter preselect** — hero `For sale` / `For rent` tabs now preselect the matching `ListingType`; category cards preselect the matching `PropertyCategory`. Previously all of them opened an unfiltered Search. `Screen.Search` gained optional `type` / `category` query args.
- **Map toggle hidden** — the List/Map segmented control was a no-op (no map view exists yet); removed from the top bar until a real map ships. `ViewMode` state retained for when it lands.
- **Misleading empty state** — Search no longer shows "No results found / try adjusting filters" when the request actually failed; the error banner alone is shown.
- **Hardcoded placeholder data removed** — category-grid counts (842/212/…) and Account stat values (4/3/7) were hardcoded and rendered as if real. Counts removed from the grid; `StatsRow` now takes nullable counts and renders an em-dash when unknown.

### Not in scope

`TwoFactor`, `AgencyHub`, and `Alerts` routes remain in the graph without a user-facing entry point — they need a product decision on where they belong, tracked separately.

## Test plan

- [x] `./gradlew :androidApp:compileDevelopmentDebugKotlin` — clean
- [x] `./gradlew spotlessApply` — clean
- [x] Walked the build on a `Small_Phone` API 30 emulator: bottom nav switches tabs; Favorites reachable; Sign-In CTAs reach Login; `For sale` preselects `type=SALE`; `Houses` card preselects `category=HOUSE`; Map toggle gone; error state no longer doubles with empty state
- [ ] Re-verify authenticated Account stats render em-dash (backend was unreachable during walkthrough)