### PR TITLE
gap-6-2-announcement-read-receipt-retry: Wire read-receipt & acknowledge flow (ppt-web + RN mobile)

### DIFF
--- a/docs/screens/ppt/announcements.md
+++ b/docs/screens/ppt/announcements.md
@@ -11,8 +11,8 @@ implementations:
     redesignStatus: in-progress
     apiStatus: partial
   mobile:
-    component: AnnouncementsScreen
-    buildStatus: shipped
+    component: AnnouncementsScreen + AnnouncementDetailScreen
+    buildStatus: in-progress
     redesignStatus: in-progress
     apiStatus: partial
 endpoints:
@@ -119,6 +119,8 @@ UC-02 announcements — manager-published, resident-acknowledged messages. The d
 ## Agent Log
 
 <!-- newest entries on top -->
+
+- 2026-05-27 — agent: gap-6-2-announcement-read-receipt-retry — Story 6.2 retry: added AnnouncementDetailScreen (mobile) with auto-fire POST /read on mount + acknowledge button; wired AnnouncementDetail case in mobile App.tsx; added auto-mark-read useEffect in ppt-web ViewAnnouncementPageInner (fire-and-forget on announcement load); ppt-web & mobile typecheck + biome clean; mobile component: AnnouncementsScreen + AnnouncementDetailScreen
 
 - 2026-05-25 — agent: gap-6-4-pinned-announcements-ui — Story 6.4: added PinnedAnnouncementsBand component + CSS; wired usePinnedAnnouncements (pinned=true) query in AnnouncementsPageRoute (App.tsx); propagated pinnedAnnouncements prop through AnnouncementsPage → AnnouncementList; mobile AnnouncementsScreen adds pinned-band with separate /api/v1/announcements?pinned=true query
 

