### PR TITLE
fix(security): scope insurance routes to authenticated tenant (closes #826)

### DIFF
--- a/backend/servers/api-server/src/routes/insurance.rs
+++ b/backend/servers/api-server/src/routes/insurance.rs
@@ -1,8 +1,21 @@
 //! Insurance management routes for Epic 22.
 //!
 //! Handles insurance policies, claims, documents, and renewal reminders.
+//!
+//! # Authentication & tenancy (SECURITY-CRITICAL)
+//!
+//! Every handler derives the owning organization from the verified
+//! [`RequestPrincipal`] (built from the bearer JWT + host-resolved tenant),
+//! never from a client-supplied `organization_id` query param / request-body
+//! field. The previous implementation read tenancy from
+//! `query.building_id.unwrap_or_default()` (a placeholder that resolved to
+//! `Uuid::nil()` when absent) on the list endpoints, and accepted an
+//! `?organization_id=` query param / body `organization_id` on the
+//! get/mutate endpoints. Both let any caller read or mutate another org's
+//! policies/claims (a cross-tenant IDOR) and produced empty/garbage results
+//! for legitimate callers. See issue #826.
 
-use api_core::extractors::AuthUser;
+use api_core::extractors::principal::RequestPrincipal;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -22,6 +35,30 @@ use utoipa::IntoParams;
 use uuid::Uuid;
 
 use crate::state::AppState;
+
+// ============================================
+// Helper Functions
+// ============================================
+
+/// Resolve the effective tenant (organization) id from a verified
+/// [`RequestPrincipal`].
+///
+/// Insurance data is per-tenant by definition. A platform-kind principal
+/// hitting the platform host has no `effective_org` — for those callers we
+/// refuse with 403 rather than fall back to a wildcard / nil org. Non-platform
+/// principals without a host-resolved tenant never reach this point because
+/// `RequestPrincipal` rejects them earlier.
+fn require_org_id(principal: &RequestPrincipal) -> Result<Uuid, (StatusCode, Json<ErrorResponse>)> {
+    principal.effective_org.ok_or_else(|| {
+        (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "TENANT_REQUIRED",
+                "Insurance endpoints require a tenant-resolved request",
+            )),
+        )
+    })
+}
 
 // ============================================
 // Request/Response Types
@@ -84,9 +121,11 @@ impl From<ListClaimsQuery> for db::models::InsuranceClaimQuery {
 }
 
 /// Request to create a policy.
+///
+/// The owning organization is derived from the authenticated principal, never
+/// from the request body (issue #826).
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct CreatePolicyRequest {
-    pub organization_id: Uuid,
     #[serde(flatten)]
     pub data: CreateInsurancePolicy,
 }
@@ -94,7 +133,6 @@ pub struct CreatePolicyRequest {
 /// Request to update a policy.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct UpdatePolicyRequest {
-    pub organization_id: Uuid,
     #[serde(flatten)]
     pub data: UpdateInsurancePolicy,
 }
@@ -102,7 +140,6 @@ pub struct UpdatePolicyRequest {
 /// Request to create a claim.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct CreateClaimRequest {
-    pub organization_id: Uuid,
     #[serde(flatten)]
     pub data: CreateInsuranceClaim,
 }
@@ -110,7 +147,6 @@ pub struct CreateClaimRequest {
 /// Request to update a claim.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct UpdateClaimRequest {
-    pub organization_id: Uuid,
     #[serde(flatten)]
     pub data: UpdateInsuranceClaim,
 }
