### PR TITLE
feat(research): dispatcher finish-first depth-first claim (PR 3/5)

### DIFF
--- a/.claude/skills/ppt-goal-gate/SKILL.md
+++ b/.claude/skills/ppt-goal-gate/SKILL.md
@@ -20,13 +20,39 @@ mode: cloud-ok
 
 Stem-uniqueness is enforced separately as `T20` in `dispatcher-self-test.sh`.
 
+### Finish-first picker (PR 3/5 — `pick-target-epic.sh`)
+
+`.research/pick-target-epic.sh` selects ONE target epic per dispatcher run
+(behind `DISPATCHER_FINISH_FIRST=1`) and writes it to
+`.research/management/objective.json`. The dispatcher's Phase 3 filters
+claim candidates to that target epic, biasing all 3 slots toward
+finishing one epic before starting another. Rule: **closest-to-done** —
+prefer the epic with fewest claimable open tasks; tie-break by max
+priority. Idempotent: KEEPs the current target until exhausted.
+
+Schema for `objective.json`:
+
+```json
+{ "schema_version": 1,
+  "epic_prefix": "gap-10a",
+  "selected_at": "2026-05-28T18:50:52Z",
+  "last_action": "select|keep|repick",
+  "reason": "<one-line explanation>",
+  "stats_at_selection": { "open": 2, "claimable": 1 } }
+```
+
+Enforced by self-test `T21` (epic_prefix matches `gap-N[a-z]?` or
+`pm-<role>` or the `NONE` sentinel for no-claimable-work runs).
+
 ## Inputs
 - `.research/management/coverage.json`, `action-list.json`, `assignments.json` (override via `COVERAGE` / `ACTION_LIST` / `ASSIGN` env).
 - `GOAL_CHECK_ENFORCE=1` makes the hard-fail subset (GC2) exit non-zero. Default: record-only (exit 0).
+- `DISPATCHER_FINISH_FIRST=1` makes Phase 3 invoke `pick-target-epic.sh` and filter claims to one epic.
 
 ## Steps
 1. `./.research/goal-check.sh` — human-readable, record-only.
 2. `./.research/goal-check.sh --json` — emit the `goal_checks[]` array (the dispatcher embeds the summary in its commit).
+3. `./.research/pick-target-epic.sh --json` — dry-run; `--update` writes `objective.json`. Dispatcher Phase 3 always runs with `--update` under `DISPATCHER_FINISH_FIRST=1`.
 
 ## Deterministic verification
 - `test -x .research/goal-check.sh`
@@ -34,9 +60,11 @@ Stem-uniqueness is enforced separately as `T20` in `dispatcher-self-test.sh`.
 - Against the fixtures, GC1 reports `orphans=1 done_with_open_gap=1` and T20 reports a duplicate stem.
 
 ## Smoke check
-`COVERAGE=.research/fixtures/goal-check/coverage.json ACTION_LIST=.research/fixtures/goal-check/action-list.json ASSIGN=.research/fixtures/goal-check/assignments.json ./.research/goal-check.sh --json | jq -e 'length >= 3'`
+- `COVERAGE=.research/fixtures/goal-check/coverage.json ACTION_LIST=.research/fixtures/goal-check/action-list.json ASSIGN=.research/fixtures/goal-check/assignments.json ./.research/goal-check.sh --json | jq -e 'length >= 3'`
+- `bash .research/test-pick-target-epic.sh` (5-case synthetic-fixture smoke)
 
 ## Cross-references
-- `.research/dispatcher-prompt.md` Phase 6 (invocation), HARD RULES.
-- `.research/dispatcher-self-test.sh` T20.
+- `.research/dispatcher-prompt.md` Phase 3 (finish-first preamble + filter), Phase 6 (goal-check invocation), Phase 7 (Target-epic line), HARD RULES.
+- `.research/dispatcher-self-test.sh` T20 (stem-uniqueness), T21 (objective.json shape).
+- `.research/pick-target-epic.sh` + `.research/test-pick-target-epic.sh`.
 - `docs/superpowers/specs/2026-05-28-dispatcher-goal-convergence-design.md` (Pillar 1).

