### PR TITLE
gap-7a-3: mobile document permission/RLS UI (DocumentPermissionsScreen + access-scope filter)

### DIFF
--- a/frontend/apps/mobile/src/App.tsx
+++ b/frontend/apps/mobile/src/App.tsx
@@ -15,6 +15,7 @@ import {
   BuildingsScreen,
   DashboardScreen,
   DocumentDetailScreen,
+  DocumentPermissionsScreen,
   DocumentPreviewScreen,
   DocumentsScreen,
   DocumentUploadScreen,
@@ -62,6 +63,7 @@ type Screen =
   | 'DocumentDetail'
   | 'DocumentPreview'
   | 'DocumentUpload'
+  | 'DocumentPermissions'
   | 'Messages'
   | 'ThreadDetail'
   | 'Settings'
@@ -161,6 +163,13 @@ function MainApp() {
             onCancel={() => handleNavigate('Documents')}
           />
         );
+      case 'DocumentPermissions':
+        return (
+          <DocumentPermissionsScreen
+            documentId={(screenParams?.documentId as string | undefined) ?? ''}
+            onBack={() => handleNavigate('Documents')}
+          />
+        );
       case 'MeterReading':
         return (
           <MeterReadingScreen
@@ -258,7 +267,8 @@ function MainApp() {
           isActive={
             currentScreen === 'Documents' ||
             currentScreen === 'DocumentDetail' ||
-            currentScreen === 'DocumentPreview'
+            currentScreen === 'DocumentPreview' ||
+            currentScreen === 'DocumentPermissions'
           }
           onPress={() => handleNavigate('Documents')}
         />

--- a/frontend/apps/mobile/src/locales/cs.json
+++ b/frontend/apps/mobile/src/locales/cs.json
@@ -208,6 +208,25 @@
         "correspondence": "Korespondence",
         "other": "Jine"
       }
+    },
+    "searchPlaceholder": "Search documents…",
+    "filter": {
+      "all": "All",
+      "audience": "Audience"
+    },
+    "permissions": {
+      "title": "Document Permissions",
+      "audience": "Audience",
+      "status": "Status",
+      "metadata": "Details",
+      "category": "Category",
+      "created": "Created",
+      "updated": "Last updated",
+      "loadError": "Could not load document details",
+      "draftNote": "This document is a draft and is only visible to the author and managers.",
+      "archivedNote": "This document has been archived and is no longer actively shared.",
+      "rlsTitle": "Row-Level Security",
+      "rlsBody": "Access to this document is enforced by the server. The audience shown above reflects who can see it."
     }
   },
   "settings": {

--- a/frontend/apps/mobile/src/locales/de.json
+++ b/frontend/apps/mobile/src/locales/de.json
@@ -148,6 +148,25 @@
     "view": "Anzeigen",
     "noDocuments": "Keine Dokumente verfugbar",
     "share": "Teilen",
+    "searchPlaceholder": "Search documents…",
+    "filter": {
+      "all": "All",
+      "audience": "Audience"
+    },
+    "permissions": {
+      "title": "Document Permissions",
+      "audience": "Audience",
+      "status": "Status",
+      "metadata": "Details",
+      "category": "Category",
+      "created": "Created",
+      "updated": "Last updated",
+      "loadError": "Could not load document details",
+      "draftNote": "This document is a draft and is only visible to the author and managers.",
+      "archivedNote": "This document has been archived and is no longer actively shared.",
+      "rlsTitle": "Row-Level Security",
+      "rlsBody": "Access to this document is enforced by the server. The audience shown above reflects who can see it."
+    },
     "preview": {
       "fetching": "Vorschau wird vorbereitet…",
       "urlReady": "Dokument bereit",

--- a/frontend/apps/mobile/src/locales/en.json
+++ b/frontend/apps/mobile/src/locales/en.json
@@ -157,6 +157,25 @@
     "emptyTitle": "No documents",
     "noMatches": "No documents match your search",
     "folderEmpty": "This folder is empty",
+    "searchPlaceholder": "Search documents…",
+    "filter": {
+      "all": "All",
+      "audience": "Audience"
+    },
+    "permissions": {
+      "title": "Document Permissions",
+      "audience": "Audience",
+      "status": "Status",
+      "metadata": "Details",
+      "category": "Category",
+      "created": "Created",
+      "updated": "Last updated",
+      "loadError": "Could not load document details",
+      "draftNote": "This document is a draft and is only visible to the author and managers.",
+      "archivedNote": "This document has been archived and is no longer actively shared.",
+      "rlsTitle": "Row-Level Security",
+      "rlsBody": "Access to this document is enforced by the server. The audience shown above reflects who can see it — this cannot be overridden on the device."
+    },
     "preview": {
       "fetching": "Preparing preview…",
       "urlReady": "Document ready",

--- a/frontend/apps/mobile/src/locales/hu.json
+++ b/frontend/apps/mobile/src/locales/hu.json
@@ -148,6 +148,25 @@
     "view": "Megtekintes",
     "noDocuments": "Nincsenek elerheto dokumentumok",
     "share": "Megosztás",
+    "searchPlaceholder": "Search documents…",
+    "filter": {
+      "all": "All",
+      "audience": "Audience"
+    },
+    "permissions": {
+      "title": "Document Permissions",
+      "audience": "Audience",
+      "status": "Status",
+      "metadata": "Details",
+      "category": "Category",
+      "created": "Created",
+      "updated": "Last updated",
+      "loadError": "Could not load document details",
+      "draftNote": "This document is a draft and is only visible to the author and managers.",
+      "archivedNote": "This document has been archived and is no longer actively shared.",
+      "rlsTitle": "Row-Level Security",
+      "rlsBody": "Access to this document is enforced by the server. The audience shown above reflects who can see it."
+    },
     "preview": {
       "fetching": "Elonézet elokészítése…",
       "urlReady": "Dokumentum kész",

--- a/frontend/apps/mobile/src/locales/pl.json
+++ b/frontend/apps/mobile/src/locales/pl.json
@@ -148,6 +148,25 @@
     "view": "Zobacz",
     "noDocuments": "Brak dostepnych dokumentow",
     "share": "Udostepnij",
+    "searchPlaceholder": "Search documents…",
+    "filter": {
+      "all": "All",
+      "audience": "Audience"
+    },
+    "permissions": {
+      "title": "Document Permissions",
+      "audience": "Audience",
+      "status": "Status",
+      "metadata": "Details",
+      "category": "Category",
+      "created": "Created",
+      "updated": "Last updated",
+      "loadError": "Could not load document details",
+      "draftNote": "This document is a draft and is only visible to the author and managers.",
+      "archivedNote": "This document has been archived and is no longer actively shared.",
+      "rlsTitle": "Row-Level Security",
+      "rlsBody": "Access to this document is enforced by the server. The audience shown above reflects who can see it."
+    },
     "preview": {
       "fetching": "Przygotowywanie podgladu…",
       "urlReady": "Dokument gotowy",

--- a/frontend/apps/mobile/src/locales/sk.json
+++ b/frontend/apps/mobile/src/locales/sk.json
@@ -157,6 +157,25 @@
     "emptyTitle": "Ziadne dokumenty",
     "noMatches": "Ziadne dokumenty nezodpovedaju hladaniu",
     "folderEmpty": "Tento priecinok je prazdny",
+    "searchPlaceholder": "Hladat dokumenty…",
+    "filter": {
+      "all": "Vsetky",
+      "audience": "Publikum"
+    },
+    "permissions": {
+      "title": "Opravnenia dokumentu",
+      "audience": "Publikum",
+      "status": "Stav",
+      "metadata": "Podrobnosti",
+      "category": "Kategoria",
+      "created": "Vytvorene",
+      "updated": "Naposledy aktualizovane",
+      "loadError": "Nepodarilo sa nacitat podrobnosti dokumentu",
+      "draftNote": "Tento dokument je koncept a je viditelny iba pre autora a spravcu.",
+      "archivedNote": "Tento dokument bol archivovany a uz nie je aktyvne zdielany.",
+      "rlsTitle": "Zabezpecenie na urovni riadkov",
+      "rlsBody": "Pristup k tomuto dokumentu je vynuceny serverom. Zobrazene publikum odrazaj tych, kto ho moze vidiet — toto nie je mozne obist na zariadeni."
+    },
     "preview": {
       "fetching": "Pripravujem nahled…",
       "urlReady": "Dokument je pripraveny",

--- a/frontend/apps/mobile/src/screens/documents/DocumentPermissionsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentPermissionsScreen.tsx
@@ -11,13 +11,7 @@
 
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  View,
-} from 'react-native';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
@@ -141,10 +135,7 @@ export interface DocumentPermissionsScreenProps {
   onBack?: () => void;
 }
 
-export function DocumentPermissionsScreen({
-  documentId,
-  onBack,
-}: DocumentPermissionsScreenProps) {
+export function DocumentPermissionsScreen({ documentId, onBack }: DocumentPermissionsScreenProps) {
   const { t } = useTranslation();
 
   const { data, isLoading, error, refetch } = useApiQuery<ApiDocumentDetailResponse>(

--- a/frontend/apps/mobile/src/screens/documents/DocumentPermissionsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentPermissionsScreen.tsx
@@ -1,0 +1,350 @@
+/**
+ * DocumentPermissionsScreen (gap-7a-3 — Permission-Based Document Access).
+ *
+ * Shows the access_scope (audience) and publication status of a document so
+ * residents and managers can understand who can see it. This is the mobile
+ * counterpart of the web's audience-badge column in DocumentsBrowse.
+ *
+ * The backend enforces PostgreSQL RLS — this screen only *visualises* the
+ * permission model, it does not grant or restrict access itself.
+ */
+
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { useApiQuery } from '../../hooks/useApi';
+import { colors, screenStyles as s } from '../shared/screenStyles';
+
+// ─── types ───────────────────────────────────────────────────────────────────
+
+export type AccessScope = 'organization' | 'building' | 'unit' | 'user' | 'public';
+export type DocumentStatus = 'published' | 'draft' | 'archived';
+
+export interface DocumentPermission {
+  id: string;
+  title: string;
+  access_scope?: AccessScope;
+  status?: DocumentStatus;
+  category?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ApiDocumentDetailResponse {
+  id: string;
+  title: string;
+  access_scope?: AccessScope;
+  status?: DocumentStatus;
+  category?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+interface AudienceMeta {
+  label: string;
+  description: string;
+  color: string;
+  bg: string;
+  icon: string;
+}
+
+function getAudienceMeta(scope: AccessScope | undefined): AudienceMeta {
+  switch (scope) {
+    case 'organization':
+      return {
+        label: 'All Residents',
+        description: 'Visible to every resident in the organization.',
+        color: colors.accent,
+        bg: colors.accentSoft,
+        icon: '🏘️',
+      };
+    case 'building':
+      return {
+        label: 'Building Only',
+        description: 'Visible to residents of the specific building.',
+        color: '#4f46e5',
+        bg: '#ede9fe',
+        icon: '🏢',
+      };
+    case 'unit':
+      return {
+        label: 'Unit Only',
+        description: 'Visible only to occupants of a specific unit.',
+        color: colors.warning,
+        bg: colors.warningBg,
+        icon: '🚪',
+      };
+    case 'user':
+      return {
+        label: 'Specific Users',
+        description: 'Visible only to explicitly named users.',
+        color: colors.warningDark,
+        bg: colors.warningBg,
+        icon: '👤',
+      };
+    case 'public':
+      return {
+        label: 'Public',
+        description: 'Visible to anyone, including unauthenticated users.',
+        color: colors.success,
+        bg: colors.successBg,
+        icon: '🌍',
+      };
+    default:
+      return {
+        label: 'All Residents',
+        description: 'Visible to every resident in the organization.',
+        color: colors.accent,
+        bg: colors.accentSoft,
+        icon: '🏘️',
+      };
+  }
+}
+
+interface StatusMeta {
+  label: string;
+  color: string;
+  bg: string;
+}
+
+function getStatusMeta(status: DocumentStatus | undefined): StatusMeta {
+  switch (status) {
+    case 'draft':
+      return { label: 'Draft', color: colors.warningDark, bg: colors.warningBg };
+    case 'archived':
+      return { label: 'Archived', color: colors.textMuted, bg: colors.surfaceMuted };
+    default:
+      return { label: 'Published', color: colors.successDark, bg: colors.successBg };
+  }
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+// ─── component ───────────────────────────────────────────────────────────────
+
+export interface DocumentPermissionsScreenProps {
+  documentId: string;
+  onBack?: () => void;
+}
+
+export function DocumentPermissionsScreen({
+  documentId,
+  onBack,
+}: DocumentPermissionsScreenProps) {
+  const { t } = useTranslation();
+
+  const { data, isLoading, error, refetch } = useApiQuery<ApiDocumentDetailResponse>(
+    ['documents', 'detail', documentId],
+    `/api/v1/documents/${documentId}`,
+    { staleTime: 60_000 }
+  );
+
+  const handleRetry = useCallback(() => {
+    void refetch();
+  }, [refetch]);
+
+  const audienceMeta = getAudienceMeta(data?.access_scope);
+  const statusMeta = getStatusMeta(data?.status);
+
+  return (
+    <View style={s.container}>
+      {/* Header */}
+      <View style={s.header}>
+        {onBack && (
+          <Pressable onPress={onBack} style={styles.backLink}>
+            <Text style={styles.backLinkText}>← {t('documents.title')}</Text>
+          </Pressable>
+        )}
+        <Text style={s.headerTitle}>{t('documents.permissions.title')}</Text>
+        {data?.title ? (
+          <Text style={s.headerSubtitle} numberOfLines={1}>
+            {data.title}
+          </Text>
+        ) : null}
+      </View>
+
+      <ScrollView style={s.scrollView}>
+        {isLoading && (
+          <View style={s.emptyState}>
+            <Text style={s.emptyTitle}>{t('common.loading')}</Text>
+          </View>
+        )}
+
+        {error && !isLoading && (
+          <View style={s.emptyState}>
+            <Text style={s.emptyIcon}>⚠️</Text>
+            <Text style={s.emptyTitle}>{t('documents.permissions.loadError')}</Text>
+            <Text style={s.emptyText}>{error.message}</Text>
+            <Pressable style={[s.primaryButton, styles.retryButton]} onPress={handleRetry}>
+              <Text style={s.primaryButtonText}>{t('common.retry')}</Text>
+            </Pressable>
+          </View>
+        )}
+
+        {!isLoading && !error && data && (
+          <>
+            {/* Audience card */}
+            <View style={s.card}>
+              <Text style={styles.sectionLabel}>{t('documents.permissions.audience')}</Text>
+              <View style={[styles.audienceBadge, { backgroundColor: audienceMeta.bg }]}>
+                <Text style={styles.audienceIcon}>{audienceMeta.icon}</Text>
+                <View style={styles.audienceBody}>
+                  <Text style={[styles.audienceLabel, { color: audienceMeta.color }]}>
+                    {audienceMeta.label}
+                  </Text>
+                  <Text style={styles.audienceDesc}>{audienceMeta.description}</Text>
+                </View>
+              </View>
+            </View>
+
+            {/* Status card */}
+            <View style={s.card}>
+              <Text style={styles.sectionLabel}>{t('documents.permissions.status')}</Text>
+              <View style={[styles.statusPill, { backgroundColor: statusMeta.bg }]}>
+                <Text style={[styles.statusText, { color: statusMeta.color }]}>
+                  {statusMeta.label}
+                </Text>
+              </View>
+              {data.status === 'draft' && (
+                <Text style={styles.statusNote}>{t('documents.permissions.draftNote')}</Text>
+              )}
+              {data.status === 'archived' && (
+                <Text style={styles.statusNote}>{t('documents.permissions.archivedNote')}</Text>
+              )}
+            </View>
+
+            {/* Metadata card */}
+            <View style={s.card}>
+              <Text style={styles.sectionLabel}>{t('documents.permissions.metadata')}</Text>
+              {data.category ? (
+                <View style={styles.metaRow}>
+                  <Text style={styles.metaKey}>{t('documents.permissions.category')}</Text>
+                  <Text style={styles.metaValue}>{data.category}</Text>
+                </View>
+              ) : null}
+              <View style={styles.metaRow}>
+                <Text style={styles.metaKey}>{t('documents.permissions.created')}</Text>
+                <Text style={styles.metaValue}>{formatDate(data.created_at)}</Text>
+              </View>
+              <View style={styles.metaRow}>
+                <Text style={styles.metaKey}>{t('documents.permissions.updated')}</Text>
+                <Text style={styles.metaValue}>{formatDate(data.updated_at)}</Text>
+              </View>
+            </View>
+
+            {/* RLS explanation card */}
+            <View style={[s.card, styles.infoCard]}>
+              <Text style={styles.infoTitle}>{t('documents.permissions.rlsTitle')}</Text>
+              <Text style={styles.infoBody}>{t('documents.permissions.rlsBody')}</Text>
+            </View>
+          </>
+        )}
+
+        <View style={s.bottomSpacer} />
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  backLink: { marginBottom: 8 },
+  backLinkText: { color: colors.accent, fontSize: 14 },
+  retryButton: { marginTop: 16 },
+  sectionLabel: {
+    fontSize: 11,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+    color: colors.textSubtle,
+    marginBottom: 10,
+  },
+  audienceBadge: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    borderRadius: 10,
+    padding: 14,
+    gap: 12,
+  },
+  audienceIcon: {
+    fontSize: 28,
+    lineHeight: 32,
+  },
+  audienceBody: {
+    flex: 1,
+  },
+  audienceLabel: {
+    fontSize: 16,
+    fontWeight: '700',
+    marginBottom: 4,
+  },
+  audienceDesc: {
+    fontSize: 13,
+    color: colors.textSecondary,
+    lineHeight: 18,
+  },
+  statusPill: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 14,
+    paddingVertical: 6,
+    borderRadius: 999,
+    marginBottom: 8,
+  },
+  statusText: {
+    fontSize: 13,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  statusNote: {
+    fontSize: 13,
+    color: colors.textMuted,
+    lineHeight: 18,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 6,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.divider,
+  },
+  metaKey: {
+    fontSize: 13,
+    color: colors.textMuted,
+  },
+  metaValue: {
+    fontSize: 13,
+    fontWeight: '500',
+    color: colors.text,
+  },
+  infoCard: {
+    backgroundColor: colors.accentSoft,
+    borderWidth: 1,
+    borderColor: colors.accentDisabled,
+  },
+  infoTitle: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: colors.accent,
+    marginBottom: 6,
+  },
+  infoBody: {
+    fontSize: 13,
+    color: colors.textSecondary,
+    lineHeight: 18,
+  },
+});

--- a/frontend/apps/mobile/src/screens/documents/DocumentsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentsScreen.tsx
@@ -11,8 +11,10 @@ import {
 } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
 import { colors } from '../shared/screenStyles';
+import type { AccessScope } from './DocumentPermissionsScreen';
 
 export type DocumentType = 'folder' | 'pdf' | 'image' | 'document' | 'spreadsheet';
+export type DocumentStatus = 'published' | 'draft' | 'archived';
 
 export interface Document {
   id: string;
@@ -24,11 +26,29 @@ export interface Document {
   parentId: string | null;
   downloadUrl?: string;
   children?: Document[];
+  /** RLS-enforced audience scope returned from the server (gap-7a-3). */
+  accessScope?: AccessScope;
+  status?: DocumentStatus;
 }
 
 interface DocumentsScreenProps {
   onNavigate?: (screen: string, params?: Record<string, unknown>) => void;
 }
+
+/** Human-readable label + style for each access_scope value. */
+const AUDIENCE_OPTIONS: ReadonlyArray<{
+  value: AccessScope;
+  label: string;
+  color: string;
+  bg: string;
+  icon: string;
+}> = [
+  { value: 'organization', label: 'All Residents', color: '#2563eb', bg: '#eff6ff', icon: '🏘️' },
+  { value: 'building', label: 'Building', color: '#4f46e5', bg: '#ede9fe', icon: '🏢' },
+  { value: 'unit', label: 'Unit', color: '#d97706', bg: '#fef3c7', icon: '🚪' },
+  { value: 'user', label: 'Specific Users', color: '#b45309', bg: '#fef3c7', icon: '👤' },
+  { value: 'public', label: 'Public', color: '#047857', bg: '#d1fae5', icon: '🌍' },
+] as const;
 
 /** Subset of `Document` returned by `GET /api/v1/documents`. */
 interface ApiDocument {
@@ -39,6 +59,10 @@ interface ApiDocument {
   content_type?: string | null;
   uploaded_at?: string | null;
   created_at: string;
+  /** RLS-enforced audience scope (gap-7a-3). */
+  access_scope?: AccessScope;
+  /** Publication status: absent means published (backward compat). */
+  status?: DocumentStatus;
 }
 
 interface ApiDocumentListResponse {
@@ -67,17 +91,52 @@ function toUiDocument(d: ApiDocument): Document {
     parentId: null,
     downloadUrl: d.file_path ?? undefined,
     children: undefined,
+    accessScope: d.access_scope,
+    status: d.status,
   };
 }
+
+/** Small inline badge showing the access_scope of a document row (gap-7a-3). */
+function AudienceScopeBadge({ scope }: { scope: AccessScope }) {
+  const opt = AUDIENCE_OPTIONS.find((o) => o.value === scope);
+  if (!opt) return null;
+  return (
+    <View style={[audienceBadgeStyles.pill, { backgroundColor: opt.bg }]}>
+      <Text style={audienceBadgeStyles.icon}>{opt.icon}</Text>
+      <Text style={[audienceBadgeStyles.label, { color: opt.color }]}>{opt.label}</Text>
+    </View>
+  );
+}
+
+const audienceBadgeStyles = StyleSheet.create({
+  pill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    borderRadius: 999,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    marginTop: 4,
+    gap: 3,
+  },
+  icon: { fontSize: 10 },
+  label: { fontSize: 10, fontWeight: '600' },
+});
 
 export function DocumentsScreen({ onNavigate: _onNavigate }: DocumentsScreenProps) {
   const { t } = useTranslation();
   const [currentPath, setCurrentPath] = useState<Document[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
+  const [downloading, setDownloading] = useState<string | null>(null);
+  /** Active access_scope audience filter (gap-7a-3). Undefined = no filter. */
+  const [selectedScope, setSelectedScope] = useState<AccessScope | undefined>(undefined);
+
+  // Build query params: include access_scope when a filter is active.
+  const queryParams = selectedScope ? `?access_scope=${selectedScope}` : '';
 
   const { data, isLoading, error, refetch, isFetching } = useApiQuery<ApiDocumentListResponse>(
-    ['documents', 'list'],
-    '/api/v1/documents',
+    ['documents', 'list', selectedScope],
+    `/api/v1/documents${queryParams}`,
     { staleTime: 60_000 }
   );
 
@@ -198,6 +257,47 @@ export function DocumentsScreen({ onNavigate: _onNavigate }: DocumentsScreenProp
         </View>
       )}
 
+      {/* Audience filter (gap-7a-3 — RLS access_scope chips) */}
+      <View style={styles.audienceFilterContainer}>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.audienceChipsRow}
+        >
+          <Pressable
+            style={[styles.audienceChip, selectedScope === undefined && styles.audienceChipAll]}
+            onPress={() => setSelectedScope(undefined)}
+          >
+            <Text
+              style={[
+                styles.audienceChipText,
+                selectedScope === undefined && styles.audienceChipTextActive,
+              ]}
+            >
+              {t('documents.filter.all')}
+            </Text>
+          </Pressable>
+          {AUDIENCE_OPTIONS.map((opt) => {
+            const isActive = selectedScope === opt.value;
+            return (
+              <Pressable
+                key={opt.value}
+                style={[
+                  styles.audienceChip,
+                  isActive && { backgroundColor: opt.color, borderColor: opt.color },
+                ]}
+                onPress={() => setSelectedScope(isActive ? undefined : opt.value)}
+              >
+                <Text style={styles.audienceChipIcon}>{opt.icon}</Text>
+                <Text style={[styles.audienceChipText, isActive && styles.audienceChipTextActive]}>
+                  {opt.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </ScrollView>
+      </View>
+
       {/* Search */}
       <View style={styles.searchContainer}>
         <TextInput
@@ -262,6 +362,27 @@ export function DocumentsScreen({ onNavigate: _onNavigate }: DocumentsScreenProp
                         </Text>
                       )}
                     </View>
+                    {/* Audience scope badge (gap-7a-3) */}
+                    {doc.accessScope ? <AudienceScopeBadge scope={doc.accessScope} /> : null}
+                  </View>
+                  <View style={styles.rowActions}>
+                    {/* Permissions detail button */}
+                    <Pressable
+                      style={styles.permissionsButton}
+                      onPress={() => _onNavigate?.('DocumentPermissions', { documentId: doc.id })}
+                      hitSlop={8}
+                    >
+                      <Text style={styles.permissionsIcon}>🔒</Text>
+                    </Pressable>
+                    {doc.type === 'folder' ? (
+                      <Text style={styles.arrowIcon}>›</Text>
+                    ) : downloading === doc.id ? (
+                      <View style={styles.downloadingIndicator}>
+                        <Text style={styles.downloadingText}>...</Text>
+                      </View>
+                    ) : (
+                      <Text style={styles.downloadIcon}>⬇️</Text>
+                    )}
                   </View>
                   {doc.type === 'folder' ? (
                     <Text style={styles.arrowIcon}>›</Text>
@@ -419,5 +540,55 @@ const styles = StyleSheet.create({
   },
   bottomSpacer: {
     height: 100,
+  },
+  // ── Audience filter strip (gap-7a-3) ──────────────────────────────────────
+  audienceFilterContainer: {
+    backgroundColor: colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    paddingVertical: 8,
+  },
+  audienceChipsRow: {
+    flexDirection: 'row',
+    paddingHorizontal: 12,
+    gap: 6,
+  },
+  audienceChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surface,
+    gap: 4,
+  },
+  audienceChipAll: {
+    borderColor: colors.accent,
+    backgroundColor: colors.accentSoft,
+  },
+  audienceChipIcon: {
+    fontSize: 13,
+  },
+  audienceChipText: {
+    fontSize: 12,
+    fontWeight: '500',
+    color: colors.textMuted,
+  },
+  audienceChipTextActive: {
+    color: colors.white,
+  },
+  // ── Row actions / permissions button ──────────────────────────────────────
+  rowActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  permissionsButton: {
+    padding: 4,
+  },
+  permissionsIcon: {
+    fontSize: 14,
   },
 });

--- a/frontend/apps/mobile/src/screens/documents/DocumentsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentsScreen.tsx
@@ -384,11 +384,6 @@ export function DocumentsScreen({ onNavigate: _onNavigate }: DocumentsScreenProp
                       <Text style={styles.downloadIcon}>⬇️</Text>
                     )}
                   </View>
-                  {doc.type === 'folder' ? (
-                    <Text style={styles.arrowIcon}>›</Text>
-                  ) : (
-                    <Text style={styles.downloadIcon}>👁️</Text>
-                  )}
                 </Pressable>
               ))}
           </>
@@ -590,5 +585,15 @@ const styles = StyleSheet.create({
   },
   permissionsIcon: {
     fontSize: 14,
+  },
+  downloadingIndicator: {
+    width: 24,
+    height: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  downloadingText: {
+    fontSize: 14,
+    color: colors.textMuted,
   },
 });

--- a/frontend/apps/mobile/src/screens/documents/index.ts
+++ b/frontend/apps/mobile/src/screens/documents/index.ts
@@ -1,7 +1,9 @@
 export { DocumentDetailScreen } from './DocumentDetailScreen';
+export type { DocumentPermissionsScreenProps } from './DocumentPermissionsScreen';
+export { DocumentPermissionsScreen } from './DocumentPermissionsScreen';
 export { DocumentPreviewScreen } from './DocumentPreviewScreen';
 export type { DocumentShareSheetProps } from './DocumentShareSheet';
 export { DocumentShareSheet } from './DocumentShareSheet';
-export type { Document, DocumentType } from './DocumentsScreen';
+export type { Document, DocumentStatus, DocumentType } from './DocumentsScreen';
 export { DocumentsScreen } from './DocumentsScreen';
 export { DocumentUploadScreen } from './DocumentUploadScreen';

--- a/frontend/apps/mobile/src/screens/index.ts
+++ b/frontend/apps/mobile/src/screens/index.ts
@@ -13,9 +13,10 @@ export type { Building } from './buildings';
 export { BuildingsScreen } from './buildings';
 // Main screens
 export { DashboardScreen } from './dashboard';
-export type { Document, DocumentType } from './documents';
+export type { Document, DocumentStatus, DocumentType } from './documents';
 export {
   DocumentDetailScreen,
+  DocumentPermissionsScreen,
   DocumentPreviewScreen,
   DocumentsScreen,
   DocumentUploadScreen,


### PR DESCRIPTION
## Task
Implement mobile document permission/RLS UI — web access-scope filtering wired in PR #443; mobile DocumentPermissionsScreen or equivalent pending (7a-3 Permission-Based Document Access)

## Owner
pm-frontend

## What was done

### `DocumentPermissionsScreen` (new)
- Dedicated screen reachable via the lock-icon button (🔒) on each document row
- Shows the `access_scope` audience (organization / building / unit / user / public) as a large colour-coded badge with icon and description
- Shows the publication status (Published / Draft / Archived) with contextual note for draft/archived
- Metadata card: category, created, updated
- RLS explanation card explaining the server enforces access — the device UI visualises but cannot override it
- Error / loading / retry states

### `DocumentsScreen` (updated)
- Horizontal scrollable filter chip strip: **All · All Residents · Building · Unit · Specific Users · Public**
- Active chip filters `GET /api/v1/documents?access_scope=<scope>` (TanStack Query key includes the scope for correct cache isolation)
- Per-row: small colour-coded audience badge rendered inline from `access_scope` field
- Per-row: lock icon button navigates to `DocumentPermissionsScreen`
- `ApiDocument` model extended with `access_scope` and `status` (both optional for backward compat)

### Navigation (`App.tsx`)
- Added `DocumentPermissions` to `Screen` union type
- Added render case passing `documentId` from `screenParams`
- Bottom nav `isActive` for the docs tab includes `DocumentPermissions`

### Barrel exports updated
- `screens/documents/index.ts`: exports `DocumentPermissionsScreen` + `DocumentStatus` type
- `screens/index.ts`: re-exports both

### i18n
- Added `documents.permissions.*`, `documents.filter.*`, `documents.searchPlaceholder` keys to all 6 locales (en, sk, cs, de, hu, pl)

## Mirrors web implementation
- Web: `DocumentsBrowse.tsx` audience chip filter + `access_scope` badge (PR #443)
- Mobile: same access_scope semantics, React Native chip strip + dedicated permissions screen

## Tested (Band A — fast check)
```
pnpm -F mobile typecheck
# exit 0 (no output)

pnpm biome check apps/mobile/src/screens/documents/DocumentPermissionsScreen.tsx \
  apps/mobile/src/screens/documents/DocumentsScreen.tsx \
  apps/mobile/src/App.tsx \
  apps/mobile/src/screens/documents/index.ts \
  apps/mobile/src/screens/index.ts
# Checked 5 files in 36ms. No fixes applied. exit 0
```

## Built (Band B — full build)
Skipped: React Native — `expo run:android/ios` not available in sandbox (per specialist agent instructions). Metro bundler dry-run not available without device. TypeScript compile (typecheck) is the authoritative check for RN.

Pre-existing test failures (3 suites) confirmed to exist before this commit — caused by `@testing-library/react-native` peer-deps version mismatch unrelated to this change.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change). This is a UI visualisation feature.

## Remote-tested
Skipped (ppt-bridge MCP not connected in this session).

## Notes
- The `access_scope` field on `GET /api/v1/documents` items must be returned by the backend (confirmed present in `@ppt/api-client` `DocumentSummary.access_scope` type)
- `DocumentPermissionsScreen` fetches `GET /api/v1/documents/:id` to get the full record — if the backend omits `access_scope` on the detail endpoint, the audience card gracefully falls back to "All Residents"
- i18n keys for cs/de/hu/pl are English fallbacks for now; native-speaker translations can follow in a separate chore PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01LX95p47cQEBuA3H7YDUVRv)_