### PR TITLE
gap-82-5-ios-keychain-push-v2: PushNotificationManager + KeychainService (iOS Reality Portal)

### DIFF
--- a/mobile-native/iosApp/iosAppTests/README.md
+++ b/mobile-native/iosApp/iosAppTests/README.md
@@ -1,10 +1,11 @@
 # Reality Portal iOS Tests
 
 Epic 80 - Story 80.6: Mobile Unit Tests (iOS)
+Epic 82 - Story 82.5: Inquiries and Account (KeychainService, PushNotificationManager)
 
 ## Overview
 
-This directory contains XCTest scaffolding for the Reality Portal iOS application.
+This directory contains XCTest unit tests for the Reality Portal iOS application.
 
 ## Test Structure
 
@@ -12,90 +13,79 @@ This directory contains XCTest scaffolding for the Reality Portal iOS applicatio
 iosAppTests/
 ├── README.md                    # This file
 ├── Info.plist                   # Test target configuration
-└── RealityPortalTests.swift     # Main test file with test classes
+└── RealityPortalTests.swift     # All test classes
 ```
 
 ## Test Classes
 
-| Class | Purpose |
-|-------|---------|
-| `RealityPortalTests` | Main test class with placeholder tests |
-| `ConfigurationTests` | Tests for app configuration |
-| `NavigationTests` | Tests for navigation coordinator |
-| `AuthenticationTests` | Tests for authentication manager |
-| `ViewTests` | Tests for SwiftUI views |
-| `DependencyInjectionTests` | Tests for DI container |
-| `ModelTests` | Tests for data models |
-| `PerformanceTests` | Performance measurements |
+| Class | Purpose | Epic |
+|-------|---------|------|
+| `ConfigurationTests` | `Configuration` singleton, `Environment` enum, `keychainService` binding | 82.1 |
+| `RouteTests` | `Route` enum equality / hashability (NavigationStack dedup) | 82.2 |
+| `DeepLinkTests` | URL scheme parsing sanity checks | 82.2 |
+| `DeepLinkHandlerTests` | Full `DeepLinkHandler` parse-table coverage (SSO, listing, search, favorites, inquiries, account, compare) | 82.2 |
+| `NavigationStateRestorationServiceTests` | Encode/decode round-trips, save/restore, auth-gating, double-restore cycle regression | 82.2 |
+| `AuthenticationTests` | `AuthManager` initial state | 82.3 |
+| `InquiryStatusTests` | `InquiryStatus` display names (locale-agnostic), badge colours | 82.5 |
+| `InquiryPreviewTests` | `InquiryPreview` model, `formattedDate`, sample data | 82.5 |
+| `PushNotificationManagerTests` | Default preferences, UserDefaults persistence, device-token Keychain round-trip, hex conversion | 82.5 |
+| `KeychainServiceTests` | Save/load/delete/overwrite/contains/deleteAll against an isolated Keychain service | 82.5 |
+| `PerformanceTests` | `Configuration.apiBaseUrl` hot-path baseline | — |
 
-## Setup Instructions
+## Running Tests
 
-### Adding Test Target to Xcode Project
+**From Xcode (macOS required):**
 
-Since this is a Kotlin Multiplatform project with iOS support, you need to add the test target to your Xcode project manually:
-
-1. Open the Xcode project (or create one if using SPM/CocoaPods)
-2. Go to File > New > Target
-3. Select "Unit Testing Bundle"
-4. Name it "iosAppTests"
-5. Add the test files to the target
-6. Configure the test target to depend on the main iosApp target
-
-### Running Tests
-
-**From Xcode:**
 ```
-Cmd + U  # Run all tests
+Cmd + U   # Run all tests
 ```
 
-**From Command Line:**
+or
+
 ```bash
 xcodebuild test \
-  -project iosApp.xcodeproj \
+  -project mobile-native/iosApp/iosApp.xcodeproj \
   -scheme iosApp \
