### PR TITLE
fix(docs): #524 — reality-mobile screen-maps pass /screens validate

### DIFF
--- a/docs/screens/reality-mobile/account.md
+++ b/docs/screens/reality-mobile/account.md
@@ -1,9 +1,8 @@
 ---
 id: reality-mobile/account
 name: Account (iOS SwiftUI)
-product: reality
-sitemapRefs:
-  reality-web: reality-account
+product: reality-mobile
+sitemapRefs: {}
 implementations:
   ios-swiftui:
     component: AccountView
@@ -11,18 +10,13 @@ implementations:
     buildStatus: in-progress
     redesignStatus: not-started
     apiStatus: partial
-endpoints:
-  - GET /api/v1/auth/me
+endpoints: []
 relatedScreens:
   - id: reality/account
     rel: web-counterpart
   - id: reality-mobile/auth-login
     rel: child
   - id: reality-mobile/saved-searches
-    rel: child
-  - id: reality-mobile/profile
-    rel: child
-  - id: reality-mobile/settings
     rel: child
 sharedComponents: []
 diagrams: []

--- a/docs/screens/reality-mobile/agencies.md
+++ b/docs/screens/reality-mobile/agencies.md
@@ -1,9 +1,9 @@
 ---
 id: reality-mobile/agencies
 name: Agencies Directory (iOS SwiftUI)
-product: reality
+product: reality-mobile
 sitemapRefs:
-  reality-web: reality-agent-profile
+  reality-web: reality-agency
 implementations:
   ios-swiftui:
     component: AgenciesView
@@ -11,8 +11,7 @@ implementations:
     buildStatus: in-progress
     redesignStatus: not-started
     apiStatus: partial
-endpoints:
-  - GET /api/v1/agencies (via AgencyRepository.listAgencies)
+endpoints: []
 relatedScreens:
   - id: reality/agent-profile
     rel: web-counterpart

--- a/docs/screens/reality-mobile/auth-login.md
+++ b/docs/screens/reality-mobile/auth-login.md
@@ -1,9 +1,8 @@
 ---
 id: reality-mobile/auth-login
 name: Login (iOS SwiftUI)
-product: reality
-sitemapRefs:
-  reality-web: reality-auth-login
+product: reality-mobile
+sitemapRefs: {}
 implementations:
   ios-swiftui:
     component: LoginView
@@ -12,14 +11,12 @@ implementations:
     redesignStatus: not-started
     apiStatus: partial
 endpoints:
-  - POST /api/v1/auth/sso/validate (via KMP SsoService.validateAndLogin)
+  - sso_login
 relatedScreens:
   - id: reality/auth-login
     rel: web-counterpart
   - id: reality-mobile/account
     rel: parent
-  - id: reality-mobile/auth-register
-    rel: sibling
 sharedComponents: []
 diagrams: []
 useCases:

--- a/docs/screens/reality-mobile/compare-listings.md
+++ b/docs/screens/reality-mobile/compare-listings.md
@@ -1,9 +1,9 @@
 ---
 id: reality-mobile/compare-listings
 name: Compare Listings (iOS SwiftUI)
-product: reality
+product: reality-mobile
 sitemapRefs:
-  reality-web: reality-compare-properties
+  reality-web: reality-compare
 implementations:
   ios-swiftui:
     component: CompareListingsView
@@ -12,7 +12,7 @@ implementations:
     redesignStatus: not-started
     apiStatus: partial
 endpoints:
-  - GET /api/v1/listings/{id} (called for each listing ID)
+  - listings_get
 relatedScreens:
   - id: reality/compare-properties
     rel: web-counterpart

--- a/docs/screens/reality-mobile/favorites.md
+++ b/docs/screens/reality-mobile/favorites.md
@@ -1,7 +1,7 @@
 ---
 id: reality-mobile/favorites
 name: Favorites (iOS SwiftUI)
-product: reality
+product: reality-mobile
 sitemapRefs:
   reality-web: reality-favorites
 implementations:
@@ -12,8 +12,8 @@ implementations:
     redesignStatus: not-started
     apiStatus: partial
 endpoints:
-  - GET /api/v1/favorites
-  - DELETE /api/v1/favorites/{id}
+  - favorites_list
+  - favorites_remove
 relatedScreens:
   - id: reality/favorites
     rel: web-counterpart

--- a/docs/screens/reality-mobile/home.md
+++ b/docs/screens/reality-mobile/home.md
@@ -1,7 +1,7 @@
 ---
 id: reality-mobile/home
 name: Home (iOS SwiftUI)
-product: reality
+product: reality-mobile
 sitemapRefs:
   reality-web: reality-home
 implementations:
@@ -12,8 +12,7 @@ implementations:
     redesignStatus: not-started
     apiStatus: partial
 endpoints:
-  - GET /api/v1/listings/featured
-  - GET /api/v1/listings/recent
+  - listings_search
 relatedScreens:
   - id: reality/home
     rel: web-counterpart

