### PR TITLE
chore(deps): drop stale deny ignores, add gradle dependabot, bump axios spec

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,19 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "gradle"
+    directory: "/mobile-native"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      kotlin:
+        patterns:
+          - "org.jetbrains.kotlin*"
+      compose:
+        patterns:
+          - "androidx.compose*"
+          - "androidx.compose.material*"
+      ktor:
+        patterns:
+          - "io.ktor*"

--- a/backend/deny.toml
+++ b/backend/deny.toml
@@ -18,26 +18,6 @@ ignore = [
     # justification per RUSTSEC entry. Each one has a tracked follow-up.
     # ---------------------------------------------------------------------
 
-    # RUSTSEC-2024-0363 — sqlx 0.7.x Postgres binary-protocol misinterpretation
-    # (truncating cast on values > 4 GiB). Fixed in sqlx 0.8.1.
-    #
-    # Why acceptable for now:
-    # - Exploit requires encoding a single parameter > 4 GiB. All Axum routes
-    #   already cap request bodies (workspace default ~1 MiB via api-core
-    #   middleware), so the actual attack surface is empty.
-    # - sqlx 0.7 → 0.8 is a breaking-API bump touching every repository in
-    #   `crates/db`. That migration is its own PR.
-    "RUSTSEC-2024-0363",
-
-    # RUSTSEC-2024-0421 — idna < 1.0.0 punycode/IDN-handling vulnerability.
-    # Pinned at 0.4.0 by `validator 0.16.1`. Fixed in idna 1.0.x (only reachable
-    # by upgrading `validator` past 0.16). The exploit path requires us to
-    # accept attacker-controlled IDN domains and use them in security-relevant
-    # comparisons; our `validator` use is form-input validation where the
-    # output is never used as an authentication primitive.
-    # Follow-up: bump `validator` to 0.18.x and drop this ignore.
-    "RUSTSEC-2024-0421",
-
     # RUSTSEC-2026-0098, -0099, -0104 — rustls-webpki 0.101.7 URI/name-constraint
     # bugs. Pinned by `rustls 0.21.12` which is in turn pinned by the entire AWS
     # SDK family (`aws-config`, `aws-smithy-http-client`, etc.). Fixed in

--- a/frontend/apps/admin-web/package.json
+++ b/frontend/apps/admin-web/package.json
@@ -18,7 +18,7 @@
     "@ppt/shared": "workspace:*",
     "@ppt/ui-kit": "workspace:*",
     "@tanstack/react-query": "^5.17.0",
-    "axios": "^1.6.0",
+    "axios": "^1.7.4",
     "i18next": "^25.7.3",
     "i18next-browser-languagedetector": "^8.2.0",
     "react": "^19.2.0",

--- a/frontend/apps/mobile/package.json
+++ b/frontend/apps/mobile/package.json
@@ -41,7 +41,6 @@
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^29.5.12",
     "@types/react": "~19.2.14",
-    "@types/react-native": "~0.73.0",
     "jest": "^29.7.0",
     "jest-expo": "^56.0.0",
     "react-test-renderer": "^19.2.0",

--- a/frontend/apps/ppt-web/package.json
+++ b/frontend/apps/ppt-web/package.json
@@ -22,7 +22,7 @@
     "@ppt/sitemap": "workspace:*",
     "@ppt/ui-kit": "workspace:*",
     "@tanstack/react-query": "^5.17.0",
-    "axios": "^1.6.0",
+    "axios": "^1.7.4",
     "dompurify": "^3.3.1",
     "i18next": "^25.7.3",
     "i18next-browser-languagedetector": "^8.2.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -41,7 +41,7 @@ importers:
         specifier: ^5.17.0
         version: 5.100.9(react@19.2.0)
       axios:
-        specifier: ^1.6.0
+        specifier: ^1.7.4
         version: 1.16.0
       i18next:
         specifier: ^25.7.3
@@ -183,9 +183,6 @@ importers:
       '@types/react':
         specifier: 19.2.14
         version: 19.2.14
-      '@types/react-native':
-        specifier: ~0.73.0
-        version: 0.73.0(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3)(@types/react@19.2.14)(react@19.2.0)
       jest:
         specifier: ^29.7.0
         version: 29.7.0
@@ -220,7 +217,7 @@ importers:
         specifier: ^5.17.0
         version: 5.100.9(react@19.2.0)
       axios:
-        specifier: ^1.6.0
+        specifier: ^1.7.4
         version: 1.16.0
       dompurify:
         specifier: ^3.3.1
@@ -4479,23 +4476,6 @@ packages:
       '@types/react': 19.2.14
     dependencies:
       '@types/react': 19.2.14
-    dev: true
-
-  /@types/react-native@0.73.0(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3)(@types/react@19.2.14)(react@19.2.0):
-    resolution: {integrity: sha512-6ZRPQrYM72qYKGWidEttRe6M5DZBEV5F+MHMHqd4TTYx0tfkcdrUFGdef6CCxY0jXU7wldvd/zA/b0A/kTeJmA==}
-    deprecated: This is a stub types definition. react-native provides its own type definitions, so you do not need this installed.
-    dependencies:
-      react-native: 0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3)(@types/react@19.2.14)(react@19.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@react-native-community/cli'
-      - '@react-native/jest-preset'
-      - '@react-native/metro-config'
-      - '@types/react'
-      - bufferutil
-      - react
-      - supports-color
-      - utf-8-validate
     dev: true
 
   /@types/react@19.2.14:


### PR DESCRIPTION
## Summary

Quick wins from the round-19 dependency audit. All low-risk config / version-spec changes; no code touched.

### Fix 1 — Drop stale `deny.toml` ignores
`backend/deny.toml`: removed two `RUSTSEC` ignores that are no longer reachable:
- `RUSTSEC-2024-0363` (sqlx 0.7) — `Cargo.lock` shows only sqlx 0.8.6
- `RUSTSEC-2024-0421` (idna < 1.0 via validator 0.16) — `Cargo.lock` shows validator 0.20.0 + idna 1.1.0

### Fix 2 — Add Gradle to Dependabot
`.github/dependabot.yml`: appended `gradle` block for `/mobile-native` with weekly schedule and groups for `kotlin`, `compose`, `ktor`. This closes a real gap — mobile-native deps were drifting silently (Kotlin 6+ mo stale, datastore-preferences 2 yr stale per audit).

### Fix 3 — Bump axios spec to `^1.7.4`
- `frontend/apps/ppt-web/package.json:25`
- `frontend/apps/admin-web/package.json:21`

Previously `^1.6.0` — caret-pinned below the 1.7.4 SSRF fix boundary. Lockfile happens to resolve 1.16.0 (safe), but a fresh install could regress.

### Fix 4 — Remove stale `@types/react-native ~0.73.0`
`frontend/apps/mobile/package.json:44`: removed. RN 0.71+ ships its own types; the @types package is unnecessary AND mismatched (RN is now 0.85.x per audit).

Lockfile regen expected to follow.

## Out of scope (deferred)

- **H1** play-services-location 21.0.1 → 21.3.0 — needs coupled `compileSdk`/`targetSdk` 35 bump per Play Store mandate (Aug 2025)
- **H3** AWS-SDK rustls 0.21 lingering — needs `cargo tree -i` deep dive
- **M2** Kotlin/Compose/Ktor mobile-native alignment — substantial bump
- L1–L5 audit items

## Verification

`cargo fmt` clean. Pure config edits. CI authoritative.

## Test plan

- [ ] `cargo deny check` passes without the dropped ignores
- [ ] CI green (Dependabot config validated by GitHub)
- [ ] Lockfile regenerated as expected