### PR TITLE
gap-10b-7-contextual-help-ui: Contextual help tooltip/sidebar in admin-web

### DIFF
--- a/docs/screens/ppt/admin-contextual-help.md
+++ b/docs/screens/ppt/admin-contextual-help.md
@@ -1,0 +1,71 @@
+---
+id: ppt/admin-contextual-help
+name: Admin Contextual Help Sidebar
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "* (AdminLayout topbar — global)"
+    component: HelpSidebar, HelpTooltip, useContextualHelp
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: static
+endpoints: []
+relatedScreens:
+  - id: ppt/admin-platform-health
+    rel: sibling
+  - id: ppt/admin-system-announcements
+    rel: sibling
+  - id: ppt/admin-oauth-clients
+    rel: sibling
+sharedComponents:
+  - HelpSidebar
+  - HelpTooltip
+  - useContextualHelp
+diagrams: []
+useCases: []
+epics:
+  - Epic-10B-7
+designSources: []
+owner: pm-frontend
+---
+
+## Functionality Checklist
+
+- [x] "?" button in AdminLayout topbar opens/closes the HelpSidebar
+- [x] HelpSidebar shows the article matched to the current page route
+- [x] Slide-over panel with backdrop; closes on Escape key and backdrop click
+- [x] Article body rendered inline (bold, code, bullet lists, tables) — no external markdown parser
+- [x] Footer link to external docs URL when article has one
+- [x] HelpTooltip component for inline field-level help (hover/focus)
+- [x] Tooltips added to Feature Flags and Platform Settings pages
+- [x] Static articles for all 12 admin pages in `src/help/articles.ts`
+- [x] i18n keys for EN / SK / CS
+
+## States
+
+- **Closed**: "?" button shows in topbar at all times; not active-styled
+- **Open**: "?" button highlighted (blue tint); panel slides in from right with backdrop
+- **No article**: Falls back to Dashboard article (safe default)
+
+## Notes
+
+### Broader context
+
+Part of Epic 10B Story 10B.7. Pure frontend feature — no backend endpoint
+required. Static markdown content lives in `frontend/apps/admin-web/src/help/articles.ts`.
+The `getArticleForPath(pathname)` function resolves the longest-prefix match
+so child routes (e.g. `/identity/memberships/123`) inherit their parent's article.
+
+### Specific (recent)
+
+- 2026-05-26 — agent: gap-10b-7-contextual-help-ui — initial implementation;
+  HelpSidebar, HelpTooltip, useContextualHelp wired into AdminLayout topbar;
+  13 static articles covering all admin sections; i18n EN/SK/CS; no backend dep.
+
+## Agent Log
+
+<!-- newest entries on top -->
+- 2026-05-26 — agent: gap-10b-7-contextual-help-ui — initial implementation of
+  contextual help sidebar and inline tooltip components for admin-web; wired
+  globally via AdminLayout; static article content for all 12 admin pages.

--- a/docs/screens/ppt/admin-contextual-help.md
+++ b/docs/screens/ppt/admin-contextual-help.md
@@ -9,7 +9,7 @@ implementations:
     component: HelpSidebar, HelpTooltip, useContextualHelp
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: static
+    apiStatus: n/a
 endpoints: []
 relatedScreens:
   - id: ppt/admin-platform-health

--- a/frontend/apps/admin-web/messages/cs.json
+++ b/frontend/apps/admin-web/messages/cs.json
@@ -84,6 +84,7 @@
         "buildingDisabled": "Vypnout tuto budovu (nouzový vypínač)",
         "newListingsSearch": "Nové vyhledávání inzerátů (beta)"
       },
+      "helpTooltip": "Feature flagy se okamžitě projeví u všech uživatelů daného nájemníka. Nouzový vypínač používejte opatrně.",
       "title": "Feature flagy",
       "warning": "Nouzový vypínač pro nájemníka — změny se okamžitě projeví u všech uživatelů tohoto nájemníka."
     },
@@ -158,6 +159,7 @@
         "supportEmail": "E-mail podpory",
         "supportEmailPlaceholder": "podpora@example.com"
       },
+      "helpTooltip": "Režim údržby vrací odpověď 503 na všechny požadavky mimo administrátorů. Jeho aktivace vyžaduje důvod auditu.",
       "title": "Nastavení platformy"
     },
     "help": {

--- a/frontend/apps/admin-web/messages/cs.json
+++ b/frontend/apps/admin-web/messages/cs.json
@@ -160,6 +160,13 @@
       },
       "title": "Nastavení platformy"
     },
+    "help": {
+      "openHelp": "Otevřít kontextovou nápovědu",
+      "panelLabel": "Kontextová nápověda",
+      "close": "Zavřít nápovědu",
+      "openDocs": "Otevřít úplnou dokumentaci",
+      "tooltip": "Nápověda"
+    },
     "users": {
       "actions": {
         "edit": "Upravit",

--- a/frontend/apps/admin-web/messages/en.json
+++ b/frontend/apps/admin-web/messages/en.json
@@ -160,6 +160,13 @@
       },
       "title": "Platform Settings"
     },
+    "help": {
+      "openHelp": "Open contextual help",
+      "panelLabel": "Contextual help",
+      "close": "Close help",
+      "openDocs": "Open full documentation",
+      "tooltip": "Help"
+    },
     "users": {
       "actions": {
         "edit": "Edit",

--- a/frontend/apps/admin-web/messages/en.json
+++ b/frontend/apps/admin-web/messages/en.json
@@ -84,6 +84,7 @@
         "buildingDisabled": "Disable this building (kill switch)",
         "newListingsSearch": "New listings search (beta)"
       },
+      "helpTooltip": "Feature flags take effect immediately for all users in the affected tenant. Use the kill switch with caution.",
       "title": "Feature Flags",
       "warning": "Per-tenant kill switch — changes take effect immediately for every user in this tenant."
     },
@@ -158,6 +159,7 @@
         "supportEmail": "Support email",
         "supportEmailPlaceholder": "support@example.com"
       },
+      "helpTooltip": "Maintenance mode returns 503 to all non-admin requests. Enabling it requires an audit reason.",
       "title": "Platform Settings"
     },
     "help": {

--- a/frontend/apps/admin-web/messages/sk.json
+++ b/frontend/apps/admin-web/messages/sk.json
@@ -160,6 +160,13 @@
       },
       "title": "Nastavenia platformy"
     },
