### PR TITLE
chore(docker): bind dev/prod ports to localhost + .dockerignore cleanup + use subtle::ConstantTimeEq

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -52,10 +52,12 @@ frontend/**/.next/
 frontend/**/dist/
 frontend/**/.turbo/
 
-# Mobile Native
-mobile-native/build/
-mobile-native/**/build/
-mobile-native/.gradle/
+# Mobile Native — Kotlin Multiplatform sources, not referenced by any Dockerfile
+mobile-native/
+
+# React Native app — frontend/apps/mobile is not built by any Dockerfile
+# (frontend Dockerfiles only build admin-web, reality-web, ppt-web)
+frontend/apps/mobile/
 
 # =============================================================================
 # Environment and Secrets
@@ -109,3 +111,4 @@ _bmad-output/
 .worktrees/
 .autopilot/
 .claude/
+.research/

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "admin-core"
-version = "0.2.400"
+version = "0.2.402"
 dependencies = [
  "api-core",
  "async-trait",
@@ -192,7 +192,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-core"
-version = "0.2.400"
+version = "0.2.402"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "api-server"
-version = "0.2.400"
+version = "0.2.402"
 dependencies = [
  "admin-core",
  "aes-gcm",
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.2.400"
+version = "0.2.402"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -2047,7 +2047,7 @@ dependencies = [
 
 [[package]]
 name = "db"
-version = "0.2.400"
+version = "0.2.402"
 dependencies = [
  "argon2",
  "async-trait",
@@ -2100,7 +2100,7 @@ dependencies = [
 
 [[package]]
 name = "deploy-server"
-version = "0.2.400"
+version = "0.2.402"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3563,7 +3563,7 @@ dependencies = [
 
 [[package]]
 name = "integrations"
-version = "0.2.400"
+version = "0.2.402"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -5367,7 +5367,7 @@ dependencies = [
 
 [[package]]
 name = "reality-server"
-version = "0.2.400"
+version = "0.2.402"
 dependencies = [
  "anyhow",
  "api-core",
@@ -6900,7 +6900,7 @@ dependencies = [
 
 [[package]]
 name = "tenant-ops"
-version = "0.2.400"
+version = "0.2.402"
 dependencies = [
  "chrono",
  "common",

--- a/backend/servers/deploy-server/src/api/webhook.rs
+++ b/backend/servers/deploy-server/src/api/webhook.rs
@@ -10,6 +10,7 @@ use hmac::{Hmac, KeyInit, Mac};
 use serde::Deserialize;
 use sha2::Sha256;
 use std::sync::Arc;
+use subtle::ConstantTimeEq;
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -146,21 +147,10 @@ fn verify_signature(headers: &HeaderMap, body: &[u8], secret: &str) -> Result<()
         .map_err(|e| DeployError::Internal(format!("hmac key: {e}")))?;
     mac.update(body);
     let expected = hex::encode(mac.finalize().into_bytes());
-    if !constant_time_eq(sig.as_bytes(), expected.as_bytes()) {
+    if !bool::from(sig.as_bytes().ct_eq(expected.as_bytes())) {
         return Err(DeployError::Unauthorized("bad signature".into()));
     }
     Ok(())
-}
-
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut diff = 0u8;
-    for (x, y) in a.iter().zip(b.iter()) {
-        diff |= x ^ y;
-    }
-    diff == 0
 }
 
 #[cfg(test)]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,7 +23,7 @@ services:
       POSTGRES_PASSWORD: ppt_dev_password
       POSTGRES_DB: ppt
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./backend/scripts/init-db.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
@@ -40,7 +40,7 @@ services:
     container_name: ppt-redis
     command: redis-server --appendonly yes
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     volumes:
       - redis_data:/data
     healthcheck:
@@ -63,8 +63,8 @@ services:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin123
     ports:
-      - "9000:9000"   # API
-      - "9001:9001"   # Console
+      - "127.0.0.1:9000:9000"   # API
+      - "127.0.0.1:9001:9001"   # Console
     volumes:
       - minio_data:/data
     healthcheck:
@@ -114,7 +114,7 @@ services:
       S3_BUCKET: ppt-documents
       S3_REGION: us-east-1
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     volumes:
       - ./backend:/app:cached
       - cargo_cache:/usr/local/cargo/registry
@@ -144,7 +144,7 @@ services:
       S3_BUCKET: ppt-images
       S3_REGION: us-east-1
     ports:
-      - "8081:8081"
+      - "127.0.0.1:8081:8081"
     volumes:
       - ./backend:/app:cached
       - cargo_cache:/usr/local/cargo/registry
@@ -170,7 +170,7 @@ services:
       VITE_API_URL: http://localhost:8080
       VITE_WS_URL: ws://localhost:8080
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     volumes:
       - ./frontend:/app:cached
       - pnpm_store:/root/.local/share/pnpm/store
@@ -188,7 +188,7 @@ services:
       NEXT_PUBLIC_API_URL: http://localhost:8081
       NEXT_PUBLIC_SITE_URL: http://localhost:3001
     ports:
-      - "3001:3001"
+      - "127.0.0.1:3001:3001"
     volumes:
       - ./frontend:/app:cached
       - pnpm_store:/root/.local/share/pnpm/store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,7 @@ services:
       S3_REGION: ${S3_REGION:-us-east-1}
       CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS}
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     depends_on:
       postgres:
         condition: service_healthy
@@ -126,7 +126,7 @@ services:
       S3_REGION: ${S3_REGION:-us-east-1}
       CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS}
     ports:
-      - "8081:8081"
+      - "127.0.0.1:8081:8081"
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Safe portion of the round-17 Docker / deploy audit. Higher-risk items (CSP/HSTS, secrets management, OIDC allowlist) deferred for human design.

### H3 — Dev compose ports world-bound (biggest "tomorrow incident" risk)
`docker-compose.dev.yml` — 8 port mappings prefixed `127.0.0.1:`:
- postgres 5432
- redis 6379
- minio 9000 + 9001
- api-server 8080
- reality-server 8081
- ppt-web 3000
- reality-web 3001

Previously all bound to 0.0.0.0 — a developer laptop on conference WiFi was exposing postgres + MinIO console (admin creds `minioadmin/minioadmin123`) to the network.

### H4 — Prod backend ports world-exposed
`docker-compose.yml` — `8080:8080` + `8081:8081` prefixed `127.0.0.1:`. Caddy reaches the backends via the docker network. SSH tunneling for ops still works.

### M3 — `.dockerignore` cleanups
Added to `.dockerignore`:
- `mobile-native/` (full source; was only excluding `build/` + `.gradle/`)
- `frontend/apps/mobile/` (React Native — not built by any Dockerfile)
- `.research/`

Verified backend Dockerfile only consumes `frontend/packages/sitemap/src/json/sitemap.json` via `include_str!` in `backend/crates/common/src/sitemap/mod.rs:10`. Frontend Dockerfiles `COPY frontend/ ./` wholesale, so they still get everything they need.

### M7 — Use `subtle::ConstantTimeEq` in webhook signature compare
`backend/servers/deploy-server/src/api/webhook.rs` — deleted local hand-rolled `constant_time_eq`, use `subtle::ConstantTimeEq::ct_eq` (already a dep, used in `auth/api_key.rs`). One less crypto re-implementation to audit.

## Deferred (HIGH/MED items needing design input)

- **H1**: SHA-pin base images + Dependabot for Docker
- **H2**: Dev vs prod Rust toolchain mismatch (`Dockerfile.dev` pins `rust:1.75-slim-bookworm`)
- **H5**: deploy-server OIDC scope derivation too permissive (any `git_ref=refs/heads/main` gets `release:deploy`)
- **H6**: Synology compose stores secrets in cleartext `.env`
- **M1**: nginx config missing CSP / HSTS / Permissions-Policy
- **M2**: prod compose lacks `read_only`, `no-new-privileges`, `cap_drop: [ALL]`
- **M8**: migration race — two api replicas may race `sqlx::migrate!` on blue/green flip
- **M9**: CI builds only `linux/amd64`; Synology compose pulls expecting arm64

## Verification

`cargo fmt` clean. `cargo check -p deploy-server` blocked locally (sandbox missing clang). Existing `#[test] signature_round_trip` and `bad_signature_rejected` cover both webhook paths. CI authoritative.

## Test plan

- [ ] Backend CI green
- [ ] Spin up dev stack; verify ports only reachable from localhost
- [ ] Confirm webhook still verifies signatures end-to-end