### PR TITLE
feat(epic-82): story 82.5 — InquiriesView and AccountView (iOS Reality Portal)

### DIFF
--- a/mobile-native/iosApp/iosApp/App/MainTabView.swift
+++ b/mobile-native/iosApp/iosApp/App/MainTabView.swift
@@ -123,14 +123,10 @@ struct MainTabView: View {
             InquiriesView()
 
         case .inquiryDetail(let id):
-            // Inquiry conversation view
-            Text("Inquiry: \(id)")
-                .navigationTitle("Conversation")
+            InquiryDetailView(inquiryId: id)
 
         case .newInquiry(let listingId):
-            // New inquiry form
-            Text("New inquiry for: \(listingId)")
-                .navigationTitle("Send Inquiry")
+            SendInquiryView(listingId: listingId)
 
         case .account:
             AccountView()

--- a/mobile-native/iosApp/iosApp/Core/Navigation/Route.swift
+++ b/mobile-native/iosApp/iosApp/Core/Navigation/Route.swift
@@ -103,16 +103,6 @@ enum Route: Hashable {
     }
 }
 
-// MARK: - Listing Type Filter
-
-/// Listing transaction type for sale/rent filtering.
-///
-/// Epic 82 - Story 82.3: Home and Search Screens
-enum ListingTypeFilter: String, Hashable {
-    case sale
-    case rent
-}
-
 // MARK: - Search Filters
 
 /// Search filter options.
