### PR TITLE
fix(api): booking push endpoints — available_count guard + 500-item batch cap (issue #572)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "admin-core"
-version = "0.2.798"
+version = "0.2.799"
 dependencies = [
  "api-core",
  "async-trait",
@@ -192,7 +192,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-core"
-version = "0.2.798"
+version = "0.2.799"
 dependencies = [
  "async-trait",
  "axum",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "api-server"
-version = "0.2.798"
+version = "0.2.799"
 dependencies = [
  "admin-core",
  "aes-gcm",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.2.798"
+version = "0.2.799"
 dependencies = [
  "async-trait",
  "axum",
@@ -1823,7 +1823,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "db"
-version = "0.2.798"
+version = "0.2.799"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "deploy-server"
-version = "0.2.798"
+version = "0.2.799"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3326,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "integrations"
-version = "0.2.798"
+version = "0.2.799"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -5052,7 +5052,7 @@ dependencies = [
 
 [[package]]
 name = "reality-server"
-version = "0.2.798"
+version = "0.2.799"
 dependencies = [
  "anyhow",
  "api-core",
@@ -6581,7 +6581,7 @@ dependencies = [
 
 [[package]]
 name = "tenant-ops"
-version = "0.2.798"
+version = "0.2.799"
 dependencies = [
  "chrono",
  "common",

--- a/backend/servers/api-server/src/routes/integrations/install.rs
+++ b/backend/servers/api-server/src/routes/integrations/install.rs
@@ -21,6 +21,8 @@ use uuid::Uuid;
 use super::sync::{OrgIdPath, ResourceIdPath};
 use common::errors::ErrorResponse;
 
+const MAX_BATCH_SIZE: usize = 500;
+
 // ==================== Airbnb Types ====================
 
 /// Airbnb connection status response.
@@ -1142,6 +1144,26 @@ pub async fn push_booking_availability(
         ));
     }
 
+    if request.updates.len() > MAX_BATCH_SIZE {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(
+                "BATCH_TOO_LARGE",
+                "A maximum of 500 updates per request is allowed",
+            )),
+        ));
+    }
+
+    if request.updates.iter().any(|u| u.available_count < 0) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(
+                "INVALID_AVAILABLE_COUNT",
+                "available_count must be non-negative",
+            )),
+        ));
+    }
+
     let rental_repo = &state.rental_repo;
 
     let connection = rental_repo
@@ -1302,6 +1324,16 @@ pub async fn push_booking_rates(
             Json(ErrorResponse::new(
                 "NO_UPDATES",
                 "At least one rate update is required",
+            )),
+        ));
+    }
+
+    if request.updates.len() > MAX_BATCH_SIZE {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(
+                "BATCH_TOO_LARGE",
+                "A maximum of 500 updates per request is allowed",
             )),
         ));
     }


### PR DESCRIPTION
## Changes

### 1. `available_count >= 0` validation (Finding 3)
`AvailabilityUpdateDto.available_count: i32` was forwarded to Booking.com without a non-negative guard. A negative value would produce an invalid OTA XML payload. Added a pre-flight check in `push_booking_availability` that returns 400 `INVALID_AVAILABLE_COUNT` if any update has a negative count.

### 2. Max-batch size cap (Finding 4)
Both `push_booking_availability` and `push_booking_rates` accepted arbitrarily large `updates` lists, which could cause OOM or upstream timeouts. Added a module-level `MAX_BATCH_SIZE = 500` constant and a 400 `BATCH_TOO_LARGE` guard on both handlers.

Closes #572