### PR TITLE
gap-81-1-schedule-cron-unit-tests: unit tests for validate_cron_expression

### DIFF
--- a/backend/servers/api-server/src/routes/reports.rs
+++ b/backend/servers/api-server/src/routes/reports.rs
@@ -2134,4 +2134,99 @@ mod tests {
         // lo > hi in a range
         assert!(!validate_cron_expression("* * 31-1 * *"));
     }
+
+    // --- macros / shorthand (gap-81-1: PR #531 review) ---
+    //
+    // The validator implements *only* the 5-field UNIX syntax. The `@reboot`,
+    // `@daily`, `@hourly`, etc. macros are NOT supported: each macro is a single
+    // whitespace-delimited token, so the field-count guard rejects them. These
+    // tests pin that contract so a future refactor can't silently start
+    // accepting (or mis-parsing) macros without updating the handler docs.
+
+    #[test]
+    fn invalid_reboot_macro_rejected() {
+        // `@reboot` is one token -> field count is 1, not 5 -> rejected.
+        assert!(!validate_cron_expression("@reboot"));
+    }
+
+    #[test]
+    fn invalid_named_macros_rejected() {
+        for macro_expr in ["@daily", "@hourly", "@weekly", "@monthly", "@yearly", "@annually"] {
+            assert!(
+                !validate_cron_expression(macro_expr),
+                "macro {macro_expr:?} must be rejected (macros are unsupported)"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_macro_padded_to_five_tokens_rejected() {
+        // Even if a macro string happens to contain five whitespace-separated
+        // tokens, each token must still be a valid numeric/`*` field.
+        assert!(!validate_cron_expression(
+            "@hourly @daily @weekly @monthly @yearly"
+        ));
+    }
+
+    // --- additional edge cases ---
+
+    #[test]
+    fn valid_range_with_step() {
+        // A step applied to an explicit range: minutes 5..15 every 3.
+        assert!(validate_cron_expression("5-15/3 * * * *"));
+    }
+
+    #[test]
+    fn valid_step_on_wildcard_dow() {
+        // `*/2` over the day-of-week wildcard.
+        assert!(validate_cron_expression("* * * * */2"));
+    }
+
+    #[test]
+    fn valid_explicit_value_list() {
+        // Comma list of discrete minute values.
+        assert!(validate_cron_expression("0,15,30,45 * * * *"));
+    }
+
+    #[test]
+    fn valid_full_range_every_field() {
+        // The inclusive bounds of every field expressed as ranges.
+        assert!(validate_cron_expression("0-59 0-23 1-31 1-12 0-7"));
+    }
+
+    #[test]
+    fn valid_tab_separated_fields() {
+        // `split_whitespace` collapses any run of whitespace, so tabs work too.
+        assert!(validate_cron_expression("0\t8\t*\t*\t1"));
+    }
+
+    #[test]
+    fn invalid_whitespace_only() {
+        // Only whitespace -> zero fields -> rejected.
+        assert!(!validate_cron_expression("     "));
+    }
+
+    #[test]
+    fn invalid_empty_list_element() {
+        // A trailing/empty comma element (`1,,`) is not a valid sub-field.
+        assert!(!validate_cron_expression("1,, * * * *"));
+    }
+
+    #[test]
+    fn invalid_dangling_range_bound() {
+        // A range missing its upper bound (`1-`) fails to parse.
+        assert!(!validate_cron_expression("1- * * * *"));
+    }
+
+    #[test]
+    fn invalid_negative_value() {
+        // Leading `-` makes the field parse as a malformed range.
+        assert!(!validate_cron_expression("-1 * * * *"));
+    }
+
+    #[test]
+    fn invalid_non_numeric_step() {
+        // Step value must be a positive integer.
+        assert!(!validate_cron_expression("*/x * * * *"));
+    }
 }

--- a/backend/servers/api-server/src/routes/reports.rs
+++ b/backend/servers/api-server/src/routes/reports.rs
@@ -2151,7 +2151,14 @@ mod tests {
 
     #[test]
     fn invalid_named_macros_rejected() {
-        for macro_expr in ["@daily", "@hourly", "@weekly", "@monthly", "@yearly", "@annually"] {
+        for macro_expr in [
+            "@daily",
+            "@hourly",
+            "@weekly",
+            "@monthly",
+            "@yearly",
+            "@annually",
+        ] {
             assert!(
                 !validate_cron_expression(macro_expr),
                 "macro {macro_expr:?} must be rejected (macros are unsupported)"


### PR DESCRIPTION
## Task

PR #531's reviewer requested unit-test coverage for the `validate_cron_expression` helper in `backend/servers/api-server/src/routes/reports.rs` (gap-81-1). This PR adds the missing cases — in particular the `@reboot`/macro edge case that the existing tests did not cover — plus several additional edge cases.

## What's in this PR (test-only)

13 new `#[cfg(test)]` tests appended to the existing `routes::reports::tests` module in `reports.rs`. **No production logic was changed** — the diff is a pure append of test code (95 insertions, 1 file).

The existing module already covered the basics (valid expressions, wrong field counts, out-of-range values, `*/5`, `*/0`, reversed range). New coverage:

- **Macros (the explicit reviewer ask):** `@reboot`, `@daily`/`@hourly`/`@weekly`/`@monthly`/`@yearly`/`@annually`, and a 5-token macro string are all asserted **rejected** — the validator implements only 5-field UNIX syntax and treats each macro as a single whitespace token, so the field-count guard rejects them. These tests pin that contract.
- **Step/range edge cases:** range-with-step (`5-15/3`), step on wildcard dow (`*/2`), explicit value list (`0,15,30,45`), full inclusive-bound ranges per field, tab-separated fields.
- **Malformed input:** whitespace-only string, empty list element (`1,,`), dangling range bound (`1-`), negative value (`-1`), non-numeric step (`*/x`).

Each assertion was first verified against the actual function behavior (extracted and run standalone) before being written — tests match real behavior, not assumptions. Notably the validator accepts `*/60` (steps are not bounded to the field max); no test asserts otherwise.

## Tested (Band A — fast check + unit run)

```
cd backend && cargo test --lib -p api-server routes::reports::tests::
running 29 tests ... test result: ok. 29 passed; 0 failed
```

(16 pre-existing + 13 new tests all green. Test binary compiled clean via `cargo test --no-run`.)

## Scope

scope_drift=false — only test code under `backend/` (pm-backend area) touched. code_reuse_warn=none.

https://claude.ai/code/session_01SVJhRDGrmJFQpbKuTjZa8G

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVJhRDGrmJFQpbKuTjZa8G)_