### PR TITLE
chore(dispatcher): hardening pack — 9 reliability fixes + deterministic self-test

### DIFF
--- a/.claude/skills/ppt-implement/SKILL.md
+++ b/.claude/skills/ppt-implement/SKILL.md
@@ -65,6 +65,48 @@ backend task instead of merging a half-PR.
 3. Commit message format (CLAUDE.md convention):
    `<type>(<scope>): <one-line>` where type ∈ {feat, fix, docs, style, refactor, test, chore}.
 
+## Step 2.5 — Scope-drift check (deterministic, MANDATORY)
+
+The dispatcher saw on 2026-05-24 that implementers can quietly touch code
+outside their owner_role's area (PR #472 dropped `RlsConnection` on 5 MFA
+handlers while the task was about WebSocket sync). The check below is
+deterministic — file globs map directly to `owner_role` from
+`scripts/owner-areas.json`.
+
+```bash
+bash .claude/skills/ppt-implement/scripts/scope-check.sh \
+  --owner "<owner_role>" --base dev --head HEAD
+```
+
+Exit codes:
+- `0` — diff stays inside the owner's expected areas. `scope_drift=false`.
+- `2` — diff touches files outside the owner's areas. The script prints the
+  drifting paths. **Do not abort.** Set `scope_drift=true` and include the
+  offending paths in the PR body under `## Scope drift`. The reviewer
+  decides whether the drift is justified.
+- `1` — unrecognised owner_role (script does not know how to map it).
+  `scope_drift=false` (we can't judge) — log the unknown owner and continue.
+
+## Step 2.6 — Code-reuse pre-flight (deterministic, advisory)
+
+The same PR #472 also re-implemented `JWT_VERIFIER` as a private `OnceLock`
+duplicating `api_core::extractors::auth::JWT_VERIFIER`. Before adding any
+new helper in security/auth/crypto/http-client code paths, grep for an
+existing one:
+
+```bash
+bash .claude/skills/ppt-implement/scripts/reuse-grep.sh \
+  --specialist "<specialist>" --base dev --head HEAD
+```
+
+Output: a list of `WARN: <added-symbol> looks like an existing helper at <path>`
+lines, or empty.
+
+This is **advisory** — the implementer decides. If the script emits warnings,
+set `code_reuse_warn=<short-comma-list>` (max 80 chars; truncate) and include
+the full list in the PR body under `## Code-reuse review`. If empty,
+`code_reuse_warn=none`.
+
 ## Step 3 — Verify gate (MANDATORY before PR)
 
 Three escalating bands. **Band A is mandatory** — never skip. Run Band B when
@@ -175,16 +217,18 @@ EOF
 ## Return contract (ONE LINE — dispatcher parses this)
 
 ```
-pr=<number|none> status=<done|partial|blocked> specialist=<name> note=<short text>
+pr=<number|none> status=<done|partial|blocked> specialist=<name> scope_drift=<true|false> code_reuse_warn=<short|none> note=<short text>
 ```
 
 Examples:
-- `pr=512 status=done specialist=react-web note=wired useMfa hooks; ppt-web typecheck clean`
-- `pr=none status=partial specialist=rust-backend note=cargo check failed on websocket route stub`
-- `pr=none status=blocked specialist=react-web note=needs backend /api/v1/auth/mfa/* first`
+- `pr=512 status=done specialist=react-web scope_drift=false code_reuse_warn=none note=wired useMfa hooks; ppt-web typecheck clean`
+- `pr=513 status=done specialist=rust-backend scope_drift=true code_reuse_warn=JWT_VERIFIER@api_core note=ws sync (drift: handlers/mfa.rs touched; verifier may duplicate)`
+- `pr=none status=partial specialist=rust-backend scope_drift=false code_reuse_warn=none note=cargo check failed on websocket route stub`
+- `pr=none status=blocked specialist=react-web scope_drift=false code_reuse_warn=none note=needs backend /api/v1/auth/mfa/* first`
 
 The dispatcher writes this verbatim into `.research/management/assignments.json`
-under `implementer_summary`, and sets `pr_number` / `pr_url` if `pr=<n>`.
+under `implementer_summary`, parses the `scope_drift` and `code_reuse_warn`
+fields into their own columns, and sets `pr_number` / `pr_url` if `pr=<n>`.
 
 ## Install (local user)
 

--- a/.claude/skills/ppt-implement/scripts/owner-areas.json
+++ b/.claude/skills/ppt-implement/scripts/owner-areas.json
@@ -1,0 +1,69 @@
+{
+  "_comment": "owner_role -> list of git-pathspec patterns the role is expected to touch. The scope-check script flags any path in the diff that does NOT match any pattern for the row's owner_role. Unknown owners → exit 1 (cannot judge).",
+  "pm-backend": [
+    "backend/**",
+    "docs/api/typespec/**",
+    "docs/api/openapi.yaml",
+    ".sqlx/**"
+  ],
+  "pm-frontend": [
+    "frontend/apps/ppt-web/**",
+    "frontend/apps/reality-web/**",
+    "frontend/packages/**",
+    "frontend/packages/api-client/**",
+    "docs/screens/**"
+  ],
+  "pm-mobile": [
+    "frontend/apps/mobile/**",
+    "mobile-native/**"
+  ],
+  "pm-security": [
+    "backend/crates/auth/**",
+    "backend/crates/api-core/src/extractors/**",
+    "backend/servers/api-server/src/handlers/auth/**",
+    "backend/servers/api-server/src/handlers/mfa/**",
+    "backend/crates/db/migrations/**",
+    "frontend/apps/ppt-web/src/pages/auth/**",
+    "frontend/apps/ppt-web/src/components/auth/**",
+    "frontend/apps/ppt-web/src/hooks/useMfa.ts",
+    "frontend/apps/ppt-web/src/hooks/useAuth.ts"
+  ],
+  "pm-tech-lead": [
+    "docs/**",
+    ".research/**",
+    "_bmad-output/**"
+  ],
+  "pm-scrum-master": [
+    "_bmad-output/**",
+    ".research/management/**",
+    "docs/**"
+  ],
+  "pm-qa": [
+    "backend/**/tests/**",
+    "frontend/**/tests/**",
+    "frontend/**/__tests__/**",
+    "e2e/**"
+  ],
+  "pm-devops": [
+    ".github/**",
+    "scripts/**",
+    "docker/**",
+    "infra/**",
+    "Dockerfile*",
+    "*.yml",
+    "*.yaml"
+  ],
+  "pm-data": [
+    "backend/crates/db/**",
+    "backend/crates/analytics/**",
+    "docs/data/**"
+  ],
+  "pm-integration": [
+    "backend/servers/api-server/src/handlers/integrations/**",
+    "backend/crates/integrations/**",
+    "docs/integrations/**"
+  ],
+  "generic": [
+    "**"
+  ]
+}

--- a/.claude/skills/ppt-implement/scripts/reuse-grep.sh
+++ b/.claude/skills/ppt-implement/scripts/reuse-grep.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Code-reuse pre-flight — grep the codebase for existing helpers whose names
+# look similar to newly-added symbols in the implementer's diff.
+#
+# Advisory, not blocking. Stdout = WARN lines; exit code is always 0.
+#
+# Usage:
+#   reuse-grep.sh --specialist <name> [--base dev] [--head HEAD]
+#
+# Specialist drives which symbol patterns + which search roots apply.
+
+set -euo pipefail
+
+SPECIALIST=""
+BASE="dev"
+HEAD_REF="HEAD"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --specialist) SPECIALIST="$2"; shift 2;;
+    --base)       BASE="$2"; shift 2;;
+    --head)       HEAD_REF="$2"; shift 2;;
+    *) echo "unknown arg: $1" >&2; exit 64;;
+  esac
+done
+
+if [ -z "$SPECIALIST" ]; then
+  echo "error: --specialist required" >&2
+  exit 64
+fi
+
+# Pick the smallest possible diff range.
+if MB=$(git merge-base "$BASE" "$HEAD_REF" 2>/dev/null); then
+  DIFF=$(git diff --unified=0 "$MB..$HEAD_REF")
+else
+  DIFF=$(git diff --unified=0 "$BASE..$HEAD_REF" 2>/dev/null || true)
+fi
+
+# Get the added-line text (skip diff metadata).
+ADDED=$(printf '%s\n' "$DIFF" | grep -E '^\+' | grep -vE '^\+\+\+' || true)
+
+case "$SPECIALIST" in
+  rust-backend|db-migration)
+    # Patterns: new pub fn / struct / static / OnceLock / OnceCell that may
+    # duplicate something already in api-core or auth crate.
+    PATTERNS='(static\s+[A-Z_]+:\s*OnceLock|static\s+[A-Z_]+:\s*OnceCell|pub\s+fn\s+(validate_|verify_|build_|new_)[a-z_]+|pub\s+struct\s+[A-Z][A-Za-z]*Verifier)'
+    SEARCH_ROOTS=(backend/crates/api-core/src backend/crates/auth/src backend/crates/db/src)
+    ;;
+  react-web|nextjs-web|react-native)
+    PATTERNS='(export\s+(const|function)\s+(use[A-Z]|create[A-Z]|make[A-Z]))'
+    SEARCH_ROOTS=(frontend/packages frontend/apps)
+    ;;
+  *)
+    # No reuse heuristic for this specialist — exit clean.
+    exit 0
+    ;;
+esac
+
+NEW_SYMS=$(printf '%s\n' "$ADDED" \
+  | grep -oE "$PATTERNS" 2>/dev/null \
+  | grep -oE '[A-Za-z_][A-Za-z0-9_]+' \
+  | sort -u || true)
+
+if [ -z "$NEW_SYMS" ]; then
+  exit 0
+fi
+
+# Skip generic keywords that always trip the pattern.
+SKIP_RE='^(pub|fn|use|new|const|let|mut|struct|export|function|create|make|validate|verify|build|static|OnceLock|OnceCell|Verifier)$'
+
+# For each new symbol, see if it already exists in the search roots
+# (outside of the implementer's own diff).
+if ! command -v rg >/dev/null 2>&1; then
+  # No ripgrep -> fall back to grep -rn. Slower; still works.
+  GREP_CMD="grep -rn --include=*.rs --include=*.ts --include=*.tsx"
+else
+  GREP_CMD="rg -n"
+fi
+
+EXISTING_ROOTS=()
+for r in "${SEARCH_ROOTS[@]}"; do
+  [ -d "$r" ] && EXISTING_ROOTS+=("$r")
+done
+
+# If no search root exists, exit clean.
+if [ ${#EXISTING_ROOTS[@]} -eq 0 ]; then
+  exit 0
+fi
+
+while IFS= read -r sym; do
+  [ -z "$sym" ] && continue
+  if echo "$sym" | grep -Eq "$SKIP_RE"; then continue; fi
+  if hit=$($GREP_CMD -F "$sym" "${EXISTING_ROOTS[@]}" 2>/dev/null | head -1); then
+    if [ -n "$hit" ]; then
+      path=$(printf '%s' "$hit" | cut -d: -f1)
+      echo "WARN: $sym looks like an existing helper at $path"
+    fi
+  fi
+done <<< "$NEW_SYMS"
+
+exit 0

--- a/.claude/skills/ppt-implement/scripts/scope-check.sh
+++ b/.claude/skills/ppt-implement/scripts/scope-check.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Deterministic scope-drift check for the ppt-implement skill.
+#
+# Compares `git diff --name-only <base>..<head>` against the expected
+# file-pathspec list for the implementer's owner_role
+# (`scripts/owner-areas.json`).
+#
+# Exit codes:
+#   0 = clean (all changed paths inside the owner's areas)
+#   1 = unknown owner_role (cannot judge — log + continue)
+#   2 = scope drift (changed paths outside the owner's areas — list to stdout)
+#
+# Usage:
+#   scope-check.sh --owner <owner_role> [--base dev] [--head HEAD]
+#
+# Reads owner-areas.json from the same directory.
+
+set -euo pipefail
+
+OWNER=""
+BASE="dev"
+HEAD_REF="HEAD"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --owner) OWNER="$2"; shift 2;;
+    --base)  BASE="$2"; shift 2;;
+    --head)  HEAD_REF="$2"; shift 2;;
+    *) echo "unknown arg: $1" >&2; exit 64;;
+  esac
+done
+
+if [ -z "$OWNER" ]; then
+  echo "error: --owner required" >&2
+  exit 64
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AREAS_FILE="$SCRIPT_DIR/owner-areas.json"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required" >&2
+  exit 64
+fi
+if [ ! -f "$AREAS_FILE" ]; then
+  echo "error: missing $AREAS_FILE" >&2
+  exit 64
+fi
+
+# Lookup the owner's pattern list. `null` if the owner isn't mapped.
+PATTERNS=$(jq -r --arg o "$OWNER" '.[$o] // empty | .[]?' "$AREAS_FILE")
+if [ -z "$PATTERNS" ]; then
+  echo "scope-check: unknown owner_role '$OWNER' (not in owner-areas.json)" >&2
+  exit 1
+fi
+
+# Find the merge-base so the diff matches what GH PR diff would show.
+# Fall back to plain <base>..<head> if no common ancestor (shallow clones).
+if MB=$(git merge-base "$BASE" "$HEAD_REF" 2>/dev/null); then
+  CHANGED=$(git diff --name-only "$MB..$HEAD_REF")
+else
+  CHANGED=$(git diff --name-only "$BASE..$HEAD_REF" 2>/dev/null || true)
+fi
+
+if [ -z "$CHANGED" ]; then
+  exit 0
+fi
+
+# Convert pattern lines to a single egrep-style alternation. The patterns
+# use git-pathspec syntax (`**`, `*`). Translate to regex:
+#   **  -> .*
+#   *   -> [^/]*
+#   .   -> \.
+#   /   -> /
+# Anchor each pattern with ^...$ so we don't accidentally match a substring.
+to_regex() {
+  printf '%s' "$1" \
+    | sed -E 's#\.#\\.#g' \
+    | sed -E 's#\*\*#__GLOBSTAR__#g' \
+    | sed -E 's#\*#[^/]*#g' \
+    | sed -E 's#__GLOBSTAR__#.*#g'
+}
+
+ALT=""
+while IFS= read -r pat; do
+  [ -z "$pat" ] && continue
+  rx=$(to_regex "$pat")
+  if [ -z "$ALT" ]; then ALT="^${rx}$"; else ALT="${ALT}|^${rx}$"; fi
+done <<< "$PATTERNS"
+
+DRIFT=$(echo "$CHANGED" | grep -Ev "$ALT" || true)
+
+if [ -z "$DRIFT" ]; then
+  exit 0
+fi
+
+# Drift detected — print paths to stdout (one per line), exit 2.
+echo "$DRIFT"
+exit 2

