### PR TITLE
fix(security): require manager role to review tenant applications (closes #806)

### DIFF
--- a/backend/servers/api-server/src/routes/leases.rs
+++ b/backend/servers/api-server/src/routes/leases.rs
@@ -11,6 +11,7 @@ use axum::{
     Json, Router,
 };
 use common::errors::ErrorResponse;
+use common::TenantRole;
 use db::models::lease::RecordPayment;
 use db::models::{
     ApplicationListQuery, CreateAmendment, CreateApplication, CreateLease, CreateLeaseTemplate,
@@ -314,6 +315,21 @@ async fn review_application(
     Path(id): Path<Uuid>,
     Json(payload): Json<ReviewApplication>,
 ) -> Result<Json<db::models::TenantApplication>, (StatusCode, Json<ErrorResponse>)> {
+    // Reviewing (approving/rejecting) a tenant application is a manager action.
+    // Without this gate any authenticated member of the org — including a
+    // resident — could approve or reject applications (privilege escalation,
+    // closes #806). Managers and higher (incl. super-admins) pass.
+    if !rls.is_super_admin() && !rls.has_role(TenantRole::Manager) {
+        rls.release().await;
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "FORBIDDEN",
+                "Only managers can review tenant applications",
+            )),
+        ));
+    }
+
     let result = state
         .lease_repo
         .review_application_rls(&mut **rls.conn(), id, auth.user_id, payload)

--- a/backend/servers/api-server/tests/lease_review_rbac_tests.rs
+++ b/backend/servers/api-server/tests/lease_review_rbac_tests.rs
@@ -1,0 +1,122 @@
+//! Real-JWT RBAC regression for tenant-application review (#806).
+//!
+//! `review_application` (`POST /api/v1/leases/applications/{id}/review`)
+//! accepted any authenticated org member and let them approve/reject tenant
+//! applications — a privilege escalation (a resident could approve their own
+//! or others' applications). The fix gates it behind manager role.
+//!
+//! These tests use a real JWT (via `create_authenticated_user`) plus
+//! `X-Tenant-ID`, with `organization_members` seeded so `RlsConnection`
+//! resolves the caller's role from the DB. A **resident** must be rejected
+//! with 403 before reaching the repository; a **manager** must pass the role
+//! gate (proven by NOT getting a 403). See report_schedule_org_scope_jwt_tests.
+
+#[allow(dead_code)]
+mod common;
+
+use axum::{
+    body::Body,
+    http::{header, Method, Request, StatusCode},
+};
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{create_authenticated_user, TestApp, TestUser};
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO organizations (name, slug, contact_email, status)
+           VALUES ($1, $2, $3, 'active') RETURNING id"#,
+    )
+    .bind(format!("LeaseRBAC {slug}"))
+    .bind(format!("lease-rbac-{slug}-{}", Uuid::new_v4()))
+    .bind(format!("{slug}-{}@lease-rbac.test", Uuid::new_v4()))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_membership(pool: &PgPool, org_id: Uuid, user_id: Uuid, role: &str) {
+    sqlx::query(
+        r#"INSERT INTO organization_members
+               (id, organization_id, user_id, role_type, status, created_at)
+           VALUES ($1, $2, $3, $4, 'active', NOW()) ON CONFLICT DO NOTHING"#,
+    )
+    .bind(Uuid::new_v4())
+    .bind(org_id)
+    .bind(user_id)
+    .bind(role)
+    .execute(pool)
+    .await
+    .expect("seed membership");
+}
+
+async fn user_id_for(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(email)
+        .fetch_one(pool)
+        .await
+        .expect("user id")
+}
+
+/// Authenticate a user and make them a member of `org` with `role`.
+/// Returns the bearer token.
+async fn member_token(pool: &PgPool, app: &TestApp, org: Uuid, role: &str) -> String {
+    let user = TestUser::new();
+    let (token, _refresh) = create_authenticated_user(app, &user).await;
+    let uid = user_id_for(pool, &user.email).await;
+    seed_membership(pool, org, uid, role).await;
+    token
+}
+
+fn review_req(token: &str, org: Uuid, application_id: Uuid) -> Request<Body> {
+    Request::builder()
+        .method(Method::POST)
+        .uri(format!(
+            "/api/v1/leases/applications/{application_id}/review"
+        ))
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .header("X-Tenant-ID", org.to_string())
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(
+            json!({ "status": "approved", "decision_notes": "ok" }).to_string(),
+        ))
+        .unwrap()
+}
+
+/// A resident must NOT be able to review applications. On dev this reached the
+/// repository and applied the decision; the fix returns 403 before that.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn resident_cannot_review_application(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org = seed_org(&pool, "res").await;
+    let token = member_token(&pool, &app, org, "resident").await;
+
+    let resp = app.execute(review_req(&token, org, Uuid::new_v4())).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "a resident reviewing an application must get 403, got {}",
+        resp.status
+    );
+}
+
+/// A manager passes the role gate (does not get 403). The random application id
+/// won't be found, so the handler errors downstream — but crucially NOT with a
+/// 403, proving managers are allowed through.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn manager_passes_review_role_gate(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org = seed_org(&pool, "mgr").await;
+    let token = member_token(&pool, &app, org, "manager").await;
+
+    let resp = app.execute(review_req(&token, org, Uuid::new_v4())).await;
+
+    assert_ne!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "a manager must pass the review role gate, got 403"
+    );
+}


### PR DESCRIPTION
## What
`review_application` (`POST /api/v1/leases/applications/{id}/review`) accepted **any** authenticated org member (triaged from #806, P1). A resident could approve/reject tenant applications — a privilege escalation.

## Fix
Gate the handler behind manager role: `!rls.is_super_admin() && !rls.has_role(TenantRole::Manager)` → 403, before the repository call.

## Tests (IG3)
`lease_review_rbac_tests.rs` (real JWT + X-Tenant-ID + seeded membership):
- resident → **403** (before the repo)
- manager → **not 403** (passes the gate)

Both pass locally; `cargo fmt --all --check` clean.

Closes #806