### PR TITLE
chore: tooling + screen-map hygiene from team audit

### DIFF
--- a/.research/IDEAS_TRIAGE.md
+++ b/.research/IDEAS_TRIAGE.md
@@ -1,6 +1,6 @@
 # Triage queue
 
-<sub>Last regenerated: 2026-05-17 00:00 UTC by routine</sub>
+<sub>Last regenerated: never (scaffold — first routine run will overwrite this)</sub>
 
 > **Canonical source:** `backlog.json` rows where `vector == "triage"`. This file is **regenerated** from it each run — do not edit by hand. To drop, defer, or re-score a triage row, edit `backlog.json` and let the next routine run rebuild this view.
 

--- a/.research/backlog.md
+++ b/.research/backlog.md
@@ -1,6 +1,6 @@
 # Backlog of vectors
 
-<sub>Last regenerated: 2026-05-17 00:00 UTC by routine</sub>
+<sub>Last regenerated: never (scaffold — first routine run will overwrite this)</sub>
 
 > **Canonical source:** `backlog.json`. This file is **regenerated** from it
 > each run — do not edit by hand. To drop, defer, or re-score a vector, edit

--- a/docs/screens/ppt/accessibility-settings.md
+++ b/docs/screens/ppt/accessibility-settings.md
@@ -31,6 +31,9 @@ designSources:
     frame: loaded / loading+saved-toast / empty+error
 useCases:
   - UC-25
+endpoints: []
+diagrams: []
+owner: pm-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/ppt/announcements.md
+++ b/docs/screens/ppt/announcements.md
@@ -39,6 +39,8 @@ designSources:
     frame: MobAnnouncementsScreen + MobAnnouncementDetailScreen
 useCases:
   - UC-02
+diagrams: []
+owner: pm-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/ppt/article-detail.md
+++ b/docs/screens/ppt/article-detail.md
@@ -35,6 +35,8 @@ designSources:
     frame: read-mode-published-7-comments / edit-mode-auto-saved / draft-preview / loading
 useCases:
   - UC-13
+diagrams: []
+owner: pm-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/ppt/dashboard.md
+++ b/docs/screens/ppt/dashboard.md
@@ -32,6 +32,9 @@ designSources:
   - adapter: claude-design
     file: guest-registration-v2-design-system/project/ui_kits/mobile/screens.jsx
     frame: MobHomeScreen
+epics: []
+diagrams: []
+owner: pm-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/ppt/dispute-detail.md
+++ b/docs/screens/ppt/dispute-detail.md
@@ -36,6 +36,8 @@ designSources:
     frame: loaded-V-mediacii / loaded-vyriesene-readonly / loading
 useCases:
   - UC-38
+diagrams: []
+owner: pm-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/ppt/disputes.md
+++ b/docs/screens/ppt/disputes.md
@@ -38,6 +38,8 @@ designSources:
     frame: loaded-3-selected / empty / loading-6-skel / error-503
 useCases:
   - UC-38
+diagrams: []
+owner: pm-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/ppt/document-detail.md
+++ b/docs/screens/ppt/document-detail.md
@@ -41,6 +41,8 @@ designSources:
     frame: MobDocumentDetailScreen
 useCases:
   - UC-08
+diagrams: []
+owner: pm-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/ppt/documents.md
+++ b/docs/screens/ppt/documents.md
@@ -43,6 +43,8 @@ designSources:
     frame: MobDocumentsScreen
 useCases:
   - UC-08
+diagrams: []
+owner: pm-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/ppt/emergency-contacts.md
+++ b/docs/screens/ppt/emergency-contacts.md
@@ -34,6 +34,8 @@ designSources:
     frame: loaded-8-rows / inline-edit / add-drawer-empty+filled / delete-confirm / empty / loading / error
 useCases:
   - UC-39
+diagrams: []
+owner: pm-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/ppt/faults-list.md
+++ b/docs/screens/ppt/faults-list.md
@@ -37,6 +37,9 @@ designSources:
     frame: mobile-faults-list
 useCases:
   - UC-03
