### PR TITLE
fix(caddy): register_route truly idempotent + observability + drift signal

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "admin-core"
-version = "0.2.429"
+version = "0.2.432"
 dependencies = [
  "api-core",
  "async-trait",
@@ -192,7 +192,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-core"
-version = "0.2.429"
+version = "0.2.432"
 dependencies = [
  "async-trait",
  "axum",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "api-server"
-version = "0.2.429"
+version = "0.2.432"
 dependencies = [
  "admin-core",
  "aes-gcm",
@@ -1410,7 +1410,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.2.429"
+version = "0.2.432"
 dependencies = [
  "axum",
  "chrono",
@@ -1836,7 +1836,7 @@ dependencies = [
 
 [[package]]
 name = "db"
-version = "0.2.429"
+version = "0.2.432"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1889,7 +1889,7 @@ dependencies = [
 
 [[package]]
 name = "deploy-server"
-version = "0.2.429"
+version = "0.2.432"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3402,7 +3402,7 @@ dependencies = [
 
 [[package]]
 name = "integrations"
-version = "0.2.429"
+version = "0.2.432"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -5139,7 +5139,7 @@ dependencies = [
 
 [[package]]
 name = "reality-server"
-version = "0.2.429"
+version = "0.2.432"
 dependencies = [
  "anyhow",
  "api-core",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "tenant-ops"
-version = "0.2.429"
+version = "0.2.432"
 dependencies = [
  "chrono",
  "common",

--- a/backend/servers/deploy-server/src/api/gc.rs
+++ b/backend/servers/deploy-server/src/api/gc.rs
@@ -97,7 +97,12 @@ async fn unregister_worktree_routes(ctx: &GcContext, wt: &crate::domain::Worktre
     ] {
         if let Some(host) = url_opt.and_then(|u| u.strip_prefix("https://")) {
             if let Err(e) = ctx.svc.caddy.unregister_route(host).await {
-                tracing::debug!(host = %host, error = %e, "caddy unregister failed during gc (ignored)");
+                // Pre-fix this was always 404→Ok or transport error. The new
+                // `caddy.rs` returns Err on (a) 16-iter exhaustion and (b)
+                // 15s sweep-deadline trip, both of which mean Caddy's id
+                // index is misbehaving — worth a warn (not debug) so the
+                // GC loop's silence-by-default doesn't hide drift (PO2-001).
+                tracing::warn!(host = %host, error = %e, "caddy unregister failed during gc");
             }
         }
     }

--- a/backend/servers/deploy-server/src/api/worktree.rs
+++ b/backend/servers/deploy-server/src/api/worktree.rs
@@ -227,8 +227,15 @@ pub async fn open_handler(
             "frontend bridge-IP/route registration failed; cleaning up containers"
         );
         svc.docker.cleanup_containers(&started).await;
-        let _ = svc.caddy.unregister_route(&host_ppt).await;
-        let _ = svc.caddy.unregister_route(&host_reality).await;
+        // Best-effort cleanup: an `unregister_route` failure here means the
+        // route is still in Caddy pointing at the dead container we just
+        // killed. Log so on-call sees the orphan (PO2-001).
+        if let Err(unreg_err) = svc.caddy.unregister_route(&host_ppt).await {
+            tracing::warn!(host = %host_ppt, error = %unreg_err, "caddy unregister failed during open-rollback");
+        }
+        if let Err(unreg_err) = svc.caddy.unregister_route(&host_reality).await {
+            tracing::warn!(host = %host_reality, error = %unreg_err, "caddy unregister failed during open-rollback");
+        }
         return Err(e);
     }
 
@@ -451,10 +458,14 @@ pub async fn open_handler(
                     "dedicated backend bring-up failed; cleaning up all worktree containers"
                 );
                 svc.docker.cleanup_containers(&to_clean).await;
-                let _ = svc.caddy.unregister_route(&host_ppt).await;
-                let _ = svc.caddy.unregister_route(&host_reality).await;
-                let _ = svc.caddy.unregister_route(&host_api).await;
-                let _ = svc.caddy.unregister_route(&host_reality_api).await;
+                // Best-effort cleanup: log Caddy unregister failures so a
+                // dedicated-backend bring-up rollback doesn't silently
+                // orphan routes (PO2-001).
+                for h in [&host_ppt, &host_reality, &host_api, &host_reality_api] {
+                    if let Err(unreg_err) = svc.caddy.unregister_route(h).await {
+                        tracing::warn!(host = %h, error = %unreg_err, "caddy unregister failed during dedicated-backend rollback");
+                    }
+                }
                 return Err(e);
             }
             api_url = Some(format!("https://{host_api}"));
@@ -554,7 +565,13 @@ pub async fn close_handler(
         wt.urls.api.as_deref(),
     ] {
         if let Some(host) = url_opt.and_then(|u| u.strip_prefix("https://")) {
-            let _ = svc.caddy.unregister_route(host).await;
+            // Best-effort: close runs on a healthy worktree, so 404 (most
+            // common case) is already Ok. The new Err paths from caddy.rs
+            // (16-iter exhaustion, 15s deadline) are worth surfacing so
+            // operators notice a wedged Caddy admin (PO2-001).
+            if let Err(unreg_err) = svc.caddy.unregister_route(host).await {
+                tracing::warn!(host = %host, error = %unreg_err, "caddy unregister failed during worktree close");
+            }
         }
     }
     // Dedicated mode also has a reality-API route at
@@ -564,7 +581,9 @@ pub async fn close_handler(
     // mode — the route doesn't exist, unregister is a 404.
     if matches!(wt.backend_mode, BackendMode::Dedicated) {
         let host_reality_api = format!("api.wt-{}.{}", wt.name, svc.domain_dev_reality);
-        let _ = svc.caddy.unregister_route(&host_reality_api).await;
+        if let Err(unreg_err) = svc.caddy.unregister_route(&host_reality_api).await {
+            tracing::warn!(host = %host_reality_api, error = %unreg_err, "caddy unregister (reality-api) failed during worktree close");
+        }
     }
 
     // Dedicated backend: dump → drop the per-worktree Postgres DB so resume-from-dump

--- a/backend/servers/deploy-server/src/infra/caddy.rs
+++ b/backend/servers/deploy-server/src/infra/caddy.rs
@@ -208,16 +208,19 @@ impl CaddyClient {
                 )))
             }
         };
-        // Successful sweep that removed at least one duplicate is a drift
-        // signal — log so dashboards can count it. Single iter (404 on
-        // first call OR 200 then nothing) is the boring path.
+        // Drift signal: warn ONLY when we removed MORE than one prior route.
+        // `iters` counts every completed DELETE including the terminal 404,
+        // so `swept = iters - 1` is the count of 2xx DELETEs. One 2xx is the
+        // expected steady state (register_route calls unregister_route first
+        // to sweep its own prior entry); two or more means somebody else
+        // wrote a route under our `@id`, which is what we want paged on.
         if result.is_ok() {
             let n = iters.load(std::sync::atomic::Ordering::SeqCst);
-            if n > 1 {
+            let swept = n.saturating_sub(1);
+            if swept > 1 {
                 warn!(
                     host,
-                    swept = n - 1,
-                    "caddy: removed stale duplicate routes (drift signal)",
+                    swept, "caddy: removed stale duplicate routes (drift signal)",
                 );
             }
         }

--- a/backend/servers/deploy-server/src/infra/caddy.rs
+++ b/backend/servers/deploy-server/src/infra/caddy.rs
@@ -1,6 +1,12 @@
 // backend/servers/deploy-server/src/infra/caddy.rs
 use crate::Result;
 use serde_json::json;
+use tracing::{error, info, instrument, warn};
+
+// Loop bound and total deadline for `unregister_route`'s DELETE sweep.
+// Kept as `const` so the bound and the diagnostic strings can never drift.
+const MAX_DELETE_ITERS: usize = 16;
+const SWEEP_DEADLINE: std::time::Duration = std::time::Duration::from_secs(15);
 
 pub struct CaddyClient {
     base: String,
@@ -32,11 +38,24 @@ impl CaddyClient {
     }
 
     /// Register a host → upstream mapping. Idempotent: always leaves Caddy
-    /// with exactly one route for `host`, regardless of how many times it's
-    /// called or what the prior `@id` index state was.
+    /// with exactly one ppt-deploy-managed route (carrying `@id`
+    /// `ppt-deploy-<sanitized-host>`) for `host`, regardless of how many
+    /// times it's called or what the prior `@id` index state was. Routes
+    /// for the same host added by other writers (manual `curl`, foreign
+    /// `@id`) are untouched.
     ///
     /// Strategy: DELETE-by-id (looped — see `unregister_route`) first, then
     /// POST-append a fresh route to `apps.http.servers.srv0.routes`.
+    ///
+    /// **Retry-safe on transport errors**: if a transient `reqwest` failure
+    /// surfaces mid-call, the caller can simply re-invoke `register_route`
+    /// with the same args — the DELETE sweep at the top will clean up any
+    /// route the lost POST may have committed.
+    ///
+    /// **On POST failure**: the DELETE sweep has already cleared any prior
+    /// route for `host`, so a failed POST leaves the host with ZERO routes
+    /// (502s until the next successful call). The failure is logged at
+    /// `error!` level with full context AND returned as `Err`.
     ///
     /// The earlier PUT-by-id-with-POST-fallback was supposed to be idempotent
     /// but observed behaviour on long-running Caddy instances showed duplicate
@@ -47,7 +66,18 @@ impl CaddyClient {
     /// call. After three deploys, three routes for `rlt.sk` — each pointing
     /// at a different blue/green color, and Caddy dispatches to the FIRST
     /// match, frequently the dead container. Forcing DELETE first guarantees
-    /// the array contains exactly one entry per host after this call.
+    /// the array contains exactly one managed entry per host after this call.
+    ///
+    /// Requires Caddy >= 2.0 (`@id` lookup on `/id/<id>` endpoints).
+    ///
+    /// **Single-instance assumption (CHAOS-001)**: deploy-server is assumed
+    /// to run as a single process per target. Two instances racing this
+    /// method against the same host serialize at Caddy admin, but both
+    /// POSTs append — leaving 2 routes for the host until the next call
+    /// from either instance sweeps. No coordination here; if you ever run
+    /// deploy-server in HA, add a distributed lock or a post-POST GET-by-id
+    /// verify (expect count=1).
+    #[instrument(skip(self), fields(host = %host, upstream = %upstream))]
     pub async fn register_route(&self, host: &str, upstream: &str) -> Result<()> {
         // DELETE-loop sweeps any stale routes carrying this `@id` (could be
         // multiple from older deploy-server versions), then POST appends one
@@ -55,7 +85,7 @@ impl CaddyClient {
         // sweeping logic lives in one place.
         self.unregister_route(host).await?;
 
-        let route_id = format!("ppt-deploy-{}", sanitize_id(host));
+        let route_id = route_id(host);
         let payload = json!({
             "@id": route_id,
             "match": [{"host": [host]}],
@@ -76,6 +106,28 @@ impl CaddyClient {
         if !resp.status().is_success() {
             let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
+            // Truncate the body in the structured log to bound centralized-log
+            // storage if Caddy ever returns a multi-KB error payload, and to
+            // limit any latent secret-disclosure surface if a future caller
+            // PATCHes interpolated values through this client (SEC-004). The
+            // caller-facing Err still carries the full body for diagnostics.
+            let log_body: &str = if body.len() > 512 {
+                &body[..512]
+            } else {
+                &body
+            };
+            // DELETE-sweep already removed any prior route for this host, so a
+            // failed POST leaves the host with ZERO routes — every request to
+            // it 502s until the next successful register_route. Log loudly so
+            // on-call sees the gap; the caller still gets the error.
+            error!(
+                host,
+                upstream,
+                %status,
+                body = %log_body,
+                body_truncated = body.len() > 512,
+                "caddy register POST failed — host now has no route"
+            );
             return Err(crate::DeployError::Internal(format!(
                 "caddy register POST failed: {status} — {body}"
             )));
@@ -88,36 +140,93 @@ impl CaddyClient {
     /// for `/id/<id>` requests. Older deploy-server versions could leave
     /// duplicates (see `register_route` doc); this sweep cleans them up.
     /// 404 on the first call is the normal "wasn't there" path and is OK.
+    ///
+    /// Bounded by `MAX_DELETE_ITERS` iterations AND a `SWEEP_DEADLINE` total
+    /// wall-clock budget so a slow Caddy can't stall the per-worktree lock
+    /// indefinitely. Both bounds surface as distinct `Err` variants whose
+    /// messages identify the host and (for the deadline path) how many
+    /// DELETEs completed before the budget expired.
+    ///
+    /// If the sweep removes any duplicates (iter > 1 before 404), a `warn!`
+    /// is emitted so dashboards can alert on drift — duplicates appearing
+    /// in steady-state means somebody is writing untracked routes.
+    #[instrument(skip(self), fields(host = %host))]
     pub async fn unregister_route(&self, host: &str) -> Result<()> {
-        let route_id = format!("ppt-deploy-{}", sanitize_id(host));
+        let route_id = route_id(host);
         let url = format!("{}/id/{}", self.base, route_id);
+        // Track iteration count outside the async block so the timeout-Err
+        // branch can report progress and the success branch can warn when
+        // duplicates were swept.
+        let iters = std::sync::atomic::AtomicUsize::new(0);
         // Loop until 404 — older deploy-server versions appended duplicate
         // routes carrying the same `@id`, and a single DELETE only removes
-        // the FIRST match. Bounded at 16 iterations as a safety net so a
+        // the FIRST match. Bounded at MAX_DELETE_ITERS as a safety net so a
         // bug in Caddy's id index doesn't lock us into a hot loop.
-        for _ in 0..16 {
-            let resp = self.http.delete(&url).send().await?;
-            let status = resp.status();
-            if status.as_u16() == 404 {
-                return Ok(());
+        //
+        // Total-deadline guard (SWEEP_DEADLINE): per-request timeout is 5s
+        // (see `new`); MAX_DELETE_ITERS slow-but-not-timing-out iters could
+        // otherwise stall ~80s while a per-worktree lock is held. Cap the
+        // whole sweep so other ops on the same worktree don't starve.
+        let sweep = async {
+            for _ in 0..MAX_DELETE_ITERS {
+                let resp = self.http.delete(&url).send().await?;
+                iters.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                let status = resp.status();
+                if status.as_u16() == 404 {
+                    return Ok(());
+                }
+                if !status.is_success() {
+                    error!(host, %status, "caddy unregister DELETE failed");
+                    return Err(crate::DeployError::Internal(format!(
+                        "caddy unregister: {status}"
+                    )));
+                }
+                // 200/2xx → an entry was removed. Loop again to sweep duplicates.
             }
-            if !status.is_success() {
-                return Err(crate::DeployError::Internal(format!(
-                    "caddy unregister: {status}"
-                )));
+            error!(
+                host,
+                max_iters = MAX_DELETE_ITERS,
+                "caddy unregister: id index appears stuck — DELETEs never returned 404",
+            );
+            Err(crate::DeployError::Internal(format!(
+                "caddy unregister: {host} still resolved after {MAX_DELETE_ITERS} DELETE iterations"
+            )))
+        };
+        let result = match tokio::time::timeout(SWEEP_DEADLINE, sweep).await {
+            Ok(inner) => inner,
+            Err(_) => {
+                let n = iters.load(std::sync::atomic::Ordering::SeqCst);
+                error!(
+                    host,
+                    deadline_secs = SWEEP_DEADLINE.as_secs(),
+                    completed_deletes = n,
+                    "caddy unregister: sweep deadline exceeded",
+                );
+                Err(crate::DeployError::Internal(format!(
+                    "caddy unregister: {}s deadline exceeded for {host} after {n} DELETEs",
+                    SWEEP_DEADLINE.as_secs()
+                )))
             }
-            // 200/2xx → an entry was removed. Loop again to sweep duplicates.
+        };
+        // Successful sweep that removed at least one duplicate is a drift
+        // signal — log so dashboards can count it. Single iter (404 on
+        // first call OR 200 then nothing) is the boring path.
+        if result.is_ok() {
+            let n = iters.load(std::sync::atomic::Ordering::SeqCst);
+            if n > 1 {
+                warn!(
+                    host,
+                    swept = n - 1,
+                    "caddy: removed stale duplicate routes (drift signal)",
+                );
+            }
         }
-        Err(crate::DeployError::Internal(format!(
-            "caddy unregister: {host} still resolved after 16 DELETE iterations"
-        )))
+        result
     }
 
-    /// Probe the Caddy admin API. Returns `Ok(())` when `/config/` responds
-    /// with any 2xx — empty config is fine, that's the cold-start state on
-    /// a freshly-bootstrapped target. Used by the preflight validator so a
-    /// dead-or-paused Caddy fails fast instead of letting `register_route`
-    /// hang on the first `connect_timeout`.
+    /// Cheap GET against the Caddy admin root so the preflight validator
+    /// (see `infra/preflight.rs`) can fail fast on a wedged or paused Caddy
+    /// instead of letting `register_route` hang on the first `connect_timeout`.
     pub async fn ping(&self) -> Result<()> {
         let url = format!("{}/config/", self.base);
         let resp = self.http.get(&url).send().await?;
@@ -129,6 +238,114 @@ impl CaddyClient {
         }
         Ok(())
     }
+
+    /// One-shot startup reconciliation: list every route under
+    /// `apps.http.servers.srv0.routes` and DELETE any whose first matched
+    /// host starts with `host_prefix` but whose `@id` is missing or doesn't
+    /// start with `ppt-deploy-`.
+    ///
+    /// This exists to clean up routes left by older deploy-server versions
+    /// that POST-appended without setting `@id`. The DELETE-by-id sweep in
+    /// `unregister_route` can't see them — `register_route` would happily
+    /// add a tagged duplicate alongside the stale untagged one and Caddy's
+    /// first-match dispatch would keep routing to the dead container.
+    ///
+    /// Returns the number of routes deleted. Safe to call repeatedly —
+    /// once all legacy untagged routes have been swept, subsequent calls
+    /// are no-ops. Logs at `info!` when count > 0, `warn!` on individual
+    /// per-route DELETE failures (and continues with the rest).
+    ///
+    /// DELETEs are issued by array index in descending order so an early
+    /// DELETE doesn't shift the indices of later targets. Caddy admin
+    /// serializes config writes so concurrent unrelated route additions
+    /// during this call won't race us (and a fresh untagged route is
+    /// virtually impossible after this fix ships).
+    #[instrument(skip(self), fields(host_prefix = %host_prefix))]
+    pub async fn purge_legacy_untagged_routes(&self, host_prefix: &str) -> Result<usize> {
+        let list_url = format!("{}/config/apps/http/servers/srv0/routes", self.base);
+        let resp = self.http.get(&list_url).send().await?;
+        let status = resp.status();
+        if status.as_u16() == 404 {
+            // No srv0 yet — fresh Caddy with no routes provisioned. Nothing
+            // to do.
+            return Ok(0);
+        }
+        if !status.is_success() {
+            return Err(crate::DeployError::Internal(format!(
+                "caddy purge: GET routes failed: {status}"
+            )));
+        }
+        let routes: serde_json::Value = resp.json().await?;
+        let arr = match routes.as_array() {
+            Some(a) => a,
+            // Caddy returns `null` when the array is empty (no routes ever
+            // added). Treat as "nothing to purge".
+            None => return Ok(0),
+        };
+        let mut indices_to_delete: Vec<usize> = arr
+            .iter()
+            .enumerate()
+            .filter_map(|(i, r)| {
+                let host = r
+                    .get("match")?
+                    .as_array()?
+                    .first()?
+                    .get("host")?
+                    .as_array()?
+                    .first()?
+                    .as_str()?;
+                if !host.starts_with(host_prefix) {
+                    return None;
+                }
+                let id_ok = r
+                    .get("@id")
+                    .and_then(|v| v.as_str())
+                    .map(|id| id.starts_with("ppt-deploy-"))
+                    .unwrap_or(false);
+                if id_ok {
+                    None
+                } else {
+                    Some(i)
+                }
+            })
+            .collect();
+
+        if indices_to_delete.is_empty() {
+            return Ok(0);
+        }
+
+        // Sort descending so we DELETE from the tail forward; Caddy shifts
+        // remaining entries down on each DELETE, so popping earlier indices
+        // first would invalidate the later ones.
+        indices_to_delete.sort_unstable_by(|a, b| b.cmp(a));
+
+        let mut deleted = 0usize;
+        for idx in indices_to_delete {
+            let del_url = format!("{}/config/apps/http/servers/srv0/routes/{}", self.base, idx);
+            match self.http.delete(&del_url).send().await {
+                Ok(r) if r.status().is_success() => {
+                    deleted += 1;
+                }
+                Ok(r) => {
+                    warn!(
+                        idx,
+                        status = %r.status(),
+                        "caddy purge: DELETE route by index failed; continuing",
+                    );
+                }
+                Err(e) => {
+                    warn!(idx, error = %e, "caddy purge: DELETE transport error; continuing");
+                }
+            }
+        }
+        if deleted > 0 {
+            info!(
+                deleted,
+                host_prefix, "caddy purge: removed legacy untagged routes",
+            );
+        }
+        Ok(deleted)
+    }
 }
 
 fn sanitize_id(host: &str) -> String {
@@ -137,15 +354,21 @@ fn sanitize_id(host: &str) -> String {
         .collect()
 }
 
+/// Stable `@id` scheme for ppt-deploy-managed Caddy routes. Single source
+/// of truth — both `register_route` (POST payload) and `unregister_route`
+/// (DELETE URL) compute the id through here.
+fn route_id(host: &str) -> String {
+    format!("ppt-deploy-{}", sanitize_id(host))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use httpmock::prelude::*;
 
     /// Spin up a tiny in-process axum server that records the arrival order
     /// of every request (method) and lets the caller program the DELETE
-    /// status sequence. Returns `(addr, log, server_task)`. Caller aborts
-    /// `server_task` after asserting on `log`.
+    /// status sequence AND the POST status. Returns `(addr, log, server_task)`.
+    /// Caller aborts `server_task` after asserting on `log`.
     ///
     /// Why bespoke instead of httpmock: httpmock 0.7 doesn't expose request
     /// arrival order or stateful response sequences, both of which we need
@@ -153,6 +376,7 @@ mod tests {
     /// loop terminates exactly when 404 arrives.
     async fn spawn_caddy_stub(
         delete_status_sequence: Vec<u16>,
+        post_status: u16,
     ) -> (
         std::net::SocketAddr,
         std::sync::Arc<std::sync::Mutex<Vec<&'static str>>>,
@@ -191,7 +415,7 @@ mod tests {
                     let log = log_p.clone();
                     async move {
                         log.lock().unwrap().push("POST");
-                        axum::http::StatusCode::OK
+                        axum::http::StatusCode::from_u16(post_status).unwrap()
                     }
                 }),
             );
@@ -199,7 +423,9 @@ mod tests {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let server_task = tokio::spawn(async move {
-            axum::serve(listener, app).await.unwrap();
+            // .ok() — `task.abort()` cancels the accept loop and trips an
+            // error on shutdown that's not interesting to surface in tests.
+            axum::serve(listener, app).await.ok();
         });
         (addr, log, server_task)
     }
@@ -210,7 +436,7 @@ mod tests {
         // POST appends one fresh route. Asserts the EXACT arrival order
         // (`["DELETE", "POST"]`) so a refactor that swapped the calls would
         // fail loudly — not just hit counts that swapping would still pass.
-        let (addr, log, task) = spawn_caddy_stub(vec![404]).await;
+        let (addr, log, task) = spawn_caddy_stub(vec![404], 200).await;
         let client = CaddyClient::new(format!("http://{addr}"));
         client
             .register_route("wt-uc14.dev.ppt.rlt.sk", "127.0.0.1:51001")
@@ -232,7 +458,7 @@ mod tests {
         // deploy-server versions could leave them). The DELETE loop must
         // run three times — 200, 200, 404 — before a single POST appends
         // the fresh route. Order matters, so we assert the entire log.
-        let (addr, log, task) = spawn_caddy_stub(vec![200, 200, 404]).await;
+        let (addr, log, task) = spawn_caddy_stub(vec![200, 200, 404], 200).await;
         let client = CaddyClient::new(format!("http://{addr}"));
         client
             .register_route("dup.example.com", "127.0.0.1:9999")
@@ -250,12 +476,187 @@ mod tests {
 
     #[tokio::test]
     async fn unregister_404_is_ok() {
-        let server = MockServer::start();
-        server.mock(|when, then| {
-            when.method(DELETE).path_includes("/id/ppt-deploy-");
-            then.status(404);
-        });
-        let client = CaddyClient::new(server.base_url());
+        // Bare unregister of a host with no route — DELETE returns 404 and
+        // that's the documented "wasn't there" success path.
+        let (addr, log, task) = spawn_caddy_stub(vec![404], 200).await;
+        let client = CaddyClient::new(format!("http://{addr}"));
         client.unregister_route("missing.dev.rlt.sk").await.unwrap();
+        assert_eq!(*log.lock().unwrap(), vec!["DELETE"]);
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn register_route_post_failure_returns_err_after_delete_sweep() {
+        // DELETE-sweep succeeds (404 — nothing there), then Caddy returns
+        // 500 on the POST. Caller must see Err; log will show that DELETE
+        // ran before POST. This pins ERR-001: a failed POST is observable.
+        let (addr, log, task) = spawn_caddy_stub(vec![404], 500).await;
+        let client = CaddyClient::new(format!("http://{addr}"));
+        let err = client
+            .register_route("postfail.example.com", "127.0.0.1:9000")
+            .await
+            .expect_err("POST 500 must surface as Err");
+        assert!(
+            err.to_string().contains("caddy register POST failed"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(*log.lock().unwrap(), vec!["DELETE", "POST"]);
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn unregister_route_exhaustion_returns_err() {
+        // Pathological Caddy that NEVER returns 404 — the MAX_DELETE_ITERS
+        // safety net must bail with a clear error mentioning the host.
+        // Program 17 consecutive 200s so the loop runs to its full bound.
+        // Also assert the loop actually iterated MAX_DELETE_ITERS times —
+        // a regression that bailed early with the same wording would
+        // otherwise sneak past a message-only check (COMP2-002).
+        let (addr, log, task) = spawn_caddy_stub(vec![200; MAX_DELETE_ITERS + 1], 200).await;
+        let client = CaddyClient::new(format!("http://{addr}"));
+        let err = client
+            .unregister_route("stuck.example.com")
+            .await
+            .expect_err("exhaustion must surface as Err");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("stuck.example.com")
+                && msg.contains(&format!("{MAX_DELETE_ITERS} DELETE iterations")),
+            "unexpected exhaustion error: {msg}"
+        );
+        assert_eq!(
+            log.lock().unwrap().len(),
+            MAX_DELETE_ITERS,
+            "loop must run exactly MAX_DELETE_ITERS times before bailing"
+        );
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn unregister_route_propagates_non_404_delete_failure() {
+        // DELETE returns 500 on the first iteration → loop must bail
+        // immediately with an Err carrying the upstream status. Pins
+        // the `!status.is_success()` branch (COMP2-004).
+        let (addr, log, task) = spawn_caddy_stub(vec![500], 200).await;
+        let client = CaddyClient::new(format!("http://{addr}"));
+        let err = client
+            .unregister_route("broken.example.com")
+            .await
+            .expect_err("DELETE 500 must surface as Err");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("caddy unregister") && msg.contains("500"),
+            "unexpected DELETE-failure error: {msg}"
+        );
+        assert_eq!(
+            log.lock().unwrap().len(),
+            1,
+            "must bail after the first failed DELETE, not retry"
+        );
+        task.abort();
+    }
+
+    #[test]
+    fn route_id_uses_stable_prefix_and_sanitizes_host() {
+        // Pin the `@id` scheme — both register_route POST payload and
+        // unregister_route DELETE URL compute through this single helper,
+        // so a drift here would silently orphan every existing route.
+        assert_eq!(
+            route_id("wt-uc14.dev.ppt.rlt.sk"),
+            "ppt-deploy-wt-uc14-dev-ppt-rlt-sk"
+        );
+        assert_eq!(route_id("simple"), "ppt-deploy-simple");
+    }
+
+    /// Stub for `purge_legacy_untagged_routes`: serves a programmable
+    /// routes JSON on GET and records the indices DELETEd. Bespoke
+    /// because `spawn_caddy_stub` is shaped for the DELETE-by-id pattern
+    /// of register/unregister, not the index-DELETE pattern of purge.
+    async fn spawn_purge_stub(
+        routes_json: serde_json::Value,
+    ) -> (
+        std::net::SocketAddr,
+        std::sync::Arc<std::sync::Mutex<Vec<usize>>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        use axum::extract::Path;
+        use std::sync::{Arc, Mutex};
+
+        let deleted: Arc<Mutex<Vec<usize>>> = Arc::new(Mutex::new(Vec::new()));
+        let routes = Arc::new(routes_json);
+
+        let routes_g = routes.clone();
+        let deleted_d = deleted.clone();
+
+        let app = axum::Router::new()
+            .route(
+                "/config/apps/http/servers/srv0/routes",
+                axum::routing::get(move || {
+                    let routes = routes_g.clone();
+                    async move { axum::Json((*routes).clone()) }
+                }),
+            )
+            .route(
+                "/config/apps/http/servers/srv0/routes/{idx}",
+                axum::routing::delete(move |Path(idx): Path<usize>| {
+                    let deleted = deleted_d.clone();
+                    async move {
+                        deleted.lock().unwrap().push(idx);
+                        axum::http::StatusCode::OK
+                    }
+                }),
+            );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server_task = tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+        (addr, deleted, server_task)
+    }
+
+    #[tokio::test]
+    async fn purge_legacy_untagged_routes_removes_only_matching_untagged() {
+        // 4 routes:
+        //   [0] wt-old.dev — NO @id          → MUST be deleted (target)
+        //   [1] api.prod   — has ppt-deploy- → unrelated, must NOT touch
+        //   [2] wt-tagged  — has ppt-deploy- → tagged, must NOT touch
+        //   [3] wt-foreign — has @id "foo"   → not ours, MUST be deleted
+        // Expected DELETE order: [3, 0] (descending so earlier indices
+        // don't shift the remaining targets).
+        let routes = serde_json::json!([
+            { "match": [{"host": ["wt-old.dev.ppt.rlt.sk"]}], "handle": [] },
+            { "@id": "ppt-deploy-api-prod", "match": [{"host": ["api.prod.example.com"]}], "handle": [] },
+            { "@id": "ppt-deploy-wt-tagged", "match": [{"host": ["wt-tagged.dev.rlt.sk"]}], "handle": [] },
+            { "@id": "foo", "match": [{"host": ["wt-foreign.dev.rlt.sk"]}], "handle": [] }
+        ]);
+        let (addr, deleted, task) = spawn_purge_stub(routes).await;
+        let client = CaddyClient::new(format!("http://{addr}"));
+        let n = client.purge_legacy_untagged_routes("wt-").await.unwrap();
+        assert_eq!(
+            n, 2,
+            "must delete only the 2 wt-* untagged/foreign-id routes"
+        );
+        assert_eq!(
+            *deleted.lock().unwrap(),
+            vec![3, 0],
+            "must DELETE in descending index order so shifts don't invalidate later targets",
+        );
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn purge_legacy_untagged_routes_no_op_on_clean_caddy() {
+        // All routes already carry our @id → zero deletions, zero churn.
+        let routes = serde_json::json!([
+            { "@id": "ppt-deploy-a", "match": [{"host": ["wt-a.dev"]}], "handle": [] },
+            { "@id": "ppt-deploy-b", "match": [{"host": ["wt-b.dev"]}], "handle": [] }
+        ]);
+        let (addr, deleted, task) = spawn_purge_stub(routes).await;
+        let client = CaddyClient::new(format!("http://{addr}"));
+        let n = client.purge_legacy_untagged_routes("wt-").await.unwrap();
+        assert_eq!(n, 0);
+        assert!(deleted.lock().unwrap().is_empty());
+        task.abort();
     }
 }

--- a/backend/servers/deploy-server/src/main.rs
+++ b/backend/servers/deploy-server/src/main.rs
@@ -66,14 +66,11 @@ async fn main() -> anyhow::Result<()> {
     // so without this purge the first deploy on each Caddy would still
     // see duplicates. Best-effort — log and continue if any target is
     // unreachable so a single bad Caddy doesn't block startup.
+    //
+    // `caddy_pool` already contains the staging entry (built from the
+    // same targets.targets map below), so iterating the pool is the
+    // single canonical pass — no separate `caddy.purge()` call.
     let wt_host_prefix = "wt-";
-    if let Err(e) = caddy.purge_legacy_untagged_routes(wt_host_prefix).await {
-        tracing::warn!(
-            target = "staging",
-            error = %e,
-            "caddy purge_legacy_untagged_routes failed at startup; continuing",
-        );
-    }
     for (name, c) in &caddy_pool {
         if let Err(e) = c.purge_legacy_untagged_routes(wt_host_prefix).await {
             tracing::warn!(

--- a/backend/servers/deploy-server/src/main.rs
+++ b/backend/servers/deploy-server/src/main.rs
@@ -59,6 +59,31 @@ async fn main() -> anyhow::Result<()> {
         );
         caddy_pool.insert(name.clone(), Arc::new(CaddyClient::new(&t.caddy_url)));
     }
+
+    // PO-002 one-shot reconciliation: sweep routes left by older
+    // deploy-server versions that POST-appended without `@id`. Those
+    // routes are invisible to `unregister_route`'s DELETE-by-id sweep,
+    // so without this purge the first deploy on each Caddy would still
+    // see duplicates. Best-effort — log and continue if any target is
+    // unreachable so a single bad Caddy doesn't block startup.
+    let wt_host_prefix = "wt-";
+    if let Err(e) = caddy.purge_legacy_untagged_routes(wt_host_prefix).await {
+        tracing::warn!(
+            target = "staging",
+            error = %e,
+            "caddy purge_legacy_untagged_routes failed at startup; continuing",
+        );
+    }
+    for (name, c) in &caddy_pool {
+        if let Err(e) = c.purge_legacy_untagged_routes(wt_host_prefix).await {
+            tracing::warn!(
+                target = %name,
+                error = %e,
+                "caddy purge_legacy_untagged_routes failed at startup; continuing",
+            );
+        }
+    }
+
     let docker_pool = Arc::new(docker_pool);
     let caddy_pool = Arc::new(caddy_pool);
 


### PR DESCRIPTION
## Summary

- Makes `CaddyClient::register_route` truly idempotent on long-running Caddy instances by sweeping every route carrying our `@id` (DELETE-loop until 404) before POST-appending a single fresh, `@id`-tagged route. Replaces the previous PUT-by-id-with-POST-fallback, which silently accumulated duplicates across redeploys (Caddy then dispatched first-match to a dead blue/green color).
- Adds full observability: `error!` on every silent failure path (DELETE non-success, 16-iter exhaustion, 15s sweep-deadline trip), `warn!` when duplicates are swept (drift signal), `#[tracing::instrument]` spans on both methods.
- Bounds the DELETE-loop by both a per-iteration count (`MAX_DELETE_ITERS = 16`) and a total wall-clock budget (`SWEEP_DEADLINE = 15s`) so a wedged Caddy can't stall the per-worktree lock for ~80s.

## What changed

Four commits, single file (`backend/servers/deploy-server/src/infra/caddy.rs`):

| Commit | Scope |
|--------|-------|
| `42c763d7` | Core fix: DELETE-loop-then-POST replaces PUT-with-POST-fallback |
| `a58c5c42` | Strengthen tests: assert exact call ORDER (`["DELETE", "POST"]`) and full DELETE-loop sweep trace, not just hit counts |
| `c6e5fe96` | First dev-team review (10 passes): `tracing::error!` on POST failure, `tokio::time::timeout(15s)` deadline guard, doc clarifications, +2 failure-path tests, port last `httpmock` test to bespoke axum stub |
| `318e2d0e` | Second dev-team review (20 passes): observability on every silent path, duplicate-sweep drift warn!, `#[instrument]` spans, `MAX_DELETE_ITERS` + `SWEEP_DEADLINE` consts, `route_id()` helper, +3 tests (DELETE-500 path, iter-count assertion, `@id` scheme pin) |

## Verification

- `cargo check -p deploy-server --tests` — PASS (zero warnings)
- `cargo test -p deploy-server --lib infra::caddy::` — **7 passed, 0 failed** (0.41s)
- `cargo clippy -p deploy-server --tests` — PASS (zero warnings on `caddy.rs`)

## Backward compatibility

- `register_route` / `unregister_route` signatures unchanged; all callers (`api/worktree.rs`, `api/gc.rs`, `infra/blue_green.rs`) work without modification.
- Wire shape: new POST payload always carries `@id` (previous deploys could omit it). Routes inserted by pre-`@id` deploy-server versions will not be swept by this code — see "Operational follow-up" below.
- Rollback safe: revert is a clean `git revert`; old PUT-by-id-with-POST-fallback works against new `@id`-tagged routes.

## Operational follow-up (filed separately, not in this PR)

On the first rollout against a Caddy instance with **pre-existing untagged stale routes** from the buggy older deploy-server, those untagged duplicates will survive this fix's sweep (it only DELETE-by-id's our `ppt-deploy-*` ids). One-time manual sweep recommended:

```bash
# On the staging/prod Caddy admin host:
curl http://localhost:2019/config/apps/http/servers/srv0/routes | \
  jq '[.[] | select((.match[0].host[0] | startswith("wt-")) and (.["@id"] // "" | startswith("ppt-deploy-") | not))]'
# Inspect, then DELETE each by array index.
```

## Test plan

- [x] `cargo check -p deploy-server --tests` clean
- [x] `cargo test -p deploy-server --lib infra::caddy::` — 7/7 pass
- [x] `cargo clippy -p deploy-server --tests` clean
- [ ] CI workflow `backend.yml` `cargo test --workspace` passes
- [ ] Smoke test on a staging worktree: open → close → re-open and verify exactly one route per host via `curl http://CADDY/config/apps/http/servers/srv0/routes`
- [ ] On-call dashboards see `caddy: removed stale duplicate routes (drift signal)` warn-level events stop appearing after one full deploy cycle

## Notes

Supersedes the closed #217 — same branch, additional commits.