### PR TITLE
fix(db): platform_admin stats — drop nonexistent deleted_at predicate

### DIFF
--- a/backend/crates/db/src/repositories/platform_admin.rs
+++ b/backend/crates/db/src/repositories/platform_admin.rs
@@ -245,6 +245,14 @@ impl PlatformAdminRepository {
     }
 
     /// Get platform statistics summary.
+    ///
+    /// Note: `total_buildings` / `total_units` count all rows. The `buildings`
+    /// and `units` tables have no `deleted_at` column and no soft-delete
+    /// mechanism — their `status` column is constrained to `'active'` or
+    /// `'archived'`, neither of which represents deletion. Counting all rows
+    /// matches the schema honestly; the previous `WHERE deleted_at IS NULL`
+    /// predicate referenced a non-existent column and caused this endpoint
+    /// to 500 on every load.
     pub async fn get_platform_stats(&self) -> Result<PlatformStats, SqlxError> {
         let stats = sqlx::query_as::<_, PlatformStats>(
             r#"
@@ -252,8 +260,8 @@ impl PlatformAdminRepository {
                 (SELECT COUNT(*) FROM organizations WHERE status = 'active') as active_orgs,
                 (SELECT COUNT(*) FROM organizations WHERE status = 'suspended') as suspended_orgs,
                 (SELECT COUNT(*) FROM users WHERE status = 'active') as active_users,
-                (SELECT COUNT(*) FROM buildings WHERE deleted_at IS NULL) as total_buildings,
-                (SELECT COUNT(*) FROM units WHERE deleted_at IS NULL) as total_units
+                (SELECT COUNT(*) FROM buildings) as total_buildings,
+                (SELECT COUNT(*) FROM units) as total_units
             "#,
         )
         .fetch_one(&self.pool)


### PR DESCRIPTION
## Summary

HIGH-severity bug found by the round-5 migration-drift sweep. `get_platform_stats()` in `backend/crates/db/src/repositories/platform_admin.rs` filtered:

```sql
(SELECT COUNT(*) FROM buildings WHERE deleted_at IS NULL)
(SELECT COUNT(*) FROM units WHERE deleted_at IS NULL)
```

Neither table has a `deleted_at` column. Migrations:
- `00007_create_buildings.sql`: `status` is `CHECK IN ('active','archived')` — no `deleted_at`.
- `00008_create_units.sql`: same shape — no `deleted_at`.
- No follow-up migration adds one.

Result: `/admin/platform/stats` 500s every load.

## Fix

Dropped the `WHERE deleted_at IS NULL` predicate from both subqueries. Counts now include `archived` rows — which matches reality (no soft-delete primitive exists for these tables). Added a doc comment noting the schema reality so the next maintainer doesn't reintroduce.

## Out of scope (flagged in the audit, not done here)

- Swap to `sqlx::query!` macro for compile-time column check — the crate isn't set up with `sqlx-offline` data; needs a separate workflow change.
- `SELECT *` pattern across `repositories/*.rs` — fragile to schema additions; opportunistic cleanup, not a hotfix.

## Verification

`cargo check -p db` blocked locally (sandbox missing `clang`/`pkg-config`). Edit is a 2-line SQL string change inside an unchanged `query_as` call. CI is authoritative.

## Test plan

- [ ] Backend CI green
- [ ] Hit `/admin/platform/stats` end-to-end; confirm building/unit counts return numerically (not 500)