### PR TITLE
test(ci): run RLS penetration tests serially (--test-threads=1)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -279,7 +279,16 @@ jobs:
         env:
           TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/ppt_test
           RUST_LOG: debug
-        run: cargo test --test rls_penetration_tests -- --ignored --nocapture
+        # `--test-threads=1`: every test in rls_penetration_tests.rs shares the
+        # SAME Postgres database and brackets itself with `db.cleanup()`, which
+        # runs `DELETE FROM roles/organizations WHERE TRUE`. Run in parallel,
+        # one test's cleanup wipes (or the org-creation trigger injects) rows
+        # while a sibling test is mid-`SELECT * FROM roles`, so the
+        # "every row belongs to my org" assertions in
+        # test_cross_tenant_role_isolation / test_cross_tenant_org_isolation
+        # fail non-deterministically. Serializing makes the suite reliable —
+        # matches the rls_smoke_tests job above.
+        run: cargo test --test rls_penetration_tests -- --ignored --nocapture --test-threads=1
 
   cargo-deny:
     runs-on: ubuntu-latest

--- a/backend/crates/db/tests/rls_penetration_tests.rs
+++ b/backend/crates/db/tests/rls_penetration_tests.rs
@@ -8,6 +8,17 @@
 //! 2. Permission boundary tests - Verify role-based access restrictions
 //! 3. Context manipulation tests - Ensure session variables cannot be spoofed
 //! 4. Null context tests - Verify behavior when no tenant context is set
+//!
+//! IMPORTANT — run serially:
+//!   cargo test --test rls_penetration_tests -- --ignored --test-threads=1
+//!
+//! Every test here shares the SAME Postgres database and brackets itself with
+//! `db.cleanup()` (a `DELETE FROM roles/organizations WHERE TRUE`). Running the
+//! tests in parallel lets one test's cleanup wipe — or the org-creation trigger
+//! inject — rows while a sibling test is mid-`SELECT`, which breaks the
+//! "every returned row belongs to my org" assertions in
+//! `test_cross_tenant_role_isolation` / `test_cross_tenant_org_isolation`.
+//! Without `--test-threads=1` those two tests fail non-deterministically.
 
 use sqlx::{postgres::PgPoolOptions, PgPool, Row};
 use std::time::Duration;


### PR DESCRIPTION
## Summary

Fixes the `security-tests` CI job failure that's been blocking every security-titled PR (#316, #317, #332, #335 currently).

## Verdict: buggy test harness — NOT a real RLS leak

Investigated whether `test_cross_tenant_role_isolation` / `test_cross_tenant_org_isolation` failing meant a genuine cross-tenant data leak. **It does not.** The RLS policies are correct:

`00006_enable_rls_policies.sql` scopes `roles` properly:
```sql
CREATE POLICY roles_select ON roles FOR SELECT USING (
  (organization_id = get_current_org_id()
   AND EXISTS (SELECT 1 FROM organization_members om
               WHERE om.organization_id = roles.organization_id
                 AND om.user_id = NULLIF(current_setting('app.current_user_id', TRUE),'')::UUID))
  OR is_super_admin());
```
Both `roles` and `organization_members` have `FORCE ROW LEVEL SECURITY` (applies even to the table-owner role CI connects as). Roles are correctly tenant-private.

## Root cause

`.github/workflows/backend.yml:282` ran:
```
cargo test --test rls_penetration_tests -- --ignored --nocapture
```
**Missing `--test-threads=1`.** All 8 `#[ignore]`d tests run in parallel against one shared Postgres DB. Each test brackets itself with `db.cleanup()` (`DELETE FROM roles/organizations`) and creates orgs whose `AFTER INSERT` trigger injects 8 roles each. Run concurrently, a sibling's `cleanup()` / org-creation trigger mutates rows mid-`SELECT` in `test_cross_tenant_role_isolation` — breaking its "every returned row belongs to my org" assertion non-deterministically.

The passing tests (`test_null_context_blocks_access`, `test_permission_boundary_update`) don't assert exact row sets, so they were immune. The sibling `rls_smoke_tests` job (line 216) **already uses `--test-threads=1`** and documents this exact race — the penetration job just missed it.

## Changes

- `.github/workflows/backend.yml`: added `--test-threads=1` to the penetration-test command + explanatory comment
- `backend/crates/db/tests/rls_penetration_tests.rs`: module-doc note that the suite must run serially

## Impact

Once merged, the `security-tests` job becomes deterministic. This **unblocks 4 CRITICAL security PRs** currently failing on this flaky test: #316, #317, #332, #335 — no code change needed on their side, just a rebase.

## Verification

YAML parses cleanly. Diff limited to 2 files. Fix mirrors the proven `rls_smoke_tests` job. `cargo test` couldn't run locally (sandbox missing clang). CI authoritative.

## Test plan

- [ ] `security-tests` job passes on this PR
- [ ] Rebase #316/#317/#332/#335 onto main after merge — confirm they go green