-  -destination 'platform=iOS Simulator,name=iPhone 15'
+  -destination 'platform=iOS Simulator,name=iPhone 15 Pro,OS=17.5'
 ```
 
-## Implementing Tests
+**Note:** `KeychainServiceTests` and `PushNotificationManagerTests` interact with the
+iOS Keychain API via `Security.framework`. They are isolated using a unique service
+name per test run (UUID suffix) and clean up after themselves in `tearDown`.
+They must run on a simulator or device — not on macOS (which has a different Keychain
+API surface).
 
-The current tests are placeholder tests that verify the test infrastructure is working.
-To implement actual tests:
+## Key Conventions
 
-1. Remove the placeholder assertions
-2. Import the actual components being tested
-3. Write meaningful assertions
+- Each test class uses isolated state: `UserDefaults(suiteName:)` for navigation tests;
+  unique Keychain service names for security tests.
+- `tearDown` clears all state so tests are order-independent.
+- `InquiryStatusTests` uses locale-agnostic assertions (`!isEmpty`, `count == Set.count`)
+  so tests pass on non-English CI runners.
+- `DEBUG`-only code (sample data) is covered with `#if DEBUG` guards — those tests
+  will pass in Release builds with no assertions (Swift `#if` omits the block entirely).
 
-### Example: Testing Configuration
+## Services Covered
 
-```swift
-func testConfigurationExists() throws {
-    let config = Configuration.shared
-    XCTAssertNotNil(config)
-    XCTAssertFalse(config.apiBaseUrl.isEmpty)
-}
-```
+### KeychainService (`Core/Services/KeychainService.swift`)
 
-### Example: Testing Navigation
+Secure token storage backed by `Security.framework`. Stores:
 
-```swift
-func testDeepLinkHandling() throws {
-    let coordinator = NavigationCoordinator()
-    let url = URL(string: "realityportal://listing/123")!
+| Key (constant) | Value |
+|----------------|-------|
+| `KeychainService.Keys.accessToken` | JWT access token |
+| `KeychainService.Keys.refreshToken` | Refresh token |
+| `KeychainService.Keys.pushDeviceToken` | APNs device token (hex string) |
 
-    coordinator.handleDeepLink(url)
+Access class: `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` — tokens survive
+restarts but are NOT migrated to a new device via iCloud Backup.
 
-    XCTAssertEqual(coordinator.selectedTab, .search)
-}
-```
+### PushNotificationManager (`Core/Services/PushNotificationManager.swift`)
 
-## Dependencies
+Manages APNs registration and per-category notification preferences.
 
-Tests use:
-- XCTest framework (built into Xcode)
-- `@testable import iosApp` for internal access
-
-## Notes
-
-- Tests marked with `async` require Swift 5.5+ concurrency support
-- Performance tests should be run in Release configuration for accurate measurements
-- Mock objects may be needed for testing network-dependent code
+- Device token stored in `KeychainService` (not `UserDefaults`).
+- Preference booleans stored in `UserDefaults` (not secret, need no Keychain protection).
+- `@Observable` — SwiftUI views observe `isAuthorized`, `isRequestingPermission`,
+  `deviceToken`, `preferences` without any explicit `objectWillChange` calls.
+- Created once in `RealityPortalApp` and injected via `.environment(pushNotificationManager)`.


### PR DESCRIPTION
## Task

Retry PushNotificationManager + Keychain token storage in iOS Reality Portal — PR #539 was closed without merge; implement in new branch, ensure draft PR stays open until macOS reviewer confirms (82-5 Inquiries and Account)

## Owner

pm-frontend / specialist: ios-swiftui

## What's in this PR

The implementation from PR #539 (`KeychainService` + `PushNotificationManager`) was merged into `dev` directly via commit `65e3fd71` (bundled with gap-82-4 photo gallery work). The complete unit-test suite (`KeychainServiceTests`, `PushNotificationManagerTests`) was merged via PR #686 in commit `ff39141b`.

This PR packages the work as a standalone reviewable unit with one incremental change:

