### PR TITLE
refactor(reality): real pagination totals + suppress DB error leak to public surface (M2+M3)

### DIFF
--- a/backend/crates/db/src/repositories/reality_portal.rs
+++ b/backend/crates/db/src/repositories/reality_portal.rs
@@ -689,6 +689,26 @@ impl RealityPortalRepository {
         .await
     }
 
+    /// Count inquiries for a realtor (matching the same filter as
+    /// `get_realtor_inquiries`). Used by paginated routes to expose the
+    /// true `total` instead of returning `len()` of the current page.
+    pub async fn count_realtor_inquiries(
+        &self,
+        realtor_id: Uuid,
+        status: Option<String>,
+    ) -> Result<i64, SqlxError> {
+        sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT COUNT(*) FROM listing_inquiries
+            WHERE realtor_id = $1 AND ($2::text IS NULL OR status = $2)
+            "#,
+        )
+        .bind(realtor_id)
+        .bind(&status)
+        .fetch_one(&self.pool)
+        .await
+    }
+
     /// Mark inquiry as read.
     pub async fn mark_inquiry_read(&self, id: Uuid) -> Result<(), SqlxError> {
         sqlx::query("UPDATE listing_inquiries SET status = 'read', read_at = NOW() WHERE id = $1 AND read_at IS NULL")

--- a/backend/servers/reality-server/src/lib.rs
+++ b/backend/servers/reality-server/src/lib.rs
@@ -19,3 +19,4 @@ pub mod handlers;
 pub mod observability;
 pub mod routes;
 pub mod state;
+pub mod util;

--- a/backend/servers/reality-server/src/main.rs
+++ b/backend/servers/reality-server/src/main.rs
@@ -33,6 +33,7 @@ mod handlers;
 mod observability;
 mod routes;
 pub mod state;
+mod util;
 
 use state::AppState;
 

--- a/backend/servers/reality-server/src/routes/agencies.rs
+++ b/backend/servers/reality-server/src/routes/agencies.rs
@@ -96,10 +96,7 @@ pub async fn create_agency(
                     "Agency with this name or slug already exists".to_string(),
                 )
             } else {
-                (
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to create agency: {}", e),
-                )
+                crate::util::errors::db_error("create agency", e)
             }
         })?;
 
@@ -127,12 +124,7 @@ pub async fn list_agencies(
         .reality_portal_repo
         .list_public_agencies(limit, offset)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to list agencies: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("list agencies", e))?;
 
     Ok(Json(AgencyListResponse { agencies, total }))
 }
@@ -156,12 +148,7 @@ pub async fn get_agency(
         .reality_portal_repo
         .get_agency(id)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to get agency: {}", e),
-            )
-        })?
+        .map_err(|e| crate::util::errors::db_error("get agency", e))?
         .ok_or_else(|| {
             (
                 axum::http::StatusCode::NOT_FOUND,
@@ -191,12 +178,7 @@ pub async fn get_agency_by_slug(
         .reality_portal_repo
         .get_agency_by_slug(&slug)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to get agency: {}", e),
-            )
-        })?
+        .map_err(|e| crate::util::errors::db_error("get agency", e))?
         .ok_or_else(|| {
             (
                 axum::http::StatusCode::NOT_FOUND,
@@ -265,12 +247,7 @@ pub async fn update_branding(
         .reality_portal_repo
         .update_agency_branding(id, data)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to update branding: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("update branding", e))?;
 
     Ok(Json(AgencyResponse { agency }))
 }
@@ -294,12 +271,7 @@ pub async fn list_members(
         .reality_portal_repo
         .get_agency_members(id)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to get members: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("get members", e))?;
 
     let total = members.len() as i64;
 
@@ -342,10 +314,7 @@ pub async fn create_invitation(
                     "Not authorized to create invitations for this agency".to_string(),
                 )
             } else {
-                (
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to create invitation: {}", e),
-                )
+                crate::util::errors::db_error("create invitation", e)
             }
         })?;
 
@@ -392,10 +361,7 @@ pub async fn accept_invitation(
                     "Invalid invitation token".to_string(),
                 )
             } else {
-                (
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to accept invitation: {}", e),
-                )
+                crate::util::errors::db_error("accept invitation", e)
             }
         })?;
 

