### PR TITLE
feat(screens): stub screen-maps for unmapped ppt-web and reality-web routes

### DIFF
--- a/docs/screens/ppt/announcement-edit.md
+++ b/docs/screens/ppt/announcement-edit.md
@@ -9,7 +9,7 @@ implementations:
     component: EditAnnouncementPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: ppt/announcements

--- a/docs/screens/ppt/announcement-edit.md
+++ b/docs/screens/ppt/announcement-edit.md
@@ -1,0 +1,35 @@
+---
+id: ppt/announcement-edit
+name: Edit Announcement
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/announcements/:announcementId/edit"
+    component: EditAnnouncementPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: ppt/announcements
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Edit Announcement
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:486`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/announcement-new.md
+++ b/docs/screens/ppt/announcement-new.md
@@ -1,0 +1,35 @@
+---
+id: ppt/announcement-new
+name: Create Announcement
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/announcements/new"
+    component: CreateAnnouncementPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: ppt/announcements
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Create Announcement
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:478`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/announcement-new.md
+++ b/docs/screens/ppt/announcement-new.md
@@ -9,7 +9,7 @@ implementations:
     component: CreateAnnouncementPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: ppt/announcements

--- a/docs/screens/ppt/community-events.md
+++ b/docs/screens/ppt/community-events.md
@@ -1,0 +1,35 @@
+---
+id: ppt/community-events
+name: Community Events
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/community/events"
+    component: EventsPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: ppt/community
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Community Events
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:515`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/community-events.md
+++ b/docs/screens/ppt/community-events.md
@@ -9,7 +9,7 @@ implementations:
     component: EventsPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: ppt/community

--- a/docs/screens/ppt/community-group-detail.md
+++ b/docs/screens/ppt/community-group-detail.md
@@ -1,0 +1,35 @@
+---
+id: ppt/community-group-detail
+name: Community Group Detail
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/community/groups/:groupId"
+    component: GroupDetailPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: ppt/community-groups
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Community Group Detail
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:512`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/community-group-detail.md
+++ b/docs/screens/ppt/community-group-detail.md
@@ -9,7 +9,7 @@ implementations:
     component: GroupDetailPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: ppt/community-groups

--- a/docs/screens/ppt/community-groups-new.md
+++ b/docs/screens/ppt/community-groups-new.md
@@ -1,0 +1,35 @@
+---
+id: ppt/community-groups-new
+name: Create Community Group
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/community/groups/new"
+    component: CreateGroupPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: ppt/community-groups
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Create Community Group
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:508`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/community-groups-new.md
+++ b/docs/screens/ppt/community-groups-new.md
@@ -9,7 +9,7 @@ implementations:
     component: CreateGroupPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: ppt/community-groups

--- a/docs/screens/ppt/community-groups.md
+++ b/docs/screens/ppt/community-groups.md
@@ -1,0 +1,35 @@
+---
+id: ppt/community-groups
+name: Community Groups
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/community/groups"
+    component: GroupsPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: ppt/community
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Community Groups
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:506`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/community-groups.md
+++ b/docs/screens/ppt/community-groups.md
@@ -9,7 +9,7 @@ implementations:
     component: GroupsPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: ppt/community

--- a/docs/screens/ppt/community-marketplace.md
+++ b/docs/screens/ppt/community-marketplace.md
@@ -9,7 +9,7 @@ implementations:
     component: MarketplacePage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: ppt/community

--- a/docs/screens/ppt/community-marketplace.md
+++ b/docs/screens/ppt/community-marketplace.md
@@ -1,0 +1,35 @@
+---
+id: ppt/community-marketplace
+name: Community Marketplace
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/community/marketplace"
+    component: MarketplacePage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: ppt/community
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Community Marketplace
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:517`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/community.md
+++ b/docs/screens/ppt/community.md
@@ -9,7 +9,7 @@ implementations:
     component: FeedPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens: []
 sharedComponents: []

--- a/docs/screens/ppt/community.md
+++ b/docs/screens/ppt/community.md
@@ -1,0 +1,33 @@
+---
+id: ppt/community
+name: Community Feed
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/community"
+    component: FeedPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens: []
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Community Feed
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:505`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/dashboard-manager.md
+++ b/docs/screens/ppt/dashboard-manager.md
@@ -9,7 +9,7 @@ implementations:
     component: ManagerDashboardPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: ppt/dashboard-resident

