### PR TITLE
feat(dispatcher): harden research routine — stacked-PR refusal, sandbox reclaim, brief sections, human-review label, nightly rebase

### DIFF
--- a/.claude/skills/ppt-pr-create/SKILL.md
+++ b/.claude/skills/ppt-pr-create/SKILL.md
@@ -45,9 +45,28 @@ plan* commands all exited 0. You're about to open the PR.
 2. **Body** — paste the template below; fill verification + IG3 evidence.
    The literal line `Closes plan: .research/plans/<slug>.md` is required
    for IG8.
-3. **Create**:
+3. **Pick the base branch.** Default base is `dev`. The only other allowed
+   base is `main` (release flow), and only when you explicitly intend a
+   release PR. **Refuse any other base unless `--allow-stacked` is set.**
+
    ```bash
-   gh pr create --base main --head "impl/$SLUG" \
+   BASE="${BASE:-dev}"
+   ALLOW_STACKED="${ALLOW_STACKED:-0}"
+   case "$BASE" in
+     dev|main) ;;
+     *)
+       if [ "$ALLOW_STACKED" != "1" ]; then
+         echo "refusing non-dev/main base '$BASE' — pass ALLOW_STACKED=1 to override (stacked PRs aren't tracked by the dispatcher's assignments.json and can't be merged bottom-up by ppt-pr-merge's mechanical-conflict resolver)" >&2
+         exit 2
+       fi
+       echo "stacked-PR base accepted via ALLOW_STACKED=1 — make sure you understand the implications (see 'Stacked PRs' below)" >&2
+       ;;
+   esac
+   ```
+
+4. **Create**:
+   ```bash
+   gh pr create --base "$BASE" --head "impl/$SLUG" \
      --title "<vector>(<area>): <title>" \
      --body "$(cat <<'EOF'
    ## Summary
@@ -115,6 +134,32 @@ A `.research/`-only commit will still trip `ci.yml` but the area-gated jobs
 (`backend.yml`, `frontend.yml`, `mobile-native.yml`) skip — that's why the
 research routine commits keep landing fast.
 
+## Stacked PRs (non-default; opt-in)
+
+By default this skill refuses any `--base` other than `dev` or `main`. Stacked
+PRs (PR-on-PR, where the base is another in-flight feature branch) are
+intentionally not supported in the normal flow because:
+
+- The dispatcher's `.research/management/assignments.json` only tracks rows
+  whose PR targets `dev`. A stacked PR is invisible to claim/review/merge
+  accounting and can be silently lost.
+- `ppt-pr-merge` resolves mechanical conflicts against `base` (default `dev`).
+  When base is a moving feature branch, the resolver's known patterns
+  (`sqlx`, `Cargo.lock`, generated openapi/api-client, lockfiles) don't apply
+  the same way and the merger can't unstick bottom-up automatically.
+- The nightly auto-rebase workflow only rebases onto `dev`; stacked PRs would
+  be force-pushed against a stale base.
+
+If you really need a stacked PR — e.g. splitting one large refactor into a
+review-friendly chain — pass `ALLOW_STACKED=1` to opt in. **You then own**
+the merge order manually: merge the bottom of the stack first, retarget the
+next PR to `dev`, repeat. Do not invoke `ppt-pr-merge` on a stacked PR
+without first retargeting its base to `dev`.
+
+```bash
+BASE=feature/foo-bar ALLOW_STACKED=1 ./ppt-pr-create …   # opt-in form
+```
+
 ## Draft / WIP handling
 
 If any of these are true → open as draft with `[WIP]` prefix and document
@@ -141,8 +186,8 @@ gh auth status >/dev/null 2>&1 && gh api user --jq .login
 gh repo view martin-janci/property-management --json id --jq .id >/dev/null
 # expected: exit 0 (repo is reachable from this token)
 
-# 3. base branch main exists on origin
-git ls-remote --heads origin main | grep -q refs/heads/main && echo OK
+# 3. base branch dev exists on origin (default PR base)
+git ls-remote --heads origin dev | grep -q refs/heads/dev && echo OK
 # expected: OK
 ```
 

--- a/.claude/skills/ppt-pr-followup/scripts/ensure-labels.sh
+++ b/.claude/skills/ppt-pr-followup/scripts/ensure-labels.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# ensure-labels.sh — idempotently create the dispatcher's gating labels.
+#
+# Called once per dispatcher run (Phase 1 init). Safe to re-run: each
+# `gh label create` is `|| true` so an existing label is a no-op.
+#
+# Adds:
+#   needs-human-review — set by the dispatcher when the reviewer note matches
+#                        a human-gate phrase. ppt-pr-merge refuses to merge
+#                        a draft carrying this label even if approved + green.
+#
+# Usage: bash ensure-labels.sh [repo-slug]
+#   default repo slug: martin-janci/property-management
+
+set -u
+
+REPO="${1:-martin-janci/property-management}"
+
+gh label create needs-human-review \
+  --repo "$REPO" \
+  --color B60205 \
+  --description "Draft PR is gated on a human-only review (macOS reviewer, domain expert, etc.). ppt-pr-merge refuses to land while this label is present." \
+  2>/dev/null || true
+
+# Future labels can be appended here in the same idempotent shape.

