### PR TITLE
gap-6-4-pin-web-ui: Wire pin/unpin announcement UI to backend

### DIFF
--- a/docs/screens/ppt/announcements.md
+++ b/docs/screens/ppt/announcements.md
@@ -7,9 +7,9 @@ sitemapRefs:
 implementations:
   ppt-web:
     component: AnnouncementsPage
-    buildStatus: planned
+    buildStatus: shipped
     redesignStatus: in-progress
-    apiStatus: partial
+    apiStatus: complete
   mobile:
     component: AnnouncementsScreen
     buildStatus: shipped
@@ -112,6 +112,8 @@ UC-02 announcements — manager-published, resident-acknowledged messages. The d
 ## Agent Log
 
 <!-- newest entries on top -->
+
+- 2026-05-25 — agent: gap-6-4-pin-web-ui — wired ViewAnnouncementPageRoute to real backend via useGetAnnouncement (replaces mock data); added useMarkReadAnnouncement+useAcknowledgeAnnouncement standalone hooks to @ppt/api-client; pin/unpin fully connected to POST /api/v1/announcements/{id}/pin; ppt-web.buildStatus planned→shipped, apiStatus partial→complete
 
 - 2026-05-24 — agent: gap-79-1 — wired AnnouncementsPage to useAnnouncements+useDeleteAnnouncement+usePublishAnnouncement+useArchiveAnnouncement+usePinAnnouncement hooks; ppt-web.apiStatus stub→partial; auth header fix applied (Authorization: Bearer from getToken())
 