--- a/docs/screens/ppt/dashboard-manager.md
+++ b/docs/screens/ppt/dashboard-manager.md
@@ -1,0 +1,37 @@
+---
+id: ppt/dashboard-manager
+name: Manager Dashboard
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/dashboard/manager"
+    component: ManagerDashboardPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: ppt/dashboard-resident
+    rel: sibling
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Manager Dashboard
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+Note: existing `ppt/dashboard` screen-map is mobile-only — this is the web-only manager view.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:392`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/dashboard-resident.md
+++ b/docs/screens/ppt/dashboard-resident.md
@@ -1,0 +1,37 @@
+---
+id: ppt/dashboard-resident
+name: Resident Dashboard
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/dashboard/resident"
+    component: ResidentDashboardPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: ppt/dashboard-manager
+    rel: sibling
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Resident Dashboard
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+Note: existing `ppt/dashboard` screen-map is mobile-only — this is the web-only resident view.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:395`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/dashboard-resident.md
+++ b/docs/screens/ppt/dashboard-resident.md
@@ -9,7 +9,7 @@ implementations:
     component: ResidentDashboardPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: ppt/dashboard-manager

--- a/docs/screens/ppt/fault-detail.md
+++ b/docs/screens/ppt/fault-detail.md
@@ -1,0 +1,35 @@
+---
+id: ppt/fault-detail
+name: Fault Detail
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/faults/:faultId"
+    component: FaultDetailPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: ppt/faults-list
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Fault Detail
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:499`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/fault-detail.md
+++ b/docs/screens/ppt/fault-detail.md
@@ -9,7 +9,7 @@ implementations:
     component: FaultDetailPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: ppt/faults-list

--- a/docs/screens/ppt/fault-edit.md
+++ b/docs/screens/ppt/fault-edit.md
@@ -1,0 +1,35 @@
+---
+id: ppt/fault-edit
+name: Edit Fault
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/faults/:faultId/edit"
+    component: EditFaultPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: ppt/fault-detail
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Edit Fault
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:501`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/fault-edit.md
+++ b/docs/screens/ppt/fault-edit.md
@@ -9,7 +9,7 @@ implementations:
     component: EditFaultPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: ppt/fault-detail

--- a/docs/screens/ppt/fault-new.md
+++ b/docs/screens/ppt/fault-new.md
@@ -1,0 +1,37 @@
+---
+id: ppt/fault-new
+name: Create Fault
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/faults/new"
+    component: CreateFaultPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: ppt/faults-list
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Create Fault
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+Note: a `ppt/report-fault` screen-map already exists (mobile-oriented). This stub covers the web `/faults/new` route specifically.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:498`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/fault-new.md
+++ b/docs/screens/ppt/fault-new.md
@@ -9,7 +9,7 @@ implementations:
     component: CreateFaultPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: ppt/faults-list

--- a/docs/screens/ppt/financial-budgets.md
+++ b/docs/screens/ppt/financial-budgets.md
@@ -9,7 +9,7 @@ implementations:
     component: BudgetManagementPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: ppt/financial

--- a/docs/screens/ppt/financial-budgets.md
+++ b/docs/screens/ppt/financial-budgets.md
@@ -1,0 +1,35 @@
+---
+id: ppt/financial-budgets
+name: Budget Management
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/financial/budgets"
+    component: BudgetManagementPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: ppt/financial
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Budget Management
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:534`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/financial-invoices.md
+++ b/docs/screens/ppt/financial-invoices.md
@@ -1,0 +1,35 @@
+---
+id: ppt/financial-invoices
+name: Invoice Management
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/financial/invoices"
+    component: InvoiceManagementPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: ppt/financial
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Invoice Management
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:526`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/financial-invoices.md
+++ b/docs/screens/ppt/financial-invoices.md
@@ -9,7 +9,7 @@ implementations:
     component: InvoiceManagementPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: ppt/financial

--- a/docs/screens/ppt/financial-payments.md
+++ b/docs/screens/ppt/financial-payments.md
@@ -1,0 +1,35 @@
+---
+id: ppt/financial-payments
+name: Payment Management
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/financial/payments"
+    component: PaymentManagementPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: ppt/financial
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Payment Management
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:530`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/financial-payments.md
+++ b/docs/screens/ppt/financial-payments.md
@@ -9,7 +9,7 @@ implementations:
     component: PaymentManagementPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: ppt/financial

