### PR TITLE
fix(security): scope mark_as_read to calling realtor — inquiry IDOR

### DIFF
--- a/backend/crates/db/src/repositories/reality_portal.rs
+++ b/backend/crates/db/src/repositories/reality_portal.rs
@@ -772,6 +772,37 @@ impl RealityPortalRepository {
         Ok(())
     }
 
+    /// Mark an inquiry as read, scoped to the calling realtor.
+    ///
+    /// Returns `true` when the inquiry belongs to `realtor_id` (idempotent 204);
+    /// `false` when not found or owned by another realtor (caller returns 404).
+    pub async fn mark_inquiry_read_for_realtor(
+        &self,
+        id: Uuid,
+        realtor_id: Uuid,
+    ) -> Result<bool, SqlxError> {
+        let owned: bool = sqlx::query_scalar::<_, bool>(
+            "SELECT EXISTS(SELECT 1 FROM listing_inquiries WHERE id = $1 AND realtor_id = $2)",
+        )
+        .bind(id)
+        .bind(realtor_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        if !owned {
+            return Ok(false);
+        }
+
+        sqlx::query(
+            "UPDATE listing_inquiries SET status = 'read', read_at = NOW() WHERE id = $1 AND read_at IS NULL",
+        )
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(true)
+    }
+
     /// Respond to inquiry.
     pub async fn respond_to_inquiry(
         &self,

--- a/backend/servers/reality-server/src/routes/inquiries.rs
+++ b/backend/servers/reality-server/src/routes/inquiries.rs
@@ -530,8 +530,11 @@ pub async fn get_inquiry(
             )
         })?;
 
-    // Mark as read if not already
-    let _ = state.reality_portal_repo.mark_inquiry_read(id).await;
+    // Mark as read if not already (ownership already verified above)
+    let _ = state
+        .reality_portal_repo
+        .mark_inquiry_read_for_realtor(id, principal.user_id)
+        .await;
 
     Ok(Json(InquiryDetailResponse {
         inquiry,
@@ -553,16 +556,23 @@ pub async fn get_inquiry(
 )]
 pub async fn mark_as_read(
     State(state): State<AppState>,
-    _principal: RequestPrincipal,
+    principal: RequestPrincipal,
     Path(id): Path<Uuid>,
 ) -> Result<axum::http::StatusCode, (axum::http::StatusCode, String)> {
-    state
+    let owned = state
         .reality_portal_repo
-        .mark_inquiry_read(id)
+        .mark_inquiry_read_for_realtor(id, principal.user_id)
         .await
         .map_err(|e| crate::util::errors::db_error("mark inquiry read", e))?;
 
-    Ok(axum::http::StatusCode::NO_CONTENT)
+    if owned {
+        Ok(axum::http::StatusCode::NO_CONTENT)
+    } else {
+        Err((
+            axum::http::StatusCode::NOT_FOUND,
+            "Inquiry not found".to_string(),
+        ))
+    }
 }
 
 /// Respond to an inquiry.


### PR DESCRIPTION
## Summary

- **IDOR fixed**: `PUT /api/v1/inquiries/{id}/read` previously accepted any authenticated portal user's `realtor_id` as a discard (`_principal`) and updated `listing_inquiries` by bare `id` — any realtor could flip another realtor's inquiry to `read` by UUID enumeration
- **`mark_inquiry_read_for_realtor(id, realtor_id)`** added to `RealityPortalRepository`: ownership verified via `SELECT EXISTS … WHERE id = $1 AND realtor_id = $2` before the UPDATE; returns `bool` so the handler can return 404 on non-owned rows (indistinguishable from not-found)
- **`mark_as_read` handler** updated: `_principal` → `principal`, calls the scoped method, returns 404 when `owned == false`
- **`get_inquiry` side-effect** migrated to the scoped method for defence in depth (ownership was already verified by the preceding `get_inquiry_for_realtor` call — no behaviour change, eliminates the unscoped call)
- **backlog.json**: `security-equipment-idor` marked `done` (already fixed in commit `48a7c39c`); `security-inquiry-read-idor` marked `done` in this commit

## Verified

- `cargo check -p db` — exit 0
- `cargo check -p reality-server` — exit 0
- `cargo clippy -p reality-server -- -D warnings` — exit 0
- `cargo fmt --all -- --check` — exit 0

## Test plan

- [ ] Integration test: realtor B calls `PUT /api/v1/inquiries/{A_inquiry_id}/read` → 404; A's inquiry `read_at` stays NULL
- [ ] Positive path: realtor A marks their own inquiry read → 204; `read_at` set
- [ ] Idempotent: A marks already-read inquiry again → 204 (owned, `read_at IS NOT NULL` skips UPDATE)

https://claude.ai/code/session_012JUp6JdKXHo8UtJ9ckxk5T

---
_Generated by [Claude Code](https://claude.ai/code/session_012JUp6JdKXHo8UtJ9ckxk5T)_