--- a/.claude/skills/ppt-pr-followup/scripts/sandbox-reclaim.sh
+++ b/.claude/skills/ppt-pr-followup/scripts/sandbox-reclaim.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# sandbox-reclaim.sh — classify a stalled in-progress assignments row and
+# decide whether it is reclaimable (sandbox-died with no branch push) or
+# terminally failed.
+#
+# Inputs (env or args):
+#   BRANCH                — branch name we expect the implementer to push
+#   STATUS_CHANGED_AT     — ISO-8601 timestamp for status_changed_at
+#   MODE_TAG              — plan's `Mode:` tag (e.g. "cloud-ok", "local-only")
+#   RECLAIM_ATTEMPTS      — current reclaim_attempts count on the row (default 0)
+#   NOW                   — optional ISO-8601 override (for testing); default = now (UTC)
+#
+# Outputs ONE line to stdout, dispatcher-friendly:
+#   action=<wait|reclaim|fail> reason=<short> branch_state=<missing|empty|present>
+#
+# Exit codes: 0 = decision printed, 2 = bad invocation.
+#
+# State machine (matches dispatcher-prompt.md Phase 2):
+#
+#   timeout = 60m  if MODE_TAG == "cloud-ok"
+#           = 120m otherwise (legacy default)
+#
+#   grace not yet elapsed                                  -> action=wait
+#   timeout elapsed AND branch missing AND attempts == 0   -> action=reclaim reason=sandbox-timeout
+#   timeout elapsed AND branch missing AND attempts >= 1   -> action=fail    reason=sandbox-failure-after-reclaim
+#   timeout elapsed AND branch present AND 0 commits ahead -> action=fail    reason=empty-branch
+#   timeout elapsed AND branch present AND commits ahead   -> action=fail    reason=agent-gave-up-with-commits (caller should still try to PR it)
+#
+# Reclaim cap is one (RECLAIM_ATTEMPTS < 1).
+
+set -u
+
+BRANCH="${BRANCH:-${1:-}}"
+STATUS_CHANGED_AT="${STATUS_CHANGED_AT:-${2:-}}"
+MODE_TAG="${MODE_TAG:-${3:-}}"
+RECLAIM_ATTEMPTS="${RECLAIM_ATTEMPTS:-${4:-0}}"
+NOW="${NOW:-$(date -u -Iseconds)}"
+
+if [ -z "$BRANCH" ] || [ -z "$STATUS_CHANGED_AT" ]; then
+  echo "usage: BRANCH=<name> STATUS_CHANGED_AT=<iso> [MODE_TAG=<tag>] [RECLAIM_ATTEMPTS=<n>] $0" >&2
+  exit 2
+fi
+
+# --- timeout selection
+case "$MODE_TAG" in
+  cloud-ok|cloud|cloud-only) TIMEOUT_MIN=60 ;;
+  *)                          TIMEOUT_MIN=120 ;;
+esac
+
+# --- elapsed minutes (portable: GNU date)
+NOW_EPOCH=$(date -u -d "$NOW" +%s 2>/dev/null) || NOW_EPOCH=$(date -u +%s)
+THEN_EPOCH=$(date -u -d "$STATUS_CHANGED_AT" +%s 2>/dev/null) || {
+  echo "action=wait reason=bad-timestamp branch_state=unknown"
+  exit 0
+}
+ELAPSED_MIN=$(( (NOW_EPOCH - THEN_EPOCH) / 60 ))
+
+if [ "$ELAPSED_MIN" -lt "$TIMEOUT_MIN" ]; then
+  echo "action=wait reason=grace-period-${ELAPSED_MIN}m-of-${TIMEOUT_MIN}m branch_state=unchecked"
+  exit 0
+fi
+
+# --- branch state probe (mirrors dispatcher-prompt.md Phase 2 Branch-state probe)
+git fetch origin "$BRANCH" 2>/dev/null || true
+if git rev-parse --verify "origin/$BRANCH" >/dev/null 2>&1; then
+  COMMITS_AHEAD=$(git rev-list --count origin/dev..origin/"$BRANCH" 2>/dev/null || echo 0)
+  if [ "$COMMITS_AHEAD" -eq 0 ]; then
+    echo "action=fail reason=empty-branch branch_state=empty"
+    exit 0
+  fi
+  echo "action=fail reason=agent-gave-up-with-commits branch_state=present commits_ahead=$COMMITS_AHEAD"
+  exit 0
+fi
+
+# --- no branch on origin: sandbox most likely died
+if [ "$RECLAIM_ATTEMPTS" -ge 1 ]; then
+  echo "action=fail reason=sandbox-failure-after-reclaim branch_state=missing"
+  exit 0
+fi
+
+echo "action=reclaim reason=sandbox-timeout branch_state=missing"
+exit 0

