### PR TITLE
fix(auth): align auth wire shape to camelCase (fixes broken ppt-web login/refresh/logout/reset)

### DIFF
--- a/backend/servers/api-server/src/routes/auth.rs
+++ b/backend/servers/api-server/src/routes/auth.rs
@@ -51,6 +51,7 @@ pub struct RegisterRequest {
 
 /// Register response.
 #[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct RegisterResponse {
     /// Success message
     pub message: String,
@@ -411,6 +412,7 @@ pub async fn resend_verification(
 
 /// Login request.
 #[derive(Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct LoginRequest {
     /// Email address
     pub email: String,
@@ -423,6 +425,7 @@ pub struct LoginRequest {
 
 /// Login response.
 #[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct LoginResponse {
     /// JWT access token (empty if MFA required)
     pub access_token: String,
@@ -818,6 +821,7 @@ pub async fn login(
 
 /// Refresh token request.
 #[derive(Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct RefreshTokenRequest {
     /// The refresh token to exchange for new tokens
     pub refresh_token: String,
@@ -1020,6 +1024,7 @@ pub async fn refresh_token(
 
 /// Logout request.
 #[derive(Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct LogoutRequest {
     /// The refresh token to revoke
     pub refresh_token: String,
@@ -1175,6 +1180,7 @@ pub async fn forgot_password(
 
 /// Reset password request.
 #[derive(Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ResetPasswordRequest {
     /// Reset token from email
     pub token: String,

--- a/backend/servers/api-server/tests/endpoints_smoke_tests.rs
+++ b/backend/servers/api-server/tests/endpoints_smoke_tests.rs
@@ -344,7 +344,7 @@ mod auth_negative_cases {
     async fn test_refresh_with_empty_string_token_is_rejected(pool: PgPool) {
         let app = TestApp::new(pool).await;
 
-        let body = json!({"refresh_token": ""});
+        let body = json!({"refreshToken": ""});
         let response = app
             .execute(json_request(Method::POST, "/api/v1/auth/refresh", body))
             .await;

--- a/frontend/apps/admin-web/src/pages/LoginPage.test.tsx
+++ b/frontend/apps/admin-web/src/pages/LoginPage.test.tsx
@@ -8,7 +8,7 @@ import { LoginPage } from './LoginPage';
 
 describe('LoginPage', () => {
   it('calls login API and stores token on success', async () => {
-    const login = vi.fn().mockResolvedValue({ access_token: 'tk' });
+    const login = vi.fn().mockResolvedValue({ accessToken: 'tk' });
     const user = userEvent.setup();
     render(
       <MemoryRouter>

--- a/frontend/apps/admin-web/src/pages/LoginPage.tsx
+++ b/frontend/apps/admin-web/src/pages/LoginPage.tsx
@@ -4,9 +4,9 @@ import { useNavigate } from 'react-router-dom';
 import { useAdminAuth } from '../auth/AdminAuthContext';
 
 export interface LoginResponse {
-  /** Empty string when `mfa_required: true` (server defers the token until MFA passes). */
-  access_token: string;
-  mfa_required?: boolean;
+  /** Empty string when `mfaRequired: true` (server defers the token until MFA passes). */
+  accessToken: string;
+  mfaRequired?: boolean;
 }
 
 export interface LoginPageProps {
@@ -14,14 +14,14 @@ export interface LoginPageProps {
   loginFn?: (creds: {
     email: string;
     password: string;
-    two_factor_code?: string;
+    twoFactorCode?: string;
   }) => Promise<LoginResponse>;
 }
 
 const defaultLoginFn = async (creds: {
   email: string;
   password: string;
-  two_factor_code?: string;
+  twoFactorCode?: string;
 }) => {
   const resp = await fetch('/api/v1/auth/login', {
     method: 'POST',
@@ -38,10 +38,10 @@ export function LoginPage({ loginFn = defaultLoginFn }: LoginPageProps) {
   const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  // `mfaRequired` flips after the first POST returns `mfa_required: true`.
+  // `mfaRequired` flips after the first POST returns `mfaRequired: true`.
   // The form then renders the TOTP code input and a second submit replays
-  // the login with `two_factor_code` populated. Until the server returns a
-  // non-empty access_token we never call `setToken` — otherwise we'd land
+  // the login with `twoFactorCode` populated. Until the server returns a
+  // non-empty accessToken we never call `setToken` — otherwise we'd land
   // on the dashboard with an empty Bearer header and every API call would
   // 401-loop.
   const [mfaRequired, setMfaRequired] = useState(false);
@@ -57,18 +57,18 @@ export function LoginPage({ loginFn = defaultLoginFn }: LoginPageProps) {
       const resp = await loginFn({
         email,
         password,
-        two_factor_code: mfaRequired ? code : undefined,
+        twoFactorCode: mfaRequired ? code : undefined,
       });
-      if (resp.mfa_required || !resp.access_token) {
+      if (resp.mfaRequired || !resp.accessToken) {
         setMfaRequired(true);
         setCode('');
-        if (!resp.access_token && !resp.mfa_required) {
+        if (!resp.accessToken && !resp.mfaRequired) {
           // Server returned 200 but no token and no MFA flag — refuse to navigate.
           setError('Login response missing access token');
         }
         return;
       }
-      auth.setToken(resp.access_token);
+      auth.setToken(resp.accessToken);
       navigate('/', { replace: true });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'login failed');


### PR DESCRIPTION
## Summary

The team audit's DTO snake→camel impact map flagged that `ppt-web` login was likely broken in production because `ppt-web/src/contexts/AuthContext.tsx` reads `response.accessToken` (camelCase) but the backend currently sends `access_token` (snake_case).

While implementing the fix, the scope turned out to be **wider than just login**: `@ppt/api-client` was also sending camelCase REQUEST bodies for `/refresh`, `/logout`, and `/reset-password` (`refreshToken`, `newPassword`) which the backend silently rejected. So the same wire-shape bug was breaking 4 flows, not 1.

## Backend changes
`backend/servers/api-server/src/routes/auth.rs` — added `#[serde(rename_all = \"camelCase\")]` to:

| Struct | Fields flipped |
|---|---|
| `RegisterResponse` | `user_id` → `userId` |
| `LoginRequest` | `two_factor_code` → `twoFactorCode` |
| `LoginResponse` | `access_token`, `refresh_token`, `expires_in`, `token_type`, `mfa_required`, `mfa_token` |
| `RefreshTokenRequest` | `refresh_token` → `refreshToken` |
| `LogoutRequest` | `refresh_token` → `refreshToken` |
| `ResetPasswordRequest` | `new_password` → `newPassword` |

The refresh endpoint reuses `LoginResponse`, so it's covered.

## Left alone (with reason)
- `RegisterRequest` — `@ppt/api-client` sends a completely different shape (`firstName`/`lastName` vs backend `name`). Not a camelCase fix — bigger semantic mismatch. **Flagged as follow-up.**
- `ForgotPasswordRequest`, `ResendVerificationRequest`, `VerifyEmailQuery` — only `email`/`token`, nothing to flip.
- Session DTOs (`SessionInfo`, `RevokeSessionRequest`, etc.) — out of scope for PR2a (login flow). Will land in later sub-PRs from the phased plan.

## Frontend changes
- `frontend/apps/admin-web/src/pages/LoginPage.tsx` — `resp.access_token` → `resp.accessToken`, `resp.mfa_required` → `resp.mfaRequired`, request body `two_factor_code` → `twoFactorCode`.
- `frontend/apps/admin-web/src/pages/LoginPage.test.tsx` — mock flipped to `{ accessToken: 'tk' }`.

`ppt-web/src/contexts/AuthContext.tsx` was already camelCase via `@ppt/api-client` — no edit needed. It'll start working once the BE flip lands.

## Verification

- `pnpm -F @ppt/admin-web exec vitest run src/pages/LoginPage.test.tsx`: 1/1 pass.
- `cargo fmt -p api-server` clean.
- `cargo check -p api-server` skipped locally (sandbox missing clang). CI is authoritative.

## Heads up for reviewers

- **Mobile-native (Kotlin)** is generated from OpenAPI via `openapi-generator`. utoipa will now expose camelCase, so a regen should fix it — but **needs a verification pass after merge**.
- **`admin-web/src/auth/tokenStore.ts`** uses `ppt.admin.access_token` as a localStorage **key** (not a wire field). Left alone — pure client-side storage key.

## Test plan

- [ ] Backend CI green
- [ ] admin-web LoginPage.test.tsx pass
- [ ] Manual: login flow on admin-web returns access token + persists session
- [ ] Manual: login flow on ppt-web (previously broken) now works end-to-end
- [ ] Manual: refresh + logout + reset-password flows on ppt-web work
- [ ] Mobile-native: regenerate Kotlin client and smoke-test login