### PR TITLE
fix(admin-web): sequence onboarding mutations + raise overlay z-index + drop skip-step (closes #702 bugs)

### DIFF
--- a/frontend/apps/admin-web/src/features/onboarding/TourOverlay.tsx
+++ b/frontend/apps/admin-web/src/features/onboarding/TourOverlay.tsx
@@ -17,8 +17,14 @@ interface TourOverlayProps {
   tour: OnboardingTour;
   progress: UserOnboardingProgress | null;
   isMutating: boolean;
-  onCompleteStep: (stepId: string) => void;
-  onCompleteTour: () => void;
+  /**
+   * Called when the user completes a step.
+   *
+   * `isLast` lets the parent chain the `completeTour` mutation into the
+   * `onSuccess` callback of the step mutation, so the two POSTs are
+   * sequenced rather than racing (see issue #702 finding #1).
+   */
+  onCompleteStep: (stepId: string, isLast: boolean) => void;
   onSkipTour: () => void;
   onResetTour: () => void;
   onClose: () => void;
@@ -88,7 +94,6 @@ interface StepRowProps {
   isLast: boolean;
   isMutating: boolean;
   onComplete: () => void;
-  onSkip: () => void;
 }
 
 function StepRow({
@@ -100,7 +105,6 @@ function StepRow({
   isLast,
   isMutating,
   onComplete,
-  onSkip,
 }: StepRowProps) {
   const { t } = useTranslation();
 
@@ -203,24 +207,12 @@ function StepRow({
             >
               {isLast ? t('onboarding.finishTour') : t('onboarding.completeStep')}
             </button>
-            {!isLast && (
-              <button
-                type="button"
-                disabled={isMutating}
-                onClick={onSkip}
-                style={{
-                  padding: '6px 14px',
-                  fontSize: 13,
-                  background: 'transparent',
-                  color: 'var(--ppt-fg-muted, #6b7280)',
-                  border: '1px solid var(--ppt-border-default, #e5e7eb)',
-                  borderRadius: 6,
-                  cursor: isMutating ? 'not-allowed' : 'pointer',
-                }}
-              >
-                {t('onboarding.skipStep')}
-              </button>
-            )}
+            {/*
+              "Skip step" button removed (issue #702 finding #2): there is no
+              backend skip-step endpoint, and aliasing it to the complete-step
+              POST recorded a misleading "completed" entry in the audit trail.
+              Tour-level skip is still available in the footer via `onSkipTour`.
+            */}
           </div>
         )}
       </div>
@@ -235,7 +227,6 @@ export function TourOverlay({
   progress,
   isMutating,
   onCompleteStep,
-  onCompleteTour,
   onSkipTour,
   onResetTour,
   onClose,
@@ -252,21 +243,17 @@ export function TourOverlay({
   const isCompleted = displayStatus === 'completed';
   const isSkipped = displayStatus === 'skipped';
 
-  // Handle the "complete step" action — auto-complete tour after last step
-  const handleCompleteStep = (stepId: string, isLast: boolean) => {
-    onCompleteStep(stepId);
-    if (isLast) {
-      onCompleteTour();
-    }
-  };
-
   return (
     /* Backdrop */
     <div
       style={{
         position: 'fixed',
         inset: 0,
-        zIndex: 1000,
+        // 1050 sits above Toast (z-index 1000 in Toast.css) and below the
+        // OAuthClients modal (9000) and DestructiveConfirmDialog (9999), so
+        // mutation-success toasts render on top of an open tour overlay
+        // instead of behind it (issue #702 finding #3).
+        zIndex: 1050,
         background: 'rgba(0,0,0,0.45)',
         display: 'flex',
         alignItems: 'center',
@@ -498,11 +485,7 @@ export function TourOverlay({
                   isCurrent={isCurrent}
                   isLast={isLast}
                   isMutating={isMutating}
-                  onComplete={() => handleCompleteStep(step.id, isLast)}
-                  onSkip={() => {
-                    // Skipping a step: mark it complete to advance
-                    handleCompleteStep(step.id, isLast);
-                  }}
+                  onComplete={() => onCompleteStep(step.id, isLast)}
                 />
               );
             })}

--- a/frontend/apps/admin-web/src/pages/OnboardingToursPage.tsx
+++ b/frontend/apps/admin-web/src/pages/OnboardingToursPage.tsx
@@ -265,11 +265,35 @@ export default function OnboardingToursPage() {
     }
   };
 
-  const handleCompleteStep = (stepId: string) => {
+  const handleCompleteStep = (stepId: string, isLast: boolean) => {
     if (!activeTour) return;
+    const tourId = activeTour.tour.tour_id;
+    const tourName = activeTour.tour.name;
     completeStepMutation.mutate(
-      { tourId: activeTour.tour.tour_id, stepId },
+      { tourId, stepId },
       {
+        onSuccess: () => {
+          // Chain `completeOnboardingTour` only after the final step POST
+          // has succeeded — keeps the two requests sequenced instead of
+          // racing against the backend (issue #702 finding #1).
+          if (!isLast) return;
+          completeTourMutation.mutate(tourId, {
+            onSuccess: () => {
+              showToast({
+                title: t('onboarding.toast.completedTitle'),
+                message: t('onboarding.toast.completedMessage', { name: tourName }),
+                type: 'success',
+              });
+            },
+            onError: (err) => {
+              showToast({
+                title: t('onboarding.toast.completeFailedTitle'),
+                message: err instanceof Error ? err.message : t('common.unknown'),
+                type: 'error',
+              });
+            },
+          });
+        },
         onError: (err) => {
           showToast({
             title: t('onboarding.toast.stepFailedTitle'),
@@ -279,26 +303,6 @@ export default function OnboardingToursPage() {
         },
       }
     );
-  };
-
-  const handleCompleteTour = () => {
-    if (!activeTour) return;
-    completeTourMutation.mutate(activeTour.tour.tour_id, {
-      onSuccess: () => {
-        showToast({
-          title: t('onboarding.toast.completedTitle'),
-          message: t('onboarding.toast.completedMessage', { name: activeTour.tour.name }),
-          type: 'success',
-        });
-      },
-      onError: (err) => {
-        showToast({
-          title: t('onboarding.toast.completeFailedTitle'),
-          message: err instanceof Error ? err.message : t('common.unknown'),
-          type: 'error',
-        });
-      },
-    });
   };
 
   const handleSkipTour = () => {
@@ -486,7 +490,6 @@ export default function OnboardingToursPage() {
           progress={syncedActiveTour.progress}
           isMutating={isMutating}
           onCompleteStep={handleCompleteStep}
-          onCompleteTour={handleCompleteTour}
           onSkipTour={handleSkipTour}
           onResetTour={handleResetTour}
           onClose={() => setActiveTour(null)}


### PR DESCRIPTION
## Summary

Follow-up fixes for the post-merge review of #689 (Epic 10B / Story 10B.6 — onboarding tour overlay in `admin-web`). Issue: #702.

This PR addresses the three **behaviour bugs** named in #702. The other findings (test gap, missing screen-map, dead `STATUS_STYLE.label`) are deferred to separate follow-ups — see below.

## Fixes

### 1. Double-fire on last step (#702 finding #1 — correctness, medium)
Previously, completing the last step fired both `completeOnboardingStep` and `completeOnboardingTour` in the same synchronous tick, racing two POSTs at the backend.

- `TourOverlay.onCompleteStep` now carries an `isLast: boolean` flag and is the sole entry point for step-complete actions.
- `OnboardingToursPage.handleCompleteStep` chains `completeTourMutation.mutate(...)` into the step mutation's `onSuccess`, so the tour-complete request is dispatched **only after** the step-complete request has succeeded.
- The dedicated `onCompleteTour` prop and `handleCompleteTour` page handler are removed (folded into the step `onSuccess`).

### 2. z-index conflict: overlay vs. toast (#702 finding #3 — UI regression, low)
`TourOverlay` backdrop was `zIndex: 1000`, identical to `Toast.css`'s `z-index: 1000`, leaving toast notifications (success / error from mutation callbacks) in an indeterminate stacking order behind the open overlay.

- Backdrop bumped to `zIndex: 1050`. Stays well below the OAuthClients modal (9000) and `DestructiveConfirmDialog` (9999). Toasts now reliably render on top of an open overlay.

### 3. "Skip step" semantic bug (#702 finding #2 — semantic, low)
The per-step "Skip step" button called `handleCompleteStep`, which POSTs to `.../steps/{id}/complete`. There is no backend skip-step endpoint, so a "skipped" click was recorded in the audit trail as a *completed* step — misleading for reporting.

- Chose option (a) from the issue: removed the per-step "Skip step" button from `StepRow`. Tour-level skip remains available via the footer "Skip tour" button, which hits the dedicated `/onboarding/tours/{id}/skip` endpoint.
- `StepRow.onSkip` prop also removed.

## Deferred (NOT in this PR)

- **#702 finding #4 — no RTL tests for tour flow**: scope creep for this PR; will land as a separate test-coverage PR alongside other admin-web onboarding test work.
- **#702 finding #5 — missing screen-map for `/platform/onboarding`**: belongs to the `/screens` workflow (`screen-map-init` / `/screens update`), separate process.
- **#702 finding #6 — dead `STATUS_STYLE.label` field**: pure cleanup, not a behaviour bug; will fold into the screen-map / test PR.

## Test plan

- [x] `pnpm install --frozen-lockfile` (workspace)
- [x] `pnpm --filter @ppt/admin-web typecheck` — clean
- [x] `pnpm -r typecheck` (via pre-commit hook) — clean
- [x] `pnpm exec biome check` on both modified files — clean
- [ ] Manual smoke (post-merge / preview env): open `/platform/onboarding`, run a multi-step tour to completion — verify exactly one `steps/{id}/complete` POST followed by one `tours/{id}/complete` POST, success toast visible on top of overlay.
- [ ] Manual smoke: confirm no "Skip step" button on per-step rows; "Skip tour" footer button still works.

Closes the three named bugs in #702.