### PR TITLE
gap-security-435-p1-debug-format: P1-04 replace Debug-format with stable Display in audit fields

### DIFF
--- a/backend/crates/admin-core/src/error.rs
+++ b/backend/crates/admin-core/src/error.rs
@@ -89,7 +89,8 @@ impl IntoResponse for AdminError {
                 StatusCode::FORBIDDEN,
                 Json(ErrorBody {
                     error: "missing_capability",
-                    message: format!("Missing capability: {:?}", cap),
+                    // P1-04: as_str() gives stable snake_case, not Rust Debug repr.
+                    message: format!("Missing capability: {}", cap.as_str()),
                 }),
             )
                 .into_response(),

--- a/backend/servers/api-server/src/routes/compliance.rs
+++ b/backend/servers/api-server/src/routes/compliance.rs
@@ -149,7 +149,8 @@ async fn get_audit_logs(
         .map(|log| AuditLogResponse {
             id: log.id,
             user_id: log.user_id,
-            action: format!("{:?}", log.action),
+            // P1-04: canonical_name() gives stable output, not Rust Debug repr.
+            action: log.action.canonical_name().to_string(),
             resource_type: log.resource_type,
             resource_id: log.resource_id,
             org_id: log.org_id,
@@ -247,7 +248,8 @@ async fn get_user_audit_logs(
         .map(|log| AuditLogResponse {
             id: log.id,
             user_id: log.user_id,
-            action: format!("{:?}", log.action),
+            // P1-04: canonical_name() gives stable output, not Rust Debug repr.
+            action: log.action.canonical_name().to_string(),
             resource_type: log.resource_type,
             resource_id: log.resource_id,
             org_id: log.org_id,

--- a/backend/servers/deploy-server/src/infra/audit.rs
+++ b/backend/servers/deploy-server/src/infra/audit.rs
@@ -38,8 +38,11 @@ impl CallerIdentity {
             Ok(())
         } else {
             Err(crate::DeployError::Forbidden(format!(
-                "missing required scope: {scope}; caller {}:{} has scopes {:?}",
-                self.kind, self.id, self.scopes
+                // P1-04: join() instead of {:?} to avoid Debug format in error strings.
+                "missing required scope: {scope}; caller {}:{} has scopes [{}]",
+                self.kind,
+                self.id,
+                self.scopes.join(", ")
             )))
         }
     }


### PR DESCRIPTION
## Task
Fix P1-04 Debug-format audit-hash domain leak from post-merge findings on PR#435: audit trail records must not include Debug-formatted internal types; use Display or structured logging for all audit fields

## Owner
pm-security

## Changes

Three sites were using `{:?}` (Rust Debug format) on audit-trail types that are either served over HTTP or appear in structured error strings/logs:

### 1. `backend/servers/api-server/src/routes/compliance.rs` (2 sites)
- `get_audit_logs` and `get_user_audit_logs` both mapped `log.action` to a string using `format!("{:?}", log.action)`
- This leaked the internal Rust PascalCase variant name (e.g. `"ResourceAccessed"`) to API callers
- Fix: `log.action.canonical_name().to_string()` — the `canonical_name()` method was already added by issue #439 P1-04 to the `AuditAction` enum specifically to provide a stable, exhaustively-matched name that doesn't rely on Debug formatting; this PR wires the API layer to use it

### 2. `backend/crates/admin-core/src/error.rs` (1 site)
- `AdminError::MissingCapability` JSON response body used `format!("Missing capability: {:?}", cap)`
- This sent PascalCase Debug representation of a `Capability` variant in the HTTP 403 error body
- Fix: `cap.as_str()` — `Capability::as_str()` already exists and returns the stable snake_case name used by the DB and storage layer

### 3. `backend/servers/deploy-server/src/infra/audit.rs` (1 site)
- `CallerIdentity::require_scope` error message used `{:?}` to format `self.scopes` (`Vec<String>`)
- Vec Debug output adds Rust-style `["a", "b"]` decoration into the `DeployError::Forbidden` message
- Fix: `self.scopes.join(", ")` — clean comma-separated list

## Tested (Band A — fast check)

```
cd /tmp/p1-debug-fix/backend && cargo check -p admin-core
Checking admin-core v0.2.846 → Finished `dev` profile [exit 0]

cd /tmp/p1-debug-fix/backend && cargo check -p api-server
Checking api-server v0.2.846 → Finished `dev` profile [exit 0]

cd /tmp/p1-debug-fix/backend && cargo check -p deploy-server
Checking deploy-server v0.2.846 → Finished `dev` profile [exit 0]
```

All three crates check clean with the changes.

## Built (Band B — full build)
skipped: change <50 LOC, no public API/config touch (all changes are display-only string formatting in existing paths)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no new security/auth/billing/data-integrity logic — this is a display fix for existing paths)

## Remote-tested
skipped

## Scope drift
Exit code 2 — the three changed paths are outside the strict `pm-security` auth globs (`backend/crates/auth/**`, `backend/crates/api-core/src/extractors/**`). The drift is **justified**: this task was explicitly assigned to `pm-security` to audit all three surfaces for Debug-format leaks. The compliance route, admin-core error layer, and deploy-server audit middleware all touch audit data and all needed this fix.

Drifting paths:
- `backend/crates/admin-core/src/error.rs`
- `backend/servers/api-server/src/routes/compliance.rs`
- `backend/servers/deploy-server/src/infra/audit.rs`

## Code-reuse review
No warnings (reuse-grep.sh exit 0). All fixes use methods that already existed (`canonical_name()`, `as_str()`) — no new helpers introduced.

## Notes
- `AuditAction::canonical_name()` was specifically added in the P1-04 pass on `audit_log.rs` and `repositories/audit_log.rs` to fix the integrity hash chain. The compliance API layer was missed in that pass — this PR closes that gap.
- The `#[error("forbidden: missing capability {0:?}")]` thiserror attribute string (used for `std::error::Error::Display`) still uses `{0:?}` — that only affects internal tracing/log chains, not the JSON response body (which now uses `as_str()`). A follow-up could add `impl Display for Capability` backed by `as_str()` to fully decouple even the log form, but that is not strictly required for the P1-04 fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TU6YunLDgS9aJeHxS3fjf3)_