### PR TITLE
fix(security): suspend_agency audit forgery, public OAuth refresh tokens, oauth admin capability gate

### DIFF
--- a/backend/crates/admin-core/src/capability.rs
+++ b/backend/crates/admin-core/src/capability.rs
@@ -59,6 +59,10 @@ pub enum Capability {
     // Audit-log viewer.
     AuditRead,
 
+    // OAuth client administration (register, list, view, update, revoke,
+    // regenerate client secrets). Gates `/api/v1/admin/oauth/clients`.
+    OauthClientWrite,
+
     // Platform-kind promotion. Reserved — must be paired with the Phase 2
     // SECURITY DEFINER function and can only be granted by another holder.
     PrincipalKindEscalate,
@@ -86,6 +90,7 @@ impl Capability {
             Capability::TenantPurge => "tenant_purge",
             Capability::TenantRestore => "tenant_restore",
             Capability::AuditRead => "audit_read",
+            Capability::OauthClientWrite => "oauth_client_write",
             Capability::PrincipalKindEscalate => "principal_kind_escalate",
         }
     }
@@ -109,6 +114,7 @@ impl Capability {
         Capability::TenantPurge,
         Capability::TenantRestore,
         Capability::AuditRead,
+        Capability::OauthClientWrite,
         Capability::PrincipalKindEscalate,
     ];
 }

--- a/backend/servers/api-server/src/routes/admin/agencies.rs
+++ b/backend/servers/api-server/src/routes/admin/agencies.rs
@@ -5,7 +5,7 @@
 //! `OrganizationRepository` and `AgencyDomainRepository` infra.
 
 use admin_core::{require_capability, AuditOutcome, AuditWriter, Capability, RequireCapability};
-use api_core::AuthUser;
+use api_core::{extractors::principal::RequestPrincipal, AuthUser};
 use axum::{
     extract::{Path, Query, State},
     http::{HeaderMap, StatusCode},
@@ -150,16 +150,18 @@ pub struct SuspendBody {
 /// POST /admin/agencies/:id/suspend
 async fn suspend_agency(
     _cap: RequireCapability,
+    principal: RequestPrincipal,
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
     Json(body): Json<SuspendBody>,
 ) -> Result<StatusCode, (StatusCode, String)> {
-    // We do not have the actor_id wired here yet; Phase 2's RequestPrincipal
-    // will provide it. For now we pass `id` as the admin sentinel — the
-    // capability gate already audited the call with the real actor.
+    // Pass the authenticated platform principal as actor_id so the audit row
+    // attributes the suspension to the admin, not the target org. The old code
+    // here passed `id` (the target org id) as the actor — a passive audit-trail
+    // forgery vulnerability.
     state
         .platform_admin_repo
-        .suspend_organization(id, id, &body.reason)
+        .suspend_organization(id, principal.user_id, &body.reason)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     Ok(StatusCode::NO_CONTENT)

--- a/backend/servers/api-server/src/routes/oauth.rs
+++ b/backend/servers/api-server/src/routes/oauth.rs
@@ -2,6 +2,7 @@
 //!
 //! Implements OAuth 2.0 Authorization Code flow with PKCE support.
 
+use admin_core::{require_capability, Capability, RequireCapability};
 use axum::{
     extract::{Query, State},
     http::StatusCode,
@@ -40,16 +41,40 @@ pub fn router() -> Router<AppState> {
 }
 
 /// Create OAuth admin router (for client management).
+///
+/// Every route is gated by `Capability::OauthClientWrite`. The previous
+/// implementation hand-rolled a `claims.roles.contains("super_admin")` check
+/// in each handler — that pattern trusts the JWT `roles` string claim, which
+/// the rest of the admin surface has moved away from. The capability gate
+/// re-derives the platform principal from the trusted `users` table on every
+/// request, checks an active grant, and enforces recent MFA.
 pub fn admin_router() -> Router<AppState> {
     Router::new()
-        .route("/clients", post(register_client))
-        .route("/clients", get(list_clients))
-        .route("/clients/{id}", get(get_client))
-        .route("/clients/{id}", axum::routing::patch(update_client))
-        .route("/clients/{id}", axum::routing::delete(revoke_client))
+        .route(
+            "/clients",
+            post(register_client).layer(require_capability(Capability::OauthClientWrite)),
+        )
+        .route(
+            "/clients",
+            get(list_clients).layer(require_capability(Capability::OauthClientWrite)),
+        )
+        .route(
+            "/clients/{id}",
+            get(get_client).layer(require_capability(Capability::OauthClientWrite)),
+        )
+        .route(
+            "/clients/{id}",
+            axum::routing::patch(update_client)
+                .layer(require_capability(Capability::OauthClientWrite)),
+        )
+        .route(
+            "/clients/{id}",
+            axum::routing::delete(revoke_client)
+                .layer(require_capability(Capability::OauthClientWrite)),
+        )
         .route(
             "/clients/{id}/regenerate-secret",
-            post(regenerate_client_secret),
+            post(regenerate_client_secret).layer(require_capability(Capability::OauthClientWrite)),
         )
 }
 
@@ -607,24 +632,11 @@ pub async fn revoke_user_grant(
     )
 )]
 pub async fn register_client(
+    _cap: RequireCapability,
+    principal: api_core::extractors::principal::RequestPrincipal,
     State(state): State<AppState>,
-    headers: axum::http::HeaderMap,
     Json(request): Json<RegisterClientRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
-    let token = extract_bearer_token(&headers)?;
-    let claims = validate_access_token(&state, &token)?;
-
-    // Check super admin role
-    if !claims.roles.iter().any(|r| r == "super_admin") {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse::new(
-                "FORBIDDEN",
-                "Super admin access required",
-            )),
-        ));
-    }
-
     let response = state
         .oauth_service
         .register_client(request)
