### PR TITLE
gap-79-2-login-flow-wiring: Wire login form, logout button, and session cleanup to AuthContext

### DIFF
--- a/docs/screens/ppt/login.md
+++ b/docs/screens/ppt/login.md
@@ -9,7 +9,7 @@ implementations:
     component: LoginPage
     buildStatus: shipped
     redesignStatus: in-progress
-    apiStatus: partial
+    apiStatus: complete
   mobile:
     buildStatus: n/a
     redesignStatus: n/a
@@ -138,6 +138,7 @@ UC-14 single sign-in entry point. Email + password is primary; magic-link, TOTP,
 
 <!-- newest entries on top -->
 
+- 2026-05-27 — agent: gap-79-2-login-flow-wiring — wired TanStack Query cache clear (queryClient.clear()) into logout() for session cleanup; loginWithSsoCode already present; apiStatus promoted to complete
 - 2026-05-24 — agent: gap-79-2 login-flow-wiring — removed local RETURN_URL_KEY constant and inline getAndClearReturnUrl; now imports getAndClearReturnUrl from @ppt/shared for consistent return-URL handling across auth flows
 - 2026-05-09 — agent: design analyzed (pages/ppt-login.html — 4 rows: loaded+magic / TOTP+SMS / loading+empty / 3 errors); flipped ppt-web redesignStatus → in-progress; attached designSource; populated functionality checklist (12 sections covering 6 distinct UI states), all states with full variants, design-specific notes; declared 6 sharedComponents; added 1 relatedScreen
 - 2026-05-08 — init: created from scan (source: sitemap)

--- a/frontend/apps/ppt-web/src/contexts/AuthContext.tsx
+++ b/frontend/apps/ppt-web/src/contexts/AuthContext.tsx
@@ -22,6 +22,7 @@ import {
   type TenantMembership,
   type TenantRole,
 } from '@ppt/api-client';
+import { useQueryClient } from '@tanstack/react-query';
 import type React from 'react';
 import {
   createContext,
@@ -268,6 +269,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [user, setUser] = useState<AuthUser | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
+  // TanStack Query client — used to clear the cache on logout so stale
+  // user-scoped data never leaks into the next session.
+  const queryClient = useQueryClient();
+
   // Track if a token refresh is in progress to prevent concurrent refreshes
   const isRefreshing = useRef(false);
   const refreshPromise = useRef<Promise<string | null> | null>(null);
@@ -458,15 +463,26 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   /**
    * Log out the current user using the API client.
+   *
+   * Session cleanup sequence:
+   *  1. Clear localStorage tokens (immediate — prevents any further API calls
+   *     from including a bearer token).
+   *  2. Reset React state so the UI reflects the unauthenticated state.
+   *  3. Purge the TanStack Query cache so user-scoped data never leaks into
+   *     the next session (e.g. a different user logging in on the same device).
+   *  4. Best-effort server-side token revocation (fire-and-forget).
    */
   const logout = useCallback(async (): Promise<void> => {
     const refreshTokenValue = tokenStorage.getRefreshToken();
 
-    // Clear local state first for immediate UI feedback
+    // 1 & 2 — Clear local state first for immediate UI feedback.
     tokenStorage.clear();
     setUser(null);
 
-    // Attempt to invalidate the refresh token on the server
+    // 3 — Purge all cached query data to prevent cross-session data leakage.
+    queryClient.clear();
+
+    // 4 — Attempt to invalidate the refresh token on the server.
     if (refreshTokenValue) {
       try {
         const authApi = getAuthApi();
@@ -475,7 +491,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         // Ignore errors - we've already cleared local state
       }
     }
-  }, []);
+  }, [queryClient]);
 
   /**
    * Update the in-memory user and persist to storage. Lets profile-edit


### PR DESCRIPTION
## Task
Wire login form, logout button, and session cleanup to AuthContext (79-2 Authentication Flow Implementation)

## Owner
pm-frontend

## What was done

**Pre-flight findings (dev branch audit):**
- `LoginPage.tsx` — already fully wired to `useAuth().login()` with validation, error mapping, and return-URL redirect via `getAndClearReturnUrl()` from `@ppt/shared`. No changes needed.
- `AppNavigation` in `App.tsx` — already has logout button calling `useAuth().logout()` + `navigate('/login', { replace: true })`. No changes needed.
- `loginWithSsoCode` — already implemented in `AuthContext` (required by `AuthCallbackPage` at `/auth/callback`). No changes needed.

**Gap identified and fixed:**
- `AuthContext.logout()` cleared localStorage tokens and set `user = null` but did NOT purge the TanStack Query cache. This allowed user-scoped queries (buildings, disputes, documents, etc.) to leak into the next session on the same device.

**Change made (`AuthContext.tsx`):**
- Added `useQueryClient()` from `@tanstack/react-query` inside `AuthProvider`
- Called `queryClient.clear()` in `logout()` after clearing localStorage and before the server-side token revocation call
- Updated `logout`'s `useCallback` dependency array to include `queryClient`
- `ppt/login` screen-map: `apiStatus` promoted from `partial` → `complete`

## Scope drift check
`scope-check.sh --owner pm-frontend` → exit 0 (clean)

## Code reuse check
`reuse-grep.sh --specialist react-web` → exit 0 (no warnings)

## Tested
```
pnpm --filter @ppt/web typecheck
→ exit 0 (no type errors)

pnpm biome check apps/ppt-web/src/contexts/AuthContext.tsx
→ exit 0 (Checked 1 file. No fixes applied.)
```

Note: `pnpm --filter @ppt/web lint` fails with ESLint v10 config format error — pre-existing infrastructure issue (the project uses Biome as the canonical linter per `frontend/CLAUDE.md`; `package.json` has an outdated `lint` script pointing to ESLint).

## Remote-tested
skipped

## Notes
- The two changed files are: `frontend/apps/ppt-web/src/contexts/AuthContext.tsx` and `docs/screens/ppt/login.md`
- `@tanstack/react-query` is already a dependency of `@ppt/web` — no new deps added
- `QueryClientProvider` wraps `App` (and therefore `AuthProvider`) in `main.tsx`, so `useQueryClient()` is always available inside `AuthProvider`

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvxeLY56mUTt5ixeCFeaxB)_