--- a/.claude/skills/ppt-pr-merge/SKILL.md
+++ b/.claude/skills/ppt-pr-merge/SKILL.md
@@ -43,6 +43,30 @@ Otherwise the skill refuses to touch a draft and points the caller at
 | `dry_run`      | `false`                            | Run preconditions + conflict resolve, skip the merge call |
 | `mode`         | `merge`                            | `merge` (default — full flow) or `rebase-only` (run Step 2 conflict-resolver + push, then return without merging — used by dispatcher Phase 5.6 to unstick stale-approved PRs) |
 
+## Stacked PRs — refused unless opt-in
+
+If the PR's `baseRefName` is anything other than `dev` or `main`, this is a
+stacked PR (PR-on-PR). The mechanical-conflict resolver in Step 2 only knows
+how to rebase onto `dev`/`main`, and the dispatcher's `assignments.json` only
+tracks PRs targeting `dev`. By default this skill refuses to merge such PRs.
+
+```bash
+BASE_REF=$(gh pr view "$PR" --repo "$REPO" --json baseRefName -q .baseRefName)
+case "$BASE_REF" in
+  dev|main) ;;
+  *)
+    if [ "${ALLOW_STACKED:-0}" != "1" ]; then
+      echo "merged=false pr=$PR note=this PR is stacked (base=$BASE_REF); refusing to merge until base is dev/main"
+      exit 0
+    fi
+    ;;
+esac
+```
+
+Resolution: the PR author should merge the bottom of the stack first, then
+retarget this PR's base to `dev` via `gh pr edit "$PR" --base dev`, then
+re-invoke `ppt-pr-merge`.
+
 ## Step 1 — Preconditions (HARD GATES — abort if any fail)
 
 ```bash

--- a/.claude/skills/ppt-pr-merge/SKILL.md
+++ b/.claude/skills/ppt-pr-merge/SKILL.md
@@ -75,7 +75,21 @@ REPO=<repo>
 
 # Read full PR state
 gh pr view "$PR" --repo "$REPO" --json \
-  number,state,isDraft,mergeable,reviewDecision,statusCheckRollup,headRefName,headRefOid,baseRefName
+  number,state,isDraft,mergeable,reviewDecision,statusCheckRollup,headRefName,headRefOid,baseRefName,labels
+```
+
+**Human-gate label check (P6).** If the PR carries the `needs-human-review`
+label, refuse regardless of approval / CI status. This overrides any
+auto-promote-from-draft behavior — an approve + green CI is not enough when
+a human gate is set.
+
+```bash
+HAS_GATE=$(gh pr view "$PR" --repo "$REPO" --json labels \
+  --jq '[.labels[].name] | index("needs-human-review") // empty')
+if [ -n "$HAS_GATE" ]; then
+  echo "merged=false pr=$PR note=blocked-by-needs-human-review-label"
+  exit 0
+fi
 ```
 
 Abort with `merged=false note=<reason>` if ANY of:
@@ -262,6 +276,7 @@ skill never touches assignments.json directly.
   that has not been promoted to ready via the auto-promote path in Step 1.
 - Never merge a PR with failing or in-progress CI.
 - Never merge a PR with unresolved review threads.
+- Never merge a PR carrying the `needs-human-review` label, even if approved + green (P6).
 - Auto-resolve ONLY the mechanical patterns listed in Step 2; real code conflicts always abort.
 - Always verify the auto-resolved branch with a quick per-stack check before pushing.
 - Never bypass branch protection (no `--admin` flag from this skill — humans only).

