### PR TITLE
fix(security): require auth on all IoT sensor endpoints (closes #817, #824, #845)

### DIFF
--- a/backend/servers/api-server/src/routes/iot.rs
+++ b/backend/servers/api-server/src/routes/iot.rs
@@ -115,8 +115,10 @@ pub fn sensor_router() -> Router<AppState> {
 )]
 async fn create_sensor(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Json(req): Json<CreateSensor>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
+    let _tenant_id = require_tenant_id(&principal)?;
     match state.sensor_repo.create(req).await {
         Ok(sensor) => Ok((StatusCode::CREATED, Json(serde_json::json!(sensor)))),
         Err(e) => {
@@ -166,8 +168,10 @@ async fn list_sensors(
 
 async fn get_sensor(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+    let _tenant_id = require_tenant_id(&principal)?;
     match state.sensor_repo.find_by_id(id).await {
         Ok(Some(sensor)) => Ok(Json(serde_json::json!(sensor))),
         Ok(None) => Err((
@@ -186,9 +190,11 @@ async fn get_sensor(
 
 async fn update_sensor(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateSensor>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+    let _tenant_id = require_tenant_id(&principal)?;
     match state.sensor_repo.update(id, req).await {
         Ok(sensor) => Ok(Json(serde_json::json!(sensor))),
         Err(e) => {
@@ -206,8 +212,10 @@ async fn update_sensor(
 
 async fn delete_sensor(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let _tenant_id = require_tenant_id(&principal)?;
     match state.sensor_repo.delete(id).await {
         Ok(true) => Ok(StatusCode::NO_CONTENT),
         Ok(false) => Err((
@@ -233,9 +241,11 @@ async fn delete_sensor(
 
 async fn list_readings(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(id): Path<Uuid>,
     Query(query): Query<ReadingQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+    let _tenant_id = require_tenant_id(&principal)?;
     match state.sensor_repo.list_readings(id, query).await {
         Ok(readings) => Ok(Json(serde_json::json!({ "readings": readings }))),
         Err(e) => {
@@ -253,9 +263,11 @@ async fn list_readings(
 
 async fn add_reading(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(id): Path<Uuid>,
     Json(mut req): Json<CreateSensorReading>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
+    let _tenant_id = require_tenant_id(&principal)?;
     req.sensor_id = id;
 
     match state.sensor_repo.create_reading(req).await {
@@ -275,9 +287,11 @@ async fn add_reading(
 
 async fn add_batch_readings(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(id): Path<Uuid>,
     Json(req): Json<BatchSensorReadings>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
+    let _tenant_id = require_tenant_id(&principal)?;
     match state
         .sensor_repo
         .create_batch_readings(id, req.readings)
@@ -302,9 +316,11 @@ async fn add_batch_readings(
 
 async fn get_aggregated_readings(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(id): Path<Uuid>,
     Query(query): Query<ReadingQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+    let _tenant_id = require_tenant_id(&principal)?;
     let aggregation = query
         .aggregation
         .clone()
@@ -339,8 +355,10 @@ async fn get_aggregated_readings(
 
 async fn list_thresholds(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+    let _tenant_id = require_tenant_id(&principal)?;
     match state.sensor_repo.list_thresholds(id).await {
         Ok(thresholds) => Ok(Json(serde_json::json!({ "thresholds": thresholds }))),
         Err(e) => {
@@ -358,9 +376,11 @@ async fn list_thresholds(
 
 async fn create_threshold(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(id): Path<Uuid>,
     Json(mut req): Json<CreateSensorThreshold>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
+    let _tenant_id = require_tenant_id(&principal)?;
     req.sensor_id = id;
 
     match state.sensor_repo.create_threshold(req).await {
@@ -380,9 +400,11 @@ async fn create_threshold(
 
 async fn update_threshold(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(threshold_id): Path<Uuid>,
     Json(req): Json<UpdateSensorThreshold>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+    let _tenant_id = require_tenant_id(&principal)?;
     match state.sensor_repo.update_threshold(threshold_id, req).await {
         Ok(threshold) => Ok(Json(serde_json::json!(threshold))),
         Err(e) => {
@@ -400,8 +422,10 @@ async fn update_threshold(
 
 async fn delete_threshold(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(threshold_id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let _tenant_id = require_tenant_id(&principal)?;
     match state.sensor_repo.delete_threshold(threshold_id).await {
         Ok(true) => Ok(StatusCode::NO_CONTENT),
         Ok(false) => Err((
@@ -482,9 +506,11 @@ pub struct ResolveAlertRequest {
 
 async fn resolve_alert(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(alert_id): Path<Uuid>,
     Json(req): Json<ResolveAlertRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+    let _tenant_id = require_tenant_id(&principal)?;
     // Pass resolved_value as Option - NULL is valid when value wasn't captured
     match state
         .sensor_repo
@@ -511,8 +537,10 @@ async fn resolve_alert(
 
 async fn list_correlations(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+    let _tenant_id = require_tenant_id(&principal)?;
     match state.sensor_repo.list_correlations_for_sensor(id).await {
         Ok(correlations) => Ok(Json(serde_json::json!({ "correlations": correlations }))),
         Err(e) => {
@@ -555,8 +583,10 @@ async fn create_correlation(
 
 async fn delete_correlation(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(correlation_id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let _tenant_id = require_tenant_id(&principal)?;
     match state.sensor_repo.delete_correlation(correlation_id).await {
         Ok(true) => Ok(StatusCode::NO_CONTENT),
         Ok(false) => Err((
@@ -613,9 +643,11 @@ pub struct TemplateQuery {
 
 async fn apply_template(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(template_id): Path<Uuid>,
     Json(req): Json<ApplyTemplateRequest>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
+    let _tenant_id = require_tenant_id(&principal)?;
     match state
         .sensor_repo
         .apply_threshold_template(template_id, req.sensor_id)

--- a/backend/servers/api-server/tests/iot_auth_tests.rs
+++ b/backend/servers/api-server/tests/iot_auth_tests.rs
@@ -1,0 +1,95 @@
+//! Regression tests: IoT sensor endpoints must require authentication
+//! (closes #817, #824, #845).
+//!
+//! 16 of the 22 handlers under `/api/v1/iot/sensors` had no auth extractor and
+//! served/mutated sensor data, readings, thresholds, alerts, correlations and
+//! templates anonymously. The fix adds `RequestPrincipal` + `require_tenant_id`
+//! to each, so an unauthenticated request is rejected at the extractor (401)
+//! before reaching the handler.
+//!
+//! `RequestPrincipal` rejects a request with no `Authorization` header with
+//! 401, so these tests need no DB seeding — they assert the auth gate fires.
+
+#[allow(dead_code)]
+mod common;
+
+use axum::{
+    body::Body,
+    http::{Method, Request, StatusCode},
+};
+use sqlx::PgPool;
+
+use common::TestApp;
+
+fn req(method: Method, uri: &str, body: Option<&str>) -> Request<Body> {
+    let b = Request::builder().method(method).uri(uri);
+    match body {
+        Some(j) => b
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from(j.to_string()))
+            .unwrap(),
+        None => b.body(Body::empty()).unwrap(),
+    }
+}
+
+/// Every previously-unauthenticated IoT endpoint must reject an anonymous
+/// request with 401. Each entry is (method, path, optional-json-body).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn iot_endpoints_require_auth(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let sid = "00000000-0000-0000-0000-000000000001";
+    let tid = "00000000-0000-0000-0000-000000000002";
+    let cid = "00000000-0000-0000-0000-000000000003";
+    let aid = "00000000-0000-0000-0000-000000000004";
+    let tpl = "00000000-0000-0000-0000-000000000005";
+    let base = "/api/v1/iot/sensors";
+
+    let cases: Vec<(Method, String, Option<&str>)> = vec![
+        (Method::POST, format!("{base}"), Some(r#"{"name":"x"}"#)),
+        (Method::GET, format!("{base}/{sid}"), None),
+        (Method::PUT, format!("{base}/{sid}"), Some(r#"{}"#)),
+        (Method::DELETE, format!("{base}/{sid}"), None),
+        (Method::GET, format!("{base}/{sid}/readings"), None),
+        (
+            Method::POST,
+            format!("{base}/{sid}/readings"),
+            Some(r#"{}"#),
+        ),
+        (
+            Method::POST,
+            format!("{base}/{sid}/readings/batch"),
+            Some(r#"{"readings":[]}"#),
+        ),
+        (
+            Method::GET,
+            format!("{base}/{sid}/readings/aggregated"),
+            None,
+        ),
+        (Method::GET, format!("{base}/{sid}/thresholds"), None),
+        (
+            Method::POST,
+            format!("{base}/{sid}/thresholds"),
+            Some(r#"{}"#),
+        ),
+        (
+            Method::PUT,
+            format!("{base}/thresholds/{tid}"),
+            Some(r#"{}"#),
+        ),
+        (Method::DELETE, format!("{base}/thresholds/{tid}"), None),
+        (Method::POST, format!("{base}/alerts/{aid}/resolve"), None),
+        (Method::GET, format!("{base}/{sid}/correlations"), None),
+        (Method::DELETE, format!("{base}/correlations/{cid}"), None),
+        (Method::POST, format!("{base}/templates/{tpl}/apply"), None),
+    ];
+
+    for (method, uri, body) in cases {
+        let resp = app.execute(req(method.clone(), &uri, body)).await;
+        assert_eq!(
+            resp.status,
+            StatusCode::UNAUTHORIZED,
+            "{method} {uri} must require auth (401), got {}",
+            resp.status
+        );
+    }
+}


### PR DESCRIPTION
## What
16 of 22 handlers under `/api/v1/iot/sensors` had **no auth extractor** and served/mutated sensor data, readings, thresholds, alerts, correlations and templates **anonymously**. Three triage issues (#817, #824, #845, all P0) reported this gap from different angles.

## Fix
Add `RequestPrincipal` + `require_tenant_id(&principal)` to every previously-open handler — the same gate the already-protected handlers use. Unauthenticated requests are now rejected at the extractor (401) before reaching the handler.

Handlers fixed: create_sensor, get_sensor, update_sensor, delete_sensor, list_readings, add_reading, add_batch_readings, get_aggregated_readings, list_thresholds, create_threshold, update_threshold, delete_threshold, resolve_alert, list_correlations, delete_correlation, apply_template.

> Deeper per-resource org-ownership scoping (e.g. `get_sensor` verifying the sensor's org) needs repo signature changes — tracked as follow-up; this PR closes the **unauthenticated-access** P0.

## Test (IG3)
`iot_auth_tests.rs` hits all 16 endpoints with no Authorization header and asserts **401**. Passes locally; `cargo check` + `clippy -p api-server -- -D warnings` clean.

Closes #817, closes #824, closes #845