### PR TITLE
gap-81-2-report-execution-history-ui: execution history table in schedule detail page

### DIFF
--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -607,5 +607,59 @@
         "message": "Pro pokračování potvrďte v autentizační aplikaci."
       }
     }
+  },
+  "reports": {
+    "detail": {
+      "subtitle": "Historie spuštění plánu",
+      "scheduleDetails": "Podrobnosti plánu",
+      "executionHistory": "Historie spuštění",
+      "executionCount": "{{filtered}} z {{total}} spuštění",
+      "backToSchedules": "Zpět na plány",
+      "frequency": {
+        "label": "Frekvence",
+        "daily": "Denně",
+        "weekly": "Týdně",
+        "monthly": "Měsíčně",
+        "quarterly": "Čtvrtletně",
+        "yearly": "Ročně"
+      },
+      "format": "Formát",
+      "statusLabel": "Stav",
+      "active": "Aktivní",
+      "inactive": "Neaktivní",
+      "recipients": "Příjemci",
+      "lastRun": "Poslední spuštění",
+      "nextRun": "Další spuštění",
+      "status": {
+        "pending": "Čeká",
+        "running": "Běží",
+        "completed": "Dokončeno",
+        "failed": "Selhalo",
+        "cancelled": "Zrušeno",
+        "skipped": "Přeskočeno"
+      },
+      "colStatus": "Stav",
+      "colStartedAt": "Zahájeno",
+      "colDuration": "Trvání",
+      "colFile": "Soubor",
+      "colSize": "Velikost",
+      "colActions": "Akce",
+      "download": "Stáhnout",
+      "downloadExecution": "Stáhnout zprávu ze dne {{date}}",
+      "retry": "Opakovat",
+      "retrying": "Opakuje se...",
+      "retryExecution": "Opakovat spuštění ze dne {{date}}",
+      "noExecutions": "Nenalezena žádná spuštění",
+      "clearFilters": "Zrušit filtry",
+      "loadMore": "Načíst více",
+      "loading": "Načítá se...",
+      "errorTitle": "Nepodařilo se načíst spuštění",
+      "errorMessage": "Zkuste to prosím později."
+    },
+    "execution": {
+      "downloadFailed": "Nepodařilo se stáhnout zprávu.",
+      "retryQueued": "Spuštění bylo zařazeno do fronty k opakování.",
+      "retryFailed": "Nepodařilo se opakovat spuštění."
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -603,5 +603,59 @@
         "message": "Bitte bestätigen Sie über Ihre Authenticator-App, um fortzufahren."
       }
     }
+  },
+  "reports": {
+    "detail": {
+      "subtitle": "Ausführungsverlauf des Zeitplans",
+      "scheduleDetails": "Zeitplandetails",
+      "executionHistory": "Ausführungsverlauf",
+      "executionCount": "{{filtered}} von {{total}} Ausführungen",
+      "backToSchedules": "Zurück zu Zeitplänen",
+      "frequency": {
+        "label": "Häufigkeit",
+        "daily": "Täglich",
+        "weekly": "Wöchentlich",
+        "monthly": "Monatlich",
+        "quarterly": "Vierteljährlich",
+        "yearly": "Jährlich"
+      },
+      "format": "Format",
+      "statusLabel": "Status",
+      "active": "Aktiv",
+      "inactive": "Inaktiv",
+      "recipients": "Empfänger",
+      "lastRun": "Letzter Lauf",
+      "nextRun": "Nächster Lauf",
+      "status": {
+        "pending": "Ausstehend",
+        "running": "Läuft",
+        "completed": "Abgeschlossen",
+        "failed": "Fehlgeschlagen",
+        "cancelled": "Abgebrochen",
+        "skipped": "Übersprungen"
+      },
+      "colStatus": "Status",
+      "colStartedAt": "Gestartet um",
+      "colDuration": "Dauer",
+      "colFile": "Datei",
+      "colSize": "Größe",
+      "colActions": "Aktionen",
+      "download": "Herunterladen",
+      "downloadExecution": "Bericht vom {{date}} herunterladen",
+      "retry": "Wiederholen",
+      "retrying": "Wird wiederholt...",
+      "retryExecution": "Ausführung vom {{date}} wiederholen",
+      "noExecutions": "Keine Ausführungen gefunden",
+      "clearFilters": "Filter zurücksetzen",
+      "loadMore": "Mehr laden",
+      "loading": "Laden...",
+      "errorTitle": "Ausführungen konnten nicht geladen werden",
+      "errorMessage": "Bitte versuchen Sie es später erneut."
+    },
+    "execution": {
+      "downloadFailed": "Bericht konnte nicht heruntergeladen werden.",
+      "retryQueued": "Ausführung zur Wiederholung in die Warteschlange gestellt.",
+      "retryFailed": "Ausführung konnte nicht wiederholt werden."
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -2895,5 +2895,59 @@
         "message": "Please confirm with your authenticator app to continue."
       }
     }
+  },
+  "reports": {
+    "detail": {
+      "subtitle": "Schedule execution history",
+      "scheduleDetails": "Schedule details",
+      "executionHistory": "Execution history",
+      "executionCount": "{{filtered}} of {{total}} executions",
+      "backToSchedules": "Back to schedules",
+      "frequency": {
+        "label": "Frequency",
+        "daily": "Daily",
+        "weekly": "Weekly",
+        "monthly": "Monthly",
+        "quarterly": "Quarterly",
+        "yearly": "Yearly"
+      },
+      "format": "Format",
+      "statusLabel": "Status",
+      "active": "Active",
+      "inactive": "Inactive",
+      "recipients": "Recipients",
+      "lastRun": "Last run",
+      "nextRun": "Next run",
+      "status": {
+        "pending": "Pending",
+        "running": "Running",
+        "completed": "Completed",
+        "failed": "Failed",
+        "cancelled": "Cancelled",
+        "skipped": "Skipped"
+      },
+      "colStatus": "Status",
+      "colStartedAt": "Started at",
+      "colDuration": "Duration",
+      "colFile": "File",
+      "colSize": "Size",
+      "colActions": "Actions",
+      "download": "Download",
+      "downloadExecution": "Download report from {{date}}",
+      "retry": "Retry",
+      "retrying": "Retrying...",
+      "retryExecution": "Retry execution from {{date}}",
+      "noExecutions": "No executions found",
+      "clearFilters": "Clear filters",
+      "loadMore": "Load more",
+      "loading": "Loading...",
+      "errorTitle": "Failed to load executions",
+      "errorMessage": "Please try again later."
+    },
+    "execution": {
+      "downloadFailed": "Failed to download report.",
+      "retryQueued": "Execution queued for retry.",
+      "retryFailed": "Failed to retry execution."
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -603,5 +603,59 @@
         "message": "A folytatáshoz erősítse meg a hitelesítő alkalmazásban."
       }
     }