--- a/docs/screens/reality-mobile/inquiries.md
+++ b/docs/screens/reality-mobile/inquiries.md
@@ -1,7 +1,7 @@
 ---
 id: reality-mobile/inquiries
 name: Inquiries (iOS SwiftUI)
-product: reality
+product: reality-mobile
 sitemapRefs:
   reality-web: reality-inquiries
 implementations:
@@ -12,9 +12,8 @@ implementations:
     redesignStatus: not-started
     apiStatus: partial
 endpoints:
-  - GET /api/v1/inquiries
-  - GET /api/v1/inquiries/{id}
-  - POST /api/v1/inquiries
+  - inquiries_list
+  - inquiries_contact
 relatedScreens:
   - id: reality/inquiries
     rel: web-counterpart

--- a/docs/screens/reality-mobile/listing-detail.md
+++ b/docs/screens/reality-mobile/listing-detail.md
@@ -1,7 +1,7 @@
 ---
 id: reality-mobile/listing-detail
 name: Listing Detail (iOS SwiftUI)
-product: reality
+product: reality-mobile
 sitemapRefs:
   reality-web: reality-listing-detail
 implementations:
@@ -12,9 +12,9 @@ implementations:
     redesignStatus: not-started
     apiStatus: partial
 endpoints:
-  - GET /api/v1/listings/{id}
-  - POST /api/v1/favorites
-  - DELETE /api/v1/favorites/{id}
+  - listings_get
+  - favorites_add
+  - favorites_remove
 relatedScreens:
   - id: reality/listing-detail
     rel: web-counterpart

--- a/docs/screens/reality-mobile/realtors.md
+++ b/docs/screens/reality-mobile/realtors.md
@@ -1,9 +1,8 @@
 ---
 id: reality-mobile/realtors
 name: Realtors Directory (iOS SwiftUI)
-product: reality
-sitemapRefs:
-  reality-web: reality-realtor
+product: reality-mobile
+sitemapRefs: {}
 implementations:
   ios-swiftui:
     component: RealtorsView
@@ -11,8 +10,7 @@ implementations:
     buildStatus: in-progress
     redesignStatus: not-started
     apiStatus: partial
-endpoints:
-  - GET /api/v1/agencies (derived list via AgencyRepository)
+endpoints: []
 relatedScreens:
   - id: reality/realtor
     rel: web-counterpart

--- a/docs/screens/reality-mobile/saved-searches.md
+++ b/docs/screens/reality-mobile/saved-searches.md
@@ -1,7 +1,7 @@
 ---
 id: reality-mobile/saved-searches
 name: Saved Searches (iOS SwiftUI)
-product: reality
+product: reality-mobile
 sitemapRefs:
   reality-web: reality-saved-searches
 implementations:
@@ -12,9 +12,8 @@ implementations:
     redesignStatus: not-started
     apiStatus: partial
 endpoints:
-  - GET /api/v1/saved-searches (via FavoritesRepository.getSavedSearches)
-  - PATCH /api/v1/saved-searches/{id} (toggle alerts)
-  - DELETE /api/v1/saved-searches/{id}
+  - saved_searches_list
+  - saved_searches_delete
 relatedScreens:
   - id: reality/saved-searches
     rel: web-counterpart

--- a/docs/screens/reality-mobile/search.md
+++ b/docs/screens/reality-mobile/search.md
@@ -1,7 +1,7 @@
 ---
 id: reality-mobile/search
 name: Search (iOS SwiftUI)
-product: reality
+product: reality-mobile
 sitemapRefs:
   reality-web: reality-listings
 implementations:
@@ -12,7 +12,7 @@ implementations:
     redesignStatus: not-started
     apiStatus: partial
 endpoints:
-  - POST /api/v1/listings/search
+  - listings_search
 relatedScreens:
   - id: reality/listings
     rel: web-counterpart

--- a/frontend/packages/screen-map/src/discover.ts
+++ b/frontend/packages/screen-map/src/discover.ts
@@ -1,7 +1,7 @@
 import { readdir, stat } from 'node:fs/promises';
 import path from 'node:path';
 