@@ -122,16 +112,15 @@ struct SearchFilters: Hashable {
     var priceMin: Int?
     var priceMax: Int?
     var propertyTypes: Set<PropertyType> = []
-    /// Sale/rent type filter, set by HomeView category chips.
-    var listingType: ListingTypeFilter?
+    /// Sale/rent type filter — maps to ListingType in the KMP layer.
+    /// Set by HomeView category chips or the FilterSheet.
+    var listingType: ListingKind?
     var bedroomsMin: Int?
     var bedroomsMax: Int?
     var bathroomsMin: Int?
     var radiusKm: Double?
     var latitude: Double?
     var longitude: Double?
-    /// Sale/rent filter — maps to ListingType in the KMP layer.
-    var listingType: ListingKind?
 
     /// Whether any filters are active.
     var hasActiveFilters: Bool {

--- a/mobile-native/iosApp/iosApp/Features/Inquiries/InquiriesView.swift
+++ b/mobile-native/iosApp/iosApp/Features/Inquiries/InquiriesView.swift
@@ -32,7 +32,7 @@ struct InquiriesView: View {
                 inquiriesListView
             }
         }
-        .navigationTitle("Inquiries")
+        .navigationTitle(String(localized: "tab_inquiries"))
         .refreshable {
             await loadInquiries()
         }
@@ -53,10 +53,10 @@ struct InquiriesView: View {
                 .font(.system(size: 64))
                 .foregroundStyle(.secondary)
 
-            Text("Sign in to see your inquiries")
+            Text(String(localized: "prompt_sign_in_inquiries"))
                 .font(.headline)
 
-            Text("Track your property inquiries and conversations with agents.")
+            Text(String(localized: "inquiries_sign_in_description"))
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -65,7 +65,7 @@ struct InquiriesView: View {
             Button {
                 coordinator.navigate(to: .login)
             } label: {
-                Text("Sign In")
+                Text(String(localized: "sign_in"))
                     .frame(maxWidth: .infinity)
                     .padding()
                     .background(Color.accentColor)
@@ -82,7 +82,7 @@ struct InquiriesView: View {
         VStack(spacing: 16) {
             Spacer()
             ProgressView()
-            Text("Loading inquiries...")
+            Text(String(localized: "status_loading_inquiries"))
                 .foregroundStyle(.secondary)
             Spacer()
         }
@@ -96,10 +96,10 @@ struct InquiriesView: View {
                 .font(.system(size: 64))
                 .foregroundStyle(.secondary)
 
-            Text("No inquiries yet")
+            Text(String(localized: "empty_inquiries"))
                 .font(.headline)
 
-            Text("When you send an inquiry about a property, it will appear here.")
+            Text(String(localized: "empty_inquiries_description"))
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -108,7 +108,7 @@ struct InquiriesView: View {
             Button {
                 coordinator.selectedTab = .search
             } label: {
-                Text("Browse Listings")
+                Text(String(localized: "action_browse_listings"))
                     .frame(maxWidth: .infinity)
                     .padding()
                     .background(Color.accentColor)
@@ -146,7 +146,7 @@ struct InquiriesView: View {
         if let response = result.getOrNull() {
             inquiries = response.inquiries.map { KMPBridge.toInquiryPreview($0) }
         } else if let error = result.exceptionOrNull() {
-            errorMessage = error.message ?? "Failed to load inquiries"
+            errorMessage = error.message ?? String(localized: "failed_to_load_inquiries")
             #if DEBUG
             print("Inquiries error: \(errorMessage ?? "Unknown")")
             #endif
@@ -282,9 +282,9 @@ enum InquiryStatus: String {
 
     var displayName: String {
         switch self {
-        case .pending: return "Pending"
-        case .replied: return "Replied"
-        case .closed: return "Closed"
+        case .pending: return String(localized: "inquiry_status_pending")
+        case .replied: return String(localized: "inquiry_status_replied")
+        case .closed:  return String(localized: "inquiry_status_closed")
         }
     }
 

--- a/mobile-native/iosApp/iosApp/Features/Inquiries/InquiryDetailView.swift
+++ b/mobile-native/iosApp/iosApp/Features/Inquiries/InquiryDetailView.swift
@@ -231,11 +231,17 @@ struct InquiryDetailView: View {
     // MARK: - Helpers
 
     /// Converts the KMP InquiryStatus enum to the Swift InquiryStatus used by UI.
+    ///
+    /// Name mismatch is intentional: the KMP shared layer uses `.responded` (past-tense
+    /// server terminology), while the Swift UI layer uses `.replied` (user-facing label
+    /// that matches `InquiryStatus.displayName`). If a new KMP status is added, a
+    /// compile-time exhaustive-switch warning on the `InquiryStatus` side in
+    /// `InquiriesView.swift` will surface the gap before it reaches production.
     private func swiftInquiryStatus(from kmpStatus: InquiryStatus) -> InquiryStatusSwift {
         switch kmpStatus {
-        case .pending: return .pending
-        case .responded: return .replied
-        case .closed: return .closed
+        case .pending:   return .pending
+        case .responded: return .replied   // KMP name differs from Swift UI name — see doc comment above
+        case .closed:    return .closed
         }
     }
 }
@@ -277,10 +283,7 @@ private struct MessageBubble: View {
                     .padding(.horizontal, 14)
                     .padding(.vertical, 10)
                     .background(bubbleColor)
-                    .clipShape(
-                        RoundedRectangle(cornerRadius: 18)
-                            .inset(by: 0)
-                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 18))
                     .cornerRadius(isFromUser ? 4 : 18, corners: isFromUser ? .bottomRight : .bottomLeft)
 
                 Text(formattedDate(from: timestamp))
@@ -292,8 +295,16 @@ private struct MessageBubble: View {
         }
     }
 
+    // ISO8601DateFormatter is expensive to allocate (bootstraps locale/calendar/timezone data).
+    // Using a static instance avoids a fresh allocation for every bubble on every redraw.
+    private static let iso8601Formatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
     private func formattedDate(from iso8601: String) -> String {
-        guard let date = ISO8601DateFormatter().date(from: iso8601) else { return iso8601 }
+        guard let date = Self.iso8601Formatter.date(from: iso8601) else { return iso8601 }
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .abbreviated
         return formatter.localizedString(for: date, relativeTo: Date())

--- a/mobile-native/iosApp/iosApp/Features/Inquiries/InquiryDetailView.swift
+++ b/mobile-native/iosApp/iosApp/Features/Inquiries/InquiryDetailView.swift
@@ -1,0 +1,340 @@
+import SwiftUI
+import shared
+
+/// Full conversation thread for a single inquiry.
+///
+/// Shows the original user message and all realtor replies, with a
+/// reply-compose area at the bottom so the user can add follow-up
+/// messages to an open inquiry.
+///
+/// Endpoint: GET /api/v1/inquiries/{id}
+/// Reply:    POST /api/v1/inquiries/{id}/replies
+///
+/// Epic 82 - Story 82.5: Inquiries and Account
+struct InquiryDetailView: View {
+    let inquiryId: String
+
+    @Environment(NavigationCoordinator.self) private var coordinator
+    @Environment(AuthManager.self) private var authManager
+
+    @State private var inquiry: Inquiry?
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+    @State private var replyText = ""
+    @State private var isSendingReply = false
+
+    private var inquiryRepository: InquiryRepository {
+        DependencyContainer.shared.makeAuthenticatedInquiryRepository(
+            sessionToken: authManager.getSessionToken()
+        )
+    }
+
+    var body: some View {
+        Group {
+            if isLoading {
+                loadingView
+            } else if let errorMessage {
+                errorView(message: errorMessage)
+            } else if let inquiry {
+                conversationView(inquiry: inquiry)
+            }
+        }
+        .navigationTitle(String(localized: "inquiry_detail_title"))
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await loadInquiry()
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var loadingView: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            ProgressView()
+            Text(String(localized: "loading"))
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+    }
+
+    private func errorView(message: String) -> some View {
+        VStack(spacing: 24) {
+            Spacer()
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+            Text(message)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+            Button(String(localized: "retry")) {
+                Task { await loadInquiry() }
+            }
+            .buttonStyle(.bordered)
+            Spacer()
+        }
+    }
+
+    private func conversationView(inquiry: Inquiry) -> some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                LazyVStack(spacing: 12) {
+                    // Listing context header
+                    if let listing = inquiry.listing {
+                        listingContextCard(listing: listing, status: inquiry.status)
+                    }
+
+                    // Original user message
+                    MessageBubble(
+                        message: inquiry.message,
+                        timestamp: inquiry.createdAt,
+                        isFromUser: true
+                    )
+
+                    // Realtor responses
+                    ForEach(inquiry.responses, id: \.id) { response in
+                        MessageBubble(
+                            message: response.message,
+                            timestamp: response.createdAt,
+                            isFromUser: false,
+                            senderName: response.realtor?.name
+                        )
+                    }
+
+                    // Bottom spacer
+                    Color.clear.frame(height: 8)
+                }
+                .padding(.horizontal)
+                .padding(.top, 8)
+            }
+
+            // Reply composer — only for open inquiries
+            if inquiry.status != .closed {
+                replyComposer
+            }
+        }
+    }
+
+    private func listingContextCard(listing: ListingSummary, status: InquiryStatus) -> some View {
+        HStack(spacing: 12) {
+            // Thumbnail placeholder
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color(.systemGray5))
+                .frame(width: 56, height: 56)
+                .overlay {
+                    Image(systemName: "photo")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(listing.title)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .lineLimit(1)
+
+                Text(listing.address.city)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            // Status pill
+            let swiftStatus = swiftInquiryStatus(from: status)
+            Text(swiftStatus.displayName)
+                .font(.caption2)
+                .fontWeight(.medium)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(swiftStatus.backgroundColor)
+                .foregroundStyle(swiftStatus.foregroundColor)
+                .clipShape(Capsule())
+        }
+        .padding()
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var replyComposer: some View {
+        VStack(spacing: 0) {
+            Divider()
+            HStack(alignment: .bottom, spacing: 12) {
+                TextField(String(localized: "inquiry_reply_placeholder"), text: $replyText, axis: .vertical)
+                    .lineLimit(1...5)
+                    .textFieldStyle(.plain)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+                    .background(Color(.secondarySystemBackground))
+                    .clipShape(RoundedRectangle(cornerRadius: 20))
+
+                Button {
+                    Task { await sendReply() }
+                } label: {
+                    if isSendingReply {
+                        ProgressView()
+                            .frame(width: 36, height: 36)
+                    } else {
+                        Image(systemName: "arrow.up.circle.fill")
+                            .font(.system(size: 36))
+                            .foregroundStyle(replyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                                ? Color(.systemGray4)
+                                : Color.accentColor)
+                    }
+                }
+                .disabled(replyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSendingReply)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(Color(.systemBackground))
+        }
+    }
+
+    // MARK: - Data Loading
+
+    private func loadInquiry() async {
+        isLoading = true
+        errorMessage = nil
+
+        let result = await inquiryRepository.getInquiry(inquiryId: inquiryId)
+
+        if let fetched = result.getOrNull() {
+            inquiry = fetched
+        } else if let error = result.exceptionOrNull() {
+            errorMessage = error.message ?? String(localized: "error_generic")
+        }
+
+        isLoading = false
+    }
+
+    private func sendReply() async {
+        let trimmed = replyText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        isSendingReply = true
+        let result = await inquiryRepository.replyToInquiry(
+            inquiryId: inquiryId,
+            message: trimmed
+        )
+        isSendingReply = false
+
+        if result.getOrNull() != nil {
+            replyText = ""
+            // Reload the full thread to show the new reply.
+            await loadInquiry()
+        } else if let error = result.exceptionOrNull() {
+            errorMessage = error.message ?? String(localized: "error_generic")
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Converts the KMP InquiryStatus enum to the Swift InquiryStatus used by UI.
+    private func swiftInquiryStatus(from kmpStatus: InquiryStatus) -> InquiryStatusSwift {
+        switch kmpStatus {
+        case .pending: return .pending
+        case .responded: return .replied
+        case .closed: return .closed
+        }
+    }
+}
+
+// MARK: - Message Bubble
+
+/// A single message bubble — right-aligned for user messages, left-aligned for replies.
+///
+/// Epic 82 - Story 82.5: Inquiries and Account
+private struct MessageBubble: View {
+    let message: String
+    let timestamp: String
+    let isFromUser: Bool
+    var senderName: String? = nil
+
+    private var bubbleColor: Color {
+        isFromUser ? Color.accentColor : Color(.secondarySystemBackground)
+    }
+
+    private var textColor: Color {
+        isFromUser ? .white : .primary
+    }
+
+    var body: some View {
+        HStack {
+            if isFromUser { Spacer(minLength: 48) }
+
+            VStack(alignment: isFromUser ? .trailing : .leading, spacing: 4) {
+                if let senderName, !isFromUser {
+                    Text(senderName)
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.secondary)
+                }
+
+                Text(message)
+                    .font(.callout)
+                    .foregroundStyle(textColor)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
+                    .background(bubbleColor)
+                    .clipShape(
+                        RoundedRectangle(cornerRadius: 18)
+                            .inset(by: 0)
+                    )
+                    .cornerRadius(isFromUser ? 4 : 18, corners: isFromUser ? .bottomRight : .bottomLeft)
+
+                Text(formattedDate(from: timestamp))
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+
+            if !isFromUser { Spacer(minLength: 48) }
+        }
+    }
+
+    private func formattedDate(from iso8601: String) -> String {
+        guard let date = ISO8601DateFormatter().date(from: iso8601) else { return iso8601 }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+}
+
+// MARK: - RoundedCorner helper
+
+private extension View {
+    func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
+        clipShape(RoundedCorner(radius: radius, corners: corners))
+    }
+}
+
+private struct RoundedCorner: Shape {
+    var radius: CGFloat
+    var corners: UIRectCorner
+
+    func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(
+            roundedRect: rect,
+            byRoundingCorners: corners,
+            cornerRadii: CGSize(width: radius, height: radius)
+        )
+        return Path(path.cgPath)
+    }
+}
+
+// MARK: - Localization Keys
+
+extension String {
+    static let inquiryDetailTitle = "inquiry_detail_title"
+    static let inquiryReplyPlaceholder = "inquiry_reply_placeholder"
+}
+
+// MARK: - Preview
+
+#Preview {
+    NavigationStack {
+        InquiryDetailView(inquiryId: "inq-preview")
+    }
+    .environment(NavigationCoordinator())
+    .environment(AuthManager())
+}

--- a/mobile-native/iosApp/iosApp/Features/Inquiries/SendInquiryView.swift
+++ b/mobile-native/iosApp/iosApp/Features/Inquiries/SendInquiryView.swift
@@ -1,0 +1,172 @@
+import SwiftUI
+import shared
+
+/// Compose and send a new property inquiry.
+///
+/// Presents a form with the user's name, e-mail, optional phone number, and a
+/// free-text message.  Pre-fills name and e-mail from `AuthManager.currentUser`
+/// when the user is signed in.
+///
+/// Endpoint: POST /api/v1/inquiries
+///
+/// Epic 82 - Story 82.5: Inquiries and Account
+struct SendInquiryView: View {
+    let listingId: String
+
+    @Environment(NavigationCoordinator.self) private var coordinator
+    @Environment(AuthManager.self) private var authManager
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var name = ""
+    @State private var email = ""
+    @State private var phone = ""
+    @State private var message = ""
+    @State private var isSending = false
+    @State private var errorMessage: String?
+    @State private var didSend = false
+
+    private var inquiryRepository: InquiryRepository {
+        DependencyContainer.shared.makeAuthenticatedInquiryRepository(
+            sessionToken: authManager.getSessionToken()
+        )
+    }
+
+    private var isFormValid: Bool {
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        email.contains("@") &&
+        !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                // Contact details section
+                Section(String(localized: "section_contact_details")) {
+                    TextField(String(localized: "label_name_required"), text: $name)
+                        .textContentType(.name)
+                        .autocorrectionDisabled()
+
+                    TextField(String(localized: "label_email_required"), text: $email)
+                        .textContentType(.emailAddress)
+                        .keyboardType(.emailAddress)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+
+                    TextField(String(localized: "label_phone_optional"), text: $phone)
+                        .textContentType(.telephoneNumber)
+                        .keyboardType(.phonePad)
+                }
+
+                // Message section
+                Section(String(localized: "section_your_message")) {
+                    TextField(String(localized: "inquiry_message_placeholder"), text: $message, axis: .vertical)
+                        .lineLimit(4...8)
+                        .frame(minHeight: 80, alignment: .topLeading)
+                }
+
+                // Error feedback
+                if let errorMessage {
+                    Section {
+                        Label(errorMessage, systemImage: "exclamationmark.circle.fill")
+                            .foregroundStyle(.red)
+                            .font(.callout)
+                    }
+                }
+
+                // Submit button
+                Section {
+                    Button {
+                        Task { await send() }
+                    } label: {
+                        HStack {
+                            Spacer()
+                            if isSending {
+                                ProgressView()
+                            } else {
+                                Text(String(localized: "send_inquiry"))
+                                    .fontWeight(.semibold)
+                            }
+                            Spacer()
+                        }
+                    }
+                    .disabled(!isFormValid || isSending)
+                }
+            }
+            .navigationTitle(String(localized: "send_inquiry"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(String(localized: "cancel")) {
+                        dismiss()
+                    }
+                }
+            }
+            .alert(String(localized: "inquiry_sent"), isPresented: $didSend) {
+                Button(String(localized: "ok")) {
+                    dismiss()
+                    coordinator.selectedTab = .inquiries
+                }
+            } message: {
+                Text(String(localized: "inquiry_sent_confirmation"))
+            }
+            .onAppear {
+                prefillFromAuthManager()
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func prefillFromAuthManager() {
+        guard let user = authManager.currentUser else { return }
+        name = user.name
+        email = user.email
+    }
+
+    private func send() async {
+        let trimmedMessage = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedName    = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedEmail   = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedPhone   = phone.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmedMessage.isEmpty, !trimmedName.isEmpty, !trimmedEmail.isEmpty else { return }
+
+        isSending = true
+        errorMessage = nil
+
+        let request = CreateInquiryRequest(
+            listingId: listingId,
+            message: trimmedMessage,
+            name: trimmedName,
+            email: trimmedEmail,
+            phone: trimmedPhone.isEmpty ? nil : trimmedPhone
+        )
+
+        let result = await inquiryRepository.createInquiry(request: request)
+
+        if result.getOrNull() != nil {
+            didSend = true
+        } else if let error = result.exceptionOrNull() {
+            errorMessage = error.message ?? String(localized: "error_generic")
+        }
+
+        isSending = false
+    }
+}
+
+// MARK: - Localisation Keys
+
+// These keys are already present in Localizable.strings; listed here for quick
+// discovery by grepping this file.
+//  "section_contact_details"        – Contact Details section header
+//  "inquiry_message_placeholder"    – Message field placeholder
+//  "inquiry_sent_confirmation"      – Body of the success alert
+
+// MARK: - Preview
+
+#Preview {
+    SendInquiryView(listingId: "lst-preview")
+        .environment(NavigationCoordinator())
+        .environment(AuthManager())
+}

--- a/mobile-native/iosApp/iosApp/Resources/cs.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/cs.lproj/Localizable.strings
@@ -283,6 +283,15 @@
 "either" = "Jakýkoliv";
 "send" = "Odeslat";
 
+/* Inquiry Detail Screen */
+"inquiry_detail_title" = "Dotaz";
+"inquiry_reply_placeholder" = "Napište odpověď…";
+
+/* Send Inquiry Screen */
+"section_contact_details" = "Kontaktní údaje";
+"inquiry_message_placeholder" = "Popište váš zájem o tuto nemovitost…";
+"inquiry_sent_confirmation" = "Váš dotaz byl odeslán. Odpověď obdržíte na zadanou e-mailovou adresu.";
+
 /* Login Screen - Additional */
 "welcome_to_reality_portal" = "Vítejte v Reality Portál";
 "sign_in_description" = "Přihlaste se pro uložení oblíbených, sledování dotazů a personalizovaná doporučení.";

--- a/mobile-native/iosApp/iosApp/Resources/cs.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/cs.lproj/Localizable.strings
@@ -292,6 +292,15 @@
 "inquiry_message_placeholder" = "Popište váš zájem o tuto nemovitost…";
 "inquiry_sent_confirmation" = "Váš dotaz byl odeslán. Odpověď obdržíte na zadanou e-mailovou adresu.";
 
+/* Inquiries Screen */
+"inquiries_sign_in_description" = "Sledujte své dotazy na nemovitosti a konverzace s agenty.";
+"failed_to_load_inquiries" = "Nepodařilo se načíst dotazy";
+
+/* Inquiry Status Badge */
+"inquiry_status_pending" = "Čekající";
+"inquiry_status_replied" = "Zodpovězený";
+"inquiry_status_closed" = "Uzavřený";
+
 /* Login Screen - Additional */
 "welcome_to_reality_portal" = "Vítejte v Reality Portál";
 "sign_in_description" = "Přihlaste se pro uložení oblíbených, sledování dotazů a personalizovaná doporučení.";

--- a/mobile-native/iosApp/iosApp/Resources/de.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/de.lproj/Localizable.strings
@@ -292,6 +292,15 @@
 "inquiry_message_placeholder" = "Beschreiben Sie Ihr Interesse an dieser Immobilie…";
 "inquiry_sent_confirmation" = "Ihre Anfrage wurde gesendet. Sie erhalten eine Antwort an die angegebene E-Mail-Adresse.";
 
+/* Inquiries Screen */
+"inquiries_sign_in_description" = "Verfolgen Sie Ihre Immobilienanfragen und Gespräche mit Maklern.";
+"failed_to_load_inquiries" = "Anfragen konnten nicht geladen werden";
+
+/* Inquiry Status Badge */
+"inquiry_status_pending" = "Ausstehend";
+"inquiry_status_replied" = "Beantwortet";
+"inquiry_status_closed" = "Geschlossen";
+
 /* Login Screen - Additional */
 "welcome_to_reality_portal" = "Willkommen bei Reality Portal";
 "sign_in_description" = "Melden Sie sich an, um Favoriten zu speichern, Anfragen zu verfolgen und personalisierte Empfehlungen zu erhalten.";

--- a/mobile-native/iosApp/iosApp/Resources/de.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/de.lproj/Localizable.strings
@@ -283,6 +283,15 @@
 "either" = "Beides";
 "send" = "Senden";
 
+/* Inquiry Detail Screen */
+"inquiry_detail_title" = "Anfrage";
+"inquiry_reply_placeholder" = "Antwort schreiben…";
+
+/* Send Inquiry Screen */
+"section_contact_details" = "Kontaktdaten";
+"inquiry_message_placeholder" = "Beschreiben Sie Ihr Interesse an dieser Immobilie…";
+"inquiry_sent_confirmation" = "Ihre Anfrage wurde gesendet. Sie erhalten eine Antwort an die angegebene E-Mail-Adresse.";
+
 /* Login Screen - Additional */
 "welcome_to_reality_portal" = "Willkommen bei Reality Portal";
 "sign_in_description" = "Melden Sie sich an, um Favoriten zu speichern, Anfragen zu verfolgen und personalisierte Empfehlungen zu erhalten.";

--- a/mobile-native/iosApp/iosApp/Resources/en.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/en.lproj/Localizable.strings
@@ -283,6 +283,15 @@
 "either" = "Either";
 "send" = "Send";
 
+/* Inquiry Detail Screen */
+"inquiry_detail_title" = "Inquiry";
+"inquiry_reply_placeholder" = "Write a reply…";
+
+/* Send Inquiry Screen */
+"section_contact_details" = "Contact Details";
+"inquiry_message_placeholder" = "Tell us about your interest in this property…";
+"inquiry_sent_confirmation" = "Your inquiry has been sent. You will receive a reply at the email address provided.";
+
 /* Login Screen - Additional */
 "welcome_to_reality_portal" = "Welcome to Reality Portal";
 "sign_in_description" = "Sign in to save favorites, track inquiries, and get personalized recommendations.";

--- a/mobile-native/iosApp/iosApp/Resources/en.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/en.lproj/Localizable.strings
@@ -292,6 +292,15 @@
 "inquiry_message_placeholder" = "Tell us about your interest in this property…";
 "inquiry_sent_confirmation" = "Your inquiry has been sent. You will receive a reply at the email address provided.";
 
+/* Inquiries Screen */
+"inquiries_sign_in_description" = "Track your property inquiries and conversations with agents.";
+"failed_to_load_inquiries" = "Failed to load inquiries";
+
+/* Inquiry Status Badge */
+"inquiry_status_pending" = "Pending";
+"inquiry_status_replied" = "Replied";
+"inquiry_status_closed" = "Closed";
+
 /* Login Screen - Additional */
 "welcome_to_reality_portal" = "Welcome to Reality Portal";
 "sign_in_description" = "Sign in to save favorites, track inquiries, and get personalized recommendations.";

--- a/mobile-native/iosApp/iosApp/Resources/hu.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/hu.lproj/Localizable.strings
@@ -283,6 +283,15 @@
 "either" = "Bármely";
 "send" = "Küldés";
 
+/* Inquiry Detail Screen */
+"inquiry_detail_title" = "Érdeklődés";
+"inquiry_reply_placeholder" = "Írjon választ…";
+
+/* Send Inquiry Screen */
+"section_contact_details" = "Kapcsolati adatok";
+"inquiry_message_placeholder" = "Írja le érdeklődését ezen ingatlan iránt…";
+"inquiry_sent_confirmation" = "Érdeklődése elküldve. Választ kap a megadott e-mail-címre.";
+
 /* Login Screen - Additional */
 "welcome_to_reality_portal" = "Üdvözöljük a Reality Portal-ban";
 "sign_in_description" = "Jelentkezzen be a kedvencek mentéséhez, érdeklődések követéséhez és személyre szabott ajánlatokhoz.";

--- a/mobile-native/iosApp/iosApp/Resources/hu.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/hu.lproj/Localizable.strings
@@ -292,6 +292,15 @@
 "inquiry_message_placeholder" = "Írja le érdeklődését ezen ingatlan iránt…";
 "inquiry_sent_confirmation" = "Érdeklődése elküldve. Választ kap a megadott e-mail-címre.";
 
+/* Inquiries Screen */
+"inquiries_sign_in_description" = "Kövesse nyomon ingatlan-érdeklődéseit és az ügynökökkel folytatott beszélgetéseit.";
+"failed_to_load_inquiries" = "Nem sikerült betölteni az érdeklődéseket";
+
+/* Inquiry Status Badge */
+"inquiry_status_pending" = "Függőben";
+"inquiry_status_replied" = "Megválaszolt";
+"inquiry_status_closed" = "Lezárt";
+
 /* Login Screen - Additional */
 "welcome_to_reality_portal" = "Üdvözöljük a Reality Portal-ban";
 "sign_in_description" = "Jelentkezzen be a kedvencek mentéséhez, érdeklődések követéséhez és személyre szabott ajánlatokhoz.";

--- a/mobile-native/iosApp/iosApp/Resources/pl.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/pl.lproj/Localizable.strings
@@ -283,6 +283,15 @@
 "either" = "Dowolny";
 "send" = "Wyślij";
 
+/* Inquiry Detail Screen */
+"inquiry_detail_title" = "Zapytanie";
+"inquiry_reply_placeholder" = "Napisz odpowiedź…";
+
+/* Send Inquiry Screen */
+"section_contact_details" = "Dane kontaktowe";
+"inquiry_message_placeholder" = "Opisz swoje zainteresowanie tą nieruchomością…";
+"inquiry_sent_confirmation" = "Twoje zapytanie zostało wysłane. Odpowiedź otrzymasz na podany adres e-mail.";
+
 /* Login Screen - Additional */
 "welcome_to_reality_portal" = "Witaj w Reality Portal";
 "sign_in_description" = "Zaloguj się, aby zapisywać ulubione, śledzić zapytania i otrzymywać spersonalizowane rekomendacje.";

--- a/mobile-native/iosApp/iosApp/Resources/pl.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/pl.lproj/Localizable.strings
@@ -97,10 +97,10 @@
 "inquiry_sent" = "Zapytanie wysłane";
 "inquiry_pending" = "Oczekujące";
 "inquiry_responded" = "Odpowiedziano";
-"inquiries_sign_in_description" = "Śledź zapytania dotyczące nieruchomości i rozmowy z agentami.";
-"error_load_inquiries" = "Nie udało się wczytać zapytań";
+"inquiries_sign_in_description" = "Śledź swoje zapytania dotyczące nieruchomości i rozmowy z agentami.";
+"failed_to_load_inquiries" = "Nie udało się załadować zapytań";
 "inquiry_status_pending" = "Oczekujące";
-"inquiry_status_replied" = "Udzielono odpowiedzi";
+"inquiry_status_replied" = "Odpowiedziane";
 "inquiry_status_closed" = "Zamknięte";
 
 /* Account */

--- a/mobile-native/iosApp/iosApp/Resources/pl.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/pl.lproj/Localizable.strings
@@ -97,6 +97,11 @@
 "inquiry_sent" = "Zapytanie wysłane";
 "inquiry_pending" = "Oczekujące";
 "inquiry_responded" = "Odpowiedziano";
+"inquiries_sign_in_description" = "Śledź zapytania dotyczące nieruchomości i rozmowy z agentami.";
+"error_load_inquiries" = "Nie udało się wczytać zapytań";
+"inquiry_status_pending" = "Oczekujące";
+"inquiry_status_replied" = "Udzielono odpowiedzi";
+"inquiry_status_closed" = "Zamknięte";
 
 /* Account */
 "my_account" = "Moje konto";

--- a/mobile-native/iosApp/iosApp/Resources/sk.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/sk.lproj/Localizable.strings
@@ -292,6 +292,15 @@
 "inquiry_message_placeholder" = "Opíšte váš záujem o túto nehnuteľnosť…";
 "inquiry_sent_confirmation" = "Váš dopyt bol odoslaný. Odpoveď dostanete na zadanú e-mailovú adresu.";
 
+/* Inquiries Screen */
+"inquiries_sign_in_description" = "Sledujte svoje dopyty na nehnuteľnosti a konverzácie s agentmi.";
+"failed_to_load_inquiries" = "Nepodarilo sa načítať dopyty";
+
+/* Inquiry Status Badge */
+"inquiry_status_pending" = "Čakajúci";
+"inquiry_status_replied" = "Zodpovedaný";
+"inquiry_status_closed" = "Uzavretý";
+
 /* Login Screen - Additional */
 "welcome_to_reality_portal" = "Vitajte v Reality Portál";
 "sign_in_description" = "Prihláste sa pre uloženie obľúbených, sledovanie dopytov a personalizované odporúčania.";

--- a/mobile-native/iosApp/iosApp/Resources/sk.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/sk.lproj/Localizable.strings
@@ -283,6 +283,15 @@
 "either" = "Akýkoľvek";
 "send" = "Odoslať";
 
+/* Inquiry Detail Screen */
+"inquiry_detail_title" = "Dopyt";
+"inquiry_reply_placeholder" = "Napíšte odpoveď…";
+
+/* Send Inquiry Screen */
+"section_contact_details" = "Kontaktné údaje";
+"inquiry_message_placeholder" = "Opíšte váš záujem o túto nehnuteľnosť…";
+"inquiry_sent_confirmation" = "Váš dopyt bol odoslaný. Odpoveď dostanete na zadanú e-mailovú adresu.";
+
 /* Login Screen - Additional */
 "welcome_to_reality_portal" = "Vitajte v Reality Portál";
 "sign_in_description" = "Prihláste sa pre uloženie obľúbených, sledovanie dopytov a personalizované odporúčania.";

--- a/mobile-native/iosApp/iosAppTests/RealityPortalTests.swift
+++ b/mobile-native/iosApp/iosAppTests/RealityPortalTests.swift
@@ -525,17 +525,33 @@ final class NavigationStateRestorationServiceTests: XCTestCase {
 final class InquiryStatusTests: XCTestCase {
 
     // MARK: displayName
+    //
+    // displayName now calls String(localized:) so the resolved string depends on the
+    // test runner's locale.  Assert that each case returns a non-empty string rather
+    // than a hardcoded English value — locale-fragile assertions break on non-English
+    // CI runners and are meaningless as a correctness check.
 
-    func testPendingDisplayName() {
-        XCTAssertEqual(InquiryStatus.pending.displayName, "Pending")
+    func testPendingDisplayNameIsNonEmpty() {
+        XCTAssertFalse(InquiryStatus.pending.displayName.isEmpty,
+                       "pending.displayName must resolve to a non-empty localised string")
     }
 
-    func testRepliedDisplayName() {
-        XCTAssertEqual(InquiryStatus.replied.displayName, "Replied")
+    func testRepliedDisplayNameIsNonEmpty() {
+        XCTAssertFalse(InquiryStatus.replied.displayName.isEmpty,
+                       "replied.displayName must resolve to a non-empty localised string")
     }
 
-    func testClosedDisplayName() {
-        XCTAssertEqual(InquiryStatus.closed.displayName, "Closed")
+    func testClosedDisplayNameIsNonEmpty() {
+        XCTAssertFalse(InquiryStatus.closed.displayName.isEmpty,
+                       "closed.displayName must resolve to a non-empty localised string")
+    }
+
+    func testAllDisplayNamesAreDistinct() {
+        let names = [InquiryStatus.pending.displayName,
+                     InquiryStatus.replied.displayName,
+                     InquiryStatus.closed.displayName]
+        XCTAssertEqual(names.count, Set(names).count,
+                       "Each InquiryStatus must have a distinct displayName")
     }
 
     // MARK: badge colours resolve without crashing

--- a/mobile-native/iosApp/iosAppTests/RealityPortalTests.swift
+++ b/mobile-native/iosApp/iosAppTests/RealityPortalTests.swift
@@ -518,6 +518,224 @@ final class NavigationStateRestorationServiceTests: XCTestCase {
     }
 }
 
+// MARK: - InquiryStatus Tests
+
+/// Verifies the Swift `InquiryStatus` enum used by `InquiriesView`
+/// and that `KMPBridge.toInquiryPreview` maps KMP status values correctly.
+final class InquiryStatusTests: XCTestCase {
+
+    // MARK: displayName
+
+    func testPendingDisplayName() {
+        XCTAssertEqual(InquiryStatus.pending.displayName, "Pending")
+    }
+
+    func testRepliedDisplayName() {
+        XCTAssertEqual(InquiryStatus.replied.displayName, "Replied")
+    }
+
+    func testClosedDisplayName() {
+        XCTAssertEqual(InquiryStatus.closed.displayName, "Closed")
+    }
+
+    // MARK: badge colours resolve without crashing
+
+    func testPendingColorsAreNonNil() {
+        // backgroundColor / foregroundColor call into InquiryStatusColors;
+        // just ensure they don't crash — we don't assert specific hex values here.
+        _ = InquiryStatus.pending.backgroundColor
+        _ = InquiryStatus.pending.foregroundColor
+    }
+
+    func testRepliedColorsAreNonNil() {
+        _ = InquiryStatus.replied.backgroundColor
+        _ = InquiryStatus.replied.foregroundColor
+    }
+
+    func testClosedColorsAreNonNil() {
+        _ = InquiryStatus.closed.backgroundColor
+        _ = InquiryStatus.closed.foregroundColor
+    }
+}
+
+// MARK: - InquiryPreview Tests
+
+/// Verifies the `InquiryPreview` model that `InquiriesView` renders.
+final class InquiryPreviewTests: XCTestCase {
+
+    func testFormattedDateProducesNonEmptyString() {
+        let preview = InquiryPreview(
+            id: "p-1",
+            listingId: "lst-1",
+            listingTitle: "Test Property",
+            lastMessage: "Hello",
+            status: .pending,
+            date: Date(),
+            hasUnread: false
+        )
+        XCTAssertFalse(preview.formattedDate.isEmpty)
+    }
+
+    func testSampleDataIsAvailableInDebug() {
+        #if DEBUG
+        XCTAssertFalse(InquiryPreview.samples.isEmpty, "Sample data required for SwiftUI previews")
+        // All sample IDs should be unique
+        let ids = InquiryPreview.samples.map(\.id)
+        XCTAssertEqual(ids.count, Set(ids).count, "Sample IDs must be unique")
+        #endif
+    }
+}
+
+// MARK: - PushNotificationManager Tests
+
+/// Unit tests for `PushNotificationManager`'s preference management.
+/// These tests do not interact with APNs and work entirely offline.
+final class PushNotificationManagerTests: XCTestCase {
+
+    private var keychain: KeychainService!
+    private var manager: PushNotificationManager!
+
+    override func setUp() {
+        super.setUp()
+        // Isolate from the real app keychain — use a unique service name.
+        keychain = KeychainService(
+            service: "three.two.bit.ppt.reality.tests.push.\(UUID().uuidString)"
+        )
+        manager = PushNotificationManager(keychainService: keychain)
+    }
+
+    override func tearDown() {
+        keychain.deleteAll()
+        super.tearDown()
+    }
+
+    // MARK: Default preferences
+
+    func testNewListingsDefaultsToEnabled() {
+        XCTAssertTrue(manager.isEnabled(.newListings))
+    }
+
+    func testPriceDropsDefaultsToEnabled() {
+        XCTAssertTrue(manager.isEnabled(.priceDrops))
+    }
+
+    func testInquiryResponsesDefaultsToEnabled() {
+        XCTAssertTrue(manager.isEnabled(.inquiryResponses))
+    }
+
+    func testMarketingDefaultsToDisabled() {
+        XCTAssertFalse(manager.isEnabled(.marketing))
+    }
+
+    // MARK: setEnabled persists the value
+
+    func testDisablingNewListingsPersists() async {
+        // Disable new listings — the manager is already authorized in this
+        // path because we skip the authorization gate (not authorized means
+        // setEnabled returns early without persisting).  We test the
+        // UserDefaults persistence side only, which doesn't require APNs.
+        UserDefaults.standard.set(false, forKey: NotificationPreferenceKey.newListings.rawValue)
+        let freshManager = PushNotificationManager(keychainService: keychain)
+        XCTAssertFalse(freshManager.isEnabled(.newListings))
+    }
+
+    // MARK: clearDeviceToken
+
+    func testClearDeviceTokenRemovesToken() {
+        // Simulate a stored token
+        try? keychain.save("abc123", forKey: KeychainService.Keys.pushDeviceToken)
+        let freshManager = PushNotificationManager(keychainService: keychain)
+        XCTAssertNotNil(freshManager.deviceToken)
+
+        freshManager.clearDeviceToken()
+        XCTAssertNil(freshManager.deviceToken)
+        XCTAssertNil(keychain.loadOptional(forKey: KeychainService.Keys.pushDeviceToken))
+    }
+
+    // MARK: didRegisterForRemoteNotifications
+
+    func testDeviceTokenConvertedToHex() {
+        let rawBytes: [UInt8] = [0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x23, 0x45, 0x67]
+        let data = Data(rawBytes)
+        manager.didRegisterForRemoteNotifications(deviceToken: data)
+        XCTAssertEqual(manager.deviceToken, "deadbeef01234567")
+    }
+
+    func testDeviceTokenPersistedToKeychain() {
+        let rawBytes: [UInt8] = [0xCA, 0xFE, 0xBA, 0xBE]
+        manager.didRegisterForRemoteNotifications(deviceToken: Data(rawBytes))
+        XCTAssertEqual(
+            keychain.loadOptional(forKey: KeychainService.Keys.pushDeviceToken),
+            "cafebabe"
+        )
+    }
+}
+
+// MARK: - KeychainService Tests
+
+/// Verifies the `KeychainService` persistence layer used for auth tokens
+/// and push device tokens.
+final class KeychainServiceTests: XCTestCase {
+
+    private var keychain: KeychainService!
+
+    override func setUp() {
+        super.setUp()
+        // Use an isolated test service so tests don't affect the real app keychain.
+        keychain = KeychainService(
+            service: "three.two.bit.ppt.reality.tests.keychain.\(UUID().uuidString)"
+        )
+    }
+
+    override func tearDown() {
+        keychain.deleteAll()
+        super.tearDown()
+    }
+
+    func testSaveAndLoad() throws {
+        try keychain.save("secret-token", forKey: "test_key")
+        let loaded = try keychain.load(forKey: "test_key")
+        XCTAssertEqual(loaded, "secret-token")
+    }
+
+    func testOverwriteExistingValue() throws {
+        try keychain.save("v1", forKey: "reuse_key")
+        try keychain.save("v2", forKey: "reuse_key")
+        XCTAssertEqual(try keychain.load(forKey: "reuse_key"), "v2")
+    }
+
+    func testLoadOptionalReturnsNilForMissingKey() {
+        XCTAssertNil(keychain.loadOptional(forKey: "does_not_exist"))
+    }
+
+    func testDeleteRemovesItem() throws {
+        try keychain.save("to-delete", forKey: "del_key")
+        try keychain.delete(forKey: "del_key")
+        XCTAssertNil(keychain.loadOptional(forKey: "del_key"))
+    }
+
+    func testDeleteMissingKeyDoesNotThrow() {
+        XCTAssertNoThrow(try keychain.delete(forKey: "never_existed"))
+    }
+
+    func testContainsReturnsFalseForMissingKey() {
+        XCTAssertFalse(keychain.contains(key: "absent"))
+    }
+
+    func testContainsReturnsTrueAfterSave() throws {
+        try keychain.save("x", forKey: "present")
+        XCTAssertTrue(keychain.contains(key: "present"))
+    }
+
+    func testDeleteAllClearsAllItems() throws {
+        try keychain.save("a", forKey: "key_a")
+        try keychain.save("b", forKey: "key_b")
+        keychain.deleteAll()
+        XCTAssertFalse(keychain.contains(key: "key_a"))
+        XCTAssertFalse(keychain.contains(key: "key_b"))
+    }
+}
+
 // MARK: - Performance Tests
 
 /// Small performance baselines. They aren't asserted hard; the


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **InquiriesView** (`Features/Inquiries/InquiriesView.swift`): Lists user inquiries from `GET /api/v1/inquiries` via KMP `InquiryRepository`. Auth-gate with sign-in CTA for unauthenticated users. Pull-to-refresh and unread indicator on each `InquiryCard`. Tapping a card navigates to `InquiryDetailView`.
- **InquiryDetailView** (`Features/Inquiries/InquiryDetailView.swift`): NEW — full conversation thread from `GET /api/v1/inquiries/{id}`. `MessageBubble` component for user messages (right-aligned) and realtor replies (left-aligned). Reply composer at the bottom calls `POST /api/v1/inquiries/{id}/replies` and reloads the thread. Disabled for `closed` inquiries.
- **SendInquiryView** (`Features/Inquiries/SendInquiryView.swift`): NEW — compose form for `POST /api/v1/inquiries`. Pre-fills name/email from `AuthManager.currentUser`. Validates required fields. Shows success alert that navigates to the Inquiries tab.
- **AccountView** (`Features/Account/AccountView.swift`): User profile, notification preference toggles backed by `PushNotificationManager` (APNs + `UserDefaults`), quick-action navigation links, app settings, sign-out with confirmation. Not-authenticated state shows SSO sign-in CTA.
- **PushNotificationManager** (`Core/Services/PushNotificationManager.swift`): APNs category registration, per-key preference persistence in `UserDefaults`, device token stored in Keychain via `KeychainService`.
- **MainTabView**: Wired `InquiryDetailView(inquiryId:)` and `SendInquiryView(listingId:)` replacing stub `Text(...)` placeholders.
- **Route.swift**: Fixed duplicate `listingType` property in `SearchFilters` (removed stale `ListingTypeFilter` enum, unified on `ListingKind`).
- **Localisation**: Added 9 new string keys across all 6 locales (en/sk/cs/de/hu/pl).
- **Tests**: Added `InquiryStatusTests`, `InquiryPreviewTests`, `PushNotificationManagerTests`, and `KeychainServiceTests` to `RealityPortalTests.swift`.

## Endpoints wired

| View | Method | Endpoint |
|------|--------|----------|
| InquiriesView | GET | `/api/v1/inquiries` |
| InquiryDetailView | GET | `/api/v1/inquiries/{id}` |
| InquiryDetailView (reply) | POST | `/api/v1/inquiries/{id}/replies` |
| SendInquiryView | POST | `/api/v1/inquiries` |

## Test plan

- [ ] Build in Xcode (iOS 17+) — no compile errors
- [ ] Run `RealityPortalTests` — all new test classes pass
- [ ] Unauthenticated: Inquiries tab shows sign-in CTA; tapping navigates to Login
- [ ] Authenticated: Inquiries tab loads list from real API; badge shown for unread; pull-to-refresh works
- [ ] Tapping an inquiry card opens `InquiryDetailView` with full message thread
- [ ] Reply composer disabled for `closed` inquiries; sends and reloads for `pending`/`responded`
- [ ] Send Inquiry form pre-fills name/email; shows validation on empty required fields; success alert navigates to Inquiries tab
- [ ] Account tab shows profile, notification toggles, sign-out confirmation
- [ ] Notification toggle on a fresh install requests APNs authorization
- [ ] All 6 locales display new strings without truncation

https://claude.ai/code/session_01TTvckCX861uyPWRjw66dAv
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTvckCX861uyPWRjw66dAv)_