### PR TITLE
fix(dispatcher): close 5 spec gaps from operator feedback (oid mandate, claimable buffer, structured deps, merge back-off, async clarification)

### DIFF
--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -224,11 +224,33 @@ Return EXACTLY: `scanned=<N> clean=<K> issues=<M> note=<short>`.
 
 ```python
 open_count = count(action-list.json items where status=="open" AND id NOT in assignments)
+
+# gap 2: an item is "dep-blocked" if any depends_on entry points at a
+# task that is NOT in assignments with status in {merged, done}.
+def is_dep_blocked(item, assignments):
+    deps = item.get("depends_on") or []
+    if not deps:
+        return False
+    for dep_id in deps:
+        row = assignments.find(task_id=dep_id)
+        if row is None or row.status not in ("merged", "done"):
+            return True
+    return False
+
+dep_blocked_count    = count(open items where is_dep_blocked(item, assignments))
+open_claimable_count = open_count - dep_blocked_count
 ```
 
-- **Tier 1 (self-refill):** if `open_count < 6` AND `coverage.json` has stories → refill from coverage using rubric, append top `(36 - open_count)`. Log `Tier 1: <old> → <new> (+N)`.
-- **Tier 2 (upstream kick):** if `open_count` still < 12 OR coverage missing → `curl POST $DISPATCHER_URL` with `Bearer $DISPATCHER_TOKEN`, `--max-time 10`, fire-and-forget. Log `Tier 2: <http-code or skipped>`.
-- Else: SKIP, log `buffer OK: <open_count>/36`.
+- **Tier 1 (self-refill):** if `open_claimable_count < 18` (half of the 36 target) AND `coverage.json` has stories → refill from coverage using rubric, append top `(36 - open_claimable_count)`. Log `Tier 1: <old_claimable> → <new_claimable> (+N)`.
+- **Tier 2 (upstream kick):** if `open_claimable_count` still `< 12` OR coverage missing → `curl POST $DISPATCHER_URL` with `Bearer $DISPATCHER_TOKEN`, `--max-time 10`, fire-and-forget. Log `Tier 2: <http-code or skipped>`.
+- Else: SKIP, log `buffer OK: claimable=<open_claimable_count>/36 (open=<open_count>, dep_blocked=<dep_blocked_count>)`.
+
+The Phase 6 commit message MUST surface both counts:
+
+```
+chore(research): dispatcher <date> — C claimed, R reviewed, M merge-attempts,
+X merged-now, F failed, A active, B <claimable>/<open> dep-blocked=<n>, RB rebased
+```
 
 ---
 
@@ -525,7 +547,7 @@ bash .claude/skills/ppt-implement/scripts/commit-scope-guard.sh \
   echo "dispatcher commit-scope-guard refused — staged paths outside .research/management/. NOT committing; surface in next run." >&2
   exit 0
 }
-git commit -m 'chore(research): dispatcher <yyyy-mm-dd HH:MM> — C claimed, R reviewed, M merged-attempts, X merged-now, F failed, A active, B buffer, RB rebased'
+git commit -m 'chore(research): dispatcher <yyyy-mm-dd HH:MM> — C claimed, R reviewed, M merge-attempts, X merged-now, F failed, A active, B <claimable>/<open> dep-blocked=<n>, RB rebased'
 git push origin dev   # if another run committed since our pull: rebase + retry once;
                       # if still conflicts, log and bail — next run will re-evaluate state
 ```
@@ -553,7 +575,7 @@ Code-reuse warnings:      [PR#<n> task=<id> note=<helper>, …]       (item #4; 
 Disk warning:             <none | "free=N%; cleaned to M%">         (item #7)
 Merged total: <Mt_total>; this cycle: <Mt_this>
 Failed total: <F_total>;  this cycle: <F_this>
-Buffer:     <open_count>/36 <T1: refilled +N | T2: upstream kicked | OK>
+Buffer:     claimable=<open_claimable_count>/36 (open=<open_count>, dep_blocked=<dep_blocked_count>) <T1: refilled +N | T2: upstream kicked | OK>
 Post-merge: <due | skipped> [<scanned=N clean=K issues=M>]
 Hang alerts:
   WARN (review >48h): [<task_id> PR#<n> age=<dd:hh:mm>, …]   (ALWAYS PRINT; [] if none)

--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -49,6 +49,42 @@ Schema per row:
 }
 ```
 
+## action-list.json schema (gap 3 — structured deps)
+
+Each item in `.research/management/action-list.json` `.items[]` carries:
+
+```jsonc
+{
+  "id":          "string",       // e.g. "gap-7a-2-folder-api"
+  "action":      "string",       // free-text description
+  "owner_role":  "string",       // e.g. "pm-backend"
+  "priority":    "high | medium | low",
+  "status":      "open | in-progress | done | dropped",
+  "source":      "string",       // provenance
+  "deadline":    "iso-8601 | null",
+
+  // -- Dependency wiring --
+  "dependency":  "string | null", // LEGACY free-text; informational only
+  "depends_on":  ["task_id", …]   // gap 3 — structured; canonical for Phase 3
+}
+```
+
+**`depends_on` is the canonical, machine-checked dependency field.**
+The free-text `dependency` is retained for human readability but the
+dispatcher MUST NOT regex-parse it for claim decisions. An empty array
+(`"depends_on": []`) means no dependencies.
+
+Refill/refresh flows (`coverage.json` rubric, Tier-1 buffer, manual
+edits) MUST populate `depends_on` directly; the dispatcher does not
+re-parse `dependency` text on each run.
+
+Migration (one-time, gap 3): for any row missing `depends_on`,
+best-effort-parse the legacy `dependency` field by splitting on
+`, ; and / AND` and matching kebab-case task-id-shaped tokens
+(`gap-…`, `pm-…`, `epic-…`). Unparseable values (owner-role names,
+epic descriptions like "Epic 2B WebSocket infrastructure") become
+`[]` and the free-text is left in `dependency` for human follow-up.
+
 ## Timestamp semantics
 
 - `claimed_at` — set ONCE at claim; never changes.
@@ -258,9 +294,25 @@ X merged-now, F failed, A active, B <claimable>/<open> dep-blocked=<n>, RB rebas
 
 ```python
 free_slots = 3   # constant per run
-candidates = [c for c in action-list if c.status=="open" and c.id not in assignments]
+
+def claimable(c, assignments):
+    # gap 3: structured depends_on is canonical. An item is claimable iff
+    # every depends_on entry references a row in {merged, done}.
+    for dep_id in (c.get("depends_on") or []):
+        row = assignments.find(task_id=dep_id)
+        if row is None or row.status not in ("merged", "done"):
+            return False
+    return True
+
+candidates = [c for c in action-list
+              if c.status == "open"
+              and c.id not in assignments
+              and claimable(c, assignments)]
 candidates.sort(key=lambda c: (priority_rank(c.priority), source_rank(c.source)))
 ```
+
+The legacy `dependency` free-text field is NOT consulted by the claim
+predicate. Only `depends_on` is.
 
 **Same-epic burst-claim guard (NEW — item #2):**
 
@@ -311,7 +363,7 @@ One per newly-claimed task IN THIS RUN. Hard cap 3.
 Prompt:
 
 > You are an implementer. Invoke `.claude/skills/ppt-implement/SKILL.md`.
-> Inputs: `task_id`, `action`, `owner_role`, `priority`, `dependency`, `branch`.
+> Inputs: `task_id`, `action`, `owner_role`, `priority`, `dependency` (legacy free-text), `depends_on` (gap 3 — structured array of task_ids), `branch`.
 > The skill picks the specialist, runs the 3-band verify gate, runs the
 > NEW scope-drift + code-reuse pre-flight checks, opens a DRAFT PR vs `dev`
 > only if verify passes.
@@ -598,7 +650,7 @@ Hang alerts:
 - max 3 followup/respawn subagents in parallel in Phase 5.7 (matches Phase 4 implementer cap)
 - no cap on reviewer (Phase 5) subagents
 - never re-claim an id already in assignments (regardless of its status)
-- never claim items whose dependency text mentions another non-`merged` task
+- never claim items whose `depends_on: [task_id, …]` array contains any task whose `assignments.json` row is not in `{merged, done}` (gap 3 — structured field replaces free-text `dependency` parsing)
 - never push to `main`
 - never bypass git hooks (no `--no-verify`)
 - never set `assignment.status="merged"` inside Phase 5.5 — only Phase 2 sets `merged` from GH truth

--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -98,8 +98,8 @@ epic descriptions like "Epic 2B WebSocket infrastructure") become
 
 | from        | to       | trigger                                                        |
 |---          |---       |---                                                              |
