### PR TITLE
gap-82-1-swiftui-audit: SwiftUI iOS project audit + reality-mobile screen maps

### DIFF
--- a/docs/screens/reality-mobile/README.md
+++ b/docs/screens/reality-mobile/README.md
@@ -1,0 +1,41 @@
+# Reality Portal iOS (SwiftUI) — Screen Map
+
+This directory contains screen maps for the SwiftUI iOS app at
+`mobile-native/iosApp/` (bundle ID `three.two.bit.ppt.reality`).
+
+Screen maps here complement the shared `docs/screens/reality/` web screen maps.
+They document iOS-specific implementation status, route bindings, and gaps.
+
+## Epic-82 Screen Coverage
+
+| Screen Map | Component | Story | buildStatus |
+|---|---|---|---|
+| [home.md](home.md) | HomeView | 82.3 | in-progress |
+| [search.md](search.md) | SearchView | 82.3 | in-progress |
+| [listing-detail.md](listing-detail.md) | ListingDetailView | 82.4 | in-progress |
+| [favorites.md](favorites.md) | FavoritesView | 82.4 | in-progress |
+| [inquiries.md](inquiries.md) | InquiriesView | 82.5 | in-progress |
+| [account.md](account.md) | AccountView | 82.5 | in-progress |
+| [auth-login.md](auth-login.md) | LoginView | 82.5 | in-progress |
+| [saved-searches.md](saved-searches.md) | SavedSearchesView | UC-45.2 | in-progress |
+| [compare-listings.md](compare-listings.md) | CompareListingsView | UC-46.5 | in-progress |
+| [realtors.md](realtors.md) | RealtorsView | UC-49.1 | in-progress |
+| [agencies.md](agencies.md) | AgenciesView | UC-51.1 | in-progress |
+
+## Stub Destinations (Routes defined, views not implemented)
+
+| Route | Destination Stub | File to create |
+|---|---|---|
+| Route.listingGallery(id:) | Text("Gallery for listing: \(id)") | Features/Listing/ListingGalleryView.swift |
+| Route.listingMap(id:) | Text("Map for listing: \(id)") | Features/Listing/ListingMapView.swift |
+| Route.inquiryDetail(id:) | Text("Inquiry: \(id)") | Features/Inquiries/InquiryDetailView.swift |
+| Route.newInquiry(listingId:) | Text("New inquiry for: \(listingId)") | Features/Inquiries/NewInquiryView.swift |
+| Route.profile | Text("Edit Profile") | Features/Account/ProfileView.swift |
+| Route.settings | Text("Settings") | Features/Account/SettingsView.swift |
+| Route.register | Text("Register") | Features/Auth/RegisterView.swift |
+| Route.featuredListings | Text("Featured Listings") | Features/Home/FeaturedListingsView.swift |
+| Route.searchResults(query:filters:) | Text("Search Results for: \(query)") | (reuse SearchView with params) |
+
+## Infrastructure Audit Summary
+
+See [gap-82-1-swiftui-audit.md](../../superpowers/plans/gap-82-1-swiftui-audit.md) for full narrative audit.

--- a/docs/screens/reality-mobile/account.md
+++ b/docs/screens/reality-mobile/account.md
@@ -1,0 +1,67 @@
+---
+id: reality-mobile/account
+name: Account (iOS SwiftUI)
+product: reality
+sitemapRefs:
+  reality-web: reality-account
+implementations:
+  ios-swiftui:
+    component: AccountView
+    route: Tab.account / Route.account
+    buildStatus: in-progress
+    redesignStatus: not-started
+    apiStatus: partial
+endpoints:
+  - GET /api/v1/auth/me
+relatedScreens:
+  - id: reality/account
+    rel: web-counterpart
+  - id: reality-mobile/auth-login
+    rel: child
+  - id: reality-mobile/saved-searches
+    rel: child
+  - id: reality-mobile/profile
+    rel: child
+  - id: reality-mobile/settings
+    rel: child
+sharedComponents: []
+diagrams: []
+useCases:
+  - UC-47
+epics:
+  - "82"
+designSources: []
+owner: reality-frontend
+---
+
+## Functionality Checklist
+
+- [x] [m] Tab root requiring auth (Tab.account.requiresAuth = true)
+- [x] [m] Authenticated: avatar initials circle, user name, email
+- [x] [m] Navigation links: Profile (→ Route.profile stub), Saved Searches (→ Route.savedSearches), Settings (→ Route.settings stub)
+- [x] [m] Sign Out button → `authManager.logout()` + reset navigation
+- [x] [m] Unauthenticated: sign-in CTA presenting LoginView sheet
+- [x] [m] App version display (Configuration.shared.fullVersionString)
+- [ ] [m] Profile editing screen (Route.profile destination is stub Text view)
+- [ ] [m] Settings screen (Route.settings destination is stub Text view)
+- [ ] [m] Avatar image upload (not implemented)
+
+## States
+
+- **Authenticated**: User info header + action list + sign-out button.
+- **Unauthenticated**: Centered "sign_in_to_access_account" message + Sign In button.
+
+## Notes
+
+### Broader context
+
+Account tab root. Auth state driven by `AuthManager.isAuthenticated` (`@Observable`, injected via `.environment`). Sign-out calls `AuthManager.logout()` which clears Keychain tokens and KMP SsoService session, then resets `NavigationCoordinator`.
+
+### Specific (recent)
+
+- Profile and Settings routes are registered in `Route.swift` and handled by `NavigationCoordinator` but their destination views are placeholder `Text` views in `MainTabView.destinationView()`.
+- App version sourced from `Bundle.main.infoDictionary` — reads `CFBundleShortVersionString` and `CFBundleVersion`.
+
+## Agent Log
+
+- 2026-05-25 — agent: created screen map from audit of mobile-native/iosApp/iosApp/Features/Account/AccountView.swift (epic-82 story 82.5). Profile/Settings stubs noted.