+  },
+  "reports": {
+    "detail": {
+      "subtitle": "Ütemterv végrehajtási előzményei",
+      "scheduleDetails": "Ütemterv részletei",
+      "executionHistory": "Végrehajtási előzmények",
+      "executionCount": "{{filtered}} / {{total}} végrehajtás",
+      "backToSchedules": "Vissza az ütemtervekhez",
+      "frequency": {
+        "label": "Gyakoriság",
+        "daily": "Napi",
+        "weekly": "Heti",
+        "monthly": "Havi",
+        "quarterly": "Negyedéves",
+        "yearly": "Éves"
+      },
+      "format": "Formátum",
+      "statusLabel": "Állapot",
+      "active": "Aktív",
+      "inactive": "Inaktív",
+      "recipients": "Címzettek",
+      "lastRun": "Utolsó futás",
+      "nextRun": "Következő futás",
+      "status": {
+        "pending": "Függőben",
+        "running": "Fut",
+        "completed": "Befejezett",
+        "failed": "Sikertelen",
+        "cancelled": "Törölve",
+        "skipped": "Kihagyva"
+      },
+      "colStatus": "Állapot",
+      "colStartedAt": "Indítva",
+      "colDuration": "Időtartam",
+      "colFile": "Fájl",
+      "colSize": "Méret",
+      "colActions": "Műveletek",
+      "download": "Letöltés",
+      "downloadExecution": "Jelentés letöltése {{date}}-ről",
+      "retry": "Újra",
+      "retrying": "Ismétlés...",
+      "retryExecution": "Végrehajtás megismétlése {{date}}-ről",
+      "noExecutions": "Nem található végrehajtás",
+      "clearFilters": "Szűrők törlése",
+      "loadMore": "Több betöltése",
+      "loading": "Betöltés...",
+      "errorTitle": "Nem sikerült betölteni a végrehajtásokat",
+      "errorMessage": "Kérjük, próbálja újra később."
+    },
+    "execution": {
+      "downloadFailed": "Nem sikerült letölteni a jelentést.",
+      "retryQueued": "A végrehajtás újraküldésre várakozik.",
+      "retryFailed": "Nem sikerült megismételni a végrehajtást."
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -607,5 +607,59 @@
         "message": "Aby kontynuować, potwierdź w aplikacji uwierzytelniającej."
       }
     }
+  },
+  "reports": {
+    "detail": {
+      "subtitle": "Historia wykonań harmonogramu",
+      "scheduleDetails": "Szczegóły harmonogramu",
+      "executionHistory": "Historia wykonań",
+      "executionCount": "{{filtered}} z {{total}} wykonań",
+      "backToSchedules": "Powrót do harmonogramów",
+      "frequency": {
+        "label": "Częstotliwość",
+        "daily": "Codziennie",
+        "weekly": "Co tydzień",
+        "monthly": "Co miesiąc",
+        "quarterly": "Co kwartał",
+        "yearly": "Co rok"
+      },
+      "format": "Format",
+      "statusLabel": "Status",
+      "active": "Aktywny",
+      "inactive": "Nieaktywny",
+      "recipients": "Odbiorcy",
+      "lastRun": "Ostatnie uruchomienie",
+      "nextRun": "Następne uruchomienie",
+      "status": {
+        "pending": "Oczekuje",
+        "running": "Działa",
+        "completed": "Zakończone",
+        "failed": "Błąd",
+        "cancelled": "Anulowane",
+        "skipped": "Pominięte"
+      },
+      "colStatus": "Status",
+      "colStartedAt": "Uruchomiono",
+      "colDuration": "Czas trwania",
+      "colFile": "Plik",
+      "colSize": "Rozmiar",
+      "colActions": "Akcje",
+      "download": "Pobierz",
+      "downloadExecution": "Pobierz raport z {{date}}",
+      "retry": "Ponów",
+      "retrying": "Ponawianie...",
+      "retryExecution": "Ponów wykonanie z {{date}}",
+      "noExecutions": "Nie znaleziono wykonań",
+      "clearFilters": "Wyczyść filtry",
+      "loadMore": "Wczytaj więcej",
+      "loading": "Wczytywanie...",
+      "errorTitle": "Nie udało się wczytać wykonań",
+      "errorMessage": "Spróbuj ponownie później."
+    },
+    "execution": {
+      "downloadFailed": "Nie udało się pobrać raportu.",
+      "retryQueued": "Wykonanie zostało dodane do kolejki ponowień.",
+      "retryFailed": "Nie udało się ponowić wykonania."
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -607,5 +607,59 @@
         "message": "Pre pokračovanie potvrďte v autentifikačnej aplikácii."
       }
     }
+  },
+  "reports": {
+    "detail": {
+      "subtitle": "História spustení plánu",
+      "scheduleDetails": "Podrobnosti plánu",
+      "executionHistory": "História spustení",
+      "executionCount": "{{filtered}} z {{total}} spustení",
+      "backToSchedules": "Späť na plány",
+      "frequency": {
+        "label": "Frekvencia",
+        "daily": "Denne",
+        "weekly": "Týždenne",
+        "monthly": "Mesačne",
+        "quarterly": "Štvrťročne",
+        "yearly": "Ročne"
+      },
+      "format": "Formát",
+      "statusLabel": "Stav",
+      "active": "Aktívny",
+      "inactive": "Neaktívny",
+      "recipients": "Príjemcovia",
+      "lastRun": "Posledné spustenie",
+      "nextRun": "Ďalšie spustenie",
+      "status": {
+        "pending": "Čaká",
+        "running": "Beží",
+        "completed": "Dokončené",
+        "failed": "Zlyhalo",
+        "cancelled": "Zrušené",
+        "skipped": "Preskočené"
+      },
+      "colStatus": "Stav",
+      "colStartedAt": "Začaté",
+      "colDuration": "Trvanie",
+      "colFile": "Súbor",
+      "colSize": "Veľkosť",
+      "colActions": "Akcie",
+      "download": "Stiahnuť",
+      "downloadExecution": "Stiahnuť správu zo dňa {{date}}",
+      "retry": "Opakovať",
+      "retrying": "Opakuje sa...",
+      "retryExecution": "Opakovať spustenie zo dňa {{date}}",
+      "noExecutions": "Nenašli sa žiadne spustenia",
+      "clearFilters": "Zrušiť filtre",
+      "loadMore": "Načítať viac",
+      "loading": "Načítava sa...",
+      "errorTitle": "Nepodarilo sa načítať spustenia",
+      "errorMessage": "Skúste to prosím neskôr."
+    },
+    "execution": {
+      "downloadFailed": "Nepodarilo sa stiahnuť správu.",
+      "retryQueued": "Spustenie bolo zaradené do frontu na opakovanie.",
+      "retryFailed": "Nepodarilo sa opakovať spustenie."
+    }
   }
 }

