### PR TITLE
feat(admin): GET /admin/audit/csv export endpoint

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "admin-core"
-version = "0.2.388"
+version = "0.2.389"
 dependencies = [
  "api-core",
  "async-trait",
@@ -192,7 +192,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-core"
-version = "0.2.388"
+version = "0.2.389"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "api-server"
-version = "0.2.388"
+version = "0.2.389"
 dependencies = [
  "admin-core",
  "aes-gcm",
@@ -236,6 +236,7 @@ dependencies = [
  "clap",
  "common",
  "config",
+ "csv",
  "db",
  "dialoguer",
  "dotenvy",
@@ -1642,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.2.388"
+version = "0.2.389"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -1958,6 +1959,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2025,7 +2047,7 @@ dependencies = [
 
 [[package]]
 name = "db"
-version = "0.2.388"
+version = "0.2.389"
 dependencies = [
  "argon2",
  "async-trait",
@@ -2078,7 +2100,7 @@ dependencies = [
 
 [[package]]
 name = "deploy-server"
-version = "0.2.388"
+version = "0.2.389"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3539,7 +3561,7 @@ dependencies = [
 
 [[package]]
 name = "integrations"
-version = "0.2.388"
+version = "0.2.389"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -5232,7 +5254,7 @@ dependencies = [
 
 [[package]]
 name = "reality-server"
-version = "0.2.388"
+version = "0.2.389"
 dependencies = [
  "anyhow",
  "api-core",
@@ -6689,7 +6711,7 @@ dependencies = [
 
 [[package]]
 name = "tenant-ops"
-version = "0.2.388"
+version = "0.2.389"
 dependencies = [
  "chrono",
  "common",

--- a/backend/servers/api-server/Cargo.toml
+++ b/backend/servers/api-server/Cargo.toml
@@ -41,6 +41,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+csv = "1.3"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 utoipa = { workspace = true }

--- a/backend/servers/api-server/src/routes/admin/audit.rs
+++ b/backend/servers/api-server/src/routes/admin/audit.rs
@@ -6,7 +6,8 @@
 use admin_core::{require_capability, Capability, RequireCapability};
 use axum::{
     extract::{Query, State},
-    http::StatusCode,
+    http::{header, HeaderMap, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
     routing::get,
     Json, Router,
 };
@@ -17,10 +18,17 @@ use uuid::Uuid;
 use crate::state::AppState;
 
 pub fn router() -> Router<AppState> {
-    Router::new().route(
-        "/",
-        get(list_audit_events).layer(require_capability(Capability::AuditRead)),
-    )
+    // `/csv` must come BEFORE `/` so axum's matcher doesn't try to treat
+    // `csv` as a path segment of the catch-all `/` route.
+    Router::new()
+        .route(
+            "/csv",
+            get(export_csv).layer(require_capability(Capability::AuditRead)),
+        )
+        .route(
+            "/",
+            get(list_audit_events).layer(require_capability(Capability::AuditRead)),
+        )
 }
 
 #[derive(Debug, Deserialize)]
@@ -54,17 +62,12 @@ pub struct AuditRow {
     pub created_at: DateTime<Utc>,
 }
 
-/// GET /admin/audit
-async fn list_audit_events(
-    _cap: RequireCapability,
-    State(state): State<AppState>,
-    Query(q): Query<AuditQuery>,
-) -> Result<Json<Vec<AuditRow>>, (StatusCode, String)> {
-    let limit = q.limit.unwrap_or(100).min(500) as i64;
-
-    // Filter dynamically. We use a single SQL with `$N IS NULL OR …`
-    // patterns rather than dynamic SQL — avoids string concat / injection.
-    let rows = sqlx::query_as::<_, AuditRow>(
+async fn fetch_rows(
+    state: &AppState,
+    q: &AuditQuery,
+    limit: i64,
+) -> Result<Vec<AuditRow>, sqlx::Error> {
+    sqlx::query_as::<_, AuditRow>(
         r#"
         SELECT id, user_id, action::text AS action, resource_type, resource_id,
                details, ip_address, user_agent, created_at
@@ -88,7 +91,85 @@ async fn list_audit_events(
     .bind(limit)
     .fetch_all(&state.db)
     .await
-    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+}
 
+/// GET /admin/audit
+async fn list_audit_events(
+    _cap: RequireCapability,
+    State(state): State<AppState>,
+    Query(q): Query<AuditQuery>,
+) -> Result<Json<Vec<AuditRow>>, (StatusCode, String)> {
+    let limit = q.limit.unwrap_or(100).min(500) as i64;
+    let rows = fetch_rows(&state, &q, limit)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     Ok(Json(rows))
+}
+
+/// GET /admin/audit/csv
+///
+/// Same filter shape as the JSON endpoint. Streams a CSV body with one
+/// header row + one row per audit event. Default limit raised to 10_000
+/// because operators usually export the full filtered range; client can
+/// still narrow via `since` / `until` / `limit` query params.
+async fn export_csv(
+    _cap: RequireCapability,
+    State(state): State<AppState>,
+    Query(q): Query<AuditQuery>,
+) -> Result<Response, (StatusCode, String)> {
+    let limit = q.limit.unwrap_or(10_000).min(50_000) as i64;
+    let rows = fetch_rows(&state, &q, limit)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    // Build CSV in memory. With limit ≤50k the buffer stays well under
+    // 10 MB even at 200 chars/row — far below the gateway timeout window.
+    let mut buf: Vec<u8> = Vec::with_capacity(rows.len() * 256);
+    {
+        let mut w = csv::Writer::from_writer(&mut buf);
+        w.write_record([
+            "id",
+            "user_id",
+            "action",
+            "resource_type",
+            "resource_id",
+            "ip_address",
+            "user_agent",
+            "created_at",
+            "details",
+        ])
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        for r in &rows {
+            w.write_record([
+                r.id.to_string(),
+                r.user_id.map(|u| u.to_string()).unwrap_or_default(),
+                r.action.clone(),
+                r.resource_type.clone().unwrap_or_default(),
+                r.resource_id.map(|u| u.to_string()).unwrap_or_default(),
+                r.ip_address.clone().unwrap_or_default(),
+                r.user_agent.clone().unwrap_or_default(),
+                r.created_at.to_rfc3339(),
+                r.details
+                    .as_ref()
+                    .map(|j| j.to_string())
+                    .unwrap_or_default(),
+            ])
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        }
+        w.flush()
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    }
+
+    let filename = format!("audit-{}.csv", Utc::now().format("%Y%m%d"));
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("text/csv; charset=utf-8"),
+    );
+    headers.insert(
+        header::CONTENT_DISPOSITION,
+        HeaderValue::from_str(&format!("attachment; filename=\"{filename}\""))
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?,
+    );
+    Ok((headers, buf).into_response())
 }

--- a/backend/servers/api-server/src/routes/admin/audit.rs
+++ b/backend/servers/api-server/src/routes/admin/audit.rs
@@ -18,8 +18,7 @@ use uuid::Uuid;
 use crate::state::AppState;
 
 pub fn router() -> Router<AppState> {
-    // `/csv` must come BEFORE `/` so axum's matcher doesn't try to treat
-    // `csv` as a path segment of the catch-all `/` route.
+    // Routes are siblings under the parent `/audit` nest.
     Router::new()
         .route(
             "/csv",
@@ -29,6 +28,25 @@ pub fn router() -> Router<AppState> {
             "/",
             get(list_audit_events).layer(require_capability(Capability::AuditRead)),
         )
+}
+
+/// Sanitize a string cell for CSV output to prevent spreadsheet formula
+/// injection. The `csv` crate already handles quoting/escaping of commas,
+/// quotes, and newlines — we only need to neutralize leading `=`, `+`,
+/// `-`, `@` characters that some spreadsheet apps interpret as formulas.
+///
+/// We prepend a single quote (`'`) which is the standard mitigation: it
+/// forces the cell to be treated as text without being visible in most
+/// spreadsheet UIs.
+fn sanitize_csv_cell(value: &str) -> String {
+    if matches!(value.chars().next(), Some('=' | '+' | '-' | '@')) {
+        let mut out = String::with_capacity(value.len() + 1);
+        out.push('\'');
+        out.push_str(value);
+        out
+    } else {
+        value.to_string()
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -108,10 +126,11 @@ async fn list_audit_events(
 
 /// GET /admin/audit/csv
 ///
-/// Same filter shape as the JSON endpoint. Streams a CSV body with one
-/// header row + one row per audit event. Default limit raised to 10_000
-/// because operators usually export the full filtered range; client can
-/// still narrow via `since` / `until` / `limit` query params.
+/// Same filter shape as the JSON endpoint. Builds the CSV in-memory and
+/// returns it as the response body (one header row + one row per audit
+/// event). Default limit raised to 10_000 because operators usually export
+/// the full filtered range; capped at 50_000 so memory stays bounded.
+/// Client can still narrow via `since` / `until` / `limit` query params.
 async fn export_csv(
     _cap: RequireCapability,
     State(state): State<AppState>,
@@ -140,19 +159,24 @@ async fn export_csv(
         ])
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
         for r in &rows {
+            // UUIDs and timestamps are well-formed and not attacker-controlled,
+            // but every free-form string column passes through `sanitize_csv_cell`
+            // to neutralize spreadsheet-formula injection.
             w.write_record([
                 r.id.to_string(),
                 r.user_id.map(|u| u.to_string()).unwrap_or_default(),
-                r.action.clone(),
-                r.resource_type.clone().unwrap_or_default(),
+                sanitize_csv_cell(&r.action),
+                sanitize_csv_cell(r.resource_type.as_deref().unwrap_or("")),
                 r.resource_id.map(|u| u.to_string()).unwrap_or_default(),
-                r.ip_address.clone().unwrap_or_default(),
-                r.user_agent.clone().unwrap_or_default(),
+                sanitize_csv_cell(r.ip_address.as_deref().unwrap_or("")),
+                sanitize_csv_cell(r.user_agent.as_deref().unwrap_or("")),
                 r.created_at.to_rfc3339(),
-                r.details
-                    .as_ref()
-                    .map(|j| j.to_string())
-                    .unwrap_or_default(),
+                sanitize_csv_cell(
+                    &r.details
+                        .as_ref()
+                        .map(|j| j.to_string())
+                        .unwrap_or_default(),
+                ),
             ])
             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
         }

--- a/frontend/apps/admin-web/src/pages/audit.tsx
+++ b/frontend/apps/admin-web/src/pages/audit.tsx
@@ -893,7 +893,7 @@ const AuditPage: FC = () => {
 
   const handleExportCsv = async () => {
     const csvQs = buildQueryString(filters);
-    const url = `/api/v1/admin/audit/csv${csvQs ? `?${csvQs}` : ''}`;
+    const url = `/api/v1/admin/audit.csv${csvQs ? `?${csvQs}` : ''}`;
     try {
       const resp = await fetch(url, {
         credentials: 'include',

--- a/frontend/apps/admin-web/src/pages/audit.tsx
+++ b/frontend/apps/admin-web/src/pages/audit.tsx
@@ -893,7 +893,7 @@ const AuditPage: FC = () => {
 
   const handleExportCsv = async () => {
     const csvQs = buildQueryString(filters);
-    const url = `/api/v1/admin/audit.csv${csvQs ? `?${csvQs}` : ''}`;
+    const url = `/api/v1/admin/audit/csv${csvQs ? `?${csvQs}` : ''}`;
     try {
       const resp = await fetch(url, {
         credentials: 'include',
@@ -910,11 +910,15 @@ const AuditPage: FC = () => {
       const dlUrl = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = dlUrl;
-      a.download = `audit-${new Date().toISOString().slice(0, 10)}.csv`;
+      // Match server's Content-Disposition filename format: YYYYMMDD (no dashes)
+      const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+      a.download = `audit-${today}.csv`;
       document.body.appendChild(a);
       a.click();
       a.remove();
-      URL.revokeObjectURL(dlUrl);
+      // Defer revoke so the browser has a tick to start the download before
+      // the object URL is invalidated.
+      setTimeout(() => URL.revokeObjectURL(dlUrl), 100);
     } catch (err) {
       showToast({
         type: 'error',

--- a/frontend/apps/admin-web/src/pages/audit.tsx
+++ b/frontend/apps/admin-web/src/pages/audit.tsx
@@ -893,17 +893,35 @@ const AuditPage: FC = () => {
 
   const handleExportCsv = async () => {
     const csvQs = buildQueryString(filters);
-    const url = `/api/v1/admin/audit.csv${csvQs ? `?${csvQs}` : ''}`;
+    const url = `/api/v1/admin/audit/csv${csvQs ? `?${csvQs}` : ''}`;
     try {
-      const probe = await fetch(url, { method: 'HEAD' });
-      if (probe.status === 404) {
-        showToast({ type: 'info', title: 'CSV export not yet implemented' });
+      const resp = await fetch(url, {
+        credentials: 'include',
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+      if (!resp.ok) {
+        showToast({
+          type: 'error',
+          title: `Export failed (${resp.status})`,
+        });
         return;
       }
-    } catch {
-      // Open anyway — let browser show error
+      const blob = await resp.blob();
+      const dlUrl = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = dlUrl;
+      a.download = `audit-${new Date().toISOString().slice(0, 10)}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(dlUrl);
+    } catch (err) {
+      showToast({
+        type: 'error',
+        title: 'Export failed',
+        message: err instanceof Error ? err.message : String(err),
+      });
     }
-    window.open(url, '_blank', 'noopener,noreferrer');
   };
 
   const toggleRow = (id: string) => {


### PR DESCRIPTION
Sprint 1 PR C from team audit punch list (#16).

New `GET /api/v1/admin/audit/csv` endpoint mirrors the JSON `/audit` endpoint's filter params and returns CSV with `Content-Disposition: attachment`. Default limit 10k, max 50k.

Frontend `Export CSV` button now:
- Fetches with Bearer auth + credentials
- Creates a Blob and triggers download with proper filename (audit-YYYYMMDD.csv)
- Shows error toast on non-2xx instead of opening a broken new tab

URL aligned to `/audit/csv` (was `/audit.csv`) to match axum nested router. Cap: `audit_read`.