### PR TITLE
gap-81-2-exec-history-api-retry: report_executions table + real SQLx execution history repo

### DIFF
--- a/backend/crates/db/migrations/00162_create_report_schedules_executions.sql
+++ b/backend/crates/db/migrations/00162_create_report_schedules_executions.sql
@@ -1,0 +1,135 @@
+-- Epic 81: Report Schedule Management & Execution History (Story 81.1, 81.2)
+--
+-- Creates:
+--   report_schedules  — configuration for recurring report delivery
+--   report_executions — per-run audit log with status and download link
+--
+-- RLS: tenant-scoped via organization_id on report_schedules; child table
+-- report_executions inherits isolation through the schedule FK.
+
+-- ============================================================================
+-- report_schedules
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS report_schedules (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    report_id       UUID        NOT NULL,
+    organization_id UUID        NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    name            TEXT        NOT NULL,
+    -- 'daily' | 'weekly' | 'monthly'
+    frequency       TEXT        NOT NULL CHECK (frequency IN ('daily', 'weekly', 'monthly')),
+    -- 0=Sunday … 6=Saturday, used when frequency = 'weekly'
+    day_of_week     INT,
+    -- 1-31, used when frequency = 'monthly'
+    day_of_month    INT,
+    -- HH:MM in the given timezone
+    time            TEXT        NOT NULL DEFAULT '08:00',
+    timezone        TEXT        NOT NULL DEFAULT 'UTC',
+    -- 'pdf' | 'excel' | 'csv'
+    format          TEXT        NOT NULL DEFAULT 'pdf',
+    -- JSON array of recipient email addresses
+    recipients      JSONB       NOT NULL DEFAULT '[]',
+    is_active       BOOLEAN     NOT NULL DEFAULT TRUE,
+    -- 'active' | 'paused' | 'inactive'
+    status          TEXT        NOT NULL DEFAULT 'active'
+                                CHECK (status IN ('active', 'paused', 'inactive')),
+    last_run_at     TIMESTAMPTZ,
+    next_run_at     TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Lookup all schedules for a tenant.
+CREATE INDEX IF NOT EXISTS idx_report_schedules_org
+    ON report_schedules(organization_id);
+
+-- Quick filter on active/paused schedules.
+CREATE INDEX IF NOT EXISTS idx_report_schedules_status
+    ON report_schedules(status);
+
+-- Auto-update updated_at.
+CREATE OR REPLACE FUNCTION update_report_schedules_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_report_schedules_updated_at
+    BEFORE UPDATE ON report_schedules
+    FOR EACH ROW EXECUTE FUNCTION update_report_schedules_updated_at();
+
+-- RLS
+ALTER TABLE report_schedules ENABLE ROW LEVEL SECURITY;
+ALTER TABLE report_schedules FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY report_schedules_tenant_isolation ON report_schedules
+    FOR ALL
+    USING (
+        is_super_admin()
+        OR organization_id = get_current_org_id()
+    )
+    WITH CHECK (
+        is_super_admin()
+        OR organization_id = get_current_org_id()
+    );
+
+-- ============================================================================
+-- report_executions
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS report_executions (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    schedule_id     UUID        NOT NULL REFERENCES report_schedules(id) ON DELETE CASCADE,
+    -- 'pending' | 'running' | 'completed' | 'failed' | 'cancelled' | 'skipped'
+    status          TEXT        NOT NULL DEFAULT 'pending'
+                                CHECK (status IN (
+                                    'pending', 'running', 'completed',
+                                    'failed', 'cancelled', 'skipped'
+                                )),
+    started_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at    TIMESTAMPTZ,
+    -- Wall-clock duration in milliseconds.
+    duration_ms     BIGINT,
+    -- S3 object key for the generated report file (NULL until completed).
+    file_key        TEXT,
+    file_name       TEXT,
+    file_size       BIGINT,
+    -- Error details (only set when status = 'failed').
+    error_code      TEXT,
+    error_message   TEXT,
+    error_details   TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Primary access pattern: all executions for a given schedule, newest first.
+CREATE INDEX IF NOT EXISTS idx_report_executions_schedule
+    ON report_executions(schedule_id, started_at DESC);
+
+-- Filter by status (e.g. show only failed ones).
+CREATE INDEX IF NOT EXISTS idx_report_executions_status
+    ON report_executions(status);
+
+-- RLS: inherit tenant isolation through the parent schedule.
+ALTER TABLE report_executions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE report_executions FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY report_executions_tenant_isolation ON report_executions
+    FOR ALL
+    USING (
+        is_super_admin()
+        OR EXISTS (
+            SELECT 1 FROM report_schedules s
+            WHERE s.id = report_executions.schedule_id
+              AND s.organization_id = get_current_org_id()
+        )
+    )
+    WITH CHECK (
+        is_super_admin()
+        OR EXISTS (
+            SELECT 1 FROM report_schedules s
+            WHERE s.id = report_executions.schedule_id
+              AND s.organization_id = get_current_org_id()
+        )
+    );

--- a/backend/crates/db/src/models/report_schedule.rs
+++ b/backend/crates/db/src/models/report_schedule.rs
@@ -4,6 +4,7 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -32,10 +33,10 @@ pub mod report_execution_status {
 // Models
 // ============================================================================
 
-/// A report schedule (in-memory representation).
+/// A report schedule (API representation).
 ///
-/// When the `report_schedules` table is added via migration this struct maps
-/// to that table row. Until then the repository returns stub data.
+/// Maps to the `report_schedules` table created by migration
+/// `00159_create_report_schedules_executions.sql`.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ReportSchedule {
     pub id: Uuid,
@@ -58,8 +59,66 @@ pub struct ReportSchedule {
     pub updated_at: DateTime<Utc>,
 }
 
+/// Raw DB row for `report_schedules`.
+///
+/// `recipients` is stored as JSONB so we use `serde_json::Value` for
+/// `FromRow`, then map to `ReportSchedule` (which exposes `Vec<String>`).
+#[derive(Debug, Clone, FromRow)]
+pub struct ReportScheduleRow {
+    pub id: Uuid,
+    pub report_id: Uuid,
+    pub organization_id: Uuid,
+    pub name: String,
+    pub frequency: String,
+    pub day_of_week: Option<i32>,
+    pub day_of_month: Option<i32>,
+    pub time: String,
+    pub timezone: String,
+    pub format: String,
+    pub recipients: serde_json::Value,
+    pub is_active: bool,
+    pub status: String,
+    pub last_run_at: Option<DateTime<Utc>>,
+    pub next_run_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl From<ReportScheduleRow> for ReportSchedule {
+    fn from(row: ReportScheduleRow) -> Self {
+        let recipients: Vec<String> = row
+            .recipients
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        Self {
+            id: row.id,
+            report_id: row.report_id,
+            organization_id: row.organization_id,
+            name: row.name,
+            frequency: row.frequency,
+            day_of_week: row.day_of_week,
+            day_of_month: row.day_of_month,
+            time: row.time,
+            timezone: row.timezone,
+            format: row.format,
+            recipients,
+            is_active: row.is_active,
+            status: row.status,
+            last_run_at: row.last_run_at,
+            next_run_at: row.next_run_at,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+        }
+    }
+}
+
 /// A single report execution record.
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize, ToSchema)]
 pub struct ReportExecution {
     pub id: Uuid,
     pub schedule_id: Uuid,

--- a/backend/crates/db/src/repositories/report_schedule.rs
+++ b/backend/crates/db/src/repositories/report_schedule.rs
@@ -1,13 +1,12 @@
 //! Report schedule repository (Epic 81: Schedule Management & Execution History).
 //!
-//! Stub implementation — `report_schedules` and `report_executions` tables do
-//! not exist yet. The repository returns synthesised data so the routes compile
-//! and the API responds with 200 instead of 404. A follow-up migration will
-//! replace the stubs with real SQLx queries.
+//! Real SQLx implementation backed by the `report_schedules` and
+//! `report_executions` tables added in migration
+//! `00159_create_report_schedules_executions.sql`.
 
 use crate::models::report_schedule::{
     report_execution_status, report_schedule_status, ExecutionDownloadUrl, ExecutionHistoryQuery,
-    ExecutionHistoryResponse, ReportExecution, ReportSchedule,
+    ExecutionHistoryResponse, ReportExecution, ReportSchedule, ReportScheduleRow,
 };
 use crate::DbPool;
 use chrono::{Duration, Utc};
@@ -17,7 +16,6 @@ use uuid::Uuid;
 /// Repository for report schedule and execution operations.
 #[derive(Clone)]
 pub struct ReportScheduleRepository {
-    #[allow(dead_code)]
     pool: DbPool,
 }
 
@@ -28,102 +26,157 @@ impl ReportScheduleRepository {
     }
 
     // ============================================================================
-    // Internal helpers
-    // ============================================================================
-
-    fn stub_schedule(id: Uuid) -> ReportSchedule {
-        let now = Utc::now();
-        ReportSchedule {
-            id,
-            report_id: Uuid::new_v4(),
-            organization_id: Uuid::new_v4(),
-            name: "Scheduled Report".to_string(),
-            frequency: "weekly".to_string(),
-            day_of_week: Some(1),
-            day_of_month: None,
-            time: "08:00".to_string(),
-            timezone: "Europe/Bratislava".to_string(),
-            format: "pdf".to_string(),
-            recipients: vec![],
-            is_active: true,
-            status: report_schedule_status::ACTIVE.to_string(),
-            last_run_at: None,
-            next_run_at: Some(now + Duration::days(7)),
-            created_at: now,
-            updated_at: now,
-        }
-    }
-
-    fn stub_execution(schedule_id: Uuid) -> ReportExecution {
-        let now = Utc::now();
-        ReportExecution {
-            id: Uuid::new_v4(),
-            schedule_id,
-            status: report_execution_status::COMPLETED.to_string(),
-            started_at: now - Duration::minutes(2),
-            completed_at: Some(now - Duration::minutes(1)),
-            duration_ms: Some(60_000),
-            file_key: Some(format!("reports/{}/{}.pdf", schedule_id, Uuid::new_v4())),
-            file_name: Some("report.pdf".to_string()),
-            file_size: Some(102_400),
-            error_code: None,
-            error_message: None,
-            error_details: None,
-            created_at: now - Duration::minutes(2),
-        }
-    }
-
-    // ============================================================================
     // Schedule operations
     // ============================================================================
 
     /// Get a schedule by ID.
-    ///
-    /// TODO: SELECT * FROM report_schedules WHERE id = $1
     pub async fn get_by_id(&self, id: Uuid) -> Result<Option<ReportSchedule>, AppError> {
-        Ok(Some(Self::stub_schedule(id)))
+        let row = sqlx::query_as::<_, ReportScheduleRow>(
+            r#"
+            SELECT id, report_id, organization_id, name, frequency,
+                   day_of_week, day_of_month, time, timezone, format,
+                   recipients, is_active, status,
+                   last_run_at, next_run_at, created_at, updated_at
+            FROM report_schedules
+            WHERE id = $1
+            "#,
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, schedule_id = %id, "Failed to get report schedule");
+            AppError::Database(e.to_string())
+        })?;
+
+        Ok(row.map(ReportSchedule::from))
     }
 
     /// Pause a schedule (Story 81.1).
     ///
-    /// TODO: UPDATE report_schedules SET is_active = false, status = 'paused',
-    ///       updated_at = NOW() WHERE id = $1 RETURNING *
+    /// Sets `is_active = false`, `status = 'paused'`.
     pub async fn pause(&self, id: Uuid) -> Result<ReportSchedule, AppError> {
-        let mut sched = Self::stub_schedule(id);
-        sched.is_active = false;
-        sched.status = report_schedule_status::PAUSED.to_string();
-        sched.updated_at = Utc::now();
-        Ok(sched)
+        let row = sqlx::query_as::<_, ReportScheduleRow>(
+            r#"
+            UPDATE report_schedules
+            SET is_active  = false,
+                status     = $1,
+                updated_at = NOW()
+            WHERE id = $2
+            RETURNING id, report_id, organization_id, name, frequency,
+                      day_of_week, day_of_month, time, timezone, format,
+                      recipients, is_active, status,
+                      last_run_at, next_run_at, created_at, updated_at
+            "#,
+        )
+        .bind(report_schedule_status::PAUSED)
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, schedule_id = %id, "Failed to pause report schedule");
+            AppError::Database(e.to_string())
+        })?
+        .ok_or_else(|| AppError::NotFound(format!("Report schedule {} not found", id)))?;
+
+        Ok(ReportSchedule::from(row))
     }
 
     /// Resume a paused schedule (Story 81.1).
     ///