+epics: []
+diagrams: []
+owner: pm-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/ppt/file-dispute.md
+++ b/docs/screens/ppt/file-dispute.md
@@ -37,6 +37,8 @@ designSources:
     frame: step1-category+severity / step3-attachments-uploading / step5-review / submitted-D-2026-0058 / step3-validation-errors
 useCases:
   - UC-38
+diagrams: []
+owner: pm-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/ppt/home.md
+++ b/docs/screens/ppt/home.md
@@ -38,6 +38,10 @@ useCases:
   - UC-02
   - UC-04
   - UC-17
+endpoints: []
+epics: []
+diagrams: []
+owner: pm-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/ppt/login.md
+++ b/docs/screens/ppt/login.md
@@ -32,6 +32,9 @@ designSources:
     frame: row1-loaded+magic / row2-totp+sms / row3-loading+empty / row4-errors-3up
 useCases:
   - UC-14
+epics: []
+diagrams: []
+owner: pm-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/ppt/news.md
+++ b/docs/screens/ppt/news.md
@@ -35,6 +35,8 @@ designSources:
     frame: loaded-grid-3up-1featured-1pinned-1scheduled-1draft / empty / loading-6-skel / error-503
 useCases:
   - UC-13
+diagrams: []
+owner: pm-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/ppt/privacy-settings.md
+++ b/docs/screens/ppt/privacy-settings.md
@@ -32,6 +32,9 @@ designSources:
     frame: loaded / export-3-state / delete-modal-2 / sessions-3 / consents-just-changed+audit / page-error
 useCases:
   - UC-23
+endpoints: []
+diagrams: []
+owner: pm-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/ppt/report-fault.md
+++ b/docs/screens/ppt/report-fault.md
@@ -33,6 +33,9 @@ designSources:
     frame: MobReportFaultScreen
 useCases:
   - UC-03
+epics: []
+diagrams: []
+owner: pm-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/ppt/upload-document.md
+++ b/docs/screens/ppt/upload-document.md
@@ -38,6 +38,8 @@ designSources:
     frame: loaded-4-files-mixed-states / empty-drag-over / success-toast
 useCases:
   - UC-08
+diagrams: []
+owner: pm-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/ppt/vote-create.md
+++ b/docs/screens/ppt/vote-create.md
@@ -32,6 +32,10 @@ designSources:
     frame: step1-yes-no-pick / step2-single-choice-3-suppliers / step3-owners-quorum-60-15-of-24 / step4-now-7days-blind-tally-off / step5-review / confirm-published
 useCases:
   - UC-04
+endpoints: []
+epics: []
+diagrams: []
+owner: pm-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/ppt/vote-detail.md
+++ b/docs/screens/ppt/vote-detail.md
@@ -37,6 +37,10 @@ designSources:
     frame: MobVoteDetailScreen
 useCases:
   - UC-04
+endpoints: []
+epics: []
+diagrams: []
+owner: pm-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/ppt/voting.md
+++ b/docs/screens/ppt/voting.md
@@ -41,6 +41,9 @@ designSources:
     frame: MobVotingScreen
 useCases:
   - UC-04
+epics: []
+diagrams: []
+owner: pm-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/about.md
+++ b/docs/screens/reality/about.md
@@ -30,6 +30,10 @@ designSources:
     frame: MAbout (KMP Android frame 412×892)
 useCases:
   - UC-42
+endpoints: []
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/agency-branding.md
+++ b/docs/screens/reality/agency-branding.md
@@ -30,6 +30,10 @@ designSources:
     frame: default-with-profile-logo-color-watermark / loading
 useCases:
   - UC-49
+endpoints: []
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/agency-dashboard.md
+++ b/docs/screens/reality/agency-dashboard.md
@@ -37,6 +37,8 @@ useCases:
   - UC-49
   - UC-50
   - UC-51
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/agency-import.md
+++ b/docs/screens/reality/agency-import.md
@@ -31,6 +31,10 @@ designSources:
     frame: 9-step-wizard-step1-connect / step2-map-fields / step3a-preview / step3b-source-vs-imported / step4-schedule / confirm / history-7-rows / empty-no-imports / error-states-4
 useCases:
   - UC-50