--- a/docs/screens/ppt/financial.md
+++ b/docs/screens/ppt/financial.md
@@ -9,7 +9,7 @@ implementations:
     component: FinancialDashboardPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens: []
 sharedComponents: []

--- a/docs/screens/ppt/financial.md
+++ b/docs/screens/ppt/financial.md
@@ -1,0 +1,33 @@
+---
+id: ppt/financial
+name: Financial Dashboard
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/financial"
+    component: FinancialDashboardPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens: []
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Financial Dashboard
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:522`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/forbidden.md
+++ b/docs/screens/ppt/forbidden.md
@@ -1,0 +1,39 @@
+---
+id: ppt/forbidden
+name: Forbidden (403)
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/forbidden"
+    component: ForbiddenPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: n/a
+endpoints: []
+relatedScreens:
+  - id: ppt/server-error
+    rel: sibling
+  - id: ppt/session-expired
+    rel: sibling
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Forbidden (403)
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+Note: chosen one-per-screen (over a combined error-pages.md) to match the existing convention in `docs/screens/_template.md`, which prefers a single screen per file.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:542`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/forgot-password.md
+++ b/docs/screens/ppt/forgot-password.md
@@ -1,0 +1,35 @@
+---
+id: ppt/forgot-password
+name: Forgot Password
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/forgot-password"
+    component: ForgotPasswordPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: ppt/login
+    rel: sibling
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Forgot Password
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:373`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/forgot-password.md
+++ b/docs/screens/ppt/forgot-password.md
@@ -9,7 +9,7 @@ implementations:
     component: ForgotPasswordPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: ppt/login

--- a/docs/screens/ppt/message-thread.md
+++ b/docs/screens/ppt/message-thread.md
@@ -9,7 +9,7 @@ implementations:
     component: ThreadDetailPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: ppt/messages

--- a/docs/screens/ppt/message-thread.md
+++ b/docs/screens/ppt/message-thread.md
@@ -1,0 +1,35 @@
+---
+id: ppt/message-thread
+name: Message Thread
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/messages/:threadId"
+    component: ThreadDetailPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: ppt/messages
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Message Thread
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:492`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/messages-new.md
+++ b/docs/screens/ppt/messages-new.md
@@ -1,0 +1,35 @@
+---
+id: ppt/messages-new
+name: New Message
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/messages/new"
+    component: NewMessagePage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: ppt/messages
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# New Message
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:491`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/messages-new.md
+++ b/docs/screens/ppt/messages-new.md
@@ -9,7 +9,7 @@ implementations:
     component: NewMessagePage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: ppt/messages

--- a/docs/screens/ppt/messages.md
+++ b/docs/screens/ppt/messages.md
@@ -9,7 +9,7 @@ implementations:
     component: MessagesPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens: []
 sharedComponents: []

--- a/docs/screens/ppt/messages.md
+++ b/docs/screens/ppt/messages.md
@@ -1,0 +1,33 @@
+---
+id: ppt/messages
+name: Messages
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/messages"
+    component: MessagesPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens: []
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Messages
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:490`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/outage-detail.md
+++ b/docs/screens/ppt/outage-detail.md
@@ -1,0 +1,35 @@
+---
+id: ppt/outage-detail
+name: Outage Detail
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/outages/:outageId"
+    component: ViewOutagePage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: ppt/outages
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Outage Detail
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:468`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/outage-detail.md
+++ b/docs/screens/ppt/outage-detail.md
@@ -9,7 +9,7 @@ implementations:
     component: ViewOutagePage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: ppt/outages

--- a/docs/screens/ppt/outage-edit.md
+++ b/docs/screens/ppt/outage-edit.md
@@ -9,7 +9,7 @@ implementations:
     component: EditOutagePage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: ppt/outage-detail

--- a/docs/screens/ppt/outage-edit.md
+++ b/docs/screens/ppt/outage-edit.md
@@ -1,0 +1,35 @@
+---
+id: ppt/outage-edit
+name: Edit Outage
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/outages/:outageId/edit"
+    component: EditOutagePage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: ppt/outage-detail
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Edit Outage
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:472`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/outage-new.md
+++ b/docs/screens/ppt/outage-new.md
@@ -9,7 +9,7 @@ implementations:
     component: CreateOutagePage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: ppt/outages

