### PR TITLE
fix(reality-web): host inference wins over env for *.rlt.sk api base

### DIFF
--- a/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/page.tsx
@@ -13,7 +13,29 @@ import type { Metadata } from 'next';
 import { headers } from 'next/headers';
 import { ListingDetailContent, ListingNotFound } from '@/components/listings';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8081';
+function inferApiBaseFromHost(host: string): string | null {
+  const bareHost = host.split(':')[0]?.toLowerCase();
+  if (!bareHost) return null;
+  if (bareHost === 'rlt.sk' || bareHost.endsWith('.rlt.sk')) {
+    if (bareHost === 'staging.rlt.sk' || bareHost.endsWith('.staging.rlt.sk')) {
+      return 'https://api.staging.rlt.sk';
+    }
+    return 'https://api.rlt.sk';
+  }
+  return null;
+}
+
+function resolveApiBase(host: string): string {
+  // SSR path: prefer an internal URL (Docker network) when set, then host
+  // inference for known *.rlt.sk topology, then the public env, then a
+  // dev-only localhost fallback. Inference comes before NEXT_PUBLIC_API_URL
+  // so a baked-in/misconfigured `http://localhost:8081` can't take down
+  // SSR on staging or prod.
+  if (process.env.API_INTERNAL_URL) return process.env.API_INTERNAL_URL;
+  const inferred = inferApiBaseFromHost(host);
+  if (inferred) return inferred;
+  return process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8081';
+}
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -44,7 +66,8 @@ async function getListing(slug: string, host: string): Promise<ListingDetail | n
     const tags = host
       ? [`host:${host}:listings`, `host:${host}:listing:${slug}`]
       : ['listings', `listing:${slug}`];
