### PR TITLE
feat(outages): resolve created_by UUID to name in response DTO

### DIFF
--- a/backend/crates/db/src/models/outage.rs
+++ b/backend/crates/db/src/models/outage.rs
@@ -116,6 +116,7 @@ pub struct OutageSummary {
 pub struct OutageWithDetails {
     #[serde(flatten)]
     pub outage: Outage,
+    #[serde(rename = "creatorName")]
     pub creator_name: String,
     pub building_names: Vec<String>,
     pub notification_count: i64,

--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -1097,7 +1097,7 @@ function ViewOutagePageRoute() {
     cancelReason: outageData.cancelReason,
     createdAt: outageData.createdAt,
     updatedAt: outageData.updatedAt,
-    createdByName: outageData.createdBy, // TODO: Fetch user name
+    createdByName: outageData.creatorName ?? outageData.createdBy ?? 'Unknown',
     buildingNames: outageData.buildings?.map((b) => b.name) ?? [],
   };
 
@@ -1208,7 +1208,7 @@ function EditOutagePageRoute() {
     cancelReason: outageData.cancelReason,
     createdAt: outageData.createdAt,
     updatedAt: outageData.updatedAt,
-    createdByName: outageData.createdBy, // TODO: Fetch user name
+    createdByName: outageData.creatorName ?? outageData.createdBy ?? 'Unknown',
     buildingNames: outageData.buildings?.map((b) => b.name) ?? [],
   };
 

--- a/frontend/packages/api-client/src/outages/types.ts
+++ b/frontend/packages/api-client/src/outages/types.ts
@@ -53,6 +53,8 @@ export interface OutageSummary {
 export interface OutageWithDetails extends Outage {
   buildings: OutageBuilding[];
   readStatus?: OutageReadStatus;
+  /** Resolved display name of the user who created the outage (joined server-side). */
+  creatorName?: string;
 }
 
 export interface OutageBuilding {


### PR DESCRIPTION
Sprint 1 PR D from team audit punch list (#17). The outage detail page in ppt-web was showing a raw UUID for 'Created by' field. Backend already had `creator_name` in `OutageWithDetails` model (via JOIN users). Frontend type added `creatorName?: string`; App.tsx uses `outageData.creatorName ?? outageData.createdBy ?? 'Unknown'` as fallback chain.