### PR TITLE
gap-6-6-neighbor-listing-verify: wire neighbor listing with privacy-aware filtering

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -49,7 +49,7 @@ development_status:
   6-3-announcement-comments-discussion: ready-for-dev
   6-4-pinned-announcements: ready-for-dev
   6-5-direct-messaging: ready-for-dev
-  6-6-neighbor-information: ready-for-dev
+  6-6-neighbor-information: done
   # Epic 7A: Basic Document Management
   7a-1-document-upload-metadata: ready-for-dev
   7a-2-folder-organization: ready-for-dev

--- a/frontend/apps/mobile/src/screens/index.ts
+++ b/frontend/apps/mobile/src/screens/index.ts
@@ -26,7 +26,6 @@ export { LeaseDetailScreen, LeasesScreen } from './leases';
 export { MessagesScreen, ThreadDetailScreen } from './messages';
 export type { Meter, MeterCommodity } from './meters';
 export { MeterDetailScreen, MeterReadingScreen, MetersScreen } from './meters';
-export type { Neighbor } from './neighbors';
 export { NeighborsScreen } from './neighbors';
 export type { NewsArticle } from './news';
 export { NewsScreen } from './news';

--- a/frontend/apps/mobile/src/screens/neighbors/NeighborsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/neighbors/NeighborsScreen.tsx
@@ -126,9 +126,7 @@ export function NeighborsScreen({ onNavigate }: NeighborsScreenProps) {
       <View style={[s.container, styles.center]}>
         <Text style={s.emptyIcon}>⚠️</Text>
         <Text style={s.emptyTitle}>Could not load neighbours</Text>
-        <Text style={s.emptyText}>
-          {error instanceof Error ? error.message : 'Unknown error'}
-        </Text>
+        <Text style={s.emptyText}>{error instanceof Error ? error.message : 'Unknown error'}</Text>
         <Pressable style={[s.primaryButton, { marginTop: 16 }]} onPress={onRefresh}>
           <Text style={s.primaryButtonText}>Retry</Text>
         </Pressable>
@@ -168,9 +166,7 @@ export function NeighborsScreen({ onNavigate }: NeighborsScreenProps) {
         {filtered.length === 0 ? (
           <View style={s.emptyState}>
             <Text style={s.emptyIcon}>🏘️</Text>
-            <Text style={s.emptyTitle}>
-              {search.trim() ? 'No matches' : 'No neighbours yet'}
-            </Text>
+            <Text style={s.emptyTitle}>{search.trim() ? 'No matches' : 'No neighbours yet'}</Text>
             <Text style={s.emptyText}>
               {search.trim()
                 ? 'Try a different name or apartment number.'
@@ -182,9 +178,7 @@ export function NeighborsScreen({ onNavigate }: NeighborsScreenProps) {
             <Pressable
               key={neighbor.user_id}
               style={[s.card, styles.row]}
-              onPress={() =>
-                onNavigate?.('NeighborDetail', { neighborId: neighbor.user_id })
-              }
+              onPress={() => onNavigate?.('NeighborDetail', { neighborId: neighbor.user_id })}
             >
               <View style={styles.avatar}>
                 <Text style={styles.avatarText}>{initials(neighbor.display_name)}</Text>
@@ -195,12 +189,8 @@ export function NeighborsScreen({ onNavigate }: NeighborsScreenProps) {
                   {neighbor.unit_label}
                   {neighbor.resident_type === 'owner' ? ' · Owner' : ''}
                 </Text>
-                {neighbor.phone && (
-                  <Text style={styles.contact}>📞 {neighbor.phone}</Text>
-                )}
-                {neighbor.email && (
-                  <Text style={styles.contact}>✉️ {neighbor.email}</Text>
-                )}
+                {neighbor.phone && <Text style={styles.contact}>📞 {neighbor.phone}</Text>}
+                {neighbor.email && <Text style={styles.contact}>✉️ {neighbor.email}</Text>}
               </View>
             </Pressable>
           ))

--- a/frontend/apps/mobile/src/screens/neighbors/NeighborsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/neighbors/NeighborsScreen.tsx
@@ -1,12 +1,17 @@
 /**
  * NeighborsScreen (UC-06).
  *
- * Lists fellow residents who have opted into the directory. Mock data is
- * used until `@ppt/api-client/neighbors` is wired in.
+ * Lists fellow residents who have opted into the directory.
+ * Wired to backend GET /api/v1/buildings/{building_id}/neighbors
+ * with privacy-aware filtering (Epic 6, Story 6.6).
+ *
+ * Building context: fetches the first building the user belongs to
+ * from GET /api/v1/buildings; consistent with other mobile screens.
  */
 
 import { useCallback, useMemo, useState } from 'react';
 import {
+  ActivityIndicator,
   Pressable,
   RefreshControl,
   ScrollView,
@@ -15,75 +20,131 @@ import {
   TextInput,
   View,
 } from 'react-native';
+import { useApiQuery } from '../../hooks/useApi';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
-export interface Neighbor {
-  id: string;
-  name: string;
-  apartment: string;
-  floor: number;
-  initials: string;
-  phone?: string;
-  email?: string;
+// ---------------------------------------------------------------------------
+// Types (mirrors backend NeighborView / PrivacySettings)
+// ---------------------------------------------------------------------------
+
+interface NeighborView {
+  user_id: string;
+  display_name: string;
+  unit_label: string;
+  is_visible: boolean;
+  email: string | null;
+  phone: string | null;
+  resident_type: string;
 }
 
-const MOCK_NEIGHBORS: Neighbor[] = [
-  {
-    id: 'n1',
-    name: 'Anna Novak',
-    apartment: '3B',
-    floor: 3,
-    initials: 'AN',
-    phone: '+421 905 123 456',
-  },
-  {
-    id: 'n2',
-    name: 'Peter Kovac',
-    apartment: '2A',
-    floor: 2,
-    initials: 'PK',
-    email: 'peter@example.com',
-  },
-  { id: 'n3', name: 'Eva Horvath', apartment: '5C', floor: 5, initials: 'EH' },
-  {
-    id: 'n4',
-    name: 'Martin Toth',
-    apartment: '1A',
-    floor: 1,
-    initials: 'MT',
-    phone: '+421 905 555 444',
-  },
-];
+interface NeighborsResponse {
+  neighbors: NeighborView[];
+  count: number;
+  total: number;
+}
+
+interface BuildingItem {
+  id: string;
+  name: string;
+}
+
+interface BuildingsPaginatedResponse {
+  items: BuildingItem[];
+  total: number;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
 
 interface NeighborsScreenProps {
   onNavigate?: (screen: string, params?: Record<string, unknown>) => void;
 }
 
 export function NeighborsScreen({ onNavigate }: NeighborsScreenProps) {
-  const [refreshing, setRefreshing] = useState(false);
   const [search, setSearch] = useState('');
+  const [refreshKey, setRefreshKey] = useState(0);
 
-  const onRefresh = useCallback(async () => {
-    setRefreshing(true);
-    await new Promise((r) => setTimeout(r, 600));
-    setRefreshing(false);
+  // Fetch the first building the user belongs to
+  const buildingsQuery = useApiQuery<BuildingsPaginatedResponse>(
+    ['buildings', 'list'],
+    '/api/v1/buildings'
+  );
+
+  const buildingId = buildingsQuery.data?.items?.[0]?.id;
+  const buildingName = buildingsQuery.data?.items?.[0]?.name;
+
+  // Fetch neighbors once we have a building id
+  const neighborsQuery = useApiQuery<NeighborsResponse>(
+    ['neighbors', 'list', buildingId ?? '', refreshKey],
+    `/api/v1/buildings/${buildingId}/neighbors`,
+    { enabled: !!buildingId }
+  );
+
+  const isLoading = buildingsQuery.isLoading || neighborsQuery.isLoading;
+  const error = buildingsQuery.error ?? neighborsQuery.error;
+
+  const onRefresh = useCallback(() => {
+    setRefreshKey((k) => k + 1);
   }, []);
+
+  // Only show visible neighbors (privacy-aware filtering)
+  const visibleNeighbors = useMemo(
+    () => (neighborsQuery.data?.neighbors ?? []).filter((n) => n.is_visible),
+    [neighborsQuery.data]
+  );
 
   const filtered = useMemo(
     () =>
-      MOCK_NEIGHBORS.filter((n) =>
+      visibleNeighbors.filter((n) =>
         search.trim() === ''
           ? true
-          : `${n.name} ${n.apartment}`.toLowerCase().includes(search.toLowerCase())
+          : `${n.display_name} ${n.unit_label}`.toLowerCase().includes(search.toLowerCase())
       ),
-    [search]
+    [visibleNeighbors, search]
   );
+
+  const initials = (name: string) =>
+    name
+      .split(' ')
+      .map((w) => w[0] ?? '')
+      .join('')
+      .toUpperCase()
+      .slice(0, 2);
+
+  if (isLoading) {
+    return (
+      <View style={[s.container, styles.center]}>
+        <ActivityIndicator size="large" color={colors.accent} />
+        <Text style={[s.cardMeta, { marginTop: 12 }]}>Loading neighbours…</Text>
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={[s.container, styles.center]}>
+        <Text style={s.emptyIcon}>⚠️</Text>
+        <Text style={s.emptyTitle}>Could not load neighbours</Text>
+        <Text style={s.emptyText}>
+          {error instanceof Error ? error.message : 'Unknown error'}
+        </Text>
+        <Pressable style={[s.primaryButton, { marginTop: 16 }]} onPress={onRefresh}>
+          <Text style={s.primaryButtonText}>Retry</Text>
+        </Pressable>
+      </View>
+    );
+  }
 
   return (
     <View style={s.container}>
       <View style={s.header}>
         <Text style={s.headerTitle}>Neighbours</Text>
-        <Text style={s.headerSubtitle}>{MOCK_NEIGHBORS.length} residents in your building</Text>
+        <Text style={s.headerSubtitle}>
+          {buildingName
+            ? `${visibleNeighbors.length} residents in ${buildingName}`
+            : `${visibleNeighbors.length} residents in your building`}
+        </Text>
       </View>
 
       <View style={s.searchContainer}>
@@ -97,31 +158,49 @@ export function NeighborsScreen({ onNavigate }: NeighborsScreenProps) {
 
       <ScrollView
         style={s.scrollView}
-        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+        refreshControl={
+          <RefreshControl
+            refreshing={neighborsQuery.isFetching && !isLoading}
+            onRefresh={onRefresh}
+          />
+        }
       >
         {filtered.length === 0 ? (
           <View style={s.emptyState}>
             <Text style={s.emptyIcon}>🏘️</Text>
-            <Text style={s.emptyTitle}>No matches</Text>
-            <Text style={s.emptyText}>Try a different name or apartment number.</Text>
+            <Text style={s.emptyTitle}>
+              {search.trim() ? 'No matches' : 'No neighbours yet'}
+            </Text>
+            <Text style={s.emptyText}>
+              {search.trim()
+                ? 'Try a different name or apartment number.'
+                : 'Residents who opt into the directory will appear here.'}
+            </Text>
           </View>
         ) : (
           filtered.map((neighbor) => (
             <Pressable
-              key={neighbor.id}
+              key={neighbor.user_id}
               style={[s.card, styles.row]}
-              onPress={() => onNavigate?.('NeighborDetail', { neighborId: neighbor.id })}
+              onPress={() =>
+                onNavigate?.('NeighborDetail', { neighborId: neighbor.user_id })
+              }
             >
               <View style={styles.avatar}>
-                <Text style={styles.avatarText}>{neighbor.initials}</Text>
+                <Text style={styles.avatarText}>{initials(neighbor.display_name)}</Text>
               </View>
               <View style={styles.info}>
-                <Text style={s.cardTitle}>{neighbor.name}</Text>
+                <Text style={s.cardTitle}>{neighbor.display_name}</Text>
                 <Text style={s.cardMeta}>
-                  Apt {neighbor.apartment} · Floor {neighbor.floor}
+                  {neighbor.unit_label}
+                  {neighbor.resident_type === 'owner' ? ' · Owner' : ''}
                 </Text>
-                {neighbor.phone && <Text style={styles.contact}>📞 {neighbor.phone}</Text>}
-                {neighbor.email && <Text style={styles.contact}>✉️ {neighbor.email}</Text>}
+                {neighbor.phone && (
+                  <Text style={styles.contact}>📞 {neighbor.phone}</Text>
+                )}
+                {neighbor.email && (
+                  <Text style={styles.contact}>✉️ {neighbor.email}</Text>
+                )}
               </View>
             </Pressable>
           ))
@@ -138,6 +217,7 @@ export function NeighborsScreen({ onNavigate }: NeighborsScreenProps) {
 }
 
 const styles = StyleSheet.create({
+  center: { alignItems: 'center', justifyContent: 'center' },
   row: { flexDirection: 'row', alignItems: 'center', gap: 16 },
   avatar: {
     width: 56,

--- a/frontend/apps/mobile/src/screens/neighbors/index.ts
+++ b/frontend/apps/mobile/src/screens/neighbors/index.ts
@@ -1,2 +1,1 @@
-export type { Neighbor } from './NeighborsScreen';
 export { NeighborsScreen } from './NeighborsScreen';

--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -66,6 +66,10 @@ import {
   useNavigationCommands,
 } from './features/command-palette';
 import { ManagerDashboardPage, ResidentDashboardPage } from './features/dashboard';
+import {
+  useNeighbors,
+  usePrivacySettings,
+} from './features/neighbors';
 import type {
   DisputeCategory,
   DisputePriority,
@@ -107,6 +111,9 @@ import {
   LoginPage,
   MarketplacePage,
   MessagesPage,
+  NeighborDetailPage,
+  NeighborsPage,
+  NeighborsPrivacySettingsPage,
   NewMessagePage,
   NewsListPage,
   NotFoundPage,
@@ -537,6 +544,19 @@ function App() {
                                 <Route
                                   path="/messages/:threadId"
                                   element={<ThreadDetailPageRoute />}
+                                />
+                                {/* Neighbors routes (Epic 6, Story 6.6) */}
+                                <Route
+                                  path="/neighbors"
+                                  element={<NeighborsPageRoute />}
+                                />
+                                <Route
+                                  path="/neighbors/:neighborId"
+                                  element={<NeighborDetailRoute />}
+                                />
+                                <Route
+                                  path="/neighbors/privacy"
+                                  element={<NeighborsPrivacySettingsRoute />}
                                 />
                                 {/* Faults routes (UC-03) */}
                                 <Route path="/faults" element={<FaultsPageRoute />} />
@@ -1953,5 +1973,117 @@ function Home() {
 }
 
 // Login component removed - now using LoginPage from ./pages/LoginPage
+
+// ---------------------------------------------------------------------------
+// Neighbor Route Wrappers (Epic 6, Story 6.6)
+// ---------------------------------------------------------------------------
+
+/**
+ * Neighbors listing page — wired to backend GET /api/v1/buildings/{id}/neighbors.
+ *
+ * Building context: The route uses the first building from `useBuildings()`.
+ * Once a building-selector is added to the app-shell, swap for the selected ID.
+ */
+function NeighborsPageRoute() {
+  const navigate = useNavigate();
+  const { data: buildingsData, isLoading: isLoadingBuildings } = useBuildings();
+
+  // Pick the first building the user has access to; URL-param selection deferred.
+  const buildingId = buildingsData?.items?.[0]?.id ?? '';
+  const buildingName = buildingsData?.items?.[0]?.name;
+
+  const { neighbors, isLoading, error } = useNeighbors(buildingId, !isLoadingBuildings);
+
+  return (
+    <NeighborsPage
+      neighbors={neighbors}
+      buildingName={buildingName}
+      isLoading={isLoading || isLoadingBuildings}
+      error={error}
+      onViewProfile={(n) => navigate(`/neighbors/${n.id}`)}
+      onContact={(n) => navigate(`/messages/new?recipientId=${n.id}`)}
+      onManagePrivacy={() => navigate('/neighbors/privacy')}
+    />
+  );
+}
+
+/**
+ * Neighbor detail page — extracts :neighborId from the URL.
+ * Fetches the neighbor from the building list and finds by id.
+ */
+function NeighborDetailRoute() {
+  const { neighborId } = useParams<{ neighborId: string }>();
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+  const { data: buildingsData } = useBuildings();
+
+  const buildingId = buildingsData?.items?.[0]?.id ?? '';
+  const { neighbors, isLoading } = useNeighbors(buildingId, !!buildingId);
+  const neighbor = neighbors.find((n) => n.id === neighborId);
+
+  if (!neighborId) {
+    return (
+      <div className="error-page">
+        <h1>{t('errors.notFound')}</h1>
+        <p>{t('errors.neighborNotFound', 'Neighbor not found.')}</p>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return <div className="loading-page"><p>{t('common.loading')}</p></div>;
+  }
+
+  if (!neighbor) {
+    return (
+      <div className="error-page">
+        <h1>{t('errors.notFound')}</h1>
+        <p>{t('errors.neighborNotFound', 'Neighbor not found.')}</p>
+      </div>
+    );
+  }
+
+  return (
+    <NeighborDetailPage
+      neighbor={neighbor}
+      onBack={() => navigate('/neighbors')}
+      onMessage={(n) => navigate(`/messages/new?recipientId=${n.id}`)}
+    />
+  );
+}
+
+/**
+ * Neighbor privacy settings page — wired to GET/PUT /api/v1/users/me/privacy.
+ */
+function NeighborsPrivacySettingsRoute() {
+  const navigate = useNavigate();
+  const { showToast } = useToast();
+  const { t } = useTranslation();
+
+  const { settings, isLoading, isSubmitting, error, updateSettings } = usePrivacySettings();
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const handleSubmit = async (newSettings: import('./features/neighbors').PrivacySettings) => {
+    try {
+      await updateSettings(newSettings);
+      setSuccessMessage(t('neighbors.privacy.saved', 'Privacy settings saved.'));
+      showToast({ type: 'success', title: t('common.success'), message: t('neighbors.privacy.saved', 'Privacy settings saved.') });
+    } catch {
+      showToast({ type: 'error', title: t('common.error'), message: t('neighbors.privacy.saveFailed', 'Failed to save privacy settings.') });
+    }
+  };
+
+  return (
+    <NeighborsPrivacySettingsPage
+      settings={settings}
+      isLoading={isLoading}
+      error={error}
+      isSubmitting={isSubmitting}
+      successMessage={successMessage}
+      onSubmit={handleSubmit}
+      onBack={() => navigate('/neighbors')}
+    />
+  );
+}
 
 export default App;

--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -66,16 +66,13 @@ import {
   useNavigationCommands,
 } from './features/command-palette';
 import { ManagerDashboardPage, ResidentDashboardPage } from './features/dashboard';
-import {
-  useNeighbors,
-  usePrivacySettings,
-} from './features/neighbors';
 import type {
   DisputeCategory,
   DisputePriority,
   DisputeSummary,
   DisputeStatus as UiDisputeStatus,
 } from './features/disputes/components/DisputeCard';
+import { useNeighbors, usePrivacySettings } from './features/neighbors';
 import type { ListOutagesParams, OutageDetail } from './features/outages';
 // Lazy-loaded route components for code splitting (Epic 130)
 import {
@@ -546,10 +543,7 @@ function App() {
                                   element={<ThreadDetailPageRoute />}
                                 />
                                 {/* Neighbors routes (Epic 6, Story 6.6) */}
-                                <Route
-                                  path="/neighbors"
-                                  element={<NeighborsPageRoute />}
-                                />
+                                <Route path="/neighbors" element={<NeighborsPageRoute />} />
                                 <Route
                                   path="/neighbors/:neighborId"
                                   element={<NeighborDetailRoute />}
@@ -2031,7 +2025,11 @@ function NeighborDetailRoute() {
   }
 
   if (isLoading) {
-    return <div className="loading-page"><p>{t('common.loading')}</p></div>;
+    return (
+      <div className="loading-page">
+        <p>{t('common.loading')}</p>
+      </div>
+    );
   }
 
   if (!neighbor) {
@@ -2067,9 +2065,17 @@ function NeighborsPrivacySettingsRoute() {
     try {
       await updateSettings(newSettings);
       setSuccessMessage(t('neighbors.privacy.saved', 'Privacy settings saved.'));
-      showToast({ type: 'success', title: t('common.success'), message: t('neighbors.privacy.saved', 'Privacy settings saved.') });
+      showToast({
+        type: 'success',
+        title: t('common.success'),
+        message: t('neighbors.privacy.saved', 'Privacy settings saved.'),
+      });
     } catch {
-      showToast({ type: 'error', title: t('common.error'), message: t('neighbors.privacy.saveFailed', 'Failed to save privacy settings.') });
+      showToast({
+        type: 'error',
+        title: t('common.error'),
+        message: t('neighbors.privacy.saveFailed', 'Failed to save privacy settings.'),
+      });
     }
   };
 

--- a/frontend/apps/ppt-web/src/features/neighbors/hooks/index.ts
+++ b/frontend/apps/ppt-web/src/features/neighbors/hooks/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Neighbors Feature Hooks
+ */
+
+export { useNeighbors, usePrivacySettings } from './useNeighbors';

--- a/frontend/apps/ppt-web/src/features/neighbors/hooks/useNeighbors.ts
+++ b/frontend/apps/ppt-web/src/features/neighbors/hooks/useNeighbors.ts
@@ -15,16 +15,12 @@
  *   residentType → isOwner (owner → true)
  */
 
-import {
-  createNeighborHooks,
-  createNeighborsApi,
-  getToken,
-} from '@ppt/api-client';
 import type {
   NeighborView as ApiNeighborView,
   PrivacySettings as ApiPrivacySettings,
   UpdatePrivacySettingsRequest as ApiUpdatePrivacySettingsRequest,
 } from '@ppt/api-client';
+import { createNeighborHooks, createNeighborsApi, getToken } from '@ppt/api-client';
 import { useMemo } from 'react';
 import type { NeighborView, PrivacySettings } from '../types';
 
@@ -91,9 +87,7 @@ export function mapApiPrivacyToFeature(api: ApiPrivacySettings): PrivacySettings
  * Map feature-layer PrivacySettings to the API UpdatePrivacySettingsRequest.
  * We collapse the granular visibility flags back to the three-value API enum.
  */
-export function mapFeaturePrivacyToApi(
-  settings: PrivacySettings
-): ApiUpdatePrivacySettingsRequest {
+export function mapFeaturePrivacyToApi(settings: PrivacySettings): ApiUpdatePrivacySettingsRequest {
   let profileVisibility: ApiUpdatePrivacySettingsRequest['profileVisibility'];
   if (!settings.listedInDirectory || settings.showName === 'private') {
     profileVisibility = 'hidden';
@@ -125,10 +119,7 @@ export function useNeighbors(buildingId: string, enabled = true) {
   const query = hooks.useNeighbors(buildingId, enabled && !!buildingId);
 
   const neighbors: NeighborView[] = useMemo(
-    () =>
-      (query.data?.neighbors ?? [])
-        .filter((n) => n.isVisible)
-        .map(mapApiNeighborToFeature),
+    () => (query.data?.neighbors ?? []).filter((n) => n.isVisible).map(mapApiNeighborToFeature),
     [query.data]
   );
 

--- a/frontend/apps/ppt-web/src/features/neighbors/hooks/useNeighbors.ts
+++ b/frontend/apps/ppt-web/src/features/neighbors/hooks/useNeighbors.ts
@@ -1,0 +1,170 @@
+/**
+ * Neighbor Feature Hooks
+ *
+ * Wires @ppt/api-client neighbor + privacy-settings routes to the
+ * feature-layer NeighborView / PrivacySettings types used by the
+ * presentational components (Epic 6, Story 6.6).
+ *
+ * API NeighborView  →  feature NeighborView mapping:
+ *   userId       → id
+ *   displayName  → displayName
+ *   unitLabel    → unitNumber
+ *   isVisible    → (used for filtering)
+ *   email        → email
+ *   phone        → phone
+ *   residentType → isOwner (owner → true)
+ */
+
+import {
+  createNeighborHooks,
+  createNeighborsApi,
+  getToken,
+} from '@ppt/api-client';
+import type {
+  NeighborView as ApiNeighborView,
+  PrivacySettings as ApiPrivacySettings,
+  UpdatePrivacySettingsRequest as ApiUpdatePrivacySettingsRequest,
+} from '@ppt/api-client';
+import { useMemo } from 'react';
+import type { NeighborView, PrivacySettings } from '../types';
+
+// ---------------------------------------------------------------------------
+// API client factory
+// ---------------------------------------------------------------------------
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '';
+
+function getNeighborsApiClient() {
+  return createNeighborsApi({
+    baseUrl: API_BASE_URL,
+    accessToken: getToken() ?? undefined,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Type adapters: API → feature layer
+// ---------------------------------------------------------------------------
+
+/**
+ * Map API NeighborView to the feature-layer NeighborView type.
+ * Privacy-aware: hidden neighbors have no email/phone.
+ */
+export function mapApiNeighborToFeature(n: ApiNeighborView): NeighborView {
+  return {
+    id: n.userId,
+    displayName: n.displayName,
+    unitNumber: n.unitLabel,
+    email: n.email ?? undefined,
+    phone: n.phone ?? undefined,
+    isOwner: n.residentType === 'owner',
+  };
+}
+
+/**
+ * Map API PrivacySettings to the feature-layer PrivacySettings type.
+ * The API uses a simplified `profile_visibility` + `show_contact_info`
+ * model; we map it to the more granular feature-layer visibility levels.
+ */
+export function mapApiPrivacyToFeature(api: ApiPrivacySettings): PrivacySettings {
+  // 'visible' → 'building', 'hidden' → 'private', 'contacts_only' → 'neighbors'
+  const visibilityMap: Record<string, PrivacySettings['showName']> = {
+    visible: 'building',
+    contacts_only: 'neighbors',
+    hidden: 'private',
+  };
+  const visibility = visibilityMap[api.profileVisibility] ?? 'building';
+  const contactVisibility = api.showContactInfo ? 'neighbors' : 'private';
+
+  return {
+    showName: visibility,
+    showEmail: contactVisibility,
+    showPhone: contactVisibility,
+    showUnit: visibility,
+    showAvatar: visibility,
+    showBio: visibility,
+    showMoveInDate: 'private',
+    listedInDirectory: api.profileVisibility !== 'hidden',
+  };
+}
+
+/**
+ * Map feature-layer PrivacySettings to the API UpdatePrivacySettingsRequest.
+ * We collapse the granular visibility flags back to the three-value API enum.
+ */
+export function mapFeaturePrivacyToApi(
+  settings: PrivacySettings
+): ApiUpdatePrivacySettingsRequest {
+  let profileVisibility: ApiUpdatePrivacySettingsRequest['profileVisibility'];
+  if (!settings.listedInDirectory || settings.showName === 'private') {
+    profileVisibility = 'hidden';
+  } else if (settings.showName === 'neighbors') {
+    profileVisibility = 'contacts_only';
+  } else {
+    profileVisibility = 'visible';
+  }
+
+  const showContactInfo =
+    settings.showEmail === 'neighbors' ||
+    settings.showEmail === 'building' ||
+    settings.showEmail === 'public';
+
+  return { profileVisibility, showContactInfo };
+}
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+/**
+ * List neighbors in a building, mapping to feature-layer types.
+ * Only includes neighbors who have not hidden their profile.
+ */
+export function useNeighbors(buildingId: string, enabled = true) {
+  const api = useMemo(() => getNeighborsApiClient(), []);
+  const hooks = useMemo(() => createNeighborHooks(api), [api]);
+  const query = hooks.useNeighbors(buildingId, enabled && !!buildingId);
+
+  const neighbors: NeighborView[] = useMemo(
+    () =>
+      (query.data?.neighbors ?? [])
+        .filter((n) => n.isVisible)
+        .map(mapApiNeighborToFeature),
+    [query.data]
+  );
+
+  return {
+    neighbors,
+    total: query.data?.total ?? 0,
+    isLoading: query.isLoading,
+    error: query.error instanceof Error ? query.error.message : null,
+  };
+}
+
+/**
+ * Get + update current user's privacy settings.
+ */
+export function usePrivacySettings() {
+  const api = useMemo(() => getNeighborsApiClient(), []);
+  const hooks = useMemo(() => createNeighborHooks(api), [api]);
+
+  const query = hooks.usePrivacySettings();
+  const mutation = hooks.useUpdatePrivacySettings();
+
+  const settings: PrivacySettings | undefined = query.data
+    ? mapApiPrivacyToFeature(query.data.settings)
+    : undefined;
+
+  const updateSettings = (newSettings: PrivacySettings) => {
+    return mutation.mutateAsync(mapFeaturePrivacyToApi(newSettings));
+  };
+
+  return {
+    settings,
+    isLoading: query.isLoading,
+    isSubmitting: mutation.isPending,
+    error:
+      (query.error instanceof Error ? query.error.message : null) ??
+      (mutation.error instanceof Error ? mutation.error.message : null),
+    updateSettings,
+  };
+}

--- a/frontend/apps/ppt-web/src/features/neighbors/index.ts
+++ b/frontend/apps/ppt-web/src/features/neighbors/index.ts
@@ -5,5 +5,6 @@
  */
 
 export * from './components';
+export * from './hooks';
 export * from './pages';
 export * from './types';

--- a/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
+++ b/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
@@ -65,6 +65,17 @@ export const PrivacySettingsPage = lazy(() =>
   import('../features/privacy').then((m) => ({ default: m.PrivacySettingsPage }))
 );
 
+// Neighbors feature (Epic 6, Story 6.6)
+export const NeighborsPage = lazy(() =>
+  import('../features/neighbors').then((m) => ({ default: m.NeighborsPage }))
+);
+export const NeighborDetailPage = lazy(() =>
+  import('../features/neighbors').then((m) => ({ default: m.NeighborDetailPage }))
+);
+export const NeighborsPrivacySettingsPage = lazy(() =>
+  import('../features/neighbors').then((m) => ({ default: m.PrivacySettingsPage }))
+);
+
 // Error / empty / loading state surfaces
 export const NotFoundPage = lazy(() =>
   import('../features/errors').then((m) => ({ default: m.NotFoundPage }))


### PR DESCRIPTION
## Task
Verify and wire neighbor listing frontend with privacy-aware filtering to backend list_neighbors + privacy_settings routes; confirm mobile NeighborsScreen.tsx integration and promote sprint-status (6-6 Neighbor Information)

## Owner
pm-frontend

## Changes
- `frontend/apps/ppt-web/src/features/neighbors/hooks/useNeighbors.ts` (new): hooks for `list_neighbors` + `privacy_settings` API routes with TanStack Query and privacy-aware type mapping
- `frontend/apps/ppt-web/src/features/neighbors/hooks/index.ts` (new): barrel export
- `frontend/apps/ppt-web/src/features/neighbors/index.ts`: exports `hooks`
- `frontend/apps/ppt-web/src/routes/lazyRoutes.tsx`: lazy `NeighborsPage`, `NeighborDetailPage`, `NeighborsPrivacySettingsPage`
- `frontend/apps/ppt-web/src/App.tsx`: NeighborsPageRoute/NeighborDetailRoute/NeighborsPrivacySettingsRoute wired to `/neighbors`, `/neighbors/:id`, `/neighbors/privacy`
- `frontend/apps/mobile/src/screens/neighbors/NeighborsScreen.tsx`: replaced MOCK_NEIGHBORS with useApiQuery hitting `/api/v1/buildings` + `/api/v1/buildings/{id}/neighbors`; privacy-aware is_visible filtering
- `frontend/apps/mobile/src/screens/neighbors/index.ts`: removed retired `Neighbor` type re-export (typecheck fix)
- `frontend/apps/mobile/src/screens/index.ts`: removed retired `Neighbor` type re-export
- `_bmad-output/implementation-artifacts/sprint-status.yaml`: 6-6-neighbor-information → done

## Tested (Band A — fast check)
```
pnpm --filter @ppt/web typecheck   → exit 0
pnpm --filter @ppt/mobile typecheck → exit 0
```

## Built (Band B — full build)
```
pnpm --filter @ppt/web build → ✓ built in 5.12s (exit 0)
Pre-existing chunk-size warning only; no new errors
```

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Notes
- Backend routes already existed: `GET /api/v1/buildings/{id}/neighbors` and `GET/PUT /api/v1/users/me/privacy` — this PR wires the frontend only
- Type mapping: API `NeighborView` (snake_case, `userId`/`displayName`/`unitLabel`) → feature `NeighborView` (`id`/`displayName`/`unitNumber`); privacy collapsed from granular 4-level to API 3-value enum
- Mobile uses `useApiQuery` from `hooks/useApi.ts` (not `@ppt/api-client` directly) per existing mobile pattern — see `useApi.ts` comment about absolute URLs in React Native