### PR TITLE
chore(ci): self-check branch protection for security-gate-conclusion (closes #683)

### DIFF
--- a/.github/workflows/branch-protection-setup.yml
+++ b/.github/workflows/branch-protection-setup.yml
@@ -193,6 +193,65 @@ jobs:
           echo "  - PRs without the 'security' label: 'security-test-gate' is skipped →"
           echo "    'security-gate-conclusion' succeeds → merge is not blocked."
 
+      - name: Self-check — verify security-gate-conclusion is required
+        # Idempotent audit step. Reads back required_status_checks from the
+        # API after the apply step ran and fails the run if
+        # 'security-gate-conclusion' is not present. This makes the workflow
+        # self-auditing: a green run guarantees the gate is registered.
+        #
+        # In dry-run mode this only warns (the apply step did not patch).
+        env:
+          GH_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+          REPO: ${{ github.repository }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          REQUIRED_CHECK="security-gate-conclusion"
+
+          echo "Reading back required status checks for dev..."
+          RESPONSE=$(gh api "repos/$REPO/branches/dev/protection/required_status_checks" 2>&1) || {
+            echo "ERROR: could not fetch required status checks (branch may not be protected)."
+            echo "$RESPONSE"
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "DRY-RUN: skipping hard failure."
+              exit 0
+            fi
+            exit 1
+          }
+
+          echo "Raw API response:"
+          echo "$RESPONSE" | python3 -m json.tool --no-ensure-ascii 2>/dev/null || echo "$RESPONSE"
+
+          NAMES=$(echo "$RESPONSE" | python3 -c "
+          import json, sys
+          d = json.load(sys.stdin)
+          checks = d.get('checks') or []
+          contexts = d.get('contexts') or []
+          names = [c['context'] for c in checks] if checks else contexts
+          print('\n'.join(names))
+          ")
+
+          echo ""
+          echo "Required status checks on dev:"
+          if [ -z "$NAMES" ]; then
+            echo "  (none)"
+          else
+            echo "$NAMES" | sed 's/^/  - /'
+          fi
+
+          if echo "$NAMES" | grep -qxF "$REQUIRED_CHECK"; then
+            echo ""
+            echo "OK: '$REQUIRED_CHECK' is registered as a required status check on dev."
+          else
+            echo ""
+            echo "ERROR: '$REQUIRED_CHECK' is NOT in the required status checks for dev."
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "DRY-RUN: not failing the run (apply step did not patch)."
+              exit 0
+            fi
+            exit 1
+          fi
+
       - name: Summary
         if: always()
         env:

--- a/scripts/check-branch-protection.sh
+++ b/scripts/check-branch-protection.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# check-branch-protection.sh — print the current required status checks
+# for a given branch on this repository.
+#
+# Usage:
+#   ./scripts/check-branch-protection.sh [branch]
+#   ./scripts/check-branch-protection.sh dev
+#
+# Exit codes:
+#   0 — required checks fetched and printed (including empty / unprotected)
+#   1 — `gh` CLI missing or not authenticated
+#   2 — unexpected API error
+#
+# Does NOT require an admin token. The default `gh auth` user only needs
+# read access to the repo. If the branch is unprotected, the script prints
+# a clear message and exits 0 so it can be used in informational checks.
+#
+# Designed for follow-up audit of issue #683 — verifies that
+# `security-gate-conclusion` (or any other gate) is registered as a
+# required status check after running `.github/workflows/branch-protection-setup.yml`.
+
+set -euo pipefail
+
+BRANCH="${1:-dev}"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: 'gh' CLI is not installed. See https://cli.github.com/" >&2
+  exit 1
+fi
+
+# gh auth status may report non-zero if any configured account has a stale
+# token, even when the active account is fine. Treat the script's ability
+# to call `gh api` as the real auth check (done below).
+
+# Resolve owner/repo from the current git remote so the script works in any clone.
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)
+if [ -z "$REPO" ]; then
+  echo "ERROR: could not resolve owner/repo via 'gh repo view'." >&2
+  echo "       Run this script from inside a git checkout with a GitHub remote." >&2
+  exit 1
+fi
+
+echo "Repository: $REPO"
+echo "Branch:     $BRANCH"
+echo
+
+API_PATH="repos/$REPO/branches/$BRANCH/protection/required_status_checks"
+RAW=$(gh api "$API_PATH" 2>&1) || RC=$? && RC=${RC:-0}
+
+if [ "${RC:-0}" -ne 0 ]; then
+  # Branch unprotected or no required checks configured — common after a
+  # fresh repo or before branch-protection-setup.yml has been run.
+  if echo "$RAW" | grep -qE 'Branch not protected|Not Found|404'; then
+    echo "Branch '$BRANCH' has NO branch-protection rule."
+    echo "Required status checks: (none)"
+    exit 0
+  fi
+  echo "ERROR: unexpected response from GitHub API:" >&2
+  echo "$RAW" >&2
+  exit 2
+fi
+
+# Pretty-print the JSON, then list the contexts one per line.
+echo "Raw API response:"
+echo "$RAW" | python3 -m json.tool --no-ensure-ascii 2>/dev/null || echo "$RAW"
+echo
+
+echo "Required status checks:"
+echo "$RAW" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+checks = d.get('checks') or []
+contexts = d.get('contexts') or []
+names = [c['context'] for c in checks] if checks else contexts
+if not names:
+    print('  (none)')
+else:
+    for n in names:
+        print(f'  - {n}')
+"


### PR DESCRIPTION
## Task

Follow-up to PR #658 — issue #683. PR #658 added the `security-gate-conclusion` job and `branch-protection-setup.yml` workflow, but the post-merge admin step ("run the workflow to register the required check") had no audit trail. This PR closes that gap.

## Changes

1. **`.github/workflows/branch-protection-setup.yml`** — appended a "Self-check" step that reads back `gh api repos/{owner}/{repo}/branches/dev/protection/required_status_checks` after the apply step runs, prints the full list, and **fails the workflow** if `security-gate-conclusion` is not present. The step is idempotent — green run guarantees registration. In `dry_run=true` mode it only warns (since apply was skipped).

2. **`scripts/check-branch-protection.sh`** — small read-only helper that prints required status checks for any branch without an admin token. Usable from local shell or by the next dispatcher run as an audit:

   ```
   ./scripts/check-branch-protection.sh dev
   ```

3. **Current gate status (captured 2026-05-29 from `gh api repos/martin-janci/property-management/branches/dev/protection/required_status_checks`):**

   ```json
   {"message":"Branch not protected","documentation_url":"https://docs.github.com/rest/branches/branch-protection#get-status-checks-protection","status":"404"}
   ```

   **The `dev` branch has NO branch-protection rule at all** — `security-gate-conclusion` is therefore NOT registered. **An admin must run the `branch-protection-setup.yml` workflow** (which requires the `GH_ADMIN_TOKEN` secret to be set). Until then the security-test-gate remains advisory; security-labelled PRs without tests can still merge into `dev`.

## Owner

pm-devops

## Tested (Band A — fast check)

```
bash -n scripts/check-branch-protection.sh       # exit 0
python3 -c "yaml.safe_load(...)"                  # exit 0 (workflow yaml parses)
./scripts/check-branch-protection.sh dev          # exit 0 — confirms "no protection rule"
```

`actionlint` is not installed on this host so the workflow was validated via YAML parse + manual review of the existing patterns. Reuses the same `python3 -m json.tool` / `gh api` idioms already in `branch-protection-setup.yml`.

## Built (Band B — full build)

skipped: change is ~80 LOC of CI/script, no public API, no migration

## CI parity (Band C — hot-path only)

skipped: not a hot-path PR — no security/auth/billing/data-integrity code change. The PR strengthens the CI audit, but does not itself touch runtime code paths.

## Remote-tested

skipped — local change only

## Follow-up action required (admin)

After this PR merges, an admin must:

1. Ensure `GH_ADMIN_TOKEN` secret is set (PAT with `administration:write`).
2. Run: `gh workflow run branch-protection-setup.yml --ref dev`.
3. The new self-check step will hard-fail if registration didn't take.
4. Verify locally: `./scripts/check-branch-protection.sh dev` should list `security-gate-conclusion`.

Closes #683