+endpoints: []
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/agent-profile.md
+++ b/docs/screens/reality/agent-profile.md
@@ -30,6 +30,10 @@ designSources:
 useCases:
   - UC-49
   - UC-51
+endpoints: []
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/careers.md
+++ b/docs/screens/reality/careers.md
@@ -32,6 +32,10 @@ designSources:
     frame: MCareers (KMP)
 useCases:
   - UC-42
+endpoints: []
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/compare-properties.md
+++ b/docs/screens/reality/compare-properties.md
@@ -34,6 +34,10 @@ designSources:
     frame: compare-loaded+empty+loading+error+add-modal
 useCases:
   - UC-48
+endpoints: []
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/contact.md
+++ b/docs/screens/reality/contact.md
@@ -33,6 +33,10 @@ designSources:
     frame: MContact (KMP)
 useCases:
   - UC-42
+endpoints: []
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/cookies.md
+++ b/docs/screens/reality/cookies.md
@@ -32,6 +32,10 @@ designSources:
     frame: MLegal[kind=cookies] (KMP)
 useCases:
   - UC-23
+endpoints: []
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/favorites.md
+++ b/docs/screens/reality/favorites.md
@@ -39,6 +39,9 @@ designSources:
     frame: KmpFavoritesScreen
 useCases:
   - UC-44
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/for-agents.md
+++ b/docs/screens/reality/for-agents.md
@@ -33,6 +33,10 @@ designSources:
     frame: MAgents (KMP)
 useCases:
   - UC-49
+endpoints: []
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/help.md
+++ b/docs/screens/reality/help.md
@@ -33,6 +33,10 @@ designSources:
     frame: MHelp (KMP)
 useCases:
   - UC-42
+endpoints: []
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/home.md
+++ b/docs/screens/reality/home.md
@@ -29,6 +29,10 @@ designSources:
 useCases:
   - UC-31
   - UC-44
+endpoints: []
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/inquiries.md
+++ b/docs/screens/reality/inquiries.md
@@ -38,6 +38,9 @@ designSources:
     frame: KmpInquiriesScreen + KmpInquiryThreadScreen
 useCases:
   - UC-46
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/journal.md
+++ b/docs/screens/reality/journal.md
@@ -32,6 +32,10 @@ designSources:
 useCases:
   - UC-13
   - UC-42
+endpoints: []
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/listing-detail.md
+++ b/docs/screens/reality/listing-detail.md
@@ -43,6 +43,9 @@ useCases:
   - UC-31
   - UC-44
   - UC-46
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/listing-edit.md
+++ b/docs/screens/reality/listing-edit.md
@@ -58,6 +58,10 @@ designSources:
     frame: mobile-variant
 useCases:
   - UC-31
+endpoints: []
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/listings.md
+++ b/docs/screens/reality/listings.md
@@ -46,6 +46,9 @@ useCases:
   - UC-44
   - UC-45
   - UC-48
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/oauth-callback.md
+++ b/docs/screens/reality/oauth-callback.md
@@ -14,6 +14,14 @@ implementations:
     buildStatus: n/a
     redesignStatus: n/a
     apiStatus: n/a
+relatedScreens:
+  - id: reality/home
+    rel: parent
+useCases: []
+endpoints: []
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/price-map.md
+++ b/docs/screens/reality/price-map.md
@@ -33,6 +33,10 @@ designSources:
     frame: MPriceMap (KMP)
 useCases:
   - UC-31
+endpoints: []
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/privacy.md
+++ b/docs/screens/reality/privacy.md
@@ -34,6 +34,10 @@ designSources:
     frame: MLegal[kind=privacy] (KMP)
 useCases:
   - UC-23
+endpoints: []
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/profile.md
+++ b/docs/screens/reality/profile.md
@@ -45,6 +45,10 @@ useCases:
   - UC-44
   - UC-45
   - UC-46