-    /// TODO: UPDATE report_schedules SET is_active = true, status = 'active',
-    ///       updated_at = NOW() WHERE id = $1 RETURNING *
+    /// Sets `is_active = true`, `status = 'active'`.
     pub async fn resume(&self, id: Uuid) -> Result<ReportSchedule, AppError> {
-        let mut sched = Self::stub_schedule(id);
-        sched.is_active = true;
-        sched.status = report_schedule_status::ACTIVE.to_string();
-        sched.updated_at = Utc::now();
-        Ok(sched)
+        let row = sqlx::query_as::<_, ReportScheduleRow>(
+            r#"
+            UPDATE report_schedules
+            SET is_active  = true,
+                status     = $1,
+                updated_at = NOW()
+            WHERE id = $2
+            RETURNING id, report_id, organization_id, name, frequency,
+                      day_of_week, day_of_month, time, timezone, format,
+                      recipients, is_active, status,
+                      last_run_at, next_run_at, created_at, updated_at
+            "#,
+        )
+        .bind(report_schedule_status::ACTIVE)
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, schedule_id = %id, "Failed to resume report schedule");
+            AppError::Database(e.to_string())
+        })?
+        .ok_or_else(|| AppError::NotFound(format!("Report schedule {} not found", id)))?;
+
+        Ok(ReportSchedule::from(row))
     }
 
     // ============================================================================
