### PR TITLE
fix(ppt-web): unblock production tsc build

### DIFF
--- a/frontend/apps/ppt-web/src/hooks/usePerformanceMetrics.ts
+++ b/frontend/apps/ppt-web/src/hooks/usePerformanceMetrics.ts
@@ -171,7 +171,7 @@ export function usePerformanceMetrics(
  * Utility to log performance metrics to console in development.
  */
 export function logPerformanceMetrics(metrics: PerformanceMetrics) {
-  if (process.env.NODE_ENV !== 'development') return;
+  if (!import.meta.env.DEV) return;
 
   const formatMs = (ms?: number) => (ms !== undefined ? `${ms.toFixed(2)}ms` : 'N/A');
 

--- a/frontend/apps/ppt-web/tsconfig.json
+++ b/frontend/apps/ppt-web/tsconfig.json
@@ -2,11 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": [
-      "ES2020",
-      "DOM",
-      "DOM.Iterable"
-    ],
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",
@@ -21,9 +17,7 @@
     "noFallthroughCasesInSwitch": true,
     "types": []
   },
-  "include": [
-    "src"
-  ],
+  "include": ["src"],
   "references": [
     {
       "path": "./tsconfig.node.json"

--- a/frontend/apps/ppt-web/tsconfig.json
+++ b/frontend/apps/ppt-web/tsconfig.json
@@ -2,7 +2,11 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2020",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",
@@ -17,6 +21,20 @@
     "noFallthroughCasesInSwitch": true,
     "types": []
   },
-  "include": ["src"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.a11y.test.tsx",
+    "src/test/**/*"
+  ]
 }


### PR DESCRIPTION
The Docker FE build has been failing on main for 30+ consecutive runs with two pre-existing TS errors:

- \`src/features/meters/hooks/useOcrMeterReading.test.tsx:14\` — \`Cannot find name 'global'\` (test file got compiled by production tsc)
- \`src/hooks/usePerformanceMetrics.ts:174\` — \`Cannot find name 'process'\` (Vite SPA doesn't have node process global)

## Fix
1. \`tsconfig.json\` adds an \`exclude\` array for \`.test.{ts,tsx}\`, \`.spec.{ts,tsx}\`, \`.a11y.test.tsx\`, \`src/test/**\`. Tests still compile under vitest (separate tsconfig + globals).
2. \`usePerformanceMetrics.ts\` replaces \`process.env.NODE_ENV !== 'development'\` with \`!import.meta.env.DEV\` — the canonical Vite check.

## Test plan
- [x] \`pnpm -F @ppt/web build\` clean (478 KB main / 144 KB gzipped)
- [ ] CI \`Docker Build & Push (Frontend)\` passes on this branch
- [ ] After merge: next push to main triggers FE rebuild successfully, \`ghcr.io/martin-janci/ppt-web:main\` updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)