### PR TITLE
gap-82-4-swiftui-listing-detail: ListingDetailView, FavoritesView, and FavoritesService (iOS SwiftUI)

### DIFF
--- a/mobile-native/iosApp/iosApp/Core/Navigation/Route.swift
+++ b/mobile-native/iosApp/iosApp/Core/Navigation/Route.swift
@@ -103,16 +103,6 @@ enum Route: Hashable {
     }
 }
 
-// MARK: - Listing Type Filter
-
-/// Listing transaction type for sale/rent filtering.
-///
-/// Epic 82 - Story 82.3: Home and Search Screens
-enum ListingTypeFilter: String, Hashable {
-    case sale
-    case rent
-}
-
 // MARK: - Search Filters
 
 /// Search filter options.
@@ -122,16 +112,15 @@ struct SearchFilters: Hashable {
     var priceMin: Int?
     var priceMax: Int?
     var propertyTypes: Set<PropertyType> = []
-    /// Sale/rent type filter, set by HomeView category chips.
-    var listingType: ListingTypeFilter?
+    /// Sale/rent type filter — maps to ListingType in the KMP layer.
+    /// Set by HomeView category chips or the FilterSheet.
+    var listingType: ListingKind?
     var bedroomsMin: Int?
     var bedroomsMax: Int?
     var bathroomsMin: Int?
     var radiusKm: Double?
     var latitude: Double?
     var longitude: Double?
-    /// Sale/rent filter — maps to ListingType in the KMP layer.
-    var listingType: ListingKind?
 
     /// Whether any filters are active.
     var hasActiveFilters: Bool {

--- a/mobile-native/iosApp/iosApp/Core/Services/FavoritesService.swift
+++ b/mobile-native/iosApp/iosApp/Core/Services/FavoritesService.swift
@@ -1,0 +1,165 @@
+import Foundation
+import Observation
+import shared
+
+/// App-wide favorites state manager for Reality Portal iOS app.
+///
+/// `FavoritesService` is the single source of truth for which listings the
+/// authenticated user has saved. It is injected via `@Environment` so that
+/// both `ListingDetailView` (heart button) and `FavoritesView` (list) stay
+/// automatically in sync without requiring manual refresh calls.
+///
+/// ## Optimistic updates
+///
+/// `toggle(listingId:)` and `remove(listingId:)` apply changes immediately
+/// to `favoriteIds` before the network call completes. If the server returns
+/// an error the optimistic change is reverted.
+///
+/// ## Session lifecycle
+///
+/// Call `configure(sessionToken:)` once a session token is available (on
+/// launch or after SSO login) to prime the in-memory set from the server.
+/// The service is a no-op when called without an authenticated session.
+///
+/// Epic 82 - Story 82.4: Listing Detail and Favorites
+@Observable
+final class FavoritesService {
+
+    // MARK: - Observable State
+
+    /// Set of listing IDs the current user has favorited.
+    ///
+    /// Observers (e.g. `FavoritesView.onChange`) react to mutations here so
+    /// the heart icon in `ListingDetailView` and the list in `FavoritesView`
+    /// are always consistent.
+    private(set) var favoriteIds: Set<String> = []
+
+    // MARK: - Private
+
+    private var sessionToken: String?
+    private let configuration = Configuration.shared
+
+    /// Creates a new `FavoritesRepository` scoped to the current session.
+    private var repository: FavoritesRepository {
+        DependencyContainer.shared.makeAuthenticatedFavoritesRepository(
+            sessionToken: sessionToken
+        )
+    }
+
+    // MARK: - Initialization
+
+    init() {}
+
+    // MARK: - Session Lifecycle
+
+    /// Prime the service with a session token and fetch the user's current
+    /// favorites from the server.
+    ///
+    /// Safe to call multiple times — subsequent calls re-fetch with the new
+    /// token (e.g. after an SSO refresh). Calling with `nil` clears the
+    /// in-memory set and disables all network operations.
+    func configure(sessionToken: String?) async {
+        self.sessionToken = sessionToken
+
+        guard sessionToken != nil else {
+            favoriteIds = []
+            return
+        }
+
+        await fetchFavorites()
+    }
+
+    // MARK: - Read
+
+    /// Returns `true` synchronously if `listingId` is in the local set.
+    ///
+    /// This is the hot path called from `ListingDetailView.body` on every
+    /// render, so it must be O(1) and never block.
+    func isFavorite(listingId: String) -> Bool {
+        favoriteIds.contains(listingId)
+    }
+
+    // MARK: - Write
+
+    /// Toggle the favorite state of a listing.
+    ///
+    /// Applies an optimistic update immediately, then calls the server.
+    /// Reverts on failure.
+    func toggle(listingId: String) async {
+        guard sessionToken != nil else { return }
+
+        let wasFavorite = favoriteIds.contains(listingId)
+
+        // Optimistic update
+        if wasFavorite {
+            favoriteIds.remove(listingId)
+        } else {
+            favoriteIds.insert(listingId)
+        }
+
+        let succeeded: Bool
+        if wasFavorite {
+            let result = await repository.removeFavorite(listingId: listingId)
+            succeeded = result.getOrNull() != nil
+        } else {
+            let result = await repository.addFavorite(listingId: listingId)
+            succeeded = result.getOrNull() != nil
+        }
+
+        if !succeeded {
+            // Revert the optimistic update
+            if wasFavorite {
+                favoriteIds.insert(listingId)
+            } else {
+                favoriteIds.remove(listingId)
+            }
+
+            #if DEBUG
+            print("FavoritesService.toggle failed for \(listingId); optimistic update reverted")
+            #endif
+        }
+    }
+
+    /// Remove a listing from favorites.
+    ///
+    /// Applies an optimistic update immediately, then calls the server.
+    /// Reverts on failure.
+    func remove(listingId: String) async {
+        guard sessionToken != nil else { return }
+        guard favoriteIds.contains(listingId) else { return }
+
+        // Optimistic update
+        favoriteIds.remove(listingId)
+
+        let result = await repository.removeFavorite(listingId: listingId)
+        let succeeded = result.getOrNull() != nil
+
+        if !succeeded {
+            // Revert
+            favoriteIds.insert(listingId)
+
+            #if DEBUG
+            print("FavoritesService.remove failed for \(listingId); optimistic update reverted")
+            #endif
+        }
+    }
+
+    // MARK: - Private helpers
+
+    /// Fetches the full favorites list from the server and populates
+    /// `favoriteIds`. Silently ignores errors — the UI will retry on
+    /// explicit pull-to-refresh.
+    private func fetchFavorites() async {
+        let result = await repository.getFavorites()
+
+        if let response = result.getOrNull() {
+            favoriteIds = Set(response.favorites.map { $0.listingId })
+        } else {
+            #if DEBUG
+            if let error = result.exceptionOrNull() {
+                print("FavoritesService.fetchFavorites error: \(error.message ?? "unknown")")
+            }
+            #endif
+        }
+    }
+}

--- a/mobile-native/iosApp/iosApp/Features/Search/SearchView.swift
+++ b/mobile-native/iosApp/iosApp/Features/Search/SearchView.swift
@@ -303,7 +303,7 @@ struct SearchView: View {
     private func buildKMPFilters() -> ListingSearchFilters? {
         guard filters.hasActiveFilters else { return nil }
 
-        // Map Swift ListingTypeFilter to KMP ListingType
+        // Map Swift ListingKind to KMP ListingType
         var listingType: ListingType? = nil
         if let swiftType = filters.listingType {
             switch swiftType {


### PR DESCRIPTION
## Task
Implement ListingDetailView and FavoritesView in SwiftUI iOS app; wire to reality-server listings/{id} and favorites endpoints

## Owner
pm-frontend (note: actual file area is mobile-native/ — see Scope drift below)

## What was done

### Already merged (from gap-82-3, PR#533)
- `ListingDetailView` — full property detail screen with photo gallery, agent card, inquiry sheet, share button, and animated heart/favorite button wired to `FavoritesService`.
- `FavoritesView` — authenticated favorites list with per-card swipe-to-remove and cross-view sync via `FavoritesService.favoriteIds`.

### Added in this PR
1. **`FavoritesService.swift`** (`Core/Services/`) — new `@Observable` service that is the app-wide source of truth for the user's saved listings. Injected via `@Environment` in both `ListingDetailView` and `FavoritesView`. Backed by the KMP `FavoritesRepository` (which calls `GET/POST/DELETE /api/v1/favorites`). Implements optimistic toggle/remove with automatic revert on server error. Seeded via `configure(sessionToken:)` on launch and after SSO login.

2. **`Route.swift` bug fix** — `SearchFilters` had a duplicate `listingType` property:
   - `var listingType: ListingTypeFilter?` (Story 82.3 leftover)
   - `var listingType: ListingKind?` (the correct canonical type)
   Removed the obsolete `ListingTypeFilter` enum and its property, keeping the `ListingKind`-based one. `SearchView` comment updated accordingly.

## Tested (Band A — fast check)
```
cd mobile-native && ./gradlew :shared:linkPodReleaseFrameworkIosArm64
EXIT: FAILED — Android SDK / Gradle plugin com.android.application:9.2.1 not available in cloud sandbox
```
This is a known constraint documented in the `ios-swiftui` specialist: KMP Gradle build requires Android SDK which is absent from the cloud sandbox. Swift correctness verified by code review against existing call-site patterns in `HomeView`, `FavoritesView`, and `ListingDetailView`.

**Reviewer action required:** run `./gradlew :shared:linkPodReleaseFrameworkIosArm64` and `xcodebuild build` on a macOS machine before merging.

## Built (Band B — full build)
skipped: Xcode/macOS not available in cloud sandbox.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped

## Scope drift
`scope_drift=true` — all changed files are in `mobile-native/` but the task was tagged `owner_role: pm-frontend`. The work is correctly `pm-mobile` territory. Drift is justified by the task assignment; no cross-area side-effects introduced.

Drifting paths:
- `mobile-native/iosApp/iosApp/Core/Services/FavoritesService.swift` (new)
- `mobile-native/iosApp/iosApp/Core/Navigation/Route.swift` (fix duplicate property)
- `mobile-native/iosApp/iosApp/Features/Search/SearchView.swift` (comment update only)

## Code-reuse review
No new auth/crypto/http-client helpers added. `FavoritesService` delegates all network work to the existing KMP `FavoritesRepository` via `DependencyContainer.shared.makeAuthenticatedFavoritesRepository(sessionToken:)`. `code_reuse_warn=none`.

## Notes
- `FavoritesService` was already wired as an `@Environment` in `RealityPortalApp.swift` (added in a prior story). This PR provides the missing concrete implementation.
- The `ListingTypeFilter` enum removal is a clean compile-time fix — it was never actually used at runtime because `SearchView.buildKMPFilters()` already pattern-matched against `ListingKind` values.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKF22XpnbM4RGoerhRu2f1)_