-    // Execution history
+    // Execution history (Story 81.2)
     // ============================================================================
 
-    /// List execution history for a schedule (Story 81.2).
+    /// List execution history for a schedule, paginated.
     ///
-    /// TODO: SELECT * FROM report_executions WHERE schedule_id = $1
-    ///       AND ($2::text IS NULL OR status = $2) ... ORDER BY started_at DESC
+    /// Optionally filters by status. Results are ordered by `started_at DESC`
+    /// (newest execution first).
     pub async fn list_executions(
         &self,
         query: ExecutionHistoryQuery,
     ) -> Result<ExecutionHistoryResponse, AppError> {
-        let exec = Self::stub_execution(query.schedule_id);
-        let executions = vec![exec];
-        let total = executions.len() as i64;
+        // Count total matching rows for pagination metadata.
+        let total: i64 = sqlx::query_scalar(
+            r#"
+            SELECT COUNT(*)
+            FROM report_executions
+            WHERE schedule_id = $1
+              AND ($2::text IS NULL OR status = $2)
+              AND ($3::timestamptz IS NULL OR started_at >= $3)
+              AND ($4::timestamptz IS NULL OR started_at <= $4)
+            "#,
+        )
+        .bind(query.schedule_id)
+        .bind(&query.status)
+        .bind(query.date_from)
+        .bind(query.date_to)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, schedule_id = %query.schedule_id, "Failed to count executions");
+            AppError::Database(e.to_string())
+        })?;
+
+        let executions = sqlx::query_as::<_, ReportExecution>(
+            r#"
+            SELECT id, schedule_id, status,
+                   started_at, completed_at, duration_ms,
+                   file_key, file_name, file_size,
+                   error_code, error_message, error_details,
+                   created_at
+            FROM report_executions
+            WHERE schedule_id = $1
+              AND ($2::text IS NULL OR status = $2)
+              AND ($3::timestamptz IS NULL OR started_at >= $3)
+              AND ($4::timestamptz IS NULL OR started_at <= $4)
+            ORDER BY started_at DESC
+            LIMIT $5 OFFSET $6
+            "#,
+        )
+        .bind(query.schedule_id)
+        .bind(&query.status)
+        .bind(query.date_from)
+        .bind(query.date_to)
+        .bind(query.limit)
+        .bind(query.offset)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, schedule_id = %query.schedule_id, "Failed to list executions");
+            AppError::Database(e.to_string())
+        })?;
+
         let has_more = (query.offset + query.limit) < total;
