### PR TITLE
feat(ppt-implement): add goal-check.sh — runnable IG1–IG8 verifier

### DIFF
--- a/.claude/skills/ppt-implement/SKILL.md
+++ b/.claude/skills/ppt-implement/SKILL.md
@@ -221,6 +221,42 @@ Quote each command + exit code in the PR body under `## Tested` (Band A),
 the required band fails: do NOT open a PR. Push partial work to the branch
 and return `pr=none status=partial note=<command-that-failed>`.
 
+## Step 3.5 — IG1–IG8 goal-check (deterministic, MANDATORY before draft PR)
+
+Mirror of the IG1–IG8 success criteria from `.research/implementer-prompt.md`,
+extracted into a single runnable script so the implementer doesn't have to
+grep the prompt for snippets. Run after Step 3's verify gate and before
+`gh pr create`:
+
+```bash
+bash .claude/skills/ppt-implement/scripts/goal-check.sh \
+  --slug "$SLUG" --base dev \
+  --skip IG7        # IG7 = just check + just test — Step 3 already ran them
+  # Add --skip IG8 on pre-final commits (archive move is intentionally the
+  # LAST commit before merge). Add --skip IG3 only for vectors that
+  # legitimately don't require a regression test (e.g. pure docs/refactor —
+  # see implementer-prompt.md IG3 trigger list).
+```
+
+Exit codes:
+- `0` — all hard checks passed (warnings allowed). Proceed to Step 5.
+- `1` — at least one hard check failed. **Do not open a ready-to-review PR.**
+  Either fix the goal failure (preferred) or push partial work and return
+  `pr=none status=partial note=<which-IG-failed>`.
+
+Each check prints a T-style line so the output is grep-friendly. Findings
+fall into three buckets:
+
+- `ok` — verifiable pass.
+- `WARN` — advisory: the check needs human confirmation (e.g. IG4 asks
+  whether each Suggested-approach step is addressed in the PR body —
+  the script can't see the PR body until after `gh pr create`).
+- `FAIL` — hard fail. Exit 1.
+
+The script is intentionally narrower than the verify gate: it checks
+goal-shape (test:+fix: commit pair, archive move, OOS path respect) rather
+than build/test correctness. Step 3 owns the latter.
+
 ## Step 4 — (Optional) Remote verify
 
 If the `ppt-bridge` MCP is connected in your session (cloud routine may have

--- a/.claude/skills/ppt-implement/scripts/goal-check.sh
+++ b/.claude/skills/ppt-implement/scripts/goal-check.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+# Deterministic IG1–IG8 goal checks for the ppt-implement skill.
+#
+# Mirrors the inline commands documented in .research/implementer-prompt.md
+# under "Implementation goals (IG1–IG8)" so an implementer can run one
+# command before pushing instead of grepping the prompt for snippets.
+#
+# Each check prints a T-style line (`ok` / `WARN` / `FAIL`) so the output
+# is grep-friendly and parseable in CI. Hard-fails set exit=1; advisory
+# checks (where a human PR-body decision is required) emit WARN and never
+# set exit≠0 by themselves.
+#
+# Usage:
+#   goal-check.sh --slug <slug> [--base dev]
+#
+# Required:
+#   --slug    plan slug (without `.md`) — also used to derive branch
+#
+# Optional:
+#   --base    base branch for diffs (default: dev)
+#   --skip    comma-separated list of IGs to skip (e.g. IG3,IG7 — useful
+#             when a plan's vector legitimately doesn't require them)
+#
+# Exit codes:
+#   0 = all hard checks passed (warnings allowed)
+#   1 = at least one hard check failed
+#   64 = bad usage (missing args, jq absent, plan file absent)
+#
+# Goal coverage:
+#   IG1 plan exists                                 HARD
+#   IG2 branch named impl/<slug>                    HARD
+#   IG3 ≥1 test commit + ≥1 fix commit on branch    HARD (skippable)
+#   IG4 cross-reference in PR body                  WARN-only (PR not local)
+#   IG5 plan's Test plan commands exist             WARN-only (parses prose)
+#   IG6 no diff in "Out of scope" paths             HARD when OOS declared
+#   IG7 `just check` + `just test` succeed          HARD (skippable)
+#   IG8 archive-move + backlog flip in this PR      HARD (skippable pre-final-commit)
+
+set -euo pipefail
+
+SLUG=""
+BASE="dev"
+SKIP_LIST=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --slug) SLUG="$2"; shift 2;;
+    --base) BASE="$2"; shift 2;;
+    --skip) SKIP_LIST="$2"; shift 2;;
+    -h|--help)
+      sed -n '2,40p' "$0"
+      exit 0
+      ;;
+    *) echo "unknown arg: $1" >&2; exit 64;;
+  esac
+done
+
+if [ -z "$SLUG" ]; then
+  echo "error: --slug required" >&2
+  exit 64
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required" >&2
+  exit 64
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+PLAN_PATH="$REPO_ROOT/.research/plans/$SLUG.md"
+ARCHIVE_PATH="$REPO_ROOT/.research/plans/_archive/$SLUG.md"
+EXPECTED_BRANCH="impl/$SLUG"
+
+skipped() {
+  case ",$SKIP_LIST," in
+    *",$1,"*) return 0;;
+    *) return 1;;
+  esac
+}
+
+fail_count=0
+warn_count=0
+ok()   { printf '  %s  %s\n' "ok"   "$*"; }
+warn() { printf '  %s %s\n' "WARN" "$*"; warn_count=$((warn_count+1)); }
+fail() { printf '  %s %s\n' "FAIL" "$*"; fail_count=$((fail_count+1)); }
+skip() { printf '  %s %s\n' "skip" "$*"; }
+
+echo "==> ppt-implement goal-check  slug=$SLUG  base=$BASE"
+echo "    plan:   $PLAN_PATH"
+echo "    repo:   $REPO_ROOT"
+[ -n "$SKIP_LIST" ] && echo "    skip:   $SKIP_LIST"
+echo
+
+# -----------------------------------------------------------------------
+# IG1 — Plan exists and starts with `# <slug>`
+# -----------------------------------------------------------------------
+echo "IG1  plan exists and is well-formed"
+if skipped IG1; then skip "IG1 skipped via --skip"
+elif [ ! -f "$PLAN_PATH" ]; then
+  if [ -f "$ARCHIVE_PATH" ]; then
+    warn "plan already archived at plans/_archive/$SLUG.md — assuming post-IG8 state"
+  else
+    fail "plan file not found: $PLAN_PATH"
+  fi
+else
+  # Skip optional YAML frontmatter (--- … ---) before checking for H1.
+  first_h1="$(awk '
+    NR==1 && $0=="---" { in_fm=1; next }
+    in_fm && $0=="---" { in_fm=0; next }
+    in_fm { next }
+    /^# / { print; exit }
+  ' "$PLAN_PATH")"
+  if [ -n "$first_h1" ]; then
+    ok "first H1: '$first_h1'"
+  else
+    fail "plan has no markdown H1 after optional frontmatter"
+  fi
+fi
+echo
+
+# -----------------------------------------------------------------------
+# IG2 — Branch named impl/<slug>
+# -----------------------------------------------------------------------
+echo "IG2  branch named impl/$SLUG"
+if skipped IG2; then skip "IG2 skipped via --skip"
+else
+  current_branch="$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null || echo '')"
+  if [ "$current_branch" = "$EXPECTED_BRANCH" ]; then
+    ok "current branch matches: $current_branch"
+  else
+    fail "current branch '$current_branch' != expected '$EXPECTED_BRANCH'"
+  fi
+fi
+echo
+
+# -----------------------------------------------------------------------
+# IG3 — TDD discipline: at least one test: commit AND at least one fix: commit
+# This is a proxy for "test fails on main, passes after fix". The script
+# cannot rerun the test against a different SHA without checking out — that
+# is the implementer's job. But the *shape* (two commits, conventional
+# subjects) is verifiable here.
+# -----------------------------------------------------------------------
+echo "IG3  TDD evidence — separate test: and fix: commits on branch"
+if skipped IG3; then skip "IG3 skipped via --skip (vector probably doesn't require IG3)"
+else
+  # Range: BASE..HEAD on this branch.
+  range="$BASE..HEAD"
+  if ! git -C "$REPO_ROOT" rev-parse "$BASE" >/dev/null 2>&1; then
+    warn "base '$BASE' not found locally — cannot diff. Run: git fetch origin $BASE"
+  else
+    test_commits="$(git -C "$REPO_ROOT" log "$range" --pretty=%s 2>/dev/null | grep -cE '^test(\([^)]+\))?:' || true)"
+    fix_commits="$(git -C "$REPO_ROOT" log "$range" --pretty=%s 2>/dev/null | grep -cE '^(fix|feat|perf|refactor)(\([^)]+\))?:' || true)"
+    if [ "$test_commits" -ge 1 ] && [ "$fix_commits" -ge 1 ]; then
+      ok "found $test_commits test: commit(s) and $fix_commits fix/feat/perf/refactor commit(s) on $range"
+    elif [ "$test_commits" -ge 1 ]; then
+      warn "found test: commits but no fix/feat/perf/refactor commit on $range — IG3 partially satisfied"
+    else
+      fail "no test: commit on $range — IG3 requires a failing-on-main test"
+    fi
+  fi
+fi
+echo
+
+# -----------------------------------------------------------------------
+# IG4 — "Suggested approach" steps addressed in PR body
+# Cannot verify locally; emit WARN with guidance.
+# -----------------------------------------------------------------------
+echo "IG4  suggested-approach cross-reference (PR body)"
+if skipped IG4; then skip "IG4 skipped via --skip"
+elif [ ! -f "$PLAN_PATH" ]; then
+  skip "plan absent — already archived?"
+else
+  step_count="$(awk '/^## Suggested approach/{f=1;next} f && /^## /{f=0} f' "$PLAN_PATH" | grep -cE '^[0-9]+\.' || true)"
+  if [ "$step_count" -gt 0 ]; then
+    warn "$step_count Suggested-approach step(s) in plan — confirm each is addressed or skipped in the PR body"
+  else
+    ok "no numbered Suggested-approach steps"
+  fi
+fi
+echo
+
+# -----------------------------------------------------------------------
+# IG5 — Test plan commands exist in the plan
+# Cannot run them generically (free-text). Emit WARN if Test plan section
+# is empty.
+# -----------------------------------------------------------------------
+echo "IG5  Test plan section non-empty"
+if skipped IG5; then skip "IG5 skipped via --skip"
+elif [ ! -f "$PLAN_PATH" ]; then
+  skip "plan absent — already archived?"
+else
+  tp_lines="$(awk '/^## Test plan/{f=1;next} f && /^## /{f=0} f' "$PLAN_PATH" | grep -cE '^- \[' || true)"
+  if [ "$tp_lines" -ge 1 ]; then
+    ok "$tp_lines Test-plan checklist item(s) declared — quote each command→exit-code in the PR body"
+  else
+    warn "Test plan section appears empty — add at least one verifiable command"
+  fi
+fi
+echo
+
+# -----------------------------------------------------------------------
+# IG6 — No diff in "Out of scope" paths
+# Parses bullet paths under `## Out of scope` and greps the diff.
+# -----------------------------------------------------------------------
+echo "IG6  diff respects 'Out of scope' paths"
+if skipped IG6; then skip "IG6 skipped via --skip"
+elif [ ! -f "$PLAN_PATH" ]; then
+  skip "plan absent — already archived?"
+else
+  oos_paths="$(awk '/^## Out of scope/{f=1;next} f && /^## /{f=0} f' "$PLAN_PATH" \
+    | grep -oE '`[^`]+`' | tr -d '`' \
+    | grep -vE '^\s*$' || true)"
+  if [ -z "$oos_paths" ]; then
+    ok "no Out-of-scope paths declared"
+  else
+    if ! git -C "$REPO_ROOT" rev-parse "$BASE" >/dev/null 2>&1; then
+      warn "base '$BASE' not found — cannot diff against OOS paths"
+    else
+      changed="$(git -C "$REPO_ROOT" diff --name-only "$BASE"..HEAD)"
+      breach=""
+      while IFS= read -r p; do
+        [ -z "$p" ] && continue
+        # Glob-style match: treat each declared OOS path as a literal
+        # prefix OR a glob. Use grep -E with the path made regex-safe.
+        re="$(printf '%s' "$p" | sed -e 's/[][\\.+*?(){}|^$]/\\&/g' -e 's/\\\*/.*/g')"
+        hits="$(printf '%s\n' "$changed" | grep -E "^$re" || true)"
+        if [ -n "$hits" ]; then
+          breach="$breach\n  - $p :: $(printf '%s' "$hits" | tr '\n' ' ')"
+        fi
+      done <<< "$oos_paths"
+      if [ -z "$breach" ]; then
+        ok "no changed paths under declared OOS prefixes"
+      else
+        fail "diff touches Out-of-scope paths:$(printf "$breach")"
+      fi
+    fi
+  fi
+fi
+echo
+
+# -----------------------------------------------------------------------
+# IG7 — just check + just test
+# These are slow; gated by --skip IG7 for fast pre-push smoke runs.
+# -----------------------------------------------------------------------
+echo "IG7  just check + just test"
+if skipped IG7; then skip "IG7 skipped via --skip (run before pushing)"
+elif ! command -v just >/dev/null 2>&1; then
+  warn "just not installed — skipping"
+else
+  if just --justfile "$REPO_ROOT/justfile" --list 2>/dev/null | grep -q '^    check'; then
+    if (cd "$REPO_ROOT" && just check) >/tmp/goal-check.check.log 2>&1; then
+      ok "just check passed"
+    else
+      fail "just check failed (see /tmp/goal-check.check.log)"
+    fi
+  else
+    warn "just check recipe not found"
+  fi
+  if just --justfile "$REPO_ROOT/justfile" --list 2>/dev/null | grep -q '^    test'; then
+    if (cd "$REPO_ROOT" && just test) >/tmp/goal-check.test.log 2>&1; then
+      ok "just test passed"
+    else
+      fail "just test failed (see /tmp/goal-check.test.log)"
+    fi
+  else
+    warn "just test recipe not found"
+  fi
+fi
+echo
+
+# -----------------------------------------------------------------------
+# IG8 — archive move + backlog flip in this PR
+# Pass when, in the BASE..HEAD diff, plans/<slug>.md was renamed to
+# plans/_archive/<slug>.md AND backlog.json has the row for SLUG with
+# status="done". Pre-final-commit, this check is expected to fail — that's
+# why it's skippable.
+# -----------------------------------------------------------------------
+echo "IG8  archive move + backlog status=done in this PR"
+if skipped IG8; then skip "IG8 skipped via --skip (pre-final-commit)"
+else
+  if ! git -C "$REPO_ROOT" rev-parse "$BASE" >/dev/null 2>&1; then
+    warn "base '$BASE' not found — cannot inspect diff"
+  else
+    renames="$(git -C "$REPO_ROOT" log "$BASE..HEAD" --diff-filter=R --name-status 2>/dev/null \
+      | awk -v slug=".research/plans/$SLUG.md" -v arch=".research/plans/_archive/$SLUG.md" '
+        $1 ~ /^R[0-9]+/ && $2 == slug && $3 == arch { print }')"
+    if [ -n "$renames" ]; then
+      ok "archive rename present in branch history"
+    else
+      fail "no rename of plans/$SLUG.md → plans/_archive/$SLUG.md on $BASE..HEAD"
+    fi
+
+    backlog="$REPO_ROOT/.research/backlog.json"
+    if [ -f "$backlog" ]; then
+      status="$(jq -r --arg slug "$SLUG" '.items[]? | select(.plan=="plans/\($slug).md" or .id==$slug) | .status' "$backlog" 2>/dev/null | head -1)"
+      if [ "$status" = "done" ]; then
+        ok "backlog.json row for $SLUG: status=done"
+      elif [ -z "$status" ]; then
+        warn "no backlog.json row references plans/$SLUG.md or id=$SLUG"
+      else
+        fail "backlog.json row for $SLUG: status=$status (expected done)"
+      fi
+    else
+      warn "backlog.json not found at $backlog"
+    fi
+  fi
+fi
+echo
+
+# -----------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------
+if [ "$fail_count" -eq 0 ]; then
+  echo "==> goal-check: PASS  (warnings=$warn_count)"
+  exit 0
+else
+  echo "==> goal-check: FAIL  (fails=$fail_count warnings=$warn_count)"
+  exit 1
+fi

