### PR TITLE
fix(security): gate org-wide notification role-defaults behind manager (closes #808)

### DIFF
--- a/backend/servers/api-server/src/routes/granular_notifications.rs
+++ b/backend/servers/api-server/src/routes/granular_notifications.rs
@@ -527,6 +527,18 @@ pub async fn update_role_defaults(
     Path(role): Path<String>,
     Json(request): Json<UpdateRoleDefaultsRequest>,
 ) -> Result<Json<RoleNotificationDefaults>, (StatusCode, Json<ErrorResponse>)> {
+    // Changing org-wide role notification defaults is a manager action
+    // (closes #808). Without this any member could rewrite org defaults.
+    if !tenant.role.is_manager() {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "INSUFFICIENT_ROLE",
+                "Manager role required to change role notification defaults",
+            )),
+        ));
+    }
+
     let organization_id = tenant.tenant_id;
     let created_by = auth.user_id;
 
@@ -589,6 +601,18 @@ pub async fn delete_role_defaults(
     tenant: TenantExtractor,
     Path(role): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    // Deleting org-wide role notification defaults is a manager action
+    // (closes #808).
+    if !tenant.role.is_manager() {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "INSUFFICIENT_ROLE",
+                "Manager role required to delete role notification defaults",
+            )),
+        ));
+    }
+
     let organization_id = tenant.tenant_id;
 
     state

--- a/backend/servers/api-server/tests/granular_notif_role_defaults_rbac_tests.rs
+++ b/backend/servers/api-server/tests/granular_notif_role_defaults_rbac_tests.rs
@@ -1,0 +1,87 @@
+//! Real-JWT RBAC regression for org-wide role notification defaults (#808).
+//!
+//! `update_role_defaults` (PUT) and `delete_role_defaults` (DELETE) on
+//! `/api/v1/users/me/notification-preferences/granular/roles/{role}` change
+//! ORG-WIDE notification defaults but had no role check, so any authenticated
+//! member could rewrite them. The fix gates both behind manager role
+//! (`tenant.role.is_manager()`). `apply_role_defaults` is intentionally left
+//! open — it only applies defaults to the *calling* user's own prefs.
+//!
+//! These endpoints use `TenantExtractor`, whose role derives from the bearer
+//! token, so a freshly-registered/logged-in user is a non-manager and must be
+//! rejected with 403.
+
+#[allow(dead_code)]
+mod common;
+
+use axum::{
+    body::Body,
+    http::{header, Method, Request, StatusCode},
+};
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{create_authenticated_user, TestApp, TestUser};
+
+const BASE: &str = "/api/v1/users/me/notification-preferences/granular/roles";
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO organizations (name, slug, contact_email, status)
+           VALUES ($1, $2, $3, 'active') RETURNING id"#,
+    )
+    .bind(format!("NotifRBAC {slug}"))
+    .bind(format!("notif-rbac-{slug}-{}", Uuid::new_v4()))
+    .bind(format!("{slug}-{}@notif-rbac.test", Uuid::new_v4()))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn non_manager_cannot_update_role_defaults(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org = seed_org(&pool, "update").await;
+    let (token, _r) = create_authenticated_user(&app, &TestUser::new()).await;
+
+    let req = Request::builder()
+        .method(Method::PUT)
+        .uri(format!("{BASE}/manager"))
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .header("X-Tenant-ID", org.to_string())
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(json!({ "eventPreferences": {} }).to_string()))
+        .unwrap();
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "non-manager updating org role defaults must be 403, got {}",
+        resp.status
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn non_manager_cannot_delete_role_defaults(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org = seed_org(&pool, "delete").await;
+    let (token, _r) = create_authenticated_user(&app, &TestUser::new()).await;
+
+    let req = Request::builder()
+        .method(Method::DELETE)
+        .uri(format!("{BASE}/manager"))
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .header("X-Tenant-ID", org.to_string())
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "non-manager deleting org role defaults must be 403, got {}",
+        resp.status
+    );
+}


### PR DESCRIPTION
## What
`update_role_defaults` (PUT) and `delete_role_defaults` (DELETE) change **org-wide** role notification defaults but had no role check (triaged from #808, P1) — any authenticated member could rewrite or delete them.

## Fix
Gate both behind `tenant.role.is_manager()` → 403 otherwise.

`apply_role_defaults` is **intentionally left open**: it only applies defaults to the *calling user's own* preferences (self-service), not an org-wide mutation, so it's not a privilege escalation.

## Tests (IG3)
`granular_notif_role_defaults_rbac_tests.rs` (real JWT + X-Tenant-ID): a non-manager gets **403** on PUT and DELETE. Both pass locally; fmt clean.

Closes #808