### PR TITLE
test(admin-web): integration tests for audit log + active impersonations pages

### DIFF
--- a/frontend/apps/admin-web/src/pages/ImpersonationListPage.test.tsx
+++ b/frontend/apps/admin-web/src/pages/ImpersonationListPage.test.tsx
@@ -1,0 +1,275 @@
+/**
+ * ImpersonationListPage — integration tests for the active-session viewer.
+ *
+ * Covers the page-level contracts that, if broken, would silently fail to
+ * surface or stop active impersonation sessions (a security primitive):
+ *   - active sessions render from /admin/impersonation/active
+ *   - Stop button issues DELETE to the right endpoint
+ *   - Stop button is HIDDEN when users_impersonate capability is absent
+ *     (this is the page-level "denied" affordance)
+ *   - empty state renders
+ *   - error state renders
+ *   - timestamp formatting renders the expires_at value
+ *   - 404 from the active endpoint is treated as empty (backend may not be
+ *     implemented yet — page contract)
+ *
+ * Skipped (with reason):
+ *   - "Stop confirmation modal": the current page (260 LoC) issues the DELETE
+ *     directly on click — no destructive-confirm dialog wraps the action.
+ *     Adding a test for non-existent behavior would just lock in the gap.
+ *   - "ForbiddenPage": as with audit.tsx, this page renders no <ForbiddenPage>
+ *     itself — capability gating happens upstream in <ProtectedRoute>. The
+ *     page-internal gate hides the Stop column when the cap is missing; that
+ *     behavior IS tested here.
+ *   - "Relative time string" ("expires in X minutes"): the page uses
+ *     `Intl.DateTimeFormat({ dateStyle: 'short', timeStyle: 'short' })` —
+ *     it renders an absolute date, not a relative string. We assert the
+ *     date-render contract instead.
+ */
+
+import { CapabilityProvider } from '@ppt/admin-ui';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AdminAuthProvider } from '../auth/AdminAuthContext';
+import { sessionTokenStore } from '../auth/tokenStore';
+import { ToastProvider } from '../components/Toast';
+import ImpersonationListPage from './ImpersonationListPage';
+
+// ---------------------------------------------------------------------------
+// i18next mock — page uses defaultValue for every key
+// ---------------------------------------------------------------------------
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? key,
+    i18n: { changeLanguage: vi.fn() },
+  }),
+  initReactI18next: { type: '3rdParty', init: vi.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, retryDelay: 0 } },
+  });
+}
+
+interface RenderOptions {
+  capabilities?: string[];
+}
+
+function Providers({
+  capabilities = ['users_impersonate'],
+  children,
+}: RenderOptions & { children: ReactNode }) {
+  sessionStorage.clear();
+  sessionTokenStore.set('test-token');
+  const qc = makeQueryClient();
+  return (
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <AdminAuthProvider>
+          <CapabilityProvider
+            value={{ isPlatformPrincipal: true, capabilities: capabilities as never[] }}
+          >
+            <ToastProvider>{children}</ToastProvider>
+          </CapabilityProvider>
+        </AdminAuthProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+function renderPage(opts: RenderOptions = {}) {
+  return render(
+    <Providers {...opts}>
+      <ImpersonationListPage />
+    </Providers>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SESSION_A = {
+  token_id: 'tok-aaaa',
+  target_user_id: 'user-1',
+  target_email: 'target-a@example.com',
+  started_by: 'admin-a@example.com',
+  expires_at: '2026-05-17T11:00:00Z',
+};
+
+const SESSION_B = {
+  token_id: 'tok-bbbb',
+  target_user_id: 'user-2',
+  target_email: 'target-b@example.com',
+  started_by: 'admin-b@example.com',
+  expires_at: '2026-05-17T12:30:00Z',
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ImpersonationListPage', () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, 'fetch');
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  // ------------------------------------------------------------------
+  // 1. Renders active sessions
+  // ------------------------------------------------------------------
+  it('renders rows for each active session from the API', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ items: [SESSION_A, SESSION_B] }),
+    } as Response);
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('target-a@example.com')).toBeDefined());
+    expect(screen.getByText('target-b@example.com')).toBeDefined();
+    expect(screen.getByText('admin-a@example.com')).toBeDefined();
+    expect(screen.getByText('admin-b@example.com')).toBeDefined();
+  });
+
+  // ------------------------------------------------------------------
+  // 2. Empty state
+  // ------------------------------------------------------------------
+  it('renders an empty state when no sessions are active', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ items: [] }),
+    } as Response);
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText(/No active impersonation sessions/i)).toBeDefined()
+    );
+  });
+
+  // ------------------------------------------------------------------
+  // 3. 404 from active endpoint → page renders empty list (backend contract)
+  // ------------------------------------------------------------------
+  it('treats 404 from /impersonation/active as an empty list', async () => {
+    vi.mocked(fetch).mockResolvedValue({ ok: false, status: 404 } as Response);
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText(/No active impersonation sessions/i)).toBeDefined()
+    );
+    // The 404 path also logs a console.warn
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  // ------------------------------------------------------------------
+  // 4. Error state (non-404 failure)
+  // ------------------------------------------------------------------
+  it('renders an error alert when the active endpoint returns 500', async () => {
+    vi.mocked(fetch).mockResolvedValue({ ok: false, status: 500 } as Response);
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeDefined());
+    expect(screen.getByText(/500/)).toBeDefined();
+  });
+
+  // ------------------------------------------------------------------
+  // 5. Stop click → DELETE /admin/impersonation/{token_id}
+  // ------------------------------------------------------------------
+  it('issues DELETE /admin/impersonation/{token_id} when Stop is clicked', async () => {
+    const user = userEvent.setup();
+    vi.mocked(fetch).mockImplementation(async (input, init) => {
+      const url = input.toString();
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (url.includes('/admin/impersonation/active') && method === 'GET') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ items: [SESSION_A] }),
+        } as Response;
+      }
+      if (method === 'DELETE' && url.includes(`/admin/impersonation/${SESSION_A.token_id}`)) {
+        return { ok: true, status: 204 } as Response;
+      }
+      return { ok: false, status: 404 } as Response;
+    });
+
+    renderPage();
+
+    const stopBtn = await screen.findByRole('button', { name: /Stop/i });
+    await user.click(stopBtn);
+
+    await waitFor(() => {
+      const deleteCall = vi
+        .mocked(fetch)
+        .mock.calls.find(
+          ([input, init]) =>
+            (init as RequestInit)?.method === 'DELETE' &&
+            input.toString().includes(`/admin/impersonation/${SESSION_A.token_id}`)
+        );
+      expect(deleteCall).toBeDefined();
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // 6. Stop column / button is HIDDEN when capability is absent
+  // ------------------------------------------------------------------
+  it('hides the Stop button when users_impersonate capability is absent', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ items: [SESSION_A] }),
+    } as Response);
+
+    renderPage({ capabilities: [] });
+
+    // Row still renders…
+    await waitFor(() => expect(screen.getByText('target-a@example.com')).toBeDefined());
+
+    // …but the Stop button does not.
+    expect(screen.queryByRole('button', { name: /Stop/i })).toBeNull();
+  });
+
+  // ------------------------------------------------------------------
+  // 7. expires_at renders as a formatted date string
+  // ------------------------------------------------------------------
+  it('formats expires_at as a localized date+time string', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ items: [SESSION_A] }),
+    } as Response);
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('target-a@example.com')).toBeDefined());
+
+    // Intl.DateTimeFormat('en-GB', { dateStyle: 'short', timeStyle: 'short' })
+    // for 2026-05-17T11:00:00Z renders the date portion "17/05/2026" — assert
+    // on a stable fragment that's not timezone-sensitive (the date in UTC).
+    const formatted = new Intl.DateTimeFormat('en-GB', {
+      dateStyle: 'short',
+      timeStyle: 'short',
+    }).format(new Date(SESSION_A.expires_at));
+    expect(screen.getByText(formatted)).toBeDefined();
+  });
+});

