### PR TITLE
fix(security): scheduler signs URLs fail-closed + cookie domain injection guard (issue #571)

### DIFF
--- a/backend/servers/api-server/src/routes/documents/core.rs
+++ b/backend/servers/api-server/src/routes/documents/core.rs
@@ -1105,8 +1105,8 @@ async fn update_document_access(
 )]
 async fn get_download_url(
     State(state): State<AppState>,
-    _auth: AuthUser,
-    _tenant: TenantExtractor,
+    auth: AuthUser,
+    tenant: TenantExtractor,
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<UrlResponse>, (StatusCode, Json<ErrorResponse>)> {
@@ -1133,6 +1133,30 @@ async fn get_download_url(
             ));
         }
     };
+
+    // Enforce access_scope for non-managers (mirrors list_documents simple path).
+    // Return 404 to avoid leaking document existence to unauthorized users.
+    if !tenant.role.is_manager() {
+        let user_id = auth.user_id;
+        let user_role = tenant.role.to_string().to_lowercase().replace(' ', "_");
+        let allowed = document.created_by == user_id
+            || document.access_scope == "organization"
+            || (document.access_scope == "role"
+                && document.access_roles.as_array().is_some_and(|arr| {
+                    arr.iter().any(|r| r.as_str() == Some(user_role.as_str()))
+                }))
+            || (document.access_scope == "users"
+                && document.access_target_ids.as_array().is_some_and(|arr| {
+                    arr.iter()
+                        .any(|id| id.as_str() == Some(&user_id.to_string()))
+                }));
+        if !allowed {
+            return Err((
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Document not found")),
+            ));
+        }
+    }
 
     // Story 7A.4: Generate presigned S3 URL with Content-Disposition: attachment.
     // Use state.storage_service (initialised at startup with the real S3 client).
@@ -1195,8 +1219,8 @@ async fn get_download_url(
 )]
 async fn get_preview_url(
     State(state): State<AppState>,
-    _auth: AuthUser,
-    _tenant: TenantExtractor,
+    auth: AuthUser,
+    tenant: TenantExtractor,
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<UrlResponse>, (StatusCode, Json<ErrorResponse>)> {
@@ -1223,6 +1247,30 @@ async fn get_preview_url(
             ));
         }
     };
+
+    // Enforce access_scope for non-managers (mirrors list_documents simple path).
+    // Return 404 to avoid leaking document existence to unauthorized users.
+    if !tenant.role.is_manager() {
+        let user_id = auth.user_id;
+        let user_role = tenant.role.to_string().to_lowercase().replace(' ', "_");
+        let allowed = document.created_by == user_id
+            || document.access_scope == "organization"
+            || (document.access_scope == "role"
+                && document.access_roles.as_array().is_some_and(|arr| {
+                    arr.iter().any(|r| r.as_str() == Some(user_role.as_str()))
+                }))
+            || (document.access_scope == "users"
+                && document.access_target_ids.as_array().is_some_and(|arr| {
+                    arr.iter()
+                        .any(|id| id.as_str() == Some(&user_id.to_string()))
+                }));
+        if !allowed {
+            return Err((
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Document not found")),
+            ));
+        }
+    }
 
     if !document.supports_preview() {
         return Err((

--- a/mobile-native/iosApp/iosApp/Features/Auth/LoginView.swift
+++ b/mobile-native/iosApp/iosApp/Features/Auth/LoginView.swift
@@ -229,9 +229,9 @@ struct LoginView: View {
     // MARK: - Actions
 
     private func loginWithSso() {
-        // Open Property Management app for SSO
-        // The app will redirect back with a token via deep link
-        if let url = URL(string: "propertymanagement://sso?callback=realityportal://sso") {
+        let state = authManager.beginSsoFlow()
+        let urlString = "propertymanagement://sso?callback=realityportal://sso&state=\(state)"
+        if let url = URL(string: urlString) {
             UIApplication.shared.open(url)
         }
     }


### PR DESCRIPTION
## Summary

- **Fix 1 (medium):** Scheduler signing URL — replace `unwrap_or_else` fallback that silently sent unsigned URLs with a `tracing::error!` + `continue`, so a broken e-signature provider skips only the affected signer rather than sending an unauthenticated link. Fields logged: `error`, `signature_request_id`, `signer_email`.
- **Fix 2 (low):** Cookie domain injection guard — validate `PPT_AUTH_COOKIE_DOMAIN` against RFC 1123 hostname characters (`[a-zA-Z0-9\-.]`) before appending to the `Set-Cookie` header. Invalid values are rejected with a `tracing::warn!` instead of being injected verbatim, preventing header-injection via environment variable misconfiguration.
- Removed the now-unused `base_url` variable from the scheduler tick (prefixed `_base_url` to suppress the compiler warning).

Closes #571

## Test plan

- [ ] `cargo check -p api-server` passes with no errors (one pre-existing warning resolved)
- [ ] Manually set `PPT_AUTH_COOKIE_DOMAIN=foo.example.com` — verify it appears in Set-Cookie
- [ ] Manually set `PPT_AUTH_COOKIE_DOMAIN="bad\nvalue"` — verify it is omitted and warning is logged
- [ ] Mock `build_signing_url` to return `Err` — verify the error is logged, the signer is skipped, and the loop continues to the next signer