### PR TITLE
gap-80-2-dispute-verify: Story 80-2 dispute filing flow — partial (EvidenceUploader + draft-save missing)

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -72,6 +72,8 @@ development_status:
   10b-5-support-data-access: ready-for-dev
   10b-6-user-onboarding-tour: ready-for-dev
   10b-7-contextual-help-documentation: ready-for-dev
+  # Epic 80: Dispute Resolution (verified 2026-05-25)
+  80-2-dispute-filing-flow: partial  # EvidenceUploader.tsx + useDraftStorage.ts missing; AC-2, AC-4 not met
 
 # Notes and blockers
 notes:

--- a/docs/screens/ppt/file-dispute.md
+++ b/docs/screens/ppt/file-dispute.md
@@ -100,5 +100,6 @@ UC-38 dispute creation flow. 5-step wizard balances thoroughness (legal record) 
 
 <!-- newest entries on top -->
 
+- 2026-05-25 — agent: verified story 80-2 AC coverage. FileDisputePage exists at /disputes/new with useCreateDispute mutation (AC-1/3/5 partial). EvidenceUploader.tsx MISSING (AC-2 not met). useDraftStorage.ts MISSING (AC-4 not met). Post-submit nav goes to list not detail. Story 80-2 stays partial; apiStatus stays partial.
 - 2026-05-09 — agent: integrated Batch C (pages/ppt-file-dispute.html — 5 artboards: step 1 / step 3 uploading / step 5 review / submitted / step 3 validation errors); flipped redesignStatus → in-progress; attached designSource; populated 6 sections + 5 states + 3 notes; declared 7 sharedComponents
 - 2026-05-08 — init: created from scan (source: sitemap)


### PR DESCRIPTION
## Task

Verify dispute filing flow (FileDisputePage + EvidenceUploader) meets all acceptance criteria; update story status from pending to done (80-2 Dispute Filing Flow)

## Owner

pm-frontend

## Verdict: PARTIAL — story 80-2 cannot be promoted to done

### AC Coverage

| AC | Status | Detail |
|----|--------|--------|
| AC-1: Dispute Filing Form | partial | `FileDisputePage.tsx` exists at `/disputes/new`. Form has category, title, description, respondent picker. Route wired in App.tsx via `FileDisputePageRoute` with `useCreateDispute(organizationId)`. However: schema uses `category`/`title` instead of story-spec `type`/`subject`; `unitId` required at route level only, not inside the form component. |
| AC-2: Evidence Upload | **MISSING** | `EvidenceUploader.tsx` does NOT exist. `useUploadEvidence` hook and `uploadEvidence` API function are implemented in `@ppt/api-client`, but no UI component renders them. Evidence notice on page says "you can add evidence after filing" — not per AC. |
| AC-3: Dispute Submission | partial | `createDispute.mutateAsync` called; success/error toast shown. Post-submit navigation goes to `/disputes` (list page) not `/disputes/{id}` (detail page) as required by AC-3. |
| AC-4: Draft Saving | **MISSING** | `useDraftStorage.ts` does NOT exist in `frontend/apps/ppt-web/src/hooks/`. No localStorage save/restore logic anywhere in the flow. |
| AC-5: Validation & Error Handling | partial | HTML5 `required` attributes + submit button disabled when fields empty. No Zod schema validation (`z.object(...)` from story spec), no inline per-field error messages. |

### Gaps to implement (follow-up tasks required)

1. `EvidenceUploader.tsx` — drag-drop, multi-file, progress per file, per-file description, 10MB limit, image/pdf/video types
2. `useDraftStorage.ts` — debounced localStorage write on form change, restore on mount, clear on submit, "Resume draft?" prompt
3. Post-submit navigate to `/disputes/${newDispute.id}` (detail page) in `FileDisputePageRoute`
4. Zod validation schema with inline field-level error messages in `FileDisputePage`

### Files verified

- `/frontend/apps/ppt-web/src/features/disputes/pages/FileDisputePage.tsx` — exists, partial
- `/frontend/apps/ppt-web/src/features/disputes/components/EvidenceUploader.tsx` — MISSING
- `/frontend/packages/api-client/src/disputes/hooks.ts` — `useCreateDispute`, `useUploadEvidence` present
- `/frontend/packages/api-client/src/disputes/api.ts` — `createDispute`, `uploadEvidence` present
- `/frontend/apps/ppt-web/src/hooks/useDraftStorage.ts` — MISSING
- `/frontend/apps/ppt-web/src/App.tsx:779` — `FileDisputePageRoute` wired at `/disputes/new`

### Tracking files updated

- `_bmad-output/implementation-artifacts/sprint-status.yaml` — added 80-2-dispute-filing-flow: partial
- `docs/screens/ppt/file-dispute.md` — Agent Log entry added

## Tested (Band A — fast check)

`pnpm -F ppt-web typecheck` and `pnpm -F ppt-web lint` — skipped: node_modules not installed in environment (consistent with other agents in this repo, e.g. pr=471). No code was added/modified; this is a verification-only PR. Existing CI will cover the codebase.

## Built (Band B — full build)

skipped: change <50 LOC, no public API/config touch (verification/docs only)

## CI parity (Band C — hot-path only)

skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested

skipped

## Notes

Story 80-2 status: **partial** (not done). Two ACs (AC-2, AC-4) are completely missing components. Three ACs (AC-1, AC-3, AC-5) are partially implemented. The story file at `_bmad-output/implementation-artifacts/stories/80-2-dispute-filing-flow.md` retains `Status: pending` (linter-managed; the sprint-status.yaml entry is the authoritative tracking).

Recommend creating two follow-up tasks: one for `EvidenceUploader.tsx` implementation and one for `useDraftStorage.ts` + the remaining AC gaps (AC-3 nav fix, AC-5 Zod validation).

---
_Generated by [Claude Code](https://claude.ai/code/session_015VC1XpRRuAutwcWxnQvA17)_