--- a/.claude/skills/ppt-implement/scripts/test-goal-check.sh
+++ b/.claude/skills/ppt-implement/scripts/test-goal-check.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Smoke test for goal-check.sh.
+#
+# Synthesises a tiny git repo + plan file + test:/fix: commit pair and
+# asserts goal-check.sh exits 0. Then mutates the state to trigger each
+# hard-fail path and asserts exit 1.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GOAL_CHECK="$SCRIPT_DIR/goal-check.sh"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$TMP"
+git init -q
+git config user.email "test@example.com"
+git config user.name  "test"
+git commit --allow-empty -q -m "init"
+git checkout -q -b dev
+git commit --allow-empty -q -m "dev base"
+
+SLUG="demo-fix-something"
+mkdir -p .research/plans/_archive
+cat > ".research/plans/$SLUG.md" <<EOF
+# $SLUG
+
+**Vector:** bug
+
+## Hypothesis
+Demo.
+
+## Suggested approach
+1. Step one.
+
+## Test plan
+- [ ] cargo test demo
+
+## Out of scope
+- \`backend/forbidden/\`
+EOF
+
+# Initial backlog with a row for SLUG.
+mkdir -p .research
+cat > .research/backlog.json <<EOF
+{ "items": [ { "id": "$SLUG", "plan": "plans/$SLUG.md", "status": "ready" } ] }
+EOF
+
+git add -A
+git commit -q -m "chore: seed plan + backlog"
+
+# Branch the implementer would use.
+git checkout -q -b "impl/$SLUG"
+echo "fix code" > app.rs
+git add app.rs
+git commit -q -m "test(demo): regression for demo"
+echo "more fix" > app2.rs
+git add app2.rs
+git commit -q -m "fix(demo): apply fix"
+
+FAIL=0
+ok()  { printf '  ok    %s\n' "$1"; }
+bad() { printf '  FAIL  %s\n' "$1" >&2; FAIL=1; }
+
+# Case 1 — happy path, skip IG7 (no justfile) and IG8 (no archive yet).
+set +e
+"$GOAL_CHECK" --slug "$SLUG" --base dev --skip IG7,IG8 >/tmp/gc.out 2>&1
+rc=$?
+set -e
+if [ "$rc" = 0 ]; then ok "happy path passes (IG7/IG8 skipped)"
+else bad "happy path expected exit 0, got $rc"; cat /tmp/gc.out >&2; fi
+
+# Case 2 — wrong branch.
+git checkout -q -b "wrong-branch-name"
+set +e
+"$GOAL_CHECK" --slug "$SLUG" --base dev --skip IG3,IG7,IG8 >/tmp/gc.out 2>&1
+rc=$?
+set -e
+if [ "$rc" = 1 ]; then ok "wrong branch trips IG2 (exit 1)"
+else bad "wrong branch expected exit 1, got $rc"; cat /tmp/gc.out >&2; fi
+git checkout -q "impl/$SLUG"
+
+# Case 3 — missing plan.
+mv ".research/plans/$SLUG.md" ".research/plans/$SLUG.md.bak"
+set +e
+"$GOAL_CHECK" --slug "$SLUG" --base dev --skip IG3,IG7,IG8 >/tmp/gc.out 2>&1
+rc=$?
+set -e
+if [ "$rc" = 1 ]; then ok "missing plan trips IG1 (exit 1)"
+else bad "missing plan expected exit 1, got $rc"; cat /tmp/gc.out >&2; fi
+mv ".research/plans/$SLUG.md.bak" ".research/plans/$SLUG.md"
+
+# Case 4 — diff into Out-of-scope path trips IG6.
+mkdir -p backend/forbidden
+echo "drift" > backend/forbidden/oops.rs
+git add backend/forbidden/oops.rs
+git commit -q -m "feat: unwanted drift"
+set +e
+"$GOAL_CHECK" --slug "$SLUG" --base dev --skip IG3,IG7,IG8 >/tmp/gc.out 2>&1
+rc=$?
+set -e
+if [ "$rc" = 1 ]; then ok "OOS path trips IG6 (exit 1)"
+else bad "OOS drift expected exit 1, got $rc"; cat /tmp/gc.out >&2; fi
+# Undo the drift commit so subsequent cases start clean.
+git reset --hard HEAD~1 -q
+
+# Case 5 — frontmatter-bearing plan still passes IG1.
+cat > ".research/plans/$SLUG.md" <<EOF
+---
+slug: $SLUG
+vector: bug
+---
+# $SLUG
+
+## Hypothesis
+Demo.
+
+## Test plan
+- [ ] cargo test demo
+EOF
+git add -A
+git commit -q -m "chore: rewrite plan with frontmatter"
+set +e
+"$GOAL_CHECK" --slug "$SLUG" --base dev --skip IG3,IG7,IG8 >/tmp/gc.out 2>&1
+rc=$?
+set -e
+if [ "$rc" = 0 ]; then ok "frontmatter-bearing plan passes IG1"
+else bad "frontmatter plan expected exit 0, got $rc"; cat /tmp/gc.out >&2; fi
+
+if [ "$FAIL" -eq 0 ]; then
+  echo "==> test-goal-check: PASS"
+  exit 0
+else
+  echo "==> test-goal-check: FAIL"
+  exit 1
+fi

--- a/.claude/skills/verify-all.sh
+++ b/.claude/skills/verify-all.sh
@@ -78,6 +78,7 @@ run "ppt-research-trigger" 10 'test -f .research/routine-prompt.md && grep -q "S
 run "ppt-next-plan"       10 'test -f .research/backlog.json && jq -e ".items" .research/backlog.json >/dev/null'
 run "ppt-project-management" 10 'test -f .claude/skills/ppt-project-management/SKILL.md && test -f .claude/agents/pm-scrum-master.md && test -d .research/management/roles && jq -e ".items" .research/management/action-list.json >/dev/null && jq -e ".items" .research/management/risks.json >/dev/null && jq -e ".stories" .research/management/coverage.json >/dev/null'
 run "ppt-implement"       10 'test -f .claude/skills/ppt-implement/SKILL.md && ls .claude/skills/ppt-implement/agents/*.md | wc -l | grep -qE "^9$" && bash .claude/skills/_verify-skill.sh .claude/skills/ppt-implement'
+run "ppt-implement/goal-check" 30 'bash .claude/skills/ppt-implement/scripts/test-goal-check.sh >/dev/null'
 run "ppt-review-merged"   10 'test -f .claude/skills/ppt-review-merged/SKILL.md && bash .claude/skills/_verify-skill.sh .claude/skills/ppt-review-merged'
 run "ppt-pr-merge"        10 'test -f .claude/skills/ppt-pr-merge/SKILL.md && bash .claude/skills/_verify-skill.sh .claude/skills/ppt-pr-merge'
 run "ppt-dev-team"        10 'test -f .claude/skills/ppt-dev-team/SKILL.md && bash .claude/skills/_verify-skill.sh .claude/skills/ppt-dev-team'

--- a/.research/implementer-prompt.md
+++ b/.research/implementer-prompt.md
@@ -22,7 +22,18 @@ needs.
 ## Goals (verifiable)
 
 Each goal has a plain-language success criterion and the exact command that
-verifies it. Run the relevant goal checks before opening the PR; quote the
+verifies it. All eight checks are also bundled into a single runnable
+script — prefer it over re-typing the inline commands:
+
+```bash
+bash .claude/skills/ppt-implement/scripts/goal-check.sh --slug "$SLUG" --base dev
+```
+
+Exit 0 = all hard checks passed (warnings OK); exit 1 = open a draft, not a
+ready PR. The individual `IG<N>` definitions below remain canonical — the
+script just bundles them.
+
+Run the relevant goal checks before opening the PR; quote the
 output in the PR body.
 
 ### IG1 — Plan exists and was loaded


### PR DESCRIPTION
## Summary

IG1–IG8 success criteria were documented as inline shell snippets in `.research/implementer-prompt.md` with no single runnable wrapper. Every implementer either re-typed the commands or grepped the prompt for them. This PR extracts them into one script and wires it into the verify pipeline.

## What's new

**`scripts/goal-check.sh`** — single entry point with `--slug` / `--base` / `--skip`. T-style output matching the dispatcher self-test's house style. Exit 0 on all-hard-pass (warnings allowed); 1 on any hard fail.

Per-IG:

| IG | Check | Verdict |
|---|---|---|
| IG1 | Plan exists + well-formed H1 (frontmatter-aware) | HARD |
| IG2 | Branch named `impl/<slug>` | HARD |
| IG3 | ≥1 `test:` commit + ≥1 fix/feat/perf/refactor commit on `<base>..HEAD` | HARD (skippable) |
| IG4 | Cross-reference in PR body | WARN (PR not local) |
| IG5 | Test plan section non-empty | WARN (free-text) |
| IG6 | Diff respects `## Out of scope` paths | HARD when declared |
| IG7 | `just check` + `just test` | HARD (skippable) |
| IG8 | Archive move + backlog `status=done` in PR | HARD (skippable pre-final-commit) |

