### PR TITLE
feat(research): dispatcher WIP throttle (PR 4/5)

### DIFF
--- a/.claude/skills/ppt-goal-gate/SKILL.md
+++ b/.claude/skills/ppt-goal-gate/SKILL.md
@@ -20,6 +20,25 @@ mode: cloud-ok
 
 Stem-uniqueness is enforced separately as `T20` in `dispatcher-self-test.sh`.
 
+### WIP throttle (PR 4/5 — `DISPATCHER_WIP_CAP`)
+
+Phase 3's `free_slots` is no longer a constant 3. It's
+`min(3, max(0, DISPATCHER_WIP_CAP - WIP_NOW))` where `WIP_NOW` is the
+count of `{in-progress, review}` rows in `assignments.json`. Default
+cap is **8**; set `DISPATCHER_WIP_CAP=0` to disable and restore the
+legacy uncapped behavior.
+
+Goal: bound the approved-but-unmergeable pool. When the pool grows
+faster than merges drain it, the throttle creates back-pressure on new
+claims so Phase 5/5.5/5.6 can catch up.
+
+Self-test `T22` enforces a soft bound (note when over cap, hard-fail
+only at `WIP > 2 × cap`).
+
+The WIP throttle composes with finish-first: WIP bounds the *quantity*
+of in-flight work; finish-first bounds the *quality* (one epic at a
+time). Both apply uniformly; finish-first does not override the WIP cap.
+
 ### Finish-first picker (PR 3/5 — `pick-target-epic.sh`)
 
 `.research/pick-target-epic.sh` selects ONE target epic per dispatcher run