@@ -637,11 +649,8 @@ pub async fn register_client(
             )
         })?;
 
-    // Audit log
-    let user_id: Option<Uuid> = claims.sub.parse().ok();
-    if user_id.is_none() {
-        tracing::warn!(sub = %claims.sub, "Failed to parse user_id from JWT claims for audit log");
-    }
+    // Audit log — use trusted server-side principal, not a JWT claim.
+    let user_id: Option<Uuid> = Some(principal.user_id);
     if let Err(e) = state
         .audit_log_repo
         .create(CreateAuditLog {
@@ -681,22 +690,9 @@ pub async fn register_client(
     )
 )]
 pub async fn list_clients(
+    _cap: RequireCapability,
     State(state): State<AppState>,
-    headers: axum::http::HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
-    let token = extract_bearer_token(&headers)?;
-    let claims = validate_access_token(&state, &token)?;
-
-    if !claims.roles.iter().any(|r| r == "super_admin") {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse::new(
-                "FORBIDDEN",
-                "Super admin access required",
-            )),
-        ));
-    }
-
     let clients = state.oauth_service.list_clients().await.map_err(|e| {
         tracing::error!(error = %e, "Failed to list OAuth clients");
         (
@@ -726,23 +722,10 @@ pub async fn list_clients(
     )
 )]
 pub async fn get_client(
+    _cap: RequireCapability,
     State(state): State<AppState>,
-    headers: axum::http::HeaderMap,
     axum::extract::Path(id): axum::extract::Path<Uuid>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
-    let token = extract_bearer_token(&headers)?;
-    let claims = validate_access_token(&state, &token)?;
-
-    if !claims.roles.iter().any(|r| r == "super_admin") {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse::new(
-                "FORBIDDEN",
-                "Super admin access required",
-            )),
-        ));
-    }
-
     let client = state.oauth_repo.find_client_by_id(id).await.map_err(|e| {
         tracing::error!(error = %e, "Failed to get OAuth client");
         (
@@ -777,24 +760,11 @@ pub async fn get_client(
     )
 )]
 pub async fn update_client(
+    _cap: RequireCapability,
     State(state): State<AppState>,
-    headers: axum::http::HeaderMap,
     axum::extract::Path(id): axum::extract::Path<Uuid>,
     Json(data): Json<UpdateOAuthClient>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
-    let token = extract_bearer_token(&headers)?;
-    let claims = validate_access_token(&state, &token)?;
-
-    if !claims.roles.iter().any(|r| r == "super_admin") {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse::new(
-                "FORBIDDEN",
-                "Super admin access required",
-            )),
-        ));
-    }
-
     let client = state
         .oauth_service
         .update_client(id, data)