--- a/frontend/apps/admin-web/src/pages/audit.test.tsx
+++ b/frontend/apps/admin-web/src/pages/audit.test.tsx
@@ -1,0 +1,373 @@
+/**
+ * AuditPage — integration tests for the audit log viewer.
+ *
+ * Covers the page-level contracts that, if broken, would silently mis-render
+ * or mis-export security-critical data:
+ *   - rows render from the API response
+ *   - filter inputs propagate into the fetch URL (actor + date range presets)
+ *   - empty/error states have user-visible affordances
+ *   - "Load more" forwards the server-provided next_cursor
+ *   - CSV export hits the right endpoint with the current filter and triggers
+ *     a real `<a download>` click
+ *
+ * Skipped (with reason):
+ *   - "Forbidden state": AuditPage itself does not render <ForbiddenPage> —
+ *     capability gating happens upstream in <ProtectedRoute>. That path is
+ *     already covered in components/ProtectedRoute.test.tsx, so we don't
+ *     re-verify it here.
+ *   - "Reason prompt fires on CSV export": the current audit.tsx does NOT
+ *     wrap export in <AuditReasonPrompt> (verified by grep) — `handleExportCsv`
+ *     calls fetch directly. Test would be asserting against behavior that
+ *     doesn't exist.
+ */
+
+import { CapabilityProvider } from '@ppt/admin-ui';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AdminAuthProvider } from '../auth/AdminAuthContext';
+import { sessionTokenStore } from '../auth/tokenStore';
+import { ToastProvider } from '../components/Toast';
+import AuditPage from './audit';
+
+// ---------------------------------------------------------------------------
+// i18next mock (Toast uses useTranslation)
+// ---------------------------------------------------------------------------
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? key,
+    i18n: { changeLanguage: vi.fn() },
+  }),
+  initReactI18next: { type: '3rdParty', init: vi.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, retryDelay: 0 } },
+  });
+}
+
+interface RenderOptions {
+  capabilities?: string[];
+  initialEntries?: string[];
+}
+
+function Providers({
+  capabilities = ['audit_read'],
+  initialEntries = ['/ops/audit'],
+  children,
+}: RenderOptions & { children: ReactNode }) {
+  sessionStorage.clear();
+  sessionTokenStore.set('test-token');
+  const qc = makeQueryClient();
+  return (
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={initialEntries}>
+        <AdminAuthProvider>
+          <CapabilityProvider
+            value={{ isPlatformPrincipal: true, capabilities: capabilities as never[] }}
+          >
+            <ToastProvider>{children}</ToastProvider>
+          </CapabilityProvider>
+        </AdminAuthProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+function renderPage(opts: RenderOptions = {}) {
+  return render(
+    <Providers {...opts}>
+      <AuditPage />
+    </Providers>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeRow(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    occurred_at: '2026-05-17T10:30:00Z',
+    actor_email: `actor-${id}@example.com`,
+    capability: 'audit_read',
+    target_kind: 'user' as const,
+    target_slug: `target-${id}`,
+    outcome: 'success' as const,
+    reason: `reason for ${id}`,
+    ip: '10.0.0.1',
+    ...overrides,
+  };
+}
+
+/** Helper to find the most recent GET call URL that fetched /admin/audit. */
+function lastAuditGetUrl(): string | undefined {
+  const calls = vi.mocked(fetch).mock.calls;
+  for (let i = calls.length - 1; i >= 0; i--) {
+    const [input, init] = calls[i] as [RequestInfo, RequestInit?];
+    const url = input.toString();
+    const method = (init?.method ?? 'GET').toUpperCase();
+    if (method === 'GET' && url.includes('/admin/audit') && !url.includes('/csv')) {
+      return url;
+    }
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AuditPage', () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, 'fetch');
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  // ------------------------------------------------------------------
+  // 1. Renders rows from /admin/audit
+  // ------------------------------------------------------------------
+  it('renders audit rows from the API response', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        items: [makeRow('a'), makeRow('b'), makeRow('c')],
+      }),
+    } as Response);
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('actor-a@example.com')).toBeDefined());
+    expect(screen.getByText('actor-b@example.com')).toBeDefined();
+    expect(screen.getByText('actor-c@example.com')).toBeDefined();
+  });
+
+  // ------------------------------------------------------------------
+  // 2. Empty state
+  // ------------------------------------------------------------------
+  it('renders empty-state copy when the API returns zero items', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ items: [] }),
+    } as Response);
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText(/No audit events match this filter/i)).toBeDefined()
+    );
+  });
+
+  // ------------------------------------------------------------------
+  // 3. Error state — page renders an alert with a Retry control
+  // ------------------------------------------------------------------
+  it('renders an error alert with a Retry button when the fetch fails', async () => {
+    vi.mocked(fetch).mockResolvedValue({ ok: false, status: 500 } as Response);
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeDefined());
+    expect(screen.getByText(/Unable to load audit log/i)).toBeDefined();
+    expect(screen.getByRole('button', { name: /Retry/i })).toBeDefined();
+  });
+
+  // ------------------------------------------------------------------
+  // 4. Filter by actor → refetches with ?actor=
+  // ------------------------------------------------------------------
+  it('refetches with ?actor= when the actor filter is typed', async () => {
+    const user = userEvent.setup();
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ items: [] }),
+    } as Response);
+
+    renderPage();
+
+    // Wait for the initial fetch
+    await waitFor(() => expect(lastAuditGetUrl()).toBeDefined());
+
+    const input = screen.getByLabelText('Actor') as HTMLInputElement;
+    await user.type(input, 'alice@example.com');
+
+    // Filter input is debounced (~250ms) — wait for a fetch that includes the actor param
+    await waitFor(
+      () => {
+        const url = lastAuditGetUrl();
+        expect(url).toBeDefined();
+        expect(url).toContain('actor=alice%40example.com');
+      },
+      { timeout: 2000 }
+    );
+  });
+
+  // ------------------------------------------------------------------
+  // 5. Filter by date range preset → refetches with ?range=
+  // ------------------------------------------------------------------
+  it('refetches with ?range= when a date-range preset is clicked', async () => {
+    const user = userEvent.setup();
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ items: [] }),
+    } as Response);
+
+    renderPage();
+
+    await waitFor(() => expect(lastAuditGetUrl()).toBeDefined());
+
+    // Click the "24h" preset button
+    await user.click(screen.getByRole('button', { name: '24h' }));
+
+    await waitFor(() => {
+      const url = lastAuditGetUrl();
+      expect(url).toBeDefined();
+      expect(url).toContain('range=24h');
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // 6. Pagination — clicking "Load more" forwards next_cursor
+  // ------------------------------------------------------------------
+  it('forwards the next_cursor to the API when "Load more" is clicked', async () => {
+    const user = userEvent.setup();
+    vi.mocked(fetch)
+      // First page
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          items: [makeRow('a')],
+          next_cursor: 'cursor-page-2',
+        }),
+      } as Response)
+      // Second page (cursor)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          items: [makeRow('b')],
+        }),
+      } as Response);
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('actor-a@example.com')).toBeDefined());
+
+    const loadMore = await screen.findByRole('button', { name: /Load more/i });
+    await user.click(loadMore);
+
+    await waitFor(() => {
+      const url = lastAuditGetUrl();
+      expect(url).toBeDefined();
+      expect(url).toContain('after=cursor-page-2');
+    });
+
+    // And the second page's row gets appended
+    await waitFor(() => expect(screen.getByText('actor-b@example.com')).toBeDefined());
+  });
+
+  // ------------------------------------------------------------------
+  // 7. CSV export click — fires fetch against /admin/audit/csv with filter
+  // ------------------------------------------------------------------
+  it('fetches /admin/audit/csv with the current filters when Export CSV is clicked', async () => {
+    const user = userEvent.setup();
+
+    // jsdom doesn't implement URL.createObjectURL — stub it (and revoke).
+    const createObjectURL = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockReturnValue('blob:fake-object-url');
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+    vi.mocked(fetch).mockImplementation(async (input) => {
+      const url = input.toString();
+      if (url.includes('/admin/audit/csv')) {
+        return {
+          ok: true,
+          status: 200,
+          blob: async () => new Blob(['col1,col2\n1,2'], { type: 'text/csv' }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ items: [] }),
+      } as Response;
+    });
+
+    renderPage();
+    await waitFor(() => expect(lastAuditGetUrl()).toBeDefined());
+
+    // Apply a filter so the CSV URL is non-trivial
+    await user.click(screen.getByRole('button', { name: '24h' }));
+    await waitFor(() => {
+      const url = lastAuditGetUrl();
+      expect(url).toContain('range=24h');
+    });
+
+    await user.click(screen.getByRole('button', { name: /Export CSV/i }));
+
+    await waitFor(() => {
+      const csvCall = vi
+        .mocked(fetch)
+        .mock.calls.find(([input]) => input.toString().includes('/admin/audit/csv'));
+      expect(csvCall).toBeDefined();
+      const url = csvCall![0].toString();
+      // Filter is forwarded
+      expect(url).toContain('range=24h');
+      // Auth header is forwarded
+      const init = csvCall![1] as RequestInit;
+      expect(init.headers).toEqual(
+        expect.objectContaining({ Authorization: 'Bearer test-token' })
+      );
+    });
+
+    // Object URL plumbing fired
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    // revokeObjectURL is deferred via setTimeout — we don't assert on it here.
+    expect(revokeObjectURL).toBeDefined();
+  });
+
+  // ------------------------------------------------------------------
+  // 8. CSV export failure → error toast surfaces
+  // ------------------------------------------------------------------
+  it('shows an error toast when the CSV export endpoint returns a non-OK status', async () => {
+    const user = userEvent.setup();
+
+    vi.mocked(fetch).mockImplementation(async (input) => {
+      const url = input.toString();
+      if (url.includes('/admin/audit/csv')) {
+        return { ok: false, status: 500 } as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ items: [] }),
+      } as Response;
+    });
+
+    renderPage();
+    await waitFor(() => expect(lastAuditGetUrl()).toBeDefined());
+
+    await user.click(screen.getByRole('button', { name: /Export CSV/i }));
+
+    await waitFor(() => expect(screen.getByText(/Export failed \(500\)/i)).toBeDefined());
+  });
+});

