### PR TITLE
fix(security): enforce org access on integration routes (refs #765)

### DIFF
--- a/backend/servers/api-server/src/routes/integrations/install.rs
+++ b/backend/servers/api-server/src/routes/integrations/install.rs
@@ -18,7 +18,7 @@ use serde::Deserialize;
 use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 
-use super::sync::{OrgIdPath, ResourceIdPath};
+use super::sync::{verify_org_access, OrgIdPath, ResourceIdPath};
 use common::errors::ErrorResponse;
 
 const MAX_BATCH_SIZE: usize = 500;
@@ -359,6 +359,9 @@ pub async fn get_airbnb_status(
         "Getting Airbnb status"
     );
 
+    // Issue #765: prevent cross-org IDOR — caller must belong to this org.
+    verify_org_access(&state, auth.user_id, path.org_id).await?;
+
     let rental_repo = &state.rental_repo;
 
     let (connected_count, listings_count, last_sync_at, sync_error) = rental_repo
@@ -432,6 +435,9 @@ pub async fn connect_airbnb(
         "Initiating Airbnb OAuth connection"
     );
 
+    // Issue #765: prevent cross-org IDOR — caller must belong to this org.
+    verify_org_access(&state, auth.user_id, path.org_id).await?;
+
     // Issue #711: AppState carries Airbnb credentials loaded once at startup.
     let client_id = state.airbnb_config.client_id.clone();
     let client_secret = state.airbnb_config.client_secret.clone();
@@ -489,6 +495,9 @@ pub async fn sync_airbnb(
         org_id = %path.org_id,
         "Syncing Airbnb"
     );
+
+    // Issue #765: prevent cross-org IDOR — caller must belong to this org.
+    verify_org_access(&state, auth.user_id, path.org_id).await?;
 
     let rental_repo = &state.rental_repo;
 
@@ -612,6 +621,9 @@ pub async fn disconnect_airbnb(
         "Disconnecting Airbnb"
     );
 
+    // Issue #765: prevent cross-org IDOR — caller must belong to this org.
+    verify_org_access(&state, auth.user_id, path.org_id).await?;
+
     let rental_repo = &state.rental_repo;
 
     let connection = rental_repo
@@ -693,6 +705,9 @@ pub async fn get_booking_status(
         "Getting Booking.com status"
     );
 
+    // Issue #765: prevent cross-org IDOR — caller must belong to this org.
+    verify_org_access(&state, auth.user_id, path.org_id).await?;
+
     let rental_repo = &state.rental_repo;
 
     let connection = rental_repo
@@ -756,6 +771,9 @@ pub async fn connect_booking(
         hotel_id = %request.hotel_id,
         "Connecting to Booking.com"
     );
+
+    // Issue #765: prevent cross-org IDOR — caller must belong to this org.
+    verify_org_access(&state, auth.user_id, path.org_id).await?;
 
     let rental_repo = &state.rental_repo;
 
@@ -838,6 +856,9 @@ pub async fn sync_booking(
         org_id = %path.org_id,
         "Syncing Booking.com"
     );
+
+    // Issue #765: prevent cross-org IDOR — caller must belong to this org.
+    verify_org_access(&state, auth.user_id, path.org_id).await?;
 
     let rental_repo = &state.rental_repo;
 
@@ -1046,6 +1067,9 @@ pub async fn disconnect_booking(
         org_id = %path.org_id,
         "Disconnecting Booking.com"
     );
+
+    // Issue #765: prevent cross-org IDOR — caller must belong to this org.
+    verify_org_access(&state, auth.user_id, path.org_id).await?;
 
     let rental_repo = &state.rental_repo;
 
@@ -1447,7 +1471,7 @@ pub async fn push_booking_rates(
     tag = "Integrations - Portals"
 )]
 pub async fn list_portal_connections(
-    State(_state): State<crate::state::AppState>,
+    State(state): State<crate::state::AppState>,
     auth: api_core::AuthUser,
     Path(path): Path<OrgIdPath>,
 ) -> Result<Json<Vec<PortalConnectionResponse>>, (StatusCode, Json<ErrorResponse>)> {
@@ -1456,6 +1480,9 @@ pub async fn list_portal_connections(
         org_id = %path.org_id,
         "Listing portal connections"
     );
+
+    // Issue #765: prevent cross-org IDOR — caller must belong to this org.
+    verify_org_access(&state, auth.user_id, path.org_id).await?;
 
     Ok(Json(Vec::new()))
 }
