### PR TITLE
fix(security): scrub email/PII from auth logs + sanitize SSO error response

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "admin-core"
-version = "0.2.400"
+version = "0.2.402"
 dependencies = [
  "api-core",
  "async-trait",
@@ -192,7 +192,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-core"
-version = "0.2.400"
+version = "0.2.402"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "api-server"
-version = "0.2.400"
+version = "0.2.402"
 dependencies = [
  "admin-core",
  "aes-gcm",
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.2.400"
+version = "0.2.402"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -1651,6 +1651,7 @@ dependencies = [
  "intl-memoizer",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "thiserror 1.0.69",
  "unic-langid",
  "utoipa",
@@ -2047,7 +2048,7 @@ dependencies = [
 
 [[package]]
 name = "db"
-version = "0.2.400"
+version = "0.2.402"
 dependencies = [
  "argon2",
  "async-trait",
@@ -2100,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "deploy-server"
-version = "0.2.400"
+version = "0.2.402"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3563,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "integrations"
-version = "0.2.400"
+version = "0.2.402"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -5367,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "reality-server"
-version = "0.2.400"
+version = "0.2.402"
 dependencies = [
  "anyhow",
  "api-core",
@@ -6900,7 +6901,7 @@ dependencies = [
 
 [[package]]
 name = "tenant-ops"
-version = "0.2.400"
+version = "0.2.402"
 dependencies = [
  "chrono",
  "common",

--- a/backend/crates/common/Cargo.toml
+++ b/backend/crates/common/Cargo.toml
@@ -17,3 +17,4 @@ validator = { workspace = true }
 fluent-bundle = { workspace = true }
 unic-langid = { workspace = true }
 intl-memoizer = { workspace = true }
+sha2 = { workspace = true }

--- a/backend/crates/common/src/lib.rs
+++ b/backend/crates/common/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod errors;
 pub mod i18n;
+pub mod log_hash;
 pub mod notifications;
 pub mod sitemap;
 pub mod tenant;
@@ -9,6 +10,7 @@ pub mod types;
 
 pub use errors::*;
 pub use i18n::{I18nResolver, Locale, MessageKey};
+pub use log_hash::{email_log_hash, EMAIL_LOG_HASH_LEN};
 pub use notifications::*;
 pub use sitemap::Sitemap;
 pub use tenant::*;

--- a/backend/crates/common/src/log_hash.rs
+++ b/backend/crates/common/src/log_hash.rs
@@ -1,0 +1,67 @@
+//! Logging helpers for personally-identifiable information (PII).
+//!
+//! Auth flows historically logged the raw `email` field to make grep-based
+//! debugging easier. That builds an enumeration log of every account that
+//! has ever been probed, which leaks PII into dev/staging/prod log sinks
+//! (the H2 / H3 findings of the logging-hygiene sweep).
+//!
+//! [`email_log_hash`] returns a short, stable hex prefix of the SHA-256
+//! digest of the normalised (trim + lowercase) email. The prefix preserves
+//! "this is the same email I saw a minute ago" correlation for debugging
+//! without exposing the address itself.
+
+use sha2::{Digest, Sha256};
+
+/// Number of hex characters returned by [`email_log_hash`].
+///
+/// 12 hex chars = 48 bits of entropy — plenty to disambiguate a small
+/// number of concurrent users in a log window, far too few to brute-force
+/// back to an address out of the global email space.
+pub const EMAIL_LOG_HASH_LEN: usize = 12;
+
+/// Return a 12-char hex prefix of `SHA-256(lower(trim(email)))`.
+///
+/// Intended for use as a `tracing` field value:
+///
+/// ```ignore
+/// tracing::debug!(email_hash = %common::email_log_hash(&req.email), "Login failed");
+/// ```
+///
+/// Never embed the raw email alongside the hash — that defeats the point.
+pub fn email_log_hash(email: &str) -> String {
+    let normalised = email.trim().to_lowercase();
+    let digest = Sha256::digest(normalised.as_bytes());
+    let mut hex = String::with_capacity(EMAIL_LOG_HASH_LEN);
+    for byte in digest.iter().take(EMAIL_LOG_HASH_LEN.div_ceil(2)) {
+        use std::fmt::Write;
+        let _ = write!(hex, "{:02x}", byte);
+    }
+    hex.truncate(EMAIL_LOG_HASH_LEN);
+    hex
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn length_is_exactly_12() {
+        assert_eq!(email_log_hash("user@example.com").len(), EMAIL_LOG_HASH_LEN);
+    }
+
+    #[test]
+    fn normalisation_collapses_case_and_whitespace() {
+        let a = email_log_hash("User@Example.com");
+        let b = email_log_hash("  user@example.com  ");
+        let c = email_log_hash("user@example.com");
+        assert_eq!(a, b);
+        assert_eq!(b, c);
+    }
+
+    #[test]
+    fn distinct_emails_have_distinct_hashes() {
+        let a = email_log_hash("alice@example.com");
+        let b = email_log_hash("bob@example.com");
+        assert_ne!(a, b);
+    }
+}

--- a/backend/servers/api-server/src/routes/auth.rs
+++ b/backend/servers/api-server/src/routes/auth.rs
@@ -170,7 +170,11 @@ pub async fn register(
     let user = match state.user_repo.create(create_user).await {
         Ok(user) => user,
         Err(e) => {
-            tracing::error!(error = %e, email = %req.email, "Failed to create user");
+            tracing::error!(
+                error = %e,
+                email_hash = %common::email_log_hash(&req.email),
+                "Failed to create user"
+            );
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new(
@@ -207,7 +211,6 @@ pub async fn register(
 
     tracing::info!(
         user_id = %user.id,
-        email = %user.email,
         "User registered successfully"
     );
 
@@ -307,7 +310,7 @@ pub async fn verify_email(
         .await
     {
         Ok(Some(user)) => {
-            tracing::info!(user_id = %user.id, email = %user.email, "Email verified");
+            tracing::info!(user_id = %user.id, "Email verified");
             Ok(Json(VerifyEmailResponse {
                 message: "Your email has been verified. You can now log in.".to_string(),
             }))
@@ -402,7 +405,10 @@ pub async fn resend_verification(
         }
         _ => {
             // User not found or already verified - don't reveal this
-            tracing::debug!(email = %req.email, "Resend verification request for non-pending account");
+            tracing::debug!(
+                email_hash = %common::email_log_hash(&req.email),
+                "Resend verification request for non-pending account"
+            );
         }
     }
 
@@ -471,7 +477,7 @@ pub async fn login(
         Ok(status) if !status.can_attempt() => {
             let remaining = status.lockout_remaining_secs.unwrap_or(900);
             tracing::warn!(
-                email = %req.email,
+                email_hash = %common::email_log_hash(&req.email),
                 ip = %ip_address,
                 remaining_secs = remaining,
                 "Login attempt blocked due to rate limiting"
@@ -503,7 +509,10 @@ pub async fn login(
                 .session_repo
                 .record_login_attempt(&req.email, &ip_address, false)
                 .await;
-            tracing::debug!(email = %req.email, "Login failed: user not found");
+            tracing::debug!(
+                email_hash = %common::email_log_hash(&req.email),
+                "Login failed: user not found"
+            );
             return Err((
                 StatusCode::UNAUTHORIZED,
                 Json(ErrorResponse::new(
@@ -574,7 +583,10 @@ pub async fn login(
             .session_repo
             .record_login_attempt(&req.email, &ip_address, false)
             .await;
-        tracing::debug!(email = %req.email, "Login failed: invalid password");
+        tracing::debug!(
+            user_id = %user.id,
+            "Login failed: invalid password"
+        );
         return Err((
             StatusCode::UNAUTHORIZED,
             Json(ErrorResponse::new(
@@ -802,7 +814,6 @@ pub async fn login(
 
     tracing::info!(
         user_id = %user.id,
-        email = %user.email,
         "User logged in successfully"
     );
 
@@ -1156,14 +1167,17 @@ pub async fn forgot_password(
         Ok(Some(user)) => {
             // User exists but not active (pending/suspended/deleted)
             tracing::debug!(
-                email = %req.email,
+                user_id = %user.id,
                 status = %user.status,
                 "Password reset requested for non-active account"
             );
         }
         Ok(None) => {
             // User not found - don't reveal this
-            tracing::debug!(email = %req.email, "Password reset requested for unknown email");
+            tracing::debug!(
+                email_hash = %common::email_log_hash(&req.email),
+                "Password reset requested for unknown email"
+            );
         }
         Err(e) => {
             tracing::error!(error = %e, "Database error finding user for password reset");

--- a/backend/servers/reality-server/src/handlers/users/mod.rs
+++ b/backend/servers/reality-server/src/handlers/users/mod.rs
@@ -303,23 +303,42 @@ impl UserHandler {
                             SsoResult::Created(p)
                         }
                     }
-                    Ok(None) => SsoResult::ProviderError(
-                        "upsert succeeded but users row not immediately visible".to_string(),
-                    ),
-                    Err(e) => SsoResult::ProviderError(e.to_string()),
+                    Ok(None) => {
+                        tracing::error!(
+                            user_id = %user.id,
+                            "SSO upsert succeeded but users row not immediately visible"
+                        );
+                        SsoResult::ProviderError("internal".to_string())
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            error = %e,
+                            user_id = %user.id,
+                            "SSO upsert: failed to re-read users row after upsert"
+                        );
+                        SsoResult::ProviderError("internal".to_string())
+                    }
                 }
             }
             Err(UnifiedPortalError::Collision { existing_user_id }) => {
+                // SECURITY (H1): the upstream IdP/SSO client receives only a
+                // sanitised error code. The collision details (email, target
+                // user_id) stay in the server-side log.
                 tracing::warn!(
-                    email = %email,
+                    email_hash = %common::email_log_hash(email),
                     existing_user_id = %existing_user_id,
                     "SSO upsert refused: email belongs to a non-public principal (collision queued)"
                 );
-                SsoResult::ProviderError(format!(
-                    "email collides with existing non-public principal (collision queued for review): {existing_user_id}"
-                ))
+                SsoResult::ProviderError("collision".to_string())
             }
-            Err(UnifiedPortalError::Db(e)) => SsoResult::ProviderError(e.to_string()),
+            Err(UnifiedPortalError::Db(e)) => {
+                tracing::error!(
+                    error = %e,
+                    email_hash = %common::email_log_hash(email),
+                    "SSO upsert failed with database error"
+                );
+                SsoResult::ProviderError("internal".to_string())
+            }
         }
     }
 

--- a/backend/servers/reality-server/src/routes/users.rs
+++ b/backend/servers/reality-server/src/routes/users.rs
@@ -131,7 +131,7 @@ pub async fn register(
 
     match handler.register(&req.email, &req.password, &req.name).await {
         RegistrationResult::Success(user) => {
-            tracing::info!(user_id = %user.id, email = %user.email, "User registered");
+            tracing::info!(user_id = %user.id, "User registered");
             Ok((
                 axum::http::StatusCode::CREATED,
                 Json(RegisterResponse {
@@ -213,7 +213,11 @@ pub async fn login(
             }))
         }
         Err(message) => {
-            tracing::debug!(email = %req.email, "Login failed: {}", message);
+            tracing::debug!(
+                email_hash = %common::email_log_hash(&req.email),
+                "Login failed: {}",
+                message
+            );
             Err((axum::http::StatusCode::UNAUTHORIZED, message.to_string()))
         }
     }
@@ -422,18 +426,24 @@ pub async fn request_password_reset(
             // builds should not log this.
             #[cfg(debug_assertions)]
             tracing::info!(
-                email = %req.email,
+                email_hash = %common::email_log_hash(&req.email),
                 token = %plaintext_token,
                 "Password reset token issued (dev: token logged for testing)"
             );
             #[cfg(not(debug_assertions))]
             {
                 let _ = plaintext_token;
-                tracing::info!(email = %req.email, "Password reset token issued");
+                tracing::info!(
+                    email_hash = %common::email_log_hash(&req.email),
+                    "Password reset token issued"
+                );
             }
         }
         Ok(PasswordResetRequestResult::UserNotFound) => {
-            tracing::debug!(email = %req.email, "Password reset requested for unknown email");
+            tracing::debug!(
+                email_hash = %common::email_log_hash(&req.email),
+                "Password reset requested for unknown email"
+            );
         }
         Err(e) => {
             tracing::error!(error = %e, "Failed to issue password reset token");


### PR DESCRIPTION
## Summary

Fixes 3 HIGH-severity logging hygiene findings from the round-12 sweep. (H4 was a false alarm — JWT_SECRET fallback is already correctly gated by `RUST_ENV=development`.)

### H1 — SSO error sanitisation
`backend/servers/reality-server/src/handlers/users/mod.rs`

Previously returned raw `ProviderError(e.to_string())` and `ProviderError(format!(\"email collides ... {existing_user_id}\"))` to the upstream IdP/SSO client — information disclosure.

Fix: returns sanitised error codes:
- `\"collision\"` — email belongs to a non-public principal
- `\"internal\"` — DB error or post-upsert read failure

Full details (`error`, `existing_user_id`, `email_hash`) stay server-side via `tracing::warn!` / `tracing::error!`.

### H2 / H3 — Email log scrubbing (GDPR Art. 4)
Auth handlers were emitting `debug!(email = %data.email, \"Login failed: ...\")` and `info!(email = %user.email)` on registration / failed-login / forgot-password / resend / password-reset. In dev/staging with `RUST_LOG=debug`, this builds an enumeration log of every account probed. In prod, info-level email logs leak directly.

Fix:
- New helper `common::email_log_hash(email) -> String` at `backend/crates/common/src/log_hash.rs` — 12-char hex prefix of SHA-256 over the normalised (trim + lowercase) email. Three unit tests cover length, normalisation, and distinctness.
- Pattern: replace `email = %x.email` with `user_id = %x.id` once user is resolved; otherwise `email_hash = %common::email_log_hash(&req.email)`; or drop the field entirely.

**15 sites scrubbed:**
- `api-server/src/routes/auth.rs` — 10 sites
- `reality-server/src/routes/users.rs` — 5 sites
- `reality-server/src/handlers/users/mod.rs` — collision/DB warn paths (covered by H1 fix)

### Out of scope — duplicate auth surface

`api-server/src/handlers/auth/mod.rs` is **dead code** — declared as `pub mod auth` in `handlers/mod.rs` but never wired to any router. The live auth surface is `routes/auth.rs` (wired in `lib.rs:135`). The `handlers/auth/mod.rs` sites with `email = %` log lines were left alone; the whole file should be deleted in a separate refactor.

## Verification

`cargo fmt -p api-server -p reality-server -p common` clean. `cargo check` blocked locally (sandbox missing clang). CI is authoritative.

## Test plan

- [ ] Backend CI green
- [ ] Trigger a failed login with `RUST_LOG=debug`; verify log shows `email_hash` (12 hex chars) not the raw email
- [ ] Confirm log volume / shape acceptable for ops