### PR TITLE
gap-7a-4-mobile-preview: DocumentPreviewScreen with presigned URLs (Story 7A.4)

### DIFF
--- a/frontend/apps/mobile/src/App.tsx
+++ b/frontend/apps/mobile/src/App.tsx
@@ -15,6 +15,7 @@ import {
   BuildingsScreen,
   DashboardScreen,
   DocumentDetailScreen,
+  DocumentPreviewScreen,
   DocumentsScreen,
   DocumentUploadScreen,
   FaultsListScreen,
@@ -59,6 +60,7 @@ type Screen =
   | 'VoteDetail'
   | 'Documents'
   | 'DocumentDetail'
+  | 'DocumentPreview'
   | 'DocumentUpload'
   | 'Messages'
   | 'ThreadDetail'
@@ -141,6 +143,17 @@ function MainApp() {
         return <DocumentsScreen onNavigate={handleNavigate} />;
       case 'DocumentDetail':
         return <DocumentDetailScreen onBack={() => handleNavigate('Documents')} />;
+      case 'DocumentPreview':
+        return screenParams?.document ? (
+          <DocumentPreviewScreen
+            document={
+              screenParams.document as Parameters<typeof DocumentPreviewScreen>[0]['document']
+            }
+            onBack={() => handleNavigate('Documents')}
+          />
+        ) : (
+          <DocumentsScreen onNavigate={handleNavigate} />
+        );
       case 'DocumentUpload':
         return (
           <DocumentUploadScreen
@@ -242,7 +255,11 @@ function MainApp() {
         <NavButton
           icon="📄"
           label={t('tabs.docs')}
-          isActive={currentScreen === 'Documents' || currentScreen === 'DocumentDetail'}
+          isActive={
+            currentScreen === 'Documents' ||
+            currentScreen === 'DocumentDetail' ||
+            currentScreen === 'DocumentPreview'
+          }
           onPress={() => handleNavigate('Documents')}
         />
         <NavButton

--- a/frontend/apps/mobile/src/locales/cs.json
+++ b/frontend/apps/mobile/src/locales/cs.json
@@ -157,6 +157,21 @@
     "emptyTitle": "Zadne dokumenty",
     "noMatches": "Zadne dokumenty neodpovidaji hledani",
     "folderEmpty": "Tato slozka je prazdna",
+    "preview": {
+      "fetching": "Pripravuji nahled…",
+      "urlReady": "Dokument je pripraven",
+      "expiresAt": "Odkaz expiruje v",
+      "updated": "Aktualizovano",
+      "openAction": "Otevrit dokument",
+      "downloadAction": "Stahnout dokument",
+      "fallbackNotice": "Nahled neni dostupny pro tento typ souboru. Muzete ho stahnout.",
+      "errorTitle": "Dokument se nepodarilo nacist",
+      "cannotOpenTitle": "Nelze otevrit",
+      "cannotOpenMessage": "Zadna aplikace v tomto zarizeni neumi otevrit tento typ souboru.",
+      "openFailed": "Dokument se nepodarilo otevrit.",
+      "sharingUnavailableTitle": "Sdileni neni dostupne",
+      "shareFailed": "Dokument se nepodarilo sdilet."
+    },
     "upload": {
       "title": "Nahrat dokument",
       "buttonLabel": "+ Nahrat",

--- a/frontend/apps/mobile/src/locales/de.json
+++ b/frontend/apps/mobile/src/locales/de.json
@@ -146,7 +146,23 @@
     "categories": "Kategorien",
     "download": "Herunterladen",
     "view": "Anzeigen",
-    "noDocuments": "Keine Dokumente verfugbar"
+    "noDocuments": "Keine Dokumente verfugbar",
+    "share": "Teilen",
+    "preview": {
+      "fetching": "Vorschau wird vorbereitet…",
+      "urlReady": "Dokument bereit",
+      "expiresAt": "Link lauft ab um",
+      "updated": "Aktualisiert",
+      "openAction": "Dokument offnen",
+      "downloadAction": "Dokument herunterladen",
+      "fallbackNotice": "Vorschau ist fur diesen Dateityp nicht verfugbar. Sie konnen es herunterladen.",
+      "errorTitle": "Dokument konnte nicht geladen werden",
+      "cannotOpenTitle": "Kann nicht geoffnet werden",
+      "cannotOpenMessage": "Keine Anwendung auf diesem Gerat kann diesen Dateityp offnen.",
+      "openFailed": "Dokument konnte nicht geoffnet werden.",
+      "sharingUnavailableTitle": "Teilen nicht verfugbar",
+      "shareFailed": "Dokument konnte nicht geteilt werden."
+    }
   },
   "settings": {
     "title": "Einstellungen",

--- a/frontend/apps/mobile/src/locales/en.json
+++ b/frontend/apps/mobile/src/locales/en.json
@@ -157,6 +157,21 @@
     "emptyTitle": "No documents",
     "noMatches": "No documents match your search",
     "folderEmpty": "This folder is empty",
+    "preview": {
+      "fetching": "Preparing preview…",
+      "urlReady": "Document ready",
+      "expiresAt": "Link expires at",
+      "updated": "Updated",
+      "openAction": "Open document",
+      "downloadAction": "Download document",
+      "fallbackNotice": "Preview is not available for this file type. You can download it instead.",
+      "errorTitle": "Could not load document",
+      "cannotOpenTitle": "Cannot open",
+      "cannotOpenMessage": "No application on this device can open this file type.",
+      "openFailed": "Failed to open document.",
+      "sharingUnavailableTitle": "Sharing unavailable",
+      "shareFailed": "Failed to share document."
+    },
     "upload": {
       "title": "Upload Document",
       "buttonLabel": "+ Upload",

--- a/frontend/apps/mobile/src/locales/hu.json
+++ b/frontend/apps/mobile/src/locales/hu.json
@@ -146,7 +146,23 @@
     "categories": "Kategoriak",
     "download": "Letoltes",
     "view": "Megtekintes",
-    "noDocuments": "Nincsenek elerheto dokumentumok"
+    "noDocuments": "Nincsenek elerheto dokumentumok",
+    "share": "Megosztás",
+    "preview": {
+      "fetching": "Elonézet elokészítése…",
+      "urlReady": "Dokumentum kész",
+      "expiresAt": "A hivatkozás lejár",
+      "updated": "Frissítve",
+      "openAction": "Dokumentum megnyitása",
+      "downloadAction": "Dokumentum letöltése",
+      "fallbackNotice": "Az elonézet nem érheto el ennél a fájltípusnál. Letöltheti helyette.",
+      "errorTitle": "A dokumentum nem tölthetö be",
+      "cannotOpenTitle": "Nem nyitható meg",
+      "cannotOpenMessage": "Az eszközön lévö alkalmazások egyike sem tudja megnyitni ezt a fájltípust.",
+      "openFailed": "A dokumentum megnyitása nem sikerült.",
+      "sharingUnavailableTitle": "A megosztás nem érheto el",
+      "shareFailed": "A dokumentum megosztása nem sikerült."
+    }
   },
   "settings": {
     "title": "Beallitasok",

--- a/frontend/apps/mobile/src/locales/pl.json
+++ b/frontend/apps/mobile/src/locales/pl.json
@@ -146,7 +146,23 @@
     "categories": "Kategorie",
     "download": "Pobierz",
     "view": "Zobacz",
-    "noDocuments": "Brak dostepnych dokumentow"
+    "noDocuments": "Brak dostepnych dokumentow",
+    "share": "Udostepnij",
+    "preview": {
+      "fetching": "Przygotowywanie podgladu…",
+      "urlReady": "Dokument gotowy",
+      "expiresAt": "Link wygasa o",
+      "updated": "Zaktualizowano",
+      "openAction": "Otworz dokument",
+      "downloadAction": "Pobierz dokument",
+      "fallbackNotice": "Podglad nie jest dostepny dla tego typu pliku. Mozesz go pobrac.",
+      "errorTitle": "Nie mozna zaladowac dokumentu",
+      "cannotOpenTitle": "Nie mozna otworzyc",
+      "cannotOpenMessage": "Zadna aplikacja na tym urzadzeniu nie moze otworzyc tego typu pliku.",
+      "openFailed": "Nie udalo sie otworzyc dokumentu.",
+      "sharingUnavailableTitle": "Udostepnianie niedostepne",
+      "shareFailed": "Nie udalo sie udostepnic dokumentu."
+    }
   },
   "settings": {
     "title": "Ustawienia",

--- a/frontend/apps/mobile/src/locales/sk.json
+++ b/frontend/apps/mobile/src/locales/sk.json
@@ -157,6 +157,21 @@
     "emptyTitle": "Ziadne dokumenty",
     "noMatches": "Ziadne dokumenty nezodpovedaju hladaniu",
     "folderEmpty": "Tento priecinok je prazdny",
+    "preview": {
+      "fetching": "Pripravujem nahled…",
+      "urlReady": "Dokument je pripraveny",
+      "expiresAt": "Odkaz expiruje o",
+      "updated": "Aktualizovany",
+      "openAction": "Otvorit dokument",
+      "downloadAction": "Stiahnut dokument",
+      "fallbackNotice": "Nahled nie je dostupny pre tento typ suboru. Mozete ho stiahnut.",
+      "errorTitle": "Dokument sa nepodarilo nacitat",
+      "cannotOpenTitle": "Nie je mozne otvorit",
+      "cannotOpenMessage": "Ziadna aplikacia na tomto zariadeni nevie otvorit tento typ suboru.",
+      "openFailed": "Dokument sa nepodarilo otvorit.",
+      "sharingUnavailableTitle": "Zdielanie nie je dostupne",
+      "shareFailed": "Dokument sa nepodarilo zdielat."
+    },
     "upload": {
       "title": "Nahrat dokument",
       "buttonLabel": "+ Nahrat",

--- a/frontend/apps/mobile/src/screens/documents/DocumentPreviewScreen.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentPreviewScreen.tsx
@@ -1,0 +1,429 @@
+/**
+ * DocumentPreviewScreen — Story 7A.4 (Document Download & Preview, mobile slice).
+ *
+ * Calls GET /api/v1/documents/{id}/preview to obtain a short-lived presigned
+ * URL (1 h) then hands it to the platform's native viewer via Linking.openURL
+ * so the OS can render PDFs, images, office docs, etc. without bundling a
+ * heavyweight in-app renderer (contrast: web uses react-pdf — PR #446).
+ *
+ * If the backend returns PREVIEW_NOT_SUPPORTED (400) we fall back to the
+ * download URL (GET /api/v1/documents/{id}/download) so the user can at
+ * least save the file.
+ *
+ * Sharing is delegated to expo-sharing after the file is downloaded locally
+ * via expo-file-system. The share sheet is only shown when Sharing.isAvailable.
+ */
+
+import * as FileSystem from 'expo-file-system/legacy';
+import * as Sharing from 'expo-sharing';
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  ActivityIndicator,
+  Alert,
+  Linking,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { apiRequest } from '../../hooks/useApi';
+import { colors, screenStyles as s } from '../shared/screenStyles';
+import type { Document } from './DocumentsScreen';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** Shape of UrlResponse from GET /api/v1/documents/{id}/preview|download */
+interface PresignedUrlResponse {
+  url: string;
+  expires_at: string;
+}
+
+type PreviewState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'ready'; url: string; expiresAt: Date }
+  | { status: 'fallback'; url: string; expiresAt: Date } // download URL used as fallback
+  | { status: 'error'; message: string };
+
+interface DocumentPreviewScreenProps {
+  /** Full document object as passed from DocumentsScreen. */
+  document: Document;
+  onBack?: () => void;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function getFileIcon(type: Document['type']): string {
+  switch (type) {
+    case 'pdf':
+      return '📄';
+    case 'image':
+      return '🖼️';
+    case 'spreadsheet':
+      return '📊';
+    default:
+      return '🗂️';
+  }
+}
+
+/**
+ * Download a remote file to the device cache directory and return the local
+ * URI. Used before invoking expo-sharing (which requires a local URI).
+ */
+async function downloadToCache(url: string, filename: string): Promise<string> {
+  const dest = `${FileSystem.cacheDirectory ?? ''}${filename}`;
+  const info = await FileSystem.getInfoAsync(dest);
+  // Re-use cached copy if it's already there (session-local cache).
+  if (info.exists) return dest;
+
+  const { uri } = await FileSystem.downloadAsync(url, dest);
+  return uri;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function DocumentPreviewScreen({ document, onBack }: DocumentPreviewScreenProps) {
+  const { t } = useTranslation();
+  const [state, setState] = useState<PreviewState>({ status: 'idle' });
+  const [isSharing, setIsSharing] = useState(false);
+
+  // ── Fetch presigned URL on mount ──────────────────────────────────────────
+
+  const fetchPreviewUrl = useCallback(async () => {
+    setState({ status: 'loading' });
+    try {
+      const data = await apiRequest<PresignedUrlResponse>(
+        `/api/v1/documents/${document.id}/preview`
+      );
+      setState({
+        status: 'ready',
+        url: data.url,
+        expiresAt: new Date(data.expires_at),
+      });
+    } catch (err) {
+      // PREVIEW_NOT_SUPPORTED (400) → fall back to download endpoint
+      const message = err instanceof Error ? err.message : '';
+      const isUnsupported =
+        message.includes('PREVIEW_NOT_SUPPORTED') ||
+        message.includes('not supported') ||
+        message.includes('HTTP 400');
+
+      if (isUnsupported) {
+        try {
+          const fallback = await apiRequest<PresignedUrlResponse>(
+            `/api/v1/documents/${document.id}/download`
+          );
+          setState({
+            status: 'fallback',
+            url: fallback.url,
+            expiresAt: new Date(fallback.expires_at),
+          });
+        } catch (fallbackErr) {
+          const fallbackMessage =
+            fallbackErr instanceof Error ? fallbackErr.message : t('errors.generic');
+          setState({ status: 'error', message: fallbackMessage });
+        }
+      } else {
+        setState({
+          status: 'error',
+          message: err instanceof Error ? err.message : t('errors.generic'),
+        });
+      }
+    }
+  }, [document.id, t]);
+
+  useEffect(() => {
+    void fetchPreviewUrl();
+  }, [fetchPreviewUrl]);
+
+  // ── Open in native viewer ─────────────────────────────────────────────────
+
+  const handleOpen = useCallback(async () => {
+    if (state.status !== 'ready' && state.status !== 'fallback') return;
+    try {
+      const canOpen = await Linking.canOpenURL(state.url);
+      if (!canOpen) {
+        Alert.alert(
+          t('documents.preview.cannotOpenTitle'),
+          t('documents.preview.cannotOpenMessage')
+        );
+        return;
+      }
+      await Linking.openURL(state.url);
+    } catch {
+      Alert.alert(t('common.error'), t('documents.preview.openFailed'));
+    }
+  }, [state, t]);
+
+  // ── Share via expo-sharing ────────────────────────────────────────────────
+
+  const handleShare = useCallback(async () => {
+    if (state.status !== 'ready' && state.status !== 'fallback') return;
+    const sharingAvailable = await Sharing.isAvailableAsync();
+    if (!sharingAvailable) {
+      Alert.alert(t('documents.preview.sharingUnavailableTitle'), '');
+      return;
+    }
+
+    setIsSharing(true);
+    try {
+      const localUri = await downloadToCache(state.url, document.name);
+      await Sharing.shareAsync(localUri, {
+        mimeType: mimeTypeFromDocType(document.type),
+        dialogTitle: document.name,
+        UTI: utiFromDocType(document.type), // iOS only
+      });
+    } catch (_err) {
+      Alert.alert(t('common.error'), t('documents.preview.shareFailed'));
+    } finally {
+      setIsSharing(false);
+    }
+  }, [state, document, t]);
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  const isReady = state.status === 'ready' || state.status === 'fallback';
+  const isFallback = state.status === 'fallback';
+
+  return (
+    <View style={s.container}>
+      {/* Header */}
+      <View style={s.header}>
+        {onBack && (
+          <Pressable onPress={onBack} style={styles.backLink}>
+            <Text style={styles.backLinkText}>← {t('documents.title')}</Text>
+          </Pressable>
+        )}
+        <Text style={s.headerTitle} numberOfLines={2}>
+          {document.name}
+        </Text>
+      </View>
+
+      <ScrollView style={s.scrollView}>
+        {/* Document metadata card */}
+        <View style={s.card}>
+          <View style={s.cardHeader}>
+            <Text style={styles.fileIcon}>{getFileIcon(document.type)}</Text>
+            <Text style={[s.cardTitle, { marginLeft: 8 }]} numberOfLines={2}>
+              {document.name}
+            </Text>
+          </View>
+          <View style={[s.cardFooter, { marginTop: 16 }]}>
+            {typeof document.size === 'number' && document.size > 0 && (
+              <Text style={s.cardMeta}>{formatBytes(document.size)}</Text>
+            )}
+            <Text style={s.cardMeta}>
+              {t('documents.preview.updated')} {new Date(document.updatedAt).toLocaleDateString()}
+            </Text>
+          </View>
+        </View>
+
+        {/* Status / URL card */}
+        {state.status === 'loading' && (
+          <View style={[s.card, styles.loadingCard]}>
+            <ActivityIndicator color={colors.accent} size="small" />
+            <Text style={styles.loadingText}>{t('documents.preview.fetching')}</Text>
+          </View>
+        )}
+
+        {state.status === 'error' && (
+          <View style={[s.card, styles.errorCard]}>
+            <Text style={styles.errorIcon}>⚠️</Text>
+            <Text style={styles.errorTitle}>{t('documents.preview.errorTitle')}</Text>
+            <Text style={styles.errorMessage}>{state.message}</Text>
+            <Pressable style={styles.retryButton} onPress={() => void fetchPreviewUrl()}>
+              <Text style={styles.retryButtonText}>{t('common.retry')}</Text>
+            </Pressable>
+          </View>
+        )}
+
+        {isReady && (
+          <>
+            {isFallback && (
+              <View style={styles.fallbackBanner}>
+                <Text style={styles.fallbackText}>{t('documents.preview.fallbackNotice')}</Text>
+              </View>
+            )}
+
+            {/* Expiry notice */}
+            <View style={[s.card, styles.urlCard]}>
+              <Text style={styles.urlLabel}>{t('documents.preview.urlReady')}</Text>
+              <Text style={styles.urlExpiry}>
+                {t('documents.preview.expiresAt')}{' '}
+                {state.expiresAt.toLocaleTimeString([], {
+                  hour: '2-digit',
+                  minute: '2-digit',
+                })}
+              </Text>
+            </View>
+
+            {/* Open action */}
+            <Pressable style={s.primaryButton} onPress={() => void handleOpen()}>
+              <Text style={s.primaryButtonText}>
+                {isFallback
+                  ? t('documents.preview.downloadAction')
+                  : t('documents.preview.openAction')}
+              </Text>
+            </Pressable>
+
+            {/* Share action */}
+            <Pressable
+              style={[styles.shareButton, isSharing && styles.shareButtonDisabled]}
+              onPress={() => void handleShare()}
+              disabled={isSharing}
+            >
+              {isSharing ? (
+                <ActivityIndicator color={colors.accent} size="small" />
+              ) : (
+                <Text style={styles.shareButtonText}>🔗 {t('documents.share')}</Text>
+              )}
+            </Pressable>
+          </>
+        )}
+
+        <View style={s.bottomSpacer} />
+      </ScrollView>
+    </View>
+  );
+}
+
+// ─── MIME / UTI helpers ───────────────────────────────────────────────────────
+
+function mimeTypeFromDocType(type: Document['type']): string {
+  switch (type) {
+    case 'pdf':
+      return 'application/pdf';
+    case 'image':
+      return 'image/*';
+    case 'spreadsheet':
+      return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+/** iOS UTI used by expo-sharing. Ignored on Android. */
+function utiFromDocType(type: Document['type']): string | undefined {
+  if (!Platform.OS) return undefined; // safety guard for test env
+  switch (type) {
+    case 'pdf':
+      return 'com.adobe.pdf';
+    case 'image':
+      return 'public.image';
+    default:
+      return 'public.data';
+  }
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  backLink: { marginBottom: 8 },
+  backLinkText: { color: colors.accent, fontSize: 14 },
+  fileIcon: { fontSize: 28 },
+
+  // Loading state
+  loadingCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 20,
+  },
+  loadingText: {
+    fontSize: 14,
+    color: colors.textMuted,
+  },
+
+  // Error state
+  errorCard: {
+    alignItems: 'center',
+    paddingVertical: 24,
+    gap: 8,
+  },
+  errorIcon: { fontSize: 32 },
+  errorTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: colors.text,
+  },
+  errorMessage: {
+    fontSize: 13,
+    color: colors.textMuted,
+    textAlign: 'center',
+    paddingHorizontal: 8,
+  },
+  retryButton: {
+    marginTop: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: colors.accent,
+  },
+  retryButtonText: {
+    color: colors.accent,
+    fontWeight: '600',
+  },
+
+  // Fallback banner
+  fallbackBanner: {
+    backgroundColor: colors.warningBg,
+    borderRadius: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    marginBottom: 8,
+  },
+  fallbackText: {
+    fontSize: 13,
+    color: colors.warningDark,
+  },
+
+  // URL ready card
+  urlCard: {
+    backgroundColor: colors.successBg,
+    borderRadius: 8,
+    paddingVertical: 12,
+  },
+  urlLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.successDark,
+    marginBottom: 2,
+  },
+  urlExpiry: {
+    fontSize: 12,
+    color: colors.textMuted,
+  },
+
+  // Share button
+  shareButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.accent,
+    marginTop: 12,
+    gap: 6,
+  },
+  shareButtonDisabled: {
+    borderColor: colors.accentDisabled,
+  },
+  shareButtonText: {
+    color: colors.accent,
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/frontend/apps/mobile/src/screens/documents/DocumentsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentsScreen.tsx
@@ -1,8 +1,6 @@
-import * as Sharing from 'expo-sharing';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
-  Alert,
   Pressable,
   RefreshControl,
   ScrollView,
@@ -76,7 +74,6 @@ export function DocumentsScreen({ onNavigate: _onNavigate }: DocumentsScreenProp
   const { t } = useTranslation();
   const [currentPath, setCurrentPath] = useState<Document[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
-  const [downloading, setDownloading] = useState<string | null>(null);
 
   const { data, isLoading, error, refetch, isFetching } = useApiQuery<ApiDocumentListResponse>(
     ['documents', 'list'],
@@ -138,35 +135,13 @@ export function DocumentsScreen({ onNavigate: _onNavigate }: DocumentsScreenProp
     setCurrentPath([]);
   };
 
-  const handleDocumentPress = async (doc: Document) => {
+  const handleDocumentPress = (doc: Document) => {
     if (doc.type === 'folder') {
       navigateToFolder(doc);
     } else {
-      // Download/View document
-      setDownloading(doc.id);
-      try {
-        // Simulate download
-        await new Promise((resolve) => setTimeout(resolve, 1500));
-
-        // In a real app, this would download from the actual URL
-        // and open with the appropriate viewer
-        Alert.alert(t('documents.readyTitle'), t('documents.readyMessage', { name: doc.name }), [
-          { text: t('common.close'), style: 'cancel' },
-          {
-            text: t('documents.share'),
-            onPress: async () => {
-              if (await Sharing.isAvailableAsync()) {
-                // Would share the actual downloaded file
-                Alert.alert(t('documents.sharing'), t('documents.sharingMessage'));
-              }
-            },
-          },
-        ]);
-      } catch (_error) {
-        Alert.alert(t('common.error'), t('documents.downloadFailed'));
-      } finally {
-        setDownloading(null);
-      }
+      // Navigate to DocumentPreviewScreen which fetches a real presigned URL
+      // (Story 7A.4 — replaces the earlier stub download simulation).
+      _onNavigate?.('DocumentPreview', { document: doc });
     }
   };
 
@@ -270,7 +245,7 @@ export function DocumentsScreen({ onNavigate: _onNavigate }: DocumentsScreenProp
               .map((doc) => (
                 <Pressable
                   key={doc.id}
-                  style={[styles.documentRow, downloading === doc.id && styles.documentDownloading]}
+                  style={styles.documentRow}
                   onPress={() => handleDocumentPress(doc)}
                 >
                   <Text style={styles.fileIcon}>{getFileIcon(doc.type)}</Text>
@@ -290,12 +265,8 @@ export function DocumentsScreen({ onNavigate: _onNavigate }: DocumentsScreenProp
                   </View>
                   {doc.type === 'folder' ? (
                     <Text style={styles.arrowIcon}>›</Text>
-                  ) : downloading === doc.id ? (
-                    <View style={styles.downloadingIndicator}>
-                      <Text style={styles.downloadingText}>...</Text>
-                    </View>
                   ) : (
-                    <Text style={styles.downloadIcon}>⬇️</Text>
+                    <Text style={styles.downloadIcon}>👁️</Text>
                   )}
                 </Pressable>
               ))}
@@ -419,9 +390,6 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
     borderBottomColor: colors.surfaceMuted,
   },
-  documentDownloading: {
-    backgroundColor: colors.surfaceMuted,
-  },
   fileIcon: {
     fontSize: 28,
     marginRight: 12,
@@ -448,14 +416,6 @@ const styles = StyleSheet.create({
   },
   downloadIcon: {
     fontSize: 18,
-  },
-  downloadingIndicator: {
-    width: 24,
-    alignItems: 'center',
-  },
-  downloadingText: {
-    fontSize: 14,
-    color: colors.textMuted,
   },
   bottomSpacer: {
     height: 100,

--- a/frontend/apps/mobile/src/screens/documents/index.ts
+++ b/frontend/apps/mobile/src/screens/documents/index.ts
@@ -1,4 +1,5 @@
 export { DocumentDetailScreen } from './DocumentDetailScreen';
+export { DocumentPreviewScreen } from './DocumentPreviewScreen';
 export type { DocumentShareSheetProps } from './DocumentShareSheet';
 export { DocumentShareSheet } from './DocumentShareSheet';
 export type { Document, DocumentType } from './DocumentsScreen';

--- a/frontend/apps/mobile/src/screens/index.ts
+++ b/frontend/apps/mobile/src/screens/index.ts
@@ -14,7 +14,12 @@ export { BuildingsScreen } from './buildings';
 // Main screens
 export { DashboardScreen } from './dashboard';
 export type { Document, DocumentType } from './documents';
-export { DocumentDetailScreen, DocumentsScreen, DocumentUploadScreen } from './documents';
+export {
+  DocumentDetailScreen,
+  DocumentPreviewScreen,
+  DocumentsScreen,
+  DocumentUploadScreen,
+} from './documents';
 // Types
 export type { Fault, FaultCategory, FaultPriority, FaultStatus } from './faults';
 export { FaultsListScreen, ReportFaultScreen } from './faults';


### PR DESCRIPTION
## Task

Implement mobile document download/preview with presigned URLs — web preview (react-pdf) shipped in PR #446; implement ppt-mobile DocumentPreviewScreen calling backend get_preview_url endpoint (7a-4 Document Download & Preview)

## Owner

pm-frontend

## What was done

- **New screen:** `frontend/apps/mobile/src/screens/documents/DocumentPreviewScreen.tsx`
  - Calls `GET /api/v1/documents/{id}/preview` for a 1-hour presigned URL
  - Falls back to `GET /api/v1/documents/{id}/download` when backend returns `PREVIEW_NOT_SUPPORTED` (400)
  - Opens URL via `Linking.openURL` → native OS viewer (PDF viewer, image gallery, etc.)
  - Share via `expo-file-system/legacy` (cache download) + `expo-sharing` share sheet
  - States: loading → ready/fallback/error with retry; expiry time displayed
  - i18n keys added for all 6 locales (en, sk, cs, de, hu, pl)

- **DocumentsScreen updated:** tapping a non-folder document now navigates to `DocumentPreview` screen instead of the previous `setTimeout` stub simulation

- **App.tsx:** `DocumentPreview` added to `Screen` union, case in `renderScreen()`, bottom nav `isActive`

- **documents/index.ts + screens/index.ts:** `DocumentPreviewScreen` exported

## Tested (Band A — fast check)

```
pnpm -F mobile typecheck
exit 0  (only pre-existing neighbors module error from concurrent dev branch work)
```

```
pnpm biome lint apps/mobile/src/screens/documents/DocumentPreviewScreen.tsx ...
Checked 3 files in 29ms. No fixes applied.
exit 0
```

## Built (Band B — full build)

```
pnpm biome check apps/mobile/src/screens/documents/ apps/mobile/src/App.tsx
Checked 8 files in 50ms. No fixes applied.
exit 0
```

Change is >50 LOC (556 insertions). No public API/migration/config touch — Metro bundle dry-run not available in sandbox.

## CI parity (Band C — hot-path only)

Skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested

Skipped (ppt-bridge MCP not connected).

## Notes

- Backend `GET /api/v1/documents/{id}/preview` already exists (routes/documents/core.rs). No backend change needed.
- `expo-file-system/legacy` subpath used — the new v55 top-level API removed `cacheDirectory` export; legacy subpath restores it.
- The `neighbors` typecheck error (TS2305) is a pre-existing issue from another agent's concurrent work on `dev`; not introduced by this PR.
- Web preview (react-pdf, PR #446) is the complementary web slice. Mobile uses native OS viewer instead of bundling a PDF renderer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wq7sWrhgJZiszpiar6Rcrp)_