### PR TITLE
gap-7a-5: document sharing UI panel in DocumentDetail (web)

### DIFF
--- a/docs/screens/ppt/document-detail.md
+++ b/docs/screens/ppt/document-detail.md
@@ -18,6 +18,9 @@ implementations:
 endpoints:
   - documents_get
   - documents_get_versions
+  - documents_shares_list
+  - documents_shares_create
+  - documents_shares_revoke
 relatedScreens:
   - id: ppt/documents
     rel: parent
@@ -104,6 +107,8 @@ UC-08 single-document detail. Manager-side full editing; resident-side filtered 
 ## Agent Log
 
 <!-- newest entries on top -->
+
+- 2026-05-24 — agent: gap-7a-5 — added DocumentSharePanel (user/role/building/link share types) to DocumentDetail; Share toggle button; share hooks in @ppt/api-client; apiStatus remains complete
 
 - 2026-05-24 — agent: gap-7a-3 — added RLS-aware permission-denied state to DocumentDetail (403 → lock icon + Slovak message); promoted ppt-web.apiStatus partial→complete
 - 2026-05-09 — agent: design analyzed (pages/ppt-document-detail.html — single artboard: loaded-v3-published with PDF preview + metadata + 5 actions + 4-version timeline); flipped ppt-web redesignStatus → in-progress; attached designSource; populated functionality checklist (5 sections), 5 states (recommended where not depicted), design-specific notes (PDF.js lazy-load + version-immutability + cross-screen attach + archive flow); declared 6 sharedComponents; added 1 relatedScreen (upload-document sibling)

--- a/docs/screens/ppt/document-detail.md
+++ b/docs/screens/ppt/document-detail.md
@@ -18,9 +18,6 @@ implementations:
 endpoints:
   - documents_get
   - documents_get_versions
-  - documents_shares_list
-  - documents_shares_create
-  - documents_shares_revoke
 relatedScreens:
   - id: ppt/documents
     rel: parent

--- a/frontend/apps/ppt-web/src/features/documents/components/DocumentSharePanel.tsx
+++ b/frontend/apps/ppt-web/src/features/documents/components/DocumentSharePanel.tsx
@@ -20,10 +20,14 @@ import { useToast } from '../../../components/Toast';
 
 function shareTypeLabel(type: ShareType): string {
   switch (type) {
-    case SHARE_TYPE.USER: return 'Specific user';
-    case SHARE_TYPE.ROLE: return 'Role';
-    case SHARE_TYPE.BUILDING: return 'Building';
-    case SHARE_TYPE.LINK: return 'Public link';
+    case SHARE_TYPE.USER:
+      return 'Specific user';
+    case SHARE_TYPE.ROLE:
+      return 'Role';
+    case SHARE_TYPE.BUILDING:
+      return 'Building';
+    case SHARE_TYPE.LINK:
+      return 'Public link';
   }
 }
 
@@ -34,10 +38,20 @@ function isActiveShare(share: ShareWithDocument): boolean {
 }
 
 function fmtExpiry(d: string): string {
-  return new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  return new Date(d).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
 }
 
