### PR TITLE
refactor(api): backend cleanup — templates unwrap + dead-code audit

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "admin-core"
-version = "0.2.395"
+version = "0.2.400"
 dependencies = [
  "api-core",
  "async-trait",
@@ -192,7 +192,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-core"
-version = "0.2.395"
+version = "0.2.400"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "api-server"
-version = "0.2.395"
+version = "0.2.400"
 dependencies = [
  "admin-core",
  "aes-gcm",
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.2.395"
+version = "0.2.400"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -2047,7 +2047,7 @@ dependencies = [
 
 [[package]]
 name = "db"
-version = "0.2.395"
+version = "0.2.400"
 dependencies = [
  "argon2",
  "async-trait",
@@ -2100,7 +2100,7 @@ dependencies = [
 
 [[package]]
 name = "deploy-server"
-version = "0.2.395"
+version = "0.2.400"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3563,7 +3563,7 @@ dependencies = [
 
 [[package]]
 name = "integrations"
-version = "0.2.395"
+version = "0.2.400"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -5367,7 +5367,7 @@ dependencies = [
 
 [[package]]
 name = "reality-server"
-version = "0.2.395"
+version = "0.2.400"
 dependencies = [
  "anyhow",
  "api-core",
@@ -6900,7 +6900,7 @@ dependencies = [
 
 [[package]]
 name = "tenant-ops"
-version = "0.2.395"
+version = "0.2.400"
 dependencies = [
  "chrono",
  "common",

--- a/backend/servers/api-server/src/routes/data_residency.rs
+++ b/backend/servers/api-server/src/routes/data_residency.rs
@@ -738,6 +738,10 @@ fn get_compliance_zone(region: &DataRegion) -> &'static str {
 }
 
 /// Generate a hash for an audit entry (for tamper-evident logging).
+///
+/// Placeholder for the audit hash-chain feature (Epic 144 data-residency).
+/// Not yet wired into the audit write path; kept here so the hashing
+/// scheme is reviewable alongside the audit entry definitions.
 #[allow(dead_code)]
 fn generate_audit_hash(entry: &AuditLogEntry, previous_hash: Option<&str>) -> String {
     let mut hasher = Sha256::new();

--- a/backend/servers/api-server/src/routes/feature_packages.rs
+++ b/backend/servers/api-server/src/routes/feature_packages.rs
@@ -112,6 +112,10 @@ fn require_super_admin(
 }
 
 /// Verify user has access to the organization.
+///
+/// Placeholder for future per-org gating in feature-package routes; current routes
+/// rely on super-admin checks via `verify_super_admin_rls`. Kept for parity with
+/// `integrations::verify_org_access` once non-super-admin flows are added.
 #[allow(dead_code)]
 async fn verify_org_access(
     rls: &mut RlsConnection,

--- a/backend/servers/api-server/src/routes/templates.rs
+++ b/backend/servers/api-server/src/routes/templates.rs
@@ -623,8 +623,6 @@ async fn generate_document(
     let file_key = format!("generated/{}/{}.md", org_id, uuid::Uuid::new_v4());
     let file_name = format!("{}.md", req.title.replace(['/', '\\'], "_"));
 
-    let _generation_metadata = serde_json::to_value(&req.values).unwrap();
-
     let create_doc = db::models::CreateDocument {
         organization_id: org_id,
         folder_id: req.folder_id,


### PR DESCRIPTION
## Summary

Round 4 of the team audit. Smaller follow-on cleanups after PRs #300/#301.

### Templates.rs unwrap
- `routes/templates.rs:626` had a `serde_json::to_value(&req.values).unwrap()` whose result was never read — the value bound an unused `_generation_metadata`. Removed the line outright (cleaner than the helper pattern).

### Dead-code audit
Reviewed all 13 `#[allow(dead_code)]` attributes in production code (full list in commit body). All 13 KEPT (conservative): the attributes mark either documented external-API protocol fields (Anthropic, OpenAI, Outlook/Graph, Xero, Salesforce, JWK) or stub repos / placeholder helpers awaiting first caller.
- 2 sites got new placeholder comments (`feature_packages.rs::verify_org_access`, `data_residency.rs::generate_audit_hash`) so the next visitor doesn't have to re-derive intent.

### Follow-up notes (not in this PR)
- The `to_json_value` helper now lives in 2 files via PR #301. Once that merges, a natural follow-up is hoisting it to `api-core/src/responses.rs`.
- `ListingWithSyndicationRow` (db/repositories/listing.rs:1057) could be slimmed to `(Uuid,)` since only `listing_id` is consumed — small win, touches SQL.

## Verification

`cargo fmt` clean. `cargo check` blocked locally (no `clang`). CI is authoritative.

## Test plan

- [ ] Backend CI compiles + tests pass