### PR TITLE
fix(security): e-signature config fail-closed + scheduler email wiring (#527 bucket A)

### DIFF
--- a/backend/crates/integrations/src/esignature.rs
+++ b/backend/crates/integrations/src/esignature.rs
@@ -149,17 +149,57 @@ pub struct LightweightConfig {
     pub token_ttl_secs: u64,
 }
 
+/// Minimum byte length required for `ESIGN_TOKEN_SECRET`.
+///
+/// Matches the 32-char floor enforced for `JWT_SECRET` in `api-server::main`
+/// — both are HMAC-SHA256 keys, so the same security floor applies.
+pub const MIN_TOKEN_SECRET_LEN: usize = 32;
+
 impl LightweightConfig {
     /// Load configuration from environment variables.
     ///
-    /// -  - hex-encoded secret (required, falls back to a dev default)
-    /// -  - base URL for signing links (required)
-    /// -  - optional webhook URL
-    /// -  - TTL in seconds (default 604800 = 7 days)
-    pub fn from_env() -> Self {
-        let token_secret = std::env::var("ESIGN_TOKEN_SECRET")
-            .map(|s| s.into_bytes())
-            .unwrap_or_else(|_| b"dev-esign-secret-key-32bytes-pad!".to_vec());
+    /// - `ESIGN_TOKEN_SECRET` — raw secret bytes used as the HMAC-SHA256 key.
+    ///   Required in production. When `RUST_ENV=development` is set the
+    ///   loader falls back to a clearly-marked development default and emits
+    ///   a `warn!`; in any other environment a missing or too-short secret
+    ///   is a hard error (the binary refuses to start). This mirrors the
+    ///   handling of `JWT_SECRET`.
+    /// - `BASE_URL` — base URL for signing links (default `http://localhost:3000`).
+    /// - `ESIGN_WEBHOOK_URL` — optional outbound webhook URL.
+    /// - `ESIGN_TOKEN_TTL` — TTL in seconds (default 604800 = 7 days).
+    ///
+    /// # Errors
+    /// Returns `ESignatureError::ConfigError` if `ESIGN_TOKEN_SECRET` is
+    /// missing in a non-development environment, or if it is shorter than
+    /// [`MIN_TOKEN_SECRET_LEN`] bytes.
+    pub fn from_env() -> Result<Self, ESignatureError> {
+        let is_development = std::env::var("RUST_ENV").unwrap_or_default() == "development";
+
+        let token_secret = match std::env::var("ESIGN_TOKEN_SECRET") {
+            Ok(s) => s.into_bytes(),
+            Err(_) if is_development => {
+                tracing::warn!(
+                    "ESIGN_TOKEN_SECRET not set, using development default (DEVELOPMENT MODE ONLY)"
+                );
+                // Distinct from any prod secret and long enough to clear the
+                // 32-byte floor; the string is recognisable in logs.
+                b"DEV_ONLY-esign-token-secret-do-not-use-in-prod".to_vec()
+            }
+            Err(_) => {
+                return Err(ESignatureError::ConfigError(
+                    "ESIGN_TOKEN_SECRET environment variable is required. \
+                     Set RUST_ENV=development to use dev defaults."
+                        .into(),
+                ));
+            }
+        };
+
+        if token_secret.len() < MIN_TOKEN_SECRET_LEN {
+            return Err(ESignatureError::ConfigError(format!(
+                "ESIGN_TOKEN_SECRET must be at least {MIN_TOKEN_SECRET_LEN} bytes long for minimum security",
+            )));
+        }
+
         let base_url =
             std::env::var("BASE_URL").unwrap_or_else(|_| "http://localhost:3000".to_string());
         let webhook_url = std::env::var("ESIGN_WEBHOOK_URL").ok();
@@ -168,12 +208,12 @@ impl LightweightConfig {
             .and_then(|v| v.parse().ok())
             .unwrap_or(604_800);
 
-        Self {
+        Ok(Self {
             token_secret,
             base_url,
             webhook_url,
             token_ttl_secs,
-        }
+        })
     }
 }
 
@@ -189,8 +229,12 @@ impl LightweightProvider {
     }
 
     /// Instantiate from environment variables.
-    pub fn from_env() -> Self {
-        Self::new(LightweightConfig::from_env())
+    ///
+    /// # Errors
+    /// Propagates errors from [`LightweightConfig::from_env`] (e.g. missing
+    /// `ESIGN_TOKEN_SECRET` outside of development).
+    pub fn from_env() -> Result<Self, ESignatureError> {
+        Ok(Self::new(LightweightConfig::from_env()?))
     }
 
     /// Generate a signed signing URL for the given signer and request.
@@ -394,5 +438,98 @@ mod tests {
 
         assert_eq!(verified.signer_email, "alice@example.com");
         assert_eq!(verified.request_id, "req-1");
+    }
+
+    // ---------------------------------------------------------------------------
+    // from_env() tests for #527 / Bucket A
+    //
+    // These tests mutate process-global env vars and must not run in parallel
+    // with each other or with any other env-touching test in this crate.
+    // A static mutex serialises them; we restore prior env state on drop.
+    // ---------------------------------------------------------------------------
+
+    use std::sync::Mutex;
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        keys: Vec<(&'static str, Option<String>)>,
+    }
+    impl EnvGuard {
+        fn capture(keys: &[&'static str]) -> Self {
+            let snap = keys
+                .iter()
+                .map(|k| (*k, std::env::var(k).ok()))
+                .collect::<Vec<_>>();
+            for k in keys {
+                std::env::remove_var(k);
+            }
+            Self { keys: snap }
+        }
+    }
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in &self.keys {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn from_env_fails_when_token_secret_missing_in_prod() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _env = EnvGuard::capture(&["ESIGN_TOKEN_SECRET", "RUST_ENV"]);
+        // RUST_ENV is not "development" (it's unset), so missing secret => error.
+
+        let result = LightweightConfig::from_env();
+        assert!(
+            matches!(result, Err(ESignatureError::ConfigError(_))),
+            "Expected ConfigError for missing ESIGN_TOKEN_SECRET outside dev, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn from_env_fails_when_token_secret_too_short() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _env = EnvGuard::capture(&["ESIGN_TOKEN_SECRET", "RUST_ENV"]);
+        std::env::set_var("ESIGN_TOKEN_SECRET", "tooshort"); // 8 bytes — below floor
+
+        let result = LightweightConfig::from_env();
+        let msg = match result {
+            Err(ESignatureError::ConfigError(m)) => m,
+            other => panic!("Expected ConfigError for too-short secret, got {other:?}"),
+        };
+        assert!(
+            msg.contains("at least"),
+            "Error message should reference the length floor, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn from_env_allows_dev_default_when_rust_env_development() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _env = EnvGuard::capture(&["ESIGN_TOKEN_SECRET", "RUST_ENV"]);
+        std::env::set_var("RUST_ENV", "development");
+
+        let cfg = LightweightConfig::from_env().expect("dev default should succeed");
+        assert!(cfg.token_secret.len() >= MIN_TOKEN_SECRET_LEN);
+    }
+
+    #[test]
+    fn from_env_accepts_valid_secret_in_prod() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _env = EnvGuard::capture(&["ESIGN_TOKEN_SECRET", "RUST_ENV"]);
+        std::env::set_var(
+            "ESIGN_TOKEN_SECRET",
+            "this-is-a-valid-32-byte-or-longer-secret",
+        );
+
+        let cfg = LightweightConfig::from_env().expect("valid secret should succeed");
+        assert_eq!(
+            cfg.token_secret,
+            b"this-is-a-valid-32-byte-or-longer-secret"
+        );
     }
 }

--- a/backend/servers/api-server/src/main.rs
+++ b/backend/servers/api-server/src/main.rs
@@ -346,6 +346,33 @@ async fn main() -> anyhow::Result<()> {
 
     let jwt_service = JwtService::new(&jwt_secret).expect("Failed to create JWT service");
 
+    // SECURITY (#527 findings #1 & #4): Validate e-signature secrets at
+    // startup so the binary refuses to boot in production without them,
+    // instead of falling back to a hardcoded dev token secret or silently
+    // disabling the webhook auth check on first use. Mirrors the JWT_SECRET
+    // handling above.
+    if let Err(e) = integrations::LightweightProvider::from_env() {
+        panic!(
+            "E-signature config invalid: {e}. \
+             Set RUST_ENV=development to use dev defaults."
+        );
+    }
+    let webhook_secret_set = std::env::var("ESIGN_WEBHOOK_SECRET")
+        .map(|s| !s.is_empty())
+        .unwrap_or(false);
+    if !webhook_secret_set {
+        if is_development {
+            tracing::warn!(
+                "ESIGN_WEBHOOK_SECRET not set, webhook receiver will reject all events (DEVELOPMENT MODE ONLY)"
+            );
+        } else {
+            panic!(
+                "ESIGN_WEBHOOK_SECRET environment variable is required (got missing or empty). \
+                 Set RUST_ENV=development to use dev defaults."
+            );
+        }
+    }
+
     // Phase 1: Build the host-resolution config + shared tenant-resolution
     // cache ONCE, then clone the `Arc` into both the middleware config and the
     // AppState so domain-management handlers can invalidate cache entries via
@@ -359,10 +386,11 @@ async fn main() -> anyhow::Result<()> {
     let tenant_resolution_cache = host_tenant_config.cache.clone();
     let tenant_rate_limiters = host_tenant_config.rate_limiters.clone();
 
-    // Create application state
+    // Create application state. Clone the EmailService into AppState so the
+    // scheduler (built below) can also receive it via `.with_email_service`.
     let state = AppState::new(
         db_pool.clone(),
-        email_service,
+        email_service.clone(),
         jwt_service,
         tenant_resolution_cache,
         tenant_rate_limiters,
@@ -397,7 +425,13 @@ async fn main() -> anyhow::Result<()> {
     };
     let scheduler_pool = state.db.clone();
     let announcement_repo = AnnouncementRepository::new(scheduler_pool.clone());
-    let scheduler = Scheduler::new(scheduler_pool, announcement_repo, scheduler_config);
+    // SECURITY (#527 finding #9): Wire the real EmailService into the
+    // scheduler. Without this, `Scheduler::new` defaulted to
+    // `EmailService::development()` (enabled=false, base_url=localhost:3000),
+    // which silently logged signature reminders instead of sending them and
+    // baked localhost links into any URL the scheduler generated.
+    let scheduler = Scheduler::new(scheduler_pool, announcement_repo, scheduler_config)
+        .with_email_service(email_service.clone());
     let _scheduler_handle = scheduler.start();
 
     // Phase 5 — admin dependency injection (B7).

--- a/backend/servers/api-server/src/routes/signatures.rs
+++ b/backend/servers/api-server/src/routes/signatures.rs
@@ -21,6 +21,7 @@ use db::models::{
     WebhookResponse,
 };
 use integrations::{generate_storage_key, LightweightProvider};
+use subtle::ConstantTimeEq;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
@@ -34,7 +35,14 @@ static BASE_URL: LazyLock<String> =
     LazyLock::new(|| std::env::var("BASE_URL").unwrap_or_else(|_| DEFAULT_BASE_URL.to_string()));
 
 /// Lightweight e-signature provider, initialised once from env.
-static ESIGN_PROVIDER: LazyLock<LightweightProvider> = LazyLock::new(LightweightProvider::from_env);
+///
+/// The `.expect` is safe because `api-server::main` runs the same
+/// `LightweightProvider::from_env` check at startup and refuses to boot if it
+/// fails — this static is only touched on the request path, after that gate.
+static ESIGN_PROVIDER: LazyLock<LightweightProvider> = LazyLock::new(|| {
+    LightweightProvider::from_env()
+        .expect("ESIGN_TOKEN_SECRET must be configured (validated at startup)")
+});
 
 /// Create router for signature endpoints.
 pub fn router() -> Router<AppState> {
@@ -526,19 +534,38 @@ pub async fn handle_webhook(
     Json(event): Json<SignatureWebhookEvent>,
 ) -> Result<Json<WebhookResponse>, (StatusCode, Json<ErrorResponse>)> {
     // Verify the webhook secret header to prevent forged events.
+    //
+    // Fail-closed: if `ESIGN_WEBHOOK_SECRET` is unset or empty the handler
+    // returns 503 rather than waving the request through. `api-server::main`
+    // validates the env var at startup and panics outside of development, so
+    // hitting this branch in production indicates the env was cleared
+    // post-start — still better to refuse than to forge-complete signature
+    // requests.
     let expected_secret = std::env::var("ESIGN_WEBHOOK_SECRET").unwrap_or_default();
-    if !expected_secret.is_empty() {
-        let provided = headers
-            .get("x-webhook-secret")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("");
-        if provided != expected_secret {
-            warn!(provider = %provider, "Webhook rejected: invalid or missing X-Webhook-Secret");
-            return Err((
-                StatusCode::UNAUTHORIZED,
-                Json(ErrorResponse::new("UNAUTHORIZED", "Invalid webhook secret")),
-            ));
-        }
+    if expected_secret.is_empty() {
+        error!(
+            provider = %provider,
+            "Webhook rejected: ESIGN_WEBHOOK_SECRET unset at runtime"
+        );
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse::new(
+                "WEBHOOK_NOT_CONFIGURED",
+                "Webhook receiver is not configured",
+            )),
+        ));
+    }
+    let provided = headers
+        .get("x-webhook-secret")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    // Constant-time compare to avoid leaking the secret via timing.
+    if !bool::from(provided.as_bytes().ct_eq(expected_secret.as_bytes())) {
+        warn!(provider = %provider, "Webhook rejected: invalid or missing X-Webhook-Secret");
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            Json(ErrorResponse::new("UNAUTHORIZED", "Invalid webhook secret")),
+        ));
     }
 
     info!(

--- a/backend/servers/api-server/src/services/scheduler.rs
+++ b/backend/servers/api-server/src/services/scheduler.rs
@@ -826,7 +826,8 @@ impl Scheduler {
             "Processing signature requests approaching expiry for reminders"
         );
 
-        let provider = LightweightProvider::from_env();
+        let provider = LightweightProvider::from_env()
+            .expect("ESIGN_TOKEN_SECRET must be configured (validated at startup)");
         let base_url =
             std::env::var("BASE_URL").unwrap_or_else(|_| "http://localhost:3000".to_string());
 


### PR DESCRIPTION
## Summary

Bucket A of the #527 follow-up (e-signature hardening). Addresses the four critical/high findings where `dev` is unsafe by default. Mirrors the existing `JWT_SECRET` pattern: hard-error in production, dev fallback gated on `RUST_ENV=development`.

- **#1 (CRITICAL)** — `LightweightConfig::from_env()` now returns `Result`. Missing `ESIGN_TOKEN_SECRET` panics outside dev instead of falling back to the hardcoded `b\"dev-esign-secret-key-32bytes-pad!\"` that lived in the binary. Minimum 32-byte floor enforced (matches the JWT secret floor).
- **#4 (HIGH)** — Webhook handler is now fail-closed. If `ESIGN_WEBHOOK_SECRET` is empty/missing at runtime, the handler returns **503** instead of waving the request through. `main.rs` also validates the env var at startup and panics in prod, so this branch is defense-in-depth.
- **#5 (MEDIUM)** — Webhook secret compare uses `subtle::ConstantTimeEq` instead of plain `&str` `!=`. `subtle = \"2.5\"` was already a direct dep of `api-server`.
- **#9 (HIGH)** — Scheduler now receives the real `EmailService` via `.with_email_service(state.email_service.clone())`. `Scheduler::new` was hardcoding `EmailService::development()` (logs only, `base_url=\"http://localhost:3000\"`), so prod scheduler reminders were silently going to logs and any generated signing URLs pointed at localhost.

Buckets B (token format hardening — replay, org binding, key rotation), C (scheduler RLS + per-signer idempotency), and D (locale threading + missing negative-path tests) are queued as separate PRs.

## Test plan

- [x] **IG3**: 4 new unit tests in `integrations::esignature::tests` cover \`from_env\` failure modes — these would have failed on \`main\` before this PR:
  - \`from_env_fails_when_token_secret_missing_in_prod\` — asserts \`Err(ConfigError)\` when \`ESIGN_TOKEN_SECRET\` is unset and \`RUST_ENV != \"development\"\`.
  - \`from_env_fails_when_token_secret_too_short\` — asserts \`Err(ConfigError)\` for an 8-byte secret.
  - \`from_env_allows_dev_default_when_rust_env_development\` — asserts the dev path still works.
  - \`from_env_accepts_valid_secret_in_prod\` — asserts the prod happy path.
  - Tests are serialised via a module-local \`Mutex\` so env mutation doesn't race the other tests.
- [x] \`cargo check --workspace --all-targets\` — clean.
- [x] \`cargo test -p integrations --lib esignature -- --test-threads=1\` — 10/10 passing (4 new + 6 existing).
- [ ] Reviewer: confirm the panic message text reads correctly in a real boot log.
- [ ] Reviewer: confirm \`ESIGN_TOKEN_SECRET\` and \`ESIGN_WEBHOOK_SECRET\` are set in all non-dev deployment environments before merge. Without them set, an api-server restart after this PR will panic.

## Deploy / env-var checklist (action required before merge)

This PR makes two previously-optional env vars **required** in any env where \`RUST_ENV != \"development\"\`. Before merging, confirm each environment has values set:

- [ ] **staging**: \`ESIGN_TOKEN_SECRET\` (≥32 bytes), \`ESIGN_WEBHOOK_SECRET\` (non-empty).
- [ ] **production**: same.
- [ ] Dev/CI: either keep \`RUST_ENV=development\` (dev default kicks in) or provide explicit values.

Refs #527.