### PR TITLE
Chore(deps-dev): bump react-test-renderer from 19.2.0 to 19.2.6 in /frontend

### DIFF
--- a/frontend/apps/mobile/package.json
+++ b/frontend/apps/mobile/package.json
@@ -43,7 +43,7 @@
     "@types/react": "~19.2.14",
     "jest": "^29.7.0",
     "jest-expo": "^56.0.0",
-    "react-test-renderer": "^19.2.0",
+    "react-test-renderer": "^19.2.6",
     "typescript": "^5.3.0"
   },
   "version": "0.2.417"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
     "overrides": {
       "react": "19.2.0",
       "react-dom": "19.2.0",
-      "react-test-renderer": "19.2.0",
+      "react-test-renderer": "19.2.6",
       "@types/react": "19.2.14",
       "@types/react-dom": "19.2.3",
       "@react-native/babel-plugin-codegen": "^0.85.0"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   react: 19.2.0
   react-dom: 19.2.0
-  react-test-renderer: 19.2.0
+  react-test-renderer: 19.2.6
   '@types/react': 19.2.14
   '@types/react-dom': 19.2.3
   '@react-native/babel-plugin-codegen': ^0.85.0
@@ -176,7 +176,7 @@ importers:
         version: 0.85.3(@babel/core@7.29.0)(react@19.2.0)
       '@testing-library/react-native':
         specifier: ^13.3.3
-        version: 13.3.3(jest@29.7.0)(react-native@0.85.3)(react-test-renderer@19.2.0)(react@19.2.0)
+        version: 13.3.3(jest@29.7.0)(react-native@0.85.3)(react-test-renderer@19.2.6)(react@19.2.0)
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.14
@@ -190,8 +190,8 @@ importers:
         specifier: ^56.0.0
         version: 56.0.0(@babel/core@7.29.0)(jest@29.7.0)(react-native@0.85.3)(react@19.2.0)
       react-test-renderer:
-        specifier: 19.2.0
-        version: 19.2.0(react@19.2.0)
+        specifier: 19.2.6
+        version: 19.2.6(react@19.2.0)
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
@@ -4333,14 +4333,14 @@ packages:
       redent: 3.0.0
     dev: true
 
-  /@testing-library/react-native@13.3.3(jest@29.7.0)(react-native@0.85.3)(react-test-renderer@19.2.0)(react@19.2.0):
+  /@testing-library/react-native@13.3.3(jest@29.7.0)(react-native@0.85.3)(react-test-renderer@19.2.6)(react@19.2.0):
     resolution: {integrity: sha512-k6Mjsd9dbZgvY4Bl7P1NIpePQNi+dfYtlJ5voi9KQlynxSyQkfOgJmYGCYmw/aSgH/rUcFvG8u5gd4npzgRDyg==}
     engines: {node: '>=18'}
     peerDependencies:
       jest: '>=29.0.0'
       react: 19.2.0
       react-native: '>=0.71'
-      react-test-renderer: 19.2.0
+      react-test-renderer: 19.2.6
     peerDependenciesMeta:
       jest:
         optional: true
@@ -4351,7 +4351,7 @@ packages:
       pretty-format: 30.4.1
       react: 19.2.0
       react-native: 0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3)(@types/react@19.2.14)(react@19.2.0)
-      react-test-renderer: 19.2.0(react@19.2.0)
+      react-test-renderer: 19.2.6(react@19.2.0)
       redent: 3.0.0
     dev: true
 
@@ -7024,7 +7024,7 @@ packages:
       json5: 2.2.3
       lodash: 4.18.1
       react-native: 0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3)(@types/react@19.2.14)(react@19.2.0)
-      react-test-renderer: 19.2.0(react@19.2.0)
+      react-test-renderer: 19.2.6(react@19.2.0)
       server-only: 0.0.1
       stacktrace-js: 2.0.2
     transitivePeerDependencies:
@@ -8931,8 +8931,8 @@ packages:
       react: 19.2.0
     dev: false
 
-  /react-test-renderer@19.2.0(react@19.2.0):
-    resolution: {integrity: sha512-zLCFMHFE9vy/w3AxO0zNxy6aAupnCuLSVOJYDe/Tp+ayGI1f2PLQsFVPANSD42gdSbmYx5oN+1VWDhcXtq7hAQ==}
+  /react-test-renderer@19.2.6(react@19.2.0):
+    resolution: {integrity: sha512-GbS6V23YduFTPiWJ5xICbKEjRcqx1Z90js/V5miqhz7qp/d6xSe9Dd6NjSQODFRdzdsqRMPW82E/sFpPRbY5Mw==}
     peerDependencies:
       react: 19.2.0
     dependencies:


### PR DESCRIPTION
Bumps react-test-renderer from 19.2.0 to 19.2.6.

Recreated from closed dependabot PR #354 (branch was deleted; re-pushed rebased onto current main for the dependency merge-sweep).