+    "help": {
+      "openHelp": "Otvoriť kontextovú pomoc",
+      "panelLabel": "Kontextová pomoc",
+      "close": "Zavrieť pomoc",
+      "openDocs": "Otvoriť úplnú dokumentáciu",
+      "tooltip": "Pomoc"
+    },
     "users": {
       "actions": {
         "edit": "Upraviť",

--- a/frontend/apps/admin-web/messages/sk.json
+++ b/frontend/apps/admin-web/messages/sk.json
@@ -84,6 +84,7 @@
         "buildingDisabled": "Vypnúť túto budovu (núdzový vypínač)",
         "newListingsSearch": "Nové vyhľadávanie inzerátov (beta)"
       },
+      "helpTooltip": "Funkčné príznaky sa prejavia okamžite pre všetkých používateľov daného nájomníka. Núdzový vypínač používajte opatrne.",
       "title": "Funkčné príznaky",
       "warning": "Núdzový vypínač pre nájomníka — zmeny sa prejavia okamžite pre každého používateľa v tomto nájomníkovi."
     },
@@ -158,6 +159,7 @@
         "supportEmail": "E-mail podpory",
         "supportEmailPlaceholder": "podpora@example.com"
       },
+      "helpTooltip": "Režim údržby vracia odpoveď 503 na všetky požiadavky mimo administrátorov. Jeho aktivácia vyžaduje dôvod auditu.",
       "title": "Nastavenia platformy"
     },
     "help": {

--- a/frontend/apps/admin-web/src/components/AdminLayout.tsx
+++ b/frontend/apps/admin-web/src/components/AdminLayout.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Link, Outlet, useLocation } from 'react-router-dom';
 
 import { useAdminAuth } from '../auth/AdminAuthContext';
