### PR TITLE
fix(build): enable clap "env" feature so ppt-seed compiles

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -93,7 +93,7 @@ aws-credential-types = "1.1"
 redis = { version = "1.2", features = ["tokio-comp", "connection-manager"] }
 
 # CLI (Epic 110)
-clap = { version = "4.4", features = ["derive"] }
+clap = { version = "4.4", features = ["derive", "env"] }
 dialoguer = "0.12"
 
 # i18n (Epic 111)


### PR DESCRIPTION
## Summary

`bin/seed.rs` (`ppt-seed`) uses `#[arg(long, env = "PPT_PM_CLIENT_SECRET")]`, but the workspace `clap` dependency only enabled `["derive"]`. Without the `env` feature, clap's `Arg` has no `env` method:

```
error[E0599]: no method named `env` found for struct `Arg`
   --> servers/api-server/src/bin/seed.rs:134
```

## Impact

This broke **all** `cargo test --tests` / `--test <name>` compilation for the `api-server` package (the `ppt-seed` bin builds as part of the package's test targets), even though the lib and main `api-server` bin compiled fine. So api-server's integration tests couldn't build locally or in CI.

## Fix

Add `"env"` to the workspace clap features. Additive — no new crates in `Cargo.lock`.

## Verification

- `cargo check -p api-server --bin ppt-seed` — now compiles
- `cargo check -p api-server --tests` — now compiles (previously errored on this bin)

## Type of Change
- [x] Bug fix (build)