### PR TITLE
fix(reality): replace list-then-filter with direct id+owner queries

### DIFF
--- a/backend/crates/db/src/repositories/reality_portal.rs
+++ b/backend/crates/db/src/repositories/reality_portal.rs
@@ -141,6 +141,22 @@ impl RealityPortalRepository {
         .await
     }
 
+    /// Check whether a user has a given listing in their favorites.
+    ///
+    /// Single-row existence query — avoids fetching the entire favorites
+    /// collection just to test membership (functional bug at large N where
+    /// list endpoints cap results).
+    pub async fn is_favorite(&self, user_id: Uuid, listing_id: Uuid) -> Result<bool, SqlxError> {
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM portal_favorites WHERE user_id = $1 AND listing_id = $2)",
+        )
+        .bind(user_id)
+        .bind(listing_id)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(exists)
+    }
+
     /// Remove listing from favorites.
     pub async fn remove_favorite(
         &self,
@@ -222,6 +238,25 @@ impl RealityPortalRepository {
         )
         .bind(user_id)
         .fetch_all(&self.pool)
+        .await
+    }
+
+    /// Get a single saved search by id, scoped to the owning user.
+    ///
+    /// Single-row query — replaces the previous list-then-filter pattern in
+    /// the handlers, which silently 404'd whenever a search wasn't in the
+    /// first page of `get_saved_searches`.
+    pub async fn get_saved_search_for_user(
+        &self,
+        id: Uuid,
+        user_id: Uuid,
+    ) -> Result<Option<PortalSavedSearch>, SqlxError> {
+        sqlx::query_as::<_, PortalSavedSearch>(
+            "SELECT * FROM portal_saved_searches WHERE id = $1 AND user_id = $2",
+        )
+        .bind(id)
+        .bind(user_id)
+        .fetch_optional(&self.pool)
         .await
     }
 
@@ -706,6 +741,25 @@ impl RealityPortalRepository {
         .bind(realtor_id)
         .bind(&status)
         .fetch_one(&self.pool)
+        .await
+    }
+
+    /// Get a single inquiry by id, scoped to the owning realtor.
+    ///
+    /// Single-row query — replaces the previous list-then-filter pattern in
+    /// the handler, which silently 404'd any inquiry beyond the first 100
+    /// for power users.
+    pub async fn get_inquiry_for_realtor(
+        &self,
+        inquiry_id: Uuid,
+        realtor_id: Uuid,
+    ) -> Result<Option<ListingInquiry>, SqlxError> {
+        sqlx::query_as::<_, ListingInquiry>(
+            "SELECT * FROM listing_inquiries WHERE id = $1 AND realtor_id = $2",
+        )
+        .bind(inquiry_id)
+        .bind(realtor_id)
+        .fetch_optional(&self.pool)
         .await
     }
 

--- a/backend/servers/reality-server/src/routes/favorites.rs
+++ b/backend/servers/reality-server/src/routes/favorites.rs
@@ -170,14 +170,13 @@ pub async fn check_favorite(
     principal: RequestPrincipal,
     Path(listing_id): Path<Uuid>,
 ) -> Result<Json<CheckFavoriteResponse>, (axum::http::StatusCode, String)> {
-    // Check if the user has this listing in favorites by getting favorites and checking
-    let favorites = state
+    // Single-row existence query (was previously a full list-then-filter which
+    // silently lost favorites past the implicit fetch cap for power users).
+    let is_favorited = state
         .reality_portal_repo
-        .get_favorites_with_listings(principal.user_id)
+        .is_favorite(principal.user_id, listing_id)
         .await
         .map_err(|e| crate::util::errors::db_error("check favorite", e))?;
-
-    let is_favorited = favorites.iter().any(|f| f.listing_id == listing_id);
 
     Ok(Json(CheckFavoriteResponse { is_favorited }))
 }