--- a/backend/servers/reality-server/src/routes/agency_branding.rs
+++ b/backend/servers/reality-server/src/routes/agency_branding.rs
@@ -121,12 +121,10 @@ pub async fn get_branding(
     State(state): State<AppState>,
     Path(agency_id): Path<Uuid>,
 ) -> Result<Json<BrandingResponse>, (axum::http::StatusCode, String)> {
-    let mut conn = state.acquire_public_conn().await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-    })?;
+    let mut conn = state
+        .acquire_public_conn()
+        .await
+        .map_err(|e| crate::util::errors::db_error("database error", e))?;
 
     let row = sqlx::query(
         r#"
@@ -140,12 +138,7 @@ pub async fn get_branding(
     .bind(agency_id)
     .fetch_optional(&mut *conn)
     .await
-    .map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to get branding: {}", e),
-        )
-    })?;
+    .map_err(|e| crate::util::errors::db_error("get branding", e))?;
 
     match row {
         Some(r) => {
@@ -170,12 +163,7 @@ pub async fn get_branding(
                     .bind(agency_id)
                     .fetch_one(&mut *conn)
                     .await
-                    .map_err(|e| {
-                        (
-                            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                            format!("Failed to check agency: {}", e),
-                        )
-                    })?;
+                    .map_err(|e| crate::util::errors::db_error("check agency", e))?;
 
             if !agency_exists {
                 return Err((
@@ -223,12 +211,10 @@ pub async fn update_branding(
     Path(agency_id): Path<Uuid>,
     Json(data): Json<UpdateBrandingRequest>,
 ) -> Result<Json<BrandingResponse>, (axum::http::StatusCode, String)> {
-    let mut conn = state.acquire_public_conn().await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-    })?;
+    let mut conn = state
+        .acquire_public_conn()
+        .await
+        .map_err(|e| crate::util::errors::db_error("database error", e))?;
 
     // Check agency exists
     let agency_exists: bool =
@@ -236,12 +222,7 @@ pub async fn update_branding(
             .bind(agency_id)
             .fetch_one(&mut *conn)
             .await
-            .map_err(|e| {
-                (
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to check agency: {}", e),
-                )
-            })?;
+            .map_err(|e| crate::util::errors::db_error("check agency", e))?;
 
     if !agency_exists {
         return Err((
@@ -263,12 +244,7 @@ pub async fn update_branding(
     .bind(principal.user_id)
     .fetch_one(&mut *conn)
     .await
-    .map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to check membership: {}", e),
-        )
-    })?;
+    .map_err(|e| crate::util::errors::db_error("check membership", e))?;
 
     if !is_member {
         return Err((
@@ -311,12 +287,7 @@ pub async fn update_branding(
     .bind(&data.watermark_url)
     .fetch_one(&mut *conn)
     .await
-    .map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to update branding: {}", e),
-        )
-    })?;
+    .map_err(|e| crate::util::errors::db_error("update branding", e))?;
 
     let branding = AgencyBranding {
         agency_id,

--- a/backend/servers/reality-server/src/routes/agency_imports.rs
+++ b/backend/servers/reality-server/src/routes/agency_imports.rs
@@ -154,12 +154,10 @@ pub async fn list_import_history(
     principal: RequestPrincipal,
     Path(agency_id): Path<Uuid>,
 ) -> Result<Json<ImportHistoryResponse>, (axum::http::StatusCode, String)> {
-    let mut conn = state.acquire_public_conn().await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-    })?;
+    let mut conn = state
+        .acquire_public_conn()
+        .await
+        .map_err(|e| crate::util::errors::db_error("database error", e))?;
 
     check_agency_membership(&mut conn, agency_id, principal.user_id).await?;
 
@@ -179,12 +177,7 @@ pub async fn list_import_history(
     .bind(agency_id)
     .fetch_all(&mut *conn)
     .await
-    .map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to list import history: {}", e),
-        )
-    })?;
+    .map_err(|e| crate::util::errors::db_error("list import history", e))?;
 
     let total = rows.len() as i64;
     let jobs: Vec<ImportJobSummary> = rows
@@ -228,12 +221,10 @@ pub async fn test_connection(
     Path(agency_id): Path<Uuid>,
     Json(data): Json<TestConnectionRequest>,
 ) -> Result<Json<TestConnectionResponse>, (axum::http::StatusCode, String)> {
-    let mut conn = state.acquire_public_conn().await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-    })?;
+    let mut conn = state
+        .acquire_public_conn()
+        .await
+        .map_err(|e| crate::util::errors::db_error("database error", e))?;
 
     check_agency_membership(&mut conn, agency_id, principal.user_id).await?;
 
@@ -271,12 +262,10 @@ pub async fn run_import(
     Path(agency_id): Path<Uuid>,
     Json(data): Json<RunImportRequest>,
 ) -> Result<(axum::http::StatusCode, Json<RunImportResponse>), (axum::http::StatusCode, String)> {
-    let mut conn = state.acquire_public_conn().await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-    })?;
+    let mut conn = state
+        .acquire_public_conn()
+        .await
+        .map_err(|e| crate::util::errors::db_error("database error", e))?;
 
     check_agency_membership(&mut conn, agency_id, principal.user_id).await?;
 
@@ -297,12 +286,7 @@ pub async fn run_import(
     .bind(&data.feed_url)
     .fetch_one(&mut *conn)
     .await
-    .map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to create import job: {}", e),
-        )
-    })?;
+    .map_err(|e| crate::util::errors::db_error("create import job", e))?;
 
     Ok((
         axum::http::StatusCode::ACCEPTED,
@@ -336,12 +320,10 @@ pub async fn get_import_job_status(
     principal: RequestPrincipal,
     Path((agency_id, job_id)): Path<(Uuid, Uuid)>,
 ) -> Result<Json<ImportJobDetailResponse>, (axum::http::StatusCode, String)> {
-    let mut conn = state.acquire_public_conn().await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-    })?;
+    let mut conn = state
+        .acquire_public_conn()
+        .await
+        .map_err(|e| crate::util::errors::db_error("database error", e))?;
 
     check_agency_membership(&mut conn, agency_id, principal.user_id).await?;
 
@@ -360,12 +342,7 @@ pub async fn get_import_job_status(
     .bind(agency_id)
     .fetch_optional(&mut *conn)
     .await
-    .map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to get import job: {}", e),
-        )
-    })?
+    .map_err(|e| crate::util::errors::db_error("get import job", e))?
     .ok_or_else(|| {
         (
             axum::http::StatusCode::NOT_FOUND,
@@ -405,12 +382,7 @@ async fn check_agency_membership(
             .bind(agency_id)
             .fetch_one(&mut **conn)
             .await
-            .map_err(|e| {
-                (
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to check agency: {}", e),
-                )
-            })?;
+            .map_err(|e| crate::util::errors::db_error("check agency", e))?;
 
     if !agency_exists {
         return Err((
@@ -431,12 +403,7 @@ async fn check_agency_membership(
     .bind(user_id)
     .fetch_one(&mut **conn)
     .await
-    .map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to check membership: {}", e),
-        )
-    })?;
+    .map_err(|e| crate::util::errors::db_error("check membership", e))?;
 
     if !is_member {
         return Err((

--- a/backend/servers/reality-server/src/routes/agent_reviews.rs
+++ b/backend/servers/reality-server/src/routes/agent_reviews.rs
@@ -85,12 +85,10 @@ pub async fn list_reviews(
     let limit = query.limit.unwrap_or(20).clamp(1, 100);
     let offset = query.offset.unwrap_or(0).max(0);
 
-    let mut conn = state.acquire_public_conn().await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-    })?;
+    let mut conn = state
+        .acquire_public_conn()
+        .await
+        .map_err(|e| crate::util::errors::db_error("database error", e))?;
 
     // Verify realtor exists
     let realtor_exists: bool =
@@ -98,12 +96,7 @@ pub async fn list_reviews(
             .bind(realtor_id)
             .fetch_one(&mut *conn)
             .await
-            .map_err(|e| {
-                (
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to check realtor: {}", e),
-                )
-            })?;
+            .map_err(|e| crate::util::errors::db_error("check realtor", e))?;
 
     if !realtor_exists {
         return Err((
@@ -136,36 +129,21 @@ pub async fn list_reviews(
     .bind(offset)
     .fetch_all(&mut *conn)
     .await
-    .map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to list reviews: {}", e),
-        )
-    })?;
+    .map_err(|e| crate::util::errors::db_error("list reviews", e))?;
 
     let total: i64 =
         sqlx::query_scalar("SELECT COUNT(*) FROM realtor_reviews WHERE realtor_id = $1")
             .bind(realtor_id)
             .fetch_one(&mut *conn)
             .await
-            .map_err(|e| {
-                (
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to count reviews: {}", e),
-                )
-            })?;
+            .map_err(|e| crate::util::errors::db_error("count reviews", e))?;
 
     let avg_rating: Option<f64> =
         sqlx::query_scalar("SELECT AVG(rating::float8) FROM realtor_reviews WHERE realtor_id = $1")
             .bind(realtor_id)
             .fetch_one(&mut *conn)
             .await
-            .map_err(|e| {
-                (
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to compute avg rating: {}", e),
-                )
-            })?;
+            .map_err(|e| crate::util::errors::db_error("compute avg rating", e))?;
 
     let reviews: Vec<RealtorReview> = rows
         .into_iter()
@@ -222,12 +200,10 @@ pub async fn create_review(
         ));
     }
 
-    let mut conn = state.acquire_public_conn().await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-    })?;
+    let mut conn = state
+        .acquire_public_conn()
+        .await
+        .map_err(|e| crate::util::errors::db_error("database error", e))?;
 
     // Verify realtor exists
     let realtor_exists: bool =
@@ -235,12 +211,7 @@ pub async fn create_review(
             .bind(realtor_id)
             .fetch_one(&mut *conn)
             .await
-            .map_err(|e| {
-                (
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to check realtor: {}", e),
-                )
-            })?;
+            .map_err(|e| crate::util::errors::db_error("check realtor", e))?;
 
     if !realtor_exists {
         return Err((
@@ -265,12 +236,7 @@ pub async fn create_review(
     .bind(realtor_id)
     .fetch_one(&mut *conn)
     .await
-    .map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to check verified buyer status: {}", e),
-        )
-    })?;
+    .map_err(|e| crate::util::errors::db_error("check verified buyer status", e))?;
 
     // Phase 6: reads from `users` (portal_users dropped in migration 00148).
     let reviewer_name: String =
@@ -278,12 +244,7 @@ pub async fn create_review(
             .bind(principal.user_id)
             .fetch_optional(&mut *conn)
             .await
-            .map_err(|e| {
-                (
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get reviewer name: {}", e),
-                )
-            })?
+            .map_err(|e| crate::util::errors::db_error("get reviewer name", e))?
             .flatten()
             .unwrap_or_else(|| "Anonymous".to_string());
 
@@ -305,12 +266,7 @@ pub async fn create_review(
     .bind(verified_buyer)
     .fetch_optional(&mut *conn)
     .await
-    .map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to create review: {}", e),
-        )
-    })?;
+    .map_err(|e| crate::util::errors::db_error("create review", e))?;
 
     match row {
         Some(r) => {

--- a/backend/servers/reality-server/src/routes/articles.rs
+++ b/backend/servers/reality-server/src/routes/articles.rs
@@ -136,12 +136,10 @@ pub async fn list_articles(
     let offset = (page - 1) * per_page;
     let search_pattern = query.search.as_ref().map(|s| format!("%{}%", s));
 
-    let mut conn = state.acquire_public_conn().await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-    })?;
+    let mut conn = state
+        .acquire_public_conn()
+        .await
+        .map_err(|e| crate::util::errors::db_error("database error", e))?;
 
     let rows = sqlx::query(
         r#"
@@ -172,12 +170,7 @@ pub async fn list_articles(
     .bind(offset)
     .fetch_all(&mut *conn)
     .await
-    .map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to list articles: {}", e),
-        )
-    })?;
+    .map_err(|e| crate::util::errors::db_error("list articles", e))?;
 
     let total: i64 = sqlx::query_scalar(
         r#"
@@ -191,12 +184,7 @@ pub async fn list_articles(
     .bind(&search_pattern)
     .fetch_one(&mut *conn)
     .await
-    .map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to count articles: {}", e),
-        )
-    })?;
+    .map_err(|e| crate::util::errors::db_error("count articles", e))?;
 
     let articles: Vec<ArticleSummary> = rows
         .into_iter()
@@ -238,12 +226,10 @@ pub async fn get_article(
     State(state): State<AppState>,
     Path(slug): Path<String>,
 ) -> Result<Json<ArticleDetailResponse>, (axum::http::StatusCode, String)> {
-    let mut conn = state.acquire_public_conn().await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-    })?;
+    let mut conn = state
+        .acquire_public_conn()
+        .await
+        .map_err(|e| crate::util::errors::db_error("database error", e))?;
 
     let row = sqlx::query(
         r#"
@@ -264,12 +250,7 @@ pub async fn get_article(
     .bind(&slug)
     .fetch_optional(&mut *conn)
     .await
-    .map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to get article: {}", e),
-        )
-    })?
+    .map_err(|e| crate::util::errors::db_error("get article", e))?
     .ok_or_else(|| {
         (
             axum::http::StatusCode::NOT_FOUND,
@@ -293,12 +274,7 @@ pub async fn get_article(
     .bind(&slug)
     .fetch_all(&mut *conn)
     .await
-    .map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to fetch related articles: {}", e),
-        )
-    })?;
+    .map_err(|e| crate::util::errors::db_error("fetch related articles", e))?;
 
     let related_articles: Vec<RelatedArticle> = related_rows
         .into_iter()
@@ -351,12 +327,10 @@ pub async fn list_comments(
     State(state): State<AppState>,
     Path(slug): Path<String>,
 ) -> Result<Json<CommentsResponse>, (axum::http::StatusCode, String)> {
-    let mut conn = state.acquire_public_conn().await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-    })?;
+    let mut conn = state
+        .acquire_public_conn()
+        .await
+        .map_err(|e| crate::util::errors::db_error("database error", e))?;
 
     // Resolve article ID
     let article_id: Option<Uuid> = sqlx::query_scalar(
@@ -365,12 +339,7 @@ pub async fn list_comments(
     .bind(&slug)
     .fetch_optional(&mut *conn)
     .await
-    .map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-    })?;
+    .map_err(|e| crate::util::errors::db_error("database error", e))?;
 
     let article_id = article_id.ok_or_else(|| {
         (
@@ -395,12 +364,7 @@ pub async fn list_comments(
     .bind(article_id)
     .fetch_all(&mut *conn)
     .await
-    .map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to list comments: {}", e),
-        )
-    })?;
+    .map_err(|e| crate::util::errors::db_error("list comments", e))?;
 
     let total = rows.len() as i64;
     let comments: Vec<ArticleComment> = rows
@@ -449,12 +413,10 @@ pub async fn create_comment(
         ));
     }
 
-    let mut conn = state.acquire_public_conn().await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-    })?;
+    let mut conn = state
+        .acquire_public_conn()
+        .await
+        .map_err(|e| crate::util::errors::db_error("database error", e))?;
 
     let article_id: Option<Uuid> = sqlx::query_scalar(
         "SELECT id FROM reality_articles WHERE slug = $1 AND published_at <= NOW()",
@@ -462,12 +424,7 @@ pub async fn create_comment(
     .bind(&slug)
     .fetch_optional(&mut *conn)
     .await
-    .map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-    })?;
+    .map_err(|e| crate::util::errors::db_error("database error", e))?;
 
     let article_id = article_id.ok_or_else(|| {
         (
@@ -483,12 +440,7 @@ pub async fn create_comment(
             .bind(principal.user_id)
             .fetch_optional(&mut *conn)
             .await
-            .map_err(|e| {
-                (
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get author name: {}", e),
-                )
-            })?
+            .map_err(|e| crate::util::errors::db_error("get author name", e))?
             .flatten()
             .unwrap_or_else(|| "Anonymous".to_string());
 
@@ -498,12 +450,7 @@ pub async fn create_comment(
     .bind(principal.user_id)
     .fetch_optional(&mut *conn)
     .await
-    .map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to get avatar: {}", e),
-        )
-    })?
+    .map_err(|e| crate::util::errors::db_error("get avatar", e))?
     .flatten();
 
     let row = sqlx::query(
@@ -518,12 +465,7 @@ pub async fn create_comment(
     .bind(&data.body)
     .fetch_one(&mut *conn)
     .await
-    .map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to create comment: {}", e),
-        )
-    })?;
+    .map_err(|e| crate::util::errors::db_error("create comment", e))?;
 
     let comment = ArticleComment {
         id: row.get("id"),

--- a/backend/servers/reality-server/src/routes/compare.rs
+++ b/backend/servers/reality-server/src/routes/compare.rs
@@ -75,12 +75,10 @@ pub async fn get_compare_list(
     State(state): State<AppState>,
     principal: RequestPrincipal,
 ) -> Result<Json<CompareListResponse>, (axum::http::StatusCode, String)> {
-    let mut conn = state.acquire_public_conn().await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-    })?;
+    let mut conn = state
+        .acquire_public_conn()
+        .await
+        .map_err(|e| crate::util::errors::db_error("database error", e))?;
 
     let rows = sqlx::query(
         r#"
@@ -108,12 +106,7 @@ pub async fn get_compare_list(
     .bind(principal.user_id)
     .fetch_all(&mut *conn)
     .await
-    .map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to fetch compare list: {}", e),
-        )
-    })?;
+    .map_err(|e| crate::util::errors::db_error("fetch compare list", e))?;
 
     use sqlx::Row;
     let entries: Vec<CompareEntry> = rows
@@ -159,24 +152,17 @@ pub async fn add_to_compare(
     principal: RequestPrincipal,
     Path(listing_id): Path<Uuid>,
 ) -> Result<(axum::http::StatusCode, Json<AddCompareResponse>), (axum::http::StatusCode, String)> {
-    let mut conn = state.acquire_public_conn().await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-    })?;
+    let mut conn = state
+        .acquire_public_conn()
+        .await
+        .map_err(|e| crate::util::errors::db_error("database error", e))?;
 
     // Check current count
     let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM compare_lists WHERE user_id = $1")
         .bind(principal.user_id)
         .fetch_one(&mut *conn)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to count compare entries: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("count compare entries", e))?;
 
     if count >= MAX_COMPARE_LISTINGS {
         return Err((
@@ -194,12 +180,7 @@ pub async fn add_to_compare(
             .bind(listing_id)
             .fetch_one(&mut *conn)
             .await
-            .map_err(|e| {
-                (
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to check listing: {}", e),
-                )
-            })?;
+            .map_err(|e| crate::util::errors::db_error("check listing", e))?;
 
     if !listing_exists {
         return Err((
@@ -216,12 +197,7 @@ pub async fn add_to_compare(
     .bind(listing_id)
     .fetch_one(&mut *conn)
     .await
-    .map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to check compare list: {}", e),
-        )
-    })?;
+    .map_err(|e| crate::util::errors::db_error("check compare list", e))?;
 
     if already_in {
         return Err((
@@ -235,12 +211,7 @@ pub async fn add_to_compare(
         .bind(listing_id)
         .execute(&mut *conn)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to add to compare list: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("add to compare list", e))?;
 
     Ok((
         axum::http::StatusCode::CREATED,
@@ -269,12 +240,10 @@ pub async fn remove_from_compare(
     principal: RequestPrincipal,
     Path(listing_id): Path<Uuid>,
 ) -> Result<axum::http::StatusCode, (axum::http::StatusCode, String)> {
-    let mut conn = state.acquire_public_conn().await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-    })?;
+    let mut conn = state
+        .acquire_public_conn()
+        .await
+        .map_err(|e| crate::util::errors::db_error("database error", e))?;
 
     let rows_affected =
         sqlx::query("DELETE FROM compare_lists WHERE user_id = $1 AND listing_id = $2")
@@ -282,12 +251,7 @@ pub async fn remove_from_compare(
             .bind(listing_id)
             .execute(&mut *conn)
             .await
-            .map_err(|e| {
-                (
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to remove from compare list: {}", e),
-                )
-            })?
+            .map_err(|e| crate::util::errors::db_error("remove from compare list", e))?
             .rows_affected();
 
     if rows_affected == 0 {

--- a/backend/servers/reality-server/src/routes/favorites.rs
+++ b/backend/servers/reality-server/src/routes/favorites.rs
@@ -79,12 +79,7 @@ pub async fn list_favorites(
         .reality_portal_repo
         .get_favorites_with_listings(principal.user_id)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to list favorites: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("list favorites", e))?;
 
     Ok(Json(FavoritesResponse { favorites }))
 }
@@ -126,10 +121,7 @@ pub async fn add_favorite(
                     "Maximum favorites limit reached".to_string(),
                 )
             } else {
-                (
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to add favorite: {}", e),
-                )
+                crate::util::errors::db_error("add favorite", e)
             }
         })?;
 
@@ -157,12 +149,7 @@ pub async fn remove_favorite(
         .reality_portal_repo
         .remove_favorite(principal.user_id, listing_id)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to remove favorite: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("remove favorite", e))?;
 
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
@@ -188,12 +175,7 @@ pub async fn check_favorite(
         .reality_portal_repo
         .get_favorites_with_listings(principal.user_id)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to check favorite: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("check favorite", e))?;
 
     let is_favorited = favorites.iter().any(|f| f.listing_id == listing_id);
 

--- a/backend/servers/reality-server/src/routes/inquiries.rs
+++ b/backend/servers/reality-server/src/routes/inquiries.rs
@@ -226,10 +226,7 @@ pub async fn send_contact_message(
                     "Listing not found".to_string(),
                 ))
             } else {
-                Err((
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to send message: {}", e),
-                ))
+                Err(crate::util::errors::db_error("send contact message", e))
             }
         }
     }
@@ -353,10 +350,7 @@ pub async fn request_viewing(
                     "Listing not found".to_string(),
                 ))
             } else {
-                Err((
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to send viewing request: {}", e),
-                ))
+                Err(crate::util::errors::db_error("send viewing request", e))
             }
         }
     }
