### PR TITLE
fix(admin-web): NaN guard for MFA chip + un-skip Toast tests

### DIFF
--- a/frontend/apps/admin-web/src/auth/usePrincipalCapabilities.ts
+++ b/frontend/apps/admin-web/src/auth/usePrincipalCapabilities.ts
@@ -110,7 +110,11 @@ export function usePrincipalCapabilities(): PrincipalCapabilitiesResult {
     retry: 1,
   });
 
-  const mfaVerifiedAtMs = data?.mfa_verified_at != null ? Date.parse(data.mfa_verified_at) : null;
+  const mfaVerifiedAtMs = (() => {
+    if (data?.mfa_verified_at == null) return null;
+    const parsed = Date.parse(data.mfa_verified_at);
+    return Number.isFinite(parsed) ? parsed : null;
+  })();
 
   // Default to 900 s if the backend omits the field (older deployments).
   const mfaWindowMs = (data?.mfa_window_seconds ?? 900) * 1000;

--- a/frontend/apps/ppt-web/src/components/Toast.test.tsx
+++ b/frontend/apps/ppt-web/src/components/Toast.test.tsx
@@ -9,7 +9,7 @@
  */
 
 /// <reference types="vitest/globals" />
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ToastProvider, useToast } from './Toast';
 
@@ -109,16 +109,82 @@ describe('Toast Component', () => {
     });
   });
 
-  // Note: Timer-based auto-dismiss tests are skipped due to complexity with fake timers and React state updates.
-  // The auto-dismiss functionality is verified through manual/E2E testing.
-  // The core rendering and interaction tests above provide sufficient coverage for unit tests.
+  // Helper that exposes the showToast function so the auto-dismiss tests can
+  // trigger a toast without going through userEvent — userEvent's internal
+  // awaits stall when combined with fake timers in this setup.
+  function ToastEmitter({
+    onReady,
+  }: {
+    onReady: (showToast: ReturnType<typeof useToast>['showToast']) => void;
+  }) {
+    const { showToast } = useToast();
+    onReady(showToast);
+    return null;
+  }
 
-  it.skip('auto-dismisses success toast after duration', async () => {
-    // Skipped: Fake timers have compatibility issues with React state batching
+  it('auto-dismisses success toast after duration', async () => {
+    // Success toasts auto-dismiss after DEFAULT_SUCCESS_DURATION (5000ms).
+    vi.useFakeTimers();
+    try {
+      let trigger: ReturnType<typeof useToast>['showToast'] | null = null;
+
+      render(
+        <ToastProvider>
+          <ToastEmitter
+            onReady={(showToast) => {
+              trigger = showToast;
+            }}
+          />
+        </ToastProvider>
+      );
+
+      await act(async () => {
+        trigger?.({ type: 'success', title: 'Auto-dismiss me' });
+      });
+      expect(screen.getByText('Auto-dismiss me')).toBeInTheDocument();
+
+      // Advance past the 5000ms success duration; flush React state updates.
+      await act(async () => {
+        vi.advanceTimersByTime(5001);
+      });
+
+      expect(screen.queryByText('Auto-dismiss me')).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
-  it.skip('error toast persists (no auto-dismiss)', async () => {
-    // Skipped: Fake timers have compatibility issues with React state batching
+  it('error toast persists (no auto-dismiss)', async () => {
+    // Error toasts have duration = 0, meaning no auto-dismiss timer is set.
+    vi.useFakeTimers();
+    try {
+      let trigger: ReturnType<typeof useToast>['showToast'] | null = null;
+
+      render(
+        <ToastProvider>
+          <ToastEmitter
+            onReady={(showToast) => {
+              trigger = showToast;
+            }}
+          />
+        </ToastProvider>
+      );
+
+      await act(async () => {
+        trigger?.({ type: 'error', title: 'Sticky error' });
+      });
+      expect(screen.getByText('Sticky error')).toBeInTheDocument();
+
+      // Advance well past any plausible auto-dismiss window.
+      await act(async () => {
+        vi.advanceTimersByTime(30_000);
+      });
+
+      // Error toast should still be present.
+      expect(screen.getByText('Sticky error')).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Output of the team audit, frontend slice.

- **MED** — `usePrincipalCapabilities.ts:113` now guards `Date.parse(data.mfa_verified_at)` with `Number.isFinite(...)` to return `null` instead of `NaN` on malformed input. Without the guard, the MFA chip would render `NaN:NaN`.
- **LOW** — `Toast.test.tsx` two `it.skip` for auto-dismiss timing un-skipped using `vi.useFakeTimers()` + a small inline `ToastEmitter` helper (userEvent.click deadlocks under fake timers; the existing click-driven dismiss test on line 93 is preserved, so coverage of the click path is intact).

## Not done (flagged by reviewer as misclassified in the original audit)

- `TenantLifecyclePage.test.tsx` lines 143-224 were flagged as "tautological `slug === slug`" tests. On inspection they actually render the component via `renderWizard()` and assert real behavior. Left untouched.

## Verification

- `pnpm -F @ppt/admin-web exec vitest run`: 108/108 pass (one pre-existing unrelated failure in `CapabilitiesAdminPage.test.tsx`)
- `pnpm -F @ppt/web exec vitest run src/components/Toast.test.tsx`: 8/8 pass

## Test plan

- [ ] CI vitest suites pass on both apps