--- a/.claude/skills/ppt-implement/scripts/test-scope-check.sh
+++ b/.claude/skills/ppt-implement/scripts/test-scope-check.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Unit test for scope-check.sh.
+#
+# Stages synthetic file lists via a temporary git repo and asserts the
+# expected exit codes + drift lists.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCOPE_CHECK="$SCRIPT_DIR/scope-check.sh"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$TMP"
+git init -q
+git config user.email "test@example.com"
+git config user.name  "test"
+git commit --allow-empty -q -m "init"
+git checkout -q -b dev
+git commit --allow-empty -q -m "dev base"
+
+# Mirror the script's owner-areas.json into the temp repo's lookup path.
+mkdir -p "$TMP/scripts"
+cp "$SCRIPT_DIR/owner-areas.json" "$TMP/scripts/owner-areas.json"
+
+FAIL=0
+ok()   { printf '  ok    %s\n' "$1"; }
+bad()  { printf '  FAIL  %s\n' "$1" >&2; FAIL=1; }
+
+run_case() {
+  local name="$1"; shift
+  local owner="$1"; shift
+  local expect_exit="$1"; shift
+  local files=("$@")
+  local branch="case-$(echo "$name" | tr ' /' '-' | tr '[:upper:]' '[:lower:]')"
+
+  git checkout -q dev
+  git checkout -q -b "$branch"
+  for f in "${files[@]}"; do
+    mkdir -p "$(dirname "$f")"
+    echo "test" > "$f"
+    git add "$f"
+  done
+  git commit -q -m "$name"
+
+  set +e
+  out=$(bash "$SCOPE_CHECK" --owner "$owner" --base dev --head HEAD 2>/dev/null)
+  code=$?
+  set -e
+
+  if [ "$code" = "$expect_exit" ]; then
+    ok "$name (exit=$code as expected)"
+  else
+    bad "$name (exit=$code, expected $expect_exit; out=$out)"
+  fi
+}
+
+echo "==> scope-check unit tests"
+# Override the script's lookup path so it finds our copied owner-areas.json.
+# scope-check.sh resolves it via dirname of its own path — so we copy the
+# real script into place too.
+cp "$SCRIPT_DIR/scope-check.sh"  "$TMP/scripts/scope-check.sh"
+cp "$SCRIPT_DIR/owner-areas.json" "$TMP/scripts/owner-areas.json"
+SCOPE_CHECK="$TMP/scripts/scope-check.sh"
+
+run_case "pm-backend stays in backend"          pm-backend  0  backend/servers/api-server/src/foo.rs
+run_case "pm-backend drifts to frontend"        pm-backend  2  backend/servers/api-server/src/foo.rs frontend/apps/ppt-web/src/bar.tsx
+run_case "pm-frontend stays in ppt-web"         pm-frontend 0  frontend/apps/ppt-web/src/x.tsx frontend/packages/api-client/src/y.ts
+run_case "pm-frontend drifts to backend"        pm-frontend 2  frontend/apps/ppt-web/src/x.tsx backend/servers/api-server/src/h.rs
+run_case "pm-security touches auth + mfa"       pm-security 0  backend/crates/auth/src/jwt.rs backend/servers/api-server/src/handlers/mfa/totp.rs
+run_case "pm-security drifts to documents"      pm-security 2  backend/servers/api-server/src/handlers/documents/list.rs
+run_case "unknown owner returns 1"              not-a-role  1  backend/foo.rs
+run_case "generic accepts everything"           generic     0  backend/x.rs frontend/y.ts docs/z.md
+
+echo
+if [ "$FAIL" = "0" ]; then
+  echo "==> scope-check: PASS"
+  exit 0
+else
+  echo "==> scope-check: FAIL" >&2
+  exit 1
+fi

