### PR TITLE
chore(dispatcher): bump to Opus 4.8 — routine + Phase 5 reviewer + Phase 8 self-review

### DIFF
--- a/.research/README.md
+++ b/.research/README.md
@@ -98,10 +98,21 @@ Setup at https://claude.ai/code/routines → **New routine**.
 | **Name** | `ppt-research` |
 | **Instructions** | full contents of `routine-prompt.md` |
 | **Repository** | `martin-janci/property-management`, branch `main`, ✅ *Allow unrestricted branch pushes* |
-| **Model** | Sonnet 4.6 (or Opus 4.7 for higher-quality analyses; Opus costs more) |
+| **Model** | Sonnet 4.6 (or Opus 4.8 for higher-quality analyses; Opus costs more) |
 | **Connectors** | **None.** The routine uses `gh` CLI via Bash. |
 | **Schedule** | Daily 05:00 local |
 | **API trigger** | Optional — handy for ad-hoc `text: "deep"` or `text: "reset"` runs |
+
+**Sibling routine — `ppt-research-dispatcher`.** Same setup as above with
+these overrides:
+
+| Field | Value |
+|---|---|
+| **Name** | `ppt-research-dispatcher` |
+| **Instructions** | full contents of `dispatcher-prompt.md` |
+| **Model** | **Opus 4.8** — the dispatcher's per-PR review (Phase 5) and self-review (Phase 8) both spawn Opus subagents internally; running the dispatcher itself on Opus avoids a Sonnet→Opus context handoff between phases and keeps reasoning consistent across the whole loop. |
+| **Schedule** | Every ~2h |
+| **Branch target** | commits to `dev` (not `main` — see *Routine vs dispatcher state* below) |
 
 ### Environment
 

--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -855,6 +855,15 @@ if new_status != prev_status:
 
 SKIP if `$DISPATCHER_SKIP_MUTATING == 1` (recent-run gate from Phase 1 step 2).
 
+**Spawn config:** every reviewer subagent runs with
+`subagent_type=general-purpose, model=opus` (pinned to Opus 4.8). The
+reviewer's job — diff-triage, security read, scope-drift judgement, vendor
+the verdict line — benefits materially from Opus's reasoning over Sonnet's
+default; the dispatcher's per-PR review is the single point where the
+bot decides "merge or block", so cost-per-PR is well spent. Reviewer cap
+is unbounded by phase contract; the cost ceiling is the count of pending
+`review` rows in `assignments.json`.
+
 For each row where `status == "review"` AND (`reviewer_summary` is null OR `PR.headRefOid != row.last_reviewed_oid`):
 
 > You are a code reviewer for PR #<n>. Task: `<task_id>: <action>`. Specialist:
@@ -1427,7 +1436,7 @@ fi
 ```
 
 **Spawn:** one Task subagent (`subagent_type=general-purpose`,
-**`model=opus`** — pin to Opus 4.7 for sharper diff-of-runs reasoning;
+**`model=opus`** — pin to Opus 4.8 for sharper diff-of-runs reasoning;
 worth the extra cost for a temporary instrumented phase). NOT parallel
 with anything else — this is the last thing the run does.
 
@@ -1631,7 +1640,7 @@ the dispatcher never auto-applies a fix.
 This line is NOT in the regular Phase 7 list above because it depends on
 this whole phase being optional. Treat it as a Phase 8 epilogue line.
 
-**Cost note (TEMP_PHASE_8):** Opus 4.7 input is ~5× Sonnet. A typical
+**Cost note (TEMP_PHASE_8):** Opus 4.8 input is ~5× Sonnet. A typical
 self-review subagent run will consume ~5-10k input tokens (gathering bash
 outputs + writing 60 lines markdown). Per-run cost: roughly $0.10-0.30 in
 Opus pricing. At 12 runs/day that's ~$2-4/day. Acceptable for the


### PR DESCRIPTION
## Summary

Spec/doc-only bump from Opus 4.7 → Opus 4.8 across three touchpoints in the dispatcher prompt and the README. No code or data changes.

## Changes

**`.research/dispatcher-prompt.md`**

- **Phase 5 reviewer** spawn config now pins `model=opus` (Opus 4.8) explicitly. Previously the reviewer subagent inherited the routine default model. The per-PR review is the single point where the bot decides *merge or block* — diff-triage + scope-drift judgement + security read benefit materially from Opus reasoning over Sonnet. Reviewer cap unchanged.
- **Phase 8 self-review** prose: "Opus 4.7" → "Opus 4.8".
- **Cost note** under TEMP_PHASE_8: "Opus 4.7 input is ~5× Sonnet" → "Opus 4.8".

**`.research/README.md`**

- Research routine table model row: "Opus 4.7" → "Opus 4.8".
- Added a sibling `ppt-research-dispatcher` routine config block documenting Opus 4.8 as the dispatcher routine's model. Rationale: running the dispatcher itself on Opus avoids a Sonnet → Opus context handoff between phases (Phase 5 + Phase 8 are already Opus-pinned internally).

## Operator action required

The actual model selection happens in the `claude.ai/code/routines` UI when the operator configures the routine. These spec edits document the intended config — **the operator needs to flip the dropdown in both routines** (`ppt-research` and `ppt-research-dispatcher`).

## Verification

- [x] `bash .research/dispatcher-self-test.sh` → PASS locally
- [ ] Same in CI

## Rollback

`git revert <merge-sha>`. Doc/spec only — no behavior change in the repo itself, only documents intent.