--- a/frontend/apps/admin-web/src/pages/audit.test.tsx
+++ b/frontend/apps/admin-web/src/pages/audit.test.tsx
@@ -334,9 +334,7 @@ describe('AuditPage', () => {
       expect(url).toContain('range=24h');
       // Auth header is forwarded
       const init = csvCall![1] as RequestInit;
-      expect(init.headers).toEqual(
-        expect.objectContaining({ Authorization: 'Bearer test-token' })
-      );
+      expect(init.headers).toEqual(expect.objectContaining({ Authorization: 'Bearer test-token' }));
     });
 
     // Object URL plumbing fired


### PR DESCRIPTION
## Summary

First-ever integration tests for two security-sensitive admin-web pages flagged by the round-15 frontend test sweep. Both shipped without any test coverage.

| File | LoC | Tests added | Notes |
|---|---|---|---|
| `frontend/apps/admin-web/src/pages/audit.tsx` | 1236 | 8 | Audit log viewer + CSV export — recently shipped via #285 |
| `frontend/apps/admin-web/src/pages/ImpersonationListPage.tsx` | 260 | 7 | Security primitive — list/stop active impersonations |

All 15 tests pass. No `.skip`.

## Test framework + precedent

- vitest 4.1.5 + jsdom + `@testing-library/react` + `@testing-library/user-event`
- Hand-rolled `vi.spyOn(globalThis, 'fetch')` (no msw) — follows `TenantLifecyclePage.test.tsx` + `CapabilitiesAdminPage.test.tsx`
- Provider stack reused verbatim: `QueryClientProvider` (retry: false) > `MemoryRouter` > `AdminAuthProvider` > `CapabilityProvider` > `ToastProvider`. Token primed via `sessionTokenStore.set('test-token')`. `react-i18next` mocked.

