### PR TITLE
fix(api): camelCase response shape on auth/mfa/oauth DTOs (PR1 from DTO impact map)

### DIFF
--- a/backend/servers/api-server/src/routes/admin/mfa/disable.rs
+++ b/backend/servers/api-server/src/routes/admin/mfa/disable.rs
@@ -26,6 +26,7 @@ pub struct DisableRequest {
 
 /// Response for `POST /admin/mfa/disable`.
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DisableResponse {
     pub message: String,
 }

--- a/backend/servers/api-server/src/routes/admin/mfa/enroll.rs
+++ b/backend/servers/api-server/src/routes/admin/mfa/enroll.rs
@@ -19,6 +19,7 @@ use crate::state::AppState;
 
 /// Response returned by `POST /admin/mfa/enroll/start`.
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct EnrollStartResponse {
     /// `otpauth://` URI — hand to a QR-code library.
     pub uri: String,

--- a/backend/servers/api-server/src/routes/admin/mfa/recovery.rs
+++ b/backend/servers/api-server/src/routes/admin/mfa/recovery.rs
@@ -25,6 +25,7 @@ pub struct UseRecoveryRequest {
 
 /// Response for `POST /admin/mfa/recovery/use`.
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UseRecoveryResponse {
     pub message: String,
     /// How many unused recovery codes remain after this call.

--- a/backend/servers/api-server/src/routes/admin/users_lifecycle.rs
+++ b/backend/servers/api-server/src/routes/admin/users_lifecycle.rs
@@ -104,6 +104,7 @@ fn default_page_size() -> u32 {
 
 /// List users response.
 #[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ListUsersResponse {
     /// Users on this page
     pub users: Vec<AdminUserInfo>,
@@ -124,6 +125,7 @@ pub struct UserActionRequest {
 
 /// Admin action response.
 #[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct AdminActionResponse {
     /// Success message
     pub message: String,

--- a/backend/servers/api-server/src/routes/auth.rs
+++ b/backend/servers/api-server/src/routes/auth.rs
@@ -229,6 +229,7 @@ pub struct VerifyEmailQuery {
 
 /// Verify email response.
 #[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct VerifyEmailResponse {
     /// Success message
     pub message: String,
@@ -341,6 +342,7 @@ pub struct ResendVerificationRequest {
 
 /// Resend verification response.
 #[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ResendVerificationResponse {
     /// Success message
     pub message: String,
@@ -1027,6 +1029,7 @@ pub struct LogoutRequest {
 
 /// Logout response.
 #[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct LogoutResponse {
     /// Success message
     pub message: String,
@@ -1088,6 +1091,7 @@ pub struct ForgotPasswordRequest {
 
 /// Forgot password response.
 #[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ForgotPasswordResponse {
     /// Success message (always same to prevent enumeration)
     pub message: String,
@@ -1184,6 +1188,7 @@ pub struct ResetPasswordRequest {
 
 /// Reset password response.
 #[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ResetPasswordResponse {
     /// Success message
     pub message: String,
@@ -1403,6 +1408,7 @@ pub async fn reset_password(
 
 /// Session info returned to clients.
 #[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct SessionInfo {
     /// Session ID
     pub id: String,
@@ -1422,6 +1428,7 @@ pub struct SessionInfo {
 
 /// List sessions response.
 #[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ListSessionsResponse {
     /// Active sessions
     pub sessions: Vec<SessionInfo>,
@@ -1513,6 +1520,7 @@ pub struct RevokeSessionRequest {
 
 /// Revoke session response.
 #[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct RevokeSessionResponse {
     /// Success message
     pub message: String,
@@ -1611,6 +1619,7 @@ pub async fn revoke_session(
 
 /// Revoke all sessions response.
 #[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct RevokeAllSessionsResponse {
     /// Success message
     pub message: String,

--- a/backend/servers/api-server/src/routes/mfa.rs
+++ b/backend/servers/api-server/src/routes/mfa.rs
@@ -29,6 +29,7 @@ pub fn router() -> Router<AppState> {
 
 /// MFA setup response.
 #[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct MfaSetupResponse {
     /// The TOTP secret (only shown once, for manual entry)
     pub secret: String,
@@ -193,6 +194,7 @@ pub struct VerifyMfaRequest {
 
 /// MFA verification response.
 #[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct VerifyMfaResponse {
     /// Success message
     pub message: String,
@@ -360,6 +362,7 @@ pub struct DisableMfaRequest {
 
 /// Disable MFA response.
 #[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct DisableMfaResponse {
     /// Success message
     pub message: String,
@@ -527,6 +530,7 @@ pub async fn disable_mfa(
 
 /// MFA status response.
 #[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct MfaStatusResponse {
     /// Whether MFA is enabled
     pub enabled: bool,
@@ -606,6 +610,7 @@ pub struct RegenerateBackupCodesRequest {
 
 /// Regenerate backup codes response.
 #[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct RegenerateBackupCodesResponse {
     /// New backup codes (only shown once)
     pub backup_codes: Vec<String>,

--- a/backend/servers/api-server/src/routes/oauth.rs
+++ b/backend/servers/api-server/src/routes/oauth.rs
@@ -138,6 +138,7 @@ pub struct ConsentForm {
 
 /// Authorization code response.
 #[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct AuthorizeResponse {
     pub code: String,
     pub state: Option<String>,
@@ -892,6 +893,7 @@ pub async fn revoke_client(
 
 /// Regenerate client secret response.
 #[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct RegenerateSecretResponse {
     pub client_secret: String,
 }


### PR DESCRIPTION
## Summary

PR1 from the team audit's DTO snake→camel impact map: the **safe flip** of response DTOs with **zero frontend consumers** (or only `{message}`-shape responses). Pure mechanical fix — adds `#[serde(rename_all = \"camelCase\")]`. Backend-only commit; no frontend files changed.

This is the cleanest tier of the multi-PR snake→camel rollout. The login flow flip (#311) is the prior PR; future PR2b–2f will couple-then-flip the higher-risk admin DTOs.

## Structs flipped (21)

| File | Structs |
|---|---|
| `routes/auth.rs` | `LogoutResponse`, `VerifyEmailResponse`, `ResendVerificationResponse`, `ForgotPasswordResponse`, `ResetPasswordResponse`, `RevokeSessionResponse`, `RevokeAllSessionsResponse`, `SessionInfo`, `ListSessionsResponse` |
| `routes/mfa.rs` | `VerifyMfaResponse`, `DisableMfaResponse`, `MfaSetupResponse`, `MfaStatusResponse`, `RegenerateBackupCodesResponse` |
| `routes/oauth.rs` | `AuthorizeResponse`, `RegenerateSecretResponse` |
| `routes/admin/mfa/enroll.rs` | `EnrollStartResponse` |
| `routes/admin/mfa/recovery.rs` | `UseRecoveryResponse` |
| `routes/admin/mfa/disable.rs` | `DisableResponse` |
| `routes/admin/users_lifecycle.rs` | `AdminActionResponse`, `ListUsersResponse` |

## Skipped (1)

- **`admin/mfa/enroll::EnrollVerifyResponse`** — `recovery_codes` is consumed by `frontend/packages/admin-ui/src/components/MfaEnrollmentScreen/MfaEnrollmentScreen.tsx` (lines 112, 115, 220). Flipping would break the admin MFA enrollment flow. Deferred to a coordinated FE+BE PR.

## Frontend verification

For each non-`{message}` struct, grepped `frontend/` for the snake_case field names:
- `revoked_count`, `qr_uri`, `backup_codes`, `enabled_at`, `backup_codes_remaining`, `client_secret`, `qr_png_base64`, `codes_remaining` → **0 hits.**
- `ip_address` → only in unrelated data-residency audit DTO (not session consumers); no FE caller of `/auth/sessions` exists.
- `page_size` → 1 hit in `useAgencies` REQUEST param, not in `ListUsersResponse` consumer.
- `recovery_codes` → 3 hits in admin-ui → forced the skip above.

**Zero frontend files modified.** Safety claim upheld.

## Verification

`cargo fmt -p api-server` clean. `cargo check -p api-server` blocked locally (sandbox missing clang). Changes are mechanical attribute additions on existing types; cannot break compilation.

## Test plan

- [ ] Backend CI green
- [ ] Smoke any one of: logout, password reset request, sessions list, MFA status — confirm camelCase response
- [ ] Mobile-native (Kotlin): the OpenAPI spec will regen with camelCase; verify mobile login + MFA still works (may need client regen)