-| in-progress | review   | Phase 4 returns `pr=<n>`                                        |
-| in-progress | failed   | Phase 4 returns `pr=none` OR Phase 2 detects sandbox-timeout AFTER one reclaim attempt OR Phase 2 detects empty-branch |
+| in-progress | review   | Phase 2 of a SUBSEQUENT run sees a PR exists on `<branch>` (gap 5 — async-spawn model). Fast-path: Phase 4 of THIS run captures `pr=<n>` from a sync return; either path is valid. |
+| in-progress | failed   | Phase 2 detects sandbox-timeout AFTER one reclaim attempt OR Phase 2 detects empty-branch OR (fast-path) Phase 4 returns `pr=none` on a synchronous return |
 | in-progress | in-progress | Phase 2 detects sandbox-timeout (`cloud-ok`: 60m, else 120m) AND `reclaim_attempts < 1` → re-spawn implementer once; bump `reclaim_attempts`, bump `status_changed_at` so the next grace window starts now |
 | review      | merged   | Phase 2 sees PR MERGED on GH (set `merged_at`)                 |
 | review      | failed   | Phase 2 sees PR CLOSED without merge                            |
@@ -360,6 +360,35 @@ If fewer than 3 candidates available (buffer drained), claim what's there — do
 
 One per newly-claimed task IN THIS RUN. Hard cap 3.
 
+### Subagent execution model (gap 5 — IMPORTANT)
+
+**Phase 4 spawn is fire-and-forget.** The Claude Code SDK launches the
+implementer subagent asynchronously; the dispatcher does NOT block on
+its completion. The dispatcher's job in Phase 4 is to:
+
+1. Record the row as `status=in-progress, claimed_at=now`.
+2. Hand off the brief to the subagent via the `Task` tool.
+3. Return — the dispatcher run ends shortly after, while implementers
+   may still be executing in the background.
+
+**Outcome observation lives in Phase 2 of the NEXT dispatcher run**,
+not in Phase 4 of THIS run. Phase 2 of that next run looks at:
+- Does a branch named `<row.branch>` exist on origin?
+- Does a PR exist for that branch?
+- What's the PR's GH state (OPEN / MERGED / CLOSED)?
+- What's `COMMITS_AHEAD`?
+
+…and authoritatively transitions the row's status from there.
+
+The state-machine row `in-progress → review (Phase 4 returns pr=<n>)` in
+the table below is a HISTORICAL note for runs that happen to complete
+before the cron interval expires; in steady-state the same transition
+fires in Phase 2 of the next run when it sees the freshly-created PR.
+
+The implementer's `pr=<n>` return-line capture in this phase is still
+useful (it lets fast runs short-circuit), but its ABSENCE is not failure
+— the next Phase 2 will reconcile from GitHub truth.
+
 Prompt:
 
 > You are an implementer. Invoke `.claude/skills/ppt-implement/SKILL.md`.
@@ -371,7 +400,13 @@ Prompt:
 > Return EXACTLY (one line):
 > `pr=<n|none> status=<done|partial|blocked> specialist=<name> scope_drift=<true|false> code_reuse_warn=<short|none> note=<short>`
 
-Capture the line. STATE TRANSITION:
+Capture the line **IFF the subagent returns synchronously within this
+run**. If it doesn't return (the SDK backgrounds it past the dispatcher's
+own exit — the common case), skip this capture entirely; leave the row
+as `status=in-progress` with `claimed_at=now`, and let Phase 2 of the
+next dispatcher run observe the outcome from GitHub.
+
+STATE TRANSITION (fast-path only — gap 5):
 
 ```python
 prev_status = "in-progress"

--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -35,13 +35,14 @@ Schema per row:
   "merged_at":          "iso-8601 | null",
 
   // -- NEW fields (hardening 2026-05-25). Backfill missing = null on first read. --
-  "last_reviewed_oid":  "string | null",   // PR.headRefOid at time of last reviewer run (item #10)
+  "last_reviewed_oid":  "string | null",   // PR.headRefOid at time of last reviewer run (item #10) — MANDATORY when reviewer_summary != null (gap 1)
   "scope_drift":        "boolean | null",  // implementer touched files outside owner_role areas (item #3)
   "code_reuse_warn":    "string | null",   // implementer reused-or-duplicated existing helpers (item #4)
   "empty_branch":       "boolean | null",  // branch pushed but 0 commits ahead of dev (item #1)
   "rebase_attempts":    "int",             // count of auto-rebase tries on this row (item #6); default 0
   "fix_rounds":         "int",             // count of ppt-pr-followup respawn rounds; default 0; hard cap 3
   "reclaim_attempts":   "int",             // count of sandbox-timeout reclaims attempted (P3); default 0, cap = 1
+  "merge_attempted_at": "iso-8601 | null", // last time Phase 5.5 tried to merge this row (gap 4); used for CI-stuck back-off
 
   "implementer_summary": "string | null",
   "reviewer_summary":    "string | null"
@@ -115,7 +116,23 @@ global in-progress count CAN exceed 3. The 3-limit is throughput, not concurrenc
 4. Backfill any row missing `status_changed_at` = `claimed_at`. Backfill any
    row missing the new fields (`last_reviewed_oid`, `scope_drift`,
    `code_reuse_warn`, `empty_branch`, `rebase_attempts`, `fix_rounds`,
-   `reclaim_attempts`) to `null` / `0`.
+   `reclaim_attempts`, `merge_attempted_at`) to `null` / `0`.
+
+   **Gap-1 backfill (re-review forcing):** for any row with
+   `reviewer_summary != null AND last_reviewed_oid == null`, LEAVE
+   `reviewer_summary` intact (do not clear it; it's still useful narrative)
+   but treat that row as oid-drifted on this cycle's Phase 2 / Phase 5 gate.
+   Concretely, in Phase 2 the re-review predicate becomes:
+
+   ```
+   spawn_reviewer iff
+     (reviewer_summary is null)
+     OR (last_reviewed_oid is null)             # gap-1: force re-review
+     OR (PR.headRefOid != last_reviewed_oid)
+   ```
+
+   Once Phase 5 runs and writes the new `last_reviewed_oid`, the forcing
+   condition self-clears on subsequent cycles.
 5. Confirm `.claude/skills/ppt-implement/SKILL.md`,
    `.claude/skills/ppt-review-merged/SKILL.md`,
    `.claude/skills/ppt-pr-merge/SKILL.md`, AND
@@ -162,7 +179,10 @@ fi
 - **PR MERGED** → `new_status="merged"`, `merged_at=PR.mergedAt`.
 - **PR CLOSED (not merged)** → `new_status="failed"`, append `' [PR closed without merge]'` to `implementer_summary`.
 - **PR OPEN** → `new_status="review"`, set `pr_number`/`pr_url` if missing.
-  - Spawn REVIEWER (Phase 5) iff (`reviewer_summary` is null) OR (`PR.headRefOid != row.last_reviewed_oid`).
+  - Spawn REVIEWER (Phase 5) iff
+    (`reviewer_summary` is null) OR
+    (`last_reviewed_oid` is null — gap-1 force re-review) OR
+    (`PR.headRefOid != row.last_reviewed_oid`).
 - **branch exists, no PR**:
   - If `COMMITS_AHEAD == 0` → **EMPTY BRANCH** (item #1): `new_status="failed"`, `empty_branch=true`, `implementer_summary='branch pushed but 0 commits ahead of dev; nothing to PR'`. Delete the orphan: `git push origin --delete <branch>` (best-effort; ignore failure).
   - Else: `gh pr create --base dev --head <branch> --draft --title '<task_id>: <short>' --body 'Auto: <action>'`, `new_status="review"`, spawn REVIEWER.
@@ -252,7 +272,9 @@ Append to `assignments.json`:
   "code_reuse_warn": null,
   "empty_branch": null,
   "rebase_attempts": 0,
-  "reclaim_attempts": 0
+  "reclaim_attempts": 0,
+  "fix_rounds": 0,
+  "merge_attempted_at": null
 }
 ```
 
