### PR TITLE
fix(reports): #646 #647 close cross-tenant IDOR on pause/resume/list_executions

### DIFF
--- a/backend/crates/db/src/repositories/report_schedule.rs
+++ b/backend/crates/db/src/repositories/report_schedule.rs
@@ -29,7 +29,13 @@ impl ReportScheduleRepository {
     // Schedule operations
     // ============================================================================
 
-    /// Get a schedule by ID.
+    /// Get a schedule by ID (no tenant scoping).
+    ///
+    /// **Prefer [`get_by_id_in_org`] in route handlers** — this method exists
+    /// only for internal callers that have already verified tenant scope (e.g.
+    /// the scheduler worker iterating all schedules). Calling it directly from
+    /// a request handler with a caller-supplied `id` re-introduces the IDOR
+    /// class fixed in #624 / #646 / #647.
     pub async fn get_by_id(&self, id: Uuid) -> Result<Option<ReportSchedule>, AppError> {
         let row = sqlx::query_as::<_, ReportScheduleRow>(
             r#"
@@ -52,17 +58,71 @@ impl ReportScheduleRepository {
         Ok(row.map(ReportSchedule::from))
     }
 
+    /// Get a schedule by ID, scoped to the caller's organization.
+    ///
+    /// # Cross-tenant safety (closes #647)
+    ///
+    /// Returns `Ok(None)` both when the schedule does not exist and when it
+    /// exists in a different organisation — the handler maps both to 404 so
+    /// no cross-tenant existence information leaks.
+    pub async fn get_by_id_in_org(
+        &self,
+        id: Uuid,
+        caller_org_id: Uuid,
+    ) -> Result<Option<ReportSchedule>, AppError> {
+        let row = sqlx::query_as::<_, ReportScheduleRow>(
+            r#"
+            SELECT id, report_id, organization_id, name, frequency,
+                   day_of_week, day_of_month, time, timezone, format,
+                   recipients, is_active, status,
+                   last_run_at, next_run_at, created_at, updated_at
+            FROM report_schedules
+            WHERE id              = $1
+              AND organization_id = $2
+            "#,
+        )
+        .bind(id)
+        .bind(caller_org_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                error = %e,
+                schedule_id = %id,
+                org_id = %caller_org_id,
+                "Failed to get report schedule"
+            );
+            AppError::Database(e.to_string())
+        })?;
+
+        Ok(row.map(ReportSchedule::from))
+    }
+
     /// Pause a schedule (Story 81.1).
     ///
     /// Sets `is_active = false`, `status = 'paused'`.
-    pub async fn pause(&self, id: Uuid) -> Result<ReportSchedule, AppError> {
+    ///
+    /// # Cross-tenant safety (closes #646)
+    ///
+    /// The WHERE clause includes `AND organization_id = $caller_org_id` so a
+    /// principal in org A cannot pause a schedule that belongs to org B, even
+    /// if they know the schedule's UUID. The UPDATE returns no row (→ 404)
+    /// when the `id` exists but the `organization_id` does not match, giving
+    /// the same opaque response as "not found" to avoid leaking existence
+    /// information.
+    pub async fn pause(
+        &self,
+        id: Uuid,
+        caller_org_id: Uuid,
+    ) -> Result<ReportSchedule, AppError> {
         let row = sqlx::query_as::<_, ReportScheduleRow>(
             r#"
             UPDATE report_schedules
             SET is_active  = false,
                 status     = $1,
                 updated_at = NOW()
-            WHERE id = $2
+            WHERE id              = $2
+              AND organization_id = $3
             RETURNING id, report_id, organization_id, name, frequency,
                       day_of_week, day_of_month, time, timezone, format,
                       recipients, is_active, status,
@@ -71,10 +131,16 @@ impl ReportScheduleRepository {
         )
         .bind(report_schedule_status::PAUSED)
         .bind(id)
+        .bind(caller_org_id)
         .fetch_optional(&self.pool)
         .await
         .map_err(|e| {
-            tracing::error!(error = %e, schedule_id = %id, "Failed to pause report schedule");
+            tracing::error!(
+                error = %e,
+                schedule_id = %id,
+                org_id = %caller_org_id,
+                "Failed to pause report schedule"
+            );
             AppError::Database(e.to_string())
         })?
         .ok_or_else(|| AppError::NotFound(format!("Report schedule {} not found", id)))?;
@@ -85,14 +151,24 @@ impl ReportScheduleRepository {
     /// Resume a paused schedule (Story 81.1).
     ///
     /// Sets `is_active = true`, `status = 'active'`.
-    pub async fn resume(&self, id: Uuid) -> Result<ReportSchedule, AppError> {
+    ///
+    /// # Cross-tenant safety (closes #646)
+    ///
+    /// Same tenant-scoping contract as [`pause`] — `AND organization_id = $3`
+    /// in the UPDATE WHERE clause, 404 on zero-row update.
+    pub async fn resume(
+        &self,
+        id: Uuid,
+        caller_org_id: Uuid,
+    ) -> Result<ReportSchedule, AppError> {
         let row = sqlx::query_as::<_, ReportScheduleRow>(
             r#"
             UPDATE report_schedules
             SET is_active  = true,
                 status     = $1,
                 updated_at = NOW()
-            WHERE id = $2
+            WHERE id              = $2
+              AND organization_id = $3
             RETURNING id, report_id, organization_id, name, frequency,
                       day_of_week, day_of_month, time, timezone, format,
                       recipients, is_active, status,
@@ -101,10 +177,16 @@ impl ReportScheduleRepository {
         )
         .bind(report_schedule_status::ACTIVE)
         .bind(id)
+        .bind(caller_org_id)
         .fetch_optional(&self.pool)
         .await
         .map_err(|e| {
-            tracing::error!(error = %e, schedule_id = %id, "Failed to resume report schedule");
+            tracing::error!(
+                error = %e,
+                schedule_id = %id,
+                org_id = %caller_org_id,
+                "Failed to resume report schedule"
+            );
             AppError::Database(e.to_string())
         })?
         .ok_or_else(|| AppError::NotFound(format!("Report schedule {} not found", id)))?;

--- a/backend/servers/api-server/src/routes/reports.rs
+++ b/backend/servers/api-server/src/routes/reports.rs
@@ -1334,6 +1334,14 @@ pub async fn get_export_job_status(
 // ============================================================================
 
 /// Pause a report schedule (Story 81.1).
+///
+/// # Security (closes #646)
+///
+/// Uses `RlsConnection` (not `AuthUser`) so:
+/// - The caller's role is re-checked against the database on every request.
+/// - Only manager-tier roles may pause schedules.
+/// - `caller_org_id` is threaded into the repository UPDATE as
+///   `AND organization_id = $caller_org_id`, preventing cross-tenant pause.
 #[utoipa::path(
     put,
     path = "/api/v1/reports/schedules/{id}/pause",
@@ -1342,28 +1350,62 @@ pub async fn get_export_job_status(
     responses(
         (status = 200, description = "Schedule paused", body = ReportSchedule),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Insufficient role"),
         (status = 404, description = "Schedule not found"),
     )
 )]
 pub async fn pause_schedule(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ReportSchedule>, (StatusCode, Json<ErrorResponse>)> {
+    if !rls.role().is_manager() {
+        rls.release().await;
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "INSUFFICIENT_ROLE",
+                "Manager role required to pause report schedules",
+            )),
+        ));
+    }
+    let caller_org_id = rls.tenant_id();
+    rls.release().await;
+
     state
         .report_schedule_repo
-        .pause(id)
+        .pause(id, caller_org_id)
         .await
         .map(Json)
-        .map_err(|_| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to pause schedule")),
-            )
+        .map_err(|e| {
+            tracing::error!(
+                error = %e,
+                schedule_id = %id,
+                org_id = %caller_org_id,
+                "Failed to pause schedule"
+            );
+            match e {
+                common::errors::AppError::NotFound(_) => (
+                    StatusCode::NOT_FOUND,
+                    Json(ErrorResponse::new(
+                        "SCHEDULE_NOT_FOUND",
+                        "Report schedule not found",
+                    )),
+                ),
+                _ => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("DB_ERROR", "Failed to pause schedule")),
+                ),
+            }
         })
 }
 
 /// Resume a paused report schedule (Story 81.1).
+///
+/// # Security (closes #646)
+///
+/// Same contract as [`pause_schedule`]: manager-tier RBAC via `RlsConnection`,
+/// `caller_org_id` threaded into the UPDATE WHERE clause.
 #[utoipa::path(
     put,
     path = "/api/v1/reports/schedules/{id}/resume",
@@ -1372,24 +1414,53 @@ pub async fn pause_schedule(
     responses(
         (status = 200, description = "Schedule resumed", body = ReportSchedule),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Insufficient role"),
         (status = 404, description = "Schedule not found"),
     )
 )]
 pub async fn resume_schedule(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ReportSchedule>, (StatusCode, Json<ErrorResponse>)> {
+    if !rls.role().is_manager() {
+        rls.release().await;
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "INSUFFICIENT_ROLE",
+                "Manager role required to resume report schedules",
+            )),
+        ));
+    }
+    let caller_org_id = rls.tenant_id();
+    rls.release().await;
+
     state
         .report_schedule_repo
