### PR TITLE
gap-6-5-direct-messaging-backend-completion: dispatch realtime WS event on new direct message

### DIFF
--- a/backend/servers/api-server/src/routes/messaging.rs
+++ b/backend/servers/api-server/src/routes/messaging.rs
@@ -26,6 +26,11 @@ use uuid::Uuid;
 /// Maximum allowed message content length (characters).
 const MAX_MESSAGE_LENGTH: usize = 10_000;
 
+/// Maximum length of the message preview embedded in the realtime WebSocket
+/// event (characters). Keeps the pub/sub payload small; full content is
+/// fetched via the thread endpoint.
+const MESSAGE_PREVIEW_LEN: usize = 120;
+
 // ============================================================================
 // Response Types
 // ============================================================================
@@ -311,22 +316,32 @@ async fn start_thread(
             ));
         }
 
-        repo.create_message_rls(
-            &mut **rls.conn(),
-            CreateMessage {
-                thread_id: thread.id,
-                sender_id: user_id,
-                content,
-            },
-        )
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to send initial message: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
+        let initial = repo
+            .create_message_rls(
+                &mut **rls.conn(),
+                CreateMessage {
+                    thread_id: thread.id,
+                    sender_id: user_id,
+                    content,
+                },
             )
-        })?;
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to send initial message: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("DB_ERROR", e.to_string())),
+                )
+            })?;
+
+        // Realtime fanout: notify the recipient's WebSocket channel (Epic 2B / 8A.3).
+        dispatch_new_message_event(
+            state.pubsub_service.as_ref(),
+            body.recipient_id,
+            &initial,
+            user_id,
+        )
+        .await;
     }
 
     // Get messages and other participant info
@@ -617,6 +632,15 @@ async fn send_message(
         })?;
 
     rls.release().await;
