### PR TITLE
Tech debt #867: build api-server production router from a single route_table()

### DIFF
--- a/backend/servers/api-server/src/lib.rs
+++ b/backend/servers/api-server/src/lib.rs
@@ -113,19 +113,27 @@ fn parse_default_origins() -> Vec<HeaderValue> {
         .collect()
 }
 
-/// Create the application router with all routes.
+/// Build the application route table — the SINGLE source of truth for every
+/// HTTP route the api-server exposes.
 ///
-/// This function is exposed for integration testing. The production binary's
-/// `serve` entry point in `main.rs` builds an equivalent router with the same
-/// extension layering (see [`attach_admin_extensions`]).
-pub fn create_router(state: AppState) -> Router {
-    // Phase 5 — Admin dependency wiring. Built via [`build_admin_extensions`]
-    // so `main.rs::serve` and this test-side router stay in sync; an extension
-    // chain divergence between them previously meant 500s on every `/admin/*`
-    // call in production while tests passed.
-    let admin_ext = build_admin_extensions(state.db.clone());
-
-    let router = Router::new()
+/// Returns a state-less [`Router<AppState>`] with no middleware and no admin
+/// extensions layered. Both [`create_router`] (integration tests) and the
+/// production binary's `main()` build their router from THIS function, so the
+/// two can never silently diverge again (issue #867). Before this refactor,
+/// `main.rs` hand-maintained its own parallel chain of `.nest(...)` calls;
+/// PR #836 had to retro-fit five routers (`push-tokens`, `mfa/recovery-codes`,
+/// `pricing`, `property-valuations`, `data-residency`) that existed only in
+/// the test-side router and were therefore unreachable in production.
+///
+/// Production-only surface — the Prometheus `/metrics` endpoint, Swagger UI,
+/// and the Phase-3 host-routing endpoints (`/tenant-config`,
+/// `/admin/tenants/{org_id}/...`, `/internal/caddy-ask`) — is intentionally
+/// NOT included here. Those depend on production-only state (the metrics
+/// registry, the live host-tenant middleware) and are layered onto the shared
+/// table by `main.rs`. They are covered by their own focused tests
+/// (`tenant_config_tests.rs`, `caddy_ask_tests.rs`).
+pub fn route_table() -> Router<AppState> {
+    Router::new()
         // Health (liveness) — shallow, no deps. Docker HEALTHCHECK target.
         .route("/health", get(routes::health::liveness))
         // Readiness — deep dep check (DB + Redis). Operator dashboards.
@@ -312,17 +320,33 @@ pub fn create_router(state: AppState) -> Router {
         .nest("/api/v1/vendor-portal", routes::vendor_portal::router())
         // Registry routes
         .nest("/api/v1/registry", routes::registry::router())
+        // Multi-Currency routes (Epic 145)
+        .nest("/api/v1/multi-currency", routes::multi_currency::router())
         // Voice Webhooks routes
         .nest(
             "/api/v1/webhooks/voice",
             routes::voice_webhooks::voice_webhook_router(),
         )
+        // Portal Webhooks routes (Epic 105)
+        .nest(
+            "/api/v1/webhooks/portals",
+            routes::portal_webhooks::router(),
+        )
+        // Feature Packages routes (Epic 108)
+        .nest(
+            "/api/v1/feature-packages",
+            routes::feature_packages::router(),
+        )
         // Features routes (Epic 109)
         .nest("/api/v1/features", routes::features::router())
         // Outages routes (UC-12)
         .nest("/api/v1/outages", routes::outages::router())
-        // Market Pricing routes (Epic 132)
+        // Market Pricing routes (Epic 132). Mounted under both `/pricing` (the
+        // canonical path) and the `/market-pricing` alias that the production
+        // binary historically exposed; keeping both preserves backwards-compat
+        // for clients on either path while the route table is unified (#867).
         .nest("/api/v1/pricing", routes::market_pricing::router())
+        .nest("/api/v1/market-pricing", routes::market_pricing::router())
         // Lease Abstraction routes (Epic 133)
         .nest(
             "/api/v1/lease-abstraction",
@@ -345,9 +369,17 @@ pub fn create_router(state: AppState) -> Router {
             "/api/v1/building-certifications",
             routes::building_certifications::router(),
         )
-        // Property Valuation routes (Epic 138)
+        // Property Valuation routes (Epic 138). Mounted under both the plural
+        // `/property-valuations` (the canonical path) and the singular
+        // `/property-valuation` alias the production binary historically
+        // exposed; keeping both preserves backwards-compat while the route
+        // table is unified (#867).
         .nest(
             "/api/v1/property-valuations",
+            routes::property_valuation::router(),
+        )
+        .nest(
+            "/api/v1/property-valuation",
             routes::property_valuation::router(),
         )
         // Investor Portal routes (Epic 139)
@@ -363,14 +395,38 @@ pub fn create_router(state: AppState) -> Router {
         .nest("/api/v1/violations", routes::violations::router())
         // Board Meetings routes (Epic 143)
         .nest("/api/v1/board-meetings", routes::board_meetings::router())
+        // Portfolio Performance routes (Epic 144)
+        .nest(
+            "/api/v1/portfolio-performance",
+            routes::portfolio_performance::router(),
+        )
+        // API Ecosystem Expansion routes (Epic 150)
+        .nest("/api/v1/ecosystem", routes::api_ecosystem::router())
         // Data Residency routes (Epic 146)
-        .nest("/api/v1/data-residency", routes::data_residency::router());
+        .nest("/api/v1/data-residency", routes::data_residency::router())
+}
+
+/// Create the application router with all routes.
+///
+/// This function is exposed for integration testing. It builds on the shared
+/// [`route_table`] (the single source of truth for the route set — see #867),
+/// then layers the admin-core extensions, tracing, a development CORS policy,
+/// and the application state. The production binary in `main.rs` builds from
+/// the same [`route_table`] but layers production-only middleware (env-driven
+/// CORS, the host-tenant resolution layer, a global body cap) and
+/// production-only routes (`/metrics`, Swagger UI, Phase-3 host routing).
+pub fn create_router(state: AppState) -> Router {
+    // Phase 5 — Admin dependency wiring. Built via [`build_admin_extensions`]
+    // so `main.rs::serve` and this test-side router stay in sync; an extension
+    // chain divergence between them previously meant 500s on every `/admin/*`
+    // call in production while tests passed.
+    let admin_ext = build_admin_extensions(state.db.clone());
 
     // Phase 5 — admin dependency injection. Layered before TraceLayer so every
     // nested route inherits these extensions. Production binary applies the
     // same chain from `main.rs::serve` via `attach_admin_extensions` so the
     // two paths cannot drift.
-    attach_admin_extensions(router, &admin_ext)
+    attach_admin_extensions(route_table(), &admin_ext)
         // Middleware
         .layer(TraceLayer::new_for_http())
         // CORS configuration

--- a/backend/servers/api-server/src/main.rs
+++ b/backend/servers/api-server/src/main.rs
@@ -11,7 +11,7 @@
 // Allow dead code for stub implementations during development
 #![allow(dead_code)]
 
-use axum::{extract::DefaultBodyLimit, http, routing::get, Router};
+use axum::{extract::DefaultBodyLimit, http, routing::get};
 use http::HeaderValue;
 use std::net::SocketAddr;
 use tower_http::cors::CorsLayer;
@@ -19,10 +19,15 @@ use tower_http::trace::TraceLayer;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
-mod observability;
-mod routes;
-mod services;
-mod state;
+// The binary shares the `api_server` library crate's modules instead of
+// compiling its own copies. This is the same single-source-of-truth principle
+// the router unification (#867) applies to the route table: a binary-local
+// `mod routes;` would be a second compilation of the route handlers that could
+// drift from the library the integration tests exercise. Pull everything from
+// `api_server::` so the binary and the tests share one set of types — in
+// particular ONE `AppState`, so `api_server::route_table()` (a
+// `Router<api_server::state::AppState>`) accepts the state built here.
+use api_server::{observability, routes, services, state};
 
 use db::repositories::AnnouncementRepository;
 use services::{
@@ -33,7 +38,7 @@ use state::AppState;
 // Phase 5 — admin extension wiring helpers (B7). Both `main.rs` (production
 // binary) and `lib.rs::create_router` (tests) build the same admin-core
 // dependency chain via these helpers so they cannot drift.
-use api_server::{attach_admin_extensions, build_admin_extensions};
+use api_server::{attach_admin_extensions, build_admin_extensions, route_table};
 
 /// Default CORS allowed origins for api-server.
 /// Includes development origins and production domains.
@@ -459,280 +464,30 @@ async fn main() -> anyhow::Result<()> {
     // because `RequireCapability` could not find `AdminDeps` in extensions.
     let admin_ext = build_admin_extensions(db_pool.clone());
 
-    // Build router
-    let app = Router::new()
-        // Health (liveness) — shallow, no deps. Docker HEALTHCHECK target.
-        .route("/health", get(routes::health::liveness))
-        // Readiness — deep dep check (DB + Redis). Operator dashboards.
-        .route("/readiness", get(routes::health::readiness))
-        // Prometheus metrics endpoint (Epic 95.4)
+    // Build router.
+    //
+    // The application route table is sourced from the SINGLE source of truth,
+    // `api_server::route_table()` (issue #867). The production binary used to
+    // hand-maintain a parallel chain of `.nest(...)` calls here, which drifted
+    // from `lib.rs::create_router` (used by the integration tests): PR #836 had
+    // to retro-fit five routers that existed only in the test-side router and
+    // were therefore unreachable in production. Building both routers from the
+    // same `route_table()` makes that class of divergence impossible — a route
+    // added to `route_table()` is reachable in production AND exercised by the
+    // tests, and the guard test `route_table_is_single_source_of_truth` fails
+    // the build if `main.rs` ever reverts to hand-listing API routes.
+    //
+    // Only production-only surface is added on top here:
+    //   - `/metrics`            — needs the production observability registry.
+    //   - Swagger UI            — dev/ops doc endpoint.
+    //   - Phase-3 host routing  — `/tenant-config`, `/admin/tenants/...`,
+    //                             `/internal/caddy-ask`; these depend on the
+    //                             live host-tenant middleware and are covered
+    //                             by their own focused tests
+    //                             (`tenant_config_tests.rs`, `caddy_ask_tests.rs`).
+    let app = route_table()
+        // Prometheus metrics endpoint (Epic 95.4) — production-only.
         .route("/metrics", get(metrics_endpoint))
-        // Auth routes
-        .nest("/api/v1/auth", routes::auth::router())
-        // Admin routes
-        .nest("/api/v1/admin", routes::admin::router())
-        // Phase 5.5: tenant lifecycle (export / purge / restore) — platform-admin only.
-        .nest("/api/v1/admin", routes::admin_tenant_lifecycle::router())
-        // Organizations routes
-        .nest("/api/v1/organizations", routes::organizations::router())
-        // Buildings routes
-        .nest("/api/v1/buildings", routes::buildings::router())
-        // Delegations routes (Epic 3, Story 3.4)
-        .nest("/api/v1/delegations", routes::delegations::router())
-        // Facilities routes (Epic 3, Story 3.7)
-        .nest("/api/v1", routes::facilities::router())
-        // Faults routes
-        .nest("/api/v1/faults", routes::faults::router())
-        // Voting routes
-        .nest("/api/v1/voting", routes::voting::router())
-        // Announcements routes (Epic 6)
-        .nest("/api/v1/announcements", routes::announcements::router())
-        // Documents routes (Epic 7A)
-        .nest("/api/v1/documents", routes::documents::router())
-        // Public shared document routes (no auth required)
-        .merge(routes::documents::public_router())
-        // Templates routes (Epic 7B)
-        .nest("/api/v1/templates", routes::templates::router())
-        // E-Signature routes (Epic 7B, Story 7B.3)
-        .nest("/api/v1/signature-requests", routes::signatures::router())
-        // Messaging routes (Epic 6, Story 6.5)
-        .nest("/api/v1/messages", routes::messaging::router())
-        // Neighbor routes (Epic 6, Story 6.6)
-        .nest("/api/v1", routes::neighbors::router())
-        // Notification preferences routes (Epic 8A)
-        .nest(
-            "/api/v1/users/me/notification-preferences",
-            routes::notification_preferences::router(),
-        )
-        // WebSocket realtime notification sync (Epic 8A, Story 8A.3)
-        .nest(
-            "/api/v1/users/me/notifications",
-            routes::ws_notifications::router(),
-        )
-        // Granular notification preferences routes (Epic 8B)
-        .nest(
-            "/api/v1/users/me/notification-preferences/granular",
-            routes::granular_notifications::router(),
-        )
-        // Critical notifications routes (Epic 8A, Story 8A.2)
-        .nest(
-            "/api/v1/organizations/{org_id}/critical-notifications",
-            routes::critical_notifications::router(),
-        )
-        // MFA routes (Epic 9, Story 9.1)
-        .nest("/api/v1/auth/mfa", routes::mfa::router())
-        // OAuth 2.0 routes (Epic 10A)
-        .nest("/api/v1/oauth", routes::oauth::router())
-        .nest("/api/v1/admin/oauth", routes::oauth::admin_router())
-        // Platform Admin routes (Epic 10B)
-        .nest("/api/v1/platform-admin", routes::platform_admin::router())
-        // Public feature flags (Epic 10B.2)
-        .nest(
-            "/api/v1/feature-flags",
-            routes::platform_admin::public_feature_flags_router(),
-        )
-        // Public system announcements (Epic 10B.4)
-        .nest(
-            "/api/v1/system-announcements",
-            routes::platform_admin::public_announcements_router(),
-        )
-        // Public maintenance (Epic 10B.4)
-        .nest(
-            "/api/v1/maintenance",
-            routes::platform_admin::public_maintenance_router(),
-        )
-        // Onboarding routes (Epic 10B.6)
-        .nest("/api/v1/onboarding", routes::onboarding::router())
-        // Help routes (Epic 10B.7)
-        .nest("/api/v1/help", routes::help::router())
-        // GDPR routes (Epic 9, Stories 9.3-9.5)
-        .nest("/api/v1/gdpr", routes::gdpr::router())
-        // Compliance routes (Epic 9, Story 9.7)
-        .nest("/api/v1/compliance", routes::compliance::router())
-        // Rentals routes
-        .nest("/api/v1/rentals", routes::rentals::router())
-        // Listings routes (management side)
-        .nest("/api/v1/listings", routes::listings::router())
-        // Integration routes
-        .nest("/api/v1/integrations", routes::integrations::router())
-        // Routes that were registered in `lib.rs::create_router` (so tests
-        // passed) but were missing from this production binary, making them
-        // unreachable in prod (closes #836; also fixes MFA recovery codes,
-        // pricing, property valuations and data residency). Keep in sync with
-        // `lib.rs`.
-        .nest(
-            "/api/v1/users/me/push-tokens",
-            routes::push_tokens::router(),
-        )
-        .nest(
-            "/api/v1/users/me/mfa/recovery-codes",
-            routes::mfa::recovery_codes_router(),
-        )
-        .nest("/api/v1/pricing", routes::market_pricing::router())
-        .nest(
-            "/api/v1/property-valuations",
-            routes::property_valuation::router(),
-        )
-        .nest("/api/v1/data-residency", routes::data_residency::router())
-        // Financial routes (Epic 11)
-        .nest("/api/v1/financial", routes::financial::router())
-        // Meters routes (Epic 12)
-        .nest("/api/v1/meters", routes::meters::router())
-        // AI routes (Epic 13)
-        .nest("/api/v1/ai/chat", routes::ai::ai_chat_router())
-        .nest("/api/v1/ai/sentiment", routes::ai::sentiment_router())
-        .nest("/api/v1/ai/equipment", routes::ai::equipment_router())
-        .nest("/api/v1/ai/workflows", routes::ai::workflow_router())
-        // AI LLM routes (Epic 64)
-        .nest("/api/v1/ai/llm", routes::ai::llm_router())
-        // IoT routes (Epic 14)
-        .nest("/api/v1/iot/sensors", routes::iot::sensor_router())
-        // Agency routes (Epic 17)
-        .nest("/api/v1/agencies", routes::agencies::router())
-        // Lease routes (Epic 19)
-        .nest("/api/v1/leases", routes::leases::router())
-        // Work Orders routes (Epic 20)
-        .nest("/api/v1/work-orders", routes::work_orders::router())
-        // Vendor routes (Epic 21)
-        .nest("/api/v1/vendors", routes::vendors::router())
-        // Insurance routes (Epic 22)
-        .nest("/api/v1/insurance", routes::insurance::router())
-        // Emergency routes (Epic 23)
-        .nest("/api/v1/emergency", routes::emergency::router())
-        // Budget routes (Epic 24)
-        .nest("/api/v1/budgets", routes::budgets::router())
-        // Legal routes (Epic 25)
-        .nest("/api/v1/legal", routes::legal::router())
-        // Subscription routes (Epic 26)
-        .nest("/api/v1/subscriptions", routes::subscriptions::router())
-        .nest(
-            "/api/v1/admin/subscriptions",
-            routes::subscriptions::admin_router(),
-        )
-        // Government Portal routes (Epic 30)
-        .nest(
-            "/api/v1/government-portal",
-            routes::government_portal::router(),
-        )
-        // Community routes (Epic 37)
-        .nest("/api/v1/community", routes::community::router())
-        // Automation routes (Epic 38)
-        .nest("/api/v1/automation", routes::automation::router())
-        // Forms routes (Epic 54)
-        .nest("/api/v1/forms", routes::forms::router())
-        // Reports routes (Epic 55)
-        .nest("/api/v1/reports", routes::reports::router())
-        // Package routes (Epic 58)
-        .nest(
-            "/api/v1/packages",
-            routes::package_visitor::packages_router(),
-        )
-        // Visitor routes (Epic 58)
-        .nest(
-            "/api/v1/visitors",
-            routes::package_visitor::visitors_router(),
-        )
-        // News routes (Epic 59)
-        .nest("/api/v1/news", routes::news_articles::router())
-        // Energy routes (Epic 65)
-        .nest("/api/v1/energy", routes::energy::router())
-        // Regional Compliance routes (Epic 72)
-        .nest(
-            "/api/v1/regional-compliance",
-            routes::regional_compliance::router(),
-        )
-        // Migration routes (Epic 66)
-        .nest("/api/v1/migration", routes::migration::router())
-        // AML/DSA Compliance routes (Epic 67)
-        .nest("/api/v1/aml-dsa", routes::aml_dsa::router())
-        // Marketplace routes (Epic 68)
-        .nest("/api/v1/marketplace", routes::marketplace::router())
-        // Public API / Developer routes (Epic 69)
-        .nest("/api/v1/developer", routes::public_api::router())
-        // Competitive Features routes (Epic 70)
-        .nest("/api/v1/competitive", routes::competitive::router())
-        // Infrastructure routes (Epic 71)
-        .nest("/api/v1/infrastructure", routes::infrastructure::router())
-        // Operations routes (Epic 73)
-        .nest("/api/v1/operations", routes::operations::router())
-        // Owner Analytics routes (Epic 74)
-        .nest("/api/v1/owner-analytics", routes::owner_analytics::router())
-        // Dispute Resolution routes (Epic 77)
-        .nest("/api/v1/disputes", routes::disputes::router())
-        // Vendor Portal routes (Epic 78)
-        .nest("/api/v1/vendor-portal", routes::vendor_portal::router())
-        // Registry routes (Epic 64)
-        .nest("/api/v1/registry", routes::registry::router())
-        // Multi-Currency routes (Epic 145)
-        .nest("/api/v1/multi-currency", routes::multi_currency::router())
-        // Voice Webhooks routes (Epic 93)
-        .nest(
-            "/api/v1/webhooks/voice",
-            routes::voice_webhooks::voice_webhook_router(),
-        )
-        // Portal Webhooks routes (Epic 105)
-        .nest(
-            "/api/v1/webhooks/portals",
-            routes::portal_webhooks::router(),
-        )
-        // Feature Packages routes (Epic 108)
-        .nest(
-            "/api/v1/feature-packages",
-            routes::feature_packages::router(),
-        )
-        // Features routes (Epic 109)
-        .nest("/api/v1/features", routes::features::router())
-        // Outages routes (UC-12)
-        .nest("/api/v1/outages", routes::outages::router())
-        // Market Pricing routes (Epic 132)
-        .nest("/api/v1/market-pricing", routes::market_pricing::router())
-        // Lease Abstraction routes (Epic 133)
-        .nest(
-            "/api/v1/lease-abstraction",
-            routes::lease_abstraction::router(),
-        )
-        // Predictive Maintenance routes (Epic 134)
-        .nest(
-            "/api/v1/predictive-maintenance",
-            routes::predictive_maintenance::router(),
-        )
-        // Enhanced Tenant Screening routes (Epic 135)
-        .nest(
-            "/api/v1/tenant-screening",
-            routes::enhanced_tenant_screening::router(),
-        )
-        // ESG Reporting routes (Epic 136)
-        .nest("/api/v1/esg", routes::esg_reporting::router())
-        // Building Certifications routes (Epic 137)
-        .nest(
-            "/api/v1/building-certifications",
-            routes::building_certifications::router(),
-        )
-        // Property Valuation routes (Epic 138)
-        .nest(
-            "/api/v1/property-valuation",
-            routes::property_valuation::router(),
-        )
-        // Investor Portal routes (Epic 139)
-        .nest("/api/v1/investor-portal", routes::investor_portal::router())
-        // Portfolio Analytics routes (Epic 140)
-        .nest(
-            "/api/v1/portfolio-analytics",
-            routes::portfolio_analytics::router(),
-        )
-        // Reserve Funds routes (Epic 141)
-        .nest("/api/v1/reserve-funds", routes::reserve_funds::router())
-        // Violations routes (Epic 142)
-        .nest("/api/v1/violations", routes::violations::router())
-        // Board Meetings routes (Epic 143)
-        .nest("/api/v1/board-meetings", routes::board_meetings::router())
-        // Portfolio Performance routes (Epic 144)
-        .nest(
-            "/api/v1/portfolio-performance",
-            routes::portfolio_performance::router(),
-        )
-        // API Ecosystem Expansion routes (Epic 150)
-        .nest("/api/v1/ecosystem", routes::api_ecosystem::router())
         // Phase 3: per-host tenant config (read by reality-web at request
         // time). Mounted at the root because reality-web hits the same host
         // Caddy serves the app on, and the path must match exactly.

--- a/backend/servers/api-server/tests/router_single_source_tests.rs
+++ b/backend/servers/api-server/tests/router_single_source_tests.rs
@@ -1,0 +1,116 @@
+//! Guard tests for the unified router (issue #867).
+//!
+//! Background: the production binary (`src/main.rs`) used to hand-maintain its
+//! own chain of `.nest(...)` calls, separate from `lib.rs::create_router`
+//! (which the integration tests exercise via `TestApp`). The two drifted —
+//! PR #836 had to retro-fit FIVE routers (`push-tokens`, `mfa/recovery-codes`,
+//! `pricing`, `property-valuations`, `data-residency`) that existed only in the
+//! test-side router and were therefore unreachable in production.
+//!
+//! These tests assert that the route table is sourced from a SINGLE builder,
+//! `api_server::route_table()`, so the two paths cannot silently diverge again.
+//! They are pure source/static checks: no database, no async runtime, so they
+//! run in every `cargo test` invocation regardless of DB availability.
+
+use std::path::PathBuf;
+
+fn read_src(file: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join(file);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()))
+}
+
+/// `main.rs` (the production binary) MUST build its application router from the
+/// shared `route_table()` builder, not from a hand-listed chain of API
+/// `.nest(...)` calls.
+#[test]
+fn main_builds_from_route_table() {
+    let main_src = read_src("main.rs");
+
+    assert!(
+        main_src.contains("route_table()"),
+        "main.rs must build its router from the shared `route_table()` \
+         (single source of truth, #867)."
+    );
+}
+
+/// The production binary MUST NOT hand-list the bulk of the API surface.
+///
+/// A handful of `.nest(...)` calls are legitimately production-only and stay in
+/// `main.rs` (the Phase-3 host-routing endpoints: `/tenant-config`,
+/// `/admin/tenants/...`, `/internal/caddy-ask`). Everything under `/api/v1`
+/// belongs in `route_table()`. This guard fails if anyone re-introduces an
+/// `/api/v1` nest in `main.rs`, which is exactly how the #836 divergence crept
+/// in. The threshold is generous (any `/api/v1` nest trips it) precisely
+/// because a single re-added API route is the failure mode we are guarding
+/// against.
+#[test]
+fn main_does_not_hand_list_api_routes() {
+    let main_src = read_src("main.rs");
+
+    let offenders: Vec<&str> = main_src
+        .lines()
+        .filter(|line| {
+            let t = line.trim_start();
+            // A route registration line targeting the public API namespace.
+            (t.starts_with(".nest(") || t.starts_with(".route(")) && t.contains("/api/v1")
+        })
+        .collect();
+
+    assert!(
+        offenders.is_empty(),
+        "main.rs must not hand-list /api/v1 routes — they belong in \
+         `route_table()` (single source of truth, #867). Offending lines:\n{}",
+        offenders.join("\n")
+    );
+}
+
+/// `route_table()` is the single source of truth, so the routers that PR #836
+/// had to manually back-fill into the production binary MUST be present in the
+/// shared builder. This locks in the #867 fix: if any of these is dropped from
+/// `route_table()`, this test fails before the divergence can ship.
+#[test]
+fn route_table_contains_the_previously_diverged_routers() {
+    let lib_src = read_src("lib.rs");
+
+    // Pin the `route_table()` function body so we assert on the SHARED builder,
+    // not on `create_router`/`main.rs` happening to mention a path elsewhere.
+    let start = lib_src
+        .find("pub fn route_table()")
+        .expect("route_table() must exist in lib.rs (#867)");
+    let after = &lib_src[start..];
+    let end = after
+        .find("\npub fn create_router")
+        .expect("create_router must follow route_table in lib.rs");
+    let table = &after[..end];
+
+    // The five routers PR #836 had to retro-fit, plus the routers that were
+    // previously main-only (multi-currency, webhooks/portals, feature-packages,
+    // ecosystem, portfolio-performance) — all must live in the shared builder.
+    let required = [
+        "routes::push_tokens::router()",
+        "routes::mfa::recovery_codes_router()",
+        "routes::market_pricing::router()",
+        "routes::property_valuation::router()",
+        "routes::data_residency::router()",
+        "routes::multi_currency::router()",
+        "routes::portal_webhooks::router()",
+        "routes::feature_packages::router()",
+        "routes::api_ecosystem::router()",
+        "routes::portfolio_performance::router()",
+    ];
+
+    let missing: Vec<&str> = required
+        .iter()
+        .filter(|needle| !table.contains(**needle))
+        .copied()
+        .collect();
+
+    assert!(
+        missing.is_empty(),
+        "route_table() is missing routers that must be in the single source of \
+         truth (#867): {missing:?}"
+    );
+}


### PR DESCRIPTION
## Task
Tech debt #867: `backend/servers/api-server/src/main.rs` built the production router with its own chain of `.nest(...)` calls, separate from `lib.rs::create_router` (used by `TestApp`/integration tests). The two drifted silently — PR #836 had to hand-register 5 routers that existed only in `create_router` and were unreachable in production. Make `main()` build its app from a single source-of-truth route builder so the two can never diverge again, and add a guard test.

## Owner
pm-backend

## What changed
- **New `api_server::route_table() -> Router<AppState>`** in `lib.rs` — the SINGLE source of truth for the full HTTP route table (health + every `/api/v1/...` nest). No middleware, no admin extensions, no state.
- **`create_router(state)`** now builds from `route_table()`, then layers admin extensions + TraceLayer + dev CORS + state (unchanged test behaviour).
- **`main.rs`** now builds its app from `route_table()` too, then layers **production-only** surface on top:
  - routes: `/metrics`, Swagger UI, and the Phase-3 host-routing endpoints (`/tenant-config`, `/admin/tenants/{org_id}/...`, `/internal/caddy-ask`).
  - middleware: `DefaultBodyLimit` (16 MiB cap), `TraceLayer`, the host-tenant resolution layer, env-driven CORS, then `with_state`. Bind address / `axum::serve` graceful path unchanged.
  - The ~250-line hand-listed `.nest(...)` chain in `main.rs` is gone.
- **`main.rs` now imports the library crate's modules** (`use api_server::{observability, routes, services, state};`) instead of compiling its own `mod routes; mod services; mod state; mod observability;`. This is required for type unification (`route_table()` returns `Router<api_server::state::AppState>`; the binary's own `mod state` would have produced a distinct, incompatible `AppState`) and removes a second source of handler double-compilation that could itself drift.

### Routes reconciled (were diverged on `dev`)
Previously **main-only** (now in the shared table, so tests cover them): `multi-currency`, `webhooks/portals`, `feature-packages`, `ecosystem`, `portfolio-performance`.
The 5 routers PR #836 back-filled (`push-tokens`, `mfa/recovery-codes`, `pricing`, `property-valuations`, `data-residency`) are sourced from the shared table.

**No route dropped.** `main.rs` previously exposed BOTH `/api/v1/pricing` + `/api/v1/market-pricing`, and BOTH `/api/v1/property-valuations` + `/api/v1/property-valuation` (a duplicate that crept in via #836 on top of the original). To preserve production behaviour exactly, the shared table mounts the market-pricing router under both `/pricing` and `/market-pricing`, and the property-valuation router under both `/property-valuations` and `/property-valuation`.

## Guard test
`tests/router_single_source_tests.rs` (DB-free static checks, run in every `cargo test`):
- `main_builds_from_route_table` — `main.rs` must contain `route_table()`.
- `main_does_not_hand_list_api_routes` — fails if any `.nest("/api/v1...")` / `.route("/api/v1...")` reappears in `main.rs` (the exact #836 failure mode).
- `route_table_contains_the_previously_diverged_routers` — pins the 10 routers that must live in the single source of truth.

## Tested (Band A — fast check)
- `cargo check -p api-server` → exit 0 (Finished dev profile).
- `cargo test -p api-server --test router_single_source_tests` → `test result: ok. 3 passed; 0 failed`.

## Built (Band B — full build)
- `cargo clippy -p api-server --all-targets -- -D warnings` → see CI parity below.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity logic change — pure router-wiring refactor; auth middleware ordering preserved).

## Remote-tested
skipped

## Notes / residual for reviewer
- The market-pricing and property-valuation **dual-mount** preserves the existing (slightly accidental) production behaviour rather than picking a canonical path. If the team wants to drop the alias, that's a separate, intentional API change — flagged here so it isn't lost.
- Integration tests that ran only against `create_router` now also exercise the 5 previously-main-only routers (multi-currency etc.) via the shared table; full `cargo test -p api-server` requires a Postgres test DB (not run here — Band A + guard test cover the wiring; the rest is unchanged handler code).
- The `mod` → `use api_server::{...}` switch in `main.rs` is a deliberate scope-expansion beyond the literal router lines; it is necessary for the single-`AppState` type unification and removes a parallel compilation of the same handlers. No handler logic changed.