--- a/docs/screens/reality-mobile/agencies.md
+++ b/docs/screens/reality-mobile/agencies.md
@@ -1,0 +1,66 @@
+---
+id: reality-mobile/agencies
+name: Agencies Directory (iOS SwiftUI)
+product: reality
+sitemapRefs:
+  reality-web: reality-agent-profile
+implementations:
+  ios-swiftui:
+    component: AgenciesView
+    route: Route.agencies (pushed onto searchPath)
+    buildStatus: in-progress
+    redesignStatus: not-started
+    apiStatus: partial
+endpoints:
+  - GET /api/v1/agencies (via AgencyRepository.listAgencies)
+relatedScreens:
+  - id: reality/agent-profile
+    rel: web-counterpart
+  - id: reality-mobile/search
+    rel: parent
+  - id: reality-mobile/realtors
+    rel: sibling
+  - id: reality-mobile/listing-detail
+    rel: child
+sharedComponents: []
+diagrams: []
+useCases:
+  - UC-51
+epics:
+  - "82"
+designSources: []
+owner: reality-frontend
+---
+
+## Functionality Checklist
+
+- [x] [m] Load agencies via `AgencyRepository.listAgencies()`
+- [x] [m] Agency list rows: name, description, realtor count, logo
+- [x] [m] Tap row → navigate to search results filtered by agency (no dedicated agency detail screen)
+- [x] [m] Loading state
+- [x] [m] Empty state
+- [x] [m] Error state
+- [ ] [m] Dedicated agency detail screen (no Route.agencyDetail defined)
+- [ ] [m] Agency branding page (web: agency-branding.md — not on iOS yet)
+
+## States
+
+- **Loading**: ProgressView.
+- **Error**: Error message + Retry.
+- **Empty**: "No agencies found" message.
+- **Success**: List of AgencyRowCard items.
+
+## Notes
+
+### Broader context
+
+UC-51.1 agency directory. Placed under the Search tab by `NavigationCoordinator`. Tapping an agency navigates to `Route.searchResults` filtered by `agencyId` — no dedicated agency profile screen exists on iOS yet. `DependencyContainer.shared.agencyRepository` is wired via KMP `AgencyRepository`.
+
+### Specific (recent)
+
+- No `Route.agencyDetail` in `Route.swift` — post-epic-82 follow-up needed.
+- `AgencyRepository.listAgencies()` maps to `shared.AgenciesResponse`.
+
+## Agent Log
+
+- 2026-05-25 — agent: created screen map from audit of mobile-native/iosApp/iosApp/Features/Agencies/AgenciesView.swift (UC-51.1). Missing agency-detail route noted.

--- a/docs/screens/reality-mobile/auth-login.md
+++ b/docs/screens/reality-mobile/auth-login.md
@@ -1,0 +1,69 @@
+---
+id: reality-mobile/auth-login
+name: Login (iOS SwiftUI)
+product: reality
+sitemapRefs:
+  reality-web: reality-auth-login
+implementations:
+  ios-swiftui:
+    component: LoginView
+    route: Route.login (sheet presentation from MainTabView / AccountView)
+    buildStatus: in-progress
+    redesignStatus: not-started
+    apiStatus: partial
+endpoints:
+  - POST /api/v1/auth/sso/validate (via KMP SsoService.validateAndLogin)
+relatedScreens:
+  - id: reality/auth-login
+    rel: web-counterpart
+  - id: reality-mobile/account
+    rel: parent
+  - id: reality-mobile/auth-register
+    rel: sibling
+sharedComponents: []
+diagrams: []
+useCases:
+  - UC-47
+epics:
+  - "82"
+designSources: []
+owner: reality-frontend
+---
+
+## Functionality Checklist
+
+- [x] [m] SSO login button — opens propertymanagement:// deep link URL scheme with callback
+- [x] [m] Email/password fields with show/hide password toggle
+- [x] [m] Form validation (email contains @, password non-empty) gating Login button
+- [x] [m] ProgressView overlay while loading
+- [x] [m] Error banner with warning icon on auth failure
+- [x] [m] "Forgot password" button (placeholder, no action wired)
+- [x] [m] Register link → Route.register
+- [x] [m] Cancel toolbar button → dismiss sheet
+- [x] [m] Pending destination consumed after successful login
+- [ ] [m] Register screen (Route.register destination is stub Text view in MainTabView)
+- [ ] [m] Forgot password flow (not implemented)
+- [ ] [m] Email/password login always throws ssoRequired error (Reality Portal is SSO-only)
+
+## States
+
+- **Idle**: SSO button + divider + email/password form.
+- **Loading**: ProgressView shown in Login button.
+- **Error**: Error banner displayed below form.
+- **Success**: Sheet dismissed; pending navigation consumed.
+
+## Notes
+
+### Broader context
+
+Presented as a sheet from `MainTabView.handleTabChange()` when an unauthenticated user taps an auth-gated tab (Favorites, Inquiries, Account). Also navigable via `Route.login` pushed onto `accountPath`. Reality Portal is SSO-only — email/password `login()` always throws `AuthError.ssoRequired`. The email form is UI-complete for potential future direct login.
+
+### Specific (recent)
+
+- SSO initiates by opening `propertymanagement://sso?callback=realityportal://sso`. The Property Management app must be installed; no fallback if not installed.
+- Token return flow: PM app redirects to `realityportal://sso?token=<token>` → handled by `RealityPortalApp.handleIncomingURL()` → `AuthManager.loginWithSsoToken()`.
+- Localization strings use `String(localized:)` — keys: `sign_in`, `welcome_to_reality_portal`, `sign_in_description`, `sign_in_with_pm`, `sso_description`, `or`, `email`, `password`, `forgot_password`, `no_account_prompt`, `create_account`.
+
+## Agent Log
+
+- 2026-05-25 — agent: created screen map from audit of mobile-native/iosApp/iosApp/Features/Auth/LoginView.swift (epic-82 story 82.5). SSO-only constraint and missing register/forgot-password flows noted.

