### PR TITLE
fix(dispatcher): close 4 spec gaps from operator review round 2

### DIFF
--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -129,7 +129,39 @@ global in-progress count CAN exceed 3. The 3-limit is throughput, not concurrenc
 ## Phase 1 — Read state + preflight
 
 1. `git fetch origin && git checkout dev && git pull --ff-only`
-2. **Disk preflight** (item #7 — runner ran out of disk on 2026-05-24 mid-implementer):
+2. **Recent-run skip-gate** (NEW — issue #1, prevents the `assignments.json` rebase-race
+   observed on 2026-05-27 when two cron runs ~1h apart both wrote `assignments.generated`):
+
+   ```bash
+   # Read assignments.generated from the freshly-pulled file.
+   GEN_AT=$(jq -r '.generated // empty' .research/management/assignments.json 2>/dev/null)
+   if [ -n "$GEN_AT" ]; then
+     GEN_EPOCH=$(date -u -d "$GEN_AT" +%s 2>/dev/null || echo 0)
+     NOW_EPOCH=$(date -u +%s)
+     AGE_MIN=$(( (NOW_EPOCH - GEN_EPOCH) / 60 ))
+     if [ "$AGE_MIN" -lt 30 ] && [ "$GEN_EPOCH" -gt 0 ]; then
+       echo "skip-gate: assignments.generated=$GEN_AT (age=${AGE_MIN}m < 30m); another run is in flight"
+       echo "  → Phase 2 (GH reconciliation, idempotent) WILL run; Phases 3/4/5/5.5/5.6/5.7 SKIP."
+       echo "  → Phase 6 will commit only if Phase 2 produced status transitions."
+       export DISPATCHER_SKIP_MUTATING=1
+     fi
+   fi
+   ```
+
+   When `DISPATCHER_SKIP_MUTATING=1`:
+   - Phase 2 (state reconciliation from GH) runs normally — it is idempotent and safe.
+   - Phase 2.5 / 2.6 / 2.7 / 3 / 4 / 5 / 5.5 / 5.6 / 5.7 SKIP. Each phase header
+     MUST check `$DISPATCHER_SKIP_MUTATING` before doing work.
+   - Phase 6 still commits + pushes IFF Phase 2 produced at least one transition
+     (otherwise nothing to write).
+   - Phase 7 prints summary as usual with `skip_reason=recent-run` in the header line.
+
+   This is a soft lock based on a repo-level timestamp, not a filesystem lock —
+   it survives cross-host parallel runs. Two runs within the same 30-min window
+   will see the same `assignments.generated` and both skip mutating phases on
+   their second pass; one of them already did the work.
+
+3. **Disk preflight** (item #7 — runner ran out of disk on 2026-05-24 mid-implementer):
 
    ```bash
    FREE_PCT=$(df -P . | awk 'NR==2{ sub("%","",$5); print 100-$5 }')
@@ -148,8 +180,8 @@ global in-progress count CAN exceed 3. The 3-limit is throughput, not concurrenc
    fi
    ```
 
-3. Read `action-list.json`, `assignments.json`, `coverage.json`.
-4. Backfill any row missing `status_changed_at` = `claimed_at`. Backfill any
+4. Read `action-list.json`, `assignments.json`, `coverage.json`.
+5. Backfill any row missing `status_changed_at` = `claimed_at`. Backfill any
    row missing the new fields (`last_reviewed_oid`, `scope_drift`,
    `code_reuse_warn`, `empty_branch`, `rebase_attempts`, `fix_rounds`,
    `reclaim_attempts`, `merge_attempted_at`) to `null` / `0`.
@@ -169,11 +201,11 @@ global in-progress count CAN exceed 3. The 3-limit is throughput, not concurrenc
 
    Once Phase 5 runs and writes the new `last_reviewed_oid`, the forcing
    condition self-clears on subsequent cycles.
-5. Confirm `.claude/skills/ppt-implement/SKILL.md`,
+6. Confirm `.claude/skills/ppt-implement/SKILL.md`,
    `.claude/skills/ppt-review-merged/SKILL.md`,
    `.claude/skills/ppt-pr-merge/SKILL.md`, AND
    `.claude/skills/ppt-pr-followup/SKILL.md` exist. If any missing, ABORT.
-6. **Ensure gating labels exist** (P6) — idempotent:
+7. **Ensure gating labels exist** (P6) — idempotent:
 
    ```bash
    bash .claude/skills/ppt-pr-followup/scripts/ensure-labels.sh \
@@ -244,6 +276,8 @@ Persist: `last_updated=now` (always); if `new_status != prev_status`: `status=ne
 
 ## Phase 2.5 — Post-merge review (24h cadence)
 
+SKIP if `$DISPATCHER_SKIP_MUTATING == 1` (recent-run gate from Phase 1 step 2).
+
 If `.research/management/last-merged-review.txt` missing OR mtime > 24h:
 spawn ONE Task subagent invoking `.claude/skills/ppt-review-merged/SKILL.md`.
 
@@ -257,6 +291,8 @@ Return EXACTLY: `scanned=<N> clean=<K> issues=<M> note=<short>`.
 ---
 
 ## Phase 2.6 — Buffer guard
+
+SKIP if `$DISPATCHER_SKIP_MUTATING == 1` (recent-run gate from Phase 1 step 2).
 
 ```python
 open_count = count(action-list.json items where status=="open" AND id NOT in assignments)
@@ -278,7 +314,23 @@ open_claimable_count = open_count - dep_blocked_count
 ```
 
 - **Tier 1 (self-refill):** if `open_claimable_count < 18` (half of the 36 target) AND `coverage.json` has stories → refill from coverage using rubric, append top `(36 - open_claimable_count)`. Log `Tier 1: <old_claimable> → <new_claimable> (+N)`.
-- **Tier 2 (upstream kick):** if `open_claimable_count` still `< 12` OR coverage missing → `curl POST $DISPATCHER_URL` with `Bearer $DISPATCHER_TOKEN`, `--max-time 10`, fire-and-forget. Log `Tier 2: <http-code or skipped>`.
+- **Tier 2 (upstream kick):** if `open_claimable_count` still `< 12` OR coverage missing → `curl POST $DISPATCHER_URL` with `Bearer $DISPATCHER_TOKEN`, `--max-time 10`. **Capture the response code AND first 200 chars of body** (NEW — issue #5: HTTP 400 from the planner used to vanish into fire-and-forget; now we see it):
+
+  ```bash
+  T2_TMP=$(mktemp)
+  T2_CODE=$(curl -sS -X POST "$DISPATCHER_URL" \
+    -H "Authorization: Bearer $DISPATCHER_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"reason":"buffer-low","claimable":'"$open_claimable_count"'}' \
+    -o "$T2_TMP" -w '%{http_code}' --max-time 10 2>/dev/null || echo "curl-error")
+  T2_BODY=$(head -c 200 "$T2_TMP" 2>/dev/null | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g')
+  rm -f "$T2_TMP"
+  echo "Tier 2: http=$T2_CODE body=\"${T2_BODY:-<empty>}\""
+  ```
+
+  Still semantically fire-and-forget (we don't retry on non-2xx), but the body
+  surfaces in the dispatcher commit log so a stuck/broken planner endpoint is
+  visible without grepping the trigger's run history.
 - Else: SKIP, log `buffer OK: claimable=<open_claimable_count>/36 (open=<open_count>, dep_blocked=<dep_blocked_count>)`.
 
 The Phase 6 commit message MUST surface both counts:
@@ -290,7 +342,50 @@ X merged-now, F failed, A active, B <claimable>/<open> dep-blocked=<n>, RB rebas
 
 ---
 
+## Phase 2.7 — Failed-dependency cascade (NEW — issue #6)
+
+SKIP if `$DISPATCHER_SKIP_MUTATING == 1` (recent-run gate from Phase 1 step 2).
+
+Problem: an open action-list item whose `depends_on` points at a row that has
+gone terminal-`failed` will never become claimable on its own. It sits in the
+buffer forever, eating a `dep_blocked_count` slot and pushing Tier-1/Tier-2
+into refill-loops for items that should be re-planned, not retried.
+
+For each `action-list.json` item with `status=="open"` and non-empty
+`depends_on`:
+
+```python
+for dep_id in item.depends_on:
+    dep_row = assignments.find(task_id=dep_id)
+    if dep_row is not None and dep_row.status == "failed":
+        # Terminal dependency. Cascade.
+        item.status = "dropped"
+        item.action = f"[CASCADED-DROP: depends_on {dep_id} terminal-failed] " + item.action
+        cascade_log.append((item.id, dep_id))
+        break  # one failed dep is enough to drop
+```
+
+Cap: process at most 20 cascades per run (defensive — avoids a runaway sweep if
+a single failed item has dozens of dependents). If more than 20 are eligible,
+process the first 20 by sort order (priority desc, id asc) and surface the
+remainder count in Phase 7.
+
+This phase modifies `action-list.json` (`status=open → status=dropped`). When
+any cascade happened, include `action-list.json` in Phase 6's commit.
+
+Re-planning is upstream: the dropped items show up in Phase 7
+(`Failed-dep cascades:`) and Tier 2 can be kicked manually
+(`curl -X POST $DISPATCHER_URL`) once the operator has decided how to unblock
+the failed parent (re-spec it, split it, or accept that the dependent work
+is also dead). The dispatcher does NOT auto-respawn failed work.
+
+Idempotency: items already `status=="dropped"` are skipped.
+
+---
+
 ## Phase 3 — Claim new (PER-RUN cap of 3) — with same-epic guard (item #2)
+
+SKIP if `$DISPATCHER_SKIP_MUTATING == 1` (recent-run gate from Phase 1 step 2).
 
 ```python
 free_slots = 3   # constant per run
@@ -357,6 +452,8 @@ If fewer than 3 candidates available (buffer drained), claim what's there — do
 ---
 
 ## Phase 4 — Spawn implementer subagents (PARALLEL via Task)
+
+SKIP if `$DISPATCHER_SKIP_MUTATING == 1` (recent-run gate from Phase 1 step 2).
 
 One per newly-claimed task IN THIS RUN. Hard cap 3.
 
@@ -431,11 +528,32 @@ if new_status != prev_status:
 
 ## Phase 5 — Spawn reviewer subagents (PARALLEL via Task)
 
+SKIP if `$DISPATCHER_SKIP_MUTATING == 1` (recent-run gate from Phase 1 step 2).
+
 For each row where `status == "review"` AND (`reviewer_summary` is null OR `PR.headRefOid != row.last_reviewed_oid`):
 
 > You are a code reviewer for PR #<n>. Task: `<task_id>: <action>`. Specialist:
 > `<sp>`. Owner: `<role>`. The implementer flagged: `scope_drift=<bool>`,
 > `code_reuse_warn=<short|none>`.
+>
+> 0. **Dedup guard (NEW — issue #3: prevents duplicate bot reviews when two
+>    dispatcher runs overlap before the Phase 1 skip-gate kicks in).** Before
+>    posting anything, check existing reviews on this PR:
+>
+>    ```bash
+>    HEAD_OID=$(gh pr view <n> --repo martin-janci/property-management --json headRefOid --jq .headRefOid)
+>    EXISTING=$(gh api repos/martin-janci/property-management/pulls/<n>/reviews \
+>      --jq '[.[] | select(.user.type=="Bot" or (.user.login|test("^claude|^github-actions"))) | {sha:.commit_id, state, at:.submitted_at}] | sort_by(.at) | last')
+>    EX_SHA=$(echo "$EXISTING" | jq -r '.sha // empty')
+>    EX_STATE=$(echo "$EXISTING" | jq -r '.state // empty')
+>    EX_AT=$(echo "$EXISTING" | jq -r '.at // empty')
+>    ```
+>
+>    If `$EX_SHA == $HEAD_OID` AND `$EX_STATE` in `{APPROVED, CHANGES_REQUESTED}`
+>    AND `(now - $EX_AT) < 2h`: a bot review for this exact SHA already exists.
+>    SKIP posting a new review. Map state → verdict (`APPROVED→approve`,
+>    `CHANGES_REQUESTED→changes`) and return:
+>    `verdict=<v> head_oid=$HEAD_OID note=dedup-existing-review-at-$EX_AT`.
 >
 > 1. `gh pr diff <n>`
 > 2. `gh pr view <n> --json title,body,files,checks,headRefOid`
@@ -523,6 +641,8 @@ No cap on reviewer subagents — review every pending review row in parallel.
 
 ## Phase 5.5 — Attempt merge for approved + green PRs
 
+SKIP if `$DISPATCHER_SKIP_MUTATING == 1` (recent-run gate from Phase 1 step 2).
+
 For each row `status=="review"` where `reviewer_summary` starts with `"verdict=approve"`:
 
 **Pre-flight:**
@@ -575,6 +695,8 @@ Phase 2 of the next cycle catches the GH `MERGED` state authoritatively.
 
 ## Phase 5.6 — Auto-rebase stale-approved PRs (NEW — item #6)
 
+SKIP if `$DISPATCHER_SKIP_MUTATING == 1` (recent-run gate from Phase 1 step 2).
+
 For each row `status == "review"` where:
 - `reviewer_summary` starts with `"verdict=approve"`, AND
 - the PR's `mergeable == "CONFLICTING"`, AND
@@ -605,6 +727,8 @@ Phase 5.5 next run will pick up the now-clean PR via the standard path.
 ---
 
 ## Phase 5.7 — Respawn implementer on `verdict=changes` (NEW)
+
+SKIP if `$DISPATCHER_SKIP_MUTATING == 1` (recent-run gate from Phase 1 step 2).
 
 For each row `status == "review"` where `reviewer_summary` starts with
 `"verdict=changes"`:
@@ -679,6 +803,10 @@ Approved+CI-pending:      [PR#<n> task=<id> attempted=<iso8601> wait=<h>, …]  
 Rebase attempts (this run):[PR#<n> rebased=<true|false> <note>, …]  (item #6; [] if none)
 Sandbox reclaims (this run):[<task_id> branch=<branch> reason=sandbox-timeout, …]  (P3; [] if none)
 Empty branches deleted:   [<branch>, …]                             (item #1; [] if none)
+Failed-dep cascades:      [<id> blocked-by=<dep_id>, …]             (issue #6; [] if none)
+Skip-gate:                <none | "recent-run age=<m>m; mutating phases SKIPPED">  (issue #1)
+Tier 2 response:          <http=<code> body="<truncated>" | not-fired>          (issue #5)
+Review dedup-skipped:     [PR#<n> existing-at=<iso>, …]             (issue #3; [] if none)
 Scope-drift flagged:      [PR#<n> task=<id> note=<paths>, …]        (item #3; [] if none)
 Code-reuse warnings:      [PR#<n> task=<id> note=<helper>, …]       (item #4; [] if none)
 Disk warning:             <none | "free=N%; cleaned to M%">         (item #7)
@@ -722,6 +850,10 @@ Hang alerts:
 - **auto-rebase** (item #6) is bounded at 3 attempts per row; after that a human must intervene
 - **sandbox-reclaim** (P3) is bounded at 1 attempt per row; the helper at `.claude/skills/ppt-pr-followup/scripts/sandbox-reclaim.sh` picks the timeout (60m for `Mode: cloud-ok`, 120m otherwise) and classifies the row as wait/reclaim/fail. Reclaim re-spawns the same specialist with the same brief and bumps `reclaim_attempts`; a second sandbox-timeout becomes `failed` with `reason: sandbox-failure-after-reclaim`
 - **disk preflight** (item #7) aborts the run gracefully at <5% free; never crashes mid-subagent
+- **recent-run skip-gate** (issue #1) — if `assignments.generated` is < 30min old, set `DISPATCHER_SKIP_MUTATING=1` and SKIP every mutating phase (2.5, 2.6, 2.7, 3, 4, 5, 5.5, 5.6, 5.7). Phase 2 (GH reconciliation) and Phase 7 (summary) still run. Prevents the `assignments.json` rebase races seen on 2026-05-27.
+- **failed-dep cascade** (issue #6) — open action-list items whose `depends_on` points at a terminal-`failed` row are dropped (`status=open → status=dropped`) in Phase 2.7 with an audit prefix; max 20 cascades/run. Re-planning is upstream (operator-driven).
+- **Tier 2 kick logging** (issue #5) — capture HTTP code + first 200 chars of response body; surface in commit message so a broken/wedged planner endpoint is visible without trawling trigger history.
+- **reviewer dedup guard** (issue #3) — reviewer subagent MUST `GET /pulls/<n>/reviews` first; if a bot review for the current `headRefOid` already exists within 2h, skip posting and return `note=dedup-existing-review-at-<iso>`. Defense-in-depth against the skip-gate window-edge case.
 
 ---
 

--- a/.research/dispatcher-self-test.sh
+++ b/.research/dispatcher-self-test.sh
@@ -117,12 +117,20 @@ fi
 echo
 
 # --- T7: branch naming convention ------------------------------------------
-echo "T7  branch starts with auto-impl/"
-BAD=$(jq -r '.assignments | map(select((.branch // "") | startswith("auto-impl/") | not)) | length' "$ASSIGN")
-if [ "$BAD" = "0" ]; then note "all branches use auto-impl/ prefix"
+# Only enforced for non-terminal rows. Merged/done/failed rows are historical
+# artifacts — if the dispatcher claimed under the auto-impl/ prefix but the
+# implementer used a manually-named branch (fix/…, feat/…) the merge already
+# happened and we don't rewrite history.
+echo "T7  non-terminal branch starts with auto-impl/"
+BAD=$(jq -r '
+  .assignments
+  | map(select(.status == "in-progress" or .status == "review"))
+  | map(select((.branch // "") | startswith("auto-impl/") | not))
+  | length' "$ASSIGN")
+if [ "$BAD" = "0" ]; then note "all non-terminal branches use auto-impl/ prefix"
 else
-  fail "$BAD rows with non-conforming branch"
-  jq -r '.assignments[] | select((.branch // "") | startswith("auto-impl/") | not) | "    \(.task_id) :: branch=\(.branch)"' "$ASSIGN" >&2
+  fail "$BAD non-terminal rows with non-conforming branch"
+  jq -r '.assignments[] | select((.status == "in-progress" or .status == "review") and ((.branch // "") | startswith("auto-impl/") | not)) | "    \(.task_id) :: branch=\(.branch) status=\(.status)"' "$ASSIGN" >&2
 fi
 echo
 

--- a/.research/management/assignments.json
+++ b/.research/management/assignments.json
@@ -307,7 +307,7 @@
       "pr_url": "https://github.com/martin-janci/property-management/pull/461",
       "merged_at": "2026-05-24T17:45:00Z",
       "implementer_summary": null,
-      "reviewer_summary": "verdict=changes note=SQL repo fix correct; handler fix not pushed \u2014 IDOR unfixed in both handlers; merge blocked until handler pushed and CI green"
+      "reviewer_summary": "verdict=changes note=SQL repo fix correct; handler fix not pushed — IDOR unfixed in both handlers; merge blocked until handler pushed and CI green"
     },
     {
       "task_id": "gap-2b-notification-pipeline",
@@ -321,7 +321,7 @@
       "pr_url": "https://github.com/martin-janci/property-management/pull/463",
       "merged_at": "2026-05-24T17:30:00Z",
       "implementer_summary": "pr=463 status=done specialist=rust-backend note=Epic 2B notification pipeline: TransportAdapter traits (Email/Push/InApp)",
-      "reviewer_summary": "verdict=approve note=CI fully green post-fmt-fix; no unwrap abuse, no RLS bypass \u2014 ready to merge"
+      "reviewer_summary": "verdict=approve note=CI fully green post-fmt-fix; no unwrap abuse, no RLS bypass — ready to merge"
     },
     {
       "task_id": "gap-6-6-neighbor-listing-verify",
@@ -433,7 +433,7 @@
       "pr_url": "https://github.com/martin-janci/property-management/pull/468",
       "merged_at": null,
       "implementer_summary": "pr=468 status=done specialist=react-web note=OAuthGrantsPage at /settings/oauth-grants; useUserGrants+useRevokeUserGrant wired; api-client oauth-grants module added; typecheck+biome+build clean",
-      "reviewer_summary": "verdict=approve note=endpoints correct (GET/DELETE /api/v1/oauth/grants); cache invalidation present; no IDOR (JWT-scoped backend query); ProtectedRoute gating; all 3 empty/load/error states handled; screen-map uses object relatedScreens and ppt-web impl key \u2014 all green"
+      "reviewer_summary": "verdict=approve note=endpoints correct (GET/DELETE /api/v1/oauth/grants); cache invalidation present; no IDOR (JWT-scoped backend query); ProtectedRoute gating; all 3 empty/load/error states handled; screen-map uses object relatedScreens and ppt-web impl key — all green"
     },
     {
       "task_id": "gap-8a-3-websocket-realtime-sync",
@@ -447,7 +447,7 @@
       "pr_url": "https://github.com/martin-janci/property-management/pull/472",
       "merged_at": "2026-05-25T01:35:09Z",
       "implementer_summary": "pr=472 status=done specialist=rust-backend note=WebSocket endpoint ws_notifications.rs; Redis pub/sub fan-out; axum ws feature added",
-      "reviewer_summary": "verdict=changes note=2 blockers: (1) mfa.rs drops RlsConnection on all 5 MFA handlers replacing rls.conn() with &state.db \u2014 user_2fa has ENABLE ROW LEVEL SECURITY keyed on app.current_user_id so all MFA ops break silently; these changes are unrelated to 8A.3 and must be reverted; (2) ws_notifications.rs creates private OnceLock WsVerifier duplicating api_core::extractors::auth JWT_VERIFIER \u2014 fix by exporting validate_access_token helper from api-core and delegating. Non-blocking: wrong endpoint path in PR body, idle-timeout double-sleep gap, 4h ceiling vs 15min JWT exp not enforced, missing cargo check exit codes."
+      "reviewer_summary": "verdict=changes note=2 blockers: (1) mfa.rs drops RlsConnection on all 5 MFA handlers replacing rls.conn() with &state.db — user_2fa has ENABLE ROW LEVEL SECURITY keyed on app.current_user_id so all MFA ops break silently; these changes are unrelated to 8A.3 and must be reverted; (2) ws_notifications.rs creates private OnceLock WsVerifier duplicating api_core::extractors::auth JWT_VERIFIER — fix by exporting validate_access_token helper from api-core and delegating. Non-blocking: wrong endpoint path in PR body, idle-timeout double-sleep gap, 4h ceiling vs 15min JWT exp not enforced, missing cargo check exit codes."
     },
     {
       "task_id": "gap-10b-3-admin-health-ui",
@@ -460,8 +460,8 @@
       "pr_number": 471,
       "pr_url": "https://github.com/martin-janci/property-management/pull/471",
       "merged_at": "2026-05-24T20:51:57Z",
-      "implementer_summary": "pr=471 status=done specialist=react-web note=wired health dashboard/metric-history/alerts/thresholds to /platform/health; 7 unit tests; Band A skipped \u2014 node_modules not installed in environment",
-      "reviewer_summary": "verdict=changes note=Two MUST issues: (1) all health API calls bypass the project's MFA interceptor in @ppt/api-client by using a bespoke inline fetchJson() \u2014 raw 401 mfa_required responses will error instead of triggering the MFA modal; (2) no screen-map file created for the new platform/health route (CLAUDE.md rule B). Also SHOULD: ~20 hardcoded English strings not covered by the i18n keys added to the locale files."
+      "implementer_summary": "pr=471 status=done specialist=react-web note=wired health dashboard/metric-history/alerts/thresholds to /platform/health; 7 unit tests; Band A skipped — node_modules not installed in environment",
+      "reviewer_summary": "verdict=changes note=Two MUST issues: (1) all health API calls bypass the project's MFA interceptor in @ppt/api-client by using a bespoke inline fetchJson() — raw 401 mfa_required responses will error instead of triggering the MFA modal; (2) no screen-map file created for the new platform/health route (CLAUDE.md rule B). Also SHOULD: ~20 hardcoded English strings not covered by the i18n keys added to the locale files."
     },
     {
       "task_id": "gap-9-1-mfa-e2e-verify",
@@ -475,7 +475,7 @@
       "pr_url": "https://github.com/martin-janci/property-management/pull/473",
       "merged_at": "2026-05-25T01:35:17Z",
       "implementer_summary": "pr=473 status=done specialist=rust-backend note=600-line MFA e2e integration tests; mod.rs declared",
-      "reviewer_summary": "verdict=changes note=All new test logic/TOTP params/auth-guard/RLS is correct, but tests/common/mod.rs reads json[\"access_token\"] (snake_case) while LoginResponse is #[serde(rename_all=\"camelCase\")] \u2014 every test that calls create_authenticated_user will panic before reaching any MFA assertion; fix json[\"accessToken\"]/json[\"refreshToken\"] required before merge."
+      "reviewer_summary": "verdict=changes note=All new test logic/TOTP params/auth-guard/RLS is correct, but tests/common/mod.rs reads json[\"access_token\"] (snake_case) while LoginResponse is #[serde(rename_all=\"camelCase\")] — every test that calls create_authenticated_user will panic before reaching any MFA assertion; fix json[\"accessToken\"]/json[\"refreshToken\"] required before merge."
     },
     {
       "task_id": "gap-10b-4-system-announcements-impl",
@@ -580,7 +580,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-80-2-dispute-verify",
@@ -599,7 +602,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-80-3-mediation-verify",
@@ -618,7 +624,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-81-1-schedule-e2e-verify",
@@ -631,13 +640,16 @@
       "pr_number": 488,
       "pr_url": "https://github.com/martin-janci/property-management/pull/488",
       "merged_at": "2026-05-25T05:16:36Z",
-      "implementer_summary": "pr=488 status=done specialist=react-web note=wired usePauseSchedule/useResumeSchedule/useUpdateSchedule to /reports route in App.tsx; ReportsPage added to lazyRoutes; typecheck baseline unchanged (36692 pre-existing errors, 0 new); Band B skipped \u2014 no node_modules in env",
+      "implementer_summary": "pr=488 status=done specialist=react-web note=wired usePauseSchedule/useResumeSchedule/useUpdateSchedule to /reports route in App.tsx; ReportsPage added to lazyRoutes; typecheck baseline unchanged (36692 pre-existing errors, 0 new); Band B skipped — no node_modules in env",
       "reviewer_summary": "verdict=changes note=PR branch contains wrong commit (unrelated migration); frontend changes already on dev have missing ProtectedRoute on /reports, hardcoded organizationId='', and no screen-map update; changes (orgId + throw e + ProtectedRoute) cherry-picked onto dev; PR superseded",
       "last_reviewed_oid": null,
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-81-2-execution-history-verify",
@@ -657,7 +669,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-8a-3-mobile-push",
@@ -671,13 +686,16 @@
       "pr_url": "https://github.com/martin-janci/property-management/pull/490",
       "merged_at": "2026-05-25T16:20:00Z",
       "implementer_summary": "pr=490 status=done specialist=rust-backend note=FCM/APNs token upsert endpoint + RN hook wiring; cargo fmt + clippy -D warnings pass; rebased on dev HEAD (migration 00157 already in c7791220)",
-      "reviewer_summary": "verdict=approve note=both blockers fixed \u2014 migration 00158 restores service-role SELECT policy correctly (FORCE RLS + app.current_user_id + service bypass), Cargo.lock uniformly at 0.2.638; no new issues; GitHub self-approval blocked so posted as comment",
+      "reviewer_summary": "verdict=approve note=both blockers fixed — migration 00158 restores service-role SELECT policy correctly (FORCE RLS + app.current_user_id + service bypass), Cargo.lock uniformly at 0.2.638; no new issues; GitHub self-approval blocked so posted as comment",
       "reviewer_verdict": "changes",
       "last_reviewed_oid": null,
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "pm-backend-fix-ai-equipment-idor",
@@ -697,7 +715,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "pm-frontend-sequence-epic6-announcement-drafts",
@@ -716,7 +737,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "pm-frontend-schedule-followup-test-batch",
@@ -735,7 +759,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "pm-tech-lead-split-ai-platform-announcements-monoliths",
@@ -749,13 +776,16 @@
       "pr_url": "https://github.com/martin-janci/property-management/pull/494",
       "merged_at": "2026-05-25T07:55:00Z",
       "implementer_summary": "pr=494 status=done specialist=pm-tech-lead note=3 module-split backlog entries added (ai.rs 3134L, platform_admin.rs 2762L, announcements.rs 2722L); check-discarded-principal.sh lint created and wired into backend.yml check job; 7 violations detected informational",
-      "reviewer_summary": "verdict=approve note=3 backlog items well-formed (ai.rs/platform_admin.rs/announcements.rs); check-discarded-principal.sh lint pattern sound; informational-only approach correct given 7 existing violations all mapped to known backlog items; advisory: automation.rs GET handlers (list_templates/get_template) intentionally discard _principal (global read-only data) \u2014 should be added to allowlist to avoid inflating violation count; CI check+test+rls-smoke-test all green on run 26386715653",
+      "reviewer_summary": "verdict=approve note=3 backlog items well-formed (ai.rs/platform_admin.rs/announcements.rs); check-discarded-principal.sh lint pattern sound; informational-only approach correct given 7 existing violations all mapped to known backlog items; advisory: automation.rs GET handlers (list_templates/get_template) intentionally discard _principal (global read-only data) — should be added to allowlist to avoid inflating violation count; CI check+test+rls-smoke-test all green on run 26386715653",
       "reviewer_verdict": "approve",
       "last_reviewed_oid": null,
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "pm-frontend-verify-epic81-schedule-execution",
@@ -774,7 +804,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-84-2-esignature-impl",
@@ -794,7 +827,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "pm-tech-lead-confirm-websocket-infra-ownership",
@@ -807,14 +843,17 @@
       "pr_number": 496,
       "pr_url": "https://github.com/martin-janci/property-management/pull/496",
       "merged_at": "2026-05-25T10:20:00Z",
-      "implementer_summary": "pr=496 status=done specialist=generic note=ADR-008 updated Accepted\u2192Implemented with owner/delivery ref; action-list item marked done; tsconfig.json node type removed; CI all-green; draft promoted",
+      "implementer_summary": "pr=496 status=done specialist=generic note=ADR-008 updated Accepted→Implemented with owner/delivery ref; action-list item marked done; tsconfig.json node type removed; CI all-green; draft promoted",
       "reviewer_summary": "verdict=approve note=ADR-008 status/owner/delivery/DEC-001/remaining-work all verified; action-list item consistently done; internal consistency confirmed; CI 5/5 green",
       "reviewer_verdict": "approve",
       "last_reviewed_oid": null,
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-85-1-rn-env-config",
@@ -834,7 +873,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-85-2-ios-build-config",
@@ -854,7 +896,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "security-inquiry-read-idor",
@@ -874,7 +919,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-7a-1-upload-verify",
@@ -887,13 +935,16 @@
       "pr_number": 502,
       "pr_url": "https://github.com/martin-janci/property-management/pull/502",
       "merged_at": "2026-05-25T12:30:53Z",
-      "implementer_summary": "pr=502 status=partial specialist=rust-backend note=POST /api/v1/documents/upload missing from backend; both web+mobile call it but endpoint not implemented \u2014 sprint-status cannot be promoted; Band A clean",
+      "implementer_summary": "pr=502 status=partial specialist=rust-backend note=POST /api/v1/documents/upload missing from backend; both web+mobile call it but endpoint not implemented — sprint-status cannot be promoted; Band A clean",
       "reviewer_summary": "verdict=approve note=findings verified: multipart /upload endpoint absent from backend; two-step S3 flow undocumented in clients; Band A clean; safe to merge as verification report; sprint-status stays ready-for-dev",
       "last_reviewed_oid": null,
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-82-1-swiftui-audit",
@@ -913,7 +964,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-82-2-deep-linking",
@@ -927,13 +981,16 @@
       "pr_url": "https://github.com/martin-janci/property-management/pull/500",
       "merged_at": "2026-05-25T14:09:56Z",
       "implementer_summary": "Fixed mirror desync: added restoreStack(_:for:) to NavigationCoordinator for atomic NavigationPath+mirror-array update; updated restore(into:isAuthenticated:) to call restoreStack() instead of direct path assignment; made .login/.register ephemeral in encodeRoute() (return nil); added testRoundTripPersistenceSurvivesDoubleRestoreCycle and testLoginAndRegisterAreNotPersisted to RealityPortalTests.swift. Pushed to PR#500 for re-review.",
-      "reviewer_summary": "verdict=approve \u2014 mirror desync bug correctly fixed: restoreStack() atomically sets NavigationPath+mirror array; all mutation paths (navigate/pop/popToRoot/reset/appendToCurrent) maintain sync; .login/.register ephemeral (encodeRoute returns nil), testLoginAndRegisterAreNotPersisted pins this; testRoundTripPersistenceSurvivesDoubleRestoreCycle covers exact failure scenario. Non-blocking: dead decode branches for login/register in decodeRoute, unused makePath helper in Service.",
+      "reviewer_summary": "verdict=approve — mirror desync bug correctly fixed: restoreStack() atomically sets NavigationPath+mirror array; all mutation paths (navigate/pop/popToRoot/reset/appendToCurrent) maintain sync; .login/.register ephemeral (encodeRoute returns nil), testLoginAndRegisterAreNotPersisted pins this; testRoundTripPersistenceSurvivesDoubleRestoreCycle covers exact failure scenario. Non-blocking: dead decode branches for login/register in decodeRoute, unused makePath helper in Service.",
       "reviewer_verdict": "verdict=approve",
       "last_reviewed_oid": null,
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-10b-4-sysannounce-admin-impl",
@@ -952,7 +1009,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-6-2-announcement-read-receipt",
@@ -971,7 +1031,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-79-1-api-client-core-wiring",
@@ -990,7 +1053,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-79-2-auth-sso-completion",
@@ -1009,7 +1075,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-7a-1-backend-multipart-upload",
@@ -1028,7 +1097,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-10b-5-support-data-api",
@@ -1047,7 +1119,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-6-3-announcement-comments-api",
@@ -1066,7 +1141,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-6-4-pinned-announcements-api",
@@ -1085,7 +1163,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-80-2-dispute-filing-api",
@@ -1098,13 +1179,16 @@
       "pr_number": 506,
       "pr_url": "https://github.com/martin-janci/property-management/pull/506",
       "merged_at": "2026-05-25T18:01:00Z",
-      "implementer_summary": "pr=506 status=done specialist=rust-backend scope_drift=false code_reuse_warn=none note=state machine enforced in update_status (BadRequest\u2192422); endpoint+migration already existed; cargo check+clippy clean",
+      "implementer_summary": "pr=506 status=done specialist=rust-backend scope_drift=false code_reuse_warn=none note=state machine enforced in update_status (BadRequest→422); endpoint+migration already existed; cargo check+clippy clean",
       "reviewer_summary": "verdict=approve note=CI 21/21 green; squash-merged sha=549bb2e96b72647445d0505b814e8c7855da4818",
       "last_reviewed_oid": null,
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "pm-qa-create-backend-servers-reality-server",
@@ -1117,13 +1201,16 @@
       "pr_number": 507,
       "pr_url": "https://github.com/martin-janci/property-management/pull/507",
       "merged_at": null,
-      "implementer_summary": "pr=507 status=closed specialist=rust-backend note=inquiry IDOR regression tests (C1/C2/C3); closed without merging \u2014 check failed on respond_to_inquiry Option type mismatch (pre-existing dev bug, now fixed by PR #508)",
+      "implementer_summary": "pr=507 status=closed specialist=rust-backend note=inquiry IDOR regression tests (C1/C2/C3); closed without merging — check failed on respond_to_inquiry Option type mismatch (pre-existing dev bug, now fixed by PR #508)",
       "reviewer_summary": null,
       "last_reviewed_oid": null,
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "pm-qa-verify-respond-to-inquiry-post-api-v1",
@@ -1142,7 +1229,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "pm-scrum-master-implement-post-api-v1-documents-upload",
@@ -1161,7 +1251,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "pm-scrum-master-wire-app-tsx-dispute-routes-replace-in",
@@ -1180,7 +1273,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "pm-qa-establish-pr-merge-policy-requiring-a",
@@ -1199,7 +1295,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-6-4-pinned-announcements-ui",
@@ -1218,7 +1317,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-8a-3-push-fanout-delivery",
@@ -1237,7 +1339,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-80-3-mediation-api",
@@ -1256,7 +1361,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-84-2-esignature-email-ui",
@@ -1270,12 +1378,15 @@
       "pr_url": "https://github.com/martin-janci/property-management/pull/513",
       "merged_at": "2026-05-26T08:28:16Z",
       "implementer_summary": "pr=513 status=done specialist=react-web note=@ppt/api-client esignature module (types+api+hooks); SignatureStatusBadge (amber/green/red/gray); RequestSignatureModal (signer selection+subject+message+loading+error); LeaseDetailPage Request Signature button + badge in header; LeaseCard badge in status row; LeaseSignatureStatus+documentId types added; typecheck exit 0; biome exit 0; vite build exit 0",
-      "reviewer_summary": "verdict=changes note=6 issues: (1) LeaseSignatureStatus duplicates SignatureRequestStatus from api-client \u2014 remove and import; (2) onSuccess hardcodes 'pending' instead of result.signature_request.status; (3) signerParties missing landlord/manager \u2014 add TODO; (4) no focus trap in modal (WCAG 2.1 \u00a72.1.2); (5) error div missing role=alert; (6) SignatureStatusBadge labels not i18n-wrapped",
+      "reviewer_summary": "verdict=changes note=6 issues: (1) LeaseSignatureStatus duplicates SignatureRequestStatus from api-client — remove and import; (2) onSuccess hardcodes 'pending' instead of result.signature_request.status; (3) signerParties missing landlord/manager — add TODO; (4) no focus trap in modal (WCAG 2.1 §2.1.2); (5) error div missing role=alert; (6) SignatureStatusBadge labels not i18n-wrapped",
       "last_reviewed_oid": null,
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-80-2-dispute-filing-ui",
@@ -1294,7 +1405,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-81-1-report-schedule-edit-api",
@@ -1313,7 +1427,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-81-2-report-execution-history-api",
@@ -1332,7 +1449,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-82-3-swiftui-home-search",
@@ -1351,7 +1471,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-83-1-airbnb-integration-backend",
@@ -1365,12 +1488,15 @@
       "pr_url": "https://github.com/martin-janci/property-management/pull/538",
       "merged_at": "2026-05-26T13:00:00Z",
       "implementer_summary": "Fixed webhook stubs: added find_airbnb_connection_by_listing_id to RentalRepo; ReservationCreated/Updated now enqueue SYNC_EXTERNAL job; ReservationCancelled finds booking by external_id and cancels; UTF-8 decode returns explicit 400; tracing::warn when encryption key absent. cargo check passed. | fix-round-2: RequireCapability/AppError skipped (N/A for public HMAC webhook); added event_id dedup + already-cancelled guard; query_as! TODO comment; external_booking_id already in 00051 migration; 2 new unit tests; commit 105cf468",
-      "reviewer_summary": "verdict=approve note=OAuth/security reviewer confirmed: IDOR guard correct, HMAC-SHA256 on Bytes correct, webhook dispatch implemented (Created/Updated enqueue jobs, Cancelled cancels DB), token encryption with warn, env-var fail-fast, no blocking issues; rust-backend reviewer findings (RequireCapability, AppError, query_as! macro) confirmed incorrect \u2014 Capability::ManageIntegrations does not exist, AppError does not impl IntoResponse, rental.rs uses query_as::<_> throughout; check=success",
+      "reviewer_summary": "verdict=approve note=OAuth/security reviewer confirmed: IDOR guard correct, HMAC-SHA256 on Bytes correct, webhook dispatch implemented (Created/Updated enqueue jobs, Cancelled cancels DB), token encryption with warn, env-var fail-fast, no blocking issues; rust-backend reviewer findings (RequireCapability, AppError, query_as! macro) confirmed incorrect — Capability::ManageIntegrations does not exist, AppError does not impl IntoResponse, rental.rs uses query_as::<_> throughout; check=success",
       "last_reviewed_oid": null,
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-83-2-booking-integration-backend",
@@ -1389,7 +1515,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-85-2-build-config-android",
@@ -1408,7 +1537,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-85-2-build-config-ios",
@@ -1427,7 +1559,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-82-3-search-enhancements",
@@ -1446,7 +1581,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-82-4-photo-gallery",
@@ -1459,13 +1597,16 @@
       "pr_url": "https://github.com/martin-janci/property-management/pull/540",
       "merged_at": null,
       "specialist": "ios-swiftui",
-      "implementer_summary": "pr=540 status=done specialist=ios-swiftui scope_drift=true code_reuse_warn=none note=ZoomablePhotoPage pinch/double-tap zoom + FavoritesService cross-view sync; Gradle/Xcode verify skipped (cloud\u2014no macOS)",
-      "reviewer_summary": "verdict=approve note=SimultaneousGesture composition correct; per-page zoom state via @State correct; offset reset on zoom-back correct; FavoritesService cross-view sync clean (isFavorite derived, no stale state); no memory leaks; CI lint+build-ios+build-android all green; one non-blocking follow-up (micro-zoom jitter at 1x swipe boundary \u2014 defer to issue)",
+      "implementer_summary": "pr=540 status=done specialist=ios-swiftui scope_drift=true code_reuse_warn=none note=ZoomablePhotoPage pinch/double-tap zoom + FavoritesService cross-view sync; Gradle/Xcode verify skipped (cloud—no macOS)",
+      "reviewer_summary": "verdict=approve note=SimultaneousGesture composition correct; per-page zoom state via @State correct; offset reset on zoom-back correct; FavoritesService cross-view sync clean (isFavorite derived, no stale state); no memory leaks; CI lint+build-ios+build-android all green; one non-blocking follow-up (micro-zoom jitter at 1x swipe boundary — defer to issue)",
       "last_reviewed_oid": null,
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-82-5-ios-push-keychain",
@@ -1479,12 +1620,15 @@
       "merged_at": null,
       "specialist": null,
       "implementer_summary": null,
-      "reviewer_summary": "verdict=approve note=Keychain attrs correct (kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly, no iCloud backup); APNs token in Keychain not UserDefaults; duplicate AuthManager raw Security calls eliminated; @Observable+@Environment consistent; UIKit decoupling via Notification.Name clean; 5 non-blocking advisories (APNs delegate wiring needs UIApplicationDelegateAdaptor\u2014macOS only, Info.plist NSUserNotificationUsageDescription missing\u2014Xcode only, no UNUserNotificationCenterDelegate, observer lifetime comment, loadOptional swallows errors\u2014pre-existing); macOS reviewer required before un-draft",
+      "reviewer_summary": "verdict=approve note=Keychain attrs correct (kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly, no iCloud backup); APNs token in Keychain not UserDefaults; duplicate AuthManager raw Security calls eliminated; @Observable+@Environment consistent; UIKit decoupling via Notification.Name clean; 5 non-blocking advisories (APNs delegate wiring needs UIApplicationDelegateAdaptor—macOS only, Info.plist NSUserNotificationUsageDescription missing—Xcode only, no UNUserNotificationCenterDelegate, observer lifetime comment, loadOptional swallows errors—pre-existing); macOS reviewer required before un-draft",
       "last_reviewed_oid": null,
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-83-1-airbnb-oauth",
@@ -1503,7 +1647,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-10b-6-onboarding-tour-api",
@@ -1522,7 +1669,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-10b-7-contextual-help-ui",
@@ -1541,7 +1691,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-82-6-kmp-android-home",
@@ -1554,13 +1707,16 @@
       "pr_number": null,
       "pr_url": null,
       "merged_at": null,
-      "implementer_summary": "pr=none status=partial specialist=kotlin-mp note=Band-A-gradle-failed-env:AGP-9.2.1-not-cached-in-sandbox;code-already-in-dev-CI-passing;screen-map-docs-only-apiStatus-partial\u2192complete;drift=dispatcher-commit-assignments.json+Cargo.lock",
+      "implementer_summary": "pr=none status=partial specialist=kotlin-mp note=Band-A-gradle-failed-env:AGP-9.2.1-not-cached-in-sandbox;code-already-in-dev-CI-passing;screen-map-docs-only-apiStatus-partial→complete;drift=dispatcher-commit-assignments.json+Cargo.lock",
       "reviewer_summary": null,
       "last_reviewed_oid": null,
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-83-2-booking-ota",
@@ -1574,12 +1730,15 @@
       "pr_url": "https://github.com/martin-janci/property-management/pull/544",
       "merged_at": "2026-05-26T10:49:51Z",
       "implementer_summary": "pr=544 status=done specialist=rust-backend scope_drift=false code_reuse_warn=none note=added push-availability+push-rates handlers with DTO types; cargo check+clippy clean, 7 booking unit tests pass; PR#544 draft vs dev",
-      "reviewer_summary": "verdict=changes note=Both IDOR and BAD_GATEWAY blockers are fixed correctly, but the CI check job (cargo check/clippy) is failing on the latest commit \u2014 PR cannot be approved until the compile/lint error is resolved",
+      "reviewer_summary": "verdict=changes note=Both IDOR and BAD_GATEWAY blockers are fixed correctly, but the CI check job (cargo check/clippy) is failing on the latest commit — PR cannot be approved until the compile/lint error is resolved",
       "last_reviewed_oid": null,
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-7a-2-folder-api",
@@ -1593,7 +1752,15 @@
       "pr_url": "https://github.com/martin-janci/property-management/pull/551",
       "merged_at": "2026-05-26T13:20:00Z",
       "implementer_summary": "pr=551 status=done specialist=rust-backend note=integration tests for folder auth guards + schema assertions; mod common->use crate::common fix",
-      "reviewer_summary": "verdict=approve note=auth guards correct, schema assertions valid, sqlx::test migrator pattern correct; merged squash 2a0c7d6b"
+      "reviewer_summary": "verdict=approve note=auth guards correct, schema assertions valid, sqlx::test migrator pattern correct; merged squash 2a0c7d6b",
+      "last_reviewed_oid": null,
+      "scope_drift": null,
+      "code_reuse_warn": null,
+      "empty_branch": null,
+      "rebase_attempts": 0,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-7a-4-document-download-api",
@@ -1607,7 +1774,15 @@
       "pr_url": "https://github.com/martin-janci/property-management/pull/550",
       "merged_at": "2026-05-26T13:15:00Z",
       "implementer_summary": "pr=550 status=done specialist=rust-backend note=fixed StorageService::from_env bug, added generate_preview_url with inline disposition",
-      "reviewer_summary": "verdict=approve note=StorageService bug fixed correctly, Content-Disposition:inline for preview correct, RLS tenant isolation via RlsConnection; merged squash 960f2307"
+      "reviewer_summary": "verdict=approve note=StorageService bug fixed correctly, Content-Disposition:inline for preview correct, RLS tenant isolation via RlsConnection; merged squash 960f2307",
+      "last_reviewed_oid": null,
+      "scope_drift": null,
+      "code_reuse_warn": null,
+      "empty_branch": null,
+      "rebase_attempts": 0,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-81-2-report-execution-history-ui",
@@ -1621,7 +1796,15 @@
       "pr_url": "https://github.com/martin-janci/property-management/pull/547",
       "merged_at": "2026-05-26T13:10:00Z",
       "implementer_summary": null,
-      "reviewer_summary": "verdict=approve note=all 3 fixes confirmed: useTranslation+t() throughout, table aria-label, download/retry aria-label with date, isError prop + error state, App.tsx passes isError from query; merged squash 618b7afd"
+      "reviewer_summary": "verdict=approve note=all 3 fixes confirmed: useTranslation+t() throughout, table aria-label, download/retry aria-label with date, isError prop + error state, App.tsx passes isError from query; merged squash 618b7afd",
+      "last_reviewed_oid": null,
+      "scope_drift": null,
+      "code_reuse_warn": null,
+      "empty_branch": null,
+      "rebase_attempts": 0,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "fix-issue-queue-backend",
@@ -1640,7 +1823,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "fix-issue-queue-ppt-web",
@@ -1659,7 +1845,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-80-3-mediation-ui",
@@ -1678,7 +1867,10 @@
       "scope_drift": null,
       "code_reuse_warn": null,
       "empty_branch": null,
-      "rebase_attempts": null
+      "rebase_attempts": null,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-7a-2-folder-ui",
@@ -1692,7 +1884,15 @@
       "pr_url": "https://github.com/martin-janci/property-management/pull/556",
       "merged_at": null,
       "implementer_summary": "pr=556 status=done specialist=react-web scope_drift=false code_reuse_warn=none note=MoveFolderDialog+FolderBreadcrumb+buildFolderCrumbs added; DocumentsBrowse+FolderTreePage wired with useMoveDocument and breadcrumb nav",
-      "reviewer_summary": "verdict=approve note=All 13 CI checks green; no blocking issues found \u2014 correct ARIA usage, proper focus trap, blob-URL download pattern, full unit test coverage for buildFolderCrumbs, no auth/RLS regressions"
+      "reviewer_summary": "verdict=approve note=All 13 CI checks green; no blocking issues found — correct ARIA usage, proper focus trap, blob-URL download pattern, full unit test coverage for buildFolderCrumbs, no auth/RLS regressions",
+      "last_reviewed_oid": null,
+      "scope_drift": null,
+      "code_reuse_warn": null,
+      "empty_branch": null,
+      "rebase_attempts": 0,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-7a-4-document-preview-ui",
@@ -1706,7 +1906,15 @@
       "pr_url": "https://github.com/martin-janci/property-management/pull/557",
       "merged_at": null,
       "implementer_summary": "pr=557 status=done specialist=react-web scope_drift=false code_reuse_warn=none note=DocumentPreviewModal (PDF/image/fallback inline preview + download button); per-row preview+download buttons in DocumentsBrowse; usePreviewUrl+useDownloadUrl wired; modal accessible (Escape, backdrop, focus, aria-modal)",
-      "reviewer_summary": "verdict=approve note=All CI green; accessibility correct (ARIA 1.2 panel, useFocusTrap, focus-restore, Escape, backdrop-click); useDocumentDownload hook correctly shared; div[role=button] nesting justified; screen-map logs updated; no blocking issues"
+      "reviewer_summary": "verdict=approve note=All CI green; accessibility correct (ARIA 1.2 panel, useFocusTrap, focus-restore, Escape, backdrop-click); useDocumentDownload hook correctly shared; div[role=button] nesting justified; screen-map logs updated; no blocking issues",
+      "last_reviewed_oid": null,
+      "scope_drift": null,
+      "code_reuse_warn": null,
+      "empty_branch": null,
+      "rebase_attempts": 0,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "gap-security-435-cookie-scope",
@@ -1719,8 +1927,16 @@
       "pr_number": 565,
       "pr_url": "https://github.com/martin-janci/property-management/pull/565",
       "merged_at": null,
-      "implementer_summary": "pr=565 status=done specialist=pm-security note=P0-12 cookie hardening: SameSite Lax\u2192Strict, Path=/api/v1/auth scoped; sso.rs build_portal_session_cookie() centralised with Path=/api/v1/sso; 13 unit tests; cargo check exit 0",
-      "reviewer_summary": null
+      "implementer_summary": "pr=565 status=done specialist=pm-security note=P0-12 cookie hardening: SameSite Lax→Strict, Path=/api/v1/auth scoped; sso.rs build_portal_session_cookie() centralised with Path=/api/v1/sso; 13 unit tests; cargo check exit 0",
+      "reviewer_summary": null,
+      "last_reviewed_oid": null,
+      "scope_drift": null,
+      "code_reuse_warn": null,
+      "empty_branch": null,
+      "rebase_attempts": 0,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "pm-qa-inquiry-idor-tests-v2",
@@ -1734,7 +1950,15 @@
       "pr_url": "https://github.com/martin-janci/property-management/pull/563",
       "merged_at": null,
       "implementer_summary": "pr=563 status=done specialist=rust-backend scope_drift=false code_reuse_warn=none note=PR#563 already open+approved; cargo check -p reality-server exit 0; 3 IDOR tests (C1/C2/C3) compile clean; mark_inquiry_read_for_realtor implemented in PR#497+#508",
-      "reviewer_summary": null
+      "reviewer_summary": null,
+      "last_reviewed_oid": null,
+      "scope_drift": null,
+      "code_reuse_warn": null,
+      "empty_branch": null,
+      "rebase_attempts": 0,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     },
     {
       "task_id": "pm-scrum-master-promote-approved-drafts-566-567",
@@ -1747,8 +1971,16 @@
       "pr_number": null,
       "pr_url": null,
       "merged_at": null,
-      "implementer_summary": "pr=none status=done specialist=pm-scrum-master note=promoted #566 and #567 from draft\u2192ready then squash-merged both to dev; #566 sha=22672563 #567 sha=05f44b93 [meta-task succeeded; failed per pr=none rule]",
-      "reviewer_summary": null
+      "implementer_summary": "pr=none status=done specialist=pm-scrum-master note=promoted #566 and #567 from draft→ready then squash-merged both to dev; #566 sha=22672563 #567 sha=05f44b93 [meta-task succeeded; failed per pr=none rule]",
+      "reviewer_summary": null,
+      "last_reviewed_oid": null,
+      "scope_drift": null,
+      "code_reuse_warn": null,
+      "empty_branch": null,
+      "rebase_attempts": 0,
+      "fix_rounds": 0,
+      "reclaim_attempts": 0,
+      "merge_attempted_at": null
     }
   ],
   "assignments.generated": "2026-05-27T06:18:00Z"


### PR DESCRIPTION
## Summary

Operator review of the 2026-05-27 dispatcher run identified 4 remaining issues after PR #562 closed the original 5. All four are addressed in `.research/dispatcher-prompt.md`:

| # | Gap | Where | Mechanism |
|---|-----|-------|-----------|
| 1 | `assignments.json` rebase-races between overlapping cron runs | Phase 1 step 2 (new) | Recent-run skip-gate: if `assignments.generated` < 30min old, set `DISPATCHER_SKIP_MUTATING=1` and SKIP every mutating phase. Phase 2 (idempotent GH reconciliation) + Phase 7 still run. |
| 3 | Duplicate bot reviews posted on overlapping runs | Phase 5 reviewer prompt step 0 (new) | Dedup guard — reviewer GETs `/pulls/<n>/reviews`; if bot review for current `headRefOid` exists within 2h, skip post and return `note=dedup-existing-review-at-<iso>`. |
| 5 | Tier 2 kick HTTP 400 vanishes into fire-and-forget | Phase 2.6 (replaced inline curl) | Capture response code + first 200 chars of body; log `Tier 2: http=<code> body="<truncated>"`. |
| 6 | Items blocked on terminal-failed deps camp in buffer forever | new Phase 2.7 | Failed-dep cascade — open items whose `depends_on` points at a `status=failed` row are dropped with audit prefix `[CASCADED-DROP: depends_on <id> terminal-failed]`. Cap 20/run. |

Phase 7 summary gains four new lines (`Skip-gate`, `Tier 2 response`, `Review dedup-skipped`, `Failed-dep cascades`). HARD RULES section gains matching entries.

This closes the gaps documented in `feedback_dispatcher_spec_gaps.md` round 2 — see also PR #562 (round 1: oid mandate, claimable buffer, structured deps, merge back-off, async clarification).

## Test plan
- [x] `.research/dispatcher-self-test.sh` T1–T10, T12–T15 pass locally (T11 fails on pre-existing data — `assignments.json` rows missing hardening fields, orthogonal to this change)
- [ ] CI runs `dispatcher-self-test.yml` against the changed prompt
- [ ] First dispatcher run on `dev` after merge prints the four new Phase 7 lines (Skip-gate, Tier 2 response, Review dedup-skipped, Failed-dep cascades)
- [ ] Next overlapping cron pair: confirm second-run sees `skip-gate: assignments.generated=<…> age=<…m> < 30m` and skips mutating phases

## Follow-up (separate PR)
After this merges, update the trigger `trig_01RDNN7kYxzr4XULbi4xn5r2` to use the bootstrap one-liner from `.research/dispatcher-trigger-bootstrap.md` so the inlined copy stops drifting from the repo. (Trigger is currently `enabled: false` so timing is non-urgent.)