@@ -48,6 +67,7 @@ Enforced by self-test `T21` (epic_prefix matches `gap-N[a-z]?` or
 - `.research/management/coverage.json`, `action-list.json`, `assignments.json` (override via `COVERAGE` / `ACTION_LIST` / `ASSIGN` env).
 - `GOAL_CHECK_ENFORCE=1` makes the hard-fail subset (GC2) exit non-zero. Default: record-only (exit 0).
 - `DISPATCHER_FINISH_FIRST=1` makes Phase 3 invoke `pick-target-epic.sh` and filter claims to one epic.
+- `DISPATCHER_WIP_CAP=<n>` (default 8) caps in-flight work; `=0` disables. Phase 3 derives `free_slots` from `cap - WIP_NOW`.
 
 ## Steps
 1. `./.research/goal-check.sh` — human-readable, record-only.
@@ -64,7 +84,7 @@ Enforced by self-test `T21` (epic_prefix matches `gap-N[a-z]?` or
 - `bash .research/test-pick-target-epic.sh` (5-case synthetic-fixture smoke)
 
 ## Cross-references
-- `.research/dispatcher-prompt.md` Phase 3 (finish-first preamble + filter), Phase 6 (goal-check invocation), Phase 7 (Target-epic line), HARD RULES.
-- `.research/dispatcher-self-test.sh` T20 (stem-uniqueness), T21 (objective.json shape).
+- `.research/dispatcher-prompt.md` Phase 3 (WIP-throttle preamble, finish-first preamble + filter), Phase 6 (goal-check invocation), Phase 7 (WIP-throttle + Target-epic lines), HARD RULES.
+- `.research/dispatcher-self-test.sh` T20 (stem-uniqueness), T21 (objective.json shape), T22 (WIP bounds).
 - `.research/pick-target-epic.sh` + `.research/test-pick-target-epic.sh`.
 - `docs/superpowers/specs/2026-05-28-dispatcher-goal-convergence-design.md` (Pillar 1).

--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -117,8 +117,8 @@ Per-run, claim up to **3 NEW** tasks. There is NO global in-progress cap —
 multiple cron runs can overlap and each may contribute 3 in-progress, so the
 global in-progress count CAN exceed 3. The 3-limit is throughput, not concurrency.
 
-- Phase 3: `free_slots = 3` (constant). Always try to claim 3 new tasks per run, regardless of current in-progress count.
-- Phase 4: hard cap of 3 implementer subagents spawned per run (matches `free_slots`).
+- Phase 3: `free_slots = min(3, max(0, DISPATCHER_WIP_CAP - WIP_NOW))` where `WIP_NOW` is the count of `{in-progress, review}` rows in `assignments.json`. Default `DISPATCHER_WIP_CAP=8`. Set `DISPATCHER_WIP_CAP=0` to restore the legacy `free_slots=3` (uncapped) behavior. See *WIP-throttle preamble* in Phase 3.
+- Phase 4: hard cap of 3 implementer subagents spawned per run (matches `free_slots` ceiling).
 
 ## Buffer
 
@@ -563,8 +563,54 @@ remaining claimable open tasks, tie-break by max priority. The dispatcher
 abandons the current target only when it is exhausted (0 claimable opens
 left). See `pick-target-epic.sh` for the full rule.
 
+### WIP-throttle preamble (PR 4/5 — addresses `approved-but-unmergeable-pool-grows`)
+
+Before sizing `free_slots`, compute the dispatcher's current
+**Work-In-Progress** count and derive how many new claims this run can
+absorb without growing the pool further. The throttle is a global cap on
+rows whose status is `in-progress` or `review`. Goal: prevent the
+approved-but-unmergeable pool from compounding when merges are slower
+than claims, and create back-pressure that surfaces merge-pipeline
+bottlenecks early.
+
+```bash
+WIP_CAP="${DISPATCHER_WIP_CAP:-8}"   # default 8; set 0 to disable
+if [ "$WIP_CAP" = "0" ]; then
+  free_slots=3
+  WIP_NOW=$(jq '[.assignments[] | select(.status=="in-progress" or .status=="review")] | length' \
+    .research/management/assignments.json)
+  echo "Phase 3 WIP throttle: disabled (DISPATCHER_WIP_CAP=0); WIP=$WIP_NOW (informational)"
+else
+  WIP_NOW=$(jq '[.assignments[] | select(.status=="in-progress" or .status=="review")] | length' \
+    .research/management/assignments.json)
+  # max(0, cap - WIP), then clamp to the per-run cap of 3.
+  HEADROOM=$(( WIP_CAP - WIP_NOW ))
+  [ "$HEADROOM" -lt 0 ] && HEADROOM=0
+  free_slots=$HEADROOM
+  [ "$free_slots" -gt 3 ] && free_slots=3
+  echo "Phase 3 WIP throttle: WIP=$WIP_NOW/$WIP_CAP free_slots=$free_slots (was 3)"
+fi
+```
+
+**Smooth back-pressure.** With WIP=7 and cap=8, this run claims at most
+1 new task. With WIP=8, claims 0. With WIP=10 (already over cap, e.g.
+because PRs piled into review), claims 0 until merges drain it.
+Phases 5 / 5.5 / 5.6 / 5.7 (review, merge, rebase, respawn) still run —
+they drain the pool. Only Phase 3 (new claims) is throttled.
+
+**Interaction with finish-first (PR 3/5).** The WIP throttle applies
+UNIFORMLY regardless of `DISPATCHER_FINISH_FIRST`. Finish-first
+concentrates the *quality* of claims (one epic); WIP throttles the
+*quantity* (how many can be open at once). The two compose: if WIP is at
+cap, no claim happens even when finish-first has a target ready. The
+target persists in `objective.json` and the next run picks it up once
+merges create headroom.
+
+**Disable via `DISPATCHER_WIP_CAP=0`.** When disabled, Phase 3 behaves
+as before (`free_slots=3`); the current WIP is logged informationally.
+
 ```python
-free_slots = 3   # constant per run
+free_slots = $free_slots   # from the WIP-throttle preamble above
 
 # gap 3 + issue #9: claimable iff every depends_on entry is in TERMINAL_IDS
 # (the set built in Phase 2.6 from active + archive — reuse it here, do not
@@ -1409,6 +1455,7 @@ Claimed (this run):       [<id> -> <specialist>, …]                (≤3, may 
 Same-epic skipped:        [<id> (would exceed 2/epic), …]          (item #2; [] if none)
 Dup-skipped:              [<id> reason=<open-pr|open-assignment|file-overlap> conflicts_with=<#n|task_id>, …]   (cross-PR dedup guards; [] if none)
 Target epic:              <epic_prefix open=N claimable=M action=<keep|select|repick|empty> | off>   (PR 3/5 finish-first; "off" when DISPATCHER_FINISH_FIRST≠1)
+WIP throttle:             <wip=N/cap=M free_slots=K | disabled (cap=0)>   (PR 4/5; smooth back-pressure on Phase 3 claims)
 Transitions (this run):   [<id> in-progress→review, …]             ([] if none)
 In-progress (global now): <N> total across all overlapping runs (no cap)
 In review (PR open):      <M>
@@ -1712,8 +1759,8 @@ Opus pricing. At 12 runs/day that's ~$2-4/day. Acceptable for the
 ## HARD RULES
 
 - per-run cap: claim at most 3 NEW tasks AND spawn at most 3 implementer subagents
-- NO global in-progress cap — parallel runs can overlap, total in-progress may exceed 3
-- per-run **per-epic** cap of 2 (item #2)
+- **WIP throttle (PR 4/5)**: `free_slots = min(3, max(0, DISPATCHER_WIP_CAP - WIP_NOW))`. Default `DISPATCHER_WIP_CAP=8`. Set `=0` to disable. Counts rows in `{in-progress, review}`. Smooth back-pressure: claims trickle until exactly at cap, then 0 until merges drain.
+- per-run **per-epic** cap of 2 (item #2). Lifted when `DISPATCHER_FINISH_FIRST=1` AND a target epic is selected (PR 3/5).
 - state transitions are MANDATORY; `merged` / `failed` are TERMINAL
 - legacy `status == "done"` is equivalent to `merged` (counting only); never auto-migrate or rewrite those rows
 - `status_changed_at` bumped ONLY on actual status value change

--- a/.research/dispatcher-self-test.sh
+++ b/.research/dispatcher-self-test.sh
@@ -502,6 +502,25 @@ if [ -f "$OBJECTIVE_FILE" ]; then
   echo
 fi
 
+# --- T22: WIP throttle bounds (PR 4/5) -------------------------------------
+# Soft invariant: WIP (count of {in-progress, review} rows) should stay
+# within DISPATCHER_WIP_CAP. State on disk may already be over cap when the
+# throttle is first enabled, so being-over-cap is a `note`, not a `fail`.
+# Hard-fail only when WIP exceeds 2 × cap (clear runaway).
+echo "T22 WIP throttle bounds (PR 4/5)"
+WIP_CAP_FOR_TEST="${DISPATCHER_WIP_CAP:-8}"
+WIP_NOW=$(jq '[.assignments[] | select(.status=="in-progress" or .status=="review")] | length' "$ASSIGN")
+if [ "$WIP_CAP_FOR_TEST" = "0" ]; then
+  note "WIP throttle disabled (DISPATCHER_WIP_CAP=0); current WIP=$WIP_NOW"
+elif [ "$WIP_NOW" -gt $(( WIP_CAP_FOR_TEST * 2 )) ]; then
+  fail "WIP=$WIP_NOW exceeds 2× cap (cap=$WIP_CAP_FOR_TEST) — clear runaway, merge throughput collapsed"
+elif [ "$WIP_NOW" -gt "$WIP_CAP_FOR_TEST" ]; then
+  note "WIP=$WIP_NOW over cap=$WIP_CAP_FOR_TEST (drain by merges; Phase 3 will claim 0 until under cap)"
+else
+  note "WIP=$WIP_NOW within cap=$WIP_CAP_FOR_TEST"
+fi
+echo
+
 # --- Summary ---------------------------------------------------------------
 if [ "$FAIL" = "0" ]; then
   echo "==> dispatcher-self-test: PASS"


### PR DESCRIPTION
## Summary

PR 4 of the dispatcher goal-convergence redesign. Bounds the **approved-but-unmergeable pool** by capping in-flight work and creating smooth back-pressure on Phase 3 claims.

## The rule

Phase 3's `free_slots` is no longer a constant 3:

```
free_slots = min(3, max(0, DISPATCHER_WIP_CAP - WIP_NOW))
```

`WIP_NOW` = count of `{in-progress, review}` rows. Default cap is **8**; set `DISPATCHER_WIP_CAP=0` to disable and restore the legacy uncapped behavior.

**Smooth back-pressure, not hard skip:**

| WIP | cap | free_slots |
|---|---|---|
| 5 | 8 | 3 (cap normal) |
| 7 | 8 | 1 (trickle) |
| 8 | 8 | 0 (at cap) |
| 10 | 8 | 0 (drain via merges) |

Phase 5 / 5.5 / 5.6 / 5.7 still run — they drain the pool. Only Phase 3 (new claims) is throttled.

## Composes with finish-first (PR 3/5)

WIP bounds *quantity*; finish-first bounds *quality* (one epic). Both apply uniformly — finish-first does NOT override the WIP cap. If WIP=cap, no claim happens even when finish-first has a target ready. The target persists in `objective.json` and the next run picks it up once merges create headroom.

## Changes

| File | Change |
|---|---|
| `.research/dispatcher-prompt.md` | Phase 3 WIP-throttle preamble; Phase 7 `WIP throttle:` line; HARD RULES bullet; Cap section formula |
| `.research/dispatcher-self-test.sh` | **T22** — WIP bounds; soft `note` when over cap, hard `fail` only at `WIP > 2 × cap` |
| `.claude/skills/ppt-goal-gate/SKILL.md` | WIP-throttle subsection (env var, defaults, composition, T22) |

## ⚠️ Behavior change at default

Default cap=8 is a behavior change on the on-path. Current dev state has **WIP=9**, so with this PR landed Phase 3 will claim 0 until 2+ merges drain the pool. T22 logs:

```
T22 WIP throttle bounds (PR 4/5)
  ok    WIP=9 over cap=8 (drain by merges; Phase 3 will claim 0 until under cap)
```

That's the intended signal — back-pressure surfaces the merge bottleneck.

If you want to revert quickly without `git revert`, set `DISPATCHER_WIP_CAP=0` on the dispatcher routine config.

## Test plan

- [x] dispatcher-self-test PASS, T22 produces the expected note
- [x] pick-target-epic smoke still PASS (no regression in PR 3/5 functionality)
- [ ] Same in CI
- [ ] Operator flips the cap on the routine; observe a real run with smooth throttling

## Rollout

PR 4 of 5. **Next (final):** PR 5 — quarantine for repeatedly-failing tasks + pre-merge autofix + claim-time dedup tightening.

## Rollback

`git revert <merge-sha>` OR `DISPATCHER_WIP_CAP=0` on the routine. Spec-only diff; no data changes.