### PR TITLE
gap-10b-4-backend-impl-v2: system announcements CRUD verified + test coverage

### DIFF
--- a/backend/crates/db/src/repositories/system_announcement.rs
+++ b/backend/crates/db/src/repositories/system_announcement.rs
@@ -371,4 +371,48 @@ mod tests {
         assert!(!announcement.is_acknowledged);
         assert!(announcement.is_dismissible);
     }
+
+    #[test]
+    fn active_announcement_acknowledged_variant() {
+        let announcement = ActiveAnnouncement {
+            id: Uuid::new_v4(),
+            title: "Critical Outage".to_string(),
+            message: "Service disruption in progress.".to_string(),
+            severity: "critical".to_string(),
+            start_at: Utc::now(),
+            end_at: Some(Utc::now() + chrono::Duration::hours(2)),
+            is_dismissible: false,
+            requires_acknowledgment: true,
+            is_acknowledged: true,
+        };
+
+        assert!(announcement.is_acknowledged);
+        assert!(!announcement.is_dismissible);
+        assert!(announcement.requires_acknowledgment);
+        assert!(announcement.end_at.is_some());
+    }
+
+    #[test]
+    fn active_announcement_serde_round_trip() {
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+        let announcement = ActiveAnnouncement {
+            id,
+            title: "Maintenance".to_string(),
+            message: "Scheduled downtime.".to_string(),
+            severity: "warning".to_string(),
+            start_at: now,
+            end_at: None,
+            is_dismissible: true,
+            requires_acknowledgment: false,
+            is_acknowledged: false,
+        };
+
+        let json = serde_json::to_value(&announcement).expect("serialize");
+        assert_eq!(json["title"], "Maintenance");
+        assert_eq!(json["severity"], "warning");
+        assert_eq!(json["is_dismissible"], true);
+        assert_eq!(json["is_acknowledged"], false);
+        assert!(json["end_at"].is_null());
+    }
 }


### PR DESCRIPTION
## Task
Implement system announcements handler bodies in platform_admin.rs — 2 prior attempts timed out; use Mode: cloud-ok, implement CRUD handlers with SQLx queries against schedule_maintenance table (10b-4 System Announcements)

## Owner
pm-backend

## Summary
The system announcements implementation (10B.4) was already fully shipped on `dev` via PR #601. This v2 task was created because the coverage scanner marked the task as open after prior timeout failures.

This PR adds two additional unit tests to `SystemAnnouncementRepository` to verify the `ActiveAnnouncement` struct:
- `active_announcement_acknowledged_variant` — covers the critical/non-dismissible/with-end_at path
- `active_announcement_serde_round_trip` — verifies JSON field names and null handling

The full CRUD handler set is already present in:
- `backend/servers/api-server/src/routes/platform_admin.rs` (lines 1742–2228)
- `backend/crates/db/src/repositories/system_announcement.rs`

Endpoints confirmed implemented:
- `GET /api/v1/platform-admin/announcements` — `list_system_announcements`
- `POST /api/v1/platform-admin/announcements` — `create_system_announcement`
- `GET /api/v1/platform-admin/announcements/{id}` — `get_system_announcement`
- `PUT /api/v1/platform-admin/announcements/{id}` — `update_system_announcement`
- `DELETE /api/v1/platform-admin/announcements/{id}` — `delete_system_announcement`
- `POST /api/v1/platform-admin/maintenance` — `schedule_maintenance`
- `GET /api/v1/platform-admin/maintenance` — `get_upcoming_maintenance_admin`
- `DELETE /api/v1/platform-admin/maintenance/{id}` — `delete_scheduled_maintenance`
- `GET /api/v1/announcements/active` — `get_active_announcements` (public)
- `POST /api/v1/announcements/{id}/acknowledge` — `acknowledge_announcement` (public)
- `GET /api/v1/maintenance/upcoming` — `get_upcoming_maintenance` (public)

Repository methods all use parameterized SQLx queries against `system_announcements`, `system_announcement_acknowledgments`, and `scheduled_maintenance` tables.

## Tested (Band A — fast check)
```
cd backend && cargo check -p api-server
exit 0 (8m 32s — all crates including db, api-core, admin-core clean)

cd backend && cargo check -p db
exit 0 (9m 34s — clean)
```

## Built (Band B — full build)
Skipped: no public API surface changes in this commit (tests only). The underlying implementation was already verified by CI when PR #601 was merged.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity changes).

## Scope drift
None — only `backend/crates/db/src/repositories/system_announcement.rs` modified. scope-check.sh exit 0.

## Code-reuse review
None — test-only change, no new helpers added. reuse-grep.sh exit 0.

## Remote-tested
Skipped.

## Notes
- Prior PR #601 (and PR #503) shipped the full implementation. This v2 task was a coverage-gap retry.
- The `schedule_maintenance` handler announces 24h before the window and links via `announcement_id` FK.
- `update_announcement` uses `COALESCE` for partial updates; `end_at` is `Option<Option<DateTime>>` to allow explicit null-setting.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SR2FsYjJPCgJthaCM9bWFV)_