+
         Ok(ExecutionHistoryResponse {
             executions,
             total,
@@ -131,68 +184,111 @@ impl ReportScheduleRepository {
         })
     }
 
-    /// Get a single execution by ID (Story 81.2).
-    ///
-    /// TODO: SELECT * FROM report_executions WHERE id = $1
+    /// Get a single execution by ID.
     pub async fn get_execution(&self, id: Uuid) -> Result<Option<ReportExecution>, AppError> {
-        let now = Utc::now();
-        let exec = ReportExecution {
-            id,
-            schedule_id: Uuid::new_v4(),
-            status: report_execution_status::COMPLETED.to_string(),
-            started_at: now - Duration::minutes(2),
-            completed_at: Some(now - Duration::minutes(1)),
-            duration_ms: Some(60_000),
-            file_key: Some(format!("reports/executions/{}.pdf", id)),
-            file_name: Some("report.pdf".to_string()),
-            file_size: Some(102_400),
-            error_code: None,
-            error_message: None,
-            error_details: None,
-            created_at: now - Duration::minutes(2),
-        };
-        Ok(Some(exec))
+        sqlx::query_as::<_, ReportExecution>(
+            r#"
+            SELECT id, schedule_id, status,
+                   started_at, completed_at, duration_ms,
+                   file_key, file_name, file_size,
+                   error_code, error_message, error_details,
+                   created_at
+            FROM report_executions
+            WHERE id = $1
+            "#,
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, execution_id = %id, "Failed to get execution");
+            AppError::Database(e.to_string())
+        })
     }
 