--- a/docs/screens/ppt/outage-new.md
+++ b/docs/screens/ppt/outage-new.md
@@ -1,0 +1,35 @@
+---
+id: ppt/outage-new
+name: Create Outage
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/outages/new"
+    component: CreateOutagePage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: ppt/outages
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Create Outage
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:466`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/outages.md
+++ b/docs/screens/ppt/outages.md
@@ -9,7 +9,7 @@ implementations:
     component: OutagesPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens: []
 sharedComponents: []

--- a/docs/screens/ppt/outages.md
+++ b/docs/screens/ppt/outages.md
@@ -1,0 +1,33 @@
+---
+id: ppt/outages
+name: Outages
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/outages"
+    component: OutagesPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens: []
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Outages
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:465`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/register.md
+++ b/docs/screens/ppt/register.md
@@ -9,7 +9,7 @@ implementations:
     component: RegisterPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: ppt/login

--- a/docs/screens/ppt/register.md
+++ b/docs/screens/ppt/register.md
@@ -1,0 +1,35 @@
+---
+id: ppt/register
+name: Register
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/register"
+    component: RegisterPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: ppt/login
+    rel: sibling
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Register
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:372`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/reset-password.md
+++ b/docs/screens/ppt/reset-password.md
@@ -9,7 +9,7 @@ implementations:
     component: ResetPasswordPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: ppt/forgot-password

--- a/docs/screens/ppt/reset-password.md
+++ b/docs/screens/ppt/reset-password.md
@@ -1,0 +1,35 @@
+---
+id: ppt/reset-password
+name: Reset Password
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/reset-password"
+    component: ResetPasswordPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: ppt/forgot-password
+    rel: sibling
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Reset Password
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:374`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/server-error.md
+++ b/docs/screens/ppt/server-error.md
@@ -1,0 +1,37 @@
+---
+id: ppt/server-error
+name: Server Error (500)
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/server-error"
+    component: ServerErrorPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: n/a
+endpoints: []
+relatedScreens:
+  - id: ppt/forbidden
+    rel: sibling
+  - id: ppt/session-expired
+    rel: sibling
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Server Error (500)
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:543`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/session-expired.md
+++ b/docs/screens/ppt/session-expired.md
@@ -1,0 +1,39 @@
+---
+id: ppt/session-expired
+name: Session Expired
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/session-expired"
+    component: SessionExpiredPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: n/a
+endpoints: []
+relatedScreens:
+  - id: ppt/forbidden
+    rel: sibling
+  - id: ppt/server-error
+    rel: sibling
+  - id: ppt/login
+    rel: child
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Session Expired
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:544`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/settings-password.md
+++ b/docs/screens/ppt/settings-password.md
@@ -9,7 +9,7 @@ implementations:
     component: ChangePasswordPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens: []
 sharedComponents: []

--- a/docs/screens/ppt/settings-password.md
+++ b/docs/screens/ppt/settings-password.md
@@ -1,0 +1,33 @@
+---
+id: ppt/settings-password
+name: Change Password
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/settings/password"
+    component: ChangePasswordPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens: []
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Change Password
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:375`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/settings-profile.md
+++ b/docs/screens/ppt/settings-profile.md
@@ -1,0 +1,33 @@
+---
+id: ppt/settings-profile
+name: Profile Edit
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/settings/profile"
+    component: ProfileEditPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens: []
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Profile Edit
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:380`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/settings-profile.md
+++ b/docs/screens/ppt/settings-profile.md
@@ -9,7 +9,7 @@ implementations:
     component: ProfileEditPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens: []
 sharedComponents: []

--- a/docs/screens/ppt/settings-two-factor.md
+++ b/docs/screens/ppt/settings-two-factor.md
@@ -9,7 +9,7 @@ implementations:
     component: TwoFactorAuthPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens: []
 sharedComponents: []

