### PR TITLE
fix(research): single-writer state ownership — stop subagent .research/ pushes to dev

### DIFF
--- a/.claude/skills/ppt-review-merged/SKILL.md
+++ b/.claude/skills/ppt-review-merged/SKILL.md
@@ -172,13 +172,31 @@ Append to `.research/management/post-merge-review.json` (create if missing):
 Merge logic: keep all prior `runs`; the latest run goes at the head of the
 array. Cap to last 20 runs to keep the file small.
 
-## Step 5 — Update marker + push
+## Step 5 — Update marker + (conditionally) commit
+
+Always write the marker file:
 
 ```bash
 date -u +%Y-%m-%dT%H:%M:%SZ > .research/management/last-merged-review.txt
-git add .research/management/post-merge-review.json .research/management/last-merged-review.txt
-git commit -m "chore(research): post-merge review <date> — scanned N, opened M follow-ups"
-git push origin <base>     # only these two files direct-to-base
+```
+
+**Single-writer (finding `subagent-race-on-dev-push`).** When an orchestrator
+that owns the `.research/` commit spawned this skill (it sets
+`DISPATCHER_OWNED_COMMIT=1`), do NOT commit or push — leave both files in the
+working tree for the orchestrator's one Phase 6 commit. An independent push
+here is a separate `dev` push: it triggers a `research-land` replay +
+`version-bump`, and can race/empty the orchestrator's own commit.
+
+```bash
+if [ "${DISPATCHER_OWNED_COMMIT:-0}" = "1" ]; then
+  echo "DISPATCHER_OWNED_COMMIT=1 — wrote post-merge-review.json + last-merged-review.txt;" \
+       "deferring commit/push to the orchestrator's Phase 6."
+else
+  # Standalone invocation: this skill owns the commit.
+  git add .research/management/post-merge-review.json .research/management/last-merged-review.txt
+  git commit -m "chore(research): post-merge review <date> — scanned N, opened M follow-ups"
+  git push origin <base>     # only these two files direct-to-base
+fi
 ```
 
 ## Step 6 — Return summary

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -29,20 +29,49 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
+      # Defence-in-depth for finding subagent-race-on-dev-push: a push that
+      # touches ONLY .research/** is dispatcher/routine bookkeeping, not a
+      # product change, so it must never bump the product version. This caps the
+      # "rapid version-bump cycles" from research-state pushes; real feature
+      # merges (which touch code) still bump as before.
+      - name: Detect .research/-only push
+        id: detect
+        run: |
+          BEFORE="${{ github.event.before }}"
+          AFTER="${{ github.event.after }}"
+          ZERO="0000000000000000000000000000000000000000"
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "$ZERO" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"; echo "no before-sha — bumping"; exit 0
+          fi
+          CHANGED=$(git diff --name-only "$BEFORE" "$AFTER" 2>/dev/null) || {
+            echo "skip=false" >> "$GITHUB_OUTPUT"; echo "diff failed — bumping to be safe"; exit 0; }
+          if [ -z "$CHANGED" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"; echo "empty diff — bumping to be safe"; exit 0
+          fi
+          if echo "$CHANGED" | grep -qvE '^\.research/'; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"; echo "non-.research changes present — bumping"
+          else
+            echo "skip=true" >> "$GITHUB_OUTPUT"; echo ".research/-only push — skipping version bump"
+          fi
+
       - name: Configure git
+        if: steps.detect.outputs.skip != 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Setup Node (for package.json sync)
+        if: steps.detect.outputs.skip != 'true'
         uses: actions/setup-node@v6
         with:
           node-version: '20'
 
       - name: Bump patch version
+        if: steps.detect.outputs.skip != 'true'
         run: ./scripts/bump-version.sh patch
 
       - name: Commit and push version bump
+        if: steps.detect.outputs.skip != 'true'
         run: |
           VERSION=$(cat VERSION | tr -d '[:space:]')
           git add VERSION

--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -525,9 +525,32 @@ Persist: `last_updated=now` (always); if `new_status != prev_status`: `status=ne
 
 SKIP if `$DISPATCHER_SKIP_MUTATING == 1` (recent-run gate from Phase 1 step 2).
 
-If `.research/management/last-merged-review.txt` missing OR mtime > 24h:
+**Cadence gate (finding `post-merge-gate-fooled-by-clone-mtime`).** Gate on the
+ISO timestamp stored *inside* `last-merged-review.txt`, NOT the file's mtime. A
+fresh clone resets every file's mtime to clone-time, so an mtime gate reads
+`age < 24h` forever and the review never fires again after a clone. The file's
+CONTENT is the last-run timestamp (the skill writes `date -u +%FT%TZ` into it),
+and content survives a clone untouched. Run the post-merge review when the file
+is missing/empty/unparseable OR its stored timestamp is > 24h old:
+
+```bash
+MARKER=.research/management/last-merged-review.txt
+DUE=1
+if [ -s "$MARKER" ]; then
+  LAST=$(tr -d '[:space:]' < "$MARKER")
+  LAST_EPOCH=$(date -u -d "$LAST" +%s 2>/dev/null || echo 0)
+  if [ "$LAST_EPOCH" -gt 0 ]; then
+    AGE_H=$(( ( $(date -u +%s) - LAST_EPOCH ) / 3600 ))
+    [ "$AGE_H" -lt 24 ] && DUE=0
+  fi
+  # LAST_EPOCH==0 (missing/garbled timestamp) leaves DUE=1 — fail safe = run.
+fi
+```
+
+If `DUE=1` (missing/empty/unparseable marker OR stored timestamp > 24h old):
 spawn ONE Task subagent invoking `.claude/skills/ppt-review-merged/SKILL.md`
-with `DISPATCHER_OWNED_COMMIT=1` in its env.
+with `DISPATCHER_OWNED_COMMIT=1` in its env. Else SKIP (log
+`Post-merge: skipped (last review <AGE_H>h ago < 24h)`).
 
 Inputs: `repo=martin-janci/property-management`, `window=14d`, `base=dev`,
 `max_prs=15`, `label=follow-up,from-merged-review`.
@@ -1824,7 +1847,7 @@ Disk warning:             <none | "free=N%; cleaned to M%">         (item #7)
 Merged total: <Mt_total>; this cycle: <Mt_this>
 Failed total: <F_total>;  this cycle: <F_this>
 Buffer:     claimable=<open_claimable_count>/<BUFFER_TARGET> ceil=<BUFFER_CEIL> (open=<open_count>, dep_blocked=<dep_blocked_count>) <T0: drained -N | T1: refilled +N | T2: upstream kicked | OK>
-Post-merge: <due | skipped> [<scanned=N clean=K issues=M>]
+Post-merge: <due (last <AGE_H>h ago | no-marker) scanned=N clean=K issues=M | skipped (last <AGE_H>h ago < 24h)>   (content-age gate, not mtime)
 Hang alerts:
   WARN (review >48h): [<task_id> PR#<n> age=<dd:hh:mm>, …]   (ALWAYS PRINT; [] if none)
   ALERT (review >7d): [<task_id> PR#<n> age=<dd:hh:mm>, …]   (ALWAYS PRINT; [] if none)

--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -526,12 +526,18 @@ Persist: `last_updated=now` (always); if `new_status != prev_status`: `status=ne
 SKIP if `$DISPATCHER_SKIP_MUTATING == 1` (recent-run gate from Phase 1 step 2).
 
 If `.research/management/last-merged-review.txt` missing OR mtime > 24h:
-spawn ONE Task subagent invoking `.claude/skills/ppt-review-merged/SKILL.md`.
+spawn ONE Task subagent invoking `.claude/skills/ppt-review-merged/SKILL.md`
+with `DISPATCHER_OWNED_COMMIT=1` in its env.
 
 Inputs: `repo=martin-janci/property-management`, `window=14d`, `base=dev`,
 `max_prs=15`, `label=follow-up,from-merged-review`.
 
-The skill commits + pushes its own files.
+**State-write ownership (finding `subagent-race-on-dev-push`).** With
+`DISPATCHER_OWNED_COMMIT=1` the skill WRITES `post-merge-review.json` +
+`last-merged-review.txt` into the working tree and RETURNS without
+committing/pushing. Phase 6 commits them with the rest of the dispatcher's
+`.research/` delta — one push, not two. (The skill still opens GitHub issues
+via API; that is not a `.research/` write and is unaffected.)
 
 Return EXACTLY: `scanned=<N> clean=<K> issues=<M> note=<short>`.
 
@@ -1099,6 +1105,37 @@ run**. If it doesn't return (the SDK backgrounds it past the dispatcher's
 own exit — the common case), skip this capture entirely; leave the row
 as `status=in-progress` with `claimed_at=now`, and let Phase 2 of the
 next dispatcher run observe the outcome from GitHub.
