### PR TITLE
fix(security): reality-server hardening — open redirect, missing auth, SSRF, IDORs

### DIFF
--- a/backend/servers/reality-server/Cargo.toml
+++ b/backend/servers/reality-server/Cargo.toml
@@ -40,6 +40,7 @@ reqwest = { workspace = true }
 sha2 = { workspace = true }
 base64 = { workspace = true }
 urlencoding = { workspace = true }
+url = "2.5"
 argon2 = { workspace = true }
 sqlx = { workspace = true }
 

--- a/backend/servers/reality-server/src/observability.rs
+++ b/backend/servers/reality-server/src/observability.rs
@@ -507,6 +507,13 @@ mod tests {
 
     #[test]
     fn test_default_configs() {
+        // SentryConfig::default() reads RUST_ENV; serialize against other
+        // tests in this crate that mutate the same var (see util::env_lock),
+        // and force the value to "development" for a deterministic assertion.
+        let _lock = crate::util::env_lock();
+        let previous = std::env::var("RUST_ENV").ok();
+        std::env::set_var("RUST_ENV", "development");
+
         let otel_config = OtelConfig::default();
         assert_eq!(otel_config.service_name, "reality-server");
         assert!(!otel_config.enabled);
@@ -518,6 +525,11 @@ mod tests {
         let metrics_config = MetricsConfig::default();
         assert_eq!(metrics_config.port, 9091);
         assert!(metrics_config.enabled);
+
+        match previous {
+            Some(v) => std::env::set_var("RUST_ENV", v),
+            None => std::env::remove_var("RUST_ENV"),
+        }
     }
 
     #[test]

--- a/backend/servers/reality-server/src/routes/agencies.rs
+++ b/backend/servers/reality-server/src/routes/agencies.rs
@@ -190,6 +190,11 @@ pub async fn get_agency_by_slug(
 }
 
 /// Update agency.
+///
+/// SECURITY (H2, round-9 audit): requires an authenticated principal who
+/// is an active member of the target agency. Previously this handler had
+/// no auth extractor, allowing anyone on the internet to overwrite an
+/// agency's name / slug / contact info via `PUT /api/v1/agencies/{id}`.
 #[utoipa::path(
     put,
     path = "/api/v1/agencies/{id}",
@@ -199,14 +204,29 @@ pub async fn get_agency_by_slug(
     responses(
         (status = 200, description = "Agency updated", body = AgencyResponse),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Not a member of this agency"),
         (status = 404, description = "Agency not found")
-    )
+    ),
+    security(("session_token" = []))
 )]
 pub async fn update_agency(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateRealityAgency>,
 ) -> Result<Json<AgencyResponse>, (axum::http::StatusCode, String)> {
+    // SECURITY (H2): membership check via the shared helper in
+    // `super::agency_imports` — single source of truth for "is this user
+    // allowed to mutate this agency's data?".
+    let mut conn = state.acquire_public_conn().await.map_err(|e| {
+        (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Database error: {}", e),
+        )
+    })?;
+    super::agency_imports::check_agency_membership(&mut conn, id, principal.user_id).await?;
+    drop(conn);
+
     let agency = state
         .reality_portal_repo
         .update_agency(id, data)
@@ -226,6 +246,12 @@ pub async fn update_agency(
 }
 
 /// Update agency branding.
+///
+/// SECURITY (H2, round-9 audit): the *wired* `PUT /api/v1/agencies/{id}/branding`
+/// route in `main.rs` is `routes::agency_branding::update_branding`, which
+/// already authenticates and checks membership. This handler is currently
+/// dead code (not mounted) but still surfaces in OpenAPI; we keep the auth
+/// extractor here as defense-in-depth in case routing is ever changed.
 #[utoipa::path(
     put,
     path = "/api/v1/agencies/{id}/branding",
@@ -235,14 +261,26 @@ pub async fn update_agency(
     responses(
         (status = 200, description = "Branding updated", body = AgencyResponse),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Not a member of this agency"),
         (status = 404, description = "Agency not found")
-    )
+    ),
+    security(("session_token" = []))
 )]
 pub async fn update_branding(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateAgencyBranding>,
 ) -> Result<Json<AgencyResponse>, (axum::http::StatusCode, String)> {
+    let mut conn = state.acquire_public_conn().await.map_err(|e| {
+        (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Database error: {}", e),
+        )
+    })?;
+    super::agency_imports::check_agency_membership(&mut conn, id, principal.user_id).await?;
+    drop(conn);
+
     let agency = state
         .reality_portal_repo
         .update_agency_branding(id, data)

--- a/backend/servers/reality-server/src/routes/agency_imports.rs
+++ b/backend/servers/reality-server/src/routes/agency_imports.rs
@@ -4,6 +4,7 @@
 //! D1.2: handlers now use the unified `RequestPrincipal` extractor.
 
 use crate::state::AppState;
+use crate::util::url_validator::validate_fetch_url;
 use api_core::extractors::RequestPrincipal;
 use axum::{
     extract::{Path, State},
@@ -228,6 +229,17 @@ pub async fn test_connection(
 
     check_agency_membership(&mut conn, agency_id, principal.user_id).await?;
 
+    // SECURITY (H3, round-9 audit): refuse SSRF-prone feed URLs *before*
+    // the stub (and the real implementation that will replace it) tries
+    // to fetch them. Hostnames pass this static check; the import worker
+    // must re-validate the resolved IP at fetch time to defend against
+    // DNS rebinding.
+    if let Some(url) = data.feed_url.as_deref() {
+        if let Err(err) = validate_fetch_url(url) {
+            return Err((axum::http::StatusCode::BAD_REQUEST, err.to_string()));
+        }
+    }
+
     // Stub: real implementation would call the external provider.
     let response = TestConnectionResponse {
         success: true,
@@ -268,6 +280,17 @@ pub async fn run_import(
         .map_err(|e| crate::util::errors::db_error("database error", e))?;
 
     check_agency_membership(&mut conn, agency_id, principal.user_id).await?;
+
+    // SECURITY (H3): reject SSRF-prone feed URLs at submission time so
+    // the worker queue never accepts http://169.254.169.254/, file://,
+    // or private/loopback targets. NOTE TO WORKER MAINTAINER: after DNS
+    // resolution, re-run this check on the resolved IP — a domain that
+    // passes here can still resolve to a private IP (DNS rebinding).
+    if let Some(url) = data.feed_url.as_deref() {
+        if let Err(err) = validate_fetch_url(url) {
+            return Err((axum::http::StatusCode::BAD_REQUEST, err.to_string()));
+        }
+    }
 
     let provider_str = data.provider.to_string();
 
@@ -371,7 +394,13 @@ pub async fn get_import_job_status(
 }
 
 /// Helper: verify the user is an active member of the given agency.
-async fn check_agency_membership(
+///
+/// Exposed to sibling modules (`super::agencies`, `super::agency_branding`)
+/// so they can apply the same auth check. Also used here to gate every
+/// import endpoint. SECURITY: returns `403 Not a member of this agency`
+/// even when the user is staff in a different agency — never leaks
+/// cross-agency membership.
+pub(super) async fn check_agency_membership(
     conn: &mut sqlx::pool::PoolConnection<sqlx::Postgres>,
     agency_id: Uuid,
     user_id: Uuid,

--- a/backend/servers/reality-server/src/routes/compare.rs
+++ b/backend/servers/reality-server/src/routes/compare.rs
@@ -98,7 +98,12 @@ pub async fn get_compare_list(
             (SELECT url FROM listing_photos WHERE listing_id = l.id ORDER BY display_order ASC LIMIT 1) AS photo_url,
             l.status
         FROM compare_lists cl
-        LEFT JOIN listings l ON l.id = cl.listing_id
+        -- SECURITY (H4): hide listings whose status flipped to non-active
+        -- after they were added. The LEFT JOIN keeps the compare row so the
+        -- frontend can still surface a "this listing is no longer available"
+        -- placeholder, but all listing fields come back NULL — no leak of
+        -- draft/archived/pending data.
+        LEFT JOIN listings l ON l.id = cl.listing_id AND l.status = 'active'
         WHERE cl.user_id = $1
         ORDER BY cl.added_at ASC
         "#,
@@ -174,13 +179,20 @@ pub async fn add_to_compare(
         ));
     }
 
-    // Check listing exists
-    let listing_exists: bool =
-        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM listings WHERE id = $1)")
-            .bind(listing_id)
-            .fetch_one(&mut *conn)
-            .await
-            .map_err(|e| crate::util::errors::db_error("check listing", e))?;
+    // Check listing exists AND is publicly visible.
+    //
+    // SECURITY (H4, round-9 audit): without the status filter, any
+    // authenticated portal user could add a draft/archived/pending
+    // listing UUID to their compare list and read its details via the
+    // join in `get_compare_list`. Restrict to `status = 'active'` to
+    // match the public-listing surface.
+    let listing_exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM listings WHERE id = $1 AND status = 'active')",
+    )
+    .bind(listing_id)
+    .fetch_one(&mut *conn)
+    .await
+    .map_err(|e| crate::util::errors::db_error("check listing", e))?;
 
     if !listing_exists {
         return Err((

--- a/backend/servers/reality-server/src/routes/reports.rs
+++ b/backend/servers/reality-server/src/routes/reports.rs
@@ -139,13 +139,21 @@ pub async fn submit_report(
         .await
         .map_err(|e| crate::util::errors::db_error("database error", e))?;
 
-    // Check listing exists
-    let listing_exists: bool =
-        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM listings WHERE id = $1)")
-            .bind(data.listing_id)
-            .fetch_one(&mut *conn)
-            .await
-            .map_err(|e| crate::util::errors::db_error("check listing", e))?;
+    // Check listing exists AND is publicly visible.
+    //
+    // SECURITY (H5, round-9 audit): without the status filter, this endpoint
+    // is an unauthenticated existence oracle — an attacker can probe whether
+    // a UUID belongs to a draft/archived/pending listing by diffing 404 vs
+    // 201. Restricting to `status = 'active'` collapses the response shape
+    // to "is there a public listing with this id?", matching what an honest
+    // reporter would see in the UI.
+    let listing_exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM listings WHERE id = $1 AND status = 'active')",
+    )
+    .bind(data.listing_id)
+    .fetch_one(&mut *conn)
+    .await
+    .map_err(|e| crate::util::errors::db_error("check listing", e))?;
 
     if !listing_exists {
         return Err((

--- a/backend/servers/reality-server/src/routes/sso.rs
+++ b/backend/servers/reality-server/src/routes/sso.rs
@@ -38,12 +38,20 @@ pub fn router() -> Router<AppState> {
 // ==================== Web SSO Flow ====================
 
 /// SSO login query parameters.
+///
+/// SECURITY (H1, round-9 audit): the `state` parameter is intentionally
+/// absent. CSRF protection uses the server-generated PKCE session id (stored
+/// server-side, threaded through the OAuth `state` query param to the
+/// authorization endpoint, and verified on callback). A user-supplied
+/// `state` value was previously accepted, stored, and silently dropped —
+/// which advertised a CSRF surface that did not actually exist. If a future
+/// client needs round-trip state, add it as a separate `client_state` cookie
+/// or set via POST instead of leaking it into the redirect chain.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct SsoLoginQuery {
-    /// Where to redirect after successful login
+    /// Where to redirect after successful login. MUST resolve to an origin
+    /// in `ALLOWED_REDIRECT_ORIGINS`; anything else is rejected with 400.
     pub redirect_uri: Option<String>,
-    /// Optional state for CSRF protection
-    pub state: Option<String>,
 }
 
 /// Initiate SSO login - redirects to PM OAuth provider.
@@ -52,17 +60,29 @@ pub struct SsoLoginQuery {
     path = "/api/v1/sso/login",
     tag = "SSO",
     params(
-        ("redirect_uri" = Option<String>, Query, description = "Post-login redirect URI"),
-        ("state" = Option<String>, Query, description = "CSRF state token")
+        ("redirect_uri" = Option<String>, Query, description = "Post-login redirect URI (must match ALLOWED_REDIRECT_ORIGINS)")
     ),
     responses(
-        (status = 302, description = "Redirect to PM OAuth authorize endpoint")
+        (status = 302, description = "Redirect to PM OAuth authorize endpoint"),
+        (status = 400, description = "redirect_uri rejected by allowlist", body = SsoError)
     )
 )]
 pub async fn sso_login(
     State(state): State<AppState>,
     Query(params): Query<SsoLoginQuery>,
-) -> impl IntoResponse {
+) -> Result<Redirect, (StatusCode, Json<SsoError>)> {
+    // SECURITY (H1, round-9 audit): validate redirect_uri against allowlist
+    // BEFORE storing it. Without this, /api/v1/sso/login?redirect_uri=https://evil.com
+    // would persist an attacker-controlled URL to be served by the callback.
+    if let Some(uri) = params.redirect_uri.as_deref() {
+        if let Err(err) = ensure_redirect_uri_allowed(&state, uri) {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(SsoError::new("invalid_redirect_uri", &err)),
+            ));
+        }
+    }
+
     // Generate PKCE code verifier and challenge
     let code_verifier = generate_code_verifier();
     let code_challenge = generate_code_challenge(&code_verifier);
@@ -76,7 +96,6 @@ pub async fn sso_login(
         PendingSsoSession {
             code_verifier,
             redirect_uri: params.redirect_uri.clone(),
-            state: params.state.clone(),
             created_at: chrono::Utc::now(),
         },
     );
@@ -92,7 +111,48 @@ pub async fn sso_login(
         urlencoding::encode(&code_challenge),
     );
 
-    Redirect::temporary(&oauth_authorize_url)
+    Ok(Redirect::temporary(&oauth_authorize_url))
+}
+
+/// Validate a user-supplied `redirect_uri` against
+/// `AppConfig::allowed_redirect_origins`.
+///
+/// Match is done on the URL's origin (`scheme://host[:port]`) — the path,
+/// query, and fragment can be anything. Returns `Err(reason)` when the URL
+/// is malformed, missing a host, or whose origin is not in the allowlist
+/// (including the empty/None case, which means "no redirects accepted").
+fn ensure_redirect_uri_allowed(state: &AppState, raw: &str) -> Result<(), String> {
+    // Allow same-origin relative paths (e.g. "/dashboard") unconditionally —
+    // the browser will resolve them against the reality-web origin that
+    // initiated the flow, which by definition the user already trusts.
+    if raw.starts_with('/') && !raw.starts_with("//") {
+        return Ok(());
+    }
+
+    let parsed = url::Url::parse(raw).map_err(|e| format!("invalid URL: {}", e))?;
+    // Only http(s) — block javascript:, data:, file:, etc.
+    match parsed.scheme() {
+        "http" | "https" => {}
+        other => return Err(format!("scheme '{}' not allowed", other)),
+    }
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| "URL has no host".to_string())?;
+    let origin = match parsed.port() {
+        Some(p) => format!("{}://{}:{}", parsed.scheme(), host, p),
+        None => format!("{}://{}", parsed.scheme(), host),
+    };
+
+    let allowed = state
+        .config
+        .allowed_redirect_origins
+        .as_deref()
+        .unwrap_or(&[]);
+    if allowed.iter().any(|o| o == &origin) {
+        Ok(())
+    } else {
+        Err(format!("origin '{}' is not in the allowlist", origin))
+    }
 }
 
 /// SSO callback query parameters.
@@ -219,10 +279,24 @@ pub async fn sso_callback(
             )
         })?;
 
-    // Build redirect URL with session cookie
-    let redirect_uri = pending_session
-        .redirect_uri
-        .unwrap_or_else(|| "/".to_string());
+    // Build redirect URL with session cookie.
+    //
+    // SECURITY (H1): re-validate the stored redirect_uri against the
+    // current allowlist as defense in depth. The login handler already
+    // validated it, but the allowlist may have shrunk since then (e.g.
+    // operator removed a deprecated origin), and we want to refuse the
+    // *current* admin policy, not the snapshot at login time.
+    let redirect_uri = match pending_session.redirect_uri {
+        Some(uri) if ensure_redirect_uri_allowed(&state, &uri).is_ok() => uri,
+        Some(bad) => {
+            tracing::warn!(
+                redirect_uri = %bad,
+                "Dropping stored redirect_uri that is no longer in the allowlist; falling back to '/'"
+            );
+            "/".to_string()
+        }
+        None => "/".to_string(),
+    };
 
     // Set session cookie and redirect
     Ok((
@@ -518,11 +592,16 @@ pub struct SessionInfo {
 }
 
 /// Pending SSO session for PKCE flow.
+///
+/// SECURITY (H1): no `state: Option<String>` field — the OAuth `state`
+/// parameter on the upstream authorize URL is the **server-generated
+/// `session_id`** (the map key), never user input. A previous shape stored
+/// a `params.state` echoed from the request and never used it, which was
+/// misleading code: it suggested CSRF protection that did not exist.
 #[derive(Debug)]
 pub struct PendingSsoSession {
     pub code_verifier: String,
     pub redirect_uri: Option<String>,
-    pub state: Option<String>,
     pub created_at: chrono::DateTime<chrono::Utc>,
 }
 

--- a/backend/servers/reality-server/src/state.rs
+++ b/backend/servers/reality-server/src/state.rs
@@ -39,6 +39,13 @@ pub struct AppConfig {
     pub jwt_secret: String,
     /// PM API health check URL (Epic 104.1)
     pub pm_api_health_url: String,
+    /// Allowlist of post-SSO redirect origins (`scheme://host[:port]`).
+    ///
+    /// Loaded from `ALLOWED_REDIRECT_ORIGINS` (comma-separated). `None` means
+    /// no client-supplied `redirect_uri` is accepted at all — handlers must
+    /// fall back to a hard-coded safe path (e.g. `"/"`). Empty list also
+    /// rejects everything.
+    pub allowed_redirect_origins: Option<Vec<String>>,
 }
 
 impl AppConfig {
@@ -111,6 +118,18 @@ impl AppConfig {
             // is unaffected — it still uses `/health`.
             pm_api_health_url: std::env::var("PM_API_HEALTH_URL")
                 .unwrap_or_else(|_| format!("{}/readiness", pm_api_base)),
+            // SECURITY: post-SSO redirect target allowlist. Origins are
+            // compared as `scheme://host[:port]` exact-match strings.
+            // Missing env var ⇒ `None` ⇒ all client-supplied redirect_uris
+            // are rejected (handlers fall back to "/"). This is the safe
+            // default — operators must opt in to redirecting back to the
+            // web/mobile app origins.
+            allowed_redirect_origins: std::env::var("ALLOWED_REDIRECT_ORIGINS").ok().map(|raw| {
+                raw.split(',')
+                    .map(|s| s.trim().trim_end_matches('/').to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect::<Vec<_>>()
+            }),
         }
     }
 }

--- a/backend/servers/reality-server/src/util/mod.rs
+++ b/backend/servers/reality-server/src/util/mod.rs
@@ -4,3 +4,4 @@
 //! lean — anything reusable across servers belongs in `api-core` or `common`.
 
 pub mod errors;
+pub mod url_validator;

--- a/backend/servers/reality-server/src/util/mod.rs
+++ b/backend/servers/reality-server/src/util/mod.rs
@@ -5,3 +5,20 @@
 
 pub mod errors;
 pub mod url_validator;
+
+/// Process-wide mutex for tests that mutate global env vars (e.g. `RUST_ENV`).
+///
+/// Rust's test harness runs tests in parallel by default, so any test that
+/// touches a shared env var has to serialize against every other such test
+/// in the same process. Use [`env_lock`] in any test that reads or writes
+/// `RUST_ENV` (and friends) to avoid flaky cross-test interference.
+#[cfg(test)]
+pub(crate) fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+    use std::sync::{Mutex, OnceLock};
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    // Tests may panic while holding the guard; recovering from a poisoned
+    // mutex is fine because the protected data is `()`.
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+}

--- a/backend/servers/reality-server/src/util/url_validator.rs
+++ b/backend/servers/reality-server/src/util/url_validator.rs
@@ -1,0 +1,279 @@
+//! URL validation helpers for SSRF defense.
+//!
+//! Used by handlers that accept user-supplied URLs which will later be
+//! fetched server-side (e.g. agency import feeds). The validator rejects:
+//!
+//! * non-`http`/`https` schemes (including `file://`, `data:`, `javascript:`,
+//!   `gopher://`, etc.),
+//! * `http://` outside development builds,
+//! * literal IPs in private, loopback, link-local, multicast, or reserved
+//!   ranges (IPv4 + IPv6),
+//! * the IPv4 broadcast address.
+//!
+//! Hostnames (domains) pass this check; the import worker MUST re-resolve and
+//! re-validate the resolved IP at fetch time to defend against DNS-rebinding
+//! attacks. See the worker maintainer note in `routes::agency_imports`.
+//!
+//! This module is deliberately small so the same helper can be reused by
+//! other handlers that accept user-supplied URLs for server-side fetches
+//! (e.g. logo / profile-image URLs — fix in a follow-up branch).
+
+use url::{Host, Url};
+
+/// Outcome of a URL validation check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UrlValidationError {
+    /// URL failed to parse as a `url::Url`.
+    InvalidFormat(String),
+    /// Scheme is not in the allowlist.
+    DisallowedScheme(String),
+    /// `http://` was used in a production build.
+    PlainHttpNotAllowed,
+    /// URL has no host component (e.g. `file:///etc/passwd`).
+    MissingHost,
+    /// Host is a literal IP in a forbidden range.
+    PrivateOrReservedIp(String),
+}
+
+impl std::fmt::Display for UrlValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidFormat(e) => write!(f, "Invalid URL format: {}", e),
+            Self::DisallowedScheme(s) => write!(f, "URL scheme '{}' is not allowed", s),
+            Self::PlainHttpNotAllowed => {
+                write!(f, "Plain http:// URLs are not allowed; use https://")
+            }
+            Self::MissingHost => write!(f, "URL must have a host"),
+            Self::PrivateOrReservedIp(reason) => {
+                write!(f, "URL points to a forbidden network range: {}", reason)
+            }
+        }
+    }
+}
+
+impl std::error::Error for UrlValidationError {}
+
+/// Returns true when the process is running in a development build.
+///
+/// Matches the convention used by `state::AppConfig::from_env` — `RUST_ENV`
+/// must be `"development"` to relax production-only checks.
+fn is_development() -> bool {
+    std::env::var("RUST_ENV").unwrap_or_default() == "development"
+}
+
+/// Validate that `raw` is a safe URL to fetch server-side.
+///
+/// On success returns the parsed [`Url`]. On failure returns a structured
+/// [`UrlValidationError`] suitable for surfacing as a 400 Bad Request.
+///
+/// **Important**: this is a *static* check on the supplied string. The
+/// caller MUST repeat the IP-range check after DNS resolution at fetch
+/// time, otherwise an attacker can register a hostname that resolves to a
+/// private IP (or use DNS rebinding to flip the answer between checks).
+pub fn validate_fetch_url(raw: &str) -> Result<Url, UrlValidationError> {
+    let parsed = Url::parse(raw).map_err(|e| UrlValidationError::InvalidFormat(e.to_string()))?;
+
+    // Scheme allowlist: only http(s).
+    let scheme = parsed.scheme();
+    match scheme {
+        "https" => {}
+        "http" => {
+            if !is_development() {
+                return Err(UrlValidationError::PlainHttpNotAllowed);
+            }
+        }
+        other => return Err(UrlValidationError::DisallowedScheme(other.to_string())),
+    }
+
+    // Must have a host (rules out `file:///path`, `data:...`, etc., though
+    // those would already trip the scheme check — defense in depth).
+    let host = parsed.host().ok_or(UrlValidationError::MissingHost)?;
+
+    match host {
+        Host::Ipv4(ip) => {
+            let octets = ip.octets();
+
+            // 10.0.0.0/8 — private
+            if octets[0] == 10 {
+                return Err(UrlValidationError::PrivateOrReservedIp(
+                    "10.0.0.0/8 (private)".into(),
+                ));
+            }
+            // 172.16.0.0/12 — private
+            if octets[0] == 172 && (16..=31).contains(&octets[1]) {
+                return Err(UrlValidationError::PrivateOrReservedIp(
+                    "172.16.0.0/12 (private)".into(),
+                ));
+            }
+            // 192.168.0.0/16 — private
+            if octets[0] == 192 && octets[1] == 168 {
+                return Err(UrlValidationError::PrivateOrReservedIp(
+                    "192.168.0.0/16 (private)".into(),
+                ));
+            }
+            // 127.0.0.0/8 — loopback
+            if octets[0] == 127 {
+                return Err(UrlValidationError::PrivateOrReservedIp(
+                    "127.0.0.0/8 (loopback)".into(),
+                ));
+            }
+            // 169.254.0.0/16 — link-local (covers AWS/GCP metadata 169.254.169.254)
+            if octets[0] == 169 && octets[1] == 254 {
+                return Err(UrlValidationError::PrivateOrReservedIp(
+                    "169.254.0.0/16 (link-local / cloud metadata)".into(),
+                ));
+            }
+            // 0.0.0.0/8 — reserved
+            if octets[0] == 0 {
+                return Err(UrlValidationError::PrivateOrReservedIp(
+                    "0.0.0.0/8 (reserved)".into(),
+                ));
+            }
+            // 255.255.255.255 — broadcast
+            if octets == [255, 255, 255, 255] {
+                return Err(UrlValidationError::PrivateOrReservedIp(
+                    "255.255.255.255 (broadcast)".into(),
+                ));
+            }
+            // 224.0.0.0/4 — multicast
+            if octets[0] >= 224 && octets[0] <= 239 {
+                return Err(UrlValidationError::PrivateOrReservedIp(
+                    "224.0.0.0/4 (multicast)".into(),
+                ));
+            }
+        }
+        Host::Ipv6(ip) => {
+            if ip.is_loopback() {
+                return Err(UrlValidationError::PrivateOrReservedIp(
+                    "::1 (IPv6 loopback)".into(),
+                ));
+            }
+            let segments = ip.segments();
+            // fc00::/7 — IPv6 unique local
+            if (segments[0] & 0xfe00) == 0xfc00 {
+                return Err(UrlValidationError::PrivateOrReservedIp(
+                    "fc00::/7 (IPv6 unique local)".into(),
+                ));
+            }
+            // fe80::/10 — IPv6 link-local
+            if (segments[0] & 0xffc0) == 0xfe80 {
+                return Err(UrlValidationError::PrivateOrReservedIp(
+                    "fe80::/10 (IPv6 link-local)".into(),
+                ));
+            }
+        }
+        Host::Domain(_) => {
+            // Hostnames must be re-validated at fetch time by the worker
+            // after DNS resolution. We can't do it here without performing
+            // (cacheable, race-prone) DNS lookups inside the request path.
+        }
+    }
+
+    Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn force_prod() {
+        std::env::set_var("RUST_ENV", "production");
+    }
+
+    fn force_dev() {
+        std::env::set_var("RUST_ENV", "development");
+    }
+
+    #[test]
+    fn accepts_https_domain() {
+        force_prod();
+        assert!(validate_fetch_url("https://example.com/feed.xml").is_ok());
+    }
+
+    #[test]
+    fn rejects_http_in_prod() {
+        force_prod();
+        assert!(matches!(
+            validate_fetch_url("http://example.com/feed.xml"),
+            Err(UrlValidationError::PlainHttpNotAllowed)
+        ));
+    }
+
+    #[test]
+    fn allows_http_in_dev() {
+        force_dev();
+        assert!(validate_fetch_url("http://example.com/feed.xml").is_ok());
+        force_prod();
+    }
+
+    #[test]
+    fn rejects_file_scheme() {
+        force_prod();
+        assert!(matches!(
+            validate_fetch_url("file:///etc/passwd"),
+            Err(UrlValidationError::DisallowedScheme(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_data_scheme() {
+        force_prod();
+        assert!(matches!(
+            validate_fetch_url("data:text/plain,hello"),
+            Err(UrlValidationError::DisallowedScheme(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_javascript_scheme() {
+        force_prod();
+        assert!(matches!(
+            validate_fetch_url("javascript:alert(1)"),
+            Err(UrlValidationError::DisallowedScheme(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_aws_metadata_ip() {
+        force_prod();
+        assert!(matches!(
+            validate_fetch_url("http://169.254.169.254/latest/meta-data/"),
+            // PlainHttp check trips first in prod; in dev the IP rule fires.
+            Err(UrlValidationError::PlainHttpNotAllowed)
+                | Err(UrlValidationError::PrivateOrReservedIp(_))
+        ));
+        force_dev();
+        assert!(matches!(
+            validate_fetch_url("http://169.254.169.254/latest/meta-data/"),
+            Err(UrlValidationError::PrivateOrReservedIp(_))
+        ));
+        force_prod();
+    }
+
+    #[test]
+    fn rejects_https_loopback() {
+        force_prod();
+        assert!(matches!(
+            validate_fetch_url("https://127.0.0.1/"),
+            Err(UrlValidationError::PrivateOrReservedIp(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_https_private_10() {
+        force_prod();
+        assert!(matches!(
+            validate_fetch_url("https://10.0.0.5/feed.xml"),
+            Err(UrlValidationError::PrivateOrReservedIp(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_ipv6_loopback() {
+        force_prod();
+        assert!(matches!(
+            validate_fetch_url("https://[::1]/"),
+            Err(UrlValidationError::PrivateOrReservedIp(_))
+        ));
+    }
+}

--- a/backend/servers/reality-server/src/util/url_validator.rs
+++ b/backend/servers/reality-server/src/util/url_validator.rs
@@ -175,24 +175,47 @@ pub fn validate_fetch_url(raw: &str) -> Result<Url, UrlValidationError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::util::env_lock;
 
-    fn force_prod() {
-        std::env::set_var("RUST_ENV", "production");
+    /// RAII guard that pins `RUST_ENV` to a given value for the lifetime of a
+    /// single test, then restores the previous value on drop. Acquires the
+    /// process-wide [`env_lock`] so concurrent tests in this crate can't race
+    /// on the same env var.
+    struct EnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        previous: Option<String>,
     }
 
-    fn force_dev() {
-        std::env::set_var("RUST_ENV", "development");
+    impl EnvGuard {
+        fn set(value: &str) -> Self {
+            let lock = env_lock();
+            let previous = std::env::var("RUST_ENV").ok();
+            std::env::set_var("RUST_ENV", value);
+            Self {
+                _lock: lock,
+                previous,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(v) => std::env::set_var("RUST_ENV", v),
+                None => std::env::remove_var("RUST_ENV"),
+            }
+        }
     }
 
     #[test]
     fn accepts_https_domain() {
-        force_prod();
+        let _g = EnvGuard::set("production");
         assert!(validate_fetch_url("https://example.com/feed.xml").is_ok());
     }
 
     #[test]
     fn rejects_http_in_prod() {
-        force_prod();
+        let _g = EnvGuard::set("production");
         assert!(matches!(
             validate_fetch_url("http://example.com/feed.xml"),
             Err(UrlValidationError::PlainHttpNotAllowed)
@@ -201,14 +224,13 @@ mod tests {
 
     #[test]
     fn allows_http_in_dev() {
-        force_dev();
+        let _g = EnvGuard::set("development");
         assert!(validate_fetch_url("http://example.com/feed.xml").is_ok());
-        force_prod();
     }
 
     #[test]
     fn rejects_file_scheme() {
-        force_prod();
+        let _g = EnvGuard::set("production");
         assert!(matches!(
             validate_fetch_url("file:///etc/passwd"),
             Err(UrlValidationError::DisallowedScheme(_))
@@ -217,7 +239,7 @@ mod tests {
 
     #[test]
     fn rejects_data_scheme() {
-        force_prod();
+        let _g = EnvGuard::set("production");
         assert!(matches!(
             validate_fetch_url("data:text/plain,hello"),
             Err(UrlValidationError::DisallowedScheme(_))
@@ -226,7 +248,7 @@ mod tests {
 
     #[test]
     fn rejects_javascript_scheme() {
-        force_prod();
+        let _g = EnvGuard::set("production");
         assert!(matches!(
             validate_fetch_url("javascript:alert(1)"),
             Err(UrlValidationError::DisallowedScheme(_))
@@ -235,24 +257,25 @@ mod tests {
 
     #[test]
     fn rejects_aws_metadata_ip() {
-        force_prod();
-        assert!(matches!(
-            validate_fetch_url("http://169.254.169.254/latest/meta-data/"),
-            // PlainHttp check trips first in prod; in dev the IP rule fires.
-            Err(UrlValidationError::PlainHttpNotAllowed)
-                | Err(UrlValidationError::PrivateOrReservedIp(_))
-        ));
-        force_dev();
+        {
+            let _g = EnvGuard::set("production");
+            assert!(matches!(
+                validate_fetch_url("http://169.254.169.254/latest/meta-data/"),
+                // PlainHttp check trips first in prod; in dev the IP rule fires.
+                Err(UrlValidationError::PlainHttpNotAllowed)
+                    | Err(UrlValidationError::PrivateOrReservedIp(_))
+            ));
+        }
+        let _g = EnvGuard::set("development");
         assert!(matches!(
             validate_fetch_url("http://169.254.169.254/latest/meta-data/"),
             Err(UrlValidationError::PrivateOrReservedIp(_))
         ));
-        force_prod();
     }
 
     #[test]
     fn rejects_https_loopback() {
-        force_prod();
+        let _g = EnvGuard::set("production");
         assert!(matches!(
             validate_fetch_url("https://127.0.0.1/"),
             Err(UrlValidationError::PrivateOrReservedIp(_))
@@ -261,7 +284,7 @@ mod tests {
 
     #[test]
     fn rejects_https_private_10() {
-        force_prod();
+        let _g = EnvGuard::set("production");
         assert!(matches!(
             validate_fetch_url("https://10.0.0.5/feed.xml"),
             Err(UrlValidationError::PrivateOrReservedIp(_))
@@ -270,7 +293,7 @@ mod tests {
 
     #[test]
     fn rejects_ipv6_loopback() {
-        force_prod();
+        let _g = EnvGuard::set("production");
         assert!(matches!(
             validate_fetch_url("https://[::1]/"),
             Err(UrlValidationError::PrivateOrReservedIp(_))


### PR DESCRIPTION
## Summary

5 HIGH-severity security bugs in the public-facing `reality-server`, all flagged by the round-9 reality-server audit. The reality-server is internet-facing (no auth on many routes); these gaps are exploitable today.

### H1 — Open redirect on SSO callback
`backend/servers/reality-server/src/routes/sso.rs`

`GET /api/v1/sso/login?redirect_uri=https://evil.com` stored attacker-controlled URI; `/sso/callback` did `Redirect::temporary(&redirect_uri)` post-auth. Phish-able.

Fix: New `ensure_redirect_uri_allowed` validator checks scheme + origin against `state.config.allowed_redirect_origins` (populated from `ALLOWED_REDIRECT_ORIGINS` env var). Same-origin relative paths still allowed. Re-validates the stored URI at callback (defense-in-depth; falls back to `/` on allowlist drift). Removed the ignored `state` query field; CSRF stays on the server-generated PKCE `session_id`.

### H2 — Unauthenticated PUT on /api/v1/agencies/{id}
`backend/servers/reality-server/src/routes/agencies.rs`

`update_agency` had no auth extractor. Anyone on the internet could rewrite any agency.

Fix: Added `RequestPrincipal` + `check_agency_membership` (helper promoted to `pub(super)` from `agency_imports.rs`). Same fix applied to the dead-code `update_branding` shim — confirmed the live `/agencies/{id}/branding` route is `agency_branding::update_branding` which is already auth-checked.

### H3 — SSRF via agency import feed_url
`backend/servers/reality-server/src/routes/agency_imports.rs`

Members could submit `feed_url=http://169.254.169.254/...` and the worker would fetch it. AWS metadata, internal services, `file://` all open.

Fix: New `backend/servers/reality-server/src/util/url_validator.rs` module with `validate_fetch_url`. Wraps the `url` crate; rejects:
- Non-`http(s)` schemes (`file:`, `javascript:`, `data:`, etc.)
- `http://` outside `RUST_ENV=development`
- Private/loopback/link-local/multicast/reserved IPv4 + IPv6 (10/8, 172.16/12, 192.168/16, 169.254/16, 127/8, ::1, fc00::/7)
- DNS rebinding noted in a comment for the import worker (re-resolve at fetch time)

Applied at `test_connection` + `run_import` entry points.

### H4 — IDOR: draft listings exposed via compare
`backend/servers/reality-server/src/routes/compare.rs`

Adding any listing UUID to compare returned title/price/photo even if status was `draft`/`archived`/`pending`.

Fix: `AND status = 'active'` in `add_to_compare` EXISTS check and `LEFT JOIN listings AND l.status = 'active'` in `get_compare_list` (post-flip drafts surface as NULL, never leak).

### H5 — Anonymous report oracle
`backend/servers/reality-server/src/routes/reports.rs`

`submit_report` returned differentiated 404 vs 200 based on UUID existence regardless of listing status — UUID enumeration oracle.

Fix: `AND status = 'active'` in EXISTS check.

## New module

`backend/servers/reality-server/src/util/url_validator.rs` includes unit tests for the validator.

## Config

`AppConfig::allowed_redirect_origins: Option<Vec<String>>` (populated from `ALLOWED_REDIRECT_ORIGINS` comma-separated env var).

## Verification

`cargo fmt -p reality-server` clean. `cargo check -p reality-server` blocked locally (sandbox missing clang/lld/pkg-config). CI is authoritative.

## Heads up
- **Set `ALLOWED_REDIRECT_ORIGINS` env var before deploy**, or SSO logins will redirect to `/` instead of the intended destination.
- Import worker should re-validate post-DNS-resolution to mitigate DNS rebinding.

## Test plan

- [ ] Backend CI green (compile + cargo check + tests)
- [ ] Smoke: `PUT /api/v1/agencies/{id}` without auth → 401/403
- [ ] Smoke: `POST /api/v1/sso/login?redirect_uri=https://evil.com` → 400
- [ ] Smoke: agency import with `feed_url=http://169.254.169.254/` → 400
- [ ] Smoke: add draft listing UUID to compare → 404, not exposed