### PR TITLE
fix(dispatcher): auto-promote approved drafts + spawn implementer on verdict=changes

### DIFF
--- a/.claude/skills/ppt-pr-followup/SKILL.md
+++ b/.claude/skills/ppt-pr-followup/SKILL.md
@@ -1,30 +1,158 @@
 ---
 name: ppt-pr-followup
-description: After a PR is pushed, monitor its CI checks and review comments, then fix and address them in a loop until the PR is green and uncontested. Triggers on phrases like "follow up on the PR", "fix the CI", "address review comments", or runs automatically right after `ppt-pr-create`.
-when_to_use: A PR has been opened on the current branch (or one you specify) and you want to close out the post-push loop — CI failures resolved, reviewer comments answered, branch ready to merge. Sister skill: `ppt-pr-create` (opens the PR; this skill closes it out).
+description: Close out a PR's post-push loop. Two modes — (a) `dispatcher` — read the dispatcher's reviewer verdict in assignments.json and respawn the original implementer on `verdict=changes` (called by ppt-research-dispatcher after Phase 5 returns changes); (b) `manual` — implementer-driven CI + review-comment loop on the current branch (called right after ppt-pr-create or by a human). Triggers on "follow up on the PR", "fix the CI", "address review comments", "respawn implementer".
+when_to_use: Dispatcher mode — a `status=review` row in `.research/management/assignments.json` has a `reviewer_summary.verdict=changes` and you want to respawn the original specialist to address the blocking findings. Manual mode — a PR you authored is open and you want to drive CI failures + reviewer comments to green. Sister skills: `ppt-pr-create` (opens the PR), `ppt-pr-merge` (lands a green, approved PR).
 mode: both
 capabilities: [C6]
-tags: [workflow, ci, review]
+tags: [workflow, ci, review, dispatcher]
 ---
 
 # PPT PR Follow-up
 
-End-to-end choreography for the post-push portion of the PR lifecycle. Assumes
-the branch is already pushed (typically by `ppt-pr-create`); this skill drives
-the iterative loop until the PR is mergeable.
+End-to-end choreography for the post-push portion of the PR lifecycle. Two
+distinct entry points share this skill:
+
+- **`mode=dispatcher`** — the `ppt-research-dispatcher` routine calls this
+  after Phase 5 when a reviewer subagent returns `verdict=changes`. The skill
+  reads `.research/management/assignments.json`, picks up the original task
+  context, and re-spawns the same specialist with the reviewer's blocking
+  notes as the new brief. Hard-capped at 3 fix rounds per task.
+- **`mode=manual`** — a human or `ppt-pr-create` invokes this on a fresh
+  PR to drive CI failures + reviewer comments to green via in-place fixes
+  on the PR branch.
+
+Default is `manual` for backward compatibility; the dispatcher passes
+`mode=dispatcher`.
 
 ## When to invoke
 
-- Right after `gh pr create` returns a URL
-- A reviewer left comments and you want them addressed
-- CI has gone red and you want the loop to diagnose + fix + push
+- **Dispatcher mode** — `assignments.json` row has
+  `status=review` AND `reviewer_summary` starts with `verdict=changes`; the
+  dispatcher calls this after Phase 5 to drive the fix loop.
+- Right after `gh pr create` returns a URL (manual mode)
+- A reviewer left comments and you want them addressed (manual mode)
+- CI has gone red and you want the loop to diagnose + fix + push (manual mode)
 - The user says: *"check on the PR"*, *"fix the CI"*, *"address the review"*,
-  *"work the PR queue"*
+  *"work the PR queue"*, *"respawn implementer"*
 
 **Do not** invoke for one-off questions ("did CI pass?"). For a single status
 check use `gh pr checks` directly.
 
