### PR TITLE
fix(ppt-web): localize evidence-upload partial-fail toast + pass list via router state (closes #627)

### DIFF
--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -233,7 +233,7 @@
     "multipleRespondentsMsg": "Zaznamenán bude pouze první odpůrce.",
     "addEvidence": "Přidat důkaz",
     "filedWithEvidenceErrors": "Spor podán (některé soubory selhaly)",
-    "evidenceUploadErrorsMsg": "Jeden nebo více souborů s důkazy se nepodařilo nahrát. Zkuste to znovu ze stránky podrobností sporu.",
+    "evidenceUploadErrorsMsg": "{{count}} souborů s důkazy se nepodařilo nahrát. Zkuste to znovu ze stránky podrobností sporu.",
     "mediation": {
       "title": "Mediační prostor",
       "backToDispute": "← Zpět na spor",

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -233,7 +233,7 @@
     "multipleRespondentsMsg": "Nur der erste Beklagte wird erfasst.",
     "addEvidence": "Beweis hinzufügen",
     "filedWithEvidenceErrors": "Streit eingereicht (einige Dateien fehlgeschlagen)",
-    "evidenceUploadErrorsMsg": "Eine oder mehrere Beweisdateien konnten nicht hochgeladen werden. Bitte erneut von der Detailseite des Streits versuchen.",
+    "evidenceUploadErrorsMsg": "{{count}} Beweisdatei(en) konnten nicht hochgeladen werden. Bitte erneut von der Detailseite des Streits versuchen.",
     "mediation": {
       "title": "Mediations-Arbeitsbereich",
       "backToDispute": "← Zurück zur Streitigkeit",

--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -295,7 +295,7 @@
     "multipleRespondentsMsg": "Only the first respondent will be recorded.",
     "addEvidence": "Add Evidence",
     "filedWithEvidenceErrors": "Dispute filed (some files failed)",
-    "evidenceUploadErrorsMsg": "One or more evidence files could not be uploaded. Retry from the dispute detail page.",
+    "evidenceUploadErrorsMsg": "{{count}} evidence file(s) could not be uploaded. Retry from the dispute detail page.",
     "mediation": {
       "title": "Mediation Workspace",
       "backToDispute": "← Back to Dispute",

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -233,7 +233,7 @@
     "multipleRespondentsMsg": "Csak az első alperes kerül rögzítésre.",
     "addEvidence": "Bizonyíték hozzáadása",
     "filedWithEvidenceErrors": "Vita benyújtva (egyes fájlok sikertelenek)",
-    "evidenceUploadErrorsMsg": "Egy vagy több bizonyítékfájlt nem sikerült feltölteni. Próbálja meg újra a vita részletoldaláról.",
+    "evidenceUploadErrorsMsg": "{{count}} bizonyítékfájlt nem sikerült feltölteni. Próbálja meg újra a vita részletoldaláról.",
     "mediation": {
       "title": "Mediációs munkaterület",
       "backToDispute": "← Vissza a vitához",

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -233,7 +233,7 @@
     "multipleRespondentsMsg": "Tylko pierwszy pozwany zostanie zarejestrowany.",
     "addEvidence": "Dodaj dowód",
     "filedWithEvidenceErrors": "Spór zgłoszony (niektóre pliki nie powiodły się)",
-    "evidenceUploadErrorsMsg": "Nie udało się przesłać jednego lub więcej plików dowodowych. Spróbuj ponownie ze strony szczegółów sporu.",
+    "evidenceUploadErrorsMsg": "Nie udało się przesłać {{count}} plików dowodowych. Spróbuj ponownie ze strony szczegółów sporu.",
     "mediation": {
       "title": "Przestrzeń mediacyjna",
       "backToDispute": "← Wróć do sporu",

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -234,7 +234,7 @@
     "multipleRespondentsMsg": "Zaznamenaný bude iba prvý odporca.",
     "addEvidence": "Pridať dôkaz",
     "filedWithEvidenceErrors": "Spor podaný (niektoré súbory zlyhali)",
-    "evidenceUploadErrorsMsg": "Jeden alebo viac súborov s dôkazmi sa nepodarilo nahrať. Skúste to znova zo stránky detailov sporu.",
+    "evidenceUploadErrorsMsg": "{{count}} súbor(ov) s dôkazmi sa nepodarilo nahrať. Skúste to znova zo stránky detailov sporu.",
     "mediation": {
       "title": "Mediačný priestor",
       "backToDispute": "← Späť na spor",

--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -885,24 +885,22 @@ function FileDisputePageRoute() {
       // We call the raw API function (not the hook) because the hook must be
       // keyed to a disputeId at render time and we only know the id after step 1.
       const validFiles = payload.evidence.filter((e) => e.status !== 'error');
-      let evidenceErrors = 0;
+      const failedEvidence: typeof validFiles = [];
       for (const item of validFiles) {
         try {
           await apiUploadEvidence(created.id, item.file, item.description || item.file.name);
         } catch {
-          evidenceErrors++;
+          failedEvidence.push(item);
         }
       }
+      const evidenceErrors = failedEvidence.length;
 
       // Step 3 — toast + navigate to the new dispute detail
       if (evidenceErrors > 0) {
         showToast({
           type: 'warning',
           title: t('disputes.filedWithEvidenceErrors', 'Dispute filed (some files failed)'),
-          message: t(
-            'disputes.evidenceUploadErrorsMsg',
-            `${evidenceErrors} file(s) could not be uploaded. Retry from the dispute detail page.`
-          ),
+          message: t('disputes.evidenceUploadErrorsMsg', { count: evidenceErrors }),
         });
       } else {
         showToast({
@@ -911,7 +909,12 @@ function FileDisputePageRoute() {
           message: t('disputes.submittedMsg', 'Your dispute has been submitted for review.'),
         });
       }
-      navigate(`/disputes/${created.id}`);
+      // TODO(#627): consume failedEvidence on DisputeDetailPage to surface a retry
+      // prompt once evidence-retry UI lands. For now we just thread it through
+      // router state so the detail page can pick it up when ready.
+      navigate(`/disputes/${created.id}`, {
+        state: evidenceErrors > 0 ? { failedEvidence } : undefined,
+      });
     } catch (error) {
       showToast({
         type: 'error',


### PR DESCRIPTION
Closes #627 — addresses findings 1 and 2 from the post-merge review of #530.

## Findings addressed

### 1. i18n fallback (low severity)
`FileDisputePageRoute` was passing a template-literal English string as the i18next default for `disputes.evidenceUploadErrorsMsg` — so the `${evidenceErrors}` count was never interpolated by i18n and the message was effectively un-localized whenever the locale fell back. Switched to the standard `t('disputes.evidenceUploadErrorsMsg', { count: evidenceErrors })` pattern and added `{{count}}` to the existing key in all 6 locales (`en`, `sk`, `cs`, `de`, `pl`, `hu`).

### 2. Failed-evidence list passed via router state (medium severity)
On partial-fail, the failed `PendingEvidence` items are now threaded through to `/disputes/:id` via `navigate(..., { state: { failedEvidence } })`. The detail page does not consume the state yet (separate story for the evidence-retry UI), but the wiring is in place and a `TODO(#627)` comment documents the intent.

## Deferred

### 3. Retry loop on transient network errors (deferred)
Out of scope for this PR. A 1-shot retry on `apiUploadEvidence` is a non-trivial change — it needs a design pass on backoff strategy, idempotency guarantees (the upload endpoint is not idempotent today), and which error classes are safe to retry. Tracked as a follow-up.

## Verification

- `pnpm --filter @ppt/web typecheck` — passes
- `biome check` on touched files — passes
- pre-commit `prepare-commit` hook (full workspace typecheck) — passes

## Files changed

- `frontend/apps/ppt-web/src/App.tsx` — i18n call + router-state wiring + TODO
- `frontend/apps/ppt-web/messages/{en,sk,cs,de,pl,hu}.json` — `{{count}}` interpolation