### PR TITLE
gap-85-2-build-config-android: Android release build config (EAS, keystore, FCM, Play Store)

### DIFF
--- a/frontend/apps/mobile/.gitignore
+++ b/frontend/apps/mobile/.gitignore
@@ -1,0 +1,25 @@
+# Epic 85 - Story 85.2: Android Release Build Configuration
+#
+# Secrets that must NEVER be committed to git.
+# These are managed via EAS secrets / secure vaults in CI.
+
+# Android keystore file -- losing this means you can't update a published app.
+# Back up securely (1Password, Bitwarden, etc.) before using in production.
+android-keystore/
+*.keystore
+*.jks
+
+# Google Services JSON -- contains Firebase API keys.
+# Template (with placeholder values) is tracked as google-services.json.template.
+google-services.json
+
+# Google Play service account JSON -- grants publish access to Play Console.
+store-metadata/android/google-play-service-account.json
+
+# iOS signing secrets (also excluded here for completeness)
+*.p12
+*.mobileprovision
+
+# Local env overrides (never commit)
+.env.local
+.env.*.local

--- a/frontend/apps/mobile/app.config.ts
+++ b/frontend/apps/mobile/app.config.ts
@@ -2,24 +2,44 @@
  * Expo Dynamic App Configuration
  *
  * Epic 85 - Story 85.1: Environment Variable Setup
- * Epic 85 - Story 85.2: iOS Release Build Configuration
+ * Epic 85 - Story 85.2: Android + iOS Release Build Configuration
  *
  * Reads environment-specific .env files and injects variables into:
  *   - `extra` block (accessible via expo-constants: Constants.expoConfig.extra)
  *   - `ios.infoPlist` (native iOS app Info.plist keys)
+ *   - `android` block (package, permissions, adaptive icon, Google Services)
  *   - `EXPO_PUBLIC_*` env vars are handled automatically by the Expo build
  *     system when loaded via Metro (see metro.config.js)
  *
  * Environment selection:
- *   APP_ENV=development  →  .env.development  (default in __DEV__ mode)
- *   APP_ENV=staging      →  .env.staging
- *   APP_ENV=production   →  .env.production   (default in release builds)
+ *   APP_ENV=development  =>  .env.development  (default in __DEV__ mode)
+ *   APP_ENV=staging      =>  .env.staging
+ *   APP_ENV=production   =>  .env.production   (default in release builds)
  *
  * Usage:
- *   APP_ENV=staging expo start      # run with staging config
- *   APP_ENV=production expo build   # build with production config
+ *   APP_ENV=staging expo start                # run with staging config
+ *   APP_ENV=production expo start             # run with production config
+ *
+ * EAS Build:
+ *   eas build --platform android --profile staging
+ *   eas build --platform android --profile production
+ *   eas submit --platform android --profile production
+ *
+ * Android release signing:
+ *   Keystore credentials managed via EAS secrets (credentialsSource=remote in eas.json).
+ *   For local Gradle builds: set ANDROID_KEYSTORE_PATH, ANDROID_KEY_ALIAS,
+ *   ANDROID_KEYSTORE_PASSWORD, ANDROID_KEY_PASSWORD in your shell or .env.local.
+ *   See scripts/setup-android-keystore.sh for keystore generation instructions.
+ *
+ * Android Google Services:
+ *   google-services.json must be at frontend/apps/mobile/google-services.json
+ *   for Firebase push notifications (FCM). Gitignored -- obtain from Firebase Console
+ *   (Project Settings > Android app > Download google-services.json).
+ *   EAS Cloud builds receive it via the GOOGLE_SERVICES_JSON secret (base64-encoded).
+ *   Template with placeholder values lives at google-services.json.template.
  */
 
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as dotenv from 'dotenv';
 import type { ConfigContext, ExpoConfig } from 'expo/config';
@@ -46,6 +66,16 @@ function getAppEnv(): AppEnvironment {
   return process.env.NODE_ENV === 'production' ? 'production' : 'development';
 }
 
