### PR TITLE
feat(research): dispatcher goal gates — Pillar 1, observe-only (PR 1/5)

### DIFF
--- a/.claude/skills/ppt-goal-gate/SKILL.md
+++ b/.claude/skills/ppt-goal-gate/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: ppt-goal-gate
+description: Deterministic goal/convergence checks for the PPT dispatcher — coverage referential integrity, coverage-progress monotonicity, and buffer bounds. Run in dispatcher Phase 6 and CI. Use when adding/auditing the dispatcher's goal-verification layer.
+mode: cloud-ok
+---
+
+# ppt-goal-gate
+
+## When to invoke
+- The dispatcher's Phase 6 runs `goal-check.sh` to record convergence health in the commit.
+- CI runs it on PRs touching the dispatcher prompt / scripts.
+- A human auditing whether the autonomous loop is making *measured* progress (not just merging PRs).
+
+## What it gives you
+`.research/goal-check.sh` emits `{check,passed,observed,expected,hard}` rows:
+- **GC1** coverage referential integrity — every `gap-*` action-list id maps to a real `coverage.json` story; no `done` story retains an open gap task.
+- **GC2** coverage progress — `done`-story count is monotonic non-decreasing vs HEAD (deep-scan commits exempt). HARD-FAIL once `GOAL_CHECK_ENFORCE=1`.
+- **GC3** buffer bounds — `open_claimable` in `[18, 60]` (catches both starvation and the 102/36 overflow).
+
+Stem-uniqueness is enforced separately as `T20` in `dispatcher-self-test.sh`.
+
+## Inputs
+- `.research/management/coverage.json`, `action-list.json`, `assignments.json` (override via `COVERAGE` / `ACTION_LIST` / `ASSIGN` env).
+- `GOAL_CHECK_ENFORCE=1` makes the hard-fail subset (GC2) exit non-zero. Default: record-only (exit 0).
+
+## Steps
+1. `./.research/goal-check.sh` — human-readable, record-only.
+2. `./.research/goal-check.sh --json` — emit the `goal_checks[]` array (the dispatcher embeds the summary in its commit).
+
+## Deterministic verification
+- `test -x .research/goal-check.sh`
+- `./.research/goal-check.sh --json | jq -e 'type == "array"'` exits 0.
+- Against the fixtures, GC1 reports `orphans=1 done_with_open_gap=1` and T20 reports a duplicate stem.
+
+## Smoke check
+`COVERAGE=.research/fixtures/goal-check/coverage.json ACTION_LIST=.research/fixtures/goal-check/action-list.json ASSIGN=.research/fixtures/goal-check/assignments.json ./.research/goal-check.sh --json | jq -e 'length >= 3'`
+
+## Cross-references
+- `.research/dispatcher-prompt.md` Phase 6 (invocation), HARD RULES.
+- `.research/dispatcher-self-test.sh` T20.
+- `docs/superpowers/specs/2026-05-28-dispatcher-goal-convergence-design.md` (Pillar 1).

--- a/.claude/skills/verify-all.sh
+++ b/.claude/skills/verify-all.sh
@@ -115,6 +115,7 @@ run "ppt-db-migrations"   10 'test -d backend/crates/db/migrations && test -d ba
 # wired up and — when pmctl is on PATH — that it at least responds to --help.
 # Live onyx / deploy ops are out of scope for a generic harness.
 run "ppt-deploy"          10 'test -f .claude/skills/ppt-deploy/SKILL.md && test -d .claude/skills/ppt-deploy/commands && test -d .claude/skills/ppt-deploy/references && { ! command -v pmctl >/dev/null 2>&1 || pmctl --help >/dev/null 2>&1; }'
+run "ppt-goal-gate"       10 'test -x .research/goal-check.sh && COVERAGE=.research/fixtures/goal-check/coverage.json ACTION_LIST=.research/fixtures/goal-check/action-list.json ASSIGN=.research/fixtures/goal-check/assignments.json ./.research/goal-check.sh --json | jq -e "length >= 3" >/dev/null'
 
 echo
 echo "== summary =="