--- a/docs/screens/ppt/settings-two-factor.md
+++ b/docs/screens/ppt/settings-two-factor.md
@@ -1,0 +1,33 @@
+---
+id: ppt/settings-two-factor
+name: Two-Factor Authentication
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/settings/two-factor"
+    component: TwoFactorAuthPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens: []
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: pm-frontend
+---
+
+# Two-Factor Authentication
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:377`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/reality/account-listing-edit.md
+++ b/docs/screens/reality/account-listing-edit.md
@@ -1,0 +1,39 @@
+---
+id: reality/account-listing-edit
+name: Edit Listing (Account)
+product: reality
+sitemapRefs: {}
+implementations:
+  reality-web:
+    route: "/account/listings/[id]/edit"
+    component: AccountListingEditPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: reality/account
+    rel: parent
+  - id: reality/listing-edit
+    rel: sibling
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: reality-frontend
+---
+
+# Edit Listing (Account)
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+Note: distinct from `reality/listing-edit` (which appears to be the realtor variant). Disambiguation needed when humans add detail.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/reality-web/src/app/[locale]/account/listings/[id]/edit/page.tsx`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/reality/account-listing-edit.md
+++ b/docs/screens/reality/account-listing-edit.md
@@ -9,7 +9,7 @@ implementations:
     component: AccountListingEditPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: reality/account

--- a/docs/screens/reality/account-password.md
+++ b/docs/screens/reality/account-password.md
@@ -9,7 +9,7 @@ implementations:
     component: AccountPasswordPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: reality/account

--- a/docs/screens/reality/account-password.md
+++ b/docs/screens/reality/account-password.md
@@ -1,0 +1,35 @@
+---
+id: reality/account-password
+name: Account Password
+product: reality
+sitemapRefs: {}
+implementations:
+  reality-web:
+    route: "/account/password"
+    component: AccountPasswordPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: reality/account
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: reality-frontend
+---
+
+# Account Password
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/reality-web/src/app/[locale]/account/password/page.tsx`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/reality/account-profile.md
+++ b/docs/screens/reality/account-profile.md
@@ -1,0 +1,37 @@
+---
+id: reality/account-profile
+name: Account Profile
+product: reality
+sitemapRefs: {}
+implementations:
+  reality-web:
+    route: "/account/profile"
+    component: AccountProfilePage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: reality/account
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: reality-frontend
+---
+
+# Account Profile
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+Note: a separate `reality/profile` screen-map exists; this one is specifically `/account/profile` (account-management variant) — disambiguate with humans later.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/reality-web/src/app/[locale]/account/profile/page.tsx`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/reality/account-profile.md
+++ b/docs/screens/reality/account-profile.md
@@ -9,7 +9,7 @@ implementations:
     component: AccountProfilePage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: reality/account

--- a/docs/screens/reality/account.md
+++ b/docs/screens/reality/account.md
@@ -1,0 +1,33 @@
+---
+id: reality/account
+name: Account Dashboard
+product: reality
+sitemapRefs: {}
+implementations:
+  reality-web:
+    route: "/account"
+    component: AccountPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens: []
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: reality-frontend
+---
+
+# Account Dashboard
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/reality-web/src/app/[locale]/account/page.tsx`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/reality/account.md
+++ b/docs/screens/reality/account.md
@@ -9,7 +9,7 @@ implementations:
     component: AccountPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens: []
 sharedComponents: []

--- a/docs/screens/reality/agency-inquiries.md
+++ b/docs/screens/reality/agency-inquiries.md
@@ -1,0 +1,35 @@
+---
+id: reality/agency-inquiries
+name: Agency Inquiries
+product: reality
+sitemapRefs: {}
+implementations:
+  reality-web:
+    route: "/agency/inquiries"
+    component: AgencyInquiriesPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: reality/agency-dashboard
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: reality-frontend
+---
+
+# Agency Inquiries
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/reality-web/src/app/[locale]/agency/inquiries/page.tsx`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/reality/agency-inquiries.md
+++ b/docs/screens/reality/agency-inquiries.md
@@ -9,7 +9,7 @@ implementations:
     component: AgencyInquiriesPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: reality/agency-dashboard

