### PR TITLE
gap-82-3-search-enhancements: iOS search debounce, infinite scroll, CoreLocation, FilterSheet

### DIFF
--- a/mobile-native/iosApp/iosApp/App/RealityPortalApp.swift
+++ b/mobile-native/iosApp/iosApp/App/RealityPortalApp.swift
@@ -28,6 +28,7 @@ struct RealityPortalApp: App {
     @State private var pushNotificationManager = PushNotificationManager(
         keychainService: KeychainService(service: Configuration.shared.keychainService)
     )
+    @State private var locationManager = LocationManager()
     @Environment(\.scenePhase) private var scenePhase
 
     private let restorationService: NavigationStateRestorationService
@@ -51,6 +52,7 @@ struct RealityPortalApp: App {
                 .environment(authManager)
                 .environment(favoritesService)
                 .environment(pushNotificationManager)
+                .environment(locationManager)
                 .onOpenURL { url in
                     handleIncomingURL(url)
                 }

--- a/mobile-native/iosApp/iosApp/Core/Location/LocationManager.swift
+++ b/mobile-native/iosApp/iosApp/Core/Location/LocationManager.swift
@@ -63,6 +63,11 @@ final class LocationManager: NSObject {
         isLocating = false
     }
 
+    /// Clear any outstanding location error (call from alert dismiss action).
+    func clearLocationError() {
+        locationError = nil
+    }
+
     // MARK: - Private
 
     private func fetchLocation() {

--- a/mobile-native/iosApp/iosApp/Core/Location/LocationManager.swift
+++ b/mobile-native/iosApp/iosApp/Core/Location/LocationManager.swift
@@ -1,0 +1,106 @@
+import CoreLocation
+import Foundation
+import Observation
+
+/// Manages CoreLocation access for the Reality Portal iOS app.
+///
+/// Requests "when in use" authorisation, publishes the user's last known
+/// coordinate, and exposes a human-readable authorisation-status string so
+/// views can show appropriate prompts.
+///
+/// Epic 82 - Story 82.3: Home and Search Screens – CoreLocation integration
+@Observable
+final class LocationManager: NSObject {
+    // MARK: - Observable state
+
+    /// The user's most recently observed coordinate, or nil if unavailable.
+    private(set) var coordinate: CLLocationCoordinate2D?
+
+    /// Current authorisation status (refreshed whenever it changes).
+    private(set) var authorizationStatus: CLAuthorizationStatus = .notDetermined
+
+    /// true while the manager is actively fetching a location fix.
+    private(set) var isLocating = false
+
+    /// Non-nil when location services fail.
+    private(set) var locationError: String?
+
+    // MARK: - Private
+
+    private let manager: CLLocationManager
+
+    // MARK: - Init
+
+    override init() {
+        manager = CLLocationManager()
+        super.init()
+        manager.delegate = self
+        manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+        manager.distanceFilter = 500
+        authorizationStatus = manager.authorizationStatus
+    }
+
+    // MARK: - Public API
+
+    /// Request permission and start a one-shot location update.
+    func requestLocation() {
+        locationError = nil
+        switch manager.authorizationStatus {
+        case .authorizedWhenInUse, .authorizedAlways:
+            fetchLocation()
+        case .notDetermined:
+            manager.requestWhenInUseAuthorization()
+        case .denied, .restricted:
+            locationError = String(localized: "location_access_denied")
+        @unknown default:
+            locationError = String(localized: "location_unavailable")
+        }
+    }
+
+    /// Stop location updates.
+    func stopLocation() {
+        manager.stopUpdatingLocation()
+        isLocating = false
+    }
+
+    // MARK: - Private
+
+    private func fetchLocation() {
+        isLocating = true
+        manager.requestLocation()
+    }
+}
+
+// MARK: - CLLocationManagerDelegate
+
+extension LocationManager: CLLocationManagerDelegate {
+    func locationManager(
+        _ manager: CLLocationManager,
+        didUpdateLocations locations: [CLLocation]
+    ) {
+        isLocating = false
+        guard let loc = locations.last else { return }
+        coordinate = loc.coordinate
+    }
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        isLocating = false
+        let clError = error as? CLError
+        if clError?.code != .locationUnknown {
+            locationError = error.localizedDescription
+        }
+    }
+
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        authorizationStatus = manager.authorizationStatus
+        switch manager.authorizationStatus {
+        case .authorizedWhenInUse, .authorizedAlways:
+            if !isLocating { fetchLocation() }
+        case .denied, .restricted:
+            locationError = String(localized: "location_access_denied")
+            isLocating = false
+        default:
+            break
+        }
+    }
+}

--- a/mobile-native/iosApp/iosApp/Core/Location/LocationManager.swift
+++ b/mobile-native/iosApp/iosApp/Core/Location/LocationManager.swift
@@ -29,6 +29,11 @@ final class LocationManager: NSObject {
 
     private let manager: CLLocationManager
 
+    /// Set to true only when the user explicitly requests location (requestLocation()).
+    /// Guards the auto-fetch in locationManagerDidChangeAuthorization so we don't
+    /// eagerly fire a location fix on every app launch after permission is granted.
+    private var wantsLocation = false
+
     // MARK: - Init
 
     override init() {
@@ -45,14 +50,17 @@ final class LocationManager: NSObject {
     /// Request permission and start a one-shot location update.
     func requestLocation() {
         locationError = nil
+        wantsLocation = true
         switch manager.authorizationStatus {
         case .authorizedWhenInUse, .authorizedAlways:
             fetchLocation()
         case .notDetermined:
             manager.requestWhenInUseAuthorization()
         case .denied, .restricted:
+            wantsLocation = false
             locationError = String(localized: "location_access_denied")
         @unknown default:
+            wantsLocation = false
             locationError = String(localized: "location_unavailable")
         }
     }
@@ -61,6 +69,7 @@ final class LocationManager: NSObject {
     func stopLocation() {
         manager.stopUpdatingLocation()
         isLocating = false
+        wantsLocation = false
     }
 
     /// Clear any outstanding location error (call from alert dismiss action).
@@ -84,6 +93,7 @@ extension LocationManager: CLLocationManagerDelegate {
         didUpdateLocations locations: [CLLocation]
     ) {
         isLocating = false
+        wantsLocation = false
         guard let loc = locations.last else { return }
         coordinate = loc.coordinate
     }
@@ -100,7 +110,9 @@ extension LocationManager: CLLocationManagerDelegate {
         authorizationStatus = manager.authorizationStatus
         switch manager.authorizationStatus {
         case .authorizedWhenInUse, .authorizedAlways:
-            if !isLocating { fetchLocation() }
+            // Only auto-fetch if the user explicitly requested location — not on
+            // every app launch after permission was previously granted.
+            if !isLocating && wantsLocation { fetchLocation() }
         case .denied, .restricted:
             locationError = String(localized: "location_access_denied")
             isLocating = false

--- a/mobile-native/iosApp/iosApp/Core/Navigation/Route.swift
+++ b/mobile-native/iosApp/iosApp/Core/Navigation/Route.swift
@@ -118,12 +118,15 @@ struct SearchFilters: Hashable {
     var radiusKm: Double?
     var latitude: Double?
     var longitude: Double?
+    /// Sale/rent filter — maps to ListingType in the KMP layer.
+    var listingType: ListingKind?
 
     /// Whether any filters are active.
     var hasActiveFilters: Bool {
         priceMin != nil ||
         priceMax != nil ||
         !propertyTypes.isEmpty ||
+        listingType != nil ||
         bedroomsMin != nil ||
         bedroomsMax != nil ||
         bathroomsMin != nil ||
@@ -135,6 +138,7 @@ struct SearchFilters: Hashable {
         priceMin = nil
         priceMax = nil
         propertyTypes = []
+        listingType = nil
         bedroomsMin = nil
         bedroomsMax = nil
         bathroomsMin = nil
@@ -169,6 +173,22 @@ enum PropertyType: String, CaseIterable, Hashable {
         case .land: return "leaf"
         case .commercial: return "building"
         case .garage: return "car"
+        }
+    }
+}
+
+/// Sale or rent classification for a listing.
+///
+/// Mirrors the KMP ListingType enum but uses a Swift-idiomatic name to
+/// avoid clashing with the ListingType symbol exported from the shared framework.
+enum ListingKind: String, CaseIterable, Hashable {
+    case sale
+    case rent
+
+    var displayName: String {
+        switch self {
+        case .sale: return String(localized: "filter_for_sale")
+        case .rent: return String(localized: "filter_for_rent")
         }
     }
 }

--- a/mobile-native/iosApp/iosApp/Features/Home/HomeView.swift
+++ b/mobile-native/iosApp/iosApp/Features/Home/HomeView.swift
@@ -86,19 +86,29 @@ struct HomeView: View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 12) {
                 CategoryChip(title: String(localized: "filter_for_sale"), icon: "tag.fill") {
-                    // Navigate to search with sale filter
+                    var f = SearchFilters()
+                    f.listingType = .sale
+                    coordinator.navigate(to: .searchResults(query: "", filters: f))
                 }
                 CategoryChip(title: String(localized: "filter_for_rent"), icon: "house.fill") {
-                    // Navigate to search with rent filter
+                    var f = SearchFilters()
+                    f.listingType = .rent
+                    coordinator.navigate(to: .searchResults(query: "", filters: f))
                 }
                 CategoryChip(title: String(localized: "filter_apartments"), icon: "building.2.fill") {
-                    // Navigate to search with apartment filter
+                    var f = SearchFilters()
+                    f.propertyTypes = [.apartment]
+                    coordinator.navigate(to: .searchResults(query: "", filters: f))
                 }
                 CategoryChip(title: String(localized: "filter_houses"), icon: "house.fill") {
-                    // Navigate to search with house filter
+                    var f = SearchFilters()
+                    f.propertyTypes = [.house]
+                    coordinator.navigate(to: .searchResults(query: "", filters: f))
                 }
                 CategoryChip(title: String(localized: "filter_land"), icon: "leaf.fill") {
-                    // Navigate to search with land filter
+                    var f = SearchFilters()
+                    f.propertyTypes = [.land]
+                    coordinator.navigate(to: .searchResults(query: "", filters: f))
                 }
             }
             .padding(.horizontal)

--- a/mobile-native/iosApp/iosApp/Features/Search/SearchView.swift
+++ b/mobile-native/iosApp/iosApp/Features/Search/SearchView.swift
@@ -6,32 +6,37 @@ import shared
 /// Provides property search with filters and results.
 ///
 /// Epic 82 - Story 82.3: Home and Search Screens
+///   — debounced search (350 ms cancellable token), infinite scroll
+///     pagination, FilterSheet with listing-type + bathrooms sections,
+///     and CoreLocation "Near Me" chip / radius picker.
 struct SearchView: View {
     @Environment(NavigationCoordinator.self) private var coordinator
+    @Environment(LocationManager.self) private var locationManager
 
     @State private var searchText = ""
     @State private var results: [ListingPreview] = []
     @State private var isLoading = false
+    @State private var isLoadingMore = false
     @State private var showFilters = false
     @State private var filters = SearchFilters()
     @State private var currentPage = 1
     @State private var totalPages = 1
     @State private var totalCount = 0
 
+    /// Cancellable token for the in-flight debounce task.
+    @State private var debounceTask: Task<Void, Never>?
+
     private let listingRepository = DependencyContainer.shared.listingRepository
+    private let debounceNs: UInt64 = 350_000_000 // 350 ms
 
     var body: some View {
         VStack(spacing: 0) {
-            // Search bar
             searchBar
-
-            // Filter bar
             filterBar
 
-            // Results
             if isLoading && results.isEmpty {
                 loadingView
-            } else if results.isEmpty && !searchText.isEmpty {
+            } else if results.isEmpty && (!searchText.isEmpty || filters.hasActiveFilters) {
                 emptyResultsView
             } else if results.isEmpty {
                 searchPromptView
@@ -42,17 +47,18 @@ struct SearchView: View {
         .navigationTitle(String(localized: "tab_search"))
         .navigationBarTitleDisplayMode(.inline)
         .sheet(isPresented: $showFilters) {
-            FilterSheet(filters: $filters) {
+            FilterSheet(filters: $filters, locationManager: locationManager) {
                 Task { await performSearch() }
             }
         }
         .onChange(of: searchText) { _, newValue in
-            // Debounced search
-            Task {
-                try? await Task.sleep(nanoseconds: 300_000_000)
-                if searchText == newValue {
-                    await performSearch()
-                }
+            scheduleSearch(for: newValue)
+        }
+        .onChange(of: locationManager.coordinate) { _, coord in
+            if let coord, filters.radiusKm != nil {
+                filters.latitude = coord.latitude
+                filters.longitude = coord.longitude
+                Task { await performSearch() }
             }
         }
     }
@@ -64,13 +70,13 @@ struct SearchView: View {
             HStack {
                 Image(systemName: "magnifyingglass")
                     .foregroundStyle(.secondary)
-
                 TextField(String(localized: "search_placeholder"), text: $searchText)
                     .textFieldStyle(.plain)
-
                 if !searchText.isEmpty {
                     Button {
                         searchText = ""
+                        debounceTask?.cancel()
+                        Task { await performSearch() }
                     } label: {
                         Image(systemName: "xmark.circle.fill")
                             .foregroundStyle(.secondary)
@@ -87,7 +93,6 @@ struct SearchView: View {
     private var filterBar: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
-                // Filter button
                 Button {
                     showFilters = true
                 } label: {
@@ -106,8 +111,7 @@ struct SearchView: View {
                     .background(filters.hasActiveFilters ? Color.accentColor.opacity(0.1) : Color(.systemGray6))
                     .clipShape(Capsule())
                 }
-
-                // Quick filter chips
+                nearMeChip
                 ForEach(PropertyType.allCases, id: \.self) { type in
                     FilterChip(
                         title: type.displayName,
@@ -127,13 +131,64 @@ struct SearchView: View {
         .padding(.bottom, 8)
     }
 
+    @ViewBuilder
+    private var nearMeChip: some View {
+        let isActive = filters.radiusKm != nil
+        Button {
+            if isActive {
+                filters.radiusKm = nil
+                filters.latitude = nil
+                filters.longitude = nil
+                locationManager.stopLocation()
+                Task { await performSearch() }
+            } else {
+                filters.radiusKm = 10.0
+                if let coord = locationManager.coordinate {
+                    filters.latitude = coord.latitude
+                    filters.longitude = coord.longitude
+                    Task { await performSearch() }
+                } else {
+                    locationManager.requestLocation()
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                if locationManager.isLocating {
+                    ProgressView().scaleEffect(0.7)
+                } else {
+                    Image(systemName: isActive ? "location.fill" : "location")
+                }
+                Text(String(localized: "filter_near_me"))
+            }
+            .font(.subheadline)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(isActive ? Color.accentColor.opacity(0.1) : Color(.systemGray6))
+            .foregroundStyle(isActive ? Color.accentColor : .primary)
+            .clipShape(Capsule())
+            .overlay {
+                Capsule().stroke(isActive ? Color.accentColor : Color.clear, lineWidth: 1)
+            }
+        }
+        .buttonStyle(.plain)
+        .alert(
+            String(localized: "location_access_denied_title"),
+            isPresented: Binding(
+                get: { locationManager.locationError != nil },
+                set: { _ in }
+            )
+        ) {
+            Button(String(localized: "ok")) {}
+        } message: {
+            if let err = locationManager.locationError { Text(err) }
+        }
+    }
+
     private var loadingView: some View {
         VStack {
             Spacer()
             ProgressView()
-            Text(String(localized: "searching"))
-                .foregroundStyle(.secondary)
-                .padding(.top, 8)
+            Text(String(localized: "searching")).foregroundStyle(.secondary).padding(.top, 8)
             Spacer()
         }
     }
@@ -141,14 +196,9 @@ struct SearchView: View {
     private var emptyResultsView: some View {
         VStack(spacing: 16) {
             Spacer()
-            Image(systemName: "magnifyingglass")
-                .font(.system(size: 48))
-                .foregroundStyle(.secondary)
-            Text(String(localized: "no_results_found"))
-                .font(.headline)
-            Text(String(localized: "search_adjust_hint"))
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+            Image(systemName: "magnifyingglass").font(.system(size: 48)).foregroundStyle(.secondary)
+            Text(String(localized: "no_results_found")).font(.headline)
+            Text(String(localized: "search_adjust_hint")).font(.subheadline).foregroundStyle(.secondary)
             Spacer()
         }
     }
@@ -156,31 +206,17 @@ struct SearchView: View {
     private var searchPromptView: some View {
         VStack(spacing: 16) {
             Spacer()
-            Image(systemName: "house.fill")
-                .font(.system(size: 48))
-                .foregroundStyle(.secondary)
-            Text(String(localized: "search_prompt_title"))
-                .font(.headline)
-            Text(String(localized: "search_prompt_description"))
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-
-            // Recent searches placeholder
+            Image(systemName: "house.fill").font(.system(size: 48)).foregroundStyle(.secondary)
+            Text(String(localized: "search_prompt_title")).font(.headline)
+            Text(String(localized: "search_prompt_description")).font(.subheadline).foregroundStyle(.secondary)
             VStack(alignment: .leading, spacing: 8) {
                 Text(String(localized: "recent_searches"))
-                    .font(.subheadline)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(.secondary)
-
+                    .font(.subheadline).fontWeight(.semibold).foregroundStyle(.secondary)
                 ForEach(["Bratislava apartments", "Houses for sale", "3 bedroom"], id: \.self) { term in
-                    Button {
-                        searchText = term
-                    } label: {
+                    Button { searchText = term } label: {
                         HStack {
-                            Image(systemName: "clock.arrow.circlepath")
-                                .foregroundStyle(.secondary)
-                            Text(term)
-                                .foregroundStyle(.primary)
+                            Image(systemName: "clock.arrow.circlepath").foregroundStyle(.secondary)
+                            Text(term).foregroundStyle(.primary)
                             Spacer()
                         }
                         .padding(.vertical, 8)
@@ -191,7 +227,6 @@ struct SearchView: View {
             .background(Color(.systemGray6))
             .clipShape(RoundedRectangle(cornerRadius: 12))
             .padding(.horizontal)
-
             Spacer()
         }
     }
@@ -199,11 +234,9 @@ struct SearchView: View {
     private var resultsGrid: some View {
         ScrollView {
             LazyVStack(spacing: 12) {
-                // Results count
                 HStack {
-                    Text("\(totalCount) properties found")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
+                    Text(String(format: String(localized: "properties_found"), totalCount))
+                        .font(.subheadline).foregroundStyle(.secondary)
                     Spacer()
                 }
                 .padding(.horizontal)
@@ -214,116 +247,116 @@ struct SearchView: View {
                     }
                 }
 
-                // Load more indicator
                 if currentPage < totalPages {
-                    ProgressView()
-                        .padding()
-                        .onAppear {
-                            Task { await loadMoreResults() }
-                        }
+                    Group {
+                        if isLoadingMore { ProgressView().padding() }
+                        else { Color.clear.frame(height: 1) }
+                    }
+                    .onAppear { Task { await loadMoreResults() } }
                 }
             }
             .padding(.vertical)
         }
     }
 
-    // MARK: - Search
+    // MARK: - Debounced search
+
+    private func scheduleSearch(for value: String) {
+        debounceTask?.cancel()
+        debounceTask = Task {
+            do {
+                try await Task.sleep(nanoseconds: debounceNs)
+                if searchText == value { await performSearch() }
+            } catch {}
+        }
+    }
+
+    // MARK: - Data
 
     private func performSearch() async {
         guard !searchText.isEmpty || filters.hasActiveFilters else {
-            results = []
-            totalCount = 0
+            results = []; totalCount = 0; totalPages = 1; currentPage = 1
             return
         }
-
         isLoading = true
         currentPage = 1
-
-        // Build search request from KMP
-        let searchFilters = buildKMPFilters()
         let request = ListingSearchRequest(
             query: searchText.isEmpty ? nil : searchText,
-            filters: searchFilters,
+            filters: buildKMPFilters(),
             sort: .newest,
             page: Int32(currentPage),
             pageSize: 20
         )
-
         let result = await listingRepository.searchListings(request: request)
-
         if let response = result.getOrNull() {
             results = response.listings.map { KMPBridge.toListingPreview($0) }
             totalPages = Int(response.totalPages)
             totalCount = Int(response.total)
-        } else if let error = result.exceptionOrNull() {
+        } else {
             #if DEBUG
-            print("Search error: \(error.message ?? "Unknown error")")
+            if let error = result.exceptionOrNull() {
+                print("Search error: \(error.message ?? "Unknown error")")
+            }
             #endif
             results = []
         }
-
         isLoading = false
     }
 
     private func loadMoreResults() async {
-        guard currentPage < totalPages, !isLoading else { return }
-
+        guard currentPage < totalPages, !isLoading, !isLoadingMore else { return }
+        isLoadingMore = true
         currentPage += 1
-
-        let searchFilters = buildKMPFilters()
         let request = ListingSearchRequest(
             query: searchText.isEmpty ? nil : searchText,
-            filters: searchFilters,
+            filters: buildKMPFilters(),
             sort: .newest,
             page: Int32(currentPage),
             pageSize: 20
         )
-
         let result = await listingRepository.searchListings(request: request)
-
         if let response = result.getOrNull() {
-            let newListings = response.listings.map { KMPBridge.toListingPreview($0) }
-            results.append(contentsOf: newListings)
+            results.append(contentsOf: response.listings.map { KMPBridge.toListingPreview($0) })
+        } else {
+            currentPage = max(1, currentPage - 1)
         }
+        isLoadingMore = false
     }
 
     private func buildKMPFilters() -> ListingSearchFilters? {
         guard filters.hasActiveFilters else { return nil }
 
-        // Map Swift PropertyType to KMP PropertyCategory
         var category: PropertyCategory? = nil
         if let firstType = filters.propertyTypes.first {
             switch firstType {
-            case .apartment:
-                category = .apartment
-            case .house:
-                category = .house
-            case .land:
-                category = .land
-            case .commercial:
-                category = .commercial
-            case .garage:
-                category = .garage
+            case .apartment:  category = .apartment
+            case .house:      category = .house
+            case .land:       category = .land
+            case .commercial: category = .commercial
+            case .garage:     category = .garage
+            }
+        }
+
+        var listingType: ListingType? = nil
+        if let kind = filters.listingType {
+            switch kind {
+            case .sale: listingType = .sale
+            case .rent: listingType = .rent
             }
         }
 
         return ListingSearchFilters(
-            type: nil,
+            type: listingType,
             category: category,
-            city: nil,
-            district: nil,
-            region: nil,
+            city: nil, district: nil, region: nil,
             minPrice: filters.priceMin.map { KotlinLong(integerLiteral: $0) },
             maxPrice: filters.priceMax.map { KotlinLong(integerLiteral: $0) },
-            minArea: nil,
-            maxArea: nil,
+            minArea: nil, maxArea: nil,
             minRooms: filters.bedroomsMin.map { KotlinInt(integerLiteral: $0) },
             maxRooms: filters.bedroomsMax.map { KotlinInt(integerLiteral: $0) },
             bedrooms: filters.bedroomsMin.map { KotlinInt(integerLiteral: $0) },
             bathrooms: filters.bathroomsMin.map { KotlinInt(integerLiteral: $0) },
-            features: nil,
-            yearBuiltMin: nil,
-            yearBuiltMax: nil,
+            features: nil, yearBuiltMin: nil, yearBuiltMax: nil,
             nearLat: filters.latitude.map { KotlinDouble(value: $0) },
             nearLng: filters.longitude.map { KotlinDouble(value: $0) },
             radiusKm: filters.radiusKm.map { KotlinDouble(value: $0) }
@@ -337,7 +370,6 @@ private struct FilterChip: View {
     let title: String
     let isSelected: Bool
     let action: () -> Void
-
     var body: some View {
         Button(action: action) {
             Text(title)
@@ -347,10 +379,7 @@ private struct FilterChip: View {
                 .background(isSelected ? Color.accentColor.opacity(0.1) : Color(.systemGray6))
                 .foregroundStyle(isSelected ? Color.accentColor : .primary)
                 .clipShape(Capsule())
-                .overlay {
-                    Capsule()
-                        .stroke(isSelected ? Color.accentColor : Color.clear, lineWidth: 1)
-                }
+                .overlay { Capsule().stroke(isSelected ? Color.accentColor : Color.clear, lineWidth: 1) }
         }
         .buttonStyle(.plain)
     }
@@ -359,92 +388,51 @@ private struct FilterChip: View {
 private struct SearchResultCard: View {
     let listing: ListingPreview
     let action: () -> Void
-
     var body: some View {
         Button(action: action) {
             VStack(alignment: .leading, spacing: 0) {
-                // Image placeholder or async image
                 ZStack {
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(Color(.systemGray5))
-                        .frame(height: 180)
-
-                    if let thumbnailUrl = listing.thumbnailUrl,
-                       let url = URL(string: thumbnailUrl) {
+                    RoundedRectangle(cornerRadius: 12).fill(Color(.systemGray5)).frame(height: 180)
+                    if let thumbnailUrl = listing.thumbnailUrl, let url = URL(string: thumbnailUrl) {
                         AsyncImage(url: url) { phase in
                             switch phase {
                             case .success(let image):
-                                image
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fill)
-                                    .frame(height: 180)
-                                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                                image.resizable().aspectRatio(contentMode: .fill)
+                                    .frame(height: 180).clipShape(RoundedRectangle(cornerRadius: 12))
                             case .failure, .empty:
-                                Image(systemName: "photo")
-                                    .font(.largeTitle)
-                                    .foregroundStyle(.secondary)
+                                Image(systemName: "photo").font(.largeTitle).foregroundStyle(.secondary)
                             @unknown default:
-                                Image(systemName: "photo")
-                                    .font(.largeTitle)
-                                    .foregroundStyle(.secondary)
+                                Image(systemName: "photo").font(.largeTitle).foregroundStyle(.secondary)
                             }
                         }
                     } else {
-                        Image(systemName: "photo")
-                            .font(.largeTitle)
-                            .foregroundStyle(.secondary)
+                        Image(systemName: "photo").font(.largeTitle).foregroundStyle(.secondary)
                     }
                 }
                 .overlay(alignment: .topTrailing) {
-                    Button {
-                        // Toggle favorite
-                    } label: {
-                        Image(systemName: "heart")
-                            .font(.title3)
-                            .padding(8)
-                            .background(.ultraThinMaterial)
-                            .clipShape(Circle())
+                    Button {} label: {
+                        Image(systemName: "heart").font(.title3).padding(8)
+                            .background(.ultraThinMaterial).clipShape(Circle())
                     }
                     .padding(8)
                 }
-
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(listing.formattedPrice)
-                        .font(.title3)
-                        .fontWeight(.bold)
-                        .foregroundStyle(Color.accentColor)
-
-                    Text(listing.title)
-                        .font(.subheadline)
-                        .lineLimit(1)
-                        .foregroundStyle(.primary)
-
+                    Text(listing.formattedPrice).font(.title3).fontWeight(.bold).foregroundStyle(Color.accentColor)
+                    Text(listing.title).font(.subheadline).lineLimit(1).foregroundStyle(.primary)
                     HStack(spacing: 4) {
-                        Image(systemName: "location.fill")
-                            .font(.caption)
-                        Text(listing.location)
-                            .font(.caption)
+                        Image(systemName: "location.fill").font(.caption)
+                        Text(listing.location).font(.caption)
                     }
                     .foregroundStyle(.secondary)
-
                     HStack(spacing: 12) {
                         if let area = listing.areaSqm {
-                            HStack(spacing: 2) {
-                                Image(systemName: "square.fill")
-                                    .font(.caption2)
-                                Text("\(area) m2")
-                            }
+                            HStack(spacing: 2) { Image(systemName: "square.fill").font(.caption2); Text("\(area) m2") }
                         }
                         if let rooms = listing.rooms {
-                            HStack(spacing: 2) {
-                                Image(systemName: "bed.double.fill")
-                                    .font(.caption2)
-                                Text("\(rooms)")
-                            }
+                            HStack(spacing: 2) { Image(systemName: "bed.double.fill").font(.caption2); Text("\(rooms)") }
                         }
                     }
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .font(.caption).foregroundStyle(.secondary)
                 }
                 .padding(12)
             }
@@ -461,51 +449,60 @@ private struct SearchResultCard: View {
 
 private struct FilterSheet: View {
     @Binding var filters: SearchFilters
+    let locationManager: LocationManager
     let onApply: () -> Void
     @Environment(\.dismiss) private var dismiss
+    private let radiusOptions: [Double] = [1, 3, 5, 10, 20, 50]
 
     var body: some View {
         NavigationStack {
             Form {
                 Section(String(localized: "filter_price_range")) {
                     HStack {
-                        TextField("Min", value: $filters.priceMin, format: .number)
-                            .textFieldStyle(.roundedBorder)
-                            .keyboardType(.numberPad)
-
+                        TextField(String(localized: "filter_price_min"), value: $filters.priceMin, format: .number)
+                            .textFieldStyle(.roundedBorder).keyboardType(.numberPad)
                         Text("-")
-
-                        TextField("Max", value: $filters.priceMax, format: .number)
-                            .textFieldStyle(.roundedBorder)
-                            .keyboardType(.numberPad)
+                        TextField(String(localized: "filter_price_max"), value: $filters.priceMax, format: .number)
+                            .textFieldStyle(.roundedBorder).keyboardType(.numberPad)
                     }
                 }
-
+                Section(String(localized: "filter_listing_type")) {
+                    ForEach(ListingKind.allCases, id: \.self) { kind in
+                        Toggle(kind.displayName, isOn: Binding(
+                            get: { filters.listingType == kind },
+                            set: { isOn in filters.listingType = isOn ? kind : nil }
+                        ))
+                    }
+                }
                 Section(String(localized: "filter_property_type")) {
                     ForEach(PropertyType.allCases, id: \.self) { type in
                         Toggle(type.displayName, isOn: Binding(
                             get: { filters.propertyTypes.contains(type) },
                             set: { isOn in
-                                if isOn {
-                                    filters.propertyTypes.insert(type)
-                                } else {
-                                    filters.propertyTypes.remove(type)
-                                }
+                                if isOn { filters.propertyTypes.insert(type) }
+                                else { filters.propertyTypes.remove(type) }
                             }
                         ))
                     }
                 }
-
                 Section(String(localized: "filter_bedrooms")) {
-                    Stepper("Min: \(filters.bedroomsMin ?? 0)", value: Binding(
-                        get: { filters.bedroomsMin ?? 0 },
-                        set: { filters.bedroomsMin = $0 > 0 ? $0 : nil }
-                    ), in: 0...10)
+                    Stepper(String(format: String(localized: "filter_min_value"), filters.bedroomsMin ?? 0),
+                        value: Binding(get: { filters.bedroomsMin ?? 0 }, set: { filters.bedroomsMin = $0 > 0 ? $0 : nil }),
+                        in: 0...10)
+                    Stepper(String(format: String(localized: "filter_max_value"), filters.bedroomsMax ?? 10),
+                        value: Binding(get: { filters.bedroomsMax ?? 10 }, set: { filters.bedroomsMax = $0 < 10 ? $0 : nil }),
+                        in: 0...10)
                 }
-
+                Section(String(localized: "filter_bathrooms")) {
+                    Stepper(String(format: String(localized: "filter_min_value"), filters.bathroomsMin ?? 0),
+                        value: Binding(get: { filters.bathroomsMin ?? 0 }, set: { filters.bathroomsMin = $0 > 0 ? $0 : nil }),
+                        in: 0...10)
+                }
+                nearMeSection
                 Section {
                     Button(String(localized: "reset_filters")) {
                         filters.reset()
+                        locationManager.stopLocation()
                     }
                     .foregroundStyle(Color.pptDanger)
                 }
@@ -513,17 +510,50 @@ private struct FilterSheet: View {
             .navigationTitle(String(localized: "filters"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(String(localized: "cancel")) {
-                        dismiss()
-                    }
-                }
+                ToolbarItem(placement: .cancellationAction) { Button(String(localized: "cancel")) { dismiss() } }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button(String(localized: "apply")) {
-                        onApply()
-                        dismiss()
+                    Button(String(localized: "apply")) { onApply(); dismiss() }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var nearMeSection: some View {
+        Section {
+            Toggle(String(localized: "filter_near_me"), isOn: Binding(
+                get: { filters.radiusKm != nil },
+                set: { enabled in
+                    if enabled {
+                        filters.radiusKm = 10.0
+                        if let coord = locationManager.coordinate {
+                            filters.latitude = coord.latitude
+                            filters.longitude = coord.longitude
+                        } else {
+                            locationManager.requestLocation()
+                        }
+                    } else {
+                        filters.radiusKm = nil; filters.latitude = nil; filters.longitude = nil
+                        locationManager.stopLocation()
                     }
                 }
+            ))
+            if filters.radiusKm != nil {
+                Picker(String(localized: "filter_radius"),
+                    selection: Binding(get: { filters.radiusKm ?? 10.0 }, set: { filters.radiusKm = $0 })) {
+                    ForEach(radiusOptions, id: \.self) { km in
+                        Text(String(format: String(localized: "radius_km_format"), Int(km))).tag(km)
+                    }
+                }
+            }
+        } header: {
+            Text(String(localized: "filter_near_me_section"))
+        } footer: {
+            if let coord = locationManager.coordinate, filters.radiusKm != nil {
+                Text(String(format: String(localized: "location_detected_format"), coord.latitude, coord.longitude))
+                    .foregroundStyle(.secondary)
+            } else if locationManager.isLocating {
+                Label(String(localized: "locating"), systemImage: "location.fill").foregroundStyle(.secondary)
             }
         }
     }
@@ -532,8 +562,7 @@ private struct FilterSheet: View {
 // MARK: - Preview
 
 #Preview {
-    NavigationStack {
-        SearchView()
-    }
-    .environment(NavigationCoordinator())
+    NavigationStack { SearchView() }
+        .environment(NavigationCoordinator())
+        .environment(LocationManager())
 }

--- a/mobile-native/iosApp/iosApp/Features/Search/SearchView.swift
+++ b/mobile-native/iosApp/iosApp/Features/Search/SearchView.swift
@@ -175,10 +175,12 @@ struct SearchView: View {
             String(localized: "location_access_denied_title"),
             isPresented: Binding(
                 get: { locationManager.locationError != nil },
-                set: { _ in }
+                set: { _ in locationManager.clearLocationError() }
             )
         ) {
-            Button(String(localized: "ok")) {}
+            Button(String(localized: "ok")) {
+                locationManager.clearLocationError()
+            }
         } message: {
             if let err = locationManager.locationError { Text(err) }
         }

--- a/mobile-native/iosApp/iosApp/Features/Search/SearchView.swift
+++ b/mobile-native/iosApp/iosApp/Features/Search/SearchView.swift
@@ -26,6 +26,9 @@ struct SearchView: View {
     /// Cancellable token for the in-flight debounce task.
     @State private var debounceTask: Task<Void, Never>?
 
+    /// Drives the location-denied alert; set by .onChange(of: locationManager.locationError).
+    @State private var showLocationDeniedAlert = false
+
     private let listingRepository = DependencyContainer.shared.listingRepository
     private let debounceNs: UInt64 = 350_000_000 // 350 ms
 
@@ -47,7 +50,7 @@ struct SearchView: View {
         .navigationTitle(String(localized: "tab_search"))
         .navigationBarTitleDisplayMode(.inline)
         .sheet(isPresented: $showFilters) {
-            FilterSheet(filters: $filters, locationManager: locationManager) {
+            FilterSheet(filters: $filters) {
                 Task { await performSearch() }
             }
         }
@@ -60,6 +63,26 @@ struct SearchView: View {
                 filters.longitude = coord.longitude
                 Task { await performSearch() }
             }
+        }
+        // Drive the location-denied alert from body-level state.
+        // The inline-Binding approach inside a @ViewBuilder var is unreliable
+        // on iOS 17+ with @Observable (dismiss can fail to reconcile).
+        .onChange(of: locationManager.locationError) { _, err in
+            if err != nil { showLocationDeniedAlert = true }
+        }
+        .onDisappear {
+            debounceTask?.cancel()
+        }
+        .alert(
+            String(localized: "location_access_denied_title"),
+            isPresented: $showLocationDeniedAlert
+        ) {
+            Button(String(localized: "ok")) {
+                showLocationDeniedAlert = false
+                locationManager.clearLocationError()
+            }
+        } message: {
+            if let err = locationManager.locationError { Text(err) }
         }
     }
 
@@ -171,19 +194,8 @@ struct SearchView: View {
             }
         }
         .buttonStyle(.plain)
-        .alert(
-            String(localized: "location_access_denied_title"),
-            isPresented: Binding(
-                get: { locationManager.locationError != nil },
-                set: { _ in locationManager.clearLocationError() }
-            )
-        ) {
-            Button(String(localized: "ok")) {
-                locationManager.clearLocationError()
-            }
-        } message: {
-            if let err = locationManager.locationError { Text(err) }
-        }
+        // Alert is handled at body level (showLocationDeniedAlert) to avoid
+        // iOS 17+ @Observable reconciliation issues with inline bindings.
     }
 
     private var loadingView: some View {
@@ -308,6 +320,7 @@ struct SearchView: View {
     private func loadMoreResults() async {
         guard currentPage < totalPages, !isLoading, !isLoadingMore else { return }
         isLoadingMore = true
+        let prevPage = currentPage
         currentPage += 1
         let request = ListingSearchRequest(
             query: searchText.isEmpty ? nil : searchText,
@@ -320,7 +333,7 @@ struct SearchView: View {
         if let response = result.getOrNull() {
             results.append(contentsOf: response.listings.map { KMPBridge.toListingPreview($0) })
         } else {
-            currentPage = max(1, currentPage - 1)
+            currentPage = prevPage
         }
         isLoadingMore = false
     }
@@ -451,8 +464,8 @@ private struct SearchResultCard: View {
 
 private struct FilterSheet: View {
     @Binding var filters: SearchFilters
-    let locationManager: LocationManager
     let onApply: () -> Void
+    @Environment(LocationManager.self) private var locationManager
     @Environment(\.dismiss) private var dismiss
     private let radiusOptions: [Double] = [1, 3, 5, 10, 20, 50]
 

--- a/mobile-native/iosApp/iosApp/Resources/cs.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/cs.lproj/Localizable.strings
@@ -252,12 +252,12 @@
 "location_access_denied_title" = "Přístup k poloze odepřen";
 
 /* Search - Listing type / FilterSheet additions (Story 82.3) */
-"filter_listing_type" = "Listing Type";
-"filter_price_min" = "Min price";
-"filter_price_max" = "Max price";
+"filter_listing_type" = "Typ nabídky";
+"filter_price_min" = "Min cena";
+"filter_price_max" = "Max cena";
 "filter_min_value" = "Min: %d";
 "filter_max_value" = "Max: %d";
-"filter_bathrooms" = "Bathrooms";
+"filter_bathrooms" = "Koupelny";
 
 /* Account Screen - Additional */
 "quick_actions" = "Rychlé akce";

--- a/mobile-native/iosApp/iosApp/Resources/cs.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/cs.lproj/Localizable.strings
@@ -241,15 +241,15 @@
 
 
 /* Search - Near Me / Location (added Story 82.3) */
-"filter_near_me" = "Near Me";
-"filter_near_me_section" = "Location";
-"filter_radius" = "Radius";
+"filter_near_me" = "V okolí";
+"filter_near_me_section" = "Poloha";
+"filter_radius" = "Poloměr";
 "radius_km_format" = "%d km";
-"location_detected_format" = "Location: %.4f, %.4f";
-"locating" = "Locating…";
-"location_access_denied" = "Location access was denied. Enable it in Settings to use Near Me filters.";
-"location_unavailable" = "Location is unavailable.";
-"location_access_denied_title" = "Location Access Denied";
+"location_detected_format" = "Poloha: %.4f, %.4f";
+"locating" = "Zjišťuji polohu…";
+"location_access_denied" = "Přístup k poloze byl odepřen. Povolte ho v Nastavení, abyste mohli používat filtry V okolí.";
+"location_unavailable" = "Poloha není dostupná.";
+"location_access_denied_title" = "Přístup k poloze odepřen";
 
 /* Search - Listing type / FilterSheet additions (Story 82.3) */
 "filter_listing_type" = "Listing Type";

--- a/mobile-native/iosApp/iosApp/Resources/cs.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/cs.lproj/Localizable.strings
@@ -239,6 +239,26 @@
 "reset_filters" = "Obnovit filtry";
 "apply" = "Použít";
 
+
+/* Search - Near Me / Location (added Story 82.3) */
+"filter_near_me" = "Near Me";
+"filter_near_me_section" = "Location";
+"filter_radius" = "Radius";
+"radius_km_format" = "%d km";
+"location_detected_format" = "Location: %.4f, %.4f";
+"locating" = "Locating…";
+"location_access_denied" = "Location access was denied. Enable it in Settings to use Near Me filters.";
+"location_unavailable" = "Location is unavailable.";
+"location_access_denied_title" = "Location Access Denied";
+
+/* Search - Listing type / FilterSheet additions (Story 82.3) */
+"filter_listing_type" = "Listing Type";
+"filter_price_min" = "Min price";
+"filter_price_max" = "Max price";
+"filter_min_value" = "Min: %d";
+"filter_max_value" = "Max: %d";
+"filter_bathrooms" = "Bathrooms";
+
 /* Account Screen - Additional */
 "quick_actions" = "Rychlé akce";
 "saved_searches" = "Uložená vyhledávání";

--- a/mobile-native/iosApp/iosApp/Resources/de.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/de.lproj/Localizable.strings
@@ -241,15 +241,15 @@
 
 
 /* Search - Near Me / Location (added Story 82.3) */
-"filter_near_me" = "Near Me";
-"filter_near_me_section" = "Location";
+"filter_near_me" = "In meiner Nähe";
+"filter_near_me_section" = "Standort";
 "filter_radius" = "Radius";
 "radius_km_format" = "%d km";
-"location_detected_format" = "Location: %.4f, %.4f";
-"locating" = "Locating…";
-"location_access_denied" = "Location access was denied. Enable it in Settings to use Near Me filters.";
-"location_unavailable" = "Location is unavailable.";
-"location_access_denied_title" = "Location Access Denied";
+"location_detected_format" = "Standort: %.4f, %.4f";
+"locating" = "Standort wird ermittelt…";
+"location_access_denied" = "Standortzugriff wurde verweigert. Aktivieren Sie ihn in den Einstellungen, um Filter „In meiner Nähe" zu nutzen.";
+"location_unavailable" = "Standort nicht verfügbar.";
+"location_access_denied_title" = "Standortzugriff verweigert";
 
 /* Search - Listing type / FilterSheet additions (Story 82.3) */
 "filter_listing_type" = "Listing Type";

--- a/mobile-native/iosApp/iosApp/Resources/de.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/de.lproj/Localizable.strings
@@ -239,6 +239,26 @@
 "reset_filters" = "Filter zurücksetzen";
 "apply" = "Anwenden";
 
+
+/* Search - Near Me / Location (added Story 82.3) */
+"filter_near_me" = "Near Me";
+"filter_near_me_section" = "Location";
+"filter_radius" = "Radius";
+"radius_km_format" = "%d km";
+"location_detected_format" = "Location: %.4f, %.4f";
+"locating" = "Locating…";
+"location_access_denied" = "Location access was denied. Enable it in Settings to use Near Me filters.";
+"location_unavailable" = "Location is unavailable.";
+"location_access_denied_title" = "Location Access Denied";
+
+/* Search - Listing type / FilterSheet additions (Story 82.3) */
+"filter_listing_type" = "Listing Type";
+"filter_price_min" = "Min price";
+"filter_price_max" = "Max price";
+"filter_min_value" = "Min: %d";
+"filter_max_value" = "Max: %d";
+"filter_bathrooms" = "Bathrooms";
+
 /* Account Screen - Additional */
 "quick_actions" = "Schnellaktionen";
 "saved_searches" = "Gespeicherte Suchen";

--- a/mobile-native/iosApp/iosApp/Resources/de.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/de.lproj/Localizable.strings
@@ -252,12 +252,12 @@
 "location_access_denied_title" = "Standortzugriff verweigert";
 
 /* Search - Listing type / FilterSheet additions (Story 82.3) */
-"filter_listing_type" = "Listing Type";
-"filter_price_min" = "Min price";
-"filter_price_max" = "Max price";
+"filter_listing_type" = "Angebotstyp";
+"filter_price_min" = "Mindestpreis";
+"filter_price_max" = "Höchstpreis";
 "filter_min_value" = "Min: %d";
 "filter_max_value" = "Max: %d";
-"filter_bathrooms" = "Bathrooms";
+"filter_bathrooms" = "Badezimmer";
 
 /* Account Screen - Additional */
 "quick_actions" = "Schnellaktionen";

--- a/mobile-native/iosApp/iosApp/Resources/en.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/en.lproj/Localizable.strings
@@ -239,6 +239,26 @@
 "reset_filters" = "Reset Filters";
 "apply" = "Apply";
 
+
+/* Search - Near Me / Location (added Story 82.3) */
+"filter_near_me" = "Near Me";
+"filter_near_me_section" = "Location";
+"filter_radius" = "Radius";
+"radius_km_format" = "%d km";
+"location_detected_format" = "Location: %.4f, %.4f";
+"locating" = "Locating…";
+"location_access_denied" = "Location access was denied. Enable it in Settings to use Near Me filters.";
+"location_unavailable" = "Location is unavailable.";
+"location_access_denied_title" = "Location Access Denied";
+
+/* Search - Listing type / FilterSheet additions (Story 82.3) */
+"filter_listing_type" = "Listing Type";
+"filter_price_min" = "Min price";
+"filter_price_max" = "Max price";
+"filter_min_value" = "Min: %d";
+"filter_max_value" = "Max: %d";
+"filter_bathrooms" = "Bathrooms";
+
 /* Account Screen - Additional */
 "quick_actions" = "Quick Actions";
 "saved_searches" = "Saved Searches";

--- a/mobile-native/iosApp/iosApp/Resources/hu.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/hu.lproj/Localizable.strings
@@ -252,12 +252,12 @@
 "location_access_denied_title" = "Helymeghatározás megtagadva";
 
 /* Search - Listing type / FilterSheet additions (Story 82.3) */
-"filter_listing_type" = "Listing Type";
-"filter_price_min" = "Min price";
-"filter_price_max" = "Max price";
+"filter_listing_type" = "Hirdetés típusa";
+"filter_price_min" = "Min ár";
+"filter_price_max" = "Max ár";
 "filter_min_value" = "Min: %d";
 "filter_max_value" = "Max: %d";
-"filter_bathrooms" = "Bathrooms";
+"filter_bathrooms" = "Fürdőszobák";
 
 /* Account Screen - Additional */
 "quick_actions" = "Gyors műveletek";

--- a/mobile-native/iosApp/iosApp/Resources/hu.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/hu.lproj/Localizable.strings
@@ -241,15 +241,15 @@
 
 
 /* Search - Near Me / Location (added Story 82.3) */
-"filter_near_me" = "Near Me";
-"filter_near_me_section" = "Location";
-"filter_radius" = "Radius";
+"filter_near_me" = "A közelemben";
+"filter_near_me_section" = "Helyszín";
+"filter_radius" = "Sugár";
 "radius_km_format" = "%d km";
-"location_detected_format" = "Location: %.4f, %.4f";
-"locating" = "Locating…";
-"location_access_denied" = "Location access was denied. Enable it in Settings to use Near Me filters.";
-"location_unavailable" = "Location is unavailable.";
-"location_access_denied_title" = "Location Access Denied";
+"location_detected_format" = "Helyszín: %.4f, %.4f";
+"locating" = "Helyszín meghatározása…";
+"location_access_denied" = "A helymeghatározáshoz való hozzáférés megtagadva. Engedélyezze a Beállításokban a Közeli szűrők használatához.";
+"location_unavailable" = "A helymeghatározás nem elérhető.";
+"location_access_denied_title" = "Helymeghatározás megtagadva";
 
 /* Search - Listing type / FilterSheet additions (Story 82.3) */
 "filter_listing_type" = "Listing Type";

--- a/mobile-native/iosApp/iosApp/Resources/hu.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/hu.lproj/Localizable.strings
@@ -239,6 +239,26 @@
 "reset_filters" = "Szűrők visszaállítása";
 "apply" = "Alkalmaz";
 
+
+/* Search - Near Me / Location (added Story 82.3) */
+"filter_near_me" = "Near Me";
+"filter_near_me_section" = "Location";
+"filter_radius" = "Radius";
+"radius_km_format" = "%d km";
+"location_detected_format" = "Location: %.4f, %.4f";
+"locating" = "Locating…";
+"location_access_denied" = "Location access was denied. Enable it in Settings to use Near Me filters.";
+"location_unavailable" = "Location is unavailable.";
+"location_access_denied_title" = "Location Access Denied";
+
+/* Search - Listing type / FilterSheet additions (Story 82.3) */
+"filter_listing_type" = "Listing Type";
+"filter_price_min" = "Min price";
+"filter_price_max" = "Max price";
+"filter_min_value" = "Min: %d";
+"filter_max_value" = "Max: %d";
+"filter_bathrooms" = "Bathrooms";
+
 /* Account Screen - Additional */
 "quick_actions" = "Gyors műveletek";
 "saved_searches" = "Mentett keresések";

--- a/mobile-native/iosApp/iosApp/Resources/pl.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/pl.lproj/Localizable.strings
@@ -241,15 +241,15 @@
 
 
 /* Search - Near Me / Location (added Story 82.3) */
-"filter_near_me" = "Near Me";
-"filter_near_me_section" = "Location";
-"filter_radius" = "Radius";
+"filter_near_me" = "W pobliżu";
+"filter_near_me_section" = "Lokalizacja";
+"filter_radius" = "Promień";
 "radius_km_format" = "%d km";
-"location_detected_format" = "Location: %.4f, %.4f";
-"locating" = "Locating…";
-"location_access_denied" = "Location access was denied. Enable it in Settings to use Near Me filters.";
-"location_unavailable" = "Location is unavailable.";
-"location_access_denied_title" = "Location Access Denied";
+"location_detected_format" = "Lokalizacja: %.4f, %.4f";
+"locating" = "Wyznaczam lokalizację…";
+"location_access_denied" = "Dostęp do lokalizacji został odmówiony. Włącz go w Ustawieniach, aby korzystać z filtrów W pobliżu.";
+"location_unavailable" = "Lokalizacja jest niedostępna.";
+"location_access_denied_title" = "Odmowa dostępu do lokalizacji";
 
 /* Search - Listing type / FilterSheet additions (Story 82.3) */
 "filter_listing_type" = "Listing Type";

--- a/mobile-native/iosApp/iosApp/Resources/pl.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/pl.lproj/Localizable.strings
@@ -252,12 +252,12 @@
 "location_access_denied_title" = "Odmowa dostępu do lokalizacji";
 
 /* Search - Listing type / FilterSheet additions (Story 82.3) */
-"filter_listing_type" = "Listing Type";
-"filter_price_min" = "Min price";
-"filter_price_max" = "Max price";
+"filter_listing_type" = "Typ ogłoszenia";
+"filter_price_min" = "Min cena";
+"filter_price_max" = "Max cena";
 "filter_min_value" = "Min: %d";
 "filter_max_value" = "Max: %d";
-"filter_bathrooms" = "Bathrooms";
+"filter_bathrooms" = "Łazienki";
 
 /* Account Screen - Additional */
 "quick_actions" = "Szybkie akcje";

--- a/mobile-native/iosApp/iosApp/Resources/pl.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/pl.lproj/Localizable.strings
@@ -239,6 +239,26 @@
 "reset_filters" = "Zresetuj filtry";
 "apply" = "Zastosuj";
 
+
+/* Search - Near Me / Location (added Story 82.3) */
+"filter_near_me" = "Near Me";
+"filter_near_me_section" = "Location";
+"filter_radius" = "Radius";
+"radius_km_format" = "%d km";
+"location_detected_format" = "Location: %.4f, %.4f";
+"locating" = "Locating…";
+"location_access_denied" = "Location access was denied. Enable it in Settings to use Near Me filters.";
+"location_unavailable" = "Location is unavailable.";
+"location_access_denied_title" = "Location Access Denied";
+
+/* Search - Listing type / FilterSheet additions (Story 82.3) */
+"filter_listing_type" = "Listing Type";
+"filter_price_min" = "Min price";
+"filter_price_max" = "Max price";
+"filter_min_value" = "Min: %d";
+"filter_max_value" = "Max: %d";
+"filter_bathrooms" = "Bathrooms";
+
 /* Account Screen - Additional */
 "quick_actions" = "Szybkie akcje";
 "saved_searches" = "Zapisane wyszukiwania";

--- a/mobile-native/iosApp/iosApp/Resources/sk.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/sk.lproj/Localizable.strings
@@ -252,12 +252,12 @@
 "location_access_denied_title" = "Prístup k polohe zamietnutý";
 
 /* Search - Listing type / FilterSheet additions (Story 82.3) */
-"filter_listing_type" = "Listing Type";
-"filter_price_min" = "Min price";
-"filter_price_max" = "Max price";
+"filter_listing_type" = "Typ ponuky";
+"filter_price_min" = "Min cena";
+"filter_price_max" = "Max cena";
 "filter_min_value" = "Min: %d";
 "filter_max_value" = "Max: %d";
-"filter_bathrooms" = "Bathrooms";
+"filter_bathrooms" = "Kúpeľne";
 
 /* Account Screen - Additional */
 "quick_actions" = "Rýchle akcie";

--- a/mobile-native/iosApp/iosApp/Resources/sk.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/sk.lproj/Localizable.strings
@@ -241,15 +241,15 @@
 
 
 /* Search - Near Me / Location (added Story 82.3) */
-"filter_near_me" = "Near Me";
-"filter_near_me_section" = "Location";
-"filter_radius" = "Radius";
+"filter_near_me" = "V blízkosti";
+"filter_near_me_section" = "Poloha";
+"filter_radius" = "Polomer";
 "radius_km_format" = "%d km";
-"location_detected_format" = "Location: %.4f, %.4f";
-"locating" = "Locating…";
-"location_access_denied" = "Location access was denied. Enable it in Settings to use Near Me filters.";
-"location_unavailable" = "Location is unavailable.";
-"location_access_denied_title" = "Location Access Denied";
+"location_detected_format" = "Poloha: %.4f, %.4f";
+"locating" = "Zisťujem polohu…";
+"location_access_denied" = "Prístup k polohe bol zamietnutý. Povoľte ho v Nastaveniach, aby ste mohli používať filtre V blízkosti.";
+"location_unavailable" = "Poloha nie je dostupná.";
+"location_access_denied_title" = "Prístup k polohe zamietnutý";
 
 /* Search - Listing type / FilterSheet additions (Story 82.3) */
 "filter_listing_type" = "Listing Type";

--- a/mobile-native/iosApp/iosApp/Resources/sk.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/sk.lproj/Localizable.strings
@@ -239,6 +239,26 @@
 "reset_filters" = "Obnoviť filtre";
 "apply" = "Použiť";
 
+
+/* Search - Near Me / Location (added Story 82.3) */
+"filter_near_me" = "Near Me";
+"filter_near_me_section" = "Location";
+"filter_radius" = "Radius";
+"radius_km_format" = "%d km";
+"location_detected_format" = "Location: %.4f, %.4f";
+"locating" = "Locating…";
+"location_access_denied" = "Location access was denied. Enable it in Settings to use Near Me filters.";
+"location_unavailable" = "Location is unavailable.";
+"location_access_denied_title" = "Location Access Denied";
+
+/* Search - Listing type / FilterSheet additions (Story 82.3) */
+"filter_listing_type" = "Listing Type";
+"filter_price_min" = "Min price";
+"filter_price_max" = "Max price";
+"filter_min_value" = "Min: %d";
+"filter_max_value" = "Max: %d";
+"filter_bathrooms" = "Bathrooms";
+
 /* Account Screen - Additional */
 "quick_actions" = "Rýchle akcie";
 "saved_searches" = "Uložené vyhľadávania";


### PR DESCRIPTION
## Task

Implement debounced search, infinite scroll pagination, CoreLocation integration + FilterSheet in HomeView/SearchView for SwiftUI Reality Portal iOS app (mobile-native/iosApp). Wire to reality-server search API via KMP shared module.

## Owner

pm-frontend

## Changes

- **SearchView.swift**: Debounced search (350ms cancellable `Task` token replacing the racy `Task.sleep` pattern), infinite scroll pagination with `isLoadingMore` guard and page rollback on error, "Near Me" chip in filter bar, `LocationManager` environment injection
- **FilterSheet**: Added listing type (For Sale / For Rent) section, bathrooms stepper, min/max bedrooms steppers, and CoreLocation-powered "Near Me" section with radius picker (1/3/5/10/20/50 km)
- **HomeView.swift**: Category chips (For Sale, For Rent, Apartments, Houses, Land) now navigate to `SearchView` with pre-populated `SearchFilters` instead of being no-ops
- **Route.swift**: Added `listingType: ListingKind?` field to `SearchFilters`, updated `hasActiveFilters` and `reset()`, added `ListingKind` enum (avoids clash with KMP `ListingType` export)
- **LocationManager.swift** (new): `@Observable` class wrapping `CLLocationManager`, requests `whenInUse` auth, one-shot location fetch, `stopLocation()` method
- **RealityPortalApp.swift**: `LocationManager` added as `@State` and injected via `.environment(locationManager)` to the root view hierarchy
- **Localizable.strings** (6 locales): Added 15 new keys for "Near Me", radius, location, filter labels

## Tested (Band A — fast check)

```
./gradlew :shared:linkPodReleaseFrameworkIosArm64
FAILURE: Plugin [id: 'com.android.application'] not found (AGP not installed in Linux CI environment)
```

Band A Gradle verify not runnable (no macOS/Xcode toolchain in this Linux environment).
Fallback: `git diff --check HEAD` — exit 0 (no whitespace errors).
Brace balance verified on all 5 modified Swift files: all balance=0.

## Built (Band B — full build)

Skipped — same environment constraint; no Xcode/swiftc available on Linux host.

## CI parity (Band C — hot-path only)

Skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested

Skipped.

## Scope drift

Scope-check exit 2 — but the flagged file (`frontend/apps/mobile/eas.json`) is a pre-existing branch divergence from `dev` (not introduced by this task). All staged commits are iOS-only. scope_drift=false for this task's changes.

## Code-reuse review

`reuse-grep.sh` exit 0 — no warnings. `LocationManager` is a new type with no duplicate in the repo.

## Notes

- The debounce token pattern properly cancels the in-flight task before scheduling a new one, fixing the race condition in the original `Task.sleep` approach where two searches could fire for the same keystroke.
- `ListingKind` avoids collision with the KMP-exported `ListingType` symbol from the `shared` framework.
- Infinite scroll uses a sentinel `Color.clear.frame(height: 1)` with `.onAppear` — standard SwiftUI pattern.
- `NSLocationWhenInUseUsageDescription` was already present in `Info.plist` from a previous story.
- The `stopLocation()` method is exposed so the filter reset button can cleanly terminate location tracking.

---
_Generated by [Claude Code](https://claude.ai/code/session_018irTagh9W1g7KH2L2P4scQ)_