--- a/.github/workflows/dispatcher-self-test.yml
+++ b/.github/workflows/dispatcher-self-test.yml
@@ -21,5 +21,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: dispatcher schema + invariant self-test
         run: bash .research/dispatcher-self-test.sh
+      - name: goal-check (observe-only)
+        continue-on-error: true
+        run: |
+          chmod +x .research/goal-check.sh
+          ./.research/goal-check.sh
       - name: scope-check unit tests
         run: bash .claude/skills/ppt-implement/scripts/test-scope-check.sh

--- a/.research/README.md
+++ b/.research/README.md
@@ -39,6 +39,7 @@ issues, commit-log hotspots), and writes structured artifacts that a separate
 - `management/` — Phase 1.6 delivery artifacts: `project-state.md` (dashboard), `action-list.json`/`.md`, `risks.json`, `decisions.md`, `stakeholders.md`, `roles/<role>.md`. Maintained by the `ppt-project-management` skill.
   - `coverage.json` — 134-story delivery coverage map (done/partial/not-started + evidence + gaps), built by `/ppt-project-management scan` (local deep scan) and maintained cheaply by the daily routine.
   - `roadmap.md` — ranked gap plan generated from `coverage.json` (balanced rubric, owner + rationale per task).
+- `goal-check.sh` — deterministic goal/convergence checks (GC1 referential integrity, GC2 coverage-progress monotonicity, GC3 buffer bounds). Record-only in dispatcher Phase 6 + CI until `GOAL_CHECK_ENFORCE=1` (PR 2). See the `ppt-goal-gate` skill.
 
 In-repo skills the implementer agent uses live at **`.claude/skills/`** (one
 level up, at the repo root). `.claude/skills/` is auto-discovered by any

--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -1076,6 +1076,20 @@ The Phase 7 summary's `Merged-now` / `Failed (this run)` counters are still
 derived from the in-memory transitions set — those are this-run-shaped
 quantities, distinct from the file-state-shaped move set above.
 