**`scripts/test-goal-check.sh`** — 5-case smoke test (happy path, wrong branch, missing plan, OOS drift trip, frontmatter plan). All pass locally. Wired into `verify-all.sh` as `ppt-implement/goal-check` with a 30s budget.

**`SKILL.md` Step 3.5** — new mandatory step right before `gh pr create`. Recommends `--skip IG7` (Step 3 already ran the verify gate) for the normal path, and additional `--skip IG8` for pre-final commits (archive move is intentionally the LAST commit).

**`implementer-prompt.md`** — points readers at the script up front; the IG1–IG8 inline definitions stay canonical and the script just bundles them, so the prompt prose remains the source of truth.

## Subtle bug worth noting

Section extraction uses `awk '/^## H/{f=1;next} f && /^## /{f=0} f'` rather than awk's range operator `/^## H/,/^## /`. The range form closes on the *same line where it opens* because the start-line itself matches the end pattern — silently dropping the body. The flag-based form is unambiguous and trips IG6 correctly even when `## Out of scope` is the last section in the plan.

## Test plan

- [x] `bash .claude/skills/ppt-implement/scripts/test-goal-check.sh` → PASS locally
- [x] `bash .claude/skills/ppt-implement/scripts/goal-check.sh --slug p0-10-mock-route-wiring --skip IG2,IG3,IG7,IG8` exercises a real frontmatter-bearing plan → IG1 passes
- [ ] `verify-all.sh --quick` in CI picks up the new test runner

## Rollback

`git revert <merge-sha>`. New files, no schema or data changes.