### PR TITLE
pm-frontend-protectedroute-failopen: harden ProtectedRoute role-gate; populate user.role

### DIFF
--- a/frontend/apps/ppt-web/src/components/ProtectedRoute.tsx
+++ b/frontend/apps/ppt-web/src/components/ProtectedRoute.tsx
@@ -113,12 +113,13 @@ export function ProtectedRoute({
     return <Navigate to={redirectTo} replace />;
   }
 
-  // Check role requirements if specified
-  if (requiredRoles && requiredRoles.length > 0 && user?.role) {
-    const hasRequiredRole = requiredRoles.includes(user.role);
+  // Check role requirements if specified.
+  // Deny-on-missing-role: if requiredRoles is set we MUST have a role to compare
+  // against. Skipping when user.role is absent would be fail-open.
+  if (requiredRoles && requiredRoles.length > 0) {
+    const hasRequiredRole = user?.role != null && requiredRoles.includes(user.role);
     if (!hasRequiredRole) {
-      // User is authenticated but lacks required role
-      // Redirect to unauthorized page or show error
+      // User is authenticated but lacks required role (or role not yet populated).
       return (
         <div className="protected-route-unauthorized">
           <h1>Access Denied</h1>

--- a/frontend/apps/ppt-web/src/contexts/AuthContext.tsx
+++ b/frontend/apps/ppt-web/src/contexts/AuthContext.tsx
@@ -311,12 +311,18 @@ export function AuthProvider({ children }: AuthProviderProps) {
       const authApi = getAuthApi();
       const response = await authApi.login(credentials);
 
+      // Derive role from tenant memberships when not embedded in user object.
+      const userWithRole =
+        response.user.role == null && response.tenants && response.tenants.length > 0
+          ? { ...response.user, role: response.tenants[0].role }
+          : response.user;
+
       // Store tokens and user
       tokenStorage.setAccessToken(response.accessToken);
       tokenStorage.setRefreshToken(response.refreshToken);
-      tokenStorage.setUser(response.user);
+      tokenStorage.setUser(userWithRole);
 
-      setUser(response.user);
+      setUser(userWithRole);
     } finally {
       setIsLoading(false);
     }

--- a/frontend/packages/api-client/src/auth/index.ts
+++ b/frontend/packages/api-client/src/auth/index.ts
@@ -28,4 +28,6 @@ export type {
   RegisterResponse,
   RequestPasswordResetRequest,
   ResetPasswordRequest,
+  TenantMembership,
+  TenantRole,
 } from './types';

--- a/frontend/packages/api-client/src/auth/types.ts
+++ b/frontend/packages/api-client/src/auth/types.ts
@@ -4,13 +4,35 @@
  * Type definitions for the Authentication API (UC-14).
  */
 
+/** User role within a tenant (mirrors Shared.TenantRole in OpenAPI spec) */
+export type TenantRole =
+  | 'super_admin'
+  | 'org_admin'
+  | 'manager'
+  | 'technical_manager'
+  | 'owner'
+  | 'owner_delegate'
+  | 'tenant'
+  | 'resident'
+  | 'property_manager'
+  | 'real_estate_agent'
+  | 'guest';
+
+/** User's membership in a tenant (mirrors Auth.TenantMembership in OpenAPI spec) */
+export interface TenantMembership {
+  tenantId: string;
+  tenantName: string;
+  role: TenantRole;
+}
+
 /** User information returned from authentication */
 export interface AuthUser {
   id: string;
   email: string;
   firstName?: string;
   lastName?: string;
-  role?: string;
+  /** The user role in the active tenant. Populated from tenants[0].role when not embedded directly. */
+  role?: TenantRole;
   organizationId?: string;
   organizationName?: string;
 }
@@ -25,7 +47,11 @@ export interface LoginRequest {
 export interface LoginResponse {
   accessToken: string;
   refreshToken: string;
+  /** Seconds until the access token expires */
+  expiresIn?: number;
   user: AuthUser;
+  /** Tenant memberships available to this user (used to derive user.role) */
+  tenants?: TenantMembership[];
 }
 
 /** Token refresh request */


### PR DESCRIPTION
## Task
Harden ProtectedRoute.tsx:117 to deny on missing role instead of skipping the role check, and populate user.role in AuthContext — before role-gating goes live (fold into 79-2 PR #444)

## Owner
pm-frontend

## Changes

### `ProtectedRoute.tsx` (line 117)
Removed the fail-open `&& user?.role` guard. The old condition skipped the role check entirely when `user.role` was absent, allowing any authenticated user through role-gated routes. The fix always evaluates the role check when `requiredRoles` is set — denying access if `user.role` is `null`/`undefined` or not in the required list.

**Before (fail-open):**
```tsx
if (requiredRoles && requiredRoles.length > 0 && user?.role) {
```
**After (deny-on-missing-role):**
```tsx
if (requiredRoles && requiredRoles.length > 0) {
  const hasRequiredRole = user?.role != null && requiredRoles.includes(user.role);
```

### `AuthContext.tsx` — `login()`
When the API login response does not embed `role` directly in the user object, derive it from `tenants[0].role`. This ensures `user.role` is populated immediately after login so role-gated routes are unblocked for legitimate users once the guard above is active.

### `@ppt/api-client` — `auth/types.ts` + `auth/index.ts`
- Added `TenantRole` union type (11 values matching `Shared.TenantRole` in OpenAPI spec).
- Added `TenantMembership` interface.
- Extended `LoginResponse` with `tenants?: TenantMembership[]` and `expiresIn?: number`.
- Tightened `AuthUser.role` from `string` to `TenantRole`.
- Exported both new types from the module index.

## Tested (Band A — fast check)
```
pnpm -F @ppt/web typecheck  →  exit 0 (no errors)
pnpm check (biome)          →  exit 0 (14 pre-existing warnings, 0 errors)
```

## Built (Band B — full build)
```
pnpm -F @ppt/web build  →  exit 0, built in 7.24s
(auth-related chunk: dist/assets/auth-C5G120gE.js 53.09 kB — clean)
```

## CI parity (Band C — auth hot-path)
```
pnpm test:run (vitest)  →  22 test files passed, 379 tests passed (exit 0)
act not installed — ran workflow commands manually per frontend.yml:
  pnpm check         exit 0
  pnpm test:run      exit 0
  pnpm typecheck     exit 0
  pnpm build         exit 0
```

## Remote-tested
skipped

## Notes
- Folded into story 79-2 PR #444 per task `pm-frontend-protectedroute-failopen`.
- `requiredRoles` prop on `ProtectedRoute` is currently unused in `App.tsx` routes; this hardens the gate before it goes live.
- `TenantRole` type aligns with `Shared.TenantRole` in the OpenAPI spec — no drift expected when the TypeSpec client is regenerated.
- If the API already embeds `role` in the user object, the `tenants[0].role` fallback is a no-op.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEpT9E8QaeEaUC9ik2NgLJ)_