--- a/.claude/skills/verify-all.sh
+++ b/.claude/skills/verify-all.sh
@@ -116,6 +116,7 @@ run "ppt-db-migrations"   10 'test -d backend/crates/db/migrations && test -d ba
 # Live onyx / deploy ops are out of scope for a generic harness.
 run "ppt-deploy"          10 'test -f .claude/skills/ppt-deploy/SKILL.md && test -d .claude/skills/ppt-deploy/commands && test -d .claude/skills/ppt-deploy/references && { ! command -v pmctl >/dev/null 2>&1 || pmctl --help >/dev/null 2>&1; }'
 run "ppt-goal-gate"       10 'test -x .research/goal-check.sh && COVERAGE=.research/fixtures/goal-check/coverage.json ACTION_LIST=.research/fixtures/goal-check/action-list.json ASSIGN=.research/fixtures/goal-check/assignments.json ./.research/goal-check.sh --json | jq -e "length >= 3" >/dev/null'
+run "ppt-goal-gate/pick-target-epic" 15 'test -x .research/pick-target-epic.sh && bash .research/test-pick-target-epic.sh >/dev/null'
 
 echo
 echo "== summary =="

--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -537,6 +537,32 @@ Idempotency: items already `status=="dropped"` are skipped.
 
 SKIP if `$DISPATCHER_SKIP_MUTATING == 1` (recent-run gate from Phase 1 step 2).
 