-function CreateShareForm({ documentId, onCreated }: { documentId: string; onCreated: (url?: string | null) => void }) {
+function CreateShareForm({
+  documentId,
+  onCreated,
+}: {
+  documentId: string;
+  onCreated: (url?: string | null) => void;
+}) {
   const [shareType, setShareType] = useState<ShareType>(SHARE_TYPE.LINK);
   const [targetId, setTargetId] = useState('');
   const [targetRole, setTargetRole] = useState('');
@@ -50,83 +64,166 @@ function CreateShareForm({ documentId, onCreated }: { documentId: string; onCrea
 
   const handleCreate = useCallback(async () => {
     setFormError(null);
-    if (shareType === SHARE_TYPE.USER && !targetId.trim()) { setFormError('User ID is required.'); return; }
-    if (shareType === SHARE_TYPE.ROLE && !targetRole.trim()) { setFormError('Role name is required.'); return; }
-    if (usePassword && password.trim().length < 4) { setFormError('Password must be at least 4 characters.'); return; }
+    if (shareType === SHARE_TYPE.USER && !targetId.trim()) {
+      setFormError('User ID is required.');
+      return;
+    }
+    if (shareType === SHARE_TYPE.ROLE && !targetRole.trim()) {
+      setFormError('Role name is required.');
+      return;
+    }
+    if (usePassword && password.trim().length < 4) {
+      setFormError('Password must be at least 4 characters.');
+      return;
+    }
     const req: CreateShareRequest = { share_type: shareType };
     if (shareType === SHARE_TYPE.USER) req.target_id = targetId.trim();
     if (shareType === SHARE_TYPE.ROLE) req.target_role = targetRole.trim();
     if (usePassword && password.trim()) req.password = password.trim();
     if (useExpiry) {
       const days = parseInt(expiryDays, 10);
-      if (Number.isNaN(days) || days < 1) { setFormError('Expiry must be at least 1 day.'); return; }
-      const expiry = new Date(); expiry.setDate(expiry.getDate() + days);
+      if (Number.isNaN(days) || days < 1) {
+        setFormError('Expiry must be at least 1 day.');
+        return;
+      }
+      const expiry = new Date();
+      expiry.setDate(expiry.getDate() + days);
       req.expires_at = expiry.toISOString();
     }
     try {
       const result = await createMutation.mutateAsync(req);
-      setTargetId(''); setTargetRole(''); setPassword(''); setUsePassword(false); setUseExpiry(false);
+      setTargetId('');
+      setTargetRole('');
+      setPassword('');
+      setUsePassword(false);
+      setUseExpiry(false);
       onCreated(result.share_url);
-    } catch (err) { setFormError(err instanceof Error ? err.message : 'Failed to create share.'); }
-  }, [shareType, targetId, targetRole, usePassword, password, useExpiry, expiryDays, createMutation, onCreated]);
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Failed to create share.');
+    }
+  }, [
+    shareType,
+    targetId,
+    targetRole,
+    usePassword,
+    password,
+    useExpiry,
+    expiryDays,
+    createMutation,
+    onCreated,
+  ]);
 
   return (
     <div className="sp-form">
       <h4 className="sp-form-title">New share</h4>
       <div className="sp-type-row">
         {(Object.values(SHARE_TYPE) as ShareType[]).map((type) => (
-          <button key={type} type="button" className={`sp-chip${shareType === type ? ' active' : ''}`}
-            onClick={() => { setShareType(type); setFormError(null); }}>
+          <button
+            key={type}
+            type="button"
+            className={`sp-chip${shareType === type ? ' active' : ''}`}
+            onClick={() => {
+              setShareType(type);
+              setFormError(null);
+            }}
+          >
             {shareTypeLabel(type)}
           </button>
         ))}
       </div>
       {shareType === SHARE_TYPE.USER && (
         <div className="sp-field">
-          <label className="sp-label" htmlFor="sp-user-id">User ID</label>
-          <input id="sp-user-id" className="sp-input" type="text" placeholder="uuid-of-user"
-            value={targetId} onChange={(e) => setTargetId(e.target.value)} autoComplete="off" />
+          <label className="sp-label" htmlFor="sp-user-id">
+            User ID
+          </label>
+          <input
+            id="sp-user-id"
+            className="sp-input"
+            type="text"
+            placeholder="uuid-of-user"
+            value={targetId}
+            onChange={(e) => setTargetId(e.target.value)}
+            autoComplete="off"
+          />
         </div>
       )}
       {shareType === SHARE_TYPE.ROLE && (
         <div className="sp-field">
-          <label className="sp-label" htmlFor="sp-role">Role name</label>
-          <input id="sp-role" className="sp-input" type="text" placeholder="e.g. manager"
-            value={targetRole} onChange={(e) => setTargetRole(e.target.value)} autoComplete="off" />
+          <label className="sp-label" htmlFor="sp-role">
+            Role name
+          </label>
+          <input
+            id="sp-role"
+            className="sp-input"
+            type="text"
+            placeholder="e.g. manager"
+            value={targetRole}
+            onChange={(e) => setTargetRole(e.target.value)}
+            autoComplete="off"
+          />
         </div>
       )}
       {shareType === SHARE_TYPE.LINK && (
         <div className="sp-toggle-row">
           <span className="sp-toggle-label">Password protect</span>
           <label className="sp-switch" aria-label="Enable password protection">
-            <input type="checkbox" checked={usePassword} onChange={(e) => setUsePassword(e.target.checked)} />
+            <input
+              type="checkbox"
+              checked={usePassword}
+              onChange={(e) => setUsePassword(e.target.checked)}
+            />
             <span className="sp-switch-track" />
           </label>
         </div>
       )}
       {shareType === SHARE_TYPE.LINK && usePassword && (
         <div className="sp-field">
-          <label className="sp-label" htmlFor="sp-password">Password</label>
-          <input id="sp-password" className="sp-input" type="password" placeholder="Min. 4 characters"
-            value={password} onChange={(e) => setPassword(e.target.value)} autoComplete="new-password" />
+          <label className="sp-label" htmlFor="sp-password">
+            Password
+          </label>
+          <input
+            id="sp-password"
+            className="sp-input"
+            type="password"
+            placeholder="Min. 4 characters"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="new-password"
+          />
         </div>
       )}
       <div className="sp-toggle-row">
         <span className="sp-toggle-label">Set expiry</span>
         <label className="sp-switch" aria-label="Enable expiry">
-          <input type="checkbox" checked={useExpiry} onChange={(e) => setUseExpiry(e.target.checked)} />
+          <input
+            type="checkbox"
+            checked={useExpiry}
+            onChange={(e) => setUseExpiry(e.target.checked)}
+          />
           <span className="sp-switch-track" />
         </label>
       </div>
       {useExpiry && (
         <div className="sp-expiry-row">
-          <input className="sp-input sp-expiry-input" type="number" min="1" max="365"
-            value={expiryDays} onChange={(e) => setExpiryDays(e.target.value)} aria-label="Expiry days" />
+          <input
+            className="sp-input sp-expiry-input"
+            type="number"
+            min="1"
+            max="365"
+            value={expiryDays}
+            onChange={(e) => setExpiryDays(e.target.value)}
+            aria-label="Expiry days"
+          />
           <span className="sp-expiry-unit">days</span>
         </div>
       )}
       {formError && <p className="sp-error">{formError}</p>}
-      <button type="button" className="sp-create-btn" onClick={handleCreate} disabled={createMutation.isPending}>
+      <button
+        type="button"
+        className="sp-create-btn"
+        onClick={handleCreate}
+        disabled={createMutation.isPending}
+      >
         {createMutation.isPending ? 'Creating…' : 'Create share'}
       </button>
     </div>
@@ -137,23 +234,41 @@ function ShareList({ documentId, shares }: { documentId: string; shares: ShareWi
   const { showToast } = useToast();
   const revokeMutation = useRevokeDocumentShare(documentId);
 
-  const handleCopyLink = useCallback((token: string) => {
-    const url = `${window.location.origin}/documents/shared/${token}`;
-    navigator.clipboard.writeText(url).then(
-      () => { showToast({ type: 'success', title: 'Link copied', message: url, duration: 3000 }); },
-      () => { showToast({ type: 'error', title: 'Copy failed', message: 'Could not copy to clipboard.' }); },
-    );
-  }, [showToast]);
+  const handleCopyLink = useCallback(
+    (token: string) => {
+      const url = `${window.location.origin}/documents/shared/${token}`;
+      navigator.clipboard.writeText(url).then(
+        () => {
+          showToast({ type: 'success', title: 'Link copied', message: url, duration: 3000 });
+        },
+        () => {
+          showToast({
+            type: 'error',
+            title: 'Copy failed',
+            message: 'Could not copy to clipboard.',
+          });
+        }
+      );
+    },
+    [showToast]
+  );
 
-  const handleRevoke = useCallback(async (shareId: string) => {
-    if (!window.confirm('Revoke this share? Recipients will lose access.')) return;
-    try {
-      await revokeMutation.mutateAsync(shareId);
-      showToast({ type: 'success', title: 'Share revoked', duration: 3000 });
-    } catch (err) {
-      showToast({ type: 'error', title: 'Revoke failed', message: err instanceof Error ? err.message : 'Failed.' });
-    }
-  }, [revokeMutation, showToast]);
+  const handleRevoke = useCallback(
+    async (shareId: string) => {
+      if (!window.confirm('Revoke this share? Recipients will lose access.')) return;
+      try {
+        await revokeMutation.mutateAsync(shareId);
+        showToast({ type: 'success', title: 'Share revoked', duration: 3000 });
+      } catch (err) {
+        showToast({
+          type: 'error',
+          title: 'Revoke failed',
+          message: err instanceof Error ? err.message : 'Failed.',
+        });
+      }
+    },
+    [revokeMutation, showToast]
+  );
 
   const active = shares.filter(isActiveShare);
   if (active.length === 0) return <p className="sp-empty">No active shares yet.</p>;
@@ -166,17 +281,30 @@ function ShareList({ documentId, shares }: { documentId: string; shares: ShareWi
           <div className="sp-row-info">
             <span className="sp-row-type">{shareTypeLabel(share.share_type)}</span>
             {share.target_role && <span className="sp-row-meta">Role: {share.target_role}</span>}
-            {share.target_id && <span className="sp-row-meta">User: <code className="sp-code">{share.target_id}</code></span>}
-            {share.expires_at && <span className="sp-row-meta">Expires: {fmtExpiry(share.expires_at)}</span>}
+            {share.target_id && (
+              <span className="sp-row-meta">
+                User: <code className="sp-code">{share.target_id}</code>
+              </span>
+            )}
+            {share.expires_at && (
+              <span className="sp-row-meta">Expires: {fmtExpiry(share.expires_at)}</span>
+            )}
             {share.share_token && (
-              <button type="button" className="sp-copy-link" onClick={() => handleCopyLink(share.share_token as string)}>
+              <button
+                type="button"
+                className="sp-copy-link"
+                onClick={() => handleCopyLink(share.share_token as string)}
+              >
                 Copy link
               </button>
             )}
           </div>
-          <button type="button" className="sp-revoke-btn"
+          <button
+            type="button"
+            className="sp-revoke-btn"
             onClick={() => handleRevoke(share.id)}
-            disabled={revokeMutation.isPending && revokeMutation.variables === share.id}>
+            disabled={revokeMutation.isPending && revokeMutation.variables === share.id}
+          >
             Revoke
           </button>
         </div>
@@ -185,28 +313,62 @@ function ShareList({ documentId, shares }: { documentId: string; shares: ShareWi
   );
 }
 
-export function DocumentSharePanel({ documentId, documentTitle }: { documentId: string; documentTitle: string }) {
+export function DocumentSharePanel({
+  documentId,
+  documentTitle,
+}: {
+  documentId: string;
+  documentTitle: string;
+}) {
   const { showToast } = useToast();
   const { data, isLoading, error, refetch } = useDocumentShares(documentId);
 
-  const handleCreated = useCallback((shareUrl?: string | null) => {
-    if (shareUrl) {
-      navigator.clipboard.writeText(shareUrl).then(
-        () => { showToast({ type: 'success', title: 'Share created', message: 'Public link copied.', duration: 5000 }); },
-        () => { showToast({ type: 'success', title: 'Share created', message: `Link: ${shareUrl}`, duration: 5000 }); },
-      );
-    } else {
-      showToast({ type: 'success', title: 'Share created', duration: 3000 });
-    }
-    refetch();
-  }, [showToast, refetch]);
+  const handleCreated = useCallback(
+    (shareUrl?: string | null) => {
+      if (shareUrl) {
+        navigator.clipboard.writeText(shareUrl).then(
+          () => {
+            showToast({
+              type: 'success',
+              title: 'Share created',
+              message: 'Public link copied.',
+              duration: 5000,
+            });
+          },
+          () => {
+            showToast({
+              type: 'success',
+              title: 'Share created',
+              message: `Link: ${shareUrl}`,
+              duration: 5000,
+            });
+          }
+        );
+      } else {
+        showToast({ type: 'success', title: 'Share created', duration: 3000 });
+      }
+      refetch();
+    },
+    [showToast, refetch]
+  );
 
   return (
     <div className="sp-panel">
       <div className="sp-panel-header">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-          <circle cx="18" cy="5" r="3" /><circle cx="6" cy="12" r="3" /><circle cx="18" cy="19" r="3" />
-          <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" /><line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          aria-hidden="true"
+        >
+          <circle cx="18" cy="5" r="3" />
+          <circle cx="6" cy="12" r="3" />
+          <circle cx="18" cy="19" r="3" />
+          <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+          <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
         </svg>
         <div className="sp-panel-titles">
           <span className="sp-panel-title">Share</span>

--- a/frontend/apps/ppt-web/src/features/documents/components/DocumentSharePanel.tsx
+++ b/frontend/apps/ppt-web/src/features/documents/components/DocumentSharePanel.tsx
@@ -1,0 +1,274 @@
+/**
+ * DocumentSharePanel (Story 7A.5)
+ *
+ * Web inline share panel for DocumentDetail.
+ * Mirrors functionality of mobile DocumentShareSheet (PR #445).
+ * Supports: user, role, building, link (+ password + expiry) share types.
+ */
+
+import {
+  type CreateShareRequest,
+  SHARE_TYPE,
+  type ShareType,
+  type ShareWithDocument,
+  useCreateDocumentShare,
+  useDocumentShares,
+  useRevokeDocumentShare,
+} from '@ppt/api-client';
+import { useCallback, useState } from 'react';
+import { useToast } from '../../../components/Toast';
+
+function shareTypeLabel(type: ShareType): string {
+  switch (type) {
+    case SHARE_TYPE.USER: return 'Specific user';
+    case SHARE_TYPE.ROLE: return 'Role';
+    case SHARE_TYPE.BUILDING: return 'Building';
+    case SHARE_TYPE.LINK: return 'Public link';
+  }
+}
+
+function isActiveShare(share: ShareWithDocument): boolean {
+  if (share.revoked_at) return false;
+  if (share.expires_at && new Date(share.expires_at) < new Date()) return false;
+  return true;
+}
+
+function fmtExpiry(d: string): string {
+  return new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function CreateShareForm({ documentId, onCreated }: { documentId: string; onCreated: (url?: string | null) => void }) {
+  const [shareType, setShareType] = useState<ShareType>(SHARE_TYPE.LINK);
+  const [targetId, setTargetId] = useState('');
+  const [targetRole, setTargetRole] = useState('');
+  const [usePassword, setUsePassword] = useState(false);
+  const [password, setPassword] = useState('');
+  const [useExpiry, setUseExpiry] = useState(false);
+  const [expiryDays, setExpiryDays] = useState('7');
+  const [formError, setFormError] = useState<string | null>(null);
+  const createMutation = useCreateDocumentShare(documentId);
+
+  const handleCreate = useCallback(async () => {
+    setFormError(null);
+    if (shareType === SHARE_TYPE.USER && !targetId.trim()) { setFormError('User ID is required.'); return; }
+    if (shareType === SHARE_TYPE.ROLE && !targetRole.trim()) { setFormError('Role name is required.'); return; }
+    if (usePassword && password.trim().length < 4) { setFormError('Password must be at least 4 characters.'); return; }
+    const req: CreateShareRequest = { share_type: shareType };
+    if (shareType === SHARE_TYPE.USER) req.target_id = targetId.trim();
+    if (shareType === SHARE_TYPE.ROLE) req.target_role = targetRole.trim();
+    if (usePassword && password.trim()) req.password = password.trim();
+    if (useExpiry) {
+      const days = parseInt(expiryDays, 10);
+      if (Number.isNaN(days) || days < 1) { setFormError('Expiry must be at least 1 day.'); return; }
+      const expiry = new Date(); expiry.setDate(expiry.getDate() + days);
+      req.expires_at = expiry.toISOString();
+    }
+    try {
+      const result = await createMutation.mutateAsync(req);
+      setTargetId(''); setTargetRole(''); setPassword(''); setUsePassword(false); setUseExpiry(false);
+      onCreated(result.share_url);
+    } catch (err) { setFormError(err instanceof Error ? err.message : 'Failed to create share.'); }
+  }, [shareType, targetId, targetRole, usePassword, password, useExpiry, expiryDays, createMutation, onCreated]);
+
+  return (
+    <div className="sp-form">
+      <h4 className="sp-form-title">New share</h4>
+      <div className="sp-type-row">
+        {(Object.values(SHARE_TYPE) as ShareType[]).map((type) => (
+          <button key={type} type="button" className={`sp-chip${shareType === type ? ' active' : ''}`}
+            onClick={() => { setShareType(type); setFormError(null); }}>
+            {shareTypeLabel(type)}
+          </button>
+        ))}
+      </div>
+      {shareType === SHARE_TYPE.USER && (
+        <div className="sp-field">
+          <label className="sp-label" htmlFor="sp-user-id">User ID</label>
+          <input id="sp-user-id" className="sp-input" type="text" placeholder="uuid-of-user"
+            value={targetId} onChange={(e) => setTargetId(e.target.value)} autoComplete="off" />
+        </div>
+      )}
+      {shareType === SHARE_TYPE.ROLE && (
+        <div className="sp-field">
+          <label className="sp-label" htmlFor="sp-role">Role name</label>
+          <input id="sp-role" className="sp-input" type="text" placeholder="e.g. manager"
+            value={targetRole} onChange={(e) => setTargetRole(e.target.value)} autoComplete="off" />
+        </div>
+      )}
+      {shareType === SHARE_TYPE.LINK && (
+        <div className="sp-toggle-row">
+          <span className="sp-toggle-label">Password protect</span>
+          <label className="sp-switch" aria-label="Enable password protection">
+            <input type="checkbox" checked={usePassword} onChange={(e) => setUsePassword(e.target.checked)} />
+            <span className="sp-switch-track" />
+          </label>
+        </div>
+      )}
+      {shareType === SHARE_TYPE.LINK && usePassword && (
+        <div className="sp-field">
+          <label className="sp-label" htmlFor="sp-password">Password</label>
+          <input id="sp-password" className="sp-input" type="password" placeholder="Min. 4 characters"
+            value={password} onChange={(e) => setPassword(e.target.value)} autoComplete="new-password" />
+        </div>
+      )}
+      <div className="sp-toggle-row">
+        <span className="sp-toggle-label">Set expiry</span>
+        <label className="sp-switch" aria-label="Enable expiry">
+          <input type="checkbox" checked={useExpiry} onChange={(e) => setUseExpiry(e.target.checked)} />
+          <span className="sp-switch-track" />
+        </label>
+      </div>
+      {useExpiry && (
+        <div className="sp-expiry-row">
+          <input className="sp-input sp-expiry-input" type="number" min="1" max="365"
+            value={expiryDays} onChange={(e) => setExpiryDays(e.target.value)} aria-label="Expiry days" />
+          <span className="sp-expiry-unit">days</span>
+        </div>
+      )}
+      {formError && <p className="sp-error">{formError}</p>}
+      <button type="button" className="sp-create-btn" onClick={handleCreate} disabled={createMutation.isPending}>
+        {createMutation.isPending ? 'Creating…' : 'Create share'}
+      </button>
+    </div>
+  );
+}
+
+function ShareList({ documentId, shares }: { documentId: string; shares: ShareWithDocument[] }) {
+  const { showToast } = useToast();
+  const revokeMutation = useRevokeDocumentShare(documentId);
+
+  const handleCopyLink = useCallback((token: string) => {
+    const url = `${window.location.origin}/documents/shared/${token}`;
+    navigator.clipboard.writeText(url).then(
+      () => { showToast({ type: 'success', title: 'Link copied', message: url, duration: 3000 }); },
+      () => { showToast({ type: 'error', title: 'Copy failed', message: 'Could not copy to clipboard.' }); },
+    );
+  }, [showToast]);
+
+  const handleRevoke = useCallback(async (shareId: string) => {
+    if (!window.confirm('Revoke this share? Recipients will lose access.')) return;
+    try {
+      await revokeMutation.mutateAsync(shareId);
+      showToast({ type: 'success', title: 'Share revoked', duration: 3000 });
+    } catch (err) {
+      showToast({ type: 'error', title: 'Revoke failed', message: err instanceof Error ? err.message : 'Failed.' });
+    }
+  }, [revokeMutation, showToast]);
+
+  const active = shares.filter(isActiveShare);
+  if (active.length === 0) return <p className="sp-empty">No active shares yet.</p>;
+
+  return (
+    <div className="sp-list">
+      <h4 className="sp-list-title">Active shares</h4>
+      {active.map((share) => (
+        <div key={share.id} className="sp-row">
+          <div className="sp-row-info">
+            <span className="sp-row-type">{shareTypeLabel(share.share_type)}</span>
+            {share.target_role && <span className="sp-row-meta">Role: {share.target_role}</span>}
+            {share.target_id && <span className="sp-row-meta">User: <code className="sp-code">{share.target_id}</code></span>}
+            {share.expires_at && <span className="sp-row-meta">Expires: {fmtExpiry(share.expires_at)}</span>}
+            {share.share_token && (
+              <button type="button" className="sp-copy-link" onClick={() => handleCopyLink(share.share_token as string)}>
+                Copy link
+              </button>
+            )}
+          </div>
+          <button type="button" className="sp-revoke-btn"
+            onClick={() => handleRevoke(share.id)}
+            disabled={revokeMutation.isPending && revokeMutation.variables === share.id}>
+            Revoke
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function DocumentSharePanel({ documentId, documentTitle }: { documentId: string; documentTitle: string }) {
+  const { showToast } = useToast();
+  const { data, isLoading, error, refetch } = useDocumentShares(documentId);
+
+  const handleCreated = useCallback((shareUrl?: string | null) => {
+    if (shareUrl) {
+      navigator.clipboard.writeText(shareUrl).then(
+        () => { showToast({ type: 'success', title: 'Share created', message: 'Public link copied.', duration: 5000 }); },
+        () => { showToast({ type: 'success', title: 'Share created', message: `Link: ${shareUrl}`, duration: 5000 }); },
+      );
+    } else {
+      showToast({ type: 'success', title: 'Share created', duration: 3000 });
+    }
+    refetch();
+  }, [showToast, refetch]);
+
+  return (
+    <div className="sp-panel">
+      <div className="sp-panel-header">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+          <circle cx="18" cy="5" r="3" /><circle cx="6" cy="12" r="3" /><circle cx="18" cy="19" r="3" />
+          <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" /><line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+        </svg>
+        <div className="sp-panel-titles">
+          <span className="sp-panel-title">Share</span>
+          <span className="sp-panel-subtitle">{documentTitle}</span>
+        </div>
+      </div>
+      <CreateShareForm documentId={documentId} onCreated={handleCreated} />
+      <div className="sp-divider" />
+      {isLoading && <p className="sp-loading">Loading shares…</p>}
+      {error && <p className="sp-fetch-error">Could not load shares.</p>}
+      {data && <ShareList documentId={documentId} shares={data.shares} />}
+      <style>{panelStyles}</style>
+    </div>
+  );
+}
+
+const panelStyles = `
+  .sp-panel{padding:1.25rem;background:var(--ppt-bg-surface);border:1px solid var(--ppt-border-default);border-radius:0.75rem}
+  .sp-panel-header{display:flex;align-items:flex-start;gap:0.625rem;margin-bottom:1rem;color:var(--ppt-fg-secondary)}
+  .sp-panel-header svg{flex-shrink:0;margin-top:2px}
+  .sp-panel-titles{display:flex;flex-direction:column}
+  .sp-panel-title{font-size:0.9375rem;font-weight:600;color:var(--ppt-fg-primary);line-height:1.3}
+  .sp-panel-subtitle{font-size:0.8125rem;color:var(--ppt-fg-muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:24rem}
+  .sp-form{display:flex;flex-direction:column;gap:0.75rem}
+  .sp-form-title{margin:0;font-size:0.875rem;font-weight:600;color:var(--ppt-fg-primary)}
+  .sp-type-row{display:flex;flex-wrap:wrap;gap:0.5rem}
+  .sp-chip{padding:0.25rem 0.875rem;border-radius:9999px;border:1px solid var(--ppt-border-default);background:var(--ppt-bg-app);font-size:0.8125rem;font-weight:500;color:var(--ppt-fg-muted);cursor:pointer;transition:all 0.12s}
+  .sp-chip.active{background:var(--ppt-brand-500);border-color:var(--ppt-brand-500);color:var(--ppt-fg-on-accent)}
+  .sp-chip:hover:not(.active){border-color:var(--ppt-border-strong);color:var(--ppt-fg-secondary)}
+  .sp-field{display:flex;flex-direction:column;gap:0.3125rem}
+  .sp-label{font-size:0.8125rem;font-weight:500;color:var(--ppt-fg-secondary)}
+  .sp-input{padding:0.5rem 0.75rem;background:var(--ppt-bg-app);border:1px solid var(--ppt-border-default);border-radius:0.375rem;font-size:0.875rem;color:var(--ppt-fg-primary);width:100%;box-sizing:border-box}
+  .sp-input:focus{outline:none;border-color:var(--ppt-brand-500)}
+  .sp-toggle-row{display:flex;align-items:center;justify-content:space-between;gap:0.75rem}
+  .sp-toggle-label{font-size:0.875rem;color:var(--ppt-fg-primary)}
+  .sp-switch{position:relative;display:inline-block;width:36px;height:20px;flex-shrink:0;cursor:pointer}
+  .sp-switch input{opacity:0;width:0;height:0;position:absolute}
+  .sp-switch-track{position:absolute;inset:0;background:var(--ppt-border-strong);border-radius:9999px;transition:background 0.15s}
+  .sp-switch-track::before{content:'';position:absolute;left:2px;top:2px;width:16px;height:16px;background:#fff;border-radius:50%;transition:transform 0.15s}
+  .sp-switch input:checked+.sp-switch-track{background:var(--ppt-brand-500)}
+  .sp-switch input:checked+.sp-switch-track::before{transform:translateX(16px)}
+  .sp-expiry-row{display:flex;align-items:center;gap:0.5rem}
+  .sp-expiry-input{width:80px;flex-shrink:0}
+  .sp-expiry-unit{font-size:0.875rem;color:var(--ppt-fg-muted)}
+  .sp-error{margin:0;padding:0.5rem 0.75rem;background:color-mix(in srgb,var(--ppt-color-danger) 10%,transparent);border:1px solid color-mix(in srgb,var(--ppt-color-danger) 30%,transparent);border-radius:0.375rem;font-size:0.8125rem;color:var(--ppt-color-danger)}
+  .sp-create-btn{padding:0.5625rem 1rem;background:var(--ppt-brand-500);border:none;border-radius:0.375rem;font-size:0.875rem;font-weight:600;color:var(--ppt-fg-on-accent);cursor:pointer;transition:background 0.12s;align-self:flex-start}
+  .sp-create-btn:hover:not(:disabled){background:var(--ppt-color-primary)}
+  .sp-create-btn:disabled{opacity:0.6;cursor:not-allowed}
+  .sp-divider{height:1px;background:var(--ppt-border-default);margin:1rem 0}
+  .sp-list-title{margin:0 0 0.625rem;font-size:0.875rem;font-weight:600;color:var(--ppt-fg-primary)}
+  .sp-row{display:flex;align-items:flex-start;justify-content:space-between;gap:0.75rem;padding:0.625rem 0;border-bottom:1px solid var(--ppt-border-default)}
+  .sp-row:last-child{border-bottom:none}
+  .sp-row-info{display:flex;flex-direction:column;gap:0.1875rem;flex:1;min-width:0}
+  .sp-row-type{font-size:0.875rem;font-weight:600;color:var(--ppt-fg-primary)}
+  .sp-row-meta{font-size:0.75rem;color:var(--ppt-fg-muted)}
+  .sp-code{font-family:monospace;font-size:0.6875rem;background:var(--ppt-bg-app);padding:0.0625rem 0.25rem;border-radius:0.1875rem}
+  .sp-copy-link{font-size:0.75rem;font-weight:500;color:var(--ppt-brand-500);background:none;border:none;padding:0;cursor:pointer;text-align:left}
+  .sp-copy-link:hover{text-decoration:underline}
+  .sp-revoke-btn{padding:0.3125rem 0.75rem;border:1px solid var(--ppt-color-danger);border-radius:0.375rem;background:none;font-size:0.75rem;font-weight:500;color:var(--ppt-color-danger);cursor:pointer;flex-shrink:0;transition:all 0.12s}
+  .sp-revoke-btn:hover:not(:disabled){background:color-mix(in srgb,var(--ppt-color-danger) 10%,transparent)}
+  .sp-revoke-btn:disabled{opacity:0.5;cursor:not-allowed}
+  .sp-empty{margin:0;font-size:0.875rem;color:var(--ppt-fg-muted);text-align:center;padding:1rem 0}
+  .sp-loading,.sp-fetch-error{margin:0;font-size:0.875rem;color:var(--ppt-fg-muted)}
+  .sp-fetch-error{color:var(--ppt-color-danger)}
+`;

--- a/frontend/apps/ppt-web/src/features/documents/components/index.ts
+++ b/frontend/apps/ppt-web/src/features/documents/components/index.ts
@@ -5,6 +5,7 @@
 export { ClassificationBadge, ClassificationUI } from './ClassificationBadge';
 export { DocumentSearch } from './DocumentSearch';
 export { DocumentSearchResult } from './DocumentSearchResult';
+export { DocumentSharePanel } from './DocumentSharePanel';
 export { DocumentSummary } from './DocumentSummary';
 export { DocumentsBrowse } from './DocumentsBrowse';
 export { DocumentUpload } from './DocumentUpload';

--- a/frontend/apps/ppt-web/src/features/documents/pages/DocumentDetail.tsx
+++ b/frontend/apps/ppt-web/src/features/documents/pages/DocumentDetail.tsx
@@ -11,6 +11,10 @@ import {
   useReprocessOcr,
 } from '@ppt/api-client';
 import { useState } from 'react';
+import { ClassificationUI } from '../components/ClassificationBadge';
+import { DocumentSharePanel } from '../components/DocumentSharePanel';
+import { DocumentSummary } from '../components/DocumentSummary';
+import { OcrProcessingStatus } from '../components/OcrStatusBadge';
 
 /** Human-readable labels for the access_scope values returned by the backend (7a-3). */
 const AUDIENCE_LABELS: Record<AccessScope, string> = {
@@ -20,11 +24,6 @@ const AUDIENCE_LABELS: Record<AccessScope, string> = {
   user: 'Specific users',
   public: 'Public',
 };
-
-import { ClassificationUI } from '../components/ClassificationBadge';
-import { DocumentSharePanel } from '../components/DocumentSharePanel';
-import { DocumentSummary } from '../components/DocumentSummary';
-import { OcrProcessingStatus } from '../components/OcrStatusBadge';
 
 interface DocumentDetailProps {
   documentId: string;
@@ -219,9 +218,20 @@ export function DocumentDetail({ documentId }: DocumentDetailProps) {
             aria-expanded={showSharePanel}
             aria-controls="doc-share-panel"
           >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-              <circle cx="18" cy="5" r="3" /><circle cx="6" cy="12" r="3" /><circle cx="18" cy="19" r="3" />
-              <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" /><line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              aria-hidden="true"
+            >
+              <circle cx="18" cy="5" r="3" />
+              <circle cx="6" cy="12" r="3" />
+              <circle cx="18" cy="19" r="3" />
+              <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+              <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
             </svg>
             Share
           </button>

--- a/frontend/apps/ppt-web/src/features/documents/pages/DocumentDetail.tsx
+++ b/frontend/apps/ppt-web/src/features/documents/pages/DocumentDetail.tsx
@@ -10,6 +10,7 @@ import {
   useDocumentClassification,
   useReprocessOcr,
 } from '@ppt/api-client';
+import { useState } from 'react';
 
 /** Human-readable labels for the access_scope values returned by the backend (7a-3). */
 const AUDIENCE_LABELS: Record<AccessScope, string> = {
@@ -21,6 +22,7 @@ const AUDIENCE_LABELS: Record<AccessScope, string> = {
 };
 
 import { ClassificationUI } from '../components/ClassificationBadge';
+import { DocumentSharePanel } from '../components/DocumentSharePanel';
 import { DocumentSummary } from '../components/DocumentSummary';
 import { OcrProcessingStatus } from '../components/OcrStatusBadge';
 
@@ -32,6 +34,7 @@ export function DocumentDetail({ documentId }: DocumentDetailProps) {
   const { data, isLoading, error, refetch } = useDocument(documentId);
   const classification = useDocumentClassification(documentId);
   const reprocessOcr = useReprocessOcr();
+  const [showSharePanel, setShowSharePanel] = useState(false);
 
   if (isLoading) {
     return (
@@ -209,7 +212,26 @@ export function DocumentDetail({ documentId }: DocumentDetailProps) {
             </svg>
             Preview
           </a>
+          <button
+            type="button"
+            className={`action-btn${showSharePanel ? ' active' : ''}`}
+            onClick={() => setShowSharePanel((v) => !v)}
+            aria-expanded={showSharePanel}
+            aria-controls="doc-share-panel"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+              <circle cx="18" cy="5" r="3" /><circle cx="6" cy="12" r="3" /><circle cx="18" cy="19" r="3" />
+              <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" /><line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+            </svg>
+            Share
+          </button>
         </div>
+
+        {showSharePanel && (
+          <div id="doc-share-panel" className="share-panel-wrapper">
+            <DocumentSharePanel documentId={doc.id} documentTitle={doc.title} />
+          </div>
+        )}
       </div>
 
       {/* Intelligence Section */}
@@ -434,6 +456,16 @@ const detailStyles = `
 
   .action-btn.primary:hover {
     background: var(--ppt-color-primary);
+  }
+
+  .action-btn.active {
+    background: var(--ppt-brand-500);
+    border-color: var(--ppt-brand-500);
+    color: var(--ppt-fg-on-accent);
+  }
+
+  .share-panel-wrapper {
+    margin-top: 1rem;
   }
 
   .intelligence-section {

--- a/frontend/packages/api-client/src/documents/api.ts
+++ b/frontend/packages/api-client/src/documents/api.ts
@@ -318,13 +318,5 @@ export async function createDocumentShare(
 }
 
 export async function revokeDocumentShare(documentId: string, shareId: string): Promise<void> {
-  const url = `${API_BASE}/${documentId}/shares/${shareId}`;
-  const response = await fetch(url, {
-    method: 'DELETE',
-    headers: { 'Content-Type': 'application/json' },
-  });
-  if (!response.ok && response.status !== 204) {
-    const error = await response.json().catch(() => ({ message: 'Request failed' }));
-    throw new Error(error.message || `HTTP ${response.status}`);
-  }
+  await fetchApi(`${API_BASE}/${documentId}/shares/${shareId}`, { method: 'DELETE' });
 }

--- a/frontend/packages/api-client/src/documents/api.ts
+++ b/frontend/packages/api-client/src/documents/api.ts
@@ -7,6 +7,8 @@ import type {
   ClassificationHistoryEntry,
   ClassificationResponse,
   CreateDocumentRequest,
+  CreateShareRequest,
+  CreateShareResponse,
   Document,
   DocumentIntelligenceStats,
   DocumentListQuery,
@@ -16,8 +18,6 @@ import type {
   FolderTreeNode,
   FolderWithCount,
   GenerateSummaryRequest,
-  CreateShareRequest,
-  CreateShareResponse,
   OcrReprocessResponse,
   ShareListResponse,
   SummarizationResponse,
@@ -309,14 +309,20 @@ export async function listDocumentShares(documentId: string): Promise<ShareListR
 
 export async function createDocumentShare(
   documentId: string,
-  data: CreateShareRequest,
+  data: CreateShareRequest
 ): Promise<CreateShareResponse> {
-  return fetchApi(`${API_BASE}/${documentId}/shares`, { method: 'POST', body: JSON.stringify(data) });
+  return fetchApi(`${API_BASE}/${documentId}/shares`, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
 }
 
 export async function revokeDocumentShare(documentId: string, shareId: string): Promise<void> {
   const url = `${API_BASE}/${documentId}/shares/${shareId}`;
-  const response = await fetch(url, { method: 'DELETE', headers: { 'Content-Type': 'application/json' } });
+  const response = await fetch(url, {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+  });
   if (!response.ok && response.status !== 204) {
     const error = await response.json().catch(() => ({ message: 'Request failed' }));
     throw new Error(error.message || `HTTP ${response.status}`);

--- a/frontend/packages/api-client/src/documents/api.ts
+++ b/frontend/packages/api-client/src/documents/api.ts
@@ -16,7 +16,10 @@ import type {
   FolderTreeNode,
   FolderWithCount,
   GenerateSummaryRequest,
+  CreateShareRequest,
+  CreateShareResponse,
   OcrReprocessResponse,
+  ShareListResponse,
   SummarizationResponse,
   UpdateDocumentRequest,
 } from './types';
@@ -296,4 +299,26 @@ export async function uploadDocument(
 
     xhr.send(formData);
   });
+}
+
+// --- Document Sharing (Story 7A.5) ---
+
+export async function listDocumentShares(documentId: string): Promise<ShareListResponse> {
+  return fetchApi(`${API_BASE}/${documentId}/shares`);
+}
+
+export async function createDocumentShare(
+  documentId: string,
+  data: CreateShareRequest,
+): Promise<CreateShareResponse> {
+  return fetchApi(`${API_BASE}/${documentId}/shares`, { method: 'POST', body: JSON.stringify(data) });
+}
+
+export async function revokeDocumentShare(documentId: string, shareId: string): Promise<void> {
+  const url = `${API_BASE}/${documentId}/shares/${shareId}`;
+  const response = await fetch(url, { method: 'DELETE', headers: { 'Content-Type': 'application/json' } });
+  if (!response.ok && response.status !== 204) {
+    const error = await response.json().catch(() => ({ message: 'Request failed' }));
+    throw new Error(error.message || `HTTP ${response.status}`);
+  }
 }

--- a/frontend/packages/api-client/src/documents/hooks.ts
+++ b/frontend/packages/api-client/src/documents/hooks.ts
@@ -251,7 +251,9 @@ export function useCreateDocumentShare(documentId: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (data: CreateShareRequest) => api.createDocumentShare(documentId, data),
-    onSuccess: () => { queryClient.invalidateQueries({ queryKey: documentKeys.shares(documentId) }); },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: documentKeys.shares(documentId) });
+    },
   });
 }
 
@@ -259,6 +261,8 @@ export function useRevokeDocumentShare(documentId: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (shareId: string) => api.revokeDocumentShare(documentId, shareId),
-    onSuccess: () => { queryClient.invalidateQueries({ queryKey: documentKeys.shares(documentId) }); },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: documentKeys.shares(documentId) });
+    },
   });
 }

--- a/frontend/packages/api-client/src/documents/hooks.ts
+++ b/frontend/packages/api-client/src/documents/hooks.ts
@@ -6,6 +6,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import * as api from './api';
 import type {
   ClassificationFeedback,
+  CreateShareRequest,
   DocumentListQuery,
   DocumentSearchRequest,
   GenerateSummaryRequest,
@@ -27,6 +28,7 @@ export const documentKeys = {
   folders: () => [...documentKeys.all, 'folders'] as const,
   folderTree: (buildingId?: string) => [...documentKeys.folders(), 'tree', buildingId] as const,
   stats: () => [...documentKeys.all, 'stats'] as const,
+  shares: (documentId: string) => [...documentKeys.all, documentId, 'shares'] as const,
 };
 
 // List documents
@@ -231,5 +233,32 @@ export function useMoveDocument() {
       queryClient.invalidateQueries({ queryKey: documentKeys.lists() });
       queryClient.invalidateQueries({ queryKey: documentKeys.folders() });
     },
+  });
+}
+
+// --- Document Sharing hooks (Story 7A.5) ---
+
+export function useDocumentShares(documentId: string) {
+  return useQuery({
+    queryKey: documentKeys.shares(documentId),
+    queryFn: () => api.listDocumentShares(documentId),
+    enabled: !!documentId,
+    staleTime: 30_000,
+  });
+}
+
+export function useCreateDocumentShare(documentId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateShareRequest) => api.createDocumentShare(documentId, data),
+    onSuccess: () => { queryClient.invalidateQueries({ queryKey: documentKeys.shares(documentId) }); },
+  });
+}
+
+export function useRevokeDocumentShare(documentId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (shareId: string) => api.revokeDocumentShare(documentId, shareId),
+    onSuccess: () => { queryClient.invalidateQueries({ queryKey: documentKeys.shares(documentId) }); },
   });
 }

--- a/frontend/packages/api-client/src/documents/types.ts
+++ b/frontend/packages/api-client/src/documents/types.ts
@@ -241,3 +241,51 @@ export const DOCUMENT_CATEGORIES = [
 ] as const;
 
 export type DocumentCategory = (typeof DOCUMENT_CATEGORIES)[number];
+
+// --- Document Sharing types (Story 7A.5) ---
+
+export const SHARE_TYPE = {
+  USER: 'user',
+  ROLE: 'role',
+  BUILDING: 'building',
+  LINK: 'link',
+} as const;
+
+export type ShareType = (typeof SHARE_TYPE)[keyof typeof SHARE_TYPE];
+
+export interface DocumentShare {
+  id: string;
+  document_id: string;
+  share_type: ShareType;
+  target_id?: string | null;
+  target_role?: string | null;
+  shared_by: string;
+  share_token?: string | null;
+  expires_at?: string | null;
+  revoked_at?: string | null;
+  created_at: string;
+}
+
+export interface ShareWithDocument extends DocumentShare {
+  document_title: string;
+  shared_by_name: string;
+}
+
+export interface ShareListResponse {
+  shares: ShareWithDocument[];
+}
+
+export interface CreateShareRequest {
+  share_type: ShareType;
+  target_id?: string;
+  target_role?: string;
+  password?: string;
+  expires_at?: string;
+}
+
+export interface CreateShareResponse {
+  id: string;
+  share_token?: string | null;
+  share_url?: string | null;
+  message: string;
+}


### PR DESCRIPTION
## Task
Implement web document sharing UI (user/role/building targeting) in DocumentDetail — backend share workflows complete; mobile DocumentShareSheet shipped in PR #445; web UI panel missing (7a-5 Document Sharing)

## Owner
pm-frontend

## Changes

### New file
- `frontend/apps/ppt-web/src/features/documents/components/DocumentSharePanel.tsx` — inline share panel with:
  - Share type selector chips: **Specific user** / **Role** / **Building** / **Public link**
  - Conditional target inputs: User ID (UUID) for user shares, Role name for role shares
  - Password protection toggle (link type only) with minimum 4-char validation
  - Optional expiry toggle with configurable day count
  - Create form with client-side validation + error display
  - Active shares list with copy-link (to clipboard) and revoke actions
  - Toast feedback for all actions via `useToast()`

### Modified files
- `frontend/apps/ppt-web/src/features/documents/pages/DocumentDetail.tsx` — added Share toggle button in the actions row (with `aria-expanded`/`aria-controls`), renders `DocumentSharePanel` inline when active
- `frontend/apps/ppt-web/src/features/documents/components/index.ts` — exports `DocumentSharePanel`
- `frontend/packages/api-client/src/documents/types.ts` — added `SHARE_TYPE`, `ShareType`, `DocumentShare`, `ShareWithDocument`, `ShareListResponse`, `CreateShareRequest`, `CreateShareResponse`
- `frontend/packages/api-client/src/documents/api.ts` — added `listDocumentShares`, `createDocumentShare`, `revokeDocumentShare`
- `frontend/packages/api-client/src/documents/hooks.ts` — added `useDocumentShares`, `useCreateDocumentShare`, `useRevokeDocumentShare` with `documentKeys.shares()` query key
- `docs/screens/ppt/document-detail.md` — added 3 share endpoints, agent log entry

## Tested (Band A — fast check)
```
pnpm -F ppt-web typecheck   → exit 0
```

## Built (Band B — full build)
```
pnpm -F ppt-web build       → exit 0 (built in 5.87s)
documents chunk: 552KB → 565KB (expected with new share panel)
```
biome check: 5 pre-existing errors in reality-web/mobile/ai-chat — 0 errors in changed files.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Notes
- Web panel is functionally equivalent to mobile `DocumentShareSheet` (PR #445) — same share types, same API endpoints (`/api/v1/documents/{id}/shares`), same revoke flow
- Building share type has no extra input (backend infers building from the document's `building_id`)
- Clipboard copy uses `navigator.clipboard.writeText` (web API) instead of expo-clipboard
- Uses `window.confirm` for revoke confirmation; could be upgraded to a modal dialog in a follow-up
- `useRevokeDocumentShare.variables` comparison works because TanStack Query tracks the latest `mutateAsync` argument

https://claude.ai/code/session_01LX95p47cQEBuA3H7YDUVRv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LX95p47cQEBuA3H7YDUVRv)_