## Scenarios deliberately skipped (with reason)

1. **audit.tsx — "Forbidden state"**: page does NOT render `<ForbiddenPage>` itself; gating is at `<ProtectedRoute>` (already covered in `ProtectedRoute.test.tsx`).
2. **audit.tsx — "Reason-prompt fires on CSV export"**: current `handleExportCsv` calls `fetch` directly with no `AuditReasonPrompt` wrap. Asserting would lock in fictional behavior. **Worth a separate follow-up** if the team wants this hardened.
3. **ImpersonationListPage — "Stop confirmation modal"**: page dispatches DELETE directly on click; no destructive-confirm dialog exists. **Worth a UX hardening follow-up.**
4. **ImpersonationListPage — "expires in X minutes" relative string**: page uses `Intl.DateTimeFormat` (absolute date+time). Replaced with absolute-format assertion (still covers the formatting contract).

The "capability denied" contract for ImpersonationListPage IS covered — its page-internal `useCapability('users_impersonate')` hides the Stop column, asserted directly.

## Verification

`pnpm -F @ppt/admin-web exec vitest run src/pages/audit.test.tsx src/pages/ImpersonationListPage.test.tsx`:
**Test Files 2 passed (2) / Tests 15 passed (15), ~3s**

## Test plan

- [ ] CI vitest passes
- [ ] No regression on existing admin-web tests
- [ ] Consider follow-up tickets for the 4 skipped scenarios (audit reason-prompt + impersonation stop-confirm)