### PR TITLE
fix(mobile-native): migrate kotlinOptions → compilerOptions DSL for Kotlin 2.3

### DIFF
--- a/mobile-native/androidApp/build.gradle.kts
+++ b/mobile-native/androidApp/build.gradle.kts
@@ -110,11 +110,7 @@ android {
     }
 }
 
-kotlin {
-    compilerOptions {
-        jvmTarget = JvmTarget.JVM_17
-    }
-}
+kotlin { compilerOptions { jvmTarget = JvmTarget.JVM_17 } }
 
 dependencies {
     implementation(project(":shared"))

--- a/mobile-native/androidApp/build.gradle.kts
+++ b/mobile-native/androidApp/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -102,11 +104,15 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions { jvmTarget = "17" }
-
     buildFeatures {
         compose = true
         buildConfig = true
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
     }
 }
 

--- a/mobile-native/shared/build.gradle.kts
+++ b/mobile-native/shared/build.gradle.kts
@@ -7,11 +7,7 @@ plugins {
 }
 
 kotlin {
-    androidTarget {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_17
-        }
-    }
+    androidTarget { compilerOptions { jvmTarget = JvmTarget.JVM_17 } }
 
     listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach {
         it.binaries.framework {

--- a/mobile-native/shared/build.gradle.kts
+++ b/mobile-native/shared/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotlin.serialization)
@@ -5,7 +7,11 @@ plugins {
 }
 
 kotlin {
-    androidTarget { compilations.all { kotlinOptions { jvmTarget = "17" } } }
+    androidTarget {
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_17
+        }
+    }
 
     listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach {
         it.binaries.framework {


### PR DESCRIPTION
## Problem

PR #359 auto-merged the Kotlin 2.1 → 2.3 bump. Kotlin 2.3 makes the legacy `kotlinOptions { jvmTarget = "17" }` String DSL a **hard compile error** ([kotl.in/u1r8ln](https://kotl.in/u1r8ln)).

This breaks the `mobile-native` Gradle build — the **`lint` (Spotless) CI job fails on `main`**, which in turn blocks every other PR (including #376).

```
build.gradle.kts:105: Using 'jvmTarget: String' is an error. Please migrate to the compilerOptions DSL.
```

## Fix

- **androidApp**: replace the `android { kotlinOptions { ... } }` block with a top-level `kotlin { compilerOptions { jvmTarget = JvmTarget.JVM_17 } }`
- **shared (KMP)**: replace `androidTarget { compilations.all { kotlinOptions { ... } } }` with `androidTarget { compilerOptions { jvmTarget = JvmTarget.JVM_17 } }`
- add the `org.jetbrains.kotlin.gradle.dsl.JvmTarget` import to both files

## Verification

⚠️ No Android/JDK toolchain available locally — this is a static migration relying on the `mobile-native` CI job for verification. It's the standard documented `kotlinOptions`→`compilerOptions` migration.

Unblocks #376 (async-storage v3 fix).