--- a/backend/servers/reality-server/src/routes/inquiries.rs
+++ b/backend/servers/reality-server/src/routes/inquiries.rs
@@ -419,19 +419,20 @@ pub async fn get_inquiry(
     principal: RequestPrincipal,
     Path(id): Path<Uuid>,
 ) -> Result<Json<InquiryDetailResponse>, (axum::http::StatusCode, String)> {
-    // Get inquiries for this user and find the one with matching ID
-    let inquiries = state
+    // Single-row lookup scoped to the calling realtor. The previous code
+    // fetched the first 100 inquiries and linear-scanned in Rust, which
+    // silently 404'd for any inquiry beyond the first page for power users.
+    let inquiry = state
         .reality_portal_repo
-        .get_realtor_inquiries(principal.user_id, None, 100, 0)
+        .get_inquiry_for_realtor(id, principal.user_id)
         .await
-        .map_err(|e| crate::util::errors::db_error("get inquiry", e))?;
-
-    let inquiry = inquiries.into_iter().find(|i| i.id == id).ok_or_else(|| {
-        (
-            axum::http::StatusCode::NOT_FOUND,
-            "Inquiry not found".to_string(),
-        )
-    })?;
+        .map_err(|e| crate::util::errors::db_error("get inquiry", e))?
+        .ok_or_else(|| {
+            (
+                axum::http::StatusCode::NOT_FOUND,
+                "Inquiry not found".to_string(),
+            )
+        })?;
 
     // Mark as read if not already
     let _ = state.reality_portal_repo.mark_inquiry_read(id).await;

--- a/backend/servers/reality-server/src/routes/saved_searches.rs
+++ b/backend/servers/reality-server/src/routes/saved_searches.rs
@@ -116,19 +116,20 @@ pub async fn get_saved_search(
     principal: RequestPrincipal,
     Path(id): Path<Uuid>,
 ) -> Result<Json<PortalSavedSearch>, (axum::http::StatusCode, String)> {
-    // Get all saved searches for user and filter by id (since repository doesn't have get_by_id)
-    let searches = state
+    // Single-row lookup scoped to the owning user. The previous code fetched
+    // the entire saved-search collection and linear-scanned, which is both
+    // wasteful and breaks at scale (functional bug for power users).
+    let search = state
         .reality_portal_repo
-        .get_saved_searches(principal.user_id)
+        .get_saved_search_for_user(id, principal.user_id)
         .await
-        .map_err(|e| crate::util::errors::db_error("get saved search", e))?;
-
-    let search = searches.into_iter().find(|s| s.id == id).ok_or_else(|| {
-        (
-            axum::http::StatusCode::NOT_FOUND,
-            "Saved search not found".to_string(),
-        )
-    })?;
+        .map_err(|e| crate::util::errors::db_error("get saved search", e))?
+        .ok_or_else(|| {
+            (
+                axum::http::StatusCode::NOT_FOUND,
+                "Saved search not found".to_string(),
+            )
+        })?;
 
     Ok(Json(search))
 }
@@ -214,19 +215,18 @@ pub async fn run_saved_search(
     principal: RequestPrincipal,
     Path(id): Path<Uuid>,
 ) -> Result<Json<RunSavedSearchResponse>, (axum::http::StatusCode, String)> {
-    // First get the saved search to verify ownership and get criteria
-    let searches = state
+    // Single-row lookup scoped to the owning user (same fix as get_saved_search).
+    let search = state
         .reality_portal_repo
-        .get_saved_searches(principal.user_id)
+        .get_saved_search_for_user(id, principal.user_id)
         .await
-        .map_err(|e| crate::util::errors::db_error("get saved search", e))?;
-
-    let search = searches.into_iter().find(|s| s.id == id).ok_or_else(|| {
-        (
-            axum::http::StatusCode::NOT_FOUND,
-            "Saved search not found".to_string(),
-        )
-    })?;
+        .map_err(|e| crate::util::errors::db_error("get saved search", e))?
+        .ok_or_else(|| {
+            (
+                axum::http::StatusCode::NOT_FOUND,
+                "Saved search not found".to_string(),
+            )
+        })?;
 
     // Parse the stored criteria JSON to a search query
     let query: db::models::PublicListingQuery = serde_json::from_value(search.criteria.clone())


### PR DESCRIPTION
## Summary

Fixes M4 from the round-9 reality-server audit — a **functional bug** that silently 404s for power users.

Several "get one" endpoints fetched the user's entire collection (capped at 100 by the underlying list method) and then linear-scanned in Rust for the requested item. For inquiries, **any inquiry beyond the first 100 page silently 404s** for any realtor with >100 inquiries — not just a perf issue.

## Files touched

- `backend/crates/db/src/repositories/reality_portal.rs` — 3 new repo methods
- `backend/servers/reality-server/src/routes/favorites.rs` — `check_favorite` handler
- `backend/servers/reality-server/src/routes/inquiries.rs` — `get_inquiry` handler
- `backend/servers/reality-server/src/routes/saved_searches.rs` — `get_saved_search` + `run_saved_search` handlers

## Repo methods added (naming matched to existing `delete_saved_search` / `remove_favorite` conventions)

- `RealityPortalRepository::is_favorite(user_id, listing_id) -> Result<bool>` — `SELECT EXISTS(...)`
- `RealityPortalRepository::get_saved_search_for_user(id, user_id) -> Result<Option<PortalSavedSearch>>`
- `RealityPortalRepository::get_inquiry_for_realtor(inquiry_id, realtor_id) -> Result<Option<ListingInquiry>>`

Inquiry method is scoped to `realtor_id` because the handler authenticates as the realtor — same as the precedent in `get_realtor_inquiries(principal.user_id, ...)` called from `list_my_inquiries`.

## Verification

- `cargo fmt -p reality-server -p db` clean
- `cargo check -p db` **passes** (where the new code lives)
- `cargo check -p reality-server` blocked locally (sandbox missing clang/lld/openssl). Handler diffs are mechanical (replace `iter().find` with `.ok_or_else` on `Option`); call-site type-correctness guaranteed by the db crate compiling cleanly. CI authoritative.

## Test plan

- [ ] Backend CI green
- [ ] Smoke: realtor account with >100 inquiries — `GET /inquiries/<id_at_page_2>` no longer 404s
- [ ] Smoke: `GET /favorites/check?listing_id=<X>` returns boolean directly without round-tripping the full list