### PR TITLE
fix(security): reject refresh tokens in RequestPrincipal extractor (closes #822)

### DIFF
--- a/backend/crates/api-core/src/extractors/principal.rs
+++ b/backend/crates/api-core/src/extractors/principal.rs
@@ -50,6 +50,14 @@ pub struct PrincipalClaims {
     /// from the `users` table (defense in depth; never trusted as authority).
     #[serde(default)]
     pub kind: Option<String>,
+    /// Token discriminator. Access tokens carry `token_type: "access"`;
+    /// refresh tokens carry `"refresh"`. Unlike `kind`, this IS enforced:
+    /// a refresh token must never be accepted on an access-only route
+    /// (mirrors the `auth.rs` RUST-002 fix). Kept `Option` + `serde(default)`
+    /// so any legacy token that omits the claim still decodes and is treated
+    /// as access — only an *explicit* non-access value is rejected.
+    #[serde(default)]
+    pub token_type: Option<String>,
 }
 
 /// The authoritative per-request principal. Built fresh on every request from
@@ -113,6 +121,24 @@ where
             &Validation::default(),
         )
         .map_err(|_| (StatusCode::UNAUTHORIZED, "Invalid or expired token"))?;
+
+        // Reject refresh tokens (and any other non-access discriminator)
+        // BEFORE touching the DB. A token that omits `token_type` is treated
+        // as access for backward-compat; an explicit "refresh" is denied so
+        // a refresh token cannot be replayed against an access-only route.
+        if let Some(token_type) = token_data.claims.token_type.as_deref() {
+            if token_type != "access" {
+                tracing::warn!(
+                    token_type = %token_type,
+                    "RequestPrincipal: rejected non-access token on access-only route"
+                );
+                return Err((
+                    StatusCode::UNAUTHORIZED,
+                    "Invalid token type for this endpoint",
+                ));
+            }
+        }
+
         let user_id = token_data.claims.sub;
 
         // ----- (2) Lookup the principal_kind from the trusted users table. -----