-## What it does
+## Inputs
+
+| Input        | Default     | Notes                                                  |
+| ---          | ---         | ---                                                    |
+| `mode`       | `manual`    | `dispatcher` \| `manual`                               |
+| `pr_number`  | (required for `dispatcher`; derived from branch in `manual`) | The PR to follow up on |
+| `repo`       | `martin-janci/property-management` | Full GH slug                         |
+| `MAX_ITERS`  | `10` (manual only) | Safety cap on manual loop                       |
+| `SCOPE`      | `both`      | `ci-only` \| `reviews-only` \| `both` (manual mode)    |
+
+## Dispatcher mode — state machine
+
+The dispatcher hands this skill a `pr_number` (or branch) and expects a
+one-line return contract. The skill MUST NOT loop or interact — it reads
+state, decides one action, mutates `assignments.json` once, optionally
+respawns the implementer once, then returns.
+
+### State source
+
+`.research/management/assignments.json` — find the row whose `pr_number`
+equals the input (fall back to matching `branch`). Read:
+
+- `task_id`, `specialist`, `branch`, `pr_number`
+- `reviewer_summary` (string, parsed for `verdict=...` and `note=...`)
+- `fix_rounds` (int; default 0 if absent — backfill on first read)
+- the task's original `action` text from `.research/management/action-list.json`
+  matched by `task_id` (the dispatcher's Phase 4 implementer prompt uses
+  this; we reuse it for re-spawn).
+
+### Decision table
+
+| Reviewer state                                  | Action                                                                 | Return line                                                |
+| ---                                             | ---                                                                    | ---                                                        |
+| `reviewer_summary` is `null`                    | No-op. Wait for next reviewer pass.                                    | `followup=skip pr=<n> note=no-verdict-yet`                 |
+| `verdict=approve`                               | No-op (the next Phase 5.5 picks it up; `ppt-pr-merge` handles drafts). | `followup=skip pr=<n> note=approved-call-pr-merge`         |
+| `verdict=changes` AND `fix_rounds >= 3`         | Mark row `status=failed`, `reason=fix-rounds-exhausted`.               | `followup=failed pr=<n> note=fix-rounds-exhausted`         |
+| `verdict=changes` AND `fix_rounds < 3` AND row already `status=in-progress` | No-op — guard against double-spawn (idempotency).         | `followup=skip pr=<n> note=in-progress-already`            |
+| `verdict=changes` AND `fix_rounds < 3`          | Increment `fix_rounds`, set `status=in-progress`, spawn original specialist via the same `Task` channel `ppt-research-dispatcher` uses in Phase 4. After the spawn returns, set `status=review`, clear `reviewer_summary` so the next reviewer pass picks it up fresh. | `followup=respawned pr=<n> specialist=<sp> round=<k>` |
+| `verdict=block` or `verdict=reject`             | Mark row `status=failed`, `reason=reviewer-rejected`.                  | `followup=failed pr=<n> note=reviewer-rejected`            |
+
+### Respawn brief
+
+The respawn does NOT re-do the whole task. Pass the spawned implementer:
+
+- `task_id`, `branch`, `pr_number` — unchanged from the original row.
+- `specialist` — same as the original row (deterministic; do not re-pick).
+- `brief` — the **reviewer's blocking findings** (`reviewer_summary.note`),
+  NOT the original `action` text. The implementer pushes commits onto the
+  existing PR branch and does **not** open a new PR.
+- `base_branch` — `dev`.
+
+Spawn template (mirrors the dispatcher's Phase 4 prompt, with `brief`
+swapped for the reviewer note):
+
+> You are a `<specialist>` implementer addressing reviewer fix-round
+> `<k>/3` on PR #`<n>` (branch `<branch>`). Do NOT open a new PR.
+> Check out `<branch>` and push commits on top.
+>
+> Reviewer's blocking findings (must be addressed):
+>
+>     <reviewer_summary.note>
+>
+> Original task context for reference only: `<task_id>: <action>`.
+>
+> Follow `.claude/skills/ppt-implement/agents/<specialist>.md`. Verify per
+> the specialist's verify command before pushing. Return EXACTLY:
+> `pr=<n> status=<done|blocked> specialist=<sp> note=<short>`.
+
+### Idempotency
+
+`fix_rounds` + `status=in-progress` together prevent double-spawn:
+
+- Running the skill once on a `verdict=changes` row: bumps `fix_rounds`
+  to N+1, flips `status` to `in-progress`, spawns.
+- Running it again before the spawn returns: row is now `in-progress`,
+  the table's penultimate row matches → `followup=skip`.
+- Running it after the spawn returned and bumped `status=review` but
+  before the next reviewer pass: `reviewer_summary` is cleared
+  (`null`) → first row matches → `followup=skip note=no-verdict-yet`.
+
+### Round cap
+
+Hard cap of **3 fix rounds**. After 3 unsuccessful respawns the row is
+terminal `failed`. This is the same shape as `Phase 5.6`'s
+`rebase_attempts < 3` guard.
+
+### Return contract (one line — dispatcher parses this)
+
+```
+followup=<respawned|skip|failed> pr=<n> [specialist=<sp>] [round=<k>] note=<short>
+```
+
+The dispatcher reads this verbatim into a Phase 5.7 log row.
+
+### Reference script
+
+`scripts/dispatcher-followup.sh` implements the decision table above. It is
+the canonical source; the SKILL.md describes the semantics for agents that
+need to reason about edge cases, but the script is what runs.
+
+```bash
+bash .claude/skills/ppt-pr-followup/scripts/dispatcher-followup.sh \
+  --pr <n> [--dry-run]
+```
+
+The script:
+- reads `.research/management/assignments.json`,
+- decides the action per the table above,
+- writes the mutation back (atomic temp-file + rename),
+- prints the spawn brief to stdout when action is `respawned` (the
+  dispatcher then feeds that brief into the `Task` tool — the script
+  itself does not call any Claude tools),
+- exits non-zero on `failed` so the dispatcher logs it.
+
+## What it does (manual mode)
 
 A single iteration:
 
