### PR TITLE
pm-tech-lead-sqlx-migration-ci-gate: SQLx migration & offline-cache CI gate

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -395,6 +395,81 @@ jobs:
             --skip test_cross_tenant_org_isolation \
             --skip test_cross_tenant_role_isolation
 
+  # SQLx migration + offline-cache gate (pm-tech-lead-sqlx-migration-ci-gate):
+  #   (a) runs every migration against a FRESH Postgres so broken/ordering-
+  #       dependent migration SQL is caught before merge (same boot pattern
+  #       as rls-smoke-test / security-tests above), and
+  #   (b) verifies the `.sqlx` offline query cache is up to date via
+  #       `cargo sqlx prepare --check`, so a stale cache (or a newly added
+  #       compile-time `query!`/`query_as!` macro whose entry wasn't
+  #       committed) fails CI rather than breaking the SQLX_OFFLINE=true
+  #       `cargo check` / release build that other jobs rely on.
+  #
+  # NOTE: today the repo deliberately uses RUNTIME `sqlx::query()` /
+  # `query_as()` (not the compile-time macros) so crates build without a live
+  # DATABASE_URL — see the comments in crates/db/src/repositories/*.rs and the
+  # gap-83-1 TODO in rental.rs. With zero macro call-sites the `--check`
+  # currently passes as a no-op; this gate locks in the convention so the day
+  # someone converts a query to the macro form (gap-83-1) and forgets to run
+  # `cargo sqlx prepare`, the offline cache drift is caught here.
+  sqlx-migrations:
+    runs-on: ubuntu-latest
+    needs: check
+    if: github.event_name == 'pull_request'
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ppt_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.94.1
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: backend
+
+      # Pin sqlx-cli to the workspace's SQLx version (0.9, see
+      # backend/Cargo.toml [workspace.dependencies]) so the offline-cache
+      # format the CLI emits/checks matches what the macros expect.
+      - name: Install SQLx CLI
+        run: cargo install sqlx-cli --version 0.9.0 --no-default-features --features native-tls,postgres --locked
+
+      # (a) Apply every migration against a fresh database. Fails the PR if any
+      #     migration SQL is broken or order-dependent in a way that doesn't
+      #     replay cleanly. Mirrors the rls-smoke-test / security-tests jobs.
+      - name: Run database migrations
+        working-directory: backend/crates/db
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/ppt_test
+        run: sqlx database create && sqlx migrate run
+
+      # (b) Verify the committed `.sqlx` offline cache matches the queries in
+      #     the source. `--check` exits non-zero if `cargo sqlx prepare` would
+      #     change anything (stale or missing entry), so it never mutates the
+      #     tree — it only fails. Runs against the freshly migrated DB above so
+      #     compile-time-checked macros (if/when added) validate against the
+      #     real schema.
+      - name: Verify SQLx offline cache is up to date
+        working-directory: backend
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/ppt_test
+        run: cargo sqlx prepare --check --workspace
+
   cargo-deny:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What

Adds a new `sqlx-migrations` job to `.github/workflows/backend.yml` that runs on backend PRs and:

1. **(a) Runs every SQLx migration against a fresh Postgres** (`sqlx database create && sqlx migrate run` from `backend/crates/db`) — catches broken or order-dependent migration SQL before merge.
2. **(b) Verifies the `.sqlx` offline query cache is up to date** (`cargo sqlx prepare --check --workspace`) — fails CI if the offline cache is stale or missing an entry, which would otherwise silently break the `SQLX_OFFLINE: true` `cargo check` / release build that the existing `check` and `build` jobs rely on.

## Why

The `check` and `build` jobs compile with `SQLX_OFFLINE: true` but nothing in CI verified that (a) the migrations actually apply cleanly to a fresh DB or (b) the committed offline cache matches the source queries. This gate closes both gaps before merge.

## How it's built (consistency with existing CI)

- Mirrors the existing `rls-smoke-test` / `security-tests` jobs: same `postgres:16` service block, `dtolnay/rust-toolchain@1.94.1`, `Swatinem/rust-cache@v2`, and the identical `working-directory: backend/crates/db` + `sqlx database create && sqlx migrate run` migration pattern.
- `needs: check` and `if: github.event_name == 'pull_request'` — only runs as a PR gate (same gating as `rls-smoke-test`), no extra cost on pushes.
- `sqlx-cli` pinned to `0.9.0` to match the workspace SQLx version (`backend/Cargo.toml` resolves `sqlx 0.9.0`), so the offline-cache format the CLI checks matches what the macros expect. (The existing jobs install unpinned `sqlx-cli`, which is fine for plain `migrate run` but not for `prepare --check`.)

## Notable repo state (documented in the job comment)

Today the backend deliberately uses **runtime** `sqlx::query()` / `query_as()` rather than the compile-time `query!` / `query_as!` macros (see comments in `crates/db/src/repositories/*.rs` and the `gap-83-1` TODO in `rental.rs`), so there is currently **no committed `.sqlx` directory** and zero macro call-sites. The `prepare --check` step therefore passes as a no-op today — its value is forward-looking: it locks in the convention so that when someone converts a query to the macro form (e.g. the planned `gap-83-1` work) and forgets to run `cargo sqlx prepare`, the offline-cache drift is caught here instead of breaking the offline build.

## How verified

- `python3 -c "import yaml; yaml.safe_load(...)"` parses the workflow cleanly; jobs resolve to `check, test, build, rls-smoke-test, security-tests, sqlx-migrations, cargo-deny`.
- Migration command verified against the existing `rls-smoke-test`/`security-tests` jobs (same path, same invocation).
- SQLx version confirmed `0.9.0` via `Cargo.lock`.
- This is a CI-config-only change; the gate itself runs in CI. No local Rust build was run (not meaningful for a YAML change).

https://claude.ai/code/session_01UXNMyGUEo47mk1rsQ3zgQU

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXNMyGUEo47mk1rsQ3zgQU)_