### PR TITLE
fix(dispatcher): poisoned-sentinel for unparseable legacy deps (closes #583)

### DIFF
--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -83,9 +83,21 @@ re-parse `dependency` text on each run.
 Migration (one-time, gap 3): for any row missing `depends_on`,
 best-effort-parse the legacy `dependency` field by splitting on
 `, ; and / AND` and matching kebab-case task-id-shaped tokens
-(`gap-…`, `pm-…`, `epic-…`). Unparseable values (owner-role names,
-epic descriptions like "Epic 2B WebSocket infrastructure") become
-`[]` and the free-text is left in `dependency` for human follow-up.
+(`gap-…`, `pm-…`, `epic-…`) AGAINST the set of known action-list
+ids. For unparseable non-empty values (owner-role names like
+`pm-frontend`/`pm-qa`/`rust-backend`, or epic descriptions like
+"Epic 2B WebSocket infrastructure"), write a **poisoned sentinel**
+`depends_on: ["UNRESOLVED:<original-text-truncated-to-80-chars>"]`
+instead of `[]` (issue #583). The Phase 3 `claimable()` predicate
+already rejects any `depends_on` entry whose id is not a terminal
+row in `assignments` — the poisoned sentinel naturally fails that
+check, so the row stays blocked until a human resolves the legacy
+text into a real task_id (or explicitly clears `depends_on` to
+`[]`). Values of `null`, `""`, or the literal string `"none"`
+(case-insensitive) in the legacy `dependency` field are treated as
+no-dependency and migrate to `[]` (not sentinel). Phase 7 surfaces
+poisoned rows under the `Unresolved-dep items:` line so they're
+visible every cycle.
 
 ## Timestamp semantics
 
@@ -1611,6 +1623,7 @@ Rebase attempts (this run):[PR#<n> rebased=<true|false> <note>, …]  (item #6; 
 Sandbox reclaims (this run):[<task_id> branch=<branch> reason=sandbox-timeout, …]  (P3; [] if none)
 Empty branches deleted:   [<branch>, …]                             (item #1; [] if none)
 Failed-dep cascades:      [<id> blocked-by=<dep_id>, …]             (issue #6; [] if none)
+Unresolved-dep items:     [<id> dep="<truncated-legacy-text>", …]   (issue #583 — poisoned-sentinel rows whose legacy `dependency` text didn't parse; need human resolution; [] if none)
 Skip-gate:                <none | "recent-run age=<m>m; mutating phases SKIPPED">  (issue #1)
 Tier 2 response:          <http=<code> body="<truncated>" | not-fired>          (issue #5)
 Review dedup-skipped:     [PR#<n> existing-at=<iso>, …]             (issue #3; [] if none)

--- a/.research/dispatcher-self-test.sh
+++ b/.research/dispatcher-self-test.sh
@@ -567,6 +567,35 @@ if [ -f "$ACTION_LIST" ]; then
   echo
 fi
 
+# --- T25: unparseable-legacy-dep guard (issue #583) -----------------------
+# When an action-list item carries a non-empty, non-"none" legacy `dependency`
+# free-text field, `depends_on` MUST NOT be empty -- it must either contain
+# real task_id(s) (when parseable) or a poisoned sentinel
+# `["UNRESOLVED:<truncated>"]` (when unparseable). An empty `depends_on` with a
+# meaningful legacy `dependency` value silently makes the item claimable while
+# its real dependency is unresolved (the gap-3 migration trap; PR #562 fallout).
+if [ -f "$ACTION_LIST" ]; then
+  echo "T25 action-list items: non-empty legacy 'dependency' => depends_on non-empty (issue #583)"
+  BAD25=$(jq -r '
+    [ .items[]
+      | select(((.dependency // "") | ascii_downcase) as $d
+               | ($d != "" and $d != "none"))
+      | select(((.depends_on // []) | length) == 0)
+    ] | length' "$ACTION_LIST")
+  if [ "$BAD25" = "0" ]; then
+    note "no action-list rows with non-empty legacy dependency and empty depends_on"
+  else
+    fail "$BAD25 action-list rows have legacy 'dependency' set but empty depends_on (gap-3 migration must emit poisoned sentinel \"UNRESOLVED:<text>\" -- issue #583)"
+    jq -r '
+      .items[]
+      | select(((.dependency // "") | ascii_downcase) as $d
+               | ($d != "" and $d != "none"))
+      | select(((.depends_on // []) | length) == 0)
+      | "    \(.id) :: dependency=\(.dependency) depends_on=[]"' "$ACTION_LIST" >&2
+  fi
+  echo
+fi
+
 # --- Summary ---------------------------------------------------------------
 if [ "$FAIL" = "0" ]; then
   echo "==> dispatcher-self-test: PASS"

--- a/.research/management/action-list.json
+++ b/.research/management/action-list.json
@@ -65,7 +65,9 @@
       "status": "done",
       "deadline": null,
       "source": "gap-scan",
-      "depends_on": [],
+      "depends_on": [
+        "UNRESOLVED:Epic 2B WebSocket infrastructure"
+      ],
       "resolved_by": "PR #597 — WebSocket realtime sync confirmed present on dev",
       "updated_at": "2026-05-29"
     },
@@ -756,7 +758,9 @@
       "status": "open",
       "deadline": null,
       "source": "pm-analysis 2026-05-25",
-      "depends_on": []
+      "depends_on": [
+        "UNRESOLVED:rust-backend"
+      ]
     },
     {
       "id": "pm-qa-verify-respond-to-inquiry-post-api-v1",
@@ -767,7 +771,9 @@
       "status": "open",
       "deadline": null,
       "source": "pm-analysis 2026-05-25",
-      "depends_on": []
+      "depends_on": [
+        "UNRESOLVED:rust-backend"
+      ]
     },
     {
       "id": "pm-qa-establish-pr-merge-policy-requiring-a",
@@ -1118,7 +1124,9 @@
       "status": "open",
       "deadline": null,
       "source": "pm-analysis 2026-05-27",
-      "depends_on": []
+      "depends_on": [
+        "UNRESOLVED:pm-frontend"
+      ]
     },
     {
       "id": "pm-devops-enforce-security-test-gate",
@@ -1129,7 +1137,9 @@
       "status": "in-progress",
       "deadline": null,
       "source": "pm-analysis 2026-05-27",
-      "depends_on": []
+      "depends_on": [
+        "UNRESOLVED:pm-qa"
+      ]
     },
     {
       "id": "pm-devops-app-tsx-churn-merge-queue",
@@ -1217,7 +1227,9 @@
       "status": "open",
       "deadline": null,
       "source": "pm-analysis 2026-05-27",
-      "depends_on": []
+      "depends_on": [
+        "UNRESOLVED:pm-backend"
+      ]
     },
     {
       "id": "pm-security-p1-04-audit-debug-format",
@@ -1239,7 +1251,9 @@
       "status": "in-progress",
       "deadline": null,
       "source": "pm-analysis 2026-05-27",
-      "depends_on": []
+      "depends_on": [
+        "UNRESOLVED:pm-qa"
+      ]
     },
     {
       "id": "pm-security-audit-reports-sibling-scope",
@@ -1250,7 +1264,9 @@
       "status": "in-progress",
       "deadline": null,
       "source": "pm-analysis 2026-05-27",
-      "depends_on": []
+      "depends_on": [
+        "UNRESOLVED:pm-backend"
+      ]
     },
     {
       "id": "pm-data-support-data-tracking-events",
@@ -1305,7 +1321,9 @@
       "status": "open",
       "deadline": null,
       "source": "pm-analysis 2026-05-28",
-      "depends_on": []
+      "depends_on": [
+        "UNRESOLVED:pm-qa"
+      ]
     },
     {
       "id": "gap-6-1-announcement-creation",
@@ -1514,7 +1532,9 @@
       "source": "coverage-refill 2026-05-28",
       "deadline": null,
       "dependency": "gap-83-1-airbnb-integration-backend",
-      "depends_on": []
+      "depends_on": [
+        "gap-83-1-airbnb-integration-backend"
+      ]
     },
     {
       "id": "gap-83-2-booking-integration-ui",
@@ -1525,7 +1545,9 @@
       "source": "coverage-refill 2026-05-28",
       "deadline": null,
       "dependency": "gap-83-2-booking-integration-backend",
-      "depends_on": []
+      "depends_on": [
+        "gap-83-2-booking-integration-backend"
+      ]
     },
     {
       "id": "gap-84-2-esignature-ui-blocking-fixes",
@@ -1558,7 +1580,9 @@
       "source": "coverage-refill 2026-05-28",
       "deadline": null,
       "dependency": "gap-80-3-mediation-sessions-backend",
-      "depends_on": []
+      "depends_on": [
+        "gap-80-3-mediation-sessions-backend"
+      ]
     },
     {
       "id": "gap-8a-3-fcm-rn-property-push",
@@ -1679,7 +1703,9 @@
       "source": "coverage-refill 2026-05-28",
       "deadline": null,
       "dependency": "gap-9-2-mfa-recovery-codes-backend",
-      "depends_on": []
+      "depends_on": [
+        "gap-9-2-mfa-recovery-codes-backend"
+      ]
     },
     {
       "id": "gap-10a-4-oauth-scopes-admin-ui",


### PR DESCRIPTION
## Task

Issue #583 (follow-up to PR #562). The dispatcher's gap-3 migration tries to parse the legacy free-text `dependency` field into structured `depends_on: [task_id]`. When the legacy text is unparseable (e.g. "Epic 2B WebSocket infrastructure", "rust-backend"), the migration writes `depends_on: []` — which makes the item silently claimable.

Closes #583.

## Owner

pm-devops (dispatcher infra)

## Changes

1. **`.research/dispatcher-prompt.md`** — gap-3 migration rule now writes `depends_on: ["UNRESOLVED:<text-truncated-80>"]` (poisoned sentinel) when the legacy text doesn't parse. Phase 3's existing `claimable()` predicate already rejects any `depends_on` entry whose id is not a terminal row in `assignments` — so the poisoned id naturally fails the claim. Clarifies that `null`/`""`/`"none"` map to `[]`.

2. **`.research/dispatcher-prompt.md`** — new Phase 7 line `Unresolved-dep items: [<id> dep="<truncated>", …]` so poisoned rows are visible every cycle.

3. **`.research/management/action-list.json`** — backfilled 13 rows that had non-empty legacy `dependency` text but empty `depends_on`. Parseable kebab-case task_ids matching real action-list ids got promoted to structured `depends_on`; truly unparseable text (owner-role names, epic descriptions) got the poisoned sentinel.

4. **`.research/dispatcher-self-test.sh`** — new T25 asserts no action-list row has empty `depends_on` while its legacy `dependency` text is non-empty + not `"none"`.

## Tested (Band A — fast check)

```
bash .research/dispatcher-self-test.sh
==> dispatcher-self-test: PASS
```

All 25 tests pass including the new T25 ingestion guard.

## Built (Band B — full build)

skipped: change <50 LOC of substantive prompt + script edits, no public API/config touch, no compile-able product code

## CI parity (Band C — hot-path only)

skipped: not a hot-path PR (dispatcher prompt + research scripts; no security/auth/billing/data-integrity change)

## Remote-tested

skipped

## Notes

- The migration rule now also matches kebab-case tokens against the set of known action-list ids (not just regex-shape), so owner-role names like `pm-frontend` / `pm-qa` / `pm-backend` / `rust-backend` correctly fall into the unparseable bucket and become sentinels.
- The 3 specific rows called out in the issue body (`gap-8a-3-websocket-realtime-sync`, `pm-qa-create-backend-servers-reality-server`, `pm-qa-verify-respond-to-inquiry-post-api-v1`) are sentinel-ised. `gap-8a-3-websocket-realtime-sync` is already `status=done` so the poisoning is cosmetic for it, but kept for consistency — the operator can clear `depends_on` to `[]` if/when they confirm Epic 2B WS infra is delivered (issue body says it is, via PR #472).
- 10 additional rows surfaced by T25 (not listed in the original issue body, accrued since the merge commit) were also backfilled in the same pass.