### PR TITLE
test(reports): exercise RBAC + cross-tenant predicates with real JWTs (closes #696)

### DIFF
--- a/backend/servers/api-server/tests/report_schedule_rbac_tests.rs
+++ b/backend/servers/api-server/tests/report_schedule_rbac_tests.rs
@@ -1,32 +1,43 @@
-//! Regression tests for update_schedule RBAC and cross-tenant isolation fixes.
+//! Regression tests for `update_schedule` RBAC and cross-tenant isolation fixes.
 //!
 //! Closes:
-//!   - #614  RequireCapability / role check on PUT /api/v1/reports/schedules/{id}
+//!   - #614  RequireCapability / role check on `PUT /api/v1/reports/schedules/{id}`
 //!   - #624  Cross-tenant mutation: caller in Org B could update Org A's schedule
+//!   - #696  Original test suite only proved the outer JWT gate worked — the
+//!          RBAC predicate (`rls.role().is_manager()`) and the cross-tenant
+//!          WHERE clause (`AND organization_id = $caller_org_id`) were never
+//!          exercised because every request was sent without a Bearer JWT.
 //!
 //! # What these tests verify
 //!
-//! 1. **Unauthorized-role regression (#614)**
-//!    An authenticated user whose role is below `Manager` (e.g. `Resident`) is
-//!    rejected with 4xx — they CANNOT mutate any report schedule.
+//! 1. **RBAC denial (#614)** — `update_schedule_without_manager_role_is_rejected`:
+//!    A user authenticated with a *real* JWT whose DB-backed role is
+//!    `Resident` (below the manager threshold) gets past `AuthUser`, gets past
+//!    `ValidatedTenantExtractor`, and is rejected by the `rls.role().is_manager()`
+//!    check inside the handler with `403 FORBIDDEN`. The schedule row is
+//!    unchanged.
 //!
-//! 2. **Cross-tenant isolation regression (#624)**
-//!    A caller authenticated in Org B cannot mutate a report schedule that
-//!    belongs to Org A, even when they know the schedule's UUID. The handler now
-//!    threads `caller_org_id` into the SQL WHERE clause so the UPDATE finds no
-//!    row (→ 404) and the original record is unchanged.
+//! 2. **Cross-tenant isolation (#624)** — `update_schedule_from_other_org_is_rejected`:
+//!    A *real* authenticated Manager in Org B sends `X-Tenant-ID: org_b` but
+//!    targets a schedule UUID owned by Org A. The handler reaches the
+//!    repository, the UPDATE WHERE clause includes `AND organization_id = org_b`,
+//!    finds no row, and the handler maps the `NotFound` error to `404 NOT_FOUND`.
+//!    The Org A schedule row is unchanged.
 //!
-//! # TestApp wiring caveat
+//! 3. **JWT gate (kept as-is)** — `update_schedule_without_any_auth_is_rejected`:
+//!    A request with no Authorization header at all is rejected with 4xx by the
+//!    `AuthUser` extractor before any handler logic runs. This is the legitimate
+//!    outer-gate test.
 //!
-//! `TestApp` mounts the router without `host_tenant_middleware`, so there is no
-//! `ResolvedTenant` extension. `ValidatedTenantExtractor` therefore looks for a
-//! `X-Tenant-ID` header (UUID string) to identify the tenant. Without a Bearer
-//! JWT the `AuthUser` extractor returns 401 before the tenant or RBAC check
-//! fires. The tests therefore assert a generic 4xx "rejected" outcome: the
-//! security contract is "the mutating operation must not be applied", which
-//! holds whether the rejection is 401 (auth gate) or 404 (tenant-scoped WHERE
-//! in production). This pattern matches `push_token_tests.rs` and the workflow /
-//! equipment IDOR tests.
+//! # Why specific status codes matter
+//!
+//! Tests 1 and 2 assert *exact* status codes (`403`, `404`) rather than "any 4xx".
+//! A future regression that removes the `is_manager()` check or drops the
+//! `AND organization_id = $caller_org_id` clause would silently start mutating
+//! the row and the response would change shape — the strict assertions catch
+//! that. The earlier "any 4xx is fine" assertion would have passed even if the
+//! security mechanism stopped firing, because the outer JWT gate was still
+//! active (issue #696).
 
 #[allow(dead_code)]
 mod common;
@@ -39,7 +50,7 @@ use serde_json::json;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use common::TestApp;
+use common::{create_authenticated_user, TestApp, TestUser};
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -53,36 +64,24 @@ async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
         "#,
     )
     .bind(format!("Sched RBAC Org {slug}"))