@@ -382,18 +376,23 @@ pub async fn list_my_inquiries(
     let limit = query.limit.unwrap_or(20).clamp(1, 100);
     let offset = (page - 1) * limit;
 
-    let inquiries = state
-        .reality_portal_repo
-        .get_realtor_inquiries(principal.user_id, query.status, limit, offset)
-        .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to list inquiries: {}", e),
-            )
-        })?;
-
-    let total = inquiries.len() as i64;
+    // Run the page query and the matching COUNT in parallel — the count
+    // must use the same filter as the page so clients can compute
+    // `total / limit` for pagination. Returning `inquiries.len()` here
+    // (the previous behaviour) silently lied on every non-final page.
+    let status_filter = query.status.clone();
+    let (inquiries, total) = tokio::try_join!(
+        state.reality_portal_repo.get_realtor_inquiries(
+            principal.user_id,
+            query.status,
+            limit,
+            offset,
+        ),
+        state
+            .reality_portal_repo
+            .count_realtor_inquiries(principal.user_id, status_filter),
+    )
+    .map_err(|e| crate::util::errors::db_error("list inquiries", e))?;
 
     Ok(Json(InquiryListResponse {
         inquiries,
@@ -425,12 +424,7 @@ pub async fn get_inquiry(
         .reality_portal_repo
         .get_realtor_inquiries(principal.user_id, None, 100, 0)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to get inquiry: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("get inquiry", e))?;
 
     let inquiry = inquiries.into_iter().find(|i| i.id == id).ok_or_else(|| {
         (
@@ -469,12 +463,7 @@ pub async fn mark_as_read(
         .reality_portal_repo
         .mark_inquiry_read(id)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to mark as read: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("mark inquiry read", e))?;
 
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
@@ -517,12 +506,7 @@ pub async fn respond_to_inquiry(
         .reality_portal_repo
         .respond_to_inquiry(id, principal.user_id, &req.message)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to send response: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("respond to inquiry", e))?;
 
     Ok(Json(InquiryMessageResponse {
         id: message.id,

--- a/backend/servers/reality-server/src/routes/reports.rs
+++ b/backend/servers/reality-server/src/routes/reports.rs
@@ -134,12 +134,10 @@ pub async fn submit_report(
         ));
     }
 
-    let mut conn = state.acquire_public_conn().await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-    })?;
+    let mut conn = state
+        .acquire_public_conn()
+        .await
+        .map_err(|e| crate::util::errors::db_error("database error", e))?;
 
     // Check listing exists
     let listing_exists: bool =
@@ -147,12 +145,7 @@ pub async fn submit_report(
             .bind(data.listing_id)
             .fetch_one(&mut *conn)
             .await
-            .map_err(|e| {
-                (
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to check listing: {}", e),
-                )
-            })?;
+            .map_err(|e| crate::util::errors::db_error("check listing", e))?;
 
     if !listing_exists {
         return Err((
@@ -187,12 +180,7 @@ pub async fn submit_report(
     .bind(&data.reporter_phone)
     .fetch_one(&mut *conn)
     .await
-    .map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to submit report: {}", e),
-        )
-    })?;
+    .map_err(|e| crate::util::errors::db_error("submit report", e))?;
 
     use sqlx::Row;
     let attachments_stored: Option<serde_json::Value> = row.get("attachments");
@@ -240,12 +228,10 @@ pub async fn list_my_reports(
     let limit = query.limit.unwrap_or(20).clamp(1, 100);
     let offset = query.offset.unwrap_or(0).max(0);
 
-    let mut conn = state.acquire_public_conn().await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-    })?;
+    let mut conn = state
+        .acquire_public_conn()
+        .await
+        .map_err(|e| crate::util::errors::db_error("database error", e))?;
 
     let rows = sqlx::query(
         r#"
@@ -265,12 +251,7 @@ pub async fn list_my_reports(
     .bind(&query.status)
     .fetch_all(&mut *conn)
     .await
-    .map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to list reports: {}", e),
-        )
-    })?;
+    .map_err(|e| crate::util::errors::db_error("list reports", e))?;
 
     use sqlx::Row;
     let reports: Vec<ListingReport> = rows

--- a/backend/servers/reality-server/src/routes/saved_searches.rs
+++ b/backend/servers/reality-server/src/routes/saved_searches.rs
@@ -58,12 +58,7 @@ pub async fn list_saved_searches(
         .reality_portal_repo
         .get_saved_searches(principal.user_id)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to list saved searches: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("list saved searches", e))?;
 
     Ok(Json(SavedSearchesResponse { searches }))
 }
@@ -97,10 +92,7 @@ pub async fn create_saved_search(
                     "Maximum saved searches limit reached".to_string(),
                 )
             } else {
-                (
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to create saved search: {}", e),
-                )
+                crate::util::errors::db_error("create saved search", e)
             }
         })?;
 
@@ -129,12 +121,7 @@ pub async fn get_saved_search(
         .reality_portal_repo
         .get_saved_searches(principal.user_id)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to get saved search: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("get saved search", e))?;
 
     let search = searches.into_iter().find(|s| s.id == id).ok_or_else(|| {
         (
@@ -177,10 +164,7 @@ pub async fn update_saved_search(
                     "Saved search not found".to_string(),
                 )
             } else {
-                (
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to update saved search: {}", e),
-                )
+                crate::util::errors::db_error("update saved search", e)
             }
         })?;
 
@@ -208,12 +192,7 @@ pub async fn delete_saved_search(
         .reality_portal_repo
         .delete_saved_search(id, principal.user_id)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to delete saved search: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("delete saved search", e))?;
 
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
@@ -240,12 +219,7 @@ pub async fn run_saved_search(
         .reality_portal_repo
         .get_saved_searches(principal.user_id)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to get saved search: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("get saved search", e))?;
 
     let search = searches.into_iter().find(|s| s.id == id).ok_or_else(|| {
         (
@@ -256,27 +230,21 @@ pub async fn run_saved_search(
 
     // Parse the stored criteria JSON to a search query
     let query: db::models::PublicListingQuery = serde_json::from_value(search.criteria.clone())
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to parse saved search criteria: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("parse saved search criteria", e))?;
 
-    // Execute the search using the portal repository
-    let results = state
-        .portal_repo
-        .search_listings(&query)
-        .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to run saved search: {}", e),
-            )
-        })?;
+    // Execute the search using the portal repository. `count` must reflect
+    // the total matching rows across all pages, not just the size of the
+    // page we're returning — otherwise the client cannot tell whether
+    // more pages exist. Run page + count concurrently against the same
+    // query criteria.
+    let (results, count) = tokio::try_join!(
+        state.portal_repo.search_listings(&query),
+        state.portal_repo.count_listings(&query),
+    )
+    .map_err(|e| crate::util::errors::db_error("run saved search", e))?;
 
     Ok(Json(RunSavedSearchResponse {
-        count: results.len() as i64,
+        count,
         listings: results,
     }))
 }

