### PR TITLE
gap-81-1-report-schedule-edit-ui: report schedule editor modal (cron picker, recipient list, enabled toggle)

### DIFF
--- a/frontend/apps/ppt-web/src/features/reports/components/CronPicker.tsx
+++ b/frontend/apps/ppt-web/src/features/reports/components/CronPicker.tsx
@@ -92,7 +92,7 @@ export function isValidCron(expr: string): boolean {
     // range: x-y
     if (field.includes('-')) {
       const [a, b] = field.split('-').map(Number);
-      if (isNaN(a) || isNaN(b) || a > b) return false;
+      if (Number.isNaN(a) || Number.isNaN(b) || a > b) return false;
       return a >= min && b <= max;
     }
 
@@ -247,7 +247,7 @@ export function CronPicker({ value, onChange, error, disabled }: CronPickerProps
   const handleDomChange = useCallback(
     (dm: string) => {
       const n = Number(dm);
-      if (isNaN(n) || n < 1 || n > 31) return;
+      if (Number.isNaN(n) || n < 1 || n > 31) return;
       setDom(dm);
       emitSimple(preset, hour, minute, dow, dm);
     },


### PR DESCRIPTION
## Task

Build report schedule editor modal in ppt-web: cron picker, recipient list, enabled toggle

## Owner

pm-frontend

## Context

The backend API `PUT /api/v1/reports/schedules/{id}` was implemented in gap-81-1-report-schedule-edit-api (PR #531, already merged). The original UI implementation landed in PR #623 which was also merged into dev. This PR carries one follow-up lint fix on top of dev.

## Changes

### Lint fix: `CronPicker.tsx` — `isNaN` → `Number.isNaN`

`frontend/apps/ppt-web/src/features/reports/components/CronPicker.tsx`

Biome `noGlobalIsNan` lint rule flags the global `isNaN()` because it performs implicit type coercion. Replaced all three occurrences with `Number.isNaN()` for strict numeric validation:

- `isValidCron` range validator (`a` and `b` after `field.split('-').map(Number)`)
- `handleDomChange` day-of-month validator

## Tested (Band A — fast check)

```
pnpm --filter @ppt/web typecheck       → exit 0
pnpm biome check apps/ppt-web/src/features/reports/ packages/api-client/src/reports/
  → Checked 25 files in 43ms. No fixes applied.  exit 0
```

## Built (Band B — full build)

```
pnpm --filter @ppt/web build           → ✓ built in 5.55s  exit 0
```

Change touches a public API surface (exported `isValidCron` helper) — Band B triggered.

## CI parity (Band C — hot-path only)

Skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested

Skipped (ppt-bridge MCP not available in this session).

## Scope drift

`scope-check.sh --owner pm-frontend --base dev --head HEAD` → exit 0 (no drift)

## Code-reuse review

`reuse-grep.sh --specialist react-web --base dev --head HEAD` → no warnings

## Notes

- The full feature (EditScheduleModal, CronPicker, RecipientManager, useUpdateScheduleCron hook, CronScheduleUpdateRequest type) was shipped in PR #623 and is already on dev.
- This PR adds only the `Number.isNaN` lint correction that was missed in the original implementation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTvckCX861uyPWRjw66dAv)_