### PR TITLE
fix(dispatcher): verdict/note extraction broken by head_oid token (issue #576)

### DIFF
--- a/.claude/skills/ppt-pr-followup/scripts/dispatcher-followup.sh
+++ b/.claude/skills/ppt-pr-followup/scripts/dispatcher-followup.sh
@@ -60,13 +60,9 @@ FR=$(jq -r      '.fix_rounds // 0'         <<<"$ROW")
 [[ "$FR" =~ ^[0-9]+$ ]] || FR=0
 
 # --- Parse verdict + note out of `reviewer_summary` string
-# Reviewer_summary shape: "verdict=<v> note=<rest>" (note can contain spaces).
-VERDICT=""
-NOTE=""
-if [[ "$RS" =~ ^verdict=([a-z]+)([[:space:]]+note=(.*))?$ ]]; then
-  VERDICT="${BASH_REMATCH[1]}"
-  NOTE="${BASH_REMATCH[3]:-}"
-fi
+# Reviewer_summary shape: "verdict=<v> head_oid=<oid> note=<rest>" (note can contain spaces).
+VERDICT=$(grep -oP '(?<=verdict=)[a-z]+' <<<"$RS" || true)
+NOTE=$(grep -oP '(?<=note=).*' <<<"$RS" || true)
 
 emit() {
   # emit "<line>"  — prints the machine-parseable result line on stdout.


### PR DESCRIPTION
## Problem
The regex in dispatcher-followup.sh expected `verdict=<v> note=<rest>` but the actual format is `verdict=<v> head_oid=<oid> note=<rest>`. VERDICT and NOTE were always empty, so every `verdict=changes` row silently skipped Phase 5.7 — the fix-and-respawn loop was broken end-to-end.

## Fix
Replace the brittle positional regex with key=value grep extraction that tolerates additional tokens between verdict and note.

Closes #576