### PR TITLE
fix(security): reality-server input hygiene — length caps, URL validation, paginate comments

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -5400,6 +5400,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "url",
  "urlencoding",
  "utoipa",
  "utoipa-swagger-ui",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -68,6 +68,7 @@ base64 = "0.22"
 
 # URL encoding
 urlencoding = "2.1"
+url = "2.5"
 
 # HTTP client (for integrations)
 reqwest = { version = "0.13", features = ["json", "form", "query"] }

--- a/backend/servers/reality-server/Cargo.toml
+++ b/backend/servers/reality-server/Cargo.toml
@@ -40,7 +40,7 @@ reqwest = { workspace = true }
 sha2 = { workspace = true }
 base64 = { workspace = true }
 urlencoding = { workspace = true }
-url = "2.5"
+url = { workspace = true }
 argon2 = { workspace = true }
 sqlx = { workspace = true }
 

--- a/backend/servers/reality-server/src/routes/agency_branding.rs
+++ b/backend/servers/reality-server/src/routes/agency_branding.rs
@@ -17,6 +17,42 @@ use sqlx::Row;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
+// ---------------------------------------------------------------------------
+// H7 — URL hygiene
+// ---------------------------------------------------------------------------
+// `logo_url`, `banner_url`, `watermark_url` end up in `<img src=>` on the
+// frontend. Reject `javascript:`, `data:`, `file:` and any non-http(s) URL.
+// Inlined locally until the auth-hardening branch lands a shared validator.
+const MAX_URL_LEN: usize = 2048;
+
+fn validate_image_or_link_url(s: &str) -> Result<(), String> {
+    if s.len() > MAX_URL_LEN {
+        return Err(format!("URL must be at most {} characters", MAX_URL_LEN));
+    }
+    let parsed = url::Url::parse(s).map_err(|_| "Invalid URL".to_string())?;
+    match parsed.scheme() {
+        "https" | "http" => Ok(()),
+        _ => Err("URL scheme must be http or https".to_string()),
+    }
+}
+
+/// Validate an optional URL field. Returns a generic 400 message that does
+/// NOT echo the rejected URL back (reflected-XSS guard).
+fn check_optional_url_field(
+    value: &Option<String>,
+    field: &'static str,
+) -> Result<(), (axum::http::StatusCode, String)> {
+    if let Some(s) = value.as_deref() {
+        if !s.is_empty() && validate_image_or_link_url(s).is_err() {
+            return Err((
+                axum::http::StatusCode::BAD_REQUEST,
+                format!("{} must be a http(s) URL (max 2048 chars)", field),
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Create agency branding router.
 /// Mounted at /api/v1/agencies/:id/branding to avoid prefix collision with
 /// routes::agencies (which nests under /api/v1/agencies — Axum's .nest() with
@@ -211,6 +247,12 @@ pub async fn update_branding(
     Path(agency_id): Path<Uuid>,
     Json(data): Json<UpdateBrandingRequest>,
 ) -> Result<Json<BrandingResponse>, (axum::http::StatusCode, String)> {
+    // H7: validate URL fields before doing any DB work. These end up in
+    // `<img src=>` on the frontend — reject `javascript:`, `data:`, `file:`.
+    check_optional_url_field(&data.logo_url, "logo_url")?;
+    check_optional_url_field(&data.banner_url, "banner_url")?;
+    check_optional_url_field(&data.watermark_url, "watermark_url")?;
+
     let mut conn = state
         .acquire_public_conn()
         .await

--- a/backend/servers/reality-server/src/routes/articles.rs
+++ b/backend/servers/reality-server/src/routes/articles.rs
@@ -16,6 +16,18 @@ use sqlx::Row;
 use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 
+// ---------------------------------------------------------------------------
+// Input hygiene constants (H6, M5)
+// ---------------------------------------------------------------------------
+// Comments are public-write (after auth) but a 100MB body still bloats the
+// DB. Mirror the 5000-char cap used elsewhere in this server.
+const MAX_COMMENT_BODY_LEN: usize = 5000;
+// Default page size for unauthenticated comment listing. Without a cap a
+// popular article DoSs both the API request and the SSR page that renders
+// it.
+const DEFAULT_COMMENTS_LIMIT: i64 = 50;
+const MAX_COMMENTS_LIMIT: i64 = 200;
+
 /// Create articles router.
 pub fn router() -> Router<AppState> {
     Router::new()
@@ -115,6 +127,15 @@ pub struct ArticlesQuery {
     pub search: Option<String>,
     pub page: Option<i64>,
     pub per_page: Option<i64>,
+}
+
+/// Comments list query parameters (M5: paginate).
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct CommentsQuery {
+    /// Maximum comments to return. Defaults to 50, capped at 200.
+    pub limit: Option<i64>,
+    /// Number of comments to skip. Defaults to 0.
+    pub offset: Option<i64>,
 }
 
 /// List articles with optional filters.
@@ -312,12 +333,15 @@ pub async fn get_article(
     Ok(Json(ArticleDetailResponse { article }))
 }
 
-/// List comments for an article.
+/// List comments for an article (paginated — M5).
 #[utoipa::path(
     get,
     path = "/api/v1/articles/{slug}/comments",
     tag = "Articles",
-    params(("slug" = String, Path, description = "Article URL slug")),
+    params(
+        ("slug" = String, Path, description = "Article URL slug"),
+        CommentsQuery,
+    ),
     responses(
         (status = 200, description = "Comment list", body = CommentsResponse),
         (status = 404, description = "Article not found")
@@ -326,7 +350,14 @@ pub async fn get_article(
 pub async fn list_comments(
     State(state): State<AppState>,
     Path(slug): Path<String>,
+    Query(query): Query<CommentsQuery>,
 ) -> Result<Json<CommentsResponse>, (axum::http::StatusCode, String)> {
+    let limit = query
+        .limit
+        .unwrap_or(DEFAULT_COMMENTS_LIMIT)
+        .clamp(1, MAX_COMMENTS_LIMIT);
+    let offset = query.offset.unwrap_or(0).max(0);
+
     let mut conn = state
         .acquire_public_conn()
         .await
@@ -348,25 +379,35 @@ pub async fn list_comments(
         )
     })?;
 
+    // COUNT(*) OVER () returns the unfiltered total alongside each page row
+    // so we get the real total without a second round-trip.
     let rows = sqlx::query(
         r#"
         SELECT
             ac.id, ac.article_id, ac.author_user_id,
             COALESCE(pu.name, 'Anonymous') AS author_name,
             pu.profile_image_url AS author_avatar_url,
-            ac.body, ac.created_at
+            ac.body, ac.created_at,
+            COUNT(*) OVER () AS total_count
         FROM reality_article_comments ac
         LEFT JOIN users pu ON pu.id = ac.author_user_id AND pu.principal_kind = 'public'
         WHERE ac.article_id = $1
         ORDER BY ac.created_at ASC
+        LIMIT $2 OFFSET $3
         "#,
     )
     .bind(article_id)
+    .bind(limit)
+    .bind(offset)
     .fetch_all(&mut *conn)
     .await
     .map_err(|e| crate::util::errors::db_error("list comments", e))?;
 
-    let total = rows.len() as i64;
+    let total: i64 = rows
+        .first()
+        .map(|r| r.get::<i64, _>("total_count"))
+        .unwrap_or(0);
+
     let comments: Vec<ArticleComment> = rows
         .into_iter()
         .map(|r| ArticleComment {
@@ -410,6 +451,15 @@ pub async fn create_comment(
         return Err((
             axum::http::StatusCode::BAD_REQUEST,
             "Comment body cannot be empty".to_string(),
+        ));
+    }
+    if data.body.len() > MAX_COMMENT_BODY_LEN {
+        return Err((
+            axum::http::StatusCode::BAD_REQUEST,
+            format!(
+                "Comment body must be at most {} characters",
+                MAX_COMMENT_BODY_LEN
+            ),
         ));
     }
 

--- a/backend/servers/reality-server/src/routes/inquiries.rs
+++ b/backend/servers/reality-server/src/routes/inquiries.rs
@@ -15,6 +15,45 @@ use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 
+// ---------------------------------------------------------------------------
+// Input hygiene constants (H6)
+// ---------------------------------------------------------------------------
+// `respond_to_inquiry` already caps at 5000; mirror the same for the
+// public-anonymous initial submit (`send_contact_message`, `request_viewing`)
+// so unauthenticated traffic cannot upload arbitrary-size payloads.
+const MAX_INQUIRY_MESSAGE_LEN: usize = 5000;
+const MAX_INQUIRY_NAME_LEN: usize = 200;
+const MAX_INQUIRY_EMAIL_LEN: usize = 320; // RFC 5321 max
+const MAX_INQUIRY_PHONE_LEN: usize = 32;
+const MAX_INQUIRY_PREFERRED_TIMES: usize = 20;
+const MAX_INQUIRY_PREFERRED_TIME_LEN: usize = 200;
+
+/// Apply length caps to a public-submitted inquiry payload. Returns a generic
+/// error message that does NOT echo the user-submitted string back (avoids
+/// reflected XSS if a frontend ever renders error bodies as HTML).
+fn validate_inquiry_lengths(
+    name: &str,
+    email: &str,
+    phone: Option<&str>,
+    message: &str,
+) -> Result<(), &'static str> {
+    if name.len() > MAX_INQUIRY_NAME_LEN {
+        return Err("Name is too long");
+    }
+    if email.len() > MAX_INQUIRY_EMAIL_LEN {
+        return Err("Email is too long");
+    }
+    if let Some(p) = phone {
+        if p.len() > MAX_INQUIRY_PHONE_LEN {
+            return Err("Phone is too long");
+        }
+    }
+    if message.len() > MAX_INQUIRY_MESSAGE_LEN {
+        return Err("Message is too long (max 5000 characters)");
+    }
+    Ok(())
+}
+
 /// Create inquiries router.
 pub fn router() -> Router<AppState> {
     Router::new()
@@ -140,6 +179,14 @@ pub async fn send_contact_message(
     Path(listing_id): Path<Uuid>,
     Json(req): Json<ContactMessageRequest>,
 ) -> Result<Json<ContactMessageResponse>, (axum::http::StatusCode, String)> {
+    // H6: length caps before semantic validation — reject oversize bodies
+    // before they bloat the request body / DB row.
+    if let Err(msg) =
+        validate_inquiry_lengths(&req.name, &req.email, req.phone.as_deref(), &req.message)
+    {
+        return Err((axum::http::StatusCode::BAD_REQUEST, msg.to_string()));
+    }
+
     // Validate contact info
     let validation = crate::handlers::inquiries::InquiriesHandler::validate_contact(
         &req.name,
@@ -250,6 +297,55 @@ pub async fn request_viewing(
     Path(listing_id): Path<Uuid>,
     Json(req): Json<ViewingRequest>,
 ) -> Result<Json<ViewingRequestResponse>, (axum::http::StatusCode, String)> {
+    // H6: cap fields BEFORE we concatenate them into the outgoing message.
+    if req.name.len() > MAX_INQUIRY_NAME_LEN {
+        return Err((
+            axum::http::StatusCode::BAD_REQUEST,
+            "Name is too long".to_string(),
+        ));
+    }
+    if req.email.len() > MAX_INQUIRY_EMAIL_LEN {
+        return Err((
+            axum::http::StatusCode::BAD_REQUEST,
+            "Email is too long".to_string(),
+        ));
+    }
+    if let Some(ref phone) = req.phone {
+        if phone.len() > MAX_INQUIRY_PHONE_LEN {
+            return Err((
+                axum::http::StatusCode::BAD_REQUEST,
+                "Phone is too long".to_string(),
+            ));
+        }
+    }
+    if let Some(ref m) = req.message {
+        if m.len() > MAX_INQUIRY_MESSAGE_LEN {
+            return Err((
+                axum::http::StatusCode::BAD_REQUEST,
+                "Message is too long (max 5000 characters)".to_string(),
+            ));
+        }
+    }
+    if let Some(ref times) = req.preferred_times {
+        if times.len() > MAX_INQUIRY_PREFERRED_TIMES {
+            return Err((
+                axum::http::StatusCode::BAD_REQUEST,
+                format!(
+                    "At most {} preferred times allowed",
+                    MAX_INQUIRY_PREFERRED_TIMES
+                ),
+            ));
+        }
+        for t in times.iter() {
+            if t.len() > MAX_INQUIRY_PREFERRED_TIME_LEN {
+                return Err((
+                    axum::http::StatusCode::BAD_REQUEST,
+                    "Preferred time entry is too long".to_string(),
+                ));
+            }
+        }
+    }
+
     // Build message with preferred times
     let message = if let Some(times) = &req.preferred_times {
         format!(

--- a/backend/servers/reality-server/src/routes/reports.rs
+++ b/backend/servers/reality-server/src/routes/reports.rs
@@ -18,6 +18,31 @@ use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 
+// ---------------------------------------------------------------------------
+// Input hygiene constants (H6, H7)
+// ---------------------------------------------------------------------------
+// Public-anonymous endpoint — without caps an unauthenticated attacker can
+// post arbitrary-size strings/arrays that bloat DB rows, log files and the
+// request body. 5000 chars mirrors the existing inquiry-response cap.
+const MAX_REPORT_DESCRIPTION_LEN: usize = 5000;
+const MAX_REPORT_ATTACHMENTS: usize = 10;
+const MAX_URL_LEN: usize = 2048;
+
+/// Reject `javascript:`, `data:`, `file:`, etc. URLs that would later be
+/// rendered in `<img src=>` / `<a href=>` on the frontend (stored XSS).
+/// Inlined locally per H7 brief — once the auth-hardening branch lands a
+/// shared `url_validator` module this should be swapped for the import.
+fn validate_image_or_link_url(s: &str) -> Result<(), String> {
+    if s.len() > MAX_URL_LEN {
+        return Err(format!("URL must be at most {} characters", MAX_URL_LEN));
+    }
+    let parsed = url::Url::parse(s).map_err(|_| "Invalid URL".to_string())?;
+    match parsed.scheme() {
+        "https" | "http" => Ok(()),
+        _ => Err("URL scheme must be http or https".to_string()),
+    }
+}
+
 /// Create reports router.
 pub fn router() -> Router<AppState> {
     Router::new()
@@ -132,6 +157,35 @@ pub async fn submit_report(
             axum::http::StatusCode::BAD_REQUEST,
             "Description is required".to_string(),
         ));
+    }
+    if data.description.len() > MAX_REPORT_DESCRIPTION_LEN {
+        return Err((
+            axum::http::StatusCode::BAD_REQUEST,
+            format!(
+                "Description must be at most {} characters",
+                MAX_REPORT_DESCRIPTION_LEN
+            ),
+        ));
+    }
+
+    // H6/H7: cap attachments array and validate each URL. Reject the request
+    // generically — do NOT echo the offending URL back, that would itself be
+    // a reflected XSS vector if the frontend renders error strings as HTML.
+    if let Some(ref atts) = data.attachments {
+        if atts.len() > MAX_REPORT_ATTACHMENTS {
+            return Err((
+                axum::http::StatusCode::BAD_REQUEST,
+                format!("At most {} attachments are allowed", MAX_REPORT_ATTACHMENTS),
+            ));
+        }
+        for url in atts.iter() {
+            if validate_image_or_link_url(url).is_err() {
+                return Err((
+                    axum::http::StatusCode::BAD_REQUEST,
+                    "Attachment URL is invalid (must be http(s) and <= 2048 chars)".to_string(),
+                ));
+            }
+        }
     }
 
     let mut conn = state

--- a/backend/servers/reality-server/src/routes/users.rs
+++ b/backend/servers/reality-server/src/routes/users.rs
@@ -18,6 +18,25 @@ use db::models::PortalUser;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+// H7 — `profile_image_url` ends up in `<img src=>` on the frontend. Reject
+// `javascript:`, `data:`, `file:` URLs. Inlined locally (see H7 brief);
+// swap for a shared `url_validator` module once it lands on main.
+const MAX_PROFILE_URL_LEN: usize = 2048;
+
+fn validate_image_or_link_url(s: &str) -> Result<(), String> {
+    if s.len() > MAX_PROFILE_URL_LEN {
+        return Err(format!(
+            "URL must be at most {} characters",
+            MAX_PROFILE_URL_LEN
+        ));
+    }
+    let parsed = url::Url::parse(s).map_err(|_| "Invalid URL".to_string())?;
+    match parsed.scheme() {
+        "https" | "http" => Ok(()),
+        _ => Err("URL scheme must be http or https".to_string()),
+    }
+}
+
 /// Create users router.
 pub fn router() -> Router<AppState> {
     Router::new()
@@ -326,6 +345,18 @@ pub async fn update_me(
             return Err((
                 axum::http::StatusCode::BAD_REQUEST,
                 format!("Locale must be one of: {}", valid_locales.join(", ")),
+            ));
+        }
+    }
+
+    // H7: validate profile image URL — reject `javascript:`, `data:`, `file:`
+    // and enforce a length cap. Use a generic error so the rejected URL is
+    // NOT echoed back (reflected-XSS guard).
+    if let Some(ref purl) = req.profile_image_url {
+        if !purl.is_empty() && validate_image_or_link_url(purl).is_err() {
+            return Err((
+                axum::http::StatusCode::BAD_REQUEST,
+                "profile_image_url must be a http(s) URL (max 2048 chars)".to_string(),
             ));
         }
     }


### PR DESCRIPTION
## Summary

3 defensive-hygiene fixes in the public-facing `reality-server`, flagged by the round-9 audit. Combined into one PR because they're all input-validation/DoS hardening.

### H6 — Length caps on public-anonymous endpoints
Previously a 100MB description from an unauthenticated attacker would bloat DB rows + log files. Now capped with explicit `400 Bad Request` on overflow.

| File | Endpoint | Caps |
|---|---|---|
| `routes/reports.rs:155-189` | report submit | `description=5000`, `attachments=10×2048` |
| `routes/articles.rs:506-515` | comment submit | `body=5000` |
| `routes/inquiries.rs:151-204, 256-308` | `send_contact_message`, `request_viewing` | `message=5000`, `name=200`, `email=320` (RFC 5321), `phone=32`, `preferred_times=20×200` |

### H7 — URL scheme validation on stored fields
`javascript:` / `data:` / `file://` URLs in profile/branding fields were accepted and rendered on the frontend (stored XSS surface).

Inline `validate_image_or_link_url` per file (per-file rather than shared, to avoid coupling with the H1-H5 branch in flight). Parses with `url::Url::parse`, requires `http`/`https`, caps at 2048 chars. Error responses do NOT echo the rejected URL back (reflected-XSS guard).

| File | Field(s) |
|---|---|
| `routes/agency_branding.rs:259-264` | `logo_url`, `banner_url`, `watermark_url` |
| `routes/users.rs:340-351` | `profile_image_url` |
| `routes/reports.rs` | each `attachments[]` URL |

**TODO comment** notes the swap to the shared `url_validator` module (added by the H1-H5 branch) once that merges.

### M5 — Paginate comments endpoint
`routes/articles.rs:385-466`

`list_comments` returned ALL comments unpaginated → DoS on popular articles.

Fix: `CommentsQuery { limit, offset }`; defaults `limit=50`, max `200`, offset clamped `>=0`. Real total via `COUNT(*) OVER ()` in same query (single round-trip).

## New dependency

`url = \"2.5\"` added to workspace `backend/Cargo.toml` + `backend/servers/reality-server/Cargo.toml` (was already transitive; now direct).

## Verification

`cargo fmt -p reality-server` clean. `cargo check -p reality-server` blocked locally. CI is authoritative.

## Out of scope (separate branches / future work)

- H1-H5 (open redirect, missing auth, SSRF, IDORs) — `fix/reality-server-auth-ssrf-idor-hardening`
- M1 (DTO camelCase on listings/inquiries DTOs) — separate PR
- M2 (pagination totals via `len()` instead of `COUNT(*)`) — applied to comments here; rest of handlers TBD
- M3 (error-message DB-internal leakage) — repo-wide refactor; separate PR
- M4 (list-then-filter on inquiries/saved searches)

## Test plan

- [ ] Backend CI green
- [ ] Smoke: POST report with 10000-char description → 400
- [ ] Smoke: PATCH `/api/v1/me` with `profile_image_url=javascript:alert(1)` → 400
- [ ] Smoke: GET `/api/v1/articles/{id}/comments` returns at most `MAX_COMMENTS_LIMIT` with real total