### PR TITLE
fix(research): GC2 surfaces no-baseline state instead of silent pass (closes #700)

### DIFF
--- a/.github/workflows/dispatcher-self-test.yml
+++ b/.github/workflows/dispatcher-self-test.yml
@@ -19,6 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # GC2 (goal-check.sh) compares the current done-story count against
+          # HEAD's coverage.json via `git show HEAD:…`. A shallow clone makes
+          # that read silently return nothing, which used to be a silent pass
+          # (issue #700). Pull the full history so the baseline is always
+          # available; the script also reports `(no-baseline)` explicitly if
+          # it ever isn't.
+          fetch-depth: 0
       - name: dispatcher schema + invariant self-test
         run: bash .research/dispatcher-self-test.sh
       - name: goal-check (enforcing)

--- a/.research/goal-check.sh
+++ b/.research/goal-check.sh
@@ -97,14 +97,41 @@ record "GC1-referential-integrity" "$GC1_PASS" \
 # (a deliberate human refresh may legitimately re-classify done -> partial).
 GC2_NOW=$(jq '[.stories[] | select(.status=="done")] | length' "$COVERAGE")
 GC2_KIND=$(jq -r '.scan_kind // "upkeep"' "$COVERAGE")
-GC2_HEAD=$(git show "HEAD:$COVERAGE" 2>/dev/null \
-           | jq '[.stories[] | select(.status=="done")] | length' 2>/dev/null || echo "$GC2_NOW")
-if [ "$GC2_KIND" = "deep" ]; then
-  record "GC2-coverage-progress" true "done=$GC2_NOW (deep-scan exempt)" "done>=$GC2_HEAD" true
-elif [ "$GC2_NOW" -ge "$GC2_HEAD" ]; then
-  record "GC2-coverage-progress" true "done=$GC2_NOW head=$GC2_HEAD" "done>=$GC2_HEAD" true
+# Read HEAD's done-story count. Distinguish three states explicitly (issue #700):
+#   GC2_BASELINE=present   — git show succeeded, count is the prior committed value
+#   GC2_BASELINE=missing   — git show failed (first commit of coverage.json,
+#                            shallow clone where the blob isn't fetched, detached
+#                            HEAD). Treated as monotonic pass but the head=N
+#                            marker is suffixed `(no-baseline)` so it's auditable.
+#   GC2_BASELINE=corrupt   — git show returned bytes but jq couldn't parse them.
+#                            Also treated as monotonic pass + marked.
+GC2_HEAD_RAW=$(git show "HEAD:$COVERAGE" 2>/dev/null || true)
+if [ -z "$GC2_HEAD_RAW" ]; then
+  GC2_HEAD="$GC2_NOW"
+  GC2_BASELINE="missing"
 else
-  record "GC2-coverage-progress" false "done=$GC2_NOW head=$GC2_HEAD" "done>=$GC2_HEAD" true
+  GC2_HEAD=$(printf '%s' "$GC2_HEAD_RAW" | jq '[.stories[] | select(.status=="done")] | length' 2>/dev/null || true)
+  if [ -z "$GC2_HEAD" ]; then
+    GC2_HEAD="$GC2_NOW"
+    GC2_BASELINE="corrupt"
+  else
+    GC2_BASELINE="present"
+  fi
+fi
+# Audit suffix: when the baseline is absent the line reads e.g.
+# `done=24 head=24(no-baseline)`, surfacing the gap in the commit log instead of
+# pretending the monotonicity check ran.
+if [ "$GC2_BASELINE" = "present" ]; then
+  GC2_HEAD_FMT="$GC2_HEAD"
+else
+  GC2_HEAD_FMT="$GC2_HEAD(no-baseline:$GC2_BASELINE)"
+fi
+if [ "$GC2_KIND" = "deep" ]; then
+  record "GC2-coverage-progress" true "done=$GC2_NOW (deep-scan exempt)" "done>=$GC2_HEAD_FMT" true
+elif [ "$GC2_NOW" -ge "$GC2_HEAD" ]; then
+  record "GC2-coverage-progress" true "done=$GC2_NOW head=$GC2_HEAD_FMT" "done>=$GC2_HEAD_FMT" true
+else
+  record "GC2-coverage-progress" false "done=$GC2_NOW head=$GC2_HEAD_FMT" "done>=$GC2_HEAD_FMT" true
 fi
 
 # --- GC3: buffer bounds. open_claimable = open action-list items not already


### PR DESCRIPTION
Closes #700.

## Problem

PR #690 introduced GC2 (coverage-progress monotonicity). The HEAD-baseline read silently fell back to `GC2_HEAD = GC2_NOW` when `git show HEAD:coverage.json` returned nothing — making the check trivially pass (`N >= N`). That's harmless for the observe-only Pillar 1, but Pillar 2 flips GC2 to hard-fail. In a shallow CI clone or a first-commit-of-coverage state, a real `done` regression would have silently passed.

## Fix

### `.research/goal-check.sh`
Distinguish three baseline states and surface them in the line:

| State | Trigger | Marker |
|---|---|---|
| `present` | `git show` succeeded and `jq` parsed | `head=N` (unchanged) |
| `missing` | `git show` returned nothing (first commit, shallow clone, detached HEAD) | `head=N(no-baseline:missing)` |
| `corrupt` | `git show` returned bytes but `jq` couldn't parse them | `head=N(no-baseline:corrupt)` |

Monotonicity passes in the no-baseline cases (fallback unchanged), but the audit trail is honest — a reviewer reading the commit log sees the gap instead of a false `ok`.

### `.github/workflows/dispatcher-self-test.yml`
`fetch-depth: 0` on `actions/checkout@v6`. This is the load-bearing fix for "shallow clone in CI" — once the full history is available, `git show HEAD:coverage.json` always resolves and the no-baseline marker never fires for shallow-clone reasons.

The two changes are complementary: the workflow setting prevents the shallow-clone case from firing in CI; the marker covers first-commit and detached-HEAD edges and any future regression.

## Verification

```
# Default run on dev (baseline present)
ok    GC2-coverage-progress — done=27 head=27

# COVERAGE pointing at a file with no git history (baseline missing)
ok    GC2-coverage-progress — done=27 head=27(no-baseline:missing)
```

Sidecar-file approach (option 3 in the issue) intentionally skipped — the marker + fetch-depth=0 cover all three real paths without introducing a new state file to keep in sync.