-    /// Get presigned download URL for a completed execution (Story 81.2).
+    /// Get presigned download URL for a completed execution.
     ///
-    /// TODO: look up file_key, generate S3 presigned URL
+    /// Generates a short-lived URL from the stored S3 `file_key`.
+    /// When `file_key` is NULL (execution not yet complete) returns an error.
     pub async fn get_download_url(
         &self,
         execution_id: Uuid,
     ) -> Result<ExecutionDownloadUrl, AppError> {
+        let execution = self
+            .get_execution(execution_id)
+            .await?
+            .ok_or_else(|| AppError::NotFound(format!("Execution {} not found", execution_id)))?;
+
+        let file_key = execution.file_key.ok_or_else(|| {
+            AppError::BadRequest("Execution does not have a completed file yet".into())
+        })?;
+
+        let file_name = execution
+            .file_name
+            .unwrap_or_else(|| "report.pdf".to_string());
+
+        // Derive MIME type from file extension.
+        let content_type = if file_name.ends_with(".pdf") {
+            "application/pdf"
+        } else if file_name.ends_with(".xlsx") {
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        } else {
+            "text/csv"
+        };
+
+        // Build a presigned-style URL. In production the S3 client would
+        // generate a short-lived signed URL; here we produce a stable
+        // API-gateway proxy path that the file-serving layer resolves.
+        let url = format!("/api/v1/reports/files/{}", file_key);
+        let expires_at = Utc::now() + Duration::hours(1);
+
         Ok(ExecutionDownloadUrl {
-            url: format!(
-                "/api/v1/reports/executions/{}/download/file.pdf",
-                execution_id
-            ),
-            expires_at: Utc::now() + Duration::hours(1),
-            file_name: "report.pdf".to_string(),
-            content_type: "application/pdf".to_string(),
+            url,
+            expires_at,
+            file_name,
+            content_type: content_type.to_string(),
         })
     }
 
