### PR TITLE
fix(security): org-scope report export + job-status endpoints (closes #832)

### DIFF
--- a/backend/servers/api-server/src/routes/reports.rs
+++ b/backend/servers/api-server/src/routes/reports.rs
@@ -1016,6 +1016,7 @@ pub enum ExportReportResponseUnion {
 pub async fn export_report(
     State(state): State<AppState>,
     auth: AuthUser,
+    mut rls: RlsConnection,
     Json(req): Json<ExportReportRequest>,
 ) -> Result<(StatusCode, Json<ExportReportResponseUnion>), (StatusCode, Json<ErrorResponse>)> {
     // Validate format
@@ -1041,6 +1042,22 @@ pub async fn export_report(
             )),
         ));
     }
+
+    // Enforce that the requested organization matches the authenticated tenant
+    // (super-admins may export across orgs). Closes a cross-tenant IDOR where a
+    // caller could export another org's data by supplying its UUID (#832).
+    // Mirrors get_fault_statistics_report and the other report handlers.
+    if !rls.is_super_admin() && req.organization_id != rls.tenant_id() {
+        rls.release().await;
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "FORBIDDEN",
+                "organization_id does not match the authenticated tenant",
+            )),
+        ));
+    }
+    rls.release().await;
 
     // Story 88.5: Estimate row count to decide sync vs async processing
     let estimated_rows = estimate_report_row_count(
@@ -1264,6 +1281,7 @@ pub struct ExportJobPath {
 pub async fn get_export_job_status(
     State(state): State<AppState>,
     _auth: AuthUser,
+    mut rls: RlsConnection,
     axum::extract::Path(path): axum::extract::Path<ExportJobPath>,
 ) -> Result<Json<ExportJobStatusResponse>, (StatusCode, Json<ErrorResponse>)> {
     // Get job from repository
@@ -1284,6 +1302,20 @@ pub async fn get_export_job_status(
                 Json(ErrorResponse::new("JOB_NOT_FOUND", "Export job not found")),
             )
         })?;
+
+    // Scope the job to the caller's tenant: export jobs record their org_id
+    // (set from the export request), so only members of that org — or
+    // super-admins — may read the status and download URL. Closes a
+    // cross-tenant IDOR (#832). Return 404 to avoid leaking the existence of
+    // another org's job.
+    if !rls.is_super_admin() && job.org_id != Some(rls.tenant_id()) {
+        rls.release().await;
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("JOB_NOT_FOUND", "Export job not found")),
+        ));
+    }
+    rls.release().await;
 
     // Map job status to response
     let status = match job.status {

--- a/backend/servers/api-server/tests/reports_export_org_scope_tests.rs
+++ b/backend/servers/api-server/tests/reports_export_org_scope_tests.rs
@@ -1,0 +1,170 @@
+//! Real-JWT cross-tenant regression tests for report export endpoints (#832).
+//!
+//! `export_report` (`POST /api/v1/reports/export`) trusted the client-supplied
+//! `organization_id`, and `get_export_job_status`
+//! (`GET /api/v1/reports/export/{job_id}/status`) returned any job's status and
+//! download URL by UUID. Neither verified the resource's org against the
+//! caller's tenant — a cross-tenant IDOR.
+//!
+//! The fix threads `RlsConnection` into both and rejects when
+//! `!is_super_admin() && org != tenant_id()`, matching the other report
+//! handlers. These tests exercise the path end-to-end with a real JWT for a
+//! Manager in Org B (so the auth gate passes — not a 401) targeting Org A.
+//!
+//! TestApp note (see report_schedule_org_scope_jwt_tests.rs): no
+//! `host_tenant_middleware`, so the tenant comes from the `X-Tenant-ID` header;
+//! `RlsConnection` validates membership against `organization_members`, seeded
+//! below.
+
+#[allow(dead_code)]
+mod common;
+
+use axum::{
+    body::Body,
+    http::{header, Method, Request, StatusCode},
+};
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{create_authenticated_user, TestApp, TestUser};
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO organizations (name, slug, contact_email, status)
+           VALUES ($1, $2, $3, 'active') RETURNING id"#,
+    )
+    .bind(format!("ExportScope {slug}"))
+    .bind(format!("export-scope-{slug}-{}", Uuid::new_v4()))
+    .bind(format!("{slug}-{}@export-scope.test", Uuid::new_v4()))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_membership(pool: &PgPool, org_id: Uuid, user_id: Uuid, role: &str) {
+    sqlx::query(
+        r#"INSERT INTO organization_members
+               (id, organization_id, user_id, role_type, status, created_at)
+           VALUES ($1, $2, $3, $4, 'active', NOW()) ON CONFLICT DO NOTHING"#,
+    )
+    .bind(Uuid::new_v4())
+    .bind(org_id)
+    .bind(user_id)
+    .bind(role)
+    .execute(pool)
+    .await
+    .expect("seed membership");
+}
+
+/// Seed a background job (an export job) owned by `org_id`.
+async fn seed_export_job(pool: &PgPool, org_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO background_jobs (job_type, queue, org_id)
+           VALUES ('report_export', 'reports', $1) RETURNING id"#,
+    )
+    .bind(org_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed export job")
+}
+
+async fn user_id_for(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(email)
+        .fetch_one(pool)
+        .await
+        .expect("user id")
+}
+
+/// Authenticate a manager in Org B; returns (token, org_a, org_b).
+async fn setup(pool: &PgPool, app: &TestApp) -> (String, Uuid, Uuid) {
+    let org_a = seed_org(pool, "a").await;
+    let org_b = seed_org(pool, "b").await;
+    let user = TestUser::new();
+    let (token, _refresh) = create_authenticated_user(app, &user).await;
+    let uid = user_id_for(pool, &user.email).await;
+    seed_membership(pool, org_b, uid, "manager").await;
+    (token, org_a, org_b)
+}
+
+/// `export_report` must reject a request whose `organization_id` (Org A) does
+/// not match the caller's tenant (Org B). On dev it trusts the body and
+/// proceeds; the fix returns 403.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn export_report_for_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (token, org_a, org_b) = setup(&pool, &app).await;
+
+    let body = json!({
+        "organization_id": org_a, // foreign org
+        "report_type": "faults",
+        "format": "csv"
+    });
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/v1/reports/export")
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .header("X-Tenant-ID", org_b.to_string())
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "exporting another org's report must be 403, got {}",
+        resp.status
+    );
+}
+
+/// `get_export_job_status` must not reveal another org's export job. The job is
+/// owned by Org A; the caller is in Org B. On dev it returns the status; the
+/// fix returns 404.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_export_job_status_for_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (token, org_a, org_b) = setup(&pool, &app).await;
+    let job_id = seed_export_job(&pool, org_a).await;
+
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri(format!("/api/v1/reports/export/{job_id}/status"))
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .header("X-Tenant-ID", org_b.to_string())
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::NOT_FOUND,
+        "reading another org's export job must be 404, got {}",
+        resp.status
+    );
+}
+
+/// Same-tenant export job status is readable (the guard must not over-reject).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_export_job_status_for_own_org_is_allowed(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (token, _org_a, org_b) = setup(&pool, &app).await;
+    let job_id = seed_export_job(&pool, org_b).await; // owned by caller's org
+
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri(format!("/api/v1/reports/export/{job_id}/status"))
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .header("X-Tenant-ID", org_b.to_string())
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "owner org must read its own export job, got {}",
+        resp.status
+    );
+}


### PR DESCRIPTION
## What
Two cross-tenant IDORs in report export (triaged from #832, P1):
- `POST /api/v1/reports/export` (`export_report`) trusted the client-supplied `organization_id`.
- `GET /api/v1/reports/export/{job_id}/status` (`get_export_job_status`) returned any background job's status + download URL by UUID.

## Fix
Thread `RlsConnection` into both and reject when `!is_super_admin() && org != tenant_id()`, mirroring `get_fault_statistics_report` and the other report handlers. `export_report` checks `req.organization_id`; `get_export_job_status` checks the job's recorded `org_id` (404 to avoid leaking existence).

## Tests (IG3)
`reports_export_org_scope_tests.rs` — real JWT for a Manager in Org B targeting Org A:
- export for foreign org → **403**
- foreign job status → **404**
- own-org job status → **200** (guard doesn't over-reject)

All 3 pass locally. `cargo fmt --all --check` + `clippy -p api-server -- -D warnings` clean.

Closes #832