### PR TITLE
fix(ppt-web): memoize STATUS_OPTIONS in HistoryFilters (closes #621)

### DIFF
--- a/frontend/apps/ppt-web/src/features/reports/components/HistoryFilters.tsx
+++ b/frontend/apps/ppt-web/src/features/reports/components/HistoryFilters.tsx
@@ -5,7 +5,7 @@
  */
 
 import type { ReportExecutionStatus } from '@ppt/api-client';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 export interface ExecutionFilters {
@@ -22,15 +22,18 @@ interface HistoryFiltersProps {
 export function HistoryFilters({ filters, onChange }: HistoryFiltersProps) {
   const { t } = useTranslation();
 
-  const STATUS_OPTIONS: { value: ReportExecutionStatus | ''; label: string }[] = [
-    { value: '', label: t('reports.filters.allStatuses', 'All Statuses') },
-    { value: 'completed', label: t('reports.filters.statusCompleted', 'Completed') },
-    { value: 'failed', label: t('reports.filters.statusFailed', 'Failed') },
-    { value: 'running', label: t('reports.filters.statusRunning', 'Running') },
-    { value: 'pending', label: t('reports.filters.statusPending', 'Pending') },
-    { value: 'cancelled', label: t('reports.filters.statusCancelled', 'Cancelled') },
-    { value: 'skipped', label: t('reports.filters.statusSkipped', 'Skipped') },
-  ];
+  const STATUS_OPTIONS: { value: ReportExecutionStatus | ''; label: string }[] = useMemo(
+    () => [
+      { value: '', label: t('reports.filters.allStatuses', 'All Statuses') },
+      { value: 'completed', label: t('reports.filters.statusCompleted', 'Completed') },
+      { value: 'failed', label: t('reports.filters.statusFailed', 'Failed') },
+      { value: 'running', label: t('reports.filters.statusRunning', 'Running') },
+      { value: 'pending', label: t('reports.filters.statusPending', 'Pending') },
+      { value: 'cancelled', label: t('reports.filters.statusCancelled', 'Cancelled') },
+      { value: 'skipped', label: t('reports.filters.statusSkipped', 'Skipped') },
+    ],
+    [t]
+  );
 
   const handleStatusChange = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {


### PR DESCRIPTION
Closes #621.

PR #606 moved `STATUS_OPTIONS` inside the component body so the labels could go through `t()` — correct, but the array was then recreated on every render. `HistoryFilters` re-renders on every keystroke in the two date inputs; the options array is stable until the locale changes.

Wrapped in `useMemo` with `[t]` as the dep (standard react-i18next pattern).

`pnpm --filter @ppt/web typecheck` ✓ clean. No behaviour change beyond identity stability of the array reference.