### PR TITLE
gap-10b-3-admin-health-ui: Platform Health Monitoring UI (admin-web)

### DIFF
--- a/frontend/apps/admin-web/src/pages/PlatformHealthPage.test.tsx
+++ b/frontend/apps/admin-web/src/pages/PlatformHealthPage.test.tsx
@@ -152,9 +152,10 @@ describe('PlatformHealthPage', () => {
     });
     renderPage();
     await waitFor(() => expect(screen.getByText('active_sessions')).toBeDefined());
-    expect(screen.getByText('error_rate')).toBeDefined();
-    // critical badge
-    expect(screen.getByText('Critical')).toBeDefined();
+    // error_rate appears in both the metric card and the alert row — use getAllByText
+    expect(screen.getAllByText('error_rate').length).toBeGreaterThanOrEqual(1);
+    // critical badge — may also appear as a threshold column header
+    expect(screen.getAllByText('Critical').length).toBeGreaterThanOrEqual(1);
   });
 
   it('renders thresholds table', async () => {
@@ -163,11 +164,15 @@ describe('PlatformHealthPage', () => {
       if (url.includes('/health/dashboard')) {
         return { ok: true, status: 200, json: async () => DASHBOARD } as Response;
       }
+      if (url.includes('/health/alerts')) {
+        return { ok: true, status: 200, json: async () => DASHBOARD.alerts } as Response;
+      }
       return { ok: false, status: 404 } as Response;
     });
     renderPage();
-    await waitFor(() => expect(screen.getByText('Metric Thresholds')).toBeDefined());
-    // threshold row
+    // Wait for threshold data to appear (requires dashboard to have loaded)
+    await waitFor(() => expect(screen.getByText('50')).toBeDefined());
+    // threshold row contains error_rate
     expect(screen.getAllByText('error_rate').length).toBeGreaterThanOrEqual(1);
   });
 


### PR DESCRIPTION
## Task
Build admin health monitoring frontend page in admin-web wired to backend health dashboard + metric history + alert routes (10b-3 Platform Health Monitoring)

## Owner
pm-frontend

## Implementation Notes
The `PlatformHealthPage` was already fully implemented on `dev` with:
- Health dashboard (`GET /api/v1/platform-admin/health/dashboard`) rendering current metrics grid with status badges
- Metric history drill-down panel with time-range selector (1h/6h/24h/7d/30d)
- Alerts table with acknowledge action (gated by `site_settings_write` capability)
- Metric thresholds table with inline edit modal (gated by `site_settings_write`)
- All API hooks (`useHealthDashboard`, `useMetricHistory`, `useHealthAlerts`, `useAcknowledgeAlert`, `useUpdateHealthThreshold`) in `@ppt/api-client`
- Route wired at `platform/health` in `App.tsx` with `audit_read` capability gate

This PR fixes 2 test assertion bugs in `PlatformHealthPage.test.tsx`: `error_rate` appeared in both the metric card and the alerts table, and `Critical` appeared as both a status badge and a thresholds column header. Both were checked with `getByText` (which throws on multiple matches); switched to `getAllByText` with `.length >= 1`. Also added an alerts mock to the thresholds test so the dashboard data resolves before the assertion runs.

## Tested (Band A — fast check)
```
pnpm -F admin-web typecheck   → exit 0
biome check apps/admin-web/src/  → Checked 69 files in 354ms. No fixes applied. → exit 0
pnpm -F admin-web test:run    → 181 passed, 1 pre-existing failure (CapabilitiesAdminPage expects 17 caps, finds 18 — unrelated to this task)
```

## Built (Band B — full build)
```
pnpm -F admin-web build → ✓ 282 modules transformed, built in 337ms → exit 0
```

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Scope drift
scope-check.sh --owner pm-frontend --base dev --head HEAD → exit 0 (no drift)

## Code-reuse review
reuse-grep.sh --specialist react-web --base dev --head HEAD → exit 0 (no warnings)

## Notes
- The CapabilitiesAdminPage test failure (`expects 17, finds 18`) is pre-existing on dev and unrelated to health monitoring.
- The `admin-web` lint script calls `eslint` which is not installed (project uses Biome); ran `biome check` instead which is the correct linter per CLAUDE.md.

---
_Generated by [Claude Code](https://claude.ai/code/session_015FHKsHJMgfQVpBzcrUEJBi)_