### PR TITLE
gap-7a-4-document-download-api: GET /documents/{id}/download and /preview presigned S3 URLs

### DIFF
--- a/backend/crates/integrations/src/storage.rs
+++ b/backend/crates/integrations/src/storage.rs
@@ -350,6 +350,31 @@ impl StorageService {
         Ok(PresignedUrl { url, expires_at })
     }
 
+    /// Generate a presigned URL for inline (in-browser) preview of a file.
+    ///
+    /// Like `generate_download_url` but sets `Content-Disposition: inline`
+    /// so browsers render the file in-place rather than triggering a download
+    /// dialog. Only meaningful for MIME types browsers can display natively
+    /// (PDF, images, plain text). Callers should check `supports_inline_preview`
+    /// before calling.
+    ///
+    /// Default expiration: 1 hour (longer than download so embedded viewers
+    /// can reload sub-resources without needing a fresh URL immediately).
+    pub async fn generate_preview_url(
+        &self,
+        key: &str,
+        content_type: &str,
+        expires_in_secs: Option<i64>,
+    ) -> Result<PresignedUrl, StorageError> {
+        const DEFAULT_PREVIEW_EXPIRATION_SECS: i64 = 60 * 60; // 1 hour
+        let expires_in = expires_in_secs.unwrap_or(DEFAULT_PREVIEW_EXPIRATION_SECS);
+        let expires_at = Utc::now() + Duration::seconds(expires_in);
+        let url = self
+            .build_presigned_inline_url(key, content_type, expires_in)
+            .await?;
+        Ok(PresignedUrl { url, expires_at })
+    }
+
     /// Generate a presigned URL for uploading a file.
     ///
     /// # Arguments
@@ -421,6 +446,38 @@ impl StorageService {
             "Generated presigned download URL"
         );
 
+        Ok(presigned.uri().to_string())
+    }
+
+    /// Build a presigned GET URL with `Content-Disposition: inline`.
+    ///
+    /// Same as `build_presigned_get_url` but omits attachment filename so
+    /// the browser treats the response as an inline resource.
+    async fn build_presigned_inline_url(
+        &self,
+        key: &str,
+        content_type: &str,
+        expires_in: i64,
+    ) -> Result<String, StorageError> {
+        let client = self.get_s3_client()?;
+        let expires = std::time::Duration::from_secs(expires_in.max(1) as u64);
+        let presign_cfg = PresigningConfig::expires_in(expires)
+            .map_err(|e| StorageError::PresignError(e.to_string()))?;
+        let presigned = client
+            .get_object()
+            .bucket(&self.config.bucket)
+            .key(key)
+            .response_content_disposition("inline")
+            .response_content_type(content_type)
+            .presigned(presign_cfg)
+            .await
+            .map_err(|e| StorageError::PresignError(e.to_string()))?;
+        tracing::debug!(
+            key = %key,
+            content_type = %content_type,
+            expires_in = %expires_in,
+            "Generated presigned inline preview URL"
+        );
         Ok(presigned.uri().to_string())
     }
 
@@ -916,5 +973,39 @@ mod tests {
         let config = StorageConfig::new("my-bucket", "us-west-2", "key", "secret")
             .with_endpoint("http://localhost:9000");
         assert_eq!(config.endpoint, Some("http://localhost:9000".to_string()));
+    }
+
+    #[test]
+    fn test_storage_service_no_s3_client_by_default() {
+        let config = StorageConfig::new("test-bucket", "us-east-1", "key", "secret");
+        let service = StorageService::new(config);
+        assert!(!service.has_s3_client());
+        assert!(service.get_s3_client().is_err());
+    }
+
+    #[test]
+    fn test_supports_inline_preview_exhaustive() {
+        for ct in &[
+            "application/pdf",
+            "image/png",
+            "image/jpeg",
+            "image/gif",
+            "image/webp",
+            "text/plain",
+        ] {
+            assert!(supports_inline_preview(ct), "{ct} should support preview");
+        }
+        for ct in &[
+            "application/msword",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/vnd.ms-excel",
+            "application/octet-stream",
+            "text/csv",
+        ] {
+            assert!(
+                !supports_inline_preview(ct),
+                "{ct} should not support preview"
+            );
+        }
     }
 }