+
+### State-write ownership (single-writer contract — finding `subagent-race-on-dev-push`)
+
+**Invariant.** `.research/**` on `dev` has exactly one writer: the dispatcher
+process. Every other actor either writes to its own feature branch or acts on a
+PR through the GitHub API — never commits or pushes `.research/**`.
+
+**Why.** Each independent push to `dev` is a discrete event: `research-land`
+replays it and (outside the GITHUB_TOKEN-no-retrigger path) `version-bump` fires.
+When a spawned skill pushes its own `.research/` state mid-run, two failures
+follow: (1) the version churns once per extra push (observed 0.2.964→0.2.968 in
+one run), and (2) the dispatcher's Phase 6 `git commit` finds *nothing to commit*
+because the skill already published the delta the dispatcher intended to own.
+Collapsing all `.research/` writes into the dispatcher's two commits makes the
+Phase 6 delta deterministic and cuts dev pushes to the minimum.
+
+**Per-actor write rules:**
+
+| Actor (phase) | May write | MUST NOT |
+|---|---|---|
+| Implementer (4), rebaser (5.6), followup (5.7) | its own feature branch, inside `/tmp/ppt-worktrees/<task_id>/` | touch `.research/**`; push `dev`; run git ops in the dispatcher CWD |
+| Reviewer (5) | a GitHub PR review via API | write any file; push anything |
+| Merger (5.5) | `gh pr merge` (the PR landing) + the PR head branch for conflict fixups | write `.research/**` |
+| Analysis: dev-review (1.5), project-management (1.6), post-merge-review (2.5) | `.research/**` artifact files **in the working tree**, then RETURN | `git add/commit/push` — persistence is deferred to the owning orchestrator's commit |
+| **Orchestrator** — dispatcher (2.5/3.5/6) or routine (1.5/1.6 → its Phase 6 `git add .research/`) | commits + pushes ALL `.research/**` for the phases it owns | — |
+
+**Mechanism.** When the dispatcher spawns an analysis skill it exports
+`DISPATCHER_OWNED_COMMIT=1`. Each such skill checks that flag and, when set,
+skips its own commit/push step (it still writes its files). Phase 6 then stages
+those files alongside the assignment/action-list state and commits once. Skills
+invoked standalone (no flag) keep committing as before.
 
 STATE TRANSITION (fast-path only — gap 5):
 