@@ -44,14 +172,14 @@ A single iteration:
 
 Then surface a short status report.
 
-## Inputs
+## Manual-mode inputs (legacy detail; see top-level Inputs table for canonical names)
 
 - `PR` — PR number (optional). If omitted, derive from the current branch via
   `gh pr view --json number,headRefName`.
 - `MAX_ITERS` — safety cap (default 10). Stops runaway loops.
 - `SCOPE` — `ci-only` | `reviews-only` | `both` (default `both`).
 
-## Iteration recipe
+## Iteration recipe (manual mode)
 
 ### Step 1 — Identify the PR
 

--- a/.claude/skills/ppt-pr-followup/install.sh
+++ b/.claude/skills/ppt-pr-followup/install.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# install.sh — copy the ppt-pr-followup skill into ~/.claude/skills/
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TARGET_PARENT="$HOME/.claude/skills"
+TARGET="$TARGET_PARENT/ppt-pr-followup"
+
+VERIFY="$(dirname "$SCRIPT_DIR")/_verify-skill.sh"
+if [[ -x "$VERIFY" ]]; then
+  bash "$VERIFY" "$SCRIPT_DIR" || { echo "Refusing to install ppt-pr-followup: validation failed"; exit 1; }
+fi
+
+mkdir -p "$TARGET_PARENT"
+
+if [[ -L "$TARGET" ]]; then
+  echo "Found symlink at $TARGET — removing"
+  rm "$TARGET"
+elif [[ -d "$TARGET" ]]; then
+  echo "Found existing directory at $TARGET — replacing"
+  rm -rf "$TARGET"
+fi
+
+cp -r "$SCRIPT_DIR" "$TARGET"
+rm -f "$TARGET/install.sh"
+
+echo
+echo "Installed ppt-pr-followup skill to: $TARGET"
+ls -la "$TARGET"