-        .resume(id)
+        .resume(id, caller_org_id)
         .await
         .map(Json)
-        .map_err(|_| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to resume schedule")),
-            )
+        .map_err(|e| {
+            tracing::error!(
+                error = %e,
+                schedule_id = %id,
+                org_id = %caller_org_id,
+                "Failed to resume schedule"
+            );
+            match e {
+                common::errors::AppError::NotFound(_) => (
+                    StatusCode::NOT_FOUND,
+                    Json(ErrorResponse::new(
+                        "SCHEDULE_NOT_FOUND",
+                        "Report schedule not found",
+                    )),
+                ),
+                _ => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("DB_ERROR", "Failed to resume schedule")),
+                ),
+            }
         })
 }
 
@@ -1460,10 +1531,16 @@ fn execution_download_url(exec: &db::models::report_schedule::ReportExecution) -
 )]
 pub async fn list_schedule_executions(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Query(params): Query<ListExecutionsParams>,
 ) -> Result<Json<ExecutionHistoryResponse>, (StatusCode, Json<ErrorResponse>)> {
+    // Capture the caller's tenant for the schedule existence/scope check.
+    // Closes #647: without this, a user in org B could list execution history
+    // for a schedule belonging to org A by knowing the UUID.
+    let caller_org_id = rls.tenant_id();
+    rls.release().await;
+
     // Validate status filter
     if let Some(ref s) = params.status {
         if !VALID_EXECUTION_STATUSES.contains(&s.to_lowercase().as_str()) {
@@ -1512,14 +1589,20 @@ pub async fn list_schedule_executions(
         }
     }
 
-    // Verify the schedule exists before querying executions.
-    // This prevents misleading "empty list" responses for non-existent schedules.
+    // Verify the schedule exists AND belongs to the caller's organisation
+    // before querying executions (closes #647). A cross-tenant attempt and a
+    // genuinely missing UUID both surface as 404 so no existence info leaks.
     let schedule = state
         .report_schedule_repo
-        .get_by_id(id)
+        .get_by_id_in_org(id, caller_org_id)
         .await
         .map_err(|e| {
-            tracing::error!(error = %e, schedule_id = %id, "Failed to look up report schedule");
+            tracing::error!(
+                error = %e,
+                schedule_id = %id,
+                org_id = %caller_org_id,
+                "Failed to look up report schedule"
+            );
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new("DB_ERROR", "Failed to look up schedule")),


### PR DESCRIPTION
Closes #646.
Closes #647.

## Summary

Three report-schedule handlers in `backend/servers/api-server/src/routes/reports.rs` used `_auth: AuthUser` and called repository methods with no `organization_id` filter — same class as #624. A manager in org B could pause/resume any org A schedule (or list its execution history) by knowing the schedule UUID.

| Route | Handler | Issue |
|---|---|---|
| `PUT  /api/v1/reports/schedules/{id}/pause` | `pause_schedule` | #646 |
| `PUT  /api/v1/reports/schedules/{id}/resume` | `resume_schedule` | #646 |
| `GET  /api/v1/reports/schedules/{id}/executions` | `list_schedule_executions` | #647 |

Mirrors the fix pattern PR #643 established for `update_schedule`.

## Changes

**Handlers** (`routes/reports.rs`)
- Switched all three from `_auth: AuthUser` to `mut rls: RlsConnection`.
- `pause_schedule` / `resume_schedule` now gate on `rls.role().is_manager()` (DB-derived role, defends against stale JWT claims).
- All three capture `caller_org_id = rls.tenant_id()` and release the RLS connection before further work.
- `pause`/`resume` errors map `AppError::NotFound` → 404.
- `list_schedule_executions` uses the new `get_by_id_in_org` helper for the existence check.

**Repository** (`crates/db/src/repositories/report_schedule.rs`)
- `pause(id, caller_org_id)` and `resume(id, caller_org_id)` — added `AND organization_id = $caller_org_id` to the UPDATE WHERE clause. Zero-row update → `AppError::NotFound` → 404.
- New `get_by_id_in_org(id, caller_org_id)` — tenant-scoped lookup. Returns `Ok(None)` for both "not exists" and "exists in another tenant" so the handler can produce identical 404s.
- Kept unscoped `get_by_id` for the scheduler worker that iterates all schedules, but added a doc-comment warning route handlers off it.

Cross-tenant attempts and genuinely missing UUIDs both surface as 404 — no existence-information leak.

## Test plan

- [x] `cargo check -p api-server --tests` clean (verified locally, 21m cold).
- [ ] CI `test` job passes (`cargo test --workspace`).
- [ ] CI `security-tests` job passes.
- [ ] CI `cargo-deny` + `lint` pass.

## Note on tests

PR #643 (still open) introduces `report_schedule_rbac_tests.rs` for the `update_schedule` IDOR. To avoid file-level conflicts, this PR ships the fix without extending that file; once PR #643 merges, a small follow-up can add three parallel tests for `pause` / `resume` / `list_executions` in that file. The TestApp wiring caveat documented in PR #643 (no `host_tenant_middleware`, so cross-tenant attempts surface as 401 rather than 404 in tests) applies to those follow-up tests as well.

## Related

- #624 — original IDOR fix on `update_schedule` (PR #643)
- #643 — model PR for this fix pattern