-const PRODUCT_DIRS = ['ppt', 'reality'];
+const PRODUCT_DIRS = ['ppt', 'reality', 'reality-mobile'];
 const IGNORED = new Set(['README.md', '_template.md']);
 
 export async function discoverScreenMaps(rootDir: string): Promise<string[]> {

--- a/frontend/packages/screen-map/src/schema.ts
+++ b/frontend/packages/screen-map/src/schema.ts
@@ -1,14 +1,27 @@
 import { z } from 'zod';
 
-export const ProductSchema = z.enum(['ppt', 'reality']);
+export const ProductSchema = z.enum(['ppt', 'reality', 'reality-mobile']);
 
-export const PlatformSchema = z.enum(['ppt-web', 'reality-web', 'mobile', 'mobile-native']);
+export const PlatformSchema = z.enum([
+  'ppt-web',
+  'reality-web',
+  'mobile',
+  'mobile-native',
+  'ios-swiftui',
+  'android-kmp',
+]);
 
 export const BuildStatusSchema = z.enum(['planned', 'in-progress', 'shipped', 'n/a']);
 export const RedesignStatusSchema = z.enum(['not-started', 'in-progress', 'applied', 'n/a']);
 export const ApiStatusSchema = z.enum(['stub', 'partial', 'complete', 'n/a']);
 
-export const RelatedRelSchema = z.enum(['parent', 'child', 'action', 'sibling']);
+export const RelatedRelSchema = z.enum([
+  'parent',
+  'child',
+  'action',
+  'sibling',
+  'web-counterpart',
+]);
 export const DiagramKindSchema = z.enum(['sequence', 'flow', 'state', 'class']);
 
 export const ImplementationSchema = z.object({
@@ -21,7 +34,7 @@ export const ImplementationSchema = z.object({
 });
 
 export const RelatedScreenSchema = z.object({
-  id: z.string().regex(/^[a-z]+\/[a-z0-9-]+$/, {
+  id: z.string().regex(/^[a-z][a-z0-9-]*\/[a-z0-9-]+$/, {
     message: 'related screen id must match <product>/<slug>',
   }),
   rel: RelatedRelSchema,
@@ -40,7 +53,7 @@ export const DesignSourceRefSchema = z
   })
   .passthrough();
 
-const IdSchema = z.string().regex(/^(ppt|reality)\/[a-z0-9-]+$/, {
+const IdSchema = z.string().regex(/^(ppt|reality|reality-mobile)\/[a-z0-9-]+$/, {
   message: 'id must match <product>/<slug> using kebab-case',
 });
 

--- a/frontend/packages/screen-map/src/types.ts
+++ b/frontend/packages/screen-map/src/types.ts
@@ -1,22 +1,29 @@
 /**
- * Two products covered by the screen-map system.
+ * Products covered by the screen-map system.
  * - `ppt`: Property Management (ppt-web + mobile)
- * - `reality`: Reality Portal (reality-web + mobile-native)
+ * - `reality`: Reality Portal web (reality-web)
+ * - `reality-mobile`: Reality Portal native iOS/Android (KMP + SwiftUI)
  */
-export type Product = 'ppt' | 'reality';
+export type Product = 'ppt' | 'reality' | 'reality-mobile';
 
 /**
- * All platforms across both products. A given screen will only use the
+ * All platforms across all products. A given screen will only use the
  * platforms relevant to its product (ppt → ppt-web/mobile;
- * reality → reality-web/mobile-native).
+ * reality → reality-web; reality-mobile → ios-swiftui/android-kmp/mobile-native).
  */
-export type Platform = 'ppt-web' | 'reality-web' | 'mobile' | 'mobile-native';
+export type Platform =
+  | 'ppt-web'
+  | 'reality-web'
+  | 'mobile'
+  | 'mobile-native'
+  | 'ios-swiftui'
+  | 'android-kmp';
 
 export type BuildStatus = 'planned' | 'in-progress' | 'shipped' | 'n/a';
 export type RedesignStatus = 'not-started' | 'in-progress' | 'applied' | 'n/a';
 export type ApiStatus = 'stub' | 'partial' | 'complete' | 'n/a';
 
-export type RelatedRel = 'parent' | 'child' | 'action' | 'sibling';
+export type RelatedRel = 'parent' | 'child' | 'action' | 'sibling' | 'web-counterpart';
 export type DiagramKind = 'sequence' | 'flow' | 'state' | 'class';
 
 export interface Implementation {


### PR DESCRIPTION
## Summary

Closes #524. Reality-mobile screen-maps from PR #501 were silently skipped by `/screens validate` because `discoverScreenMaps` hardcoded `['ppt', 'reality']`. Fixed at the root + cleaned up the content the hidden validation would have caught.

### Commits

1. **chore(screens): allow reality-mobile product + ios-swiftui/android-kmp platforms**
   - `discover.ts` scans `docs/screens/reality-mobile/`
   - Schema: `ProductSchema` += `reality-mobile`; `PlatformSchema` += `ios-swiftui`, `android-kmp`; `RelatedRelSchema` += `web-counterpart`; ID regex accepts hyphenated product prefix.

2. **fix(docs): #524 — reality-mobile screen-maps pass /screens validate**
   - All 11 files: `product` from `reality` → `reality-mobile`
   - Invalid `sitemapRefs` fixed (e.g., `reality-agent-profile` → `reality-agency`) or dropped to `{}` where no counterpart exists
   - Dangling `relatedScreens` removed
   - `endpoints` switched from raw `GET /api/v1/...` strings to real sitemap operationIds (`listings_get`, `favorites_list`, etc.) or `[]` where no operationId exists yet.

`README.md` already in the validator's `IGNORED` set — left as-is.

## Verification

- `pnpm --filter @ppt/screen-map cli validate --strict`: **117 screen-maps, 0 errors, 0 warnings** (was 106 with reality-mobile silently skipped)
- `pnpm --filter @ppt/screen-map test`: 77/77
- `pnpm --filter @ppt/screen-map typecheck`: clean

## Spin-out follow-ups

A few `endpoints: []` entries highlight real sitemap gaps worth their own ticket: `auth_me`, agencies list, listings featured/recent.

Closes #524