--- a/docs/screens/reality-mobile/compare-listings.md
+++ b/docs/screens/reality-mobile/compare-listings.md
@@ -1,0 +1,64 @@
+---
+id: reality-mobile/compare-listings
+name: Compare Listings (iOS SwiftUI)
+product: reality
+sitemapRefs:
+  reality-web: reality-compare-properties
+implementations:
+  ios-swiftui:
+    component: CompareListingsView
+    route: Route.compareListings(ids:)
+    buildStatus: in-progress
+    redesignStatus: not-started
+    apiStatus: partial
+endpoints:
+  - GET /api/v1/listings/{id} (called for each listing ID)
+relatedScreens:
+  - id: reality/compare-properties
+    rel: web-counterpart
+  - id: reality-mobile/listing-detail
+    rel: parent
+  - id: reality-mobile/favorites
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases:
+  - UC-46
+epics:
+  - "82"
+designSources: []
+owner: reality-frontend
+---
+
+## Functionality Checklist
+
+- [x] [m] Accept `listingIds: [String]` parameter
+- [x] [m] Load each listing detail via KMP `listingRepository.getListingById(id:)`
+- [x] [m] Horizontally-scrollable comparison grid: price, area, rooms, bathrooms per listing
+- [x] [m] Column per listing with header (title + thumbnail)
+- [x] [m] Tap listing column → Route.listingDetail(id:)
+- [x] [m] Loading state
+- [x] [m] Error state (if any listing fails to load)
+- [ ] [m] Add/remove listings from compare set (UI for selection not implemented in this view)
+- [ ] [m] Maximum listing count enforcement (no cap currently)
+
+## States
+
+- **Loading**: ProgressView while listings load in parallel.
+- **Error**: Error message for listings that failed to load (partial failure shows loaded ones).
+- **Success**: Horizontal scroll grid comparing loaded listings.
+
+## Notes
+
+### Broader context
+
+UC-46.5 cross-tab feature. `NavigationCoordinator.navigate(to: .compareListings)` appends to `currentPath` (whatever tab the user is in), preserving tab context. Listing IDs collected by caller (ListingDetailView's "Compare" button).
+
+### Specific (recent)
+
+- Route carries listing IDs as associated value `[String]` — comparison set is stateless per navigation push.
+- Loading uses `async let` / `await` parallel fetch for all listing IDs.
+
+## Agent Log
+
+- 2026-05-25 — agent: created screen map from audit of mobile-native/iosApp/iosApp/Features/CompareListings/CompareListingsView.swift (UC-46.5). Add/remove UI gap noted.

--- a/docs/screens/reality-mobile/favorites.md
+++ b/docs/screens/reality-mobile/favorites.md
@@ -1,0 +1,68 @@
+---
+id: reality-mobile/favorites
+name: Favorites (iOS SwiftUI)
+product: reality
+sitemapRefs:
+  reality-web: reality-favorites
+implementations:
+  ios-swiftui:
+    component: FavoritesView
+    route: Tab.favorites / Route.favorites
+    buildStatus: in-progress
+    redesignStatus: not-started
+    apiStatus: partial
+endpoints:
+  - GET /api/v1/favorites
+  - DELETE /api/v1/favorites/{id}
+relatedScreens:
+  - id: reality/favorites
+    rel: web-counterpart
+  - id: reality-mobile/listing-detail
+    rel: child
+  - id: reality-mobile/saved-searches
+    rel: sibling
+sharedComponents: []
+diagrams: []
+useCases:
+  - UC-44
+epics:
+  - "82"
+designSources: []
+owner: reality-frontend
+---
+
+## Functionality Checklist
+
+- [x] [m] Tab bar root screen requiring auth (Tab.favorites.requiresAuth = true)
+- [x] [m] Load favorites via KMP `favoritesRepository.getFavorites()`
+- [x] [m] Listing cards with Remove button
+- [x] [m] Tap card → Route.listingDetail(id:)
+- [x] [m] Remove favorite → `favoritesRepository.removeFavorite(id:)`
+- [x] [m] Loading state (ProgressView)
+- [x] [m] Empty state (heart icon + "no_favorites" + Browse button → Tab.search)
+- [x] [m] Error state (warning icon + message + Retry)
+- [ ] [m] Compare selected listings (Route.compareListings — button not present in FavoritesView)
+- [ ] [m] Sort/filter tabs (All / Sale / Rent as in web version)
+- [ ] [m] Share / Export list (web feature not implemented on iOS)
+
+## States
+
+- **Loading**: ProgressView centered in 200pt frame.
+- **Error**: Warning icon + message + Retry button.
+- **Empty**: Heart SF symbol + "no_favorites" text + "Browse properties" button switching to search tab.
+- **Success**: List of FavoriteListingCard rows.
+
+## Notes
+
+### Broader context
+
+Auth-gated tab (favorites, inquiries, account all require auth). When unauthenticated user taps the tab, `MainTabView.handleTabChange()` stores `pendingDestination = .favorites`, presents `LoginView` as sheet, reverts to previous tab. After successful SSO login, `pendingDestination` is consumed and navigation proceeds.
+
+### Specific (recent)
+
+- `FavoritesView` maps `KMP FavoritesResponse.favorites` → `[FavoriteEntry]` then to local `FavoriteItem` struct.
+- Remove action calls `removeFavorite` and refreshes the list; no optimistic removal yet.
+
+## Agent Log
+
+- 2026-05-25 — agent: created screen map from audit of mobile-native/iosApp/iosApp/Features/Favorites/FavoritesView.swift (epic-82 story 82.4). Compare/sort gaps noted.

--- a/docs/screens/reality-mobile/home.md
+++ b/docs/screens/reality-mobile/home.md
@@ -1,0 +1,77 @@
+---
+id: reality-mobile/home
+name: Home (iOS SwiftUI)
+product: reality
+sitemapRefs:
+  reality-web: reality-home
+implementations:
+  ios-swiftui:
+    component: HomeView
+    route: Tab.home / Route.home
+    buildStatus: in-progress
+    redesignStatus: not-started
+    apiStatus: partial
+endpoints:
+  - GET /api/v1/listings/featured
+  - GET /api/v1/listings/recent
+relatedScreens:
+  - id: reality/home
+    rel: web-counterpart
+  - id: reality-mobile/search
+    rel: sibling
+  - id: reality-mobile/listing-detail
+    rel: child
+sharedComponents:
+  - FeaturedListingCard
+  - ListingRowCard
+  - CategoryChip
+  - SectionHeader
+diagrams: []
+useCases:
+  - UC-31
+  - UC-44
+epics:
+  - "82"
+designSources: []
+owner: reality-frontend
+---
+
+## Functionality Checklist
+
+- [x] [m] Tab bar root screen (Tab.home)
+- [x] [m] Search bar button tap → switches to search tab
+- [x] [m] Horizontal category chip strip (For sale / For rent / Apartments / Houses / Land)
+- [x] [m] Featured listings horizontal carousel with FeaturedListingCard (4:3 photo, FEATURED badge, price, title, location, rooms/sqm)
+- [x] [m] Recent listings vertical list with ListingRowCard (thumbnail, price, title, location)
+- [x] [m] "View all" button → switches to search tab
+- [x] [m] Pull-to-refresh
+- [x] [m] Async data load via KMP ListingRepository.getFeaturedListings / getRecentListings
+- [x] [m] Loading state (ProgressView + localized text)
+- [x] [m] Error state (warning icon + message + Retry button)
+- [x] [m] Empty state ("no listings available" message when both lists empty)
+- [x] [m] Toolbar: authenticated → Inquiries / Favorites / Account icons; unauthenticated → Sign In button
+- [ ] [m] Category chip filter navigation not wired (chips have placeholder closures)
+- [ ] [m] No SectionHeader "See all" links wired to filtered search results
+
+## States
+
+- **Loading**: ProgressView centered in 200pt frame.
+- **Error**: Warning icon + error message string + Retry button, 200pt frame.
+- **Empty**: errorMessage set to "no_listings_available" string (reuses error view).
+- **Success**: Featured carousel + recent list displayed.
+
+## Notes
+
+### Broader context
+
+Root tab screen of Reality Portal iOS. Uses KMP `ListingRepository` (via `DependencyContainer.shared.listingRepository`) for data. Reads `shared.ListingSummary` and maps to Swift `ListingPreview` via `KMPBridge.toListingPreview()`. Component mirrors KmpHomeScreen on Android but with SwiftUI patterns.
+
+### Specific (recent)
+
+- Category chips currently have empty closures — navigation to filtered search not yet wired (post-epic-82 task).
+- AsyncImage used for thumbnails with graceful fallback to `photo` SF symbol.
+- `ListingPreview.sampleFeatured/sampleRecent` arrays are `#if DEBUG` guarded — not in production builds.
+
+## Agent Log
+
+- 2026-05-25 — agent: created screen map from audit of mobile-native/iosApp/iosApp/Features/Home/HomeView.swift (epic-82 story 82.3). NavigationCoordinator integration confirmed. Category chip actions unimplemented.

--- a/docs/screens/reality-mobile/inquiries.md
+++ b/docs/screens/reality-mobile/inquiries.md
@@ -1,0 +1,70 @@
+---
+id: reality-mobile/inquiries
+name: Inquiries (iOS SwiftUI)
+product: reality
+sitemapRefs:
+  reality-web: reality-inquiries
+implementations:
+  ios-swiftui:
+    component: InquiriesView
+    route: Tab.inquiries / Route.inquiries
+    buildStatus: in-progress
+    redesignStatus: not-started
+    apiStatus: partial
+endpoints:
+  - GET /api/v1/inquiries
+  - GET /api/v1/inquiries/{id}
+  - POST /api/v1/inquiries
+relatedScreens:
+  - id: reality/inquiries
+    rel: web-counterpart
+  - id: reality-mobile/listing-detail
+    rel: sibling
+  - id: reality-mobile/account
+    rel: sibling
+sharedComponents: []
+diagrams: []
+useCases:
+  - UC-46
+epics:
+  - "82"
+designSources: []
+owner: reality-frontend
+---
+
+## Functionality Checklist
+
+- [x] [m] Tab root screen requiring auth (Tab.inquiries.requiresAuth = true)
+- [x] [m] Load inquiries via KMP `inquiryRepository.getInquiries()`
+- [x] [m] Inquiry list rows: listing title, last message, status badge, date
+- [x] [m] Status badges: Pending (warning), Replied (success), Closed (neutral)
+- [x] [m] Tap row → Route.inquiryDetail(id:) — navigates to stub detail
+- [x] [m] Loading state
+- [x] [m] Empty state (envelope icon + "no_inquiries" + Browse button)
+- [x] [m] Error state
+- [x] [m] Badge count on tab bar driven by NavigationCoordinator.inquiriesBadgeCount
+- [ ] [m] InquiryDetail full screen (Route.inquiryDetail destination is stub Text view in MainTabView)
+- [ ] [m] Real-time updates / WebSocket for new replies (not implemented)
+- [ ] [m] New Inquiry creation form (Route.newInquiry destination is stub Text view)
+
+## States
+
+- **Loading**: ProgressView centered.
+- **Error**: Warning icon + message + Retry.
+- **Empty**: Envelope SF symbol + "no_inquiries" + "Browse properties" CTA.
+- **Success**: List of InquiryRowCard items.
+
+## Notes
+
+### Broader context
+
+Auth-gated tab. Maps KMP `Inquiry` → Swift `InquiryPreview` via `KMPBridge.toInquiryPreview()`. Badge count (`inquiriesBadgeCount` on `NavigationCoordinator`) is currently not auto-updated; would require background polling or WebSocket (UC-19 real-time feature).
+
+### Specific (recent)
+
+- `Route.inquiryDetail` and `Route.newInquiry` are handled in `NavigationCoordinator.navigate()` and appended to `inquiriesPath`, but `MainTabView.destinationView()` renders them as placeholder `Text` views.
+- `InquiryStatus` Swift typealias maps from KMP `shared.InquiryStatus` enum (pending/responded/closed).
+
+## Agent Log
+
+- 2026-05-25 — agent: created screen map from audit of mobile-native/iosApp/iosApp/Features/Inquiries/InquiriesView.swift (epic-82 story 82.5). Detail and newInquiry stubs noted.

--- a/docs/screens/reality-mobile/listing-detail.md
+++ b/docs/screens/reality-mobile/listing-detail.md
@@ -1,0 +1,80 @@
+---
+id: reality-mobile/listing-detail
+name: Listing Detail (iOS SwiftUI)
+product: reality
+sitemapRefs:
+  reality-web: reality-listing-detail
+implementations:
+  ios-swiftui:
+    component: ListingDetailView
+    route: Route.listingDetail(id:)
+    buildStatus: in-progress
+    redesignStatus: not-started
+    apiStatus: partial
+endpoints:
+  - GET /api/v1/listings/{id}
+  - POST /api/v1/favorites
+  - DELETE /api/v1/favorites/{id}
+relatedScreens:
+  - id: reality/listing-detail
+    rel: web-counterpart
+  - id: reality-mobile/home
+    rel: parent
+  - id: reality-mobile/search
+    rel: parent
+  - id: reality-mobile/favorites
+    rel: sibling
+  - id: reality-mobile/compare-listings
+    rel: child
+sharedComponents:
+  - AsyncImage
+diagrams: []
+useCases:
+  - UC-31
+  - UC-44
+  - UC-46
+epics:
+  - "82"
+designSources: []
+owner: reality-frontend
+---
+
+## Functionality Checklist
+
+- [x] [m] Load listing detail via KMP `listingRepository.getListingById(id:)`
+- [x] [m] Photo gallery horizontal scroll (AsyncImage with fallback)
+- [x] [m] Price (formatted currency), title, address display
+- [x] [m] Area sqm, rooms, bathrooms, floor metrics row
+- [x] [m] Amenities list
+- [x] [m] Agent info section (name, phone)
+- [x] [m] Map section (latitude/longitude if available)
+- [x] [m] Favorite toggle button (heart icon, Route.favorites integration)
+- [x] [m] "Contact Agent" button → Route.newInquiry(listingId:)
+- [x] [m] "Compare" button → Route.compareListings(ids:)
+- [x] [m] Share button (system share sheet)
+- [x] [m] Loading state (ProgressView in NavigationStack)
+- [x] [m] Error state with retry
+- [ ] [m] Full-screen photo gallery (Route.listingGallery in Route enum, NavigationCoordinator case handled, but destination is stub Text view)
+- [ ] [m] Map full-screen expansion (Route.listingMap destination is stub Text view)
+- [ ] [m] Price history chart (not implemented)
+
+## States
+
+- **Loading**: ProgressView while detail fetched.
+- **Error**: Error message + Retry button.
+- **Success**: Full listing content scrollable.
+
+## Notes
+
+### Broader context
+
+Detail view accessible from HomeView (featured/recent cards), SearchView (search results), FavoritesView (saved items). Accepts `listingId: String` parameter. Maps KMP `ListingDetail` → Swift `ListingDetailModel` via `KMPBridge.toListingDetail()`.
+
+### Specific (recent)
+
+- Favorite toggle calls `favoritesRepository.addFavorite` / `removeFavorite` via `DependencyContainer.shared.favoritesRepository`. No optimistic update currently — state refreshed after server response.
+- `Route.listingGallery` and `Route.listingMap` are registered in both `Route.swift` and `NavigationCoordinator.navigate()` but destination views in `MainTabView.destinationView()` are stub `Text` placeholders.
+
+## Agent Log
+
+- 2026-05-25 — agent: created screen map from audit of mobile-native/iosApp/iosApp/Features/Listing/ListingDetailView.swift (epic-82 story 82.4). Gallery and map stub gaps noted.

--- a/docs/screens/reality-mobile/realtors.md
+++ b/docs/screens/reality-mobile/realtors.md
@@ -1,0 +1,64 @@
+---
+id: reality-mobile/realtors
+name: Realtors Directory (iOS SwiftUI)
+product: reality
+sitemapRefs:
+  reality-web: reality-realtor
+implementations:
+  ios-swiftui:
+    component: RealtorsView
+    route: Route.realtors (pushed onto searchPath)
+    buildStatus: in-progress
+    redesignStatus: not-started
+    apiStatus: partial
+endpoints:
+  - GET /api/v1/agencies (derived list via AgencyRepository)
+relatedScreens:
+  - id: reality/realtor
+    rel: web-counterpart
+  - id: reality-mobile/search
+    rel: parent
+  - id: reality-mobile/agencies
+    rel: sibling
+sharedComponents: []
+diagrams: []
+useCases:
+  - UC-49
+epics:
+  - "82"
+designSources: []
+owner: reality-frontend
+---
+
+## Functionality Checklist
+
+- [x] [m] Load realtors derived from agency tree via `AgencyRepository.listAgencies()`
+- [x] [m] Realtor list rows: name, agency name, contact info
+- [x] [m] Tap row → navigate to listings filtered by realtor (search tab with agent filter)
+- [x] [m] Loading state
+- [x] [m] Empty state
+- [x] [m] Error state
+- [ ] [m] Dedicated realtor profile screen (Route.realtors navigates to search — no dedicated realtor detail)
+- [ ] [m] reality-server `/realtors` directory endpoint not available; data derived from agency tree workaround
+
+## States
+
+- **Loading**: ProgressView.
+- **Error**: Error message + Retry.
+- **Empty**: "No realtors found" message.
+- **Success**: List of realtor rows.
+
+## Notes
+
+### Broader context
+
+UC-49.1 realtor directory. `NavigationCoordinator.navigate(to: .realtors)` places this under the Search tab. reality-server exposes only `/realtors/profile` (own profile) and `/realtors/{user_id}/profile` (individual lookup), not a directory listing endpoint — so this view derives realtors from the agency tree (lists agencies → extracts realtors).
+
+### Specific (recent)
+
+- This is a known API gap: a `GET /api/v1/realtors` directory endpoint is missing. Workaround sources realtors from agency data. Follow-up needed in reality-server.
+- `NavigationCoordinator` places `.realtors` and `.agencies` under the Search tab so user can switch between "search by listing" and "search by realtor/agency".
+
+## Agent Log
+
+- 2026-05-25 — agent: created screen map from audit of mobile-native/iosApp/iosApp/Features/Realtors/RealtorsView.swift (UC-49.1). API gap (no directory endpoint) documented.

--- a/docs/screens/reality-mobile/saved-searches.md
+++ b/docs/screens/reality-mobile/saved-searches.md
@@ -1,0 +1,67 @@
+---
+id: reality-mobile/saved-searches
+name: Saved Searches (iOS SwiftUI)
+product: reality
+sitemapRefs:
+  reality-web: reality-saved-searches
+implementations:
+  ios-swiftui:
+    component: SavedSearchesView
+    route: Route.savedSearches (pushed onto accountPath)
+    buildStatus: in-progress
+    redesignStatus: not-started
+    apiStatus: partial
+endpoints:
+  - GET /api/v1/saved-searches (via FavoritesRepository.getSavedSearches)
+  - PATCH /api/v1/saved-searches/{id} (toggle alerts)
+  - DELETE /api/v1/saved-searches/{id}
+relatedScreens:
+  - id: reality/saved-searches
+    rel: web-counterpart
+  - id: reality-mobile/account
+    rel: parent
+  - id: reality-mobile/search
+    rel: sibling
+sharedComponents: []
+diagrams: []
+useCases:
+  - UC-45
+epics:
+  - "82"
+designSources: []
+owner: reality-frontend
+---
+
+## Functionality Checklist
+
+- [x] [m] Load saved searches via `FavoritesRepository.getSavedSearches()`
+- [x] [m] List of saved-search rows: name, filter summary, alert toggle
+- [x] [m] Alert toggle → `FavoritesRepository.toggleSavedSearchAlert(id:enabled:)`
+- [x] [m] Delete saved search (swipe-to-delete or button) → `FavoritesRepository.deleteSavedSearch(id:)`
+- [x] [m] Loading state
+- [x] [m] Empty state (magnifying-glass icon + "no_saved_searches" message)
+- [x] [m] Error state
+- [ ] [m] Navigate to search results from saved search (not implemented — no route from SavedSearch to SearchView with pre-filled filters)
+- [ ] [m] Create saved search from current search (would be triggered from SearchView — not wired)
+
+## States
+
+- **Loading**: ProgressView.
+- **Error**: Warning icon + message + Retry.
+- **Empty**: Magnifying-glass SF symbol + "no_saved_searches" + description.
+- **Success**: List of SavedSearchRow items with name, filter chips, and alert toggle.
+
+## Notes
+
+### Broader context
+
+UC-45.2 — user's personal saved searches with alert notifications. Navigated to via `Route.savedSearches` which `NavigationCoordinator` places under the Account tab stack. Feature parity with the Android `SavedSearchesScreen` composable.
+
+### Specific (recent)
+
+- Accessible from AccountView's navigation list; also navigable via deep link `realityportal://account/saved-searches`.
+- Alert toggle fires async KMP call and updates list in-place on success.
+
+## Agent Log
+
+- 2026-05-25 — agent: created screen map from audit of mobile-native/iosApp/iosApp/Features/SavedSearches/SavedSearchesView.swift (UC-45.2). Launch-from-saved-search gap noted.

--- a/docs/screens/reality-mobile/search.md
+++ b/docs/screens/reality-mobile/search.md
@@ -1,0 +1,75 @@
+---
+id: reality-mobile/search
+name: Search (iOS SwiftUI)
+product: reality
+sitemapRefs:
+  reality-web: reality-listings
+implementations:
+  ios-swiftui:
+    component: SearchView
+    route: Tab.search / Route.search
+    buildStatus: in-progress
+    redesignStatus: not-started
+    apiStatus: partial
+endpoints:
+  - POST /api/v1/listings/search
+relatedScreens:
+  - id: reality/listings
+    rel: web-counterpart
+  - id: reality-mobile/home
+    rel: sibling
+  - id: reality-mobile/listing-detail
+    rel: child
+  - id: reality-mobile/realtors
+    rel: sibling
+  - id: reality-mobile/agencies
+    rel: sibling
+sharedComponents:
+  - FilterSheet
+  - ListingRowCard
+diagrams: []
+useCases:
+  - UC-31
+  - UC-45
+epics:
+  - "82"
+designSources: []
+owner: reality-frontend
+---
+
+## Functionality Checklist
+
+- [x] [m] Search bar with text input (300ms debounce on change)
+- [x] [m] Filter bar (price range, property types, rooms, radius, location via SearchFilters)
+- [x] [m] "Show Filters" sheet presentation (FilterSheet)
+- [x] [m] Paginated search results grid
+- [x] [m] Loading state (ProgressView in 300pt frame)
+- [x] [m] Empty results state ("no_results" + "try_different_search")
+- [x] [m] Search prompt state when no query entered
+- [x] [m] Tap card → navigate to Route.listingDetail(id:)
+- [ ] [m] Horizontal scroll categories on search screen (mentioned in comments, not implemented)
+- [ ] [m] Sort order selector (not yet implemented)
+- [ ] [m] Map view toggle (Route.listingMap mentioned in Route enum but SearchView has no map toggle)
+
+## States
+
+- **Prompt**: centered "search_prompt" icon + message displayed before first search.
+- **Loading**: ProgressView while results.isEmpty and isLoading.
+- **Empty results**: magnifying-glass icon + "no_results" heading + "try_different_search" body.
+- **Success**: paginated LazyVGrid of ListingRowCards.
+
+## Notes
+
+### Broader context
+
+Search tab root. Calls `listingRepository.searchListings(request:)` via KMP. Pagination with `currentPage`/`totalPages`. Filter sheet modal (`FilterSheet`) collects `SearchFilters` struct and triggers new search.
+
+### Specific (recent)
+
+- Debounce implemented with `Task.sleep(nanoseconds: 300_000_000)` — checks if `searchText` still matches after sleep.
+- `FilterSheet` is defined inline in SearchView.swift — not a separate file.
+- `Route.searchResults(query:filters:)` is registered in NavigationCoordinator but SearchView itself is a tab root, not accessed via navigation push.
+
+## Agent Log
+
+- 2026-05-25 — agent: created screen map from audit of mobile-native/iosApp/iosApp/Features/Search/SearchView.swift (epic-82 story 82.3). Sort and map-toggle gaps noted.

--- a/docs/superpowers/plans/gap-82-1-swiftui-audit.md
+++ b/docs/superpowers/plans/gap-82-1-swiftui-audit.md
@@ -1,0 +1,232 @@
+# Gap 82-1: SwiftUI Reality Portal — Project Structure Audit
+
+**Date:** 2026-05-25
+**Task ID:** gap-82-1-swiftui-audit
+**Specialist:** ios-swiftui
+**Branch:** auto-impl/gap-82-1-swiftui-audit
+
+---
+
+## Executive Summary
+
+Epic-82 SwiftUI iOS project (`mobile-native/iosApp/`) is substantially complete
+for its 5 stories. All tab screens, navigation infrastructure, auth integration,
+and KMP bridge are implemented. 9 route destination views remain as stub `Text`
+placeholders in `MainTabView.destinationView()`. Screen maps created in
+`docs/screens/reality-mobile/` for all 11 implemented screens.
+
+---
+
+## NavigationCoordinator Audit
+
+**File:** `mobile-native/iosApp/iosApp/Core/Navigation/NavigationCoordinator.swift`
+
+### Implementation
+
+- Uses Swift 5.9 `@Observable` macro (not `ObservableObject`) — correct for iOS 17+.
+- Injected via `.environment(navigationCoordinator)` at app root; consumed with
+  `@Environment(NavigationCoordinator.self)` in all views — correct pattern.
+- `Tab` enum (5 cases: home, search, favorites, inquiries, account) with:
+  - `icon` (SF Symbol names)
+  - `title` (raw strings — not localized; minor gap)
+  - `requiresAuth` flag
+
+### Per-Tab NavigationPath
+
+One `NavigationPath` per tab (`homePath`, `searchPath`, `favoritesPath`,
+`inquiriesPath`, `accountPath`). `navigate(to:)` switches tabs and appends to
+the correct path. `pop()` / `popToRoot()` / `reset()` all correctly scoped.
+
+### Cross-Tab Route Placement
+
+| Route | Tab Placement | Rationale |
+|---|---|---|
+| `.listingDetail/.listingGallery/.listingMap` | Current tab (via `currentPath`) | Multi-context access |
+| `.compareListings` | Current tab | Cross-tab feature |
+| `.savedSearches` | Account tab | Personal data proximity |
+| `.realtors/.agencies` | Search tab | Search-mode pivot |
+| `.login/.register` | Account tab path | Auth stack |
+
+Assessment: Placement rationale is sound and matches Android KMP `AppNavigation`.
+
+### Deep Link Handling
+
+Custom scheme `realityportal://` and universal links parsed in
+`parseDeepLink(_:)`. Handles: `listing/<id>`, `search?q=`, `favorites`,
+`inquiries/<id>`, `account`, and SSO callback (`sso?token=`). SSO callback
+delegated to `RealityPortalApp.handleSsoCallback()`. Coverage is adequate for
+epic-82 scope.
+
+### Known Issue
+
+`path(for:)` returns a copy of the `NavigationPath` value, not a binding. This
+is correct for reading but the `@Bindable` workaround in `MainTabView` is
+needed to get a `$coordinator.homePath` binding — which is correctly done.
+
+---
+
+## Auth Guard Implementation
+
+**File:** `mobile-native/iosApp/iosApp/Core/AuthManager.swift`
+
+### Token Storage
+
+- Access token and refresh token stored in iOS Keychain via
+  `SecItemAdd`/`SecItemCopyMatching` with `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`.
+- Never `UserDefaults` — correct per specialist conventions.
+- Keychain service key = bundle ID (`three.two.bit.ppt.reality`).
+
+### SSO Flow
+
+1. User taps SSO button in `LoginView` → opens `propertymanagement://sso?callback=realityportal://sso`.
+2. PM app redirects back to `realityportal://sso?token=<token>`.
+3. `RealityPortalApp.handleIncomingURL()` detects SSO host → `loginWithSsoToken(_:)`.
+4. KMP `SsoService.validateAndLogin(ssoToken:)` validates token with reality-server.
+5. Session token stored to Keychain; `currentUser` set from `SsoUserInfo`.
+6. `pendingDestination` consumed and navigation proceeds.
+
+### Session Restoration
+
+`restoreSession()` called on `configureApp()`. Loads token from Keychain →
+calls `SsoService.restoreSession(token:)` → if valid, calls `getSession()` to
+reconstruct `currentUser`.
+
+### Auth Guard (MainTabView)
+
+`handleTabChange(from:to:)` checks `newTab.requiresAuth && !authManager.isAuthenticated`:
+- Stores `coordinator.pendingDestination = routeForTab(newTab)`.
+- Presents `LoginView` as sheet.
+- Reverts `coordinator.selectedTab = oldTab`.
+
+Assessment: Guard logic is correct and handles the SSO pending-destination
+pattern properly.
+
+### Gaps
+
+- `AuthManager.refreshAccessToken()` stores a placeholder `User` from refresh
+  response that lacks `avatarUrl` (maps `result.userId/email/name` directly).
+  The `SsoService.refreshSession()` KMP method's return type may not expose all
+  fields — follow-up needed.
+- Email/password `login()` always throws `AuthError.ssoRequired`. The form is
+  present as UI-only future extension.
+
+---
+
+## Project Setup Verification (Story 82.1)
+
+### Bundle Configuration
+
+- **Bundle ID:** `three.two.bit.ppt.reality` (all configurations)
+  - Dev override: `three.two.bit.ppt.reality.dev`
+- **Min OS:** iOS 15.0 (`IPHONEOS_DEPLOYMENT_TARGET = 15.0`)
+- **Architectures:** `arm64` only
+
+### xcconfig Structure
+
+4 files covering all environments:
+- `Base.xcconfig` — shared product/compiler settings
+- `Development.xcconfig` — localhost:8081, logging, `.dev` suffix
+- `Staging.xcconfig` — staging endpoints
+- `Production.xcconfig` — production endpoints
+
+### Info.plist
+
+Tokens present: `API_BASE_URL`, `ENVIRONMENT`, `ENABLE_LOGGING` (all `$(VAR)`
+expansions from xcconfig). URL scheme `realityportal://` registered.
+Location, camera, photo library usage descriptions present.
+
+### Localization
+
+6 locales: `sk.lproj`, `cs.lproj`, `de.lproj`, `en.lproj`, `hu.lproj`, `pl.lproj`.
+All string keys use `String(localized:)` in Swift — correct pattern.
+
+### @main Entry Point
+
+`RealityPortalApp` uses SwiftUI App protocol. Injects `NavigationCoordinator`
+and `AuthManager` as `@State` (persists through scene lifecycle).
+
+---
+
+## Screen Coverage vs Epic-82 Scope
+
+### Stories Mapped
+
+| Story | Description | Screens | Status |
+|---|---|---|---|
+| 82.1 | SwiftUI Project Setup | App infra (not a screen) | Complete |
+| 82.2 | Navigation and Routing | NavigationCoordinator | Complete |
+| 82.3 | Home and Search Screens | HomeView, SearchView | In-progress |
+| 82.4 | Listing Detail and Favorites | ListingDetailView, FavoritesView | In-progress |
+| 82.5 | Inquiries and Account | InquiriesView, AccountView, LoginView | In-progress |
+
+### Beyond Epic-82 (also implemented)
+
+- SavedSearchesView (UC-45.2)
+- CompareListingsView (UC-46.5)
+- RealtorsView (UC-49.1)
+- AgenciesView (UC-51.1)
+
+### Stub Destinations (9 routes have no real view)
+
+| Route | Stub | Priority |
+|---|---|---|
+| `listingGallery(id:)` | Text placeholder | High — linked from ListingDetailView |
+| `listingMap(id:)` | Text placeholder | High — linked from ListingDetailView |
+| `inquiryDetail(id:)` | Text placeholder | High — core inquiry flow |
+| `newInquiry(listingId:)` | Text placeholder | High — core contact flow |
+| `profile` | Text placeholder | Medium |
+| `settings` | Text placeholder | Medium |
+| `register` | Text placeholder | Low (SSO-only currently) |
+| `featuredListings` | Text placeholder | Low |
+| `searchResults(query:filters:)` | Text placeholder | Medium (used for deep links) |
+
+---
+
+## Architecture Findings
+
+### Positive
+
+1. `@Observable` used correctly throughout — no mixing with `ObservableObject`.
+2. Keychain correctly used for all token storage.
+3. KMP bridge (`KMPBridge` enum, `DependencyContainer`) cleanly separates KMP
+   types from SwiftUI models.
+4. `async/await` throughout, no completion-handler nesting.
+5. `#if DEBUG` guards on sample data — production builds are clean.
+6. `@discardableResult` on `handleDeepLink` — correct.
+
+### Issues / Gaps
+
+1. **Tab titles not localized** — `Tab.title` returns raw English strings. Should
+   use `String(localized:)` or `LocalizedStringKey` for full i18n support.
+2. **Category chip actions unimplemented** — `HomeView.categoryFilters` has empty
+   closures on all chips. No navigation to filtered search happens on tap.
+3. **No optimistic UI on favorites/inquiries** — state refreshed after server
+   round-trip; visible lag on slow connections.
+4. **`DependencyContainer` uses unauthenticated repositories by default** — lazy
+   vars don't inject session tokens. Views use separate `make*` factory methods
+   for authenticated operations, which is inconsistent.
+5. **`NavigationCoordinator.path(for:)` returns value copy** — this is a
+   documentation/naming issue only (it's used correctly); but could confuse
+   future contributors.
+6. **`SsoService` instantiated twice** — once in `AuthManager` (own field) and
+   once in `DependencyContainer.shared.ssoService`. These are separate instances;
+   session state may diverge.
+
+---
+
+## Screen Maps Created
+
+All under `docs/screens/reality-mobile/`:
+
+- `README.md` — index and stub-destination table
+- `home.md`
+- `search.md`
+- `listing-detail.md`
+- `favorites.md`
+- `inquiries.md`
+- `account.md`
+- `auth-login.md`
+- `saved-searches.md`
+- `compare-listings.md`
+- `realtors.md`
+- `agencies.md`


### PR DESCRIPTION
## Task

Audit SwiftUI Reality Portal project structure: verify NavigationCoordinator routing, auth guard implementation, document screen coverage vs epic-82 scope, map screens to docs/screens/reality-mobile/ (82-1 SwiftUI Project Setup)

## Owner

pm-frontend

## Tested (Band A — fast check)

```
cd mobile-native && ./gradlew :shared:linkPodReleaseFrameworkIosArm64
```

EXIT: BUILD FAILED — Android Gradle Plugin `com.android.application:9.2.1` not resolvable in cloud sandbox (no Google Maven network access). This is a known cloud-routine limitation documented in the ios-swiftui specialist guide ("Do NOT attempt `xcodebuild` in the routine — it requires macOS + Xcode which isn't available in the cloud sandbox"). The same AGP plugin resolution failure blocks the Gradle iOS framework link task.

**Code-level verification performed instead:**
- `git diff --check` → exit 0 (no whitespace issues)
- All 13 new files are `.md` documentation/screen-maps — no Swift, Kotlin, or build-config files were modified
- All 11 screen-map YAML frontmatter blocks verified (opening + closing `---` present on all)
- Source Swift files audited: NavigationCoordinator.swift, Route.swift, AuthManager.swift, RealityPortalApp.swift, MainTabView.swift + all 11 feature views — read-only, no changes made

**Requesting macOS reviewer to run `./gradlew :shared:linkPodReleaseFrameworkIosArm64` locally to confirm KMP build is unaffected.**

## Built (Band B — full build)

Skipped: change is 0 LOC of Swift/Kotlin/config — 1040 lines of markdown documentation only. No public API or build output is affected.

## CI parity (Band C — hot-path only)

Skipped: not a hot-path PR (no security/auth/billing/data-integrity change). Documentation audit only.

## Remote-tested

Skipped: ppt-bridge MCP not connected in this session.

## Notes

### NavigationCoordinator — Verified ✓
- `@Observable` macro (iOS 17+ pattern), correctly injected via `.environment()`
- Per-tab `NavigationPath` (home/search/favorites/inquiries/account)
- Typed `Route` enum with associated values — no string-based routing
- Deep link parsing: `realityportal://listing/<id>`, `search?q=`, `favorites`, `inquiries/<id>`, `account`, `sso?token=`
- Auth guard in `MainTabView.handleTabChange()` with `pendingDestination` SSO pattern — correct

### Auth Guard — Verified ✓
- Keychain storage with `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` — never UserDefaults
- SSO flow: PM app → `realityportal://sso?token=` → `loginWithSsoToken()` → `SsoService.validateAndLogin()` → Keychain
- Session restoration on launch via `SsoService.restoreSession(token:)`
- Email/password form present but always throws `ssoRequired` (Reality Portal is SSO-only)

### Gaps Found
1. **9 stub destination views** — `Route.listingGallery`, `listingMap`, `inquiryDetail`, `newInquiry`, `profile`, `settings`, `register`, `featuredListings`, `searchResults` all render `Text` placeholders in `MainTabView.destinationView()`
2. **Tab titles not localized** — `Tab.title` returns raw English strings (minor)
3. **Category chips unwired** — `HomeView.categoryFilters` chips have empty closures
4. **Dual SsoService instances** — `AuthManager` and `DependencyContainer.shared.ssoService` are separate instances; session state may diverge
5. **No realtor directory endpoint** — `RealtorsView` derives realtor list from agency tree as workaround for missing `GET /api/v1/realtors` endpoint
6. **DependencyContainer auth inconsistency** — default lazy repos use `sessionToken: nil`; authenticated `make*()` factories are ad-hoc

### Screen Maps Created
`docs/screens/reality-mobile/` — 11 screen maps + README index:
home, search, listing-detail, favorites, inquiries, account, auth-login, saved-searches, compare-listings, realtors, agencies

Full narrative audit: `docs/superpowers/plans/gap-82-1-swiftui-audit.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_018HNa2nwBKVQXMxnmPwGQk2)_