--- a/.claude/skills/ppt-pr-followup/scripts/dispatcher-followup.sh
+++ b/.claude/skills/ppt-pr-followup/scripts/dispatcher-followup.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# dispatcher-followup.sh — decide and apply the dispatcher-mode follow-up
+# action for one PR. Reads `.research/management/assignments.json`, mutates
+# the matching row per the SKILL.md decision table, and prints the spawn
+# brief to stdout when the action is "respawned" (the dispatcher then feeds
+# that brief into a Task spawn — this script does not call Claude tools).
+#
+# Usage:
+#   dispatcher-followup.sh --pr <n> [--dry-run]
+#
+# Output (last line, machine-parseable):
+#   followup=<respawned|skip|failed> pr=<n> [specialist=<sp>] [round=<k>] note=<short>
+#
+# Exit codes:
+#   0 = respawned or skip
+#   2 = failed (round cap reached or reviewer rejected)
+#   3 = bad invocation / missing state files
+
+set -euo pipefail
+
+PR=""
+DRY_RUN=0
+ASSIGNMENTS="${ASSIGNMENTS_PATH:-.research/management/assignments.json}"
+ACTION_LIST="${ACTION_LIST_PATH:-.research/management/action-list.json}"
+MAX_FIX_ROUNDS="${MAX_FIX_ROUNDS:-3}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr)        PR="$2"; shift 2 ;;
+    --dry-run)   DRY_RUN=1; shift ;;
+    -h|--help)
+      sed -n '2,18p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 3 ;;
+  esac
+done
+
+[[ -n "$PR" ]] || { echo "missing --pr <n>" >&2; exit 3; }
+[[ -f "$ASSIGNMENTS" ]] || { echo "assignments.json not found at $ASSIGNMENTS" >&2; exit 3; }
+command -v jq >/dev/null 2>&1 || { echo "jq required" >&2; exit 3; }
+
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# --- Pull the matching row out of assignments.json
+ROW=$(jq --argjson n "$PR" '
+  .assignments[] | select(.pr_number == $n)
+' "$ASSIGNMENTS")
+
+if [[ -z "$ROW" ]]; then
+  echo "no row in $ASSIGNMENTS for pr_number=$PR" >&2
+  echo "followup=skip pr=$PR note=no-assignment-row"
+  exit 0
+fi
+
+TASK_ID=$(jq -r '.task_id // ""'           <<<"$ROW")
+BRANCH=$(jq -r  '.branch // ""'            <<<"$ROW")
+SPECIALIST=$(jq -r '.specialist // "generic"' <<<"$ROW")
+STATUS=$(jq -r  '.status // ""'            <<<"$ROW")
+RS=$(jq -r      '.reviewer_summary // ""'  <<<"$ROW")
+FR=$(jq -r      '.fix_rounds // 0'         <<<"$ROW")
+[[ "$FR" =~ ^[0-9]+$ ]] || FR=0
+
+# --- Parse verdict + note out of `reviewer_summary` string
+# Reviewer_summary shape: "verdict=<v> note=<rest>" (note can contain spaces).
+VERDICT=""
+NOTE=""
+if [[ "$RS" =~ ^verdict=([a-z]+)([[:space:]]+note=(.*))?$ ]]; then
+  VERDICT="${BASH_REMATCH[1]}"
+  NOTE="${BASH_REMATCH[3]:-}"
+fi
+
+emit() {
+  # emit "<line>"  — prints the machine-parseable result line on stdout.
+  printf '%s\n' "$1"
+}
+
+mutate_row() {
+  # mutate_row '<jq update expression on .assignments[] | select(.pr_number == $n)>'
+  local upd="$1"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[dry-run] would apply: $upd" >&2
+    return 0
+  fi
+  local tmp
+  tmp="$(mktemp)"
+  jq --argjson n "$PR" --arg now "$NOW" "
+    .assignments |= map(
+      if .pr_number == \$n then ($upd) else . end
+    )
+    | .generated = \$now
+  " "$ASSIGNMENTS" > "$tmp"
+  mv "$tmp" "$ASSIGNMENTS"
+}
+
+# ============================================================================
+# Decision table — see SKILL.md "Dispatcher mode — state machine"
+# ============================================================================
+
+# 1. No verdict yet — wait.
+if [[ -z "$VERDICT" ]]; then
+  emit "followup=skip pr=$PR note=no-verdict-yet"
+  exit 0
+fi
+
+# 2. Approve — Phase 5.5 / ppt-pr-merge handles it.
+if [[ "$VERDICT" == "approve" ]]; then
+  emit "followup=skip pr=$PR note=approved-call-pr-merge"
+  exit 0
+fi
+
+# 3. Reviewer rejected outright.
+if [[ "$VERDICT" == "block" || "$VERDICT" == "reject" ]]; then
+  mutate_row '. + {status: "failed", reason: "reviewer-rejected", last_updated: $now, status_changed_at: $now}'
+  emit "followup=failed pr=$PR note=reviewer-rejected"
+  exit 2
+fi
+
+# 4. Anything other than "changes" at this point is unexpected — treat as skip.
+if [[ "$VERDICT" != "changes" ]]; then
+  emit "followup=skip pr=$PR note=unknown-verdict:$VERDICT"
+  exit 0
+fi
+
+# --- VERDICT == "changes" path ---
+
+# 5. Round cap.
+if (( FR >= MAX_FIX_ROUNDS )); then
+  mutate_row '. + {status: "failed", reason: "fix-rounds-exhausted", last_updated: $now, status_changed_at: $now}'
+  emit "followup=failed pr=$PR note=fix-rounds-exhausted round=$FR"
+  exit 2
+fi
+
+# 6. Idempotency guard — row already in-progress means a prior call respawned.
+if [[ "$STATUS" == "in-progress" ]]; then
+  emit "followup=skip pr=$PR note=in-progress-already round=$FR"
+  exit 0
+fi
+
+# 7. The real respawn path. Bump fix_rounds, flip status, clear reviewer_summary.
+NEXT_ROUND=$((FR + 1))
+mutate_row "$(cat <<JQ
+. + {
+  status: "in-progress",
+  fix_rounds: ($FR + 1),
+  reviewer_summary: null,
+  last_updated: \$now,
+  status_changed_at: \$now
+}
+JQ
+)"
+
+# Look up the original action text for context (best-effort).
+ACTION=""
+if [[ -f "$ACTION_LIST" ]]; then
+  ACTION=$(jq -r --arg id "$TASK_ID" '
+    (.. | objects | select(.id? == $id) | .action? // "") // ""
+  ' "$ACTION_LIST" 2>/dev/null | head -1)
+fi
+
+# Print the spawn brief on stdout so the calling agent can feed it to Task.
+cat <<BRIEF
+=== ppt-pr-followup respawn brief ===
+You are a $SPECIALIST implementer addressing reviewer fix-round $NEXT_ROUND/$MAX_FIX_ROUNDS
+on PR #$PR (branch $BRANCH). Do NOT open a new PR. Check out $BRANCH and push
+commits on top.
+
+Reviewer's blocking findings (must be addressed):
+
+    $NOTE
+
+Original task context for reference only: $TASK_ID: $ACTION
+
+Follow .claude/skills/ppt-implement/agents/$SPECIALIST.md. Verify per the
+specialist's verify command before pushing. Return EXACTLY:
+  pr=$PR status=<done|blocked> specialist=$SPECIALIST note=<short>
+=== end brief ===
+BRIEF
+
+emit "followup=respawned pr=$PR specialist=$SPECIALIST round=$NEXT_ROUND"
+exit 0

--- a/.claude/skills/ppt-pr-merge/SKILL.md
+++ b/.claude/skills/ppt-pr-merge/SKILL.md
@@ -20,10 +20,16 @@ the loop by getting a green, approved PR actually merged.
 - You manually want to "land PR #N".
 
 **Do NOT invoke for:**
-- PRs still in `draft` state
 - PRs with CI failures (run `ppt-pr-followup` first)
 - PRs with unresolved review threads (run `ppt-pr-followup` first)
 - PRs blocked by branch protection rules a human must override
+
+**Drafts:** this skill **auto-promotes** a draft PR to ready (`gh pr ready <pr>`)
+**iff** the PR has reviewer approval (either `reviewDecision == APPROVED` on
+GitHub, or `reviewer_summary.verdict == "approve"` in
+`.research/management/assignments.json`) AND all required CI checks are green.
+Otherwise the skill refuses to touch a draft and points the caller at
+`ppt-pr-followup` (dispatcher mode) for the next step.
 
 ## Inputs
 
@@ -53,10 +59,50 @@ Abort with `merged=false note=<reason>` if ANY of:
 | Check | Abort if |
 |---|---|
 | `state` | != `"OPEN"` (already merged or closed) |
-| `isDraft` | `true` |
-| `reviewDecision` | != `"APPROVED"` (allow `null` ONLY when repo has no required reviews) |
+| `reviewDecision` | != `"APPROVED"` (see "approval source" below; allow `null` ONLY when repo has no required reviews) |
 | `statusCheckRollup[].conclusion` | any of `"FAILURE"`, `"CANCELLED"`, `"TIMED_OUT"`, `"ACTION_REQUIRED"` |
 | `statusCheckRollup[].status` | any `"IN_PROGRESS"`/`"QUEUED"` → return `merged=false note=ci-pending` (caller can retry later) |
+
+### Approval source (GH `reviewDecision` OR dispatcher verdict)
+
+`reviewDecision` is the primary signal. If it is missing/`null` (the dispatcher's
+reviewer agents review via `gh pr review --approve` so this is usually populated,
+but some repos / draft PRs return `null`), fall back to the dispatcher's
+`reviewer_summary` in `.research/management/assignments.json`:
+
+```bash
+# Read dispatcher verdict for the row whose pr_number == <PR>
+VERDICT=$(jq -r --argjson n "$PR" '
+  .assignments[]
+  | select(.pr_number == $n)
+  | .reviewer_summary
+  | tostring
+  | capture("^verdict=(?<v>approve|changes|block|reject)").v // empty
+' .research/management/assignments.json 2>/dev/null)
+```
+
+Treat `VERDICT == "approve"` as approval-equivalent. Any other value (or
+missing assignments.json row) is **not** approval.
+
+### Draft handling — auto-promote on approve, otherwise refuse
+
+If `isDraft == true`:
+
+1. Compute the approval state using both sources above:
+   `APPROVED = (reviewDecision == "APPROVED") OR (VERDICT == "approve")`.
+2. If `APPROVED` AND CI is green per the table above: promote the PR.
+   ```bash
+   gh pr ready "$PR" --repo "$REPO"
+   # Re-read PR state once; isDraft should now be false.
+   ```
+   Then continue with the rest of Step 1 (unresolved-threads check) and the
+   normal merge flow.
+3. If NOT approved (no verdict, or verdict ∈ `{changes, block, reject}`):
+   abort with
+   `merged=false note=draft-unapproved (call ppt-pr-followup to drive the review loop)`.
+4. If CI is not green: abort via the standard CI path
+   (`merged=false note=ci-pending|ci-failed`). **Never promote a draft whose
+   CI isn't green.**
 
 Also check unresolved review threads via GraphQL (the REST `reviewDecision` doesn't catch comments-only threads):
 
@@ -188,7 +234,8 @@ skill never touches assignments.json directly.
 
 ## Hard rules
 
-- Never merge a draft PR.
+- Drafts are auto-promoted on approve; otherwise refuse. Never merge a draft
+  that has not been promoted to ready via the auto-promote path in Step 1.
 - Never merge a PR with failing or in-progress CI.
 - Never merge a PR with unresolved review threads.
 - Auto-resolve ONLY the mechanical patterns listed in Step 2; real code conflicts always abort.

--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -40,6 +40,7 @@ Schema per row:
   "code_reuse_warn":    "string | null",   // implementer reused-or-duplicated existing helpers (item #4)
   "empty_branch":       "boolean | null",  // branch pushed but 0 commits ahead of dev (item #1)
   "rebase_attempts":    "int",             // count of auto-rebase tries on this row (item #6); default 0
+  "fix_rounds":         "int",             // count of ppt-pr-followup respawn rounds; default 0; hard cap 3
 
   "implementer_summary": "string | null",
   "reviewer_summary":    "string | null"
@@ -111,10 +112,12 @@ global in-progress count CAN exceed 3. The 3-limit is throughput, not concurrenc
 3. Read `action-list.json`, `assignments.json`, `coverage.json`.
 4. Backfill any row missing `status_changed_at` = `claimed_at`. Backfill any
    row missing the new fields (`last_reviewed_oid`, `scope_drift`,
-   `code_reuse_warn`, `empty_branch`, `rebase_attempts`) to `null` / `0`.
+   `code_reuse_warn`, `empty_branch`, `rebase_attempts`, `fix_rounds`) to
+   `null` / `0`.
 5. Confirm `.claude/skills/ppt-implement/SKILL.md`,
-   `.claude/skills/ppt-review-merged/SKILL.md`, AND
-   `.claude/skills/ppt-pr-merge/SKILL.md` exist. If any missing, ABORT.
+   `.claude/skills/ppt-review-merged/SKILL.md`,
+   `.claude/skills/ppt-pr-merge/SKILL.md`, AND
+   `.claude/skills/ppt-pr-followup/SKILL.md` exist. If any missing, ABORT.
 
 ---
 
@@ -377,6 +380,41 @@ Phase 5.5 next run will pick up the now-clean PR via the standard path.
 
 ---
 
+## Phase 5.7 — Respawn implementer on `verdict=changes` (NEW)
+
+For each row `status == "review"` where `reviewer_summary` starts with
+`"verdict=changes"`:
+
+Spawn ONE Task subagent (cap 3 parallel — same as Phase 4's implementer cap):
+
+> You are the PR follow-up driver. Invoke
+> `.claude/skills/ppt-pr-followup/SKILL.md` in dispatcher mode for PR #<n>.
+>
+> 1. Run `bash .claude/skills/ppt-pr-followup/scripts/dispatcher-followup.sh --pr <n>`.
+> 2. If the script's stdout contains a `=== ppt-pr-followup respawn brief ===`
+>    block, take that brief and spawn the original specialist via the `Task`
+>    tool (same channel Phase 4 uses), waiting for it to return.
+> 3. After the spawned implementer returns, set `status=review` on the row
+>    and bump `last_updated`. (The script already cleared `reviewer_summary`
+>    and flipped `status=in-progress`; this flip back to `review` is what
+>    re-arms Phase 5 for a fresh reviewer pass on the new commits.)
+> 4. Return EXACTLY the script's final line, e.g.
+>    `followup=respawned pr=<n> specialist=<sp> round=<k>`.
+>
+> If the script exits non-zero (failed/round-cap), do not spawn; just return
+> the script's last line.
+
+Capture line. The script already mutated `assignments.json`; this phase
+adds nothing further to the file beyond the post-respawn `status=review`
+flip.
+
+Idempotency: the script's `status=in-progress` write makes a second
+Phase 5.7 invocation a no-op until the spawned implementer finishes and
+the next reviewer pass posts a fresh `reviewer_summary`. Hard cap is 3
+fix rounds per row; subsequent calls return `failed`.
+
+---
+
 ## Phase 6 — Persist & push
 
 Update `assignments.generated = now`. Include `action-list.json` if Phase 2.6 Tier 1 refilled.
@@ -439,6 +477,7 @@ Hang alerts:
 - max 1 post-merge reviewer subagent per run
 - max 2 pr-merge subagents in parallel in Phase 5.5
 - max 1 rebase subagent in parallel in Phase 5.6 (item #6)
+- max 3 followup/respawn subagents in parallel in Phase 5.7 (matches Phase 4 implementer cap)
 - no cap on reviewer (Phase 5) subagents
 - never re-claim an id already in assignments (regardless of its status)
 - never claim items whose dependency text mentions another non-`merged` task
@@ -446,7 +485,7 @@ Hang alerts:
 - never bypass git hooks (no `--no-verify`)
 - never set `assignment.status="merged"` inside Phase 5.5 — only Phase 2 sets `merged` from GH truth
 - Tier 2 upstream kick is fire-and-forget with `--max-time 10`
-- always defer to `ppt-implement`, `ppt-review-merged`, `ppt-pr-merge` skills
+- always defer to `ppt-implement`, `ppt-review-merged`, `ppt-pr-merge`, `ppt-pr-followup` skills
 - buffer guard adds items only; never edits/removes existing
 - do NOT inline implementer / reviewer / merger logic
 - Phase 2's `<2h grace, no branch yet` case respects that another run's implementer may still be working on this task — don't fail prematurely

--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -323,9 +323,15 @@ For each row `status=="review"` where `reviewer_summary` starts with `"verdict=a
 gh pr view <pr_number> --json statusCheckRollup,isDraft,reviewDecision,mergeable,state
 ```
 
-Skip if `state != OPEN`, `isDraft == true`, CI conclusion in
+Skip if `state != OPEN`, CI conclusion in
 `{FAILURE, CANCELLED, TIMED_OUT, ACTION_REQUIRED}`, or any CI status in
 `{IN_PROGRESS, QUEUED}`.
+
+**Do NOT skip on `isDraft == true`** — `ppt-pr-merge` Step 1 auto-promotes
+draft PRs to ready when the approval + green-CI gates pass. Letting drafts
+through is the whole point of the auto-promote path; pre-filtering them here
+re-introduces the stall bug (dispatcher run on 2026-05-25: 0 merge attempts,
+all approved PRs draft).
 
 If pre-flight passes: spawn ONE Task subagent per PR (cap 2 parallel):
 


### PR DESCRIPTION
## Summary

Closes two dispatcher gaps identified in the research-routine audit. Symptom: dispatcher claims and reviews continuously, but `merge-attempts: 0` because `ppt-pr-merge` aborts on draft, and nothing flips draft → ready. Audit cited dispatcher commit \`daf211c0\` ("all approved PRs are drafts"). 9 PRs were stuck on this alone.

### P0 — Auto-promote approved drafts in `ppt-pr-merge`
- New decision table: `isDraft && reviewDecision==APPROVED (or assignments verdict=approve) && checks green` → `gh pr ready`, continue merge
- Draft + no approval → abort, point at `ppt-pr-followup`
- Draft + checks pending/failing → existing abort path
- Dispatcher Phase 5.5's `Skip if isDraft` pre-filter removed (it would have neutralized the fix)

### P1 — `ppt-pr-followup` dispatcher mode
The skill directory existed with a manual CI/review-comment loop; **augmented** rather than replaced. New `mode=dispatcher` is one-shot, script-driven:
- Reads `assignments.json` row by branch/PR
- `verdict=changes` → bump `fix_rounds`, status→`in-progress`, clear `reviewer_summary`, spawn original specialist with reviewer's note as targeted brief (push onto existing PR; no new PR)
- `fix_rounds >= 3` → terminal `failed`, `reason: fix-rounds-exhausted`
- `verdict=approve` → "call ppt-pr-merge instead"
- No verdict → "waiting for reviewer"
- Idempotent: `status=in-progress` and `reviewer_summary=null` guards prevent double-spawn

### Dispatcher hook
New Phase 5.7 in `.research/dispatcher-prompt.md` invokes `ppt-pr-followup` for every `verdict=changes` row before P5.5 merge phase.

## Verification

- `_verify-skill.sh ppt-pr-merge` / `ppt-pr-followup`: OK
- `verify-all.sh --quick`: 19 PASS / 1 SKIP / 0 FAIL
- Synthetic `assignments.json` smoke for `dispatcher-followup.sh`: respawn / no-verdict / approve / round-cap → all per spec

## Files

- `.claude/skills/ppt-pr-merge/SKILL.md`
- `.claude/skills/ppt-pr-followup/SKILL.md`
- `.claude/skills/ppt-pr-followup/install.sh` (new)
- `.claude/skills/ppt-pr-followup/scripts/dispatcher-followup.sh` (new)
- `.research/dispatcher-prompt.md`

## Schema

`fix_rounds: int (default 0)` added to assignments.json row spec; missing field reads as 0 — backwards-compatible.

## Test plan
- [ ] On next dispatcher run, approved drafts (#509 #533 #539 #540) should auto-promote and merge
- [ ] On next dispatcher run, verdict=changes rows (#530 #531 #535 #536 #537) should respawn the original specialist on their existing branch
- [ ] After 3 fix-rounds without approval, row goes to terminal `failed`