--- a/backend/servers/reality-server/src/util/errors.rs
+++ b/backend/servers/reality-server/src/util/errors.rs
@@ -1,0 +1,32 @@
+//! Public-surface error helpers.
+//!
+//! Reality-server is internet-facing. Raw `sqlx::Error` / `anyhow::Error`
+//! strings can leak column names, constraint names, sometimes pool / TLS
+//! state — none of which a portal client should ever see. Use [`db_error`]
+//! at the `map_err` boundary of every DB call: it writes the full error to
+//! the tracing log (where ops can still find it) and returns a generic
+//! `500 Internal server error` to the caller.
+//!
+//! Pattern mirrors the inline `db_error` helper in
+//! `routes::listings::get_listing` — this module hoists it so every route
+//! file gets the same treatment without copy-pasting.
+
+use axum::http::StatusCode;
+
+/// Log a database / infrastructure error server-side and return a generic
+/// `(500, "Internal server error")` tuple suitable for `?` on Axum handlers
+/// that return `Result<_, (StatusCode, String)>`.
+///
+/// `ctx` is a short human description of the operation that failed
+/// (e.g. `"list inquiries"`, `"acquire db connection"`). It is included in
+/// the server-side log line but NOT returned to the client.
+///
+/// The `Display` bound (rather than `sqlx::Error`) keeps the helper usable
+/// for anyhow, serde_json, repository-wrapped errors, etc.
+pub fn db_error(ctx: &str, e: impl std::fmt::Display) -> (StatusCode, String) {
+    tracing::error!(context = ctx, error = %e, "[{}] {}", ctx, e);
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "Internal server error".to_string(),
+    )
+}