+**Goal-check (record-only — observe phase, PR 1).** Before committing, run the
+deterministic goal checks and capture the summary for the commit body. This
+NEVER blocks the commit in the observe phase (`goal-check.sh` exits 0 unless
+`GOAL_CHECK_ENFORCE=1`, which is unset until PR 2):
+
+```bash
+GOAL_CHECK=$(./.research/goal-check.sh --json 2>/dev/null || echo '[]')
+GOAL_LINE=$(echo "$GOAL_CHECK" | jq -r 'map("\(.check)=\(if .passed then "ok" else "FAIL" end)") | join(" ")')
+echo "goal-check: $GOAL_LINE"
+```
+
+Append `goal-check: <GOAL_LINE>` as a trailing line in the dispatcher commit
+message body so convergence health is visible per-run in `git log`.
+
 ```bash
 # Row-count regression guard (issue #8, adapted for split — issue #9).
 # Before split: assignments.json carried all rows; a sudden drop was always a bug.
@@ -1473,6 +1487,7 @@ Opus pricing. At 12 runs/day that's ~$2-4/day. Acceptable for the
 - **reviewer dedup guard** (issue #3) — reviewer subagent MUST `GET /pulls/<n>/reviews` first; if a bot review for the current `headRefOid` already exists within 2h, skip posting and return `note=dedup-existing-review-at-<iso>`. Defense-in-depth against the skip-gate window-edge case.
 - **subagent workspace isolation** (issue #7) — every Phase 4 (implementer), Phase 5.6 (rebaser), and Phase 5.7 (followup-respawn implementer) subagent MUST run its `git checkout` / `gh pr checkout` / build / commit work inside `/tmp/ppt-worktrees/<task_id>/` via the standard `git worktree add` preamble. NEVER touch the dispatcher's own working tree. Phase 5.5 (merger, API-only) and Phase 2 (read-only reconciliation) are exempt.
 - **TEMP_PHASE_8 — self-review** — Phase 8 spawns an Opus subagent that writes a post-mortem markdown to `.research/self-improvement/<iso8601>.md`. Off-switch: `DISPATCHER_SELF_REVIEW=0`. The subagent must NOT modify any state file or commit anything. **This phase is temporary** — remove by 2026-06-30 (search `TEMP_PHASE_8` to find every related artifact).
+- **goal-check (observe-only, PR 1)** — Phase 6 runs `.research/goal-check.sh --json` and records `goal-check: GC1=… GC2=… GC3=…` in the commit body. It does NOT block the commit while `GOAL_CHECK_ENFORCE` is unset. PR 2 flips GC2 to hard-fail.
 
 ---
 

--- a/.research/dispatcher-self-test.sh
+++ b/.research/dispatcher-self-test.sh
@@ -434,6 +434,29 @@ else
 fi
 echo
 
+# --- T20: stem-uniqueness among active rows (closes #641/#644 double-land) ---
+# At most one non-terminal (in-progress|review) row per stem(task_id), where
+# stem strips the auto-impl/|impl/ prefix and a trailing -(impl|fix|v2|retry|
+# followup|wip)<digits> suffix. Two active rows sharing a stem = duplicate work.
+echo "T20 stem-uniqueness among active (in-progress|review) rows"
+T20_DUPES=$(jq -r '
+  def stem: sub("^(auto-impl|impl)/";"") | sub("-(impl|fix|v2|retry|followup|wip)[0-9]*$";"");
+  .assignments
+  | map(select(.status=="in-progress" or .status=="review"))
+  | group_by(.task_id | stem)
+  | map(select(length>1) | (.[0].task_id | stem))
+  | join(",")' "$ASSIGN")
+if [ -z "$T20_DUPES" ]; then note "no two active rows share a stem"
+else
+  fail "duplicate active stems: $T20_DUPES (two non-terminal units of the same work)"
+  jq -r '
+    def stem: sub("^(auto-impl|impl)/";"") | sub("-(impl|fix|v2|retry|followup|wip)[0-9]*$";"");
+    .assignments | map(select(.status=="in-progress" or .status=="review"))
+    | group_by(.task_id | stem) | map(select(length>1))[] | .[]
+    | "    \(.task_id) :: stem=\(.task_id|stem) status=\(.status)"' "$ASSIGN" >&2
+fi
+echo
+
 # --- Summary ---------------------------------------------------------------
 if [ "$FAIL" = "0" ]; then
   echo "==> dispatcher-self-test: PASS"

--- a/.research/dispatcher-self-test.sh
+++ b/.research/dispatcher-self-test.sh
@@ -448,7 +448,10 @@ T20_DUPES=$(jq -r '
   | join(",")' "$ASSIGN")
 if [ -z "$T20_DUPES" ]; then note "no two active rows share a stem"
 else
-  fail "duplicate active stems: $T20_DUPES (two non-terminal units of the same work)"
+  # PR1 observe-only: surface duplicates as a WARNING without failing the
+  # self-test (matches the T12/T16 grandfather convention). PR2 flips this
+  # back to `fail` once the live duplicate(s) are resolved.
+  printf '  warn  duplicate active stems: %s (two non-terminal units; PR1 observe-only — not failing)\n' "$T20_DUPES" >&2
   jq -r '
     def stem: sub("^(auto-impl|impl)/";"") | sub("-(impl|fix|v2|retry|followup|wip)[0-9]*$";"");
     .assignments | map(select(.status=="in-progress" or .status=="review"))

--- a/.research/fixtures/goal-check/action-list.json
+++ b/.research/fixtures/goal-check/action-list.json
@@ -1,0 +1,7 @@
+{
+  "items": [
+    {"id":"gap-7a-1-upload-route","action":"Add upload route","status":"open","priority":"high","depends_on":[]},
+    {"id":"gap-6-1-announcement-extra","action":"open gap on a done story","status":"open","priority":"low","depends_on":[]},
+    {"id":"gap-nope-orphan-slug","action":"orphan — no coverage story","status":"open","priority":"low","depends_on":[]}
+  ]
+}

--- a/.research/fixtures/goal-check/assignments.json
+++ b/.research/fixtures/goal-check/assignments.json
@@ -1,0 +1,7 @@
+{
+  "generated": "2026-05-28T00:00:00Z",
+  "assignments": [
+    {"task_id":"gap-7a-1-upload-route","branch":"auto-impl/gap-7a-1-upload-route","status":"in-progress","claimed_at":"2026-05-28T00:00:00Z","last_updated":"2026-05-28T00:00:00Z","status_changed_at":"2026-05-28T00:00:00Z"},
+    {"task_id":"gap-7a-1-upload-route-impl","branch":"auto-impl/gap-7a-1-upload-route-impl","status":"review","claimed_at":"2026-05-28T00:00:00Z","last_updated":"2026-05-28T00:00:00Z","status_changed_at":"2026-05-28T00:00:00Z"}
+  ]
+}

--- a/.research/fixtures/goal-check/coverage.json
+++ b/.research/fixtures/goal-check/coverage.json
@@ -1,0 +1,9 @@
+{
+  "generated": "2026-05-28T00:00:00Z",
+  "scan_kind": "upkeep",
+  "stories": [
+    {"epic":"epic-6","id":"6-1-announcement","phase":"mvp","status":"done","gaps":[]},
+    {"epic":"epic-6","id":"6-2-announcement-web","phase":"mvp","status":"partial","gaps":["web UI"]},
+    {"epic":"epic-7a","id":"7a-1-upload","phase":"mvp","status":"not-started","gaps":["upload route"]}
+  ]
+}

--- a/.research/goal-check.sh
+++ b/.research/goal-check.sh
@@ -32,13 +32,33 @@ record() {
               '. += [{check:$c,passed:$p,observed:$o,expected:$e,hard:$h}]' <<<"$RESULTS")
   if [ "$passed" = "true" ]; then printf '  ok    %s — %s\n' "$check" "$observed" >&2
   else printf '  FAIL  %s — observed=%s expected=%s\n' "$check" "$observed" "$expected" >&2
-       [ "$hard" = "true" ] && HARD_FAIL=1
+       [ "$hard" = "true" ] && HARD_FAIL=1; return 0
   fi
 }
 
 echo "==> goal-check (coverage=$COVERAGE action-list=$ACTION_LIST assign=$ASSIGN enforce=$ENFORCE)" >&2
 
-# --- checks inserted by later tasks ---
+# --- GC1: coverage referential integrity (record-only) ---
+# (a) every gap-* action-list item maps to a real coverage story
+#     (a story id is a prefix of the gap-id with the leading "gap-" stripped);
+# (b) no `done` story retains an open gap-* task.
+GC1_ORPHANS=$(jq -n --slurpfile al "$ACTION_LIST" --slurpfile cov "$COVERAGE" '
+  ($cov[0].stories | map(.id)) as $sids
+  | [ $al[0].items[]
+      | select(.id | startswith("gap-"))
+      | (.id | ltrimstr("gap-")) as $rest
+      | select([ $sids[] | . as $sid | select($rest | startswith($sid)) ] | length == 0)
+      | .id ] | length')
+GC1_DONE_OPEN=$(jq -n --slurpfile al "$ACTION_LIST" --slurpfile cov "$COVERAGE" '
+  ($cov[0].stories | map(select(.status=="done") | .id)) as $done
+  | [ $al[0].items[]
+      | select(.status=="open" and (.id | startswith("gap-")))
+      | (.id | ltrimstr("gap-")) as $rest
+      | select([ $done[] | . as $sid | select($rest | startswith($sid)) ] | length > 0)
+      | .id ] | length')
+GC1_PASS=$([ "$GC1_ORPHANS" = "0" ] && [ "$GC1_DONE_OPEN" = "0" ] && echo true || echo false)
+record "GC1-referential-integrity" "$GC1_PASS" \
+  "orphans=$GC1_ORPHANS done_with_open_gap=$GC1_DONE_OPEN" "orphans=0 done_with_open_gap=0" false
 
 # --- emit + exit ---
 if [ "$EMIT_JSON" = "1" ]; then echo "$RESULTS"; fi

--- a/.research/goal-check.sh
+++ b/.research/goal-check.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Deterministic GOAL checks for the dispatcher — convergence, not just schema.
+# Sibling of dispatcher-self-test.sh. Reads .research/management/*.json.
+#
+# Output: human lines on stderr; a goal_checks JSON array on stdout with --json.
+# Modes:
+#   (default)            record-only: prints results, ALWAYS exits 0.
+#   GOAL_CHECK_ENFORCE=1 hard-fail subset (GC2) exits non-zero on violation.
+#                        (PR 1 leaves this off everywhere — observe-only.)
+#
+# Usage:
+#   ./.research/goal-check.sh            # against repo .research/management/*
+#   ./.research/goal-check.sh --json     # emit goal_checks[] to stdout
+#   COVERAGE=fixt/coverage.json ACTION_LIST=… ASSIGN=… ./.research/goal-check.sh
+set -euo pipefail
+
+COVERAGE="${COVERAGE:-.research/management/coverage.json}"
+ACTION_LIST="${ACTION_LIST:-.research/management/action-list.json}"
+ASSIGN="${ASSIGN:-.research/management/assignments.json}"
+ENFORCE="${GOAL_CHECK_ENFORCE:-0}"
+EMIT_JSON=0
+[ "${1:-}" = "--json" ] && EMIT_JSON=1
+
+RESULTS='[]'           # accumulates {check,passed,observed,expected,hard}
+HARD_FAIL=0
+
+# record <check> <passed:true|false> <observed> <expected> <hard:true|false>
+record() {
+  local check="$1" passed="$2" observed="$3" expected="$4" hard="$5"
+  RESULTS=$(jq -c --arg c "$check" --argjson p "$passed" --arg o "$observed" \
+              --arg e "$expected" --argjson h "$hard" \
+              '. += [{check:$c,passed:$p,observed:$o,expected:$e,hard:$h}]' <<<"$RESULTS")
+  if [ "$passed" = "true" ]; then printf '  ok    %s — %s\n' "$check" "$observed" >&2
+  else printf '  FAIL  %s — observed=%s expected=%s\n' "$check" "$observed" "$expected" >&2
+       [ "$hard" = "true" ] && HARD_FAIL=1
+  fi
+}
+
+echo "==> goal-check (coverage=$COVERAGE action-list=$ACTION_LIST assign=$ASSIGN enforce=$ENFORCE)" >&2
+
+# --- checks inserted by later tasks ---
+
+# --- emit + exit ---
+if [ "$EMIT_JSON" = "1" ]; then echo "$RESULTS"; fi
+if [ "$ENFORCE" = "1" ] && [ "$HARD_FAIL" = "1" ]; then
+  echo "==> goal-check: HARD FAIL (enforce on)" >&2; exit 1
+fi
+echo "==> goal-check: done (record-only)" >&2
+exit 0

--- a/.research/goal-check.sh
+++ b/.research/goal-check.sh
@@ -38,6 +38,15 @@ record() {
 
 echo "==> goal-check (coverage=$COVERAGE action-list=$ACTION_LIST assign=$ASSIGN enforce=$ENFORCE)" >&2
 
+# Observe-only: a missing input file must never abort a dispatcher run.
+for f in "$COVERAGE" "$ACTION_LIST" "$ASSIGN"; do
+  if [ ! -f "$f" ]; then
+    echo "==> goal-check: SKIP (missing $f)" >&2
+    [ "$EMIT_JSON" = "1" ] && echo "[]"
+    exit 0
+  fi
+done
+
 # --- GC1: coverage referential integrity (record-only) ---
 # (a) every gap-* action-list item maps to a real coverage story
 #     (a story id is a prefix of the gap-id with the leading "gap-" stripped);

--- a/.research/goal-check.sh
+++ b/.research/goal-check.sh
@@ -60,6 +60,22 @@ GC1_PASS=$([ "$GC1_ORPHANS" = "0" ] && [ "$GC1_DONE_OPEN" = "0" ] && echo true |
 record "GC1-referential-integrity" "$GC1_PASS" \
   "orphans=$GC1_ORPHANS done_with_open_gap=$GC1_DONE_OPEN" "orphans=0 done_with_open_gap=0" false
 
+# --- GC2: coverage progress — done-story count is monotonic non-decreasing
+# vs the previously-committed coverage.json (HEAD). This is the HARD-FAIL
+# check once enforcement is turned on (PR 2). Exempt deep-scan commits
+# (a deliberate human refresh may legitimately re-classify done -> partial).
+GC2_NOW=$(jq '[.stories[] | select(.status=="done")] | length' "$COVERAGE")
+GC2_KIND=$(jq -r '.scan_kind // "upkeep"' "$COVERAGE")
+GC2_HEAD=$(git show "HEAD:$COVERAGE" 2>/dev/null \
+           | jq '[.stories[] | select(.status=="done")] | length' 2>/dev/null || echo "$GC2_NOW")
+if [ "$GC2_KIND" = "deep" ]; then
+  record "GC2-coverage-progress" true "done=$GC2_NOW (deep-scan exempt)" "done>=$GC2_HEAD" true
+elif [ "$GC2_NOW" -ge "$GC2_HEAD" ]; then
+  record "GC2-coverage-progress" true "done=$GC2_NOW head=$GC2_HEAD" "done>=$GC2_HEAD" true
+else
+  record "GC2-coverage-progress" false "done=$GC2_NOW head=$GC2_HEAD" "done>=$GC2_HEAD" true
+fi
+
 # --- emit + exit ---
 if [ "$EMIT_JSON" = "1" ]; then echo "$RESULTS"; fi
 if [ "$ENFORCE" = "1" ] && [ "$HARD_FAIL" = "1" ]; then

--- a/.research/goal-check.sh
+++ b/.research/goal-check.sh
@@ -76,6 +76,28 @@ else
   record "GC2-coverage-progress" false "done=$GC2_NOW head=$GC2_HEAD" "done>=$GC2_HEAD" true
 fi
 
+# --- GC3: buffer bounds. open_claimable = open action-list items not already
+# in active assignments, minus dep-blocked (a depends_on entry not pointing at
+# a merged/done assignment). Healthy band [18, 60]; below 18 = starving,
+# above 60 = overflow (the 102/36 explosion). Record-only here.
+GC3_OPEN=$(jq --slurpfile a "$ASSIGN" '
+  [.items[] | select(.status=="open")
+            | .id as $id
+            | select(($a[0].assignments | map(.task_id) | index($id)) == null)] | length' "$ACTION_LIST")
+GC3_BLOCKED=$(jq --slurpfile a "$ASSIGN" '
+  [.items[] | select(.status=="open")
+            | .id as $id
+            | select(($a[0].assignments | map(.task_id) | index($id)) == null)
+            | select(((.depends_on // []) | length) > 0
+                     and any((.depends_on // [])[];
+                             . as $dep
+                             | (($a[0].assignments | map(select(.task_id==$dep)) | .[0].status // "missing")
+                                | IN("merged","done") | not)))] | length' "$ACTION_LIST")
+GC3_CLAIMABLE=$((GC3_OPEN - GC3_BLOCKED))
+GC3_PASS=$([ "$GC3_CLAIMABLE" -ge 18 ] && [ "$GC3_CLAIMABLE" -le 60 ] && echo true || echo false)
+record "GC3-buffer-bounds" "$GC3_PASS" \
+  "claimable=$GC3_CLAIMABLE (open=$GC3_OPEN dep_blocked=$GC3_BLOCKED)" "18<=claimable<=60" false
+
 # --- emit + exit ---
 if [ "$EMIT_JSON" = "1" ]; then echo "$RESULTS"; fi
 if [ "$ENFORCE" = "1" ] && [ "$HARD_FAIL" = "1" ]; then


### PR DESCRIPTION
## Summary

PR 1 of the **dispatcher goal-convergence redesign**. Adds a deterministic goal-verification layer that makes dispatcher convergence **observable and CI-checkable**, with **zero behavior change** — pure measurement.

- `.research/goal-check.sh` — `GC1` coverage referential integrity, `GC2` coverage-progress monotonicity vs HEAD (deep-scan exempt), `GC3` buffer bounds `[18,60]`. Emits `{check,passed,observed,expected,hard}` (`--json`).
- `.research/dispatcher-self-test.sh` — new `T20` stem-uniqueness (catches the duplicate-work / double-land class).
- `.research/dispatcher-prompt.md` — Phase 6 runs `goal-check.sh` **record-only** (records a `goal-check:` line in each dispatcher commit); HARD RULES bullet.
- `.claude/skills/ppt-goal-gate/SKILL.md` + a `verify-all.sh` smoke; non-blocking CI step in `dispatcher-self-test.yml`; fixtures + README.

Spec: `docs/superpowers/specs/2026-05-28-dispatcher-goal-convergence-design.md` · Plan: `docs/superpowers/plans/2026-05-28-dispatcher-goal-gates.md`

## What the gates already found (live, on `dev` data)

- **GC1** → `orphans=80 done_with_open_gap=9` — 80 `gap-*` action-list items don't map to a `coverage.json` story, and 9 `done` stories still carry open gap tasks (referential drift).
- **GC3** → `claimable=88` — buffer overflow (above the 60 ceiling; the 102/36 explosion).
- **T20** → live duplicate **`gap-82-4-swiftui-listing-detail`** + `…-impl`, both in `review` (the epic-82 double-land). Surfaced as a warning; resolve before PR 2 flips T20 to hard.

## Observe-only guarantee (verified)

- `goal-check.sh` exits 0 even with `GOAL_CHECK_ENFORCE=1` (GC1/GC3 are `hard=false`; GC2 passes) — and `GOAL_CHECK_ENFORCE` is never set.
- `T20` **warns**, never `fail`s → `dispatcher-self-test.sh` still **PASS** despite the live duplicate.
- Phase 6 hook is additive-only and wrapped (`|| echo '[]'`); it cannot block the commit.
- CI step is `continue-on-error: true`.

## Test plan

- [x] `./.research/dispatcher-self-test.sh` → PASS
- [x] `./.research/goal-check.sh` → exit 0 (records GC1=FAIL GC2=ok GC3=FAIL)
- [x] `SKIP_NETWORK=1 ./.claude/skills/verify-all.sh --quick` → `ppt-goal-gate ... PASS` (pre-existing unrelated `ppt-implement` failure not in this diff)
- [x] Fixtures: GC1 `orphans=1 done_with_open_gap=1`, GC3 `claimable=2`, T20 detects the seeded dup
- [x] Final independent review: APPROVE

## Rollout

PR 1 of 5 (observe-only foundation). **PR 2** flips `GC2` + `T20` to enforcing once the live coverage drift + the `gap-82-4` duplicate are resolved; **PR 3** adds `pick-target-epic.sh` + `.objective` (finish-first); **PR 4** the WIP throttle; **PR 5** quarantine + pre-merge-autofix + claim-time dedup.