### PR TITLE
chore(mobile-native): toolchain upgrade — AGP 9.2.1 / Gradle 9.4.1 / Kotlin 2.3 / Compose 2026.05

### DIFF
--- a/mobile-native/CLAUDE.md
+++ b/mobile-native/CLAUDE.md
@@ -12,12 +12,19 @@ Kotlin Multiplatform project for Reality Portal mobile apps.
 
 | Component | Version |
 |-----------|---------|
-| Kotlin | 2.1.0 |
-| Ktor | 3.0.3 |
-| Compose BOM | 2024.12.01 |
-| AGP | 8.7.3 |
+| Kotlin | 2.3.21 |
+| Ktor | 3.5.0 |
+| Compose BOM | 2026.05.01 |
+| AGP | 9.2.1 |
+| Gradle | 9.1.0 |
+| KSP | 2.3.21-2.0.4 |
 | Kotlinx Serialization | 1.7.3 |
 | Kotlinx Coroutines | 1.9.0 |
+
+> **Note:** The `:shared` module uses the AGP 9 `com.android.kotlin.multiplatform.library`
+> plugin (`kotlin { androidLibrary { } }` DSL). This plugin is variant-agnostic — it has no
+> product flavors and no `BuildConfig` generation. Android environment config is read at
+> runtime from the `:androidApp` `BuildConfig` via reflection in `PlatformConfig` (androidMain).
 
 ## Targets
 

--- a/mobile-native/androidApp/build.gradle.kts
+++ b/mobile-native/androidApp/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
+    // AGP 9 bundles the Kotlin Android plugin; `alias(libs.plugins.kotlin.android)` is no longer
+    // applied explicitly. The Compose compiler plugin must still be applied.
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
 }
 
@@ -105,6 +106,8 @@ android {
     buildFeatures {
         compose = true
         buildConfig = true
+        // AGP 9 defaults `resValues` to false; product flavors below use `resValue(...)`.
+        resValues = true
     }
 }
 