--- a/.github/workflows/auto-rebase-stale-drafts.yml
+++ b/.github/workflows/auto-rebase-stale-drafts.yml
@@ -1,0 +1,170 @@
+name: Auto-rebase stale conflicting drafts
+
+# Nightly sweep of open DRAFT PRs that are CONFLICTING with dev and haven't
+# been touched in >24h. For PRs authored by the dispatcher/owner allow-list,
+# rebase onto origin/dev and force-push with --force-with-lease. Only the
+# mechanical conflict shapes that `ppt-pr-merge` knows how to resolve are
+# auto-resolved here — anything else is left alone with a PR comment.
+#
+# Why it exists: the autonomous dispatcher's PR queue silts up when several
+# implementer branches diverge from dev. Manual rebase round-trips dominate
+# the time-to-merge curve. This unsticks the queue overnight when nobody is
+# around. (See P7 in the dispatcher-hardening plan.)
+
+on:
+  schedule:
+    # 03:00 UTC nightly — quiet hours, well after the last dispatcher tick.
+    - cron: '0 3 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: auto-rebase-stale-drafts
+  cancel-in-progress: false
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        env:
+          ACTOR_NAME: github-actions[bot]
+          ACTOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+        run: |
+          set -euo pipefail
+          git config user.name "$ACTOR_NAME"
+          git config user.email "$ACTOR_EMAIL"
+
+      - name: Find candidate draft PRs
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          # Allow-list of PR authors whose branches we'll force-push to. Keep
+          # tight — external contributors should never have their branches
+          # mutated by automation.
+          AUTHOR_ALLOWLIST: 'martin-janci'
+        run: |
+          set -euo pipefail
+
+          # Pull every open draft PR. The mergeable field can be UNKNOWN on
+          # cold reads; gh re-asks until it resolves.
+          PRS=$(gh pr list --repo "$REPO" --state open --draft \
+            --json number,author,updatedAt,mergeable,headRefName,baseRefName \
+            --limit 100)
+
+          NOW=$(date -u +%s)
+          # Pre-build a regex of allowed authors.
+          ALLOW_REGEX=$(echo "$AUTHOR_ALLOWLIST" | tr ',' '|')
+
+          CANDIDATES=$(echo "$PRS" | jq -c --arg now "$NOW" --arg allow "$ALLOW_REGEX" '
+            [
+              .[]
+              | select(.mergeable == "CONFLICTING")
+              | select(.author.login | test("^(" + $allow + ")$"))
+              | . as $pr
+              | (.updatedAt | fromdateiso8601) as $upd
+              | select(($now | tonumber) - $upd > 86400)
+              | {number, head: .headRefName, base: .baseRefName}
+            ]
+          ')
+
+          echo "candidates<<EOF"  >> "$GITHUB_OUTPUT"
+          echo "$CANDIDATES"      >> "$GITHUB_OUTPUT"
+          echo "EOF"              >> "$GITHUB_OUTPUT"
+          echo "Found $(echo "$CANDIDATES" | jq 'length') candidate PR(s)."
+
+      - name: Rebase each candidate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          CANDIDATES: ${{ steps.find.outputs.candidates }}
+        run: |
+          set -euo pipefail
+
+          COUNT=$(echo "$CANDIDATES" | jq 'length')
+          if [ "$COUNT" -eq 0 ]; then
+            echo "no candidates; exiting clean"
+            exit 0
+          fi
+
+          git fetch origin dev
+
+          # Iterate using jq -r index access so we never interpolate PR
+          # data into the shell via `${{ }}` (env-var indirection pattern).
+          for i in $(seq 0 $((COUNT - 1))); do
+            PR=$(echo "$CANDIDATES"   | jq -r ".[$i].number")
+            HEAD=$(echo "$CANDIDATES" | jq -r ".[$i].head")
+            BASE=$(echo "$CANDIDATES" | jq -r ".[$i].base")
+
+            echo "::group::PR #$PR ($HEAD -> $BASE)"
+
+            if [ "$BASE" != "dev" ]; then
+              echo "skipping: base is $BASE (only rebasing onto dev)"
+              echo "::endgroup::"
+              continue
+            fi
+
+            # Fresh worktree per PR so a previous failure can't poison the next.
+            WORKDIR="$(mktemp -d)/pr-$PR"
+            mkdir -p "$WORKDIR"
+            git worktree add "$WORKDIR" "origin/$HEAD" || {
+              echo "could not check out origin/$HEAD; skipping"
+              echo "::endgroup::"
+              continue
+            }
+
+            (
+              cd "$WORKDIR"
+              git checkout -B "$HEAD"
+
+              if git rebase origin/dev; then
+                echo "rebase clean for PR #$PR"
+                git push --force-with-lease origin "$HEAD"
+              else
+                # Inspect conflicts. Mechanical patterns (mirror ppt-pr-merge
+                # Step 2 table) get base-side resolution + a regen if needed.
+                # Everything else is real code conflict — abort and comment.
+                CONFLICTS=$(git diff --name-only --diff-filter=U || true)
+                MECHANICAL='^(backend/\.sqlx/.*\.json|backend/Cargo\.lock|docs/api/openapi\.yaml|frontend/packages/api-client/src/.*\.ts|frontend/pnpm-lock\.yaml|VERSION|mobile-native/gradle\.properties)$'
+
+                NON_MECHANICAL=$(echo "$CONFLICTS" | grep -Ev "$MECHANICAL" || true)
+
+                if [ -n "$NON_MECHANICAL" ]; then
+                  echo "real conflicts in: $NON_MECHANICAL"
+                  git rebase --abort || true
+                  BODY=$(printf 'Auto-rebase failed: real code conflict in:\n```\n%s\n```\nNeeds manual intervention. (Workflow: `.github/workflows/auto-rebase-stale-drafts.yml`.)' "$NON_MECHANICAL")
+                  gh pr comment "$PR" --repo "$REPO" --body "$BODY"
+                else
+                  echo "only mechanical conflicts: resolving from base"
+                  # Take base side for each mechanical conflict; regen later if applicable.
+                  for f in $CONFLICTS; do
+                    git checkout --theirs -- "$f" || true
+                    git add -- "$f" || true
+                  done
+                  if git rebase --continue; then
+                    git push --force-with-lease origin "$HEAD"
+                    echo "rebase resolved mechanically for PR #$PR"
+                  else
+                    echo "rebase --continue failed; aborting"
+                    git rebase --abort || true
+                    gh pr comment "$PR" --repo "$REPO" --body \
+                      "Auto-rebase aborted: mechanical-only conflict path could not finish the rebase. Needs manual intervention. (Workflow: \`.github/workflows/auto-rebase-stale-drafts.yml\`.)"
+                  fi
+                fi
+              fi
+            ) || echo "PR #$PR step errored — moving on"
+
+            git worktree remove --force "$WORKDIR" || true
+            echo "::endgroup::"
+          done

--- a/.research/README.md
+++ b/.research/README.md
@@ -49,6 +49,26 @@ for the environment smoke check.
 
 **Editing the backlog by hand:** edit `backlog.json` only. `backlog.md` is regenerated each run; hand-edits there will be lost.
 
+## Routine vs dispatcher state
+
+Two separate loops write into `.research/` and the distinction matters when
+debugging "why hasn't X been touched":
+
+| Loop | Cadence | Branch | State file | Read-only? |
+|---|---|---|---|---|
+| **Daily routine** | once / day (cloud cron) | commits on `dev` | `.research/state.json` | yes — only reads GitHub + repo |
+| **Autonomous dispatcher** | every ~2h | commits on `planning` | `.research/management/assignments.json` (on `planning` branch) | no — claims/reviews/merges |
+
+The two never share a cursor file. If `state.json` hasn't advanced in days
+while `assignments.json` is fresh, the routine is stuck (cloud cron broken,
+env vars missing, or the trigger payload disabled) — the dispatcher is fine.
+If `assignments.json` is stale while `state.json` ticks, the dispatcher is
+stuck (rate-limited, no buffer, sandbox failures) — the routine is fine.
+
+The routine's Phase 1 (or Phase 6) sanity check flags when `state.json` has
+not advanced in **3+ days** under "Since last run" → "Routine lag" in the
+daily brief, so the operator notices on the next routine commit.
+
 ## Flow
 
 1. **Routine fires** (daily 05:00 local) → reads `state.json`, scans GitHub

--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -120,6 +120,14 @@ global in-progress count CAN exceed 3. The 3-limit is throughput, not concurrenc
    `.claude/skills/ppt-review-merged/SKILL.md`,
    `.claude/skills/ppt-pr-merge/SKILL.md`, AND
    `.claude/skills/ppt-pr-followup/SKILL.md` exist. If any missing, ABORT.
+6. **Ensure gating labels exist** (P6) — idempotent:
+
+   ```bash
+   bash .claude/skills/ppt-pr-followup/scripts/ensure-labels.sh \
+     martin-janci/property-management
+   ```
+
+   This creates `needs-human-review` once and is a no-op thereafter.
 
 ---
 
@@ -328,6 +336,29 @@ For each row where `status == "review"` AND (`reviewer_summary` is null OR `PR.h
 
 Capture → `reviewer_summary`, `last_reviewed_oid = head_oid` (item #10),
 `last_updated = now`. STATUS UNCHANGED.
+
+**Human-gate label sweep (P6).** After capture, scan the reviewer's `note=`
+substring (case-insensitive) for any of these phrases — the canonical
+allow-list. Match means: the reviewer is parking the PR in draft pending a
+human-only check.
+
+| Phrase fragment (case-insensitive) | Why it's a human gate |
+|---|---|
+| `macos reviewer required` | Cross-platform check the bot can't do |
+| `needs domain expert review` | Subject-matter judgement call |
+| `needs security review` | Sec team must sign off before un-draft |
+| `needs product review` | Product/UX decision |
+| `human review required` | Generic catch-all |
+| `do not auto-merge` | Explicit operator override |
+
+If any fragment matches, label the PR:
+
+```bash
+gh pr edit "$PR" --repo martin-janci/property-management --add-label needs-human-review
+```
+
+If no fragment matches and the PR currently has the label, leave it alone
+(humans add this label too; the dispatcher only adds, never removes).
 
 No cap on reviewer subagents — review every pending review row in parallel.
 

--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -41,6 +41,7 @@ Schema per row:
   "empty_branch":       "boolean | null",  // branch pushed but 0 commits ahead of dev (item #1)
   "rebase_attempts":    "int",             // count of auto-rebase tries on this row (item #6); default 0
   "fix_rounds":         "int",             // count of ppt-pr-followup respawn rounds; default 0; hard cap 3
+  "reclaim_attempts":   "int",             // count of sandbox-timeout reclaims attempted (P3); default 0, cap = 1
 
   "implementer_summary": "string | null",
   "reviewer_summary":    "string | null"
@@ -61,7 +62,8 @@ Schema per row:
 | from        | to       | trigger                                                        |
 |---          |---       |---                                                              |
 | in-progress | review   | Phase 4 returns `pr=<n>`                                        |
-| in-progress | failed   | Phase 4 returns `pr=none` OR Phase 2 detects no-branch >2h OR Phase 2 detects empty-branch |
+| in-progress | failed   | Phase 4 returns `pr=none` OR Phase 2 detects sandbox-timeout AFTER one reclaim attempt OR Phase 2 detects empty-branch |
+| in-progress | in-progress | Phase 2 detects sandbox-timeout (`cloud-ok`: 60m, else 120m) AND `reclaim_attempts < 1` → re-spawn implementer once; bump `reclaim_attempts`, bump `status_changed_at` so the next grace window starts now |
 | review      | merged   | Phase 2 sees PR MERGED on GH (set `merged_at`)                 |
 | review      | failed   | Phase 2 sees PR CLOSED without merge                            |
 | review      | review   | PR still open (no `status_changed_at` bump)                    |
@@ -112,8 +114,8 @@ global in-progress count CAN exceed 3. The 3-limit is throughput, not concurrenc
 3. Read `action-list.json`, `assignments.json`, `coverage.json`.
 4. Backfill any row missing `status_changed_at` = `claimed_at`. Backfill any
    row missing the new fields (`last_reviewed_oid`, `scope_drift`,
-   `code_reuse_warn`, `empty_branch`, `rebase_attempts`, `fix_rounds`) to
-   `null` / `0`.
+   `code_reuse_warn`, `empty_branch`, `rebase_attempts`, `fix_rounds`,
+   `reclaim_attempts`) to `null` / `0`.
 5. Confirm `.claude/skills/ppt-implement/SKILL.md`,
    `.claude/skills/ppt-review-merged/SKILL.md`,
    `.claude/skills/ppt-pr-merge/SKILL.md`, AND
@@ -156,8 +158,21 @@ fi
 - **branch exists, no PR**:
   - If `COMMITS_AHEAD == 0` → **EMPTY BRANCH** (item #1): `new_status="failed"`, `empty_branch=true`, `implementer_summary='branch pushed but 0 commits ahead of dev; nothing to PR'`. Delete the orphan: `git push origin --delete <branch>` (best-effort; ignore failure).
   - Else: `gh pr create --base dev --head <branch> --draft --title '<task_id>: <short>' --body 'Auto: <action>'`, `new_status="review"`, spawn REVIEWER.
-- **no branch + in-progress + (now - status_changed_at) > 2h** → `new_status="failed"`, `implementer_summary='no branch pushed within 2h'`.
-- **no branch + in-progress + grace < 2h** → keep `prev_status` (another run's implementer may still be working).
+- **no branch + in-progress** → run the **sandbox-reclaim helper** (P3):
+
+  ```bash
+  MODE_TAG=$(grep -oE '^Mode:[[:space:]]*[a-z-]+' .research/plans/<slug>.md 2>/dev/null | head -1 | awk '{print $2}')
+  bash .claude/skills/ppt-pr-followup/scripts/sandbox-reclaim.sh
+  # honours BRANCH, STATUS_CHANGED_AT, MODE_TAG, RECLAIM_ATTEMPTS env vars;
+  # prints one line: `action=<wait|reclaim|fail> reason=<short> branch_state=<…>`
+  ```
+
+  Timeout is **60m for `Mode: cloud-ok`** plans, **120m otherwise**.
+
+  Apply the helper's verdict:
+  - `action=wait` → keep `prev_status`; do not touch `status_changed_at`. Another run's implementer may still be working.
+  - `action=reclaim` (only when `reclaim_attempts < 1`) → re-spawn the SAME specialist with the SAME brief via Phase 4's machinery (mirror followup-skill respawn pattern). On respawn: bump `reclaim_attempts += 1`, set `status_changed_at = now` so the next grace window restarts. Status stays `in-progress`.
+  - `action=fail` → `new_status="failed"`, append the helper's `reason=<…>` to `implementer_summary` (e.g. `'sandbox-failure-after-reclaim'` or `'empty-branch'`).
 
 Persist: `last_updated=now` (always); if `new_status != prev_status`: `status=new_status`, `status_changed_at=now`.
 
@@ -228,7 +243,8 @@ Append to `assignments.json`:
   "scope_drift": null,
   "code_reuse_warn": null,
   "empty_branch": null,
-  "rebase_attempts": 0
+  "rebase_attempts": 0,
+  "reclaim_attempts": 0
 }
 ```
 
@@ -451,6 +467,7 @@ In-progress (global now): <N> total across all overlapping runs (no cap)
 In review (PR open):      <M>
 Merge attempts (this run):[PR#<n> merged=<true|false|queued> <note>, …]
 Rebase attempts (this run):[PR#<n> rebased=<true|false> <note>, …]  (item #6; [] if none)
+Sandbox reclaims (this run):[<task_id> branch=<branch> reason=sandbox-timeout, …]  (P3; [] if none)
 Empty branches deleted:   [<branch>, …]                             (item #1; [] if none)
 Scope-drift flagged:      [PR#<n> task=<id> note=<paths>, …]        (item #3; [] if none)
 Code-reuse warnings:      [PR#<n> task=<id> note=<helper>, …]       (item #4; [] if none)
@@ -493,6 +510,7 @@ Hang alerts:
 - **scope-drift** and **code-reuse-warn** (items #3, #4) are non-blocking on implementer return, but feed the reviewer prompt and are surfaced in Phase 7
 - **reviewer re-runs** (item #10) gate on `PR.headRefOid != row.last_reviewed_oid` — never re-review the same SHA
 - **auto-rebase** (item #6) is bounded at 3 attempts per row; after that a human must intervene
+- **sandbox-reclaim** (P3) is bounded at 1 attempt per row; the helper at `.claude/skills/ppt-pr-followup/scripts/sandbox-reclaim.sh` picks the timeout (60m for `Mode: cloud-ok`, 120m otherwise) and classifies the row as wait/reclaim/fail. Reclaim re-spawns the same specialist with the same brief and bumps `reclaim_attempts`; a second sandbox-timeout becomes `failed` with `reason: sandbox-failure-after-reclaim`
 - **disk preflight** (item #7) aborts the run gracefully at <5% free; never crashes mid-subagent
 
 ---

--- a/.research/routine-prompt.md
+++ b/.research/routine-prompt.md
@@ -937,6 +937,31 @@ Run these and verify each passes:
 - Reverted: #<num> reverted #<orig> — <hypothesis>
 - Churn hotspots: <file> (<additions+deletions> lines this run, runs_seen=<N>)
 
+## PRs stuck in draft despite approval
+<!-- Query: PRs where isDraft==true AND reviewDecision==APPROVED AND updatedAt < now-24h.
+     Example:
+       gh pr list --repo martin-janci/property-management --state open --draft \
+         --json number,title,updatedAt,reviewDecision,isDraft \
+         --jq '.[] | select(.reviewDecision=="APPROVED" and .isDraft==true)'
+     Compute age-in-hours from updatedAt. If none: emit a single line "- none".
+     This catches the merge-gate bug class (#539-style): PR approved, CI green,
+     but stuck in draft because a human gate wasn't cleared. -->
+- #<num> <title> — last update <Nh> ago (age=<dd:hh>)
+- none
+
+## PRs with verdict=changes, no fix-round progress in 24h
+<!-- Query: rows in .research/management/assignments.json (planning branch) where
+     reviewer_summary starts with "verdict=changes" AND
+     (now - last_updated) > 24h AND status == "review".
+     Example (read planning's assignments via gh):
+       gh api repos/martin-janci/property-management/contents/.research/management/assignments.json?ref=planning \
+         --jq '.content' | base64 -d | jq '.assignments[]
+         | select(.status=="review" and (.reviewer_summary // "" | startswith("verdict=changes")))
+         | {task_id, pr_number, last_updated, reviewer_summary}'
+     If none: emit "- none". -->
+- <task_id> PR#<num> — last_updated <Nh> ago, reviewer note: <short>
+- none
+
 ## Code review slice
 - Segment reviewed: <SEGMENT> (reason: churn-aligned | oldest-unreviewed | fallback)
 - Experts: <rust | frontend | kotlin> [+ <security | completeness | tester>]

--- a/.research/routine-prompt.md
+++ b/.research/routine-prompt.md
@@ -300,6 +300,13 @@ if [ "$LAG_HOURS" -gt 36 ]; then
   echo "lag_warning: routine has not run in ${LAG_DAYS}d ${LAG_HOURS}h — surface in brief Since last run"
 fi
 
+# Stale-routine alert (P4) — if state.json hasn't advanced in 3+ days the
+# cloud cron is likely broken even if the dispatcher (separate loop, separate
+# branch) is still ticking. Flag in the brief so the operator notices.
+if [ "$LAG_DAYS" -ge 3 ]; then
+  echo "stale_routine_alert: state.json last_run_iso=${SINCE_ISO} is ${LAG_DAYS}d old; cloud routine may be paused. Dispatcher state lives in .research/management/assignments.json on the planning branch — check that separately."
+fi
+
 # Merged PRs since last_pr_seen
 gh pr list --state merged --base dev --limit 50 \
   --json number,title,mergedAt,author,additions,deletions,files,body,labels \

--- a/.research/state.json
+++ b/.research/state.json
@@ -1,5 +1,10 @@
 {
   "version": 3,
+  "_pointer": {
+    "dispatcher_state_at": ".research/management/assignments.json (on planning branch)",
+    "routine_state_at": ".research/state.json (this file, on dev/main)",
+    "note": "state.json is the daily routine's cursor file and is rewritten only by routine-prompt.md. The autonomous dispatcher loop writes its own state to assignments.json on a separate planning branch and never touches this file. See .research/README.md > Routine vs dispatcher state."
+  },
   "last_run_iso": "2026-05-26T03:12:00Z",
   "last_run_ms": 600000,
   "last_pr_seen": 511,


### PR DESCRIPTION
## Summary

Implements the remaining 6 recommendations (P2–P7) from the research-routine audit. Follows #559 (P0+P1 — draft auto-promote and ppt-pr-followup dispatcher mode).

### P2 — Stacked-PR refusal
`ppt-pr-create` refuses `--base` other than `dev`/`main` unless `ALLOW_STACKED=1`. `ppt-pr-merge` mirrors the refusal. Rationale: stacked PRs aren't tracked by `assignments.json` and `ppt-pr-merge`'s mechanical resolver can't rebase chains. Also: existing example in `ppt-pr-create` showed `--base main`; updated to `dev` to match current convention.

### P3 — Sandbox reclaim
Lowers no-branch-pushed timeout to 60m for `Mode: cloud-ok` (120m otherwise — was 2h). On timeout, helper re-spawns the original specialist once (`reclaim_attempts` capped at 1). After second timeout → terminal `failed`, `reason: sandbox-failure-after-reclaim`. Cuts the dominant failure mode (11/17 of recent failures).

### P4 — Routine vs dispatcher state docs
- `state.json` gains a `_pointer` block referencing `assignments.json` (planning branch) as the dispatcher's state-of-truth
- `.research/README.md` documents the split: routine = read-only daily cursor, dispatcher = autonomous loop
- `routine-prompt.md` Phase 1 emits `stale_routine_alert` when `state.json` is 3+ days stale

### P5 — Daily-brief alerts
Adds two sections to the brief template:
- **PRs stuck in draft despite approval** (would have caught this audit's root cause on day 1)
- **PRs with verdict=changes, no fix-round progress in 24h**

Inline `gh + jq` query recipes documented.

### P6 — `needs-human-review` label
- Idempotent `ensure-labels.sh` creates the label; dispatcher Phase 1 invokes it
- Phase 5 scans `reviewer_summary.note` against a phrase allow-list (e.g. "macOS reviewer required", "domain expert review") and labels the PR
- `ppt-pr-merge` Step 1 refuses any PR carrying the label (overrides P0 auto-promote)

### P7 — Nightly auto-rebase
New `.github/workflows/auto-rebase-stale-drafts.yml` (cron `0 3 * * *` UTC). For each open draft PR with `mergeable=CONFLICTING && updated_at < now-24h && author in AUTHOR_ALLOWLIST`: checkout, rebase onto `origin/dev`, mechanical-only conflict resolution (sqlx data, Cargo.lock, lockfiles), `--force-with-lease` push. If non-mechanical conflicts: leave alone, comment "auto-rebase failed; needs manual intervention." Only acts on PRs targeting `dev` so it doesn't collide with P2.

## Schema additions to `assignments.json`

- `reclaim_attempts: int` (default 0; Phase 1 backfills missing rows; cap = 1)
- Adds in-progress → in-progress self-loop for reclaim path

Backwards-compatible — missing field reads as 0.

## Verification

- `verify-all.sh --quick`: **20/20 passed**, 0 failed
- New workflow YAML: `yaml.safe_load` OK
- `actionlint` not installed locally — verify in CI

## Operator notes

- `needs-human-review` label auto-created on next dispatcher Phase 1, or run `bash .claude/skills/ppt-pr-followup/scripts/ensure-labels.sh` once
- Cron time `0 3 * * *` UTC — change if it collides with other scheduled workflows
- No new secrets; workflow uses default `GITHUB_TOKEN`

## Test plan
- [ ] Run dispatcher; confirm cloud-ok rows time out at 60m and reclaim once
- [ ] Confirm `needs-human-review` label appears on PRs with macOS-reviewer notes
- [ ] Stale draft (24h+) with CONFLICTING base → nightly workflow rebases it onto dev
- [ ] Brief includes the two new alert sections
- [ ] Try `ppt-pr-create --base feature/foo` → refuses unless `ALLOW_STACKED=1`