### PR TITLE
gap-81-1-report-schedule-edit-ui: report schedule editor modal (cron picker, recipient list, enabled toggle)

### DIFF
--- a/docs/screens/ppt/reports.md
+++ b/docs/screens/ppt/reports.md
@@ -23,15 +23,15 @@ owner: pm-frontend
 
 ## Agent Log
 
+- 2026-05-27 — agent: gap-81-1: EditScheduleModal rebuilt for cron-based PUT endpoint. CronPicker added (preset tabs + custom free-text with live validation). Pause/Resume props replaced by enabled toggle in modal (maps to `enabled` field in CronScheduleUpdateRequest). useUpdateScheduleCron hook wired. apiStatus remains partial (schedule create stub still absent).
 - 2026-05-25 — agent: Created screen-map. Route /reports wrapped in ProtectedRoute (PR #489 fix). Hooks pagination cache key fixed (executionOffset included). apiStatus=partial (schedule CRUD + execution history wired; download/retry stubs).
 
 ## Functionality Checklist
 
 ### Schedule Management (Story 81.1)
 - [x] [w] List report schedules
-- [x] [w] Update schedule (name, cron, format)
-- [x] [w] Pause schedule
-- [x] [w] Resume schedule
+- [x] [w] Update schedule (cron expression, recipients, enabled)
+- [x] [w] Enable / disable schedule (enabled toggle in EditScheduleModal)
 - [ ] [w] Create new schedule
 
 ### Execution History (Story 81.2)

--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -37,18 +37,16 @@ import {
   useMarkReadAnnouncement,
   useOutage,
   useOutages,
-  usePauseSchedule,
   usePinAnnouncement,
   usePinnedAnnouncements,
   usePublishAnnouncement,
   useReportExecutionHistory,
   useResolveOutage,
-  useResumeSchedule,
   useRetryReportExecution,
   useStartOutage,
   useUpdateDisputeStatus,
   useUpdateOutage,
-  useUpdateSchedule,
+  useUpdateScheduleCron,
 } from '@ppt/api-client';
 import { AccessibilityProvider, SkipNavigation } from '@ppt/ui-kit';
 import { type ReactNode, Suspense, useCallback, useEffect, useRef, useState } from 'react';
@@ -2750,52 +2748,15 @@ function ReportsPageRoute() {
   const { user } = useAuth();
   const organizationId = user?.organizationId ?? '';
 
-  const pauseSchedule = usePauseSchedule();
-  const resumeSchedule = useResumeSchedule();
-  const updateSchedule = useUpdateSchedule();
-
-  const handlePauseSchedule = async (id: string) => {
-    try {
-      await pauseSchedule.mutateAsync(id);
-      showToast({
-        type: 'success',
-        title: t('common.success'),
-        message: t('reports.schedule.paused', 'Schedule paused successfully.'),
-      });
-    } catch (e) {
-      showToast({
-        type: 'error',
-        title: t('common.error'),
-        message: t('reports.schedule.pauseFailed', 'Failed to pause schedule.'),
-      });
-      throw e;
-    }
-  };
-
-  const handleResumeSchedule = async (id: string) => {
-    try {
-      await resumeSchedule.mutateAsync(id);
-      showToast({
-        type: 'success',
-        title: t('common.success'),
-        message: t('reports.schedule.resumed', 'Schedule resumed successfully.'),
-      });
-    } catch (e) {
-      showToast({
-        type: 'error',
-        title: t('common.error'),
-        message: t('reports.schedule.resumeFailed', 'Failed to resume schedule.'),
-      });
-      throw e;
-    }
-  };
+  // gap-81-1: cron-based update (cron_expression, recipients, enabled)
+  const updateScheduleCronMutation = useUpdateScheduleCron();
 
   const handleUpdateSchedule = async (
     id: string,
-    data: Partial<import('@ppt/api-client').CreateReportSchedule>
+    data: import('@ppt/api-client').CronScheduleUpdateRequest
   ) => {
     try {
-      await updateSchedule.mutateAsync({ id, data });
+      await updateScheduleCronMutation.mutateAsync({ id, data });
       showToast({
         type: 'success',
         title: t('common.success'),
@@ -2900,8 +2861,6 @@ function ReportsPageRoute() {
           difference_percentage: 0,
         } as import('@ppt/api-client').PeriodComparison
       }
-      onPauseSchedule={handlePauseSchedule}
-      onResumeSchedule={handleResumeSchedule}
       onUpdateSchedule={handleUpdateSchedule}
       executions={executions}
       executionsLoading={executionsLoading}

--- a/frontend/apps/ppt-web/src/features/reports/components/CronPicker.tsx
+++ b/frontend/apps/ppt-web/src/features/reports/components/CronPicker.tsx
@@ -1,0 +1,426 @@
+/**
+ * CronPicker — Visual builder for 5-field UNIX cron expressions.
+ *
+ * Story 81.1 - Report Schedule Editor
+ *
+ * Provides two modes:
+ *   - "simple": preset helpers (daily, weekly, monthly, …) + time/day selectors
+ *   - "custom": free-text input with live validation feedback
+ *
+ * The component always emits a valid 5-field UNIX cron string or null when
+ * the current input fails validation.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+
+// ─────────────────────────────────────────────────────────────
+// Types & constants
+// ─────────────────────────────────────────────────────────────
+
+export interface CronPickerProps {
+  /** Current cron expression, e.g. "0 8 * * 1". Empty string = unset. */
+  value: string;
+  /** Called with the new cron string whenever a valid expression is built. */
+  onChange: (cron: string) => void;
+  /** Shown below the picker when the expression is invalid. */
+  error?: string;
+  disabled?: boolean;
+}
+
+type SimplePreset = 'daily' | 'weekly' | 'monthly' | 'custom';
+
+interface PresetDefinition {
+  label: string;
+  description: string;
+}
+
+const PRESETS: Record<SimplePreset, PresetDefinition> = {
+  daily: { label: 'Daily', description: 'Every day at the chosen time' },
+  weekly: { label: 'Weekly', description: 'Once a week on the chosen day' },
+  monthly: { label: 'Monthly', description: 'Once a month on the chosen day' },
+  custom: { label: 'Custom', description: 'Enter a cron expression manually' },
+};
+
+const DAYS_OF_WEEK = [
+  { value: '0', label: 'Sunday' },
+  { value: '1', label: 'Monday' },
+  { value: '2', label: 'Tuesday' },
+  { value: '3', label: 'Wednesday' },
+  { value: '4', label: 'Thursday' },
+  { value: '5', label: 'Friday' },
+  { value: '6', label: 'Saturday' },
+];
+
+const HOURS = Array.from({ length: 24 }, (_, i) => ({
+  value: String(i),
+  label: `${String(i).padStart(2, '0')}:00`,
+}));
+
+const MINUTES = [
+  { value: '0', label: ':00' },
+  { value: '15', label: ':15' },
+  { value: '30', label: ':30' },
+  { value: '45', label: ':45' },
+];
+
+// ─────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────
+
+/** Validate a 5-field UNIX cron expression — mirrors backend logic. */
+function isValidCron(expr: string): boolean {
+  const fields = expr.trim().split(/\s+/);
+  if (fields.length !== 5) return false;
+
+  function validField(field: string, min: number, max: number): boolean {
+    // wildcard
+    if (field === '*') return true;
+
+    // step: */n or x-y/n
+    if (field.includes('/')) {
+      const parts = field.split('/');
+      if (parts.length !== 2) return false;
+      const step = Number(parts[1]);
+      if (!Number.isInteger(step) || step <= 0) return false;
+      if (parts[0] !== '*') {
+        // range/step: 1-5/2
+        return validField(parts[0], min, max);
+      }
+      return true;
+    }
+
+    // range: x-y
+    if (field.includes('-')) {
+      const [a, b] = field.split('-').map(Number);
+      if (isNaN(a) || isNaN(b) || a > b) return false;
+      return a >= min && b <= max;
+    }
+
+    // list: 1,2,3
+    if (field.includes(',')) {
+      return field.split(',').every((v) => validField(v, min, max));
+    }
+
+    // single number
+    const n = Number(field);
+    return Number.isInteger(n) && n >= min && n <= max;
+  }
+
+  return (
+    validField(fields[0], 0, 59) && // minute
+    validField(fields[1], 0, 23) && // hour
+    validField(fields[2], 1, 31) && // dom
+    validField(fields[3], 1, 12) && // month
+    validField(fields[4], 0, 7) // dow (0 and 7 are both Sunday)
+  );
+}
+
+/** Derive the SimplePreset from a cron expression, falling back to "custom". */
+function detectPreset(cron: string): SimplePreset {
+  const fields = cron.trim().split(/\s+/);
+  if (fields.length !== 5) return 'custom';
+  const [, , dom, month, dow] = fields;
+
+  if (month === '*') {
+    if (dom === '*' && dow === '*') return 'daily';
+    if (dom === '*' && /^\d+$/.test(dow)) return 'weekly';
+    if (/^\d+$/.test(dom) && dow === '*') return 'monthly';
+  }
+  return 'custom';
+}
+
+/** Build a cron string from simple preset parts. */
+function buildCron(
+  preset: SimplePreset,
+  minute: string,
+  hour: string,
+  dow: string,
+  dom: string
+): string {
+  switch (preset) {
+    case 'daily':
+      return `${minute} ${hour} * * *`;
+    case 'weekly':
+      return `${minute} ${hour} * * ${dow}`;
+    case 'monthly':
+      return `${minute} ${hour} ${dom} * *`;
+    default:
+      return '';
+  }
+}
+
+/** Parse hour and minute from the first two fields of a cron expression. */
+function parseCronTime(cron: string): { hour: string; minute: string } {
+  const fields = cron.trim().split(/\s+/);
+  if (fields.length < 2) return { hour: '8', minute: '0' };
+  const minute = /^\d+$/.test(fields[0]) ? fields[0] : '0';
+  const hour = /^\d+$/.test(fields[1]) ? fields[1] : '8';
+  return { hour, minute };
+}
+
+/** Parse day-of-week from field 5 (index 4). */
+function parseCronDow(cron: string): string {
+  const fields = cron.trim().split(/\s+/);
+  if (fields.length < 5) return '1';
+  return /^\d+$/.test(fields[4]) ? fields[4] : '1';
+}
+
+/** Parse day-of-month from field 3 (index 2). */
+function parseCronDom(cron: string): string {
+  const fields = cron.trim().split(/\s+/);
+  if (fields.length < 3) return '1';
+  return /^\d+$/.test(fields[2]) ? fields[2] : '1';
+}
+
+// ─────────────────────────────────────────────────────────────
+// Component
+// ─────────────────────────────────────────────────────────────
+
+export function CronPicker({ value, onChange, error, disabled }: CronPickerProps) {
+  const [preset, setPreset] = useState<SimplePreset>(() => (value ? detectPreset(value) : 'daily'));
+  const [hour, setHour] = useState(() => parseCronTime(value).hour);
+  const [minute, setMinute] = useState(() => parseCronTime(value).minute);
+  const [dow, setDow] = useState(() => parseCronDow(value));
+  const [dom, setDom] = useState(() => parseCronDom(value));
+  const [customExpr, setCustomExpr] = useState(value || '');
+  const [customValid, setCustomValid] = useState(true);
+
+  // Sync internal state when `value` changes externally
+  useEffect(() => {
+    if (!value) return;
+    const detectedPreset = detectPreset(value);
+    setPreset(detectedPreset);
+    const { hour: h, minute: m } = parseCronTime(value);
+    setHour(h);
+    setMinute(m);
+    setDow(parseCronDow(value));
+    setDom(parseCronDom(value));
+    if (detectedPreset === 'custom') {
+      setCustomExpr(value);
+    }
+  }, [value]);
+
+  // Emit updated cron expression for simple presets
+  const emitSimple = useCallback(
+    (p: SimplePreset, h: string, m: string, d: string, dm: string) => {
+      if (p === 'custom') return;
+      const cron = buildCron(p, m, h, d, dm);
+      if (cron) onChange(cron);
+    },
+    [onChange]
+  );
+
+  const handlePresetChange = useCallback(
+    (newPreset: SimplePreset) => {
+      setPreset(newPreset);
+      if (newPreset !== 'custom') {
+        emitSimple(newPreset, hour, minute, dow, dom);
+      }
+    },
+    [hour, minute, dow, dom, emitSimple]
+  );
+
+  const handleHourChange = useCallback(
+    (h: string) => {
+      setHour(h);
+      emitSimple(preset, h, minute, dow, dom);
+    },
+    [preset, minute, dow, dom, emitSimple]
+  );
+
+  const handleMinuteChange = useCallback(
+    (m: string) => {
+      setMinute(m);
+      emitSimple(preset, hour, m, dow, dom);
+    },
+    [preset, hour, dow, dom, emitSimple]
+  );
+
+  const handleDowChange = useCallback(
+    (d: string) => {
+      setDow(d);
+      emitSimple(preset, hour, minute, d, dom);
+    },
+    [preset, hour, minute, dom, emitSimple]
+  );
+
+  const handleDomChange = useCallback(
+    (dm: string) => {
+      const n = Number(dm);
+      if (isNaN(n) || n < 1 || n > 31) return;
+      setDom(dm);
+      emitSimple(preset, hour, minute, dow, dm);
+    },
+    [preset, hour, minute, dow, emitSimple]
+  );
+
+  const handleCustomChange = useCallback(
+    (expr: string) => {
+      setCustomExpr(expr);
+      const valid = isValidCron(expr);
+      setCustomValid(valid);
+      if (valid) {
+        onChange(expr.trim());
+      }
+    },
+    [onChange]
+  );
+
+  // Current expression preview (for display)
+  const previewCron = preset === 'custom' ? customExpr : buildCron(preset, minute, hour, dow, dom);
+
+  const selectClass = `block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm
+    focus:outline-none focus:ring-blue-500 focus:border-blue-500
+    disabled:bg-gray-100 disabled:cursor-not-allowed`;
+
+  return (
+    <div className="space-y-4">
+      {/* Preset tabs */}
+      <div className="flex gap-2 flex-wrap">
+        {(Object.keys(PRESETS) as SimplePreset[]).map((p) => (
+          <button
+            key={p}
+            type="button"
+            disabled={disabled}
+            onClick={() => handlePresetChange(p)}
+            className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors
+              disabled:opacity-50 disabled:cursor-not-allowed
+              ${
+                preset === p
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+              }`}
+          >
+            {PRESETS[p].label}
+          </button>
+        ))}
+      </div>
+
+      {/* Description */}
+      <p className="text-xs text-gray-500">{PRESETS[preset].description}</p>
+
+      {/* Simple preset controls */}
+      {preset !== 'custom' && (
+        <div className="grid grid-cols-2 gap-4">
+          {/* Hour */}
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">Hour</label>
+            <select
+              value={hour}
+              onChange={(e) => handleHourChange(e.target.value)}
+              disabled={disabled}
+              className={selectClass}
+            >
+              {HOURS.map((h) => (
+                <option key={h.value} value={h.value}>
+                  {h.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Minute */}
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">Minute</label>
+            <select
+              value={minute}
+              onChange={(e) => handleMinuteChange(e.target.value)}
+              disabled={disabled}
+              className={selectClass}
+            >
+              {MINUTES.map((m) => (
+                <option key={m.value} value={m.value}>
+                  {m.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Day of week (weekly only) */}
+          {preset === 'weekly' && (
+            <div className="col-span-2">
+              <label className="block text-xs font-medium text-gray-700 mb-1">Day of week</label>
+              <select
+                value={dow}
+                onChange={(e) => handleDowChange(e.target.value)}
+                disabled={disabled}
+                className={selectClass}
+              >
+                {DAYS_OF_WEEK.map((d) => (
+                  <option key={d.value} value={d.value}>
+                    {d.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {/* Day of month (monthly only) */}
+          {preset === 'monthly' && (
+            <div className="col-span-2">
+              <label className="block text-xs font-medium text-gray-700 mb-1">
+                Day of month (1 – 31)
+              </label>
+              <input
+                type="number"
+                min="1"
+                max="31"
+                value={dom}
+                onChange={(e) => handleDomChange(e.target.value)}
+                disabled={disabled}
+                className={`${selectClass} ${disabled ? '' : 'bg-white'}`}
+              />
+              <p className="mt-1 text-xs text-gray-400">
+                For shorter months the schedule runs on the last available day.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Custom cron input */}
+      {preset === 'custom' && (
+        <div>
+          <label className="block text-xs font-medium text-gray-700 mb-1">
+            Cron expression{' '}
+            <span className="text-gray-400 font-normal">
+              (minute hour day-of-month month day-of-week)
+            </span>
+          </label>
+          <input
+            type="text"
+            value={customExpr}
+            onChange={(e) => handleCustomChange(e.target.value)}
+            disabled={disabled}
+            placeholder="0 8 * * 1"
+            className={`block w-full px-3 py-2 border rounded-md shadow-sm text-sm font-mono
+              focus:outline-none focus:ring-blue-500 focus:border-blue-500
+              disabled:bg-gray-100 disabled:cursor-not-allowed
+              ${!customValid && customExpr ? 'border-red-400' : 'border-gray-300'}`}
+          />
+          {!customValid && customExpr && (
+            <p className="mt-1 text-xs text-red-600">
+              Invalid cron — use 5 fields, e.g. <code className="font-mono">0 8 * * 1</code>
+            </p>
+          )}
+          <p className="mt-1 text-xs text-gray-400">
+            Examples: <code className="font-mono">0 8 * * *</code> (daily 8am) &nbsp;·&nbsp;{' '}
+            <code className="font-mono">30 17 * * 5</code> (Fri 17:30) &nbsp;·&nbsp;{' '}
+            <code className="font-mono">0 6 1 * *</code> (1st of month 6am)
+          </p>
+        </div>
+      )}
+
+      {/* Expression preview */}
+      {previewCron && (
+        <div className="flex items-center gap-2 px-3 py-2 bg-gray-50 rounded-md border border-gray-200">
+          <span className="text-xs text-gray-500">Expression:</span>
+          <code className="text-xs font-mono text-gray-800">{previewCron}</code>
+        </div>
+      )}
+
+      {/* External error */}
+      {error && <p className="text-sm text-red-600">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/reports/components/CronPicker.tsx
+++ b/frontend/apps/ppt-web/src/features/reports/components/CronPicker.tsx
@@ -68,7 +68,7 @@ const MINUTES = [
 // ─────────────────────────────────────────────────────────────
 
 /** Validate a 5-field UNIX cron expression — mirrors backend logic. */
-function isValidCron(expr: string): boolean {
+export function isValidCron(expr: string): boolean {
   const fields = expr.trim().split(/\s+/);
   if (fields.length !== 5) return false;
 
@@ -304,8 +304,11 @@ export function CronPicker({ value, onChange, error, disabled }: CronPickerProps
         <div className="grid grid-cols-2 gap-4">
           {/* Hour */}
           <div>
-            <label className="block text-xs font-medium text-gray-700 mb-1">Hour</label>
+            <label htmlFor="cron-hour" className="block text-xs font-medium text-gray-700 mb-1">
+              Hour
+            </label>
             <select
+              id="cron-hour"
               value={hour}
               onChange={(e) => handleHourChange(e.target.value)}
               disabled={disabled}
@@ -321,8 +324,11 @@ export function CronPicker({ value, onChange, error, disabled }: CronPickerProps
 
           {/* Minute */}
           <div>
-            <label className="block text-xs font-medium text-gray-700 mb-1">Minute</label>
+            <label htmlFor="cron-minute" className="block text-xs font-medium text-gray-700 mb-1">
+              Minute
+            </label>
             <select
+              id="cron-minute"
               value={minute}
               onChange={(e) => handleMinuteChange(e.target.value)}
               disabled={disabled}
@@ -339,8 +345,11 @@ export function CronPicker({ value, onChange, error, disabled }: CronPickerProps
           {/* Day of week (weekly only) */}
           {preset === 'weekly' && (
             <div className="col-span-2">
-              <label className="block text-xs font-medium text-gray-700 mb-1">Day of week</label>
+              <label htmlFor="cron-dow" className="block text-xs font-medium text-gray-700 mb-1">
+                Day of week
+              </label>
               <select
+                id="cron-dow"
                 value={dow}
                 onChange={(e) => handleDowChange(e.target.value)}
                 disabled={disabled}
@@ -358,10 +367,11 @@ export function CronPicker({ value, onChange, error, disabled }: CronPickerProps
           {/* Day of month (monthly only) */}
           {preset === 'monthly' && (
             <div className="col-span-2">
-              <label className="block text-xs font-medium text-gray-700 mb-1">
+              <label htmlFor="cron-dom" className="block text-xs font-medium text-gray-700 mb-1">
                 Day of month (1 – 31)
               </label>
               <input
+                id="cron-dom"
                 type="number"
                 min="1"
                 max="31"
@@ -381,13 +391,17 @@ export function CronPicker({ value, onChange, error, disabled }: CronPickerProps
       {/* Custom cron input */}
       {preset === 'custom' && (
         <div>
-          <label className="block text-xs font-medium text-gray-700 mb-1">
+          <label
+            htmlFor="cron-custom-expr"
+            className="block text-xs font-medium text-gray-700 mb-1"
+          >
             Cron expression{' '}
             <span className="text-gray-400 font-normal">
               (minute hour day-of-month month day-of-week)
             </span>
           </label>
           <input
+            id="cron-custom-expr"
             type="text"
             value={customExpr}
             onChange={(e) => handleCustomChange(e.target.value)}

--- a/frontend/apps/ppt-web/src/features/reports/components/EditScheduleModal.tsx
+++ b/frontend/apps/ppt-web/src/features/reports/components/EditScheduleModal.tsx
@@ -2,176 +2,128 @@
  * EditScheduleModal - Modal for editing report schedules.
  *
  * Story 81.1 - Report Schedule Editing
+ *
+ * Three primary controls (gap-81-1 API contract):
+ *   1. Cron picker  — builds / validates a 5-field UNIX cron expression
+ *   2. Recipient list — managed by RecipientManager
+ *   3. Enabled toggle — maps to the `enabled` flag on the backend
  */
 
-import type {
-  CreateReportSchedule,
-  ReportDefinition,
-  ReportFormat,
-  ReportSchedule,
-  ScheduleFrequency,
-} from '@ppt/api-client';
+import type { CronScheduleUpdateRequest, ReportSchedule } from '@ppt/api-client';
 import { useCallback, useEffect, useState } from 'react';
+import { CronPicker } from './CronPicker';
 import { RecipientManager } from './RecipientManager';
 
 interface EditScheduleModalProps {
   schedule: ReportSchedule;
-  reports: ReportDefinition[];
   isOpen: boolean;
   isSubmitting?: boolean;
   onClose: () => void;
-  onSave: (id: string, data: Partial<CreateReportSchedule>) => Promise<void>;
-  onPause?: (id: string) => Promise<void>;
-  onResume?: (id: string) => Promise<void>;
+  /**
+   * Called with the cron-based update payload.
+   * The modal emits `CronScheduleUpdateRequest` to match the gap-81-1 endpoint.
+   */
+  onSave: (id: string, data: CronScheduleUpdateRequest) => Promise<void>;
 }
 
-const FREQUENCIES: { value: ScheduleFrequency; label: string }[] = [
-  { value: 'daily', label: 'Daily' },
-  { value: 'weekly', label: 'Weekly' },
-  { value: 'monthly', label: 'Monthly' },
-  { value: 'quarterly', label: 'Quarterly' },
-  { value: 'yearly', label: 'Yearly' },
-];
-
-const FORMATS: { value: ReportFormat; label: string }[] = [
-  { value: 'pdf', label: 'PDF' },
-  { value: 'excel', label: 'Excel' },
-  { value: 'csv', label: 'CSV' },
-];
-
-const DAYS_OF_WEEK = [
-  { value: 0, label: 'Sunday' },
-  { value: 1, label: 'Monday' },
-  { value: 2, label: 'Tuesday' },
-  { value: 3, label: 'Wednesday' },
-  { value: 4, label: 'Thursday' },
-  { value: 5, label: 'Friday' },
-  { value: 6, label: 'Saturday' },
-];
-
-const TIMEZONES = [
-  { value: 'Europe/Bratislava', label: 'Europe/Bratislava' },
-  { value: 'Europe/Prague', label: 'Europe/Prague' },
-  { value: 'Europe/Berlin', label: 'Europe/Berlin' },
-  { value: 'Europe/London', label: 'Europe/London' },
-  { value: 'America/New_York', label: 'America/New_York' },
-  { value: 'UTC', label: 'UTC' },
-];
-
 interface FormErrors {
-  name?: string;
+  cronExpression?: string;
   recipients?: string;
-  time?: string;
+}
+
+/**
+ * Derive an initial cron expression from a schedule.
+ *
+ * The `time` field on legacy schedules stores "HH:mm"; we convert that +
+ * the frequency/day fields into a 5-field cron expression so the picker
+ * can display a sensible starting value.
+ */
+function scheduleToInitialCron(schedule: ReportSchedule): string {
+  const [hh, mm] = (schedule.time || '08:00').split(':');
+  const h = String(Number(hh) || 0);
+  const m = String(Number(mm) || 0);
+
+  switch (schedule.frequency) {
+    case 'daily':
+      return `${m} ${h} * * *`;
+    case 'weekly': {
+      const dow = schedule.day_of_week ?? 1;
+      return `${m} ${h} * * ${dow}`;
+    }
+    case 'monthly':
+    case 'quarterly': {
+      const dom = schedule.day_of_month ?? 1;
+      return `${m} ${h} ${dom} * *`;
+    }
+    case 'yearly':
+      return `${m} ${h} 1 1 *`;
+    default:
+      return `0 ${h} * * *`;
+  }
 }
 
 export function EditScheduleModal({
   schedule,
-  reports,
   isOpen,
   isSubmitting,
   onClose,
   onSave,
-  onPause,
-  onResume,
 }: EditScheduleModalProps) {
-  // Form state
-  const [name, setName] = useState(schedule.name);
-  const [reportId, setReportId] = useState(schedule.report_id);
-  const [frequency, setFrequency] = useState<ScheduleFrequency>(schedule.frequency);
-  const [dayOfWeek, setDayOfWeek] = useState(schedule.day_of_week ?? 1);
-  const [dayOfMonth, setDayOfMonth] = useState(schedule.day_of_month ?? 1);
-  const [time, setTime] = useState(schedule.time);
-  const [timezone, setTimezone] = useState(schedule.timezone);
-  const [format, setFormat] = useState<ReportFormat>(schedule.format);
+  const [cronExpression, setCronExpression] = useState(() => scheduleToInitialCron(schedule));
   const [recipients, setRecipients] = useState<string[]>(schedule.recipients);
+  const [enabled, setEnabled] = useState(schedule.is_active);
   const [errors, setErrors] = useState<FormErrors>({});
-  const [isPausing, setIsPausing] = useState(false);
 
-  // Reset form when schedule changes
+  // Reset form when the schedule prop changes (e.g. user opens a different row)
   useEffect(() => {
-    setName(schedule.name);
-    setReportId(schedule.report_id);
-    setFrequency(schedule.frequency);
-    setDayOfWeek(schedule.day_of_week ?? 1);
-    setDayOfMonth(schedule.day_of_month ?? 1);
-    setTime(schedule.time);
-    setTimezone(schedule.timezone);
-    setFormat(schedule.format);
+    setCronExpression(scheduleToInitialCron(schedule));
     setRecipients(schedule.recipients);
+    setEnabled(schedule.is_active);
     setErrors({});
   }, [schedule]);
 
   const validate = useCallback((): boolean => {
     const newErrors: FormErrors = {};
 
-    if (!name.trim()) {
-      newErrors.name = 'Schedule name is required';
+    // A cron expression must be present — the picker only calls onChange with
+    // valid expressions, but the user may have switched to "custom" mode and
+    // typed an incomplete expression.
+    if (!cronExpression.trim()) {
+      newErrors.cronExpression = 'A cron schedule expression is required';
     }
 
     if (recipients.length === 0) {
       newErrors.recipients = 'At least one recipient is required';
     }
 
-    if (!time) {
-      newErrors.time = 'Time is required';
-    }
-
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
-  }, [name, recipients, time]);
+  }, [cronExpression, recipients]);
 
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
       e.preventDefault();
-
       if (!validate()) return;
 
-      const data: Partial<CreateReportSchedule> = {
-        report_id: reportId,
-        name,
-        frequency,
-        day_of_week: frequency === 'weekly' ? dayOfWeek : undefined,
-        day_of_month: frequency === 'monthly' || frequency === 'quarterly' ? dayOfMonth : undefined,
-        time,
-        timezone,
-        format,
+      const payload: CronScheduleUpdateRequest = {
+        cron_expression: cronExpression.trim(),
         recipients,
+        enabled,
       };
 
-      await onSave(schedule.id, data);
+      await onSave(schedule.id, payload);
     },
-    [
-      validate,
-      reportId,
-      name,
-      frequency,
-      dayOfWeek,
-      dayOfMonth,
-      time,
-      timezone,
-      format,
-      recipients,
-      onSave,
-      schedule.id,
-    ]
+    [validate, cronExpression, recipients, enabled, onSave, schedule.id]
   );
-
-  const handlePauseResume = useCallback(async () => {
-    setIsPausing(true);
-    try {
-      if (schedule.is_active) {
-        await onPause?.(schedule.id);
-      } else {
-        await onResume?.(schedule.id);
-      }
-    } finally {
-      setIsPausing(false);
-    }
-  }, [schedule.id, schedule.is_active, onPause, onResume]);
 
   const handleRecipientsChange = useCallback((newRecipients: string[]) => {
     setRecipients(newRecipients);
     setErrors((prev) => ({ ...prev, recipients: undefined }));
+  }, []);
+
+  const handleCronChange = useCallback((cron: string) => {
+    setCronExpression(cron);
+    setErrors((prev) => ({ ...prev, cronExpression: undefined }));
   }, []);
 
   if (!isOpen) return null;
@@ -179,20 +131,23 @@ export function EditScheduleModal({
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto">
       {/* Backdrop */}
-      <div className="fixed inset-0 bg-black bg-opacity-50" onClick={onClose} />
+      <div className="fixed inset-0 bg-black bg-opacity-50" onClick={onClose} aria-hidden="true" />
 
-      {/* Modal */}
+      {/* Modal panel */}
       <div className="flex min-h-full items-center justify-center p-4">
-        <div className="relative bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
-          {/* Header */}
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="edit-schedule-title"
+          className="relative bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto"
+        >
+          {/* ── Header ── */}
           <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
             <div>
-              <h2 className="text-lg font-semibold text-gray-900">Edit Schedule</h2>
-              {!schedule.is_active && (
-                <span className="inline-flex items-center px-2 py-0.5 mt-1 text-xs font-medium bg-yellow-100 text-yellow-800 rounded-full">
-                  Paused
-                </span>
-              )}
+              <h2 id="edit-schedule-title" className="text-lg font-semibold text-gray-900">
+                Edit Schedule
+              </h2>
+              <p className="mt-0.5 text-sm text-gray-500 truncate max-w-xs">{schedule.name}</p>
             </div>
             <button
               type="button"
@@ -211,180 +166,64 @@ export function EditScheduleModal({
             </button>
           </div>
 
-          {/* Form */}
-          <form onSubmit={handleSubmit} className="px-6 py-4 space-y-6">
-            {/* Report Selection */}
-            <div>
-              <label htmlFor="edit-report" className="block text-sm font-medium text-gray-700">
-                Report
-              </label>
-              <select
-                id="edit-report"
-                value={reportId}
-                onChange={(e) => setReportId(e.target.value)}
-                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-              >
-                {reports.map((report) => (
-                  <option key={report.id} value={report.id}>
-                    {report.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            {/* Schedule Name */}
-            <div>
-              <label htmlFor="edit-name" className="block text-sm font-medium text-gray-700">
-                Schedule Name *
-              </label>
-              <input
-                type="text"
-                id="edit-name"
-                value={name}
-                onChange={(e) => {
-                  setName(e.target.value);
-                  setErrors((prev) => ({ ...prev, name: undefined }));
-                }}
-                className={`mt-1 block w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 ${
-                  errors.name ? 'border-red-300' : 'border-gray-300'
-                }`}
-              />
-              {errors.name && <p className="mt-1 text-sm text-red-600">{errors.name}</p>}
-            </div>
-
-            {/* Frequency */}
-            <div>
-              <label htmlFor="edit-frequency" className="block text-sm font-medium text-gray-700">
-                Frequency
-              </label>
-              <select
-                id="edit-frequency"
-                value={frequency}
-                onChange={(e) => setFrequency(e.target.value as ScheduleFrequency)}
-                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-              >
-                {FREQUENCIES.map((freq) => (
-                  <option key={freq.value} value={freq.value}>
-                    {freq.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            {/* Day Selection */}
-            {frequency === 'weekly' && (
+          {/* ── Form body ── */}
+          <form onSubmit={handleSubmit} className="px-6 py-5 space-y-6">
+            {/* ── 1. Enabled toggle ── */}
+            <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg border border-gray-200">
               <div>
-                <label
-                  htmlFor="edit-day-of-week"
-                  className="block text-sm font-medium text-gray-700"
-                >
-                  Day of Week
-                </label>
-                <select
-                  id="edit-day-of-week"
-                  value={dayOfWeek}
-                  onChange={(e) => setDayOfWeek(Number(e.target.value))}
-                  className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-                >
-                  {DAYS_OF_WEEK.map((day) => (
-                    <option key={day.value} value={day.value}>
-                      {day.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            )}
-
-            {(frequency === 'monthly' || frequency === 'quarterly') && (
-              <div>
-                <label
-                  htmlFor="edit-day-of-month"
-                  className="block text-sm font-medium text-gray-700"
-                >
-                  Day of Month
-                </label>
-                <input
-                  type="number"
-                  id="edit-day-of-month"
-                  min="1"
-                  max="31"
-                  value={dayOfMonth}
-                  onChange={(e) => {
-                    const value = Number(e.target.value);
-                    if (value >= 1 && value <= 31) {
-                      setDayOfMonth(value);
-                    }
-                  }}
-                  className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-                />
-                <p className="mt-1 text-xs text-gray-500">
-                  For months with fewer days, the schedule will run on the last day of the month.
+                <p className="text-sm font-medium text-gray-900">Schedule enabled</p>
+                <p className="text-xs text-gray-500 mt-0.5">
+                  {enabled
+                    ? 'Reports will be delivered on the configured schedule.'
+                    : 'Schedule is paused — no reports will be sent.'}
                 </p>
               </div>
-            )}
-
-            {/* Time and Timezone */}
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label htmlFor="edit-time" className="block text-sm font-medium text-gray-700">
-                  Time *
-                </label>
-                <input
-                  type="time"
-                  id="edit-time"
-                  value={time}
-                  onChange={(e) => {
-                    setTime(e.target.value);
-                    setErrors((prev) => ({ ...prev, time: undefined }));
-                  }}
-                  className={`mt-1 block w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 ${
-                    errors.time ? 'border-red-300' : 'border-gray-300'
-                  }`}
+              {/* Toggle switch */}
+              <button
+                type="button"
+                role="switch"
+                aria-checked={enabled}
+                onClick={() => setEnabled((v) => !v)}
+                disabled={isSubmitting}
+                className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full
+                  border-2 border-transparent transition-colors duration-200 ease-in-out
+                  focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
+                  disabled:opacity-50 disabled:cursor-not-allowed
+                  ${enabled ? 'bg-blue-600' : 'bg-gray-200'}`}
+              >
+                <span className="sr-only">{enabled ? 'Disable schedule' : 'Enable schedule'}</span>
+                <span
+                  className={`pointer-events-none inline-block h-5 w-5 transform rounded-full
+                    bg-white shadow ring-0 transition duration-200 ease-in-out
+                    ${enabled ? 'translate-x-5' : 'translate-x-0'}`}
                 />
-                {errors.time && <p className="mt-1 text-sm text-red-600">{errors.time}</p>}
-              </div>
-              <div>
-                <label htmlFor="edit-timezone" className="block text-sm font-medium text-gray-700">
-                  Timezone
-                </label>
-                <select
-                  id="edit-timezone"
-                  value={timezone}
-                  onChange={(e) => setTimezone(e.target.value)}
-                  className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-                >
-                  {TIMEZONES.map((tz) => (
-                    <option key={tz.value} value={tz.value}>
-                      {tz.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
+              </button>
             </div>
 
-            {/* Format */}
+            {/* ── 2. Cron picker ── */}
             <div>
-              <label className="block text-sm font-medium text-gray-700">Export Format</label>
-              <div className="mt-2 flex gap-4">
-                {FORMATS.map((fmt) => (
-                  <label key={fmt.value} className="flex items-center gap-2 cursor-pointer">
-                    <input
-                      type="radio"
-                      name="format"
-                      value={fmt.value}
-                      checked={format === fmt.value}
-                      onChange={() => setFormat(fmt.value)}
-                      className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300"
-                    />
-                    <span className="text-sm text-gray-700">{fmt.label}</span>
-                  </label>
-                ))}
-              </div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Schedule (cron)
+                <span className="ml-1 text-red-500" aria-hidden="true">
+                  *
+                </span>
+              </label>
+              <CronPicker
+                value={cronExpression}
+                onChange={handleCronChange}
+                error={errors.cronExpression}
+                disabled={isSubmitting}
+              />
             </div>
 
-            {/* Recipients */}
+            {/* ── 3. Recipients ── */}
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">Recipients *</label>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Recipients
+                <span className="ml-1 text-red-500" aria-hidden="true">
+                  *
+                </span>
+              </label>
               <RecipientManager
                 recipients={recipients}
                 onChange={handleRecipientsChange}
@@ -393,46 +232,26 @@ export function EditScheduleModal({
             </div>
           </form>
 
-          {/* Footer */}
-          <div className="flex items-center justify-between px-6 py-4 border-t border-gray-200 bg-gray-50">
-            <div>
-              {(onPause || onResume) && (
-                <button
-                  type="button"
-                  onClick={handlePauseResume}
-                  disabled={isPausing || isSubmitting}
-                  className={`px-4 py-2 text-sm font-medium rounded-md disabled:opacity-50 ${
-                    schedule.is_active
-                      ? 'text-yellow-700 bg-yellow-100 hover:bg-yellow-200'
-                      : 'text-green-700 bg-green-100 hover:bg-green-200'
-                  }`}
-                >
-                  {isPausing
-                    ? 'Processing...'
-                    : schedule.is_active
-                      ? 'Pause Schedule'
-                      : 'Resume Schedule'}
-                </button>
-              )}
-            </div>
-            <div className="flex gap-3">
-              <button
-                type="button"
-                onClick={onClose}
-                disabled={isSubmitting}
-                className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50"
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                onClick={handleSubmit}
-                disabled={isSubmitting}
-                className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50"
-              >
-                {isSubmitting ? 'Saving...' : 'Save Changes'}
-              </button>
-            </div>
+          {/* ── Footer ── */}
+          <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-gray-200 bg-gray-50">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={isSubmitting}
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300
+                rounded-md hover:bg-gray-50 disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              onClick={handleSubmit}
+              disabled={isSubmitting}
+              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md
+                hover:bg-blue-700 disabled:opacity-50"
+            >
+              {isSubmitting ? 'Saving…' : 'Save changes'}
+            </button>
           </div>
         </div>
       </div>

--- a/frontend/apps/ppt-web/src/features/reports/components/EditScheduleModal.tsx
+++ b/frontend/apps/ppt-web/src/features/reports/components/EditScheduleModal.tsx
@@ -11,7 +11,7 @@
 
 import type { CronScheduleUpdateRequest, ReportSchedule } from '@ppt/api-client';
 import { useCallback, useEffect, useState } from 'react';
-import { CronPicker } from './CronPicker';
+import { CronPicker, isValidCron } from './CronPicker';
 import { RecipientManager } from './RecipientManager';
 
 interface EditScheduleModalProps {
@@ -85,11 +85,13 @@ export function EditScheduleModal({
   const validate = useCallback((): boolean => {
     const newErrors: FormErrors = {};
 
-    // A cron expression must be present — the picker only calls onChange with
-    // valid expressions, but the user may have switched to "custom" mode and
-    // typed an incomplete expression.
-    if (!cronExpression.trim()) {
-      newErrors.cronExpression = 'A cron schedule expression is required';
+    // A cron expression must be present AND valid. The picker only calls
+    // onChange with valid expressions in simple mode, but in custom mode
+    // the user may type an invalid string; cronExpression retains the
+    // previously-valid value while the input shows the invalid text.
+    // isValidCron guards against that stale-value submission.
+    if (!cronExpression.trim() || !isValidCron(cronExpression)) {
+      newErrors.cronExpression = 'A valid cron expression is required';
     }
 
     if (recipients.length === 0) {

--- a/frontend/apps/ppt-web/src/features/reports/components/index.ts
+++ b/frontend/apps/ppt-web/src/features/reports/components/index.ts
@@ -5,7 +5,9 @@
 // Story 53.3 - Dashboard Analytics
 export { AnalyticsChart } from './AnalyticsChart';
 export { BuildingMetricsCard } from './BuildingMetricsCard';
+export type { CronPickerProps } from './CronPicker';
 // Story 81.1 - Report Schedule Editing
+export { CronPicker } from './CronPicker';
 export { EditScheduleModal } from './EditScheduleModal';
 // Story 81.2 - Report Execution History
 export { ExecutionHistory } from './ExecutionHistory';

--- a/frontend/apps/ppt-web/src/features/reports/pages/ReportsPage.tsx
+++ b/frontend/apps/ppt-web/src/features/reports/pages/ReportsPage.tsx
@@ -6,7 +6,7 @@
 
 import type {
   BuildingAnalytics,
-  CreateReportSchedule,
+  CronScheduleUpdateRequest,
   DataSource,
   KPIMetric,
   PeriodComparison,
@@ -44,11 +44,10 @@ interface ReportsPageProps {
   onCreateReport?: (data: unknown) => Promise<void>;
   onPreviewReport?: (data: unknown) => Promise<unknown>;
   onCreateSchedule?: (data: unknown) => Promise<void>;
-  onUpdateSchedule?: (id: string, data: Partial<CreateReportSchedule>) => Promise<void>;
+  /** gap-81-1: cron-based update (cron_expression, recipients, enabled) */
+  onUpdateSchedule?: (id: string, data: CronScheduleUpdateRequest) => Promise<void>;
   onDeleteSchedule?: (id: string) => Promise<void>;
   onToggleSchedule?: (id: string, isActive: boolean) => Promise<void>;
-  onPauseSchedule?: (id: string) => Promise<void>;
-  onResumeSchedule?: (id: string) => Promise<void>;
   onRunScheduleNow?: (id: string) => Promise<void>;
   onPeriodChange?: (period: 'daily' | 'weekly' | 'monthly' | 'quarterly' | 'yearly') => void;
   // Execution history props
@@ -79,8 +78,6 @@ export function ReportsPage({
   onUpdateSchedule,
   onDeleteSchedule,
   onToggleSchedule,
-  onPauseSchedule,
-  onResumeSchedule,
   onRunScheduleNow,
   onPeriodChange,
   executions,
@@ -124,7 +121,7 @@ export function ReportsPage({
   }, []);
 
   const handleSaveSchedule = useCallback(
-    async (id: string, data: Partial<CreateReportSchedule>) => {
+    async (id: string, data: CronScheduleUpdateRequest) => {
       if (!onUpdateSchedule) return;
       setIsUpdatingSchedule(true);
       try {
@@ -399,13 +396,10 @@ export function ReportsPage({
       {editingSchedule && (
         <EditScheduleModal
           schedule={editingSchedule}
-          reports={reports}
           isOpen={isEditModalOpen}
           isSubmitting={isUpdatingSchedule}
           onClose={handleCloseEditModal}
           onSave={handleSaveSchedule}
-          onPause={onPauseSchedule}
-          onResume={onResumeSchedule}
         />
       )}
 

--- a/frontend/packages/api-client/src/reports/api.ts
+++ b/frontend/packages/api-client/src/reports/api.ts
@@ -10,6 +10,7 @@ import type {
   BuildingAnalytics,
   CreateReportDefinition,
   CreateReportSchedule,
+  CronScheduleUpdateRequest,
   DataSource,
   ListReportsParams,
   ListReportsResponse,
@@ -144,6 +145,22 @@ export async function updateSchedule(
 ): Promise<ReportSchedule> {
   return fetchApi(`${API_BASE}/schedules/${id}`, {
     method: 'PATCH',
+    body: JSON.stringify(data),
+  });
+}
+
+/**
+ * Update a report schedule using the gap-81-1 cron-based endpoint.
+ *
+ * Sends a PUT request with `cron_expression`, `recipients`, and/or `enabled`.
+ * At least one field must be present (validated by the backend).
+ */
+export async function updateScheduleCron(
+  id: string,
+  data: CronScheduleUpdateRequest
+): Promise<ReportSchedule> {
+  return fetchApi(`${API_BASE}/schedules/${id}`, {
+    method: 'PUT',
     body: JSON.stringify(data),
   });
 }

--- a/frontend/packages/api-client/src/reports/hooks.ts
+++ b/frontend/packages/api-client/src/reports/hooks.ts
@@ -12,9 +12,11 @@ import {
   resumeSchedule,
   retryReportExecution,
   updateSchedule,
+  updateScheduleCron,
 } from './api';
 import type {
   CreateReportSchedule,
+  CronScheduleUpdateRequest,
   ReportExecutionHistoryParams,
   ReportExecutionStatus,
 } from './types';
@@ -44,6 +46,24 @@ export function useUpdateSchedule() {
       updateSchedule(id, data),
     onSuccess: (updatedSchedule) => {
       // Invalidate schedule-related queries
+      queryClient.invalidateQueries({ queryKey: reportKeys.schedules() });
+      queryClient.invalidateQueries({ queryKey: reportKeys.schedule(updatedSchedule.id) });
+    },
+  });
+}
+
+/**
+ * Hook to update a report schedule via the cron-based endpoint (gap-81-1).
+ *
+ * Sends cron_expression, recipients, and/or enabled to PUT /schedules/{id}.
+ */
+export function useUpdateScheduleCron() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: CronScheduleUpdateRequest }) =>
+      updateScheduleCron(id, data),
+    onSuccess: (updatedSchedule) => {
       queryClient.invalidateQueries({ queryKey: reportKeys.schedules() });
       queryClient.invalidateQueries({ queryKey: reportKeys.schedule(updatedSchedule.id) });
     },

--- a/frontend/packages/api-client/src/reports/types.ts
+++ b/frontend/packages/api-client/src/reports/types.ts
@@ -196,6 +196,21 @@ export interface UpdateScheduleRequest {
   is_active?: boolean;
 }
 
+/**
+ * Request body for the gap-81-1 PUT /api/v1/reports/schedules/{id} endpoint.
+ *
+ * The backend accepts a cron expression (5-field UNIX), a recipient list,
+ * and an enabled flag — all optional (at least one must be present).
+ */
+export interface CronScheduleUpdateRequest {
+  /** 5-field UNIX cron expression, e.g. "0 8 * * 1" */
+  cron_expression?: string;
+  /** Full replacement list of recipient email addresses */
+  recipients?: string[];
+  /** Whether the schedule is active/enabled */
+  enabled?: boolean;
+}
+
 // ============================================================================
 // DASHBOARD ANALYTICS
 // ============================================================================


### PR DESCRIPTION
## Task

Build report schedule editor modal in ppt-web: cron picker, recipient list, enabled toggle

## Owner

pm-frontend

## Changes

### New: `CronPicker` component
`frontend/apps/ppt-web/src/features/reports/components/CronPicker.tsx`

Visual cron expression builder with:
- **Preset tabs**: Daily / Weekly / Monthly / Custom
- **Simple mode**: hour dropdown (00–23), minute dropdown (:00/:15/:30/:45), day-of-week selector (weekly), day-of-month input (monthly)
- **Custom mode**: free-text input with live 5-field UNIX cron validation (mirrors backend `validate_cron_expression`)
- **Expression preview** panel showing the built cron string
- Mirrors backend validation rules exactly (e.g. minute 0–59, hour 0–23, dom 1–31, month 1–12, dow 0–7)

### Updated: `EditScheduleModal`
`frontend/apps/ppt-web/src/features/reports/components/EditScheduleModal.tsx`

Rebuilt around the **gap-81-1 API contract** (`PUT /api/v1/reports/schedules/{id}`):

| UI control | maps to API field |
|---|---|
| CronPicker | `cron_expression` |
| RecipientManager | `recipients` |
| Enabled toggle (switch) | `enabled` |

- Derives an initial cron expression from the legacy `schedule.time` + `frequency` + `day_of_week`/`day_of_month` fields for backward compat with existing schedule rows
- Removes the old `reports`, `onPause`, `onResume` props (the enabled toggle replaces pause/resume inside the modal)
- `onSave` now emits `CronScheduleUpdateRequest` instead of `Partial<CreateReportSchedule>`
- Accessible: `role="dialog"`, `aria-modal`, `aria-labelledby`, toggle has `role="switch"` + `aria-checked`

### Updated: `@ppt/api-client` reports module
- **New type**: `CronScheduleUpdateRequest` (`cron_expression?`, `recipients?`, `enabled?`)
- **New API fn**: `updateScheduleCron(id, CronScheduleUpdateRequest)` → PUT
- **New hook**: `useUpdateScheduleCron()` — TanStack Query mutation, invalidates `schedules` + `schedule(id)` on success

### Updated: `ReportsPage` + `App.tsx`
- `onUpdateSchedule` prop now accepts `CronScheduleUpdateRequest`
- `ReportsPageRoute` uses `useUpdateScheduleCron` instead of `useUpdateSchedule`
- Removed unused `onPauseSchedule` / `onResumeSchedule` props from the page interface and call site
- EditScheduleModal rendered without the removed props

## Tested (Band A — fast check)

```
pnpm --filter @ppt/web typecheck  → exit 0
pnpm check:fix                    → 3 formatting fixes applied, 0 errors, exit 0
pnpm --filter @ppt/web typecheck  → exit 0 (post-Biome)
```

## Built (Band B — full build)

```
pnpm --filter @ppt/web build      → ✓ built in 5.27s, exit 0
```

Change is ≥50 LOC and touches a public API surface — Band B triggered.

## CI parity (Band C — hot-path only)

Skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested

Skipped (ppt-bridge MCP not available in this session).

## Scope drift

`scope-check.sh --owner pm-frontend` → exit 0 (no drift)

## Code-reuse review

`reuse-grep.sh --specialist react-web` → no warnings

## Notes

- The dependency `gap-81-1-report-schedule-edit-api` is already merged (backend PUT endpoint with cron validation is live per the git log entry `a9d78fb4`).
- Legacy `useUpdateSchedule` (PATCH shape) is no longer imported by App.tsx; it remains exported from `@ppt/api-client` for any other consumers.
- The `CronPicker` `detectPreset` helper converts the 5-field cron string back to a preset on mount, so re-opening the modal shows the correct preset tab.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ay6b9Hw2CRJSy7owzNETnD)_