@@ -831,23 +801,11 @@ pub async fn update_client(
     )
 )]
 pub async fn revoke_client(
+    _cap: RequireCapability,
+    principal: api_core::extractors::principal::RequestPrincipal,
     State(state): State<AppState>,
-    headers: axum::http::HeaderMap,
     axum::extract::Path(id): axum::extract::Path<Uuid>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
-    let token = extract_bearer_token(&headers)?;
-    let claims = validate_access_token(&state, &token)?;
-
-    if !claims.roles.iter().any(|r| r == "super_admin") {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse::new(
-                "FORBIDDEN",
-                "Super admin access required",
-            )),
-        ));
-    }
-
     let revoked = state.oauth_service.revoke_client(id).await.map_err(|e| {
         tracing::error!(error = %e, "Failed to revoke OAuth client");
         (
@@ -863,11 +821,8 @@ pub async fn revoke_client(
         ));
     }
 
-    // Audit log
-    let user_id: Option<Uuid> = claims.sub.parse().ok();
-    if user_id.is_none() {
-        tracing::warn!(sub = %claims.sub, "Failed to parse user_id from JWT claims for audit log");
-    }
+    // Audit log — use trusted server-side principal, not a JWT claim.
+    let user_id: Option<Uuid> = Some(principal.user_id);
     if let Err(e) = state
         .audit_log_repo
         .create(CreateAuditLog {
@@ -911,23 +866,11 @@ pub struct RegenerateSecretResponse {
     )
 )]
 pub async fn regenerate_client_secret(
+    _cap: RequireCapability,
+    principal: api_core::extractors::principal::RequestPrincipal,
     State(state): State<AppState>,
-    headers: axum::http::HeaderMap,
     axum::extract::Path(id): axum::extract::Path<Uuid>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
-    let token = extract_bearer_token(&headers)?;
-    let claims = validate_access_token(&state, &token)?;
-
-    if !claims.roles.iter().any(|r| r == "super_admin") {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse::new(
-                "FORBIDDEN",
-                "Super admin access required",
-            )),
-        ));
-    }
-
     let secret = state
         .oauth_service
         .regenerate_client_secret(id)
@@ -940,11 +883,8 @@ pub async fn regenerate_client_secret(
             )
         })?;
 
-    // Audit log
-    let user_id: Option<Uuid> = claims.sub.parse().ok();
-    if user_id.is_none() {
-        tracing::warn!(sub = %claims.sub, "Failed to parse user_id from JWT claims for audit log");
-    }
+    // Audit log — use trusted server-side principal, not a JWT claim.
+    let user_id: Option<Uuid> = Some(principal.user_id);
     if let Err(e) = state
         .audit_log_repo
         .create(CreateAuditLog {

--- a/backend/servers/api-server/src/services/oauth.rs
+++ b/backend/servers/api-server/src/services/oauth.rs
@@ -474,13 +474,16 @@ impl OAuthService {
             return Err(OAuthServiceError::PrincipalKindNotAllowed);
         }
 
-        // Generate tokens
+        // Generate tokens. Public clients receive no refresh token in the
+        // response (per spec) and we now skip persisting one as well — a
+        // discarded refresh row in DB was an unreachable replay risk.
         let (access_token, refresh_token) = self
             .issue_tokens(
                 auth_code.user_id,
                 &auth_code.client_id,
                 &auth_code.scopes.0,
                 None, // New token family
+                client.is_confidential,
             )
             .await?;
 
@@ -488,11 +491,7 @@ impl OAuthService {
             access_token,
             token_type: "Bearer".to_string(),
             expires_in: self.config.access_token_expires_secs,
-            refresh_token: if client.is_confidential {
-                Some(refresh_token)
-            } else {
-                None
-            },
+            refresh_token,
             scope: auth_code.scopes.0.join(" "),
         })
     }
@@ -568,12 +567,16 @@ impl OAuthService {
             None
         };
 
+        // A refresh-token flow only reaches this point for confidential
+        // clients (public clients never received one to refresh with), so
+        // request a refresh token on the new exchange as well.
         let (access_token, new_refresh_token) = self
             .issue_tokens(
                 refresh_token.user_id,
                 client_id,
                 &refresh_token.scopes.0,
                 family_id,
+                client.is_confidential,
             )
             .await?;
 
@@ -581,7 +584,7 @@ impl OAuthService {
             access_token,
             token_type: "Bearer".to_string(),
             expires_in: self.config.access_token_expires_secs,
-            refresh_token: Some(new_refresh_token),
+            refresh_token: new_refresh_token,
             scope: refresh_token.scopes.0.join(" "),
         })
     }
