### PR TITLE
fix(disputes): restore dialog a11y attrs (closes #703 a11y findings)

### DIFF
--- a/frontend/apps/ppt-web/src/features/disputes/components/MediationAssignDialog.tsx
+++ b/frontend/apps/ppt-web/src/features/disputes/components/MediationAssignDialog.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useFocusTrap } from '../../../hooks/useFocusTrap';
 
 export interface MediationAssignDialogProps {
   onConfirm: (mediatorId: string) => void;
@@ -14,12 +15,16 @@ export function MediationAssignDialog({
 }: MediationAssignDialogProps) {
   const { t } = useTranslation();
   const [mediatorId, setMediatorId] = useState('');
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(dialogRef, onCancel);
 
   return (
     <div
+      ref={dialogRef}
       role="dialog"
       aria-modal="true"
       aria-labelledby="assign-dialog-title"
+      tabIndex={-1}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
     >
       <div className="bg-white rounded-xl shadow-xl w-full max-w-md p-6">
@@ -30,10 +35,14 @@ export function MediationAssignDialog({
           {t('disputes.mediation.assignMediatorDescription')}
         </p>
 
-        <label className="block text-sm font-medium text-gray-700 mb-1">
+        <label
+          htmlFor="assign-dialog-mediator-id"
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
           {t('disputes.mediation.mediatorUserId')}
         </label>
         <input
+          id="assign-dialog-mediator-id"
           type="text"
           value={mediatorId}
           onChange={(e) => setMediatorId(e.target.value)}

--- a/frontend/apps/ppt-web/src/features/disputes/components/MediationEscalateDialog.tsx
+++ b/frontend/apps/ppt-web/src/features/disputes/components/MediationEscalateDialog.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useFocusTrap } from '../../../hooks/useFocusTrap';
 
 export interface MediationEscalateDialogProps {
   onConfirm: (reason: string) => void;
@@ -14,12 +15,16 @@ export function MediationEscalateDialog({
 }: MediationEscalateDialogProps) {
   const { t } = useTranslation();
   const [reason, setReason] = useState('');
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(dialogRef, onCancel);
 
   return (
     <div
+      ref={dialogRef}
       role="dialog"
       aria-modal="true"
       aria-labelledby="escalate-dialog-title"
+      tabIndex={-1}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
     >
       <div className="bg-white rounded-xl shadow-xl w-full max-w-md p-6">
@@ -28,10 +33,14 @@ export function MediationEscalateDialog({
         </h2>
         <p className="text-sm text-gray-500 mb-4">{t('disputes.mediation.escalateDescription')}</p>
 
-        <label className="block text-sm font-medium text-gray-700 mb-1">
+        <label
+          htmlFor="escalate-dialog-reason"
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
           {t('disputes.mediation.reasonForEscalation')}
         </label>
         <textarea
+          id="escalate-dialog-reason"
           value={reason}
           onChange={(e) => setReason(e.target.value)}
           rows={4}


### PR DESCRIPTION
## Summary

PR #633 extracted `MediationEscalateDialog` and `MediationAssignDialog`
from the inline dialogs in `MediationWorkspacePage`, but in the process
dropped three a11y behaviours the inline versions had. This restores them
using the canonical `useFocusTrap` hook already used by other dialogs in
this app (e.g. `RejectBookingDialog`, `CancelBookingDialog`).

Fixes the **a11y findings** from #703:

- **Keyboard / focus regression** (WCAG 2.1.1, 3.2.2). Both dialogs now
  use a `dialogRef` + `useFocusTrap(dialogRef, onCancel)` which:
  - moves focus to the first focusable child on mount (the textarea in
    Escalate, the input in Assign),
  - traps Tab / Shift-Tab inside the modal,
  - binds `Escape` to `onCancel`,
  - restores focus to the previously-focused element on close.
- **Label not associated with control**. Added `htmlFor` / `id` pairs so
  assistive tech announces the label when the control receives focus:
  - `escalate-dialog-reason` on the Escalate textarea,
  - `assign-dialog-mediator-id` on the Assign input.

The existing `role="dialog" aria-modal="true" aria-labelledby="…"` is
preserved. `tabIndex={-1}` added to the dialog containers so the focus
trap can fall back to the container if it ever has no focusable child.

## Deferred (separate scope, tracked under #703)

- **Tests for `MediationEscalateDialog` / `MediationAssignDialog`** —
  finding 4. Not in this PR; opening a separate scope keeps the
  a11y patch reviewable.
- **Screen-map updates for `docs/screens/ppt/disputes.md` and
  `dispute-detail.md`** — finding 5.
- **`useWatch` perf nit in `MediationResolutionForm`** — finding 3.
  Orthogonal to a11y, currently low impact.

## Test plan

- [x] `pnpm --filter @ppt/web typecheck` passes locally
- [x] Pre-commit hook (full repo typecheck across all 14 workspaces) passes
- [ ] CI runs lint + tests on the PR
- [ ] Manual smoke: open escalate / assign dialog, confirm Escape closes,
      Tab cycles, focus lands on the input on open, screen reader
      announces the label.

Closes #703 (a11y portion).