--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -2906,7 +2906,11 @@ function ScheduleDetailPageRoute() {
   const EXECUTION_PAGE_SIZE = 20;
   const [executionOffset, setExecutionOffset] = useState(0);
 
-  const { data: executionHistoryData, isLoading: executionsLoading } = useReportExecutionHistory(
+  const {
+    data: executionHistoryData,
+    isLoading: executionsLoading,
+    isError: executionsError,
+  } = useReportExecutionHistory(
     { scheduleId },
     {
       limit: EXECUTION_PAGE_SIZE,
@@ -2976,6 +2980,7 @@ function ScheduleDetailPageRoute() {
       schedule={stubSchedule}
       executions={executions}
       isLoading={executionsLoading}
+      isError={executionsError}
       hasMore={hasMore}
       onLoadMore={handleLoadMore}
       onDownload={handleDownloadReport}

--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -150,6 +150,7 @@ import {
   RegisterPage,
   ReportsPage,
   ResetPasswordPage,
+  ScheduleDetailPage,
   ServerErrorPage,
   SessionExpiredPage,
   ThreadDetailPage,
@@ -665,6 +666,15 @@ function App() {
                                   element={
                                     <ProtectedRoute>
                                       <ReportsPageRoute />
+                                    </ProtectedRoute>
+                                  }
+                                />
+                                {/* Story 81.2: Schedule detail with inline execution history table */}
+                                <Route
+                                  path="/reports/schedules/:scheduleId"
+                                  element={
+                                    <ProtectedRoute>
+                                      <ScheduleDetailPageRoute />
                                     </ProtectedRoute>
                                   }
                                 />
@@ -2876,6 +2886,101 @@ function ReportsPageRoute() {
       onLoadMoreExecutions={handleLoadMoreExecutions}
       onDownloadReport={handleDownloadReport}
       onRetryExecution={handleRetryExecution}
+    />
+  );
+}
+
+/**
+ * Schedule detail page route — renders execution history table inline (Story 81.2).
+ *
+ * Route: /reports/schedules/:scheduleId
+ * Uses useReportExecutionHistory to fetch paginated executions and renders them
+ * via ScheduleDetailPage. Falls back to MSW stub data when api-server is absent.
+ */
+function ScheduleDetailPageRoute() {
+  const { scheduleId = '' } = useParams<{ scheduleId: string }>();
+  const navigate = useNavigate();
+  const { showToast } = useToast();
+  const { t } = useTranslation();
+
+  const EXECUTION_PAGE_SIZE = 20;
+  const [executionOffset, setExecutionOffset] = useState(0);
+
+  const { data: executionHistoryData, isLoading: executionsLoading } = useReportExecutionHistory(
+    { scheduleId },
+    {
+      limit: EXECUTION_PAGE_SIZE,
+      offset: executionOffset,
+      enabled: !!scheduleId,
+      refetchInterval: 10_000,
+    }
+  );
+
+  const downloadReport = useDownloadReport();
+  const retryExecution = useRetryReportExecution();
+
+  const executions = executionHistoryData?.executions ?? [];
+  const hasMore = executionHistoryData?.hasMore ?? false;
+
+  const handleLoadMore = () => setExecutionOffset((prev) => prev + EXECUTION_PAGE_SIZE);
+
+  const handleDownloadReport = (executionId: string) => {
+    downloadReport.mutate(executionId, {
+      onError: () => {
+        showToast({
+          type: 'error',
+          title: t('common.error'),
+          message: t('reports.execution.downloadFailed', 'Failed to download report.'),
+        });
+      },
+    });
+  };
+
+  const handleRetryExecution = async (executionId: string) => {
+    try {
+      await retryExecution.mutateAsync(executionId);
+      showToast({
+        type: 'success',
+        title: t('common.success'),
+        message: t('reports.execution.retryQueued', 'Execution queued for retry.'),
+      });
+    } catch {
+      showToast({
+        type: 'error',
+        title: t('common.error'),
+        message: t('reports.execution.retryFailed', 'Failed to retry execution.'),
+      });
+      throw new Error('retry failed');
+    }
+  };
+
+  // Stub schedule object — schedule metadata will be enriched once the
+  // GET /api/v1/reports/schedules/:id endpoint is wired in a future story.
+  const stubSchedule: import('@ppt/api-client').ReportSchedule = {
+    id: scheduleId,
+    report_id: '',
+    organization_id: '',
+    name: `Schedule ${scheduleId}`,
+    frequency: 'monthly',
+    time: '08:00',
+    timezone: 'UTC',
+    format: 'pdf',
+    recipients: [],
+    is_active: true,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  };
+
+  return (
+    <ScheduleDetailPage
+      schedule={stubSchedule}
+      executions={executions}
+      isLoading={executionsLoading}
+      hasMore={hasMore}
+      onLoadMore={handleLoadMore}
+      onDownload={handleDownloadReport}
+      onRetry={handleRetryExecution}
+      onBack={() => navigate('/reports')}
     />
   );
 }

--- a/frontend/apps/ppt-web/src/features/reports/index.ts
+++ b/frontend/apps/ppt-web/src/features/reports/index.ts
@@ -4,3 +4,5 @@
 
 export * from './components';
 export { ReportsPage } from './pages/ReportsPage';
+export type { ScheduleDetailPageProps } from './pages/ScheduleDetailPage';
+export { ScheduleDetailPage } from './pages/ScheduleDetailPage';

--- a/frontend/apps/ppt-web/src/features/reports/pages/ScheduleDetailPage.tsx
+++ b/frontend/apps/ppt-web/src/features/reports/pages/ScheduleDetailPage.tsx
@@ -9,23 +9,33 @@
 
 import type { ReportExecution, ReportExecutionStatus, ReportSchedule } from '@ppt/api-client';
 import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { type ExecutionFilters, HistoryFilters } from '../components/HistoryFilters';
 
 // ============================================================================
 // Sub-components
 // ============================================================================
 
-const STATUS_STYLES: Record<ReportExecutionStatus, { bg: string; text: string; label: string }> = {
-  pending: { bg: 'bg-gray-100', text: 'text-gray-700', label: 'Pending' },
-  running: { bg: 'bg-blue-100', text: 'text-blue-700', label: 'Running' },
-  completed: { bg: 'bg-green-100', text: 'text-green-700', label: 'Completed' },
-  failed: { bg: 'bg-red-100', text: 'text-red-700', label: 'Failed' },
-  cancelled: { bg: 'bg-yellow-100', text: 'text-yellow-700', label: 'Cancelled' },
-  skipped: { bg: 'bg-gray-100', text: 'text-gray-500', label: 'Skipped' },
+const STATUS_STYLE_CLASSES: Record<ReportExecutionStatus, { bg: string; text: string }> = {
+  pending: { bg: 'bg-gray-100', text: 'text-gray-700' },
+  running: { bg: 'bg-blue-100', text: 'text-blue-700' },
+  completed: { bg: 'bg-green-100', text: 'text-green-700' },
+  failed: { bg: 'bg-red-100', text: 'text-red-700' },
+  cancelled: { bg: 'bg-yellow-100', text: 'text-yellow-700' },
+  skipped: { bg: 'bg-gray-100', text: 'text-gray-500' },
 };
 
 function StatusBadge({ status }: { status: ReportExecutionStatus }) {
-  const style = STATUS_STYLES[status];
+  const { t } = useTranslation();
+  const style = STATUS_STYLE_CLASSES[status];
+  const statusLabels: Record<ReportExecutionStatus, string> = {
+    pending: t('reports.detail.status.pending', 'Pending'),
+    running: t('reports.detail.status.running', 'Running'),
+    completed: t('reports.detail.status.completed', 'Completed'),
+    failed: t('reports.detail.status.failed', 'Failed'),
+    cancelled: t('reports.detail.status.cancelled', 'Cancelled'),
+    skipped: t('reports.detail.status.skipped', 'Skipped'),
+  };
   return (
     <span
       className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${style.bg} ${style.text}`}
@@ -52,7 +62,7 @@ function StatusBadge({ status }: { status: ReportExecutionStatus }) {
           />
         </svg>
       )}
-      {style.label}
+      {statusLabels[status]}
     </span>
   );
 }
@@ -70,7 +80,7 @@ function formatDuration(startedAt: string, completedAt?: string): string {
 }
 
 function formatDateTime(dateString: string): string {
-  return new Date(dateString).toLocaleDateString('en-US', {
+  return new Date(dateString).toLocaleDateString(undefined, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
@@ -86,14 +96,6 @@ function formatFileSize(bytes?: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-const FREQUENCY_LABELS: Record<string, string> = {
-  daily: 'Daily',
-  weekly: 'Weekly',
-  monthly: 'Monthly',
-  quarterly: 'Quarterly',
-  yearly: 'Yearly',
-};
-
 // ============================================================================
 // Props
 // ============================================================================
@@ -102,6 +104,7 @@ export interface ScheduleDetailPageProps {
   schedule: ReportSchedule;
   executions: ReportExecution[];
   isLoading?: boolean;
+  isError?: boolean;
   hasMore?: boolean;
   onLoadMore?: () => void;
   onDownload?: (executionId: string) => void;
@@ -117,12 +120,14 @@ export function ScheduleDetailPage({
   schedule,
   executions,
   isLoading,
+  isError,
   hasMore,
   onLoadMore,
   onDownload,
   onRetry,
   onBack,
 }: ScheduleDetailPageProps) {
+  const { t } = useTranslation();
   const [filters, setFilters] = useState<ExecutionFilters>({});
   const [retryingId, setRetryingId] = useState<string | null>(null);
 
@@ -157,6 +162,17 @@ export function ScheduleDetailPage({
   const failedCount = executions.filter((e) => e.status === 'failed').length;
   const runningCount = executions.filter((e) => e.status === 'running').length;
 
+  const frequencyLabel = (freq: string) => {
+    const map: Record<string, string> = {
+      daily: t('reports.detail.frequency.daily', 'Daily'),
+      weekly: t('reports.detail.frequency.weekly', 'Weekly'),
+      monthly: t('reports.detail.frequency.monthly', 'Monthly'),
+      quarterly: t('reports.detail.frequency.quarterly', 'Quarterly'),
+      yearly: t('reports.detail.frequency.yearly', 'Yearly'),
+    };
+    return map[freq] ?? freq;
+  };
+
   return (
     <div className="min-h-screen bg-gray-100">
       {/* Page header */}
@@ -168,7 +184,7 @@ export function ScheduleDetailPage({
                 type="button"
                 onClick={onBack}
                 className="p-2 text-gray-400 hover:text-gray-600 rounded-md hover:bg-gray-100"
-                aria-label="Back to schedules"
+                aria-label={t('reports.detail.backToSchedules', 'Back to schedules')}
               >
                 <svg
                   className="w-5 h-5"
@@ -188,7 +204,9 @@ export function ScheduleDetailPage({
             )}
             <div>
               <h1 className="text-2xl font-bold text-gray-900">{schedule.name}</h1>
-              <p className="text-sm text-gray-500 mt-1">Schedule execution history</p>
+              <p className="text-sm text-gray-500 mt-1">
+                {t('reports.detail.subtitle', 'Schedule execution history')}
+              </p>
             </div>
           </div>
         </div>
@@ -197,42 +215,50 @@ export function ScheduleDetailPage({
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
         {/* Schedule metadata card */}
         <div className="bg-white rounded-lg shadow p-6">
-          <h2 className="text-base font-semibold text-gray-900 mb-4">Schedule details</h2>
+          <h2 className="text-base font-semibold text-gray-900 mb-4">
+            {t('reports.detail.scheduleDetails', 'Schedule details')}
+          </h2>
           <dl className="grid grid-cols-2 sm:grid-cols-4 gap-4">
             <div>
               <dt className="text-xs font-medium text-gray-500 uppercase tracking-wide">
-                Frequency
+                {t('reports.detail.frequency.label', 'Frequency')}
               </dt>
               <dd className="mt-1 text-sm text-gray-900">
-                {FREQUENCY_LABELS[schedule.frequency] ?? schedule.frequency} at {schedule.time}
+                {frequencyLabel(schedule.frequency)} at {schedule.time}
               </dd>
             </div>
             <div>
-              <dt className="text-xs font-medium text-gray-500 uppercase tracking-wide">Format</dt>
+              <dt className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+                {t('reports.detail.format', 'Format')}
+              </dt>
               <dd className="mt-1 text-sm text-gray-900 uppercase">{schedule.format}</dd>
             </div>
             <div>
-              <dt className="text-xs font-medium text-gray-500 uppercase tracking-wide">Status</dt>
+              <dt className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+                {t('reports.detail.statusLabel', 'Status')}
+              </dt>
               <dd className="mt-1">
                 <span
                   className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
                     schedule.is_active ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'
                   }`}
                 >
-                  {schedule.is_active ? 'Active' : 'Inactive'}
+                  {schedule.is_active
+                    ? t('reports.detail.active', 'Active')
+                    : t('reports.detail.inactive', 'Inactive')}
                 </span>
               </dd>
             </div>
             <div>
               <dt className="text-xs font-medium text-gray-500 uppercase tracking-wide">
-                Recipients
+                {t('reports.detail.recipients', 'Recipients')}
               </dt>
               <dd className="mt-1 text-sm text-gray-900">{schedule.recipients.length}</dd>
             </div>
             {schedule.last_run_at && (
               <div>
                 <dt className="text-xs font-medium text-gray-500 uppercase tracking-wide">
-                  Last run
+                  {t('reports.detail.lastRun', 'Last run')}
                 </dt>
                 <dd className="mt-1 text-sm text-gray-900">
                   {formatDateTime(schedule.last_run_at)}
@@ -242,7 +268,7 @@ export function ScheduleDetailPage({
             {schedule.next_run_at && schedule.is_active && (
               <div>
                 <dt className="text-xs font-medium text-gray-500 uppercase tracking-wide">
-                  Next run
+                  {t('reports.detail.nextRun', 'Next run')}
                 </dt>
                 <dd className="mt-1 text-sm text-gray-900">
                   {formatDateTime(schedule.next_run_at)}
@@ -256,24 +282,35 @@ export function ScheduleDetailPage({
         <div className="grid grid-cols-3 gap-4">
           <div className="bg-white rounded-lg shadow p-4 text-center">
             <p className="text-2xl font-bold text-green-600">{completedCount}</p>
-            <p className="text-xs text-gray-500 mt-1">Completed</p>
+            <p className="text-xs text-gray-500 mt-1">
+              {t('reports.detail.status.completed', 'Completed')}
+            </p>
           </div>
           <div className="bg-white rounded-lg shadow p-4 text-center">
             <p className="text-2xl font-bold text-red-600">{failedCount}</p>
-            <p className="text-xs text-gray-500 mt-1">Failed</p>
+            <p className="text-xs text-gray-500 mt-1">
+              {t('reports.detail.status.failed', 'Failed')}
+            </p>
           </div>
           <div className="bg-white rounded-lg shadow p-4 text-center">
             <p className="text-2xl font-bold text-blue-600">{runningCount}</p>
-            <p className="text-xs text-gray-500 mt-1">Running</p>
+            <p className="text-xs text-gray-500 mt-1">
+              {t('reports.detail.status.running', 'Running')}
+            </p>
           </div>
         </div>
 
         {/* Execution history table */}
         <div className="bg-white rounded-lg shadow overflow-hidden">
           <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
-            <h2 className="text-base font-semibold text-gray-900">Execution history</h2>
+            <h2 className="text-base font-semibold text-gray-900">
+              {t('reports.detail.executionHistory', 'Execution history')}
+            </h2>
             <span className="text-sm text-gray-500">
-              {filteredExecutions.length} of {executions.length} executions
+              {t('reports.detail.executionCount', '{{filtered}} of {{total}} executions', {
+                filtered: filteredExecutions.length,
+                total: executions.length,
+              })}
             </span>
           </div>
 
@@ -282,8 +319,31 @@ export function ScheduleDetailPage({
             <HistoryFilters filters={filters} onChange={setFilters} />
           </div>
 
-          {/* Table */}
-          {isLoading && executions.length === 0 ? (
+          {/* Error state */}
+          {isError ? (
+            <div className="p-12 text-center">
+              <svg
+                className="w-12 h-12 text-red-400 mx-auto mb-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
+                />
+              </svg>
+              <p className="text-gray-900 font-medium">
+                {t('reports.detail.errorTitle', 'Failed to load executions')}
+              </p>
+              <p className="text-gray-500 text-sm mt-1">
+                {t('reports.detail.errorMessage', 'Please try again later.')}
+              </p>
+            </div>
+          ) : isLoading && executions.length === 0 ? (
             <div className="p-6">
               <div className="animate-pulse space-y-3">
                 {[1, 2, 3, 4, 5].map((i) => (
@@ -307,57 +367,60 @@ export function ScheduleDetailPage({
                   d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
                 />
               </svg>
-              <p className="text-gray-500">No executions found</p>
+              <p className="text-gray-500">{t('reports.detail.noExecutions', 'No executions found')}</p>
               {Object.keys(filters).length > 0 && (
                 <button
                   type="button"
                   onClick={() => setFilters({})}
                   className="mt-2 text-blue-600 hover:text-blue-800 text-sm font-medium"
                 >
-                  Clear filters
+                  {t('reports.detail.clearFilters', 'Clear filters')}
                 </button>
               )}
             </div>
           ) : (
             <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200">
+              <table
+                className="min-w-full divide-y divide-gray-200"
+                aria-label={t('reports.detail.executionHistory', 'Execution history')}
+              >
                 <thead className="bg-gray-50">
                   <tr>
                     <th
                       scope="col"
                       className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
                     >
-                      Status
+                      {t('reports.detail.colStatus', 'Status')}
                     </th>
                     <th
                       scope="col"
                       className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
                     >
-                      Started at
+                      {t('reports.detail.colStartedAt', 'Started at')}
                     </th>
                     <th
                       scope="col"
                       className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
                     >
-                      Duration
+                      {t('reports.detail.colDuration', 'Duration')}
                     </th>
                     <th
                       scope="col"
                       className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
                     >
-                      File
+                      {t('reports.detail.colFile', 'File')}
                     </th>
                     <th
                       scope="col"
                       className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
                     >
-                      Size
+                      {t('reports.detail.colSize', 'Size')}
                     </th>
                     <th
                       scope="col"
                       className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
                     >
-                      Actions
+                      {t('reports.detail.colActions', 'Actions')}
                     </th>
                   </tr>
                 </thead>
@@ -393,6 +456,11 @@ export function ScheduleDetailPage({
                             <button
                               type="button"
                               onClick={() => onDownload(execution.id)}
+                              aria-label={t(
+                                'reports.detail.downloadExecution',
+                                'Download report from {{date}}',
+                                { date: formatDateTime(execution.startedAt) }
+                              )}
                               className="inline-flex items-center px-2.5 py-1 text-xs font-medium text-blue-600 bg-blue-50 rounded hover:bg-blue-100"
                             >
                               <svg
@@ -409,7 +477,7 @@ export function ScheduleDetailPage({
                                   d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
                                 />
                               </svg>
-                              Download
+                              {t('reports.detail.download', 'Download')}
                             </button>
                           )}
                           {execution.status === 'failed' && onRetry && (
@@ -417,6 +485,11 @@ export function ScheduleDetailPage({
                               type="button"
                               onClick={() => handleRetry(execution.id)}
                               disabled={retryingId === execution.id}
+                              aria-label={t(
+                                'reports.detail.retryExecution',
+                                'Retry execution from {{date}}',
+                                { date: formatDateTime(execution.startedAt) }
+                              )}
                               className="inline-flex items-center px-2.5 py-1 text-xs font-medium text-orange-600 bg-orange-50 rounded hover:bg-orange-100 disabled:opacity-50"
                             >
                               {retryingId === execution.id ? (
@@ -441,7 +514,7 @@ export function ScheduleDetailPage({
                                       d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
                                     />
                                   </svg>
-                                  Retrying...
+                                  {t('reports.detail.retrying', 'Retrying...')}
                                 </>
                               ) : (
                                 <>
@@ -459,7 +532,7 @@ export function ScheduleDetailPage({
                                       d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
                                     />
                                   </svg>
-                                  Retry
+                                  {t('reports.detail.retry', 'Retry')}
                                 </>
                               )}
                             </button>
@@ -482,7 +555,9 @@ export function ScheduleDetailPage({
                 disabled={isLoading}
                 className="text-blue-600 hover:text-blue-800 text-sm font-medium disabled:opacity-50"
               >
-                {isLoading ? 'Loading...' : 'Load more'}
+                {isLoading
+                  ? t('reports.detail.loading', 'Loading...')
+                  : t('reports.detail.loadMore', 'Load more')}
               </button>
             </div>
           )}

--- a/frontend/apps/ppt-web/src/features/reports/pages/ScheduleDetailPage.tsx
+++ b/frontend/apps/ppt-web/src/features/reports/pages/ScheduleDetailPage.tsx
@@ -1,0 +1,493 @@
+/**
+ * ScheduleDetailPage - Report schedule detail with inline execution history table.
+ *
+ * Story 81.2 - Report Execution History
+ *
+ * Displays schedule metadata and a paginated execution history table with
+ * status filtering, date-range filtering, download and retry actions.
+ */
+
+import type { ReportExecution, ReportExecutionStatus, ReportSchedule } from '@ppt/api-client';
+import { useCallback, useState } from 'react';
+import { type ExecutionFilters, HistoryFilters } from '../components/HistoryFilters';
+
+// ============================================================================
+// Sub-components
+// ============================================================================
+
+const STATUS_STYLES: Record<ReportExecutionStatus, { bg: string; text: string; label: string }> = {
+  pending: { bg: 'bg-gray-100', text: 'text-gray-700', label: 'Pending' },
+  running: { bg: 'bg-blue-100', text: 'text-blue-700', label: 'Running' },
+  completed: { bg: 'bg-green-100', text: 'text-green-700', label: 'Completed' },
+  failed: { bg: 'bg-red-100', text: 'text-red-700', label: 'Failed' },
+  cancelled: { bg: 'bg-yellow-100', text: 'text-yellow-700', label: 'Cancelled' },
+  skipped: { bg: 'bg-gray-100', text: 'text-gray-500', label: 'Skipped' },
+};
+
+function StatusBadge({ status }: { status: ReportExecutionStatus }) {
+  const style = STATUS_STYLES[status];
+  return (
+    <span
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${style.bg} ${style.text}`}
+    >
+      {status === 'running' && (
+        <svg
+          className="animate-spin -ml-0.5 mr-1.5 h-3 w-3"
+          fill="none"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+          />
+        </svg>
+      )}
+      {style.label}
+    </span>
+  );
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function formatDuration(startedAt: string, completedAt?: string): string {
+  if (!completedAt) return '-';
+  const durationMs = new Date(completedAt).getTime() - new Date(startedAt).getTime();
+  if (durationMs < 1000) return `${durationMs}ms`;
+  if (durationMs < 60_000) return `${Math.round(durationMs / 1000)}s`;
+  return `${Math.round(durationMs / 60_000)}m`;
+}
+
+function formatDateTime(dateString: string): string {
+  return new Date(dateString).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function formatFileSize(bytes?: number): string {
+  if (!bytes) return '-';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+const FREQUENCY_LABELS: Record<string, string> = {
+  daily: 'Daily',
+  weekly: 'Weekly',
+  monthly: 'Monthly',
+  quarterly: 'Quarterly',
+  yearly: 'Yearly',
+};
+
+// ============================================================================
+// Props
+// ============================================================================
+
+export interface ScheduleDetailPageProps {
+  schedule: ReportSchedule;
+  executions: ReportExecution[];
+  isLoading?: boolean;
+  hasMore?: boolean;
+  onLoadMore?: () => void;
+  onDownload?: (executionId: string) => void;
+  onRetry?: (executionId: string) => Promise<void>;
+  onBack?: () => void;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function ScheduleDetailPage({
+  schedule,
+  executions,
+  isLoading,
+  hasMore,
+  onLoadMore,
+  onDownload,
+  onRetry,
+  onBack,
+}: ScheduleDetailPageProps) {
+  const [filters, setFilters] = useState<ExecutionFilters>({});
+  const [retryingId, setRetryingId] = useState<string | null>(null);
+
+  const handleRetry = useCallback(
+    async (executionId: string) => {
+      if (!onRetry) return;
+      setRetryingId(executionId);
+      try {
+        await onRetry(executionId);
+      } finally {
+        setRetryingId(null);
+      }
+    },
+    [onRetry]
+  );
+
+  // Client-side filter on already-fetched page
+  const filteredExecutions = executions.filter((execution) => {
+    if (filters.status && execution.status !== filters.status) return false;
+
+    const executionDate = new Date(execution.startedAt);
+    const fromDate = filters.dateFrom ? new Date(filters.dateFrom) : undefined;
+    const toDate = filters.dateTo ? new Date(filters.dateTo) : undefined;
+    if (toDate) toDate.setHours(23, 59, 59, 999);
+    if (fromDate && executionDate < fromDate) return false;
+    if (toDate && executionDate > toDate) return false;
+    return true;
+  });
+
+  // Stats summary
+  const completedCount = executions.filter((e) => e.status === 'completed').length;
+  const failedCount = executions.filter((e) => e.status === 'failed').length;
+  const runningCount = executions.filter((e) => e.status === 'running').length;
+
+  return (
+    <div className="min-h-screen bg-gray-100">
+      {/* Page header */}
+      <div className="bg-white shadow">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+          <div className="flex items-center gap-4">
+            {onBack && (
+              <button
+                type="button"
+                onClick={onBack}
+                className="p-2 text-gray-400 hover:text-gray-600 rounded-md hover:bg-gray-100"
+                aria-label="Back to schedules"
+              >
+                <svg
+                  className="w-5 h-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M15 19l-7-7 7-7"
+                  />
+                </svg>
+              </button>
+            )}
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900">{schedule.name}</h1>
+              <p className="text-sm text-gray-500 mt-1">Schedule execution history</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
+        {/* Schedule metadata card */}
+        <div className="bg-white rounded-lg shadow p-6">
+          <h2 className="text-base font-semibold text-gray-900 mb-4">Schedule details</h2>
+          <dl className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            <div>
+              <dt className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+                Frequency
+              </dt>
+              <dd className="mt-1 text-sm text-gray-900">
+                {FREQUENCY_LABELS[schedule.frequency] ?? schedule.frequency} at {schedule.time}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium text-gray-500 uppercase tracking-wide">Format</dt>
+              <dd className="mt-1 text-sm text-gray-900 uppercase">{schedule.format}</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium text-gray-500 uppercase tracking-wide">Status</dt>
+              <dd className="mt-1">
+                <span
+                  className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                    schedule.is_active ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'
+                  }`}
+                >
+                  {schedule.is_active ? 'Active' : 'Inactive'}
+                </span>
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+                Recipients
+              </dt>
+              <dd className="mt-1 text-sm text-gray-900">{schedule.recipients.length}</dd>
+            </div>
+            {schedule.last_run_at && (
+              <div>
+                <dt className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+                  Last run
+                </dt>
+                <dd className="mt-1 text-sm text-gray-900">
+                  {formatDateTime(schedule.last_run_at)}
+                </dd>
+              </div>
+            )}
+            {schedule.next_run_at && schedule.is_active && (
+              <div>
+                <dt className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+                  Next run
+                </dt>
+                <dd className="mt-1 text-sm text-gray-900">
+                  {formatDateTime(schedule.next_run_at)}
+                </dd>
+              </div>
+            )}
+          </dl>
+        </div>
+
+        {/* Stats bar */}
+        <div className="grid grid-cols-3 gap-4">
+          <div className="bg-white rounded-lg shadow p-4 text-center">
+            <p className="text-2xl font-bold text-green-600">{completedCount}</p>
+            <p className="text-xs text-gray-500 mt-1">Completed</p>
+          </div>
+          <div className="bg-white rounded-lg shadow p-4 text-center">
+            <p className="text-2xl font-bold text-red-600">{failedCount}</p>
+            <p className="text-xs text-gray-500 mt-1">Failed</p>
+          </div>
+          <div className="bg-white rounded-lg shadow p-4 text-center">
+            <p className="text-2xl font-bold text-blue-600">{runningCount}</p>
+            <p className="text-xs text-gray-500 mt-1">Running</p>
+          </div>
+        </div>
+
+        {/* Execution history table */}
+        <div className="bg-white rounded-lg shadow overflow-hidden">
+          <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+            <h2 className="text-base font-semibold text-gray-900">Execution history</h2>
+            <span className="text-sm text-gray-500">
+              {filteredExecutions.length} of {executions.length} executions
+            </span>
+          </div>
+
+          {/* Filters */}
+          <div className="px-6 py-3 border-b border-gray-200 bg-gray-50">
+            <HistoryFilters filters={filters} onChange={setFilters} />
+          </div>
+
+          {/* Table */}
+          {isLoading && executions.length === 0 ? (
+            <div className="p-6">
+              <div className="animate-pulse space-y-3">
+                {[1, 2, 3, 4, 5].map((i) => (
+                  <div key={i} className="h-12 bg-gray-200 rounded" />
+                ))}
+              </div>
+            </div>
+          ) : filteredExecutions.length === 0 ? (
+            <div className="p-12 text-center">
+              <svg
+                className="w-12 h-12 text-gray-400 mx-auto mb-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+                />
+              </svg>
+              <p className="text-gray-500">No executions found</p>
+              {Object.keys(filters).length > 0 && (
+                <button
+                  type="button"
+                  onClick={() => setFilters({})}
+                  className="mt-2 text-blue-600 hover:text-blue-800 text-sm font-medium"
+                >
+                  Clear filters
+                </button>
+              )}
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-200">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th
+                      scope="col"
+                      className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                    >
+                      Status
+                    </th>
+                    <th
+                      scope="col"
+                      className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                    >
+                      Started at
+                    </th>
+                    <th
+                      scope="col"
+                      className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                    >
+                      Duration
+                    </th>
+                    <th
+                      scope="col"
+                      className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                    >
+                      File
+                    </th>
+                    <th
+                      scope="col"
+                      className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                    >
+                      Size
+                    </th>
+                    <th
+                      scope="col"
+                      className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
+                    >
+                      Actions
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y divide-gray-200">
+                  {filteredExecutions.map((execution) => (
+                    <tr key={execution.id} className="hover:bg-gray-50">
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <StatusBadge status={execution.status} />
+                        {execution.status === 'failed' && execution.error && (
+                          <p
+                            className="text-xs text-red-600 mt-1 max-w-xs truncate"
+                            title={execution.error.message}
+                          >
+                            {execution.error.code}: {execution.error.message}
+                          </p>
+                        )}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                        {formatDateTime(execution.startedAt)}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        {formatDuration(execution.startedAt, execution.completedAt)}
+                      </td>
+                      <td className="px-6 py-4 text-sm text-gray-500 max-w-[200px] truncate">
+                        {execution.fileName ?? '-'}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        {formatFileSize(execution.fileSize)}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                        <div className="flex items-center justify-end gap-2">
+                          {execution.status === 'completed' && onDownload && (
+                            <button
+                              type="button"
+                              onClick={() => onDownload(execution.id)}
+                              className="inline-flex items-center px-2.5 py-1 text-xs font-medium text-blue-600 bg-blue-50 rounded hover:bg-blue-100"
+                            >
+                              <svg
+                                className="w-3.5 h-3.5 mr-1"
+                                fill="none"
+                                stroke="currentColor"
+                                viewBox="0 0 24 24"
+                                aria-hidden="true"
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth={2}
+                                  d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+                                />
+                              </svg>
+                              Download
+                            </button>
+                          )}
+                          {execution.status === 'failed' && onRetry && (
+                            <button
+                              type="button"
+                              onClick={() => handleRetry(execution.id)}
+                              disabled={retryingId === execution.id}
+                              className="inline-flex items-center px-2.5 py-1 text-xs font-medium text-orange-600 bg-orange-50 rounded hover:bg-orange-100 disabled:opacity-50"
+                            >
+                              {retryingId === execution.id ? (
+                                <>
+                                  <svg
+                                    className="animate-spin w-3.5 h-3.5 mr-1"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    aria-hidden="true"
+                                  >
+                                    <circle
+                                      className="opacity-25"
+                                      cx="12"
+                                      cy="12"
+                                      r="10"
+                                      stroke="currentColor"
+                                      strokeWidth="4"
+                                    />
+                                    <path
+                                      className="opacity-75"
+                                      fill="currentColor"
+                                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                                    />
+                                  </svg>
+                                  Retrying...
+                                </>
+                              ) : (
+                                <>
+                                  <svg
+                                    className="w-3.5 h-3.5 mr-1"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    viewBox="0 0 24 24"
+                                    aria-hidden="true"
+                                  >
+                                    <path
+                                      strokeLinecap="round"
+                                      strokeLinejoin="round"
+                                      strokeWidth={2}
+                                      d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                                    />
+                                  </svg>
+                                  Retry
+                                </>
+                              )}
+                            </button>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {/* Load more footer */}
+          {hasMore && (
+            <div className="px-6 py-4 border-t border-gray-200 bg-gray-50 text-center">
+              <button
+                type="button"
+                onClick={onLoadMore}
+                disabled={isLoading}
+                className="text-blue-600 hover:text-blue-800 text-sm font-medium disabled:opacity-50"
+              >
+                {isLoading ? 'Loading...' : 'Load more'}
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/mocks/handlers/index.ts
+++ b/frontend/apps/ppt-web/src/mocks/handlers/index.ts
@@ -1,3 +1,4 @@
 import { buildingsHandlers } from './buildings';
+import { reportsHandlers } from './reports';
 
-export const handlers = [...buildingsHandlers];
+export const handlers = [...buildingsHandlers, ...reportsHandlers];

--- a/frontend/apps/ppt-web/src/mocks/handlers/reports.ts
+++ b/frontend/apps/ppt-web/src/mocks/handlers/reports.ts
@@ -1,0 +1,179 @@
+/**
+ * MSW handlers for reports execution history API (Story 81.2).
+ *
+ * Used in dev/test when the real api-server endpoint is not present.
+ */
+
+import type { ReportExecution, ReportExecutionHistoryResponse } from '@ppt/api-client';
+import { HttpResponse, http } from 'msw';
+
+// ---------------------------------------------------------------------------
+// Seed data
+// ---------------------------------------------------------------------------
+
+function makeExecution(
+  id: string,
+  scheduleId: string,
+  status: ReportExecution['status'],
+  daysAgo: number,
+  opts?: {
+    fileName?: string;
+    fileSize?: number;
+    durationMs?: number;
+    error?: ReportExecution['error'];
+  }
+): ReportExecution {
+  const startedAt = new Date(Date.now() - daysAgo * 86_400_000).toISOString();
+  const completedAt =
+    status === 'pending' || status === 'running'
+      ? undefined
+      : new Date(new Date(startedAt).getTime() + (opts?.durationMs ?? 12_500)).toISOString();
+
+  return {
+    id,
+    scheduleId,
+    status,
+    startedAt,
+    completedAt,
+    durationMs: completedAt ? (opts?.durationMs ?? 12_500) : undefined,
+    fileName: status === 'completed' ? (opts?.fileName ?? `report-${id}.pdf`) : undefined,
+    fileSize: status === 'completed' ? (opts?.fileSize ?? 204_800) : undefined,
+    error:
+      status === 'failed'
+        ? (opts?.error ?? { code: 'QUERY_TIMEOUT', message: 'Query timed out after 30s' })
+        : undefined,
+    createdAt: startedAt,
+  };
+}
+
+const SEED_EXECUTIONS: ReportExecution[] = [
+  makeExecution('exec-01', 'schedule-demo', 'completed', 0, {
+    fileName: 'monthly-report-may-2026.pdf',
+    fileSize: 512_000,
+    durationMs: 8_400,
+  }),
+  makeExecution('exec-02', 'schedule-demo', 'running', 0),
+  makeExecution('exec-03', 'schedule-demo', 'completed', 1, {
+    fileName: 'monthly-report-apr-2026.pdf',
+    fileSize: 487_000,
+    durationMs: 9_200,
+  }),
+  makeExecution('exec-04', 'schedule-demo', 'failed', 2, {
+    error: {
+      code: 'QUERY_TIMEOUT',
+      message: 'Query timed out after 30s',
+      details: 'SELECT * FROM ledger timed out',
+    },
+  }),
+  makeExecution('exec-05', 'schedule-demo', 'completed', 3, {
+    fileName: 'monthly-report-mar-2026.pdf',
+    fileSize: 462_000,
+    durationMs: 7_800,
+  }),
+  makeExecution('exec-06', 'schedule-demo', 'skipped', 4),
+  makeExecution('exec-07', 'schedule-demo', 'completed', 5, {
+    fileName: 'monthly-report-feb-2026.pdf',
+    fileSize: 440_000,
+    durationMs: 11_000,
+  }),
+  makeExecution('exec-08', 'schedule-demo', 'cancelled', 6),
+  makeExecution('exec-09', 'schedule-demo', 'completed', 7, {
+    fileName: 'monthly-report-jan-2026.pdf',
+    fileSize: 395_000,
+    durationMs: 6_500,
+  }),
+  makeExecution('exec-10', 'schedule-demo', 'failed', 8, {
+    error: {
+      code: 'STORAGE_ERROR',
+      message: 'S3 upload failed',
+      details: 'AccessDenied on bucket ppt-reports',
+    },
+  }),
+  makeExecution('exec-11', 'schedule-demo', 'completed', 9, {
+    fileName: 'monthly-report-dec-2025.pdf',
+    fileSize: 378_000,
+    durationMs: 7_200,
+  }),
+  makeExecution('exec-12', 'schedule-demo', 'completed', 10, {
+    fileName: 'monthly-report-nov-2025.pdf',
+    fileSize: 360_000,
+    durationMs: 6_800,
+  }),
+];
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+export const reportsHandlers = [
+  // GET /api/v1/reports/schedules/:scheduleId/executions
+  http.get('/api/v1/reports/schedules/:scheduleId/executions', ({ request, params }) => {
+    const { scheduleId } = params as { scheduleId: string };
+    const url = new URL(request.url);
+
+    const status = url.searchParams.get('status') as ReportExecution['status'] | null;
+    const dateFrom = url.searchParams.get('date_from');
+    const dateTo = url.searchParams.get('date_to');
+    const limit = Number(url.searchParams.get('limit') ?? '20');
+    const offset = Number(url.searchParams.get('offset') ?? '0');
+
+    // Return demo data for any scheduleId (fallback to seed set)
+    let results = SEED_EXECUTIONS.filter((e) => e.scheduleId === scheduleId);
+    if (results.length === 0) {
+      results = SEED_EXECUTIONS.map((e) => ({ ...e, scheduleId }));
+    }
+
+    if (status) {
+      results = results.filter((e) => e.status === status);
+    }
+    if (dateFrom) {
+      const from = new Date(dateFrom);
+      results = results.filter((e) => new Date(e.startedAt) >= from);
+    }
+    if (dateTo) {
+      const to = new Date(dateTo);
+      to.setHours(23, 59, 59, 999);
+      results = results.filter((e) => new Date(e.startedAt) <= to);
+    }
+
+    const total = results.length;
+    const page = results.slice(offset, offset + limit);
+
+    const body: ReportExecutionHistoryResponse = {
+      executions: page,
+      total,
+      hasMore: offset + limit < total,
+    };
+
+    return HttpResponse.json(body);
+  }),
+
+  // POST /api/v1/reports/executions/:executionId/retry
+  http.post('/api/v1/reports/executions/:executionId/retry', ({ params }) => {
+    const { executionId } = params as { executionId: string };
+    const original = SEED_EXECUTIONS.find((e) => e.id === executionId);
+    const scheduleId = original?.scheduleId ?? 'schedule-demo';
+
+    const retried: ReportExecution = makeExecution(
+      `${executionId}-retry-${Date.now()}`,
+      scheduleId,
+      'pending',
+      0
+    );
+    return HttpResponse.json(retried, { status: 201 });
+  }),
+
+  // GET /api/v1/reports/executions/:executionId/download
+  http.get('/api/v1/reports/executions/:executionId/download', ({ params }) => {
+    const { executionId } = params as { executionId: string };
+    const execution = SEED_EXECUTIONS.find((e) => e.id === executionId);
+    const fileName = execution?.fileName ?? `report-${executionId}.pdf`;
+
+    return HttpResponse.json({
+      url: `https://storage.example.com/reports/${fileName}?token=stub`,
+      expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+      fileName,
+      contentType: 'application/pdf',
+    });
+  }),
+];

--- a/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
+++ b/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
@@ -201,6 +201,10 @@ export const BudgetManagementPage = lazy(() =>
 export const ReportsPage = lazy(() =>
   import('../features/reports').then((m) => ({ default: m.ReportsPage }))
 );
+// Story 81.2 - Schedule detail with execution history table
+export const ScheduleDetailPage = lazy(() =>
+  import('../features/reports').then((m) => ({ default: m.ScheduleDetailPage }))
+);
 
 // Command Palette (Epic 129) - loaded eagerly since it's used globally
 // CommandPaletteDialog and CommandPaletteProvider are NOT lazy loaded


### PR DESCRIPTION
## Task
Show execution history table in ppt-web report schedule detail page

## Owner
pm-frontend

## What was done

**New route:** `/reports/schedules/:scheduleId` renders `ScheduleDetailPage`

### `ScheduleDetailPage` (new — `features/reports/pages/ScheduleDetailPage.tsx`)
- Schedule metadata header card (frequency, format, status, recipients, last/next run)
- Stats bar: completed / failed / running counts
- Inline execution history **table** with columns: Status, Started at, Duration, File, Size, Actions
- Status badge with animated spinner for `running` state
- Client-side filtering by status + date range via existing `HistoryFilters` component
- Load-more pagination (20 per page, auto-refetch every 10 s)
- Download button on `completed` rows (triggers `useDownloadReport`)
- Retry button on `failed` rows (triggers `useRetryReportExecution`) with in-progress spinner
- Back button navigates to `/reports`

### `ScheduleDetailPageRoute` (wired in `App.tsx`)
- Reads `:scheduleId` from URL params
- Uses existing `useReportExecutionHistory`, `useDownloadReport`, `useRetryReportExecution` hooks from `@ppt/api-client`
- Builds stub `ReportSchedule` object from URL param (schedule metadata endpoint not yet available — see Notes)

### MSW stub handlers (`mocks/handlers/reports.ts`)
- `GET /api/v1/reports/schedules/:scheduleId/executions` — paginated seed data with status/date filtering
- `POST /api/v1/reports/executions/:executionId/retry` — returns new pending execution
- `GET /api/v1/reports/executions/:executionId/download` — returns stub download URL
- 12 seed executions covering all 6 status variants

## Tested (Band A — fast check)
```
pnpm -F @ppt/web typecheck
exit 0

pnpm check (biome — all 1401 files)
No fixes applied. 14 warnings (all pre-existing). exit 0
```

## Built (Band B — full build)
```
pnpm -F @ppt/web build
✓ built in 6.43s
reports-DyGbWd7n.js  95.03 kB │ gzip: 19.29 kB  (ScheduleDetailPage included)
exit 0
```

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Scope drift
`scope_drift=false` — diff touches only `frontend/apps/ppt-web/` (pm-frontend area)

## Code-reuse review
`code_reuse_warn=none` — no new helpers added; reuses existing `useReportExecutionHistory`, `useDownloadReport`, `useRetryReportExecution` hooks and `HistoryFilters` component

## Notes
- The existing modal-based `ExecutionHistory` component inside `ReportsPage` is left intact; this PR adds a **navigable page** variant at a dedicated URL. Both coexist.
- `ScheduleDetailPageRoute` uses a stub `ReportSchedule` object because `GET /api/v1/reports/schedules/:id` was not wired when this task ran. A follow-up should replace the stub with a real `useSchedule` query once that endpoint ships.
- All 14 biome warnings pre-exist on `dev` — unrelated to this PR.

https://claude.ai/code/session_0143X2grzXQCnUTvgueQxKra

---
_Generated by [Claude Code](https://claude.ai/code/session_0143X2grzXQCnUTvgueQxKra)_