### PR TITLE
fix(i18n): HistoryFilters report execution history labels hardcoded in English (issue #570)

### DIFF
--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -743,6 +743,19 @@
       "downloadFailed": "Nepodařilo se stáhnout zprávu.",
       "retryQueued": "Spuštění bylo zařazeno do fronty k opakování.",
       "retryFailed": "Nepodařilo se opakovat spuštění."
+    },
+    "filters": {
+      "allStatuses": "Všechny stavy",
+      "status": "Stav:",
+      "dateFrom": "Od:",
+      "dateTo": "Do:",
+      "clearFilters": "Vymazat filtry",
+      "statusCompleted": "Dokončeno",
+      "statusFailed": "Selhalo",
+      "statusRunning": "Probíhá",
+      "statusPending": "Čekající",
+      "statusCancelled": "Zrušeno",
+      "statusSkipped": "Přeskočeno"
     }
   }
 }

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -739,6 +739,19 @@
       "downloadFailed": "Bericht konnte nicht heruntergeladen werden.",
       "retryQueued": "Ausführung zur Wiederholung in die Warteschlange gestellt.",
       "retryFailed": "Ausführung konnte nicht wiederholt werden."
+    },
+    "filters": {
+      "allStatuses": "Alle Status",
+      "status": "Status:",
+      "dateFrom": "Von:",
+      "dateTo": "Bis:",
+      "clearFilters": "Filter löschen",
+      "statusCompleted": "Abgeschlossen",
+      "statusFailed": "Fehlgeschlagen",
+      "statusRunning": "Läuft",
+      "statusPending": "Ausstehend",
+      "statusCancelled": "Abgebrochen",
+      "statusSkipped": "Übersprungen"
     }
   }
 }

--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -3055,6 +3055,19 @@
       "downloadFailed": "Failed to download report.",
       "retryQueued": "Execution queued for retry.",
       "retryFailed": "Failed to retry execution."
+    },
+    "filters": {
+      "allStatuses": "All Statuses",
+      "status": "Status:",
+      "dateFrom": "From:",
+      "dateTo": "To:",
+      "clearFilters": "Clear filters",
+      "statusCompleted": "Completed",
+      "statusFailed": "Failed",
+      "statusRunning": "Running",
+      "statusPending": "Pending",
+      "statusCancelled": "Cancelled",
+      "statusSkipped": "Skipped"
     }
   }
 }

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -739,6 +739,19 @@
       "downloadFailed": "Nem sikerült letölteni a jelentést.",
       "retryQueued": "A végrehajtás újraküldésre várakozik.",
       "retryFailed": "Nem sikerült megismételni a végrehajtást."
+    },
+    "filters": {
+      "allStatuses": "Összes állapot",
+      "status": "Állapot:",
+      "dateFrom": "Től:",
+      "dateTo": "Ig:",
+      "clearFilters": "Szűrők törlése",
+      "statusCompleted": "Befejezett",
+      "statusFailed": "Sikertelen",
+      "statusRunning": "Folyamatban",
+      "statusPending": "Függőben",
+      "statusCancelled": "Megszakított",
+      "statusSkipped": "Kihagyott"
     }
   }
 }

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -743,6 +743,19 @@
       "downloadFailed": "Nie udało się pobrać raportu.",
       "retryQueued": "Wykonanie zostało dodane do kolejki ponowień.",
       "retryFailed": "Nie udało się ponowić wykonania."
+    },
+    "filters": {
+      "allStatuses": "Wszystkie statusy",
+      "status": "Status:",
+      "dateFrom": "Od:",
+      "dateTo": "Do:",
+      "clearFilters": "Wyczyść filtry",
+      "statusCompleted": "Zakończone",
+      "statusFailed": "Nieudane",
+      "statusRunning": "W toku",
+      "statusPending": "Oczekujące",
+      "statusCancelled": "Anulowane",
+      "statusSkipped": "Pominięte"
     }
   }
 }

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -743,6 +743,19 @@
       "downloadFailed": "Nepodarilo sa stiahnuť správu.",
       "retryQueued": "Spustenie bolo zaradené do frontu na opakovanie.",
       "retryFailed": "Nepodarilo sa opakovať spustenie."