+
+    // Realtime fanout: notify the recipient's WebSocket channel (Epic 2B / 8A.3).
+    dispatch_new_message_event(
+        state.pubsub_service.as_ref(),
+        other_user_id,
+        &message,
+        user_id,
+    )
+    .await;
 
     Ok(Json(SendMessageResponse {
         message: "Message sent successfully".to_string(),
@@ -940,4 +964,98 @@ async fn get_other_participant(
         last_name,
         email,
     })
+}
+
+/// Build the realtime WebSocket event payload for a newly-sent direct message.
+///
+/// The payload mirrors the shape consumed by the `notifications:{user_id}`
+/// WebSocket channel (see `routes/ws_notifications.rs`). It carries enough
+/// for a client to badge/refresh the conversation without leaking the full
+/// message body — the preview is truncated to `MESSAGE_PREVIEW_LEN` chars.
+fn new_message_event_payload(message: &Message, sender_id: Uuid) -> serde_json::Value {
+    let preview: String = message.content.chars().take(MESSAGE_PREVIEW_LEN).collect();
+    serde_json::json!({
+        "message_id": message.id,
+        "thread_id": message.thread_id,
+        "sender_id": sender_id,
+        "preview": preview,
+    })
+}
+
+/// Publish a `message.created` realtime event to the recipient's WebSocket
+/// notification channel (Epic 2B / Story 8A.3 fanout pattern).
+///
+/// Best-effort: the message has already been persisted, so a pub/sub failure
+/// is logged and swallowed rather than failing the request. No-op when Redis
+/// pub/sub is not configured (local dev without Redis).
+async fn dispatch_new_message_event(
+    pubsub: Option<&integrations::PubSubService>,
+    recipient_id: Uuid,
+    message: &Message,
+    sender_id: Uuid,
+) {
+    let Some(pubsub) = pubsub else {
+        return;
+    };
+    let channel = format!("notifications:{recipient_id}");
+    let msg = integrations::PubSubMessage::new(
+        &channel,
+        "message.created",
+        new_message_event_payload(message, sender_id),
+    );
+    if let Err(e) = pubsub.publish(&channel, msg).await {
+        // Non-fatal: the message is already persisted; realtime fanout is
+        // best-effort and the recipient will still see it on next fetch.
+        tracing::warn!(
+            recipient_id = %recipient_id,
+            channel = %channel,
+            error = %e,
+            "[messaging] Failed to publish message.created to WebSocket channel (non-fatal)"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn sample_message(content: &str) -> Message {
+        let now = Utc::now();
+        Message {
+            id: Uuid::new_v4(),
+            thread_id: Uuid::new_v4(),
+            sender_id: Uuid::new_v4(),
+            content: content.to_string(),
+            read_at: None,
+            deleted_at: None,
+            deleted_by: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[test]
+    fn event_payload_carries_ids_and_sender() {
+        let msg = sample_message("hello there");
+        let sender = Uuid::new_v4();
+        let payload = new_message_event_payload(&msg, sender);
+
+        assert_eq!(payload["message_id"], serde_json::json!(msg.id));
+        assert_eq!(payload["thread_id"], serde_json::json!(msg.thread_id));
+        assert_eq!(payload["sender_id"], serde_json::json!(sender));
+        assert_eq!(payload["preview"], serde_json::json!("hello there"));
+    }
+
+    #[test]
+    fn event_payload_truncates_long_content_to_preview_len() {
+        let long = "x".repeat(MESSAGE_PREVIEW_LEN + 500);
+        let msg = sample_message(&long);
+        let payload = new_message_event_payload(&msg, Uuid::new_v4());
+
+        let preview = payload["preview"].as_str().expect("preview is a string");
+        assert_eq!(preview.chars().count(), MESSAGE_PREVIEW_LEN);
+        // Must not leak the full body over the wire.
+        assert!(preview.len() < long.len());
+    }
 }


### PR DESCRIPTION
## Task
Verify and complete direct messaging backend: audit direct_messages table RLS policies, ensure read-receipts endpoint exists, add WebSocket event dispatch on new message via notification pipeline (Epic 2B PR #463)

## Owner
pm-backend (specialist: rust-backend)

## Audit findings (what already existed on `dev`)
The Story 6.5 direct-messaging backend was largely complete:

- **Tables / "direct_messages":** the schema uses `message_threads` + `messages` + `user_blocks` (migration `00017_create_direct_messaging.sql`), not a literal `direct_messages` table.
- **RLS policies — COMPLETE.** `messages` and `message_threads` are RLS-enabled with participant-level isolation, hardened in `00019_fix_messaging_rls_policies.sql` with defense-in-depth `organization_id` checks (`app.current_org_id`), and `00140_rls_soft_delete_filter.sql` adds the soft-delete filter. Routes additionally enforce cross-org / participant checks in `start_thread`, `get_thread`, `send_message`, `mark_thread_read`.
- **Read-receipts endpoint — EXISTS.** `POST /api/v1/messages/threads/{id}/read` → `mark_thread_read` handler → `mark_thread_read_rls`; `read_at` column + `idx_messages_unread`; `get_thread` also marks read on open; `GET /unread-count` present.
- **WebSocket dispatch on new message — MISSING (this PR).** `send_message` and the `start_thread` initial message persisted the row but published nothing to the realtime pipeline, so connected clients on `notifications:{user_id}` (see `routes/ws_notifications.rs`) never learned of a new message until the next manual fetch.

## Change
Adds `dispatch_new_message_event`, which publishes a `message.created` event to the recipient's `notifications:{recipient_id}` Redis pub/sub channel — the exact channel the WS notification stream subscribes to (Epic 2B / Story 8A.3 fanout pattern, mirroring `notification_preferences.rs`). Wired into both message-send sites. Best-effort: non-fatal on pub/sub error (message already persisted), and a no-op when Redis pub/sub is not configured. Preview truncated to 120 chars so the full body never goes on the wire.

Scope kept entirely inside `backend/servers/api-server/src/routes/messaging.rs` (one file). No migration, no AppState, no public-API change.

## Tested (Band A — fast check)
- `SQLX_OFFLINE=true cargo check -p api-server` → exit 0
- `SQLX_OFFLINE=true cargo test -p api-server --lib messaging` → exit 0 (2 passed: `event_payload_carries_ids_and_sender`, `event_payload_truncates_long_content_to_preview_len`)
- `cargo fmt -p api-server -- --check` → clean

## Built (Band B — full build)
- `SQLX_OFFLINE=true cargo clippy -p api-server --lib` → exit 0, no warnings

## CI parity (Band C — hot-path only)
skipped: realtime fanout is best-effort and additive; RLS / auth / tenant isolation were audited as already-present and unchanged. No data-integrity or auth surface modified.

## Remote-tested
skipped (no ppt-bridge MCP in session)

## IG3 / TDD note
The two unit tests exercise the new `new_message_event_payload` helper. Because that symbol does not exist on `dev`, the tests cannot compile/pass on `dev` and only pass with this change (compile-fail-on-base evidence). A live end-to-end pub/sub test would need Redis + Postgres, which the sandbox runner lacks; the publish wiring is exercised by CI compile and the helper by unit tests.

## Notes for reviewer
- Event type chosen: `message.created` (the WS layer forwards `PubSubMessage.event_type` verbatim to clients). A richer `NotificationEvent::MessageReceived` variant already exists in `common::notifications::events` but routing it requires the full `NotificationPipeline` in `AppState`, which is not currently wired anywhere — out of scope for this "verify & complete" task. If you want full email/push fanout (not just realtime WS), that is a clean follow-up: add `NotificationPipeline` to `AppState` and call `dispatch` here instead.

https://claude.ai/code/session_016fFB2364n59hmXYnEFDvGa

---
_Generated by [Claude Code](https://claude.ai/code/session_016fFB2364n59hmXYnEFDvGa)_