+/**
+ * Returns true when a real google-services.json exists beside this config file.
+ * EAS Cloud builds inject this via GOOGLE_SERVICES_JSON secret; local dev
+ * without Firebase falls back gracefully so `expo prebuild` does not fail.
+ */
+function hasGoogleServicesJson(): boolean {
+  const p = path.resolve(__dirname, 'google-services.json');
+  return fs.existsSync(p);
+}
+
 export default ({ config }: ConfigContext): ExpoConfig => {
   const appEnv = getAppEnv();
   const envVars = loadEnvFile(appEnv);
@@ -61,6 +91,10 @@ export default ({ config }: ConfigContext): ExpoConfig => {
 
   const debugMode =
     envVars.DEBUG_MODE === 'true' || envVars.DEBUG_MODE === '1' || appEnv === 'development';
+
+  // Google Services JSON path -- only set when real file is present.
+  // EAS Cloud injects via GOOGLE_SERVICES_JSON secret; omitted for plain local dev.
+  const googleServicesFile = hasGoogleServicesJson() ? './google-services.json' : undefined;
 
   return {
     ...config,
@@ -86,18 +120,8 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       buildNumber: config.ios?.buildNumber ?? '1',
       infoPlist: {
         ...(config.ios?.infoPlist ?? {}),
-        // --------------- environment variable keys exposed natively ---------------
-        /**
-         * API base URL injected at build time.
-         * Readable via NativeModules or as an Info.plist lookup.
-         * Prefer reading via expo-constants (Constants.expoConfig.extra) in JS.
-         */
         API_BASE_URL: apiBaseUrl,
-        /**
-         * Current environment identifier: development | staging | production
-         */
         ENVIRONMENT: environment,
-        // --------------------------------------------------------------------------
         NSPhotoLibraryUsageDescription:
           'The app needs access to your photos to upload property images.',
         NSCameraUsageDescription:
@@ -118,17 +142,75 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     android: {
       ...config.android,
       package: 'three.two.bit.ppt.management',
+
+      // -----------------------------------------------------------------------
+      // Epic 85 - Story 85.2: Android Release Build Configuration
+      // -----------------------------------------------------------------------
+
+      // versionCode: auto-incremented by EAS (autoIncrement:true in eas.json).
+      // JS-side fallback only; actual versionCode in APK/AAB managed by EAS.
+      versionCode: config.android?.versionCode ?? 1,
+
+      // Adaptive icon -- required for Android 8.0+ (API level 26+).
+      // Asset: assets/images/adaptive-icon.png (1024x1024, transparent bg).
+      adaptiveIcon: {
+        foregroundImage: './assets/images/adaptive-icon.png',
+        backgroundColor: '#1A73E8',
+      },
+
+      // Google Services JSON for FCM (Android push notifications).
+      // EAS Cloud: via GOOGLE_SERVICES_JSON secret (base64-encoded).
+      //   eas secret:create --scope project --name GOOGLE_SERVICES_JSON \
+      //       --value "$(base64 -w0 google-services.json)"
+      // Local: place google-services.json beside this file (gitignored).
+      ...(googleServicesFile !== undefined ? { googleServicesFile } : {}),
+
+      // Permissions declared in AndroidManifest.xml.
+      permissions: [
+        'android.permission.CAMERA',
+        'android.permission.READ_EXTERNAL_STORAGE',
+        'android.permission.WRITE_EXTERNAL_STORAGE',
+        'android.permission.ACCESS_FINE_LOCATION',
+        'android.permission.ACCESS_COARSE_LOCATION',
+        'android.permission.RECEIVE_BOOT_COMPLETED',
+        'android.permission.VIBRATE',
+        'android.permission.POST_NOTIFICATIONS',
+        'android.permission.INTERNET',
+        'android.permission.ACCESS_NETWORK_STATE',
+        'android.permission.USE_BIOMETRIC',
+        'android.permission.USE_FINGERPRINT',
+        'android.permission.NFC',
+      ],
+
+      // Intent filters: ppt-management:// custom scheme + App Links.
+      // App Links require assetlinks.json on server with keystore SHA-256.
+      intentFilters: [
+        {
+          action: 'VIEW',
+          autoVerify: true,
+          data: [{ scheme: 'ppt-management' }],
+          category: ['BROWSABLE', 'DEFAULT'],
+        },
+        {
+          action: 'VIEW',
+          autoVerify: true,
+          data: [{ scheme: 'https', host: 'app.ppt.example.com', pathPrefix: '/' }],
+          category: ['BROWSABLE', 'DEFAULT'],
+        },
+      ],
     },
 
-    plugins: ['expo-localization', 'expo-secure-store'],
+    plugins: [
+      'expo-localization',
+      'expo-secure-store',
+      // expo-notifications: FCM (Android) + APNs (iOS).
+      // Android: requires google-services.json (see googleServicesFile above).
+      [
+        'expo-notifications',
+        { icon: './assets/images/notification-icon.png', color: '#1A73E8', sounds: [] },
+      ],
+    ],
 
-    /**
-     * `extra` block — accessible anywhere in JS via:
-     *   import Constants from 'expo-constants';
-     *   Constants.expoConfig?.extra?.API_BASE_URL
-     *
-     * See src/config/api.ts which reads these values.
-     */
     extra: {
       ...config.extra,
       API_BASE_URL: apiBaseUrl,

--- a/frontend/apps/mobile/eas.json
+++ b/frontend/apps/mobile/eas.json
@@ -15,7 +15,8 @@
         "bundleIdentifier": "three.two.bit.ppt.management"
       },
       "android": {
-        "buildType": "apk"
+        "buildType": "apk",
+        "gradleCommand": ":app:assembleDebug"
       },
       "env": {
         "APP_ENV": "development"
@@ -45,7 +46,10 @@
         "credentialsSource": "remote"
       },
       "android": {
-        "buildType": "apk"
+        "buildType": "apk",
+        "gradleCommand": ":app:assembleRelease",
+        "credentialsSource": "remote",
+        "image": "latest"
       },
       "env": {
         "APP_ENV": "staging"
@@ -62,7 +66,10 @@
         "credentialsSource": "remote"
       },
       "android": {
-        "buildType": "app-bundle"
+        "buildType": "app-bundle",
+        "gradleCommand": ":app:bundleRelease",
+        "credentialsSource": "remote",
+        "image": "latest"
       },
       "env": {
         "APP_ENV": "production"
@@ -79,6 +86,25 @@
         "sku": "three-two-bit-ppt-management",
         "companyName": "32bit s.r.o.",
         "metadataPath": "./store-metadata/ios"
+      },
+      "android": {
+        "serviceAccountKeyPath": "./store-metadata/android/google-play-service-account.json",
+        "track": "production",
+        "releaseStatus": "completed",
+        "changesNotSentForReview": false
+      }
+    },
+    "staging": {
+      "ios": {
+        "appleId": "APPLE_ID_PLACEHOLDER",
+        "ascAppId": "ASC_APP_ID_PLACEHOLDER",
+        "appleTeamId": "APPLE_TEAM_ID_PLACEHOLDER",
+        "language": "en-US"
+      },
+      "android": {
+        "serviceAccountKeyPath": "./store-metadata/android/google-play-service-account.json",
+        "track": "internal",
+        "releaseStatus": "completed"
       }
     }
   }

--- a/frontend/apps/mobile/google-services.json.template
+++ b/frontend/apps/mobile/google-services.json.template
@@ -1,0 +1,48 @@
+{
+  "_comment": "TEMPLATE — copy to google-services.json and fill in real values from Firebase Console.",
+  "_howto": [
+    "1. Go to Firebase Console: https://console.firebase.google.com/",
+    "2. Select or create the PPT Management project.",
+    "3. Project Settings > Your apps > Android app (package: three.two.bit.ppt.management).",
+    "4. Download google-services.json and place it beside this template file.",
+    "5. The real file is gitignored. For EAS Cloud builds, store it as a secret:",
+    "     eas secret:create --scope project --name GOOGLE_SERVICES_JSON --value \"$(base64 -w0 google-services.json)\""
+  ],
+  "project_info": {
+    "project_number": "FIREBASE_PROJECT_NUMBER",
+    "project_id": "ppt-management-PLACEHOLDER",
+    "storage_bucket": "ppt-management-PLACEHOLDER.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:FIREBASE_PROJECT_NUMBER:android:PLACEHOLDER",
+        "android_client_info": {
+          "package_name": "three.two.bit.ppt.management"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "FIREBASE_OAUTH_CLIENT_ID.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "FIREBASE_ANDROID_API_KEY"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "FIREBASE_OAUTH_CLIENT_ID.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/frontend/apps/mobile/store-metadata/android/google-play-service-account.json.template
+++ b/frontend/apps/mobile/store-metadata/android/google-play-service-account.json.template
@@ -1,0 +1,22 @@
+{
+  "_comment": "TEMPLATE -- place real google-play-service-account.json here (gitignored).",
+  "_howto": [
+    "1. Google Play Console > Setup > API access > Link to Google Cloud project.",
+    "2. Create a Service Account with 'Release Manager' role.",
+    "3. Create and download a JSON key for that service account.",
+    "4. Place the downloaded file at this path (without the .template suffix).",
+    "5. The real file is gitignored. For EAS submit, reference it in eas.json",
+    "     'serviceAccountKeyPath': './store-metadata/android/google-play-service-account.json'",
+    "   or store it as an EAS secret."
+  ],
+  "type": "service_account",
+  "project_id": "GOOGLE_CLOUD_PROJECT_ID",
+  "private_key_id": "KEY_ID_PLACEHOLDER",
+  "private_key": "-----BEGIN RSA PRIVATE KEY-----\nPLACEHOLDER\n-----END RSA PRIVATE KEY-----\n",
+  "client_email": "ppt-management-play@GOOGLE_CLOUD_PROJECT_ID.iam.gserviceaccount.com",
+  "client_id": "CLIENT_ID_PLACEHOLDER",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "CERT_URL_PLACEHOLDER"
+}

--- a/scripts/setup-android-keystore.sh
+++ b/scripts/setup-android-keystore.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# setup-android-keystore.sh
+#
+# Epic 85 - Story 85.2: Android Release Build Configuration
+#
+# Generates the release keystore for the PPT Management Android app
+# (three.two.bit.ppt.management) and prints the EAS secret upload command.
+#
+# Usage:
+#   ./scripts/setup-android-keystore.sh
+#
+# The generated keystore is placed at:
+#   frontend/apps/mobile/android-keystore/ppt-management-release.keystore
+#
+# SECURITY NOTES:
+#   - Never commit the generated .keystore file. It is listed in .gitignore.
+#   - Store the keystore and passwords in a secure vault (e.g. 1Password, Bitwarden).
+#   - If the keystore is lost and the app is published, you cannot update the app
+#     on the Play Store. Back it up securely before using it in production.
+#   - For EAS Remote builds the keystore is uploaded to Expo's encrypted store via:
+#       eas credentials --platform android
+#     or by setting the ANDROID_KEYSTORE, ANDROID_KEY_ALIAS, etc. EAS secrets.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+KEYSTORE_DIR="${REPO_ROOT}/frontend/apps/mobile/android-keystore"
+KEYSTORE_FILE="${KEYSTORE_DIR}/ppt-management-release.keystore"
+
+KEY_ALIAS="ppt-management"
+KEYSTORE_VALIDITY_DAYS=10950  # 30 years
+DISTINGUISHED_NAME="CN=PPT Management, OU=Mobile, O=32bit s.r.o., L=Bratislava, ST=Slovakia, C=SK"
+
+echo "=== PPT Management Android Release Keystore Setup ==="
+echo ""
+
+# Check for keytool
+if ! command -v keytool &>/dev/null; then
+  echo "ERROR: keytool not found. Install a JDK (e.g. 'apt install default-jdk')." >&2
+  exit 1
+fi
+
+# Create output directory
+mkdir -p "${KEYSTORE_DIR}"
+
+# Check if keystore already exists
+if [[ -f "${KEYSTORE_FILE}" ]]; then
+  echo "WARNING: Keystore already exists at:"
+  echo "  ${KEYSTORE_FILE}"
+  echo ""
+  echo "To regenerate, delete the file first. Reusing an existing keystore is"
+  echo "STRONGLY PREFERRED once the app is published to the Play Store."
+  echo ""
+  read -r -p "Print keystore certificate info instead? [y/N]: " SHOW_INFO
+  if [[ "${SHOW_INFO,,}" == "y" ]]; then
+    keytool -list -v \
+      -keystore "${KEYSTORE_FILE}" \
+      -alias "${KEY_ALIAS}"
+  fi
+  exit 0
+fi
+
+echo "Keystore path : ${KEYSTORE_FILE}"
+echo "Key alias     : ${KEY_ALIAS}"
+echo "Validity      : ${KEYSTORE_VALIDITY_DAYS} days (~30 years)"
+echo ""
+echo "You will be prompted for:"
+echo "  - Keystore password  (store securely — required for every release build)"
+echo "  - Key password       (can be same as keystore password)"
+echo ""
+
+keytool -genkeypair \
+  -keystore "${KEYSTORE_FILE}" \
+  -alias "${KEY_ALIAS}" \
+  -keyalg RSA \
+  -keysize 4096 \
+  -validity "${KEYSTORE_VALIDITY_DAYS}" \
+  -dname "${DISTINGUISHED_NAME}" \
+  -storetype PKCS12
+
+echo ""
+echo "=== Keystore generated successfully ==="
+echo ""
+echo "NEXT STEPS"
+echo "----------"
+echo ""
+echo "1. Print the SHA-256 certificate fingerprint (needed for App Links / assetlinks.json):"
+echo ""
+echo "   keytool -list -v -keystore ${KEYSTORE_FILE} -alias ${KEY_ALIAS}"
+echo ""
+echo "2. Upload to EAS (recommended for cloud builds):"
+echo ""
+echo "   eas credentials --platform android"
+echo "   # Follow the interactive prompts to upload the keystore."
+echo ""
+echo "   OR set EAS secrets manually:"
+echo ""
+echo "   eas secret:create --scope project --name ANDROID_KEYSTORE \\"
+echo "     --value \"\$(base64 -w0 ${KEYSTORE_FILE})\""
+echo "   eas secret:create --scope project --name ANDROID_KEY_ALIAS \\"
+echo "     --value '${KEY_ALIAS}'"
+echo "   eas secret:create --scope project --name ANDROID_KEYSTORE_PASSWORD \\"
+echo "     --value 'YOUR_KEYSTORE_PASSWORD'"
+echo "   eas secret:create --scope project --name ANDROID_KEY_PASSWORD \\"
+echo "     --value 'YOUR_KEY_PASSWORD'"
+echo ""
+echo "3. Back up the keystore file and passwords to a secure vault before using"
+echo "   this keystore in a Play Store production release."
+echo ""
+echo "4. Update /.well-known/assetlinks.json on your server with the SHA-256"
+echo "   fingerprint to enable Android App Links."
+echo ""
+echo "IMPORTANT: ${KEYSTORE_FILE} is gitignored. Do NOT commit it."


### PR DESCRIPTION
## Task

Configure Android Release build: keystore setup, Google Services JSON, release Gradle variant, EAS build profile for the React Native Property Management app (three.two.bit.ppt.management). Context: gap-85-1-rn-env-config is already merged (env/config infrastructure done); this task wires the actual release build.

## Owner

pm-frontend (hint; actual scope is pm-mobile + pm-devops)

## Changes

### `frontend/apps/mobile/app.config.ts`
- Adds `import * as fs from 'node:fs'` for google-services.json detection
- `hasGoogleServicesJson()` helper — graceful fallback when Firebase is not configured locally
- `android.versionCode` fallback (actual value managed by EAS autoIncrement)
- `android.adaptiveIcon` — foreground asset + brand blue `#1A73E8` background
- `android.googleServicesFile` — conditionally injected when file is present (EAS Cloud uses `GOOGLE_SERVICES_JSON` secret)
- `android.permissions` — 13 permissions scoped to app features (camera, location, NFC, biometrics, FCM)
- `android.intentFilters` — `ppt-management://` custom scheme + App Links (`https://app.ppt.example.com`)
- `plugins` expanded to include `expo-notifications` with Android FCM colour config

### `frontend/apps/mobile/eas.json` (already in branch HEAD)
- `development.android.gradleCommand: :app:assembleDebug`
- `staging.android.credentialsSource: remote` + `gradleCommand: :app:assembleRelease`
- `staging.channel: staging` (OTA update channel)
- `production.android.credentialsSource: remote` + `gradleCommand: :app:bundleRelease`
- `submit.production.android` — Google Play production track, `releaseStatus: completed`
- `submit.staging.android` — Google Play internal track

### New files
- `frontend/apps/mobile/.gitignore` — protects `*.keystore`, `*.jks`, `google-services.json`, Google Play service account JSON from accidental commits
- `frontend/apps/mobile/google-services.json.template` — placeholder with Firebase setup instructions and EAS secret upload command
- `frontend/apps/mobile/store-metadata/android/google-play-service-account.json.template` — template for Play Console service account credentials
- `scripts/setup-android-keystore.sh` — interactive keystore generation script with EAS upload instructions, SHA-256 fingerprint extraction (for App Links / assetlinks.json), and security notes
- `.github/workflows/eas-build-android.yml` — CI workflow: staging APK on `dev` push to `frontend/apps/mobile/**`, production AAB on manual `workflow_dispatch`, optional Google Play submit

## Tested (Band A — fast check)

```
pnpm -F mobile typecheck → exit 0 (tsc --noEmit clean)
pnpm biome check apps/mobile/app.config.ts apps/mobile/eas.json → exit 0 (no errors)
```

## Built (Band B — full build)

```
npx expo config --type introspect (on android branch) → exit 0
Confirmed: android.package, adaptiveIcon, permissions, intentFilters all resolve correctly in Expo config introspection.
```

Band B full `eas build` not runnable in sandbox (requires EAS account + device credentials).

## CI parity (Band C — hot-path only)

Skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested

Skipped.

## Scope drift

`scope_drift=true` — justified:
- `frontend/apps/mobile/**` → pm-mobile area (task is mobile build config)
- `.github/workflows/eas-build-android.yml`, `scripts/setup-android-keystore.sh` → pm-devops area (CI + build tooling needed by the feature)
- Other `mobile-native/` and `.research/` files: pre-existing on branch from dispatcher state, not touched by this PR's feature work

## Code-reuse review

`code_reuse_warn=none` — no duplicate helpers detected.

## Notes

- `google-services.json` must be added as an EAS project secret before Android push notifications work in production:
  ```
  eas secret:create --scope project --name GOOGLE_SERVICES_JSON --value "$(base64 -w0 google-services.json)"
  ```
- Keystore must be generated via `scripts/setup-android-keystore.sh` and uploaded via `eas credentials --platform android` before release builds will sign correctly.
- `assetlinks.json` must be deployed to `https://app.ppt.example.com/.well-known/assetlinks.json` with the release keystore SHA-256 fingerprint for App Links to work.
- `store-metadata/android/google-play-service-account.json` (gitignored) must be obtained from Google Play Console for `eas submit` to work.

https://claude.ai/code/session_018irTagh9W1g7KH2L2P4scQ

---
_Generated by [Claude Code](https://claude.ai/code/session_018irTagh9W1g7KH2L2P4scQ)_