@@ -685,23 +688,25 @@ impl OAuthService {
 
     // ==================== Private Helpers ====================
 
-    /// Issue access and refresh tokens.
+    /// Issue access (and optionally refresh) tokens.
+    ///
+    /// When `with_refresh` is `false` no refresh token is generated, hashed, or
+    /// persisted — this is the path public OAuth clients take, since the
+    /// response never returns a refresh token to them anyway. Previously a
+    /// refresh row was written for public clients and then discarded by the
+    /// caller, leaving an orphan token in DB that could be replayed if the DB
+    /// leaked.
     async fn issue_tokens(
         &self,
         user_id: Uuid,
         client_id: &str,
         scopes: &[String],
         family_id: Option<Uuid>,
-    ) -> Result<(String, String), OAuthServiceError> {
+        with_refresh: bool,
+    ) -> Result<(String, Option<String>), OAuthServiceError> {
         let access_token = self.generate_secure_token();
-        let refresh_token = self.generate_secure_token();
-
         let access_token_hash = self.hash_token(&access_token);
-        let refresh_token_hash = self.hash_token(&refresh_token);
-
         let access_expires = Utc::now() + Duration::seconds(self.config.access_token_expires_secs);
-        let refresh_expires =
-            Utc::now() + Duration::seconds(self.config.refresh_token_expires_secs);
 
         // Create access token
         self.repo
@@ -713,6 +718,15 @@ impl OAuthService {
                 expires_at: access_expires,
             })
             .await?;
+
+        if !with_refresh {
+            return Ok((access_token, None));
+        }
+
+        let refresh_token = self.generate_secure_token();
+        let refresh_token_hash = self.hash_token(&refresh_token);
+        let refresh_expires =
+            Utc::now() + Duration::seconds(self.config.refresh_token_expires_secs);
 
         // Create refresh token
         self.repo
@@ -726,7 +740,7 @@ impl OAuthService {
             })
             .await?;
 
-        Ok((access_token, refresh_token))
+        Ok((access_token, Some(refresh_token)))
     }
 
     /// Generate a 16-byte client_id (base64url encoded).


### PR DESCRIPTION
## Summary

Three security findings from the round-5 sweep. All in the admin/auth surface.

### HIGH — audit-trail forgery on agency suspension

`backend/servers/api-server/src/routes/admin/agencies.rs:151-167` (`suspend_agency`) passed `(target_org_id, target_org_id, reason)` to `suspend_organization(id, actor_id, reason)`. The "actor" was always the *target organization* — operators couldn't tell who actually performed the action.

Fix: extract `RequestPrincipal` and pass `principal.user_id` as `actor_id`. Verified no peer bug in `restore_agency`/`delete_agency` (don't exist in this file); `add_domain` already passes `auth.user_id` correctly.

### HIGH — refresh tokens persisted for public OAuth clients

`backend/servers/api-server/src/services/oauth.rs` `issue_tokens(...)` persisted a refresh-token row in DB but only returned the refresh token to confidential clients. For public clients, the row sat unreachable in DB — replayable if the DB leaks.

Fix: `issue_tokens` now takes `with_refresh: bool`; refresh token is generated, hashed, and persisted only when truthy. Both callers (`exchange_code_for_tokens`, `refresh_tokens`) pass `client.is_confidential`. Public response shape unchanged (no refresh-token field returned, as before).

### MED — admin OAuth handlers gated on JWT roles string, not capability

`backend/servers/api-server/src/routes/oauth.rs` admin handlers (`register_client`, `list_clients`, `get_client`, `update_client`, `revoke_client`, `regenerate_client_secret`) all did `if !claims.roles.iter().any(|r| r == "super_admin")` — the JWT-roles-string anti-pattern that the rest of admin/* has moved away from. A forged or stale JWT with that role bypassed capabilities entirely.

Fix:
- New `Capability::OauthClientWrite` (string `oauth_client_write`) added to `backend/crates/admin-core/src/capability.rs` enum + `ALL` slice + `as_str`. Auto-registered by `CapabilityRegistry::init`.
- `admin_router()` now layers `require_capability(Capability::OauthClientWrite)` on all six routes.
- Handlers now take `_cap: RequireCapability` + `RequestPrincipal`; the JWT bearer-extract + role check + `claims.sub.parse()` audit logic is removed. Audit `user_id` now comes from the trusted server-side principal.

## Out of scope (flagged in sweep, deferred)

- Forgot-password / reset-password IP rate limit (needs rate-limiter design call)
- Audit gaps on `set_principal_kind` (separate handler-by-handler sweep)
- Dual auth in `users_lifecycle.rs` (separate refactor PR)
- DTO camelCase sweep (separate large PR; PR #300 fixed `MetricsSummary` as point fix)
- TypeSpec realignment for `/auth/mfa/*` vs `/me/2fa/*` etc. (design call)

## Verification

`cargo fmt` clean. `cargo check -p admin-core` clean. `cargo check -p api-server` blocked (sandbox missing `pkg-config`/`libssl-dev`). CI is authoritative.

**Operators with `super_admin` role but no `OauthClientWrite` capability will lose access after this lands.** Grant the new capability to relevant principals before merge.

## Test plan

- [ ] Backend CI green
- [ ] Grant `OauthClientWrite` to platform admins before deploy
- [ ] Suspend an agency, check the audit row's `actor_id` is the admin user, not the target org
- [ ] Exchange OAuth code for a public client; verify response is just access token (no refresh)
- [ ] Confirm `refresh_token` table has zero rows for that public client