### PR TITLE
fix(security): IDOR on voice device delete/list-commands endpoints

### DIFF
--- a/backend/crates/db/src/repositories/llm_document.rs
+++ b/backend/crates/db/src/repositories/llm_document.rs
@@ -1136,11 +1136,22 @@ impl LlmDocumentRepository {
     }
 
     /// Deactivate a voice device.
-    pub async fn deactivate_voice_device(&self, id: Uuid) -> Result<bool, SqlxError> {
+    ///
+    /// The `user_id` parameter scopes the update to devices owned by the
+    /// caller, preventing cross-tenant IDOR writes.  Returns `Ok(false)` when
+    /// no row is updated — either the `id` does not exist or the device is not
+    /// owned by `user_id`.  The handler maps both cases to `404 Not Found`,
+    /// giving an attacker no information about whether the target id exists.
+    pub async fn deactivate_voice_device(
+        &self,
+        id: Uuid,
+        user_id: Uuid,
+    ) -> Result<bool, SqlxError> {
         let result = sqlx::query(
-            "UPDATE voice_assistant_devices SET is_active = FALSE, updated_at = NOW() WHERE id = $1",
+            "UPDATE voice_assistant_devices SET is_active = FALSE, updated_at = NOW() WHERE id = $1 AND user_id = $2",
         )
         .bind(id)
+        .bind(user_id)
         .execute(&self.pool)
         .await?;
         Ok(result.rows_affected() > 0)
@@ -1188,21 +1199,30 @@ impl LlmDocumentRepository {
     }
 
     /// List voice command history for a device.
+    ///
+    /// `user_id` scopes the query to commands for devices owned by the caller,
+    /// preventing cross-tenant IDOR reads.  Returns an empty list (not 404) when
+    /// the device does not exist or is not owned by `user_id`, matching the same
+    /// conservative disclosure posture used by the deactivate path.
     pub async fn list_voice_commands(
         &self,
         device_id: Uuid,
+        user_id: Uuid,
         limit: i64,
         offset: i64,
     ) -> Result<Vec<VoiceCommandHistory>, SqlxError> {
         sqlx::query_as::<_, VoiceCommandHistory>(
             r#"
-            SELECT * FROM voice_command_history
-            WHERE device_id = $1
-            ORDER BY created_at DESC
-            LIMIT $2 OFFSET $3
+            SELECT vch.* FROM voice_command_history vch
+            JOIN voice_assistant_devices vad ON vad.id = vch.device_id
+            WHERE vch.device_id = $1
+              AND vad.user_id = $2
+            ORDER BY vch.created_at DESC
+            LIMIT $3 OFFSET $4
             "#,
         )
         .bind(device_id)
+        .bind(user_id)
         .bind(limit)
         .bind(offset)
         .fetch_all(&self.pool)

--- a/backend/servers/api-server/src/routes/ai.rs
+++ b/backend/servers/api-server/src/routes/ai.rs
@@ -3001,10 +3001,17 @@ async fn exchange_voice_oauth_tokens(
 
 async fn unlink_voice_device(
     State(state): State<AppState>,
-    _principal: RequestPrincipal,
+    principal: RequestPrincipal,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    match state.llm_document_repo.deactivate_voice_device(id).await {
+    // Scope the deactivation to the caller's own devices.  A non-owned or
+    // non-existent id both return false from the repository and are mapped to
+    // 404, giving an attacker no information about whether the target id exists.
+    match state
+        .llm_document_repo
+        .deactivate_voice_device(id, principal.user_id)
+        .await
+    {
         Ok(true) => Ok(StatusCode::NO_CONTENT),
         Ok(false) => Err((
             StatusCode::NOT_FOUND,
@@ -3022,7 +3029,7 @@ async fn unlink_voice_device(
 
 async fn list_voice_commands(
     State(state): State<AppState>,
-    _principal: RequestPrincipal,
+    principal: RequestPrincipal,
     Path(device_id): Path<Uuid>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
@@ -3030,6 +3037,7 @@ async fn list_voice_commands(
         .llm_document_repo
         .list_voice_commands(
             device_id,
+            principal.user_id,
             query.limit.unwrap_or(50),
             query.offset.unwrap_or(0),
         )


### PR DESCRIPTION
## Summary

- `DELETE /api/v1/ai/llm/voice/devices/{id}` accepted any authenticated user's request and deactivated the row by `id` alone — no ownership check. Any user could delete another user's voice device (IDOR).
- `GET /api/v1/ai/llm/voice/commands/{device_id}` had the same pattern: returned commands for any device regardless of owner.

### Fix

- `deactivate_voice_device(id, user_id)`: SQL updated to `WHERE id = $1 AND user_id = $2`. Non-owned or non-existent IDs return `false` → 404, giving no information about existence.
- `list_voice_commands(device_id, user_id, limit, offset)`: SQL updated to JOIN `voice_assistant_devices` and filter by `vad.user_id = $2`, scoping results to the caller's own devices only.
- `unlink_voice_device` handler: `_principal` → `principal`, passes `principal.user_id` to repository.
- `list_voice_commands` handler: `_principal` → `principal`, passes `principal.user_id` to repository.

### Files changed

- `backend/crates/db/src/repositories/llm_document.rs` — repository layer fix (pushed)
- `backend/servers/api-server/src/routes/ai.rs` — handler layer fix (local, push pending)

### Verify

- Band A: `cargo check -p api-server` — passed (exit 0)
- Band B: env failure (sandbox broken), not a code error
- Band C: N/A (contained security fix, no migration)

Ref: `.research/plans/security-voice-device-idor.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEpT9E8QaeEaUC9ik2NgLJ)_