@@ -118,7 +154,6 @@ pub struct UpdateClaimRequest {
 /// Request to review a claim.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct ReviewClaimRequest {
-    pub organization_id: Uuid,
     pub status: String,
     pub approved_amount: Option<rust_decimal::Decimal>,
     pub denial_reason: Option<String>,
@@ -128,7 +163,6 @@ pub struct ReviewClaimRequest {
 /// Request to record claim payment.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct RecordClaimPaymentRequest {
-    pub organization_id: Uuid,
     pub payment_amount: rust_decimal::Decimal,
 }
 
@@ -251,10 +285,11 @@ pub fn router() -> Router<AppState> {
 async fn list_policies(
     State(state): State<AppState>,
     Query(query): Query<ListPoliciesQuery>,
-    _user: AuthUser,
+    principal: RequestPrincipal,
 ) -> Result<Json<ListPoliciesResponse>, (StatusCode, Json<ErrorResponse>)> {
-    // For now, require organization_id in query. In production, would get from tenant context.
-    let org_id = query.building_id.unwrap_or_default(); // Placeholder - would need proper org extraction
+    // SECURITY: the org is derived from the verified principal, never from a
+    // client-supplied query param (issue #826 — was `building_id.unwrap_or_default()`).
+    let org_id = require_org_id(&principal)?;
 
     let policies = state
         .insurance_repo
@@ -273,12 +308,13 @@ async fn list_policies(
 /// Create a new insurance policy.
 async fn create_policy(
     State(state): State<AppState>,
-    _user: AuthUser,
+    principal: RequestPrincipal,
     Json(payload): Json<CreatePolicyRequest>,
 ) -> Result<Json<InsurancePolicy>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = require_org_id(&principal)?;
     let policy = state
         .insurance_repo
-        .create_policy(payload.organization_id, payload.data)
+        .create_policy(org_id, payload.data)
         .await
         .map_err(|e| {
             (
@@ -294,12 +330,12 @@ async fn create_policy(
 async fn get_policy(
     State(state): State<AppState>,
     Path(policy_id): Path<Uuid>,
-    Query(params): Query<OrgIdQuery>,
-    _user: AuthUser,
+    principal: RequestPrincipal,
 ) -> Result<Json<InsurancePolicy>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = require_org_id(&principal)?;
     let policy = state
         .insurance_repo
-        .find_policy_by_id(params.organization_id, policy_id)
+        .find_policy_by_id(org_id, policy_id)
         .await
         .map_err(|e| {
             (
@@ -321,12 +357,13 @@ async fn get_policy(
 async fn update_policy(
     State(state): State<AppState>,
     Path(policy_id): Path<Uuid>,
-    _user: AuthUser,
+    principal: RequestPrincipal,
     Json(payload): Json<UpdatePolicyRequest>,
 ) -> Result<Json<InsurancePolicy>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = require_org_id(&principal)?;
     let policy = state
         .insurance_repo
-        .update_policy(payload.organization_id, policy_id, payload.data)
+        .update_policy(org_id, policy_id, payload.data)
         .await
         .map_err(|e| {
             (
@@ -348,12 +385,12 @@ async fn update_policy(
 async fn delete_policy(
     State(state): State<AppState>,
     Path(policy_id): Path<Uuid>,
-    Query(params): Query<OrgIdQuery>,
-    _user: AuthUser,
+    principal: RequestPrincipal,
 ) -> Result<Json<DeleteResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = require_org_id(&principal)?;
     let success = state
         .insurance_repo
-        .delete_policy(params.organization_id, policy_id)
+        .delete_policy(org_id, policy_id)
         .await
         .map_err(|e| {
             (
@@ -369,13 +406,14 @@ async fn delete_policy(
 async fn get_expiring_policies(
     State(state): State<AppState>,
     Query(params): Query<ExpiringQuery>,
-    _user: AuthUser,
+    principal: RequestPrincipal,
 ) -> Result<Json<ExpiringPoliciesResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = require_org_id(&principal)?;
     let days_ahead = params.days_ahead.unwrap_or(30);
 
     let policies = state
         .insurance_repo
-        .get_expiring_policies(params.organization_id, days_ahead)
+        .get_expiring_policies(org_id, days_ahead)
         .await
         .map_err(|e| {
             (
@@ -395,7 +433,7 @@ async fn get_expiring_policies(
 async fn list_policy_documents(
     State(state): State<AppState>,
     Path(policy_id): Path<Uuid>,
-    _user: AuthUser,
+    _principal: RequestPrincipal,
 ) -> Result<Json<PolicyDocumentsResponse>, (StatusCode, Json<ErrorResponse>)> {
     let documents = state
         .insurance_repo
@@ -415,7 +453,7 @@ async fn list_policy_documents(
 async fn add_policy_document(
     State(state): State<AppState>,
     Path(policy_id): Path<Uuid>,
-    _user: AuthUser,
+    _principal: RequestPrincipal,
     Json(payload): Json<AddPolicyDocument>,
 ) -> Result<Json<InsurancePolicyDocument>, (StatusCode, Json<ErrorResponse>)> {
     let document = state
@@ -436,7 +474,7 @@ async fn add_policy_document(
 async fn remove_policy_document(
     State(state): State<AppState>,
     Path((policy_id, document_id)): Path<(Uuid, Uuid)>,
-    _user: AuthUser,
+    _principal: RequestPrincipal,
 ) -> Result<Json<DeleteResponse>, (StatusCode, Json<ErrorResponse>)> {
     let success = state
         .insurance_repo
@@ -460,7 +498,7 @@ async fn remove_policy_document(
 async fn list_reminders(
     State(state): State<AppState>,
     Path(policy_id): Path<Uuid>,
-    _user: AuthUser,
+    _principal: RequestPrincipal,
 ) -> Result<Json<RemindersResponse>, (StatusCode, Json<ErrorResponse>)> {
     let reminders = state
         .insurance_repo
@@ -480,7 +518,7 @@ async fn list_reminders(
 async fn create_reminder(
     State(state): State<AppState>,
     Path(policy_id): Path<Uuid>,
-    _user: AuthUser,
+    _principal: RequestPrincipal,
     Json(payload): Json<CreateRenewalReminder>,
 ) -> Result<Json<InsuranceRenewalReminder>, (StatusCode, Json<ErrorResponse>)> {
     let reminder = state
@@ -501,7 +539,7 @@ async fn create_reminder(
 async fn update_reminder(
     State(state): State<AppState>,
     Path(reminder_id): Path<Uuid>,
-    _user: AuthUser,
+    _principal: RequestPrincipal,
     Json(payload): Json<UpdateRenewalReminder>,
 ) -> Result<Json<InsuranceRenewalReminder>, (StatusCode, Json<ErrorResponse>)> {
     let reminder = state
@@ -528,7 +566,7 @@ async fn update_reminder(
 async fn delete_reminder(
     State(state): State<AppState>,
     Path(reminder_id): Path<Uuid>,
-    _user: AuthUser,
+    _principal: RequestPrincipal,
 ) -> Result<Json<DeleteResponse>, (StatusCode, Json<ErrorResponse>)> {
     let success = state
         .insurance_repo
@@ -552,10 +590,11 @@ async fn delete_reminder(
 async fn list_claims(
     State(state): State<AppState>,
     Query(query): Query<ListClaimsQuery>,
-    _user: AuthUser,
+    principal: RequestPrincipal,
 ) -> Result<Json<ListClaimsResponse>, (StatusCode, Json<ErrorResponse>)> {
-    // For now, require organization_id in query
-    let org_id = query.building_id.unwrap_or_default(); // Placeholder
+    // SECURITY: the org is derived from the verified principal, never from a
+    // client-supplied query param (issue #826 — was `building_id.unwrap_or_default()`).
+    let org_id = require_org_id(&principal)?;
 
     let claims = state
         .insurance_repo
@@ -574,12 +613,13 @@ async fn list_claims(
 /// Create a new insurance claim.
 async fn create_claim(
     State(state): State<AppState>,
-    user: AuthUser,
+    principal: RequestPrincipal,
     Json(payload): Json<CreateClaimRequest>,
 ) -> Result<Json<InsuranceClaim>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = require_org_id(&principal)?;
     let claim = state
         .insurance_repo
-        .create_claim(payload.organization_id, user.user_id, payload.data)
+        .create_claim(org_id, principal.user_id, payload.data)
         .await
         .map_err(|e| {
             (
@@ -595,12 +635,12 @@ async fn create_claim(
 async fn get_claim(
     State(state): State<AppState>,
     Path(claim_id): Path<Uuid>,
-    Query(params): Query<OrgIdQuery>,
-    _user: AuthUser,
+    principal: RequestPrincipal,
 ) -> Result<Json<InsuranceClaimWithPolicy>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = require_org_id(&principal)?;
     let claim = state
         .insurance_repo
-        .find_claim_with_policy(params.organization_id, claim_id)
+        .find_claim_with_policy(org_id, claim_id)
         .await
         .map_err(|e| {
             (
@@ -622,12 +662,13 @@ async fn get_claim(
 async fn update_claim(
     State(state): State<AppState>,
     Path(claim_id): Path<Uuid>,
-    _user: AuthUser,
+    principal: RequestPrincipal,
     Json(payload): Json<UpdateClaimRequest>,
 ) -> Result<Json<InsuranceClaim>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = require_org_id(&principal)?;
     let claim = state
         .insurance_repo
-        .update_claim(payload.organization_id, claim_id, payload.data)
+        .update_claim(org_id, claim_id, payload.data)
         .await
         .map_err(|e| {
             (
@@ -649,12 +690,12 @@ async fn update_claim(
 async fn submit_claim(
     State(state): State<AppState>,
     Path(claim_id): Path<Uuid>,
-    Query(params): Query<OrgIdQuery>,
-    user: AuthUser,
+    principal: RequestPrincipal,
 ) -> Result<Json<InsuranceClaim>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = require_org_id(&principal)?;
     let claim = state
         .insurance_repo
-        .submit_claim(params.organization_id, claim_id, user.user_id)
+        .submit_claim(org_id, claim_id, principal.user_id)
         .await
         .map_err(|e| {
             (
@@ -679,15 +720,16 @@ async fn submit_claim(
 async fn review_claim(
     State(state): State<AppState>,
     Path(claim_id): Path<Uuid>,
-    user: AuthUser,
+    principal: RequestPrincipal,
     Json(payload): Json<ReviewClaimRequest>,
 ) -> Result<Json<InsuranceClaim>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = require_org_id(&principal)?;
     let claim = state
         .insurance_repo
         .review_claim(
-            payload.organization_id,
+            org_id,
             claim_id,
-            user.user_id,
+            principal.user_id,
             &payload.status,
             payload.approved_amount,
             payload.denial_reason.as_deref(),
@@ -714,12 +756,13 @@ async fn review_claim(
 async fn record_claim_payment(
     State(state): State<AppState>,
     Path(claim_id): Path<Uuid>,
-    _user: AuthUser,
+    principal: RequestPrincipal,
     Json(payload): Json<RecordClaimPaymentRequest>,
 ) -> Result<Json<InsuranceClaim>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = require_org_id(&principal)?;
     let claim = state
         .insurance_repo
-        .record_claim_payment(payload.organization_id, claim_id, payload.payment_amount)
+        .record_claim_payment(org_id, claim_id, payload.payment_amount)
         .await
         .map_err(|e| {
             (
@@ -741,12 +784,12 @@ async fn record_claim_payment(
 async fn delete_claim(
     State(state): State<AppState>,
     Path(claim_id): Path<Uuid>,
-    Query(params): Query<OrgIdQuery>,
-    _user: AuthUser,
+    principal: RequestPrincipal,
 ) -> Result<Json<DeleteResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = require_org_id(&principal)?;
     let success = state
         .insurance_repo
-        .delete_claim(params.organization_id, claim_id)
+        .delete_claim(org_id, claim_id)
         .await
         .map_err(|e| {
             (
@@ -762,7 +805,7 @@ async fn delete_claim(
 async fn get_claim_history(
     State(state): State<AppState>,
     Path(claim_id): Path<Uuid>,
-    _user: AuthUser,
+    _principal: RequestPrincipal,
 ) -> Result<Json<ClaimHistoryResponse>, (StatusCode, Json<ErrorResponse>)> {
     let history = state
         .insurance_repo
@@ -786,7 +829,7 @@ async fn get_claim_history(
 async fn list_claim_documents(
     State(state): State<AppState>,
     Path(claim_id): Path<Uuid>,
-    _user: AuthUser,
+    _principal: RequestPrincipal,
 ) -> Result<Json<ClaimDocumentsResponse>, (StatusCode, Json<ErrorResponse>)> {
     let documents = state
         .insurance_repo
@@ -806,7 +849,7 @@ async fn list_claim_documents(
 async fn add_claim_document(
     State(state): State<AppState>,
     Path(claim_id): Path<Uuid>,
-    _user: AuthUser,
+    _principal: RequestPrincipal,
     Json(payload): Json<AddClaimDocument>,
 ) -> Result<Json<InsuranceClaimDocument>, (StatusCode, Json<ErrorResponse>)> {
     let document = state
@@ -827,7 +870,7 @@ async fn add_claim_document(
 async fn remove_claim_document(
     State(state): State<AppState>,
     Path((claim_id, document_id)): Path<(Uuid, Uuid)>,
-    _user: AuthUser,
+    _principal: RequestPrincipal,
 ) -> Result<Json<DeleteResponse>, (StatusCode, Json<ErrorResponse>)> {
     let success = state
         .insurance_repo
@@ -850,12 +893,12 @@ async fn remove_claim_document(
 /// Get insurance statistics.
 async fn get_statistics(
     State(state): State<AppState>,
-    Query(params): Query<OrgIdQuery>,
-    _user: AuthUser,
+    principal: RequestPrincipal,
 ) -> Result<Json<StatisticsResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = require_org_id(&principal)?;
     let statistics = state
         .insurance_repo
-        .get_statistics(params.organization_id)
+        .get_statistics(org_id)
         .await
         .map_err(|e| {
             (
@@ -866,7 +909,7 @@ async fn get_statistics(
 
     let claims_by_status = state
         .insurance_repo
-        .get_claim_summary_by_status(params.organization_id)
+        .get_claim_summary_by_status(org_id)
         .await
         .map_err(|e| {
             (
@@ -877,7 +920,7 @@ async fn get_statistics(
 
     let policies_by_type = state
         .insurance_repo
-        .get_policy_summary_by_type(params.organization_id)
+        .get_policy_summary_by_type(org_id)
         .await
         .map_err(|e| {
             (
@@ -897,15 +940,8 @@ async fn get_statistics(
 // Helper Query Types
 // ============================================
 
-/// Query parameter for organization ID.
-#[derive(Debug, Deserialize, IntoParams)]
-pub struct OrgIdQuery {
-    pub organization_id: Uuid,
-}
-
 /// Query parameter for expiring policies.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct ExpiringQuery {
-    pub organization_id: Uuid,
     pub days_ahead: Option<i32>,
 }

--- a/backend/servers/api-server/tests/insurance_cross_tenant_idor_tests.rs
+++ b/backend/servers/api-server/tests/insurance_cross_tenant_idor_tests.rs
@@ -1,0 +1,522 @@
+//! Regression tests for the cross-tenant IDOR fix on insurance endpoints
+//! (issue #826).
+//!
+//! Audit history: every handler on `/api/v1/insurance/*` derived the owning
+//! organization from client-supplied data instead of the authenticated
+//! principal:
+//!
+//! - `GET /policies` / `GET /claims` used
+//!   `query.building_id.unwrap_or_default()` as the org id (a placeholder that
+//!   resolves to `Uuid::nil()` when absent) — listed the wrong org's data, or
+//!   nothing.
+//! - `GET/PUT/DELETE /policies/{id}`, `GET/PUT/DELETE /claims/{id}`,
+//!   `POST /claims`, `POST /claims/{id}/{submit,review,payment}`,
+//!   `GET /policies/expiring`, `GET /statistics` accepted an
+//!   `?organization_id=` query param / body `organization_id` field that was
+//!   passed straight into the (correctly org-scoped) repository — so any
+//!   caller could read or mutate another org's rows by naming a foreign org.
+//!
+//! The fix removes every client-supplied org id and derives the org from the
+//! verified `RequestPrincipal` via `require_org_id(&principal)`.
+//!
+//! These tests exercise two layers:
+//!
+//!   1. HTTP surface — a request that claims to be from Org B (via a forged
+//!      `X-Tenant-Context` header, replicating the attack) is rejected with a
+//!      4xx and Org A's rows are neither read nor mutated.
+//!   2. Repository layer — proves the org-scoping contract directly: Org A
+//!      sees only its own policies/claims, never Org B's, and a lookup with
+//!      the wrong org id returns `None`/empty (the positive "legitimate org
+//!      sees its own data" case the issue asks for).
+//!
+//! TestApp wiring caveat (same as `equipment_cross_tenant_idor_tests`):
+//! `TestApp` mounts the router without `host_tenant_middleware`, so
+//! `RequestPrincipal` cannot derive a tenant from the Host header. A request
+//! carrying a forged `X-Tenant-Context` header (and no bearer JWT that
+//! `RequestPrincipal` would require) is rejected at the auth gate with
+//! 401/403 rather than the 404 the handler returns in production. Both are
+//! 4xx — the security contract (a cross-tenant request is never applied to the
+//! row) holds either way. The repo-layer tests below pin the positive path
+//! that the HTTP harness cannot reach.
+
+#[allow(dead_code)]
+mod common;
+
+use api_core::middleware::host_tenant::{ResolvedTenant, TenantSource};
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{header, Method, StatusCode},
+    middleware::Next,
+    response::Response,
+};
+use chrono::NaiveDate;
+use db::models::{
+    CreateInsuranceClaim, CreateInsurancePolicy, InsuranceClaimQuery, InsurancePolicyQuery,
+};
+use db::repositories::InsuranceRepository;
+use serde_json::json;
+use sqlx::PgPool;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use common::{create_authenticated_user, TestApp, TestUser};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active') RETURNING id
+        "#,
+    )
+    .bind(format!("InsIDOR Org {slug}"))
+    .bind(format!("ins-idor-org-{slug}"))
+    .bind(format!("{slug}@ins-idor.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'test_hash', 'InsIDOR User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Look up the user id created by `create_authenticated_user`.
+async fn user_id_for(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(email)
+        .fetch_one(pool)
+        .await
+        .expect("user id lookup")
+}
+
+/// Grant an active `user_memberships` row so `MembershipRepository::is_active`
+/// (used by `RequestPrincipal`) returns true for `(user, org)`.
+async fn seed_user_membership(pool: &PgPool, org_id: Uuid, user_id: Uuid) {
+    sqlx::query(
+        r#"
+        INSERT INTO user_memberships (user_id, organization_id, role)
+        VALUES ($1, $2, 'manager')
+        ON CONFLICT DO NOTHING
+        "#,
+    )
+    .bind(user_id)
+    .bind(org_id)
+    .execute(pool)
+    .await
+    .expect("seed user_membership");
+}
+
+fn sample_policy(suffix: &str) -> CreateInsurancePolicy {
+    CreateInsurancePolicy {
+        policy_number: format!("POL-{suffix}"),
+        policy_name: format!("Policy {suffix}"),
+        provider_name: "Acme Insure".to_string(),
+        provider_contact: None,
+        provider_phone: None,
+        provider_email: None,
+        policy_type: "property".to_string(),
+        coverage_amount: None,
+        deductible: None,
+        premium_amount: None,
+        premium_frequency: None,
+        building_id: None,
+        unit_id: None,
+        coverage_description: None,
+        effective_date: NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+        expiration_date: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+        renewal_date: None,
+        auto_renew: None,
+        terms: None,
+        metadata: None,
+    }
+}
+
+fn sample_claim(policy_id: Uuid, suffix: &str) -> CreateInsuranceClaim {
+    CreateInsuranceClaim {
+        policy_id,
+        claim_number: Some(format!("CLM-{suffix}")),
+        incident_date: NaiveDate::from_ymd_opt(2025, 6, 1).unwrap(),
+        incident_description: format!("Incident {suffix}"),
+        incident_location: None,
+        building_id: None,
+        unit_id: None,
+        fault_id: None,
+        claimed_amount: None,
+        currency: None,
+        metadata: None,
+    }
+}
+
+/// Forge an `X-Tenant-Context` header claiming membership in `org_id`.
+fn tenant_context_header(org_id: Uuid, user_id: Uuid) -> String {
+    json!({
+        "tenant_id": org_id,
+        "user_id": user_id,
+        "role": "OrgAdmin",
+    })
+    .to_string()
+}
+
+fn req(method: Method, uri: &str, ctx: &str, body: Option<serde_json::Value>) -> Request<Body> {
+    let mut b = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("X-Tenant-Context", ctx);
+    if body.is_some() {
+        b = b.header(header::CONTENT_TYPE, "application/json");
+    }
+    let payload = body
+        .map(|v| Body::from(v.to_string()))
+        .unwrap_or_else(Body::empty);
+    b.body(payload).unwrap()
+}
+
+/// Assert that the response is a rejection (any 4xx).
+fn assert_rejected(status: StatusCode, ctx: &str) {
+    let code = status.as_u16();
+    assert!(
+        (400..500).contains(&code),
+        "{ctx}: cross-tenant request must be rejected with 4xx, got {status}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// H1 — HTTP: list_policies cross-tenant (the P0 finding)
+// ---------------------------------------------------------------------------
+
+/// GET /policies with a forged Org-B context targeting Org A's data → rejected.
+/// The pre-fix handler used `building_id.unwrap_or_default()` as the org, so it
+/// never consulted the principal at all.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_policies_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org_a = seed_org(&pool, "lst-pol-a").await;
+    let org_b = seed_org(&pool, "lst-pol-b").await;
+    let user_b = seed_user(&pool, "lst-pol-b@ins-idor.test").await;
+
+    let repo = InsuranceRepository::new(pool.clone());
+    repo.create_policy(org_a, sample_policy("a1"))
+        .await
+        .expect("seed policy in org A");
+
+    let ctx_b = tenant_context_header(org_b, user_b);
+    let response = app
+        .execute(req(Method::GET, "/api/v1/insurance/policies", &ctx_b, None))
+        .await;
+
+    assert_rejected(response.status, "list_policies cross-tenant");
+}
+
+// ---------------------------------------------------------------------------
+// H2 — HTTP: get_policy cross-tenant (information disclosure / IDOR)
+// ---------------------------------------------------------------------------
+
+/// GET /policies/{id} naming Org A's policy from an Org-B context → rejected,
+/// Org A's policy is not disclosed.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_policy_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org_a = seed_org(&pool, "get-pol-a").await;
+    let org_b = seed_org(&pool, "get-pol-b").await;
+    let user_b = seed_user(&pool, "get-pol-b@ins-idor.test").await;
+
+    let repo = InsuranceRepository::new(pool.clone());
+    let policy_in_a = repo
+        .create_policy(org_a, sample_policy("a2"))
+        .await
+        .expect("seed policy in org A");
+
+    let ctx_b = tenant_context_header(org_b, user_b);
+    let uri = format!("/api/v1/insurance/policies/{}", policy_in_a.id);
+    let response = app.execute(req(Method::GET, &uri, &ctx_b, None)).await;
+
+    assert_rejected(response.status, "get_policy cross-tenant");
+}
+
+// ---------------------------------------------------------------------------
+// H3 — HTTP: delete_policy cross-tenant (mutation must not apply)
+// ---------------------------------------------------------------------------
+
+/// DELETE /policies/{id} from an Org-B context targeting Org A's policy →
+/// rejected, and the row still exists.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn delete_policy_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org_a = seed_org(&pool, "del-pol-a").await;
+    let org_b = seed_org(&pool, "del-pol-b").await;
+    let user_b = seed_user(&pool, "del-pol-b@ins-idor.test").await;
+
+    let repo = InsuranceRepository::new(pool.clone());
+    let policy_in_a = repo
+        .create_policy(org_a, sample_policy("a3"))
+        .await
+        .expect("seed policy in org A");
+
+    let ctx_b = tenant_context_header(org_b, user_b);
+    let uri = format!("/api/v1/insurance/policies/{}", policy_in_a.id);
+    let response = app.execute(req(Method::DELETE, &uri, &ctx_b, None)).await;
+
+    assert_rejected(response.status, "delete_policy cross-tenant");
+
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM insurance_policies WHERE id = $1")
+        .bind(policy_in_a.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count, 1, "policy must survive cross-tenant DELETE");
+}
+
+// ---------------------------------------------------------------------------
+// H4 — HTTP: list_claims cross-tenant (the P0 finding)
+// ---------------------------------------------------------------------------
+
+/// GET /claims with a forged Org-B context → rejected.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_claims_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org_a = seed_org(&pool, "lst-clm-a").await;
+    let org_b = seed_org(&pool, "lst-clm-b").await;
+    let user_a = seed_user(&pool, "lst-clm-a@ins-idor.test").await;
+    let user_b = seed_user(&pool, "lst-clm-b@ins-idor.test").await;
+
+    let repo = InsuranceRepository::new(pool.clone());
+    let policy_in_a = repo
+        .create_policy(org_a, sample_policy("a4"))
+        .await
+        .expect("seed policy in org A");
+    repo.create_claim(org_a, user_a, sample_claim(policy_in_a.id, "a4"))
+        .await
+        .expect("seed claim in org A");
+
+    let ctx_b = tenant_context_header(org_b, user_b);
+    let response = app
+        .execute(req(Method::GET, "/api/v1/insurance/claims", &ctx_b, None))
+        .await;
+
+    assert_rejected(response.status, "list_claims cross-tenant");
+}
+
+// ---------------------------------------------------------------------------
+// H5 — Repository: org A sees only its own policies (positive + negative)
+// ---------------------------------------------------------------------------
+
+/// The repository is the authority the handler now scopes to. This pins the
+/// contract directly so the "legitimate org sees its own data, and only its
+/// own" guarantee is regression-tested independent of the HTTP harness.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn repo_policies_are_scoped_to_owning_org(pool: PgPool) {
+    let org_a = seed_org(&pool, "repo-pol-a").await;
+    let org_b = seed_org(&pool, "repo-pol-b").await;
+
+    let repo = InsuranceRepository::new(pool.clone());
+    let policy_a = repo
+        .create_policy(org_a, sample_policy("repo-a"))
+        .await
+        .expect("policy A");
+    let _policy_b = repo
+        .create_policy(org_b, sample_policy("repo-b"))
+        .await
+        .expect("policy B");
+
+    // Org A's list contains only org A's policy.
+    let listed_a = repo
+        .list_policies(org_a, InsurancePolicyQuery::default())
+        .await
+        .expect("list A");
+    assert_eq!(listed_a.len(), 1, "org A must see exactly its own policy");
+    assert_eq!(listed_a[0].id, policy_a.id);
+
+    // Org A's list never contains org B's policy.
+    assert!(
+        listed_a.iter().all(|p| p.organization_id == org_a),
+        "org A's policy list must not leak org B rows"
+    );
+
+    // Looking up org A's policy with org B's id returns nothing (closed IDOR).
+    let cross = repo
+        .find_policy_by_id(org_b, policy_a.id)
+        .await
+        .expect("find with wrong org");
+    assert!(
+        cross.is_none(),
+        "org B must not be able to read org A's policy by id"
+    );
+
+    // The legitimate owner can read it.
+    let own = repo
+        .find_policy_by_id(org_a, policy_a.id)
+        .await
+        .expect("find with right org");
+    assert!(own.is_some(), "org A must read its own policy by id");
+}
+
+// ---------------------------------------------------------------------------
+// H6 — Repository: org A sees only its own claims (positive + negative)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn repo_claims_are_scoped_to_owning_org(pool: PgPool) {
+    let org_a = seed_org(&pool, "repo-clm-a").await;
+    let org_b = seed_org(&pool, "repo-clm-b").await;
+    let user_a = seed_user(&pool, "repo-clm-a@ins-idor.test").await;
+    let user_b = seed_user(&pool, "repo-clm-b@ins-idor.test").await;
+
+    let repo = InsuranceRepository::new(pool.clone());
+    let policy_a = repo
+        .create_policy(org_a, sample_policy("repo-clm-a"))
+        .await
+        .expect("policy A");
+    let policy_b = repo
+        .create_policy(org_b, sample_policy("repo-clm-b"))
+        .await
+        .expect("policy B");
+    let claim_a = repo
+        .create_claim(org_a, user_a, sample_claim(policy_a.id, "repo-a"))
+        .await
+        .expect("claim A");
+    let _claim_b = repo
+        .create_claim(org_b, user_b, sample_claim(policy_b.id, "repo-b"))
+        .await
+        .expect("claim B");
+
+    // Org A's claim list contains only org A's claim.
+    let listed_a = repo
+        .list_claims(org_a, InsuranceClaimQuery::default())
+        .await
+        .expect("list A");
+    assert_eq!(listed_a.len(), 1, "org A must see exactly its own claim");
+    assert!(
+        listed_a.iter().all(|c| c.organization_id == org_a),
+        "org A's claim list must not leak org B rows"
+    );
+
+    // Org B cannot read org A's claim by id.
+    let cross = repo
+        .find_claim_with_policy(org_b, claim_a.id)
+        .await
+        .expect("find with wrong org");
+    assert!(
+        cross.is_none(),
+        "org B must not be able to read org A's claim by id"
+    );
+
+    // The legitimate owner can.
+    let own = repo
+        .find_claim_with_policy(org_a, claim_a.id)
+        .await
+        .expect("find with right org");
+    assert!(own.is_some(), "org A must read its own claim by id");
+}
+
+// ---------------------------------------------------------------------------
+// H7 — HTTP positive path: a legitimately tenant-resolved caller sees its
+//      OWN org's policies (the IG3 fail-on-main case).
+// ---------------------------------------------------------------------------
+//
+// This is the end-to-end proof that the handler now derives the org from the
+// authenticated principal. We wrap `create_router` with a middleware that
+// injects `ResolvedTenant { Subdomain, org_a }` (standing in for
+// `host_tenant_middleware`, which `TestApp` does not mount), mint a real JWT
+// for a user who has an active membership in org A, and seed one policy in
+// org A.
+//
+// On the FIXED code, `list_policies` resolves `org_id = principal.effective_org
+// = org_a` and returns that policy → `policies.len() == 1`.
+//
+// On `main`, `list_policies` ignores the principal and uses
+// `query.building_id.unwrap_or_default()` = `Uuid::nil()`, so the org-scoped
+// repository query matches nothing → `policies.len() == 0`. This assertion is
+// what fails on main and passes on the fix.
+
+/// Build a router (the production `create_router`) wrapped so that every
+/// request carries a `ResolvedTenant` for `org_id`, mimicking a real
+/// tenant-resolved host.
+async fn tenant_resolved_app(pool: PgPool, org_id: Uuid) -> (TestApp, axum::Router) {
+    let app = TestApp::new(pool).await;
+    let router = app.router.clone().layer(axum::middleware::from_fn(
+        move |mut req: Request, next: Next| async move {
+            req.extensions_mut().insert(ResolvedTenant {
+                organization_id: org_id,
+                source: TenantSource::Subdomain,
+            });
+            next.run(req).await
+        },
+    ));
+    (app, router)
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_policies_returns_only_callers_own_org(pool: PgPool) {
+    let org_a = seed_org(&pool, "pos-pol-a").await;
+
+    // Register + verify + login a user → real access-token JWT.
+    let bootstrap = TestApp::new(pool.clone()).await;
+    let user = TestUser::with_email(&format!("pos-pol-{}@ins-idor.test", Uuid::new_v4()));
+    let (access_token, _refresh) = create_authenticated_user(&bootstrap, &user).await;
+    let uid = user_id_for(&pool, &user.email).await;
+
+    // Active membership in org A so `RequestPrincipal` resolves `effective_org`.
+    seed_user_membership(&pool, org_a, uid).await;
+
+    // Seed a policy owned by org A.
+    let repo = InsuranceRepository::new(pool.clone());
+    let policy_a = repo
+        .create_policy(org_a, sample_policy("positive-a"))
+        .await
+        .expect("seed policy in org A");
+
+    // Router with org_a as the resolved tenant.
+    let (_app, router) = tenant_resolved_app(pool.clone(), org_a).await;
+
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/api/v1/insurance/policies")
+        .header(header::AUTHORIZATION, format!("Bearer {access_token}"))
+        .body(Body::empty())
+        .unwrap();
+
+    let response = router.oneshot(request).await.expect("request");
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "legitimate tenant-resolved caller must get 200"
+    );
+
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let json: serde_json::Value = serde_json::from_slice(&bytes).expect("parse body");
+    let policies = json["policies"].as_array().expect("policies array");
+
+    // FIX: principal-derived org_a → sees its own policy.
+    // MAIN: nil-org placeholder → sees nothing (this assertion fails on main).
+    assert_eq!(
+        policies.len(),
+        1,
+        "org A must see exactly its own policy via the authenticated principal"
+    );
+    assert_eq!(
+        policies[0]["id"].as_str().unwrap(),
+        policy_a.id.to_string(),
+        "the returned policy must be org A's own"
+    );
+}

--- a/backend/servers/api-server/tests/insurance_cross_tenant_idor_tests.rs
+++ b/backend/servers/api-server/tests/insurance_cross_tenant_idor_tests.rs
@@ -45,10 +45,8 @@ mod common;
 use api_core::middleware::host_tenant::{ResolvedTenant, TenantSource};
 use axum::{
     body::Body,
-    extract::Request,
-    http::{header, Method, StatusCode},
+    http::{header, Method, Request, StatusCode},
     middleware::Next,
-    response::Response,
 };
 use chrono::NaiveDate;
 use db::models::{
@@ -453,7 +451,7 @@ async fn repo_claims_are_scoped_to_owning_org(pool: PgPool) {
 async fn tenant_resolved_app(pool: PgPool, org_id: Uuid) -> (TestApp, axum::Router) {
     let app = TestApp::new(pool).await;
     let router = app.router.clone().layer(axum::middleware::from_fn(
-        move |mut req: Request, next: Next| async move {
+        move |mut req: Request<Body>, next: Next| async move {
             req.extensions_mut().insert(ResolvedTenant {
                 organization_id: org_id,
                 source: TenantSource::Subdomain,


### PR DESCRIPTION
## Summary
- Closes a cross-tenant IDOR + correctness bug in the insurance routes (Epic 22). Every handler on `/api/v1/insurance/*` derived the owning organization from client-supplied data — `query.building_id.unwrap_or_default()` (a `Uuid::nil()` placeholder) on the list endpoints, and a `?organization_id=` query param / body `organization_id` field on the get/mutate endpoints. Any caller could read or mutate another org's policies/claims, and legitimate callers got empty/garbage results.
- All insurance handlers now derive the org from the verified `RequestPrincipal` via a `require_org_id(&principal)` helper (the same idiom `ai.rs` / equipment routes use), and the client-supplied org fields are removed from request/query structs.

## Closes
Closes #826

## Routes changed (`backend/servers/api-server/src/routes/insurance.rs`)
Org now derived from the authenticated principal (was client-supplied):
- `list_policies`, `list_claims` (the P0 placeholder-org bug)
- `get_policy`, `update_policy`, `delete_policy`, `get_expiring_policies`
- `get_claim`, `create_claim`, `update_claim`, `submit_claim`, `review_claim`, `record_claim_payment`, `delete_claim`
- `get_statistics`
- `create_policy`

Removed client-supplied org surface: `organization_id` field dropped from `CreatePolicyRequest`, `UpdatePolicyRequest`, `CreateClaimRequest`, `UpdateClaimRequest`, `ReviewClaimRequest`, `RecordClaimPaymentRequest`; the `OrgIdQuery` struct deleted; `organization_id` removed from `ExpiringQuery`.

Tenant-scoping helper reused: `RequestPrincipal::effective_org` (api_core), wrapped in a local `require_org_id` that 403s when no tenant is resolved — mirrors `ai.rs::require_tenant_id`.

## Tenant-scoping mechanism
`api_core::extractors::principal::RequestPrincipal` — built from the bearer JWT + host-resolved tenant, validates active membership. The repository layer was already correctly org-scoped (`WHERE ... AND organization_id = $org`); only the route layer was passing the wrong org in.

## Tested
```
cargo check -p api-server                 # exit 0
cargo test -p api-server --test insurance_cross_tenant_idor_tests   # see IG3 below
cargo clippy -p api-server --all-targets -- -D warnings
```

## IG3 — failing test on main (two-commit TDD)
New test file `backend/servers/api-server/tests/insurance_cross_tenant_idor_tests.rs`:
- HTTP cross-tenant rejection tests (`list_policies`, `get_policy`, `delete_policy`, `list_claims`) — a forged Org-B context never reads/mutates Org A's rows.
- Repo-layer scoping tests — Org A sees only its own policies/claims; Org B cannot read Org A's row by id; the legitimate owner can.
- `list_policies_returns_only_callers_own_org` — the genuine fail-on-main case: wraps `create_router` with a middleware injecting `ResolvedTenant{org_a}`, mints a real JWT for a user with an active `user_memberships` row in Org A, seeds one policy. On the fix the principal-derived org returns that policy (`len==1`); on `main` the `nil`-org placeholder returns nothing (`len==0`) → assertion fails.

Commits: `test:` (regression) precedes `fix:`.

## Follow-up (out of scope)
The policy-document / claim-document / renewal-reminder sub-routes (`list_policy_documents`, `add_policy_document`, `remove_policy_document`, `list_reminders`, `create_reminder`, `update_reminder`, `delete_reminder`, `list_claim_documents`, `add_claim_document`, `remove_claim_document`, `get_claim_history`) call repository methods that take only `policy_id`/`claim_id`/`reminder_id` and have **no** `organization_id` parameter — they cannot be org-scoped without repository signature + SQL changes. They now require authentication (`RequestPrincipal`) but are not yet org-scoped. Recommend a follow-up issue to add `organization_id` guards to those repo methods.
