### PR TITLE
fix(api-server): register 5 routers missing from the production binary (closes #836)

### DIFF
--- a/backend/servers/api-server/src/main.rs
+++ b/backend/servers/api-server/src/main.rs
@@ -555,6 +555,25 @@ async fn main() -> anyhow::Result<()> {
         .nest("/api/v1/listings", routes::listings::router())
         // Integration routes
         .nest("/api/v1/integrations", routes::integrations::router())
+        // Routes that were registered in `lib.rs::create_router` (so tests
+        // passed) but were missing from this production binary, making them
+        // unreachable in prod (closes #836; also fixes MFA recovery codes,
+        // pricing, property valuations and data residency). Keep in sync with
+        // `lib.rs`.
+        .nest(
+            "/api/v1/users/me/push-tokens",
+            routes::push_tokens::router(),
+        )
+        .nest(
+            "/api/v1/users/me/mfa/recovery-codes",
+            routes::mfa::recovery_codes_router(),
+        )
+        .nest("/api/v1/pricing", routes::market_pricing::router())
+        .nest(
+            "/api/v1/property-valuations",
+            routes::property_valuation::router(),
+        )
+        .nest("/api/v1/data-residency", routes::data_residency::router())
         // Financial routes (Epic 11)
         .nest("/api/v1/financial", routes::financial::router())
         // Meters routes (Epic 12)


### PR DESCRIPTION
## What
`main.rs` builds its router **separately** from `lib.rs::create_router` (which the tests use). Five routers were registered only in `create_router`, so the test suite passed but the endpoints were **unreachable in the production binary** (triaged from #836):

| Route | Impact |
|-------|--------|
| `/api/v1/users/me/push-tokens` | #836 — mobile push / device registration |
| `/api/v1/users/me/mfa/recovery-codes` | account recovery unusable in prod |
| `/api/v1/pricing` | Epic 132 |
| `/api/v1/property-valuations` | Epic 133 |
| `/api/v1/data-residency` | Epic 146 |

## Fix
Register all five in `main.rs`, mirroring `create_router`. The handlers are already covered by the `create_router`-based integration tests (so the logic is tested); this change only makes them reachable in the deployed binary, which `TestApp` (built from `create_router`) cannot regression-test.

## Root cause / follow-up
The `lib.rs` vs `main.rs` router duplication is fragile — it will diverge again. Recommend consolidating the production binary onto `create_router` (filed as follow-up).

Closes #836