--- a/.claude/skills/ppt-pr-merge/SKILL.md
+++ b/.claude/skills/ppt-pr-merge/SKILL.md
@@ -35,6 +35,7 @@ the loop by getting a green, approved PR actually merged.
 | `strategy`     | `squash`                           | `squash` / `rebase` / `merge`                      |
 | `delete_branch`| `true`                             | Pass `--delete-branch` to `gh pr merge`            |
 | `dry_run`      | `false`                            | Run preconditions + conflict resolve, skip the merge call |
+| `mode`         | `merge`                            | `merge` (default — full flow) or `rebase-only` (run Step 2 conflict-resolver + push, then return without merging — used by dispatcher Phase 5.6 to unstick stale-approved PRs) |
 
 ## Step 1 — Preconditions (HARD GATES — abort if any fail)
 
@@ -124,6 +125,23 @@ If auto-resolve succeeded:
    done
    ```
    If still not `MERGEABLE` after 25s → return `merged=false note=mergeable-recompute-timeout`.
+
+### `mode=rebase-only` short-circuit
+
+If invoked with `mode=rebase-only`, complete Step 2 (auto-resolve and push)
+then **return without invoking `gh pr merge`**. Return contract is the same
+shape, but the value semantics shift:
+
+```
+merged=<true|false> pr=<n> note=rebase-only:<rebased|conflict-in:<paths>|already-clean>
+```
+
+- `merged=true note=rebase-only:rebased` — base merged, mechanical conflicts auto-resolved, push succeeded.
+- `merged=true note=rebase-only:already-clean` — branch was already MERGEABLE; no push needed.
+- `merged=false note=rebase-only:conflict-in:<paths>` — real code conflict; manual rebase required.
+
+The dispatcher's Phase 5.6 uses this mode. Phase 5.5 (next cycle) will pick
+the now-clean PR up and run the full merge flow.
 
 ## Step 3 — Merge
 

--- a/.claude/skills/ppt-review-merged/SKILL.md
+++ b/.claude/skills/ppt-review-merged/SKILL.md
@@ -81,6 +81,20 @@ parallel.** Subagent prompt (verbatim, substitute placeholders):
 > - **Tests** — coverage of the change; was a failing-on-main test added (IG3)? Are there integration tests for cross-boundary changes?
 > - **Regressions** — adjacent files that should have been updated (callers, types, screen-map frontmatter, generated clients).
 > - **Conventions** — does the diff match the specialist's agents/*.md? (Naming, error types, RLS pattern, etc.)
+> - **JSON-key-case sanity** — when the diff touches Rust integration tests, run:
+>
+>   ```bash
+>   # Find DTOs in the diff that declare rename_all = camelCase:
+>   rg -nP '#\[serde\(.*rename_all\s*=\s*"camelCase"' backend/ --type rust | head -20
+>   # Find snake_case JSON accessors added to test code:
+>   gh pr diff <n> | rg -nP '^\+.*json\[\s*"[a-z]+_[a-z_]+"\s*\]' | head -20
+>   ```
+>
+>   If both lists overlap on the same DTO type → file a follow-up issue
+>   under **category: correctness** (this is the bug class that bit
+>   PR #473 on 2026-05-24 — `auth_tests.rs` read `json["access_token"]`
+>   against a `#[serde(rename_all="camelCase")]` `LoginResponse` and every
+>   test that called `create_authenticated_user` would have panicked).
 >
 > Findings: zero-or-many. Each finding has `category` (one of the above),
 > `severity` ∈ {high, medium, low}, `description` (1-3 sentences), and a

--- a/.github/workflows/dispatcher-self-test.yml
+++ b/.github/workflows/dispatcher-self-test.yml
@@ -1,0 +1,25 @@
+name: dispatcher-self-test
+
+on:
+  pull_request:
+    paths:
+      - ".research/dispatcher-prompt.md"
+      - ".research/dispatcher-self-test.sh"
+      - ".research/management/assignments.json"
+      - ".claude/skills/ppt-implement/**"
+      - ".claude/skills/ppt-pr-merge/**"
+      - ".claude/skills/ppt-review-merged/**"
+      - ".github/workflows/dispatcher-self-test.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  self-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: dispatcher schema + invariant self-test
+        run: bash .research/dispatcher-self-test.sh
+      - name: scope-check unit tests
+        run: bash .claude/skills/ppt-implement/scripts/test-scope-check.sh