+    },
+    "filters": {
+      "allStatuses": "Všetky stavy",
+      "status": "Stav:",
+      "dateFrom": "Od:",
+      "dateTo": "Do:",
+      "clearFilters": "Vymazať filtre",
+      "statusCompleted": "Dokončené",
+      "statusFailed": "Zlyhalo",
+      "statusRunning": "Prebieha",
+      "statusPending": "Čakajúce",
+      "statusCancelled": "Zrušené",
+      "statusSkipped": "Preskočené"
     }
   },
   "leases": {

--- a/frontend/apps/ppt-web/src/features/reports/components/HistoryFilters.tsx
+++ b/frontend/apps/ppt-web/src/features/reports/components/HistoryFilters.tsx
@@ -6,6 +6,7 @@
 
 import type { ReportExecutionStatus } from '@ppt/api-client';
 import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 
 export interface ExecutionFilters {
   status?: ReportExecutionStatus;
@@ -18,17 +19,19 @@ interface HistoryFiltersProps {
   onChange: (filters: ExecutionFilters) => void;
 }
 
-const STATUS_OPTIONS: { value: ReportExecutionStatus | ''; label: string }[] = [
-  { value: '', label: 'All Statuses' },
-  { value: 'completed', label: 'Completed' },
-  { value: 'failed', label: 'Failed' },
-  { value: 'running', label: 'Running' },
-  { value: 'pending', label: 'Pending' },
-  { value: 'cancelled', label: 'Cancelled' },
-  { value: 'skipped', label: 'Skipped' },
-];
-
 export function HistoryFilters({ filters, onChange }: HistoryFiltersProps) {
+  const { t } = useTranslation();
+
+  const STATUS_OPTIONS: { value: ReportExecutionStatus | ''; label: string }[] = [
+    { value: '', label: t('reports.filters.allStatuses', 'All Statuses') },
+    { value: 'completed', label: t('reports.filters.statusCompleted', 'Completed') },
+    { value: 'failed', label: t('reports.filters.statusFailed', 'Failed') },
+    { value: 'running', label: t('reports.filters.statusRunning', 'Running') },
+    { value: 'pending', label: t('reports.filters.statusPending', 'Pending') },
+    { value: 'cancelled', label: t('reports.filters.statusCancelled', 'Cancelled') },
+    { value: 'skipped', label: t('reports.filters.statusSkipped', 'Skipped') },
+  ];
+
   const handleStatusChange = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
       const value = e.target.value as ReportExecutionStatus | '';
@@ -71,7 +74,7 @@ export function HistoryFilters({ filters, onChange }: HistoryFiltersProps) {
       {/* Status Filter */}
       <div className="flex items-center gap-2">
         <label htmlFor="status-filter" className="text-sm font-medium text-gray-700">
-          Status:
+          {t('reports.filters.status', 'Status:')}
         </label>
         <select
           id="status-filter"
@@ -90,7 +93,7 @@ export function HistoryFilters({ filters, onChange }: HistoryFiltersProps) {
       {/* Date Range Filter */}
       <div className="flex items-center gap-2">
         <label htmlFor="date-from" className="text-sm font-medium text-gray-700">
-          From:
+          {t('reports.filters.dateFrom', 'From:')}
         </label>
         <input
           type="date"
@@ -104,7 +107,7 @@ export function HistoryFilters({ filters, onChange }: HistoryFiltersProps) {
 
       <div className="flex items-center gap-2">
         <label htmlFor="date-to" className="text-sm font-medium text-gray-700">
-          To:
+          {t('reports.filters.dateTo', 'To:')}
         </label>
         <input
           type="date"
@@ -123,7 +126,7 @@ export function HistoryFilters({ filters, onChange }: HistoryFiltersProps) {
           onClick={handleClear}
           className="text-sm text-gray-500 hover:text-gray-700 underline"
         >
-          Clear filters
+          {t('reports.filters.clearFilters', 'Clear filters')}
         </button>
       )}
     </div>


### PR DESCRIPTION
## Bug

`HistoryFilters.tsx` rendered all filter labels and dropdown options in hardcoded English, bypassing the `react-i18next` translation system. Affected strings:

- `"All Statuses"` (select placeholder)
- `"Status:"`, `"From:"`, `"To:"` (field labels)
- `"Clear filters"` (action button)
- All six status option labels (`Completed`, `Failed`, `Running`, `Pending`, `Cancelled`, `Skipped`)

## Fix

- Added `import { useTranslation } from 'react-i18next'` and `const { t } = useTranslation()` to the component.
- Replaced every hardcoded string with a `t('reports.filters.<key>', 'English fallback')` call.
- Moved `STATUS_OPTIONS` array inside the component so it picks up the live translation context.
- Added `reports.filters` keys to all 6 locale files: **en, sk, de, cs, pl, hu**.

## Testing

- `pnpm --filter @ppt/web typecheck` — only pre-existing unrelated errors (`qrcode`, `react-pdf` missing types); no new errors.

Closes #570 (finding 4)