### PR TITLE
pm-qa-establish-pr-merge-policy-requiring-a: security-label test-file gate

### DIFF
--- a/.github/workflows/security-test-gate.yml
+++ b/.github/workflows/security-test-gate.yml
@@ -44,7 +44,7 @@ jobs:
       pull-requests: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Fetch the full diff between the base and head commits so
           # `git diff --name-only` works without a shallow-clone issue.

--- a/.github/workflows/security-test-gate.yml
+++ b/.github/workflows/security-test-gate.yml
@@ -7,7 +7,7 @@ name: Security-label test-file gate
 # labelled fix must land with at least one new or modified test file.
 #
 # This workflow enforces that contract at merge time:
-#   - Triggered whenever a PR is opened, updated, or re-labelled.
+#   - Triggered whenever a PR is opened, updated, re-labelled, or un-labelled.
 #   - If the PR carries the 'security' label, it scans the changed files
 #     for test-file patterns (Rust integration tests, Rust unit test mods,
 #     TypeScript __tests__/ files, etc.).
@@ -25,6 +25,7 @@ on:
       - synchronize
       - reopened
       - labeled
+      - unlabeled
       - ready_for_review
 
 jobs:
@@ -34,7 +35,8 @@ jobs:
 
     # Only apply to PRs that carry the 'security' label.
     # If the label is not present this job finishes immediately as a no-op
-    # (exit 0) so it never blocks non-security PRs.
+    # (exit 0) so it never blocks non-security PRs, and clears any stale
+    # failure when the 'security' label is removed.
     if: contains(github.event.pull_request.labels.*.name, 'security')
 
     permissions:
@@ -42,7 +44,7 @@ jobs:
       pull-requests: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           # Fetch the full diff between the base and head commits so
           # `git diff --name-only` works without a shallow-clone issue.
@@ -83,10 +85,8 @@ jobs:
           # Test-file patterns
           # A file counts as a "test file" when its path matches any of:
           #
-          #   Rust integration tests  backend/*/tests/*.rs
-          #   Rust unit test modules  any *.rs file that contains #[cfg(test)]
-          #                           (detected by path heuristic: *_test.rs,
-          #                            *_tests.rs, tests.rs, test_*.rs)
+          #   Rust integration tests  backend/*/tests/*.rs   (one dir level)
+          #   Rust unit test modules  any *.rs file with _test/_tests/test_ name
           #   TypeScript tests        **/__tests__/**  or  *.test.ts / *.spec.ts
           #   Frontend e2e            e2e/**
           # -------------------------------------------------------------------
@@ -97,8 +97,10 @@ jobs:
             [ -z "$f" ] && continue
 
             case "$f" in
