### PR TITLE
fix(mobile): adapt to async-storage v3 API (multiRemove → removeMany)

### DIFF
--- a/frontend/apps/mobile/src/hooks/useOfflineSupport.ts
+++ b/frontend/apps/mobile/src/hooks/useOfflineSupport.ts
@@ -186,7 +186,7 @@ export function useOfflineSupport(): UseOfflineSupportReturn {
         // Clear all cache entries
         const keys = await AsyncStorage.getAllKeys();
         const cacheKeys = keys.filter((k: string) => k.startsWith(CACHE_PREFIX));
-        await AsyncStorage.multiRemove(cacheKeys);
+        await AsyncStorage.removeMany(cacheKeys);
       }
     } catch (error) {
       console.error('Failed to clear cache:', error);

--- a/frontend/apps/mobile/src/test/integration/offline-support.integration.test.tsx
+++ b/frontend/apps/mobile/src/test/integration/offline-support.integration.test.tsx
@@ -47,7 +47,7 @@ jest.mock('@react-native-async-storage/async-storage', () => {
     clear: jest.fn(async () => {
       store.clear();
     }),
-    multiRemove: jest.fn(async (keys: string[]) => {
+    removeMany: jest.fn(async (keys: string[]) => {
       for (const k of keys) store.delete(k);
     }),
     getAllKeys: jest.fn(async () => Array.from(store.keys())),
@@ -64,7 +64,7 @@ const mockAsyncStorage = AsyncStorage as unknown as {
   setItem: jest.Mock;
   removeItem: jest.Mock;
   clear: jest.Mock;
-  multiRemove: jest.Mock;
+  removeMany: jest.Mock;
   getAllKeys: jest.Mock;
   __store: Map<string, string>;
 };

--- a/frontend/apps/mobile/src/types/expo-modules.d.ts
+++ b/frontend/apps/mobile/src/types/expo-modules.d.ts
@@ -219,20 +219,20 @@ declare module 'expo-notifications' {
 }
 
 declare module '@react-native-async-storage/async-storage' {
-  interface AsyncStorageStatic {
+  // Scoped storage API introduced in async-storage v3.
+  interface AsyncStorage {
     getItem(key: string): Promise<string | null>;
     setItem(key: string, value: string): Promise<void>;
     removeItem(key: string): Promise<void>;
-    mergeItem(key: string, value: string): Promise<void>;
+    getMany(keys: string[]): Promise<Record<string, string | null>>;
+    setMany(entries: Record<string, string>): Promise<void>;
+    removeMany(keys: string[]): Promise<void>;
+    getAllKeys(): Promise<string[]>;
     clear(): Promise<void>;
-    getAllKeys(): Promise<readonly string[]>;
-    multiGet(keys: readonly string[]): Promise<readonly [string, string | null][]>;
-    multiSet(keyValuePairs: readonly [string, string][]): Promise<void>;
-    multiRemove(keys: readonly string[]): Promise<void>;
-    multiMerge(keyValuePairs: readonly [string, string][]): Promise<void>;
   }
 
-  const AsyncStorage: AsyncStorageStatic;
+  export function createAsyncStorage(databaseName: string): AsyncStorage;
+  const AsyncStorage: AsyncStorage;
   export default AsyncStorage;
 }
 


### PR DESCRIPTION
## Summary

Recovers the async-storage v3 adaptation fix. (Original PR #376 was accidentally closed when a rebase flattened its branch to equal `main` — the fix commit `a20a10f6` was dropped. This re-applies it cleanly via cherry-pick onto current main.)

`@react-native-async-storage/async-storage` v3 (bumped in #350, now on main) renamed `multiRemove` → `removeMany`. Main's `useOfflineSupport.ts` still calls the removed `multiRemove`, which would throw at runtime when clearing the offline cache.

## Changes (3 files, +11/-11)

- `frontend/apps/mobile/src/hooks/useOfflineSupport.ts` — `AsyncStorage.multiRemove(...)` → `removeMany(...)`
- `frontend/apps/mobile/src/test/integration/offline-support.integration.test.tsx` — update the in-memory AsyncStorage mock
- `frontend/apps/mobile/src/types/expo-modules.d.ts` — type-decl alignment

## Verification

Per the original commit: `@ppt/mobile` typecheck + 33/33 mobile tests pass.

## Test plan

- [ ] Frontend CI green