--- a/docs/screens/reality/agency-listings.md
+++ b/docs/screens/reality/agency-listings.md
@@ -1,0 +1,35 @@
+---
+id: reality/agency-listings
+name: Agency Listings
+product: reality
+sitemapRefs: {}
+implementations:
+  reality-web:
+    route: "/agency/listings"
+    component: AgencyListingsPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: reality/agency-dashboard
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: reality-frontend
+---
+
+# Agency Listings
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/reality-web/src/app/[locale]/agency/listings/page.tsx`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/reality/agency-listings.md
+++ b/docs/screens/reality/agency-listings.md
@@ -9,7 +9,7 @@ implementations:
     component: AgencyListingsPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: reality/agency-dashboard

--- a/docs/screens/reality/agency-realtors.md
+++ b/docs/screens/reality/agency-realtors.md
@@ -9,7 +9,7 @@ implementations:
     component: AgencyRealtorsPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: reality/agency-dashboard

--- a/docs/screens/reality/agency-realtors.md
+++ b/docs/screens/reality/agency-realtors.md
@@ -1,0 +1,35 @@
+---
+id: reality/agency-realtors
+name: Agency Realtors
+product: reality
+sitemapRefs: {}
+implementations:
+  reality-web:
+    route: "/agency/realtors"
+    component: AgencyRealtorsPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: reality/agency-dashboard
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: reality-frontend
+---
+
+# Agency Realtors
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/reality-web/src/app/[locale]/agency/realtors/page.tsx`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/reality/auth-forgot-password.md
+++ b/docs/screens/reality/auth-forgot-password.md
@@ -1,0 +1,35 @@
+---
+id: reality/auth-forgot-password
+name: Forgot Password (Reality Portal)
+product: reality
+sitemapRefs: {}
+implementations:
+  reality-web:
+    route: "/auth/forgot-password"
+    component: AuthForgotPasswordPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: reality/auth-login
+    rel: sibling
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: reality-frontend
+---
+
+# Forgot Password (Reality Portal)
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/reality-web/src/app/[locale]/auth/forgot-password/page.tsx`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/reality/auth-forgot-password.md
+++ b/docs/screens/reality/auth-forgot-password.md
@@ -9,7 +9,7 @@ implementations:
     component: AuthForgotPasswordPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: reality/auth-login

--- a/docs/screens/reality/auth-login.md
+++ b/docs/screens/reality/auth-login.md
@@ -1,0 +1,37 @@
+---
+id: reality/auth-login
+name: Login (Reality Portal)
+product: reality
+sitemapRefs: {}
+implementations:
+  reality-web:
+    route: "/auth/login"
+    component: AuthLoginPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: reality/auth-register
+    rel: sibling
+  - id: reality/auth-forgot-password
+    rel: sibling
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: reality-frontend
+---
+
+# Login (Reality Portal)
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/reality-web/src/app/[locale]/auth/login/page.tsx`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/reality/auth-login.md
+++ b/docs/screens/reality/auth-login.md
@@ -9,7 +9,7 @@ implementations:
     component: AuthLoginPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: reality/auth-register

--- a/docs/screens/reality/auth-register.md
+++ b/docs/screens/reality/auth-register.md
@@ -1,0 +1,35 @@
+---
+id: reality/auth-register
+name: Register (Reality Portal)
+product: reality
+sitemapRefs: {}
+implementations:
+  reality-web:
+    route: "/auth/register"
+    component: AuthRegisterPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: reality/auth-login
+    rel: sibling
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: reality-frontend
+---
+
+# Register (Reality Portal)
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/reality-web/src/app/[locale]/auth/register/page.tsx`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/reality/auth-register.md
+++ b/docs/screens/reality/auth-register.md
@@ -9,7 +9,7 @@ implementations:
     component: AuthRegisterPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: reality/auth-login

--- a/docs/screens/reality/auth-reset-password.md
+++ b/docs/screens/reality/auth-reset-password.md
@@ -9,7 +9,7 @@ implementations:
     component: AuthResetPasswordPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: reality/auth-forgot-password

--- a/docs/screens/reality/auth-reset-password.md
+++ b/docs/screens/reality/auth-reset-password.md
@@ -1,0 +1,35 @@
+---
+id: reality/auth-reset-password
+name: Reset Password (Reality Portal)
+product: reality
+sitemapRefs: {}
+implementations:
+  reality-web:
+    route: "/auth/reset-password"
+    component: AuthResetPasswordPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: reality/auth-forgot-password
+    rel: sibling
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: reality-frontend
+---
+
+# Reset Password (Reality Portal)
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/reality-web/src/app/[locale]/auth/reset-password/page.tsx`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/reality/forbidden.md
+++ b/docs/screens/reality/forbidden.md
@@ -1,0 +1,33 @@
+---
+id: reality/forbidden
+name: Forbidden (Reality Portal)
+product: reality
+sitemapRefs: {}
+implementations:
+  reality-web:
+    route: "/forbidden"
+    component: ForbiddenPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: n/a
+endpoints: []
+relatedScreens: []
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: reality-frontend
+---
+
+# Forbidden (Reality Portal)
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/reality-web/src/app/[locale]/forbidden/page.tsx`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/reality/realtor-analytics.md
+++ b/docs/screens/reality/realtor-analytics.md
@@ -1,0 +1,35 @@
+---
+id: reality/realtor-analytics
+name: Realtor Analytics
+product: reality
+sitemapRefs: {}
+implementations:
+  reality-web:
+    route: "/realtor/analytics"
+    component: RealtorAnalyticsPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: reality/realtor
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: reality-frontend
+---
+
+# Realtor Analytics
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/reality-web/src/app/[locale]/realtor/analytics/page.tsx`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/reality/realtor-analytics.md
+++ b/docs/screens/reality/realtor-analytics.md
@@ -9,7 +9,7 @@ implementations:
     component: RealtorAnalyticsPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: reality/realtor