--- a/backend/servers/reality-server/src/util/mod.rs
+++ b/backend/servers/reality-server/src/util/mod.rs
@@ -1,0 +1,6 @@
+//! Reality-server utility modules.
+//!
+//! Crate-internal helpers shared across route handlers. Keep this module
+//! lean — anything reusable across servers belongs in `api-core` or `common`.
+
+pub mod errors;


### PR DESCRIPTION
## Summary

Two MED-severity findings from the round-9 reality-server audit. Combined into one PR because both are repo-wide hygiene.

### M2 — Pagination totals
Two handlers were returning `total = page.len()` — lying to clients about how many items exist.

| File | Handler | Fix |
|---|---|---|
| `routes/inquiries.rs::list_my_inquiries` | runs page query + new `count_realtor_inquiries` repo method in parallel via `tokio::try_join!` |
| `routes/saved_searches.rs::run_saved_search` | uses existing `PortalRepository::count_listings` alongside `search_listings` |

No response-shape changes (`total`/`count` fields existed and were already in the type — they just lied).

Triaged but **not** changed:
- `articles.rs::list_articles` — already counts via separate `SELECT COUNT(*)`
- `articles.rs::list_comments` — owned by PR #317 (paginated comments)
- `agencies.rs::list_members` — repo has no LIMIT, `len()` is correct
- `compare.rs` — capped at 4

