### PR TITLE
fix(ci): verify-all ppt-pr-create smoke — point at backend.yml (ci.yml deleted in #326)

### DIFF
--- a/.claude/skills/verify-all.sh
+++ b/.claude/skills/verify-all.sh
@@ -86,7 +86,7 @@ if [[ $QUICK -eq 1 ]]; then
   # without spinning up the toolchain (just / gh / cargo / pnpm / gradle /
   # npx-tsp / stack). Suitable for cold caches and offline CI runners.
   run "ppt-tests"         10 'test -f justfile && grep -qE "^test(-(backend|frontend|integration))?:" justfile'
-  run "ppt-pr-create"     10 'test -d .github && test -f .github/workflows/ci.yml'
+  run "ppt-pr-create"     10 'test -d .github && test -f .github/workflows/backend.yml'
   run "ppt-rust-backend"  10 'test -f backend/Cargo.toml && test -d backend/crates'
   run "ppt-frontend"      10 'test -f frontend/pnpm-workspace.yaml || test -f frontend/package.json'
   run "ppt-screens"       10 'test -f .claude/skills/ppt-screens/SKILL.md && find docs/screens/ppt docs/screens/reality -name "*.md" -type f -not -name "_template.md" -not -name "README.md" 2>/dev/null | grep -q .'


### PR DESCRIPTION
## Summary

PR #326 deleted `.github/workflows/ci.yml` (it was a duplicate of `backend.yml`). But `.claude/skills/verify-all.sh`'s `ppt-pr-create` quick smoke check still asserted `test -f .github/workflows/ci.yml` — so the check now fails on **every PR** that runs `verify-all.sh --quick`.

Fix: point the smoke check at `backend.yml` (a workflow file that exists and is stable).

## Verification

`bash .claude/skills/verify-all.sh --quick` locally:
```
ppt-pr-create          ... PASS
== summary ==
passed: 14
failed: 0
```

## Impact

This unblocks the `verify-all.sh --quick` CI job for all open PRs (notably #364, which surfaced the regression).

## Test plan

- [ ] CI `verify-all.sh --quick` passes