--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -14,6 +14,7 @@ import type {
 } from '@ppt/api-client';
 import {
   setMfaChallengeHandler,
+  useAcknowledgeAnnouncement,
   useAnnouncements,
   useArchiveAnnouncement,
   useBuildings,
@@ -24,6 +25,8 @@ import {
   useDispute,
   useDisputes,
   useFaults,
+  useGetAnnouncement,
+  useMarkReadAnnouncement,
   useOutage,
   useOutages,
   usePinAnnouncement,
@@ -1454,49 +1457,134 @@ function CreateAnnouncementPageRoute() {
   );
 }
 
+/**
+ * Route wrapper for announcement detail / view page (UC-06, gap-6-4).
+ *
+ * Wired to @ppt/api-client standalone hooks:
+ *   useGetAnnouncement         — fetches full details + attachments
+ *   usePublishAnnouncement     — publishes a draft announcement
+ *   useArchiveAnnouncement     — archives a published announcement
+ *   usePinAnnouncement         — pins / unpins (Story 6.4)
+ *   useDeleteAnnouncement      — deletes a draft announcement
+ *   useMarkReadAnnouncement    — marks announcement as read
+ *   useAcknowledgeAnnouncement — acknowledges announcement
+ */
 function ViewAnnouncementPageRoute() {
   const { announcementId } = useParams<{ announcementId: string }>();
   const navigate = useNavigate();
   const { showToast } = useToast();
 
+  // All hooks called unconditionally (Rules of Hooks).
+  // announcementId absence is handled via the enabled flag.
+  const { data, isLoading, error } = useGetAnnouncement(announcementId ?? '', !!announcementId);
+  const publishAnnouncement = usePublishAnnouncement();
+  const archiveAnnouncement = useArchiveAnnouncement();
+  const pinAnnouncement = usePinAnnouncement();
+  const deleteAnnouncement = useDeleteAnnouncement();
+  const markRead = useMarkReadAnnouncement();
+  const acknowledge = useAcknowledgeAnnouncement();
+
   if (!announcementId) {
     return <div>Announcement not found</div>;
   }
 
-  // Mock data - would use useAnnouncement hook
-  const mockAnnouncement: import('@ppt/api-client').AnnouncementWithDetails = {
-    id: announcementId,
-    organizationId: 'org-1',
-    authorId: 'user-1',
-    authorName: 'Admin User',
-    title: 'Sample Announcement',
-    content: 'This is a sample announcement content.',
-    status: 'published',
-    targetType: 'all',
-    targetIds: [],
-    pinned: false,
-    acknowledgmentRequired: false,
-    commentsEnabled: true,
-    readCount: 10,
-    acknowledgedCount: 5,
-    commentCount: 2,
-    attachmentCount: 0,
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
+  if (error) {
+    return (
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        <p className="text-red-600">Failed to load announcement.</p>
+        <button
+          type="button"
+          onClick={() => navigate('/announcements')}
+          className="mt-4 text-blue-600"
+        >
+          Back to Announcements
+        </button>
+      </div>
+    );
+  }
+
+  if (isLoading || !data) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+      </div>
+    );
+  }
+
+  const handlePublish = async () => {
+    try {
+      await publishAnnouncement.mutateAsync(announcementId);
+      showToast({ type: 'success', title: 'Published', message: 'Announcement published.' });
+    } catch {
+      showToast({ type: 'error', title: 'Publish failed', message: 'Could not publish.' });
+    }
+  };
+
+  const handleArchive = async () => {
+    try {
+      await archiveAnnouncement.mutateAsync(announcementId);
+      showToast({ type: 'info', title: 'Archived', message: 'Announcement archived.' });
+    } catch {
+      showToast({ type: 'error', title: 'Archive failed', message: 'Could not archive.' });
+    }
+  };
+
+  const handlePin = async (pinned: boolean) => {
+    try {
+      await pinAnnouncement.mutateAsync({ id: announcementId, pinned });
+      showToast({
+        type: 'success',
+        title: pinned ? 'Pinned' : 'Unpinned',
+        message: pinned ? 'Announcement pinned.' : 'Announcement unpinned.',
+      });
+    } catch {
+      showToast({
+        type: 'error',
+        title: 'Pin action failed',
+        message: 'Could not update pin status.',
+      });
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await deleteAnnouncement.mutateAsync(announcementId);
+      showToast({ type: 'success', title: 'Deleted', message: 'Announcement deleted.' });
+      navigate('/announcements');
+    } catch {
+      showToast({ type: 'error', title: 'Delete failed', message: 'Could not delete.' });
+    }
+  };
+
+  const handleMarkRead = async () => {
+    try {
+      await markRead.mutateAsync(announcementId);
+    } catch {
+      // silently ignore — non-critical read tracking
+    }
+  };
+
+  const handleAcknowledge = async () => {
+    try {
+      await acknowledge.mutateAsync(announcementId);
+      showToast({ type: 'success', title: 'Acknowledged', message: 'Announcement acknowledged.' });
+    } catch {
+      showToast({ type: 'error', title: 'Acknowledge failed', message: 'Could not acknowledge.' });
+    }
   };
 
   return (
     <ViewAnnouncementPage
-      announcement={mockAnnouncement}
-      attachments={[]}
+      announcement={data.announcement}
+      attachments={data.attachments}
       onEdit={() => navigate(`/announcements/${announcementId}/edit`)}
-      onPublish={() => showToast({ type: 'success', title: 'Published', message: '' })}
-      onArchive={() => showToast({ type: 'info', title: 'Archived', message: '' })}
-      onPin={(pinned) =>
-        showToast({ type: 'info', title: pinned ? 'Pinned' : 'Unpinned', message: '' })
-      }
-      onDelete={() => navigate('/announcements')}
+      onPublish={handlePublish}
+      onArchive={handleArchive}
+      onPin={handlePin}
+      onDelete={handleDelete}
       onBack={() => navigate('/announcements')}
+      onMarkRead={handleMarkRead}
+      onAcknowledge={handleAcknowledge}
     />
   );
 }

--- a/frontend/packages/api-client/src/announcements/hooks.ts
+++ b/frontend/packages/api-client/src/announcements/hooks.ts
@@ -447,3 +447,44 @@ export function usePinAnnouncement() {
     },
   });
 }
+
+/** Get a single announcement with full details and attachments (Story 6.4) */
+export function useGetAnnouncement(id: string, enabled = true) {
+  return useQuery<{
+    announcement: import('./types').AnnouncementWithDetails;
+    attachments: import('./types').AnnouncementAttachment[];
+  }>({
+    queryKey: announcementKeys.detail(id),
+    queryFn: () =>
+      fetchJson<{
+        announcement: import('./types').AnnouncementWithDetails;
+        attachments: import('./types').AnnouncementAttachment[];
+      }>(`${ANNOUNCEMENTS_BASE}/${id}`),
+    enabled: enabled && !!id,
+  });
+}
+
+/** Mark an announcement as read */
+export function useMarkReadAnnouncement() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      fetchJson<void>(`${ANNOUNCEMENTS_BASE}/${id}/read`, { method: 'POST' }),
+    onSuccess: (_data, id) => {
+      queryClient.invalidateQueries({ queryKey: announcementKeys.detail(id) });
+      queryClient.invalidateQueries({ queryKey: announcementKeys.unreadCount() });
+    },
+  });
+}
+
+/** Acknowledge an announcement */
+export function useAcknowledgeAnnouncement() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      fetchJson<void>(`${ANNOUNCEMENTS_BASE}/${id}/acknowledge`, { method: 'POST' }),
+    onSuccess: (_data, id) => {
+      queryClient.invalidateQueries({ queryKey: announcementKeys.detail(id) });
+    },
+  });
+}


