### PR TITLE
fix(security): enforce agency membership on agency read/import endpoints (closes #818)

### DIFF
--- a/backend/servers/api-server/src/routes/agencies.rs
+++ b/backend/servers/api-server/src/routes/agencies.rs
@@ -92,8 +92,13 @@ pub async fn create_agency(
 )]
 pub async fn get_agency(
     State(state): State<AppState>,
+    TenantExtractor(tenant): TenantExtractor,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Agency>, (axum::http::StatusCode, String)> {
+    // Only members of the agency may read its record (closes #818 — the
+    // endpoint previously had no auth and leaked the full agency to anyone).
+    verify_agency_member(&state, id, tenant.user_id).await?;
+
     let agency = state.agency_repo.find_by_id(id).await.map_err(|e| {
         (
             axum::http::StatusCode::INTERNAL_SERVER_ERROR,
@@ -195,9 +200,12 @@ pub async fn update_branding(
 )]
 pub async fn list_members(
     State(state): State<AppState>,
-    TenantExtractor(_tenant): TenantExtractor,
+    TenantExtractor(tenant): TenantExtractor,
     Path(id): Path<Uuid>,
 ) -> Result<Json<AgencyMembersResponse>, (axum::http::StatusCode, String)> {
+    // Only members may see the agency roster (closes #818).
+    verify_agency_member(&state, id, tenant.user_id).await?;
+
     let members = state.agency_repo.get_members(id).await.map_err(|e| {
         (
             axum::http::StatusCode::INTERNAL_SERVER_ERROR,
@@ -556,6 +564,11 @@ pub async fn create_import_job(
     Path(id): Path<Uuid>,
     Json(data): Json<db::models::CreateImportJob>,
 ) -> Result<Json<ListingImportJob>, (axum::http::StatusCode, String)> {
+    // Starting an import is an admin action scoped to the caller's agency
+    // (closes #818 — previously any authenticated user could import into
+    // any agency by id).
+    verify_agency_admin(&state, id, tenant.user_id).await?;
+
     let job = state
         .agency_repo
         .create_import_job(id, tenant.user_id, &data.source)
@@ -586,8 +599,12 @@ pub async fn create_import_job(
 )]
 pub async fn get_import_job(
     State(state): State<AppState>,
-    Path((_id, job_id)): Path<(Uuid, Uuid)>,
+    TenantExtractor(tenant): TenantExtractor,
+    Path((id, job_id)): Path<(Uuid, Uuid)>,
 ) -> Result<Json<ListingImportJob>, (axum::http::StatusCode, String)> {
+    // Only members of the agency may read its import jobs (closes #818).
+    verify_agency_member(&state, id, tenant.user_id).await?;
+
     let job = state
         .agency_repo
         .get_import_job(job_id)
@@ -600,8 +617,11 @@ pub async fn get_import_job(
         })?;
 
     match job {
-        Some(j) => Ok(Json(j)),
-        None => Err((
+        // Bind the job to the agency in the path: the caller is a verified
+        // member of `id`, but the job is fetched by `job_id` alone, so a job
+        // belonging to a different agency must not be returned (closes #818).
+        Some(j) if j.agency_id == id => Ok(Json(j)),
+        _ => Err((
             axum::http::StatusCode::NOT_FOUND,
             "Import job not found".to_string(),
         )),
@@ -621,9 +641,12 @@ pub async fn get_import_job(
 )]
 pub async fn list_import_jobs(
     State(state): State<AppState>,
-    TenantExtractor(_tenant): TenantExtractor,
+    TenantExtractor(tenant): TenantExtractor,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Vec<ListingImportJob>>, (axum::http::StatusCode, String)> {
+    // Only members may list the agency's import jobs (closes #818).
+    verify_agency_member(&state, id, tenant.user_id).await?;
+
     let jobs = state
         .agency_repo
         .get_import_jobs(id, 20)
@@ -641,6 +664,35 @@ pub async fn list_import_jobs(
 // ============================================================================
 // Helper Functions
 // ============================================================================
+
+/// Verify that the user is an active member of the specified agency (any
+/// role). Used to gate *reads* of agency-scoped resources so the data is
+/// only exposed to people who belong to the agency. Returns Ok(()) if the
+/// user has an active membership, Err with 403 otherwise.
+async fn verify_agency_member(
+    state: &AppState,
+    agency_id: Uuid,
+    user_id: Uuid,
+) -> Result<(), (axum::http::StatusCode, String)> {
+    let member = state
+        .agency_repo
+        .get_member(agency_id, user_id)
+        .await
+        .map_err(|e| {
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to check membership: {}", e),
+            )
+        })?;
+
+    match member {
+        Some(m) if m.is_active => Ok(()),
+        _ => Err((
+            axum::http::StatusCode::FORBIDDEN,
+            "You are not a member of this agency".to_string(),
+        )),
+    }
+}
 
 /// Verify that the user is an admin of the specified agency.
 /// Returns Ok(()) if authorized, Err with 403 status if not.

--- a/backend/servers/api-server/tests/agency_authz_idor_tests.rs
+++ b/backend/servers/api-server/tests/agency_authz_idor_tests.rs
@@ -1,0 +1,155 @@
+//! Regression tests for the agency endpoint authorization gaps (#818).
+//!
+//! Audit history: several `/api/v1/agencies/*` handlers exposed agency-scoped
+//! data without verifying the caller belongs to the agency:
+//!
+//! - `GET /api/v1/agencies/{id}`            (`get_agency`)      — NO auth at all.
+//! - `GET /api/v1/agencies/{id}/import/{job_id}` (`get_import_job`) — NO auth.
+//! - `GET /api/v1/agencies/{id}/members`    (`list_members`)    — extractor but
+//!   no membership check.
+//! - `GET /api/v1/agencies/{id}/import`     (`list_import_jobs`) — ditto.
+//! - `POST /api/v1/agencies/{id}/import`    (`create_import_job`)— authenticated
+//!   but no per-agency authorization.
+//!
+//! The fix gates reads behind `verify_agency_member` and the import-creation
+//! write behind `verify_agency_admin`, and binds a fetched import job to the
+//! agency in the path.
+//!
+//! TestApp wiring caveat (see `equipment_cross_tenant_idor_tests.rs`): the
+//! harness mounts the router without `host_tenant_middleware`, so a request
+//! lacking a fully-provisioned bearer JWT is rejected at the auth/extractor
+//! gate. That is exactly the security contract under test here — an
+//! unauthenticated caller must never receive agency data. The headline
+//! regression is `get_agency`, which previously returned 200 with the full
+//! agency record and now returns 4xx.
+
+#[allow(dead_code)]
+mod common;
+
+use axum::{
+    body::Body,
+    http::{Method, Request, StatusCode},
+};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::TestApp;
+
+async fn seed_agency(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO agencies (name, slug, email, status)
+        VALUES ($1, $2, $3, 'verified') RETURNING id
+        "#,
+    )
+    .bind(format!("AuthzIDOR Agency {slug}"))
+    .bind(format!("authz-idor-agency-{slug}"))
+    .bind(format!("{slug}@authz-idor.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed agency")
+}
+
+fn get(uri: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::GET)
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn assert_rejected(status: StatusCode, ctx: &str) {
+    let code = status.as_u16();
+    assert!(
+        (400..500).contains(&code),
+        "{ctx}: expected a 4xx rejection, got {status}"
+    );
+    assert_ne!(
+        status,
+        StatusCode::OK,
+        "{ctx}: agency data must NOT be returned to an unauthenticated caller"
+    );
+}
+
+/// Headline regression: `GET /api/v1/agencies/{id}` had NO auth extractor and
+/// returned the full agency record to anyone. With a seeded agency, dev
+/// returns 200; the fix returns 4xx.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_agency_without_auth_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let agency_id = seed_agency(&pool, "get").await;
+
+    let resp = app
+        .execute(get(&format!("/api/v1/agencies/{agency_id}")))
+        .await;
+
+    assert_rejected(resp.status, "GET /api/v1/agencies/{id} without auth");
+}
+
+/// `GET /api/v1/agencies/{id}/members` must not list the roster anonymously.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_members_without_auth_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let agency_id = seed_agency(&pool, "members").await;
+
+    let resp = app
+        .execute(get(&format!("/api/v1/agencies/{agency_id}/members")))
+        .await;
+
+    assert_rejected(
+        resp.status,
+        "GET /api/v1/agencies/{id}/members without auth",
+    );
+}
+
+/// `GET /api/v1/agencies/{id}/import/{job_id}` had NO auth extractor.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_import_job_without_auth_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let agency_id = seed_agency(&pool, "getjob").await;
+    let job_id = Uuid::new_v4();
+
+    let resp = app
+        .execute(get(&format!(
+            "/api/v1/agencies/{agency_id}/import/{job_id}"
+        )))
+        .await;
+
+    assert_rejected(
+        resp.status,
+        "GET /api/v1/agencies/{id}/import/{job_id} without auth",
+    );
+}
+
+/// `GET /api/v1/agencies/{id}/import` must not list import jobs anonymously.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_import_jobs_without_auth_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let agency_id = seed_agency(&pool, "listjobs").await;
+
+    let resp = app
+        .execute(get(&format!("/api/v1/agencies/{agency_id}/import")))
+        .await;
+
+    assert_rejected(resp.status, "GET /api/v1/agencies/{id}/import without auth");
+}
+
+/// `POST /api/v1/agencies/{id}/import` must not start an import anonymously.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_import_job_without_auth_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let agency_id = seed_agency(&pool, "createjob").await;
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(format!("/api/v1/agencies/{agency_id}/import"))
+        .header(axum::http::header::CONTENT_TYPE, "application/json")
+        .body(Body::from(r#"{"source":"csv"}"#))
+        .unwrap();
+    let resp = app.execute(req).await;
+
+    assert_rejected(
+        resp.status,
+        "POST /api/v1/agencies/{id}/import without auth",
+    );
+}


### PR DESCRIPTION
## What

Several `/api/v1/agencies/*` handlers exposed agency-scoped data without verifying the caller belongs to the agency (triaged from #818, P0, validated on `origin/dev`):

- `GET /agencies/{id}` (`get_agency`) — **no auth extractor**, leaked the full agency record to anyone.
- `GET /agencies/{id}/import/{job_id}` (`get_import_job`) — **no auth extractor**.
- `GET /agencies/{id}/members` and `GET /agencies/{id}/import` — extracted the tenant but never checked membership.
- `POST /agencies/{id}/import` (`create_import_job`) — authenticated but no per-agency authorization.

## Fix

- New `verify_agency_member` (any active member) gates the **reads**.
- Existing `verify_agency_admin` gates the **import-creation write**.
- `get_import_job` now binds the fetched job to the agency in the path, so a member of agency A can't read agency B's job via A's id.

## Test (IG3)

`backend/servers/api-server/tests/agency_authz_idor_tests.rs` — each endpoint rejects an unauthenticated caller (4xx, never 200). `get_agency` is the headline: it returned **200 with the full record** on `dev`; now 4xx. (5 tests, all pass locally.)

## Verification
- `cargo test -p api-server --test agency_authz_idor_tests` → 5 passed
- `cargo fmt --all --check` clean

Closes #818