### PR TITLE
fix-579: HelpSidebar a11y — focus-trap, dialog role + aria-modal, tooltips on 11 pages, inline-style cleanup

### DIFF
--- a/frontend/apps/admin-web/messages/en.json
+++ b/frontend/apps/admin-web/messages/en.json
@@ -13,6 +13,7 @@
         "status": "Status"
       },
       "empty": "No agencies found.",
+      "helpTooltip": "Agencies group users and buildings under a single tenant organisation. Suspend an agency to block all logins immediately.",
       "loadError": "Failed to load agencies: {{message}}",
       "loading": "Loading agencies…",
       "title": "Agencies",
@@ -26,6 +27,9 @@
       },
       "unknownError": "Unknown error"
     },
+    "announcements": {
+      "helpTooltip": "System-wide banners shown to all Property Management users. Set a start/end time to schedule announcements automatically."
+    },
     "audit": {
       "columns": {
         "action": "Action",
@@ -36,6 +40,7 @@
         "time": "Time"
       },
       "empty": "No audit events match the current filters.",
+      "helpTooltip": "Every significant platform action is recorded here. High-severity events (purge, escalate, impersonation) also appear on the Dashboard.",
       "filters": {
         "action": "Action",
         "actor": "Actor",
@@ -66,6 +71,10 @@
       },
       "title": "Audit Log"
     },
+    "capabilities": {
+      "helpTooltip": "Capabilities are named permission flags. Grant carefully — some (tenant_purge, principal_kind_escalate) are irreversible and require MFA.",
+      "title": "Capabilities"
+    },
     "common": {
       "actions": "Actions",
       "cancel": "Cancel",
@@ -88,12 +97,24 @@
       "title": "Feature Flags",
       "warning": "Per-tenant kill switch — changes take effect immediately for every user in this tenant."
     },
+    "dashboard": {
+      "helpTooltip": "Live overview of platform health, high-risk events, and active impersonation sessions. Refresh the page to update stats."
+    },
     "impersonation": {
       "asUser": "as {{name}}",
       "expires": "expires {{time}}",
+      "helpTooltip": "Active impersonation sessions are listed here. Every session start and stop is recorded in the audit log. Sessions expire after 1 hour.",
       "label": "IMPERSONATING",
       "stop": "End impersonation",
+      "title": "Active Impersonation Sessions",
       "youAreImpersonating": "You are impersonating {{name}}"
+    },
+    "memberships": {
+      "helpTooltip": "Memberships link a user to an agency or building with a specific role. Revoking a membership takes effect on the user's next API request.",
+      "title": "Memberships"
+    },
+    "mobile": {
+      "helpTooltip": "Remote config delivered to the mobile app on startup. Set min_version to force older builds to update before connecting."
     },
     "mfa": {
       "cancel": "Cancel",
@@ -122,6 +143,7 @@
       },
       "description": "Manage third-party OAuth 2.0 clients that can obtain tokens on behalf of your users. Capability required: oauth_client_write.",
       "empty": "No OAuth clients registered yet.",
+      "helpTooltip": "OAuth clients allow third-party apps to obtain access tokens. Regenerate the secret immediately if it is compromised — old secrets are invalidated at once.",
       "loadError": "Failed to load OAuth clients: {{message}}",
       "navLabel": "OAuth Clients",
       "revokeDialog": {
@@ -143,6 +165,7 @@
     },
     "health": {
       "activeOnly": "Active only",
+      "helpTooltip": "Real-time API server metrics and alerts. Auto-refreshes every 60 seconds. Acknowledge alerts to record your review in the audit log.",
       "allAlerts": "All alerts",
       "alertsTitle": "Alerts",
       "loadError": "Failed to load health dashboard. Check your connection and try again.",
@@ -181,6 +204,7 @@
         "principalKind": "Principal kind"
       },
       "empty": "Search to load users.",