--- a/frontend/apps/mobile/src/App.tsx
+++ b/frontend/apps/mobile/src/App.tsx
@@ -10,6 +10,7 @@ import { useOfflineSupport } from './hooks';
 import { colors } from './screens/shared/screenStyles';
 import './i18n'; // Initialize i18n
 import {
+  AnnouncementDetailScreen,
   AnnouncementsScreen,
   AuthFlow,
   BuildingsScreen,
@@ -57,6 +58,7 @@ type Screen =
   | 'Faults'
   | 'ReportFault'
   | 'Announcements'
+  | 'AnnouncementDetail'
   | 'Voting'
   | 'VoteDetail'
   | 'Documents'
@@ -132,6 +134,13 @@ function MainApp() {
         );
       case 'Announcements':
         return <AnnouncementsScreen onNavigate={handleNavigate} />;
+      case 'AnnouncementDetail':
+        return (
+          <AnnouncementDetailScreen
+            announcementId={(screenParams?.announcementId as string | undefined) ?? ''}
+            onBack={() => handleNavigate('Announcements')}
+          />
+        );
       case 'Voting':
         return <VotingScreen onNavigate={handleNavigate} />;
       case 'VoteDetail':

--- a/frontend/apps/mobile/src/App.tsx
+++ b/frontend/apps/mobile/src/App.tsx
@@ -134,13 +134,19 @@ function MainApp() {
         );
       case 'Announcements':
         return <AnnouncementsScreen onNavigate={handleNavigate} />;
-      case 'AnnouncementDetail':
+      case 'AnnouncementDetail': {
+        const announcementId = screenParams?.announcementId as string | undefined;
+        if (!announcementId) {
+          handleNavigate('Announcements');
+          return null;
+        }
         return (
           <AnnouncementDetailScreen
-            announcementId={(screenParams?.announcementId as string | undefined) ?? ''}
+            announcementId={announcementId}
             onBack={() => handleNavigate('Announcements')}
           />
         );
+      }
       case 'Voting':
         return <VotingScreen onNavigate={handleNavigate} />;
       case 'VoteDetail':

--- a/frontend/apps/mobile/src/locales/cs.json
+++ b/frontend/apps/mobile/src/locales/cs.json
@@ -325,7 +325,8 @@
       "ackRequired": "Toto oznameni vyzaduje vase potvrzeni.",
       "ackButton": "Potvrdit",
       "ackDone": "Toto oznameni jste potvrdili.",
-      "ackError": "Nepodarilo se potvrdit: {{message}}"
+      "ackError": "Nepodarilo se potvrdit: {{message}}",
+      "publishedAt": "Zverejneno: {{date}}"
     }
   },
   "widgets": {

--- a/frontend/apps/mobile/src/locales/cs.json
+++ b/frontend/apps/mobile/src/locales/cs.json
@@ -313,7 +313,20 @@
     "empty": "Zadna oznameni",
     "emptyMessage": "Podivejte se pozdeji na aktuality",
     "pinned": "Pripnuto",
-    "by": "Od {author}"
+    "by": "Od {author}",
+    "detail": {
+      "loadError": "Nepodarilo se nacist oznameni",
+      "backToList": "← Oznameni",
+      "back": "← Zpet",
+      "attachments": "Prilohy",
+      "reads": "precteno",
+      "acknowledged": "potvrzeno",
+      "comments": "komentare",
+      "ackRequired": "Toto oznameni vyzaduje vase potvrzeni.",
+      "ackButton": "Potvrdit",
+      "ackDone": "Toto oznameni jste potvrdili.",
+      "ackError": "Nepodarilo se potvrdit: {{message}}"
+    }
   },
   "widgets": {
     "addedTitle": "Widget pridan",

--- a/frontend/apps/mobile/src/locales/de.json
+++ b/frontend/apps/mobile/src/locales/de.json
@@ -267,7 +267,20 @@
     "empty": "Keine Ankundigungen",
     "emptyMessage": "Schauen Sie spater fur Updates vorbei",
     "pinned": "Angepinnt",
-    "by": "Von {author}"
+    "by": "Von {author}",
+    "detail": {
+      "loadError": "Ankundigung konnte nicht geladen werden",
+      "backToList": "← Ankundigungen",
+      "back": "← Zuruck",
+      "attachments": "Anhange",
+      "reads": "gelesen",
+      "acknowledged": "bestatigt",
+      "comments": "Kommentare",
+      "ackRequired": "Diese Ankundigung erfordert Ihre Bestatigung.",
+      "ackButton": "Bestatigen",
+      "ackDone": "Sie haben diese Ankundigung bestatigt.",
+      "ackError": "Bestatigung fehlgeschlagen: {{message}}"
+    }
   },
   "widgets": {
     "addedTitle": "Widget hinzugefugt",

--- a/frontend/apps/mobile/src/locales/de.json
+++ b/frontend/apps/mobile/src/locales/de.json
@@ -279,7 +279,8 @@
       "ackRequired": "Diese Ankundigung erfordert Ihre Bestatigung.",
       "ackButton": "Bestatigen",
       "ackDone": "Sie haben diese Ankundigung bestatigt.",
-      "ackError": "Bestatigung fehlgeschlagen: {{message}}"
+      "ackError": "Bestatigung fehlgeschlagen: {{message}}",
+      "publishedAt": "Veroffentlicht: {{date}}"
     }
   },
   "widgets": {

--- a/frontend/apps/mobile/src/locales/en.json
+++ b/frontend/apps/mobile/src/locales/en.json
@@ -313,7 +313,20 @@
     "empty": "No announcements",
     "emptyMessage": "Check back later for updates",
     "pinned": "Pinned",
-    "by": "By {author}"
+    "by": "By {author}",
+    "detail": {
+      "loadError": "Couldn't load announcement",
+      "backToList": "← Announcements",
+      "back": "← Back",
+      "attachments": "Attachments",
+      "reads": "reads",
+      "acknowledged": "acknowledged",
+      "comments": "comments",
+      "ackRequired": "This announcement requires your acknowledgment.",
+      "ackButton": "Acknowledge",
+      "ackDone": "You have acknowledged this announcement.",
+      "ackError": "Failed to acknowledge: {{message}}"
+    }
   },
   "widgets": {
     "addedTitle": "Widget Added",

--- a/frontend/apps/mobile/src/locales/en.json
+++ b/frontend/apps/mobile/src/locales/en.json
@@ -325,7 +325,8 @@
       "ackRequired": "This announcement requires your acknowledgment.",
       "ackButton": "Acknowledge",
       "ackDone": "You have acknowledged this announcement.",
-      "ackError": "Failed to acknowledge: {{message}}"
+      "ackError": "Failed to acknowledge: {{message}}",
+      "publishedAt": "Published: {{date}}"
     }
   },
   "widgets": {

--- a/frontend/apps/mobile/src/locales/hu.json
+++ b/frontend/apps/mobile/src/locales/hu.json
@@ -267,7 +267,20 @@
     "empty": "Nincsenek kozlemenyek",
     "emptyMessage": "Nezzen vissza kesobb a frissitesekert",
     "pinned": "Kituzott",
-    "by": "{author} altal"
+    "by": "{author} altal",
+    "detail": {
+      "loadError": "A kozlemeny nem toltheto be",
+      "backToList": "← Kozlemenyek",
+      "back": "← Vissza",
+      "attachments": "Mellekeletek",
+      "reads": "olvasva",
+      "acknowledged": "visszajelzett",
+      "comments": "hozzaszolasok",
+      "ackRequired": "Ez a kozlemeny visszaigazolast igenyel.",
+      "ackButton": "Visszaigazolas",
+      "ackDone": "Visszaigazolta ezt a kozlemenyt.",
+      "ackError": "A visszaigazolas sikertelen: {{message}}"
+    }
   },
   "widgets": {
     "addedTitle": "Widget hozzaadva",

--- a/frontend/apps/mobile/src/locales/hu.json
+++ b/frontend/apps/mobile/src/locales/hu.json
@@ -279,7 +279,8 @@
       "ackRequired": "Ez a kozlemeny visszaigazolast igenyel.",
       "ackButton": "Visszaigazolas",
       "ackDone": "Visszaigazolta ezt a kozlemenyt.",
-      "ackError": "A visszaigazolas sikertelen: {{message}}"
+      "ackError": "A visszaigazolas sikertelen: {{message}}",
+      "publishedAt": "Kozzeteve: {{date}}"
     }
   },
   "widgets": {

--- a/frontend/apps/mobile/src/locales/pl.json
+++ b/frontend/apps/mobile/src/locales/pl.json
@@ -267,7 +267,20 @@
     "empty": "Brak ogloszen",
     "emptyMessage": "Sprawdz pozniej, czy sa aktualizacje",
     "pinned": "Przypiete",
-    "by": "Przez {author}"
+    "by": "Przez {author}",
+    "detail": {
+      "loadError": "Nie mozna zaladowac ogloszenia",
+      "backToList": "← Ogloszenia",
+      "back": "← Powrot",
+      "attachments": "Zalaczniki",
+      "reads": "odczytano",
+      "acknowledged": "potwierdzono",
+      "comments": "komentarze",
+      "ackRequired": "To ogloszenie wymaga potwierdzenia.",
+      "ackButton": "Potwierdz",
+      "ackDone": "Potwierdzono to ogloszenie.",
+      "ackError": "Blad potwierdzenia: {{message}}"
+    }
   },
   "widgets": {
     "addedTitle": "Widget dodany",

--- a/frontend/apps/mobile/src/locales/pl.json
+++ b/frontend/apps/mobile/src/locales/pl.json
@@ -279,7 +279,8 @@
       "ackRequired": "To ogloszenie wymaga potwierdzenia.",
       "ackButton": "Potwierdz",
       "ackDone": "Potwierdzono to ogloszenie.",
-      "ackError": "Blad potwierdzenia: {{message}}"
+      "ackError": "Blad potwierdzenia: {{message}}",
+      "publishedAt": "Opublikowano: {{date}}"
     }
   },
   "widgets": {

--- a/frontend/apps/mobile/src/locales/sk.json
+++ b/frontend/apps/mobile/src/locales/sk.json
@@ -313,7 +313,20 @@
     "empty": "Ziadne oznamenia",
     "emptyMessage": "Pozrite sa neskor pre aktuality",
     "pinned": "Pripnute",
-    "by": "Od {author}"
+    "by": "Od {author}",
+    "detail": {
+      "loadError": "Nepodarilo sa nacitat oznamenie",
+      "backToList": "← Oznamenia",
+      "back": "← Spat",
+      "attachments": "Prilohy",
+      "reads": "precitane",
+      "acknowledged": "potvrdene",
+      "comments": "komentare",
+      "ackRequired": "Toto oznamenie vyzaduje vas potvrdenie.",
+      "ackButton": "Potvrdit",
+      "ackDone": "Toto oznamenie ste potvrdili.",
+      "ackError": "Nepodarilo sa potvrdit: {{message}}"
+    }
   },
   "widgets": {
     "addedTitle": "Widget pridany",

--- a/frontend/apps/mobile/src/locales/sk.json
+++ b/frontend/apps/mobile/src/locales/sk.json
@@ -325,7 +325,8 @@
       "ackRequired": "Toto oznamenie vyzaduje vas potvrdenie.",
       "ackButton": "Potvrdit",
       "ackDone": "Toto oznamenie ste potvrdili.",
-      "ackError": "Nepodarilo sa potvrdit: {{message}}"
+      "ackError": "Nepodarilo sa potvrdit: {{message}}",
+      "publishedAt": "Zverejnene: {{date}}"
     }
   },
   "widgets": {

--- a/frontend/apps/mobile/src/screens/announcements/AnnouncementDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/announcements/AnnouncementDetailScreen.tsx
@@ -17,6 +17,7 @@
 
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { apiRequest, useApiMutation, useApiQuery } from '../../hooks/useApi';
 import { colors } from '../shared/screenStyles';
@@ -70,6 +71,7 @@ export function AnnouncementDetailScreen({
   onBack,
 }: AnnouncementDetailScreenProps) {
   const queryClient = useQueryClient();
+  const { t, i18n } = useTranslation();
   const markReadFired = useRef(false);
 
   // Fetch announcement detail
@@ -87,7 +89,6 @@ export function AnnouncementDetailScreen({
 
   // Fire mark-read on first render.
   // Guard ref prevents double-fire on StrictMode or re-mount.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: markReadFired ref excluded intentionally
   useEffect(() => {
     if (!markReadFired.current) {
       markReadFired.current = true;
@@ -115,7 +116,7 @@ export function AnnouncementDetailScreen({
 
   const formatDate = (dateString?: string | null): string => {
     if (!dateString) return '';
-    return new Date(dateString).toLocaleDateString('en-US', {
+    return new Date(dateString).toLocaleDateString(i18n.language, {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
@@ -132,7 +133,7 @@ export function AnnouncementDetailScreen({
     return (
       <View style={styles.center}>
         <ActivityIndicator size="large" color={colors.accent} />
-        <Text style={styles.loadingText}>Loading…</Text>
+        <Text style={styles.loadingText}>{t('common.loading')}</Text>
       </View>
     );
   }
@@ -141,11 +142,11 @@ export function AnnouncementDetailScreen({
     return (
       <View style={styles.container}>
         <Pressable style={styles.backButton} onPress={onBack}>
-          <Text style={styles.backButtonText}>← Back</Text>
+          <Text style={styles.backButtonText}>{t('announcements.detail.back')}</Text>
         </Pressable>
         <View style={styles.center}>
-          <Text style={styles.errorTitle}>Couldn't load announcement</Text>
-          <Text style={styles.errorText}>{error?.message ?? 'Unknown error'}</Text>
+          <Text style={styles.errorTitle}>{t('announcements.detail.loadError')}</Text>
+          <Text style={styles.errorText}>{error?.message ?? t('errors.unknown')}</Text>
         </View>
       </View>
     );
@@ -157,7 +158,7 @@ export function AnnouncementDetailScreen({
   return (
     <View style={styles.container}>
       <Pressable style={styles.backButton} onPress={onBack}>
-        <Text style={styles.backButtonText}>← Announcements</Text>
+        <Text style={styles.backButtonText}>{t('announcements.detail.backToList')}</Text>
       </Pressable>
 
       <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent}>
@@ -166,7 +167,7 @@ export function AnnouncementDetailScreen({
           <View style={styles.badgeRow}>
             {announcement.pinned ? (
               <View style={styles.pinnedBadge}>
-                <Text style={styles.pinnedBadgeText}>Pinned</Text>
+                <Text style={styles.pinnedBadgeText}>{t('announcements.pinned')}</Text>
               </View>
             ) : null}
             <View style={[styles.statusPill, statusPillStyle(announcement.status)]}>
@@ -180,7 +181,9 @@ export function AnnouncementDetailScreen({
 
           <View style={styles.metaRow}>
             {announcement.author_name ? (
-              <Text style={styles.metaText}>By {announcement.author_name}</Text>
+              <Text style={styles.metaText}>
+                {t('announcements.by', { author: announcement.author_name })}
+              </Text>
             ) : null}
             {announcement.published_at ? (
               <Text style={styles.metaText}>
@@ -192,17 +195,19 @@ export function AnnouncementDetailScreen({
           {/* Stats row */}
           <View style={styles.statsRow}>
             <Text style={styles.statItem}>
-              <Text style={styles.statNumber}>{announcement.read_count}</Text> reads
+              <Text style={styles.statNumber}>{announcement.read_count}</Text>{' '}
+              {t('announcements.detail.reads')}
             </Text>
             {announcement.acknowledgment_required ? (
               <Text style={styles.statItem}>
                 <Text style={styles.statNumber}>{announcement.acknowledged_count}</Text>{' '}
-                acknowledged
+                {t('announcements.detail.acknowledged')}
               </Text>
             ) : null}
             {announcement.comments_enabled ? (
               <Text style={styles.statItem}>
-                <Text style={styles.statNumber}>{announcement.comment_count}</Text> comments
+                <Text style={styles.statNumber}>{announcement.comment_count}</Text>{' '}
+                {t('announcements.detail.comments')}
               </Text>
             ) : null}
           </View>
@@ -216,7 +221,7 @@ export function AnnouncementDetailScreen({
         {/* Attachments */}
         {attachments.length > 0 ? (
           <View style={styles.card}>
-            <Text style={styles.sectionTitle}>Attachments</Text>
+            <Text style={styles.sectionTitle}>{t('announcements.detail.attachments')}</Text>
             {attachments.map((att) => (
               <View key={att.id} style={styles.attachmentRow}>
                 <Text style={styles.attachmentName}>{att.file_name}</Text>
@@ -229,10 +234,10 @@ export function AnnouncementDetailScreen({
         {/* Acknowledge button */}
         {announcement.acknowledgment_required ? (
           <View style={styles.ackCard}>
-            <Text style={styles.ackLabel}>This announcement requires your acknowledgment.</Text>
+            <Text style={styles.ackLabel}>{t('announcements.detail.ackRequired')}</Text>
             {ackDone ? (
               <View style={styles.ackDoneBanner}>
-                <Text style={styles.ackDoneText}>You have acknowledged this announcement.</Text>
+                <Text style={styles.ackDoneText}>{t('announcements.detail.ackDone')}</Text>
               </View>
             ) : (
               <Pressable
@@ -243,13 +248,15 @@ export function AnnouncementDetailScreen({
                 {acknowledge.isPending ? (
                   <ActivityIndicator size="small" color={colors.surface} />
                 ) : (
-                  <Text style={styles.ackButtonText}>Acknowledge</Text>
+                  <Text style={styles.ackButtonText}>{t('announcements.detail.ackButton')}</Text>
                 )}
               </Pressable>
             )}
             {acknowledge.isError ? (
               <Text style={styles.ackError}>
-                Failed to acknowledge: {acknowledge.error?.message ?? 'Unknown error'}
+                {t('announcements.detail.ackError', {
+                  message: acknowledge.error?.message ?? t('errors.unknown'),
+                })}
               </Text>
             ) : null}
           </View>

--- a/frontend/apps/mobile/src/screens/announcements/AnnouncementDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/announcements/AnnouncementDetailScreen.tsx
@@ -187,7 +187,9 @@ export function AnnouncementDetailScreen({
             ) : null}
             {announcement.published_at ? (
               <Text style={styles.metaText}>
-                Published: {formatDate(announcement.published_at)}
+                {t('announcements.detail.publishedAt', {
+                  date: formatDate(announcement.published_at),
+                })}
               </Text>
             ) : null}
           </View>

--- a/frontend/apps/mobile/src/screens/announcements/AnnouncementDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/announcements/AnnouncementDetailScreen.tsx
@@ -1,0 +1,516 @@
+/**
+ * AnnouncementDetailScreen — Story 6.2 read-receipt & acknowledgment flow (mobile).
+ *
+ * On mount:
+ *   1. Fetches full announcement detail via GET /api/v1/announcements/{id}
+ *   2. Fires a fire-and-forget POST /api/v1/announcements/{id}/read so the
+ *      backend persists the per-user read state (idempotent upsert).
+ *
+ * Retry: TanStack Query default retry (3 attempts, exponential back-off) covers
+ * transient network failures for the GET. The mark-read call uses apiRequest
+ * directly and silently ignores transient failures — read-receipt is best-effort.
+ *
+ * Acknowledgment: shown only when `acknowledgment_required` is true.
+ * Calls POST /api/v1/announcements/{id}/acknowledge and disables the button
+ * on success so the user cannot double-submit.
+ */
+
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
+import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { apiRequest, useApiMutation, useApiQuery } from '../../hooks/useApi';
+import { colors } from '../shared/screenStyles';
+
+// ─── API shapes ──────────────────────────────────────────────────────────────
+
+interface AnnouncementDetail {
+  id: string;
+  title: string;
+  content: string;
+  status: string;
+  pinned: boolean;
+  acknowledgment_required: boolean;
+  comments_enabled: boolean;
+  published_at?: string | null;
+  created_at: string;
+  read_count: number;
+  acknowledged_count: number;
+  comment_count: number;
+  author_name?: string;
+  target_type: string;
+}
+
+interface AnnouncementAttachment {
+  id: string;
+  file_name: string;
+  file_type: string;
+  file_size: number;
+}
+
+interface AnnouncementDetailResponse {
+  announcement: AnnouncementDetail;
+  attachments: AnnouncementAttachment[];
+}
+
+// ─── Query key factory ────────────────────────────────────────────────────────
+
+export const announcementDetailKey = (id: string) => ['announcements', 'detail', id] as const;
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface AnnouncementDetailScreenProps {
+  announcementId: string;
+  onBack: () => void;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function AnnouncementDetailScreen({
+  announcementId,
+  onBack,
+}: AnnouncementDetailScreenProps) {
+  const queryClient = useQueryClient();
+  const markReadFired = useRef(false);
+
+  // Fetch announcement detail
+  const { data, isLoading, error } = useApiQuery<AnnouncementDetailResponse>(
+    announcementDetailKey(announcementId),
+    `/api/v1/announcements/${announcementId}`,
+    { staleTime: 60_000 }
+  );
+
+  // Acknowledge mutation
+  const acknowledge = useApiMutation<void, void>(
+    `/api/v1/announcements/${announcementId}/acknowledge`,
+    'POST'
+  );
+
+  // Fire mark-read on first render.
+  // Guard ref prevents double-fire on StrictMode or re-mount.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: markReadFired ref excluded intentionally
+  useEffect(() => {
+    if (!markReadFired.current) {
+      markReadFired.current = true;
+      // Fire-and-forget — UI is not blocked by read-receipt.
+      // Silently ignores failures; the user can still read the announcement.
+      apiRequest<void>(`/api/v1/announcements/${announcementId}/read`, { method: 'POST' })
+        .then(() => {
+          queryClient.invalidateQueries({ queryKey: ['announcements', 'unread-count'] });
+          queryClient.invalidateQueries({ queryKey: ['announcements', 'list'] });
+        })
+        .catch(() => {
+          // best-effort — no blocking UX failure on missed read-receipt
+        });
+    }
+  }, [announcementId, queryClient]);
+
+  const handleAcknowledge = () => {
+    acknowledge.mutate(undefined, {
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: announcementDetailKey(announcementId) });
+        queryClient.invalidateQueries({ queryKey: ['announcements', 'list'] });
+      },
+    });
+  };
+
+  const formatDate = (dateString?: string | null): string => {
+    if (!dateString) return '';
+    return new Date(dateString).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  };
+
+  const formatFileSize = (bytes: number): string => {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  };
+
+  if (isLoading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" color={colors.accent} />
+        <Text style={styles.loadingText}>Loading…</Text>
+      </View>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <View style={styles.container}>
+        <Pressable style={styles.backButton} onPress={onBack}>
+          <Text style={styles.backButtonText}>← Back</Text>
+        </Pressable>
+        <View style={styles.center}>
+          <Text style={styles.errorTitle}>Couldn't load announcement</Text>
+          <Text style={styles.errorText}>{error?.message ?? 'Unknown error'}</Text>
+        </View>
+      </View>
+    );
+  }
+
+  const { announcement, attachments } = data;
+  const ackDone = acknowledge.isSuccess;
+
+  return (
+    <View style={styles.container}>
+      <Pressable style={styles.backButton} onPress={onBack}>
+        <Text style={styles.backButtonText}>← Announcements</Text>
+      </Pressable>
+
+      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent}>
+        {/* Header card */}
+        <View style={styles.headerCard}>
+          <View style={styles.badgeRow}>
+            {announcement.pinned ? (
+              <View style={styles.pinnedBadge}>
+                <Text style={styles.pinnedBadgeText}>Pinned</Text>
+              </View>
+            ) : null}
+            <View style={[styles.statusPill, statusPillStyle(announcement.status)]}>
+              <Text style={[styles.statusPillText, statusPillTextStyle(announcement.status)]}>
+                {announcement.status.charAt(0).toUpperCase() + announcement.status.slice(1)}
+              </Text>
+            </View>
+          </View>
+
+          <Text style={styles.title}>{announcement.title}</Text>
+
+          <View style={styles.metaRow}>
+            {announcement.author_name ? (
+              <Text style={styles.metaText}>By {announcement.author_name}</Text>
+            ) : null}
+            {announcement.published_at ? (
+              <Text style={styles.metaText}>
+                Published: {formatDate(announcement.published_at)}
+              </Text>
+            ) : null}
+          </View>
+
+          {/* Stats row */}
+          <View style={styles.statsRow}>
+            <Text style={styles.statItem}>
+              <Text style={styles.statNumber}>{announcement.read_count}</Text> reads
+            </Text>
+            {announcement.acknowledgment_required ? (
+              <Text style={styles.statItem}>
+                <Text style={styles.statNumber}>{announcement.acknowledged_count}</Text>{' '}
+                acknowledged
+              </Text>
+            ) : null}
+            {announcement.comments_enabled ? (
+              <Text style={styles.statItem}>
+                <Text style={styles.statNumber}>{announcement.comment_count}</Text> comments
+              </Text>
+            ) : null}
+          </View>
+        </View>
+
+        {/* Body */}
+        <View style={styles.bodyCard}>
+          <Text style={styles.bodyText}>{announcement.content}</Text>
+        </View>
+
+        {/* Attachments */}
+        {attachments.length > 0 ? (
+          <View style={styles.card}>
+            <Text style={styles.sectionTitle}>Attachments</Text>
+            {attachments.map((att) => (
+              <View key={att.id} style={styles.attachmentRow}>
+                <Text style={styles.attachmentName}>{att.file_name}</Text>
+                <Text style={styles.attachmentSize}>{formatFileSize(att.file_size)}</Text>
+              </View>
+            ))}
+          </View>
+        ) : null}
+
+        {/* Acknowledge button */}
+        {announcement.acknowledgment_required ? (
+          <View style={styles.ackCard}>
+            <Text style={styles.ackLabel}>This announcement requires your acknowledgment.</Text>
+            {ackDone ? (
+              <View style={styles.ackDoneBanner}>
+                <Text style={styles.ackDoneText}>You have acknowledged this announcement.</Text>
+              </View>
+            ) : (
+              <Pressable
+                style={[styles.ackButton, acknowledge.isPending && styles.ackButtonDisabled]}
+                onPress={handleAcknowledge}
+                disabled={acknowledge.isPending}
+              >
+                {acknowledge.isPending ? (
+                  <ActivityIndicator size="small" color={colors.surface} />
+                ) : (
+                  <Text style={styles.ackButtonText}>Acknowledge</Text>
+                )}
+              </Pressable>
+            )}
+            {acknowledge.isError ? (
+              <Text style={styles.ackError}>
+                Failed to acknowledge: {acknowledge.error?.message ?? 'Unknown error'}
+              </Text>
+            ) : null}
+          </View>
+        ) : null}
+
+        <View style={styles.bottomSpacer} />
+      </ScrollView>
+    </View>
+  );
+}
+
+// ─── Status pill helpers ──────────────────────────────────────────────────────
+
+function statusPillStyle(status: string): object {
+  switch (status) {
+    case 'published':
+      return { backgroundColor: colors.successBg };
+    case 'draft':
+      return { backgroundColor: colors.surfaceMuted };
+    case 'scheduled':
+      return { backgroundColor: colors.infoBg };
+    default:
+      return { backgroundColor: colors.surfaceMuted };
+  }
+}
+
+function statusPillTextStyle(status: string): object {
+  switch (status) {
+    case 'published':
+      return { color: colors.successDark };
+    case 'draft':
+      return { color: colors.textMuted };
+    case 'scheduled':
+      return { color: colors.info };
+    default:
+      return { color: colors.textMuted };
+  }
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  loadingText: {
+    marginTop: 12,
+    fontSize: 14,
+    color: colors.textMuted,
+  },
+  errorTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: colors.textSecondary,
+    marginBottom: 4,
+  },
+  errorText: {
+    fontSize: 14,
+    color: colors.textMuted,
+    textAlign: 'center',
+  },
+  backButton: {
+    paddingHorizontal: 20,
+    paddingTop: 56,
+    paddingBottom: 12,
+    backgroundColor: colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  backButtonText: {
+    fontSize: 15,
+    color: colors.accent,
+    fontWeight: '500',
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: 16,
+    gap: 12,
+  },
+  headerCard: {
+    backgroundColor: colors.surface,
+    borderRadius: 12,
+    padding: 20,
+    shadowColor: colors.shadow,
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 2,
+    elevation: 1,
+  },
+  badgeRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginBottom: 12,
+    flexWrap: 'wrap',
+  },
+  pinnedBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 4,
+    backgroundColor: colors.warningBg,
+  },
+  pinnedBadgeText: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: colors.warningInk,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  statusPill: {
+    paddingHorizontal: 10,
+    paddingVertical: 3,
+    borderRadius: 4,
+  },
+  statusPillText: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.text,
+    marginBottom: 10,
+    lineHeight: 28,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12,
+    marginBottom: 12,
+  },
+  metaText: {
+    fontSize: 13,
+    color: colors.textMuted,
+  },
+  statsRow: {
+    flexDirection: 'row',
+    gap: 16,
+    borderTopWidth: 1,
+    borderTopColor: colors.divider,
+    paddingTop: 12,
+    flexWrap: 'wrap',
+  },
+  statItem: {
+    fontSize: 13,
+    color: colors.textMuted,
+  },
+  statNumber: {
+    fontWeight: '700',
+    color: colors.text,
+  },
+  bodyCard: {
+    backgroundColor: colors.surface,
+    borderRadius: 12,
+    padding: 20,
+    shadowColor: colors.shadow,
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 2,
+    elevation: 1,
+  },
+  bodyText: {
+    fontSize: 15,
+    color: colors.text,
+    lineHeight: 24,
+  },
+  card: {
+    backgroundColor: colors.surface,
+    borderRadius: 12,
+    padding: 20,
+    shadowColor: colors.shadow,
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 2,
+    elevation: 1,
+  },
+  sectionTitle: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: 12,
+  },
+  attachmentRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 8,
+    borderTopWidth: 1,
+    borderTopColor: colors.divider,
+  },
+  attachmentName: {
+    fontSize: 14,
+    color: colors.text,
+    flex: 1,
+    marginRight: 12,
+  },
+  attachmentSize: {
+    fontSize: 12,
+    color: colors.textMuted,
+  },
+  ackCard: {
+    backgroundColor: colors.surface,
+    borderRadius: 12,
+    padding: 20,
+    borderWidth: 1,
+    borderColor: colors.warning,
+    shadowColor: colors.shadow,
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 2,
+    elevation: 1,
+  },
+  ackLabel: {
+    fontSize: 14,
+    color: colors.textSecondary,
+    marginBottom: 16,
+    lineHeight: 20,
+  },
+  ackButton: {
+    backgroundColor: colors.accent,
+    borderRadius: 8,
+    paddingVertical: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 48,
+  },
+  ackButtonDisabled: {
+    backgroundColor: colors.accentDisabled,
+  },
+  ackButtonText: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: colors.surface,
+  },
+  ackDoneBanner: {
+    backgroundColor: colors.successBg,
+    borderRadius: 8,
+    padding: 14,
+    alignItems: 'center',
+  },
+  ackDoneText: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: colors.successDark,
+  },
+  ackError: {
+    marginTop: 8,
+    fontSize: 12,
+    color: colors.danger,
+  },
+  bottomSpacer: {
+    height: 32,
+  },
+});

--- a/frontend/apps/mobile/src/screens/announcements/index.ts
+++ b/frontend/apps/mobile/src/screens/announcements/index.ts
@@ -1,3 +1,4 @@
+export { AnnouncementDetailScreen } from './AnnouncementDetailScreen';
 export type {
   Announcement,
   AnnouncementAttachment,

--- a/frontend/apps/mobile/src/screens/index.ts
+++ b/frontend/apps/mobile/src/screens/index.ts
@@ -1,7 +1,7 @@
 // Auth screens (UC-14)
 
 export type { Announcement, AnnouncementAttachment, AnnouncementCategory } from './announcements';
-export { AnnouncementsScreen } from './announcements';
+export { AnnouncementDetailScreen, AnnouncementsScreen } from './announcements';
 export {
   AuthFlow,
   ForgotPasswordScreen,

--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -50,7 +50,7 @@ import {
   useUpdateSchedule,
 } from '@ppt/api-client';
 import { AccessibilityProvider, SkipNavigation } from '@ppt/ui-kit';
-import { type ReactNode, Suspense, useCallback, useEffect, useState } from 'react';
+import { type ReactNode, Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   BrowserRouter,
@@ -1683,6 +1683,9 @@ function ViewAnnouncementPageInner({ announcementId }: { announcementId: string 
   const { t } = useTranslation();
   const { user } = useAuth();
 
+  // Guard ref: fire mark-read exactly once per announcement view, even in StrictMode.
+  const autoMarkReadFired = useRef(false);
+
   const { data, isLoading, error } = useAnnouncement(announcementId);
   const markRead = useMarkReadAnnouncement();
   const acknowledge = useAcknowledgeAnnouncement();
@@ -1716,6 +1719,21 @@ function ViewAnnouncementPageInner({ announcementId }: { announcementId: string 
       });
     }
   }, [error, showToast, t]);
+
+  // Story 6.2: auto-fire read-receipt when announcement loads.
+  // Fire-and-forget — the user shouldn't have to click "Mark as Read".
+  // The mutation is idempotent (upsert on server), so double-firing is safe.
+  // Retry is handled by TanStack Mutation default (3 attempts, exponential back-off).
+  // markRead.mutate is intentionally excluded from deps — including a new mutate
+  // instance on each render would cause an infinite loop; the ref guard ensures
+  // the call fires exactly once per viewed announcement.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: markRead.mutate excluded intentionally (see comment)
+  useEffect(() => {
+    if (data?.announcement && !autoMarkReadFired.current) {
+      autoMarkReadFired.current = true;
+      markRead.mutate(announcementId);
+    }
+  }, [data?.announcement, announcementId]);
 
   const announcement = data?.announcement;
   const attachments = data?.attachments ?? [];

--- a/frontend/packages/api-client/src/announcements/hooks.ts
+++ b/frontend/packages/api-client/src/announcements/hooks.ts
@@ -468,6 +468,8 @@ export function useMarkReadAnnouncement() {
     onSuccess: (_data, id) => {
       queryClient.invalidateQueries({ queryKey: announcementKeys.detail(id) });
       queryClient.invalidateQueries({ queryKey: announcementKeys.unreadCount() });
+      // Invalidate list cache so unread badges update immediately (Story 6.2 fix)
+      queryClient.invalidateQueries({ queryKey: announcementKeys.lists() });
     },
   });
 }


### PR DESCRIPTION
## Task

Wire read-receipt and acknowledgment flow for announcements in ppt-web and RN mobile; PUT /api/v1/announcements/{id}/read; persist per-user read state; retry of failed gap-6-2-announcement-read-receipt

## Owner

pm-frontend

## Changes

### ppt-web (ViewAnnouncementPageInner in App.tsx)
- Added `useRef` import for `autoMarkReadFired` guard
- Added `useEffect` that auto-fires `markRead.mutate(announcementId)` on first render when announcement data loads (fire-and-forget, ref guard prevents StrictMode double-fire, idempotent server-side upsert)
- Existing manual "Mark as Read" button remains as retry surface
- Acknowledge button already wired (gap-6-2 original work); no changes needed

### mobile (new: AnnouncementDetailScreen)
- Created `frontend/apps/mobile/src/screens/announcements/AnnouncementDetailScreen.tsx`
  - Fetches detail via GET /api/v1/announcements/{id}
  - Fires POST /api/v1/announcements/{id}/read on mount (fire-and-forget, ref guard)
  - Invalidates `['announcements', 'unread-count']` and `['announcements', 'list']` cache on success
  - Shows Acknowledge button when `acknowledgment_required = true`; disabled after success
  - Error state with back navigation; loading spinner
- Exported from `announcements/index.ts` and main `screens/index.ts`
- Wired in `App.tsx`: added `'AnnouncementDetail'` to `Screen` type union; added `case 'AnnouncementDetail'` in `renderScreen()` consuming `screenParams.announcementId`
- `AnnouncementsScreen.handleCardPress` already navigates to `'AnnouncementDetail'` (from earlier work) — now there's a screen to land on

## Backend note

Task spec says `PUT /api/v1/announcements/{id}/read` but the backend router only registers `post(mark_read)` at that path. Frontend uses POST to match the backend. A backend story should add PUT as an alias if the spec requires idempotent semantics via PUT.

## Tested (Band A — fast check)

```
pnpm -F ppt-web typecheck → exit 0
pnpm -F mobile typecheck  → exit 0
pnpm check (biome)        → 0 errors, 16 warnings (all pre-existing in other files)
```

## Built (Band B — full build)

```
pnpm -F ppt-web build → ✓ built in 6.57s, exit 0
mobile: typecheck pass (expo prebuild not run — no native toolchain in env)
```

## CI parity (Band C — hot-path only)

Skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested

Skipped: ppt-bridge MCP not connected.

## Scope drift

None — all changes are in `frontend/` and `docs/screens/`. scope-check.sh exit 0.

## Code-reuse review

None — no new auth/crypto/http-client helpers added. reuse-grep.sh returned empty.

https://claude.ai/code/session_017utVQcLRcgUFofhZd6M2Fb

---
_Generated by [Claude Code](https://claude.ai/code/session_017utVQcLRcgUFofhZd6M2Fb)_