-    /// Retry a failed execution (Story 81.2).
+    /// Retry a failed execution.
     ///
-    /// TODO: UPDATE report_executions SET status = 'pending', error_message = NULL,
-    ///       completed_at = NULL WHERE id = $1 AND status = 'failed' RETURNING *
+    /// Resets `status = 'pending'` and clears error fields so the
+    /// scheduler picks the job up again. Only allowed when the current
+    /// status is `'failed'`; all other statuses return a BadRequest error.
     pub async fn retry_execution(&self, id: Uuid) -> Result<ReportExecution, AppError> {
-        let now = Utc::now();
-        let exec = ReportExecution {
-            id,
-            schedule_id: Uuid::new_v4(),
-            status: report_execution_status::PENDING.to_string(),
-            started_at: now,
-            completed_at: None,
-            duration_ms: None,
-            file_key: None,
-            file_name: None,
-            file_size: None,
-            error_code: None,
-            error_message: None,
-            error_details: None,
-            created_at: now,
-        };
-        Ok(exec)
+        let updated = sqlx::query_as::<_, ReportExecution>(
+            r#"
+            UPDATE report_executions
+            SET status        = $1,
+                completed_at  = NULL,
+                duration_ms   = NULL,
+                error_code    = NULL,
+                error_message = NULL,
+                error_details = NULL
+            WHERE id = $2
+              AND status = $3
+            RETURNING id, schedule_id, status,
+                      started_at, completed_at, duration_ms,
+                      file_key, file_name, file_size,
+                      error_code, error_message, error_details,
+                      created_at
+            "#,
+        )
+        .bind(report_execution_status::PENDING)
+        .bind(id)
+        .bind(report_execution_status::FAILED)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, execution_id = %id, "Failed to retry execution");
+            AppError::Database(e.to_string())
+        })?
+        .ok_or_else(|| {
+            AppError::BadRequest(
+                "Execution not found or not in 'failed' state; only failed executions can be retried".into(),
+            )
+        })?;
+
+        Ok(updated)
     }
 }


### PR DESCRIPTION
## Task

Re-implement GET /api/v1/reports/schedules/{id}/executions returning paginated execution log with status and download link; add report_executions table migration; retry of failed gap-81-2-report-execution-history-api

## Owner

pm-backend

## Changes

### 1. Migration: `00162_create_report_schedules_executions.sql`

Creates two tables with RLS policies:

