### PR TITLE
fix(research): extract archive-move into reconcile script (closes #759)

### DIFF
--- a/.research/archive-reconcile.sh
+++ b/.research/archive-reconcile.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Archive-move reconciler — sibling of gc1-reconcile.sh.
+#
+# Sweeps active assignments.json for rows whose status is terminal
+# (merged/failed/done) and moves them to assignments-archive.json
+# idempotently. This is the same operation Phase 6 of dispatcher-prompt.md
+# performs at the end of every dispatcher run; this script extracts it so
+# it can also be invoked at merge-time on a dispatcher-state branch.
+#
+# Why a standalone script:
+#
+#   When a stacked dispatcher PR merges `origin/dev` into its branch, dev's
+#   newer terminal rows for ids the branch still has as `review` land in
+#   the branch's active assignments.json. Phase 6 only sweeps inside a
+#   dispatcher run, so the CI self-test (T19: active contains no terminal
+#   rows) goes red on the PR before the next dispatcher run gets a chance
+#   to clean up. Issue #759 (PR #734 hit this with two leaked rows:
+#   gap-82-5-ios-keychain-push-v2 and gap-82-3-search-enhancements-fix).
+#
+#   Running this script after the dev-merge resolves the leak in one shot
+#   and preserves the T17 combined-count invariant (active+archive total
+#   unchanged — rows move, never disappear).
+#
+# Idempotent + re-runnable: after --apply, the moved rows are gone from
+# active so they no longer match the sweep set. Concurrent runs that each
+# re-archive the same id produce ONE row per task_id in the archive
+# (group_by + map(last) keeps the freshest row by file position; same
+# behaviour as Phase 6).
+#
+# Usage:
+#   ./.research/archive-reconcile.sh             # dry-run: print move set, write nothing
+#   ./.research/archive-reconcile.sh --apply     # actually move terminal rows
+#   ASSIGN=… ARCHIVE=… ./.research/archive-reconcile.sh [--apply]
+
+set -euo pipefail
+
+ASSIGN="${ASSIGN:-.research/management/assignments.json}"
+ARCHIVE="${ARCHIVE:-.research/management/assignments-archive.json}"
+APPLY=0
+[ "${1:-}" = "--apply" ] && APPLY=1
+
+if [ ! -f "$ASSIGN" ]; then
+  echo "archive-reconcile: active file missing — nothing to do: $ASSIGN" >&2
+  exit 0
+fi
+
+# Build the move set from CURRENT active file state (sweep semantics — same as
+# dispatcher-prompt.md Phase 6). Terminal = status in {merged, failed, done}.
+MOVE_IDS_JSON=$(jq '[.assignments[]
+  | select(.status=="merged" or .status=="failed" or .status=="done")
+  | .task_id]' "$ASSIGN")
+
+MOVE_COUNT=$(echo "$MOVE_IDS_JSON" | jq 'length')
+ACTIVE_BEFORE=$(jq '.assignments | length' "$ASSIGN")
+ARCHIVE_BEFORE=0
+[ -f "$ARCHIVE" ] && ARCHIVE_BEFORE=$(jq '.assignments | length' "$ARCHIVE")
+COMBINED_BEFORE=$((ACTIVE_BEFORE + ARCHIVE_BEFORE))
+
+if [ "$MOVE_COUNT" = "0" ]; then
+  echo "archive-reconcile: no terminal rows in active (clean)"
+  echo "  active=$ACTIVE_BEFORE archive=$ARCHIVE_BEFORE combined=$COMBINED_BEFORE"
+  exit 0
+fi
+
+echo "archive-reconcile: $MOVE_COUNT terminal row(s) leaked into active"
+jq -r --argjson ids "$MOVE_IDS_JSON" '
+  .assignments[]
+  | select(.task_id as $t | $ids | index($t))
+  | "  \(.task_id) :: status=\(.status) pr=\(.pr_number // "-") merged_at=\(.merged_at // "-")"' "$ASSIGN"
+
+if [ "$APPLY" = "0" ]; then
+  echo "  (dry-run — pass --apply to move them)"
+  exit 0
+fi
+
+# Ensure the archive file exists with a valid skeleton before we extend it.
+if [ ! -f "$ARCHIVE" ]; then
+  echo '{"assignments":[]}' > "$ARCHIVE"
+fi
+
+TMP_ARCHIVE=$(mktemp)
+TMP_ACTIVE=$(mktemp)
+trap 'rm -f "$TMP_ARCHIVE" "$TMP_ACTIVE"' EXIT
+
+# Append matching active rows to archive, then dedup by task_id keeping the
+# freshest row (group_by + map(last)). Stamp archived_at as Phase 6 does.
+jq --argjson ids "$MOVE_IDS_JSON" --slurpfile active "$ASSIGN" '
+  .assignments = (
+    (.assignments + [ $active[0].assignments[] | select(.task_id as $t | $ids | index($t)) ])
+    | group_by(.task_id)
+    | map(last)
+  )
+  | .archived_at = (now | todate)
+' "$ARCHIVE" > "$TMP_ARCHIVE"
+
+# Drop matching rows from active.
+jq --argjson ids "$MOVE_IDS_JSON" '
+  .assignments |= map(select(.task_id as $t | $ids | index($t) | not))
+' "$ASSIGN" > "$TMP_ACTIVE"
+
+# T17 combined-count guard — refuse to write a destructive result.
+NEW_ACTIVE=$(jq '.assignments | length' "$TMP_ACTIVE")
+NEW_ARCHIVE=$(jq '.assignments | length' "$TMP_ARCHIVE")
+NEW_COMBINED=$((NEW_ACTIVE + NEW_ARCHIVE))
+
+# Combined count can only DECREASE if the same id existed in both files before
+# the sweep (impossible by T18 + T19 invariants), so a drop is a hard refuse.
+# An increase by MOVE_COUNT is also wrong — append happened without dedup.
+# Expected: combined stays exactly equal (move, not copy).
+if [ "$NEW_COMBINED" -ne "$COMBINED_BEFORE" ]; then
+  echo "archive-reconcile: ABORT — combined count changed $COMBINED_BEFORE → $NEW_COMBINED" >&2
+  echo "  refusing to write; leaving $ASSIGN and $ARCHIVE untouched." >&2
+  exit 2
+fi
+
+mv "$TMP_ARCHIVE" "$ARCHIVE"
+mv "$TMP_ACTIVE"  "$ASSIGN"
+trap - EXIT
+
+echo "archive-reconcile: moved $MOVE_COUNT row(s)"
+echo "  active=$ACTIVE_BEFORE → $NEW_ACTIVE  archive=$ARCHIVE_BEFORE → $NEW_ARCHIVE  combined=$COMBINED_BEFORE (unchanged)"

--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -1719,35 +1719,43 @@ won't see it in *their* transitions set either. The sweep formulation is
 idempotent and self-healing — every run cleans up any orphans left by
 prior runs at zero extra cost.
 
+The move is delegated to `.research/archive-reconcile.sh --apply`. The script
+is the single source of truth for sweep semantics (sibling of
+`.research/gc1-reconcile.sh`); it can also be invoked outside a dispatcher
+run — see the **Merge-time reconcile** note below.
+
 ```bash
-# Build the move set from CURRENT active file state (sweep), not from
-# this run's transitions. Terminal = status in {merged, failed, done}.
-MOVE_IDS_JSON=$(jq '[.assignments[]
-  | select(.status=="merged" or .status=="failed" or .status=="done")
-  | .task_id]' .research/management/assignments.json)
-
-# Append to archive AND upsert by task_id. Concurrent runs that each
-# re-archive the same id used to produce duplicate rows inside the
-# archive (T4 FAIL: gap-82-4-*-impl + 3 others present twice). The
-# upsert makes the write idempotent regardless of run overlap; group_by
-# preserves order within a group so `map(last)` keeps the freshest row
-# (latest merged_at / last_updated).
-jq --argjson ids "$MOVE_IDS_JSON" --slurpfile active .research/management/assignments.json '
-  .assignments = (
-    (.assignments + [ $active[0].assignments[] | select(.task_id as $t | $ids | index($t)) ])
-    | group_by(.task_id)
-    | map(last)
-  )
-  | .archived_at = (now | todate)
-' .research/management/assignments-archive.json > /tmp/archive.new
-
-jq --argjson ids "$MOVE_IDS_JSON" '
-  .assignments |= map(select(.task_id as $t | $ids | index($t) | not))
-' .research/management/assignments.json > /tmp/active.new
-
-mv /tmp/archive.new .research/management/assignments-archive.json
-mv /tmp/active.new  .research/management/assignments.json
+bash .research/archive-reconcile.sh --apply
 ```
+
+The script does the equivalent of:
+
+- Build the move set from current active file state (sweep — `status ∈
+  {merged, failed, done}`).
+- Append matching rows to `assignments-archive.json` and upsert by
+  `task_id` (concurrent runs that each re-archive the same id used to
+  produce duplicate archive rows — T4 FAIL: gap-82-4-*-impl + 3 others
+  present twice; `group_by | map(last)` is the dedupe).
+- Drop those rows from `assignments.json`.
+- Stamp `archived_at = now` on the archive.
+- T17 guard: refuse to write if combined active+archive count would
+  change (move, not copy).
+
+**Merge-time reconcile (issue #759).** Phase 6 only runs inside a
+dispatcher run, so a stacked dispatcher PR that merges `origin/dev` into
+its branch will pull dev's newer terminal rows for ids the branch still
+has as `review` — the CI self-test then trips T19 before the next
+dispatcher run gets a chance to sweep (observed on PR #734: two leaked
+rows, `gap-82-5-ios-keychain-push-v2` and `gap-82-3-search-enhancements-fix`).
+After any `git merge origin/dev` on a branch that carries
+`.research/management/assignments.json`, run:
+
+```bash
+bash .research/archive-reconcile.sh           # dry-run; lists any leaks
+bash .research/archive-reconcile.sh --apply   # move + commit alongside the merge
+```
+
+The script is idempotent and a no-op on a clean state.
 
 The Phase 7 summary's `Merged-now` / `Failed (this run)` counters are still
 derived from the in-memory transitions set — those are this-run-shaped


### PR DESCRIPTION
Closes #759.

## Problem (recap)

Phase 6 archive-move is already declarative-sweep — it re-reads active `assignments.json` and moves any terminal-status row to the archive every run. The bug isn't the sweep; it's that **Phase 6 only runs inside a dispatcher run**.

When a stacked dispatcher PR merges `origin/dev`, dev's newer terminal rows for ids the branch still has as `review` land in the branch's active `assignments.json`. CI runs `dispatcher-self-test.sh` on the PR and **T19** trips (`terminal rows still in active assignments.json (Phase 6 archive-move bug)`) before the next dispatcher run gets to sweep. PR #734 hit this with two leaked rows; they had to be hand-moved to unstick the merge.

## Fix

- **`.research/archive-reconcile.sh`** — new standalone reconciler. Same sweep semantics as Phase 6 (`status ∈ {merged, failed, done}` → move to archive, upsert by `task_id`, stamp `archived_at`). Default dry-run; `--apply` writes. Refuses to write if the T17 combined-count invariant would change. Idempotent and a no-op on clean state.
- **`.research/dispatcher-prompt.md` Phase 6** — now invokes the script instead of inlining the jq pipeline. Single source of truth for sweep semantics. Behaviour unchanged.
- **Merge-time recipe documented inline** — after `git merge origin/dev` on any branch carrying `assignments.json`, run the script.

## Verification

Simulated the #734 scenario locally:

\`\`\`
# Poisoned active with two synthetic terminal rows
archive-reconcile: 2 terminal row(s) leaked into active
  test-leak-merged :: status=merged pr=99999 merged_at=2026-05-30T00:00:00Z
  test-leak-failed :: status=failed pr=99998 merged_at=-
archive-reconcile: moved 2 row(s)
  active=5 → 3  archive=159 → 161  combined=164 (unchanged)

# Re-run: clean
archive-reconcile: no terminal rows in active (clean)
  active=3 archive=161 combined=164
\`\`\`

Full \`dispatcher-self-test.sh\` PASS on the post-apply state and on the committed branch state.

## Acceptance criteria from #759

- [x] After a \`dev\` merge flips an active row to terminal, running the script archives it with no manual intervention.
- [x] T19 stays green on stacked dispatcher PRs (verified locally; CI on this PR exercises it).
- [x] T17 combined active+archive row count preserved (script aborts otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)