### PR TITLE
fix: scheduler schema drift + reality get_listing functional bug (perf-sweep HIGH)

### DIFF
--- a/backend/servers/api-server/src/services/scheduler.rs
+++ b/backend/servers/api-server/src/services/scheduler.rs
@@ -268,9 +268,20 @@ impl Scheduler {
 
         match announcement.target_type.as_str() {
             "all" => {
-                // Get all users in the organization
+                // Get all users in the organization. `users` has no
+                // `organization_id` column — membership lives in
+                // `user_memberships` (migration 00128, the canonical authz
+                // spine). Join through it and filter to active grants.
                 let users: Vec<(uuid::Uuid,)> = sqlx::query_as(
-                    "SELECT id FROM users WHERE organization_id = $1 AND status = 'active'",
+                    r#"
+                    SELECT DISTINCT u.id
+                    FROM users u
+                    JOIN user_memberships m ON m.user_id = u.id
+                    WHERE m.organization_id = $1
+                      AND m.revoked_at IS NULL
+                      AND (m.expires_at IS NULL OR m.expires_at > NOW())
+                      AND u.status = 'active'
+                    "#,
                 )
                 .bind(announcement.organization_id)
                 .fetch_all(&self.pool)

--- a/backend/servers/reality-server/src/handlers/listings/mod.rs
+++ b/backend/servers/reality-server/src/handlers/listings/mod.rs
@@ -72,34 +72,16 @@ impl ListingHandler {
 
     /// Get listing by ID with full details.
     pub async fn get_listing(&self, id: Uuid) -> Result<Option<PublicListingDetail>, String> {
-        // For now, we'll construct the detail from a search result
-        // In a real implementation, this would have a dedicated repository method
-        let query = PublicListingQuery {
-            q: None,
-            property_type: None,
-            transaction_type: None,
-            price_min: None,
-            price_max: None,
-            area_min: None,
-            area_max: None,
-            rooms_min: None,
-            rooms_max: None,
-            city: None,
-            country: None,
-            page: Some(1),
-            limit: Some(1),
-            sort: None,
-        };
-
-        // Search for this specific listing
-        let listings = self
+        // Direct lookup by id. The previous implementation called
+        // `search_listings(limit=1)` and then `.find(|l| l.id == id)`, which
+        // returns the first active listing regardless of id (and `.find`
+        // would then yield `None` whenever that arbitrary first row didn't
+        // match) — a functional bug, not just a perf issue.
+        let summary = self
             .repo
-            .search_listings(&query)
+            .get_listing_by_id(id)
             .await
             .map_err(|e| format!("Failed to fetch listing: {}", e))?;
-
-        // Find the specific listing
-        let summary = listings.into_iter().find(|l| l.id == id);
 
         match summary {
             Some(s) => Ok(Some(PublicListingDetail {


### PR DESCRIPTION
## Summary

Two HIGH-severity bugs found by the round-13 performance sweep.

### Bug 1 — Scheduler queries nonexistent `users.organization_id`
`backend/servers/api-server/src/services/scheduler.rs:270-291`

The "all-targets" announcement path queried:
```sql
SELECT id FROM users WHERE organization_id = $1 AND status = 'active'
```

**`users.organization_id` doesn't exist.** Membership lives in `user_memberships` (mig 00128) or `organization_members` (mig 00005). Result: every "all"-targeted announcement either errored silently or returned 0 rows.

Fix: rewrite to JOIN through `user_memberships` with `revoked_at`/`expires_at` filtering. The "roles" branch in the same function already correctly uses `organization_members` — followed the same pattern.

### Bug 2 — Reality `get_listing` returns wrong row
`backend/servers/reality-server/src/handlers/listings/mod.rs:73-90`

Previously:
```rust
repo.search_listings(query{limit:1}).find(|l| l.id == id)
```

With `limit=1`, this fetches the first active listing in the DB and returns `None` unless it happens to match the requested id. **Functional bug masking as a perf issue** — most `get_listing` calls 404 silently.

Fix: use the existing `repo.get_listing_by_id(id)` (`backend/crates/db/src/repositories/portal.rs:386`) directly.

## Out of scope (flagged for follow-up)

Peer call sites of the same `u.organization_id` JOIN drift, not addressed in this PR (separate handler family):
- `backend/crates/db/src/repositories/announcement.rs:955-957` — `get_acknowledgment_stats_rls`
- `backend/crates/db/src/repositories/announcement.rs:996-997` — `get_acknowledgment_list_rls`

These do `JOIN announcements a ON a.organization_id = u.organization_id` (aliased form). Same fix shape — JOIN through `user_memberships` — but needs the same rewrite pattern.

## Verification

`cargo fmt -p api-server -p reality-server` clean. `cargo check` blocked locally (sandbox missing clang/lld). CI authoritative. Both edits use signatures already exercised elsewhere in their crates.

## Test plan

- [ ] Backend CI green
- [ ] Smoke: create an announcement with `target = all` and confirm it reaches all members of the org (was reaching zero before)
- [ ] Smoke: `GET /api/v1/listings/<known-id>` returns that listing (was returning the first active listing in DB before)