### PR TITLE
test(api-server): tighten OAuth security test assertions (closes #704)

### DIFF
--- a/backend/servers/api-server/tests/oauth_integration_tests.rs
+++ b/backend/servers/api-server/tests/oauth_integration_tests.rs
@@ -2094,12 +2094,11 @@ mod provider_security {
         .await
         .expect("insert public user");
 
-        // Generate a valid JWT for this public user using the test secret.
-        // TestConfig::default() uses the 72-character secret below.
-        const TEST_JWT_SECRET: &str =
-            "test-secret-key-that-is-at-least-64-characters-long-for-testing-purposes";
-        let jwt_svc =
-            api_server::services::JwtService::new(TEST_JWT_SECRET).expect("jwt service for test");
+        // Generate a valid JWT for this public user using the TestApp's
+        // configured secret. Reading it back off `app.config` keeps the test
+        // honest if `TestConfig` ever rotates its default — issue #704 R4.
+        let jwt_svc = api_server::services::JwtService::new(&app.config.jwt_secret)
+            .expect("jwt service for test");
         let public_at = jwt_svc
             .generate_access_token(public_user_id, &public_email, "Portal User", None, None)
             .expect("access token for public user");
@@ -2156,6 +2155,62 @@ mod provider_security {
         assert_eq!(
             err["error"], "access_denied",
             "error must be access_denied for principal_kind mismatch, got {}",
+            err
+        );
+    }
+
+    /// R3 (issue #704): `OAuthService::refresh_tokens` re-checks
+    /// `allowed_principal_kinds` so a token issued while the user's kind was
+    /// permitted cannot be refreshed once that kind is removed from the
+    /// client's policy (e.g. an admin tightens access after issuance).
+    ///
+    /// Strategy: a normal staff user gets tokens from a client whose default
+    /// `allowed_principal_kinds=['public','staff','platform']` permits staff,
+    /// then we mutate the client's policy down to `['public']` only and
+    /// attempt to refresh. There is no DB trigger on `oauth_clients` so the
+    /// UPDATE proceeds without GUC gymnastics. The expected response is
+    /// HTTP 403 with `error=access_denied`, mirroring the code-exchange path.
+    #[sqlx::test(migrator = "db::MIGRATOR")]
+    async fn test_principal_kind_mismatch_rejected_at_refresh(pool: PgPool) {
+        let app = TestApp::new(pool.clone()).await;
+        let user = TestUser::new();
+        let (user_at, _) = create_authenticated_user(&app, &user).await;
+        // Default allowed_principal_kinds covers 'staff', so initial issuance succeeds.
+        let (client_id, client_secret, redirect_uri) = seed_confidential_client(&pool).await;
+
+        let (_at, rt) =
+            auth_flow_confidential(&app, &user_at, &client_id, &client_secret, &redirect_uri).await;
+
+        // Tighten policy: client now only allows 'public'. The staff user's
+        // kind ('staff') is no longer in the allowed set, but they hold a
+        // live refresh token issued under the old policy.
+        sqlx::query(
+            "UPDATE oauth_clients SET allowed_principal_kinds = ARRAY['public'] WHERE client_id = $1",
+        )
+        .bind(&client_id)
+        .execute(&pool)
+        .await
+        .expect("tighten allowed_principal_kinds");
+
+        let refresh_body = form_body(&[
+            ("grant_type", "refresh_token"),
+            ("refresh_token", &rt),
+            ("client_id", &client_id),
+            ("client_secret", &client_secret),
+        ]);
+        let refresh_resp = app
+            .execute(form_request("/api/v1/oauth/token", &refresh_body))
+            .await;
+        assert_eq!(
+            refresh_resp.status,
+            StatusCode::FORBIDDEN,
+            "refresh with newly-disallowed principal_kind must return 403. body={}",
+            refresh_resp.text()
+        );
+        let err = refresh_resp.json_value();
+        assert_eq!(
+            err["error"], "access_denied",
+            "error must be access_denied at refresh principal_kind mismatch, got {}",
             err
         );
     }
@@ -2248,11 +2303,25 @@ mod provider_security {
         let refresh_resp = app
             .execute(form_request("/api/v1/oauth/token", &refresh_body))
             .await;
-        assert!(
-            refresh_resp.status.is_client_error(),
-            "deactivated client must be rejected at token endpoint (got {}). body={}",
+        // R2 (issue #704): mirror the precision of the introspect-side
+        // assertion. The token endpoint looks the client up via
+        // `find_active_client_by_client_id` BEFORE reaching the refresh-token
+        // lookup (routes/oauth.rs:297-307), so a deactivated client must
+        // produce 401 + `invalid_client` — not any 4xx. Asserting the exact
+        // status + error pins the order of checks so a future regression
+        // that hits the refresh-token lookup first (and returns 400
+        // invalid_grant) cannot pass silently.
+        assert_eq!(
             refresh_resp.status,
+            StatusCode::UNAUTHORIZED,
+            "deactivated client at token endpoint must return 401. body={}",
             refresh_resp.text()
+        );
+        let err = refresh_resp.json_value();
+        assert_eq!(
+            err["error"], "invalid_client",
+            "error must be invalid_client for deactivated client at token endpoint, got {}",
+            err
         );
     }
 


### PR DESCRIPTION
## Summary

Closes #704. Test-only PR addressing three findings from the post-merge review of PR #661 (`pm-security-oauth-10a-security-tests`). No production code touched.

## Changes

### R2 — Tighten `test_deactivated_client_rejected_at_token_endpoint`

The original test asserted `refresh_resp.status.is_client_error()`, accepting any 4xx. The symmetric introspect-side test correctly pins `401 + invalid_client`. The token endpoint looks up the client via `find_active_client_by_client_id` before reaching the refresh-token lookup (`routes/oauth.rs:297-307`), so a deactivated client must return `401 + invalid_client` — not any 4xx.

Asserting the exact status + error pins the order of checks. A future regression that hits the refresh-token lookup first (and returns `400 invalid_grant`) can no longer pass silently.

### R3 — New test `test_principal_kind_mismatch_rejected_at_refresh`

The original test suite covered the code-exchange path for `principal_kind` enforcement but not the refresh path. `OAuthService::refresh_tokens` does re-check `principal_kind` (`services/oauth.rs:544-561`), but that branch had no integration coverage. New test:

1. Staff user gets tokens from a client with default `allowed_principal_kinds=['public','staff','platform']`.
2. The client's policy is tightened to `['public']` only (simulating an admin tightening access).
3. Refresh attempt must return `403 + access_denied`.

Mutating the client (rather than the user's `principal_kind`) avoids the `users_principal_kind_guard_trg` GUC dance and exercises the same security re-check — the realistic operational scenario.

### R4 — Drop hardcoded `TEST_JWT_SECRET` constant

`test_principal_kind_mismatch_rejected_at_token_exchange` duplicated the 72-character JWT secret from `TestConfig::default()`. Reading `app.config.jwt_secret` removes the brittle coupling — if `TestConfig` ever rotates its default the test now fails loudly at the source, not via a confusing JWT-rejection at the authorize step.

## Deferred

- **R1 (duplicate test removal)** — `test_pkce_plain_method_rejected_at_token_exchange` and `test_introspect_revoked_access_token_returns_inactive` in `provider_security` are duplicates of earlier-module tests. Removal is straightforward but mixing deletion with assertion tightening would muddle review scope. Tracking separately is fine; no security impact, just compile-time waste.

## Test plan

- [x] `cargo check -p api-server --tests` clean on dev base
- [x] `cargo fmt -p api-server` clean
- [ ] CI runs all three modified/added integration tests