@@ -1476,7 +1503,7 @@ pub async fn list_portal_connections(
     tag = "Integrations - Portals"
 )]
 pub async fn create_portal_connection(
-    State(_state): State<crate::state::AppState>,
+    State(state): State<crate::state::AppState>,
     auth: api_core::AuthUser,
     Path(path): Path<OrgIdPath>,
     Json(request): Json<CreatePortalConnectionRequest>,
@@ -1487,6 +1514,9 @@ pub async fn create_portal_connection(
         portal_type = %request.portal_type,
         "Creating portal connection"
     );
+
+    // Issue #765: prevent cross-org IDOR — caller must belong to this org.
+    verify_org_access(&state, auth.user_id, path.org_id).await?;
 
     let portal_type = PortalType::from_str(&request.portal_type).ok_or_else(|| {
         (
@@ -1587,7 +1617,7 @@ pub async fn delete_portal_connection(
     tag = "Integrations - Portals"
 )]
 pub async fn list_portal_inquiries(
-    State(_state): State<crate::state::AppState>,
+    State(state): State<crate::state::AppState>,
     auth: api_core::AuthUser,
     Path(path): Path<OrgIdPath>,
     Query(_query): Query<PortalInquiryQuery>,
@@ -1597,6 +1627,9 @@ pub async fn list_portal_inquiries(
         org_id = %path.org_id,
         "Listing portal inquiries"
     );
+
+    // Issue #765: prevent cross-org IDOR — caller must belong to this org.
+    verify_org_access(&state, auth.user_id, path.org_id).await?;
 
     Ok(Json(Vec::new()))
 }

--- a/backend/servers/api-server/src/routes/integrations/oauth.rs
+++ b/backend/servers/api-server/src/routes/integrations/oauth.rs
@@ -18,7 +18,7 @@ use uuid::Uuid;
 
 use super::{
     install::{AirbnbCallbackResponse, OAuthCallbackQuery},
-    sync::OrgIdPath,
+    sync::{verify_org_access, OrgIdPath},
 };
 use crate::state::AppState;
 use common::errors::ErrorResponse;
@@ -103,6 +103,12 @@ pub async fn airbnb_oauth_callback(
             )),
         ));
     }
+
+    // Issue #765: prevent cross-org IDOR — the embedded-state org match above
+    // is not an authorization check (the `state` value is client-visible and
+    // forgeable). Require the authenticated caller to actually be a member of
+    // the organization before binding Airbnb tokens to it.
+    verify_org_access(&state, auth.user_id, path.org_id).await?;
 
     // Issue #711: pull Airbnb OAuth credentials from the AppState-cached
     // config rather than re-reading the env on every callback.