+### Finish-first preamble (PR 3/5 — behind `DISPATCHER_FINISH_FIRST=1`)
+
+When the flag is set, the dispatcher biases all 3 slots toward **one
+target epic per run** instead of spraying claims across epics. The goal
+is depth-first convergence: close out one epic before starting the next.
+
+The target epic lives in `.research/management/objective.json` (schema:
+`{schema_version, epic_prefix, selected_at, last_action, reason,
+stats_at_selection}`). The picker keeps it idempotent — re-running on a
+target with claimable work is a no-op KEEP.
+
+```bash
+if [ "${DISPATCHER_FINISH_FIRST:-0}" = "1" ]; then
+  PICK_OUT=$(.research/pick-target-epic.sh --update --json)
+  TARGET_EP=$(echo "$PICK_OUT" | jq -r .epic_prefix)
+  PICK_ACTION=$(echo "$PICK_OUT" | jq -r .action)
+  # Surface in Phase 7 → "Target epic:" line (see Phase 7 spec).
+  echo "Phase 3 finish-first: $PICK_OUT"
+fi
+```
+
+The picker rule is **closest-to-done**: prefer the epic with the fewest
+remaining claimable open tasks, tie-break by max priority. The dispatcher
+abandons the current target only when it is exhausted (0 claimable opens
+left). See `pick-target-epic.sh` for the full rule.
+
 ```python
 free_slots = 3   # constant per run
 
@@ -593,6 +619,27 @@ Define `epic_prefix(task_id)` as the first matching pattern:
 - else: full `task_id`
 
 After candidate sort, walk the list and **claim at most 2 tasks per `epic_prefix` per run**, unless the epic has at least one task in `merged` status in `assignments.json` already (cold-epic protection: avoid spending all 3 slots on the same blocked epic). If the 3rd candidate has the same prefix as the first 2 picked, skip it and continue scanning for a different-prefix candidate. If no different-prefix candidate exists, claim only the 2 — `free_slots=1` is fine, do not pad with same-prefix.
+
+**Finish-first override (PR 3/5).** When `DISPATCHER_FINISH_FIRST=1` AND the
+finish-first preamble selected a target epic (`TARGET_EP != "NONE"`):
+
+1. Before sort, **filter candidates** to those whose `epic_prefix == TARGET_EP`.
+2. The same-epic 2/run cap is **lifted** — claim up to all 3 slots from the
+   target epic. The whole point of finish-first is depth-first concentration.
+3. **Fallback to the unfiltered pool** if the target epic yields 0 claimable
+   candidates after the filter (e.g. all dep-blocked at this exact moment).
+   This prevents the run from going idle when the target is temporarily
+   stuck; the picker will repick on the next exhaustion.
+4. Cold-epic protection (the existing carve-out) doesn't apply when
+   finish-first is active — the operator chose to concentrate on the target
+   even if it has no merges yet; that's the bootstrap case.
+
+The fallback is intentionally narrow: it only triggers when the *filtered*
+candidate list is empty, NOT when finish-first claims fewer than 3 from the
+target. If the target has only 1 claimable task, claim 1 — don't pad with
+other-epic candidates. Filling the run with off-target work defeats the
+finish-first contract and dilutes the signal in Phase 7's `Target epic:`
+line.
 
 **Cross-PR dedup guards.**
 
@@ -1361,6 +1408,7 @@ always appear so it is visible in dispatcher commits when the check actually ran
 Claimed (this run):       [<id> -> <specialist>, …]                (≤3, may be [])
 Same-epic skipped:        [<id> (would exceed 2/epic), …]          (item #2; [] if none)
 Dup-skipped:              [<id> reason=<open-pr|open-assignment|file-overlap> conflicts_with=<#n|task_id>, …]   (cross-PR dedup guards; [] if none)
+Target epic:              <epic_prefix open=N claimable=M action=<keep|select|repick|empty> | off>   (PR 3/5 finish-first; "off" when DISPATCHER_FINISH_FIRST≠1)
 Transitions (this run):   [<id> in-progress→review, …]             ([] if none)
 In-progress (global now): <N> total across all overlapping runs (no cap)
 In review (PR open):      <M>

--- a/.research/dispatcher-self-test.sh
+++ b/.research/dispatcher-self-test.sh
@@ -477,6 +477,31 @@ else
 fi
 echo
 
+# --- T21: objective.json sanity (PR 3/5 finish-first) ----------------------
+# When DISPATCHER_FINISH_FIRST=1, the dispatcher reads/writes
+# .research/management/objective.json. T21 enforces:
+#   * if the file exists, it's valid JSON with the expected schema
+#   * epic_prefix is a non-empty string and either matches one of the
+#     epic-prefix regexes used by the dispatcher (gap-N[a-z]? or pm-<role>)
+#     OR equals "NONE" (the picker's "no claimable work" sentinel).
+# Soft-fail: if the file doesn't exist, T21 is a no-op (the picker
+# creates it on first finish-first run; absence is the default state).
+OBJECTIVE_FILE="${OBJECTIVE_FILE:-.research/management/objective.json}"
+if [ -f "$OBJECTIVE_FILE" ]; then
+  echo "T21 objective.json schema + epic_prefix shape (PR 3/5)"
+  if ! jq -e '.schema_version and .epic_prefix and .selected_at' "$OBJECTIVE_FILE" >/dev/null 2>&1; then
+    fail "$OBJECTIVE_FILE missing one of {schema_version, epic_prefix, selected_at}"
+  else
+    EP=$(jq -r '.epic_prefix' "$OBJECTIVE_FILE")
+    case "$EP" in
+      NONE) note "objective=NONE (no claimable work)";;
+      gap-[0-9]*|pm-*) note "objective epic_prefix='$EP' is well-formed";;
+      *) fail "objective.epic_prefix='$EP' does not match gap-N[a-z]? or pm-<role> or NONE";;
+    esac
+  fi
+  echo
+fi
+
 # --- Summary ---------------------------------------------------------------
 if [ "$FAIL" = "0" ]; then
   echo "==> dispatcher-self-test: PASS"

--- a/.research/management/objective.json
+++ b/.research/management/objective.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "epic_prefix": "gap-10a",
+  "selected_at": "2026-05-28T18:50:52Z",
+  "last_action": "select",
+  "reason": "initial selection: closest-to-done is 'gap-10a' (open=2 claimable=1)",
+  "stats_at_selection": {
+    "open": 2,
+    "claimable": 1
+  }
+}

--- a/.research/pick-target-epic.sh
+++ b/.research/pick-target-epic.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# pick-target-epic.sh — finish-first depth-first epic selector for the
+# dispatcher's Phase 3 claim, behind DISPATCHER_FINISH_FIRST=1.
+#
+# Rule (matches the PR 3/5 design decision):
+#   1. Load current target from objective.json.
+#   2. If the current target still has ≥1 claimable open task →
+#      KEEP. Print + exit 0.
+#   3. Else: pick the epic with the fewest remaining open claimable
+#      tasks (tie-break: max priority among that epic's open items).
+#      "Closest-to-done" semantics — bias toward finishing what's
+#      almost done.
+#   4. Write the new target to objective.json (idempotent — same
+#      epic_prefix → same file content).
+#
+# "Claimable" = open in action-list, NOT in active assignments,
+#               NOT in archive, NOT dep-blocked.
+#
+# Output (default — line-oriented, grep-friendly):
+#   epic_prefix=<prefix> open=<n> claimable=<m> action=<keep|repick|empty> reason=<short>
+#
+# Output (--json):
+#   {"epic_prefix":..., "open":N, "claimable":M, "action":..., "reason":...}
+#
+# Exit codes:
+#   0 — target selected (or no work available; epic_prefix=NONE)
+#  64 — usage error
+#  65 — input files missing or unparseable
+#
+# Usage:
+#   pick-target-epic.sh [--update] [--json]
+#                       [--action-list <path>] [--assignments <path>]
+#                       [--archive <path>] [--objective <path>]
+#
+# Flags:
+#   --update     write the chosen target to <objective>. Without it,
+#                the script is read-only (dry-run; prints the choice).
+#   --json       emit one-line JSON instead of key=value pairs.
+#   --action-list / --assignments / --archive / --objective
+#                override the default paths (under .research/).
+
+set -euo pipefail
+
+ACTION_LIST="${ACTION_LIST:-.research/management/action-list.json}"
+ASSIGN="${ASSIGN:-.research/management/assignments.json}"
+ARCHIVE="${ARCHIVE:-.research/management/assignments-archive.json}"
+OBJECTIVE="${OBJECTIVE:-.research/management/objective.json}"
+UPDATE=0
+EMIT_JSON=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --update) UPDATE=1; shift;;
+    --json)   EMIT_JSON=1; shift;;
+    --action-list) ACTION_LIST="$2"; shift 2;;
+    --assignments) ASSIGN="$2"; shift 2;;
+    --archive)     ARCHIVE="$2"; shift 2;;
+    --objective)   OBJECTIVE="$2"; shift 2;;
+    -h|--help) sed -n '2,40p' "$0"; exit 0;;
+    *) echo "unknown arg: $1" >&2; exit 64;;
+  esac
+done
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq required" >&2; exit 64
+fi
+for f in "$ACTION_LIST" "$ASSIGN" "$ARCHIVE"; do
+  if [ ! -f "$f" ]; then
+    echo "error: missing input: $f" >&2; exit 65
+  fi
+done
+
+# ---- helpers -------------------------------------------------------
+
+# epic_prefix(task_id) — mirror the definition in dispatcher-prompt.md
+# Phase 3 "Same-epic burst-claim guard":
+#   ^(gap-\d+[a-z]?)
+#   ^(pm-[a-z-]+?)-
+#   else: full task_id
+epic_prefix_jq='
+  def epic_prefix:
+    if test("^gap-[0-9]+[a-z]?") then capture("^(?<e>gap-[0-9]+[a-z]?)").e
+    elif test("^pm-[a-z-]+?-") then capture("^(?<e>pm-[a-z-]+?)-").e
+    else . end;
+'
+
+# Build the set of task_ids that are NOT claimable: in active assignments
+# (any non-terminal status) OR in archive (terminal).
+NOT_CLAIMABLE=$(jq -r '
+  .assignments[]
+  | select(.status=="in-progress" or .status=="review" or .status=="merged" or .status=="failed" or .status=="done")
+  | .task_id' "$ASSIGN" "$ARCHIVE" | sort -u)
+
+# Build per-epic stats over action-list open items.
+# Each row: epic_prefix \t total_open \t claimable_open \t max_priority_rank
+# priority_rank: critical=4 high=3 medium=2 low=1 (default 0)
+STATS=$(jq -r --argjson not_claimable "$(printf '%s\n' "$NOT_CLAIMABLE" | jq -R . | jq -s .)" '
+  '"$epic_prefix_jq"'
+  def pri_rank:
+    if . == "critical" then 4
+    elif . == "high" then 3
+    elif . == "medium" then 2
+    elif . == "low" then 1
+    else 0 end;
+  # Items with non-empty depends_on are conservatively treated as
+  # not-claimable here (Phase 2.6 computes the precise dep_blocked set).
+  # The dispatcher will refine this; the picker only needs a useful
+  # approximation for finish-first.
+  [ .items[]
+    | select(.status=="open")
+    | .id as $tid
+    | { ep: ($tid | epic_prefix),
+        id: $tid,
+        claimable: ((($not_claimable | index($tid)) | not)
+                    and ((.depends_on // []) | length == 0)),
+        pr: (.priority | pri_rank) }
+  ]
+  | group_by(.ep)
+  | map({
+      ep: .[0].ep,
+      total_open: length,
+      claimable_open: (map(select(.claimable)) | length),
+      max_priority: (map(.pr) | max)
+    })
+  | sort_by([.claimable_open, -.max_priority])
+  | .[]
+  | "\(.ep)\t\(.total_open)\t\(.claimable_open)\t\(.max_priority)"
+' "$ACTION_LIST")
+
+# ---- decide --------------------------------------------------------
+
+CURRENT_EP=""
+if [ -f "$OBJECTIVE" ]; then
+  CURRENT_EP=$(jq -r '.epic_prefix // empty' "$OBJECTIVE" 2>/dev/null || true)
+fi
+
+ACTION=""
+CHOSEN_EP=""
+CHOSEN_OPEN=0
+CHOSEN_CLAIMABLE=0
+REASON=""
+
+# 1. If we have a current target, check whether it still has claimable work.
+if [ -n "$CURRENT_EP" ]; then
+  cur_row=$(printf '%s\n' "$STATS" | awk -F'\t' -v ep="$CURRENT_EP" '$1==ep {print; exit}')
+  if [ -n "$cur_row" ]; then
+    cur_claimable=$(echo "$cur_row" | awk -F'\t' '{print $3}')
+    cur_open=$(echo "$cur_row" | awk -F'\t' '{print $2}')
+    if [ "$cur_claimable" -ge 1 ]; then
+      ACTION="keep"
+      CHOSEN_EP="$CURRENT_EP"
+      CHOSEN_OPEN="$cur_open"
+      CHOSEN_CLAIMABLE="$cur_claimable"
+      REASON="current target still has claimable work"
+    fi
+  fi
+fi
+
+# 2. No current target, or current target exhausted → pick closest-to-done.
+if [ -z "$ACTION" ]; then
+  # First epic with claimable_open >= 1 in the sorted stats (sorted ascending
+  # by claimable_open, then descending by max_priority for tie-break).
+  pick=$(printf '%s\n' "$STATS" | awk -F'\t' '$3 >= 1 {print; exit}')
+  if [ -z "$pick" ]; then
+    ACTION="empty"
+    CHOSEN_EP="NONE"
+    REASON="no epic has claimable open work"
+  else
+    ACTION=$([ -n "$CURRENT_EP" ] && echo "repick" || echo "select")
+    CHOSEN_EP=$(echo "$pick" | awk -F'\t' '{print $1}')
+    CHOSEN_OPEN=$(echo "$pick" | awk -F'\t' '{print $2}')
+    CHOSEN_CLAIMABLE=$(echo "$pick" | awk -F'\t' '{print $3}')
+    if [ "$ACTION" = "repick" ]; then
+      REASON="prior target '$CURRENT_EP' exhausted; closest-to-done is '$CHOSEN_EP' (open=$CHOSEN_OPEN claimable=$CHOSEN_CLAIMABLE)"
+    else
+      REASON="initial selection: closest-to-done is '$CHOSEN_EP' (open=$CHOSEN_OPEN claimable=$CHOSEN_CLAIMABLE)"
+    fi
+  fi
+fi
+
+# ---- emit ----------------------------------------------------------
+
+if [ "$EMIT_JSON" = "1" ]; then
+  jq -nc \
+    --arg ep "$CHOSEN_EP" \
+    --argjson open "$CHOSEN_OPEN" \
+    --argjson claimable "$CHOSEN_CLAIMABLE" \
+    --arg action "$ACTION" \
+    --arg reason "$REASON" \
+    '{epic_prefix:$ep, open:$open, claimable:$claimable, action:$action, reason:$reason}'
+else
+  printf 'epic_prefix=%s open=%s claimable=%s action=%s reason=%s\n' \
+    "$CHOSEN_EP" "$CHOSEN_OPEN" "$CHOSEN_CLAIMABLE" "$ACTION" "$REASON"
+fi
+
+# ---- persist (if --update) ----------------------------------------
+
+if [ "$UPDATE" = "1" ] && [ "$ACTION" != "empty" ]; then
+  mkdir -p "$(dirname "$OBJECTIVE")"
+  # Idempotent: keep the existing selected_at when we KEEP, refresh when
+  # we SELECT or REPICK.
+  if [ "$ACTION" = "keep" ] && [ -f "$OBJECTIVE" ]; then
+    PRIOR_SELECTED_AT=$(jq -r '.selected_at // empty' "$OBJECTIVE" 2>/dev/null || true)
+  else
+    PRIOR_SELECTED_AT=""
+  fi
+  SELECTED_AT="${PRIOR_SELECTED_AT:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+  jq -n \
+    --arg ep "$CHOSEN_EP" \
+    --arg sel "$SELECTED_AT" \
+    --argjson open "$CHOSEN_OPEN" \
+    --argjson claimable "$CHOSEN_CLAIMABLE" \
+    --arg action "$ACTION" \
+    --arg reason "$REASON" \
+    '{schema_version: 1,
+      epic_prefix: $ep,
+      selected_at: $sel,
+      last_action: $action,
+      reason: $reason,
+      stats_at_selection: { open: $open, claimable: $claimable }
+     }' > "$OBJECTIVE.tmp"
+  mv "$OBJECTIVE.tmp" "$OBJECTIVE"
+fi
+
+exit 0

--- a/.research/test-pick-target-epic.sh
+++ b/.research/test-pick-target-epic.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Smoke test for pick-target-epic.sh.
+#
+# Synthesises a tiny action-list / assignments / archive in a tmpdir and
+# asserts the picker behaviour across the four cases that matter:
+#   1. Empty objective → SELECT closest-to-done.
+#   2. Current target still has claimable work → KEEP.
+#   3. Current target exhausted (all claimed/merged) → REPICK.
+#   4. All open work is dep-blocked or claimed → action=empty.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PICKER="$SCRIPT_DIR/pick-target-epic.sh"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# Common args pointing at fixtures inside $TMP.
+ARGS=(--action-list "$TMP/action-list.json"
+      --assignments "$TMP/assignments.json"
+      --archive     "$TMP/archive.json"
+      --objective   "$TMP/objective.json")
+
+fail_count=0
+ok()   { printf '  ok    %s\n' "$1"; }
+fail() { printf '  FAIL  %s\n' "$1" >&2; fail_count=$((fail_count+1)); }
+
+# Helper: write a minimal action-list with the named open items.
+write_actions() {
+  jq -n --argjson rows "$1" '{generated: "test", items: $rows}' > "$TMP/action-list.json"
+}
+write_assignments() {
+  jq -n --argjson rows "$1" '{generated: "test", assignments: $rows}' > "$TMP/assignments.json"
+}
+write_archive() {
+  jq -n --argjson rows "$1" '{generated: "test", assignments: $rows}' > "$TMP/archive.json"
+}
+
+# ---------------------------------------------------------------------------
+# Case 1 — empty objective, multiple epics. Closest-to-done = gap-7 (1 open).
+# ---------------------------------------------------------------------------
+write_actions '[
+  {"id":"gap-10b-1","status":"open","priority":"medium","depends_on":[]},
+  {"id":"gap-10b-2","status":"open","priority":"medium","depends_on":[]},
+  {"id":"gap-10b-3","status":"open","priority":"medium","depends_on":[]},
+  {"id":"gap-7-1",  "status":"open","priority":"high",  "depends_on":[]},
+  {"id":"gap-82-1", "status":"open","priority":"low",   "depends_on":[]},
+  {"id":"gap-82-2", "status":"open","priority":"low",   "depends_on":[]}
+]'
+write_assignments '[]'
+write_archive '[]'
+rm -f "$TMP/objective.json"
+
+out=$("$PICKER" --json "${ARGS[@]}")
+ep=$(echo "$out" | jq -r '.epic_prefix')
+action=$(echo "$out" | jq -r '.action')
+if [ "$ep" = "gap-7" ] && [ "$action" = "select" ]; then
+  ok "Case 1: empty objective → SELECT closest-to-done (gap-7)"
+else
+  fail "Case 1: expected ep=gap-7 action=select; got ep=$ep action=$action"
+fi
+
+# Persist for Case 2.
+"$PICKER" --update "${ARGS[@]}" >/dev/null
+
+# ---------------------------------------------------------------------------
+# Case 2 — current target still has claimable work → KEEP.
+# ---------------------------------------------------------------------------
+# Same action-list, no assignments yet. gap-7 still has 1 claimable.
+out=$("$PICKER" --json "${ARGS[@]}")
+ep=$(echo "$out" | jq -r '.epic_prefix')
+action=$(echo "$out" | jq -r '.action')
+if [ "$ep" = "gap-7" ] && [ "$action" = "keep" ]; then
+  ok "Case 2: current target has claimable work → KEEP"
+else
+  fail "Case 2: expected ep=gap-7 action=keep; got ep=$ep action=$action"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 3 — current target exhausted (all gap-7 work claimed/merged) → REPICK.
+# Now closest-to-done is whichever remaining epic has fewest open.
+# We claim gap-7-1 to active so it's no longer claimable; then expect repick
+# to gap-82 (2 open) or gap-10b (3 open). gap-82 wins.
+# ---------------------------------------------------------------------------
+write_assignments '[
+  {"task_id":"gap-7-1","status":"in-progress","branch":"auto-impl/gap-7-1"}
+]'
+out=$("$PICKER" --json "${ARGS[@]}")
+ep=$(echo "$out" | jq -r '.epic_prefix')
+action=$(echo "$out" | jq -r '.action')
+if [ "$ep" = "gap-82" ] && [ "$action" = "repick" ]; then
+  ok "Case 3: target exhausted → REPICK to next closest-to-done (gap-82)"
+else
+  fail "Case 3: expected ep=gap-82 action=repick; got ep=$ep action=$action"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 4 — all open work is dep-blocked or claimed → action=empty.
+# ---------------------------------------------------------------------------
+write_actions '[
+  {"id":"gap-99-1","status":"open","priority":"medium","depends_on":["gap-99-0"]},
+  {"id":"gap-99-2","status":"open","priority":"medium","depends_on":["gap-99-0"]}
+]'
+write_assignments '[]'
+write_archive '[]'
+rm -f "$TMP/objective.json"
+
+out=$("$PICKER" --json "${ARGS[@]}")
+ep=$(echo "$out" | jq -r '.epic_prefix')
+action=$(echo "$out" | jq -r '.action')
+if [ "$ep" = "NONE" ] && [ "$action" = "empty" ]; then
+  ok "Case 4: all dep-blocked → action=empty"
+else
+  fail "Case 4: expected ep=NONE action=empty; got ep=$ep action=$action"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 5 — tie-break: two epics with same open count, higher priority wins.
+# gap-50 and gap-51 each have 1 claimable open. gap-50:critical, gap-51:medium.
+# Expect gap-50.
+# ---------------------------------------------------------------------------
+write_actions '[
+  {"id":"gap-50-1","status":"open","priority":"critical","depends_on":[]},
+  {"id":"gap-51-1","status":"open","priority":"medium","depends_on":[]}
+]'
+write_assignments '[]'
+write_archive '[]'
+rm -f "$TMP/objective.json"
+
+out=$("$PICKER" --json "${ARGS[@]}")
+ep=$(echo "$out" | jq -r '.epic_prefix')
+if [ "$ep" = "gap-50" ]; then
+  ok "Case 5: tie-break on open count → higher priority wins (gap-50)"
+else
+  fail "Case 5: expected ep=gap-50; got ep=$ep"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+if [ "$fail_count" -eq 0 ]; then
+  echo "==> test-pick-target-epic: PASS"
+  exit 0
+else
+  echo "==> test-pick-target-epic: FAIL ($fail_count case(s))"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

PR 3 of the dispatcher goal-convergence redesign. Adds a depth-first **finish-first** claim mode behind `DISPATCHER_FINISH_FIRST=1` — the dispatcher picks ONE target epic per run and concentrates all 3 claim slots on it instead of spraying across epics. Goal: close out one epic's work before starting the next.

## Picker rule — closest-to-done

`.research/pick-target-epic.sh` selects the target each Phase 3:

1. Group action-list open items by `epic_prefix` (same regex as the same-epic guard — `gap-N[a-z]?` or `pm-<role>`).
2. Filter to **claimable** items (open in action-list, not in active assignments, not in archive, no open `depends_on`).
3. Pick the epic with the fewest claimable opens; tie-break by max priority among that epic's open items.

Idempotent **KEEP** when the current target still has claimable work; **REPICK** only when the current target is exhausted. (Operator confirmed: no stall-detection re-pick.)

## What landed

| File | Change |
|---|---|
| `.research/pick-target-epic.sh` | **NEW** — closest-to-done selector; `--update` writes objective.json; `--json` for machine output |
| `.research/test-pick-target-epic.sh` | **NEW** — 5-case smoke (SELECT / KEEP / REPICK / dep-blocked-empty / priority tie-break) |
| `.research/management/objective.json` | **NEW** — initial selection from live data: `gap-10a` (open=2, claimable=1) |
| `.research/dispatcher-prompt.md` | Phase 3 finish-first preamble (runs picker behind flag); finish-first override (filters candidates, lifts 2/run cap, falls back to unfiltered pool when target dep-blocked); Phase 7 `Target epic:` line |
| `.research/dispatcher-self-test.sh` | **T21** — objective.json schema + epic_prefix shape (soft no-op when file absent) |
| `.claude/skills/verify-all.sh` | New `ppt-goal-gate/pick-target-epic` smoke row (15s budget) |
| `.claude/skills/ppt-goal-gate/SKILL.md` | "Finish-first picker" subsection documenting schema + invocation + T21 |

## Default behavior — unchanged

`DISPATCHER_FINISH_FIRST` defaults unset. Without it, Phase 3 behaves exactly as before (priority sort, same-epic 2/run cap). This PR is **observe-ready but opt-in** — flip the flag on the routine config to enable.

## Verification

```
$ bash .research/dispatcher-self-test.sh
...
T21 objective.json schema + epic_prefix shape (PR 3/5)
  ok    objective epic_prefix='gap-10a' is well-formed
==> dispatcher-self-test: PASS

$ bash .research/test-pick-target-epic.sh
  ok    Case 1: empty objective → SELECT closest-to-done (gap-7)
  ok    Case 2: current target has claimable work → KEEP
  ok    Case 3: target exhausted → REPICK to next closest-to-done (gap-82)
  ok    Case 4: all dep-blocked → action=empty
  ok    Case 5: tie-break on open count → higher priority wins (gap-50)
==> test-pick-target-epic: PASS
```

Live picker dry-run on current dev data → `gap-10a (open=2 claimable=1 action=select)`. Matches expected closest-to-done behavior.

## Test plan

- [x] 5-case smoke PASS
- [x] T21 catches well-formed + malformed objective.json
- [x] Live data run produces sensible target
- [ ] Same in CI
- [ ] Operator flips `DISPATCHER_FINISH_FIRST=1` on the routine config; observe a real run

## Rollout

PR 3 of 5. **Next:** PR 4 — WIP throttle. **PR 5** — quarantine + pre-merge autofix + claim-time dedup.

## Rollback

`git revert <merge-sha>`. Flag-gated; reverting removes the picker + spec without touching dispatcher behavior in the unflagged path.