### PR TITLE
chore(migrations): idempotency hardening for 00019, 00060, 00135 (replay-safe)

### DIFF
--- a/backend/crates/db/migrations/00019_fix_messaging_rls_policies.sql
+++ b/backend/crates/db/migrations/00019_fix_messaging_rls_policies.sql
@@ -62,7 +62,7 @@ BEGIN
         WHERE table_name = 'user_blocks' AND column_name = 'organization_id'
     ) THEN
         ALTER TABLE user_blocks
-            ADD COLUMN organization_id UUID REFERENCES organizations(id) ON DELETE CASCADE;
+            ADD COLUMN IF NOT EXISTS organization_id UUID REFERENCES organizations(id) ON DELETE CASCADE;
 
         -- Update existing blocks with org from blocker (via organization_members)
         UPDATE user_blocks ub

--- a/backend/crates/db/migrations/00060_create_document_intelligence.sql
+++ b/backend/crates/db/migrations/00060_create_document_intelligence.sql
@@ -83,12 +83,16 @@ CREATE TRIGGER trigger_update_document_search_vector
     EXECUTE FUNCTION update_document_search_vector();
 
 -- Update existing documents' search vectors
+-- Idempotency hardening: WHERE search_vector IS NULL makes replay cheap and
+-- avoids a multi-minute table rewrite on dev DB resets / backup restores.
+-- No semantic change on first run: at that point all rows already had NULL.
 UPDATE documents SET search_vector =
     setweight(to_tsvector('english', COALESCE(title, '')), 'A') ||
     setweight(to_tsvector('english', COALESCE(description, '')), 'B') ||
     setweight(to_tsvector('english', COALESCE(file_name, '')), 'B') ||
     setweight(to_tsvector('english', COALESCE(extracted_text, '')), 'C') ||
-    setweight(to_tsvector('english', COALESCE(ai_summary, '')), 'C');
+    setweight(to_tsvector('english', COALESCE(ai_summary, '')), 'C')
+WHERE search_vector IS NULL;
 
 -- ============================================================================
 -- Story 28.3: Document Auto-Classification

--- a/backend/crates/db/migrations/00135_listings_publish_state.sql
+++ b/backend/crates/db/migrations/00135_listings_publish_state.sql
@@ -29,7 +29,7 @@
 -- row in a "global portal" table — the global view is a filter (see 00136).
 
 ALTER TABLE listings
-    ADD COLUMN is_published BOOLEAN NOT NULL DEFAULT FALSE;
+    ADD COLUMN IF NOT EXISTS is_published BOOLEAN NOT NULL DEFAULT FALSE;
 
 -- Backfill: rows previously visible via the reality-server `status='active'`
 -- filter become published. Other status values remain unpublished.


### PR DESCRIPTION
## Summary

Three migrations made replay-safe per round-20 DB migration audit. **None of these change first-run behavior** — all are pure defensive additions for replay scenarios (dev DB resets, snapshot restores).

### Fix 1 — `00060_create_document_intelligence.sql:86`
Added `WHERE search_vector IS NULL` to the `UPDATE documents SET search_vector = ...` backfill. Without it, replay touches every row and takes multi-minute locks on large tables.

First run is unchanged: every row's `search_vector` was NULL at first apply, so the WHERE clause selects the same row set.

### Fix 2 — `00019_fix_messaging_rls_policies.sql:65`
`ADD COLUMN organization_id` → `ADD COLUMN IF NOT EXISTS organization_id`. Belt-and-suspenders since this is already inside a `DO $$` block that guards via `information_schema.columns`.

### Fix 3 — `00135_listings_publish_state.sql:32`
`ADD COLUMN is_published` → `ADD COLUMN IF NOT EXISTS is_published`.

## Out of scope (audit follow-ups)

- **M1**: ~20 seed `INSERT`s lack `ON CONFLICT DO UPDATE` — needs a strategic refresh-seed migration (similar to PR #300's 00153). Worth dedicated PR with reference data update policy.
- **H4**: 00148 `portal_users` `DROP TABLE CASCADE` lacked a precondition guard — but it's already executed in prod, so a SQL-level fix has no effect. Runbook documentation only.
- **L1**: Sentinel nil-UUID `COALESCE` pattern in notification migrations — needs design discussion.

## Verification

Pure SQL string edits. No build needed. Diff inspected: each hunk matches the audit's minimal-edit shape; first-run semantics unchanged.

## Test plan

- [ ] CI green (migration framework will accept)
- [ ] (Optional) Run migrations against a snapshot of dev DB to confirm replay safety