### PR TITLE
gap-80-3-mediation-verify: Story 80-3 stays partial — DisputeDetailPage/MediationPage unwired in App.tsx

### DIFF
--- a/.research/management/coverage.json
+++ b/.research/management/coverage.json
@@ -239,7 +239,7 @@
         "handlers get_download_url/get_preview_url",
         "screen document-detail with PDF preview spec",
         "SigV4 presigned URLs via aws-sdk-s3",
-        "PR #446 (gap-7a-4) merged 2026-05-24: PDF.js client-side rendering shipped in ppt-web DocumentDetail via react-pdf — web preview done; mobile slice still pending"
+        "PR #446 (gap-7a-4) merged 2026-05-24: PDF.js client-side rendering shipped in ppt-web DocumentDetail via react-pdf \u2014 web preview done; mobile slice still pending"
       ],
       "gaps": [
         "sprint-status ready-for-dev",
@@ -743,24 +743,30 @@
       "title": "Mediation and Resolution",
       "phase": "mvp",
       "status": "partial",
-      "confidence": "medium",
+      "confidence": "high",
       "platform": [
         "frontend"
       ],
       "owner_role": "pm-frontend",
       "evidence": [
-        "MediationPage.tsx large impl",
-        "DisputeDetailPage.tsx mediation UI",
-        "useAssignMediator/useResolveDispute/useEscalateDispute/useAddMediationNote",
-        "backend mediation routes implemented",
-        "dispute-detail screen shipped"
+        "MediationPage.tsx fully implemented: sessions (scheduled/past), submissions, parties sidebar, schedule/complete/submit dialogs, mediator-only gate",
+        "DisputeDetailPage.tsx fully implemented: evidence upload/delete, resolutions with voting/accept/implement/terms, action items with escalation, timeline, status flow",
+        "useAssignMediator/useResolveDispute/useEscalateDispute/useAddMediationNote hooks in api-client/disputes/hooks.ts",
+        "api.ts: assignMediator, resolveDispute, escalateDispute, addMediationNote, listMediationNotes, getTimeline",
+        "types.ts: ResolveDisputeRequest, AssignMediatorRequest, EscalateDisputeRequest, AddMediationNoteRequest, MediationNote, TimelineEvent",
+        "ResolutionCard: voting, accept, implement, term-completion flows",
+        "ActionItemCard: onEscalate callback present",
+        "backend mediation routes assumed implemented (prior scan)"
       ],
       "gaps": [
-        "story Status: pending despite shipped UI",
-        "task checklist unchecked",
-        "escalation paths/notifications unverified"
+        "CRITICAL: DisputeDetailRoute in App.tsx is inline JSX stub \u2014 does not render DisputeDetailPage.tsx",
+        "CRITICAL: No /disputes/:disputeId/mediation route \u2014 MediationPage never rendered",
+        "CRITICAL: useEscalateDispute, useResolveDispute, useAssignMediator, useAddMediationNote not called from any App.tsx route handler",
+        "CRITICAL: onNavigateToMediation prop in DisputeDetailPage but no route target exists",
+        "No mediation screen-map entry under docs/screens/ppt/"
       ],
-      "last_checked": "2026-05-23"
+      "last_checked": "2026-05-25",
+      "verification_note": "Verified 2026-05-25 by gap-80-3-mediation-verify. Pages and hooks are complete; only App.tsx route wiring is missing. Cannot promote to done \u2014 needs dedicated wiring task."
     },
     {
       "epic": "epic-81",

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -40,6 +40,11 @@ epics:
     status: in-progress
     stories_total: 7
     stories_completed: 3
+  epic-80:
+    name: "Dispute Resolution"
+    status: partial
+    stories_total: 3
+    stories_completed: 1
 
 # Story-level development status
 development_status:
@@ -73,8 +78,14 @@ development_status:
   10b-6-user-onboarding-tour: ready-for-dev
   10b-7-contextual-help-documentation: ready-for-dev
 
+  # Epic 80: Dispute Resolution (verified 2026-05-25)
+  80-1-disputes-api-integration: done
+  80-2-dispute-filing-flow: partial
+  80-3-mediation-resolution: partial
+
 # Notes and blockers
 notes:
+  - "Story 80-3 verified 2026-05-25: DisputeDetailPage.tsx+MediationPage.tsx+all hooks confirmed implemented; DisputeDetailRoute in App.tsx is inline JSX stub not using DisputeDetailPage; no /disputes/:id/mediation route; useEscalateDispute/useResolveDispute/useAssignMediator not wired from App.tsx — story stays partial, follow-up wiring task needed"
   - "Epic 6 depends on Epic 2B Notification Infrastructure for sending notifications on publish"
   - "Story 6.1 is the foundation - other stories build on announcement infrastructure"
   - "Story 6.1 completed 2025-12-21 - awaiting code review"

--- a/docs/screens/ppt/dispute-detail.md
+++ b/docs/screens/ppt/dispute-detail.md
@@ -89,5 +89,6 @@ UC-38 single-dispute deep view. Combines patterns from `ppt/announcements` (chro
 
 <!-- newest entries on top -->
 
+- 2026-05-25 — agent: verified story 80-3 AC coverage; DisputeDetailPage.tsx fully implemented (evidence, resolutions with voting/accept/implement, action items with escalation, timeline). MediationPage.tsx fully implemented (sessions, submissions, schedule/complete/submit dialogs). All hooks present (useAssignMediator/useResolveDispute/useEscalateDispute/useAddMediationNote). CRITICAL GAP: DisputeDetailRoute in App.tsx is inline JSX stub not using DisputeDetailPage.tsx; no /disputes/:id/mediation route exists; none of the mediation mutation hooks are wired. Story 80-3 stays partial; apiStatus remains partial. Follow-up wiring task required.
 - 2026-05-09 — agent: integrated Batch C (pages/ppt-dispute-detail.html — 3 artboards: V mediácii / Vyriešený read-only / Loading); flipped redesignStatus → in-progress; attached designSource; populated 4 sections + 3 states + 3 notes; declared 6 sharedComponents
 - 2026-05-08 — init: created from scan (source: sitemap)


### PR DESCRIPTION
## Task

Verify mediation resolution flow (MediationPage/DisputeDetailPage) meets all ACs including escalation paths; promote story from pending to done (80-3 Mediation and Resolution)

## Owner

pm-frontend

## Verification Summary

Story **80-3 (Mediation and Resolution) cannot be promoted to done**. The component layer is fully implemented but the router layer is completely unwired.

### What is implemented (COMPLETE)

| Layer | Status |
|-------|--------|
| `DisputeDetailPage.tsx` | Complete — evidence, resolutions (vote/accept/implement/terms), action items (escalation), timeline, status transitions |
| `MediationPage.tsx` | Complete — sessions (scheduled/past), submissions, parties sidebar, schedule/complete/submit dialogs, mediator-only gate |
| `useAssignMediator` hook | Present — invalidates detail+list+timeline |
| `useResolveDispute` hook | Present — invalidates detail+list+timeline+statistics |
| `useEscalateDispute` hook | Present — invalidates detail+list+timeline+statistics |
| `useAddMediationNote` hook | Present — invalidates detail+notes+timeline |
| `ResolutionCard` component | Complete — voting, accept, implement, term-completion |
| `ActionItemCard` component | Complete — `onEscalate` callback wired |
| API client `api.ts` | Complete — assignMediator, resolveDispute, escalateDispute, addMediationNote, getTimeline |
| API types `types.ts` | Complete — all Story 80.3 request/response types |

### Critical gaps (BLOCKING promotion to done)

1. **`DisputeDetailRoute` in `App.tsx` is an inline JSX stub** — it does NOT render `DisputeDetailPage.tsx`. It only shows subject, raw status, description, and a plain timeline list. None of the mediation callbacks are passed.

2. **No `/disputes/:disputeId/mediation` route** — `MediationPage.tsx` is exported from `pages/index.ts` but is never imported in `App.tsx`. The page is unreachable at runtime.

3. **None of the mediation mutation hooks are called from any App.tsx route handler** — `useEscalateDispute`, `useResolveDispute`, `useAssignMediator`, `useAddMediationNote` are dead code from the router's perspective.

4. **`onNavigateToMediation` prop exists in `DisputeDetailPage`** — but there is no route target to navigate to.

5. **No mediation screen-map entry** — `docs/screens/ppt/` has `disputes.md`, `dispute-detail.md`, `file-dispute.md` but no `mediation.md`.

### Required follow-up task

Wire `DisputeDetailRoute` to use `DisputeDetailPage.tsx` and add `/disputes/:disputeId/mediation` route rendering `MediationPage.tsx` — approximately 50-80 LOC change in `App.tsx`.

## Tested (Band A — fast check)

```
pnpm --filter @ppt/web typecheck
Exit status: 2 (pre-existing errors in LoginPage.tsx TS7026 + lazyRoutes.tsx missing react types)
These errors are NOT caused by this verification task — no dispute-related source files were modified.

git diff --check: clean
```

## Built (Band B — full build)

Skipped: verification-only task; only documentation files changed (sprint-status.yaml, coverage.json, dispute-detail.md screen-map). No substantive LOC change.

## CI parity (Band C)

Skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested

Skipped.

## Notes

- Story 80-3 status remains **partial** in `coverage.json` and `sprint-status.yaml`
- A new action-list task should be created: "Wire DisputeDetailRoute to DisputeDetailPage.tsx and add /disputes/:id/mediation route for MediationPage" (owner: pm-frontend, priority: medium)
- Escalation notification delivery (backend side) was not verifiable from frontend code; assumed covered by prior backend implementation scan

---
_Generated by [Claude Code](https://claude.ai/code/session_015VC1XpRRuAutwcWxnQvA17)_