### PR TITLE
fix-573-ingestion-branch-prefix-guard: dispatcher ingestion branch-prefix guard + T16 self-test

### DIFF
--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -421,6 +421,15 @@ After candidate sort, walk the list and **claim at most 2 tasks per `epic_prefix
 
 For each picked task: `branch = "auto-impl/" + first_40_chars_kebab(task_id)`.
 
+**Branch-prefix guard (ingestion contract — issue #573):**
+Before appending any row to `assignments.json`, assert that `branch` starts
+with `"auto-impl/"`. If for any reason the computed branch does NOT match this
+prefix, log `SKIP ingestion: branch prefix guard failed for <task_id>
+(branch=<branch>)` and do NOT append the row -- treat it as unclaimed.
+Manual/hotfix branches (e.g. `fix/*`, `feat/*`) must never enter
+`assignments.json` via this path; they are tracked outside the dispatcher.
+This invariant is verified by the self-test (T16) and T7.
+
 Append to `assignments.json`:
 
 ```jsonc

--- a/.research/dispatcher-self-test.sh
+++ b/.research/dispatcher-self-test.sh
@@ -289,6 +289,65 @@ else
 fi
 echo
 
+# --- T16: branch-prefix guard (issue #573) ---------------------------------
+# Hard fail for any non-terminal row (in-progress or review) that does NOT
+# carry an auto-impl/ prefix -- T7 already covers this but T16 also checks
+# newly-ingested terminal rows (merged/failed) claimed on/after the guard
+# cutoff, where the ingestion guard should have prevented the bad row from
+# ever being written.
+#
+# Terminal rows (merged/failed/done) with claimed_at < T16_GUARD_CUTOFF are
+# historical manual-PR rows added before the guard existed -- reported as info
+# but not a hard fail.
+#
+# T16_GUARD_CUTOFF is the date the ingestion guard was introduced (this PR,
+# 2026-05-27). Only rows claimed by the dispatcher AFTER this date are held
+# to the auto-impl/ contract.
+T16_GUARD_CUTOFF="${T16_GUARD_CUTOFF:-2026-05-27T18:00:00Z}"
+echo "T16 branch starts with auto-impl/ -- ingestion prefix guard (issue #573; guard cutoff=$T16_GUARD_CUTOFF)"
+# Hard fail: non-terminal rows with wrong prefix (all dates).
+BAD_NONTERMINAL=$(jq -r '
+  .assignments
+  | map(select(
+      (.status == "in-progress" or .status == "review")
+      and ((.branch // "") | startswith("auto-impl/") | not)
+    ))
+  | length' "$ASSIGN")
+if [ "$BAD_NONTERMINAL" = "0" ]; then
+  note "no non-terminal rows with non-auto-impl/ branch"
+else
+  fail "$BAD_NONTERMINAL non-terminal rows ingested with non-auto-impl/ branch (ingestion guard violated -- issue #573)"
+  jq -r '.assignments[] | select((.status == "in-progress" or .status == "review") and ((.branch // "") | startswith("auto-impl/") | not)) | "    \(.task_id) :: branch=\(.branch) status=\(.status)"' "$ASSIGN" >&2
+fi
+# Hard fail: terminal rows claimed on/after the guard cutoff with wrong prefix.
+BAD_TERMINAL=$(jq --arg d "$T16_GUARD_CUTOFF" '
+  .assignments
+  | map(select(
+      (.status | IN("merged","failed","done"))
+      and .claimed_at >= $d
+      and ((.branch // "") | startswith("auto-impl/") | not)
+    ))
+  | length' "$ASSIGN")
+if [ "$BAD_TERMINAL" = "0" ]; then
+  note "no post-guard-cutoff terminal rows with non-auto-impl/ branch"
+else
+  fail "$BAD_TERMINAL post-guard-cutoff terminal rows carry non-auto-impl/ branch (should have been blocked at ingestion)"
+  jq --arg d "$T16_GUARD_CUTOFF" -r '.assignments[] | select((.status | IN("merged","failed","done")) and .claimed_at >= $d and ((.branch // "") | startswith("auto-impl/") | not)) | "    \(.task_id) :: branch=\(.branch) status=\(.status) claimed_at=\(.claimed_at)"' "$ASSIGN" >&2
+fi
+# Informational: historical terminal rows (pre-guard-cutoff) with non-auto-impl/ branch.
+INFO_LEGACY=$(jq --arg d "$T16_GUARD_CUTOFF" '
+  .assignments
+  | map(select(
+      (.status | IN("merged","failed","done"))
+      and .claimed_at < $d
+      and ((.branch // "") | startswith("auto-impl/") | not)
+    ))
+  | length' "$ASSIGN")
+if [ "$INFO_LEGACY" -gt "0" ]; then
+  printf '  info  %s historical terminal rows carry non-auto-impl/ branch (pre-guard cutoff; manual PRs exempt)\n' "$INFO_LEGACY"
+fi
+echo
+
 # --- Summary ---------------------------------------------------------------
 if [ "$FAIL" = "0" ]; then
   echo "==> dispatcher-self-test: PASS"


### PR DESCRIPTION
## Task
dispatcher ingestion (PR #561): add branch-prefix guard so only auto-impl/* branches enter assignments.json; add T7-style self-test assertion for non-auto-impl rows. OID regression in assignments.json already patched on dev. Tracking issue #573.

## Owner
pm-devops

## Changes
- **.research/dispatcher-prompt.md Phase 3**: Added explicit **branch-prefix guard (ingestion contract — issue #573)**. Before appending any row to `assignments.json`, the dispatcher MUST assert the branch starts with `auto-impl/`. Non-conforming branches (fix/*, feat/*) must never enter via this path — they are tracked outside the dispatcher.
- **.research/dispatcher-self-test.sh T16**: New hard-fail test for the ingestion prefix contract:
  - Hard fail: any non-terminal (in-progress/review) row with non-auto-impl/ branch
  - Hard fail: any terminal row claimed on/after guard cutoff (2026-05-27T18:00:00Z) with non-auto-impl/ branch
  - Info-only: historical pre-guard terminal rows (fix-issue-queue-*, fix-issue-574-* — all merged before the guard existed)

## Tested (Band A — fast check)
```
git diff --check: exit 0
bash -n .research/dispatcher-self-test.sh: exit 0 (bash syntax OK)
bash .research/dispatcher-self-test.sh T16 output:
  T16 branch starts with auto-impl/ -- ingestion prefix guard (issue #573; guard cutoff=2026-05-27T18:00:00Z)
    ok    no non-terminal rows with non-auto-impl/ branch
    ok    no post-guard-cutoff terminal rows with non-auto-impl/ branch
    info  3 historical terminal rows carry non-auto-impl/ branch (pre-guard cutoff; manual PRs exempt)
Self-test pre-existing failures (T3, T5) are unrelated to this change — confirmed to exist on dev before this PR.
```

## Built (Band B — full build)
skipped: change is documentation + shell script only; no public API/config touch

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Scope drift
.research/dispatcher-prompt.md and .research/dispatcher-self-test.sh are outside the pm-devops registered area (.github/**, scripts/**, docker/**, infra/**, Dockerfile*, *.yml, *.yaml). **Drift is justified**: these files constitute the dispatcher's operational infrastructure and are the natural home for this fix. The pm-scrum-master role covers .research/management/** but not the dispatcher prompt/test itself.

## Notes
- OID regression (issue #573) was already patched on dev in commit 7419365d — this PR addresses only the ingestion guard and T16 test.
- T16_GUARD_CUTOFF is overridable via env var for testing.
- T7 (non-terminal rows) and T16 (all rows with cutoff) are now complementary and cross-reference issue #573.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvxeLY56mUTt5ixeCFeaxB)_