-    .bind(format!("sched-rbac-org-{slug}"))
-    .bind(format!("{slug}@sched-rbac.test"))
+    .bind(format!("sched-rbac-org-{slug}-{}", Uuid::new_v4()))
+    .bind(format!("{slug}-{}@sched-rbac.test", Uuid::new_v4()))
     .fetch_one(pool)
     .await
     .expect("seed org")
 }
 
-async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO users (email, password_hash, name, status, email_verified_at)
-        VALUES ($1, 'test_hash', 'RBAC User', 'active', NOW())
-        RETURNING id
-        "#,
-    )
-    .bind(email)
-    .fetch_one(pool)
-    .await
-    .expect("seed user")
-}
-
 /// Insert a membership row so the user is a recognised tenant member.
 ///
-/// Uses `organization_members` (the table queried by `OrganizationMemberRepository`
-/// via `ValidatedTenantExtractor`). Matches the pattern used by push_token_tests
-/// and document_upload_tests.
+/// Uses `organization_members` (the table queried by
+/// `OrganizationMemberRepository` via `ValidatedTenantExtractor`). The role
+/// string is normalized case-insensitively in `extractors/tenant.rs`, so
+/// `"manager"` and `"Resident"` both round-trip to the right `TenantRole`.
 async fn seed_membership(pool: &PgPool, org_id: Uuid, user_id: Uuid, role: &str) {
     sqlx::query(
         r#"
-        INSERT INTO organization_members (id, organization_id, user_id, role_type, status, created_at)
+        INSERT INTO organization_members
+            (id, organization_id, user_id, role_type, status, created_at)
         VALUES ($1, $2, $3, $4, 'active', NOW())
         ON CONFLICT DO NOTHING
         "#,
@@ -103,7 +102,8 @@ async fn seed_schedule(pool: &PgPool, org_id: Uuid) -> Uuid {
         INSERT INTO report_schedules
             (report_id, organization_id, name, frequency, time, timezone, format, recipients)
         VALUES
-            (gen_random_uuid(), $1, 'Original Schedule Name', 'weekly', '08:00', 'UTC', 'pdf', '["original@example.com"]')
+            (gen_random_uuid(), $1, 'Original Schedule Name', 'weekly', '08:00', 'UTC', 'pdf',
+             '["original@example.com"]')
         RETURNING id
         "#,
     )
@@ -113,71 +113,91 @@ async fn seed_schedule(pool: &PgPool, org_id: Uuid) -> Uuid {
     .expect("seed report schedule")
 }
 
-/// Build a PUT request targeting `PUT /api/v1/reports/schedules/{id}`.
-///
-/// Sends `X-Tenant-ID` (the UUID header read by `ValidatedTenantExtractor`)
-/// but no Bearer JWT. Without a JWT, `AuthUser` returns 401 before the
-/// RBAC or IDOR check runs — demonstrating the auth gate is the outer
-/// line of defence. In production (with a valid JWT for Org B) the
-/// tenant-scoped WHERE clause would return no row and the handler
-/// returns 404, achieving the IDOR isolation contract.
-fn put_schedule_req(schedule_id: Uuid, org_id: Uuid, body: serde_json::Value) -> Request<Body> {
+/// Look up a user id by email (the user is created by
+/// `create_authenticated_user` via `POST /api/v1/auth/register`).
+async fn user_id_for(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(email)
+        .fetch_one(pool)
+        .await
+        .expect("fetch user id")
+}
+
+/// Build an authenticated `PUT /api/v1/reports/schedules/{id}` request.
+fn put_schedule_req_auth(
+    schedule_id: Uuid,
+    tenant_id: Uuid,
+    access_token: &str,
+    body: serde_json::Value,
+) -> Request<Body> {
     Request::builder()
         .method(Method::PUT)
         .uri(format!("/api/v1/reports/schedules/{}", schedule_id))
-        .header("X-Tenant-ID", org_id.to_string())
+        .header(header::AUTHORIZATION, format!("Bearer {}", access_token))
+        .header("X-Tenant-ID", tenant_id.to_string())
         .header(header::CONTENT_TYPE, "application/json")
         .body(Body::from(body.to_string()))
-        .unwrap()
-}
-
-/// Assert the response is a 4xx rejection.
-///
-/// The RBAC/cross-tenant contract is "the mutating request must NOT succeed".
-/// Both 401/403 (auth gate, no valid JWT in TestApp) and 404 (tenant-scoped
-/// WHERE found no row in production) satisfy this contract.
-fn assert_rejected(status: StatusCode, label: &str) {
-    let code = status.as_u16();
-    assert!(
-        (400..500).contains(&code),
-        "{label}: expected 4xx rejection, got {status}"
-    );
+        .expect("build request")
 }
 
 // ---------------------------------------------------------------------------
-// Test 1 — #614: unauthorized role is rejected
+// Test 1 — #614/#696: an authenticated Resident gets 403 from the RBAC check
 // ---------------------------------------------------------------------------
 
-/// A user with a sub-manager role (here: no valid JWT) is rejected before any
-/// DB mutation occurs.
+/// A user with a real Bearer JWT whose DB-backed membership role is
+/// `Resident` attempts to update a schedule in their own org. The request
+/// passes `AuthUser` and `ValidatedTenantExtractor` and reaches the handler;
+/// the handler's `if !rls.role().is_manager()` branch fires and returns
+/// `403 FORBIDDEN` with the `FORBIDDEN` error code. The schedule row is
+/// unchanged.
 ///
-/// Sends `X-Tenant-ID` (correct header for `ValidatedTenantExtractor`) but no
-/// Bearer JWT. The `AuthUser` extractor returns 401 before the RBAC check
-/// fires, demonstrating the auth gate is the outer line of defence.
+/// Issue #696 noted the previous version of this test sent NO JWT, so
+/// `AuthUser` returned 401 before the RBAC check ever ran — the test only
+/// proved the outer auth gate worked. This rewrite exercises the actual
+/// RBAC predicate.
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn update_schedule_without_manager_role_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
-    let org = seed_org(&pool, "role-a").await;
-    let user = seed_user(&pool, "resident@sched-rbac.test").await;
-    // Seed as Resident — below the manager threshold.
-    seed_membership(&pool, org, user, "Resident").await;
+    let org = seed_org(&pool, "role").await;
     let schedule = seed_schedule(&pool, org).await;
 
-    // X-Tenant-ID is the header read by ValidatedTenantExtractor.
-    // Without a Bearer JWT, AuthUser returns 401 before RBAC runs.
-    let req = Request::builder()
-        .method(Method::PUT)
-        .uri(format!("/api/v1/reports/schedules/{}", schedule))
-        .header("X-Tenant-ID", org.to_string())
-        .header(header::CONTENT_TYPE, "application/json")
-        .body(Body::from(
-            json!({"recipients": ["attacker@evil.test"]}).to_string(),
-        ))
-        .unwrap();
+    // Register + login a real user, then attach them to `org` as a Resident.
+    let resident = TestUser::new();
+    let (access_token, _) = create_authenticated_user(&app, &resident).await;
+    let resident_user_id = user_id_for(&pool, &resident.email).await;
+    seed_membership(&pool, org, resident_user_id, "Resident").await;
 
-    let response = app.execute(req).await;
-    assert_rejected(response.status, "unauthorized role (#614)");
+    let response = app
+        .execute(put_schedule_req_auth(
+            schedule,
+            org,
+            &access_token,
+            json!({ "recipients": ["attacker@evil.test"] }),
+        ))
+        .await;
+
+    // The RBAC check inside the handler must fire — not the outer JWT gate.
+    assert_eq!(
+        response.status,
+        StatusCode::FORBIDDEN,
+        "#614/#696: authenticated Resident must be rejected by the RBAC check \
+         (`rls.role().is_manager()`) with 403, got {} body={}",
+        response.status,
+        response.text(),
+    );
+
+    // The handler returns the `FORBIDDEN` error code for this branch.
+    let body: serde_json::Value = response.json_value();
+    let code = body
+        .get("code")
+        .and_then(|c| c.as_str())
+        .unwrap_or_default();
+    assert_eq!(
+        code, "FORBIDDEN",
+        "#614/#696: 403 response must carry the FORBIDDEN code, body={}",
+        body
+    );
 
     // Verify the DB row was NOT mutated.
     let recipients_json: serde_json::Value =
@@ -186,52 +206,74 @@ async fn update_schedule_without_manager_role_is_rejected(pool: PgPool) {
             .fetch_one(&pool)
             .await
             .expect("fetch schedule recipients");
-
-    // The original seed value must be unchanged.
     assert_eq!(
         recipients_json,
         json!(["original@example.com"]),
-        "#614 regression: recipients must not be changed by an unauthenticated/low-role request"
+        "#614 regression: recipients must not be changed by a Resident-role request"
     );
 }
 
 // ---------------------------------------------------------------------------
-// Test 2 — #624: cross-tenant mutation is rejected
+// Test 2 — #624/#696: cross-tenant Manager gets 404 from the org-scoped WHERE
 // ---------------------------------------------------------------------------
 
-/// A caller claiming Org B attempts to mutate a report schedule belonging to
-/// Org A. The request must be rejected (4xx) and the record must remain
-/// unchanged.
+/// A *real* authenticated Manager in Org B targets a schedule UUID that lives
+/// in Org A. The request passes the JWT gate, passes the tenant-membership
+/// extractor (the user IS a member of Org B), passes the RBAC check (they
+/// ARE a manager), and reaches the repository. The UPDATE WHERE clause
+/// `... AND organization_id = $caller_org_id` finds no row for
+/// `schedule_in_a` and the repo returns `AppError::NotFound`, which the
+/// handler maps to `404 NOT_FOUND` with code `SCHEDULE_NOT_FOUND`.
 ///
-/// In production (with a valid Manager JWT for Org B) the repo UPDATE
-/// includes `AND organization_id = org_b_id` which finds no row for
-/// schedule_in_a → 404. In TestApp (no JWT) the auth gate fires first →
-/// 401. Either way the cross-tenant mutation is never applied.
+/// Issue #696 noted the previous version of this test sent NO JWT, so the
+/// repository UPDATE was never executed. This rewrite forces the org-scoped
+/// WHERE clause to actually fire.
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn update_schedule_from_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
     // Org A owns the target schedule.
-    let org_a = seed_org(&pool, "ctor-a").await;
-    let user_a = seed_user(&pool, "user-a@sched-rbac.test").await;
-    seed_membership(&pool, org_a, user_a, "Manager").await;
+    let org_a = seed_org(&pool, "victim").await;
     let schedule_in_a = seed_schedule(&pool, org_a).await;
 
     // Org B is the attacker's org.
-    let org_b = seed_org(&pool, "ctor-b").await;
-    let user_b = seed_user(&pool, "user-b@sched-rbac.test").await;
-    seed_membership(&pool, org_b, user_b, "Manager").await;
+    let org_b = seed_org(&pool, "attacker").await;
 
-    // Attacker (Org B) sends X-Tenant-ID=org_b but targets schedule_in_a.
+    // Real authenticated Manager in Org B.
+    let attacker = TestUser::new();
+    let (access_token, _) = create_authenticated_user(&app, &attacker).await;
+    let attacker_user_id = user_id_for(&pool, &attacker.email).await;
+    seed_membership(&pool, org_b, attacker_user_id, "manager").await;
+
     let response = app
-        .execute(put_schedule_req(
+        .execute(put_schedule_req_auth(
             schedule_in_a,
             org_b,
-            json!({"recipients": ["attacker@evil.test"]}),
+            &access_token,
+            json!({ "recipients": ["attacker@evil.test"] }),
         ))
         .await;
 
-    assert_rejected(response.status, "cross-tenant update (#624)");
+    // The org-scoped WHERE must fire — not the JWT gate, not RBAC.
+    assert_eq!(
+        response.status,
+        StatusCode::NOT_FOUND,
+        "#624/#696: cross-tenant Manager must hit the org-scoped WHERE and get \
+         404 (schedule not found in caller's org), got {} body={}",
+        response.status,
+        response.text(),
+    );
+
+    let body: serde_json::Value = response.json_value();
+    let code = body
+        .get("code")
+        .and_then(|c| c.as_str())
+        .unwrap_or_default();
+    assert_eq!(
+        code, "SCHEDULE_NOT_FOUND",
+        "#624/#696: 404 response must carry SCHEDULE_NOT_FOUND, body={}",
+        body
+    );
 
     // Verify the original row in Org A is untouched.
     let recipients_json: serde_json::Value =
@@ -240,7 +282,6 @@ async fn update_schedule_from_other_org_is_rejected(pool: PgPool) {
             .fetch_one(&pool)
             .await
             .expect("fetch schedule recipients");
-
     assert_eq!(
         recipients_json,
         json!(["original@example.com"]),
@@ -249,11 +290,12 @@ async fn update_schedule_from_other_org_is_rejected(pool: PgPool) {
 }
 
 // ---------------------------------------------------------------------------
-// Test 3 — No auth header at all → 401
+// Test 3 — No auth header at all → 4xx from `AuthUser` (legitimate gate test)
 // ---------------------------------------------------------------------------
 
-/// Unauthenticated request (no Authorization header, no tenant header)
-/// must be rejected with 4xx before any DB access.
+/// Unauthenticated request (no Authorization header, no tenant header) must
+/// be rejected with 4xx by `AuthUser` before any DB access. This is the
+/// legitimate outer-gate test and is intentionally kept as-is.
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn update_schedule_without_any_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -265,9 +307,25 @@ async fn update_schedule_without_any_auth_is_rejected(pool: PgPool) {
         .method(Method::PUT)
         .uri(format!("/api/v1/reports/schedules/{}", schedule))
         .header(header::CONTENT_TYPE, "application/json")
-        .body(Body::from(json!({"enabled": false}).to_string()))
+        .body(Body::from(json!({ "enabled": false }).to_string()))
         .unwrap();
 
     let response = app.execute(req).await;
-    assert_rejected(response.status, "no-auth request must be rejected");
+    let code = response.status.as_u16();
+    assert!(
+        (400..500).contains(&code),
+        "no-auth request must be rejected with 4xx, got {}",
+        response.status,
+    );
+
+    // Verify the row was not mutated either.
+    let active: bool = sqlx::query_scalar("SELECT is_active FROM report_schedules WHERE id = $1")
+        .bind(schedule)
+        .fetch_one(&pool)
+        .await
+        .expect("fetch is_active");
+    assert!(
+        active,
+        "no-auth request must not have flipped is_active to false"
+    );
 }


### PR DESCRIPTION
## Summary

Rewrites `backend/servers/api-server/tests/report_schedule_rbac_tests.rs` so the regression tests for #614 (RBAC) and #624 (cross-tenant IDOR) actually exercise the handler-side security predicates instead of just the outer JWT gate.

Closes #696.

### Problem

The previous version of these tests sent requests **without a Bearer JWT**, so `AuthUser` returned `401` before the handler's `rls.role().is_manager()` check or the repository's `AND organization_id = $caller_org_id` WHERE clause ever ran. Any future regression that removed those checks would have left the suite green — the tests only proved the outer auth gate worked.

### Fix

Use `common::create_authenticated_user` to obtain real Bearer JWTs, then drive each test to the exact internal branch it should be guarding:

1. **#614/#696 — RBAC predicate fires**
   Authenticate a `Resident`, send `X-Tenant-ID = their org`, target a schedule in that same org. Assert exactly `403 FORBIDDEN` with code `FORBIDDEN`. The Resident passes `AuthUser` and `ValidatedTenantExtractor`, hits the handler, and the `if !rls.role().is_manager()` branch fires. The DB row is verified unchanged.

2. **#624/#696 — org-scoped WHERE fires**
   Authenticate a `Manager` in Org B, send `X-Tenant-ID = org_b`, target a schedule UUID owned by Org A. Assert exactly `404 NOT_FOUND` with code `SCHEDULE_NOT_FOUND`. The attacker is a real authenticated manager — the only thing that can save Org A's row is the repository's tenant-scoped UPDATE WHERE clause. The Org A row is verified unchanged.

3. **No-auth gate (kept as-is)**
   Request with no `Authorization` header → 4xx from `AuthUser`. Now also asserts the row was not mutated, just for symmetry.

Status-code assertions are tightened from "any 4xx" to exact `(code, error_body.code)` pairs so a silent regression that bypasses the intended security mechanism but is still caught by some other gate would now fail loudly.

## Test plan

- [x] `cargo check -p api-server --tests` (6m31s, clean)
- [x] `cargo fmt --all` (pre-commit hook green)
- [ ] CI: backend tests pass — these three sqlx tests run real migrations against a fresh DB, register a real user via `POST /api/v1/auth/register`, and assert the exact status + error code
- [ ] Verify the test names + closes-issue map to #614, #624, #696 in the test docblock