### PR TITLE
gap-82-3-search-enhancements-fix: fix untranslated filter-stepper i18n keys in 5 non-EN locales

### DIFF
--- a/mobile-native/iosApp/iosApp/Resources/cs.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/cs.lproj/Localizable.strings
@@ -255,8 +255,8 @@
 "filter_listing_type" = "Typ nabídky";
 "filter_price_min" = "Min cena";
 "filter_price_max" = "Max cena";
-"filter_min_value" = "Min: %d";
-"filter_max_value" = "Max: %d";
+"filter_min_value" = "Od: %d";
+"filter_max_value" = "Do: %d";
 "filter_bathrooms" = "Koupelny";
 
 /* Account Screen - Additional */

--- a/mobile-native/iosApp/iosApp/Resources/de.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/de.lproj/Localizable.strings
@@ -243,7 +243,7 @@
 /* Search - Near Me / Location (added Story 82.3) */
 "filter_near_me" = "In meiner Nähe";
 "filter_near_me_section" = "Standort";
-"filter_radius" = "Radius";
+"filter_radius" = "Umkreis";
 "radius_km_format" = "%d km";
 "location_detected_format" = "Standort: %.4f, %.4f";
 "locating" = "Standort wird ermittelt…";
@@ -255,8 +255,8 @@
 "filter_listing_type" = "Angebotstyp";
 "filter_price_min" = "Mindestpreis";
 "filter_price_max" = "Höchstpreis";
-"filter_min_value" = "Min: %d";
-"filter_max_value" = "Max: %d";
+"filter_min_value" = "Min.: %d";
+"filter_max_value" = "Max.: %d";
 "filter_bathrooms" = "Badezimmer";
 
 /* Account Screen - Additional */

--- a/mobile-native/iosApp/iosApp/Resources/hu.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/hu.lproj/Localizable.strings
@@ -255,8 +255,8 @@
 "filter_listing_type" = "Hirdetés típusa";
 "filter_price_min" = "Min ár";
 "filter_price_max" = "Max ár";
-"filter_min_value" = "Min: %d";
-"filter_max_value" = "Max: %d";
+"filter_min_value" = "Min.: %d";
+"filter_max_value" = "Max.: %d";
 "filter_bathrooms" = "Fürdőszobák";
 
 /* Account Screen - Additional */

--- a/mobile-native/iosApp/iosApp/Resources/pl.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/pl.lproj/Localizable.strings
@@ -255,8 +255,8 @@
 "filter_listing_type" = "Typ ogłoszenia";
 "filter_price_min" = "Min cena";
 "filter_price_max" = "Max cena";
-"filter_min_value" = "Min: %d";
-"filter_max_value" = "Max: %d";
+"filter_min_value" = "Od: %d";
+"filter_max_value" = "Do: %d";
 "filter_bathrooms" = "Łazienki";
 
 /* Account Screen - Additional */

--- a/mobile-native/iosApp/iosApp/Resources/sk.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/sk.lproj/Localizable.strings
@@ -255,8 +255,8 @@
 "filter_listing_type" = "Typ ponuky";
 "filter_price_min" = "Min cena";
 "filter_price_max" = "Max cena";
-"filter_min_value" = "Min: %d";
-"filter_max_value" = "Max: %d";
+"filter_min_value" = "Od: %d";
+"filter_max_value" = "Do: %d";
 "filter_bathrooms" = "Kúpeľne";
 
 /* Account Screen - Additional */


### PR DESCRIPTION
## Task
Fix two must-fix bugs in PR#537 iOS search enhancements: (1) nearMeChip alert binding uses no-op setter making location-denied alert undismissible — fix binding; (2) properties_found i18n key used but absent from all 6 locale files — add key plus translate 15 new keys for 5 non-English locales (blocking from PR#537 reviewer verdict=changes)

## Owner
pm-frontend

## Analysis
On inspection of the current `dev` branch:

**Bug (1) — nearMeChip alert binding**: Already resolved. The squash-merge of PR#537 (commit `90b85da6`) includes the fix: `SearchView` uses `@State private var showLocationDeniedAlert = false` driven by `.onChange(of: locationManager.locationError)` and bound with `isPresented: $showLocationDeniedAlert`. No `set:{_ in}` no-op binding exists anywhere in SearchView.swift.

**Bug (2) — i18n key gaps**: The `properties_found` key is present in all 6 locale files. However, 3 Story 82.3 keys were still identical to their English originals in 5 non-English locales:
- `filter_min_value = "Min: %d"` (untranslated in SK, CS, DE, PL, HU)
- `filter_max_value = "Max: %d"` (untranslated in SK, CS, DE, PL, HU)
- `filter_radius = "Radius"` (untranslated in DE only)

This PR fixes those 3 remaining untranslated keys.

## Changes
- **SK**: `filter_min_value` → `"Od: %d"`, `filter_max_value` → `"Do: %d"`
- **CS**: `filter_min_value` → `"Od: %d"`, `filter_max_value` → `"Do: %d"`
- **DE**: `filter_radius` → `"Umkreis"`, `filter_min_value` → `"Min.: %d"`, `filter_max_value` → `"Max.: %d"`
- **PL**: `filter_min_value` → `"Od: %d"`, `filter_max_value` → `"Do: %d"`
- **HU**: `filter_min_value` → `"Min.: %d"`, `filter_max_value` → `"Max.: %d"`

## Tested (Band A — fast check)
`cd mobile-native && ./gradlew :shared:linkPodReleaseFrameworkIosArm64`
→ EXIT 1: Android SDK / AGP not installed on Linux sandbox (expected; same environment as PR#537 implementer)
→ Change is purely to `.strings` resource files — no Swift/Kotlin code paths affected; correctness verified by Python parse-and-compare script confirming 0 untranslated keys across all 5 non-EN locales for all 16 Story 82.3 keys.

## Built (Band B — full build)
Skipped: change is 11 LOC of `.strings` file edits only, no public API or config touch.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
Skipped.

## Scope drift
`scope-check.sh --owner pm-frontend --base dev --head HEAD` → exit 0 (no drift)

## Notes
- Both bugs from the reviewer verdict are addressed: (1) alert binding was already fixed in dev via `showLocationDeniedAlert @State` pattern; (2) remaining untranslated filter-stepper keys are now translated.
- `radius_km_format = "%d km"` is unchanged — "km" is the international unit symbol used identically in all 6 languages; this is correct.
- macOS reviewer should confirm Swift compilation and UI correctness with Xcode.

---
_Generated by [Claude Code](https://claude.ai/code/session_0177LCbGc5iPgJPccj9pG4Nv)_