+      "helpTooltip": "Search by email or name. Use Change kind with care — it permanently alters how the user authenticates.",
       "principalKinds": {
         "agency": "Agency",
         "platform": "Platform",

--- a/frontend/apps/admin-web/src/components/AdminLayout.css
+++ b/frontend/apps/admin-web/src/components/AdminLayout.css
@@ -1,0 +1,31 @@
+/* -------------------------------------------------------------------------
+ * AdminLayout — topbar help-toggle button
+ *
+ * Moved out of AdminLayout.tsx inline styles (fix #579) so that the
+ * aria-expanded attribute drives open/closed appearance without JS.
+ * ------------------------------------------------------------------------- */
+
+.ppt-topbar-help-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1px solid var(--ppt-border-default, #e5e7eb);
+  background: var(--ppt-bg-subtle, #f3f4f6);
+  color: var(--ppt-fg-muted, #6b7280);
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    border-color 80ms,
+    background 80ms,
+    color 80ms;
+}
+
+.ppt-topbar-help-btn[aria-expanded='true'] {
+  border: 1.5px solid var(--ppt-brand-400, #60a5fa);
+  background: var(--ppt-brand-100, #dbeafe);
+  color: var(--ppt-brand-700, #1d4ed8);
+}

--- a/frontend/apps/admin-web/src/components/AdminLayout.css
+++ b/frontend/apps/admin-web/src/components/AdminLayout.css
@@ -24,7 +24,7 @@
     color 80ms;
 }
 
-.ppt-topbar-help-btn[aria-expanded='true'] {
+.ppt-topbar-help-btn[aria-expanded="true"] {
   border: 1.5px solid var(--ppt-brand-400, #60a5fa);
   background: var(--ppt-brand-100, #dbeafe);
   color: var(--ppt-brand-700, #1d4ed8);

--- a/frontend/apps/admin-web/src/components/AdminLayout.tsx
+++ b/frontend/apps/admin-web/src/components/AdminLayout.tsx
@@ -6,6 +6,7 @@ import { Link, Outlet, useLocation } from 'react-router-dom';
 
 import { useAdminAuth } from '../auth/AdminAuthContext';
 import { HelpSidebar, useContextualHelp } from '../features/help';
+import './AdminLayout.css';
 import { ConnectedMfaWindowChip } from './MfaWindowChip';
 
 interface SidebarGroupProps {
@@ -196,29 +197,13 @@ export function AdminLayout() {
         >
           <span style={{ flex: 1 }} />
           <ConnectedMfaWindowChip />
+          {/* Help toggle — styles live in AdminLayout.css (.ppt-topbar-help-btn) */}
           <button
             type="button"
             onClick={help.toggle}
             aria-expanded={help.isOpen}
             aria-label={t('admin.help.openHelp', 'Open contextual help')}
-            style={{
-              display: 'inline-flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: '28px',
-              height: '28px',
-              borderRadius: '50%',
-              border: help.isOpen
-                ? '1.5px solid var(--ppt-brand-400, #60a5fa)'
-                : '1px solid var(--ppt-border-default, #e5e7eb)',
-              background: help.isOpen
-                ? 'var(--ppt-brand-100, #dbeafe)'
-                : 'var(--ppt-bg-subtle, #f3f4f6)',
-              color: help.isOpen ? 'var(--ppt-brand-700, #1d4ed8)' : 'var(--ppt-fg-muted, #6b7280)',
-              fontSize: '13px',
-              fontWeight: 700,
-              cursor: 'pointer',
-            }}
+            className="ppt-topbar-help-btn"
           >
             ?
           </button>

--- a/frontend/apps/admin-web/src/features/help/HelpSidebar.test.tsx
+++ b/frontend/apps/admin-web/src/features/help/HelpSidebar.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * HelpSidebar component tests.
+ *
+ * Covers:
+ *   - Rendering (article title, body, docs link)
+ *   - Accessibility: role=dialog, aria-modal, aria-labelledby
+ *   - Focus trap: useFocusTrap is invoked with the panel ref
+ *   - Escape key closes the sidebar
+ *   - Backdrop click closes the sidebar
+ *   - Close button click closes the sidebar
+ *   - No docs link when article.docsUrl is absent
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}));
+
+// Mock useFocusTrap: capture the onEscape callback so tests can invoke it,
+// and simulate Tab-focus cycling is delegated to the hook (not re-tested here).
+const capturedEscapeHandlers: Array<() => void> = [];
+
+vi.mock('../../components/useFocusTrap', () => ({
+  useFocusTrap: (_ref: unknown, onEscape: () => void) => {
+    capturedEscapeHandlers.push(onEscape);
+  },
+}));
+
+import type { HelpArticle } from '../../help/articles';
+import { HelpSidebar } from './HelpSidebar';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ARTICLE_WITH_DOCS: HelpArticle = {
+  id: 'test-article',
+  title: 'Test Article',
+  body: 'Simple body text.\n\n- List item one\n- List item two',
+  docsUrl: '/docs/test',
+};
+
+const ARTICLE_NO_DOCS: HelpArticle = {
+  id: 'no-docs-article',
+  title: 'No Docs',
+  body: 'No external link.',
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderSidebar(props: Partial<{ article: HelpArticle; onClose: () => void }> = {}) {
+  const onClose = props.onClose ?? vi.fn();
+  const article = props.article ?? ARTICLE_WITH_DOCS;
+  render(<HelpSidebar article={article} onClose={onClose} />);
+  return { onClose };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  capturedEscapeHandlers.length = 0;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('HelpSidebar', () => {
+  // --- Rendering ---
+
+  it('renders the article title', () => {
+    renderSidebar();
+    expect(screen.getByText('Test Article')).toBeDefined();
+  });
+
+  it('renders article body as paragraphs', () => {
+    renderSidebar();
+    expect(screen.getByText('Simple body text.')).toBeDefined();
+  });
+
+  it('renders list items from body', () => {
+    renderSidebar();
+    expect(screen.getByText('List item one')).toBeDefined();
+    expect(screen.getByText('List item two')).toBeDefined();
+  });
+
+  it('renders docs link when docsUrl is present', () => {
+    renderSidebar({ article: ARTICLE_WITH_DOCS });
+    const link = screen.getByRole('link');
+    expect(link.getAttribute('href')).toBe('/docs/test');
+  });
+
+  it('does not render docs link when docsUrl is absent', () => {
+    renderSidebar({ article: ARTICLE_NO_DOCS });
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+
+  // --- Accessibility: dialog semantics ---
+
+  it('renders the panel with role="dialog"', () => {
+    renderSidebar();
+    expect(screen.getByRole('dialog')).toBeDefined();
+  });
+
+  it('panel has aria-modal="true"', () => {
+    renderSidebar();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+  });
+
+  it('panel has aria-labelledby that matches the title heading id', () => {
+    renderSidebar();
+    const dialog = screen.getByRole('dialog');
+    const labelledBy = dialog.getAttribute('aria-labelledby');
+    expect(labelledBy).toBeTruthy();
+
+    // The heading with that id should contain the article title
+    const heading = document.getElementById(labelledBy as string);
+    expect(heading).not.toBeNull();
+    expect(heading?.textContent).toContain('Test Article');
+  });
+
+  it('panel has tabIndex=-1 so useFocusTrap can programmatically focus it', () => {
+    renderSidebar();
+    const dialog = screen.getByRole('dialog');
+    expect(Number(dialog.getAttribute('tabindex'))).toBe(-1);
+  });
+
+  // --- Close button ---
+
+  it('renders a close button with accessible label', () => {
+    renderSidebar();
+    expect(screen.getByRole('button', { name: /close help/i })).toBeDefined();
+  });
+
+  it('calls onClose when close button is clicked', async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderSidebar();
+    await user.click(screen.getByRole('button', { name: /close help/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // --- Backdrop ---
+
+  it('renders backdrop element', () => {
+    const { container } = render(<HelpSidebar article={ARTICLE_WITH_DOCS} onClose={vi.fn()} />);
+    expect(container.querySelector('.ppt-help-backdrop')).not.toBeNull();
+  });
+
+  it('calls onClose when backdrop is clicked', () => {
+    const onClose = vi.fn();
+    const { container } = render(<HelpSidebar article={ARTICLE_WITH_DOCS} onClose={onClose} />);
+    const backdrop = container.querySelector('.ppt-help-backdrop') as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // --- Escape key via useFocusTrap ---
+
+  it('invokes useFocusTrap with onClose as the escape handler', () => {
+    const onClose = vi.fn();
+    renderSidebar({ onClose });
+    // The mock captured the onEscape callback — invoking it should call onClose
+    expect(capturedEscapeHandlers.length).toBeGreaterThan(0);
+    act(() => {
+      capturedEscapeHandlers[capturedEscapeHandlers.length - 1]();
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // --- Styles injection guard ---
+
+  it('does not inject duplicate style element on re-render', () => {
+    const { rerender } = render(<HelpSidebar article={ARTICLE_WITH_DOCS} onClose={vi.fn()} />);
+    rerender(<HelpSidebar article={ARTICLE_NO_DOCS} onClose={vi.fn()} />);
+
+    const styleElements = document.querySelectorAll('#ppt-help-sidebar-styles');
+    expect(styleElements.length).toBe(1);
+  });
+});

--- a/frontend/apps/admin-web/src/features/help/HelpSidebar.tsx
+++ b/frontend/apps/admin-web/src/features/help/HelpSidebar.tsx
@@ -5,21 +5,34 @@
  * The panel renders the article body as pre-formatted text (no external
  * markdown parser required — keeps the bundle lean). Section headings
  * (`**bold**`) and bullet lists (lines starting with `-`) are styled inline.
+ *
+ * Accessibility:
+ *   - role="dialog" + aria-modal="true" marks the panel as a modal dialog.
+ *   - Focus is trapped inside the panel while it is open (via useFocusTrap).
+ *   - Escape closes the panel and returns focus to the trigger button.
+ *   - aria-labelledby links the panel to its visible title heading.
  */
 
-import React, { useEffect, useRef } from 'react';
+import React, { useId, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useFocusTrap } from '../../components/useFocusTrap';
 import type { HelpArticle } from '../../help/articles';
 
 // ---------------------------------------------------------------------------
-// Styles (injected once)
+// Styles (injected once at module load — not on every render)
 // ---------------------------------------------------------------------------
 
 const STYLE_ID = 'ppt-help-sidebar-styles';
 
+let _stylesInjected = false;
+
 function ensureStyles() {
+  if (_stylesInjected) return;
   if (typeof document === 'undefined') return;
-  if (document.getElementById(STYLE_ID)) return;
+  if (document.getElementById(STYLE_ID)) {
+    _stylesInjected = true;
+    return;
+  }
   const el = document.createElement('style');
   el.id = STYLE_ID;
   el.textContent = `
@@ -174,6 +187,7 @@ function ensureStyles() {
     }
   `;
   document.head.appendChild(el);
+  _stylesInjected = true;
 }
 
 // ---------------------------------------------------------------------------
@@ -305,39 +319,41 @@ interface HelpSidebarProps {
 }
 
 export function HelpSidebar({ article, onClose }: HelpSidebarProps) {
+  // Styles injected once on first mount (the flag prevents re-injection on
+  // subsequent mounts or HMR refreshes).
   ensureStyles();
+
   const { t } = useTranslation();
-  const closeRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
 
-  // Focus the close button on mount for keyboard accessibility
-  useEffect(() => {
-    closeRef.current?.focus();
-  }, []);
-
-  // Close on Escape
-  useEffect(() => {
-    function onKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Escape') onClose();
-    }
-    document.addEventListener('keydown', onKeyDown);
-    return () => document.removeEventListener('keydown', onKeyDown);
-  }, [onClose]);
+  // Focus-trap: Tab/Shift-Tab cycle within the panel; Escape calls onClose.
+  // Returns focus to the element that was focused before the panel opened.
+  useFocusTrap(panelRef, onClose);
 
   return (
     <>
       {/* Backdrop */}
       <div className="ppt-help-backdrop" onClick={onClose} aria-hidden="true" />
 
-      {/* Panel */}
-      <aside className="ppt-help-panel" aria-label={t('admin.help.panelLabel', 'Contextual help')}>
+      {/* Panel — role="dialog" + aria-modal confines assistive tech to this element */}
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="ppt-help-panel"
+        tabIndex={-1}
+      >
         {/* Header */}
         <div className="ppt-help-header">
           <div className="ppt-help-header__icon" aria-hidden="true">
             ?
           </div>
-          <h2 className="ppt-help-header__title">{article.title}</h2>
+          <h2 id={titleId} className="ppt-help-header__title">
+            {article.title}
+          </h2>
           <button
-            ref={closeRef}
             type="button"
             className="ppt-help-header__close"
             onClick={onClose}
@@ -365,7 +381,7 @@ export function HelpSidebar({ article, onClose }: HelpSidebarProps) {
             </a>
           </div>
         )}
-      </aside>
+      </div>
     </>
   );
 }

--- a/frontend/apps/admin-web/src/features/help/HelpTooltip.test.tsx
+++ b/frontend/apps/admin-web/src/features/help/HelpTooltip.test.tsx
@@ -96,8 +96,9 @@ describe('HelpTooltip', () => {
   });
 
   it('renders the tooltip text content', () => {
-    render(<HelpTooltip text="Important context" />);
-    expect(screen.getByRole('tooltip').textContent).toBe('Important context');
+    const { container } = render(<HelpTooltip text="Important context" />);
+    const bubble = container.querySelector('[role="tooltip"]');
+    expect(bubble?.textContent).toBe('Important context');
   });
 
   it('does not inject duplicate style element on multiple mounts', () => {

--- a/frontend/apps/admin-web/src/features/help/HelpTooltip.test.tsx
+++ b/frontend/apps/admin-web/src/features/help/HelpTooltip.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * HelpTooltip component tests.
+ *
+ * Covers:
+ *   - Renders the trigger button with accessible label
+ *   - Tooltip bubble is hidden by default
+ *   - Tooltip bubble becomes visible on hover (mouseenter)
+ *   - Tooltip bubble becomes visible on focus
+ *   - Tooltip bubble hides on blur / mouseleave
+ *   - role="tooltip" on the bubble
+ *   - aria-describedby links button to bubble
+ *   - No duplicate style injection
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}));
+
+import { HelpTooltip } from './HelpTooltip';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('HelpTooltip', () => {
+  it('renders a button with aria-label="Help"', () => {
+    render(<HelpTooltip text="Tooltip content" />);
+    const btn = screen.getByRole('button', { name: /help/i });
+    expect(btn).toBeDefined();
+  });
+
+  it('tooltip bubble is hidden by default', () => {
+    const { container } = render(<HelpTooltip text="Hidden tooltip" />);
+    const bubble = container.querySelector('.ppt-help-tip__bubble') as HTMLElement;
+    expect(bubble.style.visibility).toBe('hidden');
+  });
+
+  it('tooltip bubble becomes visible on mouseenter', () => {
+    const { container } = render(<HelpTooltip text="Show on hover" />);
+    const btn = screen.getByRole('button', { name: /help/i });
+    fireEvent.mouseEnter(btn);
+    const bubble = container.querySelector('.ppt-help-tip__bubble') as HTMLElement;
+    expect(bubble.style.visibility).toBe('visible');
+  });
+
+  it('tooltip bubble hides again on mouseleave', () => {
+    const { container } = render(<HelpTooltip text="Hide on leave" />);
+    const btn = screen.getByRole('button', { name: /help/i });
+    fireEvent.mouseEnter(btn);
+    fireEvent.mouseLeave(btn);
+    const bubble = container.querySelector('.ppt-help-tip__bubble') as HTMLElement;
+    expect(bubble.style.visibility).toBe('hidden');
+  });
+
+  it('tooltip bubble becomes visible on focus', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<HelpTooltip text="Show on focus" />);
+    const btn = screen.getByRole('button', { name: /help/i });
+    await user.tab(); // move focus to the button
+    // Ensure the button received focus
+    btn.focus();
+    fireEvent.focus(btn);
+    const bubble = container.querySelector('.ppt-help-tip__bubble') as HTMLElement;
+    expect(bubble.style.visibility).toBe('visible');
+  });
+
+  it('tooltip bubble hides on blur', () => {
+    const { container } = render(<HelpTooltip text="Hide on blur" />);
+    const btn = screen.getByRole('button', { name: /help/i });
+    fireEvent.focus(btn);
+    fireEvent.blur(btn);
+    const bubble = container.querySelector('.ppt-help-tip__bubble') as HTMLElement;
+    expect(bubble.style.visibility).toBe('hidden');
+  });
+
+  it('bubble has role="tooltip"', () => {
+    const { container } = render(<HelpTooltip text="Role check" />);
+    const bubble = container.querySelector('[role="tooltip"]');
+    expect(bubble).not.toBeNull();
+  });
+
+  it('button aria-describedby points to the bubble id', () => {
+    render(<HelpTooltip text="Aria check" />);
+    const btn = screen.getByRole('button', { name: /help/i });
+    const describedBy = btn.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    const bubble = document.getElementById(describedBy as string);
+    expect(bubble).not.toBeNull();
+    expect(bubble?.textContent).toBe('Aria check');
+  });
+
+  it('renders the tooltip text content', () => {
+    render(<HelpTooltip text="Important context" />);
+    expect(screen.getByRole('tooltip').textContent).toBe('Important context');
+  });
+
+  it('does not inject duplicate style element on multiple mounts', () => {
+    const { unmount } = render(<HelpTooltip text="First" />);
+    render(<HelpTooltip text="Second" />);
+    const styleElements = document.querySelectorAll('#ppt-help-tooltip-styles');
+    expect(styleElements.length).toBe(1);
+    unmount();
+  });
+});

--- a/frontend/apps/admin-web/src/features/help/HelpTooltip.tsx
+++ b/frontend/apps/admin-web/src/features/help/HelpTooltip.tsx
@@ -10,14 +10,20 @@ import { useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 // ---------------------------------------------------------------------------
-// Styles (injected once)
+// Styles (injected once — guarded by a module-level flag so subsequent mounts
+// or HMR refreshes do not re-inject).
 // ---------------------------------------------------------------------------
 
 const STYLE_ID = 'ppt-help-tooltip-styles';
+let _stylesInjected = false;
 
 function ensureStyles() {
+  if (_stylesInjected) return;
   if (typeof document === 'undefined') return;
-  if (document.getElementById(STYLE_ID)) return;
+  if (document.getElementById(STYLE_ID)) {
+    _stylesInjected = true;
+    return;
+  }
   const el = document.createElement('style');
   el.id = STYLE_ID;
   el.textContent = `
@@ -82,6 +88,7 @@ function ensureStyles() {
     }
   `;
   document.head.appendChild(el);
+  _stylesInjected = true;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/apps/admin-web/src/features/system-announcements/SystemAnnouncementsPage.tsx
+++ b/frontend/apps/admin-web/src/features/system-announcements/SystemAnnouncementsPage.tsx
@@ -39,6 +39,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DestructiveConfirmDialog } from '../../components/DestructiveConfirmDialog';
 import { useToast } from '../../components/Toast';
+import { HelpTooltip } from '../help';
 import { AnnForm, type AnnFormValues, annToForm } from './components/AnnForm';
 import { AnnouncementsTable } from './components/AnnouncementsTable';
 import { toIso } from './lib/formatters';
@@ -239,8 +240,18 @@ export default function SystemAnnouncementsPage() {
   return (
     <div style={containerStyle}>
       <div style={{ display: 'flex', alignItems: 'center', marginBottom: 20, gap: 12 }}>
-        <h2 style={{ margin: 0, fontSize: 20, flex: 1 }}>
+        <h2
+          style={{
+            margin: 0,
+            fontSize: 20,
+            flex: 1,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+          }}
+        >
           {t('admin.announcements.heading', 'System Announcements')}
+          <HelpTooltip text={t('admin.announcements.helpTooltip')} />
         </h2>
         <label
           style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13, cursor: 'pointer' }}

--- a/frontend/apps/admin-web/src/pages/CapabilitiesAdminPage.tsx
+++ b/frontend/apps/admin-web/src/pages/CapabilitiesAdminPage.tsx
@@ -21,10 +21,12 @@
 import { CAPABILITIES, useCapability, useMfaChallenge } from '@ppt/admin-ui';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 
 import { useAdminAuth } from '../auth/AdminAuthContext';
 import { AuditReasonPrompt, useAuditReasonValid } from '../components/AuditReasonPrompt';
+import { HelpTooltip } from '../features/help';
 
 // ---------------------------------------------------------------------------
 // Constants & helpers
@@ -1201,6 +1203,7 @@ function GrantDrawer({ userId, token, onClose, onSuccess }: GrantDrawerProps) {
 export default function CapabilitiesAdminPage() {
   ensureStyles();
 
+  const { t } = useTranslation();
   const [searchParams, setSearchParams] = useSearchParams();
   const view = searchParams.get('view') ?? 'registry';
   const userId = searchParams.get('id') ?? 'me';
@@ -1229,7 +1232,10 @@ export default function CapabilitiesAdminPage() {
     <div className="cap-page">
       <div className="cap-page__header">
         <div>
-          <h1 className="cap-page__title">Capabilities registry</h1>
+          <h1 className="cap-page__title" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            Capabilities registry
+            <HelpTooltip text={t('admin.capabilities.helpTooltip')} />
+          </h1>
           <p className="cap-page__subtitle">
             All {CAPABILITIES.length} platform capability strings. Click "View holders" to inspect
             grants for a specific user.

--- a/frontend/apps/admin-web/src/pages/Dashboard.tsx
+++ b/frontend/apps/admin-web/src/pages/Dashboard.tsx
@@ -16,10 +16,12 @@
 
 import { useCapability } from '@ppt/admin-ui';
 import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
 import { useAdminAuth } from '../auth/AdminAuthContext';
 import { useMfaWindow } from '../components/MfaWindowChip';
+import { HelpTooltip } from '../features/help';
 
 // ---------------------------------------------------------------------------
 // Styles (injected once)
@@ -424,6 +426,7 @@ function formatTime(iso: string): string {
 export function Dashboard() {
   ensureStyles();
 
+  const { t } = useTranslation();
   const { token } = useAdminAuth();
   const navigate = useNavigate();
   const { state: mfaState, msRemaining } = useMfaWindow();
@@ -519,8 +522,9 @@ export function Dashboard() {
   return (
     <div className="ppt-dash">
       {/* Greeting */}
-      <h1 className="ppt-dash__title">
+      <h1 className="ppt-dash__title" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
         {greeting}, {firstName}.
+        <HelpTooltip text={t('admin.dashboard.helpTooltip')} />
       </h1>
       <p className="ppt-dash__sub">
         {attentionCount > 0

--- a/frontend/apps/admin-web/src/pages/ImpersonationListPage.tsx
+++ b/frontend/apps/admin-web/src/pages/ImpersonationListPage.tsx
@@ -13,6 +13,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { useAdminAuth } from '../auth/AdminAuthContext';
 import { useToast } from '../components/Toast';
+import { HelpTooltip } from '../features/help';
 
 interface ActiveSession {
   token_id: string;
@@ -109,9 +110,13 @@ export default function ImpersonationListPage() {
           fontWeight: 700,
           color: 'var(--ppt-fg-primary, #111827)',
           margin: '0 0 20px',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
         }}
       >
         {t('admin.impersonation.title', { defaultValue: 'Active Impersonation Sessions' })}
+        <HelpTooltip text={t('admin.impersonation.helpTooltip')} />
       </h1>
 
       {isLoading && (

--- a/frontend/apps/admin-web/src/pages/MembershipsPage.tsx
+++ b/frontend/apps/admin-web/src/pages/MembershipsPage.tsx
@@ -18,6 +18,7 @@ import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAdminAuth } from '../auth/AdminAuthContext';
 import { useToast } from '../components/Toast';
+import { HelpTooltip } from '../features/help';
 
 interface MembershipRow {
   user_id: string;
@@ -168,9 +169,13 @@ export default function MembershipsPage() {
           fontWeight: 700,
           color: 'var(--ppt-fg-primary, #111827)',
           margin: '0 0 20px',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
         }}
       >
         {t('admin.memberships.title', { defaultValue: 'Memberships' })}
+        <HelpTooltip text={t('admin.memberships.helpTooltip')} />
       </h1>
 
       {/* Org selector */}

--- a/frontend/apps/admin-web/src/pages/MobileConfigPage.tsx
+++ b/frontend/apps/admin-web/src/pages/MobileConfigPage.tsx
@@ -16,6 +16,7 @@ import { useAdminAuth } from '../auth/AdminAuthContext';
 import { AuditReasonPrompt, useAuditReasonValid } from '../components/AuditReasonPrompt';
 import { useToast } from '../components/Toast';
 import { useFocusTrap } from '../components/useFocusTrap';
+import { HelpTooltip } from '../features/help';
 
 interface ForceUpdateValues extends Record<string, unknown> {
   min_ios_version: string;
@@ -305,9 +306,13 @@ export default function MobileConfigPage() {
               fontWeight: 700,
               color: 'var(--ppt-fg-primary, #111827)',
               margin: '0 0 8px',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
             }}
           >
             {t('admin.mobile.title', { defaultValue: 'Mobile configuration' })}
+            <HelpTooltip text={t('admin.mobile.helpTooltip')} />
           </h1>
           <p style={{ fontSize: 13, color: 'var(--ppt-fg-muted, #6b7280)', margin: 0 }}>
             {t('admin.mobile.subtitle', {

--- a/frontend/apps/admin-web/src/pages/OAuthClientsPage.tsx
+++ b/frontend/apps/admin-web/src/pages/OAuthClientsPage.tsx
@@ -40,6 +40,7 @@ import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { DestructiveConfirmDialog } from '../components/DestructiveConfirmDialog';
 import { useToast } from '../components/Toast';
+import { HelpTooltip } from '../features/help';
 
 // ============================================================
 // Utility helpers
@@ -899,7 +900,10 @@ export default function OAuthClientsPage() {
   return (
     <div className="ppt-oc-page">
       <div className="ppt-oc-header">
-        <h1 className="ppt-oc-title">{t('admin.oauthClients.title')}</h1>
+        <h1 className="ppt-oc-title" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {t('admin.oauthClients.title')}
+          <HelpTooltip text={t('admin.oauthClients.helpTooltip')} />
+        </h1>
         <button
           type="button"
           className="ppt-oc-btn ppt-oc-btn--primary"

--- a/frontend/apps/admin-web/src/pages/PlatformHealthPage.tsx
+++ b/frontend/apps/admin-web/src/pages/PlatformHealthPage.tsx
@@ -34,6 +34,7 @@ import type React from 'react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useToast } from '../components/Toast';
+import { HelpTooltip } from '../features/help';
 
 // ---------------------------------------------------------------------------
 // Status badge
@@ -733,8 +734,18 @@ const PlatformHealthPage: React.FC = () => {
   return (
     <section style={{ padding: '24px 28px', maxWidth: 1200 }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <h1 style={{ fontSize: 20, fontWeight: 700, margin: 0 }}>
+        <h1
+          style={{
+            fontSize: 20,
+            fontWeight: 700,
+            margin: 0,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+          }}
+        >
           {t('admin.health.title', 'Platform Health')}
+          <HelpTooltip text={t('admin.health.helpTooltip')} />
         </h1>
         <button
           type="button"

--- a/frontend/apps/admin-web/src/pages/agencies.tsx
+++ b/frontend/apps/admin-web/src/pages/agencies.tsx
@@ -21,6 +21,7 @@ import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAdminAuth } from '../auth/AdminAuthContext';
 import { useToast } from '../components/Toast';
+import { HelpTooltip } from '../features/help';
 
 const AgenciesPage: React.FC = () => {
   const { t } = useTranslation();
@@ -128,7 +129,10 @@ const AgenciesPage: React.FC = () => {
     // and would be overkill for a sub-route partial fetch.
     return (
       <section>
-        <h1>{t('admin.agencies.title')}</h1>
+        <h1 style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {t('admin.agencies.title')}
+          <HelpTooltip text={t('admin.agencies.helpTooltip')} />
+        </h1>
         <div role="status" aria-live="polite">
           {t('admin.agencies.loading')}
         </div>
@@ -141,7 +145,10 @@ const AgenciesPage: React.FC = () => {
       query.error instanceof Error ? query.error.message : t('admin.agencies.unknownError');
     return (
       <section>
-        <h1>{t('admin.agencies.title')}</h1>
+        <h1 style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {t('admin.agencies.title')}
+          <HelpTooltip text={t('admin.agencies.helpTooltip')} />
+        </h1>
         <div role="alert" className="ppt-admin-error">
           <p>{t('admin.agencies.loadError', { message })}</p>
           <button type="button" onClick={() => query.refetch()}>
@@ -156,7 +163,10 @@ const AgenciesPage: React.FC = () => {
 
   return (
     <section>
-      <h1>{t('admin.agencies.title')}</h1>
+      <h1 style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        {t('admin.agencies.title')}
+        <HelpTooltip text={t('admin.agencies.helpTooltip')} />
+      </h1>
       <ResourceTable<Agency>
         columns={columns}
         data={items}

--- a/frontend/apps/admin-web/src/pages/audit.tsx
+++ b/frontend/apps/admin-web/src/pages/audit.tsx
@@ -11,9 +11,11 @@
 import { CAPABILITIES } from '@ppt/admin-ui';
 import { useQuery } from '@tanstack/react-query';
 import { type FC, Fragment, useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 import { useAdminAuth } from '../auth/AdminAuthContext';
 import { useToast } from '../components/Toast';
+import { HelpTooltip } from '../features/help';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -807,6 +809,7 @@ function FilterRail({ filters, onChange }: FilterRailProps) {
 // ---------------------------------------------------------------------------
 
 const AuditPage: FC = () => {
+  const { t } = useTranslation();
   const [searchParams, setSearchParams] = useSearchParams();
   const { showToast } = useToast();
   const { token } = useAdminAuth();
@@ -985,9 +988,13 @@ const AuditPage: FC = () => {
                 fontWeight: 700,
                 color: 'var(--ppt-fg-primary)',
                 margin: 0,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
               }}
             >
               Audit log
+              <HelpTooltip text={t('admin.audit.helpTooltip')} />
             </h1>
             <button
               type="button"

--- a/frontend/apps/admin-web/src/pages/users.tsx
+++ b/frontend/apps/admin-web/src/pages/users.tsx
@@ -19,6 +19,7 @@ import { useAdminAuth } from '../auth/AdminAuthContext';
 import { AuditReasonPrompt, useAuditReasonValid } from '../components/AuditReasonPrompt';
 import { useToast } from '../components/Toast';
 import { useFocusTrap } from '../components/useFocusTrap';
+import { HelpTooltip } from '../features/help';
 
 interface UserRow {
   id: string;
@@ -315,7 +316,10 @@ const UsersPage: React.FC = () => {
         />
       )}
       <section>
-        <h1>{t('admin.users.title')}</h1>
+        <h1 style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {t('admin.users.title')}
+          <HelpTooltip text={t('admin.users.helpTooltip')} />
+        </h1>
         <div style={{ marginBottom: 16 }}>
           <input
             type="search"


### PR DESCRIPTION
## Task
HelpSidebar (PR #541): add focus-trap, dialog role + aria-modal, tooltips on remaining 11/13 pages, component tests, remove ensureStyles on every render, replace inline topbar button styles.

Tracking issue: #579

## Owner
pm-frontend (all changes are in `frontend/apps/admin-web/**`)

## Changes

### HelpSidebar (`src/features/help/HelpSidebar.tsx`)
- Added `role="dialog"`, `aria-modal="true"`, `aria-labelledby` (via `useId`) to the panel element
- Added `tabIndex={-1}` so `useFocusTrap` can programmatically focus it
- Wired `useFocusTrap(panelRef, onClose)` — handles Tab cycling and Escape key
- Module-level `_stylesInjected` flag — `ensureStyles()` is now a no-op after first call

### HelpTooltip (`src/features/help/HelpTooltip.tsx`)
- Same module-level `_stylesInjected` flag pattern — no DOM query on every render

### AdminLayout (`src/components/AdminLayout.tsx` + new `AdminLayout.css`)
- Replaced 14-line inline `style={{…}}` object on the help-toggle button with `className="ppt-topbar-help-btn"`
- CSS file uses `[aria-expanded='true']` selector — open/closed states handled by CSS, not JS

### Tooltips added (11 pages)
All pages now have a `<HelpTooltip>` next to their `<h1>` heading:
- `agencies.tsx` (all 3 render states: loading, error, success)
- `users.tsx`, `audit.tsx`, `ImpersonationListPage.tsx`, `MembershipsPage.tsx`
- `MobileConfigPage.tsx`, `OAuthClientsPage.tsx`, `PlatformHealthPage.tsx`
- `CapabilitiesAdminPage.tsx`, `Dashboard.tsx`
- `SystemAnnouncementsPage.tsx` (list view `h2`)

### Component tests
- `HelpSidebar.test.tsx` — 13 tests: rendering, dialog role, aria-modal, aria-labelledby, tabIndex, close button, backdrop click, useFocusTrap escape delegation, style deduplication
- `HelpTooltip.test.tsx` — 10 tests: button aria-label, show/hide on hover/focus/blur, role, aria-describedby, text content, style deduplication

## Tested (Band A — fast check)

```
pnpm -F @ppt/admin-web typecheck   # exit 0
pnpm check                         # exit 0 (no errors, 17 warnings pre-existing)
vitest run src/features/help/      # exit 0 — 25/25 pass
vitest run (all)                   # 170/173 pass; 3 pre-existing failures in
                                   #   CapabilitiesAdminPage (count 17→18) and
                                   #   PlatformHealthPage (getAllByText ambiguity)
                                   #   — confirmed same failures on dev branch
```

## Built (Band B — full build)

```
pnpm -F @ppt/admin-web build       # exit 0 — 275 modules, vite build clean
```

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
Skipped.

## Scope drift
scope-check exits 2 — all changed paths are `frontend/apps/admin-web/**` which is the correct admin-web sub-app but the `owner-areas.json` for `pm-frontend` maps to `frontend/apps/ppt-web/**` only. The admin-web app should be added to pm-frontend's owner areas (unrelated to this task).

Drifting paths (all expected for admin-web work):
- `frontend/apps/admin-web/messages/en.json`
- `frontend/apps/admin-web/src/**` (18 files)

## Code-reuse review
`reuse-grep.sh` emitted no warnings (`code_reuse_warn=none`).

## Notes
- The `useFocusTrap` hook already existed at `src/components/useFocusTrap.ts` — no new hook needed
- 3 pre-existing test failures remain unchanged (they fail on `dev` too)
- The `loginPage` route has no help article so it does not get a tooltip

https://claude.ai/code/session_011WoJfPUX9HUejGiFAzApsR

---
_Generated by [Claude Code](https://claude.ai/code/session_011WoJfPUX9HUejGiFAzApsR)_