### PR TITLE
fix(ppt-implement): add admin-web to pm-frontend owner-areas (closes #692)

### DIFF
--- a/.claude/skills/ppt-implement/scripts/owner-areas.json
+++ b/.claude/skills/ppt-implement/scripts/owner-areas.json
@@ -9,6 +9,7 @@
   "pm-frontend": [
     "frontend/apps/ppt-web/**",
     "frontend/apps/reality-web/**",
+    "frontend/apps/admin-web/**",
     "frontend/packages/**",
     "frontend/packages/api-client/**",
     "docs/screens/**"


### PR DESCRIPTION
Closes #692.

`frontend/apps/admin-web/**` was missing from the `pm-frontend` entry in `.claude/skills/ppt-implement/scripts/owner-areas.json`. PR #687 added admin-web unit tests under a pm-frontend assignment, which then tripped `scope_drift=true` via the scope-check script.

One-line config: add the pattern alongside `ppt-web`, `reality-web`, `packages/**`, `api-client/**`, `docs/screens/**`.

JSON validated with `jq .`. No code paths read this file outside the scope-check script, so the fix lands at config level only.