+import { HelpSidebar, useContextualHelp } from '../features/help';
 import { ConnectedMfaWindowChip } from './MfaWindowChip';
 
 interface SidebarGroupProps {
@@ -70,6 +71,7 @@ function NavItem({ to, label }: NavItemProps) {
 export function AdminLayout() {
   const { t } = useTranslation();
   const auth = useAdminAuth();
+  const help = useContextualHelp();
 
   // TENANTS
   const canAgenciesRead = useCapability('agencies_read');
@@ -194,11 +196,42 @@ export function AdminLayout() {
         >
           <span style={{ flex: 1 }} />
           <ConnectedMfaWindowChip />
+          <button
+            type="button"
+            onClick={help.toggle}
+            aria-expanded={help.isOpen}
+            aria-label={t('admin.help.openHelp', 'Open contextual help')}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: '28px',
+              height: '28px',
+              borderRadius: '50%',
+              border: help.isOpen
+                ? '1.5px solid var(--ppt-brand-400, #60a5fa)'
+                : '1px solid var(--ppt-border-default, #e5e7eb)',
+              background: help.isOpen
+                ? 'var(--ppt-brand-100, #dbeafe)'
+                : 'var(--ppt-bg-subtle, #f3f4f6)',
+              color: help.isOpen
+                ? 'var(--ppt-brand-700, #1d4ed8)'
+                : 'var(--ppt-fg-muted, #6b7280)',
+              fontSize: '13px',
+              fontWeight: 700,
+              cursor: 'pointer',
+            }}
+          >
+            ?
+          </button>
           <button type="button" onClick={auth.logout} style={{ fontSize: '13px' }}>
             {t('admin.actions.signOut', 'Sign out')}
           </button>
         </div>
         <Outlet />
+        {help.isOpen && (
+          <HelpSidebar article={help.article} onClose={help.close} />
+        )}
       </main>
     </div>
   );

--- a/frontend/apps/admin-web/src/components/AdminLayout.tsx
+++ b/frontend/apps/admin-web/src/components/AdminLayout.tsx
@@ -214,9 +214,7 @@ export function AdminLayout() {
               background: help.isOpen
                 ? 'var(--ppt-brand-100, #dbeafe)'
                 : 'var(--ppt-bg-subtle, #f3f4f6)',
-              color: help.isOpen
-                ? 'var(--ppt-brand-700, #1d4ed8)'
-                : 'var(--ppt-fg-muted, #6b7280)',
+              color: help.isOpen ? 'var(--ppt-brand-700, #1d4ed8)' : 'var(--ppt-fg-muted, #6b7280)',
               fontSize: '13px',
               fontWeight: 700,
               cursor: 'pointer',
@@ -229,9 +227,7 @@ export function AdminLayout() {
           </button>
         </div>
         <Outlet />
-        {help.isOpen && (
-          <HelpSidebar article={help.article} onClose={help.close} />
-        )}
+        {help.isOpen && <HelpSidebar article={help.article} onClose={help.close} />}
       </main>
     </div>
   );

--- a/frontend/apps/admin-web/src/features/help/HelpSidebar.tsx
+++ b/frontend/apps/admin-web/src/features/help/HelpSidebar.tsx
@@ -1,0 +1,383 @@
+/**
+ * HelpSidebar — slide-over panel showing the contextual help article for the
+ * current admin page. Opened by the "?" button in the AdminLayout topbar.
+ *
+ * The panel renders the article body as pre-formatted text (no external
+ * markdown parser required — keeps the bundle lean). Section headings
+ * (`**bold**`) and bullet lists (lines starting with `-`) are styled inline.
+ */
+
+import React, { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { HelpArticle } from '../../help/articles';
+
+// ---------------------------------------------------------------------------
+// Styles (injected once)
+// ---------------------------------------------------------------------------
+
+const STYLE_ID = 'ppt-help-sidebar-styles';
+
+function ensureStyles() {
+  if (typeof document === 'undefined') return;
+  if (document.getElementById(STYLE_ID)) return;
+  const el = document.createElement('style');
+  el.id = STYLE_ID;
+  el.textContent = `
+    /* Backdrop */
+    .ppt-help-backdrop {
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.25);
+      z-index: 200;
+      animation: ppt-help-fade-in 120ms ease;
+    }
+    @keyframes ppt-help-fade-in { from { opacity: 0; } to { opacity: 1; } }
+
+    /* Panel */
+    .ppt-help-panel {
+      position: fixed;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      width: min(400px, 90vw);
+      background: var(--ppt-bg-surface, #ffffff);
+      border-left: 1px solid var(--ppt-border-default, #e5e7eb);
+      box-shadow: -4px 0 24px rgba(0,0,0,0.12);
+      display: flex;
+      flex-direction: column;
+      z-index: 201;
+      animation: ppt-help-slide-in 160ms ease;
+    }
+    @keyframes ppt-help-slide-in {
+      from { transform: translateX(100%); }
+      to   { transform: translateX(0); }
+    }
+
+    /* Header */
+    .ppt-help-header {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 18px;
+      border-bottom: 1px solid var(--ppt-border-default, #e5e7eb);
+      flex-shrink: 0;
+    }
+    .ppt-help-header__icon {
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      background: var(--ppt-brand-100, #dbeafe);
+      color: var(--ppt-brand-700, #1d4ed8);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 14px;
+      font-weight: 700;
+      flex-shrink: 0;
+    }
+    .ppt-help-header__title {
+      flex: 1;
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--ppt-fg-primary, #111827);
+      margin: 0;
+    }
+    .ppt-help-header__close {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 28px;
+      height: 28px;
+      border: 0;
+      background: transparent;
+      border-radius: var(--ppt-radius-md, 6px);
+      cursor: pointer;
+      color: var(--ppt-fg-muted, #6b7280);
+      font-size: 18px;
+      line-height: 1;
+      padding: 0;
+    }
+    .ppt-help-header__close:hover {
+      background: var(--ppt-bg-subtle, #f3f4f6);
+      color: var(--ppt-fg-primary, #111827);
+    }
+
+    /* Body */
+    .ppt-help-body {
+      flex: 1;
+      overflow-y: auto;
+      padding: 18px;
+    }
+
+    /* Article content */
+    .ppt-help-article {
+      font-size: 13.5px;
+      line-height: 1.65;
+      color: var(--ppt-fg-secondary, #374151);
+    }
+    .ppt-help-article p {
+      margin: 0 0 12px;
+    }
+    .ppt-help-article strong {
+      color: var(--ppt-fg-primary, #111827);
+      font-weight: 600;
+    }
+    .ppt-help-article ul {
+      margin: 0 0 12px;
+      padding-left: 18px;
+    }
+    .ppt-help-article li {
+      margin-bottom: 4px;
+    }
+    .ppt-help-article code {
+      font-family: var(--ppt-font-mono, ui-monospace, monospace);
+      font-size: 12px;
+      background: var(--ppt-bg-subtle, #f3f4f6);
+      border-radius: 3px;
+      padding: 1px 5px;
+      color: var(--ppt-fg-primary, #111827);
+    }
+    .ppt-help-article table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-bottom: 12px;
+      font-size: 12.5px;
+    }
+    .ppt-help-article th,
+    .ppt-help-article td {
+      text-align: left;
+      padding: 5px 8px;
+      border: 1px solid var(--ppt-border-default, #e5e7eb);
+    }
+    .ppt-help-article th {
+      background: var(--ppt-bg-subtle, #f3f4f6);
+      font-weight: 600;
+      color: var(--ppt-fg-primary, #111827);
+    }
+
+    /* Footer */
+    .ppt-help-footer {
+      padding: 12px 18px;
+      border-top: 1px solid var(--ppt-border-default, #e5e7eb);
+      flex-shrink: 0;
+    }
+    .ppt-help-footer__link {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      font-size: 12.5px;
+      color: var(--ppt-brand-600, #2563eb);
+      text-decoration: none;
+    }
+    .ppt-help-footer__link:hover {
+      text-decoration: underline;
+    }
+  `;
+  document.head.appendChild(el);
+}
+
+// ---------------------------------------------------------------------------
+// Simple inline "markdown" renderer
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders the article body string into React nodes without any external
+ * markdown library. Handles: paragraphs, **bold**, `code`, bullet lists,
+ * | table | rows |.
+ */
+function renderArticleBody(body: string): React.ReactNode {
+  const lines = body.split('\n');
+  const nodes: React.ReactNode[] = [];
+  let listItems: string[] = [];
+  let tableLines: string[] = [];
+  let key = 0;
+
+  function flushList() {
+    if (listItems.length === 0) return;
+    nodes.push(
+      <ul key={key++}>
+        {listItems.map((item, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: stable list
+          <li key={i}>{renderInline(item)}</li>
+        ))}
+      </ul>
+    );
+    listItems = [];
+  }
+
+  function flushTable() {
+    if (tableLines.length < 2) {
+      // Not a real table — emit as paragraphs
+      for (const l of tableLines) {
+        nodes.push(<p key={key++}>{renderInline(l)}</p>);
+      }
+      tableLines = [];
+      return;
+    }
+    const rows = tableLines.map((l) =>
+      l
+        .replace(/^\|/, '')
+        .replace(/\|$/, '')
+        .split('|')
+        .map((c) => c.trim())
+    );
+    // Row 1 = header, Row 2 = separator (---, skip), Rows 3+ = data
+    const headers = rows[0];
+    const dataRows = rows.slice(2);
+    nodes.push(
+      <table key={key++}>
+        <thead>
+          <tr>
+            {headers.map((h, i) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: stable
+              <th key={i}>{renderInline(h)}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {dataRows.map((row, ri) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: stable
+            <tr key={ri}>
+              {row.map((cell, ci) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: stable
+                <td key={ci}>{renderInline(cell)}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+    tableLines = [];
+  }
+
+  for (const line of lines) {
+    if (line.startsWith('- ')) {
+      flushTable();
+      listItems.push(line.slice(2));
+    } else if (line.startsWith('|')) {
+      flushList();
+      tableLines.push(line);
+    } else {
+      flushList();
+      flushTable();
+      if (line.trim() === '') continue;
+      nodes.push(<p key={key++}>{renderInline(line)}</p>);
+    }
+  }
+
+  flushList();
+  flushTable();
+
+  return <>{nodes}</>;
+}
+
+/** Renders inline **bold** and `code` spans. */
+function renderInline(text: string): React.ReactNode {
+  // Split on **...** and `...`
+  const parts: React.ReactNode[] = [];
+  const re = /(\*\*[^*]+\*\*|`[^`]+`)/g;
+  let last = 0;
+  let m: RegExpExecArray | null;
+  let idx = 0;
+
+  // biome-ignore lint/suspicious/noAssignInExpressions: intentional
+  while ((m = re.exec(text)) !== null) {
+    if (m.index > last) {
+      parts.push(<React.Fragment key={idx++}>{text.slice(last, m.index)}</React.Fragment>);
+    }
+    const token = m[0];
+    if (token.startsWith('**')) {
+      parts.push(<strong key={idx++}>{token.slice(2, -2)}</strong>);
+    } else {
+      parts.push(<code key={idx++}>{token.slice(1, -1)}</code>);
+    }
+    last = m.index + token.length;
+  }
+  if (last < text.length) {
+    parts.push(<React.Fragment key={idx++}>{text.slice(last)}</React.Fragment>);
+  }
+  return <>{parts}</>;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface HelpSidebarProps {
+  article: HelpArticle;
+  onClose: () => void;
+}
+
+export function HelpSidebar({ article, onClose }: HelpSidebarProps) {
+  ensureStyles();
+  const { t } = useTranslation();
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  // Focus the close button on mount for keyboard accessibility
+  useEffect(() => {
+    closeRef.current?.focus();
+  }, []);
+
+  // Close on Escape
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [onClose]);
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="ppt-help-backdrop"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Panel */}
+      <aside
+        className="ppt-help-panel"
+        role="complementary"
+        aria-label={t('admin.help.panelLabel', 'Contextual help')}
+      >
+        {/* Header */}
+        <div className="ppt-help-header">
+          <div className="ppt-help-header__icon" aria-hidden="true">?</div>
+          <h2 className="ppt-help-header__title">{article.title}</h2>
+          <button
+            ref={closeRef}
+            type="button"
+            className="ppt-help-header__close"
+            onClick={onClose}
+            aria-label={t('admin.help.close', 'Close help')}
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="ppt-help-body">
+          <div className="ppt-help-article">
+            {renderArticleBody(article.body)}
+          </div>
+        </div>
+
+        {/* Footer — link to external docs if available */}
+        {article.docsUrl && (
+          <div className="ppt-help-footer">
+            <a
+              href={article.docsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ppt-help-footer__link"
+            >
+              {t('admin.help.openDocs', 'Open full documentation')} ↗
+            </a>
+          </div>
+        )}
+      </aside>
+    </>
+  );
+}

--- a/frontend/apps/admin-web/src/features/help/HelpSidebar.tsx
+++ b/frontend/apps/admin-web/src/features/help/HelpSidebar.tsx
@@ -197,7 +197,6 @@ function renderArticleBody(body: string): React.ReactNode {
     nodes.push(
       <ul key={key++}>
         {listItems.map((item, i) => (
-          // biome-ignore lint/suspicious/noArrayIndexKey: stable list
           <li key={i}>{renderInline(item)}</li>
         ))}
       </ul>
@@ -229,17 +228,14 @@ function renderArticleBody(body: string): React.ReactNode {
         <thead>
           <tr>
             {headers.map((h, i) => (
-              // biome-ignore lint/suspicious/noArrayIndexKey: stable
               <th key={i}>{renderInline(h)}</th>
             ))}
           </tr>
         </thead>
         <tbody>
           {dataRows.map((row, ri) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: stable
             <tr key={ri}>
               {row.map((cell, ci) => (
-                // biome-ignore lint/suspicious/noArrayIndexKey: stable
                 <td key={ci}>{renderInline(cell)}</td>
               ))}
             </tr>
@@ -330,21 +326,15 @@ export function HelpSidebar({ article, onClose }: HelpSidebarProps) {
   return (
     <>
       {/* Backdrop */}
-      <div
-        className="ppt-help-backdrop"
-        onClick={onClose}
-        aria-hidden="true"
-      />
+      <div className="ppt-help-backdrop" onClick={onClose} aria-hidden="true" />
 
       {/* Panel */}
-      <aside
-        className="ppt-help-panel"
-        role="complementary"
-        aria-label={t('admin.help.panelLabel', 'Contextual help')}
-      >
+      <aside className="ppt-help-panel" aria-label={t('admin.help.panelLabel', 'Contextual help')}>
         {/* Header */}
         <div className="ppt-help-header">
-          <div className="ppt-help-header__icon" aria-hidden="true">?</div>
+          <div className="ppt-help-header__icon" aria-hidden="true">
+            ?
+          </div>
           <h2 className="ppt-help-header__title">{article.title}</h2>
           <button
             ref={closeRef}
@@ -359,9 +349,7 @@ export function HelpSidebar({ article, onClose }: HelpSidebarProps) {
 
         {/* Body */}
         <div className="ppt-help-body">
-          <div className="ppt-help-article">
-            {renderArticleBody(article.body)}
-          </div>
+          <div className="ppt-help-article">{renderArticleBody(article.body)}</div>
         </div>
 
         {/* Footer — link to external docs if available */}

--- a/frontend/apps/admin-web/src/features/help/HelpTooltip.tsx
+++ b/frontend/apps/admin-web/src/features/help/HelpTooltip.tsx
@@ -6,7 +6,7 @@
  *   <HelpTooltip text="Maintenance mode suspends all non-admin API requests." />
  */
 
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 // ---------------------------------------------------------------------------
@@ -97,6 +97,7 @@ export function HelpTooltip({ text }: HelpTooltipProps) {
   ensureStyles();
   const { t } = useTranslation();
   const [visible, setVisible] = useState(false);
+  const tooltipId = useId();
 
   return (
     <span className="ppt-help-tip">
@@ -104,6 +105,7 @@ export function HelpTooltip({ text }: HelpTooltipProps) {
         type="button"
         className="ppt-help-tip__btn"
         aria-label={t('admin.help.tooltip', 'Help')}
+        aria-describedby={tooltipId}
         onMouseEnter={() => setVisible(true)}
         onMouseLeave={() => setVisible(false)}
         onFocus={() => setVisible(true)}
@@ -112,7 +114,7 @@ export function HelpTooltip({ text }: HelpTooltipProps) {
         ?
       </button>
       {visible && (
-        <span className="ppt-help-tip__bubble" role="tooltip">
+        <span id={tooltipId} className="ppt-help-tip__bubble" role="tooltip">
           {text}
         </span>
       )}

--- a/frontend/apps/admin-web/src/features/help/HelpTooltip.tsx
+++ b/frontend/apps/admin-web/src/features/help/HelpTooltip.tsx
@@ -113,11 +113,14 @@ export function HelpTooltip({ text }: HelpTooltipProps) {
       >
         ?
       </button>
-      {visible && (
-        <span id={tooltipId} className="ppt-help-tip__bubble" role="tooltip">
-          {text}
-        </span>
-      )}
+      <span
+        id={tooltipId}
+        className="ppt-help-tip__bubble"
+        role="tooltip"
+        style={{ visibility: visible ? 'visible' : 'hidden' }}
+      >
+        {text}
+      </span>
     </span>
   );
 }

--- a/frontend/apps/admin-web/src/features/help/HelpTooltip.tsx
+++ b/frontend/apps/admin-web/src/features/help/HelpTooltip.tsx
@@ -1,0 +1,121 @@
+/**
+ * HelpTooltip — inline "?" icon that shows a small tooltip on hover/focus.
+ * Can be placed next to any label or heading to provide brief context.
+ *
+ * Usage:
+ *   <HelpTooltip text="Maintenance mode suspends all non-admin API requests." />
+ */
+
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+// ---------------------------------------------------------------------------
+// Styles (injected once)
+// ---------------------------------------------------------------------------
+
+const STYLE_ID = 'ppt-help-tooltip-styles';
+
+function ensureStyles() {
+  if (typeof document === 'undefined') return;
+  if (document.getElementById(STYLE_ID)) return;
+  const el = document.createElement('style');
+  el.id = STYLE_ID;
+  el.textContent = `
+    .ppt-help-tip {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+    }
+
+    .ppt-help-tip__btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      border: 1px solid var(--ppt-border-default, #e5e7eb);
+      background: var(--ppt-bg-subtle, #f3f4f6);
+      color: var(--ppt-fg-muted, #6b7280);
+      font-size: 10px;
+      font-weight: 700;
+      cursor: default;
+      line-height: 1;
+      padding: 0;
+      flex-shrink: 0;
+    }
+    .ppt-help-tip__btn:hover,
+    .ppt-help-tip__btn:focus {
+      background: var(--ppt-brand-100, #dbeafe);
+      border-color: var(--ppt-brand-300, #93c5fd);
+      color: var(--ppt-brand-700, #1d4ed8);
+      outline: none;
+    }
+
+    .ppt-help-tip__bubble {
+      position: absolute;
+      bottom: calc(100% + 6px);
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--ppt-fg-primary, #111827);
+      color: #fff;
+      font-size: 12px;
+      line-height: 1.5;
+      padding: 7px 10px;
+      border-radius: var(--ppt-radius-md, 6px);
+      width: 220px;
+      white-space: normal;
+      pointer-events: none;
+      z-index: 300;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+    }
+
+    /* Tail */
+    .ppt-help-tip__bubble::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: var(--ppt-fg-primary, #111827);
+    }
+  `;
+  document.head.appendChild(el);
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface HelpTooltipProps {
+  /** Short text shown in the tooltip bubble. */
+  text: string;
+}
+
+export function HelpTooltip({ text }: HelpTooltipProps) {
+  ensureStyles();
+  const { t } = useTranslation();
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <span className="ppt-help-tip">
+      <button
+        type="button"
+        className="ppt-help-tip__btn"
+        aria-label={t('admin.help.tooltip', 'Help')}
+        onMouseEnter={() => setVisible(true)}
+        onMouseLeave={() => setVisible(false)}
+        onFocus={() => setVisible(true)}
+        onBlur={() => setVisible(false)}
+      >
+        ?
+      </button>
+      {visible && (
+        <span className="ppt-help-tip__bubble" role="tooltip">
+          {text}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/frontend/apps/admin-web/src/features/help/HelpTooltip.tsx
+++ b/frontend/apps/admin-web/src/features/help/HelpTooltip.tsx
@@ -6,7 +6,7 @@
  *   <HelpTooltip text="Maintenance mode suspends all non-admin API requests." />
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 // ---------------------------------------------------------------------------

--- a/frontend/apps/admin-web/src/features/help/index.ts
+++ b/frontend/apps/admin-web/src/features/help/index.ts
@@ -1,0 +1,3 @@
+export { HelpSidebar } from './HelpSidebar';
+export { HelpTooltip } from './HelpTooltip';
+export { useContextualHelp } from './useContextualHelp';

--- a/frontend/apps/admin-web/src/features/help/useContextualHelp.ts
+++ b/frontend/apps/admin-web/src/features/help/useContextualHelp.ts
@@ -1,0 +1,37 @@
+/**
+ * useContextualHelp — tracks whether the help sidebar is open and which
+ * article to show, based on the current router location.
+ *
+ * The AdminLayout calls this hook and passes the returned props down to
+ * the help button and HelpSidebar.
+ */
+
+import { useCallback, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { type HelpArticle, getArticleForPath } from '../../help/articles';
+
+export interface ContextualHelpState {
+  /** True when the help sidebar is visible. */
+  isOpen: boolean;
+  /** The article matched to the current page. */
+  article: HelpArticle;
+  /** Open the help sidebar. */
+  open: () => void;
+  /** Close the help sidebar. */
+  close: () => void;
+  /** Toggle the help sidebar. */
+  toggle: () => void;
+}
+
+export function useContextualHelp(): ContextualHelpState {
+  const { pathname } = useLocation();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const article = getArticleForPath(pathname);
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+  const toggle = useCallback(() => setIsOpen((prev) => !prev), []);
+
+  return { isOpen, article, open, close, toggle };
+}

--- a/frontend/apps/admin-web/src/features/help/useContextualHelp.ts
+++ b/frontend/apps/admin-web/src/features/help/useContextualHelp.ts
@@ -8,7 +8,7 @@
 
 import { useCallback, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import { type HelpArticle, getArticleForPath } from '../../help/articles';
+import { getArticleForPath, type HelpArticle } from '../../help/articles';
 
 export interface ContextualHelpState {
   /** True when the help sidebar is visible. */

--- a/frontend/apps/admin-web/src/help/articles.ts
+++ b/frontend/apps/admin-web/src/help/articles.ts
@@ -1,0 +1,311 @@
+/**
+ * Static help articles for the admin contextual help system.
+ *
+ * Each article has a stable `id`, a `title`, and `body` (plain text / simple
+ * markdown rendered as-is in the HelpSidebar). Articles are keyed by page
+ * context so the AdminLayout can surface the right one automatically.
+ */
+
+export interface HelpArticle {
+  id: string;
+  title: string;
+  /** Plain text with light markdown (# heading, - list, **bold**). */
+  body: string;
+  /** Optional external docs URL. */
+  docsUrl?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Individual articles
+// ---------------------------------------------------------------------------
+
+const DASHBOARD: HelpArticle = {
+  id: 'dashboard',
+  title: 'Admin Dashboard',
+  body: `The dashboard gives a real-time overview of platform health.
+
+**Stat tiles (top row)**
+- **Tenants active** — total registered tenants with at least one active user.
+- **Operators online** — platform principals with a valid session token.
+- **Pending merges** — membership merge collisions awaiting manual resolution.
+- **High-risk · 24h** — purge / kind-escalate events fired in the last 24 hours.
+
+**High-risk events**
+Shows the 10 most recent audit events with severity=high. Requires the \`audit_read\` capability. Click *View all →* to open the full Audit log.
+
+**Active impersonation**
+Lists all live impersonation sessions. Visible with \`users_impersonate\` or \`audit_read\`. Click *Stop* to navigate to the Impersonation page and end a session.
+
+**Quick actions**
+Fast navigation links scoped to your capabilities. Only shown when at least one action is available.`,
+  docsUrl: '/docs/admin/dashboard',
+};
+
+const AGENCIES: HelpArticle = {
+  id: 'agencies',
+  title: 'Agencies',
+  body: `Agencies are top-level tenant organisations that group multiple buildings and users.
+
+**Listing**
+The table shows every agency with its slug, member count, and status. Use the search bar (top-right) to filter by name or slug.
+
+**Suspending an agency**
+Suspending prevents all users in the agency from logging in. Active sessions are not terminated immediately; they expire normally. Requires the \`agencies_read\` capability to view and a destructive-confirm dialog to proceed.
+
+**Adding a domain**
+Domains are used to auto-assign new user registrations to an agency. Only one domain per TLD suffix is allowed across the platform.`,
+  docsUrl: '/docs/admin/agencies',
+};
+
+const USERS: HelpArticle = {
+  id: 'users',
+  title: 'Users',
+  body: `The Users page lets you search for and manage platform principals.
+
+**Search**
+Enter an email address or display name fragment. Results are returned from the API — the list is not pre-loaded.
+
+**Principal kinds**
+- **Tenant** — normal property-management user.
+- **Agency** — agency-level operator.
+- **Platform** — super-admin (this console). Use *Change kind* carefully.
+- **Service** — machine principal used by integrations.
+
+**Impersonation**
+Click *Impersonate* to start a time-limited session as that user. The session appears in Active Impersonation on the Dashboard. Requires the \`users_impersonate\` capability.
+
+**Change kind**
+Permanently changes how the user authenticates and which capabilities they may hold. This action is irreversible without a further change. Requires \`principal_kind_escalate\`.`,
+  docsUrl: '/docs/admin/users',
+};
+
+const MEMBERSHIPS: HelpArticle = {
+  id: 'memberships',
+  title: 'Memberships',
+  body: `Memberships link a user (principal) to an agency or building with a specific role.
+
+**Granting a membership**
+Click *Grant* and select the target user, agency/building, and role. Requires the \`memberships_grant\` capability.
+
+**Revoking a membership**
+Select one or more rows and click *Revoke*. Active sessions are not terminated; the next API call from that user will be denied. Requires \`memberships_revoke\`.
+
+**Merge collisions**
+When two users' memberships conflict during a tenant merge, a collision record is created. Resolve these from the Dashboard *Pending merge collisions* card or on this page.`,
+  docsUrl: '/docs/admin/memberships',
+};
+
+const CAPABILITIES: HelpArticle = {
+  id: 'capabilities',
+  title: 'Capabilities',
+  body: `Capabilities are named permission flags assigned to platform principals.
+
+**Viewing**
+The table lists every capability that exists in the system alongside the principals who currently hold it.
+
+**Granting**
+Click *Grant capability* and choose the target principal and capability name. Requires \`memberships_grant\`.
+
+**Revoking**
+Click the revoke button next to a row. Requires \`memberships_revoke\`.
+
+**Common capabilities**
+| Capability | Effect |
+|---|---|
+| \`audit_read\` | Read the audit log |
+| \`users_read\` | Search and view users |
+| \`users_impersonate\` | Start impersonation sessions |
+| \`memberships_grant\` | Grant capabilities/memberships |
+| \`memberships_revoke\` | Revoke capabilities/memberships |
+| \`site_settings_write\` | Manage platform settings |
+| \`feature_flags_write\` | Toggle feature flags |
+| \`oauth_client_write\` | Manage OAuth clients |`,
+  docsUrl: '/docs/admin/capabilities',
+};
+
+const AUDIT: HelpArticle = {
+  id: 'audit',
+  title: 'Audit Log',
+  body: `The Audit log records every significant action performed by any principal.
+
+**Filters**
+- **Actor** / **Actor ID** — who performed the action.
+- **Target** / **Target type** — what was affected.
+- **Action** — the specific operation name.
+- **Outcome** — \`success\`, \`failure\`, or \`denied\`.
+- **From / Until** — ISO date range.
+
+**Severity**
+Events are tagged high / medium / low. High-severity events (purge, escalate, impersonation) appear on the Dashboard.
+
+**Pagination**
+Results are paginated server-side. Use *Previous* / *Next* to navigate. The API returns up to 50 items per page.
+
+Requires the \`audit_read\` capability.`,
+  docsUrl: '/docs/admin/audit',
+};
+
+const IMPERSONATION: HelpArticle = {
+  id: 'impersonation',
+  title: 'Impersonation',
+  body: `Impersonation lets a platform operator act as another user temporarily.
+
+**Starting a session**
+From the Users page, find the target user and click *Impersonate*. A time-limited JWT is issued; the operator's browser is redirected to the property-management SPA as that user.
+
+**Session limits**
+Sessions last a maximum of 1 hour and cannot be renewed. Every impersonation start/end is recorded in the audit log.
+
+**Ending a session**
+Click *End impersonation* in the banner that appears across the top of the SPA, or use the *Stop* button on the Dashboard or this page.
+
+Requires the \`users_impersonate\` capability.`,
+  docsUrl: '/docs/admin/impersonation',
+};
+
+const FEATURE_FLAGS: HelpArticle = {
+  id: 'feature-flags',
+  title: 'Feature Flags',
+  body: `Feature flags enable or disable functionality per tenant in real time.
+
+**Available flags**
+- **AI fault triage (beta)** — enables the AI-powered fault severity classifier for a tenant's operators.
+- **New listings search (beta)** — activates the redesigned property search UI in the Reality Portal for this tenant.
+- **Disable this building (kill switch)** — immediately prevents all API access for the selected building. Use in emergencies.
+
+**Effect**
+Changes take effect on the next API request from any user in the affected tenant — no deployment is needed.
+
+Requires the \`feature_flags_write\` capability.`,
+  docsUrl: '/docs/admin/feature-flags',
+};
+
+const PLATFORM_SETTINGS: HelpArticle = {
+  id: 'platform-settings',
+  title: 'Platform Settings',
+  body: `Global settings that apply to the entire PPT platform.
+
+**Maintenance mode**
+When enabled, all non-admin API requests return 503. Existing sessions are preserved. Use this before database migrations or infrastructure changes.
+
+**Signup enabled**
+Controls whether new user registrations are accepted. Disabling this prevents new accounts without affecting existing users.
+
+**Support email**
+Shown in error pages and automated emails sent to end users. Must be a valid email address.
+
+Changes are applied immediately without requiring a server restart.
+
+Requires the \`site_settings_write\` capability.`,
+  docsUrl: '/docs/admin/platform-settings',
+};
+
+const MOBILE_CONFIG: HelpArticle = {
+  id: 'mobile-config',
+  title: 'Mobile Config',
+  body: `Remote configuration delivered to the Property Management mobile app on startup.
+
+**Config keys**
+The mobile app polls this endpoint every 60 seconds. Keys control feature availability, API endpoint overrides, and minimum app version requirements.
+
+**Minimum app version**
+Set \`min_version\` to force users on older builds to update before they can connect. The app compares this against the build number embedded in the binary.
+
+**Force update URL**
+When \`min_version\` is enforced, the app shows a prompt and links to this URL (usually the App Store / Google Play listing).
+
+Requires the \`mobile_config_write\` capability.`,
+  docsUrl: '/docs/admin/mobile-config',
+};
+
+const HEALTH: HelpArticle = {
+  id: 'health',
+  title: 'Platform Health',
+  body: `Real-time monitoring of API server metrics and alert conditions.
+
+**Metrics grid**
+Each tile shows the current value and status (Normal / Warning / Critical). Click a metric name to open the time-series drill-down panel.
+
+**Time ranges**
+Select 1h, 6h, 24h, 7d, or 30d to view historical values. The panel shows min, max, and average alongside the raw data points.
+
+**Alerts**
+Active alerts require attention. Toggle *Active only* to hide resolved alerts. Click *Acknowledge* to mark an alert as reviewed; this records your identity in the audit log.
+
+**Thresholds**
+Edit Warning and Critical threshold values inline. Threshold changes take effect on the next metric evaluation cycle (every 60 seconds).
+
+Auto-refreshes every 60 seconds. Requires the \`audit_read\` capability.`,
+  docsUrl: '/docs/admin/health',
+};
+
+const ANNOUNCEMENTS: HelpArticle = {
+  id: 'system-announcements',
+  title: 'System Announcements',
+  body: `System-wide banners shown to all users of the Property Management application.
+
+**Creating an announcement**
+Click *New announcement* and fill in the title, body, and optional call-to-action URL. Set the severity (info / warning / critical) to control the banner color.
+
+**Scheduling**
+Announcements can have a start and end time. Outside these times the banner is not shown. Leave end time blank for an indefinite announcement.
+
+**Targeting**
+An announcement can target all tenants or a specific tenant slug.
+
+**Deleting**
+Announcements can be deleted at any time. This immediately removes the banner for all users.
+
+Requires the \`site_settings_write\` capability.`,
+  docsUrl: '/docs/admin/system-announcements',
+};
+
+const OAUTH_CLIENTS: HelpArticle = {
+  id: 'oauth-clients',
+  title: 'OAuth Clients',
+  body: `Third-party applications that obtain access tokens on behalf of your users via OAuth 2.0.
+
+**Registering a client**
+Click *Register client* and provide a display name and list of redirect URIs. The server generates a client ID and secret — **save the secret immediately**, it is shown only once.
+
+**Regenerating the secret**
+If a secret is compromised, click *Regenerate secret*. Old secrets are immediately invalidated. Requires an MFA confirmation.
+
+**Revoking a client**
+Revoking permanently deactivates the client. Existing access tokens continue to work until they expire (max 15 minutes). No new tokens can be issued.
+
+Requires the \`oauth_client_write\` capability.`,
+  docsUrl: '/docs/admin/oauth-clients',
+};
+
+// ---------------------------------------------------------------------------
+// Route → article map
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps admin route prefixes to the help article to show for that page.
+ * Matched with `location.pathname.startsWith(prefix)`, longest-match wins.
+ */
+export const ROUTE_HELP_MAP: Array<{ prefix: string; article: HelpArticle }> = [
+  { prefix: '/tenants/agencies', article: AGENCIES },
+  { prefix: '/identity/users', article: USERS },
+  { prefix: '/identity/memberships', article: MEMBERSHIPS },
+  { prefix: '/identity/capabilities', article: CAPABILITIES },
+  { prefix: '/identity/oauth-clients', article: OAUTH_CLIENTS },
+  { prefix: '/ops/audit', article: AUDIT },
+  { prefix: '/ops/impersonation', article: IMPERSONATION },
+  { prefix: '/ops/feature-flags', article: FEATURE_FLAGS },
+  { prefix: '/platform/settings', article: PLATFORM_SETTINGS },
+  { prefix: '/platform/mobile', article: MOBILE_CONFIG },
+  { prefix: '/platform/health', article: HEALTH },
+  { prefix: '/platform/announcements', article: ANNOUNCEMENTS },
+  { prefix: '/', article: DASHBOARD },
+];
+
+/** Returns the best-matching article for the given pathname. */
+export function getArticleForPath(pathname: string): HelpArticle {
+  // Sort by prefix length descending so the most specific match wins.
+  const sorted = [...ROUTE_HELP_MAP].sort((a, b) => b.prefix.length - a.prefix.length);
+  const match = sorted.find((entry) => pathname.startsWith(entry.prefix));
+  return match?.article ?? DASHBOARD;
+}

--- a/frontend/apps/admin-web/src/pages/feature-flags.tsx
+++ b/frontend/apps/admin-web/src/pages/feature-flags.tsx
@@ -20,6 +20,7 @@ import { useAdminAuth } from '../auth/AdminAuthContext';
 import { AuditReasonPrompt, useAuditReasonValid } from '../components/AuditReasonPrompt';
 import { useToast } from '../components/Toast';
 import { useFocusTrap } from '../components/useFocusTrap';
+import { HelpTooltip } from '../features/help';
 
 interface FeatureFlagValues extends Record<string, unknown> {
   'beta.new_listings_search': boolean;
@@ -376,7 +377,10 @@ const FeatureFlagsPage: React.FC = () => {
         />
       )}
       <section>
-        <h1>{t('admin.featureFlags.title')}</h1>
+        <h1 style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {t('admin.featureFlags.title')}
+          <HelpTooltip text="Feature flags take effect immediately for all users in the affected tenant. Use the kill switch with caution." />
+        </h1>
         <p role="alert" className="ppt-admin-warning" style={{ color: '#b00020', fontWeight: 600 }}>
           {t('admin.featureFlags.warning')}
         </p>

--- a/frontend/apps/admin-web/src/pages/feature-flags.tsx
+++ b/frontend/apps/admin-web/src/pages/feature-flags.tsx
@@ -379,7 +379,7 @@ const FeatureFlagsPage: React.FC = () => {
       <section>
         <h1 style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           {t('admin.featureFlags.title')}
-          <HelpTooltip text="Feature flags take effect immediately for all users in the affected tenant. Use the kill switch with caution." />
+          <HelpTooltip text={t('admin.featureFlags.helpTooltip')} />
         </h1>
         <p role="alert" className="ppt-admin-warning" style={{ color: '#b00020', fontWeight: 600 }}>
           {t('admin.featureFlags.warning')}

--- a/frontend/apps/admin-web/src/pages/platform.tsx
+++ b/frontend/apps/admin-web/src/pages/platform.tsx
@@ -241,7 +241,7 @@ const PlatformPage: React.FC = () => {
       <section>
         <h1 style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           {t('admin.platform.title')}
-          <HelpTooltip text="Maintenance mode returns 503 to all non-admin requests. Enabling it requires an audit reason." />
+          <HelpTooltip text={t('admin.platform.helpTooltip')} />
         </h1>
         <SettingsForm<PlatformValues>
           fields={fields}

--- a/frontend/apps/admin-web/src/pages/platform.tsx
+++ b/frontend/apps/admin-web/src/pages/platform.tsx
@@ -18,6 +18,7 @@ import { useTranslation } from 'react-i18next';
 import { AuditReasonPrompt, useAuditReasonValid } from '../components/AuditReasonPrompt';
 import { useToast } from '../components/Toast';
 import { useFocusTrap } from '../components/useFocusTrap';
+import { HelpTooltip } from '../features/help';
 
 interface PlatformValues extends Record<string, unknown> {
   'platform.maintenance_mode': boolean;
@@ -238,7 +239,10 @@ const PlatformPage: React.FC = () => {
         />
       )}
       <section>
-        <h1>{t('admin.platform.title')}</h1>
+        <h1 style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {t('admin.platform.title')}
+          <HelpTooltip text="Maintenance mode returns 503 to all non-admin requests. Enabling it requires an audit reason." />
+        </h1>
         <SettingsForm<PlatformValues>
           fields={fields}
           initialValues={initialValues}


### PR DESCRIPTION
## Task
Add contextual help tooltip/sidebar in admin-web pages linking to docs; use static markdown files or help_articles table

## Owner
pm-frontend

## Implementation Summary

Pure frontend implementation — no backend endpoint required. Static help content lives in `frontend/apps/admin-web/src/help/articles.ts`.

### New files
- `src/help/articles.ts` — 13 static help articles (one per admin page), `getArticleForPath()` resolver using longest-prefix match on `window.location.pathname`
- `src/features/help/HelpSidebar.tsx` — slide-over panel (400px, right-anchored) with inline markdown renderer (bold, code, bullet lists, tables — no external dep), Escape + backdrop-click to close, footer docs link
- `src/features/help/HelpTooltip.tsx` — inline `?` icon with hover/focus tooltip bubble; no library
- `src/features/help/useContextualHelp.ts` — hook tracking `isOpen`, `article`, `open/close/toggle` from router location
- `src/features/help/index.ts` — barrel export

### Modified files
- `src/components/AdminLayout.tsx` — topbar "?" button toggles `HelpSidebar`; button highlights when open
- `src/pages/feature-flags.tsx` — `HelpTooltip` added next to page heading
- `src/pages/platform.tsx` — `HelpTooltip` added next to page heading
- `messages/{en,sk,cs}.json` — i18n keys: `admin.help.{openHelp,panelLabel,close,openDocs,tooltip}`
- `docs/screens/ppt/admin-contextual-help.md` — screen map entry

### Articles covered
Dashboard, Agencies, Users, Memberships, Capabilities, Audit Log, Impersonation, Feature Flags, Platform Settings, Mobile Config, Health, System Announcements, OAuth Clients.

## Tested (Band A — fast check)

```
pnpm -F @ppt/admin-web typecheck
```
Exit: 1 (pre-existing — 1863 errors on clean repo with no node_modules installed; identical count before and after our changes)

```
npx biome check apps/admin-web/
```
Exit: 0 — clean on all admin-web files including new help components.

Note: typecheck is broken in this environment due to missing node_modules (no pnpm install has been run). All errors are pre-existing (`Cannot find module 'react'`, JSX IntrinsicElements) affecting every file equally. Biome lint (which does not require installed packages) passes cleanly.

## Built (Band B — full build)
Skipped: change is pure UI with no public API surface changes, no migrations, no config affecting build output. Biome (exit 0) covers structural correctness.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change). Low-priority UI feature.

## Remote-tested
Skipped (ppt-bridge MCP not connected).

## Scope drift
Exit code 2 — `frontend/apps/admin-web/**` is not listed in `pm-frontend` owner-areas.json (the json predates admin-web being added to the frontend monorepo). All changes are legitimately frontend. The react-web specialist explicitly covers `frontend/apps/admin-web/` per `agents/react-web.md`. Reviewer should update `owner-areas.json` to add `frontend/apps/admin-web/**` under `pm-frontend`.

Drifting paths:
- `frontend/apps/admin-web/messages/cs.json`
- `frontend/apps/admin-web/messages/en.json`
- `frontend/apps/admin-web/messages/sk.json`
- `frontend/apps/admin-web/src/components/AdminLayout.tsx`
- `frontend/apps/admin-web/src/features/help/HelpSidebar.tsx`
- `frontend/apps/admin-web/src/features/help/HelpTooltip.tsx`
- `frontend/apps/admin-web/src/features/help/index.ts`
- `frontend/apps/admin-web/src/features/help/useContextualHelp.ts`
- `frontend/apps/admin-web/src/help/articles.ts`
- `frontend/apps/admin-web/src/pages/feature-flags.tsx`
- `frontend/apps/admin-web/src/pages/platform.tsx`

## Code-reuse review
`WARN: useC looks like an existing helper at frontend/packages/screen-map/tests/grouping.test.ts`

This is a false positive — the grep matched `useC` as a prefix of `useContextualHelp`, but the existing helper is in a test file (`grouping.test.ts`) and is unrelated to the contextual help hook.

## Notes
- No backend changes required — articles are static TypeScript constants.
- `getArticleForPath()` uses longest-prefix match so child routes (e.g. `/identity/memberships/123`) inherit the parent article.
- The inline markdown renderer handles `**bold**`, `` `code` ``, `- bullet lists`, and `| table | rows |` without any external parser dependency.
- HelpSidebar is rendered inside `AdminLayout` (not a portal) — it uses fixed positioning so z-index stacking is handled correctly without needing a React portal.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3zhMLhCQ75Ma4jqpD4Uei)_