--- a/backend/crates/api-core/tests/principal_token_type_tests.rs
+++ b/backend/crates/api-core/tests/principal_token_type_tests.rs
@@ -1,0 +1,142 @@
+//! Regression: `RequestPrincipal` must reject refresh tokens (#822).
+//!
+//! Before this fix the canonical `RequestPrincipal` extractor decoded the
+//! bearer JWT permissively and never inspected `token_type`, so a refresh
+//! token could be replayed against any access-only route — the same class of
+//! bug `auth.rs` had closed under RUST-002. These tests pin the contract:
+//!
+//!   * `token_type: "refresh"` (or any non-access value) → 401 BEFORE the DB
+//!     lookup runs.
+//!   * `token_type: "access"` (or the claim omitted, for legacy tokens) →
+//!     passes the discriminator and proceeds to the DB lookup.
+//!
+//! Like `optional_principal_tests.rs`, the stub pool points at an unreachable
+//! address: the refresh-rejection branch returns before any query, so the
+//! pool is never touched. The access-token case DOES reach the DB and fails
+//! there (unreachable pool → non-401), which is exactly how we prove it got
+//! *past* the token_type gate without standing up Postgres.
+
+use api_core::extractors::tenant::TenantMembershipProvider;
+use api_core::extractors::RequestPrincipal;
+use axum::extract::FromRequestParts;
+use axum::http::{header::AUTHORIZATION, Request, StatusCode};
+use db::DbPool;
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+const TEST_SECRET: &str = "test-secret-key-at-least-32-chars-long!!";
+
+#[derive(Clone)]
+struct StubState {
+    pool: DbPool,
+}
+
+impl StubState {
+    fn new() -> Self {
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .max_connections(1)
+            .connect_lazy("postgres://never-used:never@127.0.0.1:1/never")
+            .expect("lazy pool init");
+        Self { pool }
+    }
+}
+
+impl TenantMembershipProvider for StubState {
+    fn db_pool(&self) -> &DbPool {
+        &self.pool
+    }
+}
+
+/// Mirrors `PrincipalClaims` field-for-field; the extractor decodes by claim
+/// name, not by struct identity. `token_type` is optional here so we can mint
+/// tokens that omit it (legacy shape) as well as explicit access/refresh.
+#[derive(Debug, Serialize, Deserialize)]
+struct TestClaims {
+    sub: Uuid,
+    iat: i64,
+    exp: i64,
+    kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    token_type: Option<String>,
+}
+
+fn mint(token_type: Option<&str>) -> String {
+    let claims = TestClaims {
+        sub: Uuid::new_v4(),
+        iat: 1_700_000_000,
+        // Far-future expiry so `Validation::default()` (which checks `exp`)
+        // never trips — we want to test the token_type branch, not expiry.
+        exp: 4_102_444_800, // 2100-01-01
+        kind: Some("Public".to_string()),
+        token_type: token_type.map(str::to_string),
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(TEST_SECRET.as_bytes()),
+    )
+    .expect("encode test token")
+}
+
+async fn extract(token: &str) -> Result<RequestPrincipal, (StatusCode, &'static str)> {
+    // `JWT_SECRET` is process-global; this test binary owns it.
+    std::env::set_var("JWT_SECRET", TEST_SECRET);
+    let state = StubState::new();
+    let req = Request::builder()
+        .uri("/anything")
+        .header(AUTHORIZATION, format!("Bearer {token}"))
+        .body(())
+        .expect("build req");
+    let (mut parts, _) = req.into_parts();
+    RequestPrincipal::from_request_parts(&mut parts, &state).await
+}
+
+#[tokio::test]
+async fn refresh_token_is_rejected_with_401_before_db() {
+    let result = extract(&mint(Some("refresh"))).await;
+    let (status, msg) = result.expect_err("refresh token must be rejected");
+    assert_eq!(status, StatusCode::UNAUTHORIZED, "refresh → 401");
+    assert_eq!(msg, "Invalid token type for this endpoint");
+}
+
+#[tokio::test]
+async fn arbitrary_token_type_is_rejected() {
+    let result = extract(&mint(Some("magic-link"))).await;
+    let (status, _) = result.expect_err("non-access token_type must be rejected");
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn access_token_passes_discriminator_then_hits_db() {
+    // An access token clears the token_type gate and proceeds to the DB
+    // lookup, which fails against the unreachable stub pool. The key
+    // assertion is that the failure is NOT the 401 token-type rejection —
+    // i.e. the discriminator let it through.
+    let result = extract(&mint(Some("access"))).await;
+    let (status, msg) = result.expect_err("unreachable pool → lookup error");
+    assert_ne!(
+        (status, msg),
+        (
+            StatusCode::UNAUTHORIZED,
+            "Invalid token type for this endpoint"
+        ),
+        "access token must NOT be rejected by the token_type gate"
+    );
+}
+
+#[tokio::test]
+async fn legacy_token_without_token_type_passes_discriminator() {
+    // Backward-compat: a token minted before token_type existed omits the
+    // claim entirely. It must still clear the gate (treated as access).
+    let result = extract(&mint(None)).await;
+    let (status, msg) = result.expect_err("unreachable pool → lookup error");
+    assert_ne!(
+        (status, msg),
+        (
+            StatusCode::UNAUTHORIZED,
+            "Invalid token type for this endpoint"
+        ),
+        "legacy token (no token_type) must NOT be rejected by the gate"
+    );
+}


### PR DESCRIPTION
## What

`RequestPrincipal` — the canonical per-request auth extractor used across the API — decoded the bearer JWT permissively and **never inspected `token_type`**. A **refresh token could be replayed against any access-only route**, the same class of bug `auth.rs` had already closed under RUST-002. (Triaged from code-review issue #822, P0, validated still-present on `origin/dev`.)

## Fix

- Add an optional `token_type` claim to `PrincipalClaims`.
- After decode and **before the DB lookup**, reject any *explicit* non-access value with 401.
- Tokens that **omit** `token_type` are treated as access (backward-compat with legacy issuance paths) — only an explicit `refresh`/other is denied. This matches the extractor's documented permissive-decode philosophy while closing the replay hole.

## Test (IG3)

New `backend/crates/api-core/tests/principal_token_type_tests.rs` mints refresh / access / arbitrary / legacy(no-claim) tokens and runs them through the **real** extractor with an unreachable stub pool (mirrors `optional_principal_tests.rs`):

- `refresh` / arbitrary → **401 "Invalid token type for this endpoint"**, before any DB access.
- `access` and legacy(no token_type) → clear the gate, then fail at the unreachable pool (proving they got *past* the discriminator).

**Fails on `dev`**: without the check a refresh token reaches the DB lookup and returns 500, not the asserted 401.

## Verification
- `cargo test -p api-core --test principal_token_type_tests` → 4 passed
- `cargo fmt --all --check` clean, `cargo clippy -p api-core --all-targets -- -D warnings` clean

Closes #822