@@ -1684,7 +1721,17 @@ fi
 
 git add .research/management/assignments.json \
         .research/management/assignments-archive.json \
-        [.research/management/action-list.json if refilled]
+        [.research/management/action-list.json if refilled or GC1 cascade closed rows] \
+        [.research/management/gc1-orphan-triage.md if GC1 cascade wrote it] \
+        [.research/management/post-merge-review.json .research/management/last-merged-review.txt if Phase 2.5 ran]
+# State-write ownership (finding subagent-race-on-dev-push): the dispatcher is
+# the single writer of .research/management/** for the phases IT owns, so when
+# Phase 2.5 runs its post-merge artifacts are folded into THIS commit rather
+# than pushed by ppt-review-merged itself (it now defers under
+# DISPATCHER_OWNED_COMMIT=1). All paths are under .research/management/, so the
+# commit-scope guard below still passes. (Phase 1.5/1.6 artifacts are owned by
+# the routine, not the dispatcher — the routine's own Phase 6 `git add .research/`
+# stages those; do not duplicate them here.)
 # Commit-scope guard (#526): before the dispatcher's self-commit, refuse
 # if `git diff --cached` strays outside `.research/management/`. Catches
 # the PR #496 class of failure (stop hook bundling parallel-agent work
@@ -2092,6 +2139,7 @@ Opus pricing. At 12 runs/day that's ~$2-4/day. Acceptable for the
 - **Tier 2 kick logging** (issue #5) — capture HTTP code + first 200 chars of response body; surface in commit message so a broken/wedged planner endpoint is visible without trawling trigger history.
 - **reviewer dedup guard** (issue #3) — reviewer subagent MUST `GET /pulls/<n>/reviews` first; if a bot review for the current `headRefOid` already exists within 2h, skip posting and return `note=dedup-existing-review-at-<iso>`. Defense-in-depth against the skip-gate window-edge case.
 - **subagent workspace isolation** (issue #7) — every Phase 4 (implementer), Phase 5.6 (rebaser), and Phase 5.7 (followup-respawn implementer) subagent MUST run its `git checkout` / `gh pr checkout` / build / commit work inside `/tmp/ppt-worktrees/<task_id>/` via the standard `git worktree add` preamble. NEVER touch the dispatcher's own working tree. Phase 5.5 (merger, API-only) and Phase 2 (read-only reconciliation) are exempt.
+- **state-write ownership / single writer** (finding `subagent-race-on-dev-push`) — `.research/**` on `dev` is written by the ORCHESTRATOR process only, never by a spawned skill. The dispatcher owns the phases it runs (the Phase 3.5 claim commit + the Phase 6 main commit); the research routine owns its own Phase 1.5/1.6 outputs via its single `git add .research/` at the routine's Phase 6. NO spawned subagent may `git add/commit/push` any `.research/**` file: analysis skills (dev-review, project-management, post-merge-review) WRITE their artifacts into the working tree and RETURN, and the owning orchestrator folds them into its one commit. Implementers/rebasers/followups commit only on their own feature branch inside their worktree; reviewers/mergers act only via the GitHub API on the PR. Each independent `.research/` push to `dev` is a separate research-land replay + version-bump and can empty the orchestrator's commit by pre-empting its delta — see the contract under "Subagent execution model". The orchestrator sets `DISPATCHER_OWNED_COMMIT=1` in the env of every analysis subagent it spawns; those skills gate their own commit/push on it. (`ppt-project-management` and `ppt-dev-review` already return without committing; `ppt-review-merged` is the one that self-pushed and is fixed here.)
 - **TEMP_PHASE_8 — self-review** — Phase 8 spawns an Opus subagent that writes a post-mortem markdown to `.research/self-improvement/<iso8601>.md`. Off-switch: `DISPATCHER_SELF_REVIEW=0`. The subagent must NOT modify any state file or commit anything. **This phase is temporary** — remove by 2026-06-30 (search `TEMP_PHASE_8` to find every related artifact).
 - **goal-check (ENFORCING, PR 2)** — Phase 6 runs `GOAL_CHECK_ENFORCE=1 .research/goal-check.sh`. GC2 (coverage regression) ABORTS the commit; GC1/GC3 are recorded but non-blocking. The `goal-check:` summary line is still written to the commit body.
 

--- a/.research/self-improvement/findings.json
+++ b/.research/self-improvement/findings.json
@@ -211,7 +211,7 @@
       ],
       "proposed_fix": "Persist last_post_merge_review_at in management state (e.g. assignments.json meta) and gate Phase 6 on that timestamp rather than file mtime — immune to clone resets.",
       "affected_artifact": ".research/dispatcher-prompt.md (Phase 6 post-merge cadence)",
-      "operator_notes": ""
+      "operator_notes": "Drafted on fix/dispatcher-postmerge-cadence-clone-mtime. Simpler than the proposed fix (no new assignments.json meta field needed): last-merged-review.txt ALREADY stores an ISO timestamp as its content — the bug was the gate reading the file's mtime instead of its content. Phase 2.5 cadence gate rewritten to parse the ISO timestamp inside the file (date -u -d) and compute age; missing/empty/unparseable/>24h => DUE=1 (fail-safe = run). Content survives a clone untouched; mtime does not. Verified against the live marker (content 16:24 vs mtime 19:07 — exactly the divergence that breaks mtime) plus fresh/ancient/garbled/empty/missing cases. The gate lives in Phase 2.5, not Phase 6 (affected_artifact said Phase 6 — corrected). Awaiting next dispatcher run to confirm."
     },
     {
       "finding_id": "stale-local-base-wastes-cycle",

--- a/.research/self-improvement/findings.json
+++ b/.research/self-improvement/findings.json
@@ -36,7 +36,7 @@
       ],
       "proposed_fix": "Serialize state writes behind a single owner: subagents return diffs, only the dispatcher commits/pushes assignments + version.",
       "affected_artifact": ".research/dispatcher-prompt.md (state-write ownership)",
-      "operator_notes": ""
+      "operator_notes": "Drafted on fix/dispatcher-state-write-ownership. Audited every dispatcher-spawned skill: ppt-project-management + ppt-dev-review already RETURN without committing; ppt-implement/ppt-pr-followup commit only on their own feature branch; the ONE violator was ppt-review-merged (Step 5 did its own `git add .research/management/... && commit && push origin dev` — a separate dev push that research-land replays + version-bump churns, and that can empty the orchestrator's Phase 6 commit). Fix: (a) dispatcher-prompt.md gains a single-writer invariant (HARD RULE) + a per-actor contract table; orchestrator owns all .research/** commits (dispatcher: Phase 3.5+6; routine: its Phase 6 `git add .research/`). (b) Dispatcher Phase 2.5 spawns ppt-review-merged with DISPATCHER_OWNED_COMMIT=1 and folds post-merge-review.json+last-merged-review.txt into the Phase 6 commit. (c) ppt-review-merged gates its commit/push on that flag (standalone still self-commits). (d) Defense-in-depth: version-bump.yml skips a push that touches ONLY .research/** (bookkeeping is not a product change), capping the rapid-bump cycles for direct-push paths. Note: GITHUB_TOKEN pushes (research-land/version-bump's own) already don't re-trigger workflows, so the churn bit hardest where the dispatcher pushes dev with a PAT. Awaiting next dispatcher run to confirm."
     },
     {
       "finding_id": "archive-append-not-idempotent-duplicate-rows",


### PR DESCRIPTION
**Stacked: base = `fix/dispatcher-gc1-referential-integrity` (#737 → #734 → dev).** Merge the stack bottom-up.

Addresses `subagent-race-on-dev-push` (**critical**). During one run, concurrent `.research/` pushes to `dev` caused rapid version-bump cycles (`0.2.964→0.2.968`) and emptied the orchestrator's commit (`nothing to commit`) by pre-empting its delta.

## Audit — who pushes `.research/` state?

| Skill | Before | Verdict |
|---|---|---|
| `ppt-project-management` (1.6) | writes files, returns | ✅ already clean |
| `ppt-dev-review` (1.5) | assembles, returns | ✅ already clean |
| `ppt-implement` (4) / `ppt-pr-followup` | own feature branch only | ✅ |
| `ppt-pr-merge` (5.5) | `gh pr merge` + head-branch fixups | ✅ no `.research/` |
| **`ppt-review-merged` (2.5)** | **Step 5: `git add .research/… && commit && push origin dev`** | ❌ **the violator** |

That independent push is a separate `dev` push → `research-land` replay + `version-bump` → races the orchestrator's own commit.

## Changes

1. **`dispatcher-prompt.md`** — single-writer invariant (HARD RULE) + a per-actor write-ownership contract table. The **orchestrator** is the only actor that commits/pushes `.research/**`: the dispatcher for the phases it owns (3.5 claim + 6 main), the routine for 1.5/1.6 (its existing `git add .research/`).
2. **Phase 2.5** spawns `ppt-review-merged` with `DISPATCHER_OWNED_COMMIT=1` and folds `post-merge-review.json` + `last-merged-review.txt` into the Phase 6 commit (under `.research/management/`, so the commit-scope guard still passes).
3. **`ppt-review-merged` Step 5** — gates commit/push on `DISPATCHER_OWNED_COMMIT`: when set, write files and defer; standalone still self-commits.
4. **`version-bump.yml`** (defense-in-depth) — skip the bump when a push touches **only** `.research/**` (bookkeeping ≠ product change). Feature merges still bump. Mainly bites direct-PAT pushes; `GITHUB_TOKEN` pushes already don't re-trigger workflows.

## Attribution correction

The finding's one-liner said "only the dispatcher commits." In fact **Phase 1.5/1.6 are routine-owned** (the routine already single-writes them via `git add .research/`); the dispatcher owns 2.5/3.5/6. The fix reflects both orchestrators.

## Verification

- `version-bump.yml` YAML valid; 4 steps gated on `steps.detect.outputs.skip`.
- Detect grep verified: research-only → **skip**; mixed / code-only / version-files → **bump**.
- `dispatcher-self-test` PASS; `findings.json` valid (24). No mutated state files committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)