### PR TITLE
fix(ci): add Redis service + dedicated step for WS pub/sub fanout test (closes #681)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -98,6 +98,20 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      # Redis service for the WebSocket pub/sub fanout integration test
+      # (issue #681). The test is marked #[ignore] because it needs a live
+      # Redis; the dedicated step below opts it in via --include-ignored
+      # with REDIS_URL pointing here. Default `cargo test --workspace`
+      # stays fast and ignored-test-skipping for the rest of the run.
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - uses: actions/checkout@v6
@@ -128,6 +142,23 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/test
           RUST_ENV: development
         run: cargo test --workspace
+
+      # WS pub/sub fanout — closes issue #681. The test
+      # `ws_pubsub_fanout_delivers_to_correct_subscriber` in
+      # api-server/tests/ws_integration_tests.rs is marked `#[ignore]`
+      # because it requires a real Redis to exercise the actual pub/sub
+      # delivery path (the core value of the WebSocket push feature; the
+      # other 9 tests in that file only cover JWT + HTTP-upgrade
+      # mechanics). The Redis service container above provides the live
+      # instance; `--include-ignored` opts it in without un-ignoring it
+      # in source — local runs without REDIS_URL still skip it.
+      - name: Run ignored WS+Redis integration tests
+        working-directory: backend
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/test
+          REDIS_URL: redis://localhost:6379
+          RUST_ENV: development
+        run: cargo test -p api-server --test ws_integration_tests -- --include-ignored
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #681.

## What was untested

PR #650 (gap-8a-3) shipped `backend/servers/api-server/tests/ws_integration_tests.rs` with 9 active tests covering JWT validation + HTTP-upgrade mechanics, plus one `#[ignore]`'d test:

```rust
// line 456:
#[ignore = "requires live Redis — set REDIS_URL and run with --include-ignored"]
async fn ws_pubsub_fanout_delivers_to_correct_subscriber() { … }
```

That ignored test is the only one that exercises the **actual Redis pub/sub delivery path** — the load-bearing thing the WebSocket push feature exists for. CI never ran it, so every regression in fanout would have shipped silently.

## Fix

In `.github/workflows/backend.yml` `test` job:

1. Added a `redis:7-alpine` service alongside the existing `postgres:16`, with the standard `redis-cli ping` health-check.
2. Added a dedicated post-step `Run ignored WS+Redis integration tests` that runs:

   ```bash
   cargo test -p api-server --test ws_integration_tests -- --include-ignored
   ```

   with `REDIS_URL=redis://localhost:6379`. The `#[ignore]` stays in source so local `cargo test` (without Redis) keeps skipping it; CI opts in explicitly.

Default `cargo test --workspace` is unchanged — still skips ignored tests, so the rest of the workspace's runtime is unaffected. The new step only compiles and runs the one test binary, so the wall-time delta is small.

## Why option 1 (Redis service)

The issue listed three options. Picked option 1:
- **Mocking the Redis binary pub/sub protocol** (option 2) is high-effort and would mostly test the mock, not the path.
- **A `cfg` feature flag** (option 3) duplicates what the `#[ignore]` attribute already does, with no upside.
- **Service container** (option 1) is what the issue recommended and matches the pattern `backend.yml` already uses for postgres.

## Verification

`ruby -ryaml -e 'YAML.load_file(".github/workflows/backend.yml")'` validates. CI on this PR will exercise the new step end-to-end.