### PR TITLE
gap-10b-6-onboarding-api-retry: implement onboarding tour SQLx handlers

### DIFF
--- a/backend/crates/db/migrations/00164_user_onboarding_progress_rls.sql
+++ b/backend/crates/db/migrations/00164_user_onboarding_progress_rls.sql
@@ -1,0 +1,44 @@
+-- Epic 10B, Story 10B.6: User Onboarding Progress — RLS Policies
+--
+-- Adds Row-Level Security to user_onboarding_progress so each user
+-- can only read and modify their own progress rows.
+-- onboarding_tours is a global config table (no user-scoped RLS needed).
+
+-- Enable RLS on user_onboarding_progress
+ALTER TABLE user_onboarding_progress ENABLE ROW LEVEL SECURITY;
+-- Force RLS even for the table owner (needed for tests running as postgres user)
+ALTER TABLE user_onboarding_progress FORCE ROW LEVEL SECURITY;
+
+-- Policy: users can only SELECT their own rows; super-admins bypass
+CREATE POLICY user_onboarding_progress_select ON user_onboarding_progress
+    FOR SELECT
+    USING (
+        user_id = NULLIF(current_setting('app.current_user_id', TRUE), '')::UUID
+        OR is_super_admin()
+    );
+
+-- Policy: users can only INSERT rows for themselves; super-admins bypass
+CREATE POLICY user_onboarding_progress_insert ON user_onboarding_progress
+    FOR INSERT
+    WITH CHECK (
+        user_id = NULLIF(current_setting('app.current_user_id', TRUE), '')::UUID
+        OR is_super_admin()
+    );
+
+-- Policy: users can only UPDATE their own rows; super-admins bypass
+CREATE POLICY user_onboarding_progress_update ON user_onboarding_progress
+    FOR UPDATE
+    USING (
+        user_id = NULLIF(current_setting('app.current_user_id', TRUE), '')::UUID
+        OR is_super_admin()
+    );
+
+-- Policy: users can only DELETE their own rows; super-admins bypass
+CREATE POLICY user_onboarding_progress_delete ON user_onboarding_progress
+    FOR DELETE
+    USING (
+        user_id = NULLIF(current_setting('app.current_user_id', TRUE), '')::UUID
+        OR is_super_admin()
+    );
+
+COMMENT ON TABLE user_onboarding_progress IS 'Tracks user progress through onboarding tours (Epic 10B, Story 10B.6) — RLS enforced per user_id';

--- a/backend/crates/db/migrations/00164_user_onboarding_progress_rls.sql
+++ b/backend/crates/db/migrations/00164_user_onboarding_progress_rls.sql
@@ -6,7 +6,8 @@
 
 -- Enable RLS on user_onboarding_progress
 ALTER TABLE user_onboarding_progress ENABLE ROW LEVEL SECURITY;
--- Force RLS even for the table owner (needed for tests running as postgres user)
+-- Force RLS for the table owner (superusers always bypass RLS regardless;
+-- this applies to any non-superuser role that owns the table)
 ALTER TABLE user_onboarding_progress FORCE ROW LEVEL SECURITY;
 
 -- Policy: users can only SELECT their own rows; super-admins bypass


### PR DESCRIPTION
## Summary

- Onboarding tour backend was already implemented and merged to `dev` (via the earlier `gap-10b-6-onboarding-impl` work, which the UI PR built on top of).
- This retry PR adds the **missing RLS policies** for the `user_onboarding_progress` table via migration `00164_user_onboarding_progress_rls.sql`.
- The four policies (SELECT / INSERT / UPDATE / DELETE) scope all access to `user_id = app.current_user_id`, with `is_super_admin()` bypass. `FORCE ROW LEVEL SECURITY` ensures the table owner cannot bypass policies.
- `onboarding_tours` is a global config table (no user-scoped RLS needed — all authenticated users can read tour definitions).

## What already existed on `dev`

| File | Description |
|------|-------------|
| `backend/crates/db/migrations/00033_create_user_onboarding.sql` | Creates `user_onboarding_progress` + `onboarding_tours` tables, indexes, default main tour |
| `backend/crates/db/src/repositories/onboarding.rs` | Full SQLx repository: `get_progress`, `get_tours_for_user`, `start_tour`, `complete_step`, `complete_tour`, `skip_tour`, `reset_tour`, `needs_onboarding` |
| `backend/servers/api-server/src/routes/onboarding.rs` | Axum router with GET `/status`, GET `/tours`, GET `/tours/{id}`, POST `/tours/{id}/start`, POST `.../steps/{step_id}/complete`, POST `.../complete`, POST `.../skip`, POST `.../reset` |

## New in this PR

| File | Description |
|------|-------------|
| `backend/crates/db/migrations/00164_user_onboarding_progress_rls.sql` | RLS ENABLE + FORCE + 4 policies scoped per `user_id` |

## Bands verified

- **Band A** `cargo check -p api-server` — PASS (exit 0)
- **Band B** `cargo clippy -p api-server -- -D warnings` — PASS (exit 0, no warnings)

## Test plan

- [ ] Apply migration against dev DB; verify `user_onboarding_progress` has RLS enabled
- [ ] Confirm a user can only see/modify their own rows (connect as user A, cannot read user B progress)
- [ ] Confirm super-admin context bypasses RLS
- [ ] GET /api/v1/onboarding/status returns correct `needs_onboarding` + tours list
- [ ] POST /api/v1/onboarding/tours/{id}/start creates progress row
- [ ] POST /api/v1/onboarding/tours/{id}/steps/{step_id}/complete updates `completed_steps`
- [ ] POST /api/v1/onboarding/tours/{id}/reset clears progress

https://claude.ai/code/session_01QD48JHVDGukhx4Gaon2FRC

---
_Generated by [Claude Code](https://claude.ai/code/session_01QD48JHVDGukhx4Gaon2FRC)_