@@ -334,8 +356,34 @@ For each row where `status == "review"` AND (`reviewer_summary` is null OR `PR.h
 > Return EXACTLY (one line):
 > `verdict=<approve|changes> head_oid=<PR.headRefOid> note=<short>`
 
-Capture → `reviewer_summary`, `last_reviewed_oid = head_oid` (item #10),
+Capture → `reviewer_summary`, **`last_reviewed_oid = head_oid` (item #10 — MANDATORY)**,
 `last_updated = now`. STATUS UNCHANGED.
+
+**Data invariant (NEW — gap 1):** every reviewer write MUST set
+`last_reviewed_oid` to the `head_oid` returned by the reviewer subagent. It is
+NEVER acceptable to write `reviewer_summary != null` while leaving
+`last_reviewed_oid == null` — that combination breaks the Phase 2 re-review
+gate (the `PR.headRefOid != row.last_reviewed_oid` clause silently evaluates
+true against `null` on some shells but false in `jq`-style equality, and the
+behaviour is platform-dependent). If the reviewer subagent's return line is
+missing `head_oid=…`, treat that as a failed reviewer run: do NOT persist
+`reviewer_summary`, and re-spawn on the next cycle.
+
+**Phase-end self-check (NEW — gap 1):** after persisting all reviewer rows,
+scan `assignments.json` for the invariant violation:
+
+```bash
+BAD=$(jq -r '
+  .assignments
+  | map(select(.reviewer_summary != null and .last_reviewed_oid == null))
+  | length' .research/management/assignments.json)
+if [ "$BAD" != "0" ]; then
+  echo "PHASE 5 INVARIANT VIOLATION: $BAD rows have reviewer_summary but null last_reviewed_oid" >&2
+  jq -r '.assignments[] | select(.reviewer_summary != null and .last_reviewed_oid == null) | "  \(.task_id) pr=\(.pr_number)"' .research/management/assignments.json >&2
+  # Do not exit — this is a data-quality warning. Phase 1 of the next run
+  # will force a re-review (see gap-1 backfill rule).
+fi
+```
 
 **Human-gate label sweep (P6).** After capture, scan the reviewer's `note=`
 substring (case-insensitive) for any of these phrases — the canonical

--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -505,7 +505,27 @@ through is the whole point of the auto-promote path; pre-filtering them here
 re-introduces the stall bug (dispatcher run on 2026-05-25: 0 merge attempts,
 all approved PRs draft).
 
-If pre-flight passes: spawn ONE Task subagent per PR (cap 2 parallel):
+**CI-stuck escalation (gap 4):** if the PR's CI rollup is `IN_PROGRESS` or
+`QUEUED` AND `row.merge_attempted_at != null` AND
+`(now - merge_attempted_at) > 6h` → the CI is wedged. Mark the row:
+
+```python
+row.status = "failed"
+row.status_changed_at = now
+row.last_updated = now
+row.implementer_summary += ' [ci-stuck >6h after first merge attempt; escalating]'
+```
+
+Post a comment on the PR explaining (`gh pr comment <n> --body
+"Auto-escalation: CI has been IN_PROGRESS for >6h since first merge attempt at
+<merge_attempted_at>. Human action required — check the runner / re-trigger /
+close the PR."`), then surface in Phase 7 (`CI-stuck escalations: [PR#<n> …]`).
+
+Do NOT spawn the merger subagent for an escalated row.
+
+If pre-flight passes (and not CI-stuck): spawn ONE Task subagent per PR
+(cap 2 parallel). **Set `row.merge_attempted_at = now` BEFORE spawning**,
+regardless of outcome — this is the back-off anchor.
 
 > You are a PR merger. Invoke `.claude/skills/ppt-pr-merge/SKILL.md` end-to-end.
 > Inputs: `pr_number=<n>`, `repo=martin-janci/property-management`, `base=dev`,
@@ -619,6 +639,8 @@ Transitions (this run):   [<id> in-progress→review, …]             ([] if no
 In-progress (global now): <N> total across all overlapping runs (no cap)
 In review (PR open):      <M>
 Merge attempts (this run):[PR#<n> merged=<true|false|queued> <note>, …]
+CI-stuck escalations:     [PR#<n> task=<id> waited=<h>, …]                (gap 4; [] if none)
+Approved+CI-pending:      [PR#<n> task=<id> attempted=<iso8601> wait=<h>, …]  (gap 4; [] if none)
 Rebase attempts (this run):[PR#<n> rebased=<true|false> <note>, …]  (item #6; [] if none)
 Sandbox reclaims (this run):[<task_id> branch=<branch> reason=sandbox-timeout, …]  (P3; [] if none)
 Empty branches deleted:   [<branch>, …]                             (item #1; [] if none)

--- a/.research/dispatcher-self-test.sh
+++ b/.research/dispatcher-self-test.sh
@@ -187,6 +187,100 @@ else
 fi
 echo
 
+# --- T12: gap 1 invariant — reviewer_summary != null => last_reviewed_oid != null
+echo "T12 reviewer_summary != null implies last_reviewed_oid != null (gap 1; informational)"
+# Informational only. Pre-existing rows in this state are exactly what the
+# gap-1 Phase 1 backfill rule targets — they self-heal on the next cycle.
+# Becomes a hard fail only for rows created AFTER the gap-1 cutoff.
+GAP1_CUTOFF="${GAP1_CUTOFF:-2026-05-27T00:00:00Z}"
+INFO=$(jq --arg d "$HARDENING_DATE" '
+  .assignments
+  | map(select(.claimed_at >= $d
+               and .reviewer_summary != null
+               and .last_reviewed_oid == null))
+  | length' "$ASSIGN")
+BAD=$(jq --arg d "$GAP1_CUTOFF" '
+  .assignments
+  | map(select(.claimed_at >= $d
+               and .reviewer_summary != null
+               and .last_reviewed_oid == null))
+  | length' "$ASSIGN")
+if [ "$INFO" = "0" ]; then
+  note "all reviewed rows carry last_reviewed_oid"
+elif [ "$BAD" = "0" ]; then
+  printf '  info  %s pre-gap-1 rows lack last_reviewed_oid (will force re-review next cycle)\n' "$INFO"
+else
+  fail "$BAD post-gap-1-cutoff rows have reviewer_summary but null last_reviewed_oid"
+  jq --arg d "$GAP1_CUTOFF" -r '.assignments[] | select(.claimed_at >= $d and .reviewer_summary != null and .last_reviewed_oid == null) | "    \(.task_id) pr=\(.pr_number)"' "$ASSIGN" >&2
+fi
+echo
+
+# --- T13: gap 3 — every action-list row has depends_on: array --------------
+echo "T13 action-list.json items carry depends_on: array (gap 3)"
+ACTION_LIST="${ACTION_LIST:-.research/management/action-list.json}"
+if [ -f "$ACTION_LIST" ]; then
+  BAD=$(jq -r '
+    [.items[] | select((.depends_on | type) != "array")] | length' "$ACTION_LIST")
+  if [ "$BAD" = "0" ]; then note "all action-list items carry depends_on array"
+  else
+    fail "$BAD action-list items missing depends_on or wrong type"
+    jq -r '.items[] | select((.depends_on | type) != "array") | "    \(.id) depends_on=\(.depends_on)"' "$ACTION_LIST" >&2
+  fi
+else
+  printf '  skip  %s not found\n' "$ACTION_LIST"
+fi
+echo
+
+# --- T14: gap 4 — merge_attempted_at is iso-8601 or null --------------------
+echo "T14 merge_attempted_at is iso-8601 or null (gap 4)"
+BAD=$(jq -r '
+  .assignments
+  | map(select(
+      has("merge_attempted_at")
+      and .merge_attempted_at != null
+      and ((.merge_attempted_at | type) != "string"
+           or (.merge_attempted_at | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T") | not))
+    ))
+  | length' "$ASSIGN")
+if [ "$BAD" = "0" ]; then note "merge_attempted_at values are well-formed"
+else
+  fail "$BAD rows with malformed merge_attempted_at"
+  jq -r '.assignments[] | select(has("merge_attempted_at") and .merge_attempted_at != null and ((.merge_attempted_at | type) != "string" or (.merge_attempted_at | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T") | not))) | "    \(.task_id) merge_attempted_at=\(.merge_attempted_at)"' "$ASSIGN" >&2
+fi
+echo
+
+# --- T15: gap 2 — open_count / open_claimable_count / dep_blocked smoke ----
+echo "T15 buffer metrics computable (gap 2 smoke)"
+if [ -f "$ACTION_LIST" ]; then
+  # Compute open_count = open items not in assignments
+  OPEN_COUNT=$(jq --slurpfile a "$ASSIGN" '
+    [.items[] | select(.status == "open")
+                | .id as $id
+                | select(($a[0].assignments | map(.task_id) | index($id)) == null)
+    ] | length' "$ACTION_LIST")
+  # Compute dep_blocked = of those, the ones whose depends_on has any
+  # element NOT pointing at an assignment in {merged, done}.
+  DEP_BLOCKED=$(jq --slurpfile a "$ASSIGN" '
+    [.items[]
+      | select(.status == "open")
+      | .id as $id
+      | select(($a[0].assignments | map(.task_id) | index($id)) == null)
+      | select(
+          ((.depends_on // []) | length) > 0
+          and any(
+            (.depends_on // [])[];
+            . as $dep
+            | (($a[0].assignments | map(select(.task_id == $dep)) | .[0].status // "missing") | IN("merged","done") | not)
+          )
+        )
+    ] | length' "$ACTION_LIST")
+  CLAIMABLE=$((OPEN_COUNT - DEP_BLOCKED))
+  note "open_count=$OPEN_COUNT dep_blocked=$DEP_BLOCKED open_claimable=$CLAIMABLE"
+else
+  printf '  skip  %s not found\n' "$ACTION_LIST"
+fi
+echo
+
 # --- Summary ---------------------------------------------------------------
 if [ "$FAIL" = "0" ]; then
   echo "==> dispatcher-self-test: PASS"

--- a/.research/management/action-list.json
+++ b/.research/management/action-list.json
@@ -3,25 +3,27 @@
   "items": [
     {
       "id": "pm-backend-fix-ai-equipment-idor",
-      "action": "Fix cross-tenant IDOR cluster in ai.rs: thread tenant_id into equipment_repo.update/delete/update_maintenance and scope the WHERE clauses (or route through the RLS connection) for update_equipment (ai.rs:1113), delete_equipment (ai.rs:1131), update_maintenance (ai.rs:1192) — all currently discard `_principal`; add a cross-tenant regression test",
+      "action": "Fix cross-tenant IDOR cluster in ai.rs: thread tenant_id into equipment_repo.update/delete/update_maintenance and scope the WHERE clauses (or route through the RLS connection) for update_equipment (ai.rs:1113), delete_equipment (ai.rs:1131), update_maintenance (ai.rs:1192) \u2014 all currently discard `_principal`; add a cross-tenant regression test",
       "owner_role": "pm-backend",
       "priority": "high",
       "dependency": "none",
       "status": "done",
       "deadline": null,
       "source": "code-review-finding 2026-05-25",
-      "resolved": "PR #493 merged 2026-05-25 (with regression test)"
+      "resolved": "PR #493 merged 2026-05-25 (with regression test)",
+      "depends_on": []
     },
     {
       "id": "pm-frontend-sequence-epic6-announcement-drafts",
-      "action": "Sequence and land the Epic 6 announcement web UI draft PRs in dependency order: #474 (viewing/ack) → #475 (comments) → #479 (pin), avoiding shared-AnnouncementsPage conflicts; promote out of draft once apiStatus wiring is verified against the now-live notification pipeline",
+      "action": "Sequence and land the Epic 6 announcement web UI draft PRs in dependency order: #474 (viewing/ack) \u2192 #475 (comments) \u2192 #479 (pin), avoiding shared-AnnouncementsPage conflicts; promote out of draft once apiStatus wiring is verified against the now-live notification pipeline",
       "owner_role": "pm-frontend",
       "priority": "high",
       "dependency": "none",
       "status": "done",
       "deadline": null,
       "source": "pm-analysis 2026-05-25",
-      "resolved": "PR #492 merged 2026-05-25"
+      "resolved": "PR #492 merged 2026-05-25",
+      "depends_on": []
     },
     {
       "id": "pm-frontend-schedule-followup-test-batch",
@@ -31,17 +33,19 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "pm-analysis 2026-05-25"
+      "source": "pm-analysis 2026-05-25",
+      "depends_on": []
     },
     {
       "id": "pm-tech-lead-split-ai-platform-announcements-monoliths",
-      "action": "Add ai.rs (3142 LOC), platform_admin.rs (2762), announcements.rs (2722) to the module-split backlog; add a CI grep/clippy lint that flags mutating handlers binding `_principal` (discarded principal) — the pattern behind the ai.rs IDOR cluster",
+      "action": "Add ai.rs (3142 LOC), platform_admin.rs (2762), announcements.rs (2722) to the module-split backlog; add a CI grep/clippy lint that flags mutating handlers binding `_principal` (discarded principal) \u2014 the pattern behind the ai.rs IDOR cluster",
       "owner_role": "pm-tech-lead",
       "priority": "medium",
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "pm-analysis 2026-05-25"
+      "source": "pm-analysis 2026-05-25",
+      "depends_on": []
     },
     {
       "id": "pm-frontend-verify-epic81-schedule-execution",
@@ -51,7 +55,8 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "pm-analysis 2026-05-25"
+      "source": "pm-analysis 2026-05-25",
+      "depends_on": []
     },
     {
       "id": "pm-scrum-master-review-decision-pr-435",
@@ -61,7 +66,8 @@
       "dependency": "none",
       "status": "done",
       "deadline": null,
-      "source": "pm-analysis 2026-05-23"
+      "source": "pm-analysis 2026-05-23",
+      "depends_on": []
     },
     {
       "id": "pm-scrum-master-review-epic-8a",
@@ -71,7 +77,8 @@
       "dependency": "none",
       "status": "done",
       "deadline": null,
-      "source": "pm-analysis 2026-05-23"
+      "source": "pm-analysis 2026-05-23",
+      "depends_on": []
     },
     {
       "id": "pm-scrum-master-review-story-6-1",
@@ -81,7 +88,8 @@
       "dependency": "none",
       "status": "done",
       "deadline": null,
-      "source": "pm-analysis 2026-05-23"
+      "source": "pm-analysis 2026-05-23",
+      "depends_on": []
     },
     {
       "id": "pm-scrum-master-sequence-epic-2b",
@@ -92,7 +100,10 @@
       "status": "done",
       "deadline": null,
       "source": "pm-analysis 2026-05-23",
-      "resolved": "2026-05-24 — sprint-status.yaml sequenced, DEC-001 augmented with unblock-trigger table, action-list updated; PR #442 (DEC-001) already merged"
+      "resolved": "2026-05-24 \u2014 sprint-status.yaml sequenced, DEC-001 augmented with unblock-trigger table, action-list updated; PR #442 (DEC-001) already merged",
+      "depends_on": [
+        "pm-tech-lead"
+      ]
     },
     {
       "id": "pm-scrum-master-land-voice-device-idor",
@@ -103,7 +114,8 @@
       "status": "done",
       "deadline": null,
       "source": "pm-analysis 2026-05-23",
-      "resolved": "2026-05-25 — voice device IDOR fix PR #461 merged"
+      "resolved": "2026-05-25 \u2014 voice device IDOR fix PR #461 merged",
+      "depends_on": []
     },
     {
       "id": "pm-tech-lead-decide-2b-build-order",
@@ -114,7 +126,10 @@
       "status": "done",
       "deadline": null,
       "source": "pm-analysis 2026-05-23",
-      "resolved": "2026-05-24 — DEC-001 merged via PR #442"
+      "resolved": "2026-05-24 \u2014 DEC-001 merged via PR #442",
+      "depends_on": [
+        "pm-scrum-master"
+      ]
     },
     {
       "id": "pm-tech-lead-remove-dead-handler-modules",
@@ -124,7 +139,8 @@
       "dependency": "none",
       "status": "done",
       "deadline": null,
-      "source": "pm-analysis 2026-05-23"
+      "source": "pm-analysis 2026-05-23",
+      "depends_on": []
     },
     {
       "id": "pm-tech-lead-split-churn-hot-routes",
@@ -134,7 +150,8 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "pm-analysis 2026-05-23"
+      "source": "pm-analysis 2026-05-23",
+      "depends_on": []
     },
     {
       "id": "pm-tech-lead-define-oauth-provider-design",
@@ -144,7 +161,8 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "pm-analysis 2026-05-23"
+      "source": "pm-analysis 2026-05-23",
+      "depends_on": []
     },
     {
       "id": "pm-tech-lead-confirm-websocket-infra-ownership",
@@ -155,18 +173,22 @@
       "status": "done",
       "deadline": null,
       "source": "pm-analysis 2026-05-23",
-      "resolved": "2026-05-25 — WS infra ownership confirmed: delivered as Epic 2B story 2B-C.1 (PR #472, owner: pm-backend); ADR-008 updated to status Implemented with explicit owner + delivery note; 8A.3 WS half unblocked, mobile-push leg tracked separately as gap-8a-3-mobile-push"
+      "resolved": "2026-05-25 \u2014 WS infra ownership confirmed: delivered as Epic 2B story 2B-C.1 (PR #472, owner: pm-backend); ADR-008 updated to status Implemented with explicit owner + delivery note; 8A.3 WS half unblocked, mobile-push leg tracked separately as gap-8a-3-mobile-push",
+      "depends_on": [
+        "pm-scrum-master"
+      ]
     },
     {
       "id": "gap-9-1-mfa-frontend-integration",
-      "action": "Wire TwoFactorAuthPage to /api/v1/auth/mfa/* — add useMfa hooks (setup/verify/disable/status/backup-codes) to @ppt/api-client and remove 'feature not exposed' scaffold (9-1 TOTP Two-Factor Authentication Setup)",
+      "action": "Wire TwoFactorAuthPage to /api/v1/auth/mfa/* \u2014 add useMfa hooks (setup/verify/disable/status/backup-codes) to @ppt/api-client and remove 'feature not exposed' scaffold (9-1 TOTP Two-Factor Authentication Setup)",
       "owner_role": "pm-security",
       "priority": "high",
       "dependency": null,
       "status": "done",
       "deadline": null,
       "source": "gap-scan",
-      "resolved": "2026-05-25 — PR #441 merged (MFA frontend integration); e2e coverage PR #473 merged"
+      "resolved": "2026-05-25 \u2014 PR #441 merged (MFA frontend integration); e2e coverage PR #473 merged",
+      "depends_on": []
     },
     {
       "id": "gap-8a-3-websocket-realtime-sync",
@@ -176,18 +198,20 @@
       "dependency": "Epic 2B WebSocket infrastructure",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan"
+      "source": "gap-scan",
+      "depends_on": []
     },
     {
       "id": "gap-7a-3-frontend-api-integration",
-      "action": "Complete frontend API integration for documents permission-based access — promote screen apiStatus from partial to complete; surface RLS-aware filtering in UI (7a-3 Permission-Based Document Access)",
+      "action": "Complete frontend API integration for documents permission-based access \u2014 promote screen apiStatus from partial to complete; surface RLS-aware filtering in UI (7a-3 Permission-Based Document Access)",
       "owner_role": "pm-backend",
       "priority": "high",
       "dependency": null,
       "status": "done",
       "deadline": null,
       "source": "gap-scan",
-      "resolved": "2026-05-25 — web access-scope UI PR #443 + mobile permission UI PRs #462/#465 merged"
+      "resolved": "2026-05-25 \u2014 web access-scope UI PR #443 + mobile permission UI PRs #462/#465 merged",
+      "depends_on": []
     },
     {
       "id": "gap-79-2-login-flow-wiring",
@@ -197,7 +221,8 @@
       "dependency": null,
       "status": "in-progress",
       "deadline": null,
-      "source": "gap-scan"
+      "source": "gap-scan",
+      "depends_on": []
     },
     {
       "id": "gap-7a-1-mobile-document-upload",
@@ -208,28 +233,31 @@
       "status": "done",
       "deadline": null,
       "source": "gap-scan",
-      "resolved": "2026-05-25 — mobile document upload UI PR #447 merged"
+      "resolved": "2026-05-25 \u2014 mobile document upload UI PR #447 merged",
+      "depends_on": []
     },
     {
       "id": "gap-7a-5-mobile-share-ui",
-      "action": "Implement mobile document sharing UI (user/role/public link/password) — backend share workflows already exist (7a-5 Document Sharing)",
+      "action": "Implement mobile document sharing UI (user/role/public link/password) \u2014 backend share workflows already exist (7a-5 Document Sharing)",
       "owner_role": "pm-frontend",
       "priority": "high",
       "dependency": null,
       "status": "done",
       "deadline": null,
       "source": "gap-scan",
-      "resolved": "2026-05-25 — mobile DocumentShareSheet PR #445 merged"
+      "resolved": "2026-05-25 \u2014 mobile DocumentShareSheet PR #445 merged",
+      "depends_on": []
     },
     {
       "id": "gap-7a-4-pdf-preview",
-      "action": "Implement PDF.js client-side rendering for document preview — backend presigned URLs already wired (7a-4 Document Download & Preview)",
+      "action": "Implement PDF.js client-side rendering for document preview \u2014 backend presigned URLs already wired (7a-4 Document Download & Preview)",
       "owner_role": "pm-frontend",
       "priority": "high",
       "dependency": null,
       "status": "done",
       "deadline": null,
-      "source": "gap-scan"
+      "source": "gap-scan",
+      "depends_on": []
     },
     {
       "id": "gap-6-5-direct-messaging-apistatus",
@@ -240,38 +268,42 @@
       "status": "done",
       "deadline": null,
       "source": "gap-scan",
-      "resolved": "2026-05-25 — messaging screens wired PR #449 + WebSocket realtime sync PR #472 merged"
+      "resolved": "2026-05-25 \u2014 messaging screens wired PR #449 + WebSocket realtime sync PR #472 merged",
+      "depends_on": []
     },
     {
       "id": "gap-7a-2-folder-tree-ui",
-      "action": "Build dedicated folder-tree UI page for document organization — backend supports 5-level hierarchy + circular check (7a-2 Folder Organization)",
+      "action": "Build dedicated folder-tree UI page for document organization \u2014 backend supports 5-level hierarchy + circular check (7a-2 Folder Organization)",
       "owner_role": "pm-frontend",
       "priority": "high",
       "dependency": null,
       "status": "open",
       "deadline": null,
-      "source": "gap-scan"
+      "source": "gap-scan",
+      "depends_on": []
     },
     {
       "id": "gap-10b-stub-handlers",
-      "action": "Implement handler bodies for 10b-4 system announcements, 10b-5 support data access, 10b-6 user onboarding tour, 10b-7 contextual help — routes mounted but handlers are stubs (return 501 until real)",
+      "action": "Implement handler bodies for 10b-4 system announcements, 10b-5 support data access, 10b-6 user onboarding tour, 10b-7 contextual help \u2014 routes mounted but handlers are stubs (return 501 until real)",
       "owner_role": "pm-backend",
       "priority": "high",
       "dependency": null,
       "status": "done",
       "deadline": null,
       "source": "gap-scan",
-      "note": "Already implemented in feat(epic-10b) commit cf533ae4; all four handler groups have real sqlx SQL implementations in platform_admin.rs, help.rs, onboarding.rs — no stubs found. cargo check -p api-server exit 0."
+      "note": "Already implemented in feat(epic-10b) commit cf533ae4; all four handler groups have real sqlx SQL implementations in platform_admin.rs, help.rs, onboarding.rs \u2014 no stubs found. cargo check -p api-server exit 0.",
+      "depends_on": []
     },
     {
       "id": "pm-security-resolve-435-followups",
-      "action": "Resolve the residual post-merge security findings in issues #438/#439 — P0-12 cookie scope, P1-04 Debug-format audit-hash domain, P1-01 ordering, IG3 test gap; assign a single owner and treat P0/P1 as pre-feature-work (P1-05 SSRF resolved by PR #450)",
+      "action": "Resolve the residual post-merge security findings in issues #438/#439 \u2014 P0-12 cookie scope, P1-04 Debug-format audit-hash domain, P1-01 ordering, IG3 test gap; assign a single owner and treat P0/P1 as pre-feature-work (P1-05 SSRF resolved by PR #450)",
       "owner_role": "pm-security",
       "priority": "high",
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "pm-analysis 2026-05-24"
+      "source": "pm-analysis 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "pm-backend-fix-ssrf-outbound",
@@ -282,39 +314,43 @@
       "status": "done",
       "deadline": null,
       "source": "pm-analysis 2026-05-24",
-      "resolved": "2026-05-25 — PR #450 merged (SSRF outbound URL validation)"
+      "resolved": "2026-05-25 \u2014 PR #450 merged (SSRF outbound URL validation)",
+      "depends_on": []
     },
     {
       "id": "pm-frontend-protectedroute-failopen",
-      "action": "Harden ProtectedRoute.tsx:117 to deny on missing role instead of skipping the role check, and populate user.role in AuthContext — before role-gating goes live (fold into 79-2 PR #444)",
+      "action": "Harden ProtectedRoute.tsx:117 to deny on missing role instead of skipping the role check, and populate user.role in AuthContext \u2014 before role-gating goes live (fold into 79-2 PR #444)",
       "owner_role": "pm-frontend",
       "priority": "medium",
       "dependency": "none",
       "status": "done",
       "deadline": null,
       "source": "pm-analysis 2026-05-24",
-      "resolved": "2026-05-25 — PR #459 merged (ProtectedRoute fail-open fix)"
+      "resolved": "2026-05-25 \u2014 PR #459 merged (ProtectedRoute fail-open fix)",
+      "depends_on": []
     },
     {
       "id": "pm-backend-implement-81-schedule-endpoints",
-      "action": "Implement Epic 81 report-schedule endpoints the frontend already calls (/schedules/{id}/pause, /resume, /executions) — currently 404 in production",
+      "action": "Implement Epic 81 report-schedule endpoints the frontend already calls (/schedules/{id}/pause, /resume, /executions) \u2014 currently 404 in production",
       "owner_role": "pm-backend",
       "priority": "high",
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "pm-analysis 2026-05-24"
+      "source": "pm-analysis 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "gap-2b-notification-pipeline",
-      "action": "Implement Epic 2B core notification delivery pipeline (stories 2b-1 through 2b-5): channel infrastructure, preference routing, delivery tracking, email/push/in-app transport adapters — unblocks 6-2/6-3/6-4/6-5 announcements, 8A.2 dispatch, 8A.3 sync",
+      "action": "Implement Epic 2B core notification delivery pipeline (stories 2b-1 through 2b-5): channel infrastructure, preference routing, delivery tracking, email/push/in-app transport adapters \u2014 unblocks 6-2/6-3/6-4/6-5 announcements, 8A.2 dispatch, 8A.3 sync",
       "owner_role": "pm-backend",
       "priority": "high",
       "dependency": "none",
       "status": "done",
       "deadline": null,
       "source": "gap-scan 2026-05-24",
-      "resolved": "2026-05-25 — Epic 2B notification pipeline PR #463 merged; WebSocket realtime sync PR #472 merged (DEC-001 unblock triggers fired)"
+      "resolved": "2026-05-25 \u2014 Epic 2B notification pipeline PR #463 merged; WebSocket realtime sync PR #472 merged (DEC-001 unblock triggers fired)",
+      "depends_on": []
     },
     {
       "id": "gap-6-6-neighbor-listing-verify",
@@ -325,49 +361,54 @@
       "status": "done",
       "deadline": null,
       "source": "gap-scan 2026-05-24",
-      "resolved": "2026-05-25 — neighbor listing UI with privacy-aware filtering PR #464 merged"
+      "resolved": "2026-05-25 \u2014 neighbor listing UI with privacy-aware filtering PR #464 merged",
+      "depends_on": []
     },
     {
       "id": "gap-7a-4-mobile-preview",
-      "action": "Implement mobile document download/preview with presigned URLs — web preview (react-pdf) shipped in PR #446; implement ppt-mobile DocumentPreviewScreen calling backend get_preview_url endpoint (7a-4 Document Download & Preview)",
+      "action": "Implement mobile document download/preview with presigned URLs \u2014 web preview (react-pdf) shipped in PR #446; implement ppt-mobile DocumentPreviewScreen calling backend get_preview_url endpoint (7a-4 Document Download & Preview)",
       "owner_role": "pm-frontend",
       "priority": "high",
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-24"
+      "source": "gap-scan 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "gap-7a-5-web-share-ui",
-      "action": "Implement web document sharing UI (user/role/building targeting) in DocumentDetail — backend share workflows complete; mobile DocumentShareSheet shipped in PR #445; web UI panel missing (7a-5 Document Sharing)",
+      "action": "Implement web document sharing UI (user/role/building targeting) in DocumentDetail \u2014 backend share workflows complete; mobile DocumentShareSheet shipped in PR #445; web UI panel missing (7a-5 Document Sharing)",
       "owner_role": "pm-frontend",
       "priority": "high",
       "dependency": "none",
       "status": "done",
       "deadline": null,
       "source": "gap-scan 2026-05-24",
-      "resolved": "2026-05-25 — web document sharing UI PRs #451/#467 merged"
+      "resolved": "2026-05-25 \u2014 web document sharing UI PRs #451/#467 merged",
+      "depends_on": []
     },
     {
       "id": "gap-7a-3-mobile-rls-ui",
-      "action": "Implement mobile document permission/RLS UI — web access-scope filtering wired in PR #443; mobile DocumentPermissionsScreen or equivalent pending (7a-3 Permission-Based Document Access)",
+      "action": "Implement mobile document permission/RLS UI \u2014 web access-scope filtering wired in PR #443; mobile DocumentPermissionsScreen or equivalent pending (7a-3 Permission-Based Document Access)",
       "owner_role": "pm-frontend",
       "priority": "high",
       "dependency": "none",
       "status": "done",
       "deadline": null,
       "source": "gap-scan 2026-05-24",
-      "resolved": "2026-05-25 — mobile document permission/RLS UI PRs #462/#465 merged"
+      "resolved": "2026-05-25 \u2014 mobile document permission/RLS UI PRs #462/#465 merged",
+      "depends_on": []
     },
     {
       "id": "gap-79-1-announcements-page-wiring",
-      "action": "Wire AnnouncementsPage and FaultsPage to @ppt/api-client query hooks — infra exists (queryKeys/axios interceptors/51 hooks) but AnnouncementsPage/FaultsPage integration incomplete (79-1 API Client Integration)",
+      "action": "Wire AnnouncementsPage and FaultsPage to @ppt/api-client query hooks \u2014 infra exists (queryKeys/axios interceptors/51 hooks) but AnnouncementsPage/FaultsPage integration incomplete (79-1 API Client Integration)",
       "owner_role": "pm-frontend",
       "priority": "high",
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-24"
+      "source": "gap-scan 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "gap-10a-1-oauth-tests",
@@ -377,29 +418,32 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-24"
+      "source": "gap-scan 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "gap-10a-2-oauth-admin-ui",
-      "action": "Build OAuth client management admin UI in admin-web — backend client CRUD fully implemented (register/list/update/revoke/regenerate_secret); scope management console missing (10a-2 OAuth Client Registration)",
+      "action": "Build OAuth client management admin UI in admin-web \u2014 backend client CRUD fully implemented (register/list/update/revoke/regenerate_secret); scope management console missing (10a-2 OAuth Client Registration)",
       "owner_role": "pm-frontend",
       "priority": "high",
       "dependency": "none",
       "status": "done",
       "deadline": null,
       "source": "gap-scan 2026-05-24",
-      "resolved": "2026-05-25 — OAuth provider client-management admin UI PRs #468/#469/#471 merged"
+      "resolved": "2026-05-25 \u2014 OAuth provider client-management admin UI PRs #468/#469/#471 merged",
+      "depends_on": []
     },
     {
       "id": "gap-10a-3-user-grants-ui",
-      "action": "Build user OAuth grants management page in ppt-web so users can revoke third-party app access — backend list_user_grants/revoke_user_grant and introspection implemented (10a-3 OAuth Token Management)",
+      "action": "Build user OAuth grants management page in ppt-web so users can revoke third-party app access \u2014 backend list_user_grants/revoke_user_grant and introspection implemented (10a-3 OAuth Token Management)",
       "owner_role": "pm-frontend",
       "priority": "high",
       "dependency": "none",
       "status": "done",
       "deadline": null,
       "source": "gap-scan 2026-05-24",
-      "resolved": "2026-05-25 — user OAuth grants management UI PRs #468/#469/#471 merged"
+      "resolved": "2026-05-25 \u2014 user OAuth grants management UI PRs #468/#469/#471 merged",
+      "depends_on": []
     },
     {
       "id": "gap-10b-3-admin-health-ui",
@@ -409,91 +453,100 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-24"
+      "source": "gap-scan 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "gap-9-1-mfa-e2e-verify",
-      "action": "Verify TOTP MFA works end-to-end after gap-9-1-mfa-frontend-integration (PR #441) merge: QR scan → TOTP verify → login 2FA prompt → disable flow → backup-codes regeneration (9-1 TOTP Two-Factor Authentication Setup)",
+      "action": "Verify TOTP MFA works end-to-end after gap-9-1-mfa-frontend-integration (PR #441) merge: QR scan \u2192 TOTP verify \u2192 login 2FA prompt \u2192 disable flow \u2192 backup-codes regeneration (9-1 TOTP Two-Factor Authentication Setup)",
       "owner_role": "pm-security",
       "priority": "high",
       "dependency": "none",
       "status": "done",
       "deadline": null,
       "source": "gap-scan 2026-05-24",
-      "resolved": "2026-05-25 — MFA e2e test coverage PR #473 merged"
+      "resolved": "2026-05-25 \u2014 MFA e2e test coverage PR #473 merged",
+      "depends_on": []
     },
     {
       "id": "gap-10b-4-system-announcements-impl",
-      "action": "Implement system announcements handler bodies in platform_admin.rs — CRUD routes mounted but handlers return 501; add SQLx queries, schedule_maintenance table operations (10b-4 System Announcements)",
+      "action": "Implement system announcements handler bodies in platform_admin.rs \u2014 CRUD routes mounted but handlers return 501; add SQLx queries, schedule_maintenance table operations (10b-4 System Announcements)",
       "owner_role": "pm-backend",
       "priority": "medium",
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-24"
+      "source": "gap-scan 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "gap-10b-5-support-data-impl",
-      "action": "Implement support data access handler bodies — search/get user/memberships/sessions/activity routes defined but stubs; add SQLx queries with parameterized search (10b-5 Support Data Access)",
+      "action": "Implement support data access handler bodies \u2014 search/get user/memberships/sessions/activity routes defined but stubs; add SQLx queries with parameterized search (10b-5 Support Data Access)",
       "owner_role": "pm-backend",
       "priority": "medium",
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-24"
+      "source": "gap-scan 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "gap-10b-6-onboarding-impl",
-      "action": "Implement user onboarding tour handler bodies in onboarding.rs — get/start/complete/skip/reset routes mounted; handlers call todo!() or return empty; add SQLx queries + onboarding_progress table (10b-6 User Onboarding Tour)",
+      "action": "Implement user onboarding tour handler bodies in onboarding.rs \u2014 get/start/complete/skip/reset routes mounted; handlers call todo!() or return empty; add SQLx queries + onboarding_progress table (10b-6 User Onboarding Tour)",
       "owner_role": "pm-backend",
       "priority": "medium",
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-24"
+      "source": "gap-scan 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "gap-10b-7-help-impl",
-      "action": "Implement contextual help handler bodies in help.rs — articles/FAQ/tooltips with search+context routes mounted; handlers return stubs; add SQLx queries + help_articles table (10b-7 Contextual Help & Documentation)",
+      "action": "Implement contextual help handler bodies in help.rs \u2014 articles/FAQ/tooltips with search+context routes mounted; handlers return stubs; add SQLx queries + help_articles table (10b-7 Contextual Help & Documentation)",
       "owner_role": "pm-backend",
       "priority": "medium",
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-24"
+      "source": "gap-scan 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "gap-6-2-announcement-web-ui",
-      "action": "Wire AnnouncementsPage web frontend to viewing/acknowledgment APIs (mark_read, acknowledge, get_acknowledgments) — apiStatus stub; blocked on Epic 2B notification delivery pipeline (6-2 Announcement Viewing & Acknowledgment)",
+      "action": "Wire AnnouncementsPage web frontend to viewing/acknowledgment APIs (mark_read, acknowledge, get_acknowledgments) \u2014 apiStatus stub; blocked on Epic 2B notification delivery pipeline (6-2 Announcement Viewing & Acknowledgment)",
       "owner_role": "pm-frontend",
       "priority": "high",
       "dependency": "none",
       "status": "in-progress",
       "deadline": null,
       "source": "gap-scan 2026-05-24",
-      "note": "unblocked — Epic 2B pipeline (#463) + WS sync (#472) merged; web UI in draft PR #474"
+      "note": "unblocked \u2014 Epic 2B pipeline (#463) + WS sync (#472) merged; web UI in draft PR #474",
+      "depends_on": []
     },
     {
       "id": "gap-6-3-comments-web-ui",
-      "action": "Wire announcement comments/discussion web UI to backend list/create/delete comment routes — AnnouncementComments frontend buildStatus planned; blocked on Epic 2B (6-3 Announcement Comments & Discussion)",
+      "action": "Wire announcement comments/discussion web UI to backend list/create/delete comment routes \u2014 AnnouncementComments frontend buildStatus planned; blocked on Epic 2B (6-3 Announcement Comments & Discussion)",
       "owner_role": "pm-frontend",
       "priority": "high",
       "dependency": "none",
       "status": "in-progress",
       "deadline": null,
       "source": "gap-scan 2026-05-24",
-      "note": "unblocked — Epic 2B (#463) merged; web UI in draft PR #475"
+      "note": "unblocked \u2014 Epic 2B (#463) merged; web UI in draft PR #475",
+      "depends_on": []
     },
     {
       "id": "gap-6-4-pin-web-ui",
-      "action": "Wire pin/unpin announcement UI to backend pin_announcement route — frontend buildStatus planned; blocked on Epic 2B (6-4 Pinned Announcements)",
+      "action": "Wire pin/unpin announcement UI to backend pin_announcement route \u2014 frontend buildStatus planned; blocked on Epic 2B (6-4 Pinned Announcements)",
       "owner_role": "pm-frontend",
       "priority": "high",
       "dependency": "none",
       "status": "in-progress",
       "deadline": null,
       "source": "gap-scan 2026-05-24",
-      "note": "unblocked — Epic 2B (#463) merged; web UI in draft PR #479"
+      "note": "unblocked \u2014 Epic 2B (#463) merged; web UI in draft PR #479",
+      "depends_on": []
     },
     {
       "id": "gap-80-2-dispute-verify",
@@ -503,7 +556,8 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-24"
+      "source": "gap-scan 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "gap-80-3-mediation-verify",
@@ -513,7 +567,8 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-24"
+      "source": "gap-scan 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "gap-81-1-schedule-e2e-verify",
@@ -523,7 +578,8 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-24"
+      "source": "gap-scan 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "gap-81-2-execution-history-verify",
@@ -533,18 +589,20 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-24"
+      "source": "gap-scan 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "gap-8a-3-mobile-push",
-      "action": "Implement mobile OS push notification registration and system channel binding for 8a-3 preference sync — WebSocket deferred; implement FCM/APNs registration + delivery to mobile (8a-3 Notification Preference Sync)",
+      "action": "Implement mobile OS push notification registration and system channel binding for 8a-3 preference sync \u2014 WebSocket deferred; implement FCM/APNs registration + delivery to mobile (8a-3 Notification Preference Sync)",
       "owner_role": "pm-backend",
       "priority": "high",
       "dependency": "none",
       "status": "in-progress",
       "deadline": null,
       "source": "gap-scan 2026-05-24",
-      "note": "dependency cleared — Epic 2B pipeline (#463) + WS sync (#472) merged; only the mobile-push leg of 8a-3 remains before promotion to done"
+      "note": "dependency cleared \u2014 Epic 2B pipeline (#463) + WS sync (#472) merged; only the mobile-push leg of 8a-3 remains before promotion to done",
+      "depends_on": []
     },
     {
       "id": "gap-84-2-esignature-impl",
@@ -554,7 +612,8 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-24"
+      "source": "gap-scan 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "gap-85-1-rn-env-config",
@@ -564,7 +623,8 @@
       "dependency": "none",
       "status": "in-progress",
       "deadline": null,
-      "source": "gap-scan 2026-05-24"
+      "source": "gap-scan 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "gap-85-2-ios-build-config",
@@ -574,7 +634,8 @@
       "dependency": "none",
       "status": "in-progress",
       "deadline": null,
-      "source": "gap-scan 2026-05-24"
+      "source": "gap-scan 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "gap-7a-1-upload-verify",
@@ -584,7 +645,8 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-24"
+      "source": "gap-scan 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "gap-82-1-swiftui-audit",
@@ -594,7 +656,8 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-24"
+      "source": "gap-scan 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "gap-82-2-deep-linking",
@@ -604,7 +667,8 @@
       "dependency": "none",
       "status": "in-progress",
       "deadline": null,
-      "source": "gap-scan 2026-05-24"
+      "source": "gap-scan 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "gap-82-3-search-enhancements",
@@ -614,7 +678,8 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-24"
+      "source": "gap-scan 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "gap-82-4-photo-gallery",
@@ -624,7 +689,8 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-24"
+      "source": "gap-scan 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "gap-82-5-ios-push-keychain",
@@ -634,7 +700,8 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-24"
+      "source": "gap-scan 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "gap-83-1-airbnb-oauth",
@@ -644,7 +711,8 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-24"
+      "source": "gap-scan 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "gap-83-2-booking-ota",
@@ -654,7 +722,8 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-24"
+      "source": "gap-scan 2026-05-24",
+      "depends_on": []
     },
     {
       "id": "gap-10b-4-sysannounce-admin-impl",
@@ -664,7 +733,8 @@
       "dependency": "none",
       "status": "in-progress",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": []
     },
     {
       "id": "gap-6-2-announcement-read-receipt",
@@ -674,7 +744,8 @@
       "dependency": "none",
       "status": "in-progress",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": []
     },
     {
       "id": "gap-79-1-api-client-core-wiring",
@@ -684,7 +755,8 @@
       "dependency": "none",
       "status": "in-progress",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": []
     },
     {
       "id": "gap-79-2-auth-sso-completion",
@@ -694,7 +766,10 @@
       "dependency": "gap-79-1-api-client-core-wiring",
       "status": "in-progress",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": [
+        "gap-79-1-api-client-core-wiring"
+      ]
     },
     {
       "id": "gap-7a-1-backend-multipart-upload",
@@ -704,7 +779,8 @@
       "dependency": "none",
       "status": "in-progress",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": []
     },
     {
       "id": "gap-10b-5-support-data-api",
@@ -714,7 +790,8 @@
       "dependency": "none",
       "status": "in-progress",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": []
     },
     {
       "id": "gap-6-3-announcement-comments-api",
@@ -724,7 +801,8 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": []
     },
     {
       "id": "gap-6-3-announcement-comments-ui",
@@ -735,7 +813,10 @@
       "status": "done",
       "deadline": null,
       "source": "gap-scan 2026-05-25",
-      "resolved": "PR #475 merged 2026-05-25"
+      "resolved": "PR #475 merged 2026-05-25",
+      "depends_on": [
+        "gap-6-3-announcement-comments-api"
+      ]
     },
     {
       "id": "gap-6-4-pinned-announcements-api",
@@ -745,7 +826,8 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": []
     },
     {
       "id": "gap-6-4-pinned-announcements-ui",
@@ -755,7 +837,10 @@
       "dependency": "gap-6-4-pinned-announcements-api",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": [
+        "gap-6-4-pinned-announcements-api"
+      ]
     },
     {
       "id": "gap-7a-2-folder-api",
@@ -765,7 +850,10 @@
       "dependency": "gap-7a-1-backend-multipart-upload",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": [
+        "gap-7a-1-backend-multipart-upload"
+      ]
     },
     {
       "id": "gap-7a-2-folder-ui",
@@ -775,7 +863,10 @@
       "dependency": "gap-7a-2-folder-api",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": [
+        "gap-7a-2-folder-api"
+      ]
     },
     {
       "id": "gap-7a-4-document-download-api",
@@ -785,7 +876,10 @@
       "dependency": "gap-7a-1-backend-multipart-upload",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": [
+        "gap-7a-1-backend-multipart-upload"
+      ]
     },
     {
       "id": "gap-7a-4-document-preview-ui",
@@ -795,7 +889,10 @@
       "dependency": "gap-7a-4-document-download-api",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": [
+        "gap-7a-4-document-download-api"
+      ]
     },
     {
       "id": "gap-8a-3-push-fanout-delivery",
@@ -805,7 +902,10 @@
       "dependency": "gap-8a-3-mobile-push must be merged first",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": [
+        "gap-8a-3-mobile-push"
+      ]
     },
     {
       "id": "gap-10b-6-onboarding-tour-api",
@@ -815,7 +915,8 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": []
     },
     {
       "id": "gap-10b-6-onboarding-tour-ui",
@@ -825,7 +926,10 @@
       "dependency": "gap-10b-6-onboarding-tour-api",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": [
+        "gap-10b-6-onboarding-tour-api"
+      ]
     },
     {
       "id": "gap-10b-7-contextual-help-ui",
@@ -835,17 +939,19 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": []
     },
     {
       "id": "gap-80-2-dispute-filing-api",
-      "action": "Add POST /api/v1/disputes endpoint with migration for disputes table; implement dispute state machine (open→in-review→resolved)",
+      "action": "Add POST /api/v1/disputes endpoint with migration for disputes table; implement dispute state machine (open\u2192in-review\u2192resolved)",
       "owner_role": "pm-backend",
       "priority": "medium",
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": []
     },
     {
       "id": "gap-80-2-dispute-filing-ui",
@@ -855,7 +961,10 @@
       "dependency": "gap-80-2-dispute-filing-api",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": [
+        "gap-80-2-dispute-filing-api"
+      ]
     },
     {
       "id": "gap-80-3-mediation-api",
@@ -865,7 +974,10 @@
       "dependency": "gap-80-2-dispute-filing-api",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": [
+        "gap-80-2-dispute-filing-api"
+      ]
     },
     {
       "id": "gap-80-3-mediation-ui",
@@ -875,7 +987,10 @@
       "dependency": "gap-80-3-mediation-api",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": [
+        "gap-80-3-mediation-api"
+      ]
     },
     {
       "id": "gap-81-1-report-schedule-edit-api",
@@ -885,7 +1000,8 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": []
     },
     {
       "id": "gap-81-1-report-schedule-edit-ui",
@@ -895,7 +1011,10 @@
       "dependency": "gap-81-1-report-schedule-edit-api",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": [
+        "gap-81-1-report-schedule-edit-api"
+      ]
     },
     {
       "id": "gap-81-2-report-execution-history-api",
@@ -905,7 +1024,8 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": []
     },
     {
       "id": "gap-81-2-report-execution-history-ui",
@@ -915,7 +1035,10 @@
       "dependency": "gap-81-2-report-execution-history-api",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": [
+        "gap-81-2-report-execution-history-api"
+      ]
     },
     {
       "id": "gap-82-3-swiftui-home-search",
@@ -925,7 +1048,10 @@
       "dependency": "gap-82-2-deep-linking",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": [
+        "gap-82-2-deep-linking"
+      ]
     },
     {
       "id": "gap-82-4-swiftui-listing-detail",
@@ -935,7 +1061,10 @@
       "dependency": "gap-82-3-swiftui-home-search",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": [
+        "gap-82-3-swiftui-home-search"
+      ]
     },
     {
       "id": "gap-82-5-swiftui-inquiries-account",
@@ -945,7 +1074,10 @@
       "dependency": "gap-82-4-swiftui-listing-detail",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": [
+        "gap-82-4-swiftui-listing-detail"
+      ]
     },
     {
       "id": "gap-83-1-airbnb-integration-backend",
@@ -955,7 +1087,8 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": []
     },
     {
       "id": "gap-83-2-booking-integration-backend",
@@ -965,7 +1098,8 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": []
     },
     {
       "id": "gap-84-2-esignature-email-backend",
@@ -976,7 +1110,8 @@
       "status": "done",
       "deadline": null,
       "source": "gap-scan 2026-05-25",
-      "resolved": "PR #495 merged 2026-05-25 (HMAC provider)"
+      "resolved": "PR #495 merged 2026-05-25 (HMAC provider)",
+      "depends_on": []
     },
     {
       "id": "gap-84-2-esignature-email-ui",
@@ -986,7 +1121,10 @@
       "dependency": "gap-84-2-esignature-email-backend",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": [
+        "gap-84-2-esignature-email-backend"
+      ]
     },
     {
       "id": "gap-85-2-build-config-android",
@@ -996,7 +1134,10 @@
       "dependency": "gap-85-1-rn-env-config",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": [
+        "gap-85-1-rn-env-config"
+      ]
     },
     {
       "id": "gap-85-2-build-config-ios",
@@ -1006,7 +1147,10 @@
       "dependency": "gap-85-1-rn-env-config",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": [
+        "gap-85-1-rn-env-config"
+      ]
     },
     {
       "id": "gap-10b-5-support-data-ui",
@@ -1016,7 +1160,10 @@
       "dependency": "gap-10b-5-support-data-api",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": [
+        "gap-10b-5-support-data-api"
+      ]
     },
     {
       "id": "gap-82-6-kmp-android-home",
@@ -1026,7 +1173,8 @@
       "dependency": "none",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": []
     },
     {
       "id": "gap-82-7-kmp-android-detail",
@@ -1036,7 +1184,10 @@
       "dependency": "gap-82-6-kmp-android-home",
       "status": "open",
       "deadline": null,
-      "source": "gap-scan 2026-05-25"
+      "source": "gap-scan 2026-05-25",
+      "depends_on": [
+        "gap-82-6-kmp-android-home"
+      ]
     },
     {
       "id": "pm-qa-create-backend-servers-reality-server",
@@ -1046,7 +1197,8 @@
       "dependency": "rust-backend",
       "status": "open",
       "deadline": null,
-      "source": "pm-analysis 2026-05-25"
+      "source": "pm-analysis 2026-05-25",
+      "depends_on": []
     },
     {
       "id": "pm-qa-verify-respond-to-inquiry-post-api-v1",
@@ -1056,7 +1208,8 @@
       "dependency": "rust-backend",
       "status": "open",
       "deadline": null,
-      "source": "pm-analysis 2026-05-25"
+      "source": "pm-analysis 2026-05-25",
+      "depends_on": []
     },
     {
       "id": "pm-qa-establish-pr-merge-policy-requiring-a",
@@ -1066,7 +1219,10 @@
       "dependency": "pm-tech-lead",
       "status": "open",
       "deadline": null,
-      "source": "pm-analysis 2026-05-25"
+      "source": "pm-analysis 2026-05-25",
+      "depends_on": [
+        "pm-tech-lead"
+      ]
     },
     {
       "id": "pm-scrum-master-implement-post-api-v1-documents-upload",
@@ -1076,7 +1232,10 @@
       "dependency": "pm-backend",
       "status": "open",
       "deadline": null,
-      "source": "pm-analysis 2026-05-25"
+      "source": "pm-analysis 2026-05-25",
+      "depends_on": [
+        "pm-backend"
+      ]
     },
     {
       "id": "pm-scrum-master-wire-app-tsx-dispute-routes-replace-in",
@@ -1086,7 +1245,10 @@
       "dependency": "pm-frontend",
       "status": "open",
       "deadline": null,
-      "source": "pm-analysis 2026-05-25"
+      "source": "pm-analysis 2026-05-25",
+      "depends_on": [
+        "pm-frontend"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes 5 spec gaps in `.research/dispatcher-prompt.md` from an operator's reflection after a real dispatcher run. One commit per gap + a self-test commit.

### Gap 1 — Mandate `last_reviewed_oid` on every review write
Phase 5 mandatory write + Phase-end invariant check; Phase 1 backfill forces re-review when oid is null; Phase 2 predicate updated. T12 informational before `2026-05-27T00:00:00Z` (`GAP1_CUTOFF`), hard-fail after — gives existing 13 rows one cycle to self-heal.

### Gap 2 — `open_claimable_count` vs `open_count`
Phase 2.6 defines `dep_blocked_count` and `open_claimable_count`. Tier-1 buffer trigger flips from `open < 18` to `open_claimable < 18` (preserves half-of-36 semantics, but measured against claimables). Phase 6 commit message and Phase 7 brief now surface both numbers.

**On current state**: `open=6 dep_blocked=6 open_claimable=0` — direct validation of why this gap mattered.

### Gap 3 — Structured `depends_on: [task_id]`
New schema doc section; Phase 3 claim predicate switched to structured field; migrated 106 action-list items (28 with concrete deps, 3 free-form unparseable kept as `[]` with legacy `dependency` text preserved). Free-form parser: regex on `gap-…`, `pm-…`, `epic-…` kebab tokens, split on `, ; and / AND`.

### Gap 4 — `merge_attempted_at` for CI back-off
Schema field added. Phase 5.5 sets it before spawn. After 6h with CI still pending, row marked `failed reason=ci-stuck`, comment posted to PR, surfaced in daily brief. Phase 7 now shows CI-stuck + Approved+CI-pending lines.

### Gap 5 — Async-spawn clarification
New "Subagent execution model" subsection at top of Phase 4. State-machine row rewritten to credit Phase 2 of subsequent run with detecting the implementer's outcome. Fast-path return (when the SDK does return synchronously) is now optional, not assumed.

## Self-test

T12–T15 added. Final result: **PASS**.

## Files

- `.research/dispatcher-prompt.md`
- `.research/management/action-list.json` (`depends_on` field added to every item)
- `.research/dispatcher-self-test.sh` (+T12–T15)

## Operator notes

- Tier-1 buffer threshold is `open_claimable_count < 18`. Easy to retune in Phase 2.6 if dispatcher behavior changes.
- 3 action-list items couldn't be auto-migrated (Epic 2B WebSocket infrastructure, two `rust-backend` mentions). Their legacy `dependency` text is preserved for human follow-up.
- `GAP1_CUTOFF=2026-05-27T00:00:00Z` — informational T12 today, mandatory tomorrow.

## Test plan
- [ ] Self-test green in CI on this branch
- [ ] Next dispatcher run logs both `open_count` and `open_claimable_count` in its chore(research) commit
- [ ] Next dispatcher run treats null-oid rows as re-review candidates
- [ ] CI-stuck row appears in brief after 6h