-    const response = await fetch(`${API_BASE}/api/v1/listings/${slug}`, {
+    const apiBase = resolveApiBase(host);
+    const response = await fetch(`${apiBase}/api/v1/listings/${slug}`, {
       headers: host ? { Host: host } : {},
       next: { revalidate: 60, tags },
     });

--- a/frontend/apps/reality-web/src/lib/env.ts
+++ b/frontend/apps/reality-web/src/lib/env.ts
@@ -67,30 +67,31 @@ function inferSiteUrlFromHost(host: string, protocol: string): string | null {
  */
 export function getApiBase(): string {
   if (typeof window !== 'undefined') {
+    const host = window.location.hostname;
+    const onWorktree = WORKTREE_HOST_RE.test(host);
     const envUrl = window.__ENV__?.NEXT_PUBLIC_API_URL;
-    const onWorktree = WORKTREE_HOST_RE.test(window.location.hostname);
 
-    if (envUrl) {
-      // Distinguish dedicated vs shared worktree backends. The deploy-server
-      // sets NEXT_PUBLIC_API_URL=https://api.rlt.sk on shared-mode worktrees
-      // (which is correct for the build but wrong for the browser — prod's
-      // CORS allow-list rejects wt-* origins). When we're on a worktree host
-      // and env points at a non-dedicated backend, prefer the relative-URL
-      // proxy so next.config.js's rewrite handles CORS server-side.
-      try {
-        const envHost = new URL(envUrl).hostname;
-        if (envHost.startsWith('api.wt-')) return envUrl; // dedicated
-        if (onWorktree) return ''; // shared worktree → proxy
-        return envUrl;
-      } catch {
-        // Malformed env value — ignore and fall through.
+    if (onWorktree) {
+      // Worktree dedicated backend (api.wt-*) is the one case where env
+      // wins over inference — inference doesn't know about worktree apis.
+      if (envUrl) {
+        try {
+          if (new URL(envUrl).hostname.startsWith('api.wt-')) return envUrl;
+        } catch {
+          // malformed env value — ignore
+        }
       }
+      return ''; // shared worktree → relative URL via next.config.js rewrite
     }
 
-    if (onWorktree) return '';
-
-    const inferred = inferApiBaseFromHost(window.location.hostname);
+    // For known *.rlt.sk hosts, host inference is authoritative. A
+    // misconfigured env (e.g. a baked-in `http://localhost:8081` from a
+    // bad container build) would otherwise leak through to the browser
+    // and every request would ERR_CONNECTION_REFUSED in the user's tab.
+    const inferred = inferApiBaseFromHost(host);
     if (inferred) return inferred;
+
+    if (envUrl) return envUrl;
   }
   return process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8081';
 }
@@ -100,11 +101,13 @@ export function getApiBase(): string {
  */
 export function getSiteUrl(): string {
   if (typeof window !== 'undefined') {
+    // Same rationale as getApiBase: for known *.rlt.sk hosts the page's
+    // own origin is the authoritative answer, even if env says otherwise.
+    const inferred = inferSiteUrlFromHost(window.location.hostname, window.location.protocol);
+    if (inferred) return inferred;
     if (window.__ENV__?.NEXT_PUBLIC_SITE_URL) {
       return window.__ENV__.NEXT_PUBLIC_SITE_URL;
     }
-    const inferred = inferSiteUrlFromHost(window.location.hostname, window.location.protocol);
-    if (inferred) return inferred;
   }
   return process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3001';
 }

--- a/frontend/packages/reality-api-client/src/config.ts
+++ b/frontend/packages/reality-api-client/src/config.ts
@@ -16,28 +16,43 @@
 
 const WORKTREE_HOST_RE = /^wt-.+\.(dev|staging)\.rlt\.sk$/;
 
+function inferApiBaseFromHost(host: string): string | null {
+  if (host === 'rlt.sk' || host.endsWith('.rlt.sk')) {
+    if (host.endsWith('.staging.rlt.sk') || host === 'staging.rlt.sk') {
+      return 'https://api.staging.rlt.sk';
+    }
+    return 'https://api.rlt.sk';
+  }
+  return null;
+}
+
 function getRuntimeApiUrl(): string | undefined {
   if (typeof window === 'undefined') return undefined;
   const env = (window as { __ENV__?: Record<string, string> }).__ENV__;
   const envUrl = env?.NEXT_PUBLIC_API_URL;
-  const onWorktree = WORKTREE_HOST_RE.test(window.location.hostname);
+  const host = window.location.hostname;
+  const onWorktree = WORKTREE_HOST_RE.test(host);
 
-  // The deploy-server sets NEXT_PUBLIC_API_URL=https://api.rlt.sk on shared
-  // worktrees (correct for the build, wrong for the browser — prod's CORS
-  // allow-list rejects wt-* origins). When env points at a non-dedicated
-  // backend and we're on a worktree, prefer the relative-URL proxy so the
-  // next.config.js rewrite handles CORS server-side.
-  if (envUrl) {
-    try {
-      const envHost = new URL(envUrl).hostname;
-      if (envHost.startsWith('api.wt-')) return envUrl; // dedicated worktree
-      if (onWorktree) return ''; // shared worktree → proxy
-      return envUrl;
-    } catch {
-      // Malformed env value — fall through.
+  if (onWorktree) {
+    // Dedicated worktree backend is the one case where env wins over
+    // host inference — inference can't know about wt-* api hosts.
+    if (envUrl) {
+      try {
+        if (new URL(envUrl).hostname.startsWith('api.wt-')) return envUrl;
+      } catch {
+        // malformed env value — ignore
+      }
     }
+    return ''; // shared worktree → relative URL via next.config.js rewrite
   }
-  if (onWorktree) return '';
+
+  // For known *.rlt.sk hosts, host inference is authoritative. A
+  // misconfigured env (e.g. a baked-in `http://localhost:8081`) would
+  // otherwise leak to the browser and break every request.
+  const inferred = inferApiBaseFromHost(host);
+  if (inferred) return inferred;
+
+  if (envUrl) return envUrl;
   return undefined;
 }
 


### PR DESCRIPTION
## Summary

Registration (and any other reality-server POST) was failing on `https://staging.rlt.sk/en/auth/register` because the client was POSTing to `http://localhost:8081/api/v1/users/register`. Root cause: `getApiBase()` trusted `window.__ENV__.NEXT_PUBLIC_API_URL` over host inference, so a misconfigured/baked-in localhost env value leaked straight to the browser.

For known `*.rlt.sk` hosts, host inference is now authoritative. Env is only consulted for worktree-dedicated backends (`api.wt-*`) and as a last resort.

## Changes

- `frontend/apps/reality-web/src/lib/env.ts` — invert priority in `getApiBase` / `getSiteUrl`: for `*.rlt.sk` hosts, infer first, env second. Worktree dedicated backends still honor env.
- `frontend/packages/reality-api-client/src/config.ts` — mirror the same inversion; added local `inferApiBaseFromHost` helper.
- `frontend/apps/reality-web/src/app/[locale]/listings/[slug]/page.tsx` — drop module-level `API_BASE` fallback to localhost; resolve per-request from `API_INTERNAL_URL` → host inference → `NEXT_PUBLIC_API_URL` → dev localhost. SSR no longer hits localhost on staging if env is missing.

## Test plan

- [x] `pnpm --filter @ppt/reality-web typecheck`
- [x] `pnpm --filter @ppt/reality-api-client typecheck`
- [x] `pnpm check` clean on touched files
- [ ] Verify on staging: POST `https://staging.rlt.sk` → `/auth/register` resolves to `https://api.staging.rlt.sk/api/v1/users/register`