### PR TITLE
fix(dispatcher): MODE_TAG slug placeholder + reclaim-cap prose + needs-human-review removal docs (issue #577)

### DIFF
--- a/.claude/skills/ppt-pr-merge/SKILL.md
+++ b/.claude/skills/ppt-pr-merge/SKILL.md
@@ -92,6 +92,12 @@ if [ -n "$HAS_GATE" ]; then
 fi
 ```
 
+**Clearing the gate (human or automation):** Once a human reviewer has approved, remove the label manually:
+```bash
+gh pr edit "$PR" --repo martin-janci/property-management --remove-label needs-human-review
+```
+After the label is removed, `ppt-pr-merge` will proceed normally on the next invocation.
+
 Abort with `merged=false note=<reason>` if ANY of:
 
 | Check | Abort if |

--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -257,7 +257,8 @@ fi
 - **no branch + in-progress** → run the **sandbox-reclaim helper** (P3):
 
   ```bash
-  MODE_TAG=$(grep -oE '^Mode:[[:space:]]*[a-z-]+' .research/plans/<slug>.md 2>/dev/null | head -1 | awk '{print $2}')
+  PLAN_FILE=".research/plans/${TASK_ID}.md"
+  MODE_TAG=$(grep -oE '^Mode:[[:space:]]*[a-z-]+' "$PLAN_FILE" 2>/dev/null | head -1 | awk '{print $2}')
   bash .claude/skills/ppt-pr-followup/scripts/sandbox-reclaim.sh
   # honours BRANCH, STATUS_CHANGED_AT, MODE_TAG, RECLAIM_ATTEMPTS env vars;
   # prints one line: `action=<wait|reclaim|fail> reason=<short> branch_state=<…>`
@@ -267,7 +268,7 @@ fi
 
   Apply the helper's verdict:
   - `action=wait` → keep `prev_status`; do not touch `status_changed_at`. Another run's implementer may still be working.
-  - `action=reclaim` (only when `reclaim_attempts < 1`) → re-spawn the SAME specialist with the SAME brief via Phase 4's machinery (mirror followup-skill respawn pattern). On respawn: bump `reclaim_attempts += 1`, set `status_changed_at = now` so the next grace window restarts. Status stays `in-progress`.
+  - `action=reclaim` → re-spawn the SAME specialist with the SAME brief via Phase 4's machinery (mirror followup-skill respawn pattern). On respawn: bump `reclaim_attempts += 1`, set `status_changed_at = now` so the next grace window restarts. Status stays `in-progress`. (Reclaim cap is enforced by `sandbox-reclaim.sh` — that script returns `action=fail` when `RECLAIM_ATTEMPTS >= 1`.)
   - `action=fail` → `new_status="failed"`, append the helper's `reason=<…>` to `implementer_summary` (e.g. `'sandbox-failure-after-reclaim'` or `'empty-branch'`).
 
 Persist: `last_updated=now` (always); if `new_status != prev_status`: `status=new_status`, `status_changed_at=now`.


### PR DESCRIPTION
## Changes

### 1. Fix `<slug>` placeholder in sandbox-reclaim block
`MODE_TAG` was derived from `.research/plans/<slug>.md` where `<slug>` was never explained or substituted. Since the plan file is named after the task's `task_id`, the fix derives the path as `\`.research/plans/\${TASK_ID}.md\``. This enables the 60m fast-timeout for `Mode: cloud-ok` plans to actually fire — previously `MODE_TAG` was always empty and the 120m fallback was always used.

### 2. Remove redundant reclaim-cap guard from prose
The `(only when reclaim_attempts < 1)` condition was duplicated — the helper already enforces the cap and returns `action=fail` when `RECLAIM_ATTEMPTS >= 1`. Removed the duplicate guard from the prose and added a comment pointing to the helper as the single source of truth.

### 3. Document needs-human-review removal path in ppt-pr-merge/SKILL.md
The skill blocked merges for PRs carrying `needs-human-review` but gave no instruction on how to clear the gate. Added the removal command so the queue doesn't stall permanently after a human reviewer approves.

Closes #577