### PR TITLE
gap-84-2-esignature-ui-fixes: PR#513 reviewer fixes — i18n keys + confirm all 6 issues resolved

### DIFF
--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -52,7 +52,8 @@
     "selectOrganization": "Please select an organization",
     "unknown": "Unknown",
     "expand": "Expand",
-    "collapse": "Collapse"
+    "collapse": "Collapse",
+    "unknownError": "An error occurred. Please try again."
   },
   "nav": {
     "home": "Home",
@@ -2567,6 +2568,30 @@
           "dateRequired": "Please provide the date of the violation",
           "dateInFuture": "Violation date cannot be in the future"
         }
+      }
+    },
+    "esign": {
+      "requestSignature": "Request Signature",
+      "modal": {
+        "title": "Request Signature",
+        "selectSigners": "Select signers",
+        "subject": "Subject (optional)",
+        "subjectPlaceholder": "e.g. Lease Agreement Signing",
+        "message": "Message to signers (optional)",
+        "messagePlaceholder": "Please review and sign the attached lease agreement.",
+        "sending": "Sending…",
+        "send": "Send for Signature"
+      },
+      "role": {
+        "tenant": "Tenant"
+      },
+      "status": {
+        "pending": "Pending Signature",
+        "in_progress": "Signing In Progress",
+        "completed": "Signed",
+        "declined": "Declined",
+        "expired": "Expired",
+        "cancelled": "Cancelled"
       }
     }
   },

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -39,7 +39,8 @@
     "copied": "Skopírované",
     "copyErrorMessage": "Kopírovať chybovú správu",
     "dismissNotification": "Zavrieť oznámenie",
-    "notifications": "Oznámenia"
+    "notifications": "Oznámenia",
+    "unknownError": "Nastala chyba. Prosím skúste znova."
   },
   "nav": {
     "home": "Domov",
@@ -223,7 +224,6 @@
     "selectUnit": "Vyberte jednotku pre tento spor.",
     "multipleRespondents": "Viacerí odporcovia",
     "multipleRespondentsMsg": "Zaznamenaný bude iba prvý odporca.",
-
     "mediation": {
       "title": "Mediation Workspace",
       "backToDispute": "← Back to Dispute",
@@ -743,6 +743,32 @@
       "downloadFailed": "Nepodarilo sa stiahnuť správu.",
       "retryQueued": "Spustenie bolo zaradené do frontu na opakovanie.",
       "retryFailed": "Nepodarilo sa opakovať spustenie."
+    }
+  },
+  "leases": {
+    "esign": {
+      "requestSignature": "Žiadosť o podpis",
+      "modal": {
+        "title": "Žiadosť o podpis",
+        "selectSigners": "Vyberte podpisovateľov",
+        "subject": "Predmet (voliťeľné)",
+        "subjectPlaceholder": "napr. Podpis nájomnej zmluvy",
+        "message": "Správa pre podpisovateľov (voliťeľné)",
+        "messagePlaceholder": "Prosím, prečítajte si a podpíšte priloženú nájomnú zmluvu.",
+        "sending": "Odosiela sa…",
+        "send": "Odoslať na podpis"
+      },
+      "role": {
+        "tenant": "Nájomník"
+      },
+      "status": {
+        "pending": "Čaká na podpis",
+        "in_progress": "Prebíha podpisovanie",
+        "completed": "Podpísané",
+        "declined": "Odmietnuté",
+        "expired": "Vypršané",
+        "cancelled": "Zrušené"
+      }
     }
   }
 }


### PR DESCRIPTION
## Task
Fix 6 reviewer issues from PR#513 esignature UI:
1. Remove duplicate LeaseSignatureStatus type, import from api-client
2. onSuccess uses result.signature_request.status not hardcoded pending
3. Add TODO for landlord/manager signerParties
4. Add focus trap (WCAG 2.1 2.1.2)
5. Error div gets role=alert
6. SignatureStatusBadge labels wrapped in i18n t()

## Owner
pm-frontend

## What was done

Issues 1–5 were already implemented on the `dev` branch (shipped in the large epic-83 megacommit d00dd310 that created the esignature UI files):

- **(1) No duplicate `LeaseSignatureStatus`** — all files use `SignatureRequestStatus` imported from `@ppt/api-client` throughout (`leases/types.ts`, `RequestSignatureModal.tsx`, `SignatureStatusBadge.tsx`).
- **(2) `onSuccess` uses `result.signature_request.status`** — `RequestSignatureModal.tsx` line 112: `onSuccess(result.signature_request.status)`.
- **(3) TODO for landlord/manager** — `LeaseDetailPage.tsx` line 72: `// TODO: add landlord/manager as signer once lease.manager is available from the API`.
- **(4) Focus trap (WCAG 2.1 2.1.2)** — `RequestSignatureModal.tsx` lines 45–73 implement full Tab/Shift+Tab cycling + Escape key handler via `useEffect` + `addEventListener`.
- **(5) `role="alert"` on error div** — `RequestSignatureModal.tsx` line 215.

**Issue 6 (this PR's commit):** Added missing `leases.esign.*` and `common.unknownError` keys to both `en.json` and `sk.json`. The components already called `t()` with fallback strings; this PR seeds the canonical translation values in the message catalogs, completing the i18n requirement properly.

Keys added:
- `common.unknownError` (used by `RequestSignatureModal` error boundary)
- `leases.esign.requestSignature`
- `leases.esign.modal.{title,selectSigners,subject,subjectPlaceholder,message,messagePlaceholder,sending,send}`
- `leases.esign.role.tenant`
- `leases.esign.status.{pending,in_progress,completed,declined,expired,cancelled}`

## Tested (Band A — fast check)
```
pnpm -F @ppt/web typecheck  → exit 0
pnpm check (biome)          → exit 0 (15 warnings pre-existing in other files)
```

## Built (Band B — full build)
skipped: change <50 LOC, no public API/config touch (JSON message catalog additions only)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Scope drift
scope_drift=false — only `frontend/apps/ppt-web/messages/en.json` and `sk.json` modified.

## Code-reuse review
code_reuse_warn=none — no new helpers added (JSON-only change).

https://claude.ai/code/session_01BjJcjtMgPwJxmBnWbHj4na

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjJcjtMgPwJxmBnWbHj4na)_