### PR TITLE
docs(screens): #581 add missing Agent Log entries on 11 reality-mobile maps + flag sitemap gaps

### DIFF
--- a/docs/screens/reality-mobile/account.md
+++ b/docs/screens/reality-mobile/account.md
@@ -59,3 +59,4 @@ Account tab root. Auth state driven by `AuthManager.isAuthenticated` (`@Observab
 ## Agent Log
 
 - 2026-05-25 — agent: created screen map from audit of mobile-native/iosApp/iosApp/Features/Account/AccountView.swift (epic-82 story 82.5). Profile/Settings stubs noted.
+- 2026-05-28 — agent: fix(#581) added missing Agent Log entry that PR #554 omitted (CLAUDE.md screen-map Rule A.3); flagged dropped operationIds on home + saved-searches in Notes > Specific (recent) pending @ppt/sitemap extension.

--- a/docs/screens/reality-mobile/agencies.md
+++ b/docs/screens/reality-mobile/agencies.md
@@ -63,3 +63,4 @@ UC-51.1 agency directory. Placed under the Search tab by `NavigationCoordinator`
 ## Agent Log
 
 - 2026-05-25 — agent: created screen map from audit of mobile-native/iosApp/iosApp/Features/Agencies/AgenciesView.swift (UC-51.1). Missing agency-detail route noted.
+- 2026-05-28 — agent: fix(#581) added missing Agent Log entry that PR #554 omitted (CLAUDE.md screen-map Rule A.3); flagged dropped operationIds on home + saved-searches in Notes > Specific (recent) pending @ppt/sitemap extension.

--- a/docs/screens/reality-mobile/auth-login.md
+++ b/docs/screens/reality-mobile/auth-login.md
@@ -64,3 +64,4 @@ Presented as a sheet from `MainTabView.handleTabChange()` when an unauthenticate
 ## Agent Log
 
 - 2026-05-25 — agent: created screen map from audit of mobile-native/iosApp/iosApp/Features/Auth/LoginView.swift (epic-82 story 82.5). SSO-only constraint and missing register/forgot-password flows noted.
+- 2026-05-28 — agent: fix(#581) added missing Agent Log entry that PR #554 omitted (CLAUDE.md screen-map Rule A.3); flagged dropped operationIds on home + saved-searches in Notes > Specific (recent) pending @ppt/sitemap extension.

--- a/docs/screens/reality-mobile/compare-listings.md
+++ b/docs/screens/reality-mobile/compare-listings.md
@@ -62,3 +62,4 @@ UC-46.5 cross-tab feature. `NavigationCoordinator.navigate(to: .compareListings)
 ## Agent Log
 
 - 2026-05-25 — agent: created screen map from audit of mobile-native/iosApp/iosApp/Features/CompareListings/CompareListingsView.swift (UC-46.5). Add/remove UI gap noted.
+- 2026-05-28 — agent: fix(#581) added missing Agent Log entry that PR #554 omitted (CLAUDE.md screen-map Rule A.3); flagged dropped operationIds on home + saved-searches in Notes > Specific (recent) pending @ppt/sitemap extension.

--- a/docs/screens/reality-mobile/favorites.md
+++ b/docs/screens/reality-mobile/favorites.md
@@ -66,3 +66,4 @@ Auth-gated tab (favorites, inquiries, account all require auth). When unauthenti
 ## Agent Log
 
 - 2026-05-25 — agent: created screen map from audit of mobile-native/iosApp/iosApp/Features/Favorites/FavoritesView.swift (epic-82 story 82.4). Compare/sort gaps noted.
+- 2026-05-28 — agent: fix(#581) added missing Agent Log entry that PR #554 omitted (CLAUDE.md screen-map Rule A.3); flagged dropped operationIds on home + saved-searches in Notes > Specific (recent) pending @ppt/sitemap extension.

--- a/docs/screens/reality-mobile/home.md
+++ b/docs/screens/reality-mobile/home.md
@@ -70,8 +70,10 @@ Root tab screen of Reality Portal iOS. Uses KMP `ListingRepository` (via `Depend
 - Category chips currently have empty closures — navigation to filtered search not yet wired (post-epic-82 task).
 - AsyncImage used for thumbnails with graceful fallback to `photo` SF symbol.
 - `ListingPreview.sampleFeatured/sampleRecent` arrays are `#if DEBUG` guarded — not in production builds.
+- ⚠️ **Sitemap gap (#581):** Featured carousel calls `GET /api/v1/listings/featured` and recent list calls `GET /api/v1/listings/recent`, but `@ppt/sitemap` has no `listings_featured` / `listings_recent` operationIds — only the more general `listings_search` is referenced above. Extend the sitemap and restore both specific endpoints here.
 
 ## Agent Log
 
 - 2026-05-25 — agent: created screen map from audit of mobile-native/iosApp/iosApp/Features/Home/HomeView.swift (epic-82 story 82.3). NavigationCoordinator integration confirmed. Category chip actions unimplemented.
 - 2026-05-25 — agent: wired category chips to pendingSearchFilters on NavigationCoordinator; SearchView.onAppear consumes and auto-searches. buildStatus → shipped.
+- 2026-05-28 — agent: fix(#581) added missing Agent Log entry that PR #554 omitted (CLAUDE.md screen-map Rule A.3); flagged dropped operationIds on home + saved-searches in Notes > Specific (recent) pending @ppt/sitemap extension.

--- a/docs/screens/reality-mobile/inquiries.md
+++ b/docs/screens/reality-mobile/inquiries.md
@@ -67,3 +67,4 @@ Auth-gated tab. Maps KMP `Inquiry` → Swift `InquiryPreview` via `KMPBridge.toI
 ## Agent Log
 
 - 2026-05-25 — agent: created screen map from audit of mobile-native/iosApp/iosApp/Features/Inquiries/InquiriesView.swift (epic-82 story 82.5). Detail and newInquiry stubs noted.
+- 2026-05-28 — agent: fix(#581) added missing Agent Log entry that PR #554 omitted (CLAUDE.md screen-map Rule A.3); flagged dropped operationIds on home + saved-searches in Notes > Specific (recent) pending @ppt/sitemap extension.

--- a/docs/screens/reality-mobile/listing-detail.md
+++ b/docs/screens/reality-mobile/listing-detail.md
@@ -78,3 +78,4 @@ Detail view accessible from HomeView (featured/recent cards), SearchView (search
 ## Agent Log
 
 - 2026-05-25 — agent: created screen map from audit of mobile-native/iosApp/iosApp/Features/Listing/ListingDetailView.swift (epic-82 story 82.4). Gallery and map stub gaps noted.
+- 2026-05-28 — agent: fix(#581) added missing Agent Log entry that PR #554 omitted (CLAUDE.md screen-map Rule A.3); flagged dropped operationIds on home + saved-searches in Notes > Specific (recent) pending @ppt/sitemap extension.

--- a/docs/screens/reality-mobile/realtors.md
+++ b/docs/screens/reality-mobile/realtors.md
@@ -60,3 +60,4 @@ UC-49.1 realtor directory. `NavigationCoordinator.navigate(to: .realtors)` place
 ## Agent Log
 
 - 2026-05-25 — agent: created screen map from audit of mobile-native/iosApp/iosApp/Features/Realtors/RealtorsView.swift (UC-49.1). API gap (no directory endpoint) documented.
+- 2026-05-28 — agent: fix(#581) added missing Agent Log entry that PR #554 omitted (CLAUDE.md screen-map Rule A.3); flagged dropped operationIds on home + saved-searches in Notes > Specific (recent) pending @ppt/sitemap extension.

--- a/docs/screens/reality-mobile/saved-searches.md
+++ b/docs/screens/reality-mobile/saved-searches.md
@@ -60,7 +60,9 @@ UC-45.2 — user's personal saved searches with alert notifications. Navigated t
 
 - Accessible from AccountView's navigation list; also navigable via deep link `realityportal://account/saved-searches`.
 - Alert toggle fires async KMP call and updates list in-place on success.
+- ⚠️ **Sitemap gap (#581):** the alert-toggle UI calls `PATCH /api/v1/saved-searches/{id}`, but no `saved_searches_update` (or `saved_searches_toggle_alert`) operationId exists in `@ppt/sitemap` yet — so it is intentionally omitted from `endpoints` above. Restore the endpoint here once the sitemap is extended.
 
 ## Agent Log
 
 - 2026-05-25 — agent: created screen map from audit of mobile-native/iosApp/iosApp/Features/SavedSearches/SavedSearchesView.swift (UC-45.2). Launch-from-saved-search gap noted.
+- 2026-05-28 — agent: fix(#581) added missing Agent Log entry that PR #554 omitted (CLAUDE.md screen-map Rule A.3); flagged dropped operationIds on home + saved-searches in Notes > Specific (recent) pending @ppt/sitemap extension.

--- a/docs/screens/reality-mobile/search.md
+++ b/docs/screens/reality-mobile/search.md
@@ -74,3 +74,4 @@ Search tab root. Calls `listingRepository.searchListings(request:)` via KMP. Pag
 
 - 2026-05-25 — agent: created screen map from audit of mobile-native/iosApp/iosApp/Features/Search/SearchView.swift (epic-82 story 82.3). Sort and map-toggle gaps noted.
 - 2026-05-25 — agent: added SortOption enum (7 cases) with toolbar button; added onAppear to consume pendingSearchFilters from HomeView; mapped ListingTypeFilter to KMP ListingType in buildKMPFilters. buildStatus → shipped. Map toggle remains future work.
+- 2026-05-28 — agent: fix(#581) added missing Agent Log entry that PR #554 omitted (CLAUDE.md screen-map Rule A.3); flagged dropped operationIds on home + saved-searches in Notes > Specific (recent) pending @ppt/sitemap extension.


### PR DESCRIPTION
Closes #581.

## Summary

Two post-merge follow-ups from PR #554:

1. **Agent Log entries (Rule A.3)** — PR #554 modified all 11 `docs/screens/reality-mobile/*.md` files without appending an Agent Log entry. Added a 2026-05-28 entry to all 11.
2. **Sitemap gaps flagged** — PR #554 dropped 3 endpoints because they had no matching operationId in `@ppt/sitemap`:
   - `home.md`: `GET /api/v1/listings/featured`, `GET /api/v1/listings/recent`
   - `saved-searches.md`: `PATCH /api/v1/saved-searches/{id}` (alert toggle)

   Added a ⚠️ Sitemap gap bullet to `Notes > Specific (recent)` on both files so the next agent knows the gap exists.

## Out of scope

Extending `@ppt/sitemap` itself with `listings_featured`, `listings_recent`, `saved_searches_update` operationIds. That requires TypeSpec changes + regenerating both clients — a separate PR. The Notes warnings here unblock future agents in the meantime.

## Test plan

- [ ] CI `Validate screen-maps` job passes.
- [ ] Diff is append-only (no frontmatter or endpoint-array changes), so schema/reference checks should still pass.