### PR TITLE
fix(admin): address PR audit punch list — metrics column, audit reasons, defensive cleanups

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "admin-core"
-version = "0.2.395"
+version = "0.2.400"
 dependencies = [
  "api-core",
  "async-trait",
@@ -192,7 +192,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-core"
-version = "0.2.395"
+version = "0.2.400"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "api-server"
-version = "0.2.395"
+version = "0.2.400"
 dependencies = [
  "admin-core",
  "aes-gcm",
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.2.395"
+version = "0.2.400"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -2047,7 +2047,7 @@ dependencies = [
 
 [[package]]
 name = "db"
-version = "0.2.395"
+version = "0.2.400"
 dependencies = [
  "argon2",
  "async-trait",
@@ -2100,7 +2100,7 @@ dependencies = [
 
 [[package]]
 name = "deploy-server"
-version = "0.2.395"
+version = "0.2.400"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3563,7 +3563,7 @@ dependencies = [
 
 [[package]]
 name = "integrations"
-version = "0.2.395"
+version = "0.2.400"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -5367,7 +5367,7 @@ dependencies = [
 
 [[package]]
 name = "reality-server"
-version = "0.2.395"
+version = "0.2.400"
 dependencies = [
  "anyhow",
  "api-core",
@@ -6900,7 +6900,7 @@ dependencies = [
 
 [[package]]
 name = "tenant-ops"
-version = "0.2.395"
+version = "0.2.400"
 dependencies = [
  "chrono",
  "common",

--- a/backend/crates/admin-core/src/mfa.rs
+++ b/backend/crates/admin-core/src/mfa.rs
@@ -54,19 +54,23 @@ impl PgMfaRecency {
 #[async_trait]
 impl MfaRecency for PgMfaRecency {
     async fn recent_mfa(&self, user_id: Uuid) -> Result<bool, AdminError> {
-        // The `INTERVAL` literal mirrors `RECENT_MFA_WINDOW`. Keep them
-        // in sync if the constant changes.
+        // Bind the window from the `RECENT_MFA_WINDOW` constant instead of
+        // hard-coding `INTERVAL '15 minutes'` so a single source of truth
+        // drives both Rust-side checks and the SQL filter. `make_interval`
+        // accepts a double-precision seconds value.
+        let window_seconds = RECENT_MFA_WINDOW.num_seconds() as f64;
         let row: Option<(bool,)> = sqlx::query_as(
             r#"
             SELECT TRUE
             FROM two_factor_auth_verifications
             WHERE user_id = $1
-              AND verified_at > NOW() - INTERVAL '15 minutes'
+              AND verified_at > NOW() - make_interval(secs => $2)
             ORDER BY verified_at DESC
             LIMIT 1
             "#,
         )
         .bind(user_id)
+        .bind(window_seconds)
         .fetch_optional(&self.pool)
         .await
         .map_err(|e: SqlxError| AdminError::Internal(format!("mfa_recency: {}", e)))?;

--- a/backend/crates/db/migrations/00153_capability_descriptions_refresh.sql
+++ b/backend/crates/db/migrations/00153_capability_descriptions_refresh.sql
@@ -1,0 +1,36 @@
+-- Refresh the capability descriptions seeded by migration 00152.
+--
+-- Migration 00152 used `ON CONFLICT (capability) DO NOTHING`, which meant a
+-- re-run of the seed could not update stale descriptions or risk levels —
+-- only newly-added capabilities took effect. The repo convention (see
+-- migration 00141_fix_listings_soft_delete.sql) is to add a follow-up
+-- migration rather than edit an applied migration in place, so this file
+-- re-runs the INSERT with `DO UPDATE` to refresh the canonical text.
+--
+-- Idempotent: running this multiple times converges on the same final state.
+-- Adding a new capability here is the supported way to ship description
+-- changes going forward — bump `updated_at` so registry readers can detect
+-- staleness if/when they start caching.
+
+INSERT INTO capability_descriptions (capability, description, risk_level) VALUES
+  ('agencies_read',             'View agencies and their basic profile data.',                         'low'),
+  ('agencies_write',            'Edit agency profile, branding, contact info.',                        'medium'),
+  ('agencies_suspend',          'Suspend or reactivate an agency. Affects all members.',              'high'),
+  ('users_read',                'View global user search results across all tenants.',                 'low'),
+  ('users_write',               'Edit user profile fields, status, locale.',                           'medium'),
+  ('users_impersonate',         'Assume the identity of any user for support purposes.',               'high'),
+  ('memberships_grant',         'Add users to organizations and assign roles.',                        'medium'),
+  ('memberships_revoke',        'Remove users from organizations.',                                    'medium'),
+  ('site_settings_read',        'Read platform-wide settings and configuration.',                      'low'),
+  ('site_settings_write',       'Modify platform-wide settings including maintenance mode.',           'high'),
+  ('mobile_config_write',       'Push mobile app config: force-update floor, feature flags.',          'high'),
+  ('feature_flags_write',       'Toggle feature flags per tenant or globally.',                        'medium'),
+  ('tenant_export',             'Export a tenant''s full data as encrypted tarball.',                  'medium'),
+  ('tenant_purge',              'Permanently delete a tenant. Irreversible.',                          'critical'),
+  ('tenant_restore',            'Restore a previously exported tenant tarball.',                       'high'),
+  ('audit_read',                'View the full audit log across all operators and capabilities.',      'low'),
+  ('principal_kind_escalate',   'Promote a user to platform principal. Bypasses tenant isolation.',    'critical')
+ON CONFLICT (capability) DO UPDATE
+    SET description = EXCLUDED.description,
+        risk_level  = EXCLUDED.risk_level,
+        updated_at  = NOW();

--- a/backend/crates/tenant-ops/src/purge.rs
+++ b/backend/crates/tenant-ops/src/purge.rs
@@ -242,7 +242,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "empty identifier after sanitization")]
     fn sanitize_panics_on_empty() {
         let _ = sanitize_ident("");
     }

--- a/backend/servers/api-server/src/routes/admin/capabilities.rs
+++ b/backend/servers/api-server/src/routes/admin/capabilities.rs
@@ -18,7 +18,7 @@
 //!                                                   before deleting; returns 404 if ownership fails.
 
 use admin_core::{
-    require_capability, AuditOutcome, AuditWriter, Capability, CapabilityGrant,
+    require_capability, AdminDeps, AuditOutcome, AuditWriter, Capability, CapabilityGrant,
     CapabilityGrantsRepository, RequireCapability,
 };
 use api_core::extractors::principal::RequestPrincipal;
@@ -298,13 +298,18 @@ fn default_true() -> bool {
 async fn grant_capability(
     _cap: RequireCapability,
     auth: AuthUser,
-    Extension(grants): Extension<Arc<dyn CapabilityGrantsRepository>>,
-    Extension(audit): Extension<Arc<dyn AuditWriter>>,
+    // Both `grants` and `audit` live inside the already-attached `AdminDeps`
+    // bundle (`lib.rs::attach_admin_extensions`). Using the bundle directly
+    // keeps this handler under clippy's `too_many_arguments` 7-arg limit
+    // without dropping any extractor — see PR #300 review.
+    Extension(deps): Extension<AdminDeps>,
     axum::extract::State(state): axum::extract::State<AppState>,
     Path(user_id): Path<Uuid>,
     headers: HeaderMap,
     Json(body): Json<GrantBody>,
 ) -> Result<Json<CapabilityGrant>, (StatusCode, String)> {
+    let grants = &deps.grants;
+    let audit = &deps.audit;
     if body.capability == Capability::PrincipalKindEscalate {
         let has = grants
             .user_has(auth.user_id, Capability::PrincipalKindEscalate)
@@ -342,7 +347,7 @@ async fn grant_capability(
     // Emit a route-level audit row that carries the operator-supplied
     // `reason` in the hashed payload (the baseline audit from
     // `RequireCapability` only sees the capability name, not the body).
-    let ip = headers.get("x-forwarded-for").and_then(|h| h.to_str().ok());
+    let ip = super::audit_ip_from_headers(&headers);
     let ua = headers
         .get(axum::http::header::USER_AGENT)
         .and_then(|h| h.to_str().ok());
@@ -398,8 +403,9 @@ async fn grant_capability(
 async fn revoke_capability(
     _cap: RequireCapability,
     auth: AuthUser,
-    Extension(grants): Extension<Arc<dyn CapabilityGrantsRepository>>,
-    Extension(audit): Extension<Arc<dyn AuditWriter>>,
+    // See `grant_capability` — collapsing `grants` + `audit` into the
+    // `AdminDeps` bundle keeps the signature under clippy's 7-arg limit.
+    Extension(deps): Extension<AdminDeps>,
     axum::extract::State(state): axum::extract::State<AppState>,
     Path((user_id, grant_id)): Path<(Uuid, Uuid)>,
     headers: HeaderMap,
@@ -408,6 +414,8 @@ async fn revoke_capability(
     // get it plumbed into the audit log, while body-less callers still 204.
     body: Option<Json<RevokeBody>>,
 ) -> Result<StatusCode, (StatusCode, String)> {
+    let grants = &deps.grants;
+    let audit = &deps.audit;
     let enforcer = AuthPolicyEnforcer::new(state.db.clone());
     if let Err(err) = enforcer.check_capability_revoke(auth.user_id).await {
         return Err(map_auth_policy_error(err));
@@ -433,7 +441,7 @@ async fn revoke_capability(
     // Emit a route-level audit row that carries the operator-supplied
     // `reason` (if any) in the hashed payload. Mirrors the grant path.
     let reason = body.and_then(|Json(b)| b.reason);
-    let ip = headers.get("x-forwarded-for").and_then(|h| h.to_str().ok());
+    let ip = super::audit_ip_from_headers(&headers);
     let ua = headers
         .get(axum::http::header::USER_AGENT)
         .and_then(|h| h.to_str().ok());

--- a/backend/servers/api-server/src/routes/admin/capabilities.rs
+++ b/backend/servers/api-server/src/routes/admin/capabilities.rs
@@ -191,17 +191,22 @@ async fn list_for_me(
     // TODO(refactor): move into MfaRecency trait to dedupe with
     // PgMfaRecency::is_recent — add `latest_verification(user_id)` to the
     // trait + Pg impl + tests so the raw SQL lives in one place.
+    // Bind the MFA window from the single-source-of-truth constant
+    // (`MFA_WINDOW_SECONDS`) instead of duplicating the magic number as a
+    // SQL literal. `make_interval(secs => $2)` keeps the type explicit on
+    // the Postgres side. See item 5 of the admin backend audit follow-ups.
     let mfa_verified_at: Option<DateTime<Utc>> = match sqlx::query_scalar::<_, DateTime<Utc>>(
         r#"
         SELECT verified_at
         FROM two_factor_auth_verifications
         WHERE user_id = $1
-          AND verified_at > NOW() - INTERVAL '900 seconds'
+          AND verified_at > NOW() - make_interval(secs => $2)
         ORDER BY verified_at DESC
         LIMIT 1
         "#,
     )
     .bind(principal.user_id)
+    .bind(MFA_WINDOW_SECONDS as f64)
     .fetch_optional(state.db_pool())
     .await
     {
@@ -253,6 +258,22 @@ pub struct GrantBody {
     #[serde(default = "default_true")]
     pub mfa_required: bool,
     pub note: Option<String>,
+    /// Free-form justification supplied by the granter. Surfaced into the
+    /// audit-log payload so the trail records *why* the grant was issued
+    /// (distinct from `note`, which is operator-facing and persists on the
+    /// grant row itself).
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct RevokeBody {
+    /// Free-form justification supplied by the revoker. Plumbed into the
+    /// audit-log payload. Optional and defaulted because some clients
+    /// (curl one-liners, ops tooling) issue DELETE with no body — those
+    /// fall through to `None` rather than failing the request.
+    #[serde(default)]
+    pub reason: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -278,8 +299,10 @@ async fn grant_capability(
     _cap: RequireCapability,
     auth: AuthUser,
     Extension(grants): Extension<Arc<dyn CapabilityGrantsRepository>>,
+    Extension(audit): Extension<Arc<dyn AuditWriter>>,
     axum::extract::State(state): axum::extract::State<AppState>,
     Path(user_id): Path<Uuid>,
+    headers: HeaderMap,
     Json(body): Json<GrantBody>,
 ) -> Result<Json<CapabilityGrant>, (StatusCode, String)> {
     if body.capability == Capability::PrincipalKindEscalate {
@@ -311,10 +334,42 @@ async fn grant_capability(
             auth.user_id,
             body.expires_at,
             body.mfa_required,
-            body.note,
+            body.note.clone(),
         )
         .await
         .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    // Emit a route-level audit row that carries the operator-supplied
+    // `reason` in the hashed payload (the baseline audit from
+    // `RequireCapability` only sees the capability name, not the body).
+    let ip = headers.get("x-forwarded-for").and_then(|h| h.to_str().ok());
+    let ua = headers
+        .get(axum::http::header::USER_AGENT)
+        .and_then(|h| h.to_str().ok());
+    let payload = serde_json::json!({
+        "grant_id": row.id,
+        "user_id": user_id,
+        "capability": body.capability.as_str(),
+        "reason": body.reason,
+        "expires_at": body.expires_at,
+        "mfa_required": body.mfa_required,
+    });
+    if let Err(e) = audit
+        .record(
+            Some(auth.user_id),
+            Capability::MembershipsGrant,
+            AuditOutcome::Allowed,
+            Some("capability_grant"),
+            Some(row.id),
+            Some(&payload),
+            ip,
+            ua,
+        )
+        .await
+    {
+        tracing::warn!(error = %e, "audit write for capability grant (reason) failed");
+    }
+
     Ok(Json(row))
 }
 
@@ -344,8 +399,14 @@ async fn revoke_capability(
     _cap: RequireCapability,
     auth: AuthUser,
     Extension(grants): Extension<Arc<dyn CapabilityGrantsRepository>>,
+    Extension(audit): Extension<Arc<dyn AuditWriter>>,
     axum::extract::State(state): axum::extract::State<AppState>,
     Path((user_id, grant_id)): Path<(Uuid, Uuid)>,
+    headers: HeaderMap,
+    // DELETE requests historically arrive without a body; `Option<Json<_>>`
+    // makes the body optional so callers that do supply a JSON `reason`
+    // get it plumbed into the audit log, while body-less callers still 204.
+    body: Option<Json<RevokeBody>>,
 ) -> Result<StatusCode, (StatusCode, String)> {
     let enforcer = AuthPolicyEnforcer::new(state.db.clone());
     if let Err(err) = enforcer.check_capability_revoke(auth.user_id).await {
@@ -368,6 +429,35 @@ async fn revoke_capability(
         .revoke(grant_id, auth.user_id)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    // Emit a route-level audit row that carries the operator-supplied
+    // `reason` (if any) in the hashed payload. Mirrors the grant path.
+    let reason = body.and_then(|Json(b)| b.reason);
+    let ip = headers.get("x-forwarded-for").and_then(|h| h.to_str().ok());
+    let ua = headers
+        .get(axum::http::header::USER_AGENT)
+        .and_then(|h| h.to_str().ok());
+    let payload = serde_json::json!({
+        "grant_id": grant_id,
+        "user_id": user_id,
+        "reason": reason,
+    });
+    if let Err(e) = audit
+        .record(
+            Some(auth.user_id),
+            Capability::MembershipsRevoke,
+            AuditOutcome::Allowed,
+            Some("capability_revoke"),
+            Some(grant_id),
+            Some(&payload),
+            ip,
+            ua,
+        )
+        .await
+    {
+        tracing::warn!(error = %e, "audit write for capability revoke (reason) failed");
+    }
+
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/backend/servers/api-server/src/routes/admin/impersonation.rs
+++ b/backend/servers/api-server/src/routes/admin/impersonation.rs
@@ -173,7 +173,7 @@ async fn start(
         .await
         .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
 
-    let ip = headers.get("x-forwarded-for").and_then(|h| h.to_str().ok());
+    let ip = super::audit_ip_from_headers(&headers);
     let ua = headers
         .get(axum::http::header::USER_AGENT)
         .and_then(|h| h.to_str().ok());

--- a/backend/servers/api-server/src/routes/admin/impersonation.rs
+++ b/backend/servers/api-server/src/routes/admin/impersonation.rs
@@ -118,6 +118,14 @@ async fn list_active(
 #[derive(Debug, Deserialize)]
 pub struct StartBody {
     pub target_user_id: Uuid,
+    /// Free-form justification supplied by the operator. The frontend
+    /// surface requires this for compliance; we plumb it into the audit
+    /// payload so the audit trail records *why* impersonation was started
+    /// (the `impersonation_tokens` table itself has no `reason` column —
+    /// see `ActiveImpersonationRow::reason` for the existing capability-
+    /// string substitute).
+    #[serde(default)]
+    pub reason: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -140,10 +148,20 @@ impl From<IssuedImpersonationToken> for StartResponse {
 }
 
 /// POST /admin/impersonation/start
+///
+/// `PgImpersonationService::start_impersonation` already writes a baseline
+/// audit row (capability + token id + expiry). We additionally emit a
+/// route-level audit row that carries the operator's free-form `reason` in
+/// the hashed payload so the audit trail records *why* the session was
+/// opened. Plumbing `reason` into the service's audit call would require a
+/// trait-signature change in `admin-core`; emitting at the route layer is
+/// strictly additive and stays within this file's scope.
 async fn start(
     _cap: RequireCapability,
     auth: AuthUser,
     Extension(svc): Extension<Arc<dyn ImpersonationService>>,
+    Extension(audit): Extension<Arc<dyn AuditWriter>>,
+    headers: HeaderMap,
     Json(body): Json<StartBody>,
 ) -> Result<Json<StartResponse>, (StatusCode, String)> {
     let issued = svc
@@ -154,6 +172,32 @@ async fn start(
         )
         .await
         .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    let ip = headers.get("x-forwarded-for").and_then(|h| h.to_str().ok());
+    let ua = headers
+        .get(axum::http::header::USER_AGENT)
+        .and_then(|h| h.to_str().ok());
+    let payload = serde_json::json!({
+        "impersonation_token_id": issued.record.id,
+        "target_user_id": body.target_user_id,
+        "reason": body.reason,
+    });
+    if let Err(e) = audit
+        .record(
+            Some(auth.user_id),
+            Capability::UsersImpersonate,
+            AuditOutcome::Allowed,
+            Some("impersonation_start"),
+            Some(body.target_user_id),
+            Some(&payload),
+            ip,
+            ua,
+        )
+        .await
+    {
+        tracing::warn!(error = %e, "audit write for impersonation/start (reason) failed");
+    }
+
     Ok(Json(issued.into()))
 }
 

--- a/backend/servers/api-server/src/routes/admin/metrics.rs
+++ b/backend/servers/api-server/src/routes/admin/metrics.rs
@@ -19,6 +19,7 @@ pub fn router() -> Router<AppState> {
 }
 
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct MetricsSummary {
     /// Organizations whose `status` is not `'deleted'`.
     ///
@@ -71,8 +72,11 @@ async fn metrics_summary(
     .await
     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
+    // `user_merge_collisions` (migration 00131) tracks unresolved rows via
+    // `status = 'pending'` — there is no `resolved_at` column. The previous
+    // query referenced a nonexistent column and would 500 at runtime.
     let pending_merges: i64 =
-        sqlx::query_scalar("SELECT COUNT(*) FROM user_merge_collisions WHERE resolved_at IS NULL")
+        sqlx::query_scalar("SELECT COUNT(*) FROM user_merge_collisions WHERE status = 'pending'")
             .fetch_one(&state.db)
             .await
             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;

--- a/backend/servers/api-server/src/routes/admin/mod.rs
+++ b/backend/servers/api-server/src/routes/admin/mod.rs
@@ -31,9 +31,96 @@ pub use users_lifecycle::{
     AdminActionResponse, AdminUserInfo, ListUsersQuery, ListUsersResponse, UserActionRequest,
 };
 
+use axum::http::HeaderMap;
 use axum::Router;
 
 use crate::state::AppState;
+
+/// Maximum width of `audit_logs.ip_address` (VARCHAR(45)) — covers IPv6.
+/// Defined here so the audit-row construction never silently fails its
+/// INSERT because an upstream proxy passed back a comma-separated chain.
+pub(super) const AUDIT_IP_MAX_LEN: usize = 45;
+
+/// Extract the client IP for audit logging from the `x-forwarded-for`
+/// header.
+///
+/// `x-forwarded-for` is canonically a comma-separated list (`client, proxy1,
+/// proxy2`). The leftmost entry is the original client; downstream entries
+/// are intermediaries. We take the first entry, trim whitespace, and
+/// truncate at [`AUDIT_IP_MAX_LEN`] (45) so the value always fits the
+/// `audit_logs.ip_address` column. Returning the raw header value risks
+/// silently dropping the audit row when the column rejects an overlong
+/// chain — see PR #300 review.
+///
+/// Returns `None` when the header is absent, non-ASCII, or empty after
+/// trimming, matching the previous `.and_then(|h| h.to_str().ok())`
+/// behaviour at the call sites.
+pub(super) fn audit_ip_from_headers(headers: &HeaderMap) -> Option<&str> {
+    let raw = headers.get("x-forwarded-for")?.to_str().ok()?;
+    let first = raw.split(',').next()?.trim();
+    if first.is_empty() {
+        return None;
+    }
+    // Truncate on a char boundary; ASCII IPs are 1-byte chars so this is a
+    // no-op for valid IPs but keeps us safe if a proxy injects garbage.
+    let end = first
+        .char_indices()
+        .take_while(|(i, _)| *i < AUDIT_IP_MAX_LEN)
+        .last()
+        .map(|(i, c)| i + c.len_utf8())
+        .unwrap_or(0);
+    Some(&first[..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::audit_ip_from_headers;
+    use axum::http::HeaderMap;
+
+    fn hdr(value: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert("x-forwarded-for", value.parse().unwrap());
+        h
+    }
+
+    #[test]
+    fn returns_none_when_header_absent() {
+        assert_eq!(audit_ip_from_headers(&HeaderMap::new()), None);
+    }
+
+    #[test]
+    fn returns_first_ip_from_chain() {
+        let h = hdr("203.0.113.7, 198.51.100.1, 10.0.0.1");
+        assert_eq!(audit_ip_from_headers(&h), Some("203.0.113.7"));
+    }
+
+    #[test]
+    fn trims_whitespace() {
+        let h = hdr("  203.0.113.7  ");
+        assert_eq!(audit_ip_from_headers(&h), Some("203.0.113.7"));
+    }
+
+    #[test]
+    fn returns_none_for_empty_first_entry() {
+        let h = hdr("   , 198.51.100.1");
+        assert_eq!(audit_ip_from_headers(&h), None);
+    }
+
+    #[test]
+    fn truncates_to_45_chars() {
+        // A pathological 60-char garbage value — still fits VARCHAR(45).
+        let garbage = "x".repeat(60);
+        let h = hdr(&garbage);
+        assert_eq!(audit_ip_from_headers(&h).unwrap().len(), 45);
+    }
+
+    #[test]
+    fn ipv6_fits_unchanged() {
+        let v6 = "2001:0db8:85a3:0000:0000:8a2e:0370:7334"; // 39 chars
+        let h = hdr(v6);
+        assert_eq!(audit_ip_from_headers(&h), Some(v6));
+    }
+}
 
 /// Combined `/api/v1/admin` router. Layered with admin extensions in
 /// `lib.rs::create_router`.

--- a/backend/servers/api-server/src/routes/buildings.rs
+++ b/backend/servers/api-server/src/routes/buildings.rs
@@ -1938,11 +1938,17 @@ pub async fn assign_unit_owner(
                 user_id = %req.user_id,
                 "Owner row was created but user lookup returned None — invariant violation"
             );
+            // Distinct from client-facing `USER_NOT_FOUND` 400s earlier in
+            // this handler: the owner row was just written successfully, so
+            // the user MUST exist. Reaching this arm is a server-side
+            // invariant violation, not a missing-input error — surface it
+            // as `INTERNAL_ERROR` so log/consumer triage can tell the two
+            // apart (PR #300 review).
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new(
-                    "USER_NOT_FOUND",
-                    "Owner user not found after assignment",
+                    "INTERNAL_ERROR",
+                    "User row missing after successful write",
                 )),
             )
         })?;
@@ -2098,11 +2104,15 @@ pub async fn update_unit_owner(
                 user_id = %owner_user_id,
                 "Owner row was updated but user lookup returned None — invariant violation"
             );
+            // See `assign_unit_owner` — `INTERNAL_ERROR` instead of
+            // `USER_NOT_FOUND` so the invariant-violation path is
+            // distinguishable from the client-input 400s earlier in this
+            // handler (PR #300 review).
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new(
-                    "USER_NOT_FOUND",
-                    "Owner user not found after update",
+                    "INTERNAL_ERROR",
+                    "User row missing after successful write",
                 )),
             )
         })?;

--- a/backend/servers/api-server/src/routes/buildings.rs
+++ b/backend/servers/api-server/src/routes/buildings.rs
@@ -1919,7 +1919,9 @@ pub async fn assign_unit_owner(
         "Unit owner assigned"
     );
 
-    // Return owner info
+    // Return owner info. The owner row was just written above so the user
+    // must exist; if `find_by_id` returns `None` we have an invariant break
+    // (race with delete, foreign-key drift) and surface 500 rather than panic.
     let user = state
         .user_repo
         .find_by_id(req.user_id)
@@ -1931,7 +1933,19 @@ pub async fn assign_unit_owner(
                 Json(ErrorResponse::new("DB_ERROR", "Database error")),
             )
         })?
-        .unwrap();
+        .ok_or_else(|| {
+            tracing::error!(
+                user_id = %req.user_id,
+                "Owner row was created but user lookup returned None — invariant violation"
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(
+                    "USER_NOT_FOUND",
+                    "Owner user not found after assignment",
+                )),
+            )
+        })?;
 
     rls.release().await;
 
@@ -2065,7 +2079,9 @@ pub async fn update_unit_owner(
         "Unit owner updated"
     );
 
-    // Get user info
+    // Get user info. The owner update succeeded above, so the user must
+    // exist; if not we have an invariant break and surface 500 rather than
+    // panic on `.unwrap()`.
     let user = state
         .user_repo
         .find_by_id(owner_user_id)
@@ -2077,7 +2093,19 @@ pub async fn update_unit_owner(
                 Json(ErrorResponse::new("DB_ERROR", "Database error")),
             )
         })?
-        .unwrap();
+        .ok_or_else(|| {
+            tracing::error!(
+                user_id = %owner_user_id,
+                "Owner row was updated but user lookup returned None — invariant violation"
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(
+                    "USER_NOT_FOUND",
+                    "Owner user not found after update",
+                )),
+            )
+        })?;
 
     rls.release().await;
 

--- a/frontend/apps/admin-web/src/pages/Dashboard.test.tsx
+++ b/frontend/apps/admin-web/src/pages/Dashboard.test.tsx
@@ -104,13 +104,15 @@ describe('Dashboard', () => {
         return {
           ok: true,
           status: 200,
-          // Backend serializes snake_case — mirror the real wire shape so
-          // this test would catch a regression in the Dashboard adapter.
+          // Backend serializes camelCase (`MetricsSummary` has
+          // `#[serde(rename_all = "camelCase")]`) — mirror the real wire
+          // shape so this test would catch a regression in the Dashboard
+          // adapter.
           json: async () => ({
-            tenants_active: 42,
-            operators_online: 7,
-            pending_merges: 3,
-            high_risk_24h: 5,
+            tenantsActive: 42,
+            operatorsOnline: 7,
+            pendingMerges: 3,
+            highRisk24h: 5,
           }),
         } as Response;
       }

--- a/frontend/apps/admin-web/src/pages/Dashboard.tsx
+++ b/frontend/apps/admin-web/src/pages/Dashboard.tsx
@@ -298,14 +298,15 @@ async function fetchMetricsSummary(token: string | null): Promise<MetricsSummary
       );
       return STUB;
     }
-    // Backend serializes snake_case (no #[serde(rename_all)] on MetricsSummary);
-    // adapt to the camelCase shape used by the rest of the FE.
-    const raw = (await resp.json()) as Record<string, unknown>;
+    // Backend now serializes camelCase (MetricsSummary has
+    // `#[serde(rename_all = "camelCase")]`). Coerce each field through
+    // `Number()` so missing / null values fall back to 0 instead of NaN.
+    const raw = (await resp.json()) as Partial<MetricsSummary>;
     return {
-      tenantsActive: Number(raw.tenantsActive ?? raw.tenants_active ?? 0),
-      operatorsOnline: Number(raw.operatorsOnline ?? raw.operators_online ?? 0),
-      pendingMerges: Number(raw.pendingMerges ?? raw.pending_merges ?? 0),
-      highRisk24h: Number(raw.highRisk24h ?? raw.high_risk_24h ?? 0),
+      tenantsActive: Number(raw.tenantsActive ?? 0),
+      operatorsOnline: Number(raw.operatorsOnline ?? 0),
+      pendingMerges: Number(raw.pendingMerges ?? 0),
+      highRisk24h: Number(raw.highRisk24h ?? 0),
     };
   } catch (err) {
     console.warn(


### PR DESCRIPTION
## Summary

Output of a multi-agent team audit of recently merged admin PRs (#282–#289). Addresses 7 punch-list items + 1 review-pass fix on the Dashboard test mock.

### Backend
- **HIGH** — `/admin/metrics/summary` was 500-ing on `pending_merges` (`user_merge_collisions.resolved_at` doesn't exist; migration 00131 uses `status`). Query now `WHERE status = 'pending'`.
- **HIGH** — Replaced two `.unwrap()` calls in `routes/buildings.rs` (lines ~1934, ~2080) with `.ok_or_else(... INTERNAL_SERVER_ERROR)` — these were post-write invariant checks that would panic on a `None` instead of returning a clean error.
- **MED** — `reason` from UI prompts was silently dropped by:
  - `POST /admin/impersonation/start` — `StartBody` didn't deserialize `reason`
  - `POST /admin/capabilities/grant` — `GrantBody` didn't deserialize `reason`
  - `DELETE /admin/capabilities/revoke` — no body extractor at all
  Added the field to each and emit a route-level `AuditWriter::record` carrying the reason in the audit payload, matching the pattern in `agencies.rs` / `memberships.rs`.
- **MED** — `MetricsSummary` DTO now uses `#[serde(rename_all = "camelCase")]` to match other admin DTOs; Dashboard.tsx drops the snake/camel fallback; Dashboard.test.tsx mock updated to camelCase.
- **MED** — MFA window literal `INTERVAL '900 seconds'` replaced with `make_interval(secs => $N)` bound to `MFA_WINDOW_SECONDS as f64` in both `capabilities.rs` and the same duplication in `admin-core/src/mfa.rs`.
- **MED** — New migration `00153_capability_descriptions_refresh.sql` re-runs the seed with `ON CONFLICT DO UPDATE`, since 00152 used `DO NOTHING` and leaves stale descriptions in already-seeded environments. Migration 00152 left untouched (follow-up migration convention, cf. 00141).
- **LOW** — `tenant-ops/purge.rs:245` `#[should_panic]` now carries `expected = "empty identifier after sanitization"`.

## Out of scope (flagged by reviewer)

`PgAuditWriter` SHA-256-hashes the payload and stores only `payload_hash` in `details` JSONB — so the new `reason` field is plumbed but not recoverable from the audit log in plaintext. Fixing requires changing the `AuditWriter::record` trait to take an unhashed-details slot; separate ticket.

## Verification

- Static review (two passes) by separate agents — second pass found one bug (Dashboard.test.tsx mock still snake_case) and fixed it.
- `cargo check -p api-server` and `cargo test -p tenant-ops` could not run locally (sandbox missing `clang` / `pkg-config`). **Please confirm CI is green before merge.**

## Test plan

- [ ] Backend CI compiles + tests pass
- [ ] Hit `/admin/metrics/summary` end-to-end and confirm `pendingMerges` is numeric (not 500)
- [ ] Trigger impersonation with a reason; confirm audit row's hashed payload changes (proof of plumbing)
- [ ] Apply migration 00153 against a previously-seeded DB; confirm descriptions update