-              # Rust integration test files (backend/.../tests/*.rs)
-              backend/*/tests/*.rs | backend/**/tests/*.rs)
+              # Rust integration test files (backend/<crate>/tests/*.rs)
+              # Note: bash `case` globs are single-level only; one wildcard
+              # is sufficient for the current repo layout.
+              backend/*/tests/*.rs)
                 echo "  [TEST] $f  (Rust integration test)"
                 HAS_TEST=true
                 ;;
@@ -164,7 +166,7 @@ jobs:
           echo "  boundary check, or an input-validation edge case)."
           echo ""
           echo "  Test-file patterns recognised by this gate:"
-          echo "    Rust integration : backend/**/tests/*.rs"
+          echo "    Rust integration : backend/*/tests/*.rs"
           echo "    Rust test module : *_test.rs, *_tests.rs, test_*.rs, tests.rs"
           echo "    TypeScript       : **/__tests__/**, *.test.ts, *.spec.ts"
           echo "    End-to-end       : e2e/**"

--- a/.github/workflows/security-test-gate.yml
+++ b/.github/workflows/security-test-gate.yml
@@ -1,0 +1,172 @@
+name: Security-label test-file gate
+
+# Why this exists
+# ---------------
+# PR #497 (inquiry IDOR fix) shipped to dev without a regression test.
+# PR #493 (equipment IDOR fix) set the right precedent: every security-
+# labelled fix must land with at least one new or modified test file.
+#
+# This workflow enforces that contract at merge time:
+#   - Triggered whenever a PR is opened, updated, or re-labelled.
+#   - If the PR carries the 'security' label, it scans the changed files
+#     for test-file patterns (Rust integration tests, Rust unit test mods,
+#     TypeScript __tests__/ files, etc.).
+#   - If no test file is present it fails with an actionable error message
+#     so the author knows exactly what is missing before merge.
+#
+# The check is advisory (non-blocking) on draft PRs — a draft is a work
+# in progress and we don't want to gate review iteration.  It becomes
+# blocking the moment the PR is marked "ready for review".
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - ready_for_review
+
+jobs:
+  security-test-gate:
+    name: Security label — test-file required
+    runs-on: ubuntu-latest
+
+    # Only apply to PRs that carry the 'security' label.
+    # If the label is not present this job finishes immediately as a no-op
+    # (exit 0) so it never blocks non-security PRs.
+    if: contains(github.event.pull_request.labels.*.name, 'security')
+
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Fetch the full diff between the base and head commits so
+          # `git diff --name-only` works without a shallow-clone issue.
+          fetch-depth: 0
+
+      - name: Collect changed files
+        id: files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+          echo "Base: $BASE_SHA"
+          echo "Head: $HEAD_SHA"
+
+          # List files changed between the merge-base and the PR head so
+          # rebased PRs (where base.sha != merge-base) are handled correctly.
+          MERGE_BASE=$(git merge-base "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || echo "$BASE_SHA")
+          echo "Merge-base: $MERGE_BASE"
+
+          CHANGED=$(git diff --name-only "$MERGE_BASE" "$HEAD_SHA")
+          echo "Changed files:"
+          echo "$CHANGED"
+          # Store as newline-delimited output
+          {
+            echo "list<<EOF"
+            echo "$CHANGED"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check for test file
+        id: gate
+        run: |
+          CHANGED="${{ steps.files.outputs.list }}"
+
+          # -------------------------------------------------------------------
+          # Test-file patterns
+          # A file counts as a "test file" when its path matches any of:
+          #
+          #   Rust integration tests  backend/*/tests/*.rs
+          #   Rust unit test modules  any *.rs file that contains #[cfg(test)]
+          #                           (detected by path heuristic: *_test.rs,
+          #                            *_tests.rs, tests.rs, test_*.rs)
+          #   TypeScript tests        **/__tests__/**  or  *.test.ts / *.spec.ts
+          #   Frontend e2e            e2e/**
+          # -------------------------------------------------------------------
+
+          HAS_TEST=false
+
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+
+            case "$f" in
+              # Rust integration test files (backend/.../tests/*.rs)
+              backend/*/tests/*.rs | backend/**/tests/*.rs)
+                echo "  [TEST] $f  (Rust integration test)"
+                HAS_TEST=true
+                ;;
+
+              # Rust files with _test / _tests / test_ naming conventions
+              *_test.rs | *_tests.rs | */test_*.rs | */tests.rs)
+                echo "  [TEST] $f  (Rust test module)"
+                HAS_TEST=true
+                ;;
+
+              # TypeScript __tests__ directories
+              */__tests__/*)
+                echo "  [TEST] $f  (TypeScript __tests__)"
+                HAS_TEST=true
+                ;;
+
+              # TypeScript test / spec files
+              *.test.ts | *.spec.ts | *.test.tsx | *.spec.tsx)
+                echo "  [TEST] $f  (TypeScript test/spec)"
+                HAS_TEST=true
+                ;;
+
+              # End-to-end tests
+              e2e/*)
+                echo "  [TEST] $f  (e2e)"
+                HAS_TEST=true
+                ;;
+            esac
+          done <<< "$CHANGED"
+
+          echo "has_test=$HAS_TEST" >> "$GITHUB_OUTPUT"
+
+      - name: Enforce policy
+        run: |
+          IS_DRAFT="${{ github.event.pull_request.draft }}"
+          HAS_TEST="${{ steps.gate.outputs.has_test }}"
+
+          if [ "$HAS_TEST" = "true" ]; then
+            echo "PASS: at least one test file is present in this security PR."
+            exit 0
+          fi
+
+          # Draft PRs: warn but don't block (work in progress).
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "WARN: No test file found in this security-labelled draft PR."
+            echo "      A test file will be required before this PR can merge."
+            echo "      (This check is advisory on draft PRs.)"
+            exit 0
+          fi
+
+          # Ready-for-review / open PRs: hard fail.
+          echo ""
+          echo "FAIL: This PR is labelled 'security' but contains no test file."
+          echo ""
+          echo "  Every security fix must ship with at least one regression test."
+          echo "  This policy was established after PR #497 (inquiry IDOR fix)"
+          echo "  merged without a test, and mirrors the pattern set by PR #493"
+          echo "  (equipment IDOR fix) which included:"
+          echo "    backend/servers/api-server/tests/equipment_cross_tenant_idor_tests.rs"
+          echo ""
+          echo "  Add a test file that covers the security contract introduced"
+          echo "  by this PR (e.g. a cross-tenant isolation assertion, an auth"
+          echo "  boundary check, or an input-validation edge case)."
+          echo ""
+          echo "  Test-file patterns recognised by this gate:"
+          echo "    Rust integration : backend/**/tests/*.rs"
+          echo "    Rust test module : *_test.rs, *_tests.rs, test_*.rs, tests.rs"
+          echo "    TypeScript       : **/__tests__/**, *.test.ts, *.spec.ts"
+          echo "    End-to-end       : e2e/**"
+          echo ""
+          exit 1


### PR DESCRIPTION
## Task

Establish PR-merge policy requiring a test file for every security-labelled fix (mirroring PR #493; PR #497 shipped without one)

## Owner

pm-qa

## Background

- **PR #493** (`equipment IDOR fix`) set the correct pattern: it shipped with `backend/servers/api-server/tests/equipment_cross_tenant_idor_tests.rs` — a 368-line integration test exercising 6 cross-tenant isolation assertions.
- **PR #497** (`inquiry IDOR fix`) merged without any test file. It included a "Test plan" checklist in the PR body but no actual test code.

This workflow makes that expectation machine-enforceable: every PR labelled `security` must include at least one test file before it can merge.

## What this PR adds

**`.github/workflows/security-test-gate.yml`** — a new GitHub Actions workflow that:

1. Triggers on `pull_request` events: `opened`, `synchronize`, `reopened`, `labeled`, `ready_for_review`
2. Is a **no-op** if the PR does not carry the `security` label (never blocks non-security PRs)
3. Scans the PR's changed-file list for test-file patterns:
   - Rust integration tests: `backend/**/tests/*.rs`
   - Rust test modules: `*_test.rs`, `*_tests.rs`, `test_*.rs`, `tests.rs`
   - TypeScript: `**/__tests__/**`, `*.test.ts`, `*.spec.ts`, `*.test.tsx`, `*.spec.tsx`
   - End-to-end: `e2e/**`
4. **Advisory** (passes) on draft PRs — work in progress should not be gated
5. **Hard fails** with an actionable error message on non-draft `security`-labelled PRs with no test file

## Tested (Band A — fast check)

```
git diff --check HEAD                  → exit 0  (no whitespace/merge-marker issues)
python3 -c "import yaml; yaml.safe_load(open(...))"  → exit 0  (YAML valid)
actionlint not available — syntax-only check via Python yaml
```

## Built (Band B — full build)

Skipped: generic specialist — Band B not defined for generic. Change is a CI workflow file (no build output affected).

## CI parity (Band C — hot-path only)

Skipped: not a hot-path PR (no security/auth/billing/data-integrity code change — this is a policy enforcement CI file).

## Remote-tested

skipped

## Scope drift

**scope_drift=true** — `.github/workflows/security-test-gate.yml` is outside `pm-qa`'s declared owner areas (test directories). Justification: a QA-owned merge policy must be enforced at the CI layer; `.github/workflows/` is the only place that can block a merge. The drift is intentional and narrowly scoped (one new workflow file). `pm-devops` reviewer should confirm.

## Code-reuse review

No warnings — reuse-grep found no duplicated helpers.

## Notes

- The workflow uses `contains(github.event.pull_request.labels.*.name, 'security')` for label detection — this is the standard GitHub Actions idiom and fires correctly when a label is added to an already-open PR (via the `labeled` event type).
- The `fetch-depth: 0` in the checkout step ensures `git merge-base` works correctly for rebased PRs.
- The pattern list can be extended by editing the `case` block in the "Check for test file" step.
- To retroactively apply this to PR #497's gap: a follow-up task should add the inquiry IDOR regression test that was planned but never implemented.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PYYJdSW2Y5sEjd7UPM2Kje)_