--- a/backend/servers/api-server/src/routes/documents/core.rs
+++ b/backend/servers/api-server/src/routes/documents/core.rs
@@ -1134,53 +1134,49 @@ async fn get_download_url(
         }
     };
 
-    // Story 84.1: Generate S3 presigned URL for download
-    // Security: Storage service must be configured to serve documents
-    let (url, expires_at) = match integrations::StorageService::from_env() {
-        Ok(storage) => {
-            match storage
-                .generate_download_url(
-                    &document.file_key,
-                    &document.file_name,
-                    &document.mime_type,
-                    None, // Use default 15 minute expiration
-                )
-                .await
-            {
-                Ok(presigned) => (presigned.url, presigned.expires_at),
-                Err(e) => {
-                    tracing::error!(
-                        error = %e,
-                        file_key = %document.file_key,
-                        "Failed to generate presigned URL"
-                    );
-                    return Err((
-                        StatusCode::SERVICE_UNAVAILABLE,
-                        Json(ErrorResponse::new(
-                            "STORAGE_ERROR",
-                            "Unable to generate download URL. Please try again later.",
-                        )),
-                    ));
-                }
-            }
-        }
-        Err(e) => {
+    // Story 7A.4: Generate presigned S3 URL with Content-Disposition: attachment.
+    // Use state.storage_service (initialised at startup with the real S3 client).
+    // StorageService::from_env() is sync and does NOT set up the S3 client, so
+    // presigning would always fail — that was the bug in the original stub.
+    let storage = state.storage_service.as_ref().ok_or_else(|| {
+        tracing::error!("Storage service not configured — document downloads unavailable");
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse::new(
+                "STORAGE_NOT_CONFIGURED",
+                "Document storage is not configured. Please contact support.",
+            )),
+        )
+    })?;
+
+    let presigned = storage
+        .generate_download_url(
+            &document.file_key,
+            &document.file_name,
+            &document.mime_type,
+            None, // Default: 15-minute expiration
+        )
+        .await
+        .map_err(|e| {
             tracing::error!(
                 error = %e,
-                "Storage service not configured - document downloads unavailable"
+                file_key = %document.file_key,
+                "Failed to generate presigned download URL"
             );
-            return Err((
+            (
                 StatusCode::SERVICE_UNAVAILABLE,
                 Json(ErrorResponse::new(
-                    "STORAGE_NOT_CONFIGURED",
-                    "Document storage is not configured. Please contact support.",
+                    "STORAGE_ERROR",
+                    "Unable to generate download URL. Please try again later.",
                 )),
-            ));
-        }
-    };
+            )
+        })?;
 
     rls.release().await;
-    Ok(Json(UrlResponse { url, expires_at }))
+    Ok(Json(UrlResponse {
+        url: presigned.url,
+        expires_at: presigned.expires_at,
+    }))
 }
 
 /// Get preview URL for a document.
@@ -1238,54 +1234,48 @@ async fn get_preview_url(
         ));
     }
 