+endpoints: []
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/report-listing.md
+++ b/docs/screens/reality/report-listing.md
@@ -35,6 +35,10 @@ designSources:
 useCases:
   - UC-23
   - UC-31
+endpoints: []
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/saved-searches.md
+++ b/docs/screens/reality/saved-searches.md
@@ -37,6 +37,9 @@ designSources:
 useCases:
   - UC-45
   - UC-31
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/security.md
+++ b/docs/screens/reality/security.md
@@ -32,6 +32,10 @@ designSources:
     frame: MLegal[kind=security] (KMP)
 useCases:
   - UC-23
+endpoints: []
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/sell.md
+++ b/docs/screens/reality/sell.md
@@ -36,6 +36,10 @@ designSources:
     frame: MSell (KMP)
 useCases:
   - UC-31
+endpoints: []
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/docs/screens/reality/terms.md
+++ b/docs/screens/reality/terms.md
@@ -32,6 +32,10 @@ designSources:
     frame: MLegal[kind=terms] (KMP)
 useCases:
   - UC-23
+endpoints: []
+epics: []
+diagrams: []
+owner: reality-frontend
 ---
 
 ## Functionality Checklist

--- a/mobile-native/androidApp/src/main/res/xml/backup_rules.xml
+++ b/mobile-native/androidApp/src/main/res/xml/backup_rules.xml
@@ -4,11 +4,10 @@
 
   Primary protection is `android:allowBackup="false"` in AndroidManifest;
   these rules are a defense-in-depth safety net in case backup is ever
-  re-enabled. At the moment the app has no persistent sharedprefs that hold
-  auth secrets, so there's nothing explicit to exclude. When SSO session
-  persistence is added (see SsoService.restoreSession TODO), add an
-  <exclude domain="sharedpref" path="..."/> entry that matches the actual
-  SharedPreferences filename used.
+  re-enabled. The `secure/` file-domain exclusion below covers any auth
+  tokens or secrets persisted to internal storage under that subdirectory.
+  If SharedPreferences are later used to persist session state, add an
+  <exclude domain="sharedpref" path="..."/> entry matching the prefs file.
 -->
 <full-backup-content>
     <exclude domain="file" path="secure/" />


### PR DESCRIPTION
## Summary

Output of the team audit, hygiene slice. 50 files; mostly defaults filled in.

- **47 screen-map files** (`docs/screens/{ppt,reality}/*.md`) gained missing frontmatter defaults: `owner`, `diagrams: []`, `endpoints: []`, `epics: []`. Defaults inserted at the tail of frontmatter; no existing keys reordered.
  - PPT screens default to `owner: pm-frontend`; reality screens default to `owner: reality-frontend`.
  - `docs/screens/reality/oauth-callback.md` (the most-incomplete file) also gained `relatedScreens: [{id: reality/home, rel: parent}]` and `useCases: []`.
- **`.research/backlog.md`** and **`.research/IDEAS_TRIAGE.md`**: replaced misleading `Last regenerated: 2026-05-17 00:00 UTC by routine` sentinel (the cloud routine has never actually run) with `Last regenerated: never (scaffold — first routine run will overwrite this)`.
- **`mobile-native/androidApp/src/main/res/xml/backup_rules.xml`** comment cleaned up — referenced a fictional TODO; rewrote to neutrally describe the `secure/` exclusion (the `SsoService.restoreSession` symbol referenced does exist at `mobile-native/shared/src/commonMain/kotlin/.../SsoService.kt:318`, so the TODO framing was just stale).

## Not done

Three items from the original audit (`justfile new-plan` slug validation, `cloud-setup.sh` SCOPES whitespace, `ppt-screens/SKILL.md` paths) were already correct on main — verified twice. The audit-agent's notes were stale.

## Verification

- All 47 changed screen-maps parse cleanly with `yaml.safe_load` (no duplicate keys, no broken indentation).
- Spot-checked 8 random files + `oauth-callback.md`.

## Test plan

- [ ] `/screens validate` or equivalent CI passes
- [ ] Screen-map render diagrams still build