--- a/backend/servers/api-server/tests/integrations_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/integrations_cross_org_idor_tests.rs
@@ -1,0 +1,223 @@
+//! Real-JWT regression tests for the integration-route cross-org IDOR fix
+//! (closes #765).
+//!
+//! # Background
+//!
+//! The org-scoped Airbnb / Booking.com integration routes in
+//! `routes/integrations/install.rs` (`get_airbnb_status`, `connect_airbnb`,
+//! `sync_airbnb`, `disconnect_airbnb`, and the Booking.com equivalents)
+//! extracted the authenticated caller (`AuthUser`) purely for logging and
+//! then operated on the `{org_id}` taken from the URL path WITHOUT ever
+//! verifying that the caller belonged to that organization. Any authenticated
+//! user could therefore read another org's connection status, kick off a
+//! sync, or disconnect another org's Airbnb / Booking.com integration by
+//! guessing the org UUID — a textbook IDOR.
+//!
+//! The Airbnb OAuth callback (`routes/integrations/oauth.rs`) had a related
+//! hole: it matched the org id embedded in the (client-visible, forgeable)
+//! `state` parameter against the path, but never checked org membership, so a
+//! caller could bind Airbnb tokens to an arbitrary org.
+//!
+//! # The fix
+//!
+//! Every org-scoped handler now calls `verify_org_access(&state,
+//! auth.user_id, path.org_id)` — the same membership guard already used by
+//! the calendar / accounting / e-signature handlers in `sync.rs` and the
+//! webhook handlers in `webhook.rs`. A caller who is not a member of the
+//! target org receives `403 FORBIDDEN`.
+//!
+//! # What these tests verify
+//!
+//! Using a *real* JWT (minted via `/api/v1/auth/register` +
+//! `/api/v1/auth/login`):
+//!
+//!   - A user who is NOT a member of Org A is rejected with `403` on every
+//!     org-scoped Airbnb / Booking.com route (the IDOR is closed).
+//!   - A legitimate member of Org A passes the guard (NOT `403`) — proving
+//!     the fix does not lock out authorized callers.
+
+#[allow(dead_code)]
+mod common;
+
+use axum::{
+    body::Body,
+    http::{header, Method, Request, StatusCode},
+};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{create_authenticated_user, TestApp, TestUser};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active') RETURNING id
+        "#,
+    )
+    .bind(format!("Integrations IDOR {slug}"))
+    .bind(format!("integrations-idor-{slug}-{}", Uuid::new_v4()))
+    .bind(format!("{slug}-{}@integrations-idor.test", Uuid::new_v4()))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+/// Insert an `organization_members` row so `verify_org_access` (which calls
+/// `OrganizationMemberRepository::is_member`) returns true for this pair.
+async fn seed_membership(pool: &PgPool, org_id: Uuid, user_id: Uuid, role: &str) {
+    sqlx::query(
+        r#"
+        INSERT INTO organization_members
+            (id, organization_id, user_id, role_type, status, created_at)
+        VALUES ($1, $2, $3, $4, 'active', NOW())
+        ON CONFLICT DO NOTHING
+        "#,
+    )
+    .bind(Uuid::new_v4())
+    .bind(org_id)
+    .bind(user_id)
+    .bind(role)
+    .execute(pool)
+    .await
+    .expect("seed membership");
+}
+
+async fn user_id_for(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(email)
+        .fetch_one(pool)
+        .await
+        .expect("fetch user id")
+}
+
+fn authed_req(
+    method: Method,
+    uri: &str,
+    access_token: &str,
+    body: Option<serde_json::Value>,
+) -> Request<Body> {
+    let mut b = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header(header::AUTHORIZATION, format!("Bearer {}", access_token));
+    if body.is_some() {
+        b = b.header(header::CONTENT_TYPE, "application/json");
+    }
+    let payload = body
+        .map(|v| Body::from(v.to_string()))
+        .unwrap_or_else(Body::empty);
+    b.body(payload).expect("build request")
+}
+
+/// The org-scoped Airbnb / Booking.com routes a non-member must be barred
+/// from. Each tuple is (method, path-suffix, optional-body).
+fn org_scoped_routes(org_id: Uuid) -> Vec<(Method, String, Option<serde_json::Value>)> {
+    let base = format!("/api/v1/integrations/organizations/{org_id}");
+    vec![
+        (Method::GET, format!("{base}/airbnb/status"), None),
+        (
+            Method::POST,
+            format!("{base}/airbnb/connect"),
+            Some(serde_json::json!({})),
+        ),
+        (Method::POST, format!("{base}/airbnb/sync"), None),
+        (Method::DELETE, format!("{base}/airbnb"), None),
+        (Method::GET, format!("{base}/booking/status"), None),
+        (
+            Method::POST,
+            format!("{base}/booking/connect"),
+            Some(serde_json::json!({
+                "hotel_id": "H1",
+                "username": "u",
+                "password": "p"
+            })),
+        ),
+        (Method::POST, format!("{base}/booking/sync"), None),
+        (Method::DELETE, format!("{base}/booking"), None),
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — a non-member is rejected with 403 on every org-scoped route
+// ---------------------------------------------------------------------------
+
+/// #765: a real authenticated user who is NOT a member of Org A must be
+/// rejected with `403 FORBIDDEN` on every org-scoped Airbnb / Booking.com
+/// integration route. Before the fix these handlers ignored the caller's
+/// org entirely and proceeded against Org A's data.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn non_member_is_forbidden_on_org_integration_routes(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org_a = seed_org(&pool, "victim").await;
+    let org_b = seed_org(&pool, "attacker").await;
+
+    // Attacker: a real authenticated user who belongs to Org B only.
+    let attacker = TestUser::new();
+    let (access_token, _) = create_authenticated_user(&app, &attacker).await;
+    let attacker_id = user_id_for(&pool, &attacker.email).await;
+    seed_membership(&pool, org_b, attacker_id, "manager").await;
+
+    for (method, uri, body) in org_scoped_routes(org_a) {
+        let response = app
+            .execute(authed_req(method.clone(), &uri, &access_token, body))
+            .await;
+
+        assert_eq!(
+            response.status,
+            StatusCode::FORBIDDEN,
+            "#765: {method} {uri} from a non-member must return 403, got {} body={}",
+            response.status,
+            response.text()
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 2 — a legitimate org member passes the org-access guard
+// ---------------------------------------------------------------------------
+
+/// #765 (no-lockout sanity): a real authenticated member of Org A must NOT
+/// be rejected with `403` by the new org-access guard. `get_airbnb_status`
+/// returns `200` with `connected: false` when no connection exists, so we can
+/// assert the exact success status for the read path.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn member_passes_org_access_guard(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org_a = seed_org(&pool, "member-org").await;
+
+    // A real authenticated user who IS a member of Org A.
+    let member = TestUser::new();
+    let (access_token, _) = create_authenticated_user(&app, &member).await;
+    let member_id = user_id_for(&pool, &member.email).await;
+    seed_membership(&pool, org_a, member_id, "manager").await;
+
+    let uri = format!("/api/v1/integrations/organizations/{org_a}/airbnb/status");
+    let response = app
+        .execute(authed_req(Method::GET, &uri, &access_token, None))
+        .await;
+
+    assert_ne!(
+        response.status,
+        StatusCode::FORBIDDEN,
+        "#765: a legitimate org member must NOT be blocked by the org-access guard; body={}",
+        response.text()
+    );
+    assert_eq!(
+        response.status,
+        StatusCode::OK,
+        "#765: airbnb/status for a member with no connection should be 200; body={}",
+        response.text()
+    );
+    let json = response.json_value();
+    assert_eq!(
+        json["connected"], false,
+        "expected connected=false for an org with no Airbnb connection"
+    );
+}


### PR DESCRIPTION
## Task

Address the CORE finding of #765: **IDOR on the org-scoped Airbnb / Booking.com integration routes**. Any authenticated user could read another org's connection status, initiate a sync, connect, or disconnect another org's Airbnb / Booking.com integration by guessing the `{org_id}` in the URL — the handlers extracted `AuthUser` only for logging and never verified org membership.

## Owner

pm-security

## What changed

Added the existing `verify_org_access(&state, auth.user_id, path.org_id)` membership guard (the same helper already used by every sibling handler in `sync.rs` and `webhook.rs` — `OrganizationMemberRepository::is_member`, returns 403 for non-members) to every previously-unguarded org-scoped integration handler:

`backend/servers/api-server/src/routes/integrations/install.rs`
- `get_airbnb_status`, `connect_airbnb`, `sync_airbnb`, `disconnect_airbnb`
- `get_booking_status`, `connect_booking`, `sync_booking`, `disconnect_booking`
- `list_portal_connections`, `create_portal_connection`, `list_portal_inquiries` (read-only stubs — guarded for consistency; switched `_state` → `state`)

`backend/servers/api-server/src/routes/integrations/oauth.rs`
- `airbnb_oauth_callback` — added a membership check after the existing embedded-state org match. Finding #3: the `state` value is client-visible/forgeable, so the org-match is not an authorization check; the caller must actually be a member of the org before tokens are bound to it.

Routes that already carried an org guard were left as-is (the Gap 83-1 direct-connect / availability-sync handlers, the Booking push handlers, and `booking_channel.rs` use the `auth.tenant_id == path.org_id || is_platform_admin` idiom). This PR adds the missing guard to the original Story 83.1/83.2 handlers that had none.

## Test (IG3 — failing-on-main)

New `backend/servers/api-server/tests/integrations_cross_org_idor_tests.rs` (modeled on `report_schedule_org_scope_jwt_tests.rs`, real JWTs via `create_authenticated_user`):
- `non_member_is_forbidden_on_org_integration_routes` — a real authenticated user who is a member of Org B (not Org A) is rejected with **403** on all 8 Airbnb/Booking routes for Org A. **Fails on dev** (routes returned 200 with the org's data before the guard).
- `member_passes_org_access_guard` — a legitimate Org A member is NOT blocked (200 on `airbnb/status`), proving no lockout of authorized callers.

## Tested (Band A)

```
cargo fmt --all                                              # exit 0
cargo check -p api-server                                    # exit 0
cargo clippy -p api-server --lib -- -D warnings              # exit 0 (clean)
cargo test -p api-server --test integrations_cross_org_idor_tests   # 2 passed; 0 failed
```

Note: `cargo clippy -p api-server --all-targets` surfaces pre-existing `doc_overindented_list_items` errors in untouched test files (`report_schedule_rbac_tests.rs`, `ws_integration_tests`) — an artifact of the local Homebrew Rust 1.94 toolchain's newer lint, not introduced here. The `--lib` clippy (which covers the edited source) is clean.

## Built (Band B)

skipped: contained change (<50 LOC substantive, no public API/migration/config change); `cargo check` + lib clippy + integration test cover it.

## CI parity (Band C)

skipped locally: hot-path security change verified via the dedicated IDOR integration test above; `backend.yml` will run fmt/clippy/test on the PR.

## Deferred follow-ups (remaining #765 sub-findings — NOT in this PR)

- **#2 OAuth `state` not server-bound** — `connect_airbnb` still returns a stateless `{org_id}:{uuid}` state with no single-use Redis/DB nonce. The callback now requires org membership (closing the IDOR vector), but full CSRF/state-fixation hardening (server-side single-use nonce) is a larger, separable change and should be tracked as a follow-up.
- **#4 token plaintext fallback** / **#6 workflow `call_webhook` SSRF** / **#5/#7/#8** — out of scope for this contained IDOR fix.

Committed as `refs #765` (not `closes`) because the OAuth-state and token-encryption sub-findings remain open.