### PR TITLE
fix(mobile-native): real Price history tab + friendly network-error copy

### DIFF
--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/navigation/Navigation.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/navigation/Navigation.kt
@@ -275,6 +275,14 @@ fun RealityNavHost(
                     },
                     onForgotPasswordClick = { navController.navigate(Screen.ForgotPassword.route) },
                     onRegisterClick = { navController.navigate(Screen.Register.route) },
+                    // On success, drop the whole auth stack and land on Home. Home (and
+                    // every top-level screen) collects authState, so it re-renders signed in.
+                    onLoginSuccess = {
+                        navController.navigate(Screen.Home.route) {
+                            popUpTo(Screen.Home.route) { inclusive = true }
+                            launchSingleTop = true
+                        }
+                    },
                 )
             }
             composable(Screen.Register.route) {

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/ForgotPasswordScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/ForgotPasswordScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import three.two.bit.ppt.reality.R
+import three.two.bit.ppt.reality.util.isNetworkError
 
 /**
  * Forgot-password screen — KMP / Compose M3 redesign matching the design (`KmpForgotScreen`).
@@ -126,6 +127,7 @@ fun ForgotPasswordScreen(
                 val emailRequiredMsg = stringResource(R.string.auth_validation_email_required)
                 val emailInvalidMsg = stringResource(R.string.auth_validation_email_invalid)
                 val sendFailedMsg = stringResource(R.string.auth_validation_send_reset_failed)
+                val networkErrorMsg = stringResource(R.string.error_network)
                 Button(
                     onClick = {
                         val trimmed = email.trim()
@@ -143,7 +145,10 @@ fun ForgotPasswordScreen(
                             isSubmitting = false
                             result.fold(
                                 onSuccess = { submitted = true },
-                                onFailure = { generalError = it.message ?: sendFailedMsg },
+                                onFailure = {
+                                    generalError =
+                                        if (it.isNetworkError()) networkErrorMsg else sendFailedMsg
+                                },
                             )
                         }
                     },

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/LoginScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/LoginScreen.kt
@@ -46,6 +46,7 @@ fun LoginScreen(
     onSubmit: suspend (email: String, password: String) -> Result<Unit>,
     onForgotPasswordClick: () -> Unit,
     onRegisterClick: () -> Unit,
+    onLoginSuccess: () -> Unit,
 ) {
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
@@ -149,10 +150,14 @@ fun LoginScreen(
                         scope.launch {
                             val result = onSubmit(email.trim(), password)
                             isSubmitting = false
-                            result.onFailure {
-                                generalError =
-                                    if (it.isNetworkError()) networkErrorMsg else signInFailedMsg
-                            }
+                            result.fold(
+                                onSuccess = { onLoginSuccess() },
+                                onFailure = {
+                                    generalError =
+                                        if (it.isNetworkError()) networkErrorMsg
+                                        else signInFailedMsg
+                                },
+                            )
                         }
                     },
                     enabled = !isSubmitting,

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/LoginScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/LoginScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import three.two.bit.ppt.reality.R
+import three.two.bit.ppt.reality.util.isNetworkError
 
 /**
  * Email/password login screen — KMP / Compose M3 redesign matching the design bundle
@@ -132,6 +133,7 @@ fun LoginScreen(
                 val emailInvalidMsg = stringResource(R.string.auth_validation_email_invalid)
                 val passwordRequiredMsg = stringResource(R.string.auth_validation_password_required)
                 val signInFailedMsg = stringResource(R.string.auth_validation_sign_in_failed)
+                val networkErrorMsg = stringResource(R.string.error_network)
                 Button(
                     onClick = {
                         emailError =
@@ -147,7 +149,10 @@ fun LoginScreen(
                         scope.launch {
                             val result = onSubmit(email.trim(), password)
                             isSubmitting = false
-                            result.onFailure { generalError = it.message ?: signInFailedMsg }
+                            result.onFailure {
+                                generalError =
+                                    if (it.isNetworkError()) networkErrorMsg else signInFailedMsg
+                            }
                         }
                     },
                     enabled = !isSubmitting,

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/RegisterScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/RegisterScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import three.two.bit.ppt.reality.R
+import three.two.bit.ppt.reality.util.isNetworkError
 
 /**
  * Account-creation screen — KMP / Compose M3 redesign matching the design (`KmpRegisterScreen`).
@@ -224,6 +225,7 @@ fun RegisterScreen(
             val passwordMismatchMsg = stringResource(R.string.auth_validation_password_mismatch)
             val termsRequiredMsg = stringResource(R.string.auth_validation_terms_required)
             val registerFailedMsg = stringResource(R.string.auth_validation_register_failed)
+            val networkErrorMsg = stringResource(R.string.error_network)
             Button(
                 onClick = {
                     displayNameError = if (displayName.isBlank()) nameRequiredMsg else null
@@ -253,7 +255,10 @@ fun RegisterScreen(
                         isSubmitting = false
                         result.fold(
                             onSuccess = { submitted = true },
-                            onFailure = { generalError = it.message ?: registerFailedMsg },
+                            onFailure = {
+                                generalError =
+                                    if (it.isNetworkError()) networkErrorMsg else registerFailedMsg
+                            },
                         )
                     }
                 },

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/ResetPasswordScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/ResetPasswordScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import three.two.bit.ppt.reality.R
+import three.two.bit.ppt.reality.util.isNetworkError
 
 /**
  * New-password screen — KMP / Compose M3 redesign matching the design (`KmpResetScreen`). Either
@@ -185,6 +186,7 @@ fun ResetPasswordScreen(
                     )
                 val passwordMismatchMsg = stringResource(R.string.auth_validation_password_mismatch)
                 val resetFailedMsg = stringResource(R.string.auth_validation_reset_failed)
+                val networkErrorMsg = stringResource(R.string.error_network)
                 Button(
                     onClick = {
                         passwordError =
@@ -203,7 +205,10 @@ fun ResetPasswordScreen(
                             isSubmitting = false
                             result.fold(
                                 onSuccess = { success = true },
-                                onFailure = { generalError = it.message ?: resetFailedMsg },
+                                onFailure = {
+                                    generalError =
+                                        if (it.isNetworkError()) networkErrorMsg else resetFailedMsg
+                                },
                             )
                         }
                     },

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/favorites/FavoritesScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/favorites/FavoritesScreen.kt
@@ -36,6 +36,7 @@ import three.two.bit.ppt.reality.favorites.*
 import three.two.bit.ppt.reality.listing.ListingRepository
 import three.two.bit.ppt.reality.listing.ListingSummary
 import three.two.bit.ppt.reality.util.FormatUtils
+import three.two.bit.ppt.reality.util.isNetworkError
 
 private const val TAG = "FavoritesScreen"
 
@@ -71,6 +72,9 @@ fun FavoritesScreen(
 ) {
     val scope = rememberCoroutineScope()
     val authState by ssoService.authState.collectAsState()
+    val networkErrorMsg = stringResource(R.string.error_network)
+    val genericErrorMsg = stringResource(R.string.error_generic)
+    fun friendlyError(e: Throwable) = if (e.isNetworkError()) networkErrorMsg else genericErrorMsg
 
     var selectedTab by remember { mutableIntStateOf(0) }
     var transactionFilter by remember { mutableStateOf(TransactionFilter.ALL) }
@@ -94,7 +98,7 @@ fun FavoritesScreen(
                 .getFavorites()
                 .fold(
                     onSuccess = { response -> favorites = response.favorites },
-                    onFailure = { error -> errorMessage = error.message },
+                    onFailure = { error -> errorMessage = friendlyError(error) },
                 )
             favoritesRepository
                 .getSavedSearches()
@@ -168,7 +172,7 @@ fun FavoritesScreen(
                                             .getFavorites()
                                             .fold(
                                                 onSuccess = { favorites = it.favorites },
-                                                onFailure = { errorMessage = it.message },
+                                                onFailure = { errorMessage = friendlyError(it) },
                                             )
                                         isLoading = false
                                     }
@@ -199,7 +203,7 @@ fun FavoritesScreen(
                                                 },
                                                 onFailure = {
                                                     Log.e(TAG, "Failed to remove favorite", it)
-                                                    errorMessage = it.message
+                                                    errorMessage = friendlyError(it)
                                                 },
                                             )
                                     }
@@ -221,7 +225,7 @@ fun FavoritesScreen(
                                                             if (it.id == id) updated else it
                                                         }
                                                 },
-                                                onFailure = { errorMessage = it.message },
+                                                onFailure = { errorMessage = friendlyError(it) },
                                             )
                                     }
                                 },
@@ -234,7 +238,7 @@ fun FavoritesScreen(
                                                     savedSearches =
                                                         savedSearches.filter { it.id != id }
                                                 },
-                                                onFailure = { errorMessage = it.message },
+                                                onFailure = { errorMessage = friendlyError(it) },
                                             )
                                     }
                                 },

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/home/HomeScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/home/HomeScreen.kt
@@ -48,6 +48,7 @@ import three.two.bit.ppt.reality.ui.theme.BadgeColors
 import three.two.bit.ppt.reality.ui.theme.Brand500
 import three.two.bit.ppt.reality.ui.theme.Brand800
 import three.two.bit.ppt.reality.util.FormatUtils
+import three.two.bit.ppt.reality.util.isNetworkError
 
 /**
  * Home screen — KMP / Compose M3 redesign matching the design bundle
@@ -88,19 +89,25 @@ fun HomeScreen(
     var isLoading by remember { mutableStateOf(true) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
 
+    val networkErrorMsg = stringResource(R.string.error_network)
+    val genericErrorMsg = stringResource(R.string.error_generic)
+
     LaunchedEffect(Unit) {
         isLoading = true
+        val onLoadFailure = { error: Throwable ->
+            errorMessage = if (error.isNetworkError()) networkErrorMsg else genericErrorMsg
+        }
         repository
             .getFeaturedListings()
             .fold(
                 onSuccess = { response -> featuredListings = response.listings },
-                onFailure = { error -> errorMessage = error.message },
+                onFailure = onLoadFailure,
             )
         repository
             .getRecentListings(limit = 10)
             .fold(
                 onSuccess = { response -> recentListings = response.listings },
-                onFailure = { error -> errorMessage = error.message },
+                onFailure = onLoadFailure,
             )
         isLoading = false
     }

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/inquiries/InquiriesScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/inquiries/InquiriesScreen.kt
@@ -40,6 +40,7 @@ import three.two.bit.ppt.reality.ui.theme.Brand500
 import three.two.bit.ppt.reality.ui.theme.Brand800
 import three.two.bit.ppt.reality.ui.theme.InquiryStatusColors
 import three.two.bit.ppt.reality.ui.theme.ViewingStatusColors
+import three.two.bit.ppt.reality.util.isNetworkError
 
 private const val TAG = "InquiriesScreen"
 
@@ -79,6 +80,9 @@ fun InquiriesScreen(
 ) {
     val scope = rememberCoroutineScope()
     val authState by ssoService.authState.collectAsState()
+    val networkErrorMsg = stringResource(R.string.error_network)
+    val genericErrorMsg = stringResource(R.string.error_generic)
+    fun friendlyError(e: Throwable) = if (e.isNetworkError()) networkErrorMsg else genericErrorMsg
 
     var selectedTab by remember { mutableIntStateOf(0) }
     var statusFilter by remember { mutableStateOf<InquiryStatus?>(null) }
@@ -101,7 +105,7 @@ fun InquiriesScreen(
                 .getInquiries()
                 .fold(
                     onSuccess = { inquiries = it.inquiries },
-                    onFailure = { errorMessage = it.message },
+                    onFailure = { errorMessage = friendlyError(it) },
                 )
             inquiryRepository
                 .getViewings()
@@ -172,7 +176,7 @@ fun InquiriesScreen(
                                             .getInquiries()
                                             .fold(
                                                 onSuccess = { inquiries = it.inquiries },
-                                                onFailure = { errorMessage = it.message },
+                                                onFailure = { errorMessage = friendlyError(it) },
                                             )
                                         isLoading = false
                                     }
@@ -201,7 +205,7 @@ fun InquiriesScreen(
                                                 },
                                                 onFailure = {
                                                     Log.e(TAG, "Failed to cancel viewing", it)
-                                                    errorMessage = it.message
+                                                    errorMessage = friendlyError(it)
                                                 },
                                             )
                                     }

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingDetailScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingDetailScreen.kt
@@ -18,6 +18,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Message
+import androidx.compose.material.icons.automirrored.filled.ShowChart
+import androidx.compose.material.icons.automirrored.filled.TrendingDown
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -30,6 +32,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
@@ -45,6 +48,7 @@ import three.two.bit.ppt.reality.inquiry.InquiryRepository
 import three.two.bit.ppt.reality.listing.*
 import three.two.bit.ppt.reality.ui.theme.BadgeColors
 import three.two.bit.ppt.reality.util.FormatUtils
+import three.two.bit.ppt.reality.util.isNetworkError
 
 /**
  * Listing Detail screen — KMP / Compose M3 redesign matching the design bundle
@@ -85,6 +89,9 @@ fun ListingDetailScreen(
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
     val authState by ssoService.authState.collectAsState()
+    val networkErrorMsg = stringResource(R.string.error_network)
+    val genericErrorMsg = stringResource(R.string.error_generic)
+    fun friendlyError(e: Throwable) = if (e.isNetworkError()) networkErrorMsg else genericErrorMsg
 
     var listing by remember { mutableStateOf<ListingDetail?>(null) }
     var isLoading by remember { mutableStateOf(true) }
@@ -126,7 +133,7 @@ fun ListingDetailScreen(
                     isLoading = false
                 },
                 onFailure = {
-                    errorMessage = it.message
+                    errorMessage = friendlyError(it)
                     isLoading = false
                 },
             )
@@ -155,7 +162,7 @@ fun ListingDetailScreen(
                                 .getListingDetail(listingId)
                                 .fold(
                                     onSuccess = { listing = it },
-                                    onFailure = { errorMessage = it.message },
+                                    onFailure = { errorMessage = friendlyError(it) },
                                 )
                             isLoading = false
                         }
@@ -232,7 +239,7 @@ fun ListingDetailScreen(
                             },
                             onFailure = { error ->
                                 isInquirySubmitting = false
-                                inquiryError = error.message ?: "Failed to send inquiry"
+                                inquiryError = friendlyError(error)
                             },
                         )
                 }
@@ -292,7 +299,7 @@ private fun ListingContent(
                 }
                 1 -> item { BuildingPassportCard(listing = listing) }
                 2 -> item { NearbyPreviewCard() }
-                3 -> item { PlaceholderSection(stringResource(R.string.detail_tab_price_history)) }
+                3 -> item { PriceHistoryCard(listing = listing) }
             }
             item { Spacer(modifier = Modifier.height(16.dp)) }
         }
@@ -893,6 +900,122 @@ private fun BuildingPassportCard(listing: ListingDetail) {
                 }
             }
         }
+    }
+}
+
+// ─── Price history tab ──────────────────────────────────────────────────────
+//
+// The reality-server listing payload exposes a single `previousPrice` alongside
+// `isPriceReduced` rather than a full change log, so we render the one known
+// transition when present and fall back to a proper empty state otherwise.
+
+@Composable
+private fun PriceHistoryCard(listing: ListingDetail) {
+    val previous = listing.previousPrice
+    if (!listing.isPriceReduced || previous == null) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Icon(
+                Icons.AutoMirrored.Filled.ShowChart,
+                contentDescription = null,
+                modifier = Modifier.size(40.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.price_history_empty_title),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = stringResource(R.string.price_history_empty_body),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+        }
+        return
+    }
+
+    val delta = previous - listing.price
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            PriceHistoryRow(
+                label = stringResource(R.string.price_history_previous),
+                value = FormatUtils.formatPrice(previous, listing.currency),
+                muted = true,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            PriceHistoryRow(
+                label = stringResource(R.string.price_history_current),
+                value = FormatUtils.formatPrice(listing.price, listing.currency),
+                muted = false,
+            )
+            if (delta > 0) {
+                Spacer(modifier = Modifier.height(14.dp))
+                Surface(
+                    shape = RoundedCornerShape(999.dp),
+                    color = Color(0xFFD1FAE5),
+                ) {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.TrendingDown,
+                            contentDescription = null,
+                            tint = Color(0xFF065F46),
+                            modifier = Modifier.size(14.dp),
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text =
+                                stringResource(
+                                    R.string.price_history_reduced_by,
+                                    FormatUtils.formatPrice(delta, listing.currency),
+                                ),
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            color = Color(0xFF065F46),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PriceHistoryRow(label: String, value: String, muted: Boolean) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style =
+                if (muted) MaterialTheme.typography.bodyMedium
+                else MaterialTheme.typography.titleMedium,
+            fontWeight = if (muted) FontWeight.Normal else FontWeight.Bold,
+            color =
+                if (muted) MaterialTheme.colorScheme.onSurfaceVariant
+                else MaterialTheme.colorScheme.onSurface,
+        )
     }
 }
 

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/profile/ProfileEditScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/profile/ProfileEditScreen.kt
@@ -35,6 +35,7 @@ import three.two.bit.ppt.reality.ui.auth.SuccessBanner
 import three.two.bit.ppt.reality.ui.auth.rememberAuthScope
 import three.two.bit.ppt.reality.ui.theme.Brand500
 import three.two.bit.ppt.reality.ui.theme.Brand800
+import three.two.bit.ppt.reality.util.isNetworkError
 
 /**
  * Edit-profile screen — KMP / Compose M3 redesign matching the design (`KmpEditProfileScreen`).
@@ -72,6 +73,8 @@ fun ProfileEditScreen(
     var savedMessage by remember { mutableStateOf<String?>(null) }
     var isSaving by remember { mutableStateOf(false) }
 
+    val networkErrorMsg = stringResource(R.string.error_network)
+    val saveFailedMsg = stringResource(R.string.error_generic)
     val scope = rememberAuthScope()
 
     Scaffold(
@@ -116,7 +119,8 @@ fun ProfileEditScreen(
                             result.fold(
                                 onSuccess = { savedMessage = "Profile updated." },
                                 onFailure = {
-                                    generalError = it.message ?: "Could not save profile."
+                                    generalError =
+                                        if (it.isNetworkError()) networkErrorMsg else saveFailedMsg
                                 },
                             )
                         }

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/realtor/CreateListingScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/realtor/CreateListingScreen.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.launch
 import three.two.bit.ppt.reality.R
 import three.two.bit.ppt.reality.ui.auth.AuthFieldLabel
 import three.two.bit.ppt.reality.ui.auth.ErrorBanner
+import three.two.bit.ppt.reality.util.isNetworkError
 
 /**
  * Create-listing screen — KMP / Compose M3 redesign matching the design (`KmpCreateListingScreen`).
@@ -88,6 +89,7 @@ fun CreateListingScreen(
             val cityRequiredMsg = stringResource(R.string.realtor_create_validation_city_required)
             val priceInvalidMsg = stringResource(R.string.realtor_create_validation_price_invalid)
             val publishFailedMsg = stringResource(R.string.realtor_create_validation_publish_failed)
+            val networkErrorMsg = stringResource(R.string.error_network)
             CreateListingFooter(
                 onCancel = onBackClick,
                 onSubmit = {
@@ -117,7 +119,10 @@ fun CreateListingScreen(
                         isSubmitting = false
                         result.fold(
                             onSuccess = { onCreated() },
-                            onFailure = { generalError = it.message ?: publishFailedMsg },
+                            onFailure = {
+                                generalError =
+                                    if (it.isNetworkError()) networkErrorMsg else publishFailedMsg
+                            },
                         )
                     }
                 },

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/search/SearchScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/search/SearchScreen.kt
@@ -37,6 +37,7 @@ import three.two.bit.ppt.reality.R
 import three.two.bit.ppt.reality.listing.*
 import three.two.bit.ppt.reality.ui.theme.BadgeColors
 import three.two.bit.ppt.reality.util.FormatUtils
+import three.two.bit.ppt.reality.util.isNetworkError
 
 /**
  * Search / Listings screen — KMP / Compose M3 redesign matching the design bundle
@@ -96,6 +97,9 @@ fun SearchScreen(
     var minRooms by remember { mutableStateOf<Int?>(null) }
     var selectedSort by remember { mutableStateOf(ListingSortOption.NEWEST) }
 
+    val networkErrorMsg = stringResource(R.string.error_network)
+    val searchFailedMsg = stringResource(R.string.error_generic)
+
     fun performSearch(page: Int = 1) {
         scope.launch {
             isLoading = true
@@ -126,7 +130,9 @@ fun SearchScreen(
                         totalResults = response.total
                         currentPage = page
                     },
-                    onFailure = { errorMessage = it.message ?: "Search failed" },
+                    onFailure = {
+                        errorMessage = if (it.isNetworkError()) networkErrorMsg else searchFailedMsg
+                    },
                 )
             isLoading = false
         }

--- a/mobile-native/androidApp/src/main/res/values-sk/strings.xml
+++ b/mobile-native/androidApp/src/main/res/values-sk/strings.xml
@@ -411,6 +411,11 @@
     <string name="detail_tab_building">Pasport budovy</string>
     <string name="detail_tab_nearby">Okolie</string>
     <string name="detail_tab_price_history">História cien</string>
+    <string name="price_history_empty_title">Žiadne zmeny ceny</string>
+    <string name="price_history_empty_body">Cena sa od zverejnenia tejto ponuky nezmenila.</string>
+    <string name="price_history_previous">Pôvodná cena</string>
+    <string name="price_history_current">Aktuálna cena</string>
+    <string name="price_history_reduced_by">Znížené o %1$s</string>
     <string name="detail_realtor_unknown">Maklér</string>
     <string name="detail_building_no_data">Informácie o budove nie sú zatiaľ k dispozícii.</string>
     <string name="action_request_viewing">Žiadať obhliadku</string>

--- a/mobile-native/androidApp/src/main/res/values/strings.xml
+++ b/mobile-native/androidApp/src/main/res/values/strings.xml
@@ -411,6 +411,11 @@
     <string name="detail_tab_building">Building passport</string>
     <string name="detail_tab_nearby">Nearby</string>
     <string name="detail_tab_price_history">Price history</string>
+    <string name="price_history_empty_title">No price changes recorded</string>
+    <string name="price_history_empty_body">The price hasn\'t changed since this listing was published.</string>
+    <string name="price_history_previous">Previous price</string>
+    <string name="price_history_current">Current price</string>
+    <string name="price_history_reduced_by">Reduced by %1$s</string>
     <string name="detail_realtor_unknown">Realtor</string>
     <string name="detail_building_no_data">No building details available yet.</string>
     <string name="action_request_viewing">Request viewing</string>

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/util/NetworkError.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/util/NetworkError.kt
@@ -1,0 +1,43 @@
+package three.two.bit.ppt.reality.util
+
+/**
+ * Heuristic check for "the server couldn't be reached" failures — connection refused, DNS
+ * resolution failure, socket/connect timeouts, generic IO errors.
+ *
+ * Ktor surfaces these as a spread of platform-specific exception types (`ConnectException`,
+ * `UnresolvedAddressException`, `ConnectTimeoutException`, `SocketTimeoutException`, `IOException`,
+ * …), so rather than importing each per-platform type we match on class name and message. The UI
+ * uses this to swap the raw technical exception text for friendly copy.
+ */
+fun Throwable.isNetworkError(): Boolean {
+    var cause: Throwable? = this
+    while (cause != null) {
+        val name = cause::class.simpleName.orEmpty()
+        val msg = cause.message.orEmpty()
+        if (NETWORK_EXCEPTION_NAMES.any { name.contains(it, ignoreCase = true) }) return true
+        if (NETWORK_MESSAGE_HINTS.any { msg.contains(it, ignoreCase = true) }) return true
+        cause = cause.cause?.takeIf { it !== cause }
+    }
+    return false
+}
+
+private val NETWORK_EXCEPTION_NAMES =
+    listOf(
+        "ConnectException",
+        "ConnectTimeoutException",
+        "SocketTimeoutException",
+        "HttpRequestTimeoutException",
+        "UnresolvedAddressException",
+        "UnknownHostException",
+        "IOException",
+    )
+
+private val NETWORK_MESSAGE_HINTS =
+    listOf(
+        "failed to connect",
+        "connection refused",
+        "unable to resolve host",
+        "network is unreachable",
+        "no route to host",
+        "timeout",
+    )


### PR DESCRIPTION
## Summary

Three issues found during an emulator walkthrough of the redesigned KMP screens against a (mock) backend.

### 1. ListingDetail "Price history" tab was a bare placeholder

Rendered just the label text "Price history" with no content/empty state. Replaced with a real `PriceHistoryCard`:
- **Empty state** — chart icon + "No price changes recorded" + body, for listings whose price is unchanged
- **Price-change card** — previous → current price + a green "Reduced by €X" delta chip, for `isPriceReduced` listings

### 2. Raw exception text leaked to users on connection failures

Connection failures surfaced the raw Ktor exception string (e.g. `Failed to connect to /10.0.2.2:8081`) in error banners across ~15 catch sites in 11 screens.
- New shared helper `util/NetworkError.kt` — `Throwable.isNetworkError()`, a KMP-safe heuristic
- Every error-banner catch site routes through it: localized `error_network` for connection failures, `error_generic` otherwise

### 3. Successful login stranded the user on the form

`LoginScreen` only handled the failure branch of the auth `Result` — on success it did nothing, leaving the user on the login form even though `authState` had flipped to `Authenticated`. Added an `onLoginSuccess` callback wired to navigate to Home and clear the auth back stack.

## Test plan

- [x] `compileDevelopmentDebugKotlin` + `spotlessApply` — clean, no warnings
- [x] Price history empty state verified live on the emulator
- [x] Network-error copy verified live — Home shows "Network error. Please check your connection." with the backend down
- [x] Login flow verified end-to-end — submit lands on a signed-in Home (avatar shows user initials); Account shows the authenticated profile
- [x] Registration flow verified end-to-end — submit reaches the "Check your inbox" success state