### PR TITLE
fix: defaultLocale to sk + focus trap on 3 ppt-web dialogs

### DIFF
--- a/frontend/apps/ppt-web/src/features/dashboard/components/KeyboardShortcutsHelp.tsx
+++ b/frontend/apps/ppt-web/src/features/dashboard/components/KeyboardShortcutsHelp.tsx
@@ -5,8 +5,9 @@
  * @module features/dashboard/components/KeyboardShortcutsHelp
  */
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useFocusTrap } from '../../../hooks/useFocusTrap';
 import './KeyboardShortcutsHelp.css';
 
 interface KeyboardShortcutsHelpProps {
@@ -31,29 +32,22 @@ const shortcuts: ShortcutItem[] = [
 
 export function KeyboardShortcutsHelp({ isOpen, onClose }: KeyboardShortcutsHelpProps) {
   const { t } = useTranslation();
+
+  if (!isOpen) return null;
+
+  return <KeyboardShortcutsHelpDialog t={t} onClose={onClose} />;
+}
+
+interface KeyboardShortcutsHelpDialogProps {
+  t: ReturnType<typeof useTranslation>['t'];
+  onClose: () => void;
+}
+
+// Inner component so useFocusTrap only mounts when the dialog is actually open,
+// guaranteeing focus capture + restore on each open/close cycle.
+function KeyboardShortcutsHelpDialog({ t, onClose }: KeyboardShortcutsHelpDialogProps) {
   const dialogRef = useRef<HTMLDivElement>(null);
-
-  // Close on Escape key
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        onClose();
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, onClose]);
-
-  // Focus trap
-  useEffect(() => {
-    if (isOpen && dialogRef.current) {
-      dialogRef.current.focus();
-    }
-  }, [isOpen]);
+  useFocusTrap(dialogRef, onClose);
 
   // Handle backdrop click
   const handleBackdropClick = useCallback(
@@ -64,8 +58,6 @@ export function KeyboardShortcutsHelp({ isOpen, onClose }: KeyboardShortcutsHelp
     },
     [onClose]
   );
-
-  if (!isOpen) return null;
 
   return (
     <div className="kbd-help-overlay" onClick={handleBackdropClick} role="presentation">

--- a/frontend/apps/ppt-web/src/features/facilities/components/CancelBookingDialog.tsx
+++ b/frontend/apps/ppt-web/src/features/facilities/components/CancelBookingDialog.tsx
@@ -4,7 +4,8 @@
  * Modal dialog for cancelling a booking with an optional reason.
  */
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
+import { useFocusTrap } from '../../../hooks/useFocusTrap';
 
 interface CancelBookingDialogProps {
   bookingId: string;
@@ -34,6 +35,8 @@ export function CancelBookingDialog({
   isSubmitting,
 }: CancelBookingDialogProps) {
   const [reason, setReason] = useState('');
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(dialogRef, onCancel);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -42,10 +45,12 @@ export function CancelBookingDialog({
 
   return (
     <div
+      ref={dialogRef}
       className="fixed inset-0 z-50 overflow-y-auto"
       role="dialog"
       aria-modal="true"
       aria-labelledby="dialog-title"
+      tabIndex={-1}
     >
       {/* Backdrop - click handler for dismiss, keyboard users use ESC or Cancel button */}
       <div

--- a/frontend/apps/ppt-web/src/features/facilities/components/RejectBookingDialog.tsx
+++ b/frontend/apps/ppt-web/src/features/facilities/components/RejectBookingDialog.tsx
@@ -4,7 +4,8 @@
  * Modal dialog for rejecting a booking with a reason.
  */
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
+import { useFocusTrap } from '../../../hooks/useFocusTrap';
 
 interface RejectBookingDialogProps {
   bookingId: string;
@@ -22,6 +23,8 @@ export function RejectBookingDialog({
 }: RejectBookingDialogProps) {
   const [reason, setReason] = useState('');
   const [error, setError] = useState('');
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(dialogRef, onCancel);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -34,10 +37,12 @@ export function RejectBookingDialog({
 
   return (
     <div
+      ref={dialogRef}
       className="fixed inset-0 z-50 overflow-y-auto"
       role="dialog"
       aria-modal="true"
       aria-labelledby="dialog-title"
+      tabIndex={-1}
     >
       {/* Backdrop - click handler for dismiss, keyboard users use ESC or Cancel button */}
       <div

--- a/frontend/apps/ppt-web/src/hooks/useFocusTrap.ts
+++ b/frontend/apps/ppt-web/src/hooks/useFocusTrap.ts
@@ -1,0 +1,86 @@
+/**
+ * useFocusTrap — minimal focus-trap + Escape handler for modal dialogs.
+ *
+ * On mount the hook:
+ *   - records the currently-focused element so we can restore focus on unmount
+ *   - moves focus to the first focusable element inside the container (or the
+ *     container itself if none, requiring tabIndex={-1} on the container)
+ *
+ * While mounted:
+ *   - Tab / Shift-Tab cycle within the container (focus trap)
+ *   - Escape calls `onEscape` (typically the dialog's cancel handler)
+ *
+ * On unmount:
+ *   - returns focus to the originally-focused element
+ *
+ * Usage:
+ *   const ref = useRef<HTMLDivElement | null>(null);
+ *   useFocusTrap(ref, onCancel);
+ *   return <div ref={ref} role="dialog" aria-modal="true" tabIndex={-1}>…</div>;
+ *
+ * This is a deliberately small implementation copied from admin-web's
+ * useFocusTrap. It is duplicated here (rather than extracted into a shared
+ * package) to keep this a low-risk WCAG 2.1.2 fix; consolidation can happen
+ * in a follow-up. It does NOT handle:
+ *   - portals (assumes the container is rendered in-place under document.body)
+ *   - elements becoming focusable after mount (re-queries on every Tab keydown)
+ *   - inert backgrounding of the rest of the page (caller can rely on the
+ *     overlay div blocking pointer events)
+ */
+import { useEffect } from 'react';
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export function useFocusTrap(
+  containerRef: React.RefObject<HTMLElement | null>,
+  onEscape: () => void
+): void {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: bind once on mount — the dialog lives for a single open cycle; re-binding on onEscape/ref identity would reset focus and lose `previouslyFocused`.
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) return;
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    // Initial focus: first focusable child, else the container itself.
+    const initialFocusable = node.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+    (initialFocusable ?? node).focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onEscape();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+
+      const focusable = Array.from(node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+      if (focusable.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+
+      if (e.shiftKey) {
+        if (active === first || !node.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (active === last || !node.contains(active)) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    node.addEventListener('keydown', handleKeyDown);
+    return () => {
+      node.removeEventListener('keydown', handleKeyDown);
+      previouslyFocused?.focus?.();
+    };
+  }, []);
+}

--- a/frontend/apps/reality-web/src/i18n/config.ts
+++ b/frontend/apps/reality-web/src/i18n/config.ts
@@ -5,7 +5,7 @@
 export const locales = ['en', 'sk', 'cs', 'de', 'pl', 'hu'] as const;
 export type Locale = (typeof locales)[number];
 
-export const defaultLocale: Locale = 'en';
+export const defaultLocale: Locale = 'sk';
 
 export const localeNames: Record<Locale, string> = {
   en: 'English',


### PR DESCRIPTION
## Summary

Two hotfixes from the team audit's i18n + a11y sweep.

### Fix 1 — defaultLocale: 'en' → 'sk'
`frontend/apps/reality-web/src/i18n/config.ts` had `defaultLocale: 'en'` contradicting CLAUDE.md's "SK primary". Slovak first-time visitors were landing on English. Flipped to `'sk'`.

With `localePrefix: 'as-needed'`, SK URLs are now canonical (no prefix), English routes prefix with `/en/...` — matches the primary-locale convention.

Verified `lib/page-metadata.ts` (the only consumer) uses `defaultLocale` parametrically; no other code depends on the value.

### Fix 2 — Focus trap on 3 ppt-web dialogs

Three custom dialogs declared `role=\"dialog\"` + `aria-modal=\"true\"` but had no focus trap. Tab key escaped to the page underneath (WCAG 2.4.3 / 2.1.2 keyboard trap fail).

Affected files:
- `frontend/apps/ppt-web/src/features/facilities/components/CancelBookingDialog.tsx`
- `frontend/apps/ppt-web/src/features/facilities/components/RejectBookingDialog.tsx`
- `frontend/apps/ppt-web/src/features/dashboard/components/KeyboardShortcutsHelp.tsx`

**Approach: hook (B)** rather than replacing with `@ppt/ui-kit/Modal`. The dialogs have custom layouts (forms with headers/footers/icons, keyboard-shortcut rows) that don't fit Modal's API without significant restructuring. A 60-line `useFocusTrap` hook is a clean drop-in.

**Hook placement:** copied to `frontend/apps/ppt-web/src/hooks/useFocusTrap.ts` rather than extracted to `@ppt/shared`. Lower risk; consolidation can come later when more apps need it.

`KeyboardShortcutsHelp.tsx` split into outer/inner component so the hook mounts/unmounts on each open cycle — ensures focus capture + restore work correctly.

## Out of scope (separate PRs)
- The dialog text strings (`\"Cancel Booking\"`, etc.) are hardcoded English — flagged for a separate ppt-web i18n PR.
- 23 untranslated Czech strings + other i18n findings — separate translation PR.
- Other a11y findings (color-only state, heading order) — separate a11y polish PR.

## Verification

- ppt-web typecheck: clean.
- reality-web typecheck: clean.
- Biome on 5 changed files: 0 issues.
- ppt-web vitest: 375 passed (4 pre-existing failures in `shared-auth.test.ts` — verified unrelated by stashing + re-running on main).
- reality-web: no vitest script + no tests referencing `defaultLocale`.

## Visual smoke (maintainer to verify)

1. **reality-web**: visit `/` — should render SK; visit `/en/...` for English.
2. **ppt-web**: open each of the 3 dialogs (Cancel Booking, Reject Booking, `?` Keyboard Shortcuts). Press Tab: focus must cycle inside dialog and never reach page content underneath. Shift-Tab cycles backward. Escape closes and returns focus to the trigger element.

## Test plan

- [ ] CI green
- [ ] Tab-test the 3 dialogs in a browser
- [ ] Reality-web fresh visit lands on SK