### M3 — DB error leak suppression
`format!(\"...: {}\", e)` patterns in many handlers exposed DB column names, constraint names, and sometimes pool state to public clients. Bad on a public-facing server.

New helper: `backend/servers/reality-server/src/util/errors.rs::db_error(ctx, e)` — logs `tracing::error!` server-side with context; returns generic `500 \"Internal server error\"` to client.

**69 sites updated** across 10 route files: `favorites.rs`, `inquiries.rs`, `reports.rs`, `agencies.rs`, `articles.rs`, `agent_reviews.rs`, `agency_branding.rs`, `agency_imports.rs`, `saved_searches.rs`, `compare.rs`.

Each call preserved its original context string (e.g. `\"list favorites\"`, `\"create review\"`) — that text goes to the log, not the HTTP body.

Verified `grep` against the 10 files returns zero leaky-format sites post-sweep. Remaining `format!(\"...: {}\", e)` sites in `listings.rs`, `realtors.rs`, `imports.rs`, `price_map.rs`, `health.rs` are out of scope for this batch.

## Verification

`cargo fmt -p reality-server` clean. `cargo check -p reality-server` blocked locally (no clang). CI is authoritative.

## Test plan

- [ ] Backend CI green
- [ ] Smoke: `GET /api/v1/inquiries` with more than one page of inquiries — confirm `total` is the real count, not the page length
- [ ] Smoke: hit any error path on a previously-leaky handler — confirm response is generic `Internal server error` and the DB detail is in the server log