### PR TITLE
fix(security): require manager role for building create/archive/bulk-import (closes #799)

### DIFF
--- a/backend/servers/api-server/src/routes/buildings.rs
+++ b/backend/servers/api-server/src/routes/buildings.rs
@@ -12,6 +12,7 @@ use axum::{
     Json, Router,
 };
 use common::errors::ErrorResponse;
+use common::TenantRole;
 use db::models::{
     Building, BuildingStatistics, BuildingSummary, CreateBuilding, CreateUnit, Unit, UnitOwnerInfo,
     UnitSummary, UnitWithOwners, UpdateBuilding, UpdateUnit,
@@ -474,6 +475,19 @@ pub async fn create_building(
         ));
     }
 
+    // Creating a building is a manager action (closes #799). RLS enforces org
+    // isolation but not role level, so gate explicitly.
+    if !rls.is_super_admin() && !rls.has_role(TenantRole::Manager) {
+        rls.release().await;
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "INSUFFICIENT_ROLE",
+                "Manager role required to create buildings",
+            )),
+        ));
+    }
+
     // Validate required fields
     if req.street.trim().is_empty() {
         rls.release().await;
@@ -609,6 +623,18 @@ pub async fn bulk_import_buildings(
     // organizations they belong to
 
     let user_id = rls.user_id();
+
+    // Bulk-importing buildings is a manager action (closes #799).
+    if !rls.is_super_admin() && !rls.has_role(TenantRole::Manager) {
+        rls.release().await;
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "INSUFFICIENT_ROLE",
+                "Manager role required to bulk-import buildings",
+            )),
+        ));
+    }
 
     // Validate bulk import size
     if req.buildings.is_empty() {
@@ -852,6 +878,18 @@ pub async fn archive_building(
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    // Archiving a building is a manager action (closes #799).
+    if !rls.is_super_admin() && !rls.has_role(TenantRole::Manager) {
+        rls.release().await;
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "INSUFFICIENT_ROLE",
+                "Manager role required to archive buildings",
+            )),
+        ));
+    }
+
     // RLS policies automatically enforce tenant isolation and access control
     let building = state
         .building_repo

--- a/backend/servers/api-server/tests/building_manager_rbac_tests.rs
+++ b/backend/servers/api-server/tests/building_manager_rbac_tests.rs
@@ -1,0 +1,158 @@
+//! Real-JWT RBAC regression for building mutations (#799).
+//!
+//! `create_building`, `archive_building` and `bulk_import_buildings` relied
+//! only on RLS tenant isolation and never checked the caller's *role*, so any
+//! org member (e.g. a resident) could create, archive or bulk-import
+//! buildings. The fix gates each behind manager role.
+//!
+//! Uses a real JWT + `X-Tenant-ID` with `organization_members` seeded so
+//! `RlsConnection` resolves the role from the DB (see
+//! report_schedule_org_scope_jwt_tests.rs). A resident must get 403 before the
+//! mutation; the role gate runs after the org-membership check.
+
+#[allow(dead_code)]
+mod common;
+
+use axum::{
+    body::Body,
+    http::{header, Method, Request, StatusCode},
+};
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{create_authenticated_user, TestApp, TestUser};
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO organizations (name, slug, contact_email, status)
+           VALUES ($1, $2, $3, 'active') RETURNING id"#,
+    )
+    .bind(format!("BldgRBAC {slug}"))
+    .bind(format!("bldg-rbac-{slug}-{}", Uuid::new_v4()))
+    .bind(format!("{slug}-{}@bldg-rbac.test", Uuid::new_v4()))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_membership(pool: &PgPool, org_id: Uuid, user_id: Uuid, role: &str) {
+    sqlx::query(
+        r#"INSERT INTO organization_members
+               (id, organization_id, user_id, role_type, status, created_at)
+           VALUES ($1, $2, $3, $4, 'active', NOW()) ON CONFLICT DO NOTHING"#,
+    )
+    .bind(Uuid::new_v4())
+    .bind(org_id)
+    .bind(user_id)
+    .bind(role)
+    .execute(pool)
+    .await
+    .expect("seed membership");
+}
+
+async fn user_id_for(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(email)
+        .fetch_one(pool)
+        .await
+        .expect("user id")
+}
+
+/// Authenticate a resident member of a fresh org. Returns (token, org_id).
+async fn resident(pool: &PgPool, app: &TestApp, slug: &str) -> (String, Uuid) {
+    let org = seed_org(pool, slug).await;
+    let user = TestUser::new();
+    let (token, _r) = create_authenticated_user(app, &user).await;
+    let uid = user_id_for(pool, &user.email).await;
+    seed_membership(pool, org, uid, "resident").await;
+    (token, org)
+}
+
+fn authed(
+    method: Method,
+    uri: &str,
+    org: Uuid,
+    token: &str,
+    body: serde_json::Value,
+) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .header("X-Tenant-ID", org.to_string())
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn resident_cannot_create_building(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (token, org) = resident(&pool, &app, "create").await;
+
+    let body = json!({
+        "organization_id": org,
+        "street": "Main 1", "city": "Bratislava", "postal_code": "81101",
+        "country": "SK", "total_floors": 1, "total_entrances": 1, "amenities": []
+    });
+    let resp = app
+        .execute(authed(Method::POST, "/api/v1/buildings", org, &token, body))
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "create as resident must be 403, got {}",
+        resp.status
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn resident_cannot_archive_building(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (token, org) = resident(&pool, &app, "archive").await;
+
+    let resp = app
+        .execute(authed(
+            Method::DELETE,
+            &format!("/api/v1/buildings/{}", Uuid::new_v4()),
+            org,
+            &token,
+            json!({}),
+        ))
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "archive as resident must be 403, got {}",
+        resp.status
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn resident_cannot_bulk_import_buildings(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (token, org) = resident(&pool, &app, "bulk").await;
+
+    // Empty list deserializes fine and the role gate runs before the
+    // size/empty validation, so this is enough to reach (and assert) the gate.
+    let body = json!({ "organization_id": org, "buildings": [] });
+    let resp = app
+        .execute(authed(
+            Method::POST,
+            "/api/v1/buildings/bulk",
+            org,
+            &token,
+            body,
+        ))
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "bulk import as resident must be 403, got {}",
+        resp.status
+    );
+}


### PR DESCRIPTION
## What
`create_building`, `archive_building` and `bulk_import_buildings` relied **only** on RLS tenant isolation and never checked the caller's **role** (triaged from #799, P1). Any org member — including a resident — could create, archive or bulk-import buildings.

## Fix
Gate each behind manager role: `!rls.is_super_admin() && !rls.has_role(TenantRole::Manager)` → 403, mirroring the lease/report handlers.

## Tests (IG3)
`building_manager_rbac_tests.rs` (real JWT + X-Tenant-ID + resident membership): create / archive / bulk-import each return **403** for a resident. All pass locally; fmt clean.

Closes #799