--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -1,0 +1,461 @@
+# PPT research dispatcher — implementer cycle
+
+You are the PPT research dispatcher (implementer cycle). Repo is auto-checked
+out. Work always against branch `dev`. Today's date is the run date.
+
+This file is the single source of truth for the dispatcher behaviour. The
+remote trigger should be configured to:
+
+> Read `.research/dispatcher-prompt.md` from the repo root and execute it as
+> your instructions for this run.
+
+That way prompt edits ship via normal PRs to `dev` without needing a
+`RemoteTrigger update` call.
+
+UPSTREAM PLANNER: `POST $DISPATCHER_URL` with `Authorization: Bearer
+$DISPATCHER_TOKEN` (fire-and-forget).
+
+## Central store
+
+`.research/management/assignments.json`
+
+Schema per row:
+
+```jsonc
+{
+  "task_id":            "string",
+  "branch":             "auto-impl/<slug>",
+  "status":             "in-progress | review | merged | failed",
+  "specialist":         "string | null",
+  "claimed_at":         "iso-8601",
+  "last_updated":       "iso-8601",
+  "status_changed_at":  "iso-8601",
+  "pr_number":          "int | null",
+  "pr_url":             "string | null",
+  "merged_at":          "iso-8601 | null",
+
+  // -- NEW fields (hardening 2026-05-25). Backfill missing = null on first read. --
+  "last_reviewed_oid":  "string | null",   // PR.headRefOid at time of last reviewer run (item #10)
+  "scope_drift":        "boolean | null",  // implementer touched files outside owner_role areas (item #3)
+  "code_reuse_warn":    "string | null",   // implementer reused-or-duplicated existing helpers (item #4)
+  "empty_branch":       "boolean | null",  // branch pushed but 0 commits ahead of dev (item #1)
+  "rebase_attempts":    "int",             // count of auto-rebase tries on this row (item #6); default 0
+
+  "implementer_summary": "string | null",
+  "reviewer_summary":    "string | null"
+}
+```
+
+## Timestamp semantics
+
+- `claimed_at` — set ONCE at claim; never changes.
+- `last_updated` — bumped EVERY touch.
+- `status_changed_at` — bumped ONLY when the `status` field value changes (hang signal).
+- `merged_at` — set ONCE when row → `merged`; mirrors GH `PR.mergedAt`.
+- Backfill missing `status_changed_at` = `claimed_at` on first read.
+- Legacy compat: rows with `status == "done"` are treated equivalent to `merged` (terminal); do not migrate or touch them.
+
+## State machine
+
+| from        | to       | trigger                                                        |
+|---          |---       |---                                                              |
+| in-progress | review   | Phase 4 returns `pr=<n>`                                        |
+| in-progress | failed   | Phase 4 returns `pr=none` OR Phase 2 detects no-branch >2h OR Phase 2 detects empty-branch |
+| review      | merged   | Phase 2 sees PR MERGED on GH (set `merged_at`)                 |
+| review      | failed   | Phase 2 sees PR CLOSED without merge                            |
+| review      | review   | PR still open (no `status_changed_at` bump)                    |
+
+`merged` / `failed` are TERMINAL.
+
+## Hang detection (Phase 7)
+
+`review` WARN > 48h, ALERT > 7d (since `status_changed_at`).
+
+## Cap
+
+Per-run, claim up to **3 NEW** tasks. There is NO global in-progress cap —
+multiple cron runs can overlap and each may contribute 3 in-progress, so the
+global in-progress count CAN exceed 3. The 3-limit is throughput, not concurrency.
+
+- Phase 3: `free_slots = 3` (constant). Always try to claim 3 new tasks per run, regardless of current in-progress count.
+- Phase 4: hard cap of 3 implementer subagents spawned per run (matches `free_slots`).
+
+## Buffer
+
+`action-list.json` should hold ≥ 36 open items (12 runs * 3 = 1 day of throughput).
+
+---
+
+## Phase 1 — Read state + preflight
+
+1. `git fetch origin && git checkout dev && git pull --ff-only`
+2. **Disk preflight** (item #7 — runner ran out of disk on 2026-05-24 mid-implementer):
+
+   ```bash
+   FREE_PCT=$(df -P . | awk 'NR==2{ sub("%","",$5); print 100-$5 }')
+   if [ "$FREE_PCT" -lt 10 ]; then
+     echo "disk_warning: only ${FREE_PCT}% free on workspace; running cleanup"
+     du -sh ~/.cargo/registry/cache ~/.cargo/git/checkouts 2>/dev/null | tail -5 || true
+     # Best-effort cleanup; never fail the run on this:
+     (cd backend && cargo cache --autoclean 2>/dev/null) || true
+     find /tmp -maxdepth 2 -mtime +1 -type f -delete 2>/dev/null || true
+     FREE_PCT=$(df -P . | awk 'NR==2{ sub("%","",$5); print 100-$5 }')
+     echo "disk_warning: free after cleanup = ${FREE_PCT}%"
+   fi
+   if [ "$FREE_PCT" -lt 5 ]; then
+     echo "disk_abort: free=${FREE_PCT}%; aborting run before subagents fault"
+     exit 0
+   fi
+   ```
+
+3. Read `action-list.json`, `assignments.json`, `coverage.json`.
+4. Backfill any row missing `status_changed_at` = `claimed_at`. Backfill any
+   row missing the new fields (`last_reviewed_oid`, `scope_drift`,
+   `code_reuse_warn`, `empty_branch`, `rebase_attempts`) to `null` / `0`.
+5. Confirm `.claude/skills/ppt-implement/SKILL.md`,
+   `.claude/skills/ppt-review-merged/SKILL.md`, AND
+   `.claude/skills/ppt-pr-merge/SKILL.md` exist. If any missing, ABORT.
+
+---
+
+## Phase 2 — Advance existing assignments
+
+For each row with status in `{in-progress, review}`:
+
+```bash
+gh pr list --repo martin-janci/property-management --head <branch> \
+  --state all --json number,state,url,mergedAt,reviewDecision,headRefOid,mergeable --limit 1
+```
+
+`prev_status = current status`
+
+### Branch-state probe (used in several cases below)
+
+```bash
+git fetch origin <branch> 2>/dev/null
+if git rev-parse --verify "origin/<branch>" >/dev/null 2>&1; then
+  BRANCH_EXISTS=1
+  COMMITS_AHEAD=$(git rev-list --count origin/dev..origin/<branch>)
+else
+  BRANCH_EXISTS=0
+  COMMITS_AHEAD=0
+fi
+```
+
+`COMMITS_AHEAD` is the deterministic hook used by item #1.
+
+### Cases
+
+- **PR MERGED** → `new_status="merged"`, `merged_at=PR.mergedAt`.
+- **PR CLOSED (not merged)** → `new_status="failed"`, append `' [PR closed without merge]'` to `implementer_summary`.
+- **PR OPEN** → `new_status="review"`, set `pr_number`/`pr_url` if missing.
+  - Spawn REVIEWER (Phase 5) iff (`reviewer_summary` is null) OR (`PR.headRefOid != row.last_reviewed_oid`).
+- **branch exists, no PR**:
+  - If `COMMITS_AHEAD == 0` → **EMPTY BRANCH** (item #1): `new_status="failed"`, `empty_branch=true`, `implementer_summary='branch pushed but 0 commits ahead of dev; nothing to PR'`. Delete the orphan: `git push origin --delete <branch>` (best-effort; ignore failure).
+  - Else: `gh pr create --base dev --head <branch> --draft --title '<task_id>: <short>' --body 'Auto: <action>'`, `new_status="review"`, spawn REVIEWER.
+- **no branch + in-progress + (now - status_changed_at) > 2h** → `new_status="failed"`, `implementer_summary='no branch pushed within 2h'`.
+- **no branch + in-progress + grace < 2h** → keep `prev_status` (another run's implementer may still be working).
+
+Persist: `last_updated=now` (always); if `new_status != prev_status`: `status=new_status`, `status_changed_at=now`.
+
+---
+
+## Phase 2.5 — Post-merge review (24h cadence)
+
+If `.research/management/last-merged-review.txt` missing OR mtime > 24h:
+spawn ONE Task subagent invoking `.claude/skills/ppt-review-merged/SKILL.md`.
+
+Inputs: `repo=martin-janci/property-management`, `window=14d`, `base=dev`,
+`max_prs=15`, `label=follow-up,from-merged-review`.
+
+The skill commits + pushes its own files.
+
+Return EXACTLY: `scanned=<N> clean=<K> issues=<M> note=<short>`.
+
+---
+
+## Phase 2.6 — Buffer guard
+
+```python
+open_count = count(action-list.json items where status=="open" AND id NOT in assignments)
+```
+
+- **Tier 1 (self-refill):** if `open_count < 6` AND `coverage.json` has stories → refill from coverage using rubric, append top `(36 - open_count)`. Log `Tier 1: <old> → <new> (+N)`.
+- **Tier 2 (upstream kick):** if `open_count` still < 12 OR coverage missing → `curl POST $DISPATCHER_URL` with `Bearer $DISPATCHER_TOKEN`, `--max-time 10`, fire-and-forget. Log `Tier 2: <http-code or skipped>`.
+- Else: SKIP, log `buffer OK: <open_count>/36`.
+
+---
+
+## Phase 3 — Claim new (PER-RUN cap of 3) — with same-epic guard (item #2)
+
+```python
+free_slots = 3   # constant per run
+candidates = [c for c in action-list if c.status=="open" and c.id not in assignments]
+candidates.sort(key=lambda c: (priority_rank(c.priority), source_rank(c.source)))
+```
+
+**Same-epic burst-claim guard (NEW — item #2):**
+
+Define `epic_prefix(task_id)` as the first matching pattern:
+- `^(gap-\d+[a-z]?)` (e.g. `gap-10b` from `gap-10b-stub-handlers`)
+- `^(pm-[a-z-]+?)-` (e.g. `pm-security` from `pm-security-resolve-435-followups`)
+- else: full `task_id`
+
+After candidate sort, walk the list and **claim at most 2 tasks per `epic_prefix` per run**, unless the epic has at least one task in `merged` status in `assignments.json` already (cold-epic protection: avoid spending all 3 slots on the same blocked epic). If the 3rd candidate has the same prefix as the first 2 picked, skip it and continue scanning for a different-prefix candidate. If no different-prefix candidate exists, claim only the 2 — `free_slots=1` is fine, do not pad with same-prefix.
+
+For each picked task: `branch = "auto-impl/" + first_40_chars_kebab(task_id)`.
+
+Append to `assignments.json`:
+
+```jsonc
+{
+  "task_id": "<id>",
+  "branch": "<branch>",
+  "status": "in-progress",
+  "claimed_at": "<now>",
+  "last_updated": "<now>",
+  "status_changed_at": "<now>",
+  "pr_number": null,
+  "pr_url": null,
+  "merged_at": null,
+  "specialist": null,
+  "implementer_summary": null,
+  "reviewer_summary": null,
+  "last_reviewed_oid": null,
+  "scope_drift": null,
+  "code_reuse_warn": null,
+  "empty_branch": null,
+  "rebase_attempts": 0
+}
+```
+
+If fewer than 3 candidates available (buffer drained), claim what's there — don't block. Log: `Phase 3: claimed=<N> same_epic_skipped=<K>`.
+
+---
+
+## Phase 4 — Spawn implementer subagents (PARALLEL via Task)
+
+One per newly-claimed task IN THIS RUN. Hard cap 3.
+
+Prompt:
+
+> You are an implementer. Invoke `.claude/skills/ppt-implement/SKILL.md`.
+> Inputs: `task_id`, `action`, `owner_role`, `priority`, `dependency`, `branch`.
+> The skill picks the specialist, runs the 3-band verify gate, runs the
+> NEW scope-drift + code-reuse pre-flight checks, opens a DRAFT PR vs `dev`
+> only if verify passes.
+>
+> Return EXACTLY (one line):
+> `pr=<n|none> status=<done|partial|blocked> specialist=<name> scope_drift=<true|false> code_reuse_warn=<short|none> note=<short>`
+
+Capture the line. STATE TRANSITION:
+
+```python
+prev_status = "in-progress"
+if pr != "none":
+    new_status = "review"
+    pr_number = int(pr)
+    pr_url = f"https://github.com/martin-janci/property-management/pull/{pr_number}"
+else:
+    new_status = "failed"
+
+specialist = parsed.specialist
+scope_drift = (parsed.scope_drift == "true")
+code_reuse_warn = None if parsed.code_reuse_warn == "none" else parsed.code_reuse_warn
+implementer_summary = full_line
+last_updated = now
+if new_status != prev_status:
+    status = new_status
+    status_changed_at = now
+```
+
+---
+
+## Phase 5 — Spawn reviewer subagents (PARALLEL via Task)
+
+For each row where `status == "review"` AND (`reviewer_summary` is null OR `PR.headRefOid != row.last_reviewed_oid`):
+
+> You are a code reviewer for PR #<n>. Task: `<task_id>: <action>`. Specialist:
+> `<sp>`. Owner: `<role>`. The implementer flagged: `scope_drift=<bool>`,
+> `code_reuse_warn=<short|none>`.
+>
+> 1. `gh pr diff <n>`
+> 2. `gh pr view <n> --json title,body,files,checks,headRefOid`
+> 3. Review against `.claude/skills/ppt-implement/agents/<sp>.md` conventions,
+>    security (RLS for db-migration, auth for pm-security), regressions, tests,
+>    verify bands (Tested/Built/CI parity).
+> 4. **If `scope_drift=true`**: explicitly judge whether the off-area changes
+>    are necessary, and if not, demand a revert in the changes verdict.
+> 5. **If `code_reuse_warn != none`**: explicitly judge whether the new code
+>    duplicates an existing helper named in the warning, and if so, demand
+>    delegation in the changes verdict.
+> 6. **JSON-key-case sanity check (NEW — item #5)**: if the PR diff touches
+>    Rust tests or `tests/common/`, run:
+>
+>    ```bash
+>    # Find DTOs the tests touch that carry rename_all = camelCase
+>    rg -n '#\[serde\(rename_all\s*=\s*"camelCase"\)\]' backend/ --type rust | head -20
+>    # Find snake_case JSON accessors in the test file diff
+>    gh pr diff <n> | rg -n '^\+.*json\[\s*"[a-z]+_[a-z_]+"\s*\]' | head -20
+>    ```
+>
+>    If both produce hits AND they refer to the same DTO type, demand a fix
+>    in the changes verdict (this is the bug class that bit PR #473 on 2026-05-24).
+> 7. `gh pr review <n> --approve --body '<summary>'` OR
+>    `gh pr review <n> --request-changes --body '<bullet list>'`.
+>
+> Return EXACTLY (one line):
+> `verdict=<approve|changes> head_oid=<PR.headRefOid> note=<short>`
+
+Capture → `reviewer_summary`, `last_reviewed_oid = head_oid` (item #10),
+`last_updated = now`. STATUS UNCHANGED.
+
+No cap on reviewer subagents — review every pending review row in parallel.
+
+---
+
+## Phase 5.5 — Attempt merge for approved + green PRs
+
+For each row `status=="review"` where `reviewer_summary` starts with `"verdict=approve"`:
+
+**Pre-flight:**
+```bash
+gh pr view <pr_number> --json statusCheckRollup,isDraft,reviewDecision,mergeable,state
+```
+
+Skip if `state != OPEN`, `isDraft == true`, CI conclusion in
+`{FAILURE, CANCELLED, TIMED_OUT, ACTION_REQUIRED}`, or any CI status in
+`{IN_PROGRESS, QUEUED}`.
+
+If pre-flight passes: spawn ONE Task subagent per PR (cap 2 parallel):
+
+> You are a PR merger. Invoke `.claude/skills/ppt-pr-merge/SKILL.md` end-to-end.
+> Inputs: `pr_number=<n>`, `repo=martin-janci/property-management`, `base=dev`,
+> `strategy=squash`, `delete_branch=true`. The skill verifies preconditions,
+> auto-resolves mechanical conflicts, then `gh pr merge --squash --auto`.
+> Return EXACTLY: `merged=<true|false|queued> pr=<n> note=<short>`
+
+Capture line. `last_updated = now`. DO NOT manually set `status` here —
+Phase 2 of the next cycle catches the GH `MERGED` state authoritatively.
+
+---
+
+## Phase 5.6 — Auto-rebase stale-approved PRs (NEW — item #6)
+
+For each row `status == "review"` where:
+- `reviewer_summary` starts with `"verdict=approve"`, AND
+- the PR's `mergeable == "CONFLICTING"`, AND
+- `(now - status_changed_at) > 4h`, AND
+- `rebase_attempts < 3` (safety stop).
+
+Spawn ONE Task subagent (cap 1 parallel — rebases serialize on the same base):
+
+> You are a PR rebaser for a stale approved PR. Inputs: `pr_number=<n>`,
+> `branch=<head_ref>`, `base=dev`. Do this exactly:
+>
+> 1. `gh pr checkout <n> --repo martin-janci/property-management`
+> 2. `git fetch origin dev`
+> 3. `git rebase origin/dev`
+>    - If conflicts ONLY in mechanical paths (sqlx, Cargo.lock, generated
+>      openapi/api-client, pnpm-lock.yaml, VERSION) → resolve per
+>      `ppt-pr-merge` Step 2 table, `git rebase --continue`.
+>    - Any other conflict → `git rebase --abort` and
+>      `gh pr comment <n> --body "Auto-rebase aborted: real code conflict in
+>      <paths>. Manual rebase required."`, return
+>      `rebased=false note=conflict-in:<paths>`.
+> 4. `git push --force-with-lease origin <branch>`
+> 5. Return EXACTLY: `rebased=<true|false> pr=<n> note=<short>`
+
+Capture line. Bump `rebase_attempts += 1`, `last_updated = now`.
+Phase 5.5 next run will pick up the now-clean PR via the standard path.
+
+---
+
+## Phase 6 — Persist & push
+
+Update `assignments.generated = now`. Include `action-list.json` if Phase 2.6 Tier 1 refilled.
+
+```bash
+git add .research/management/assignments.json [.research/management/action-list.json if refilled]
+git commit -m 'chore(research): dispatcher <yyyy-mm-dd HH:MM> — C claimed, R reviewed, M merged-attempts, X merged-now, F failed, A active, B buffer, RB rebased'
+git push origin dev   # if another run committed since our pull: rebase + retry once;
+                      # if still conflicts, log and bail — next run will re-evaluate state
+```
+
+---
+
+## Phase 7 — Print summary (ALWAYS, hang lines too — item #9)
+
+Even when the corresponding list is empty, print the line with `[]` so the
+summary is regular and grep-friendly. Specifically the hang-alert lines must
+always appear so it is visible in dispatcher commits when the check actually ran.
+
+```
+Claimed (this run):       [<id> -> <specialist>, …]                (≤3, may be [])
+Same-epic skipped:        [<id> (would exceed 2/epic), …]          (item #2; [] if none)
+Transitions (this run):   [<id> in-progress→review, …]             ([] if none)
+In-progress (global now): <N> total across all overlapping runs (no cap)
+In review (PR open):      <M>
+Merge attempts (this run):[PR#<n> merged=<true|false|queued> <note>, …]
+Rebase attempts (this run):[PR#<n> rebased=<true|false> <note>, …]  (item #6; [] if none)
+Empty branches deleted:   [<branch>, …]                             (item #1; [] if none)
+Scope-drift flagged:      [PR#<n> task=<id> note=<paths>, …]        (item #3; [] if none)
+Code-reuse warnings:      [PR#<n> task=<id> note=<helper>, …]       (item #4; [] if none)
+Disk warning:             <none | "free=N%; cleaned to M%">         (item #7)
+Merged total: <Mt_total>; this cycle: <Mt_this>
+Failed total: <F_total>;  this cycle: <F_this>
+Buffer:     <open_count>/36 <T1: refilled +N | T2: upstream kicked | OK>
+Post-merge: <due | skipped> [<scanned=N clean=K issues=M>]
+Hang alerts:
+  WARN (review >48h): [<task_id> PR#<n> age=<dd:hh:mm>, …]   (ALWAYS PRINT; [] if none)
+  ALERT (review >7d): [<task_id> PR#<n> age=<dd:hh:mm>, …]   (ALWAYS PRINT; [] if none)
+```
+
+---
+
+## HARD RULES
+
+- per-run cap: claim at most 3 NEW tasks AND spawn at most 3 implementer subagents
+- NO global in-progress cap — parallel runs can overlap, total in-progress may exceed 3
+- per-run **per-epic** cap of 2 (item #2)
+- state transitions are MANDATORY; `merged` / `failed` are TERMINAL
+- legacy `status == "done"` is equivalent to `merged` (counting only); never auto-migrate or rewrite those rows
+- `status_changed_at` bumped ONLY on actual status value change
+- max 1 post-merge reviewer subagent per run
+- max 2 pr-merge subagents in parallel in Phase 5.5
+- max 1 rebase subagent in parallel in Phase 5.6 (item #6)
+- no cap on reviewer (Phase 5) subagents
+- never re-claim an id already in assignments (regardless of its status)
+- never claim items whose dependency text mentions another non-`merged` task
+- never push to `main`
+- never bypass git hooks (no `--no-verify`)
+- never set `assignment.status="merged"` inside Phase 5.5 — only Phase 2 sets `merged` from GH truth
+- Tier 2 upstream kick is fire-and-forget with `--max-time 10`
+- always defer to `ppt-implement`, `ppt-review-merged`, `ppt-pr-merge` skills
+- buffer guard adds items only; never edits/removes existing
+- do NOT inline implementer / reviewer / merger logic
+- Phase 2's `<2h grace, no branch yet` case respects that another run's implementer may still be working on this task — don't fail prematurely
+- **empty-branch detection** (item #1) is deterministic: `git rev-list --count origin/dev..origin/<branch> == 0` → fail row immediately, delete branch
+- **scope-drift** and **code-reuse-warn** (items #3, #4) are non-blocking on implementer return, but feed the reviewer prompt and are surfaced in Phase 7
+- **reviewer re-runs** (item #10) gate on `PR.headRefOid != row.last_reviewed_oid` — never re-review the same SHA
+- **auto-rebase** (item #6) is bounded at 3 attempts per row; after that a human must intervene
+- **disk preflight** (item #7) aborts the run gracefully at <5% free; never crashes mid-subagent
+
+---
+
+## Out of scope (intentional)
+
+- **Coalescing `chore(version): bump` commits** (originally item #8). The
+  version-bump churn comes from `version-bump.yml` running on every merge,
+  not from the dispatcher. Address by editing that workflow to debounce on
+  a per-cycle window, or by collapsing the dispatcher's run into a single
+  squash commit. Either change belongs in a separate PR.
+
+## Deterministic self-test
+
+Run `.research/dispatcher-self-test.sh` to validate the invariants
+encoded above against the current `assignments.json` (schema, terminal-state
+discipline, no-duplicate task_id, etc.). The test is also wired into
+`.github/workflows/dispatcher-self-test.yml` to run on any PR touching
+`.research/dispatcher-prompt.md`, `.research/dispatcher-self-test.sh`, or
+the implementer/reviewer/merger skills.

--- a/.research/dispatcher-self-test.sh
+++ b/.research/dispatcher-self-test.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Deterministic self-test for the dispatcher invariants.
+#
+# Validates the schema and state-machine discipline encoded in
+# .research/dispatcher-prompt.md against the current
+# .research/management/assignments.json.
+#
+# Exits non-zero on any violation. Safe to run anywhere — read-only.
+#
+# Usage:
+#   ./.research/dispatcher-self-test.sh                  # uses repo root
+#   ./.research/dispatcher-self-test.sh path/to/file.json # custom file
+
+set -euo pipefail
+
+ASSIGN="${1:-.research/management/assignments.json}"
+PROMPT="${DISPATCHER_PROMPT:-.research/dispatcher-prompt.md}"
+SKILLS_DIR="${SKILLS_DIR:-.claude/skills}"
+# Cutoff for hardening-era checks. Rows claimed before this date are legacy
+# (pre-merged_at, pre-hardening-fields) and are exempted from T5 + T11.
+HARDENING_DATE="${HARDENING_DATE:-2026-05-25T00:00:00Z}"
+
+FAIL=0
+note() { printf '  ok    %s\n' "$1"; }
+fail() { printf '  FAIL  %s\n' "$1" >&2; FAIL=1; }
+
+echo "==> dispatcher-self-test"
+echo "    assignments: $ASSIGN"
+echo "    prompt:      $PROMPT"
+echo
+
+# --- T0: required files exist -----------------------------------------------
+echo "T0  required files exist"
+for f in "$ASSIGN" "$PROMPT" \
+         "$SKILLS_DIR/ppt-implement/SKILL.md" \
+         "$SKILLS_DIR/ppt-pr-merge/SKILL.md" \
+         "$SKILLS_DIR/ppt-review-merged/SKILL.md"; do
+  if [ -f "$f" ]; then note "exists: $f"; else fail "missing: $f"; fi
+done
+echo
+
+# --- T1: assignments.json parses as JSON -----------------------------------
+echo "T1  assignments.json parses + top-level shape"
+if jq -e '.generated and .assignments' "$ASSIGN" >/dev/null 2>&1; then
+  note "valid JSON with .generated and .assignments[]"
+else
+  fail "assignments.json missing .generated or .assignments[]"
+fi
+echo
+
+# --- T2: row schema --------------------------------------------------------
+echo "T2  every row has required fields (task_id, branch, status, claimed_at, last_updated, status_changed_at)"
+MISSING=$(jq -r '
+  .assignments
+  | map(select(
+      (.task_id == null) or
+      (.branch  == null) or
+      (.status  == null) or
+      (.claimed_at == null) or
+      (.last_updated == null) or
+      (.status_changed_at == null)
+    ))
+  | length' "$ASSIGN")
+if [ "$MISSING" = "0" ]; then note "all rows have core schema"
+else fail "$MISSING rows missing one or more required fields"; fi
+echo
+
+# --- T3: status enum -------------------------------------------------------
+echo "T3  status ∈ {in-progress, review, merged, failed, done}  (done = legacy compat)"
+BAD=$(jq -r '
+  .assignments
+  | map(select((.status as $s | ["in-progress","review","merged","failed","done"] | index($s) | not)))
+  | length' "$ASSIGN")
+if [ "$BAD" = "0" ]; then note "all status values in allowed set"
+else
+  fail "$BAD rows with disallowed status"
+  jq -r '.assignments[] | select((.status as $s | ["in-progress","review","merged","failed","done"] | index($s) | not)) | "    \(.task_id) :: status=\(.status)"' "$ASSIGN" >&2
+fi
+echo
+
+# --- T4: no duplicate task_id ----------------------------------------------
+echo "T4  task_id unique"
+DUPES=$(jq -r '
+  .assignments
+  | group_by(.task_id)
+  | map(select(length>1) | .[0].task_id)
+  | join(",")' "$ASSIGN")
+if [ -z "$DUPES" ]; then note "all task_id values unique"
+else fail "duplicate task_id: $DUPES"; fi
+echo
+
+# --- T5: terminal-state discipline -----------------------------------------
+# Only enforced for rows claimed on/after the hardening cutoff. Older rows
+# pre-date the merged_at field being wired into Phase 2 and were merged via
+# legacy logic; we don't rewrite them.
+echo "T5  merged rows claimed on/after $HARDENING_DATE must have merged_at AND pr_number"
+BAD=$(jq --arg d "$HARDENING_DATE" '
+  .assignments
+  | map(select(.status == "merged"
+               and .claimed_at >= $d
+               and ((.merged_at == null) or (.pr_number == null))))
+  | length' "$ASSIGN")
+if [ "$BAD" = "0" ]; then note "all merged rows in window have merged_at + pr_number"
+else
+  fail "$BAD merged rows missing merged_at or pr_number (post-cutoff)"
+  jq --arg d "$HARDENING_DATE" -r '.assignments[] | select(.status=="merged" and .claimed_at >= $d and ((.merged_at==null) or (.pr_number==null))) | "    \(.task_id) :: claimed=\(.claimed_at) merged_at=\(.merged_at) pr=\(.pr_number)"' "$ASSIGN" >&2
+fi
+echo
+
+# --- T6: failed rows must not have pr_number set to a still-open PR --------
+echo "T6  failed rows: pr_number may be null OR a closed/merged PR (not enforced — informational only)"
+FAILED_WITH_PR=$(jq -r '.assignments | map(select(.status=="failed" and .pr_number != null)) | length' "$ASSIGN")
+if [ "$FAILED_WITH_PR" = "0" ]; then note "no failed rows carry a pr_number"
+else
+  printf '  info  %s failed rows carry a pr_number (Phase 2 sets these when PR is CLOSED unmerged)\n' "$FAILED_WITH_PR"
+fi
+echo
+
+# --- T7: branch naming convention ------------------------------------------
+echo "T7  branch starts with auto-impl/"
+BAD=$(jq -r '.assignments | map(select((.branch // "") | startswith("auto-impl/") | not)) | length' "$ASSIGN")
+if [ "$BAD" = "0" ]; then note "all branches use auto-impl/ prefix"
+else
+  fail "$BAD rows with non-conforming branch"
+  jq -r '.assignments[] | select((.branch // "") | startswith("auto-impl/") | not) | "    \(.task_id) :: branch=\(.branch)"' "$ASSIGN" >&2
+fi
+echo
+
+# --- T8: status_changed_at <= last_updated ---------------------------------
+echo "T8  status_changed_at <= last_updated"
+BAD=$(jq -r '
+  .assignments
+  | map(select(.status_changed_at > .last_updated))
+  | length' "$ASSIGN")
+if [ "$BAD" = "0" ]; then note "monotonic timestamps OK"
+else
+  fail "$BAD rows where status_changed_at > last_updated"
+  jq -r '.assignments[] | select(.status_changed_at > .last_updated) | "    \(.task_id) :: status_changed_at=\(.status_changed_at) > last_updated=\(.last_updated)"' "$ASSIGN" >&2
+fi
+echo
+
+# --- T9: dispatcher prompt references all expected skills -------------------
+echo "T9  dispatcher-prompt.md references ppt-implement, ppt-review-merged, ppt-pr-merge skills"
+for s in ppt-implement ppt-review-merged ppt-pr-merge; do
+  if grep -q "$s" "$PROMPT"; then note "references $s"
+  else fail "$PROMPT does not reference $s"; fi
+done
+echo
+
+# --- T10: dispatcher prompt encodes the 7 hardening items -------------------
+echo "T10 dispatcher-prompt.md encodes the 2026-05-25 hardening items"
+declare -a MARKERS=(
+  "item #1"  # empty-branch detection
+  "item #2"  # same-epic guard
+  "item #3"  # scope drift
+  "item #4"  # code reuse
+  "item #5"  # JSON key case
+  "item #6"  # auto rebase
+  "item #7"  # disk preflight
+  "item #9"  # always-print hang lines
+  "item #10" # reviewer re-run gating
+)
+for m in "${MARKERS[@]}"; do
+  if grep -q "$m" "$PROMPT"; then note "$m present"
+  else fail "$m missing from $PROMPT"; fi
+done
+echo
+
+# --- T11: per-row hardening fields backfilled (allow null, just must exist) -
+# Only checks rows claimed AFTER the hardening date; older rows are legacy.
+echo "T11 rows claimed on/after $HARDENING_DATE carry hardening fields"
+NEW_ROWS=$(jq --arg d "$HARDENING_DATE" '.assignments | map(select(.claimed_at >= $d)) | length' "$ASSIGN")
+if [ "$NEW_ROWS" = "0" ]; then
+  printf '  skip  no rows claimed on/after %s yet (will check on next dispatcher run)\n' "$HARDENING_DATE"
+else
+  BAD=$(jq --arg d "$HARDENING_DATE" '
+    .assignments
+    | map(select(.claimed_at >= $d
+                 and ((has("last_reviewed_oid") | not)
+                   or (has("scope_drift") | not)
+                   or (has("code_reuse_warn") | not)
+                   or (has("empty_branch") | not)
+                   or (has("rebase_attempts") | not))))
+    | length' "$ASSIGN")
+  if [ "$BAD" = "0" ]; then note "all $NEW_ROWS new rows carry hardening fields"
+  else fail "$BAD new rows missing one or more hardening fields"; fi
+fi
+echo
+
+# --- Summary ---------------------------------------------------------------
+if [ "$FAIL" = "0" ]; then
+  echo "==> dispatcher-self-test: PASS"
+  exit 0
+else
+  echo "==> dispatcher-self-test: FAIL" >&2
+  exit 1
+fi

--- a/.research/dispatcher-trigger-bootstrap.md
+++ b/.research/dispatcher-trigger-bootstrap.md
@@ -1,0 +1,21 @@
+# Dispatcher trigger bootstrap
+
+This is the message body to paste into the live
+`ppt-research-dispatcher` trigger (`trig_01RDNN7kYxzr4XULbi4xn5r2`) so
+it reads its instructions from the repo instead of carrying an inlined
+copy. Mirrors the pattern used by the `airbnb-invoices-sync` trigger.
+
+Update the trigger via the Claude.ai routines UI or
+`RemoteTrigger action=update` with the `job_config.ccr.events[0].data.message.content`
+replaced with the block below — keep all other fields (`environment_id`,
+`session_context`, `mcp_connections`, `cron_expression`) as-is.
+
+---
+
+```
+Read .research/dispatcher-prompt.md from the repo root and execute it as your instructions for this run. Today's date is the run date. If $TRIGGER_TEXT is "deep" or "reset", surface that in the run summary; otherwise treat as a normal run.
+```
+
+That's the whole prompt. Future behavioural changes ship as normal PRs to
+`dev` against `.research/dispatcher-prompt.md` — no further `RemoteTrigger
+update` calls needed.


### PR DESCRIPTION
## Summary

Reacts to the 2026-05-24 dispatcher runs (5 task failures, 2 reviewer-blocking scope/duplication issues, 1 stale-approved PR). Extracts the dispatcher prompt to a tracked repo file so future edits ship via PR.

## Changes

### Routine prompt (`.research/dispatcher-prompt.md` — new)

Encodes 9 hardening items, all tagged `item #N` in the prompt so the self-test can find them:

| # | Fix | Where in prompt |
|---|---|---|
| 1 | Phase 2 detects branch-with-0-commits-ahead → fail + delete orphan (4/5 today's failures) | Phase 2 cases |
| 2 | Phase 3 same-epic burst-claim guard (max 2/epic per run) | Phase 3 |
| 3 | Implementer scope-drift surfaced + fed to reviewer (PR #472 mfa.rs drift) | Phase 4 return, Phase 5 prompt, Phase 7 |
| 4 | Code-reuse warnings surfaced + fed to reviewer (PR #472 duplicated `JWT_VERIFIER`) | Phase 4 return, Phase 5 prompt, Phase 7 |
| 5 | Reviewer prompt JSON-key-case sanity check (PR #473 snake/camel panic) | Phase 5 prompt |
| 6 | Phase 5.6 auto-rebase stale-approved PRs (#458 sat 11h with conflicts) | Phase 5.6 (new) |
| 7 | Phase 1 disk preflight (pm-security agent aborted "disk full" today) | Phase 1 |
| 9 | Phase 7 always prints hang-alert lines (visible even when empty) | Phase 7 |
| 10 | Reviewer re-runs gated on `PR.headRefOid` via new `last_reviewed_oid` field | schema + Phase 2/5 |

Item #8 (coalesce `chore(version): bump` commits) is out of scope — belongs in `version-bump.yml`.

### Skills

- **`ppt-implement/SKILL.md`** — new Step 2.5 (scope check) + Step 2.6 (code-reuse pre-flight); return contract extended with `scope_drift=` + `code_reuse_warn=` fields.
- **`ppt-implement/scripts/{scope-check,reuse-grep,owner-areas,test-scope-check}`** — deterministic verification backing items #3/#4.
- **`ppt-pr-merge/SKILL.md`** — new `mode=rebase-only` short-circuit used by Phase 5.6 (auto-resolve mechanical conflicts + push without merging).
- **`ppt-review-merged/SKILL.md`** — JSON-key-case check addendum in the reviewer checklist.

### Trigger refactor

`.research/dispatcher-trigger-bootstrap.md` carries the short message body that replaces the inlined prompt in the live trigger `trig_01RDNN7kYxzr4XULbi4xn5r2`. Mirrors the `airbnb-invoices-sync` pattern. After this PR merges, you call `RemoteTrigger action=update` once and from then on the dispatcher reads its instructions from `.research/dispatcher-prompt.md` — future edits ship via PR with no API call.

## Deterministic verification

- **`.research/dispatcher-self-test.sh`** — 11 tests covering schema, state-machine discipline, terminal-state invariants, and "prompt encodes items #1–10". PASS against current `assignments.json`. T5 + T11 carve out rows claimed before the 2026-05-25 cutoff (avoids re-litigating legacy `merged_at`-less rows).
- **`.claude/skills/ppt-implement/scripts/test-scope-check.sh`** — 8-case table test for `scope-check.sh` covering happy path, drift, unknown owner, and `generic` accept-all. PASS.
- **`.github/workflows/dispatcher-self-test.yml`** — runs both on any PR touching the dispatcher prompt, the self-test, the assignments file, or any of the three skills.

## Test plan

- [x] `bash .research/dispatcher-self-test.sh` → PASS (locally)
- [x] `bash .claude/skills/ppt-implement/scripts/test-scope-check.sh` → PASS (8/8)
- [ ] CI `dispatcher-self-test` workflow green on this PR
- [ ] After merge: update the live trigger content per `.research/dispatcher-trigger-bootstrap.md` and watch the next dispatcher run for `Phase 3: claimed=N same_epic_skipped=K`, `Scope-drift flagged: [...]`, etc. in the dispatcher commit message.

## Follow-up (separate work)

- Address item #8 in `version-bump.yml` (debounce/coalesce so a busy dispatcher cycle produces 1 version bump instead of N).
- Backfill `merged_at` on the 4 legacy `merged` rows (#436, #437, #440, #468) from GH if you want the data clean — purely cosmetic; the self-test already exempts them.