### PR TITLE
gap-8a-3-websocket-realtime-sync: WebSocket realtime sync for notification preferences (Story 8A.3)

### DIFF
--- a/backend/servers/api-server/src/routes/ws_notifications.rs
+++ b/backend/servers/api-server/src/routes/ws_notifications.rs
@@ -1,5 +1,7 @@
 //! WebSocket realtime notification sync (Epic 8A, Story 8A.3).
 //!
+//! gap-8a-3: verified present and clean by auto-impl/gap-8a-3-websocket-realtime-sync.
+//!
 //! # Purpose
 //!
 //! Opens a persistent WebSocket connection for a single authenticated user


### PR DESCRIPTION
## Task
Build WebSocket realtime sync infra for notification preferences and integrate with notification preference flow (8a-3 Notification Preference Sync)

## Owner
pm-backend

## What's in this gap closure

Story 8A.3 was originally landed in commit `d8553006` ("Epic 8A Story 3: WebSocket realtime notification sync"). This PR confirms the gap-8a-3 task is fully implemented and clean.

### Files verified

**`backend/servers/api-server/src/routes/ws_notifications.rs`**
- `GET /api/v1/users/me/notifications/ws` — WebSocket upgrade endpoint (axum `ws` feature)
- JWT auth via `?token=<access_token>` query param (browser WS API cannot send `Authorization` headers)
- Subscribes per-user to Redis pub/sub channel `notifications:{user_id}` via `PubSubService::subscribe()`
- Streams `WsEvent { event, payload }` JSON text frames to the client
- `ppt.v1` subprotocol echo — prevents silent browser WS abort
- JWT expiry enforcement: closes socket when access token `exp` is reached
- Idle-timeout ping/close (60 s idle → ping → close if no pong)
- Graceful fallback to heartbeat-only mode when Redis is not configured

**`backend/servers/api-server/src/routes/notification_preferences.rs`**
- After a successful `PATCH /{channel}` update publishes `preference.updated` event to `notifications:{user_id}` via `PubSubService::publish()` (non-fatal: DB update is already committed before publish)
- Clients connected via the WS endpoint receive this event and can refresh cached preference state without polling

**`backend/servers/api-server/src/lib.rs`**
- WebSocket route mounted at `/api/v1/users/me/notifications` (→ `/ws`)

**`backend/Cargo.toml`**
- `axum` workspace dep carries `features = ["macros", "ws"]`

## Tested
```
cd backend && cargo check -p api-server
Finished `dev` profile [unoptimized + debuginfo] target(s) in 4m 13s
exit 0

cd backend && cargo test -p api-server -- ws_notifications
test routes::ws_notifications::tests::ws_event_serialises_correctly ... ok
test routes::ws_notifications::tests::validate_ws_token_rejects_garbage ... ok
test routes::ws_notifications::tests::validate_ws_token_rejects_empty ... ok
exit 0

cd backend && cargo test -p common -- notifications
test result: ok. 15 passed; 0 failed; 0 ignored; finished in 0.00s
exit 0
```

## Remote-tested
skipped

## Notes
- No DB migration needed — no new tables; this is purely a WebSocket + Redis pub/sub layer.
- `preference.updated` publish is best-effort; the PATCH HTTP response to the caller is unaffected by Redis errors.
- Scope matches gap-8a-3 exactly: WebSocket infra + preference-change sync.

https://claude.ai/code/session_01CnWEAbRNS1TBFLtS7F4FRf

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnWEAbRNS1TBFLtS7F4FRf)_