-    // Story 84.1: Generate S3 presigned URL for inline preview
-    // Security: Storage service must be configured to serve previews
-    let (url, expires_at) = match integrations::StorageService::from_env() {
-        Ok(storage) => {
-            // For preview, we use a longer expiration time
-            match storage
-                .generate_download_url(
-                    &document.file_key,
-                    &document.file_name,
-                    &document.mime_type,
-                    Some(3600), // 1 hour for preview
-                )
-                .await
-            {
-                Ok(presigned) => (presigned.url, presigned.expires_at),
-                Err(e) => {
-                    tracing::error!(
-                        error = %e,
-                        file_key = %document.file_key,
-                        "Failed to generate presigned preview URL"
-                    );
-                    return Err((
-                        StatusCode::SERVICE_UNAVAILABLE,
-                        Json(ErrorResponse::new(
-                            "STORAGE_ERROR",
-                            "Unable to generate preview URL. Please try again later.",
-                        )),
-                    ));
-                }
-            }
-        }
-        Err(e) => {
+    // Story 7A.4: Generate presigned S3 URL with Content-Disposition: inline.
+    // generate_preview_url (new method) sets inline disposition so the browser
+    // renders the file rather than downloading it.
+    // Use state.storage_service (same reason as get_download_url).
+    let storage = state.storage_service.as_ref().ok_or_else(|| {
+        tracing::error!("Storage service not configured — document previews unavailable");
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse::new(
+                "STORAGE_NOT_CONFIGURED",
+                "Document storage is not configured. Please contact support.",
+            )),
+        )
+    })?;
+
+    let presigned = storage
+        .generate_preview_url(
+            &document.file_key,
+            &document.mime_type,
+            None, // Default: 1-hour expiration for inline preview
+        )
+        .await
+        .map_err(|e| {
             tracing::error!(
                 error = %e,
-                "Storage service not configured - document previews unavailable"
+                file_key = %document.file_key,
+                "Failed to generate presigned preview URL"
             );
-            return Err((
+            (
                 StatusCode::SERVICE_UNAVAILABLE,
                 Json(ErrorResponse::new(
-                    "STORAGE_NOT_CONFIGURED",
-                    "Document storage is not configured. Please contact support.",
+                    "STORAGE_ERROR",
+                    "Unable to generate preview URL. Please try again later.",
                 )),
-            ));
-        }
-    };
+            )
+        })?;
 
     rls.release().await;
-    Ok(Json(UrlResponse { url, expires_at }))
+    Ok(Json(UrlResponse {
+        url: presigned.url,
+        expires_at: presigned.expires_at,
+    }))
 }
 
 // ============================================================================


### PR DESCRIPTION
## Task

Add GET /api/v1/documents/{id}/download returning presigned S3 URL; add GET /api/v1/documents/{id}/preview for inline view.

## Owner

pm-backend

## Problem fixed

The download and preview handlers on `dev` called `integrations::StorageService::from_env()` (the *sync* constructor) which creates a `StorageService` without an S3 client. Any call to `generate_download_url` / presigning then fails immediately with "S3 client not initialised". Additionally, the preview handler reused `generate_download_url` which sets `Content-Disposition: attachment`, so browsers would download rather than render the file inline.

## Changes

**`backend/crates/integrations/src/storage.rs`**
- Added `generate_preview_url(key, content_type, expires_in_secs)` — sets `Content-Disposition: inline` so browsers render PDF/images in-place (default 1-hour expiry).
- Added private `build_presigned_inline_url` helper (parallel to the existing `build_presigned_get_url`).
- Added 2 unit tests: `test_storage_service_no_s3_client_by_default`, `test_supports_inline_preview_exhaustive`.

**`backend/servers/api-server/src/routes/documents/core.rs`**
- `get_download_url`: replaced `StorageService::from_env()` with `state.storage_service` (the async-initialised service) + `generate_download_url`. Uses 15-minute default expiry.
- `get_preview_url`: replaced `StorageService::from_env()` with `state.storage_service` + new `generate_preview_url`. Uses 1-hour default expiry. `Content-Disposition: inline` so browsers render inline.

## Tested (Band A — fast check)

```
cd backend && cargo check -p integrations -p api-server
Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 44s
EXIT: 0

cd backend && cargo test -p integrations -- storage
running 9 tests: all ok (0 failed)
EXIT: 0
```

## Built (Band B — full build)

`cargo build --release -p api-server` confirmed clean on the committed branch (exit 0, background job).

## CI parity (Band C — hot-path only)

Skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested

Skipped.

## Scope drift

None — all changed files are within `backend/` (pm-backend area). scope-check.sh exit: 0.

## Code-reuse review

No warnings from reuse-grep.sh. `generate_preview_url` is a new method on the existing `StorageService` — not a duplicate helper.

## Dependency note

Depends on gap-7a-1-backend-multipart-upload (PR #509, branch `auto-impl/pm-scrum-master-implement-post-api-v1-do`). The upload endpoint stores `file_key` and `mime_type` in the document record; both are read here to generate the presigned URL.

https://claude.ai/code/session_0143X2grzXQCnUTvgueQxKra

---
_Generated by [Claude Code](https://claude.ai/code/session_0143X2grzXQCnUTvgueQxKra)_