--- a/mobile-native/androidApp/build.gradle.kts
+++ b/mobile-native/androidApp/build.gradle.kts
@@ -64,7 +64,7 @@ android {
             buildConfigField(
                 "String",
                 "API_BASE_URL",
-                "\"https://staging-reality.ppt.example.com\""
+                "\"https://staging-reality.ppt.example.com\"",
             )
             buildConfigField("String", "ENVIRONMENT", "\"staging\"")
             buildConfigField("Boolean", "ENABLE_LOGGING", "true")
@@ -84,7 +84,7 @@ android {
             isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
+                "proguard-rules.pro",
             )
             // Use release signing config if keystore exists
             val keystoreFile = file(System.getenv("KEYSTORE_FILE") ?: "../keystore/release.jks")

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/MainActivity.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/MainActivity.kt
@@ -54,12 +54,12 @@ class MainActivity : ComponentActivity() {
             RealityPortalTheme {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background
+                    color = MaterialTheme.colorScheme.background,
                 ) {
                     RealityPortalApp(
                         ssoService = ssoService,
                         pendingDeepLink = pendingDeepLink.value,
-                        onDeepLinkHandled = { pendingDeepLink.value = null }
+                        onDeepLinkHandled = { pendingDeepLink.value = null },
                     )
                 }
             }
@@ -123,7 +123,7 @@ sealed class DeepLinkTarget {
 fun RealityPortalApp(
     ssoService: SsoService,
     pendingDeepLink: DeepLinkTarget? = null,
-    onDeepLinkHandled: () -> Unit = {}
+    onDeepLinkHandled: () -> Unit = {},
 ) {
     val navController = rememberNavController()
 

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/navigation/Navigation.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/navigation/Navigation.kt
@@ -66,10 +66,7 @@ sealed class Screen(val route: String) {
     data object Home : Screen("home")
 
     data object Search : Screen("search?type={type}&category={category}") {
-        fun createRoute(
-            type: ListingType? = null,
-            category: PropertyCategory? = null,
-        ): String {
+        fun createRoute(type: ListingType? = null, category: PropertyCategory? = null): String {
             val params = buildList {
                 type?.let { add("type=${it.name.lowercase()}") }
                 category?.let { add("category=${it.name.lowercase()}") }
@@ -155,7 +152,7 @@ fun RealityNavHost(
                     onAccountClick = { tabNavigate(Screen.Account.route) },
                 )
             }
-        },
+        }
     ) { innerPadding ->
         NavHost(
             navController = navController,
@@ -215,7 +212,7 @@ fun RealityNavHost(
 
             composable(
                 route = Screen.ListingDetail.route,
-                arguments = listOf(navArgument("listingId") { type = NavType.StringType })
+                arguments = listOf(navArgument("listingId") { type = NavType.StringType }),
             ) { backStackEntry ->
                 val listingId =
                     backStackEntry.arguments?.getString("listingId") ?: return@composable
@@ -224,7 +221,7 @@ fun RealityNavHost(
                     repository = listingRepository,
                     ssoService = ssoService,
                     onBackClick = { navController.popBackStack() },
-                    onInquirySuccess = { navController.navigate(Screen.Inquiries.route) }
+                    onInquirySuccess = { navController.navigate(Screen.Inquiries.route) },
                 )
             }
 

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/account/AccountScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/account/AccountScreen.kt
@@ -101,10 +101,7 @@ fun AccountScreen(
         }
     }
 
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background,
-    ) {
+    Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
         when (val state = authState) {
             is AuthState.Unauthenticated,
             is AuthState.Error -> {
@@ -159,7 +156,7 @@ fun AccountScreen(
                                                     Log.e(
                                                         TAG,
                                                         "Failed to update notification preferences",
-                                                        it
+                                                        it,
                                                     )
                                                 },
                                             )
@@ -193,7 +190,7 @@ fun AccountScreen(
                     },
                     colors =
                         ButtonDefaults.textButtonColors(
-                            contentColor = MaterialTheme.colorScheme.error,
+                            contentColor = MaterialTheme.colorScheme.error
                         ),
                 ) {
                     Text(stringResource(R.string.sign_out))
@@ -275,7 +272,7 @@ private fun ProfileHero(user: SsoUserInfo) {
                                     colors = listOf(Brand800, Brand500),
                                     start = Offset(0f, 0f),
                                     end = Offset(size.width, size.height),
-                                ),
+                                )
                         )
                     },
                 contentAlignment = Alignment.Center,
@@ -310,10 +307,7 @@ private fun ProfileHero(user: SsoUserInfo) {
 
 @Composable
 private fun VerifiedPill() {
-    Surface(
-        shape = RoundedCornerShape(999.dp),
-        color = Color(0xFFD1FAE5),
-    ) {
+    Surface(shape = RoundedCornerShape(999.dp), color = Color(0xFFD1FAE5)) {
         Row(
             modifier = Modifier.padding(horizontal = 7.dp, vertical = 2.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -426,7 +420,7 @@ private fun SectionList(
                 title = stringResource(R.string.profile_section_compare),
                 subtitle = stringResource(R.string.profile_section_compare_sub),
                 trailing = SectionTrailing.Chevron,
-                onClick = { /* nav to compare */},
+                onClick = { /* nav to compare */ },
             )
             SectionDivider()
             SectionRow(
@@ -442,7 +436,7 @@ private fun SectionList(
                 title = stringResource(R.string.profile_section_privacy),
                 subtitle = null,
                 trailing = SectionTrailing.Chevron,
-                onClick = { /* nav to privacy */},
+                onClick = { /* nav to privacy */ },
             )
             SectionDivider()
             SectionRow(
@@ -451,7 +445,7 @@ private fun SectionList(
                 subtitle =
                     stringResource(R.string.profile_section_about_sub, BuildConfig.VERSION_NAME),
                 trailing = SectionTrailing.Chevron,
-                onClick = { /* nav to about */},
+                onClick = { /* nav to about */ },
             )
         }
     }
@@ -518,10 +512,7 @@ private fun SectionRow(
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             is SectionTrailing.Toggle ->
-                Switch(
-                    checked = trailing.checked,
-                    onCheckedChange = { onClick() },
-                )
+                Switch(checked = trailing.checked, onCheckedChange = { onClick() })
         }
     }
 }
@@ -632,40 +623,35 @@ private fun AppSettingsCard() {
                 icon = Icons.Default.Language,
                 title = stringResource(R.string.setting_language),
                 value = stringResource(R.string.language_english),
-                onClick = { /* picker */},
+                onClick = { /* picker */ },
             )
             SectionDivider()
             SettingsRow(
                 icon = Icons.Default.Euro,
                 title = stringResource(R.string.setting_currency),
                 value = stringResource(R.string.currency_eur),
-                onClick = { /* picker */},
+                onClick = { /* picker */ },
             )
             SectionDivider()
             SettingsRow(
                 icon = Icons.Default.Straighten,
                 title = stringResource(R.string.setting_units),
                 value = stringResource(R.string.units_metric),
-                onClick = { /* picker */},
+                onClick = { /* picker */ },
             )
             SectionDivider()
             SettingsRow(
                 icon = Icons.Default.DarkMode,
                 title = stringResource(R.string.setting_theme),
                 value = stringResource(R.string.theme_system),
-                onClick = { /* picker */},
+                onClick = { /* picker */ },
             )
         }
     }
 }
 
 @Composable
-private fun SettingsRow(
-    icon: ImageVector,
-    title: String,
-    value: String,
-    onClick: () -> Unit,
-) {
+private fun SettingsRow(icon: ImageVector, title: String, value: String, onClick: () -> Unit) {
     Row(
         modifier =
             Modifier.fillMaxWidth()
@@ -722,25 +708,25 @@ private fun AboutCard() {
             AboutRow(
                 icon = Icons.Default.Description,
                 title = stringResource(R.string.terms_of_service),
-                onClick = { /* open terms */},
+                onClick = { /* open terms */ },
             )
             SectionDivider()
             AboutRow(
                 icon = Icons.Default.PrivacyTip,
                 title = stringResource(R.string.privacy_policy),
-                onClick = { /* open privacy */},
+                onClick = { /* open privacy */ },
             )
             SectionDivider()
             AboutRow(
                 icon = Icons.AutoMirrored.Filled.Help,
                 title = stringResource(R.string.help_support),
-                onClick = { /* open help */},
+                onClick = { /* open help */ },
             )
             SectionDivider()
             AboutRow(
                 icon = Icons.Default.Feedback,
                 title = stringResource(R.string.send_feedback),
-                onClick = { /* open feedback */},
+                onClick = { /* open feedback */ },
             )
         }
     }
@@ -868,7 +854,7 @@ private fun NotSignedInContent(onSignInClick: () -> Unit) {
             Icon(
                 Icons.AutoMirrored.Filled.Login,
                 contentDescription = null,
-                modifier = Modifier.size(18.dp)
+                modifier = Modifier.size(18.dp),
             )
             Spacer(modifier = Modifier.width(8.dp))
             Text(stringResource(R.string.sign_in_pm_app))

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/agency/AgencyHubScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/agency/AgencyHubScreen.kt
@@ -45,10 +45,7 @@ fun AgencyHubScreen(
     onAnalyticsClick: () -> Unit,
     onNotificationsClick: () -> Unit = onInquiriesClick,
 ) {
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background,
-    ) {
+    Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
         Box(modifier = Modifier.fillMaxSize()) {
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
@@ -58,7 +55,7 @@ fun AgencyHubScreen(
                 item {
                     StatsGrid(
                         onInquiriesClick = onInquiriesClick,
-                        onAnalyticsClick = onAnalyticsClick
+                        onAnalyticsClick = onAnalyticsClick,
                     )
                 }
                 item { Spacer(modifier = Modifier.height(8.dp)) }
@@ -114,17 +111,12 @@ private fun AgencyHeader(onNotificationsClick: () -> Unit) {
                                 colors = listOf(Brand800, Brand500),
                                 start = Offset(0f, 0f),
                                 end = Offset(size.width, size.height),
-                            ),
+                            )
                     )
                 },
             contentAlignment = Alignment.Center,
         ) {
-            Text(
-                text = "RP",
-                color = Color.White,
-                fontWeight = FontWeight.Bold,
-                fontSize = 16.sp,
-            )
+            Text(text = "RP", color = Color.White, fontWeight = FontWeight.Bold, fontSize = 16.sp)
         }
         Spacer(modifier = Modifier.width(10.dp))
         Column(modifier = Modifier.weight(1f)) {
@@ -158,17 +150,14 @@ private fun AgencyHeader(onNotificationsClick: () -> Unit) {
                         .size(8.dp)
                         .clip(CircleShape)
                         .background(MaterialTheme.colorScheme.error)
-                        .align(Alignment.TopEnd),
+                        .align(Alignment.TopEnd)
             )
         }
     }
 }
 
 @Composable
-private fun StatsGrid(
-    onInquiriesClick: () -> Unit,
-    onAnalyticsClick: () -> Unit,
-) {
+private fun StatsGrid(onInquiriesClick: () -> Unit, onAnalyticsClick: () -> Unit) {
     Column(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
         verticalArrangement = Arrangement.spacedBy(10.dp),
@@ -224,7 +213,7 @@ private fun StatCard(
             CardDefaults.cardColors(
                 containerColor =
                     if (accent) MaterialTheme.colorScheme.primary
-                    else MaterialTheme.colorScheme.surface,
+                    else MaterialTheme.colorScheme.surface
             ),
     ) {
         Column(modifier = Modifier.padding(14.dp)) {
@@ -326,12 +315,7 @@ private fun AgencyActions(
 }
 
 @Composable
-private fun ActionRow(
-    icon: ImageVector,
-    title: String,
-    subtitle: String,
-    onClick: () -> Unit,
-) {
+private fun ActionRow(icon: ImageVector, title: String, subtitle: String, onClick: () -> Unit) {
     Row(
         modifier =
             Modifier.fillMaxWidth()
@@ -387,19 +371,14 @@ private fun ActionDivider() {
 
 @Composable
 private fun ActivityRow(activity: ActivitySample) {
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 6.dp),
-    ) {
+    Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 6.dp)) {
         Card(
             modifier = Modifier.fillMaxWidth(),
             shape = RoundedCornerShape(12.dp),
             elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
             colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         ) {
-            Row(
-                modifier = Modifier.padding(14.dp),
-                verticalAlignment = Alignment.Top,
-            ) {
+            Row(modifier = Modifier.padding(14.dp), verticalAlignment = Alignment.Top) {
                 Box(
                     modifier =
                         Modifier.size(36.dp)
@@ -429,10 +408,7 @@ private fun ActivityRow(activity: ActivitySample) {
                     )
                 }
                 activity.tag?.let { tag ->
-                    Surface(
-                        shape = RoundedCornerShape(999.dp),
-                        color = tag.bg,
-                    ) {
+                    Surface(shape = RoundedCornerShape(999.dp), color = tag.bg) {
                         Text(
                             text = tag.label.uppercase(),
                             modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/agency/AgencyInquiriesScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/agency/AgencyInquiriesScreen.kt
@@ -48,10 +48,7 @@ fun AgencyInquiriesScreen(
     onInquiryClick: (id: String) -> Unit,
 ) {
     var statusFilter by remember { mutableStateOf<String?>(null) }
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background,
-    ) {
+    Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
         Box(modifier = Modifier.fillMaxSize()) {
             Column(modifier = Modifier.fillMaxSize()) {
                 AgencyInquiriesHeader(onBackClick = onBackClick)
@@ -90,7 +87,7 @@ fun AgencyInquiriesScreen(
                 }
             }
             ExtendedFloatingActionButton(
-                onClick = { /* batch reply */},
+                onClick = { /* batch reply */ },
                 modifier = Modifier.align(Alignment.BottomEnd).padding(end = 16.dp, bottom = 24.dp),
                 containerColor = MaterialTheme.colorScheme.primary,
                 contentColor = Color.White,
@@ -111,7 +108,7 @@ private fun AgencyInquiriesHeader(onBackClick: () -> Unit) {
         IconButton(onClick = onBackClick) {
             Icon(
                 Icons.AutoMirrored.Filled.ArrowBack,
-                contentDescription = stringResource(R.string.cd_back)
+                contentDescription = stringResource(R.string.cd_back),
             )
         }
         Text(
@@ -121,7 +118,7 @@ private fun AgencyInquiriesHeader(onBackClick: () -> Unit) {
             color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.weight(1f),
         )
-        IconButton(onClick = { /* search */}) {
+        IconButton(onClick = { /* search */ }) {
             Icon(Icons.Default.Search, contentDescription = stringResource(R.string.cd_search))
         }
     }
@@ -160,23 +157,14 @@ private fun StatusChips(
 }
 
 @Composable
-private fun FilterChipPill(
-    label: String,
-    count: Int,
-    selected: Boolean,
-    onClick: () -> Unit,
-) {
+private fun FilterChipPill(label: String, count: Int, selected: Boolean, onClick: () -> Unit) {
     Surface(
         onClick = onClick,
         shape = RoundedCornerShape(8.dp),
         color = if (selected) MaterialTheme.colorScheme.primaryContainer else Color.Transparent,
         border =
             if (selected) null
-            else
-                androidx.compose.foundation.BorderStroke(
-                    1.dp,
-                    MaterialTheme.colorScheme.outline,
-                ),
+            else androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
     ) {
         Row(modifier = Modifier.padding(horizontal = 14.dp, vertical = 7.dp)) {
             Text(
@@ -207,7 +195,7 @@ private fun InquiryRow(inquiry: AgencyInquiry, onClick: () -> Unit) {
         modifier =
             Modifier.fillMaxWidth()
                 .background(MaterialTheme.colorScheme.surface)
-                .clickable(onClick = onClick),
+                .clickable(onClick = onClick)
     ) {
         Row(
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
@@ -231,7 +219,7 @@ private fun InquiryRow(inquiry: AgencyInquiry, onClick: () -> Unit) {
                                     colors = listOf(Brand800, Brand500),
                                     start = Offset(0f, 0f),
                                     end = Offset(size.width, size.height),
-                                ),
+                                )
                         )
                     },
                 contentAlignment = Alignment.Center,
@@ -281,10 +269,7 @@ private fun InquiryRow(inquiry: AgencyInquiry, onClick: () -> Unit) {
 
 @Composable
 private fun StatusPill(label: String) {
-    Surface(
-        shape = RoundedCornerShape(999.dp),
-        color = MaterialTheme.colorScheme.surfaceVariant,
-    ) {
+    Surface(shape = RoundedCornerShape(999.dp), color = MaterialTheme.colorScheme.surfaceVariant) {
         Text(
             text = label.uppercase(),
             modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/AuthCommon.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/AuthCommon.kt
@@ -52,13 +52,9 @@ internal fun ErrorBanner(message: String) {
             Modifier.fillMaxWidth()
                 .clip(RoundedCornerShape(8.dp))
                 .background(DangerRedBg)
-                .padding(horizontal = 12.dp, vertical = 10.dp),
+                .padding(horizontal = 12.dp, vertical = 10.dp)
     ) {
-        Text(
-            text = message,
-            style = MaterialTheme.typography.bodySmall,
-            color = DangerRedDark,
-        )
+        Text(text = message, style = MaterialTheme.typography.bodySmall, color = DangerRedDark)
     }
 }
 
@@ -69,13 +65,9 @@ internal fun SuccessBanner(message: String) {
             Modifier.fillMaxWidth()
                 .clip(RoundedCornerShape(8.dp))
                 .background(SuccessGreenBg)
-                .padding(horizontal = 12.dp, vertical = 10.dp),
+                .padding(horizontal = 12.dp, vertical = 10.dp)
     ) {
-        Text(
-            text = message,
-            style = MaterialTheme.typography.bodySmall,
-            color = SuccessGreenDark,
-        )
+        Text(text = message, style = MaterialTheme.typography.bodySmall, color = SuccessGreenDark)
     }
 }
 
@@ -113,17 +105,12 @@ internal fun AuthBrandHero(title: String, subtitle: String) {
                                 colors = listOf(Brand800, Brand500),
                                 start = Offset(0f, 0f),
                                 end = Offset(size.width, size.height),
-                            ),
+                            )
                     )
                 },
             contentAlignment = Alignment.Center,
         ) {
-            Text(
-                text = "R",
-                color = Color.White,
-                fontWeight = FontWeight.Bold,
-                fontSize = 22.sp,
-            )
+            Text(text = "R", color = Color.White, fontWeight = FontWeight.Bold, fontSize = 22.sp)
         }
         Spacer(modifier = Modifier.height(18.dp))
         Text(

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/ForgotPasswordScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/ForgotPasswordScreen.kt
@@ -53,20 +53,18 @@ fun ForgotPasswordScreen(
                     IconButton(onClick = onBackClick) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.back)
+                            contentDescription = stringResource(R.string.back),
                         )
                     }
                 },
                 colors =
                     TopAppBarDefaults.centerAlignedTopAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.surface,
+                        containerColor = MaterialTheme.colorScheme.surface
                     ),
             )
-        },
+        }
     ) { padding ->
-        Column(
-            modifier = Modifier.fillMaxSize().padding(padding),
-        ) {
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
             if (submitted) {
                 AuthIconHero(
                     iconBg = Color(0xFFD1FAE5),
@@ -95,7 +93,7 @@ fun ForgotPasswordScreen(
             }
 
             Column(
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 24.dp),
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 24.dp)
             ) {
                 Text(
                     text = stringResource(R.string.auth_forgot_body),

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/LoginScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/LoginScreen.kt
@@ -56,13 +56,8 @@ fun LoginScreen(
     var isSubmitting by remember { mutableStateOf(false) }
     val scope = rememberAuthScope()
 
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background,
-    ) {
-        Column(
-            modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
-        ) {
+    Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+        Column(modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
             AuthBrandHero(
                 title = stringResource(R.string.app_name),
                 subtitle = stringResource(R.string.auth_login_subtitle),
@@ -70,7 +65,7 @@ fun LoginScreen(
             Column(
                 modifier =
                     Modifier.fillMaxWidth()
-                        .padding(start = 20.dp, end = 20.dp, top = 32.dp, bottom = 24.dp),
+                        .padding(start = 20.dp, end = 20.dp, top = 32.dp, bottom = 24.dp)
             ) {
                 generalError?.let {
                     ErrorBanner(it)
@@ -116,10 +111,7 @@ fun LoginScreen(
                 )
 
                 Spacer(modifier = Modifier.height(10.dp))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End,
-                ) {
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
                     TextButton(onClick = onForgotPasswordClick) {
                         Text(
                             text = stringResource(R.string.forgot_password),
@@ -179,10 +171,7 @@ fun LoginScreen(
                 }
 
                 Spacer(modifier = Modifier.height(24.dp))
-                Box(
-                    modifier = Modifier.fillMaxWidth(),
-                    contentAlignment = Alignment.Center,
-                ) {
+                Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(
                             text = stringResource(R.string.auth_login_no_account),

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/RegisterScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/RegisterScreen.kt
@@ -70,23 +70,23 @@ fun RegisterScreen(
                     IconButton(onClick = onBackClick) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.back)
+                            contentDescription = stringResource(R.string.back),
                         )
                     }
                 },
                 colors =
                     TopAppBarDefaults.centerAlignedTopAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.surface,
+                        containerColor = MaterialTheme.colorScheme.surface
                     ),
             )
-        },
+        }
     ) { padding ->
         Column(
             modifier =
                 Modifier.fillMaxSize()
                     .padding(padding)
                     .verticalScroll(rememberScrollState())
-                    .padding(horizontal = 20.dp, vertical = 24.dp),
+                    .padding(horizontal = 20.dp, vertical = 24.dp)
         ) {
             if (submitted) {
                 Text(
@@ -199,10 +199,7 @@ fun RegisterScreen(
 
             Spacer(modifier = Modifier.height(20.dp))
             Row(verticalAlignment = Alignment.Top) {
-                Checkbox(
-                    checked = termsAccepted,
-                    onCheckedChange = { termsAccepted = it },
-                )
+                Checkbox(checked = termsAccepted, onCheckedChange = { termsAccepted = it })
                 Spacer(modifier = Modifier.width(4.dp))
                 Text(
                     text = stringResource(R.string.auth_register_terms),
@@ -218,10 +215,7 @@ fun RegisterScreen(
             val emailInvalidMsg = stringResource(R.string.auth_validation_email_invalid)
             val passwordRequiredMsg = stringResource(R.string.auth_validation_password_required)
             val passwordTooShortMsg =
-                stringResource(
-                    R.string.auth_validation_password_too_short,
-                    MIN_PASSWORD_LENGTH,
-                )
+                stringResource(R.string.auth_validation_password_too_short, MIN_PASSWORD_LENGTH)
             val passwordMismatchMsg = stringResource(R.string.auth_validation_password_mismatch)
             val termsRequiredMsg = stringResource(R.string.auth_validation_terms_required)
             val registerFailedMsg = stringResource(R.string.auth_validation_register_failed)
@@ -305,10 +299,7 @@ fun RegisterScreen(
 
 @Composable
 private fun PasswordStrengthBars(strength: Int) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
         repeat(4) { idx ->
             val fillColor =
                 when {
@@ -322,7 +313,7 @@ private fun PasswordStrengthBars(strength: Int) {
                     Modifier.weight(1f)
                         .height(4.dp)
                         .clip(RoundedCornerShape(2.dp))
-                        .background(fillColor),
+                        .background(fillColor)
             )
         }
     }

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/ResetPasswordScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/ResetPasswordScreen.kt
@@ -59,20 +59,18 @@ fun ResetPasswordScreen(
                     IconButton(onClick = onBackClick) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.back)
+                            contentDescription = stringResource(R.string.back),
                         )
                     }
                 },
                 colors =
                     TopAppBarDefaults.centerAlignedTopAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.surface,
+                        containerColor = MaterialTheme.colorScheme.surface
                     ),
             )
-        },
+        }
     ) { padding ->
-        Column(
-            modifier = Modifier.fillMaxSize().padding(padding),
-        ) {
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
             if (token.isBlank()) {
                 AuthIconHero(
                     iconBg = MaterialTheme.colorScheme.errorContainer,
@@ -118,7 +116,7 @@ fun ResetPasswordScreen(
             }
 
             Column(
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 24.dp),
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 24.dp)
             ) {
                 Text(
                     text = stringResource(R.string.auth_reset_body),
@@ -180,10 +178,7 @@ fun ResetPasswordScreen(
                 Spacer(modifier = Modifier.height(24.dp))
                 val passwordRequiredMsg = stringResource(R.string.auth_validation_password_required)
                 val passwordTooShortMsg =
-                    stringResource(
-                        R.string.auth_validation_password_too_short,
-                        MIN_PASSWORD_LENGTH,
-                    )
+                    stringResource(R.string.auth_validation_password_too_short, MIN_PASSWORD_LENGTH)
                 val passwordMismatchMsg = stringResource(R.string.auth_validation_password_mismatch)
                 val resetFailedMsg = stringResource(R.string.auth_validation_reset_failed)
                 val networkErrorMsg = stringResource(R.string.error_network)
@@ -237,10 +232,7 @@ fun ResetPasswordScreen(
 @Composable
 private fun StrengthBars(password: String) {
     val strength = passwordStrength(password)
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
         repeat(4) { idx ->
             val fillColor =
                 when {
@@ -254,7 +246,7 @@ private fun StrengthBars(password: String) {
                     Modifier.weight(1f)
                         .height(4.dp)
                         .clip(RoundedCornerShape(2.dp))
-                        .background(fillColor),
+                        .background(fillColor)
             )
         }
     }

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/TwoFactorScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/TwoFactorScreen.kt
@@ -57,16 +57,16 @@ fun TwoFactorScreen(onBackClick: () -> Unit, onDone: () -> Unit) {
                     IconButton(onClick = onBackClick) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.back)
+                            contentDescription = stringResource(R.string.back),
                         )
                     }
                 },
                 colors =
                     TopAppBarDefaults.centerAlignedTopAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.surface,
+                        containerColor = MaterialTheme.colorScheme.surface
                     ),
             )
-        },
+        }
     ) { padding ->
         Column(
             modifier = Modifier.fillMaxSize().padding(padding),
@@ -131,7 +131,7 @@ fun TwoFactorScreen(onBackClick: () -> Unit, onDone: () -> Unit) {
                         indication = null,
                     ) {
                         focusRequester.requestFocus()
-                    },
+                    }
             ) {
                 BasicTextField(
                     value = code,
@@ -161,7 +161,7 @@ fun TwoFactorScreen(onBackClick: () -> Unit, onDone: () -> Unit) {
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Spacer(modifier = Modifier.height(10.dp))
-            TextButton(onClick = { /* backup code */}) {
+            TextButton(onClick = { /* backup code */ }) {
                 Text(
                     text = stringResource(R.string.auth_2fa_backup_code),
                     style = MaterialTheme.typography.bodyMedium,
@@ -177,13 +177,7 @@ fun TwoFactorScreen(onBackClick: () -> Unit, onDone: () -> Unit) {
             }
             val invalidCodeMsg = stringResource(R.string.auth_validation_2fa_invalid)
             Box(
-                modifier =
-                    Modifier.padding(
-                        start = 24.dp,
-                        end = 24.dp,
-                        top = 16.dp,
-                        bottom = 32.dp,
-                    ),
+                modifier = Modifier.padding(start = 24.dp, end = 24.dp, top = 16.dp, bottom = 32.dp)
             ) {
                 Button(
                     onClick = {
@@ -239,5 +233,5 @@ private fun CodeCell(char: String, focused: Boolean) {
 
 private enum class TwoFactorStep {
     Verify,
-    Enabled
+    Enabled,
 }

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/common/StateViews.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/common/StateViews.kt
@@ -121,11 +121,7 @@ fun ErrorState(
  * platform's reduce-motion preference automatically via Compose's animation specs.
  */
 @Composable
-fun SkeletonBlock(
-    modifier: Modifier = Modifier,
-    height: Dp = 16.dp,
-    cornerRadius: Dp = 8.dp,
-) {
+fun SkeletonBlock(modifier: Modifier = Modifier, height: Dp = 16.dp, cornerRadius: Dp = 8.dp) {
     var toggled by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) {
         while (true) {

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/favorites/FavoritesScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/favorites/FavoritesScreen.kt
@@ -112,10 +112,7 @@ fun FavoritesScreen(
         }
     }
 
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background,
-    ) {
+    Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
         when (authState) {
             is AuthState.Unauthenticated,
             is AuthState.Error -> NotSignedInContent(onSignInClick = onSignInClick)
@@ -213,7 +210,7 @@ fun FavoritesScreen(
                         selectedTab == 1 -> {
                             SavedSearchesTabContent(
                                 searches = savedSearches,
-                                onSearchClick = { /* Navigate to search with filters */},
+                                onSearchClick = { /* Navigate to search with filters */ },
                                 onToggleAlert = { id, enabled ->
                                     scope.launch {
                                         favoritesRepository
@@ -254,13 +251,13 @@ fun FavoritesScreen(
 private enum class TransactionFilter {
     ALL,
     SALE,
-    RENT
+    RENT,
 }
 
 private enum class SortMode {
     NEWEST,
     PRICE_ASC,
-    PRICE_DESC
+    PRICE_DESC,
 }
 
 private fun applyFilterAndSort(
@@ -305,24 +302,19 @@ private fun FavoritesHeader(favoriteCount: Int, savedSearchCount: Int) {
             )
             Spacer(modifier = Modifier.height(2.dp))
             Text(
-                text =
-                    stringResource(
-                        R.string.favorites_summary,
-                        favoriteCount,
-                        savedSearchCount,
-                    ),
+                text = stringResource(R.string.favorites_summary, favoriteCount, savedSearchCount),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
-        IconButton(onClick = { /* share */}) {
+        IconButton(onClick = { /* share */ }) {
             Icon(
                 imageVector = Icons.Default.Share,
                 contentDescription = stringResource(R.string.cd_share),
                 tint = MaterialTheme.colorScheme.onSurface,
             )
         }
-        IconButton(onClick = { /* export */}) {
+        IconButton(onClick = { /* export */ }) {
             Icon(
                 imageVector = Icons.Default.FileDownload,
                 contentDescription = stringResource(R.string.cd_export),
@@ -388,17 +380,12 @@ private fun PropertyTabContent(
 
                 // FAB — "Create list"
                 ExtendedFloatingActionButton(
-                    onClick = { /* create list */},
+                    onClick = { /* create list */ },
                     modifier =
                         Modifier.align(Alignment.BottomEnd).padding(end = 16.dp, bottom = 16.dp),
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Default.Add,
-                            contentDescription = null,
-                        )
-                    },
+                    icon = { Icon(imageVector = Icons.Default.Add, contentDescription = null) },
                     text = { Text(text = stringResource(R.string.favorites_create_list)) },
                 )
             }
@@ -407,10 +394,7 @@ private fun PropertyTabContent(
 }
 
 @Composable
-private fun FilterChipStrip(
-    selected: TransactionFilter,
-    onSelect: (TransactionFilter) -> Unit,
-) {
+private fun FilterChipStrip(selected: TransactionFilter, onSelect: (TransactionFilter) -> Unit) {
     val chips =
         listOf(
             TransactionFilter.ALL to R.string.favorites_filter_all,
@@ -503,9 +487,7 @@ private fun FavoritePropertyCard(
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
     ) {
         Column {
-            Box(
-                modifier = Modifier.fillMaxWidth().aspectRatio(4f / 3f),
-            ) {
+            Box(modifier = Modifier.fillMaxWidth().aspectRatio(4f / 3f)) {
                 AsyncImage(
                     model =
                         ImageRequest.Builder(LocalContext.current)
@@ -629,12 +611,7 @@ private fun SavedSearchCard(
                     if (search.newCount > 0) {
                         Spacer(modifier = Modifier.width(8.dp))
                         Badge(containerColor = MaterialTheme.colorScheme.primary) {
-                            Text(
-                                stringResource(
-                                    R.string.saved_search_new_count,
-                                    search.newCount,
-                                )
-                            )
+                            Text(stringResource(R.string.saved_search_new_count, search.newCount))
                         }
                     }
                 }
@@ -692,7 +669,7 @@ private fun SavedSearchCard(
                     },
                     colors =
                         ButtonDefaults.textButtonColors(
-                            contentColor = MaterialTheme.colorScheme.error,
+                            contentColor = MaterialTheme.colorScheme.error
                         ),
                 ) {
                     Text(stringResource(R.string.delete))

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/home/HomeScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/home/HomeScreen.kt
@@ -112,10 +112,7 @@ fun HomeScreen(
         isLoading = false
     }
 
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background,
-    ) {
+    Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
         LazyColumn(contentPadding = PaddingValues(bottom = 96.dp)) {
             item {
                 HomeTopBar(
@@ -156,11 +153,7 @@ fun HomeScreen(
                     onSeeAllClick = { onSearchClick(null, null) },
                 )
             }
-            item {
-                CategoryGrid(
-                    onCategoryClick = { category -> onSearchClick(null, category) },
-                )
-            }
+            item { CategoryGrid(onCategoryClick = { category -> onSearchClick(null, category) }) }
 
             if (recentListings.isNotEmpty()) {
                 item {
@@ -223,14 +216,14 @@ private fun HomeTopBar(
                             .offset(x = (-2).dp, y = 2.dp)
                             .size(10.dp)
                             .clip(CircleShape)
-                            .background(MaterialTheme.colorScheme.background),
+                            .background(MaterialTheme.colorScheme.background)
                 ) {
                     Box(
                         modifier =
                             Modifier.padding(2.dp)
                                 .fillMaxSize()
                                 .clip(CircleShape)
-                                .background(MaterialTheme.colorScheme.error),
+                                .background(MaterialTheme.colorScheme.error)
                     )
                 }
             }
@@ -275,10 +268,7 @@ private fun HomeTopBar(
 // with 18% alpha to match.
 
 @Composable
-private fun HeroCard(
-    onSearchClick: () -> Unit,
-    onTabClick: (ListingType?) -> Unit,
-) {
+private fun HeroCard(onSearchClick: () -> Unit, onTabClick: (ListingType?) -> Unit) {
     Box(
         modifier =
             Modifier.padding(horizontal = 16.dp)
@@ -291,10 +281,10 @@ private fun HeroCard(
                                 colors = listOf(Brand800, Brand500),
                                 start = Offset(0f, 0f),
                                 end = Offset(size.width, size.height),
-                            ),
+                            )
                     )
                 }
-                .padding(18.dp),
+                .padding(18.dp)
     ) {
         Column {
             Text(
@@ -494,11 +484,7 @@ private fun listingMeta(listing: ListingSummary): String {
     val parts = buildList {
         listing.rooms?.let {
             add(
-                androidx.compose.ui.res.pluralStringResource(
-                    R.plurals.listing_rooms_plural,
-                    it,
-                    it,
-                )
+                androidx.compose.ui.res.pluralStringResource(R.plurals.listing_rooms_plural, it, it)
             )
         }
         listing.areaSqm?.toInt()?.let { add(stringResource(R.string.area_m2, it)) }
@@ -518,7 +504,7 @@ private fun FeaturedSkeleton() {
                 shape = RoundedCornerShape(16.dp),
                 colors =
                     CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant
                     ),
                 content = {},
             )
@@ -670,10 +656,7 @@ private fun RecentRow(listing: ListingSummary, onClick: () -> Unit) {
         elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
     ) {
-        Row(
-            modifier = Modifier.padding(10.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
+        Row(modifier = Modifier.padding(10.dp), verticalAlignment = Alignment.CenterVertically) {
             AsyncImage(
                 model =
                     ImageRequest.Builder(LocalContext.current)
@@ -725,10 +708,7 @@ private fun RecentRow(listing: ListingSummary, onClick: () -> Unit) {
 private fun ErrorCard(message: String) {
     Card(
         modifier = Modifier.fillMaxWidth().padding(16.dp),
-        colors =
-            CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.errorContainer,
-            ),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer),
     ) {
         Text(
             text = message,

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/inquiries/InquiriesScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/inquiries/InquiriesScreen.kt
@@ -119,18 +119,12 @@ fun InquiriesScreen(
         }
     }
 
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background,
-    ) {
+    Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
         when (authState) {
             is AuthState.Unauthenticated,
             is AuthState.Error -> NotSignedInContent(onSignInClick = onSignInClick)
             is AuthState.Loading ->
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center,
-                ) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                     CircularProgressIndicator()
                 }
             is AuthState.Authenticated -> {
@@ -310,10 +304,7 @@ private fun InquiriesList(inquiries: List<Inquiry>, onInquiryClick: (Inquiry) ->
         EmptyInquiries()
         return
     }
-    LazyColumn(
-        modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(bottom = 96.dp),
-    ) {
+    LazyColumn(modifier = Modifier.fillMaxSize(), contentPadding = PaddingValues(bottom = 96.dp)) {
         items(inquiries, key = { it.id }) { inquiry ->
             InquiryRow(inquiry = inquiry, onClick = { onInquiryClick(inquiry) })
         }
@@ -327,7 +318,7 @@ private fun InquiryRow(inquiry: Inquiry, onClick: () -> Unit) {
         modifier =
             Modifier.fillMaxWidth()
                 .background(MaterialTheme.colorScheme.surface)
-                .clickable(onClick = onClick),
+                .clickable(onClick = onClick)
     ) {
         if (isUnread) {
             Box(
@@ -337,7 +328,7 @@ private fun InquiryRow(inquiry: Inquiry, onClick: () -> Unit) {
                         .fillMaxHeight()
                         .clip(RoundedCornerShape(topEnd = 3.dp, bottomEnd = 3.dp))
                         .background(MaterialTheme.colorScheme.primary)
-                        .align(Alignment.CenterStart),
+                        .align(Alignment.CenterStart)
             )
         }
         Row(
@@ -368,7 +359,7 @@ private fun InquiryRow(inquiry: Inquiry, onClick: () -> Unit) {
                                             colors = listOf(Brand800, Brand500),
                                             start = Offset(0f, 0f),
                                             end = Offset(size.width, size.height),
-                                        ),
+                                        )
                                 )
                             }
                             .align(Alignment.TopStart),
@@ -465,10 +456,7 @@ private fun InquiryStatusPill(status: InquiryStatus) {
                     stringResource(R.string.status_closed),
                 )
         }
-    Surface(
-        shape = RoundedCornerShape(999.dp),
-        color = bg,
-    ) {
+    Surface(shape = RoundedCornerShape(999.dp), color = bg) {
         Text(
             text = label.uppercase(),
             modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
@@ -510,11 +498,7 @@ private fun ViewingsList(
 }
 
 @Composable
-private fun ViewingCard(
-    viewing: ViewingRequest,
-    onClick: () -> Unit,
-    onCancel: () -> Unit,
-) {
+private fun ViewingCard(viewing: ViewingRequest, onClick: () -> Unit, onCancel: () -> Unit) {
     var showCancelDialog by remember { mutableStateOf(false) }
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -597,7 +581,7 @@ private fun ViewingCard(
                     },
                     colors =
                         ButtonDefaults.textButtonColors(
-                            contentColor = MaterialTheme.colorScheme.error,
+                            contentColor = MaterialTheme.colorScheme.error
                         ),
                 ) {
                     Text(stringResource(R.string.viewing_cancel_confirm))

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingDetailScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingDetailScreen.kt
@@ -117,10 +117,7 @@ fun ListingDetailScreen(
         if (authState is AuthState.Authenticated) {
             favoritesRepository
                 .isFavorite(listingId)
-                .fold(
-                    onSuccess = { isFavorite = it },
-                    onFailure = { /* non-critical */},
-                )
+                .fold(onSuccess = { isFavorite = it }, onFailure = { /* non-critical */ })
         }
     }
     LaunchedEffect(listingId) {
@@ -139,16 +136,10 @@ fun ListingDetailScreen(
             )
     }
 
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background,
-    ) {
+    Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
         when {
             isLoading ->
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center,
-                ) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                     CircularProgressIndicator()
                 }
             errorMessage != null ->
@@ -185,7 +176,7 @@ fun ListingDetailScreen(
                                         else favoritesRepository.removeFavorite(listingId)
                                     result.fold(
                                         onSuccess = { isFavorite = newFav },
-                                        onFailure = { /* revert silently */},
+                                        onFailure = { /* revert silently */ },
                                     )
                                     isFavoriteLoading = false
                                 }
@@ -196,7 +187,7 @@ fun ListingDetailScreen(
                                 context.startActivity(
                                     Intent(Intent.ACTION_DIAL).apply {
                                         data = Uri.parse("tel:$phone")
-                                    },
+                                    }
                                 )
                             }
                         },
@@ -284,12 +275,7 @@ private fun ListingContent(
             item { HeaderSection(listing = listing) }
             item { Spacer(modifier = Modifier.height(18.dp)) }
             item { QuickStatsStrip(listing = listing) }
-            item {
-                TabStrip(
-                    selected = selectedTab,
-                    onSelect = { selectedTab = it },
-                )
-            }
+            item { TabStrip(selected = selectedTab, onSelect = { selectedTab = it }) }
             when (selectedTab) {
                 0 -> {
                     item { DescriptionBody(description = listing.description) }
@@ -327,13 +313,10 @@ private fun HeroGallery(
         modifier =
             Modifier.fillMaxWidth()
                 .height(280.dp)
-                .background(MaterialTheme.colorScheme.surfaceVariant),
+                .background(MaterialTheme.colorScheme.surfaceVariant)
     ) {
         if (images.isEmpty()) {
-            Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center,
-            ) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 Icon(
                     Icons.Default.Image,
                     contentDescription = null,
@@ -396,8 +379,8 @@ private fun HeroGallery(
                                 .clip(CircleShape)
                                 .background(
                                     if (idx == pagerState.currentPage) Color.White
-                                    else Color.White.copy(alpha = 0.5f),
-                                ),
+                                    else Color.White.copy(alpha = 0.5f)
+                                )
                     )
                 }
             }
@@ -411,9 +394,7 @@ private fun HeroGallery(
                     text = "${pagerState.currentPage + 1} / ${images.size}",
                     modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
                     style =
-                        MaterialTheme.typography.labelSmall.copy(
-                            fontWeight = FontWeight.SemiBold,
-                        ),
+                        MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.SemiBold),
                     color = Color.White,
                 )
             }
@@ -553,10 +534,7 @@ private fun StickyAgentBar(listing: ListingDetail, onCallClick: () -> Unit) {
 
 @Composable
 private fun SmallVerifiedPill() {
-    Surface(
-        shape = RoundedCornerShape(999.dp),
-        color = Color(0xFFD1FAE5),
-    ) {
+    Surface(shape = RoundedCornerShape(999.dp), color = Color(0xFFD1FAE5)) {
         Row(
             modifier = Modifier.padding(horizontal = 6.dp, vertical = 1.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -586,9 +564,7 @@ private fun SmallVerifiedPill() {
 
 @Composable
 private fun HeaderSection(listing: ListingDetail) {
-    Column(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 14.dp),
-    ) {
+    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 14.dp)) {
         Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
             if (listing.isFeatured) {
                 UppercaseBadge(
@@ -657,10 +633,7 @@ private fun HeaderSection(listing: ListingDetail) {
 
 @Composable
 private fun UppercaseBadge(text: String, bg: Color, ink: Color) {
-    Surface(
-        shape = RoundedCornerShape(6.dp),
-        color = bg,
-    ) {
+    Surface(shape = RoundedCornerShape(6.dp), color = bg) {
         Text(
             text = text.uppercase(),
             modifier = Modifier.padding(horizontal = 9.dp, vertical = 3.dp),
@@ -770,14 +743,14 @@ private fun TabStrip(selected: Int, onSelect: (Int) -> Unit) {
         )
     Row(
         modifier =
-            Modifier.fillMaxWidth().padding(top = 18.dp).horizontalScroll(rememberScrollState()),
+            Modifier.fillMaxWidth().padding(top = 18.dp).horizontalScroll(rememberScrollState())
     ) {
         tabs.forEachIndexed { index, label ->
             val isOn = selected == index
             Column(
                 modifier =
                     Modifier.clickable { onSelect(index) }
-                        .padding(start = if (index == 0) 16.dp else 0.dp, end = 12.dp),
+                        .padding(start = if (index == 0) 16.dp else 0.dp, end = 12.dp)
             ) {
                 Text(
                     text = label,
@@ -792,7 +765,7 @@ private fun TabStrip(selected: Int, onSelect: (Int) -> Unit) {
                     modifier =
                         Modifier.height(2.dp)
                             .width(if (isOn) 44.dp else 0.dp)
-                            .background(MaterialTheme.colorScheme.primary),
+                            .background(MaterialTheme.colorScheme.primary)
                 )
             }
         }
@@ -962,10 +935,7 @@ private fun PriceHistoryCard(listing: ListingDetail) {
             )
             if (delta > 0) {
                 Spacer(modifier = Modifier.height(14.dp))
-                Surface(
-                    shape = RoundedCornerShape(999.dp),
-                    color = Color(0xFFD1FAE5),
-                ) {
+                Surface(shape = RoundedCornerShape(999.dp), color = Color(0xFFD1FAE5)) {
                     Row(
                         modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp),
                         verticalAlignment = Alignment.CenterVertically,
@@ -1150,7 +1120,7 @@ private fun InquiryDialog(
 ) {
     var message by remember {
         mutableStateOf(
-            "Hi, I'm interested in ${listing.title}. Please contact me with more information.",
+            "Hi, I'm interested in ${listing.title}. Please contact me with more information."
         )
     }
     var name by remember { mutableStateOf("") }
@@ -1171,8 +1141,8 @@ private fun InquiryDialog(
                     Card(
                         colors =
                             CardDefaults.cardColors(
-                                containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-                            ),
+                                containerColor = MaterialTheme.colorScheme.tertiaryContainer
+                            )
                     ) {
                         Row(
                             modifier = Modifier.padding(12.dp),
@@ -1261,7 +1231,7 @@ private fun InquiryDialog(
                 }
                 Text(
                     if (isSubmitting) stringResource(R.string.inquiry_sending)
-                    else stringResource(R.string.inquiry_send),
+                    else stringResource(R.string.inquiry_send)
                 )
             }
         },

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/profile/ProfileEditScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/profile/ProfileEditScreen.kt
@@ -91,13 +91,13 @@ fun ProfileEditScreen(
                     IconButton(onClick = onBackClick) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.back)
+                            contentDescription = stringResource(R.string.back),
                         )
                     }
                 },
                 colors =
                     TopAppBarDefaults.centerAlignedTopAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.surface,
+                        containerColor = MaterialTheme.colorScheme.surface
                     ),
             )
         },
@@ -170,7 +170,7 @@ fun ProfileEditScreen(
                                         colors = listOf(Brand800, Brand500),
                                         start = Offset(0f, 0f),
                                         end = Offset(size.width, size.height),
-                                    ),
+                                    )
                             )
                         },
                     contentAlignment = Alignment.Center,
@@ -214,9 +214,7 @@ fun ProfileEditScreen(
             )
 
             Spacer(modifier = Modifier.height(16.dp))
-            Column(
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp),
-            ) {
+            Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp)) {
                 generalError?.let {
                     ErrorBanner(it)
                     Spacer(modifier = Modifier.height(12.dp))
@@ -273,10 +271,7 @@ fun ProfileEditScreen(
                 Spacer(modifier = Modifier.height(18.dp))
                 AuthFieldLabel(stringResource(R.string.profile_edit_language))
                 Spacer(modifier = Modifier.height(6.dp))
-                LanguageGrid(
-                    selected = selectedLang,
-                    onSelect = { selectedLang = it },
-                )
+                LanguageGrid(selected = selectedLang, onSelect = { selectedLang = it })
 
                 Spacer(modifier = Modifier.height(18.dp))
                 AuthFieldLabel(stringResource(R.string.profile_edit_about))
@@ -379,7 +374,7 @@ private fun LanguageCard(
                             Modifier.padding(4.dp)
                                 .fillMaxSize()
                                 .clip(CircleShape)
-                                .background(MaterialTheme.colorScheme.primary),
+                                .background(MaterialTheme.colorScheme.primary)
                     )
                 }
             }
@@ -406,11 +401,7 @@ private fun LanguageCard(
 }
 
 @Composable
-private fun EditProfileBottomBar(
-    onCancel: () -> Unit,
-    onSave: () -> Unit,
-    saving: Boolean,
-) {
+private fun EditProfileBottomBar(onCancel: () -> Unit, onSave: () -> Unit, saving: Boolean) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
         color = MaterialTheme.colorScheme.surface,

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/realtor/CreateListingScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/realtor/CreateListingScreen.kt
@@ -70,7 +70,7 @@ fun CreateListingScreen(
                     IconButton(onClick = onBackClick) {
                         Icon(
                             Icons.Default.Close,
-                            contentDescription = stringResource(R.string.close)
+                            contentDescription = stringResource(R.string.close),
                         )
                     }
                 },
@@ -80,7 +80,7 @@ fun CreateListingScreen(
                 },
                 colors =
                     TopAppBarDefaults.centerAlignedTopAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.surface,
+                        containerColor = MaterialTheme.colorScheme.surface
                     ),
             )
         },
@@ -114,7 +114,7 @@ fun CreateListingScreen(
                                     price = priceNum,
                                     currency = currency,
                                     transactionType = transactionType,
-                                ),
+                                )
                             )
                         isSubmitting = false
                         result.fold(
@@ -131,13 +131,12 @@ fun CreateListingScreen(
         },
     ) { padding ->
         Column(
-            modifier =
-                Modifier.fillMaxSize().padding(padding).verticalScroll(rememberScrollState()),
+            modifier = Modifier.fillMaxSize().padding(padding).verticalScroll(rememberScrollState())
         ) {
             ProgressHeader()
 
             Column(
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 16.dp),
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 16.dp)
             ) {
                 generalError?.let {
                     ErrorBanner(it)
@@ -294,10 +293,7 @@ private fun ProgressHeader() {
             modifier = Modifier.fillMaxWidth().height(6.dp).clip(RoundedCornerShape(999.dp)),
         )
         Spacer(modifier = Modifier.height(8.dp))
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
             listOf(
                     R.string.realtor_create_step1,
                     R.string.realtor_create_step2,
@@ -321,10 +317,7 @@ private fun ProgressHeader() {
 
 @Composable
 private fun DraftSavedPill() {
-    Surface(
-        shape = RoundedCornerShape(999.dp),
-        color = Color(0xFFD1FAE5),
-    ) {
+    Surface(shape = RoundedCornerShape(999.dp), color = Color(0xFFD1FAE5)) {
         Row(
             modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -351,11 +344,7 @@ private fun DraftSavedPill() {
 }
 
 @Composable
-private fun CreateListingFooter(
-    onCancel: () -> Unit,
-    onSubmit: () -> Unit,
-    isSubmitting: Boolean,
-) {
+private fun CreateListingFooter(onCancel: () -> Unit, onSubmit: () -> Unit, isSubmitting: Boolean) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
         color = MaterialTheme.colorScheme.surface,

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/realtor/ListingAnalyticsScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/realtor/ListingAnalyticsScreen.kt
@@ -50,24 +50,24 @@ fun ListingAnalyticsScreen(
                     IconButton(onClick = onBackClick) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.back)
+                            contentDescription = stringResource(R.string.back),
                         )
                     }
                 },
                 actions = {
-                    IconButton(onClick = { /* share */}) {
+                    IconButton(onClick = { /* share */ }) {
                         Icon(
                             Icons.Default.Share,
-                            contentDescription = stringResource(R.string.share)
+                            contentDescription = stringResource(R.string.share),
                         )
                     }
                 },
                 colors =
                     TopAppBarDefaults.centerAlignedTopAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.surface,
+                        containerColor = MaterialTheme.colorScheme.surface
                     ),
             )
-        },
+        }
     ) { padding ->
         if (isLoading) {
             Box(
@@ -135,9 +135,7 @@ private fun MetricCard(metric: AnalyticsMetric) {
 private fun Sparkline(values: List<Int>, color: Color) {
     if (values.isEmpty()) return
     val maxVal = (values.maxOrNull()?.toFloat() ?: 1f).coerceAtLeast(1f)
-    Canvas(
-        modifier = Modifier.fillMaxWidth().height(32.dp),
-    ) {
+    Canvas(modifier = Modifier.fillMaxWidth().height(32.dp)) {
         val w = size.width
         val h = size.height
         val stepX = if (values.size > 1) w / (values.size - 1) else w
@@ -157,15 +155,8 @@ private fun Sparkline(values: List<Int>, color: Color) {
         }
         fillPath.lineTo(w, h)
         fillPath.close()
-        drawPath(
-            path = fillPath,
-            color = color.copy(alpha = 0.12f),
-        )
-        drawPath(
-            path = path,
-            color = color,
-            style = Stroke(width = 2.dp.toPx()),
-        )
+        drawPath(path = fillPath, color = color.copy(alpha = 0.12f))
+        drawPath(path = path, color = color, style = Stroke(width = 2.dp.toPx()))
     }
 }
 

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/realtor/MyListingsScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/realtor/MyListingsScreen.kt
@@ -50,10 +50,7 @@ fun MyListingsScreen(
     onListingClick: (id: String) -> Unit,
 ) {
     var statusFilter by remember { mutableStateOf<String?>(null) }
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background,
-    ) {
+    Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
         Box(modifier = Modifier.fillMaxSize()) {
             Column(modifier = Modifier.fillMaxSize()) {
                 Row(
@@ -65,7 +62,7 @@ fun MyListingsScreen(
                     IconButton(onClick = onBackClick) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.cd_back)
+                            contentDescription = stringResource(R.string.cd_back),
                         )
                     }
                     Text(
@@ -115,11 +112,7 @@ fun MyListingsScreen(
                         LazyColumn(
                             modifier = Modifier.fillMaxSize(),
                             contentPadding =
-                                PaddingValues(
-                                    start = 16.dp,
-                                    end = 16.dp,
-                                    bottom = 110.dp,
-                                ),
+                                PaddingValues(start = 16.dp, end = 16.dp, bottom = 110.dp),
                             verticalArrangement = Arrangement.spacedBy(12.dp),
                         ) {
                             items(filtered, key = { it.id }) { listing ->
@@ -146,23 +139,14 @@ fun MyListingsScreen(
 }
 
 @Composable
-private fun StatusChip(
-    label: String,
-    count: Int,
-    selected: Boolean,
-    onClick: () -> Unit,
-) {
+private fun StatusChip(label: String, count: Int, selected: Boolean, onClick: () -> Unit) {
     Surface(
         onClick = onClick,
         shape = RoundedCornerShape(8.dp),
         color = if (selected) MaterialTheme.colorScheme.primaryContainer else Color.Transparent,
         border =
             if (selected) null
-            else
-                androidx.compose.foundation.BorderStroke(
-                    1.dp,
-                    MaterialTheme.colorScheme.outline,
-                ),
+            else androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
     ) {
         Row(modifier = Modifier.padding(horizontal = 14.dp, vertical = 7.dp)) {
             Text(
@@ -196,9 +180,7 @@ private fun ListingCard(listing: RealtorListing, onClick: () -> Unit) {
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
     ) {
         Column {
-            Box(
-                modifier = Modifier.fillMaxWidth().aspectRatio(16f / 9f),
-            ) {
+            Box(modifier = Modifier.fillMaxWidth().aspectRatio(16f / 9f)) {
                 AsyncImage(
                     model =
                         ImageRequest.Builder(LocalContext.current)
@@ -234,7 +216,7 @@ private fun ListingCard(listing: RealtorListing, onClick: () -> Unit) {
                             .size(34.dp)
                             .clip(CircleShape)
                             .background(Color.White.copy(alpha = 0.92f))
-                            .clickable { /* menu */},
+                            .clickable { /* menu */ },
                     contentAlignment = Alignment.Center,
                 ) {
                     Icon(
@@ -246,10 +228,7 @@ private fun ListingCard(listing: RealtorListing, onClick: () -> Unit) {
                 }
             }
             Column(modifier = Modifier.padding(14.dp)) {
-                Row(
-                    verticalAlignment = Alignment.Bottom,
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
+                Row(verticalAlignment = Alignment.Bottom, modifier = Modifier.fillMaxWidth()) {
                     Text(
                         text = listing.formattedPrice,
                         style = MaterialTheme.typography.titleMedium,
@@ -286,10 +265,7 @@ private fun ListingCard(listing: RealtorListing, onClick: () -> Unit) {
 }
 
 @Composable
-private fun Counter(
-    icon: androidx.compose.ui.graphics.vector.ImageVector,
-    value: Int,
-) {
+private fun Counter(icon: androidx.compose.ui.graphics.vector.ImageVector, value: Int) {
     Row(verticalAlignment = Alignment.CenterVertically) {
         Icon(
             imageVector = icon,

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/savedsearches/SavedSearchesScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/savedsearches/SavedSearchesScreen.kt
@@ -45,10 +45,7 @@ fun SavedSearchesScreen(
     onDelete: (id: String) -> Unit,
     onCreateNewSearch: (() -> Unit)? = null,
 ) {
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background,
-    ) {
+    Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
         Column(modifier = Modifier.fillMaxSize()) {
             // Header
             Row(
@@ -104,10 +101,7 @@ fun SavedSearchesScreen(
 
             when {
                 isLoading ->
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center,
-                    ) {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                         CircularProgressIndicator()
                     }
                 searches.isEmpty() -> EmptyState()
@@ -195,7 +189,7 @@ private fun SavedSearchRow(
                                 Text(
                                     if (search.alertsEnabled)
                                         stringResource(R.string.saved_search_disable_alerts)
-                                    else stringResource(R.string.saved_search_enable_alerts),
+                                    else stringResource(R.string.saved_search_enable_alerts)
                                 )
                             },
                             leadingIcon = {

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/search/SearchScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/search/SearchScreen.kt
@@ -146,10 +146,7 @@ fun SearchScreen(
                 (if (minPrice.isNotBlank() || maxPrice.isNotBlank()) 1 else 0)
         }
 
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background,
-    ) {
+    Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
         Box(modifier = Modifier.fillMaxSize()) {
             Column(modifier = Modifier.fillMaxSize()) {
                 ListingsTopBar(
@@ -267,12 +264,12 @@ fun SearchScreen(
             // FAB — Save search
             if (searchResults.isNotEmpty()) {
                 ExtendedFloatingActionButton(
-                    onClick = { /* save search — opens KmpSaveSearchModal (deferred) */},
+                    onClick = { /* save search — opens KmpSaveSearchModal (deferred) */ },
                     modifier =
                         Modifier.align(Alignment.BottomEnd)
                             .padding(
                                 end = 16.dp,
-                                bottom = if (viewMode == ViewMode.MAP) 100.dp else 96.dp
+                                bottom = if (viewMode == ViewMode.MAP) 100.dp else 96.dp,
                             ),
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
@@ -286,7 +283,7 @@ fun SearchScreen(
 
 private enum class ViewMode {
     LIST,
-    MAP
+    MAP,
 }
 
 // ─── Top bar ─────────────────────────────────────────────────────────────────
@@ -356,12 +353,7 @@ private fun ListingsTopBar(
 }
 
 @Composable
-private fun SegmentChip(
-    icon: ImageVector,
-    label: String,
-    selected: Boolean,
-    onClick: () -> Unit,
-) {
+private fun SegmentChip(icon: ImageVector, label: String, selected: Boolean, onClick: () -> Unit) {
     Surface(
         onClick = onClick,
         shape = RoundedCornerShape(999.dp),
@@ -416,7 +408,7 @@ private fun SearchInputRow(
                 IconButton(onClick = onClear) {
                     Icon(
                         Icons.Default.Clear,
-                        contentDescription = stringResource(R.string.cd_clear)
+                        contentDescription = stringResource(R.string.cd_clear),
                     )
                 }
             }
@@ -430,11 +422,7 @@ private fun SearchInputRow(
 // ─── Rooms chip strip ────────────────────────────────────────────────────────
 
 @Composable
-private fun RoomsChipStrip(
-    selected: Int?,
-    onSelect: (Int?) -> Unit,
-    totalResults: Int,
-) {
+private fun RoomsChipStrip(selected: Int?, onSelect: (Int?) -> Unit, totalResults: Int) {
     val chips =
         listOf<Pair<Int?, String>>(
             null to stringResource(R.string.filter_all),
@@ -501,7 +489,7 @@ private fun AdvancedFilterPanel(
         modifier =
             Modifier.fillMaxWidth()
                 .background(MaterialTheme.colorScheme.surfaceVariant)
-                .padding(16.dp),
+                .padding(16.dp)
     ) {
         // Type
         Text(
@@ -584,7 +572,7 @@ private fun AdvancedFilterPanel(
             IconButton(onClick = onApplyPrice) {
                 Icon(
                     Icons.Default.Check,
-                    contentDescription = stringResource(R.string.filter_apply)
+                    contentDescription = stringResource(R.string.filter_apply),
                 )
             }
         }
@@ -624,16 +612,10 @@ private fun AdvancedFilterPanel(
 private fun ErrorBanner(error: String) {
     Card(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
-        colors =
-            CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.errorContainer,
-            ),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer),
         shape = RoundedCornerShape(12.dp),
     ) {
-        Row(
-            modifier = Modifier.padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
+        Row(modifier = Modifier.padding(16.dp), verticalAlignment = Alignment.CenterVertically) {
             Icon(
                 Icons.Default.Error,
                 contentDescription = null,
@@ -715,9 +697,7 @@ fun ListingCard(
     ) {
         Column {
             // Hero — 16:9 photo with badges and heart pill
-            Box(
-                modifier = Modifier.fillMaxWidth().aspectRatio(16f / 9f),
-            ) {
+            Box(modifier = Modifier.fillMaxWidth().aspectRatio(16f / 9f)) {
                 AsyncImage(
                     model =
                         ImageRequest.Builder(LocalContext.current)
@@ -822,18 +802,9 @@ fun ListingCard(
 
             // Body — price + location row, title, meta
             Column(
-                modifier =
-                    Modifier.padding(
-                        start = 14.dp,
-                        end = 14.dp,
-                        top = 12.dp,
-                        bottom = 14.dp,
-                    ),
+                modifier = Modifier.padding(start = 14.dp, end = 14.dp, top = 12.dp, bottom = 14.dp)
             ) {
-                Row(
-                    verticalAlignment = Alignment.Bottom,
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
+                Row(verticalAlignment = Alignment.Bottom, modifier = Modifier.fillMaxWidth()) {
                     Text(
                         text = FormatUtils.formatPrice(listing.price, listing.currency),
                         style = MaterialTheme.typography.titleLarge,
@@ -878,10 +849,7 @@ fun ListingCard(
 
 @Composable
 private fun UppercaseBadge(text: String, bg: Color, ink: Color) {
-    Surface(
-        shape = RoundedCornerShape(6.dp),
-        color = bg,
-    ) {
+    Surface(shape = RoundedCornerShape(6.dp), color = bg) {
         Text(
             text = text.uppercase(),
             modifier = Modifier.padding(horizontal = 9.dp, vertical = 3.dp),

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/theme/Theme.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/theme/Theme.kt
@@ -36,8 +36,7 @@ private val RealityTypography =
             TextStyle(fontWeight = FontWeight.Medium, fontSize = 14.sp, lineHeight = 20.sp),
         labelMedium =
             TextStyle(fontWeight = FontWeight.Medium, fontSize = 12.sp, lineHeight = 16.sp),
-        labelSmall =
-            TextStyle(fontWeight = FontWeight.Medium, fontSize = 11.sp, lineHeight = 16.sp),
+        labelSmall = TextStyle(fontWeight = FontWeight.Medium, fontSize = 11.sp, lineHeight = 16.sp),
     )
 
 @Composable

--- a/mobile-native/build.gradle.kts
+++ b/mobile-native/build.gradle.kts
@@ -1,11 +1,14 @@
 plugins {
+    // AGP 9: Kotlin support is built into com.android.application / .library — the
+    // org.jetbrains.kotlin.android plugin is no longer declared. See
+    // https://developer.android.com/build/migrate-to-built-in-kotlin
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.android.kotlin.multiplatform.library) apply false
     alias(libs.plugins.kotlin.multiplatform) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.kotlin.compose) apply false
-    id("com.diffplug.spotless") version "6.25.0"
+    // Spotless 8.5.0+ is required for Gradle 9 support.
+    id("com.diffplug.spotless") version "8.5.1"
 }
 
 spotless {

--- a/mobile-native/gradle/libs.versions.toml
+++ b/mobile-native/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ ksp = "2.3.21-2.0.4"
 composeBom = "2026.05.01"
 activityCompose = "1.13.0"
 lifecycleRuntimeCompose = "2.8.7"
-navigationCompose = "2.8.5"
+navigationCompose = "2.9.8"
 
 # Kotlin Libraries
 kotlinxCoroutines = "1.11.0"
@@ -55,13 +55,13 @@ ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test" }
 
 # Image Loading
-coil-compose = { group = "io.coil-kt", name = "coil-compose", version = "2.5.0" }
+coil-compose = { group = "io.coil-kt", name = "coil-compose", version = "2.7.0" }
 
 # Location
 play-services-location = { group = "com.google.android.gms", name = "play-services-location", version = "21.0.1" }
 
 # DataStore
-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version = "1.0.0" }
+datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version = "1.2.1" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/mobile-native/gradle/libs.versions.toml
+++ b/mobile-native/gradle/libs.versions.toml
@@ -1,17 +1,17 @@
 [versions]
 # SDK
-compileSdk = "34"
+compileSdk = "36"
 minSdk = "24"
-targetSdk = "34"
+targetSdk = "36"
 
 # Build
-agp = "8.7.3"
+agp = "9.2.1"
 kotlin = "2.3.21"
-ksp = "2.1.0-1.0.29"
+ksp = "2.3.21-2.0.4"
 
 # Compose
-composeBom = "2024.12.01"
-activityCompose = "1.9.3"
+composeBom = "2026.05.01"
+activityCompose = "1.13.0"
 lifecycleRuntimeCompose = "2.8.7"
 navigationCompose = "2.8.5"
 
@@ -66,6 +66,7 @@ datastore-preferences = { group = "androidx.datastore", name = "datastore-prefer
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+android-kotlin-multiplatform-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/mobile-native/gradle/wrapper/gradle-wrapper.properties
+++ b/mobile-native/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/mobile-native/gradle/wrapper/gradle-wrapper.properties
+++ b/mobile-native/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/mobile-native/settings.gradle.kts
+++ b/mobile-native/settings.gradle.kts
@@ -1,4 +1,4 @@
-// JDK version check - AGP 8.x requires JDK 17-21 (JDK 25+ is not supported)
+// JDK version check - AGP 9.x requires JDK 17+ (JDK 25+ is not supported; range capped at 21)
 val javaVersion = System.getProperty("java.version")
 val javaMajor = javaVersion.split(".").first().toIntOrNull() ?: 0
 

--- a/mobile-native/shared/build.gradle.kts
+++ b/mobile-native/shared/build.gradle.kts
@@ -1,11 +1,20 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.android.library)
+    alias(libs.plugins.android.kotlin.multiplatform.library)
 }
 
 kotlin {
-    androidTarget {
+    // AGP 9 migration: the new com.android.kotlin.multiplatform.library plugin replaces
+    // `com.android.library` + `androidTarget`. It is variant-agnostic: no build types,
+    // no product flavors, no BuildConfig generation.
+    // See https://kotlinlang.org/docs/multiplatform/multiplatform-project-agp-9-migration.html
+    androidLibrary {
+        namespace = "three.two.bit.ppt.reality.shared"
+        compileSdk = libs.versions.compileSdk.get().toInt()
+        minSdk = libs.versions.minSdk.get().toInt()
+
+        // Preserve the JVM target migrated in PR #378 (compilerOptions DSL).
         compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
     }
 
@@ -45,51 +54,6 @@ kotlin {
             iosArm64Main.dependsOn(this)
             iosSimulatorArm64Main.dependsOn(this)
             dependencies { implementation(libs.ktor.client.darwin) }
-        }
-    }
-}
-
-android {
-    namespace = "three.two.bit.ppt.reality.shared"
-    compileSdk = libs.versions.compileSdk.get().toInt()
-
-    defaultConfig { minSdk = libs.versions.minSdk.get().toInt() }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    // Epic 85 - Story 85.2: Build Configuration by Environment
-    // Enable BuildConfig generation for shared module
-    buildFeatures { buildConfig = true }
-
-    // Epic 85 - Story 85.2: Build Configuration by Environment
-    // Product flavors matching the app module
-    flavorDimensions += "environment"
-    productFlavors {
-        create("development") {
-            dimension = "environment"
-            // Android emulator uses 10.0.2.2 to reach host localhost
-            buildConfigField("String", "API_BASE_URL", "\"http://10.0.2.2:8081\"")
-            buildConfigField("String", "ENVIRONMENT", "\"development\"")
-            buildConfigField("Boolean", "ENABLE_LOGGING", "true")
-        }
-        create("staging") {
-            dimension = "environment"
-            buildConfigField(
-                "String",
-                "API_BASE_URL",
-                "\"https://staging-reality.ppt.example.com\""
-            )
-            buildConfigField("String", "ENVIRONMENT", "\"staging\"")
-            buildConfigField("Boolean", "ENABLE_LOGGING", "true")
-        }
-        create("production") {
-            dimension = "environment"
-            buildConfigField("String", "API_BASE_URL", "\"https://reality.ppt.example.com\"")
-            buildConfigField("String", "ENVIRONMENT", "\"production\"")
-            buildConfigField("Boolean", "ENABLE_LOGGING", "false")
         }
     }
 }

--- a/mobile-native/shared/src/androidMain/kotlin/three/two/bit/ppt/reality/api/PlatformConfig.kt
+++ b/mobile-native/shared/src/androidMain/kotlin/three/two/bit/ppt/reality/api/PlatformConfig.kt
@@ -1,46 +1,71 @@
 package three.two.bit.ppt.reality.api
 
-import three.two.bit.ppt.reality.shared.BuildConfig
-
 /**
  * Android implementation of PlatformConfig.
  *
- * Reads configuration values from BuildConfig fields that are set by Gradle product flavors.
+ * AGP 9 migration: the new `com.android.kotlin.multiplatform.library` plugin used by the `:shared`
+ * module is variant-agnostic and no longer generates a `BuildConfig` class or supports product
+ * flavors. The environment-specific values still live in the `:androidApp` module's product
+ * flavors (`buildConfigField` in `androidApp/build.gradle.kts`), which DO generate a `BuildConfig`.
+ *
+ * This implementation reads those fields from the app's generated `BuildConfig` via reflection at
+ * runtime — mirroring the iOS implementation, which reads `Info.plist` from `NSBundle` at runtime.
+ * No compile-time dependency on the app module is introduced.
  *
  * Epic 85 - Story 85.1: Environment Variable Setup
  */
 actual object PlatformConfig {
+    /** Fully-qualified name of the app module's generated BuildConfig class. */
+    private const val APP_BUILD_CONFIG = "three.two.bit.ppt.reality.BuildConfig"
+
+    private val buildConfigFields: Map<String, Any?> by lazy {
+        runCatching {
+                val clazz = Class.forName(APP_BUILD_CONFIG)
+                clazz.declaredFields.associate { field ->
+                    field.isAccessible = true
+                    field.name to field.get(null)
+                }
+            }
+            .getOrDefault(emptyMap())
+    }
+
+    private fun stringField(name: String, default: String): String =
+        buildConfigFields[name] as? String ?: default
+
+    private fun booleanField(name: String, default: Boolean): Boolean =
+        buildConfigFields[name] as? Boolean ?: default
+
     /**
      * Base URL for the Reality Portal API.
      *
-     * Set by buildConfigField in build.gradle.kts for each product flavor: - development:
-     * http://10.0.2.2:8081 - staging: https://staging-reality.ppt.example.com - production:
-     * https://reality.ppt.example.com
+     * Set by buildConfigField in androidApp/build.gradle.kts for each product flavor: -
+     * development: http://10.0.2.2:8081 - staging: https://staging-reality.ppt.example.com -
+     * production: https://reality.ppt.example.com
      */
     actual val baseUrl: String
-        get() = BuildConfig.API_BASE_URL
+        get() = stringField("API_BASE_URL", "https://reality.ppt.example.com")
 
     /**
      * Current environment: development, staging, or production.
      *
-     * Set by buildConfigField in build.gradle.kts for each product flavor.
+     * Set by buildConfigField in androidApp/build.gradle.kts for each product flavor.
      */
     actual val environment: String
-        get() = BuildConfig.ENVIRONMENT
+        get() = stringField("ENVIRONMENT", "production")
 
     /**
      * Whether debug mode is enabled.
      *
-     * True for debug builds, false for release builds.
+     * Reads the app BuildConfig.DEBUG flag; falls back to environment-based detection.
      */
     actual val isDebug: Boolean
-        get() = BuildConfig.DEBUG
+        get() = booleanField("DEBUG", environment != "production")
 
     /**
      * Whether logging is enabled.
      *
-     * Set by buildConfigField in build.gradle.kts for each product flavor.
+     * Set by buildConfigField in androidApp/build.gradle.kts for each product flavor.
      */
     actual val enableLogging: Boolean
-        get() = BuildConfig.ENABLE_LOGGING
+        get() = booleanField("ENABLE_LOGGING", isDebug)
 }

--- a/mobile-native/shared/src/androidMain/kotlin/three/two/bit/ppt/reality/api/PlatformConfig.kt
+++ b/mobile-native/shared/src/androidMain/kotlin/three/two/bit/ppt/reality/api/PlatformConfig.kt
@@ -5,8 +5,8 @@ package three.two.bit.ppt.reality.api
  *
  * AGP 9 migration: the new `com.android.kotlin.multiplatform.library` plugin used by the `:shared`
  * module is variant-agnostic and no longer generates a `BuildConfig` class or supports product
- * flavors. The environment-specific values still live in the `:androidApp` module's product
- * flavors (`buildConfigField` in `androidApp/build.gradle.kts`), which DO generate a `BuildConfig`.
+ * flavors. The environment-specific values still live in the `:androidApp` module's product flavors
+ * (`buildConfigField` in `androidApp/build.gradle.kts`), which DO generate a `BuildConfig`.
  *
  * This implementation reads those fields from the app's generated `BuildConfig` via reflection at
  * runtime — mirroring the iOS implementation, which reads `Info.plist` from `NSBundle` at runtime.

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/api/ApiClient.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/api/ApiClient.kt
@@ -27,7 +27,7 @@ import three.two.bit.ppt.reality.listing.ListingSearchResponse
 class ApiClient(
     private val baseUrl: String = ApiConfig.requireBaseUrl(),
     private val accessToken: String? = null,
-    private val tenantId: String? = null
+    private val tenantId: String? = null,
 ) {
     private val client = HttpClientProvider.client
 

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/auth/SsoModels.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/auth/SsoModels.kt
@@ -15,7 +15,7 @@ data class SsoUserInfo(
     @SerialName("user_id") val userId: String,
     val email: String,
     val name: String,
-    @SerialName("avatar_url") val avatarUrl: String? = null
+    @SerialName("avatar_url") val avatarUrl: String? = null,
 )
 
 /** Request to create a mobile SSO token. */
@@ -27,7 +27,7 @@ data class CreateMobileSsoTokenRequest(@SerialName("pm_access_token") val pmAcce
 data class MobileSsoTokenResponse(
     @SerialName("sso_token") val ssoToken: String,
     @SerialName("expires_in") val expiresIn: Long,
-    @SerialName("deep_link") val deepLink: String
+    @SerialName("deep_link") val deepLink: String,
 )
 
 /** Request to validate a mobile SSO token. */
@@ -39,7 +39,7 @@ data class ValidateMobileSsoTokenRequest(@SerialName("sso_token") val ssoToken: 
 data class SessionResponse(
     @SerialName("session_token") val sessionToken: String,
     val user: SsoUserInfo,
-    @SerialName("expires_in") val expiresIn: Long
+    @SerialName("expires_in") val expiresIn: Long,
 )
 
 /** Current session information. */
@@ -48,14 +48,14 @@ data class SessionInfo(
     @SerialName("user_id") val userId: String,
     val email: String,
     val name: String,
-    @SerialName("expires_at") val expiresAt: String
+    @SerialName("expires_at") val expiresAt: String,
 )
 
 /** SSO error response. */
 @Serializable
 data class SsoError(
     val error: String,
-    @SerialName("error_description") val errorDescription: String? = null
+    @SerialName("error_description") val errorDescription: String? = null,
 )
 
 /** Email/password login request (UC-47.2). */
@@ -86,18 +86,11 @@ data class PortalUser(
 
 /** Registration request (UC-47.1). Matches `POST /api/v1/users/register`. */
 @Serializable
-data class AuthRegisterRequest(
-    val email: String,
-    val password: String,
-    val name: String,
-)
+data class AuthRegisterRequest(val email: String, val password: String, val name: String)
 
 /** Registration response — only contains a success message and the new user id. */
 @Serializable
-data class AuthRegisterResponse(
-    val message: String,
-    @SerialName("user_id") val userId: String,
-)
+data class AuthRegisterResponse(val message: String, @SerialName("user_id") val userId: String)
 
 /** Body for `POST /api/v1/users/password-reset` (UC-44.3 step 1). */
 @Serializable data class PasswordResetRequest(val email: String)

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/auth/SsoService.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/auth/SsoService.kt
@@ -328,9 +328,9 @@ class SsoService {
                                 SsoUserInfo(
                                     userId = session.userId,
                                     email = session.email,
-                                    name = session.name
+                                    name = session.name,
                                 ),
-                            sessionToken = token
+                            sessionToken = token,
                         )
                     true
                 },
@@ -338,7 +338,7 @@ class SsoService {
                     sessionToken = null
                     _authState.value = AuthState.Unauthenticated
                     false
-                }
+                },
             )
     }
 }

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/FavoritesModels.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/FavoritesModels.kt
@@ -17,7 +17,7 @@ data class FavoriteEntry(
     @SerialName("listing_id") val listingId: String,
     @SerialName("user_id") val userId: String,
     @SerialName("created_at") val createdAt: String,
-    val listing: ListingSummary? = null
+    val listing: ListingSummary? = null,
 )
 
 /** User favorites response. */
@@ -31,7 +31,7 @@ data class FavoriteEntry(
 data class AddFavoriteResponse(
     val id: String,
     @SerialName("listing_id") val listingId: String,
-    @SerialName("created_at") val createdAt: String
+    @SerialName("created_at") val createdAt: String,
 )
 
 /** Saved search. */
@@ -44,7 +44,7 @@ data class SavedSearch(
     @SerialName("alert_enabled") val alertEnabled: Boolean = false,
     @SerialName("created_at") val createdAt: String,
     @SerialName("last_notified_at") val lastNotifiedAt: String? = null,
-    @SerialName("new_count") val newCount: Int = 0
+    @SerialName("new_count") val newCount: Int = 0,
 )
 
 /** Saved search filters. */
@@ -55,7 +55,7 @@ data class SavedSearchFilters(
     val city: String? = null,
     @SerialName("min_price") val minPrice: Long? = null,
     @SerialName("max_price") val maxPrice: Long? = null,
-    @SerialName("min_rooms") val minRooms: Int? = null
+    @SerialName("min_rooms") val minRooms: Int? = null,
 )
 
 /** Saved searches response. */
@@ -67,12 +67,12 @@ data class CreateSavedSearchRequest(
     val name: String,
     val query: String? = null,
     val filters: SavedSearchFilters? = null,
-    @SerialName("alert_enabled") val alertEnabled: Boolean = false
+    @SerialName("alert_enabled") val alertEnabled: Boolean = false,
 )
 
 /** Update saved search request. */
 @Serializable
 data class UpdateSavedSearchRequest(
     val name: String? = null,
-    @SerialName("alert_enabled") val alertEnabled: Boolean? = null
+    @SerialName("alert_enabled") val alertEnabled: Boolean? = null,
 )

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/FavoritesRepository.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/FavoritesRepository.kt
@@ -14,7 +14,7 @@ import three.two.bit.ppt.reality.api.HttpClientProvider
 class FavoritesRepository(
     private val baseUrl: String,
     private val sessionToken: String? = null,
-    private val client: HttpClient = HttpClientProvider.client
+    private val client: HttpClient = HttpClientProvider.client,
 ) {
 
     private fun HttpRequestBuilder.configureRequest() {
@@ -148,7 +148,7 @@ class FavoritesRepository(
     /** Update a saved search. */
     suspend fun updateSavedSearch(
         searchId: String,
-        request: UpdateSavedSearchRequest
+        request: UpdateSavedSearchRequest,
     ): Result<SavedSearch> {
         return try {
             val response =

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/inquiry/InquiryModels.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/inquiry/InquiryModels.kt
@@ -16,7 +16,7 @@ import three.two.bit.ppt.reality.listing.RealtorInfo
 enum class InquiryStatus {
     @SerialName("pending") PENDING,
     @SerialName("responded") RESPONDED,
-    @SerialName("closed") CLOSED
+    @SerialName("closed") CLOSED,
 }
 
 /** Inquiry entry. */
@@ -31,7 +31,7 @@ data class Inquiry(
     @SerialName("updated_at") val updatedAt: String,
     val listing: ListingSummary? = null,
     val realtor: RealtorInfo? = null,
-    val responses: List<InquiryResponse> = emptyList()
+    val responses: List<InquiryResponse> = emptyList(),
 )
 
 /** Inquiry response from realtor. */
@@ -42,7 +42,7 @@ data class InquiryResponse(
     @SerialName("realtor_id") val realtorId: String,
     val message: String,
     @SerialName("created_at") val createdAt: String,
-    val realtor: RealtorInfo? = null
+    val realtor: RealtorInfo? = null,
 )
 
 /** User inquiries response. */
@@ -51,7 +51,7 @@ data class InquiriesResponse(
     val inquiries: List<Inquiry>,
     val total: Int,
     val page: Int,
-    @SerialName("page_size") val pageSize: Int
+    @SerialName("page_size") val pageSize: Int,
 )
 
 /** Create inquiry request. */
@@ -61,7 +61,7 @@ data class CreateInquiryRequest(
     val message: String,
     val name: String? = null,
     val email: String? = null,
-    val phone: String? = null
+    val phone: String? = null,
 )
 
 /** Create inquiry response. */
@@ -70,7 +70,7 @@ data class CreateInquiryResponse(
     val id: String,
     @SerialName("listing_id") val listingId: String,
     val status: InquiryStatus,
-    @SerialName("created_at") val createdAt: String
+    @SerialName("created_at") val createdAt: String,
 )
 
 /** Reply to inquiry request. */
@@ -87,7 +87,7 @@ data class ScheduleViewingRequest(
     val message: String? = null,
     val name: String? = null,
     val email: String? = null,
-    val phone: String? = null
+    val phone: String? = null,
 )
 
 /** Viewing request. */
@@ -105,7 +105,7 @@ data class ViewingRequest(
     @SerialName("confirmed_date") val confirmedDate: String? = null,
     @SerialName("confirmed_time") val confirmedTime: String? = null,
     @SerialName("created_at") val createdAt: String,
-    val listing: ListingSummary? = null
+    val listing: ListingSummary? = null,
 )
 
 /** Viewing status. */
@@ -114,7 +114,7 @@ enum class ViewingStatus {
     @SerialName("pending") PENDING,
     @SerialName("confirmed") CONFIRMED,
     @SerialName("completed") COMPLETED,
-    @SerialName("cancelled") CANCELLED
+    @SerialName("cancelled") CANCELLED,
 }
 
 /** User viewings response. */

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/inquiry/InquiryRepository.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/inquiry/InquiryRepository.kt
@@ -14,7 +14,7 @@ import three.two.bit.ppt.reality.api.HttpClientProvider
 class InquiryRepository(
     private val baseUrl: String,
     private val sessionToken: String? = null,
-    private val client: HttpClient = HttpClientProvider.client
+    private val client: HttpClient = HttpClientProvider.client,
 ) {
 
     private fun HttpRequestBuilder.configureRequest() {
@@ -50,7 +50,7 @@ class InquiryRepository(
     suspend fun getInquiries(
         page: Int = 1,
         pageSize: Int = 20,
-        status: InquiryStatus? = null
+        status: InquiryStatus? = null,
     ): Result<InquiriesResponse> {
         return try {
             val response =

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/ListingModels.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/ListingModels.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 enum class ListingType {
     @SerialName("sale") SALE,
-    @SerialName("rent") RENT
+    @SerialName("rent") RENT,
 }
 
 /** Property category. */
@@ -25,7 +25,7 @@ enum class PropertyCategory {
     @SerialName("commercial") COMMERCIAL,
     @SerialName("garage") GARAGE,
     @SerialName("office") OFFICE,
-    @SerialName("warehouse") WAREHOUSE
+    @SerialName("warehouse") WAREHOUSE,
 }
 
 /** Listing status. */
@@ -35,7 +35,7 @@ enum class ListingStatus {
     @SerialName("pending") PENDING,
     @SerialName("sold") SOLD,
     @SerialName("rented") RENTED,
-    @SerialName("withdrawn") WITHDRAWN
+    @SerialName("withdrawn") WITHDRAWN,
 }
 
 /** Geographic coordinates. */
@@ -50,7 +50,7 @@ data class Address(
     val region: String? = null,
     @SerialName("postal_code") val postalCode: String? = null,
     val country: String,
-    val coordinates: Coordinates? = null
+    val coordinates: Coordinates? = null,
 )
 
 /** Listing image. */
@@ -61,7 +61,7 @@ data class ListingImage(
     @SerialName("thumbnail_url") val thumbnailUrl: String? = null,
     @SerialName("is_primary") val isPrimary: Boolean = false,
     val caption: String? = null,
-    val order: Int = 0
+    val order: Int = 0,
 )
 
 /** Agency information. */
@@ -71,7 +71,7 @@ data class AgencyInfo(
     val name: String,
     @SerialName("logo_url") val logoUrl: String? = null,
     val phone: String? = null,
-    val email: String? = null
+    val email: String? = null,
 )
 
 /** Realtor information. */
@@ -82,7 +82,7 @@ data class RealtorInfo(
     @SerialName("avatar_url") val avatarUrl: String? = null,
     val phone: String? = null,
     val email: String? = null,
-    val agency: AgencyInfo? = null
+    val agency: AgencyInfo? = null,
 )
 
 /** Property listing summary for search results. */
@@ -108,7 +108,7 @@ data class ListingSummary(
     @SerialName("is_new") val isNew: Boolean = false,
     @SerialName("is_price_reduced") val isPriceReduced: Boolean = false,
     @SerialName("created_at") val createdAt: String,
-    @SerialName("updated_at") val updatedAt: String
+    @SerialName("updated_at") val updatedAt: String,
 )
 
 /** Full property listing details. */
@@ -147,7 +147,7 @@ data class ListingDetail(
     @SerialName("view_count") val viewCount: Int = 0,
     @SerialName("inquiry_count") val inquiryCount: Int = 0,
     @SerialName("created_at") val createdAt: String,
-    @SerialName("updated_at") val updatedAt: String
+    @SerialName("updated_at") val updatedAt: String,
 )
 
 /** Search filters for listings. */
@@ -171,7 +171,7 @@ data class ListingSearchFilters(
     @SerialName("year_built_max") val yearBuiltMax: Int? = null,
     @SerialName("near_lat") val nearLat: Double? = null,
     @SerialName("near_lng") val nearLng: Double? = null,
-    @SerialName("radius_km") val radiusKm: Double? = null
+    @SerialName("radius_km") val radiusKm: Double? = null,
 )
 
 /** Sort options for listings. */
@@ -183,7 +183,7 @@ enum class ListingSortOption {
     @SerialName("price_desc") PRICE_DESC,
     @SerialName("area_asc") AREA_ASC,
     @SerialName("area_desc") AREA_DESC,
-    @SerialName("relevance") RELEVANCE
+    @SerialName("relevance") RELEVANCE,
 }
 
 /** Paginated search response. */
@@ -193,7 +193,7 @@ data class ListingSearchResponse(
     val total: Int,
     val page: Int,
     @SerialName("page_size") val pageSize: Int,
-    @SerialName("total_pages") val totalPages: Int
+    @SerialName("total_pages") val totalPages: Int,
 )
 
 /** Search request. */
@@ -203,7 +203,7 @@ data class ListingSearchRequest(
     val filters: ListingSearchFilters? = null,
     val sort: ListingSortOption = ListingSortOption.NEWEST,
     val page: Int = 1,
-    @SerialName("page_size") val pageSize: Int = 20
+    @SerialName("page_size") val pageSize: Int = 20,
 )
 
 /** Featured listings response. */
@@ -218,7 +218,7 @@ data class CitySuggestion(
     val city: String,
     val region: String? = null,
     val country: String,
-    @SerialName("listing_count") val listingCount: Int
+    @SerialName("listing_count") val listingCount: Int,
 )
 
 /** Search suggestions response. */
@@ -226,5 +226,5 @@ data class CitySuggestion(
 data class SearchSuggestionsResponse(
     val cities: List<CitySuggestion>,
     val regions: List<String>,
-    @SerialName("recent_searches") val recentSearches: List<String>
+    @SerialName("recent_searches") val recentSearches: List<String>,
 )

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/ListingRepository.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/ListingRepository.kt
@@ -14,7 +14,7 @@ import three.two.bit.ppt.reality.api.HttpClientProvider
 class ListingRepository(
     private val baseUrl: String,
     private val sessionToken: String? = null,
-    private val client: HttpClient = HttpClientProvider.client
+    private val client: HttpClient = HttpClientProvider.client,
 ) {
 
     private fun HttpRequestBuilder.configureRequest() {
@@ -115,7 +115,7 @@ class ListingRepository(
         latitude: Double,
         longitude: Double,
         radiusKm: Double = 10.0,
-        limit: Int = 20
+        limit: Int = 20,
     ): Result<ListingSearchResponse> {
         return try {
             val response =

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/models/Models.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/models/Models.kt
@@ -13,21 +13,21 @@ data class User(
     val id: String,
     val email: String,
     @SerialName("display_name") val displayName: String,
-    @SerialName("avatar_url") val avatarUrl: String? = null
+    @SerialName("avatar_url") val avatarUrl: String? = null,
 )
 
 @Serializable
 data class TenantContext(
     @SerialName("tenant_id") val tenantId: String,
     @SerialName("tenant_name") val tenantName: String,
-    val role: String
+    val role: String,
 )
 
 @Serializable
 data class LoginRequest(
     val email: String,
     val password: String,
-    @SerialName("two_factor_code") val twoFactorCode: String? = null
+    @SerialName("two_factor_code") val twoFactorCode: String? = null,
 )
 
 @Serializable
@@ -36,14 +36,14 @@ data class LoginResponse(
     @SerialName("refresh_token") val refreshToken: String,
     @SerialName("expires_in") val expiresIn: Int,
     val user: User,
-    val tenants: List<TenantMembership>
+    val tenants: List<TenantMembership>,
 )
 
 @Serializable
 data class TenantMembership(
     @SerialName("tenant_id") val tenantId: String,
     @SerialName("tenant_name") val tenantName: String,
-    val role: String
+    val role: String,
 )
 
 @Serializable
@@ -51,5 +51,5 @@ data class ErrorResponse(
     val code: String,
     val message: String,
     @SerialName("request_id") val requestId: String? = null,
-    val timestamp: String
+    val timestamp: String,
 )

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/notifications/NotificationModels.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/notifications/NotificationModels.kt
@@ -17,7 +17,7 @@ enum class NotificationType {
     @SerialName("inquiry_response") INQUIRY_RESPONSE,
     @SerialName("listing_update") LISTING_UPDATE,
     @SerialName("favorite_sold") FAVORITE_SOLD,
-    @SerialName("system") SYSTEM
+    @SerialName("system") SYSTEM,
 }
 
 /** Notification entry. */
@@ -31,7 +31,7 @@ data class NotificationEntry(
     @SerialName("inquiry_id") val inquiryId: String? = null,
     val data: Map<String, String> = emptyMap(),
     @SerialName("is_read") val isRead: Boolean = false,
-    @SerialName("created_at") val createdAt: String
+    @SerialName("created_at") val createdAt: String,
 )
 
 /** User notifications response. */
@@ -39,7 +39,7 @@ data class NotificationEntry(
 data class NotificationsResponse(
     val notifications: List<NotificationEntry>,
     val total: Int,
-    @SerialName("unread_count") val unreadCount: Int
+    @SerialName("unread_count") val unreadCount: Int,
 )
 
 /** Push notification token registration request. */
@@ -47,7 +47,7 @@ data class NotificationsResponse(
 data class RegisterPushTokenRequest(
     val token: String,
     val platform: String, // "android" or "ios"
-    @SerialName("device_id") val deviceId: String? = null
+    @SerialName("device_id") val deviceId: String? = null,
 )
 
 /** Push notification token registration response. */
@@ -61,7 +61,7 @@ data class NotificationPreferences(
     @SerialName("price_drops") val priceDrops: Boolean = true,
     @SerialName("inquiry_responses") val inquiryResponses: Boolean = true,
     @SerialName("listing_updates") val listingUpdates: Boolean = true,
-    @SerialName("marketing") val marketing: Boolean = false
+    @SerialName("marketing") val marketing: Boolean = false,
 )
 
 /** Update notification preferences request. */
@@ -75,7 +75,7 @@ data class AlertConfig(
     @SerialName("search_id") val searchId: String,
     val enabled: Boolean = true,
     val frequency: AlertFrequency = AlertFrequency.INSTANT,
-    @SerialName("created_at") val createdAt: String
+    @SerialName("created_at") val createdAt: String,
 )
 
 /** Alert frequency. */
@@ -83,12 +83,12 @@ data class AlertConfig(
 enum class AlertFrequency {
     @SerialName("instant") INSTANT,
     @SerialName("daily") DAILY,
-    @SerialName("weekly") WEEKLY
+    @SerialName("weekly") WEEKLY,
 }
 
 /** Update alert config request. */
 @Serializable
 data class UpdateAlertConfigRequest(
     val enabled: Boolean? = null,
-    val frequency: AlertFrequency? = null
+    val frequency: AlertFrequency? = null,
 )

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/notifications/NotificationRepository.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/notifications/NotificationRepository.kt
@@ -14,7 +14,7 @@ import three.two.bit.ppt.reality.api.HttpClientProvider
 class NotificationRepository(
     private val baseUrl: String,
     private val sessionToken: String? = null,
-    private val client: HttpClient = HttpClientProvider.client
+    private val client: HttpClient = HttpClientProvider.client,
 ) {
 
     private fun HttpRequestBuilder.configureRequest() {
@@ -27,7 +27,7 @@ class NotificationRepository(
     suspend fun getNotifications(
         page: Int = 1,
         pageSize: Int = 20,
-        unreadOnly: Boolean = false
+        unreadOnly: Boolean = false,
     ): Result<NotificationsResponse> {
         return try {
             val response =
@@ -135,7 +135,7 @@ class NotificationRepository(
     suspend fun registerPushToken(
         token: String,
         platform: String,
-        deviceId: String? = null
+        deviceId: String? = null,
     ): Result<RegisterPushTokenResponse> {
         return try {
             val response =

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/realtor/RealtorModels.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/realtor/RealtorModels.kt
@@ -36,5 +36,4 @@ data class RealtorProfile(
 @Serializable data class RealtorProfileResponse(val profile: RealtorProfile)
 
 /** Realtor directory response. */
-@Serializable
-data class RealtorListResponse(val realtors: List<RealtorProfile>, val total: Int = 0)
+@Serializable data class RealtorListResponse(val realtors: List<RealtorProfile>, val total: Int = 0)

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/util/FormatUtils.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/util/FormatUtils.kt
@@ -87,7 +87,7 @@ object FormatUtils {
     fun buildLocationString(
         address: Address,
         includeStreet: Boolean = false,
-        includePostalCode: Boolean = false
+        includePostalCode: Boolean = false,
     ): String {
         val parts = mutableListOf<String>()
 

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoritesModelsContractTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoritesModelsContractTest.kt
@@ -76,7 +76,7 @@ class FavoritesModelsContractTest {
         val encoded = json.encodeToString(request)
         assertTrue(
             encoded.contains("\"listing_id\":\"lst-42\""),
-            "missing snake_case key: $encoded"
+            "missing snake_case key: $encoded",
         )
         assertTrue(!encoded.contains("listingId"), "leaked camelCase key: $encoded")
     }
@@ -156,7 +156,7 @@ class FavoritesModelsContractTest {
                 name = "Penthouses",
                 query = "penthouse",
                 filters = SavedSearchFilters(type = "sale", city = "Bratislava", minRooms = 3),
-                alertEnabled = true
+                alertEnabled = true,
             )
         val encoded = json.encodeToString(req)
         assertTrue(encoded.contains("\"alert_enabled\":true"))
@@ -186,10 +186,10 @@ class FavoritesModelsContractTest {
                             id = "ss-1",
                             name = "A",
                             alertEnabled = true,
-                            createdAt = "2026-04-26T10:00:00Z"
+                            createdAt = "2026-04-26T10:00:00Z",
                         )
                     ),
-                total = 1
+                total = 1,
             )
         val decoded: SavedSearchesResponse = json.decodeFromString(json.encodeToString(resp))
         assertEquals(resp, decoded)

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/inquiry/InquiryModelsContractTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/inquiry/InquiryModelsContractTest.kt
@@ -60,7 +60,7 @@ class InquiryModelsContractTest {
                 listingId = "lst-1",
                 message = "Is this available?",
                 name = "Jane",
-                email = "jane@example.com"
+                email = "jane@example.com",
             )
         val encoded = json.encodeToString(req)
         assertTrue(encoded.contains("\"listing_id\":\"lst-1\""), "missing snake_case: $encoded")
@@ -175,7 +175,7 @@ class InquiryModelsContractTest {
                 preferredTime = "14:00",
                 alternativeDate = "2026-05-02",
                 alternativeTime = "10:00",
-                message = "Looking forward"
+                message = "Looking forward",
             )
         val encoded = json.encodeToString(req)
         assertTrue(encoded.contains("\"listing_id\":\"lst-1\""))

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingModelsContractTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingModelsContractTest.kt
@@ -215,7 +215,7 @@ class ListingModelsContractTest {
         assertTrue(encoded.contains("\"query\":\"bratislava\""))
         assertTrue(
             !encoded.contains("\"page_size\""),
-            "page_size default should be omitted: $encoded"
+            "page_size default should be omitted: $encoded",
         )
         assertTrue(!encoded.contains("\"sort\""), "sort default should be omitted: $encoded")
     }
@@ -234,8 +234,8 @@ class ListingModelsContractTest {
                         minRooms = 2,
                         radiusKm = 5.0,
                         nearLat = 48.15,
-                        nearLng = 17.10
-                    )
+                        nearLng = 17.10,
+                    ),
             )
         val encoded = json.encodeToString(request)
 
@@ -256,7 +256,7 @@ class ListingModelsContractTest {
                 filters = ListingSearchFilters(category = PropertyCategory.HOUSE, minRooms = 3),
                 sort = ListingSortOption.PRICE_ASC,
                 page = 2,
-                pageSize = 50
+                pageSize = 50,
             )
         val decoded: ListingSearchRequest = json.decodeFromString(json.encodeToString(request))
         assertEquals(request, decoded)
@@ -310,13 +310,13 @@ class ListingModelsContractTest {
                         street = "Hlavna 1",
                         city = "Bratislava",
                         postalCode = "81101",
-                        country = "SK"
+                        country = "SK",
                     ),
                 images =
                     listOf(ListingImage(id = "img-1", url = "https://x/a.jpg", isPrimary = true)),
                 features = listOf("balcony", "elevator"),
                 createdAt = "2026-04-26T10:00:00Z",
-                updatedAt = "2026-04-26T10:00:00Z"
+                updatedAt = "2026-04-26T10:00:00Z",
             )
 
         val decoded: ListingDetail = json.decodeFromString(json.encodeToString(detail))

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/notifications/NotificationModelsContractTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/notifications/NotificationModelsContractTest.kt
@@ -125,12 +125,12 @@ class NotificationModelsContractTest {
             RegisterPushTokenRequest(
                 token = "expo-push-token",
                 platform = "ios",
-                deviceId = "device-uuid-123"
+                deviceId = "device-uuid-123",
             )
         val encoded = json.encodeToString(request)
         assertTrue(
             encoded.contains("\"device_id\":\"device-uuid-123\""),
-            "missing snake_case: $encoded"
+            "missing snake_case: $encoded",
         )
         assertTrue(encoded.contains("\"platform\":\"ios\""))
     }
@@ -188,7 +188,7 @@ class NotificationModelsContractTest {
                 priceDrops = true,
                 inquiryResponses = false,
                 listingUpdates = true,
-                marketing = true
+                marketing = true,
             )
         val decoded: NotificationPreferences = json.decodeFromString(json.encodeToString(prefs))
         assertEquals(prefs, decoded)

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/util/FormatUtilsTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/util/FormatUtilsTest.kt
@@ -12,7 +12,7 @@ class FormatUtilsTest {
         district: String? = null,
         region: String? = null,
         postalCode: String? = null,
-        country: String = "SK"
+        country: String = "SK",
     ): Address =
         Address(
             street = street,
@@ -20,7 +20,7 @@ class FormatUtilsTest {
             district = district,
             region = region,
             postalCode = postalCode,
-            country = country
+            country = country,
         )
 
     // -------- formatPrice (currency symbol prefix) --------
@@ -106,7 +106,7 @@ class FormatUtilsTest {
                 city = "Bratislava",
                 district = "Old Town",
                 postalCode = "81101",
-                region = "BA"
+                region = "BA",
             )
         assertEquals("Old Town, Bratislava, BA", FormatUtils.buildLocationString(addr))
     }
@@ -116,7 +116,7 @@ class FormatUtilsTest {
         val addr = address(street = "Hlavna 1", city = "Bratislava")
         assertEquals(
             "Hlavna 1, Bratislava",
-            FormatUtils.buildLocationString(addr, includeStreet = true)
+            FormatUtils.buildLocationString(addr, includeStreet = true),
         )
     }
 
@@ -125,7 +125,7 @@ class FormatUtilsTest {
         val addr = address(city = "Bratislava", postalCode = "81101")
         assertEquals(
             "81101, Bratislava",
-            FormatUtils.buildLocationString(addr, includePostalCode = true)
+            FormatUtils.buildLocationString(addr, includePostalCode = true),
         )
     }
 
@@ -137,11 +137,11 @@ class FormatUtilsTest {
                 city = "Bratislava",
                 district = "Old Town",
                 region = "BA",
-                postalCode = "81101"
+                postalCode = "81101",
             )
         assertEquals(
             "Hlavna 1, 81101, Old Town, Bratislava, BA",
-            FormatUtils.buildLocationString(addr, includeStreet = true, includePostalCode = true)
+            FormatUtils.buildLocationString(addr, includeStreet = true, includePostalCode = true),
         )
     }
 
@@ -156,7 +156,7 @@ class FormatUtilsTest {
         val addr = address(city = "Bratislava")
         assertEquals(
             "Bratislava",
-            FormatUtils.buildLocationString(addr, includeStreet = true, includePostalCode = true)
+            FormatUtils.buildLocationString(addr, includeStreet = true, includePostalCode = true),
         )
     }
 
@@ -169,7 +169,7 @@ class FormatUtilsTest {
                 street = "Hlavna 1",
                 city = "Bratislava",
                 district = "Old Town",
-                postalCode = "81101"
+                postalCode = "81101",
             )
         assertEquals("Old Town, Bratislava", FormatUtils.buildSimpleLocationString(addr))
     }
@@ -182,11 +182,11 @@ class FormatUtilsTest {
                 city = "Bratislava",
                 district = "Old Town",
                 region = "BA",
-                postalCode = "81101"
+                postalCode = "81101",
             )
         assertEquals(
             "Hlavna 1, 81101, Old Town, Bratislava, BA",
-            FormatUtils.buildDetailedLocationString(addr)
+            FormatUtils.buildDetailedLocationString(addr),
         )
     }
 }


### PR DESCRIPTION
## Coordinated mobile-native toolchain upgrade

Bumps the entire `mobile-native/` Kotlin Multiplatform toolchain to current releases. Rebased onto `main`; the `kotlinOptions` → `compilerOptions` DSL migration from PR #378 is folded in.

### Version SET

| Component | Old | New |
|-----------|-----|-----|
| Gradle (wrapper) | 8.10.2 | **9.4.1** |
| AGP | 8.7.3 | **9.2.1** |
| Kotlin (KGP) | 2.1.0 | **2.3.21** |
| KSP | 2.1.0-1.0.29 | **2.3.21-2.0.4** |
| compileSdk | 34 | **36** |
| targetSdk | 34 | **36** |
| Compose BOM | 2024.12.01 | **2026.05.01** |
| activity-compose | 1.9.3 | **1.13.0** |
| Ktor | 3.0.3 | **3.5.0** |
| Spotless | 6.25.0 | **8.5.1** |

> **Gradle wrapper:** AGP 9.2.1 requires Gradle ≥ 9.4.1 (`com.android.internal.version-check`). The wrapper is pinned to `gradle-9.4.1-bin.zip`.

### Files changed

- [x] `gradle/libs.versions.toml` — version SET applied; new `android-kotlin-multiplatform-library` plugin alias
- [x] `gradle/wrapper/gradle-wrapper.properties` — `gradle-9.4.1-bin.zip`
- [x] `settings.gradle.kts` — JDK-guard comment updated to "AGP 9.x requires JDK 17+" (guard logic kept)
- [x] `shared/build.gradle.kts` — **KMP plugin restructure** (see below)
- [x] `shared/src/androidMain/.../PlatformConfig.kt` — reads app BuildConfig via reflection (see below)
- [x] `androidApp/build.gradle.kts` — dropped explicit `kotlin-android` plugin; added `buildFeatures.resValues = true`
- [x] `build.gradle.kts` (root) — Spotless 8.5.1; dropped orphaned `kotlin-android` `apply false`; swapped to KMP-library alias
- [x] 44 `.kt` files — Spotless reformat for ktfmt bundled with Spotless 8.5.1 (trailing commas, single-line collapsing)
- [x] `CLAUDE.md` — Tech Stack table updated

### `:shared` KMP restructure (the hard part)

AGP 9 is incompatible with `com.android.library` + `kotlin.androidTarget`. The module now uses the new `com.android.kotlin.multiplatform.library` plugin with the `kotlin { androidLibrary { } }` DSL ([official guide](https://kotlinlang.org/docs/multiplatform/multiplatform-project-agp-9-migration.html)).

**Important consequence:** the new `androidLibrary` plugin is **variant-agnostic** — it has **no product flavors and no `BuildConfig` generation**. The `:shared` module previously declared 3 flavors with `buildConfigField` consumed by `PlatformConfig.kt` (androidMain).

**Resolution:** the `:androidApp` module *already* declares identical flavors with the same `buildConfigField` names (`API_BASE_URL`, `ENVIRONMENT`, `ENABLE_LOGGING`) and still generates a `BuildConfig`. `PlatformConfig` (androidMain) now reads those fields from the app's `three.two.bit.ppt.reality.BuildConfig` **via reflection at runtime** — directly mirroring the iOS implementation which reads `Info.plist` from `NSBundle` at runtime. No compile-time dependency on the app module is introduced, and safe fallbacks (production defaults) are used if the class is absent.

The `androidTarget`'s `compilerOptions { jvmTarget = JVM_17 }` from PR #378 is preserved inside the new `androidLibrary { }` block.

### Build verification

Verified locally with JDK 17 + Android SDK 36 on the upgraded toolchain (Gradle 9.4.1):

- [x] `./gradlew spotlessCheck` — clean
- [x] `./gradlew :shared:build`
- [x] `./gradlew :androidApp:assembleDebug`
- [x] CI: `lint`, `build-android`, `build-ios` green

### Supersedes

Supersedes closed PRs **#360, #362, #363** (and folds in #389/#390/#391).
