### PR TITLE
fix(ios): #618 #625 + #578 tests — gesture mask, sheet env, SSO CSRF tests

### DIFF
--- a/mobile-native/iosApp/iosApp/Features/Listing/ListingDetailView.swift
+++ b/mobile-native/iosApp/iosApp/Features/Listing/ListingDetailView.swift
@@ -600,11 +600,17 @@ private struct ZoomablePhotoPage: View {
                             .scaleEffect(effectiveScale)
                             .offset(x: offset.width + gestureOffset.width,
                                     y: offset.height + gestureOffset.height)
+                            // Magnification is always active. The drag gesture
+                            // is mask-disabled at 1x so the parent TabView's
+                            // swipe-to-page recognizer wins horizontal swipes
+                            // when the photo is not zoomed in (closes #618).
+                            // Without this, DragGesture competed with TabView
+                            // even though `gestureOffset` was guarded — the
+                            // recognizer still consumed touches arbitrarily.
+                            .gesture(magnificationGesture)
                             .gesture(
-                                SimultaneousGesture(
-                                    magnificationGesture,
-                                    dragGesture
-                                )
+                                dragGesture,
+                                including: scale > minScale ? .all : .none
                             )
                             .onTapGesture(count: 2) {
                                 handleDoubleTap()

--- a/mobile-native/iosApp/iosApp/Features/Search/SearchView.swift
+++ b/mobile-native/iosApp/iosApp/Features/Search/SearchView.swift
@@ -63,9 +63,17 @@ struct SearchView: View {
             }
         }
         .sheet(isPresented: $showFilters) {
+            // SwiftUI's `.sheet` creates a new view-hierarchy context that
+            // does NOT inherit `@Observable` environment values injected
+            // above the presenter. Without this `.environment(locationManager)`
+            // re-injection the FilterSheet's `@Environment(LocationManager.self)`
+            // would resolve to a default-initialised LocationManager (or crash
+            // on older iOS), so the "Near Me" toggle inside the sheet would
+            // never call `requestLocation()` on the shared instance (closes #625).
             FilterSheet(filters: $filters) {
                 Task { await performSearch() }
             }
+            .environment(locationManager)
         }
         .confirmationDialog(String(localized: "sort_by"), isPresented: $showSortPicker, titleVisibility: .visible) {
             ForEach(SortOption.allCases, id: \.self) { option in

--- a/mobile-native/iosApp/iosAppTests/RealityPortalTests.swift
+++ b/mobile-native/iosApp/iosAppTests/RealityPortalTests.swift
@@ -118,6 +118,81 @@ final class AuthenticationTests: XCTestCase {
         let auth = AuthManager()
         XCTAssertFalse(auth.isAuthenticated)
     }
+
+    // MARK: SSO CSRF nonce (closes #578 secondary finding)
+    //
+    // These tests pin the contract of `beginSsoFlow` / `consumeSsoState`:
+    // a freshly minted nonce must validate exactly once, all other inputs
+    // (nil, empty, mismatched, replay) must be rejected, and successive
+    // calls to `beginSsoFlow` must yield distinct values.
+
+    func testBeginSsoFlowReturnsHexString() throws {
+        let auth = AuthManager()
+        let nonce = auth.beginSsoFlow()
+        // 32 random bytes → 64 hex chars; allow the UUID fallback (≥ 32 chars).
+        XCTAssertGreaterThanOrEqual(nonce.count, 32)
+        let allowed = CharacterSet(charactersIn: "0123456789abcdefABCDEF-")
+        XCTAssertTrue(nonce.unicodeScalars.allSatisfy { allowed.contains($0) })
+    }
+
+    func testBeginSsoFlowGeneratesUniqueNoncesAcrossCalls() throws {
+        let auth = AuthManager()
+        // We compare two successive calls — the second overwrites the first
+        // pending value, which is acceptable (caller starts a new flow).
+        let first = auth.beginSsoFlow()
+        let second = auth.beginSsoFlow()
+        XCTAssertNotEqual(first, second, "Two SSO flows must mint different nonces")
+    }
+
+    func testConsumeSsoStateAcceptsMatchingNonce() throws {
+        let auth = AuthManager()
+        let nonce = auth.beginSsoFlow()
+        XCTAssertTrue(auth.consumeSsoState(nonce))
+    }
+
+    func testConsumeSsoStateRejectsMismatch() throws {
+        let auth = AuthManager()
+        _ = auth.beginSsoFlow()
+        XCTAssertFalse(auth.consumeSsoState("not-the-real-nonce"))
+    }
+
+    func testConsumeSsoStateRejectsNil() throws {
+        let auth = AuthManager()
+        _ = auth.beginSsoFlow()
+        XCTAssertFalse(auth.consumeSsoState(nil))
+    }
+
+    func testConsumeSsoStateRejectsEmptyString() throws {
+        let auth = AuthManager()
+        _ = auth.beginSsoFlow()
+        XCTAssertFalse(auth.consumeSsoState(""))
+    }
+
+    func testConsumeSsoStateIsSingleUse() throws {
+        // Replay protection: a successful consume must clear the pending
+        // value, so a second attempt with the same nonce returns false.
+        let auth = AuthManager()
+        let nonce = auth.beginSsoFlow()
+        XCTAssertTrue(auth.consumeSsoState(nonce))
+        XCTAssertFalse(auth.consumeSsoState(nonce))
+    }
+
+    func testConsumeSsoStateRejectsWhenNoFlowStarted() throws {
+        // Fresh AuthManager — no `beginSsoFlow` call — must reject any input.
+        let auth = AuthManager()
+        XCTAssertFalse(auth.consumeSsoState("anything"))
+        XCTAssertFalse(auth.consumeSsoState(nil))
+    }
+
+    func testFailedConsumeAlsoClearsPendingState() throws {
+        // A mismatched consume must also clear the pending nonce so a
+        // probe with the wrong state can't be retried with the right one.
+        let auth = AuthManager()
+        let nonce = auth.beginSsoFlow()
+        XCTAssertFalse(auth.consumeSsoState("wrong"))
+        XCTAssertFalse(auth.consumeSsoState(nonce),
+                       "First consume cleared the pending nonce, second must fail")
+    }
 }
 
 // MARK: - Deep Link / URL Parsing Tests


### PR DESCRIPTION
Closes #618.
Closes #625.
Partially closes #578 (primary fix already on dev — this PR adds the missing unit tests called out as a secondary finding).

## Summary

Three iOS SwiftUI follow-ups bundled into one focused PR.

### #618 — `ZoomablePhotoPage` DragGesture vs TabView swipe at 1x

`ZoomablePhotoPage` combined drag + magnification via `SimultaneousGesture` at all zoom levels. The `scale > minScale` guard inside `dragGesture` blocked visual movement, but the recognizer still competed with the parent `TabView`'s swipe-to-page, so horizontal swipes at 1x intermittently got eaten by drag.

Fix: split the two gestures and use the `including:` mask on the drag gesture so it is fully disabled at 1x — TabView wins all touches at default zoom.

```swift
.gesture(magnificationGesture)
.gesture(dragGesture, including: scale > minScale ? .all : .none)
```

### #625 — `FilterSheet` missing `LocationManager` environment

`FilterSheet` is presented via `.sheet(isPresented:)` and declares `@Environment(LocationManager.self)`, but SwiftUI does NOT propagate `@Observable` environment values across the sheet boundary on iOS 17. The "Near Me" toggle inside the sheet therefore resolved to a default-initialised `LocationManager` and `requestLocation()` was never invoked on the shared instance.

Fix: re-inject `.environment(locationManager)` on the sheet content so `FilterSheet` sees the same manager as `SearchView`.

### #578 — primary fix already on dev; this PR adds the missing tests

The blocking correctness defect (`LoginView` not calling `authManager.beginSsoFlow()`) is already in dev — `LoginView.swift` now mints the state and embeds it as `&state=…`. The follow-up issue also called out three secondary findings; this PR handles **one** of them: unit tests for `AuthManager.beginSsoFlow` / `consumeSsoState`.

Added under `AuthenticationTests` in `RealityPortalTests.swift`:
- returns a hex/UUID-shaped nonce
- successive calls mint distinct nonces
- matching nonce validates, mismatched / nil / empty are rejected
- single-use replay protection
- failed consume also clears pending (no second-shot probing)
- rejects all inputs when no flow was started

## Deferred (still tracked on #578)

- `DeepLinkHandler.allowedUniversalLinkHosts` still contains `reality.example.com` / `staging-reality.example.com` placeholders. Needs the real production/staging hostnames before AASA is wired — separate PR once the domain is decided.
- `Base.xcconfig` `MARKETING_VERSION = $(inherited)` with no fallback. Verify CI passes `MARKETING_VERSION=…` on `xcodebuild`, or add a concrete fallback — separate PR.

## Test plan

- [ ] CI `build-ios` job builds the app
- [ ] CI runs the new `AuthenticationTests` cases
- [ ] Manual: in the photo gallery, swipe horizontally at 1x — TabView advances to next photo without hesitation
- [ ] Manual: open Search → Filters → toggle "Near Me" — verify it requests location (the same shared `LocationManager` the parent uses)