- **Updated** `mobile-native/iosApp/iosAppTests/README.md` — replaces the outdated "placeholder tests" description with an accurate inventory of all 11 test classes, including the `KeychainServiceTests` and `PushNotificationManagerTests` added in Story 82.5, plus architecture notes for both services.

## Implementation summary (already on dev)

### `Core/Services/KeychainService.swift`
- Full CRUD wrapper around `Security.framework` (`SecItemAdd`, `SecItemCopyMatching`, `SecItemDelete`).
- Access class: `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` — tokens survive restarts, not migrated to new devices.
- Well-known key constants: `accessToken`, `refreshToken`, `pushDeviceToken`.
- `deleteAll()` for logout wipe.

### `Core/Services/PushNotificationManager.swift`
- `@Observable` — no delegate pattern needed from SwiftUI.
- APNs device token stored in `KeychainService` (hex string).
- Notification preference booleans stored in `UserDefaults` (not secret).
- `configure()` re-reads `UNAuthorizationStatus` on every launch; re-registers with APNs if already authorized.
- `requestAuthorization()` guard against concurrent requests via `isRequestingPermission`.
- Category registration: `INQUIRY_REPLY`, `NEW_LISTING`, `PRICE_DROP`, `SAVED_SEARCH`.
- UIKit-free: posts `pushNotificationManagerRequestsRegistration` notification; `RealityPortalApp` installs an observer and calls `UIApplication.shared.registerForRemoteNotifications()`.

### `App/RealityPortalApp.swift` wiring
- `@State private var pushNotificationManager = PushNotificationManager(keychainService:)` on launch.
- `.environment(pushNotificationManager)` injected into view tree.
- `configureApp()` calls `pushNotificationManager.configure()` in a `Task`.
- `didRegisterForRemoteNotifications` / `didFailToRegisterForRemoteNotifications` forwarding stubs.

### `Features/Account/AccountView.swift`
- Notification section with `NotificationToggle` sub-view (4 toggles: newListings, priceDrops, inquiryResponses, marketing).
- Optimistic toggle with `Task { await pushManager.setEnabled(...) }`.
- Disabled while `pushManager.isRequestingPermission` is true.

## Tested (Band A — fast check)

```
cd mobile-native && ./gradlew :shared:linkPodReleaseFrameworkIosArm64
```

BUILD FAILED — AGP 9.2.1 unavailable in cloud sandbox Maven (known constraint, same as PR #688).

The KMP shared framework is Kotlin-only. The Swift files in `iosApp/` are NOT compiled by Gradle — they require Xcode on macOS. Band A cannot pass in the cloud sandbox for iOS Swift code.

## Built (Band B — full build)

Skipped: Band A incomplete due to sandbox constraint.

## CI parity (Band C — hot-path only)

Skipped: not a security/auth/billing/data-integrity change.

## Remote-tested

Skipped: ppt-bridge MCP not connected.

## Scope drift

`scope-check.sh --owner pm-frontend --base dev --head HEAD` → exit 0 (no drift)

## Code-reuse review

`reuse-grep.sh --specialist ios-swiftui --base dev --head HEAD` → exit 0 (no warnings)

## Notes

**REQUIRES MACOS REVIEWER.** Swift files (`KeychainService.swift`, `PushNotificationManager.swift`, `AccountView.swift` notification toggles, `RealityPortalApp.swift` APNs wiring) cannot be compiled in the cloud sandbox — `xcodebuild` requires macOS + Xcode.

A macOS reviewer must:
1. Open `mobile-native/iosApp/iosApp.xcodeproj` in Xcode.
2. Build the `iosApp` scheme (`Cmd+B`) — verify no compiler errors.
3. Run unit tests (`Cmd+U`) — `KeychainServiceTests` and `PushNotificationManagerTests` require a simulator (not macOS host).
4. Confirm test results and mark this PR ready for merge.

**This PR should remain DRAFT until macOS reviewer confirms Steps 2–4 above.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01SR2FsYjJPCgJthaCM9bWFV)_