### PR DESCRIPTION
## Task

Wire pin/unpin announcement UI to backend pin_announcement route — frontend buildStatus planned; blocked on Epic 2B (6-4 Pinned Announcements). Epic 2B is now merged (PR #463). The backend pin_announcement endpoint exists. Implement the web UI (React/TypeScript in frontend/apps/ppt-web) to call it.

## Owner

pm-frontend

## Changes

### `@ppt/api-client` — 3 new standalone hooks

Added to `frontend/packages/api-client/src/announcements/hooks.ts`:

- **`useGetAnnouncement(id, enabled?)`** — `GET /api/v1/announcements/{id}` returning `{ announcement: AnnouncementWithDetails, attachments: AnnouncementAttachment[] }`. Shares the `announcementKeys.detail(id)` cache key.
- **`useMarkReadAnnouncement()`** — `POST /api/v1/announcements/{id}/read`; invalidates detail + unread-count on success.
- **`useAcknowledgeAnnouncement()`** — `POST /api/v1/announcements/{id}/acknowledge`; invalidates detail on success.

(`usePinAnnouncement` already existed — no change needed there.)

### `App.tsx` — `ViewAnnouncementPageRoute` rewritten

- Replaced mock `AnnouncementWithDetails` object with `useGetAnnouncement`
- Replaced stub `showToast` handlers with real `async/await` mutations:
  - `handlePin` → `usePinAnnouncement.mutateAsync({ id, pinned })` → `POST /{id}/pin`
  - `handlePublish` → `usePublishAnnouncement`
  - `handleArchive` → `useArchiveAnnouncement`
  - `handleDelete` → `useDeleteAnnouncement` + navigate away
  - `handleMarkRead` / `handleAcknowledge` wired with `useMarkReadAnnouncement` / `useAcknowledgeAnnouncement`
- Loading state: spinner rendered at route level while `isLoading || !data`
- Error state: inline error with back-link
- Rules of Hooks: all hooks called unconditionally; `enabled` flag gates the `useGetAnnouncement` query when `announcementId` is absent

### Screen-map `docs/screens/ppt/announcements.md`

- `ppt-web.buildStatus`: `planned` → `shipped`
- `ppt-web.apiStatus`: `partial` → `complete`
- Agent Log entry added

## Tested (Band A — fast check)

```
pnpm -F @ppt/api-client build   # exit 0 — tsc clean
pnpm -F @ppt/web typecheck      # exit 0 — tsc --noEmit clean
pnpm check:fix && pnpm check    # exit 0 — 0 errors, 15 pre-existing warnings
```

## Built (Band B — full build)

```
pnpm -F @ppt/web build   # exit 0 — Vite production build ✓ built in 4.35s
```

Change is >50 LOC and touches a public API surface (`@ppt/api-client` exports), so Band B was triggered.

## CI parity (Band C — hot-path only)

Skipped: not a hot-path PR (no security/auth/billing/data-integrity change). Pin/unpin is a content management action gated by manager role at the backend.

## Remote-tested

Skipped (ppt-bridge MCP not connected).

## Notes

- The `AnnouncementsPageRoute` already wired `usePinAnnouncement` correctly (from gap-79-1). This PR completes the detail view.
- Pin button on `AnnouncementCard` (list view) was already functional. Pin button on `ViewAnnouncementPage` was connected only to a toast stub — now calls the real endpoint.
- Backend enforces max-3-pinned-per-org; the frontend surfaces that as a generic "Pin action failed" toast (the error message from the API will propagate via the `fetchJson` error throw).
- `useGetAnnouncement` uses the same `announcementKeys.detail(id)` key as the factory hook, so pin mutations from the list view correctly invalidate the detail view cache.

---
_Generated by [Claude Code](https://claude.ai/code/session_015VC1XpRRuAutwcWxnQvA17)_