- **`report_schedules`** — configuration for recurring report delivery (tenant-scoped via `organization_id`; CHECK constraints on `frequency`, `status`; `recipients` stored as JSONB)
- **`report_executions`** — per-run audit log (FK → `report_schedules`; status CHECK; `started_at DESC` composite index; tenant isolation via parent schedule's `organization_id`)

RLS on both tables uses `is_super_admin()` / `get_current_org_id()` helper functions (consistent with the rest of the schema).

### 2. Model: `backend/crates/db/src/models/report_schedule.rs`

- Added `use sqlx::FromRow`
- Added `ReportScheduleRow` (DB row type with `recipients: serde_json::Value` for JSONB compat) + `From<ReportScheduleRow> for ReportSchedule` mapping
- Added `#[derive(FromRow)]` to `ReportExecution`

### 3. Repository: `backend/crates/db/src/repositories/report_schedule.rs`

Replaced all stubs with real `sqlx::query_as` / `sqlx::query_scalar` queries:

| Method | Query |
|--------|-------|
| `get_by_id` | `SELECT … FROM report_schedules WHERE id = $1` |
| `pause` | `UPDATE … SET is_active=false, status='paused' … RETURNING *` |
| `resume` | `UPDATE … SET is_active=true, status='active' … RETURNING *` |
| `list_executions` | paginated + status/date-range filter, `ORDER BY started_at DESC`, count query for `total`/`has_more` |
| `get_execution` | `SELECT … FROM report_executions WHERE id = $1` |
| `get_download_url` | looks up `file_key`, returns presigned-style URL path |
| `retry_execution` | `UPDATE … WHERE id=$1 AND status='failed' RETURNING *` (rejects non-failed) |

All errors use `AppError::Database(e.to_string())`, `AppError::NotFound(…)`, `AppError::BadRequest(…)`.

**Note:** The route `GET /api/v1/reports/schedules/{id}/executions` and supporting routes (`GET /executions/{id}`, `GET /executions/{id}/download`, `POST /executions/{id}/retry`) already existed in `backend/servers/api-server/src/routes/reports.rs` (Epic 81, Story 81.2). This PR provides the DB backend that was previously stubbed.

## Tested (Band A — fast check)

```
cd backend && cargo check -p db
```

- **`bhdg8o6tp`**: `cargo check -p db` → `Checking db v0.2.841 ... Finished` (exit 0)
- **`b5cbecnpj`**: `cargo check -p db` + api-server → `Finished dev profile` (exit 0)
- **`bj21x22lb`**: `cargo check -p db` — blocked on build lock due to ~9 parallel cargo processes in this session; all structural and syntax checks pass (see below)

Structural validation (all 13 checks OK):
- `sqlx::query_as` used for all DB calls
- `AppError::Database`, `AppError::NotFound`, `AppError::BadRequest` correct
- All 7 repository methods present
- `#[allow(dead_code)]` removed (pool is now used)
- `FROM report_executions` with pagination `LIMIT/OFFSET/ORDER BY started_at DESC`
- `ReportScheduleRow` imported and used

Model validation (all 5 checks OK):
- `use sqlx::FromRow` import
- `#[derive(FromRow)]` on `ReportScheduleRow` and `ReportExecution`
- `recipients: serde_json::Value` in row struct
- `impl From<ReportScheduleRow> for ReportSchedule`

Migration validation (all 9 checks OK):
- Both tables created, RLS enabled/forced, tenant isolation policies, CHECK constraints, indexes

## Built (Band B — full build)

Skipped: build lock contention (9+ parallel cargo processes in session); see Band A note.

## CI parity (Band C — hot-path only)

Skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested

Skipped.

## Scope drift

```
bash .claude/skills/ppt-implement/scripts/scope-check.sh --owner pm-backend --base dev --head HEAD
exit 0 — no drift
```

## Code-reuse review

```
bash .claude/skills/ppt-implement/scripts/reuse-grep.sh --specialist rust-backend --base dev --head HEAD
exit 0 — no warnings
```

## Notes

- Migration is numbered `00162` (dev already has `00159_fix_device_push_tokens_rls.sql`, `00160_disputes_mediation_notes.sql`, `00161_device_push_tokens_service_delete.sql`)
- Uses string-based `sqlx::query_as` (not compile-time `query!` macro) → no offline SQLx data regeneration needed
- `get_download_url` returns an API-gateway proxy path `/api/v1/reports/files/{file_key}`; in production this should be replaced with a proper S3 presigned URL generator via the integrations crate


---
_Generated by [Claude Code](https://claude.ai/code/session_01TU6YunLDgS9aJeHxS3fjf3)_