### PR TITLE
feat(admin-web): implement Claude Design super-admin design system

### DIFF
--- a/frontend/apps/admin-web/src/App.tsx
+++ b/frontend/apps/admin-web/src/App.tsx
@@ -35,6 +35,20 @@ function AdminCapabilityScope({ children }: { children: ReactNode }) {
   );
 }
 
+/** Placeholder for pages being implemented in Round 2. */
+function PlaceholderPage({ title }: { title: string }) {
+  return (
+    <section style={{ padding: '32px' }}>
+      <h1 style={{ fontSize: '1.5rem', fontWeight: 700, color: 'var(--ppt-fg-primary, #111827)' }}>
+        {title}
+      </h1>
+      <p style={{ color: 'var(--ppt-fg-muted, #6b7280)', marginTop: '8px' }}>
+        {title} page coming in Round 2
+      </p>
+    </section>
+  );
+}
+
 export function App() {
   return (
     <AdminAuthProvider>
@@ -52,12 +66,98 @@ export function App() {
                 </ProtectedRoute>
               }
             >
+              {/* Overview — no cap required */}
               <Route index element={<Dashboard />} />
-              <Route path="agencies" element={<AgenciesPage />} />
-              <Route path="users" element={<UsersPage />} />
-              <Route path="audit" element={<AuditPage />} />
-              <Route path="feature-flags" element={<FeatureFlagsPage />} />
-              <Route path="platform" element={<PlatformPage />} />
+
+              {/* TENANTS */}
+              <Route
+                path="tenants/agencies"
+                element={
+                  <ProtectedRoute requiredCapability="agencies_read">
+                    <AgenciesPage />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="tenants/lifecycle"
+                element={
+                  <ProtectedRoute
+                    requiredCapability={['tenant_export', 'tenant_purge', 'tenant_restore']}
+                  >
+                    <PlaceholderPage title="Lifecycle" />
+                  </ProtectedRoute>
+                }
+              />
+
+              {/* IDENTITY */}
+              <Route
+                path="identity/users"
+                element={
+                  <ProtectedRoute requiredCapability={['users_read', 'principal_kind_escalate']}>
+                    <UsersPage />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="identity/memberships"
+                element={
+                  <ProtectedRoute requiredCapability={['memberships_grant', 'memberships_revoke']}>
+                    <PlaceholderPage title="Memberships" />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="identity/capabilities"
+                element={
+                  <ProtectedRoute requiredCapability="memberships_grant">
+                    <PlaceholderPage title="Capabilities" />
+                  </ProtectedRoute>
+                }
+              />
+
+              {/* OPERATIONS */}
+              <Route
+                path="ops/audit"
+                element={
+                  <ProtectedRoute requiredCapability="audit_read">
+                    <AuditPage />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="ops/impersonation"
+                element={
+                  <ProtectedRoute requiredCapability="users_impersonate">
+                    <PlaceholderPage title="Impersonation" />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="ops/feature-flags"
+                element={
+                  <ProtectedRoute requiredCapability="feature_flags_write">
+                    <FeatureFlagsPage />
+                  </ProtectedRoute>
+                }
+              />
+
+              {/* PLATFORM */}
+              <Route
+                path="platform/settings"
+                element={
+                  <ProtectedRoute requiredCapability="site_settings_write">
+                    <PlatformPage />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="platform/mobile"
+                element={
+                  <ProtectedRoute requiredCapability="mobile_config_write">
+                    <PlaceholderPage title="Mobile config" />
+                  </ProtectedRoute>
+                }
+              />
             </Route>
           </Routes>
         </MfaWrapper>

--- a/frontend/apps/admin-web/src/App.tsx
+++ b/frontend/apps/admin-web/src/App.tsx
@@ -17,6 +17,7 @@ import { Dashboard } from './pages/Dashboard';
 import FeatureFlagsPage from './pages/feature-flags';
 import { LoginPage } from './pages/LoginPage';
 import PlatformPage from './pages/platform';
+import TenantLifecyclePage from './pages/TenantLifecyclePage';
 import UsersPage from './pages/users';
 
 /**
@@ -87,7 +88,7 @@ export function App() {
                     <ProtectedRoute
                       requiredCapability={['tenant_export', 'tenant_purge', 'tenant_restore']}
                     >
-                      <PlaceholderPage title="Lifecycle" />
+                      <TenantLifecyclePage />
                     </ProtectedRoute>
                   }
                 />

--- a/frontend/apps/admin-web/src/App.tsx
+++ b/frontend/apps/admin-web/src/App.tsx
@@ -6,11 +6,13 @@ import { AdminAuthProvider } from './auth/AdminAuthContext';
 import { usePrincipalCapabilities } from './auth/usePrincipalCapabilities';
 import { AdminLayout } from './components/AdminLayout';
 import { ImpersonationWrapper } from './components/ImpersonationWrapper';
+import { MfaWindowProvider } from './components/MfaWindowChip';
 import { MfaWrapper } from './components/MfaWrapper';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { ToastProvider } from './components/Toast';
 import AgenciesPage from './pages/agencies';
 import AuditPage from './pages/audit';
+import CapabilitiesAdminPage from './pages/CapabilitiesAdminPage';
 import { Dashboard } from './pages/Dashboard';
 import FeatureFlagsPage from './pages/feature-flags';
 import { LoginPage } from './pages/LoginPage';
@@ -52,116 +54,120 @@ function PlaceholderPage({ title }: { title: string }) {
 export function App() {
   return (
     <AdminAuthProvider>
-      <ToastProvider>
-        <MfaWrapper>
-          <ImpersonationWrapper />
-          <Routes>
-            <Route path="/login" element={<LoginPage />} />
-            <Route
-              element={
-                <ProtectedRoute>
-                  <AdminCapabilityScope>
-                    <AdminLayout />
-                  </AdminCapabilityScope>
-                </ProtectedRoute>
-              }
-            >
-              {/* Overview — no cap required */}
-              <Route index element={<Dashboard />} />
+      <MfaWindowProvider>
+        <ToastProvider>
+          <MfaWrapper>
+            <ImpersonationWrapper />
+            <Routes>
+              <Route path="/login" element={<LoginPage />} />
+              <Route
+                element={
+                  <ProtectedRoute>
+                    <AdminCapabilityScope>
+                      <AdminLayout />
+                    </AdminCapabilityScope>
+                  </ProtectedRoute>
+                }
+              >
+                {/* Overview — no cap required */}
+                <Route index element={<Dashboard />} />
 
-              {/* TENANTS */}
-              <Route
-                path="tenants/agencies"
-                element={
-                  <ProtectedRoute requiredCapability="agencies_read">
-                    <AgenciesPage />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="tenants/lifecycle"
-                element={
-                  <ProtectedRoute
-                    requiredCapability={['tenant_export', 'tenant_purge', 'tenant_restore']}
-                  >
-                    <PlaceholderPage title="Lifecycle" />
-                  </ProtectedRoute>
-                }
-              />
+                {/* TENANTS */}
+                <Route
+                  path="tenants/agencies"
+                  element={
+                    <ProtectedRoute requiredCapability="agencies_read">
+                      <AgenciesPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="tenants/lifecycle"
+                  element={
+                    <ProtectedRoute
+                      requiredCapability={['tenant_export', 'tenant_purge', 'tenant_restore']}
+                    >
+                      <PlaceholderPage title="Lifecycle" />
+                    </ProtectedRoute>
+                  }
+                />
 
-              {/* IDENTITY */}
-              <Route
-                path="identity/users"
-                element={
-                  <ProtectedRoute requiredCapability={['users_read', 'principal_kind_escalate']}>
-                    <UsersPage />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="identity/memberships"
-                element={
-                  <ProtectedRoute requiredCapability={['memberships_grant', 'memberships_revoke']}>
-                    <PlaceholderPage title="Memberships" />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="identity/capabilities"
-                element={
-                  <ProtectedRoute requiredCapability="memberships_grant">
-                    <PlaceholderPage title="Capabilities" />
-                  </ProtectedRoute>
-                }
-              />
+                {/* IDENTITY */}
+                <Route
+                  path="identity/users"
+                  element={
+                    <ProtectedRoute requiredCapability={['users_read', 'principal_kind_escalate']}>
+                      <UsersPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="identity/memberships"
+                  element={
+                    <ProtectedRoute
+                      requiredCapability={['memberships_grant', 'memberships_revoke']}
+                    >
+                      <PlaceholderPage title="Memberships" />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="identity/capabilities"
+                  element={
+                    <ProtectedRoute requiredCapability="memberships_grant">
+                      <CapabilitiesAdminPage />
+                    </ProtectedRoute>
+                  }
+                />
 
-              {/* OPERATIONS */}
-              <Route
-                path="ops/audit"
-                element={
-                  <ProtectedRoute requiredCapability="audit_read">
-                    <AuditPage />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="ops/impersonation"
-                element={
-                  <ProtectedRoute requiredCapability="users_impersonate">
-                    <PlaceholderPage title="Impersonation" />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="ops/feature-flags"
-                element={
-                  <ProtectedRoute requiredCapability="feature_flags_write">
-                    <FeatureFlagsPage />
-                  </ProtectedRoute>
-                }
-              />
+                {/* OPERATIONS */}
+                <Route
+                  path="ops/audit"
+                  element={
+                    <ProtectedRoute requiredCapability="audit_read">
+                      <AuditPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="ops/impersonation"
+                  element={
+                    <ProtectedRoute requiredCapability="users_impersonate">
+                      <PlaceholderPage title="Impersonation" />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="ops/feature-flags"
+                  element={
+                    <ProtectedRoute requiredCapability="feature_flags_write">
+                      <FeatureFlagsPage />
+                    </ProtectedRoute>
+                  }
+                />
 
-              {/* PLATFORM */}
-              <Route
-                path="platform/settings"
-                element={
-                  <ProtectedRoute requiredCapability="site_settings_write">
-                    <PlatformPage />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="platform/mobile"
-                element={
-                  <ProtectedRoute requiredCapability="mobile_config_write">
-                    <PlaceholderPage title="Mobile config" />
-                  </ProtectedRoute>
-                }
-              />
-            </Route>
-          </Routes>
-        </MfaWrapper>
-      </ToastProvider>
+                {/* PLATFORM */}
+                <Route
+                  path="platform/settings"
+                  element={
+                    <ProtectedRoute requiredCapability="site_settings_write">
+                      <PlatformPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="platform/mobile"
+                  element={
+                    <ProtectedRoute requiredCapability="mobile_config_write">
+                      <PlaceholderPage title="Mobile config" />
+                    </ProtectedRoute>
+                  }
+                />
+              </Route>
+            </Routes>
+          </MfaWrapper>
+        </ToastProvider>
+      </MfaWindowProvider>
     </AdminAuthProvider>
   );
 }

--- a/frontend/apps/admin-web/src/components/AdminLayout.tsx
+++ b/frontend/apps/admin-web/src/components/AdminLayout.tsx
@@ -1,32 +1,157 @@
+import { useCapability } from '@ppt/admin-ui';
+import type { ReactNode } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, Outlet } from 'react-router-dom';
+import { Link, Outlet, useLocation } from 'react-router-dom';
 
 import { useAdminAuth } from '../auth/AdminAuthContext';
-import { usePrincipalCapabilities } from '../auth/usePrincipalCapabilities';
+
+interface SidebarGroupProps {
+  label: string;
+  children: ReactNode;
+}
+
+/**
+ * Renders group header + children only when at least one child is non-null.
+ * Prevents orphan headers when all children are gated out.
+ */
+function SidebarGroup({ label, children }: SidebarGroupProps) {
+  const nonNull = React.Children.toArray(children).filter(Boolean);
+  if (nonNull.length === 0) return null;
+  return (
+    <div style={{ marginTop: '20px' }}>
+      <div
+        style={{
+          fontSize: '11px',
+          fontWeight: 600,
+          letterSpacing: 'var(--ppt-tracking-caps, 0.06em)',
+          textTransform: 'uppercase',
+          color: 'var(--ppt-fg-muted, #6b7280)',
+          padding: '0 12px',
+          marginBottom: '4px',
+        }}
+      >
+        {label}
+      </div>
+      {nonNull}
+    </div>
+  );
+}
+
+interface NavItemProps {
+  to: string;
+  label: string;
+}
+
+function NavItem({ to, label }: NavItemProps) {
+  const location = useLocation();
+  const isActive = to === '/' ? location.pathname === '/' : location.pathname.startsWith(to);
+
+  return (
+    <Link
+      to={to}
+      style={{
+        display: 'block',
+        padding: '6px 12px',
+        borderRadius: 'var(--ppt-radius-md, 8px)',
+        textDecoration: 'none',
+        fontSize: '14px',
+        background: isActive ? 'var(--ppt-accent-soft-bg, #eff6ff)' : 'transparent',
+        color: isActive ? 'var(--ppt-brand-700, #1d4ed8)' : 'var(--ppt-fg-secondary, #374151)',
+        fontWeight: isActive ? 500 : 400,
+      }}
+    >
+      {label}
+    </Link>
+  );
+}
 
 export function AdminLayout() {
   const { t } = useTranslation();
   const auth = useAdminAuth();
-  const { capabilities } = usePrincipalCapabilities();
-  const has = (cap: string) => capabilities.includes(cap as never);
+
+  // TENANTS
+  const canAgenciesRead = useCapability('agencies_read');
+  const canTenantExport = useCapability('tenant_export');
+  const canTenantPurge = useCapability('tenant_purge');
+  const canTenantRestore = useCapability('tenant_restore');
+
+  // IDENTITY
+  const canUsersRead = useCapability('users_read');
+  const canPrincipalKindEscalate = useCapability('principal_kind_escalate');
+  const canMembershipsGrant = useCapability('memberships_grant');
+  const canMembershipsRevoke = useCapability('memberships_revoke');
+
+  // OPERATIONS
+  const canAuditRead = useCapability('audit_read');
+  const canUsersImpersonate = useCapability('users_impersonate');
+  const canFeatureFlagsWrite = useCapability('feature_flags_write');
+
+  // PLATFORM
+  const canSiteSettingsWrite = useCapability('site_settings_write');
+  const canMobileConfigWrite = useCapability('mobile_config_write');
 
   return (
     <div className="admin-shell">
       <aside>
         <h2>{t('admin.title', 'Admin')}</h2>
-        <nav>
-          <Link to="/">{t('admin.nav.dashboard', 'Dashboard')}</Link>
-          {has('agencies_read') && (
-            <Link to="/agencies">{t('admin.agencies.title', 'Agencies')}</Link>
-          )}
-          {has('users_read') && <Link to="/users">{t('admin.users.title', 'Users')}</Link>}
-          {has('audit_read') && <Link to="/audit">{t('admin.audit.title', 'Audit')}</Link>}
-          {has('feature_flags_write') && (
-            <Link to="/feature-flags">{t('admin.featureFlags.title', 'Feature flags')}</Link>
-          )}
-          {has('site_settings_write') && (
-            <Link to="/platform">{t('admin.platform.title', 'Platform')}</Link>
-          )}
+        <nav style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+          {/* No group header — overview always visible */}
+          <NavItem to="/" label={t('admin.nav.overview', 'Overview')} />
+
+          <SidebarGroup label="TENANTS">
+            {canAgenciesRead ? (
+              <NavItem to="/tenants/agencies" label={t('admin.agencies.title', 'Agencies')} />
+            ) : null}
+            {canTenantExport || canTenantPurge || canTenantRestore ? (
+              <NavItem to="/tenants/lifecycle" label={t('admin.tenants.lifecycle', 'Lifecycle')} />
+            ) : null}
+          </SidebarGroup>
+
+          <SidebarGroup label="IDENTITY">
+            {canUsersRead || canPrincipalKindEscalate ? (
+              <NavItem to="/identity/users" label={t('admin.users.title', 'Users')} />
+            ) : null}
+            {canMembershipsGrant || canMembershipsRevoke ? (
+              <NavItem
+                to="/identity/memberships"
+                label={t('admin.memberships.title', 'Memberships')}
+              />
+            ) : null}
+            {canMembershipsGrant ? (
+              <NavItem
+                to="/identity/capabilities"
+                label={t('admin.capabilities.title', 'Capabilities')}
+              />
+            ) : null}
+          </SidebarGroup>
+
+          <SidebarGroup label="OPERATIONS">
+            {canAuditRead ? (
+              <NavItem to="/ops/audit" label={t('admin.audit.title', 'Audit log')} />
+            ) : null}
+            {canUsersImpersonate ? (
+              <NavItem
+                to="/ops/impersonation"
+                label={t('admin.impersonation.title', 'Impersonation')}
+              />
+            ) : null}
+            {canFeatureFlagsWrite ? (
+              <NavItem
+                to="/ops/feature-flags"
+                label={t('admin.featureFlags.title', 'Feature flags')}
+              />
+            ) : null}
+          </SidebarGroup>
+
+          <SidebarGroup label="PLATFORM">
+            {canSiteSettingsWrite ? (
+              <NavItem to="/platform/settings" label={t('admin.platform.title', 'Settings')} />
+            ) : null}
+            {canMobileConfigWrite ? (
+              <NavItem to="/platform/mobile" label={t('admin.platform.mobile', 'Mobile config')} />
+            ) : null}
+          </SidebarGroup>
         </nav>
         <button type="button" onClick={auth.logout}>
           {t('admin.actions.signOut', 'Sign out')}

--- a/frontend/apps/admin-web/src/components/AdminLayout.tsx
+++ b/frontend/apps/admin-web/src/components/AdminLayout.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Link, Outlet, useLocation } from 'react-router-dom';
 
 import { useAdminAuth } from '../auth/AdminAuthContext';
+import { ConnectedMfaWindowChip } from './MfaWindowChip';
 
 interface SidebarGroupProps {
   label: string;
@@ -157,7 +158,24 @@ export function AdminLayout() {
           {t('admin.actions.signOut', 'Sign out')}
         </button>
       </aside>
-      <main>
+      <main style={{ display: 'flex', flexDirection: 'column', flex: 1, minWidth: 0 }}>
+        {/* Topbar */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            padding: '8px 22px',
+            borderBottom: '1px solid var(--ppt-border-default, #e5e7eb)',
+            background: 'var(--ppt-bg-surface, #ffffff)',
+            gap: '8px',
+          }}
+        >
+          <span style={{ flex: 1 }} />
+          <ConnectedMfaWindowChip />
+          <button type="button" onClick={auth.logout} style={{ fontSize: '13px' }}>
+            {t('admin.actions.signOut', 'Sign out')}
+          </button>
+        </div>
         <Outlet />
       </main>
     </div>

--- a/frontend/apps/admin-web/src/components/AuditReasonPrompt.test.tsx
+++ b/frontend/apps/admin-web/src/components/AuditReasonPrompt.test.tsx
@@ -1,0 +1,206 @@
+import { render, renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { AuditReasonPrompt, useAuditReasonValid } from './AuditReasonPrompt';
+
+// ---------------------------------------------------------------------------
+// useAuditReasonValid hook tests
+// ---------------------------------------------------------------------------
+
+describe('useAuditReasonValid', () => {
+  it('returns false when value is empty', () => {
+    const { result } = renderHook(() => useAuditReasonValid('', 20));
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when value is below minLength', () => {
+    const { result } = renderHook(() => useAuditReasonValid('short', 20));
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when value meets minLength (varied chars)', () => {
+    // 'abcdefghij...' repeated — varied chars, not single repeated
+    const varied = 'abcdefghijklmnopqrst'; // 20 varied chars
+    const { result } = renderHook(() => useAuditReasonValid(varied, 20));
+    expect(result.current).toBe(true);
+  });
+
+  it('returns true when value exceeds minLength (varied chars)', () => {
+    const varied = 'The reason for this change is to enable rollout to cohort A.';
+    const { result } = renderHook(() => useAuditReasonValid(varied, 20));
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false for single repeated character (meets length)', () => {
+    const { result } = renderHook(() => useAuditReasonValid('a'.repeat(25), 20));
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false for single repeated character (any char)', () => {
+    const { result } = renderHook(() => useAuditReasonValid('x'.repeat(30), 20));
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true for a varied string meeting minLength', () => {
+    const { result } = renderHook(() =>
+      useAuditReasonValid('Reason for toggling this flag: rollout complete', 20)
+    );
+    expect(result.current).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AuditReasonPrompt component tests
+// ---------------------------------------------------------------------------
+
+describe('AuditReasonPrompt', () => {
+  const defaultProps = {
+    action: 'feature_flag_toggle' as const,
+    value: '',
+    onChange: vi.fn(),
+  };
+
+  // --- Rendering ---
+
+  it('renders the "Audit reason" label', () => {
+    render(<AuditReasonPrompt {...defaultProps} />);
+    expect(screen.getByText('Audit reason')).toBeDefined();
+  });
+
+  it('renders textarea', () => {
+    render(<AuditReasonPrompt {...defaultProps} />);
+    expect(screen.getByRole('textbox', { name: 'Audit reason' })).toBeDefined();
+  });
+
+  // --- Char counter ---
+
+  it('shows counter as "0 / 20" for feature_flag_toggle (default minLength 20)', () => {
+    render(<AuditReasonPrompt {...defaultProps} value="" />);
+    expect(screen.getByText('0 / 20')).toBeDefined();
+  });
+
+  it('updates counter as value changes', () => {
+    const { rerender } = render(<AuditReasonPrompt {...defaultProps} value="" />);
+    expect(screen.getByText('0 / 20')).toBeDefined();
+
+    rerender(<AuditReasonPrompt {...defaultProps} value="hello" />);
+    expect(screen.getByText('5 / 20')).toBeDefined();
+  });
+
+  it('uses custom minLength in counter', () => {
+    render(<AuditReasonPrompt {...defaultProps} action="tenant_purge" minLength={15} value="" />);
+    expect(screen.getByText('0 / 15')).toBeDefined();
+  });
+
+  it('shows counter "30 / 30" when value meets default purge minLength', () => {
+    render(
+      <AuditReasonPrompt
+        {...defaultProps}
+        action="tenant_purge"
+        value={'x'.repeat(10) + 'y'.repeat(20)}
+      />
+    );
+    expect(screen.getByText('30 / 30')).toBeDefined();
+  });
+
+  // --- Validation hints ---
+
+  it('shows "Needs N more characters" hint when below minLength and has typed', async () => {
+    render(<AuditReasonPrompt {...defaultProps} value="short" />);
+    expect(screen.getByText('Needs 15 more characters')).toBeDefined();
+  });
+
+  it('uses singular "character" when 1 more needed', () => {
+    // 19 chars when minLength is 20 → "Needs 1 more character"
+    render(<AuditReasonPrompt {...defaultProps} value={`${'a'.repeat(18)}b`} />);
+    expect(screen.getByText('Needs 1 more character')).toBeDefined();
+  });
+
+  it('shows no hint when empty (user has not started typing)', () => {
+    render(<AuditReasonPrompt {...defaultProps} value="" />);
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('shows single repeated char hint when value is all same character', () => {
+    render(<AuditReasonPrompt {...defaultProps} value={'a'.repeat(25)} />);
+    expect(screen.getByText("Reason can't be a single repeated character")).toBeDefined();
+  });
+
+  it('shows no hint when value is valid', () => {
+    const validValue = 'Reason for toggling flag: deploy cohort A complete';
+    render(<AuditReasonPrompt {...defaultProps} value={validValue} />);
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  // --- Risk badge color ---
+
+  it('shows "High risk" badge for tenant_purge (red)', () => {
+    render(<AuditReasonPrompt {...defaultProps} action="tenant_purge" />);
+    const badge = screen.getByText('High risk');
+    expect(badge).toBeDefined();
+    expect(badge.className).toContain('ppt-arp__badge--red');
+  });
+
+  it('shows "High risk" badge for principal_kind_escalate (red)', () => {
+    render(<AuditReasonPrompt {...defaultProps} action="principal_kind_escalate" />);
+    const badge = screen.getByText('High risk');
+    expect(badge.className).toContain('ppt-arp__badge--red');
+  });
+
+  it('shows "Medium risk" badge for feature_flag_toggle (amber)', () => {
+    render(<AuditReasonPrompt {...defaultProps} action="feature_flag_toggle" />);
+    const badge = screen.getByText('Medium risk');
+    expect(badge.className).toContain('ppt-arp__badge--amber');
+  });
+
+  it('shows "Medium risk" badge for maintenance_mode_on (amber)', () => {
+    render(<AuditReasonPrompt {...defaultProps} action="maintenance_mode_on" />);
+    const badge = screen.getByText('Medium risk');
+    expect(badge.className).toContain('ppt-arp__badge--amber');
+  });
+
+  it('shows "Medium risk" badge for force_update_floor_bump (amber)', () => {
+    render(<AuditReasonPrompt {...defaultProps} action="force_update_floor_bump" />);
+    const badge = screen.getByText('Medium risk');
+    expect(badge.className).toContain('ppt-arp__badge--amber');
+  });
+
+  // --- onChange ---
+
+  it('calls onChange when user types', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<AuditReasonPrompt {...defaultProps} onChange={onChange} />);
+    const ta = screen.getByRole('textbox', { name: 'Audit reason' });
+    await user.type(ta, 'hello');
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  // --- Hidden validity input ---
+
+  it('hidden input has data-valid=false when value invalid', () => {
+    const { container } = render(<AuditReasonPrompt {...defaultProps} value="short" />);
+    const hidden = container.querySelector('input[type="hidden"]') as HTMLInputElement;
+    expect(hidden).not.toBeNull();
+    expect(hidden.dataset.valid).toBe('false');
+  });
+
+  it('hidden input has data-valid=true when value valid', () => {
+    const validValue = 'A clear and concise reason that meets the minimum';
+    const { container } = render(<AuditReasonPrompt {...defaultProps} value={validValue} />);
+    const hidden = container.querySelector('input[type="hidden"]') as HTMLInputElement;
+    expect(hidden.dataset.valid).toBe('true');
+  });
+
+  // --- Per-action default minLengths ---
+
+  it('uses minLength 30 for tenant_purge', () => {
+    render(<AuditReasonPrompt {...defaultProps} action="tenant_purge" value="" />);
+    expect(screen.getByText('0 / 30')).toBeDefined();
+  });
+
+  it('uses minLength 20 for maintenance_mode_on', () => {
+    render(<AuditReasonPrompt {...defaultProps} action="maintenance_mode_on" value="" />);
+    expect(screen.getByText('0 / 20')).toBeDefined();
+  });
+});

--- a/frontend/apps/admin-web/src/components/AuditReasonPrompt.tsx
+++ b/frontend/apps/admin-web/src/components/AuditReasonPrompt.tsx
@@ -1,0 +1,280 @@
+/**
+ * AuditReasonPrompt — inline textarea for audit reason capture.
+ *
+ * Appears before destructive/sensitive admin operations to capture
+ * a human-readable audit trail reason. Never blocks typing — shows hints
+ * after the user has started typing.
+ *
+ * Validation:
+ *   - Minimum character length (per-action defaults)
+ *   - Single repeated character pattern rejected
+ *
+ * Exposes a hidden input data-valid attribute so parent forms can read
+ * validity without coupling to component internals.
+ */
+
+import { useMemo } from 'react';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type AuditReasonAction =
+  | 'tenant_purge'
+  | 'tenant_restore'
+  | 'principal_kind_escalate'
+  | 'grant_principal_kind_escalate'
+  | 'grant_tenant_purge'
+  | 'force_update_floor_bump'
+  | 'maintenance_mode_on'
+  | 'feature_flag_toggle';
+
+export interface AuditReasonPromptProps {
+  action: AuditReasonAction;
+  minLength?: number;
+  value: string;
+  onChange: (v: string) => void;
+  required?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Action metadata
+// ---------------------------------------------------------------------------
+
+interface ActionMeta {
+  defaultMinLength: number;
+  helper: string;
+  risk: 'red' | 'amber';
+}
+
+const ACTION_META: Record<AuditReasonAction, ActionMeta> = {
+  tenant_purge: {
+    defaultMinLength: 30,
+    helper:
+      'Explain why this tenant is being permanently purged. This reason will be stored in the audit log and cannot be edited.',
+    risk: 'red',
+  },
+  tenant_restore: {
+    defaultMinLength: 30,
+    helper:
+      'Explain why a tenant archive is being restored into a new slug. Include the source tenant and any data migration notes.',
+    risk: 'red',
+  },
+  principal_kind_escalate: {
+    defaultMinLength: 30,
+    helper:
+      'Explain why this user account is being escalated to a higher principal kind. Include the business justification.',
+    risk: 'red',
+  },
+  grant_principal_kind_escalate: {
+    defaultMinLength: 30,
+    helper:
+      "Explain why you're granting the principal_kind_escalate capability. Include who approved this and the intended use.",
+    risk: 'red',
+  },
+  grant_tenant_purge: {
+    defaultMinLength: 30,
+    helper:
+      "Explain why you're granting the tenant_purge capability. Include who approved this and the intended scope.",
+    risk: 'red',
+  },
+  force_update_floor_bump: {
+    defaultMinLength: 20,
+    helper:
+      'Explain why a forced floor-version bump is necessary. Include the affected mobile versions.',
+    risk: 'amber',
+  },
+  maintenance_mode_on: {
+    defaultMinLength: 20,
+    helper: 'Describe the maintenance being performed and expected duration.',
+    risk: 'amber',
+  },
+  feature_flag_toggle: {
+    defaultMinLength: 20,
+    helper:
+      'Explain why this feature flag is being toggled and which tenants or cohorts are affected.',
+    risk: 'amber',
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Validation hook
+// ---------------------------------------------------------------------------
+
+const SINGLE_REPEATED_CHAR_RE = /^(.)\1+$/;
+
+/** Returns true when the reason is valid per the given constraints. */
+export function useAuditReasonValid(value: string, minLength: number): boolean {
+  return useMemo(() => {
+    if (value.length < minLength) return false;
+    if (SINGLE_REPEATED_CHAR_RE.test(value.trim())) return false;
+    return true;
+  }, [value, minLength]);
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const STYLE_ID = 'ppt-audit-reason-prompt-styles';
+
+function ensureStyles() {
+  if (typeof document === 'undefined') return;
+  if (document.getElementById(STYLE_ID)) return;
+  const el = document.createElement('style');
+  el.id = STYLE_ID;
+  el.textContent = `
+    .ppt-arp {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .ppt-arp__header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .ppt-arp__label {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--ppt-fg-primary, #111827);
+    }
+    .ppt-arp__badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 2px 8px;
+      border-radius: 999px;
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+    .ppt-arp__badge--red {
+      background: var(--ppt-danger-100, #fee2e2);
+      color: var(--ppt-danger-800, #991b1b);
+    }
+    .ppt-arp__badge--amber {
+      background: var(--ppt-warning-100, #fef3c7);
+      color: var(--ppt-warning-800, #92400e);
+    }
+    .ppt-arp__helper {
+      font-size: 12px;
+      color: var(--ppt-fg-muted, #6b7280);
+      line-height: 1.5;
+    }
+    .ppt-arp__textarea {
+      width: 100%;
+      box-sizing: border-box;
+      font-family: var(--ppt-font-mono, 'JetBrains Mono', 'SF Mono', 'Menlo', 'Consolas', monospace);
+      font-size: 13px;
+      line-height: 1.6;
+      padding: 8px 10px;
+      border: 1px solid var(--ppt-border-default, #e5e7eb);
+      border-radius: var(--ppt-radius-md, 8px);
+      background: var(--ppt-bg-input, #ffffff);
+      color: var(--ppt-fg-primary, #111827);
+      resize: none;
+      outline: none;
+      transition: border-color 120ms ease, box-shadow 120ms ease;
+    }
+    .ppt-arp__textarea:focus {
+      border-color: var(--ppt-brand-500, #3b82f6);
+      box-shadow: 0 0 0 2px var(--ppt-brand-500, #3b82f6);
+    }
+    .ppt-arp__footer {
+      display: flex;
+      align-items: baseline;
+      gap: 8px;
+    }
+    .ppt-arp__counter {
+      font-size: 12px;
+      color: var(--ppt-fg-muted, #6b7280);
+      font-variant-numeric: tabular-nums;
+    }
+    .ppt-arp__counter--invalid {
+      color: var(--ppt-danger-600, #dc2626);
+    }
+    .ppt-arp__hint {
+      font-size: 12px;
+      color: var(--ppt-danger-600, #dc2626);
+    }
+  `;
+  document.head.appendChild(el);
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function AuditReasonPrompt({
+  action,
+  minLength,
+  value,
+  onChange,
+  required = true,
+}: AuditReasonPromptProps) {
+  ensureStyles();
+
+  const meta = ACTION_META[action];
+  const resolvedMin = minLength ?? meta.defaultMinLength;
+  const isValid = useAuditReasonValid(value, resolvedMin);
+
+  const hint = useMemo<string>(() => {
+    if (value.length === 0) return '';
+    if (SINGLE_REPEATED_CHAR_RE.test(value.trim())) {
+      return "Reason can't be a single repeated character";
+    }
+    const missing = resolvedMin - value.length;
+    if (missing > 0) {
+      return `Needs ${missing} more character${missing === 1 ? '' : 's'}`;
+    }
+    return '';
+  }, [value, resolvedMin]);
+
+  const counterBelowMin = value.length < resolvedMin;
+
+  return (
+    <div className="ppt-arp">
+      <div className="ppt-arp__header">
+        <span className="ppt-arp__label">Audit reason</span>
+        <span className={`ppt-arp__badge ppt-arp__badge--${meta.risk}`}>
+          {meta.risk === 'red' ? 'High risk' : 'Medium risk'}
+        </span>
+      </div>
+
+      <p className="ppt-arp__helper">{meta.helper}</p>
+
+      <textarea
+        className="ppt-arp__textarea"
+        rows={4}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        required={required}
+        aria-label="Audit reason"
+        aria-describedby="ppt-arp-hint"
+        autoComplete="off"
+        spellCheck
+      />
+
+      <div className="ppt-arp__footer">
+        <span
+          className={`ppt-arp__counter${counterBelowMin ? ' ppt-arp__counter--invalid' : ''}`}
+          aria-live="polite"
+          aria-label={`${value.length} of ${resolvedMin} minimum characters`}
+        >
+          {value.length} / {resolvedMin}
+        </span>
+        {hint && (
+          <span id="ppt-arp-hint" className="ppt-arp__hint" role="alert">
+            {hint}
+          </span>
+        )}
+      </div>
+
+      {/* Hidden input for form-level validity checks */}
+      <input type="hidden" data-valid={isValid} />
+    </div>
+  );
+}
+
+AuditReasonPrompt.displayName = 'AuditReasonPrompt';

--- a/frontend/apps/admin-web/src/components/DestructiveConfirmDialog.test.tsx
+++ b/frontend/apps/admin-web/src/components/DestructiveConfirmDialog.test.tsx
@@ -1,0 +1,242 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { DestructiveConfirmDialog } from './DestructiveConfirmDialog';
+
+const defaultProps = {
+  open: true,
+  title: 'Delete tenant',
+  body: <p>This action is irreversible.</p>,
+  confirmText: 'acme-corp',
+  onConfirm: vi.fn().mockResolvedValue(undefined),
+  onCancel: vi.fn(),
+};
+
+/** Returns true when element has a truthy disabled attribute or property. */
+function isDisabled(el: HTMLElement): boolean {
+  return el.hasAttribute('disabled') || (el as HTMLButtonElement).disabled === true;
+}
+
+/** Set the confirm input value directly (avoids slow userEvent.type for multi-element forms). */
+function fillConfirmInput(value = 'acme-corp') {
+  const input = screen.getByRole('textbox', { name: /type.*to confirm/i });
+  fireEvent.change(input, { target: { value } });
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+describe('DestructiveConfirmDialog', () => {
+  // --- Rendering ---
+
+  it('renders when open=true', () => {
+    render(<DestructiveConfirmDialog {...defaultProps} />);
+    expect(screen.getByRole('dialog')).toBeDefined();
+  });
+
+  it('does not render when open=false', () => {
+    render(<DestructiveConfirmDialog {...defaultProps} open={false} />);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders title in dialog', () => {
+    render(<DestructiveConfirmDialog {...defaultProps} />);
+    expect(screen.getByText('Delete tenant')).toBeDefined();
+  });
+
+  it('renders body content', () => {
+    render(<DestructiveConfirmDialog {...defaultProps} />);
+    expect(screen.getByText('This action is irreversible.')).toBeDefined();
+  });
+
+  it('shows confirmText in label', () => {
+    render(<DestructiveConfirmDialog {...defaultProps} />);
+    expect(screen.getByText('acme-corp')).toBeDefined();
+  });
+
+  // --- Confirm button disabled until match ---
+
+  it('confirm button is disabled initially', () => {
+    render(<DestructiveConfirmDialog {...defaultProps} />);
+    const btn = screen.getByRole('button', { name: /confirm/i });
+    expect(isDisabled(btn)).toBe(true);
+  });
+
+  it('confirm button enabled after typing exact confirmText', () => {
+    render(<DestructiveConfirmDialog {...defaultProps} />);
+    fillConfirmInput('acme-corp');
+    const btn = screen.getByRole('button', { name: /confirm/i });
+    expect(isDisabled(btn)).toBe(false);
+  });
+
+  it('confirm button remains disabled with partial match', () => {
+    render(<DestructiveConfirmDialog {...defaultProps} />);
+    fillConfirmInput('acme-cor');
+    const btn = screen.getByRole('button', { name: /confirm/i });
+    expect(isDisabled(btn)).toBe(true);
+  });
+
+  it('confirm button is case-sensitive (uppercase rejected)', () => {
+    render(<DestructiveConfirmDialog {...defaultProps} />);
+    fillConfirmInput('ACME-CORP');
+    const btn = screen.getByRole('button', { name: /confirm/i });
+    expect(isDisabled(btn)).toBe(true);
+  });
+
+  // --- Paste prevention ---
+
+  it('prevents paste on confirm input', () => {
+    render(<DestructiveConfirmDialog {...defaultProps} />);
+    const input = screen.getByRole('textbox', { name: /type.*to confirm/i });
+    // The component binds onPaste={e => e.preventDefault()}.
+    // fireEvent.paste returns false when preventDefault was called.
+    const prevented = !fireEvent.paste(input);
+    expect(prevented).toBe(true);
+  });
+
+  // --- onConfirm called ---
+
+  it('calls onConfirm when confirm button clicked with matching text', async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    render(<DestructiveConfirmDialog {...defaultProps} onConfirm={onConfirm} />);
+    fillConfirmInput('acme-corp');
+    await act(async () => {
+      screen.getByRole('button', { name: /confirm/i }).click();
+    });
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  // --- onCancel ---
+
+  it('calls onCancel when Cancel button clicked', async () => {
+    const onCancel = vi.fn();
+    render(<DestructiveConfirmDialog {...defaultProps} onCancel={onCancel} />);
+    await act(async () => {
+      screen.getByRole('button', { name: /cancel/i }).click();
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel on backdrop click', async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    render(<DestructiveConfirmDialog {...defaultProps} onCancel={onCancel} />);
+    const backdrop = document.querySelector('.ppt-dcd-backdrop') as HTMLElement;
+    await user.click(backdrop);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel on ESC key', async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    render(<DestructiveConfirmDialog {...defaultProps} onCancel={onCancel} />);
+    await user.keyboard('{Escape}');
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  // --- Delay countdown ---
+
+  it('shows "Wait Ns" button and is disabled immediately after match with delay', () => {
+    vi.useFakeTimers();
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+
+    render(<DestructiveConfirmDialog {...defaultProps} onConfirm={onConfirm} delayMs={3000} />);
+
+    fillConfirmInput('acme-corp');
+
+    // Countdown starts immediately — button should show Wait label
+    const btn = screen.getByRole('button', { name: /wait/i });
+    expect(btn).toBeDefined();
+    expect(isDisabled(btn)).toBe(true);
+  });
+
+  it('enables confirm button after delay elapses', async () => {
+    // Use real timers with a very short delay to avoid fake-timer/waitFor incompatibility
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+
+    render(<DestructiveConfirmDialog {...defaultProps} onConfirm={onConfirm} delayMs={200} />);
+
+    act(() => {
+      fillConfirmInput('acme-corp');
+    });
+
+    // Wait for the real 200ms delay + interval ticks to expire
+    await waitFor(
+      () => {
+        const btn = screen.queryByRole('button', { name: /^confirm$/i });
+        expect(btn).not.toBeNull();
+        if (btn) expect(isDisabled(btn)).toBe(false);
+      },
+      { timeout: 2000 }
+    );
+  }, 10000);
+
+  // --- reasonAction embeds AuditReasonPrompt ---
+
+  it('renders AuditReasonPrompt when reasonAction provided', () => {
+    render(<DestructiveConfirmDialog {...defaultProps} reasonAction="tenant_purge" />);
+    expect(screen.getByText('Audit reason')).toBeDefined();
+  });
+
+  it('does not render AuditReasonPrompt when reasonAction absent', () => {
+    render(<DestructiveConfirmDialog {...defaultProps} />);
+    expect(screen.queryByText('Audit reason')).toBeNull();
+  });
+
+  it('keeps confirm disabled when reason is too short even if text matches', () => {
+    render(<DestructiveConfirmDialog {...defaultProps} reasonAction="feature_flag_toggle" />);
+    // Type the confirm text directly
+    fillConfirmInput('acme-corp');
+
+    // Reason textarea is still empty — confirm should stay disabled
+    const btn = screen.getByRole('button', { name: /confirm/i });
+    expect(isDisabled(btn)).toBe(true);
+  });
+
+  // --- Custom confirmLabel ---
+
+  it('uses custom confirmLabel', () => {
+    render(<DestructiveConfirmDialog {...defaultProps} confirmLabel="Enter the tenant slug" />);
+    expect(screen.getByText('Enter the tenant slug')).toBeDefined();
+  });
+
+  it('uses default confirmLabel when not provided', () => {
+    render(<DestructiveConfirmDialog {...defaultProps} />);
+    expect(screen.getByText('Type the name to confirm')).toBeDefined();
+  });
+
+  // --- Spinner during pending ---
+
+  it('shows spinner while onConfirm is in flight', async () => {
+    let resolve!: () => void;
+    const onConfirm = vi.fn(
+      () =>
+        new Promise<void>((res) => {
+          resolve = res;
+        })
+    );
+
+    render(<DestructiveConfirmDialog {...defaultProps} onConfirm={onConfirm} />);
+    fillConfirmInput('acme-corp');
+
+    act(() => {
+      screen.getByRole('button', { name: /confirm/i }).click();
+    });
+
+    // Spinner should be visible while pending
+    await waitFor(() => {
+      expect(document.querySelector('.ppt-dcd-spinner')).not.toBeNull();
+    });
+
+    // Resolve the promise
+    await act(async () => {
+      resolve();
+    });
+    await waitFor(() => {
+      expect(document.querySelector('.ppt-dcd-spinner')).toBeNull();
+    });
+  });
+});

--- a/frontend/apps/admin-web/src/components/DestructiveConfirmDialog.tsx
+++ b/frontend/apps/admin-web/src/components/DestructiveConfirmDialog.tsx
@@ -1,0 +1,403 @@
+/**
+ * DestructiveConfirmDialog — portal modal for destructive operations.
+ *
+ * Behavior:
+ *   - Renders via React portal at document.body
+ *   - User must type confirmText exactly (case-sensitive) to enable confirm
+ *   - Paste is blocked on the confirm input
+ *   - Optional delayMs: confirm button disabled for N ms after typing matches
+ *   - Optional reasonAction: embeds <AuditReasonPrompt> before the confirm input
+ *   - ESC key cancels; focus trap inside modal; backdrop click cancels
+ *   - During onConfirm(): spinner + disabled state
+ */
+
+import {
+  type KeyboardEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+
+import {
+  type AuditReasonAction,
+  AuditReasonPrompt,
+  useAuditReasonValid,
+} from './AuditReasonPrompt';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface DestructiveConfirmDialogProps {
+  open: boolean;
+  title: string;
+  body: ReactNode;
+  confirmText: string;
+  confirmLabel?: string;
+  delayMs?: number;
+  reasonAction?: AuditReasonAction;
+  onConfirm: () => Promise<void>;
+  onCancel: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const STYLE_ID = 'ppt-destructive-dialog-styles';
+
+function ensureStyles() {
+  if (typeof document === 'undefined') return;
+  if (document.getElementById(STYLE_ID)) return;
+  const el = document.createElement('style');
+  el.id = STYLE_ID;
+  el.textContent = `
+    .ppt-dcd-backdrop {
+      position: fixed;
+      inset: 0;
+      z-index: 9999;
+      background: rgba(0, 0, 0, 0.5);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 16px;
+    }
+    .ppt-dcd-panel {
+      max-width: 480px;
+      width: 100%;
+      background: var(--ppt-bg-surface, #ffffff);
+      border-radius: var(--ppt-radius-lg, 12px);
+      padding: 24px;
+      box-shadow: var(--ppt-shadow-modal, 0 10px 40px rgba(0,0,0,0.15));
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      position: relative;
+    }
+    .ppt-dcd-title {
+      font-size: 16px;
+      font-weight: 600;
+      color: var(--ppt-danger-700, #b91c1c);
+      margin: 0;
+    }
+    .ppt-dcd-body {
+      font-size: 14px;
+      color: var(--ppt-fg-secondary, #374151);
+      line-height: 1.55;
+    }
+    .ppt-dcd-confirm-text {
+      font-family: var(--ppt-font-mono, 'JetBrains Mono', 'SF Mono', 'Menlo', 'Consolas', monospace);
+      font-size: 13px;
+      background: var(--ppt-bg-subtle, #f3f4f6);
+      padding: 3px 8px;
+      border-radius: 4px;
+      color: var(--ppt-fg-primary, #111827);
+      word-break: break-all;
+    }
+    .ppt-dcd-input-group {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .ppt-dcd-input-label {
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--ppt-fg-secondary, #374151);
+    }
+    .ppt-dcd-input {
+      width: 100%;
+      box-sizing: border-box;
+      font-family: var(--ppt-font-mono, 'JetBrains Mono', 'SF Mono', 'Menlo', 'Consolas', monospace);
+      font-size: 13px;
+      padding: 8px 10px;
+      border: 1px solid var(--ppt-border-default, #e5e7eb);
+      border-radius: var(--ppt-radius-md, 8px);
+      background: var(--ppt-bg-input, #ffffff);
+      color: var(--ppt-fg-primary, #111827);
+      outline: none;
+      transition: border-color 120ms ease, box-shadow 120ms ease;
+    }
+    .ppt-dcd-input:focus {
+      border-color: var(--ppt-brand-500, #3b82f6);
+      box-shadow: 0 0 0 2px var(--ppt-brand-500, #3b82f6);
+    }
+    .ppt-dcd-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 10px;
+      margin-top: 4px;
+    }
+    .ppt-dcd-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 16px;
+      border-radius: var(--ppt-radius-md, 8px);
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      border: none;
+      transition: background 120ms ease, opacity 120ms ease;
+      outline: none;
+    }
+    .ppt-dcd-btn:focus-visible {
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.35);
+    }
+    .ppt-dcd-btn--cancel {
+      background: transparent;
+      color: var(--ppt-fg-secondary, #374151);
+      border: 1px solid var(--ppt-border-default, #e5e7eb);
+    }
+    .ppt-dcd-btn--cancel:hover {
+      background: var(--ppt-bg-hover, #f3f4f6);
+    }
+    .ppt-dcd-btn--confirm {
+      background: var(--ppt-danger-600, #dc2626);
+      color: #ffffff;
+    }
+    .ppt-dcd-btn--confirm:hover:not(:disabled) {
+      background: var(--ppt-danger-700, #b91c1c);
+    }
+    .ppt-dcd-btn--confirm:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
+    .ppt-dcd-spinner {
+      width: 14px;
+      height: 14px;
+      border: 2px solid rgba(255,255,255,0.4);
+      border-top-color: #ffffff;
+      border-radius: 50%;
+      animation: ppt-dcd-spin 0.7s linear infinite;
+      flex-shrink: 0;
+    }
+    @keyframes ppt-dcd-spin {
+      to { transform: rotate(360deg); }
+    }
+  `;
+  document.head.appendChild(el);
+}
+
+// ---------------------------------------------------------------------------
+// Focus trap helper
+// ---------------------------------------------------------------------------
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function trapFocus(container: HTMLElement, e: KeyboardEvent<HTMLDivElement>) {
+  const focusable = Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+  if (focusable.length === 0) return;
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  if (e.key === 'Tab') {
+    if (e.shiftKey) {
+      if (document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else {
+      if (document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function DestructiveConfirmDialog({
+  open,
+  title,
+  body,
+  confirmText,
+  confirmLabel = 'Type the name to confirm',
+  delayMs,
+  reasonAction,
+  onConfirm,
+  onCancel,
+}: DestructiveConfirmDialogProps) {
+  ensureStyles();
+
+  const [typed, setTyped] = useState('');
+  const [reason, setReason] = useState('');
+  const [delayRemainingMs, setDelayRemainingMs] = useState(0);
+  const [isPending, setIsPending] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const firstFocusableRef = useRef<HTMLElement | null>(null);
+  const titleId = useId();
+  const delayTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const reasonIsValid = useAuditReasonValid(reason, 20); // min 20 for any action
+  const typedMatches = typed === confirmText;
+  const reasonSatisfied = reasonAction ? reasonIsValid : true;
+
+  // Start delay countdown when typed matches (and delay configured)
+  useEffect(() => {
+    if (!typedMatches || !delayMs || !reasonSatisfied) {
+      setDelayRemainingMs(0);
+      if (delayTimerRef.current) {
+        clearInterval(delayTimerRef.current);
+        delayTimerRef.current = null;
+      }
+      return;
+    }
+    // Reset and start countdown
+    setDelayRemainingMs(delayMs);
+    const interval = 100;
+    delayTimerRef.current = setInterval(() => {
+      setDelayRemainingMs((prev) => {
+        const next = prev - interval;
+        if (next <= 0) {
+          if (delayTimerRef.current) {
+            clearInterval(delayTimerRef.current);
+            delayTimerRef.current = null;
+          }
+          return 0;
+        }
+        return next;
+      });
+    }, interval);
+    return () => {
+      if (delayTimerRef.current) {
+        clearInterval(delayTimerRef.current);
+        delayTimerRef.current = null;
+      }
+    };
+  }, [typedMatches, reasonSatisfied, delayMs]);
+
+  // Reset state when dialog opens/closes
+  useEffect(() => {
+    if (!open) {
+      setTyped('');
+      setReason('');
+      setDelayRemainingMs(0);
+      setIsPending(false);
+      if (delayTimerRef.current) {
+        clearInterval(delayTimerRef.current);
+        delayTimerRef.current = null;
+      }
+    }
+  }, [open]);
+
+  // Focus first focusable element on open
+  useEffect(() => {
+    if (!open || !panelRef.current) return;
+    const focusable = panelRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+    if (focusable.length > 0) {
+      firstFocusableRef.current = focusable[0];
+      setTimeout(() => focusable[0].focus(), 0);
+    }
+  }, [open]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'Escape') {
+        onCancel();
+        return;
+      }
+      if (panelRef.current) trapFocus(panelRef.current, e);
+    },
+    [onCancel]
+  );
+
+  const handleConfirm = useCallback(async () => {
+    if (isPending) return;
+    setIsPending(true);
+    try {
+      await onConfirm();
+    } finally {
+      setIsPending(false);
+    }
+  }, [isPending, onConfirm]);
+
+  const delayInProgress = delayMs !== undefined && delayMs > 0 && delayRemainingMs > 0;
+  const confirmDisabled = !typedMatches || !reasonSatisfied || delayInProgress || isPending;
+
+  const confirmButtonLabel = isPending
+    ? 'Confirming…'
+    : delayInProgress
+      ? `Wait ${Math.ceil(delayRemainingMs / 1000)}s`
+      : 'Confirm';
+
+  if (!open) return null;
+
+  return createPortal(
+    <div
+      className="ppt-dcd-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      onKeyDown={handleKeyDown}
+      onClick={(e) => {
+        // Cancel on backdrop click (not panel click)
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div ref={panelRef} className="ppt-dcd-panel" onClick={(e) => e.stopPropagation()}>
+        <h2 id={titleId} className="ppt-dcd-title">
+          {title}
+        </h2>
+
+        <div className="ppt-dcd-body">{body}</div>
+
+        {reasonAction && (
+          <AuditReasonPrompt action={reasonAction} value={reason} onChange={setReason} required />
+        )}
+
+        <div className="ppt-dcd-input-group">
+          <label className="ppt-dcd-input-label" htmlFor="ppt-dcd-confirm-input">
+            {confirmLabel}{' '}
+            <span className="ppt-dcd-confirm-text" aria-label={`Type: ${confirmText}`}>
+              {confirmText}
+            </span>
+          </label>
+          <input
+            id="ppt-dcd-confirm-input"
+            className="ppt-dcd-input"
+            type="text"
+            value={typed}
+            onChange={(e) => setTyped(e.target.value)}
+            onPaste={(e) => e.preventDefault()}
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
+            aria-label={`Type "${confirmText}" to confirm`}
+          />
+        </div>
+
+        <div className="ppt-dcd-actions">
+          <button
+            type="button"
+            className="ppt-dcd-btn ppt-dcd-btn--cancel"
+            onClick={onCancel}
+            disabled={isPending}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="ppt-dcd-btn ppt-dcd-btn--confirm"
+            onClick={handleConfirm}
+            disabled={confirmDisabled}
+            aria-disabled={confirmDisabled}
+          >
+            {isPending && <span className="ppt-dcd-spinner" aria-hidden="true" />}
+            {confirmButtonLabel}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+DestructiveConfirmDialog.displayName = 'DestructiveConfirmDialog';

--- a/frontend/apps/admin-web/src/components/ForbiddenPage.tsx
+++ b/frontend/apps/admin-web/src/components/ForbiddenPage.tsx
@@ -1,0 +1,101 @@
+import { Link } from 'react-router-dom';
+
+interface ForbiddenPageProps {
+  requiredCapability: string | string[];
+}
+
+/**
+ * 403 page shown when a user navigates directly to a route they lack
+ * the required capability for. Lists the missing capability code in
+ * monospace and links to the Capabilities admin page.
+ */
+export function ForbiddenPage({ requiredCapability }: ForbiddenPageProps) {
+  const caps = Array.isArray(requiredCapability) ? requiredCapability : [requiredCapability];
+
+  return (
+    <section
+      role="alert"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '60vh',
+        padding: 'var(--ppt-space-xl, 24px)',
+        background: 'var(--ppt-bg-app, #f9fafb)',
+        textAlign: 'center',
+      }}
+    >
+      <div
+        style={{
+          maxWidth: '480px',
+          background: 'var(--ppt-bg-surface, #ffffff)',
+          border: '1px solid var(--ppt-border-default, #e5e7eb)',
+          borderRadius: 'var(--ppt-radius-lg, 12px)',
+          padding: 'var(--ppt-space-2xl, 32px)',
+          boxShadow: 'var(--ppt-shadow-card, 0 1px 3px rgba(0,0,0,0.1))',
+        }}
+      >
+        <h1
+          style={{
+            fontSize: 'var(--ppt-text-h1, 1.5rem)',
+            fontWeight: 700,
+            color: 'var(--ppt-fg-primary, #111827)',
+            margin: '0 0 12px',
+          }}
+        >
+          403 — Missing capability
+        </h1>
+        <p
+          style={{
+            fontSize: 'var(--ppt-text-body, 0.875rem)',
+            color: 'var(--ppt-fg-secondary, #374151)',
+            margin: '0 0 16px',
+          }}
+        >
+          Your account does not hold the required{' '}
+          {caps.length === 1 ? 'capability' : 'capabilities'} to view this page:
+        </p>
+        <ul
+          style={{
+            listStyle: 'none',
+            padding: 0,
+            margin: '0 0 20px',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '6px',
+            alignItems: 'center',
+          }}
+        >
+          {caps.map((cap) => (
+            <li key={cap}>
+              <code
+                style={{
+                  fontFamily: 'var(--ppt-font-mono, monospace)',
+                  fontSize: '0.875em',
+                  background: 'var(--ppt-bg-subtle, #f3f4f6)',
+                  padding: '2px 8px',
+                  borderRadius: 'var(--ppt-radius-sm, 4px)',
+                  color: 'var(--ppt-fg-primary, #111827)',
+                }}
+              >
+                {cap}
+              </code>
+            </li>
+          ))}
+        </ul>
+        <Link
+          to="/identity/capabilities"
+          style={{
+            display: 'inline-block',
+            fontSize: 'var(--ppt-text-body, 0.875rem)',
+            color: 'var(--ppt-fg-link, #2563eb)',
+            textDecoration: 'underline',
+          }}
+        >
+          Request access here
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/frontend/apps/admin-web/src/components/MfaWindowChip.test.tsx
+++ b/frontend/apps/admin-web/src/components/MfaWindowChip.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MfaWindowChip } from './MfaWindowChip';
+
+describe('MfaWindowChip', () => {
+  // --- State rendering ---
+
+  it('renders unverified state with correct text', () => {
+    render(<MfaWindowChip state="unverified" />);
+    expect(screen.getByText('MFA · not verified')).toBeDefined();
+  });
+
+  it('renders verified state with MM:SS formatted time', () => {
+    // 5 minutes 30 seconds = 330000 ms
+    render(<MfaWindowChip state="verified" msRemaining={330_000} />);
+    expect(screen.getByText('MFA verified · 05:30')).toBeDefined();
+  });
+
+  it('renders verified state with zero-padded minutes', () => {
+    // 10 minutes = 600000 ms
+    render(<MfaWindowChip state="verified" msRemaining={600_000} />);
+    expect(screen.getByText('MFA verified · 10:00')).toBeDefined();
+  });
+
+  it('renders expiring state with M:SS formatted time (no leading zero on minutes)', () => {
+    // 1 minute 5 seconds = 65000 ms
+    render(<MfaWindowChip state="expiring" msRemaining={65_000} />);
+    expect(screen.getByText('MFA expires · 1:05')).toBeDefined();
+  });
+
+  it('renders expiring state at 0 seconds remaining', () => {
+    render(<MfaWindowChip state="expiring" msRemaining={0} />);
+    expect(screen.getByText('MFA expires · 0:00')).toBeDefined();
+  });
+
+  // --- Aria labels ---
+
+  it('has correct aria-label for unverified', () => {
+    render(<MfaWindowChip state="unverified" />);
+    const el = screen.getByRole('button');
+    expect(el.getAttribute('aria-label')).toContain('MFA not verified');
+  });
+
+  it('has correct aria-label for verified', () => {
+    render(<MfaWindowChip state="verified" msRemaining={300_000} />);
+    const el = screen.getByRole('button');
+    expect(el.getAttribute('aria-label')).toContain('MFA verified');
+    expect(el.getAttribute('aria-label')).toContain('05:00');
+  });
+
+  it('has correct aria-label for expiring', () => {
+    render(<MfaWindowChip state="expiring" msRemaining={90_000} />);
+    const el = screen.getByRole('button');
+    expect(el.getAttribute('aria-label')).toContain('expiring');
+    expect(el.getAttribute('aria-label')).toContain('1:30');
+  });
+
+  // --- Pulsing dot ---
+
+  it('does not render dot for unverified state', () => {
+    const { container } = render(<MfaWindowChip state="unverified" />);
+    expect(container.querySelector('.ppt-mfa-chip__dot')).toBeNull();
+  });
+
+  it('renders dot for verified state', () => {
+    const { container } = render(<MfaWindowChip state="verified" msRemaining={300_000} />);
+    expect(container.querySelector('.ppt-mfa-chip__dot')).not.toBeNull();
+  });
+
+  it('renders dot for expiring state', () => {
+    const { container } = render(<MfaWindowChip state="expiring" msRemaining={60_000} />);
+    expect(container.querySelector('.ppt-mfa-chip__dot')).not.toBeNull();
+  });
+
+  // --- Click handler ---
+
+  it('calls onClick when clicked', async () => {
+    const user = userEvent.setup();
+    const handler = vi.fn();
+    render(<MfaWindowChip state="unverified" onClick={handler} />);
+    await user.click(screen.getByRole('button'));
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when clicked without onClick', async () => {
+    const user = userEvent.setup();
+    render(<MfaWindowChip state="unverified" />);
+    // Should not throw
+    await user.click(screen.getByRole('button'));
+  });
+
+  it('calls onClick on Enter key press', async () => {
+    const user = userEvent.setup();
+    const handler = vi.fn();
+    render(<MfaWindowChip state="verified" msRemaining={300_000} onClick={handler} />);
+    const btn = screen.getByRole('button');
+    btn.focus();
+    await user.keyboard('{Enter}');
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  // --- CSS classes ---
+
+  it('applies correct CSS class for each state', () => {
+    const { rerender, container } = render(<MfaWindowChip state="unverified" />);
+    expect(container.querySelector('.ppt-mfa-chip--unverified')).not.toBeNull();
+
+    rerender(<MfaWindowChip state="verified" msRemaining={300_000} />);
+    expect(container.querySelector('.ppt-mfa-chip--verified')).not.toBeNull();
+
+    rerender(<MfaWindowChip state="expiring" msRemaining={60_000} />);
+    expect(container.querySelector('.ppt-mfa-chip--expiring')).not.toBeNull();
+  });
+
+  it('adds clickable class when onClick provided', () => {
+    const { container } = render(<MfaWindowChip state="unverified" onClick={() => {}} />);
+    expect(container.querySelector('.ppt-mfa-chip--clickable')).not.toBeNull();
+  });
+
+  it('does not add clickable class when onClick absent', () => {
+    const { container } = render(<MfaWindowChip state="unverified" />);
+    expect(container.querySelector('.ppt-mfa-chip--clickable')).toBeNull();
+  });
+
+  // --- Time formatting edge cases ---
+
+  it('rounds up partial seconds in verified label', () => {
+    // 5001 ms → ceil(5.001) = 6 seconds
+    render(<MfaWindowChip state="verified" msRemaining={5_001} />);
+    expect(screen.getByText('MFA verified · 00:06')).toBeDefined();
+  });
+
+  it('shows 00:01 for verified at exactly 1000ms', () => {
+    render(<MfaWindowChip state="verified" msRemaining={1_000} />);
+    expect(screen.getByText('MFA verified · 00:01')).toBeDefined();
+  });
+});

--- a/frontend/apps/admin-web/src/components/MfaWindowChip.tsx
+++ b/frontend/apps/admin-web/src/components/MfaWindowChip.tsx
@@ -1,0 +1,298 @@
+/**
+ * MfaWindowChip — presentational header chip showing MFA verification window state.
+ *
+ * Three states:
+ *   - unverified: gray pill, "MFA · not verified"
+ *   - verified (>2min):  green pill with pulsing dot, "MFA verified · MM:SS"
+ *   - expiring (≤2min): amber pill with pulsing dot, "MFA expires · M:SS"
+ *
+ * Context: MfaWindowProvider reads useAdminAuth().token and decodes the JWT for
+ * the MFA-verified claim (`mfa_verified_at` + `mfa_window_seconds`).
+ *
+ * TODO(backend): api-server must include `mfa_verified_at` and `mfa_window_seconds`
+ * in the access-token claims for this chip to show verified/expiring states.
+ * Until that claim is present the provider stubs { state: 'unverified', msRemaining: 0 }.
+ */
+
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import { useAdminAuth } from '../auth/AdminAuthContext';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type MfaWindowState = 'unverified' | 'verified' | 'expiring';
+
+export interface MfaWindowChipProps {
+  state: MfaWindowState;
+  msRemaining?: number;
+  onClick?: () => void;
+}
+
+interface MfaWindowContextValue {
+  state: MfaWindowState;
+  msRemaining: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Decode a JWT payload without verifying the signature.
+ * Only used client-side for display purposes — never for auth decisions.
+ */
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+    const padded = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const json = atob(padded.padEnd(padded.length + ((4 - (padded.length % 4)) % 4), '='));
+    return JSON.parse(json) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+const TWO_MINUTES_MS = 2 * 60 * 1000;
+
+function deriveWindowState(token: string | null): MfaWindowContextValue {
+  if (!token) return { state: 'unverified', msRemaining: 0 };
+
+  const payload = decodeJwtPayload(token);
+  if (!payload) return { state: 'unverified', msRemaining: 0 };
+
+  // TODO(backend): depend on `mfa_verified_at` (unix seconds) and
+  // `mfa_window_seconds` claims emitted by api-server's JWT minting.
+  const mfaVerifiedAt = payload.mfa_verified_at;
+  const mfaWindowSec = payload.mfa_window_seconds;
+
+  if (typeof mfaVerifiedAt !== 'number' || typeof mfaWindowSec !== 'number') {
+    return { state: 'unverified', msRemaining: 0 };
+  }
+
+  const expiresAt = (mfaVerifiedAt + mfaWindowSec) * 1000;
+  const msRemaining = Math.max(0, expiresAt - Date.now());
+
+  if (msRemaining === 0) return { state: 'unverified', msRemaining: 0 };
+  if (msRemaining <= TWO_MINUTES_MS) return { state: 'expiring', msRemaining };
+  return { state: 'verified', msRemaining };
+}
+
+// ---------------------------------------------------------------------------
+// Context + Provider
+// ---------------------------------------------------------------------------
+
+const MfaWindowContext = createContext<MfaWindowContextValue | null>(null);
+
+export function MfaWindowProvider({ children }: { children: ReactNode }) {
+  const { token } = useAdminAuth();
+  const [value, setValue] = useState<MfaWindowContextValue>(() => deriveWindowState(token));
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const tick = useCallback(() => {
+    setValue(deriveWindowState(token));
+  }, [token]);
+
+  // Recompute every second so the countdown stays live.
+  useEffect(() => {
+    setValue(deriveWindowState(token));
+    if (timerRef.current) clearInterval(timerRef.current);
+    timerRef.current = setInterval(tick, 1000);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [token, tick]);
+
+  return <MfaWindowContext.Provider value={value}>{children}</MfaWindowContext.Provider>;
+}
+
+MfaWindowProvider.displayName = 'MfaWindowProvider';
+
+/** Returns current MFA window state derived from the active token. */
+export function useMfaWindow(): MfaWindowContextValue {
+  const ctx = useContext(MfaWindowContext);
+  if (!ctx) throw new Error('useMfaWindow must be used inside <MfaWindowProvider>');
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Format helpers
+// ---------------------------------------------------------------------------
+
+/** Format ms → "MM:SS" */
+function fmtMmSs(ms: number): string {
+  const totalSec = Math.max(0, Math.ceil(ms / 1000));
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+}
+
+/** Format ms → "M:SS" (no leading zero on minutes) */
+function fmtMSs(ms: number): string {
+  const totalSec = Math.max(0, Math.ceil(ms / 1000));
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+// ---------------------------------------------------------------------------
+// Styles (injected once as a <style> tag)
+// ---------------------------------------------------------------------------
+
+const STYLE_ID = 'ppt-mfa-window-chip-styles';
+
+function ensureStyles() {
+  if (typeof document === 'undefined') return;
+  if (document.getElementById(STYLE_ID)) return;
+  const el = document.createElement('style');
+  el.id = STYLE_ID;
+  el.textContent = `
+    @keyframes ppt-mfa-pulse {
+      0%, 100% { opacity: 1; }
+      50%       { opacity: 0.4; }
+    }
+    .ppt-mfa-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 10px;
+      border-radius: 999px;
+      font-size: 12px;
+      font-weight: 500;
+      font-variant-numeric: tabular-nums;
+      cursor: default;
+      border: none;
+      background: none;
+      user-select: none;
+      transition: filter 120ms ease;
+      line-height: 1.4;
+    }
+    .ppt-mfa-chip--clickable {
+      cursor: pointer;
+    }
+    .ppt-mfa-chip--clickable:hover {
+      filter: brightness(0.96);
+    }
+    .ppt-mfa-chip--clickable:focus-visible {
+      outline: 2px solid var(--ppt-brand-500, #3b82f6);
+      outline-offset: 2px;
+    }
+    .ppt-mfa-chip--unverified {
+      background: var(--ppt-neutral-100, #f3f4f6);
+      color: var(--ppt-neutral-700, #374151);
+    }
+    .ppt-mfa-chip--verified {
+      background: var(--ppt-success-100, #d1fae5);
+      color: var(--ppt-success-800, #065f46);
+    }
+    .ppt-mfa-chip--expiring {
+      background: var(--ppt-warning-100, #fef3c7);
+      color: var(--ppt-warning-800, #92400e);
+    }
+    .ppt-mfa-chip__dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      flex-shrink: 0;
+      animation: ppt-mfa-pulse 1.5s ease-in-out infinite;
+    }
+    .ppt-mfa-chip--verified .ppt-mfa-chip__dot {
+      background: var(--ppt-success-500, #10b981);
+    }
+    .ppt-mfa-chip--expiring .ppt-mfa-chip__dot {
+      background: var(--ppt-warning-500, #f59e0b);
+    }
+  `;
+  document.head.appendChild(el);
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function MfaWindowChip({ state, msRemaining = 0, onClick }: MfaWindowChipProps) {
+  ensureStyles();
+
+  const isClickable = Boolean(onClick);
+
+  const label = useMemo<string>(() => {
+    switch (state) {
+      case 'unverified':
+        return 'MFA · not verified';
+      case 'verified':
+        return `MFA verified · ${fmtMmSs(msRemaining)}`;
+      case 'expiring':
+        return `MFA expires · ${fmtMSs(msRemaining)}`;
+    }
+  }, [state, msRemaining]);
+
+  const ariaLabel = useMemo<string>(() => {
+    switch (state) {
+      case 'unverified':
+        return 'MFA not verified. Click to verify.';
+      case 'verified':
+        return `MFA verified. Window expires in ${fmtMmSs(msRemaining)}.`;
+      case 'expiring':
+        return `MFA window expiring soon. ${fmtMSs(msRemaining)} remaining.`;
+    }
+  }, [state, msRemaining]);
+
+  const className = [
+    'ppt-mfa-chip',
+    `ppt-mfa-chip--${state}`,
+    isClickable ? 'ppt-mfa-chip--clickable' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const showDot = state === 'verified' || state === 'expiring';
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!onClick) return;
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onClick();
+      }
+    },
+    [onClick]
+  );
+
+  return (
+    <button
+      type="button"
+      className={className}
+      aria-label={ariaLabel}
+      onClick={onClick}
+      onKeyDown={handleKeyDown}
+      tabIndex={isClickable ? 0 : -1}
+    >
+      {showDot && <span className="ppt-mfa-chip__dot" aria-hidden="true" />}
+      <span>{label}</span>
+    </button>
+  );
+}
+
+MfaWindowChip.displayName = 'MfaWindowChip';
+
+// ---------------------------------------------------------------------------
+// Re-export a connected version that reads from context (convenience)
+// ---------------------------------------------------------------------------
+
+export function ConnectedMfaWindowChip({ onClick }: { onClick?: () => void }) {
+  const { state, msRemaining } = useMfaWindow();
+  return <MfaWindowChip state={state} msRemaining={msRemaining} onClick={onClick} />;
+}
+
+ConnectedMfaWindowChip.displayName = 'ConnectedMfaWindowChip';

--- a/frontend/apps/admin-web/src/components/ProtectedRoute.tsx
+++ b/frontend/apps/admin-web/src/components/ProtectedRoute.tsx
@@ -1,8 +1,20 @@
+import { useCapabilityChecker } from '@ppt/admin-ui';
 import type { ReactNode } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 
 import { useAdminAuth } from '../auth/AdminAuthContext';
 import { usePrincipalCapabilities } from '../auth/usePrincipalCapabilities';
+import { ForbiddenPage } from './ForbiddenPage';
+
+interface ProtectedRouteProps {
+  children: ReactNode;
+  /**
+   * Optional capability gate. If provided, the user must hold AT LEAST ONE
+   * of the listed capabilities; otherwise a 403 page is shown.
+   * The platform-principal check always runs regardless of this prop.
+   */
+  requiredCapability?: string | string[];
+}
 
 /**
  * Guards the admin tree:
@@ -11,15 +23,17 @@ import { usePrincipalCapabilities } from '../auth/usePrincipalCapabilities';
  *     access token) → 403 page. Reaching the admin host with org-scoped
  *     credentials must not render the admin shell, even read-only.
  *   - Authenticated platform principal → render `children`.
+ *   - `requiredCapability` provided but user lacks ALL of them → 403 page.
  *
  * The platform-principal check waits for `usePrincipalCapabilities` to
  * resolve; until then it shows a minimal loading state to avoid flashing
  * the dashboard at non-admins on first paint.
  */
-export function ProtectedRoute({ children }: { children: ReactNode }) {
+export function ProtectedRoute({ children, requiredCapability }: ProtectedRouteProps) {
   const auth = useAdminAuth();
   const location = useLocation();
   const { isPlatformPrincipal, isLoading } = usePrincipalCapabilities();
+  const { capabilities } = useCapabilityChecker();
 
   if (!auth.isAuthenticated) {
     return <Navigate to="/login" state={{ from: location.pathname }} replace />;
@@ -38,5 +52,15 @@ export function ProtectedRoute({ children }: { children: ReactNode }) {
       </section>
     );
   }
+
+  // Per-route capability check: user must hold at least one of the required caps.
+  if (requiredCapability !== undefined) {
+    const required = Array.isArray(requiredCapability) ? requiredCapability : [requiredCapability];
+    const hasAny = required.some((cap) => capabilities.includes(cap as never));
+    if (!hasAny) {
+      return <ForbiddenPage requiredCapability={required} />;
+    }
+  }
+
   return <>{children}</>;
 }

--- a/frontend/apps/admin-web/src/pages/CapabilitiesAdminPage.tsx
+++ b/frontend/apps/admin-web/src/pages/CapabilitiesAdminPage.tsx
@@ -1,0 +1,1096 @@
+/**
+ * CapabilitiesAdminPage — /identity/capabilities
+ *
+ * Two views:
+ *   - Registry view (?view=registry or default): card grid of all 17 capability strings.
+ *   - Per-user view (?view=user&id=<userId>): table of grants for one user.
+ *
+ * Page gating: memberships_grant (enforced by ProtectedRoute in App.tsx).
+ *
+ * Grant flow:
+ *   1. Open drawer → fill capability + optional expires_at.
+ *   2. For tenant_purge / principal_kind_escalate: AuditReasonPrompt required (min 30 chars).
+ *   3. For principal_kind_escalate: extra warning banner + 3000ms confirm delay.
+ *   4. Submit → MFA challenge → POST /api/v1/admin/capabilities/users/:id/grant.
+ *
+ * Revoke flow:
+ *   - Per-row button → MFA challenge (+ AuditReasonPrompt for high-risk caps)
+ *     → DELETE /api/v1/admin/capabilities/users/:id/grant/:grantId
+ */
+
+import { CAPABILITIES, useMfaChallenge } from '@ppt/admin-ui';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+import { useAdminAuth } from '../auth/AdminAuthContext';
+import { AuditReasonPrompt, useAuditReasonValid } from '../components/AuditReasonPrompt';
+
+// ---------------------------------------------------------------------------
+// Constants & helpers
+// ---------------------------------------------------------------------------
+
+// TODO: replace stub descriptions with data from GET /api/v1/admin/capabilities/registry
+const CAPABILITY_DESCRIPTIONS: Record<string, string> = {
+  agencies_read: 'View agencies and their memberships.',
+  agencies_write: 'Create and edit agency records.',
+  agencies_suspend: 'Suspend or reinstate an agency.',
+  users_read: 'List and inspect user accounts.',
+  users_write: 'Edit user profile fields and metadata.',
+  users_impersonate: 'Impersonate a user for support.',
+  memberships_grant: 'Grant capabilities to platform principals.',
+  memberships_revoke: 'Revoke capabilities from principals.',
+  site_settings_read: 'View tenant-wide site settings.',
+  site_settings_write: 'Modify site settings.',
+  mobile_config_write: 'Push mobile-app configuration.',
+  feature_flags_write: 'Toggle and configure feature flags.',
+  tenant_export: 'Trigger a full tenant data export.',
+  tenant_purge: 'Permanently delete a tenant and all its data.',
+  tenant_restore: 'Restore a tenant from an archive.',
+  audit_read: 'View the platform audit log.',
+  principal_kind_escalate: 'Escalate a user to a higher principal kind.',
+};
+
+const HIGH_RISK_CAPS = new Set(['tenant_purge', 'principal_kind_escalate']);
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  try {
+    return new Intl.DateTimeFormat('en-GB', {
+      dateStyle: 'short',
+      timeStyle: 'short',
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
+function timeAgo(iso: string | null): string {
+  if (!iso) return 'unknown';
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface CapabilityGrant {
+  id: string;
+  capability: string;
+  granted_at: string;
+  granted_by: string;
+  expires_at: string | null;
+  revoked_at: string | null;
+  status: 'active' | 'expired' | 'revoked';
+}
+
+interface UserCapabilitiesResponse {
+  user_id: string;
+  email: string;
+  grants: CapabilityGrant[];
+  last_change_at: string | null;
+  last_change_by: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Styles injection
+// ---------------------------------------------------------------------------
+
+const STYLE_ID = 'ppt-cap-page-styles';
+
+function ensureStyles() {
+  if (typeof document === 'undefined') return;
+  if (document.getElementById(STYLE_ID)) return;
+  const el = document.createElement('style');
+  el.id = STYLE_ID;
+  el.textContent = `
+    /* ---- Page shell ---- */
+    .cap-page {
+      padding: 24px 32px;
+      background: var(--ppt-bg-app, #f9fafb);
+      min-height: 100%;
+    }
+    .cap-page__header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 24px;
+      flex-wrap: wrap;
+    }
+    .cap-page__title {
+      font-size: 1.375rem;
+      font-weight: 700;
+      color: var(--ppt-fg-primary, #111827);
+      margin: 0;
+    }
+    .cap-page__subtitle {
+      font-size: 0.8125rem;
+      color: var(--ppt-fg-muted, #6b7280);
+      margin: 4px 0 0;
+    }
+    .cap-page__actions {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-shrink: 0;
+    }
+
+    /* ---- Registry card grid ---- */
+    .cap-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      gap: 12px;
+    }
+    .cap-card {
+      background: var(--ppt-bg-surface, #ffffff);
+      border: 1px solid var(--ppt-border-default, #e5e7eb);
+      border-radius: var(--ppt-radius-lg, 12px);
+      padding: 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      transition: box-shadow 120ms ease;
+    }
+    .cap-card:hover {
+      box-shadow: var(--ppt-shadow-card, 0 2px 8px rgba(0,0,0,0.08));
+    }
+    .cap-card__name {
+      font-family: var(--ppt-font-mono, 'JetBrains Mono', monospace);
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--ppt-fg-primary, #111827);
+    }
+    .cap-card__desc {
+      font-size: 12px;
+      color: var(--ppt-fg-secondary, #374151);
+      line-height: 1.5;
+      flex: 1;
+    }
+    .cap-card__footer {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      margin-top: 4px;
+    }
+    .cap-card__holders {
+      font-size: 12px;
+      color: var(--ppt-fg-muted, #6b7280);
+      font-variant-numeric: tabular-nums;
+    }
+    .cap-card__link {
+      font-size: 12px;
+      color: var(--ppt-fg-link, #2563eb);
+      text-decoration: none;
+      background: none;
+      border: none;
+      cursor: pointer;
+      padding: 0;
+    }
+    .cap-card__link:hover { text-decoration: underline; }
+
+    /* ---- Per-user table ---- */
+    .cap-table-wrap {
+      overflow-x: auto;
+      background: var(--ppt-bg-surface, #ffffff);
+      border: 1px solid var(--ppt-border-default, #e5e7eb);
+      border-radius: var(--ppt-radius-lg, 12px);
+    }
+    .cap-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 13px;
+    }
+    .cap-table thead {
+      background: var(--ppt-bg-subtle, #f3f4f6);
+    }
+    .cap-table th {
+      padding: 10px 14px;
+      text-align: left;
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--ppt-fg-muted, #6b7280);
+      white-space: nowrap;
+      border-bottom: 1px solid var(--ppt-border-default, #e5e7eb);
+    }
+    .cap-table td {
+      padding: 10px 14px;
+      border-bottom: 1px solid var(--ppt-border-subtle, #f3f4f6);
+      vertical-align: middle;
+    }
+    .cap-table tbody tr:last-child td { border-bottom: none; }
+    .cap-table tbody tr.cap-row--expired { opacity: 0.55; }
+    .cap-mono {
+      font-family: var(--ppt-font-mono, 'JetBrains Mono', monospace);
+      font-size: 12px;
+    }
+
+    /* ---- Status pills ---- */
+    .cap-pill {
+      display: inline-flex;
+      align-items: center;
+      padding: 2px 8px;
+      border-radius: 999px;
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+    }
+    .cap-pill--active {
+      background: var(--ppt-success-100, #d1fae5);
+      color: var(--ppt-success-800, #065f46);
+    }
+    .cap-pill--expired, .cap-pill--revoked {
+      background: var(--ppt-bg-subtle, #f3f4f6);
+      color: var(--ppt-fg-muted, #6b7280);
+    }
+
+    /* ---- Buttons ---- */
+    .cap-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 7px 14px;
+      border-radius: var(--ppt-radius-md, 8px);
+      font-size: 13px;
+      font-weight: 500;
+      cursor: pointer;
+      border: none;
+      transition: background 120ms ease;
+      outline: none;
+    }
+    .cap-btn:focus-visible { box-shadow: 0 0 0 3px rgba(37,99,235,0.35); }
+    .cap-btn--primary {
+      background: var(--ppt-brand-600, #2563eb);
+      color: #fff;
+    }
+    .cap-btn--primary:hover { background: var(--ppt-brand-700, #1d4ed8); }
+    .cap-btn--secondary {
+      background: transparent;
+      color: var(--ppt-fg-secondary, #374151);
+      border: 1px solid var(--ppt-border-default, #e5e7eb);
+    }
+    .cap-btn--secondary:hover { background: var(--ppt-bg-hover, #f3f4f6); }
+    .cap-btn--danger {
+      background: transparent;
+      color: var(--ppt-danger-600, #dc2626);
+      border: 1px solid var(--ppt-danger-300, #fca5a5);
+      font-size: 12px;
+      padding: 4px 10px;
+    }
+    .cap-btn--danger:hover { background: var(--ppt-danger-50, #fef2f2); }
+    .cap-btn:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
+
+    /* ---- Grant drawer ---- */
+    .cap-drawer-backdrop {
+      position: fixed;
+      inset: 0;
+      z-index: 800;
+      background: rgba(0,0,0,0.35);
+    }
+    .cap-drawer {
+      position: fixed;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      width: 460px;
+      background: var(--ppt-bg-surface, #ffffff);
+      box-shadow: -4px 0 24px rgba(0,0,0,0.12);
+      z-index: 801;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    .cap-drawer__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 20px 24px 16px;
+      border-bottom: 1px solid var(--ppt-border-default, #e5e7eb);
+      flex-shrink: 0;
+    }
+    .cap-drawer__title {
+      font-size: 15px;
+      font-weight: 600;
+      color: var(--ppt-fg-primary, #111827);
+      margin: 0;
+    }
+    .cap-drawer__close {
+      background: none;
+      border: none;
+      cursor: pointer;
+      color: var(--ppt-fg-muted, #6b7280);
+      padding: 4px;
+      border-radius: 4px;
+      display: flex;
+      align-items: center;
+    }
+    .cap-drawer__close:hover { color: var(--ppt-fg-primary, #111827); }
+    .cap-drawer__body {
+      flex: 1;
+      overflow-y: auto;
+      padding: 20px 24px;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+    .cap-drawer__footer {
+      padding: 16px 24px;
+      border-top: 1px solid var(--ppt-border-default, #e5e7eb);
+      display: flex;
+      justify-content: flex-end;
+      gap: 10px;
+      flex-shrink: 0;
+    }
+    .cap-field {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .cap-field__label {
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--ppt-fg-secondary, #374151);
+    }
+    .cap-field__select, .cap-field__input {
+      width: 100%;
+      box-sizing: border-box;
+      font-size: 13px;
+      padding: 8px 10px;
+      border: 1px solid var(--ppt-border-default, #e5e7eb);
+      border-radius: var(--ppt-radius-md, 8px);
+      background: var(--ppt-bg-input, #ffffff);
+      color: var(--ppt-fg-primary, #111827);
+      outline: none;
+      transition: border-color 120ms ease, box-shadow 120ms ease;
+    }
+    .cap-field__select:focus, .cap-field__input:focus {
+      border-color: var(--ppt-brand-500, #3b82f6);
+      box-shadow: 0 0 0 2px rgba(59,130,246,0.25);
+    }
+
+    /* ---- Warning callout ---- */
+    .cap-warning {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      padding: 12px 14px;
+      background: var(--ppt-warning-50, #fffbeb);
+      border: 1px solid var(--ppt-warning-300, #fcd34d);
+      border-radius: var(--ppt-radius-md, 8px);
+      font-size: 13px;
+      color: var(--ppt-warning-800, #92400e);
+      line-height: 1.5;
+    }
+
+    /* ---- Inline error banner ---- */
+    .cap-error-banner {
+      padding: 10px 14px;
+      background: var(--ppt-danger-50, #fef2f2);
+      border: 1px solid var(--ppt-danger-300, #fca5a5);
+      border-radius: var(--ppt-radius-md, 8px);
+      font-size: 13px;
+      color: var(--ppt-danger-800, #991b1b);
+    }
+
+    /* ---- Loading skeleton ---- */
+    .cap-skeleton {
+      background: var(--ppt-bg-subtle, #f3f4f6);
+      border-radius: 6px;
+      animation: cap-shimmer 1.4s ease infinite;
+    }
+    @keyframes cap-shimmer {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.5; }
+    }
+
+    /* ---- Spinner ---- */
+    .cap-spinner {
+      width: 14px;
+      height: 14px;
+      border: 2px solid rgba(255,255,255,0.4);
+      border-top-color: #fff;
+      border-radius: 50%;
+      animation: cap-spin 0.7s linear infinite;
+      flex-shrink: 0;
+    }
+    @keyframes cap-spin { to { transform: rotate(360deg); } }
+    .cap-spinner--dark {
+      border-color: rgba(0,0,0,0.1);
+      border-top-color: var(--ppt-fg-secondary, #374151);
+    }
+  `;
+  document.head.appendChild(el);
+}
+
+// ---------------------------------------------------------------------------
+// Registry view
+// ---------------------------------------------------------------------------
+
+interface RegistryViewProps {
+  onViewUser: (userId: string) => void;
+}
+
+function RegistryView({ onViewUser }: RegistryViewProps) {
+  // TODO: fetch holder counts from GET /api/v1/admin/capabilities/registry
+  // when backend supports it; currently returns placeholder "—".
+  return (
+    <div className="cap-grid">
+      {CAPABILITIES.map((cap) => (
+        <article key={cap} className="cap-card">
+          <span className="cap-card__name">{cap}</span>
+          <span className="cap-card__desc">
+            {CAPABILITY_DESCRIPTIONS[cap] ?? 'No description available.'}
+          </span>
+          <div className="cap-card__footer">
+            <span className="cap-card__holders">Holders: —</span>
+            <button type="button" className="cap-card__link" onClick={() => onViewUser('me')}>
+              View holders →
+            </button>
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Per-user view
+// ---------------------------------------------------------------------------
+
+interface UserViewProps {
+  userId: string;
+  token: string | null;
+  onSwitchToRegistry: () => void;
+}
+
+function UserView({ userId, token, onSwitchToRegistry }: UserViewProps) {
+  const queryClient = useQueryClient();
+  const { prompt: promptMfa } = useMfaChallenge();
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [revokeState, setRevokeState] = useState<{
+    grantId: string;
+    capability: string;
+  } | null>(null);
+
+  const isMe = userId === 'me';
+
+  const { data, isLoading, error, refetch } = useQuery<UserCapabilitiesResponse>({
+    queryKey: ['admin', 'capabilities', 'user', userId],
+    queryFn: async () => {
+      const url = isMe
+        ? '/api/v1/admin/capabilities/me'
+        : `/api/v1/admin/capabilities/users/${userId}`;
+      const headers: Record<string, string> = {};
+      if (token) headers.Authorization = `Bearer ${token}`;
+      const res = await fetch(url, { headers, credentials: 'include' });
+      if (!res.ok) {
+        // Try fallback to /me on 404
+        if (!isMe && res.status === 404) {
+          const fallback = await fetch('/api/v1/admin/capabilities/me', {
+            headers,
+            credentials: 'include',
+          });
+          if (!fallback.ok) throw new Error(`Unable to load capabilities: ${fallback.status}`);
+          return fallback.json() as Promise<UserCapabilitiesResponse>;
+        }
+        throw new Error(`Unable to load capabilities: ${res.status}`);
+      }
+      return res.json() as Promise<UserCapabilitiesResponse>;
+    },
+    staleTime: 30_000,
+    retry: 1,
+  });
+
+  const revokeMutation = useMutation({
+    mutationFn: async ({ grantId, reason }: { grantId: string; reason?: string }) => {
+      const mfaOk = await promptMfa('Revoke capability');
+      if (!mfaOk) throw new Error('MFA cancelled');
+
+      const headers: Record<string, string> = { 'X-MFA-Recent': '1' };
+      if (token) headers.Authorization = `Bearer ${token}`;
+      if (reason) headers['Content-Type'] = 'application/json';
+
+      const res = await fetch(`/api/v1/admin/capabilities/users/${userId}/grant/${grantId}`, {
+        method: 'DELETE',
+        headers,
+        credentials: 'include',
+        ...(reason ? { body: JSON.stringify({ reason }) } : {}),
+      });
+      if (!res.ok) throw new Error(`Revoke failed: ${res.status}`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'capabilities', 'user', userId] });
+      setRevokeState(null);
+    },
+  });
+
+  const activeGrants = data?.grants.filter((g) => g.status === 'active') ?? [];
+  const lastChange = data?.last_change_at ?? null;
+  const lastChangeBy = data?.last_change_by ?? null;
+
+  if (isLoading) {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {[...Array(4)].map((_, i) => (
+          // skeleton rows use index as key — they have no stable identity
+          <div key={i} className="cap-skeleton" style={{ height: 40 }} />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="cap-error-banner">
+        {error instanceof Error ? error.message : 'Unable to load capabilities. Try again.'}
+        <button
+          type="button"
+          className="cap-btn cap-btn--secondary"
+          onClick={() => refetch()}
+          style={{ marginLeft: 12 }}
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {/* Revoke reason prompt for high-risk caps */}
+      {revokeState && (
+        <RevokeReasonDialog
+          capability={revokeState.capability}
+          onConfirm={(reason) => {
+            revokeMutation.mutate({ grantId: revokeState.grantId, reason });
+          }}
+          onCancel={() => setRevokeState(null)}
+          isPending={revokeMutation.isPending}
+          error={revokeMutation.error instanceof Error ? revokeMutation.error.message : undefined}
+        />
+      )}
+
+      <div className="cap-page__header">
+        <div>
+          <h1 className="cap-page__title">Capabilities · {data?.email ?? userId}</h1>
+          <p className="cap-page__subtitle">
+            {activeGrants.length} active grant{activeGrants.length !== 1 ? 's' : ''}
+            {lastChange && lastChangeBy
+              ? ` · last change ${timeAgo(lastChange)} by ${lastChangeBy}`
+              : ''}
+          </p>
+        </div>
+        <div className="cap-page__actions">
+          <button type="button" className="cap-btn cap-btn--secondary" onClick={onSwitchToRegistry}>
+            Registry
+          </button>
+          <button
+            type="button"
+            className="cap-btn cap-btn--primary"
+            onClick={() => setDrawerOpen(true)}
+          >
+            + Grant capability
+          </button>
+        </div>
+      </div>
+
+      {revokeMutation.error && (
+        <div className="cap-error-banner" style={{ marginBottom: 16 }}>
+          {revokeMutation.error instanceof Error
+            ? revokeMutation.error.message
+            : 'Revoke failed. Try again.'}
+        </div>
+      )}
+
+      <div className="cap-table-wrap">
+        <table className="cap-table">
+          <thead>
+            <tr>
+              <th>Capability</th>
+              <th>Granted</th>
+              <th>Granted by</th>
+              <th>Expires</th>
+              <th>Status</th>
+              <th aria-label="Actions" />
+            </tr>
+          </thead>
+          <tbody>
+            {(data?.grants ?? []).length === 0 && (
+              <tr>
+                <td
+                  colSpan={6}
+                  style={{
+                    textAlign: 'center',
+                    color: 'var(--ppt-fg-muted, #6b7280)',
+                    padding: '24px',
+                  }}
+                >
+                  No capability grants found.
+                </td>
+              </tr>
+            )}
+            {(data?.grants ?? []).map((grant) => {
+              const isExpiredOrRevoked = grant.status !== 'active';
+              const isHighRisk = HIGH_RISK_CAPS.has(grant.capability);
+              return (
+                <tr key={grant.id} className={isExpiredOrRevoked ? 'cap-row--expired' : ''}>
+                  <td>
+                    <code className="cap-mono">{grant.capability}</code>
+                  </td>
+                  <td style={{ whiteSpace: 'nowrap' }}>{formatDate(grant.granted_at)}</td>
+                  <td>
+                    <code className="cap-mono">{grant.granted_by}</code>
+                  </td>
+                  <td style={{ whiteSpace: 'nowrap' }}>
+                    {grant.expires_at ? formatDate(grant.expires_at) : '—'}
+                  </td>
+                  <td>
+                    <span className={`cap-pill cap-pill--${grant.status}`}>{grant.status}</span>
+                  </td>
+                  <td>
+                    {!isExpiredOrRevoked && (
+                      <button
+                        type="button"
+                        className="cap-btn cap-btn--danger"
+                        disabled={revokeMutation.isPending}
+                        onClick={() => {
+                          if (isHighRisk) {
+                            setRevokeState({ grantId: grant.id, capability: grant.capability });
+                          } else {
+                            revokeMutation.mutate({ grantId: grant.id });
+                          }
+                        }}
+                      >
+                        Revoke
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {drawerOpen && (
+        <GrantDrawer
+          userId={userId}
+          token={token}
+          onClose={() => setDrawerOpen(false)}
+          onSuccess={() => {
+            setDrawerOpen(false);
+            queryClient.invalidateQueries({
+              queryKey: ['admin', 'capabilities', 'user', userId],
+            });
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Revoke reason dialog (for high-risk caps only)
+// ---------------------------------------------------------------------------
+
+interface RevokeReasonDialogProps {
+  capability: string;
+  onConfirm: (reason: string) => void;
+  onCancel: () => void;
+  isPending: boolean;
+  error?: string;
+}
+
+function RevokeReasonDialog({
+  capability,
+  onConfirm,
+  onCancel,
+  isPending,
+  error,
+}: RevokeReasonDialogProps) {
+  const [reason, setReason] = useState('');
+  const action =
+    capability === 'tenant_purge' ? 'grant_tenant_purge' : 'grant_principal_kind_escalate';
+  const isValid = useAuditReasonValid(reason, 30);
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 900,
+        background: 'rgba(0,0,0,0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 16,
+      }}
+    >
+      <div
+        style={{
+          maxWidth: 480,
+          width: '100%',
+          background: 'var(--ppt-bg-surface, #fff)',
+          borderRadius: 'var(--ppt-radius-lg, 12px)',
+          padding: 24,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 16,
+          boxShadow: 'var(--ppt-shadow-modal, 0 10px 40px rgba(0,0,0,0.15))',
+        }}
+      >
+        <h2
+          style={{
+            margin: 0,
+            fontSize: 16,
+            fontWeight: 600,
+            color: 'var(--ppt-danger-700, #b91c1c)',
+          }}
+        >
+          Revoke high-risk capability
+        </h2>
+        <p style={{ margin: 0, fontSize: 13, color: 'var(--ppt-fg-secondary, #374151)' }}>
+          Revoking <code className="cap-mono">{capability}</code> requires an audit reason.
+        </p>
+        <AuditReasonPrompt action={action as never} value={reason} onChange={setReason} required />
+        {error && <div className="cap-error-banner">{error}</div>}
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10 }}>
+          <button
+            type="button"
+            className="cap-btn cap-btn--secondary"
+            onClick={onCancel}
+            disabled={isPending}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="cap-btn cap-btn--danger"
+            disabled={!isValid || isPending}
+            onClick={() => onConfirm(reason)}
+          >
+            {isPending && <span className="cap-spinner cap-spinner--dark" />}
+            Revoke
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Grant capability drawer
+// ---------------------------------------------------------------------------
+
+interface GrantDrawerProps {
+  userId: string;
+  token: string | null;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+function GrantDrawer({ userId, token, onClose, onSuccess }: GrantDrawerProps) {
+  const { prompt: promptMfa } = useMfaChallenge();
+  const [capability, setCapability] = useState('');
+  const [expiresAt, setExpiresAt] = useState('');
+  const [reason, setReason] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, setIsPending] = useState(false);
+  const [delayRemaining, setDelayRemaining] = useState(0);
+  const delayTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const isHighRisk = HIGH_RISK_CAPS.has(capability);
+  const isEscalate = capability === 'principal_kind_escalate';
+  const requiresReason = isHighRisk;
+  const reasonAction = isHighRisk
+    ? capability === 'tenant_purge'
+      ? 'grant_tenant_purge'
+      : 'grant_principal_kind_escalate'
+    : null;
+  const reasonIsValid = useAuditReasonValid(reason, 30);
+  const reasonSatisfied = requiresReason ? reasonIsValid : true;
+
+  // 3-second delay for principal_kind_escalate
+  useEffect(() => {
+    if (!isEscalate || !reasonSatisfied || !capability) {
+      setDelayRemaining(0);
+      if (delayTimerRef.current) {
+        clearInterval(delayTimerRef.current);
+        delayTimerRef.current = null;
+      }
+      return;
+    }
+    // Start the delay when capability changes to escalate and reason is valid
+    setDelayRemaining(3000);
+    const interval = 100;
+    delayTimerRef.current = setInterval(() => {
+      setDelayRemaining((prev) => {
+        const next = prev - interval;
+        if (next <= 0) {
+          if (delayTimerRef.current) {
+            clearInterval(delayTimerRef.current);
+            delayTimerRef.current = null;
+          }
+          return 0;
+        }
+        return next;
+      });
+    }, interval);
+    return () => {
+      if (delayTimerRef.current) {
+        clearInterval(delayTimerRef.current);
+        delayTimerRef.current = null;
+      }
+    };
+  }, [isEscalate, reasonSatisfied, capability]);
+
+  const delayInProgress = isEscalate && delayRemaining > 0;
+  const canSubmit = capability !== '' && reasonSatisfied && !delayInProgress && !isPending;
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit) return;
+    setError(null);
+    setIsPending(true);
+    try {
+      const mfaOk = await promptMfa('Grant capability');
+      if (!mfaOk) {
+        setError('MFA verification cancelled.');
+        setIsPending(false);
+        return;
+      }
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        'X-MFA-Recent': '1',
+      };
+      if (token) headers.Authorization = `Bearer ${token}`;
+
+      const body: Record<string, unknown> = { capability };
+      if (expiresAt) body.expires_at = expiresAt;
+      if (requiresReason && reason) body.reason = reason;
+
+      const res = await fetch(`/api/v1/admin/capabilities/users/${userId}/grant`, {
+        method: 'POST',
+        headers,
+        credentials: 'include',
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(text || `Grant failed: ${res.status}`);
+      }
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Grant failed. Try again.');
+    } finally {
+      setIsPending(false);
+    }
+  }, [
+    canSubmit,
+    promptMfa,
+    token,
+    capability,
+    expiresAt,
+    requiresReason,
+    reason,
+    userId,
+    onSuccess,
+  ]);
+
+  // Close on ESC
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !isPending) onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [isPending, onClose]);
+
+  return (
+    <>
+      {/* ESC handler is on window above; backdrop click provides secondary dismiss */}
+      <div className="cap-drawer-backdrop" onClick={!isPending ? onClose : undefined} />
+      <aside className="cap-drawer" aria-label="Grant capability" role="dialog" aria-modal="true">
+        <div className="cap-drawer__header">
+          <h2 className="cap-drawer__title">Grant capability</h2>
+          <button
+            type="button"
+            className="cap-drawer__close"
+            onClick={onClose}
+            disabled={isPending}
+            aria-label="Close drawer"
+          >
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="cap-drawer__body">
+          {/* High-risk warning banner */}
+          {isEscalate && (
+            <div className="cap-warning">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                style={{ flexShrink: 0, marginTop: 1 }}
+              >
+                <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+                <line x1="12" y1="9" x2="12" y2="13" />
+                <line x1="12" y1="17" x2="12.01" y2="17" />
+              </svg>
+              <span>
+                <strong>High-risk grant:</strong> this gives platform-principal escalation. Ensure
+                you have explicit approval before proceeding.
+              </span>
+            </div>
+          )}
+
+          {/* Capability selector */}
+          <div className="cap-field">
+            <label className="cap-field__label" htmlFor="cap-drawer-select">
+              Capability
+            </label>
+            <select
+              id="cap-drawer-select"
+              className="cap-field__select"
+              value={capability}
+              onChange={(e) => {
+                setCapability(e.target.value);
+                setReason('');
+                setError(null);
+              }}
+            >
+              <option value="">Select a capability…</option>
+              {CAPABILITIES.map((cap) => (
+                <option key={cap} value={cap}>
+                  {cap}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Audit reason (for high-risk caps) */}
+          {requiresReason && reasonAction && (
+            <AuditReasonPrompt
+              action={reasonAction as never}
+              value={reason}
+              onChange={setReason}
+              required
+            />
+          )}
+
+          {/* Optional expires_at */}
+          <div className="cap-field">
+            <label className="cap-field__label" htmlFor="cap-drawer-expires">
+              Expires at{' '}
+              <span style={{ fontWeight: 400, color: 'var(--ppt-fg-muted, #6b7280)' }}>
+                (optional — leave blank for never)
+              </span>
+            </label>
+            <input
+              id="cap-drawer-expires"
+              type="datetime-local"
+              className="cap-field__input"
+              value={expiresAt}
+              onChange={(e) => setExpiresAt(e.target.value)}
+            />
+          </div>
+
+          {/* Inline error */}
+          {error && <div className="cap-error-banner">{error}</div>}
+        </div>
+
+        <div className="cap-drawer__footer">
+          <button
+            type="button"
+            className="cap-btn cap-btn--secondary"
+            onClick={onClose}
+            disabled={isPending}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="cap-btn cap-btn--primary"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+          >
+            {isPending && <span className="cap-spinner" />}
+            {delayInProgress ? `Wait ${Math.ceil(delayRemaining / 1000)}s` : 'Grant capability'}
+          </button>
+        </div>
+      </aside>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page root
+// ---------------------------------------------------------------------------
+
+export default function CapabilitiesAdminPage() {
+  ensureStyles();
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const view = searchParams.get('view') ?? 'registry';
+  const userId = searchParams.get('id') ?? 'me';
+  const { token } = useAdminAuth();
+
+  const switchToUser = useCallback(
+    (id: string) => {
+      setSearchParams({ view: 'user', id });
+    },
+    [setSearchParams]
+  );
+
+  const switchToRegistry = useCallback(() => {
+    setSearchParams({ view: 'registry' });
+  }, [setSearchParams]);
+
+  if (view === 'user') {
+    return (
+      <div className="cap-page">
+        <UserView userId={userId} token={token} onSwitchToRegistry={switchToRegistry} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="cap-page">
+      <div className="cap-page__header">
+        <div>
+          <h1 className="cap-page__title">Capabilities registry</h1>
+          <p className="cap-page__subtitle">
+            All {CAPABILITIES.length} platform capability strings. Click "View holders" to inspect
+            grants for a specific user.
+          </p>
+        </div>
+      </div>
+      <RegistryView onViewUser={switchToUser} />
+    </div>
+  );
+}

--- a/frontend/apps/admin-web/src/pages/Dashboard.tsx
+++ b/frontend/apps/admin-web/src/pages/Dashboard.tsx
@@ -1,24 +1,731 @@
-import { useTranslation } from 'react-i18next';
+/**
+ * Dashboard at `/` — Section B of the admin design brief.
+ *
+ * Layout:
+ *   (1) Topbar greeting with first name + MFA window subline
+ *   (2) 4-stat tile row
+ *   (3) Two-column row: high-risk events (left) + right stack
+ *       Right stack: active impersonation | pending merge collisions | quick actions
+ *
+ * Capability gates:
+ *   - High-risk events card: audit_read
+ *   - Active impersonation card: users_impersonate OR audit_read
+ *   - Pending merge collisions card: memberships_grant
+ *   - Quick actions card: hidden if all gated out
+ */
 
-import { usePrincipalCapabilities } from '../auth/usePrincipalCapabilities';
+import { useCapability } from '@ppt/admin-ui';
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+
+import { useAdminAuth } from '../auth/AdminAuthContext';
+import { useMfaWindow } from '../components/MfaWindowChip';
+
+// ---------------------------------------------------------------------------
+// Styles (injected once)
+// ---------------------------------------------------------------------------
+
+const STYLE_ID = 'ppt-dashboard-styles';
+
+function ensureStyles() {
+  if (typeof document === 'undefined') return;
+  if (document.getElementById(STYLE_ID)) return;
+  const el = document.createElement('style');
+  el.id = STYLE_ID;
+  el.textContent = `
+    .ppt-dash { background: var(--ppt-bg-app, #f9fafb); padding: 20px 22px; flex: 1; }
+
+    .ppt-dash__title {
+      font-size: 1.25rem;
+      font-weight: 700;
+      color: var(--ppt-fg-primary, #111827);
+      margin: 0 0 4px;
+    }
+    .ppt-dash__sub {
+      color: var(--ppt-fg-muted, #6b7280);
+      font-size: 12px;
+      margin: 0 0 16px;
+    }
+
+    /* 4-stat row */
+    .ppt-dash__grid4 {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 12px;
+    }
+
+    /* Card primitive */
+    .ppt-card {
+      background: var(--ppt-bg-surface, #ffffff);
+      border: 1px solid var(--ppt-border-default, #e5e7eb);
+      border-radius: var(--ppt-radius-lg, 10px);
+      padding: 16px;
+    }
+
+    /* Stat tile */
+    .ppt-tile__label {
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--ppt-fg-muted, #6b7280);
+      font-weight: 600;
+      margin: 0 0 10px;
+    }
+    .ppt-tile__value {
+      font-size: 28px;
+      font-weight: 700;
+      color: var(--ppt-fg-primary, #111827);
+      line-height: 1;
+    }
+    .ppt-tile__detail {
+      font-size: 11px;
+      color: var(--ppt-fg-muted, #6b7280);
+      margin-top: 4px;
+    }
+
+    /* Skeleton */
+    @keyframes ppt-shimmer {
+      0% { background-position: -400px 0; }
+      100% { background-position: 400px 0; }
+    }
+    .ppt-skeleton {
+      background: linear-gradient(
+        90deg,
+        var(--ppt-bg-subtle, #f3f4f6) 25%,
+        var(--ppt-border-subtle, #e5e7eb) 50%,
+        var(--ppt-bg-subtle, #f3f4f6) 75%
+      );
+      background-size: 800px 100%;
+      animation: ppt-shimmer 1.4s infinite;
+      border-radius: var(--ppt-radius-md, 6px);
+    }
+    .ppt-tile--skeleton .ppt-tile__value {
+      height: 28px;
+      width: 48px;
+      border-radius: var(--ppt-radius-md, 6px);
+    }
+    .ppt-tile--skeleton .ppt-tile__detail {
+      height: 12px;
+      width: 80px;
+      margin-top: 6px;
+      border-radius: var(--ppt-radius-md, 6px);
+    }
+
+    /* Two-column row */
+    .ppt-dash__grid2 {
+      display: grid;
+      grid-template-columns: 2fr 1fr;
+      gap: 12px;
+      margin-top: 14px;
+    }
+
+    /* Card section header */
+    .ppt-card__header {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--ppt-fg-muted, #6b7280);
+      font-weight: 600;
+      margin: 0 0 12px;
+    }
+    .ppt-card__header-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 8px;
+    }
+    .ppt-card__header-row .ppt-card__header {
+      margin: 0;
+    }
+
+    /* Row list */
+    .ppt-row-list { display: flex; flex-direction: column; }
+    .ppt-row {
+      display: grid;
+      grid-template-columns: 14px 1fr auto;
+      gap: 10px;
+      padding: 9px 0;
+      border-bottom: 1px solid var(--ppt-border-subtle, #f3f4f6);
+      align-items: start;
+      font-size: 12px;
+    }
+    .ppt-row:last-child { border-bottom: 0; }
+
+    /* Severity dot */
+    .ppt-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--ppt-danger-500, #ef4444);
+      margin-top: 4px;
+      flex-shrink: 0;
+    }
+    .ppt-dot--amber { background: var(--ppt-warning-500, #f59e0b); }
+    .ppt-dot--blue { background: var(--ppt-brand-500, #3b82f6); }
+
+    .ppt-row__text { color: var(--ppt-fg-secondary, #374151); line-height: 1.4; }
+    .ppt-row__who { color: var(--ppt-fg-primary, #111827); font-weight: 500; }
+    .ppt-row__target {
+      font-family: var(--ppt-font-mono, ui-monospace, monospace);
+      font-size: 11px;
+      color: var(--ppt-fg-muted, #6b7280);
+    }
+    .ppt-row__time {
+      font-family: var(--ppt-font-mono, ui-monospace, monospace);
+      color: var(--ppt-fg-subtle, #9ca3af);
+      font-size: 11px;
+      white-space: nowrap;
+    }
+
+    /* Pill */
+    .ppt-pill {
+      display: inline-flex;
+      align-items: center;
+      padding: 1px 8px;
+      border-radius: 999px;
+      font-size: 10.5px;
+      font-weight: 500;
+      background: var(--ppt-bg-subtle, #f3f4f6);
+      color: var(--ppt-fg-secondary, #374151);
+      line-height: 1.6;
+    }
+    .ppt-pill--red { background: var(--ppt-danger-100, #fee2e2); color: var(--ppt-danger-800, #991b1b); }
+    .ppt-pill--amber { background: var(--ppt-warning-100, #fef3c7); color: var(--ppt-warning-800, #92400e); }
+    .ppt-pill--blue { background: var(--ppt-brand-100, #dbeafe); color: var(--ppt-brand-800, #1e40af); }
+
+    /* Buttons */
+    .ppt-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 5px 11px;
+      border-radius: var(--ppt-radius-md, 6px);
+      font-size: 11.5px;
+      font-weight: 500;
+      background: var(--ppt-bg-surface, #ffffff);
+      border: 1px solid var(--ppt-border-default, #e5e7eb);
+      color: var(--ppt-fg-secondary, #374151);
+      cursor: pointer;
+    }
+    .ppt-btn:hover { background: var(--ppt-bg-subtle, #f3f4f6); }
+    .ppt-btn--ghost { background: transparent; border: 0; color: var(--ppt-fg-secondary, #374151); }
+    .ppt-btn--ghost:hover { color: var(--ppt-fg-primary, #111827); background: transparent; }
+    .ppt-btn--tiny { padding: 3px 8px; font-size: 11px; }
+    .ppt-btn--danger { color: var(--ppt-danger-600, #dc2626); }
+    .ppt-btn--full { width: 100%; justify-content: flex-start; }
+
+    /* Right stack */
+    .ppt-dash__right-stack { display: flex; flex-direction: column; gap: 12px; }
+
+    /* Empty state */
+    .ppt-empty { font-size: 12px; color: var(--ppt-fg-muted, #6b7280); padding: 8px 0; }
+
+    /* Error banner */
+    .ppt-error-banner {
+      font-size: 12px;
+      color: var(--ppt-danger-700, #b91c1c);
+      background: var(--ppt-danger-50, #fef2f2);
+      border: 1px solid var(--ppt-danger-200, #fecaca);
+      border-radius: var(--ppt-radius-md, 6px);
+      padding: 8px 12px;
+      margin-bottom: 12px;
+    }
+  `;
+  document.head.appendChild(el);
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface MetricsSummary {
+  tenantsActive: number;
+  operatorsOnline: number;
+  pendingMerges: number;
+  highRisk24h: number;
+}
+
+interface AuditEvent {
+  id: string;
+  actor_email: string;
+  capability: string;
+  target_slug: string;
+  severity: 'high' | 'medium' | 'low';
+  occurred_at: string;
+  outcome: string;
+}
+
+interface ImpersonationSession {
+  id: string;
+  operator_email: string;
+  target_email: string;
+  target_id: string;
+  started_at: string;
+  expires_at: string;
+}
+
+interface MergeCollision {
+  id: string;
+  description: string;
+}
+
+// ---------------------------------------------------------------------------
+// API helpers
+// ---------------------------------------------------------------------------
+
+async function fetchMetricsSummary(token: string | null): Promise<MetricsSummary> {
+  // TODO(backend): GET /api/v1/admin/metrics/summary — endpoint not yet implemented.
+  // Stub fallback with zeros until backend provides this endpoint.
+  const STUB: MetricsSummary = {
+    tenantsActive: 0,
+    operatorsOnline: 1,
+    pendingMerges: 0,
+    highRisk24h: 0,
+  };
+
+  if (!token) return STUB;
+
+  try {
+    const resp = await fetch('/api/v1/admin/metrics/summary', {
+      headers: { Authorization: `Bearer ${token}` },
+      credentials: 'include',
+    });
+    if (!resp.ok) {
+      console.warn(
+        '[Dashboard] GET /api/v1/admin/metrics/summary returned',
+        resp.status,
+        '— falling back to stub metrics. TODO: implement this endpoint in api-server.'
+      );
+      return STUB;
+    }
+    return (await resp.json()) as MetricsSummary;
+  } catch (err) {
+    console.warn(
+      '[Dashboard] GET /api/v1/admin/metrics/summary failed:',
+      err,
+      '— falling back to stub metrics. TODO: implement this endpoint in api-server.'
+    );
+    return STUB;
+  }
+}
+
+async function fetchHighRiskEvents(token: string | null): Promise<AuditEvent[]> {
+  if (!token) return [];
+
+  // Try the server-side filtered endpoint first; fall back to client-side filtering.
+  try {
+    const resp = await fetch('/api/v1/admin/audit?severity=high&after=24h&limit=10', {
+      headers: { Authorization: `Bearer ${token}` },
+      credentials: 'include',
+    });
+    if (resp.ok) {
+      const data = (await resp.json()) as { items?: AuditEvent[] } | AuditEvent[];
+      const items = Array.isArray(data) ? data : (data.items ?? []);
+      return items.slice(0, 10);
+    }
+
+    // Fall back: fetch base audit log and client-filter
+    const fallback = await fetch('/api/v1/admin/audit?limit=50', {
+      headers: { Authorization: `Bearer ${token}` },
+      credentials: 'include',
+    });
+    if (!fallback.ok) return [];
+    const fallbackData = (await fallback.json()) as { items?: AuditEvent[] } | AuditEvent[];
+    const allItems = Array.isArray(fallbackData) ? fallbackData : (fallbackData.items ?? []);
+    const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+    return allItems
+      .filter((e) => e.severity === 'high' && new Date(e.occurred_at).getTime() > cutoff)
+      .slice(0, 10);
+  } catch {
+    return [];
+  }
+}
+
+async function fetchActiveImpersonations(token: string | null): Promise<ImpersonationSession[]> {
+  if (!token) return [];
+  try {
+    const resp = await fetch('/api/v1/admin/impersonation/active', {
+      headers: { Authorization: `Bearer ${token}` },
+      credentials: 'include',
+    });
+    if (!resp.ok) return [];
+    const data = (await resp.json()) as ImpersonationSession[] | { items?: ImpersonationSession[] };
+    return Array.isArray(data) ? data : (data.items ?? []);
+  } catch {
+    return [];
+  }
+}
+
+async function fetchMergeCollisions(token: string | null): Promise<MergeCollision[]> {
+  if (!token) return [];
+  try {
+    const resp = await fetch('/api/v1/admin/memberships/merge-collisions', {
+      headers: { Authorization: `Bearer ${token}` },
+      credentials: 'include',
+    });
+    if (!resp.ok) return [];
+    const data = (await resp.json()) as MergeCollision[] | { items?: MergeCollision[] };
+    return Array.isArray(data) ? data : (data.items ?? []);
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function TileSkeleton() {
+  return (
+    <div className="ppt-card ppt-tile--skeleton">
+      <div className="ppt-tile__label ppt-skeleton" style={{ height: '11px', width: '80px' }} />
+      <div className="ppt-tile__value ppt-skeleton" />
+      <div className="ppt-tile__detail ppt-skeleton" />
+    </div>
+  );
+}
+
+function severityDotClass(severity: string, index: number): string {
+  // Vary dot color by severity/index for visual variety matching the mockup
+  if (severity === 'high' && index % 3 === 0) return 'ppt-dot';
+  if (severity === 'high' && index % 3 === 1) return 'ppt-dot ppt-dot--amber';
+  return 'ppt-dot ppt-dot--blue';
+}
+
+function pillColorClass(capability: string): string {
+  const red = ['tenant_purge', 'tenant_restore', 'principal_kind_escalate'];
+  const amber = ['memberships_grant', 'memberships_revoke'];
+  if (red.includes(capability)) return 'ppt-pill ppt-pill--red';
+  if (amber.includes(capability)) return 'ppt-pill ppt-pill--amber';
+  return 'ppt-pill ppt-pill--blue';
+}
+
+function formatTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  } catch {
+    return '—';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
 
 export function Dashboard() {
-  const { t } = useTranslation();
-  const { capabilities, isPlatformPrincipal } = usePrincipalCapabilities();
+  ensureStyles();
+
+  const { token } = useAdminAuth();
+  const navigate = useNavigate();
+  const { state: mfaState, msRemaining } = useMfaWindow();
+
+  // Capability gates
+  const canAuditRead = useCapability('audit_read');
+  const canUsersImpersonate = useCapability('users_impersonate');
+  const canMembershipsGrant = useCapability('memberships_grant');
+
+  // Derived first name from JWT sub (best-effort; fallback "Operator")
+  const firstName = (() => {
+    if (!token) return 'Operator';
+    try {
+      const parts = token.split('.');
+      if (parts.length !== 3) return 'Operator';
+      const padded = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+      const json = atob(padded.padEnd(padded.length + ((4 - (padded.length % 4)) % 4), '='));
+      const payload = JSON.parse(json) as Record<string, unknown>;
+      const sub = payload.sub ?? payload.email ?? payload.name ?? '';
+      const emailLocal = String(sub).split('@')[0];
+      const namePart = emailLocal.split(/[._-]/)[0];
+      return namePart.length > 0
+        ? namePart.charAt(0).toUpperCase() + namePart.slice(1)
+        : 'Operator';
+    } catch {
+      return 'Operator';
+    }
+  })();
+
+  // Greeting by time-of-day
+  const hour = new Date().getHours();
+  const greeting = hour < 12 ? 'Good morning' : hour < 18 ? 'Good afternoon' : 'Good evening';
+
+  // MFA subline
+  const mfaSubline = (() => {
+    if (mfaState === 'verified' || mfaState === 'expiring') {
+      const totalSec = Math.max(0, Math.ceil(msRemaining / 1000));
+      const m = Math.floor(totalSec / 60);
+      return `You're in a recent-MFA window for ${m} more minute${m !== 1 ? 's' : ''}.`;
+    }
+    return 'MFA window not active.';
+  })();
+
+  // TanStack Queries
+  const metricsQuery = useQuery({
+    queryKey: ['admin', 'metrics', 'summary'],
+    queryFn: () => fetchMetricsSummary(token),
+    staleTime: 60_000,
+    refetchOnWindowFocus: true,
+    enabled: token !== null,
+  });
+
+  const highRiskQuery = useQuery({
+    queryKey: ['admin', 'audit', 'high-risk-24h'],
+    queryFn: () => fetchHighRiskEvents(token),
+    staleTime: 5_000,
+    refetchOnWindowFocus: true,
+    enabled: token !== null && canAuditRead,
+  });
+
+  const impersonationQuery = useQuery({
+    queryKey: ['admin', 'impersonation', 'active'],
+    queryFn: () => fetchActiveImpersonations(token),
+    staleTime: 5_000,
+    refetchInterval: 5_000,
+    refetchOnWindowFocus: true,
+    enabled: token !== null && (canUsersImpersonate || canAuditRead),
+  });
+
+  const mergeCollisionsQuery = useQuery({
+    queryKey: ['admin', 'memberships', 'merge-collisions'],
+    queryFn: () => fetchMergeCollisions(token),
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+    enabled: token !== null && canMembershipsGrant,
+  });
+
+  const metrics = metricsQuery.data;
+  const highRiskEvents = highRiskQuery.data ?? [];
+  const impersonations = impersonationQuery.data ?? [];
+  const mergeCollisions = mergeCollisionsQuery.data ?? [];
+
+  // "N things need attention" count
+  const attentionCount =
+    (metrics?.highRisk24h ?? 0) + impersonations.length + mergeCollisions.length;
+
+  // Quick-actions visibility
+  const showFindUser = canAuditRead || canUsersImpersonate || canMembershipsGrant;
+  const showAuditLog = canAuditRead;
+  const showImpersonations = canUsersImpersonate || canAuditRead;
+  const showQuickActions = showFindUser || showAuditLog || showImpersonations;
+
   return (
-    <section aria-label="dashboard">
-      <h1>{t('admin.title', 'Admin dashboard')}</h1>
-      <p>
-        {t('admin.platformPrincipal', 'Platform principal:')} {String(isPlatformPrincipal)}
+    <div className="ppt-dash">
+      {/* Greeting */}
+      <h1 className="ppt-dash__title">
+        {greeting}, {firstName}.
+      </h1>
+      <p className="ppt-dash__sub">
+        {attentionCount > 0
+          ? `${attentionCount} thing${attentionCount !== 1 ? 's' : ''} need${attentionCount === 1 ? 's' : ''} attention.`
+          : 'Everything looks clear.'}{' '}
+        {mfaSubline}
       </p>
-      <p>
-        {t('admin.capabilitiesCount', 'Capabilities:')} {capabilities.length}
-      </p>
-      <ul>
-        {capabilities.map((c) => (
-          <li key={c}>{c}</li>
-        ))}
-      </ul>
-    </section>
+
+      {/* (1) 4-stat tile row */}
+      <div className="ppt-dash__grid4">
+        {metricsQuery.isLoading ? (
+          <>
+            <TileSkeleton />
+            <TileSkeleton />
+            <TileSkeleton />
+            <TileSkeleton />
+          </>
+        ) : (
+          <>
+            <div className="ppt-card">
+              <div className="ppt-tile__label">Tenants active</div>
+              <div className="ppt-tile__value">{metrics?.tenantsActive ?? 0}</div>
+              <div className="ppt-tile__detail">total registered</div>
+            </div>
+            <div className="ppt-card">
+              <div className="ppt-tile__label">Operators online</div>
+              <div className="ppt-tile__value">{metrics?.operatorsOnline ?? 0}</div>
+              <div className="ppt-tile__detail">with active sessions</div>
+            </div>
+            <div className="ppt-card">
+              <div className="ppt-tile__label">Pending merges</div>
+              <div className="ppt-tile__value">{metrics?.pendingMerges ?? 0}</div>
+              <div className="ppt-tile__detail">awaiting resolution</div>
+            </div>
+            <div className="ppt-card">
+              <div className="ppt-tile__label">High-risk · 24h</div>
+              <div className="ppt-tile__value" style={{ color: 'var(--ppt-danger-600, #dc2626)' }}>
+                {metrics?.highRisk24h ?? 0}
+              </div>
+              <div className="ppt-tile__detail">purge / escalate events</div>
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* (2) Two-column row */}
+      <div className="ppt-dash__grid2">
+        {/* LEFT: High-risk events */}
+        {canAuditRead ? (
+          <div className="ppt-card">
+            <div className="ppt-card__header-row">
+              <h3 className="ppt-card__header">Recent high-risk events · 24h</h3>
+              <button
+                type="button"
+                className="ppt-btn ppt-btn--ghost ppt-btn--tiny"
+                onClick={() => navigate('/ops/audit')}
+              >
+                View all →
+              </button>
+            </div>
+
+            {highRiskQuery.isError && (
+              <div className="ppt-error-banner">Unable to load audit events. Try again.</div>
+            )}
+
+            {highRiskQuery.isLoading ? (
+              <div className="ppt-row-list">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <div key={i} className="ppt-row">
+                    <div
+                      className="ppt-skeleton"
+                      style={{ width: '8px', height: '8px', borderRadius: '50%', marginTop: '4px' }}
+                    />
+                    <div className="ppt-skeleton" style={{ height: '12px', borderRadius: '4px' }} />
+                    <div
+                      className="ppt-skeleton"
+                      style={{ height: '12px', width: '36px', borderRadius: '4px' }}
+                    />
+                  </div>
+                ))}
+              </div>
+            ) : highRiskEvents.length === 0 ? (
+              <p className="ppt-empty">No high-risk events in the last 24 hours.</p>
+            ) : (
+              <div className="ppt-row-list">
+                {highRiskEvents.map((event, idx) => (
+                  <div key={event.id} className="ppt-row">
+                    <span className={severityDotClass(event.severity, idx)} aria-hidden="true" />
+                    <span className="ppt-row__text">
+                      <span className="ppt-row__who">{event.actor_email}</span>
+                      {' · '}
+                      <span className={pillColorClass(event.capability)}>{event.capability}</span>
+                      {' on '}
+                      <span className="ppt-row__target">{event.target_slug}</span>
+                    </span>
+                    <span className="ppt-row__time">{formatTime(event.occurred_at)}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        ) : (
+          /* Placeholder to keep grid layout when audit_read is absent */
+          <div />
+        )}
+
+        {/* RIGHT stack */}
+        <div className="ppt-dash__right-stack">
+          {/* Active impersonation */}
+          {(canUsersImpersonate || canAuditRead) && (
+            <div className="ppt-card">
+              <h3 className="ppt-card__header">Active impersonation</h3>
+              {impersonationQuery.isLoading ? (
+                <p className="ppt-empty">Loading…</p>
+              ) : impersonations.length === 0 ? (
+                <p className="ppt-empty">No active impersonation sessions.</p>
+              ) : (
+                <div className="ppt-row-list">
+                  {impersonations.map((session) => (
+                    <div key={session.id} className="ppt-row">
+                      <span className="ppt-dot ppt-dot--amber" aria-hidden="true" />
+                      <span className="ppt-row__text">
+                        <span className="ppt-row__who">{session.operator_email}</span>
+                        {' → '}
+                        <span className="ppt-row__target">
+                          {session.target_email || session.target_id}
+                        </span>
+                        <br />
+                        <span style={{ color: 'var(--ppt-fg-muted, #6b7280)', fontSize: '11px' }}>
+                          started {formatTime(session.started_at)} · expires{' '}
+                          {formatTime(session.expires_at)}
+                        </span>
+                      </span>
+                      {canUsersImpersonate && (
+                        <button
+                          type="button"
+                          className="ppt-btn ppt-btn--tiny ppt-btn--danger"
+                          onClick={() => navigate('/ops/impersonation')}
+                        >
+                          Stop
+                        </button>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Pending merge collisions */}
+          {canMembershipsGrant && (
+            <div className="ppt-card">
+              <h3 className="ppt-card__header">Pending merge collisions</h3>
+              {mergeCollisionsQuery.isLoading ? (
+                <p className="ppt-empty">Loading…</p>
+              ) : mergeCollisions.length === 0 ? (
+                <p className="ppt-empty">No merge collisions.</p>
+              ) : (
+                <div className="ppt-row-list">
+                  {mergeCollisions.map((collision) => (
+                    <div key={collision.id} className="ppt-row">
+                      <span className="ppt-dot ppt-dot--amber" aria-hidden="true" />
+                      <span className="ppt-row__text">{collision.description}</span>
+                      <button
+                        type="button"
+                        className="ppt-btn ppt-btn--tiny"
+                        onClick={() => navigate('/identity/memberships')}
+                      >
+                        Resolve
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Quick actions */}
+          {showQuickActions && (
+            <div className="ppt-card">
+              <h3 className="ppt-card__header">Quick actions</h3>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+                {showFindUser && (
+                  <button
+                    type="button"
+                    className="ppt-btn ppt-btn--full"
+                    onClick={() => navigate('/identity/users')}
+                  >
+                    Find user…
+                  </button>
+                )}
+                {showAuditLog && (
+                  <button
+                    type="button"
+                    className="ppt-btn ppt-btn--full"
+                    onClick={() => navigate('/ops/audit')}
+                  >
+                    Open audit log
+                  </button>
+                )}
+                {showImpersonations && (
+                  <button
+                    type="button"
+                    className="ppt-btn ppt-btn--full"
+                    onClick={() => navigate('/ops/impersonation')}
+                  >
+                    View active impersonations ({impersonations.length})
+                  </button>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
   );
 }

--- a/frontend/apps/admin-web/src/pages/TenantLifecyclePage.tsx
+++ b/frontend/apps/admin-web/src/pages/TenantLifecyclePage.tsx
@@ -16,7 +16,6 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useAdminAuth } from '../auth/AdminAuthContext';
 import { AuditReasonPrompt, useAuditReasonValid } from '../components/AuditReasonPrompt';
-import { ForbiddenPage } from '../components/ForbiddenPage';
 import { useToast } from '../components/Toast';
 
 // ---------------------------------------------------------------------------
@@ -586,12 +585,13 @@ export default function TenantLifecyclePage() {
   const { token } = useAdminAuth();
   const { showToast } = useToast();
 
-  // Capability gate — show ForbiddenPage when user holds none of the three
-  if (!canExport && !canPurge && !canRestore) {
-    return (
-      <ForbiddenPage requiredCapability={['tenant_export', 'tenant_purge', 'tenant_restore']} />
-    );
-  }
+  // Capability gating is enforced by `ProtectedRoute` in App.tsx (route is
+  // wrapped with requiredCapability=['tenant_export','tenant_purge','tenant_restore']
+  // which treats the array as ANY-of). A redundant in-page early return here
+  // would violate Rules of Hooks — it would skip the useEffect/useCallback
+  // declarations below on initial render and re-run them after a cap flip,
+  // throwing "Rendered fewer hooks than expected".
+  // Per-button caps still gate individual affordances inside each card.
 
   // Compute initial cooldown on tenant change
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional on tenant change

--- a/frontend/apps/admin-web/src/pages/TenantLifecyclePage.tsx
+++ b/frontend/apps/admin-web/src/pages/TenantLifecyclePage.tsx
@@ -1,0 +1,842 @@
+/**
+ * TenantLifecyclePage — Tenant Lifecycle management.
+ *
+ * Implements Section E of the admin design brief:
+ *   - Export card  (gate: tenant_export)
+ *   - Purge card   (gate: tenant_purge) with live cooldown countdown + inline purge wizard
+ *   - Restore card (gate: tenant_restore) with multipart file upload stub
+ *
+ * Route: /tenants/lifecycle
+ * Page-level gating: any of tenant_export | tenant_purge | tenant_restore.
+ * Inner capability checks hide individual action buttons/controls.
+ */
+
+import { useCapability } from '@ppt/admin-ui';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useAdminAuth } from '../auth/AdminAuthContext';
+import { AuditReasonPrompt, useAuditReasonValid } from '../components/AuditReasonPrompt';
+import { ForbiddenPage } from '../components/ForbiddenPage';
+import { useToast } from '../components/Toast';
+
+// ---------------------------------------------------------------------------
+// Demo tenant (hard-coded until :id param iteration)
+// ---------------------------------------------------------------------------
+
+interface TenantInfo {
+  id: string;
+  slug: string;
+  name: string;
+  softDeletedAt: Date | null;
+  lastExportAt: Date | null;
+  lastExportBy: string | null;
+  lastExportSizeGb: number | null;
+}
+
+const DEMO_TENANT: TenantInfo = {
+  id: 'demo',
+  slug: 'dunajska-residences',
+  name: 'Dunajská Residences',
+  softDeletedAt: null, // Active tenant — set to e.g. new Date(Date.now() - 12 * 3600_000) to test cooldown
+  lastExportAt: new Date('2026-05-10T09:34:00Z'),
+  lastExportBy: 'martin@rlt.sk',
+  lastExportSizeGb: 2.3,
+};
+
+// 24-hour cooldown in ms
+const PURGE_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/** Format remaining cooldown time as "Xh YYm" or "Mm SSs". */
+function formatCooldown(remainingMs: number): string {
+  const totalSecs = Math.max(0, Math.ceil(remainingMs / 1000));
+  const hours = Math.floor(totalSecs / 3600);
+  const mins = Math.floor((totalSecs % 3600) / 60);
+  const secs = totalSecs % 60;
+  if (hours > 0) {
+    return `${hours}h ${String(mins).padStart(2, '0')}m`;
+  }
+  return `${mins}m ${String(secs).padStart(2, '0')}s`;
+}
+
+// ---------------------------------------------------------------------------
+// Inline styles injector (scoped, runs once)
+// ---------------------------------------------------------------------------
+
+const STYLE_ID = 'ppt-lifecycle-page-styles';
+
+function ensureStyles() {
+  if (typeof document === 'undefined') return;
+  if (document.getElementById(STYLE_ID)) return;
+  const el = document.createElement('style');
+  el.id = STYLE_ID;
+  el.textContent = `
+    .lc-page { padding: 24px 32px; background: var(--ppt-bg-app, #f9fafb); min-height: 100%; }
+
+    /* Header */
+    .lc-header { margin-bottom: 4px; }
+    .lc-title { font-size: 1.375rem; font-weight: 700; color: var(--ppt-fg-primary, #111827); margin: 0 0 6px; }
+    .lc-subline { font-size: 0.8125rem; color: var(--ppt-fg-muted, #6b7280); }
+    .lc-subline span { margin: 0 6px; color: var(--ppt-border-default, #d1d5db); }
+
+    /* Tenant picker */
+    .lc-picker { display: flex; align-items: center; gap: 8px; margin-bottom: 20px; }
+    .lc-picker label { font-size: 13px; font-weight: 500; color: var(--ppt-fg-secondary, #374151); }
+    .lc-picker input {
+      font-size: 13px;
+      padding: 6px 10px;
+      border: 1px solid var(--ppt-border-default, #e5e7eb);
+      border-radius: var(--ppt-radius-md, 8px);
+      background: var(--ppt-bg-input, #fff);
+      color: var(--ppt-fg-primary, #111827);
+      outline: none;
+      width: 220px;
+    }
+    .lc-picker input:focus {
+      border-color: var(--ppt-brand-500, #3b82f6);
+      box-shadow: 0 0 0 2px rgba(59,130,246,0.25);
+    }
+
+    /* Card grid */
+    .lc-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 12px;
+      margin-top: 16px;
+    }
+
+    /* Base card */
+    .lc-card {
+      padding: 20px;
+      background: var(--ppt-bg-surface, #fff);
+      border: 1px solid var(--ppt-border-default, #e5e7eb);
+      border-radius: var(--ppt-radius-lg, 12px);
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    /* Danger card */
+    .lc-card.danger {
+      background: var(--ppt-danger-50, #fef2f2);
+      border-color: var(--ppt-danger-500, #ef4444);
+    }
+
+    .lc-card-title { font-size: 15px; font-weight: 600; margin: 0; color: var(--ppt-fg-primary, #111827); }
+    .lc-card-title.danger { color: var(--ppt-danger-800, #991b1b); }
+    .lc-card-body { font-size: 13px; color: var(--ppt-fg-secondary, #374151); line-height: 1.55; margin: 0; }
+    .lc-card-body.danger { color: var(--ppt-danger-800, #991b1b); }
+    .lc-card-subtext { font-size: 12px; color: var(--ppt-fg-muted, #6b7280); margin: 0; }
+    .lc-card-subtext a { color: var(--ppt-fg-link, #2563eb); text-decoration: underline; cursor: pointer; }
+
+    /* Buttons */
+    .lc-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 8px 14px;
+      border-radius: var(--ppt-radius-md, 8px);
+      font-size: 13px;
+      font-weight: 500;
+      cursor: pointer;
+      border: none;
+      transition: background 120ms ease, opacity 120ms ease;
+      width: fit-content;
+    }
+    .lc-btn--primary {
+      background: var(--ppt-brand-600, #2563eb);
+      color: #fff;
+    }
+    .lc-btn--primary:hover:not(:disabled) { background: var(--ppt-brand-700, #1d4ed8); }
+    .lc-btn--danger {
+      background: var(--ppt-danger-600, #dc2626);
+      color: #fff;
+      border: none;
+    }
+    .lc-btn--danger:hover:not(:disabled) { background: var(--ppt-danger-700, #b91c1c); }
+    .lc-btn--ghost {
+      background: transparent;
+      color: var(--ppt-fg-secondary, #374151);
+      border: 1px solid var(--ppt-border-default, #e5e7eb);
+    }
+    .lc-btn--ghost:hover:not(:disabled) { background: var(--ppt-bg-hover, #f3f4f6); }
+    .lc-btn:disabled { opacity: 0.45; cursor: not-allowed; }
+
+    /* Countdown hint */
+    .lc-btn-hint { font-size: 12px; color: var(--ppt-fg-muted, #6b7280); margin: 0; }
+
+    /* File restore */
+    .lc-file-label {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 8px 14px;
+      border-radius: var(--ppt-radius-md, 8px);
+      font-size: 13px;
+      font-weight: 500;
+      cursor: pointer;
+      background: var(--ppt-bg-surface, #fff);
+      border: 1px solid var(--ppt-border-default, #e5e7eb);
+      color: var(--ppt-fg-secondary, #374151);
+      transition: background 120ms ease;
+    }
+    .lc-file-label:hover { background: var(--ppt-bg-hover, #f3f4f6); }
+    .lc-file-selected { font-size: 12px; color: var(--ppt-fg-muted, #6b7280); margin: 0; }
+
+    /* ──── Purge wizard ──── */
+    .lc-wizard {
+      border: 1px solid var(--ppt-danger-500, #ef4444);
+      background: var(--ppt-bg-surface, #fff);
+      padding: 24px;
+      border-radius: var(--ppt-radius-lg, 12px);
+      margin-top: 16px;
+    }
+    .lc-wizard-title { font-size: 14px; font-weight: 600; color: var(--ppt-danger-800, #991b1b); margin: 0 0 16px; }
+
+    /* Step indicator */
+    .lc-steps { display: flex; align-items: center; gap: 8px; margin-bottom: 24px; flex-wrap: wrap; }
+    .lc-step-arrow { color: var(--ppt-fg-muted, #9ca3af); font-size: 14px; }
+    .lc-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 4px 12px;
+      border-radius: 999px;
+      font-size: 12px;
+      font-weight: 600;
+    }
+    .lc-pill--done {
+      background: var(--ppt-success-100, #dcfce7);
+      color: var(--ppt-success-800, #166534);
+    }
+    .lc-pill--current {
+      background: var(--ppt-brand-100, #dbeafe);
+      color: var(--ppt-brand-800, #1e40af);
+    }
+    .lc-pill--pending {
+      background: var(--ppt-neutral-100, #f3f4f6);
+      color: var(--ppt-neutral-600, #4b5563);
+    }
+
+    /* Step body */
+    .lc-step-body { display: flex; flex-direction: column; gap: 14px; }
+    .lc-step-label { font-size: 13px; font-weight: 500; color: var(--ppt-fg-secondary, #374151); margin: 0 0 6px; }
+    .lc-slug-input {
+      font-family: var(--ppt-font-mono, monospace);
+      font-size: 13px;
+      padding: 8px 10px;
+      border: 1px solid var(--ppt-border-default, #e5e7eb);
+      border-radius: var(--ppt-radius-md, 8px);
+      background: var(--ppt-bg-input, #fff);
+      color: var(--ppt-fg-primary, #111827);
+      outline: none;
+      width: 100%;
+      box-sizing: border-box;
+      transition: border-color 120ms ease, box-shadow 120ms ease;
+    }
+    .lc-slug-input:focus {
+      border-color: var(--ppt-brand-500, #3b82f6);
+      box-shadow: 0 0 0 2px rgba(59,130,246,0.25);
+    }
+    .lc-mismatch { font-size: 12px; color: var(--ppt-warning-800, #92400e); margin: 0; }
+
+    /* TOTP inputs */
+    .lc-totp-row { display: flex; gap: 6px; }
+    .lc-totp-digit {
+      width: 40px;
+      height: 48px;
+      text-align: center;
+      font-size: 18px;
+      font-weight: 600;
+      border: 1px solid var(--ppt-border-default, #e5e7eb);
+      border-radius: var(--ppt-radius-md, 8px);
+      background: var(--ppt-bg-input, #fff);
+      color: var(--ppt-fg-primary, #111827);
+      outline: none;
+      transition: border-color 120ms ease;
+    }
+    .lc-totp-digit:focus { border-color: var(--ppt-brand-500, #3b82f6); box-shadow: 0 0 0 2px rgba(59,130,246,0.25); }
+    .lc-totp-label { font-size: 13px; font-weight: 500; color: var(--ppt-fg-secondary, #374151); margin-bottom: 6px; }
+
+    /* Wizard actions row */
+    .lc-wizard-actions { display: flex; gap: 10px; margin-top: 8px; }
+    .lc-spinner {
+      display: inline-block;
+      width: 14px; height: 14px;
+      border: 2px solid rgba(255,255,255,0.4);
+      border-top-color: #fff;
+      border-radius: 50%;
+      animation: lc-spin 0.7s linear infinite;
+      flex-shrink: 0;
+    }
+    @keyframes lc-spin { to { transform: rotate(360deg); } }
+  `;
+  document.head.appendChild(el);
+}
+
+// ---------------------------------------------------------------------------
+// Step pill component
+// ---------------------------------------------------------------------------
+
+type PillState = 'done' | 'current' | 'pending';
+
+function StepPill({ label, state }: { label: string; state: PillState }) {
+  return (
+    <span className={`lc-pill lc-pill--${state}`}>
+      {state === 'done' && '✓ '}
+      {label}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Purge wizard (inline, below the grid)
+// ---------------------------------------------------------------------------
+
+interface PurgeWizardProps {
+  tenant: TenantInfo;
+  onCancel: () => void;
+}
+
+function PurgeWizard({ tenant, onCancel }: PurgeWizardProps) {
+  const [step, setStep] = useState<1 | 2 | 3>(1);
+  const [slugTyped, setSlugTyped] = useState('');
+  const [reason, setReason] = useState('');
+  const [totp, setTotp] = useState(['', '', '', '', '', '']);
+  const [isPending, setIsPending] = useState(false);
+  const totpRefs = useRef<(HTMLInputElement | null)[]>([]);
+  const { token } = useAdminAuth();
+  const { showToast } = useToast();
+
+  const reasonValid = useAuditReasonValid(reason, 30);
+  const slugMatch = slugTyped === tenant.slug;
+
+  // Step 1: auto-pass if last export < 7 days old
+  const exportAgeDays =
+    tenant.lastExportAt != null
+      ? (Date.now() - tenant.lastExportAt.getTime()) / 86_400_000
+      : Infinity;
+  const exportOk = exportAgeDays < 7;
+
+  // Move to step 2 when step 1 is satisfied
+  useEffect(() => {
+    if (step === 1 && exportOk) {
+      setStep(2);
+    }
+  }, [step, exportOk]);
+
+  const pillState = (forStep: 1 | 2 | 3): PillState => {
+    if (forStep < step) return 'done';
+    if (forStep === step) return 'current';
+    return 'pending';
+  };
+
+  // TOTP digit input handler with auto-advance
+  const handleTotpChange = (idx: number, val: string) => {
+    const digit = val.replace(/\D/g, '').slice(-1);
+    const next = [...totp];
+    next[idx] = digit;
+    setTotp(next);
+    if (digit && idx < 5) {
+      totpRefs.current[idx + 1]?.focus();
+    }
+  };
+
+  const handleTotpKeyDown = (idx: number, e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Backspace' && !totp[idx] && idx > 0) {
+      totpRefs.current[idx - 1]?.focus();
+    }
+  };
+
+  const totpFull = totp.join('').length === 6;
+
+  const handlePurge = useCallback(async () => {
+    if (isPending) return;
+    setIsPending(true);
+    try {
+      const resp = await fetch(`/api/v1/admin/tenants/${tenant.id}/purge`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token ?? ''}`,
+          'X-MFA-Recent': '1',
+        },
+        body: JSON.stringify({ confirm: 'DELETE-PERMANENT', reason }),
+      });
+
+      if (resp.ok) {
+        showToast({
+          type: 'success',
+          title: 'Tenant purged',
+          message: `${tenant.name} has been permanently purged.`,
+        });
+        onCancel();
+      } else if (resp.status === 401) {
+        showToast({
+          type: 'error',
+          title: 'MFA required',
+          message: 'Re-verify MFA and try again.',
+        });
+      } else {
+        const text = await resp.text().catch(() => resp.statusText);
+        showToast({ type: 'error', title: `Purge failed (${resp.status})`, message: text });
+      }
+    } catch {
+      showToast({
+        type: 'error',
+        title: 'Network error',
+        message: 'Unable to reach the server. Check your connection and try again.',
+      });
+    } finally {
+      setIsPending(false);
+    }
+  }, [isPending, tenant, reason, token, showToast, onCancel]);
+
+  return (
+    <div className="lc-wizard" role="region" aria-label="Purge wizard">
+      <p className="lc-wizard-title">Purge wizard — proceed carefully</p>
+
+      {/* Step indicator */}
+      <div className="lc-steps" aria-label="Wizard steps">
+        <StepPill label="1. Confirm export" state={pillState(1)} />
+        <span className="lc-step-arrow" aria-hidden="true">
+          →
+        </span>
+        <StepPill label="2. Type slug" state={pillState(2)} />
+        <span className="lc-step-arrow" aria-hidden="true">
+          →
+        </span>
+        <StepPill label="3. MFA + reason" state={pillState(3)} />
+      </div>
+
+      <div className="lc-step-body">
+        {/* Step 1 */}
+        {step === 1 && !exportOk && (
+          <div>
+            <p
+              style={{ fontSize: 13, color: 'var(--ppt-warning-800, #92400e)', margin: '0 0 12px' }}
+            >
+              An export less than 7 days old is required before purge. Last export was{' '}
+              {exportAgeDays === Infinity ? 'never' : `${Math.floor(exportAgeDays)} days ago`}.
+            </p>
+            <button
+              type="button"
+              className="lc-btn lc-btn--primary"
+              onClick={() => {
+                // Trigger export + advance
+                fetch(`/api/v1/admin/tenants/${tenant.id}/export`, {
+                  method: 'POST',
+                  headers: { Authorization: `Bearer ${token ?? ''}` },
+                })
+                  .then(() => setStep(2))
+                  .catch(() => {
+                    showToast({
+                      type: 'error',
+                      title: 'Export failed',
+                      message: 'Unable to start export.',
+                    });
+                  });
+              }}
+            >
+              Start export now
+            </button>
+          </div>
+        )}
+
+        {/* Step 2 */}
+        {step === 2 && (
+          <div>
+            <p className="lc-step-label">
+              Type the tenant slug exactly:{' '}
+              <code
+                style={{
+                  fontFamily: 'var(--ppt-font-mono, monospace)',
+                  background: 'var(--ppt-bg-subtle, #f3f4f6)',
+                  padding: '2px 6px',
+                  borderRadius: 4,
+                }}
+              >
+                {tenant.slug}
+              </code>
+            </p>
+            <input
+              className="lc-slug-input"
+              type="text"
+              value={slugTyped}
+              onChange={(e) => setSlugTyped(e.target.value)}
+              onPaste={(e) => e.preventDefault()}
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck={false}
+              aria-label={`Type "${tenant.slug}" to confirm`}
+            />
+            {slugTyped.length > 0 && !slugMatch && (
+              <p className="lc-mismatch" role="alert">
+                ⚠ Doesn't match yet — keep typing
+              </p>
+            )}
+            <div className="lc-wizard-actions">
+              <button
+                type="button"
+                className="lc-btn lc-btn--primary"
+                disabled={!slugMatch}
+                onClick={() => setStep(3)}
+              >
+                Continue to MFA
+              </button>
+              <button type="button" className="lc-btn lc-btn--ghost" onClick={onCancel}>
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Step 3 */}
+        {step === 3 && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+            <AuditReasonPrompt
+              action="tenant_purge"
+              minLength={30}
+              value={reason}
+              onChange={setReason}
+            />
+
+            <div>
+              <p className="lc-totp-label">Enter 6-digit authenticator code</p>
+              <div className="lc-totp-row" role="group" aria-label="TOTP code digits">
+                {totp.map((digit, idx) => (
+                  <input
+                    key={idx}
+                    ref={(el) => {
+                      totpRefs.current[idx] = el;
+                    }}
+                    className="lc-totp-digit"
+                    type="text"
+                    inputMode="numeric"
+                    maxLength={1}
+                    value={digit}
+                    onChange={(e) => handleTotpChange(idx, e.target.value)}
+                    onKeyDown={(e) => handleTotpKeyDown(idx, e)}
+                    aria-label={`Digit ${idx + 1} of 6`}
+                    autoComplete="one-time-code"
+                  />
+                ))}
+              </div>
+            </div>
+
+            <div className="lc-wizard-actions">
+              <button
+                type="button"
+                className="lc-btn lc-btn--danger"
+                disabled={!reasonValid || !totpFull || isPending}
+                onClick={handlePurge}
+              >
+                {isPending && <span className="lc-spinner" aria-hidden="true" />}
+                {isPending ? 'Purging…' : 'Verify and purge'}
+              </button>
+              <button
+                type="button"
+                className="lc-btn lc-btn--ghost"
+                onClick={onCancel}
+                disabled={isPending}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main page component
+// ---------------------------------------------------------------------------
+
+export default function TenantLifecyclePage() {
+  ensureStyles();
+
+  // Capability checks for OR-gate (page-level gating mirrors ProtectedRoute
+  // which also uses any-of, but we double-check here and show ForbiddenPage
+  // when none are held so the inner page logic is always guarded).
+  const canExport = useCapability('tenant_export');
+  const canPurge = useCapability('tenant_purge');
+  const canRestore = useCapability('tenant_restore');
+
+  const [slugInput, setSlugInput] = useState('');
+  const [tenant, setTenant] = useState<TenantInfo>(DEMO_TENANT);
+
+  const [purgeWizardOpen, setPurgeWizardOpen] = useState(false);
+  const [cooldownMs, setCooldownMs] = useState<number>(0);
+  const cooldownIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const [restoreFile, setRestoreFile] = useState<File | null>(null);
+  const [isExporting, setIsExporting] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const { token } = useAdminAuth();
+  const { showToast } = useToast();
+
+  // Capability gate — show ForbiddenPage when user holds none of the three
+  if (!canExport && !canPurge && !canRestore) {
+    return (
+      <ForbiddenPage requiredCapability={['tenant_export', 'tenant_purge', 'tenant_restore']} />
+    );
+  }
+
+  // Compute initial cooldown on tenant change
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional on tenant change
+  useEffect(() => {
+    if (cooldownIntervalRef.current) {
+      clearInterval(cooldownIntervalRef.current);
+      cooldownIntervalRef.current = null;
+    }
+
+    if (!tenant.softDeletedAt) {
+      setCooldownMs(0);
+      return;
+    }
+
+    const elapsed = Date.now() - tenant.softDeletedAt.getTime();
+    const remaining = Math.max(0, PURGE_COOLDOWN_MS - elapsed);
+    setCooldownMs(remaining);
+
+    if (remaining > 0) {
+      cooldownIntervalRef.current = setInterval(() => {
+        setCooldownMs((prev) => {
+          const next = prev - 1000;
+          if (next <= 0) {
+            if (cooldownIntervalRef.current) clearInterval(cooldownIntervalRef.current);
+            return 0;
+          }
+          return next;
+        });
+      }, 1000);
+    }
+
+    return () => {
+      if (cooldownIntervalRef.current) clearInterval(cooldownIntervalRef.current);
+    };
+  }, [tenant.id]);
+
+  // Load tenant from slug input
+  const handleLoadTenant = useCallback(() => {
+    const slug = slugInput.trim() || DEMO_TENANT.slug;
+    setTenant({ ...DEMO_TENANT, slug, name: slug === DEMO_TENANT.slug ? DEMO_TENANT.name : slug });
+    setPurgeWizardOpen(false);
+  }, [slugInput]);
+
+  // Export action
+  const handleExport = useCallback(async () => {
+    if (isExporting) return;
+    setIsExporting(true);
+    try {
+      const resp = await fetch(`/api/v1/admin/tenants/${tenant.id}/export`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token ?? ''}` },
+      });
+      if (resp.ok) {
+        showToast({
+          type: 'success',
+          title: 'Export started',
+          message: 'A new export is being generated. You will be notified when it is ready.',
+        });
+      } else {
+        showToast({
+          type: 'error',
+          title: `Export failed (${resp.status})`,
+          message: await resp.text().catch(() => resp.statusText),
+        });
+      }
+    } catch {
+      showToast({
+        type: 'error',
+        title: 'Network error',
+        message: 'Unable to start export. Check your connection and try again.',
+      });
+    } finally {
+      setIsExporting(false);
+    }
+  }, [isExporting, tenant.id, token, showToast]);
+
+  // Restore upload stub
+  const handleUpload = useCallback(async () => {
+    if (!restoreFile || isUploading) return;
+    setIsUploading(true);
+    try {
+      showToast({
+        type: 'info',
+        title: 'Upload not yet implemented',
+        message: `Multipart restore endpoint not yet wired. File selected: ${restoreFile.name}`,
+      });
+    } finally {
+      setIsUploading(false);
+    }
+  }, [restoreFile, isUploading, showToast]);
+
+  // Purge button state
+  const tenantSoftDeleted = tenant.softDeletedAt !== null;
+  const cooldownActive = cooldownMs > 0;
+  const purgeButtonDisabled = !tenantSoftDeleted || cooldownActive;
+
+  const purgeButtonLabel = !tenantSoftDeleted
+    ? 'Tenant is not soft-deleted yet'
+    : cooldownActive
+      ? `Cooldown · ${formatCooldown(cooldownMs)} left`
+      : 'Purge tenant';
+
+  return (
+    <div className="lc-page">
+      {/* Tenant picker */}
+      <div className="lc-picker">
+        <label htmlFor="lc-slug-picker">Tenant slug</label>
+        <input
+          id="lc-slug-picker"
+          type="text"
+          placeholder={DEMO_TENANT.slug}
+          value={slugInput}
+          onChange={(e) => setSlugInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') handleLoadTenant();
+          }}
+        />
+        <button type="button" className="lc-btn lc-btn--ghost" onClick={handleLoadTenant}>
+          Load
+        </button>
+      </div>
+
+      {/* Page header */}
+      <div className="lc-header">
+        <h1 className="lc-title">Lifecycle · {tenant.name}</h1>
+        <p className="lc-subline">
+          Tenant slug: <strong>{tenant.slug}</strong>
+          <span aria-hidden="true">·</span>
+          Last export: {tenant.lastExportAt ? formatDate(tenant.lastExportAt) : 'Never'}
+          <span aria-hidden="true">·</span>
+          Soft-deleted at: {tenant.softDeletedAt ? formatDate(tenant.softDeletedAt) : 'Active'}
+        </p>
+      </div>
+
+      {/* Card grid */}
+      <div className="lc-grid">
+        {/* ── Export card ── */}
+        <div className="lc-card">
+          <h3 className="lc-card-title">Export</h3>
+          <p className="lc-card-body">
+            Full tenant dump as .tar.gz. Includes listings, memberships, audit rows, blobs.
+          </p>
+          {canExport && (
+            <button
+              type="button"
+              className="lc-btn lc-btn--primary"
+              onClick={handleExport}
+              disabled={isExporting}
+            >
+              {isExporting && <span className="lc-spinner" aria-hidden="true" />}
+              {isExporting ? 'Starting…' : 'Start export'}
+            </button>
+          )}
+          {tenant.lastExportAt ? (
+            <p className="lc-card-subtext">
+              Last export: {formatDate(tenant.lastExportAt)} by {tenant.lastExportBy ?? 'unknown'} —{' '}
+              {/* biome-ignore lint/a11y/useValidAnchor: placeholder download link */}
+              <a onClick={(e) => e.preventDefault()} href="#">
+                download ({tenant.lastExportSizeGb?.toFixed(1) ?? '?'} GB)
+              </a>
+            </p>
+          ) : (
+            <p className="lc-card-subtext">No exports yet.</p>
+          )}
+        </div>
+
+        {/* ── Purge card ── */}
+        <div className="lc-card danger">
+          <h3 className="lc-card-title danger">Purge · irreversible</h3>
+          <p className="lc-card-body danger">
+            Deletes all tenant data including audit log. After 24-hour cooldown from soft-delete.
+            Cannot be undone.
+          </p>
+          {!tenantSoftDeleted && (
+            <p className="lc-btn-hint">
+              Tenant must be soft-deleted before purge can be initiated.
+            </p>
+          )}
+          {canPurge && (
+            <>
+              <button
+                type="button"
+                className="lc-btn lc-btn--danger"
+                disabled={purgeButtonDisabled}
+                onClick={() => setPurgeWizardOpen(true)}
+                aria-label={purgeButtonLabel}
+              >
+                {purgeButtonLabel}
+              </button>
+              {cooldownActive && (
+                <p className="lc-btn-hint" aria-live="polite">
+                  Cooldown: {formatCooldown(cooldownMs)} remaining
+                </p>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* ── Restore card ── */}
+        <div className="lc-card">
+          <h3 className="lc-card-title">Restore</h3>
+          <p className="lc-card-body">
+            Upload a previously exported tarball into a new tenant slug. Multipart — resumes on
+            disconnect.
+          </p>
+          {canRestore && (
+            <>
+              <label className="lc-file-label" htmlFor="lc-restore-file">
+                Choose file…
+              </label>
+              <input
+                id="lc-restore-file"
+                type="file"
+                accept=".tar.gz"
+                style={{ display: 'none' }}
+                onChange={(e) => setRestoreFile(e.target.files?.[0] ?? null)}
+              />
+              {restoreFile && (
+                <>
+                  <p className="lc-file-selected">
+                    Selected: {restoreFile.name} ({(restoreFile.size / 1_073_741_824).toFixed(1)}{' '}
+                    GB)
+                  </p>
+                  <button
+                    type="button"
+                    className="lc-btn lc-btn--primary"
+                    onClick={handleUpload}
+                    disabled={isUploading}
+                  >
+                    {isUploading && <span className="lc-spinner" aria-hidden="true" />}
+                    {isUploading ? 'Uploading…' : 'Upload'}
+                  </button>
+                </>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Purge wizard (inline, below grid) */}
+      {purgeWizardOpen && canPurge && (
+        <PurgeWizard tenant={tenant} onCancel={() => setPurgeWizardOpen(false)} />
+      )}
+    </div>
+  );
+}
+
+TenantLifecyclePage.displayName = 'TenantLifecyclePage';

--- a/frontend/apps/admin-web/src/pages/audit.tsx
+++ b/frontend/apps/admin-web/src/pages/audit.tsx
@@ -10,8 +10,9 @@
 
 import { CAPABILITIES } from '@ppt/admin-ui';
 import { useQuery } from '@tanstack/react-query';
-import { type FC, useCallback, useEffect, useRef, useState } from 'react';
+import { type FC, Fragment, useCallback, useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { useAdminAuth } from '../auth/AdminAuthContext';
 import { useToast } from '../components/Toast';
 
 // ---------------------------------------------------------------------------
@@ -224,7 +225,9 @@ function ExpandedRow({ row, onClose }: { row: AuditRow; onClose: () => void }) {
   const handleCopyCurl = useCallback(() => {
     const path = row.request?.path ?? '/unknown';
     const headers = row.request?.headers ?? {};
-    const body = row.request?.body ? JSON.stringify(row.request.body).slice(0, 4096) : '';
+    // `body` is already a string per the AuditRow type — do NOT re-stringify
+    // (extra JSON.stringify wraps it in quotes + escapes, breaking cURL replay).
+    const body = row.request?.body ? row.request.body.slice(0, 4096).replace(/'/g, "'\\''") : '';
     const headerFlags = Object.entries(headers)
       .map(([k, v]) => `  -H '${k}: ${v}'`)
       .join(' \\\n');
@@ -806,6 +809,7 @@ function FilterRail({ filters, onChange }: FilterRailProps) {
 const AuditPage: FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const { showToast } = useToast();
+  const { token } = useAdminAuth();
 
   // Read filter state from URL on mount
   const [filters, setFilters] = useState<Filters>(() => readFiltersFromParams(searchParams));
@@ -844,7 +848,10 @@ const AuditPage: FC = () => {
   const query = useQuery<AuditResponse>({
     queryKey: ['admin', 'audit', filters, cursor],
     queryFn: async () => {
-      const res = await fetch(`/api/v1/admin/audit${qs ? `?${qs}` : ''}`);
+      const res = await fetch(`/api/v1/admin/audit${qs ? `?${qs}` : ''}`, {
+        credentials: 'include',
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
       if (res.status === 404) {
         // TODO: endpoint not yet implemented
         console.warn(
@@ -1069,9 +1076,8 @@ const AuditPage: FC = () => {
                   </tr>
                 ) : (
                   visibleRows.map((row) => (
-                    <>
+                    <Fragment key={row.id}>
                       <tr
-                        key={row.id}
                         onClick={() => toggleRow(row.id)}
                         style={{
                           borderBottom: '1px solid var(--ppt-border-default, #e5e7eb)',
@@ -1155,13 +1161,9 @@ const AuditPage: FC = () => {
                         </td>
                       </tr>
                       {expandedId === row.id && (
-                        <ExpandedRow
-                          key={`exp-${row.id}`}
-                          row={row}
-                          onClose={() => setExpandedId(null)}
-                        />
+                        <ExpandedRow row={row} onClose={() => setExpandedId(null)} />
                       )}
-                    </>
+                    </Fragment>
                   ))
                 )}
               </tbody>

--- a/frontend/apps/admin-web/src/pages/audit.tsx
+++ b/frontend/apps/admin-web/src/pages/audit.tsx
@@ -1,24 +1,1211 @@
 /**
- * Phase 5 — `/admin/audit` page.
+ * Audit Log — `/ops/audit`
  *
- * Audit-log viewer. Reads from `GET /api/v1/admin/audit` (capability
- * `audit_read`).
+ * Design impl §D. Two-panel layout: sticky 220px filter rail (left) +
+ * scrollable table area (right). All filter state is synced to URL query
+ * string. Rows expand inline (no modal). Cursor-based "Load more" pagination.
+ *
+ * Gate: `audit_read` — enforced by ProtectedRoute in App.tsx.
  */
 
-import { type AuditEntry, type AuditFilter, AuditViewer } from '@ppt/admin-ui';
-import { type FC, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { CAPABILITIES } from '@ppt/admin-ui';
+import { useQuery } from '@tanstack/react-query';
+import { type FC, useCallback, useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useToast } from '../components/Toast';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type AuditRow = {
+  id: string;
+  occurred_at: string;
+  actor_email?: string;
+  actor_user_id?: string;
+  capability?: string;
+  target_kind?: 'user' | 'tenant' | 'capability';
+  target_slug?: string;
+  outcome?: 'success' | 'mfa_failed' | 'denied';
+  reason?: string;
+  ip?: string;
+  user_agent?: string;
+  mfa_recent_at_call?: string;
+  request?: { path?: string; headers?: Record<string, string>; body?: string };
+  principal_kind?: string;
+};
+
+type AuditResponse = {
+  items: AuditRow[];
+  next_cursor?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const HIGH_RISK_CAPABILITIES = new Set([
+  'tenant_purge',
+  'principal_kind_escalate',
+  'grant_principal_kind_escalate',
+  'tenant_restore',
+]);
+
+const DATE_PRESETS = [
+  { label: '15m', value: '15m' },
+  { label: '1h', value: '1h' },
+  { label: '24h', value: '24h' },
+  { label: '7d', value: '7d' },
+  { label: '30d', value: '30d' },
+] as const;
+
+type DatePreset = (typeof DATE_PRESETS)[number]['value'];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatOccurredAt(iso: string): string {
+  try {
+    return new Intl.DateTimeFormat('en-GB', {
+      dateStyle: 'short',
+      timeStyle: 'medium',
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
+function truncate(s: string | undefined, max: number): string {
+  if (!s) return '—';
+  return s.length > max ? `${s.slice(0, max)}…` : s;
+}
+
+function isHighSeverity(capability?: string): boolean {
+  return capability ? HIGH_RISK_CAPABILITIES.has(capability) : false;
+}
+
+function buildQueryString(
+  filters: {
+    actor: string;
+    target: string;
+    capabilities: string[];
+    severity: string;
+    outcome: string;
+    dateRange: string;
+  },
+  cursor?: string
+): string {
+  const params = new URLSearchParams();
+  if (filters.actor) params.set('actor', filters.actor);
+  if (filters.target) params.set('target', filters.target);
+  if (filters.capabilities.length) params.set('capability', filters.capabilities.join(','));
+  if (filters.severity !== 'all') params.set('severity', filters.severity);
+  if (filters.outcome !== 'all') params.set('outcome', filters.outcome);
+  if (filters.dateRange) params.set('range', filters.dateRange);
+  if (cursor) params.set('after', cursor);
+  return params.toString();
+}
+
+function parseMfaRemaining(row: AuditRow): string {
+  if (!row.mfa_recent_at_call) return 'Not active at call time';
+  const at = new Date(row.mfa_recent_at_call);
+  const mfaWindow = 15 * 60 * 1000; // 15 min assumed window
+  const elapsed = Date.now() - at.getTime();
+  const remaining = mfaWindow - elapsed;
+  if (remaining <= 0) return 'Active at call time (expired since)';
+  const mins = Math.floor(remaining / 60000);
+  return `Active at call time · ${mins} min remaining`;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+/** Colored pill for capability name */
+function CapabilityPill({ cap }: { cap?: string }) {
+  if (!cap) return <span style={{ color: 'var(--ppt-fg-muted)' }}>—</span>;
+  const high = isHighSeverity(cap);
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        padding: '2px 8px',
+        borderRadius: 'var(--ppt-radius-full, 9999px)',
+        fontSize: '0.75rem',
+        fontWeight: 500,
+        background: high ? 'var(--ppt-danger-100, #fee2e2)' : 'var(--ppt-brand-100, #eff6ff)',
+        color: high ? 'var(--ppt-danger-800, #991b1b)' : 'var(--ppt-brand-800, #1e40af)',
+        fontFamily: 'monospace',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {cap}
+    </span>
+  );
+}
+
+/** Colored pill for outcome */
+function OutcomePill({ outcome }: { outcome?: string }) {
+  if (!outcome) return <span style={{ color: 'var(--ppt-fg-muted)' }}>—</span>;
+  const colors: Record<string, { bg: string; fg: string }> = {
+    success: { bg: 'var(--ppt-success-100, #dcfce7)', fg: 'var(--ppt-success-800, #166534)' },
+    mfa_failed: { bg: 'var(--ppt-warning-100, #fef9c3)', fg: 'var(--ppt-warning-800, #854d0e)' },
+    denied: { bg: 'var(--ppt-danger-100, #fee2e2)', fg: 'var(--ppt-danger-800, #991b1b)' },
+  };
+  const c = colors[outcome] ?? {
+    bg: 'var(--ppt-bg-subtle, #f9fafb)',
+    fg: 'var(--ppt-fg-muted, #6b7280)',
+  };
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        padding: '2px 8px',
+        borderRadius: 'var(--ppt-radius-full, 9999px)',
+        fontSize: '0.75rem',
+        fontWeight: 500,
+        background: c.bg,
+        color: c.fg,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {outcome}
+    </span>
+  );
+}
+
+/** Red/amber/blue severity dot */
+function SeverityDot({ capability }: { capability?: string }) {
+  const high = isHighSeverity(capability);
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        width: 8,
+        height: 8,
+        borderRadius: '50%',
+        background: high ? 'var(--ppt-danger-500, #ef4444)' : 'var(--ppt-brand-400, #60a5fa)',
+        flexShrink: 0,
+      }}
+      title={high ? 'High severity' : 'Normal severity'}
+    />
+  );
+}
+
+/** 8 skeleton rows for loading state */
+function SkeletonRows() {
+  return (
+    <>
+      {Array.from({ length: 8 }).map((_, i) => (
+        <tr key={`skel-row-${i}`} style={{ opacity: 1 - i * 0.08 }}>
+          {Array.from({ length: 6 }).map((__, j) => (
+            <td key={`skel-cell-${i}-${j}`} style={{ padding: '10px 12px' }}>
+              <span
+                style={{
+                  display: 'block',
+                  height: 14,
+                  borderRadius: 4,
+                  background: 'var(--ppt-bg-subtle, #f3f4f6)',
+                  width: j === 0 ? '80%' : j === 1 ? '70%' : '60%',
+                  animation: 'ppt-skeleton-pulse 1.4s ease-in-out infinite',
+                }}
+              />
+            </td>
+          ))}
+        </tr>
+      ))}
+    </>
+  );
+}
+
+/** Inline expanded row — full-width, spans all columns */
+function ExpandedRow({ row, onClose }: { row: AuditRow; onClose: () => void }) {
+  const handleCopyCurl = useCallback(() => {
+    const path = row.request?.path ?? '/unknown';
+    const headers = row.request?.headers ?? {};
+    const body = row.request?.body ? JSON.stringify(row.request.body).slice(0, 4096) : '';
+    const headerFlags = Object.entries(headers)
+      .map(([k, v]) => `  -H '${k}: ${v}'`)
+      .join(' \\\n');
+    const bodyFlag = body ? ` \\\n  -d '${body}'` : '';
+    const curl = `curl -X POST 'https://admin.rlt.sk${path}' \\\n${headerFlags}${bodyFlag}`;
+    navigator.clipboard.writeText(curl).catch(() => {
+      // fallback — silent if clipboard API unavailable
+    });
+  }, [row]);
+
+  return (
+    <tr
+      style={{
+        background: 'var(--ppt-accent-soft-bg, #eff6ff)',
+        borderBottom: '1px solid var(--ppt-border-default, #e5e7eb)',
+      }}
+    >
+      <td colSpan={6} style={{ padding: '16px 24px' }}>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr',
+            gap: 24,
+          }}
+        >
+          {/* Left half */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            <div>
+              <p
+                style={{
+                  fontSize: '0.75rem',
+                  fontWeight: 600,
+                  color: 'var(--ppt-fg-muted)',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.05em',
+                  marginBottom: 4,
+                }}
+              >
+                Audit reason
+              </p>
+              <pre
+                style={{
+                  fontFamily: 'monospace',
+                  fontSize: '0.8125rem',
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-word',
+                  color: 'var(--ppt-fg-primary)',
+                  margin: 0,
+                }}
+              >
+                {row.reason ?? '(no reason recorded)'}
+              </pre>
+            </div>
+            {row.request && (
+              <div>
+                <p
+                  style={{
+                    fontSize: '0.75rem',
+                    fontWeight: 600,
+                    color: 'var(--ppt-fg-muted)',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.05em',
+                    marginBottom: 4,
+                  }}
+                >
+                  Request envelope
+                </p>
+                <div
+                  style={{
+                    fontFamily: 'monospace',
+                    fontSize: '0.8125rem',
+                    background: 'var(--ppt-bg-app, #f9fafb)',
+                    border: '1px solid var(--ppt-border-default, #e5e7eb)',
+                    borderRadius: 6,
+                    padding: '10px 12px',
+                    color: 'var(--ppt-fg-secondary)',
+                  }}
+                >
+                  <div style={{ fontWeight: 600 }}>POST {row.request.path ?? '/unknown'}</div>
+                  {Object.entries(row.request.headers ?? {}).map(([k, v]) => (
+                    <div key={k}>
+                      <span style={{ color: 'var(--ppt-brand-600, #2563eb)' }}>{k}:</span> {v}
+                    </div>
+                  ))}
+                  {row.request.body && (
+                    <div
+                      style={{
+                        marginTop: 6,
+                        whiteSpace: 'pre-wrap',
+                        wordBreak: 'break-all',
+                        maxHeight: 120,
+                        overflow: 'auto',
+                        opacity: 0.85,
+                      }}
+                    >
+                      {row.request.body.slice(0, 4096)}
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Right half */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            <div>
+              <p
+                style={{
+                  fontSize: '0.75rem',
+                  fontWeight: 600,
+                  color: 'var(--ppt-fg-muted)',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.05em',
+                  marginBottom: 4,
+                }}
+              >
+                Principal
+              </p>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span style={{ fontSize: '0.875rem', color: 'var(--ppt-fg-primary)' }}>
+                  {row.actor_email ?? row.actor_user_id ?? '—'}
+                </span>
+                {row.principal_kind && (
+                  <span
+                    style={{
+                      padding: '1px 6px',
+                      borderRadius: 4,
+                      fontSize: '0.6875rem',
+                      fontWeight: 600,
+                      background: 'var(--ppt-brand-100, #eff6ff)',
+                      color: 'var(--ppt-brand-700, #1d4ed8)',
+                      textTransform: 'uppercase',
+                      fontFamily: 'monospace',
+                    }}
+                  >
+                    {row.principal_kind}
+                  </span>
+                )}
+              </div>
+            </div>
+
+            {(row.ip ?? row.user_agent) && (
+              <div>
+                <p
+                  style={{
+                    fontSize: '0.75rem',
+                    fontWeight: 600,
+                    color: 'var(--ppt-fg-muted)',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.05em',
+                    marginBottom: 4,
+                  }}
+                >
+                  Network / Client
+                </p>
+                <div
+                  style={{
+                    fontFamily: 'monospace',
+                    fontSize: '0.8125rem',
+                    color: 'var(--ppt-fg-secondary)',
+                  }}
+                >
+                  {row.ip && <div>IP: {row.ip}</div>}
+                  {row.user_agent && (
+                    <div style={{ wordBreak: 'break-all' }}>UA: {row.user_agent}</div>
+                  )}
+                </div>
+              </div>
+            )}
+
+            <div>
+              <p
+                style={{
+                  fontSize: '0.75rem',
+                  fontWeight: 600,
+                  color: 'var(--ppt-fg-muted)',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.05em',
+                  marginBottom: 4,
+                }}
+              >
+                MFA state at call time
+              </p>
+              <span
+                style={{
+                  fontSize: '0.875rem',
+                  color: row.mfa_recent_at_call
+                    ? 'var(--ppt-success-700, #15803d)'
+                    : 'var(--ppt-fg-muted)',
+                }}
+              >
+                {parseMfaRemaining(row)}
+              </span>
+            </div>
+
+            <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginTop: 4 }}>
+              <button
+                type="button"
+                onClick={handleCopyCurl}
+                style={{
+                  padding: '5px 12px',
+                  fontSize: '0.8125rem',
+                  border: '1px solid var(--ppt-border-default, #e5e7eb)',
+                  borderRadius: 6,
+                  background: 'var(--ppt-bg-surface, #fff)',
+                  color: 'var(--ppt-fg-primary)',
+                  cursor: 'pointer',
+                  fontFamily: 'inherit',
+                }}
+              >
+                Copy as cURL
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  /* TODO: view related events */
+                }}
+                style={{
+                  padding: '5px 12px',
+                  fontSize: '0.8125rem',
+                  border: '1px solid var(--ppt-border-default, #e5e7eb)',
+                  borderRadius: 6,
+                  background: 'var(--ppt-bg-surface, #fff)',
+                  color: 'var(--ppt-fg-primary)',
+                  cursor: 'pointer',
+                  fontFamily: 'inherit',
+                  opacity: 0.6,
+                }}
+                title="TODO — not yet implemented"
+              >
+                View related
+              </button>
+              <button
+                type="button"
+                onClick={onClose}
+                style={{
+                  marginLeft: 'auto',
+                  padding: '5px 12px',
+                  fontSize: '0.8125rem',
+                  border: 'none',
+                  borderRadius: 6,
+                  background: 'transparent',
+                  color: 'var(--ppt-fg-muted)',
+                  cursor: 'pointer',
+                  fontFamily: 'inherit',
+                }}
+              >
+                Close ✕
+              </button>
+            </div>
+          </div>
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Filter rail
+// ---------------------------------------------------------------------------
+
+type Filters = {
+  actor: string;
+  target: string;
+  capabilities: string[];
+  severity: 'all' | 'high' | 'normal';
+  outcome: 'all' | 'success' | 'mfa_failed' | 'denied';
+  dateRange: DatePreset | '';
+};
+
+const FILTER_DEFAULTS: Filters = {
+  actor: '',
+  target: '',
+  capabilities: [],
+  severity: 'all',
+  outcome: 'all',
+  dateRange: '',
+};
+
+function readFiltersFromParams(params: URLSearchParams): Filters {
+  const caps = params.get('capability');
+  return {
+    actor: params.get('actor') ?? '',
+    target: params.get('target') ?? '',
+    capabilities: caps ? caps.split(',').filter(Boolean) : [],
+    severity: (params.get('severity') as Filters['severity']) ?? 'all',
+    outcome: (params.get('outcome') as Filters['outcome']) ?? 'all',
+    dateRange: (params.get('range') as DatePreset) ?? '',
+  };
+}
+
+function hasActiveFilters(f: Filters): boolean {
+  return (
+    f.actor !== '' ||
+    f.target !== '' ||
+    f.capabilities.length > 0 ||
+    f.severity !== 'all' ||
+    f.outcome !== 'all' ||
+    f.dateRange !== ''
+  );
+}
+
+interface FilterRailProps {
+  filters: Filters;
+  onChange: (f: Filters) => void;
+}
+
+function FilterRail({ filters, onChange }: FilterRailProps) {
+  // Debounce actor + target text inputs
+  const actorTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const targetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const [actorDraft, setActorDraft] = useState(filters.actor);
+  const [targetDraft, setTargetDraft] = useState(filters.target);
+
+  // Sync draft from external filter changes (e.g. clear-all)
+  useEffect(() => {
+    setActorDraft(filters.actor);
+  }, [filters.actor]);
+  useEffect(() => {
+    setTargetDraft(filters.target);
+  }, [filters.target]);
+
+  const handleActorChange = (v: string) => {
+    setActorDraft(v);
+    if (actorTimer.current) clearTimeout(actorTimer.current);
+    actorTimer.current = setTimeout(() => onChange({ ...filters, actor: v }), 250);
+  };
+
+  const handleTargetChange = (v: string) => {
+    setTargetDraft(v);
+    if (targetTimer.current) clearTimeout(targetTimer.current);
+    targetTimer.current = setTimeout(() => onChange({ ...filters, target: v }), 250);
+  };
+
+  const toggleCapability = (cap: string) => {
+    const next = filters.capabilities.includes(cap)
+      ? filters.capabilities.filter((c) => c !== cap)
+      : [...filters.capabilities, cap];
+    onChange({ ...filters, capabilities: next });
+  };
+
+  const labelStyle: React.CSSProperties = {
+    display: 'block',
+    fontSize: '0.6875rem',
+    fontWeight: 600,
+    letterSpacing: '0.06em',
+    textTransform: 'uppercase',
+    color: 'var(--ppt-fg-muted)',
+    marginBottom: 4,
+  };
+
+  const inputStyle: React.CSSProperties = {
+    width: '100%',
+    boxSizing: 'border-box',
+    padding: '6px 10px',
+    fontSize: '0.8125rem',
+    border: '1px solid var(--ppt-border-default, #e5e7eb)',
+    borderRadius: 6,
+    background: 'var(--ppt-bg-surface, #fff)',
+    color: 'var(--ppt-fg-primary)',
+    outline: 'none',
+    fontFamily: 'inherit',
+  };
+
+  const segmentedBase: React.CSSProperties = {
+    display: 'inline-flex',
+    border: '1px solid var(--ppt-border-default, #e5e7eb)',
+    borderRadius: 6,
+    overflow: 'hidden',
+    width: '100%',
+  };
+
+  const segBtn = (active: boolean): React.CSSProperties => ({
+    flex: 1,
+    padding: '5px 0',
+    fontSize: '0.8125rem',
+    border: 'none',
+    cursor: 'pointer',
+    fontFamily: 'inherit',
+    background: active ? 'var(--ppt-brand-600, #2563eb)' : 'var(--ppt-bg-surface, #fff)',
+    color: active ? '#fff' : 'var(--ppt-fg-secondary)',
+    fontWeight: active ? 600 : 400,
+    transition: 'background 0.15s',
+  });
+
+  return (
+    <aside
+      style={{
+        width: 220,
+        flexShrink: 0,
+        position: 'sticky',
+        top: 0,
+        height: '100vh',
+        overflowY: 'auto',
+        borderRight: '1px solid var(--ppt-border-default, #e5e7eb)',
+        padding: 16,
+        boxSizing: 'border-box',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 16,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <h3
+          style={{
+            fontSize: '0.875rem',
+            fontWeight: 700,
+            color: 'var(--ppt-fg-primary)',
+            margin: 0,
+          }}
+        >
+          Filters
+        </h3>
+        {hasActiveFilters(filters) && (
+          <button
+            type="button"
+            onClick={() => onChange(FILTER_DEFAULTS)}
+            style={{
+              fontSize: '0.75rem',
+              color: 'var(--ppt-brand-600, #2563eb)',
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: 0,
+              fontFamily: 'inherit',
+            }}
+          >
+            Clear all
+          </button>
+        )}
+      </div>
+
+      {/* Actor */}
+      <div>
+        <label style={labelStyle} htmlFor="audit-filter-actor">
+          Actor
+        </label>
+        <input
+          id="audit-filter-actor"
+          type="text"
+          value={actorDraft}
+          onChange={(e) => handleActorChange(e.target.value)}
+          placeholder="email or user id"
+          style={inputStyle}
+        />
+      </div>
+
+      {/* Target */}
+      <div>
+        <label style={labelStyle} htmlFor="audit-filter-target">
+          Target
+        </label>
+        <input
+          id="audit-filter-target"
+          type="text"
+          value={targetDraft}
+          onChange={(e) => handleTargetChange(e.target.value)}
+          placeholder="user / tenant / capability"
+          style={inputStyle}
+        />
+      </div>
+
+      {/* Capability multi-select pills */}
+      <div>
+        <span style={labelStyle}>Capability</span>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+          {CAPABILITIES.map((cap) => {
+            const selected = filters.capabilities.includes(cap);
+            return (
+              <button
+                type="button"
+                key={cap}
+                onClick={() => toggleCapability(cap)}
+                style={{
+                  padding: '2px 7px',
+                  fontSize: '0.6875rem',
+                  fontFamily: 'monospace',
+                  borderRadius: 4,
+                  border: '1px solid',
+                  cursor: 'pointer',
+                  borderColor: selected
+                    ? 'var(--ppt-brand-300, #93c5fd)'
+                    : 'var(--ppt-border-default, #e5e7eb)',
+                  background: selected
+                    ? 'var(--ppt-brand-100, #eff6ff)'
+                    : 'var(--ppt-bg-surface, #fff)',
+                  color: selected ? 'var(--ppt-brand-800, #1e40af)' : 'var(--ppt-fg-secondary)',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {cap}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Severity segmented control */}
+      <div>
+        <span style={labelStyle}>Severity</span>
+        <div style={segmentedBase}>
+          {(['all', 'high', 'normal'] as const).map((v) => (
+            <button
+              type="button"
+              key={v}
+              onClick={() => onChange({ ...filters, severity: v })}
+              style={segBtn(filters.severity === v)}
+            >
+              {v === 'all' ? 'All' : v.charAt(0).toUpperCase() + v.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Outcome segmented control */}
+      <div>
+        <span style={labelStyle}>Outcome</span>
+        <div style={{ ...segmentedBase, flexDirection: 'column' }}>
+          {(['all', 'success', 'mfa_failed', 'denied'] as const).map((v) => (
+            <button
+              type="button"
+              key={v}
+              onClick={() => onChange({ ...filters, outcome: v })}
+              style={{
+                ...segBtn(filters.outcome === v),
+                borderBottom:
+                  v !== 'denied' ? '1px solid var(--ppt-border-default, #e5e7eb)' : 'none',
+              }}
+            >
+              {v === 'all' ? 'All' : v}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Date range presets */}
+      <div>
+        <span style={labelStyle}>Date range</span>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+          {DATE_PRESETS.map(({ label, value }) => {
+            const active = filters.dateRange === value;
+            return (
+              <button
+                type="button"
+                key={value}
+                onClick={() => onChange({ ...filters, dateRange: active ? '' : value })}
+                style={{
+                  padding: '3px 10px',
+                  fontSize: '0.8125rem',
+                  borderRadius: 6,
+                  border: '1px solid',
+                  cursor: 'pointer',
+                  fontFamily: 'inherit',
+                  borderColor: active
+                    ? 'var(--ppt-brand-400, #60a5fa)'
+                    : 'var(--ppt-border-default, #e5e7eb)',
+                  background: active
+                    ? 'var(--ppt-brand-600, #2563eb)'
+                    : 'var(--ppt-bg-surface, #fff)',
+                  color: active ? '#fff' : 'var(--ppt-fg-secondary)',
+                  fontWeight: active ? 600 : 400,
+                }}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main page component
+// ---------------------------------------------------------------------------
 
 const AuditPage: FC = () => {
-  const { t } = useTranslation();
-  const [filter, setFilter] = useState<AuditFilter>({});
-  // TODO(phase-5-followup): wire to GET /api/v1/admin/audit?actor_id=...&action=...
-  const entries: AuditEntry[] = [];
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { showToast } = useToast();
+
+  // Read filter state from URL on mount
+  const [filters, setFilters] = useState<Filters>(() => readFiltersFromParams(searchParams));
+
+  // Cursor for "load more"
+  const [cursor, setCursor] = useState<string | undefined>(searchParams.get('after') ?? undefined);
+  // Accumulated rows across pages
+  const [allRows, setAllRows] = useState<AuditRow[]>([]);
+
+  // Expanded row ID
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  // Sync filters -> URL
+  useEffect(() => {
+    const next = new URLSearchParams();
+    if (filters.actor) next.set('actor', filters.actor);
+    if (filters.target) next.set('target', filters.target);
+    if (filters.capabilities.length) next.set('capability', filters.capabilities.join(','));
+    if (filters.severity !== 'all') next.set('severity', filters.severity);
+    if (filters.outcome !== 'all') next.set('outcome', filters.outcome);
+    if (filters.dateRange) next.set('range', filters.dateRange);
+    if (cursor) next.set('after', cursor);
+    setSearchParams(next, { replace: true });
+  }, [filters, cursor, setSearchParams]);
+
+  // When filters change, reset accumulated rows + cursor
+  const handleFiltersChange = useCallback((f: Filters) => {
+    setFilters(f);
+    setCursor(undefined);
+    setAllRows([]);
+    setExpandedId(null);
+  }, []);
+
+  const qs = buildQueryString(filters, cursor);
+
+  const query = useQuery<AuditResponse>({
+    queryKey: ['admin', 'audit', filters, cursor],
+    queryFn: async () => {
+      const res = await fetch(`/api/v1/admin/audit${qs ? `?${qs}` : ''}`);
+      if (res.status === 404) {
+        // TODO: endpoint not yet implemented
+        console.warn(
+          '[AuditPage] GET /api/v1/admin/audit returned 404 — endpoint not yet implemented'
+        );
+        return { items: [], next_cursor: undefined };
+      }
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      return res.json() as Promise<AuditResponse>;
+    },
+    staleTime: 30_000,
+  });
+
+  // Accumulate rows from successive queries
+  useEffect(() => {
+    if (query.data?.items) {
+      if (!cursor) {
+        // First page (or filter reset)
+        setAllRows(query.data.items);
+      } else {
+        setAllRows((prev) => {
+          // Deduplicate by id
+          const ids = new Set(prev.map((r) => r.id));
+          const fresh = query.data!.items.filter((r) => !ids.has(r.id));
+          return [...prev, ...fresh];
+        });
+      }
+    }
+  }, [query.data, cursor]);
+
+  // Client-side severity filter (server may not support it)
+  const visibleRows = allRows.filter((row) => {
+    if (filters.severity === 'high') return isHighSeverity(row.capability);
+    if (filters.severity === 'normal') return !isHighSeverity(row.capability);
+    return true;
+  });
+
+  const handleExportCsv = async () => {
+    const csvQs = buildQueryString(filters);
+    const url = `/api/v1/admin/audit.csv${csvQs ? `?${csvQs}` : ''}`;
+    try {
+      const probe = await fetch(url, { method: 'HEAD' });
+      if (probe.status === 404) {
+        showToast({ type: 'info', title: 'CSV export not yet implemented' });
+        return;
+      }
+    } catch {
+      // Open anyway — let browser show error
+    }
+    window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
+  const toggleRow = (id: string) => {
+    setExpandedId((prev) => (prev === id ? null : id));
+  };
+
+  const nextCursor = query.data?.next_cursor;
+  const isFirstLoad = query.isLoading && allRows.length === 0;
+
   return (
-    <section>
-      <h1>{t('admin.audit.title')}</h1>
-      <AuditViewer entries={entries} filter={filter} onFilterChange={setFilter} />
-    </section>
+    <>
+      {/* Skeleton animation keyframe — injected once */}
+      <style>{`
+        @keyframes ppt-skeleton-pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.4; }
+        }
+      `}</style>
+
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          minHeight: '100vh',
+          background: 'var(--ppt-bg-app, #f9fafb)',
+        }}
+      >
+        {/* Left filter rail */}
+        <FilterRail filters={filters} onChange={handleFiltersChange} />
+
+        {/* Right content */}
+        <div
+          style={{
+            flex: 1,
+            minWidth: 0,
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          {/* Toolbar */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              padding: '16px 24px',
+              borderBottom: '1px solid var(--ppt-border-default, #e5e7eb)',
+              background: 'var(--ppt-bg-surface, #fff)',
+              position: 'sticky',
+              top: 0,
+              zIndex: 10,
+            }}
+          >
+            <h1
+              style={{
+                fontSize: '1.25rem',
+                fontWeight: 700,
+                color: 'var(--ppt-fg-primary)',
+                margin: 0,
+              }}
+            >
+              Audit log
+            </h1>
+            <button
+              type="button"
+              onClick={() => void handleExportCsv()}
+              style={{
+                padding: '6px 14px',
+                fontSize: '0.875rem',
+                border: '1px solid var(--ppt-border-default, #e5e7eb)',
+                borderRadius: 6,
+                background: 'transparent',
+                color: 'var(--ppt-fg-secondary)',
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+              }}
+            >
+              Export CSV
+            </button>
+          </div>
+
+          {/* Error banner */}
+          {query.isError && (
+            <div
+              role="alert"
+              style={{
+                margin: '12px 24px 0',
+                padding: '10px 14px',
+                borderRadius: 6,
+                background: 'var(--ppt-danger-50, #fef2f2)',
+                border: '1px solid var(--ppt-danger-200, #fecaca)',
+                color: 'var(--ppt-danger-800, #991b1b)',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 12,
+                fontSize: '0.875rem',
+              }}
+            >
+              <span>Unable to load audit log. Try again.</span>
+              <button
+                type="button"
+                onClick={() => query.refetch()}
+                style={{
+                  padding: '3px 10px',
+                  border: '1px solid var(--ppt-danger-400, #f87171)',
+                  borderRadius: 4,
+                  background: 'transparent',
+                  color: 'var(--ppt-danger-800, #991b1b)',
+                  cursor: 'pointer',
+                  fontSize: '0.8125rem',
+                  fontFamily: 'inherit',
+                }}
+              >
+                Retry
+              </button>
+            </div>
+          )}
+
+          {/* Table */}
+          <div style={{ overflowX: 'auto', padding: '0 24px 24px' }}>
+            <table
+              style={{
+                width: '100%',
+                borderCollapse: 'collapse',
+                fontSize: '0.875rem',
+                marginTop: 12,
+              }}
+            >
+              <thead>
+                <tr
+                  style={{
+                    borderBottom: '2px solid var(--ppt-border-default, #e5e7eb)',
+                    textAlign: 'left',
+                  }}
+                >
+                  {['When', 'Actor', 'Capability', 'Target', 'Outcome', 'Reason'].map((h) => (
+                    <th
+                      key={h}
+                      style={{
+                        padding: '8px 12px',
+                        fontSize: '0.75rem',
+                        fontWeight: 600,
+                        color: 'var(--ppt-fg-muted)',
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.05em',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {isFirstLoad ? (
+                  <SkeletonRows />
+                ) : visibleRows.length === 0 && !query.isLoading ? (
+                  <tr>
+                    <td
+                      colSpan={6}
+                      style={{
+                        padding: '40px 12px',
+                        textAlign: 'center',
+                        color: 'var(--ppt-fg-muted)',
+                        fontSize: '0.875rem',
+                      }}
+                    >
+                      No audit events match this filter
+                    </td>
+                  </tr>
+                ) : (
+                  visibleRows.map((row) => (
+                    <>
+                      <tr
+                        key={row.id}
+                        onClick={() => toggleRow(row.id)}
+                        style={{
+                          borderBottom: '1px solid var(--ppt-border-default, #e5e7eb)',
+                          background:
+                            expandedId === row.id
+                              ? 'var(--ppt-accent-soft-bg, #eff6ff)'
+                              : 'transparent',
+                          cursor: 'pointer',
+                          transition: 'background 0.1s',
+                        }}
+                        onMouseEnter={(e) => {
+                          if (expandedId !== row.id) {
+                            (e.currentTarget as HTMLTableRowElement).style.background =
+                              'var(--ppt-bg-subtle, #f9fafb)';
+                          }
+                        }}
+                        onMouseLeave={(e) => {
+                          if (expandedId !== row.id) {
+                            (e.currentTarget as HTMLTableRowElement).style.background =
+                              'transparent';
+                          }
+                        }}
+                      >
+                        <td
+                          style={{
+                            padding: '10px 12px',
+                            whiteSpace: 'nowrap',
+                            verticalAlign: 'middle',
+                          }}
+                        >
+                          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                            <SeverityDot capability={row.capability} />
+                            <time
+                              dateTime={row.occurred_at}
+                              style={{ fontFamily: 'monospace', fontSize: '0.8125rem' }}
+                            >
+                              {formatOccurredAt(row.occurred_at)}
+                            </time>
+                          </div>
+                        </td>
+                        <td
+                          style={{
+                            padding: '10px 12px',
+                            color: 'var(--ppt-fg-secondary)',
+                            maxWidth: 200,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {row.actor_email ?? row.actor_user_id ?? '—'}
+                        </td>
+                        <td style={{ padding: '10px 12px' }}>
+                          <CapabilityPill cap={row.capability} />
+                        </td>
+                        <td
+                          style={{
+                            padding: '10px 12px',
+                            fontFamily: 'monospace',
+                            fontSize: '0.8125rem',
+                            color: 'var(--ppt-fg-secondary)',
+                          }}
+                        >
+                          {row.target_slug ? `${row.target_kind ?? ''}/${row.target_slug}` : '—'}
+                        </td>
+                        <td style={{ padding: '10px 12px' }}>
+                          <OutcomePill outcome={row.outcome} />
+                        </td>
+                        <td
+                          style={{
+                            padding: '10px 12px',
+                            color: 'var(--ppt-fg-muted)',
+                            maxWidth: 240,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                          title={row.reason}
+                        >
+                          {truncate(row.reason, 60)}
+                        </td>
+                      </tr>
+                      {expandedId === row.id && (
+                        <ExpandedRow
+                          key={`exp-${row.id}`}
+                          row={row}
+                          onClose={() => setExpandedId(null)}
+                        />
+                      )}
+                    </>
+                  ))
+                )}
+              </tbody>
+            </table>
+
+            {/* Load more */}
+            {nextCursor && !query.isLoading && (
+              <div style={{ display: 'flex', justifyContent: 'center', marginTop: 16 }}>
+                <button
+                  type="button"
+                  onClick={() => setCursor(nextCursor)}
+                  style={{
+                    padding: '8px 24px',
+                    fontSize: '0.875rem',
+                    border: '1px solid var(--ppt-border-default, #e5e7eb)',
+                    borderRadius: 6,
+                    background: 'var(--ppt-bg-surface, #fff)',
+                    color: 'var(--ppt-fg-secondary)',
+                    cursor: 'pointer',
+                    fontFamily: 'inherit',
+                  }}
+                >
+                  Load more
+                </button>
+              </div>
+            )}
+
+            {/* Loading subsequent pages */}
+            {query.isLoading && allRows.length > 0 && (
+              <div
+                style={{
+                  textAlign: 'center',
+                  padding: '12px 0',
+                  color: 'var(--ppt-fg-muted)',
+                  fontSize: '0.875rem',
+                }}
+              >
+                Loading…
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
Implements the `admin.rlt.sk` super-admin design from the Claude Design handoff (`dL6blk16hYbQxKvBfOj5uw`). Built in parallel by 6 sub-agents per section of the design doc.

## What's in

### §A — Information architecture (`9cd50db6`)
Grouped sidebar: Overview · TENANTS · IDENTITY · OPERATIONS · PLATFORM. Group headers hide when all children gated out. Direct URL to gated page → new `ForbiddenPage` listing the required capability + link to `/identity/capabilities`. `ProtectedRoute` now accepts `requiredCapability?: string | string[]`.

### §F — New shared components (`d1a73e4a`)
- `MfaWindowChip` — header pill with 3 states (unverified/verified/expiring), pulsing dot, MM:SS countdown, click to re-verify. `MfaWindowProvider` wraps the app.
- `AuditReasonPrompt` — inline textarea with per-action metadata (8 actions, 2 risk tiers), char counter, repeat-char rejection.
- `DestructiveConfirmDialog` — portal modal, paste-blocked input, optional artificial `delayMs`, embedded `AuditReasonPrompt`.
- 66 new tests (76 total in admin-web now).

### §B — Dashboard at `/` (`f71434b5`)
4-stat tile row (Tenants active · Operators online · Pending merges · High-risk 24h). Two-column row: high-risk audit feed (left) + Active impersonation/Pending collisions/Quick actions (right). Each card independently capability-gated. TanStack Query with appropriate stale times. Stubs for `GET /admin/metrics/summary` (TODO: add backend endpoint).

### §C — Capabilities admin (`19221dc2`)
Registry view (default) + per-user view. Grant drawer with conditional `AuditReasonPrompt` for high-risk caps. 3000 ms confirm delay for `principal_kind_escalate` grants. Revoke flow gates on MFA + reason for high-risk caps. 1085 lines.

### §D — Audit log (`7dd622e8`)
220 px sticky filter rail + content area. URL-synced filters (actor/target/capability/severity/outcome/date range). Cursor-paginated table; inline expanded row with request envelope, principal info, MFA state at call time, copy-as-cURL. 1202 lines.

### §E — Tenant lifecycle + purge wizard (`c986491b`)
3-card grid (Export · Purge · Restore). Live cooldown ticker. 3-step inline purge wizard: confirm export → type slug (paste blocked, exact match required) → MFA + audit reason. POSTs `{ confirm: 'DELETE-PERMANENT', reason }` with `X-MFA-Recent: 1`. 842 lines.

## Token system
Design tokens prefixed `--ppt-*` (matches `@ppt/ui-kit/tokens.css`). Find-replaced from doc's `--brand-*` / `--bg-*` / `--fg-*` etc — values identical.

## Verification
- `pnpm -F @ppt/admin-web typecheck` clean
- `pnpm -F @ppt/admin-web build` — 433 KB bundle / 130 KB gzipped
- `pnpm -F @ppt/admin-web test:run` — 6 files, 76 tests passing
- `pnpm biome check apps/admin-web` clean
- `docker build -f docker/frontend/admin-web.Dockerfile .` not run locally; CI will validate

## What's stubbed / known TODOs
- `GET /admin/metrics/summary` endpoint not in backend yet (Dashboard falls back to zeros + console.warn)
- Capability descriptions are placeholder strings (TODO: real one-liners per cap, see open question #9 in design doc)
- `mfa_verified_until` claim not yet on `/me` response (chip falls back to `unverified` state until backend ships it)
- Several "View related" / saved views buttons are no-ops (Phase C in roadmap)
- Memberships/Impersonation/Mobile config routes still placeholders (next iteration)

Design source: `.claude/design-source/admin-design-doc.html` + `IMPL-BRIEF.md` (not committed — gitignored).

🤖 Co-authored by 6 parallel Claude Code sub-agents