--- a/docs/screens/reality/realtor-detail.md
+++ b/docs/screens/reality/realtor-detail.md
@@ -1,0 +1,37 @@
+---
+id: reality/realtor-detail
+name: Realtor Detail (Public)
+product: reality
+sitemapRefs: {}
+implementations:
+  reality-web:
+    route: "/realtor/[id]"
+    component: RealtorDetailPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: reality/realtor
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: reality-frontend
+---
+
+# Realtor Detail (Public)
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+Note: differs from `reality/agent-profile` (the realtor's own profile view) — this is a public-facing realtor profile page.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/reality-web/src/app/[locale]/realtor/[id]/page.tsx`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/reality/realtor-detail.md
+++ b/docs/screens/reality/realtor-detail.md
@@ -9,7 +9,7 @@ implementations:
     component: RealtorDetailPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: reality/realtor

--- a/docs/screens/reality/realtor-listings-edit.md
+++ b/docs/screens/reality/realtor-listings-edit.md
@@ -1,0 +1,37 @@
+---
+id: reality/realtor-listings-edit
+name: Realtor Edit Listing
+product: reality
+sitemapRefs: {}
+implementations:
+  reality-web:
+    route: "/realtor/listings/[id]/edit"
+    component: RealtorListingEditPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: reality/realtor-listings
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: reality-frontend
+---
+
+# Realtor Edit Listing
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+Note: an existing `reality/listing-edit` screen-map may overlap. Humans should reconcile whether one entry should cover the realtor edit route.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/reality-web/src/app/[locale]/realtor/listings/[id]/edit/page.tsx`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/reality/realtor-listings-edit.md
+++ b/docs/screens/reality/realtor-listings-edit.md
@@ -9,7 +9,7 @@ implementations:
     component: RealtorListingEditPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: reality/realtor-listings

--- a/docs/screens/reality/realtor-listings-new.md
+++ b/docs/screens/reality/realtor-listings-new.md
@@ -1,0 +1,35 @@
+---
+id: reality/realtor-listings-new
+name: Realtor New Listing
+product: reality
+sitemapRefs: {}
+implementations:
+  reality-web:
+    route: "/realtor/listings/new"
+    component: RealtorListingNewPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: reality/realtor-listings
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: reality-frontend
+---
+
+# Realtor New Listing
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/reality-web/src/app/[locale]/realtor/listings/new/page.tsx`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/reality/realtor-listings-new.md
+++ b/docs/screens/reality/realtor-listings-new.md
@@ -9,7 +9,7 @@ implementations:
     component: RealtorListingNewPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: reality/realtor-listings

--- a/docs/screens/reality/realtor-listings.md
+++ b/docs/screens/reality/realtor-listings.md
@@ -9,7 +9,7 @@ implementations:
     component: RealtorListingsPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: reality/realtor

--- a/docs/screens/reality/realtor-listings.md
+++ b/docs/screens/reality/realtor-listings.md
@@ -1,0 +1,35 @@
+---
+id: reality/realtor-listings
+name: Realtor Listings
+product: reality
+sitemapRefs: {}
+implementations:
+  reality-web:
+    route: "/realtor/listings"
+    component: RealtorListingsPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: reality/realtor
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: reality-frontend
+---
+
+# Realtor Listings
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/reality-web/src/app/[locale]/realtor/listings/page.tsx`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/reality/realtor-profile.md
+++ b/docs/screens/reality/realtor-profile.md
@@ -1,0 +1,37 @@
+---
+id: reality/realtor-profile
+name: Realtor Profile (Edit)
+product: reality
+sitemapRefs: {}
+implementations:
+  reality-web:
+    route: "/realtor/profile"
+    component: RealtorProfilePage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens:
+  - id: reality/realtor
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: reality-frontend
+---
+
+# Realtor Profile (Edit)
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+Note: an `reality/agent-profile` screen-map exists; this stub is for the realtor self-edit profile route specifically. Humans should reconcile.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/reality-web/src/app/[locale]/realtor/profile/page.tsx`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/reality/realtor-profile.md
+++ b/docs/screens/reality/realtor-profile.md
@@ -9,7 +9,7 @@ implementations:
     component: RealtorProfilePage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens:
   - id: reality/realtor

--- a/docs/screens/reality/realtor.md
+++ b/docs/screens/reality/realtor.md
@@ -1,0 +1,33 @@
+---
+id: reality/realtor
+name: Realtor Dashboard
+product: reality
+sitemapRefs: {}
+implementations:
+  reality-web:
+    route: "/realtor"
+    component: RealtorDashboardPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: unknown
+endpoints: []
+relatedScreens: []
+sharedComponents: []
+diagrams: []
+useCases: []
+epics: []
+designSources: []
+owner: reality-frontend
+---
+
+# Realtor Dashboard
+
+Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+
+## Notes
+
+### Specific (recent)
+- 2026-05-18 — audit: stub created from `frontend/apps/reality-web/src/app/[locale]/realtor/page.tsx`.
+
+## Agent Log
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/reality/realtor.md
+++ b/docs/screens/reality/realtor.md
@@ -9,7 +9,7 @@ implementations:
     component: RealtorDashboardPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: unknown
+    apiStatus: stub
 endpoints: []
 relatedScreens: []
 sharedComponents: []


### PR DESCRIPTION
## Summary

Round 4 of the team audit. The original audit identified ~41 routes in ppt-web and reality-web that had no screen-map under `docs/screens/`. This PR stubs **52 new screen-maps** (33 ppt + 19 reality) so the screen-map system has a complete picture of what's actually mounted in code.

### Stub policy (intentionally conservative)

- `buildStatus: shipped` (routes verified present in code)
- `redesignStatus: not-started`, `apiStatus: unknown`
- `useCases: []`, `epics: []` — no fabricated IDs. Humans fill these during the next curation pass.
- `relatedScreens` only when there's an obvious parent screen-map; no reverse-edge edits to existing files (avoids scope creep).
- Default owners: `pm-frontend` (ppt) / `reality-frontend` (reality).

### Slug deviations (documented in stubs)
- `/faults/:id` → `ppt/fault-detail` (clearer than bare `ppt/fault`)
- `/announcements/new` → `ppt/announcement-new`, `:id/edit` → `ppt/announcement-edit`, etc.
- `/messages/:threadId` → `ppt/message-thread`

### Error pages decision
Three separate files (`ppt/forbidden`, `ppt/server-error`, `ppt/session-expired`) cross-linked as `rel: sibling`. The `_template.md` convention is one-screen-per-file.

### Overlaps flagged for humans (in stubs' Specific Notes)
- `ppt/fault-new` ↔ existing `ppt/report-fault` (mobile-flavored)
- `ppt/dashboard-{manager,resident}` (web) ↔ existing `ppt/dashboard` (mobile-only)
- `reality/realtor-profile` ↔ `reality/agent-profile`
- `reality/realtor-listings-edit` ↔ `reality/listing-edit`
- `reality/account-profile` ↔ `reality/profile`

These need a human decision: merge vs keep distinct. Stubs deliberately don't pre-empt that call.

## Verification

- All 52 new files parse cleanly with `python yaml.safe_load`.
- Routes cross-referenced against `frontend/apps/ppt-web/src/App.tsx` and `frontend/apps/reality-web/src/app/[locale]/**/page.tsx`.

## Test plan

- [ ] `/screens validate` (or whatever CI runs for screen-maps) passes
- [ ] Screen-map render still works
- [ ] Owner review: agree with default owners and overlap-reconciliation notes