### PR TITLE
chore(dependabot): group minor+patch bumps, keep majors as individual PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,15 @@
 version: 2
+
+# Grouping strategy
+# -----------------
+# - Coordinated dependency families (tokio, axum, ...) update together so
+#   their versions never drift apart across a partial merge.
+# - Every remaining minor + patch bump is batched into one "safe" PR per
+#   ecosystem, to cut review noise for low-risk updates.
+# - Major-version bumps deliberately fall OUT of the safe groups and land as
+#   individual PRs, so the breaking change is obvious and gets reviewed on
+#   its own. (See #350 / #359: majors merged in a batch without the required
+#   code changes broke `main`.)
 updates:
   - package-ecosystem: "cargo"
     directory: "/backend"
@@ -13,14 +24,28 @@ updates:
         patterns: ["serde*"]
       sqlx:
         patterns: ["sqlx*"]
+      cargo-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
       interval: "weekly"
+    groups:
+      npm-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
   - package-ecosystem: "gradle"
     directory: "/mobile-native"
     schedule:
@@ -37,3 +62,6 @@ updates:
       ktor:
         patterns:
           - "io.ktor*"
+      gradle-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
## Why

#350 (async-storage 2→3) and #359 (Kotlin 2.1→2.3) were major bumps that needed code changes. Merged in a batch without them, they broke `main` (runtime crash + Gradle compile error). They looked as routine as any patch bump.

## Change

Adds Dependabot `groups` so the safe/risky split is structural:

- **Minor + patch** bumps → one batched "safe" PR per ecosystem (`cargo-minor-patch`, `npm-minor-patch`, `actions-minor-patch`, `gradle-minor-patch`) — less review noise.
- **Major** bumps fall *out* of those groups → individual PRs, so each breaking change is reviewed on its own.
- Coordinated families (tokio, axum, serde, sqlx, kotlin, compose, ktor) keep their existing grouping so their versions never drift.

Config-only change — no code impact.