### PR TITLE
fix(mobile-native): empty-body construction, isFavorite repo test, priceChanged direction (closes #697)

### DIFF
--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/favorites/FavoritesScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/favorites/FavoritesScreen.kt
@@ -496,7 +496,14 @@ private fun FavoriteEntryCard(
     val photoUrl = entry.photoUrl ?: entry.listing?.primaryImage?.url ?: ""
     val metaText = buildString {
         entry.city?.let { append(it) } ?: entry.listing?.address?.city?.let { append(it) }
-        if (entry.priceChanged) append(" · ↓")
+        if (entry.priceChanged) {
+            // `price_change_percentage = (current - original) / original * 100`, so a positive
+            // percentage means the price went up (↑) and a negative one means it went down (↓).
+            // When the percentage is null but `priceChanged` is true, fall back to ↓ to preserve
+            // the prior visual (the only case the server still emits today).
+            val pct = entry.priceChangePercentage
+            append(if (pct != null && pct > 0) " · ↑" else " · ↓")
+        }
     }
 
     Card(

--- a/mobile-native/gradle/libs.versions.toml
+++ b/mobile-native/gradle/libs.versions.toml
@@ -50,9 +50,11 @@ ktor-client-darwin = { group = "io.ktor", name = "ktor-client-darwin", version.r
 ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version.ref = "ktor" }
+ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor" }
 
 # Testing
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 
 # Image Loading
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version = "2.7.0" }

--- a/mobile-native/shared/build.gradle.kts
+++ b/mobile-native/shared/build.gradle.kts
@@ -41,7 +41,15 @@ kotlin {
             }
         }
 
-        val commonTest by getting { dependencies { implementation(libs.kotlin.test) } }
+        val commonTest by getting {
+            dependencies {
+                implementation(libs.kotlin.test)
+                implementation(libs.ktor.client.mock)
+                implementation(libs.ktor.client.content.negotiation)
+                implementation(libs.ktor.serialization.kotlinx.json)
+                implementation(libs.kotlinx.coroutines.test)
+            }
+        }
 
         val androidMain by getting { dependencies { implementation(libs.ktor.client.android) } }
 

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/api/ApiClient.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/api/ApiClient.kt
@@ -3,6 +3,7 @@ package three.two.bit.ppt.reality.api
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
+import three.two.bit.ppt.reality.favorites.AddFavoriteBody
 import three.two.bit.ppt.reality.favorites.AddFavoriteResponse
 import three.two.bit.ppt.reality.favorites.FavoritesResponse
 import three.two.bit.ppt.reality.inquiry.CreateInquiryRequest
@@ -118,8 +119,10 @@ class ApiClient(
             val response =
                 client.post("$baseUrl/api/v1/favorites/$listingId") {
                     configureRequest()
+                    // Empty typed body — `AddFavoriteBody` serializes to `{}` via
+                    // ContentNegotiation, keeping this call on the same pipeline as every other.
                     contentType(ContentType.Application.Json)
-                    setBody("{}")
+                    setBody(AddFavoriteBody)
                 }
             if (response.status.isSuccess()) {
                 Result.success(response.body())

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/FavoritesModels.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/FavoritesModels.kt
@@ -65,6 +65,15 @@ data class FavoriteEntry(
 @Serializable data class CheckFavoriteResponse(@SerialName("is_favorited") val isFavorited: Boolean)
 
 /**
+ * Empty body for `POST /api/v1/favorites/{listing_id}`.
+ *
+ * The server's `AddFavorite` schema is `{notes?: String}`; we omit the optional `notes`. Encoding
+ * via a typed `@Serializable data object` routes through Ktor's `ContentNegotiation` pipeline (same
+ * as every other call), instead of bypassing it with a raw `setBody("{}")` string literal.
+ */
+@Serializable data object AddFavoriteBody
+
+/**
  * Add favorite response from `POST /api/v1/favorites/{listing_id}`.
  *
  * Matches `PortalFavorite` returned by the server on 201.

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/FavoritesRepository.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/FavoritesRepository.kt
@@ -51,9 +51,11 @@ class FavoritesRepository(
             val response =
                 client.post("$baseUrl/api/v1/favorites/$listingId") {
                     configureRequest()
-                    // Empty body — the server accepts `{notes?: String}` which we omit.
+                    // Empty typed body — server's `AddFavorite` is `{notes?: String}`; we omit it.
+                    // Using the @Serializable `AddFavoriteBody` keeps the call on the
+                    // ContentNegotiation pipeline instead of bypassing it with a raw "{}" string.
                     contentType(ContentType.Application.Json)
-                    setBody("{}")
+                    setBody(AddFavoriteBody)
                 }
 
             if (response.status.isSuccess()) {

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoritesRepositoryTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoritesRepositoryTest.kt
@@ -1,0 +1,89 @@
+package three.two.bit.ppt.reality.favorites
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+
+/**
+ * Repository-level coroutine tests for [FavoritesRepository.isFavorite].
+ *
+ * Issue #697 — pins the critical regression case: `GET /api/v1/favorites/{id}/check` always returns
+ * HTTP 200 with `{"is_favorited": bool}`, so the repository must inspect the body rather than
+ * collapse any 2xx to `Result.success(true)`.
+ */
+class FavoritesRepositoryTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+    }
+
+    private fun repoWith(status: HttpStatusCode, body: String): FavoritesRepository {
+        val engine = MockEngine { _ ->
+            respond(
+                content = ByteReadChannel(body),
+                status = status,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = HttpClient(engine) { install(ContentNegotiation) { json(json) } }
+        return FavoritesRepository(
+            baseUrl = "https://example.test",
+            sessionToken = "test-token",
+            client = client,
+        )
+    }
+
+    @Test
+    fun isFavorite_returns_true_when_server_reports_is_favorited_true() = runTest {
+        val repo = repoWith(HttpStatusCode.OK, """{"is_favorited": true}""")
+        val result = repo.isFavorite("lst-1")
+        assertTrue(result.isSuccess, "expected success, got $result")
+        assertEquals(true, result.getOrNull())
+    }
+
+    /**
+     * Key regression case for the gap-82-7 fix: a 200 with `is_favorited: false` must surface as
+     * `Result.success(false)`. The pre-fix code collapsed any 2xx to `true`, silently flipping the
+     * heart icon on un-favorited listings.
+     */
+    @Test
+    fun isFavorite_returns_false_when_server_reports_is_favorited_false() = runTest {
+        val repo = repoWith(HttpStatusCode.OK, """{"is_favorited": false}""")
+        val result = repo.isFavorite("lst-1")
+        assertTrue(result.isSuccess, "expected success, got $result")
+        assertEquals(false, result.getOrNull())
+    }
+
+    @Test
+    fun isFavorite_returns_false_on_unauthorized() = runTest {
+        val repo = repoWith(HttpStatusCode.Unauthorized, """{"error":"unauthenticated"}""")
+        val result = repo.isFavorite("lst-1")
+        assertTrue(result.isSuccess, "401 should map to Result.success(false), got $result")
+        assertEquals(false, result.getOrNull())
+    }
+
+    @Test
+    fun isFavorite_returns_failure_on_server_error() = runTest {
+        val repo = repoWith(HttpStatusCode.InternalServerError, """{"error":"boom"}""")
+        val result = repo.isFavorite("lst-1")
+        assertTrue(result.isFailure, "5xx should surface as Result.failure, got $result")
+        val ex = result.exceptionOrNull()
+        assertTrue(
+            ex is FavoritesException,
+            "expected FavoritesException, got ${ex?.let { it::class }}",
+        )
+    }
+}


### PR DESCRIPTION
Closes #697.

## Summary

Three post-merge follow-up fixes from the review of PR #688 (gap-82-7 — Reality Portal mobile favorites).

### 1. Raw-string empty body bypassed ContentNegotiation

`ApiClient.addFavorite` and `FavoritesRepository.addFavorite` used `setBody("{}")`, which sends a raw `String` and skips Ktor's `ContentNegotiation` pipeline. Replaced with a new `@Serializable data object AddFavoriteBody` so both call sites encode through the same serializer pipeline as every other request — future serializer config changes can no longer drift past these two endpoints.

### 2. `priceChanged` arrow always pointed down

`FavoriteEntryCard` in `FavoritesScreen.kt` rendered `· ↓` whenever `priceChanged` was true, regardless of the sign of `priceChangePercentage`. The reality-server computes `(current_price - original_price) / original_price * 100` (see `backend/crates/db/src/repositories/reality_portal.rs:89`), so a positive percentage = price went up. Now renders `↑` for increases and `↓` for decreases (with a `↓` fallback when the percentage is null, preserving the prior visual for the single-case server emits today).

### 3. Missing repository-level test for `isFavorite`

`FavoritesModelsContractTest` only pinned the JSON shape — the critical regression case (`isSuccess() → true` vs `body.isFavorited`) lived entirely in `FavoritesRepository.isFavorite` and had no coverage. Added `FavoritesRepositoryTest` with four Ktor `MockEngine` cases:

- `200 + {"is_favorited": true}` → `Result.success(true)`
- `200 + {"is_favorited": false}` → `Result.success(false)` ← the key regression case
- `401` → `Result.success(false)` (treat unauthenticated as not-favorited)
- `500` → `Result.failure(FavoritesException)`

Added `ktor-client-mock` and `kotlinx-coroutines-test` to `commonTest` deps.

## Files changed

- `mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/FavoritesModels.kt` — new `AddFavoriteBody` typed empty body.
- `mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/FavoritesRepository.kt` — `setBody(AddFavoriteBody)`.
- `mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/api/ApiClient.kt` — `setBody(AddFavoriteBody)`.
- `mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/favorites/FavoritesScreen.kt` — sign-aware arrow.
- `mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoritesRepositoryTest.kt` — new test (4 cases).
- `mobile-native/gradle/libs.versions.toml`, `mobile-native/shared/build.gradle.kts` — `ktor-client-mock` + `kotlinx-coroutines-test` test deps.

## Verification

- `./gradlew :shared:compileTestKotlinIosSimulatorArm64` — ✅ compiles `commonMain` + `commonTest` clean.
- `./gradlew spotlessCheck` — ✅ green.
- Test execution (`iosSimulatorArm64Test`) requires an installed Xcode iOS simulator SDK, which is not available in this sandbox; compile-green on the test source set is the strongest available local signal, and CI will run the tests with the SDK present.

## Out of scope

Finding 4 from #697 (consolidate the `addFavorite` duplication between `ApiClient` and `FavoritesRepository`) was deferred — it's a refactor concern, not a contract or correctness bug, and #697 only asked for the three contract/test fixes above.

---
_Generated by [Claude Code](https://claude.ai/code)_