### PR TITLE
fix(security): scope work-order routes to authenticated tenant (closes #821)

### DIFF
--- a/backend/servers/api-server/src/routes/work_orders.rs
+++ b/backend/servers/api-server/src/routes/work_orders.rs
@@ -63,6 +63,110 @@ pub fn router() -> Router<AppState> {
         .route("/cost-summary", get(get_cost_summary))
 }
 
+// ==================== Authorization Helpers ====================
+
+/// Verify the authenticated user is a member of the given organization.
+///
+/// Work-order routes accept the target `organization_id` from the client
+/// (request body / query string) or derive it from the resource being
+/// addressed by id. Either way the caller's membership must be checked
+/// against `organization_members` so org A cannot read or mutate org B's
+/// work orders (cross-tenant IDOR). Mirrors `integrations::sync::verify_org_access`.
+async fn verify_org_access(
+    state: &AppState,
+    user_id: Uuid,
+    org_id: Uuid,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    let is_member = state
+        .org_member_repo
+        .is_member(org_id, user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = ?e, "Failed to check org membership");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", "Database error")),
+            )
+        })?;
+
+    if !is_member {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "FORBIDDEN",
+                "You are not a member of this organization",
+            )),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Load a work order by id and authorize the caller against its owning org.
+///
+/// Returns `404 NOT_FOUND` if the work order does not exist and `403 FORBIDDEN`
+/// if the caller is not a member of the organization that owns it. By-id
+/// handlers route through this so an org A caller can never read or address an
+/// org B work order. Mirrors the fetch-then-`verify_org_access` idiom in
+/// `integrations::sync`.
+async fn load_work_order_for_user(
+    state: &AppState,
+    user_id: Uuid,
+    work_order_id: Uuid,
+) -> Result<WorkOrder, (StatusCode, Json<ErrorResponse>)> {
+    let work_order = state
+        .work_order_repo
+        .find_by_id(work_order_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get work order: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", "Failed to get work order")),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Work order not found")),
+            )
+        })?;
+
+    verify_org_access(state, user_id, work_order.organization_id).await?;
+
+    Ok(work_order)
+}
+
+/// Load a maintenance schedule by id and authorize the caller against its
+/// owning org. Same contract as [`load_work_order_for_user`] for schedules.
+async fn load_schedule_for_user(
+    state: &AppState,
+    user_id: Uuid,
+    schedule_id: Uuid,
+) -> Result<MaintenanceSchedule, (StatusCode, Json<ErrorResponse>)> {
+    let schedule = state
+        .work_order_repo
+        .find_schedule_by_id(schedule_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get schedule: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", "Failed to get schedule")),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Schedule not found")),
+            )
+        })?;
+
+    verify_org_access(state, user_id, schedule.organization_id).await?;
+
+    Ok(schedule)
+}
+
 // ==================== Request/Response Types ====================
 
 /// Organization query parameter.
@@ -209,6 +313,7 @@ async fn create_work_order(
     user: AuthUser,
     Json(payload): Json<CreateWorkOrderRequest>,
 ) -> Result<(StatusCode, Json<WorkOrder>), (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, user.user_id, payload.organization_id).await?;
     state
         .work_order_repo
         .create_work_order(payload.organization_id, user.user_id, payload.data)
@@ -228,9 +333,10 @@ async fn create_work_order(
 
 async fn list_work_orders(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Query(query): Query<ListWorkOrdersQuery>,
 ) -> Result<Json<Vec<WorkOrder>>, (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, user.user_id, query.organization_id).await?;
     state
         .work_order_repo
         .list(query.organization_id, (&query).into())
@@ -247,9 +353,10 @@ async fn list_work_orders(
 
 async fn list_work_orders_with_details(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Query(query): Query<ListWorkOrdersQuery>,
 ) -> Result<Json<Vec<WorkOrderWithDetails>>, (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, user.user_id, query.organization_id).await?;
     state
         .work_order_repo
         .list_with_details(query.organization_id, (&query).into())
@@ -266,9 +373,10 @@ async fn list_work_orders_with_details(
 
 async fn get_statistics(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Query(query): Query<OrgQuery>,
 ) -> Result<Json<WorkOrderStatistics>, (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, user.user_id, query.organization_id).await?;
     state
         .work_order_repo
         .get_statistics(query.organization_id)
@@ -291,9 +399,10 @@ pub struct OverdueQuery {
 
 async fn list_overdue(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Query(query): Query<OverdueQuery>,
 ) -> Result<Json<Vec<WorkOrder>>, (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, user.user_id, query.organization_id).await?;
     state
         .work_order_repo
         .list_overdue(query.organization_id, query.limit.unwrap_or(20))
@@ -310,27 +419,11 @@ async fn list_overdue(
 
 async fn get_work_order(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<Json<WorkOrder>, (StatusCode, Json<ErrorResponse>)> {
-    state
-        .work_order_repo
-        .find_by_id(id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to get work order: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to get work order")),
-            )
-        })?
-        .map(Json)
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Work order not found")),
-            )
-        })
+    let work_order = load_work_order_for_user(&state, user.user_id, id).await?;
+    Ok(Json(work_order))
 }
 
 async fn update_work_order(
@@ -339,6 +432,7 @@ async fn update_work_order(
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateWorkOrder>,
 ) -> Result<Json<WorkOrder>, (StatusCode, Json<ErrorResponse>)> {
+    load_work_order_for_user(&state, user.user_id, id).await?;
     state
         .work_order_repo
         .update(id, user.user_id, data)
@@ -358,9 +452,10 @@ async fn update_work_order(
 
 async fn delete_work_order(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    load_work_order_for_user(&state, user.user_id, id).await?;
     let deleted = state.work_order_repo.delete(id).await.map_err(|e| {
         tracing::error!("Failed to delete work order: {:?}", e);
         (
@@ -388,6 +483,7 @@ async fn assign_work_order(
     Path(id): Path<Uuid>,
     Json(data): Json<AssignRequest>,
 ) -> Result<Json<WorkOrder>, (StatusCode, Json<ErrorResponse>)> {
+    load_work_order_for_user(&state, user.user_id, id).await?;
     state
         .work_order_repo
         .assign(id, user.user_id, data.assigned_to, data.vendor_id)
@@ -410,6 +506,7 @@ async fn start_work(
     user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<Json<WorkOrder>, (StatusCode, Json<ErrorResponse>)> {
+    load_work_order_for_user(&state, user.user_id, id).await?;
     state
         .work_order_repo
         .start_work(id, user.user_id)
@@ -430,6 +527,7 @@ async fn complete_work_order(
     Path(id): Path<Uuid>,
     Json(data): Json<CompleteRequest>,
 ) -> Result<Json<WorkOrder>, (StatusCode, Json<ErrorResponse>)> {
+    load_work_order_for_user(&state, user.user_id, id).await?;
     state
         .work_order_repo
         .complete(
@@ -458,6 +556,7 @@ async fn put_on_hold(
     Path(id): Path<Uuid>,
     Json(data): Json<HoldRequest>,
 ) -> Result<Json<WorkOrder>, (StatusCode, Json<ErrorResponse>)> {
+    load_work_order_for_user(&state, user.user_id, id).await?;
     state
         .work_order_repo
         .put_on_hold(id, user.user_id, &data.reason)
@@ -478,6 +577,7 @@ async fn add_comment(
     Path(id): Path<Uuid>,
     Json(data): Json<AddWorkOrderUpdate>,
 ) -> Result<(StatusCode, Json<WorkOrderUpdate>), (StatusCode, Json<ErrorResponse>)> {
+    load_work_order_for_user(&state, user.user_id, id).await?;
     state
         .work_order_repo
         .add_comment(id, user.user_id, data)
@@ -494,10 +594,11 @@ async fn add_comment(
 
 async fn list_comments(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<Vec<WorkOrderUpdate>>, (StatusCode, Json<ErrorResponse>)> {
+    load_work_order_for_user(&state, user.user_id, id).await?;
     state
         .work_order_repo
         .list_updates(id, query.limit.unwrap_or(50), query.offset.unwrap_or(0))
@@ -519,6 +620,7 @@ async fn create_schedule(
     user: AuthUser,
     Json(payload): Json<CreateScheduleRequest>,
 ) -> Result<(StatusCode, Json<MaintenanceSchedule>), (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, user.user_id, payload.organization_id).await?;
     state
         .work_order_repo
         .create_schedule(payload.organization_id, user.user_id, payload.data)
@@ -535,9 +637,10 @@ async fn create_schedule(
 
 async fn list_schedules(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Query(query): Query<ListSchedulesQuery>,
 ) -> Result<Json<Vec<MaintenanceSchedule>>, (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, user.user_id, query.organization_id).await?;
     state
         .work_order_repo
         .list_schedules(query.organization_id, (&query).into())
@@ -554,9 +657,10 @@ async fn list_schedules(
 
 async fn get_upcoming_schedules(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Query(query): Query<UpcomingQuery>,
 ) -> Result<Json<Vec<UpcomingSchedule>>, (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, user.user_id, query.organization_id).await?;
     state
         .work_order_repo
         .get_upcoming_schedules(
@@ -577,9 +681,10 @@ async fn get_upcoming_schedules(
 
 async fn process_due_schedules(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Query(query): Query<OrgQuery>,
 ) -> Result<Json<Vec<WorkOrder>>, (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, user.user_id, query.organization_id).await?;
     state
         .work_order_repo
         .process_due_schedules(query.organization_id)
@@ -599,35 +704,20 @@ async fn process_due_schedules(
 
 async fn get_schedule(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<Json<MaintenanceSchedule>, (StatusCode, Json<ErrorResponse>)> {
-    state
-        .work_order_repo
-        .find_schedule_by_id(id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to get schedule: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to get schedule")),
-            )
-        })?
-        .map(Json)
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Schedule not found")),
-            )
-        })
+    let schedule = load_schedule_for_user(&state, user.user_id, id).await?;
+    Ok(Json(schedule))
 }
 
 async fn update_schedule(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateMaintenanceSchedule>,
 ) -> Result<Json<MaintenanceSchedule>, (StatusCode, Json<ErrorResponse>)> {
+    load_schedule_for_user(&state, user.user_id, id).await?;
     state
         .work_order_repo
         .update_schedule(id, data)
@@ -644,9 +734,10 @@ async fn update_schedule(
 
 async fn delete_schedule(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    load_schedule_for_user(&state, user.user_id, id).await?;
     let deleted = state
         .work_order_repo
         .delete_schedule(id)
@@ -671,9 +762,10 @@ async fn delete_schedule(
 
 async fn activate_schedule(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<Json<MaintenanceSchedule>, (StatusCode, Json<ErrorResponse>)> {
+    load_schedule_for_user(&state, user.user_id, id).await?;
     state
         .work_order_repo
         .set_schedule_active(id, true)
@@ -693,9 +785,10 @@ async fn activate_schedule(
 
 async fn deactivate_schedule(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<Json<MaintenanceSchedule>, (StatusCode, Json<ErrorResponse>)> {
+    load_schedule_for_user(&state, user.user_id, id).await?;
     state
         .work_order_repo
         .set_schedule_active(id, false)
@@ -715,10 +808,11 @@ async fn deactivate_schedule(
 
 async fn skip_schedule(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
     Json(data): Json<SkipRequest>,
 ) -> Result<Json<MaintenanceSchedule>, (StatusCode, Json<ErrorResponse>)> {
+    load_schedule_for_user(&state, user.user_id, id).await?;
     state
         .work_order_repo
         .skip_schedule_execution(id, &data.reason)
@@ -735,10 +829,11 @@ async fn skip_schedule(
 
 async fn list_executions(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<Vec<ScheduleExecution>>, (StatusCode, Json<ErrorResponse>)> {
+    load_schedule_for_user(&state, user.user_id, id).await?;
     state
         .work_order_repo
         .list_executions(id, query.limit.unwrap_or(50), query.offset.unwrap_or(0))
@@ -754,6 +849,16 @@ async fn list_executions(
 }
 
 // ==================== Service History (Story 20.4) ====================
+//
+// NOTE (#821 P2 — deferred): the two service-history endpoints below are keyed
+// by `equipment_id` / `building_id`, neither of which carries an
+// `organization_id` the handler can authorize against without a cross-resource
+// lookup (equipment/building → owning org). The work_order_repo exposes no
+// org-scoped variant for these queries, so closing the cross-tenant gap here
+// requires an org-scoped repo method (or threading the equipment/building repo
+// RLS lookup) — a separate slice tracked as the #821 P2 follow-up. The P1
+// IDOR on the work-order and schedule handlers (read/mutate by id, plus the
+// org-supplied create/list endpoints) is fixed above.
 
 async fn get_equipment_service_history(
     State(state): State<AppState>,
@@ -811,9 +916,10 @@ async fn get_building_service_history(
 
 async fn get_cost_summary(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Query(query): Query<CostSummaryQuery>,
 ) -> Result<Json<Vec<MaintenanceCostSummary>>, (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, user.user_id, query.organization_id).await?;
     state
         .work_order_repo
         .get_cost_summary(query.organization_id, query.start_date, query.end_date)

--- a/backend/servers/api-server/tests/work_order_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/work_order_cross_org_idor_tests.rs
@@ -1,0 +1,403 @@
+//! Real-JWT regression tests for work-order / maintenance-schedule org-scope
+//! (closes #821).
+//!
+//! # Background
+//!
+//! The Epic 20 work-order routes (`/api/v1/work-orders/*`) authenticated the
+//! caller with `AuthUser` but never checked that the caller belonged to the
+//! organization that owns the resource:
+//!
+//!   - by-id reads/mutations (`get`, `update`, `delete`, `assign`, `start`,
+//!     `complete`, `hold`, comments, schedule by-id) called
+//!     `work_order_repo.find_by_id(id)` (and friends) with no org predicate, so
+//!     org A could read or mutate org B's work order by guessing its UUID;
+//!   - org-supplied create/list endpoints trusted the client-supplied
+//!     `organization_id` (request body / query string) without verifying the
+//!     caller's membership, so org B could create or enumerate work orders in
+//!     org A.
+//!
+//! # Fix
+//!
+//! Every handler now authorizes the caller against the resource's owning org
+//! via `verify_org_access(&state, user_id, org_id)` (membership check against
+//! `organization_members`). For by-id handlers the org is read from the
+//! fetched row (`load_work_order_for_user` / `load_schedule_for_user`); a
+//! missing row yields `404` and a foreign-org row yields `403`. For
+//! org-supplied handlers the client `organization_id` is checked before any
+//! repo call.
+//!
+//! # What these tests verify
+//!
+//! Using a *real* JWT minted for a user who is a member of Org B only:
+//!
+//!   - a cross-tenant by-id read/mutate of an Org A work order is rejected and
+//!     the Org A row is left untouched;
+//!   - a create that names Org A as the owner is rejected and no row is
+//!     inserted;
+//!   - the legitimate same-org path still succeeds (no false-positive 403).
+//!
+//! # TestApp wiring note
+//!
+//! `TestApp` mounts the full router but no `host_tenant_middleware`. The
+//! work-order routes use `AuthUser` (bearer JWT) and derive the org from the
+//! request/resource, so no `X-Tenant-ID` header is involved here.
+
+#[allow(dead_code)]
+mod common;
+
+use axum::http::StatusCode;
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{create_authenticated_user, TestApp, TestUser};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active') RETURNING id
+        "#,
+    )
+    .bind(format!("WO IDOR {slug}"))
+    .bind(format!("wo-idor-{slug}-{}", Uuid::new_v4()))
+    .bind(format!("{slug}-{}@wo-idor.test", Uuid::new_v4()))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+/// Insert an `organization_members` row so `verify_org_access` sees the user
+/// as a member of the org. Role is irrelevant for work-order access (only
+/// membership is checked), so any valid role string works.
+async fn seed_membership(pool: &PgPool, org_id: Uuid, user_id: Uuid, role: &str) {
+    sqlx::query(
+        r#"
+        INSERT INTO organization_members
+            (id, organization_id, user_id, role_type, status, created_at)
+        VALUES ($1, $2, $3, $4, 'active', NOW())
+        ON CONFLICT DO NOTHING
+        "#,
+    )
+    .bind(Uuid::new_v4())
+    .bind(org_id)
+    .bind(user_id)
+    .bind(role)
+    .execute(pool)
+    .await
+    .expect("seed membership");
+}
+
+async fn seed_building(pool: &PgPool, org_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO buildings (organization_id, street, city, postal_code, country)
+        VALUES ($1, 'WO IDOR Street 1', 'Bratislava', '81101', 'Slovakia')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed building")
+}
+
+/// Seed a `work_orders` row owned by `org_id`. `created_by` must be a real
+/// user row (FK), so we pass one in.
+async fn seed_work_order(pool: &PgPool, org_id: Uuid, building_id: Uuid, created_by: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO work_orders
+            (organization_id, building_id, title, description, created_by)
+        VALUES ($1, $2, 'Original title', 'Original description', $3)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(building_id)
+    .bind(created_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed work order")
+}
+
+async fn user_id_for(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(email)
+        .fetch_one(pool)
+        .await
+        .expect("fetch user id")
+}
+
+async fn work_order_title(pool: &PgPool, id: Uuid) -> String {
+    sqlx::query_scalar::<_, String>("SELECT title FROM work_orders WHERE id = $1")
+        .bind(id)
+        .fetch_one(pool)
+        .await
+        .expect("fetch work order title")
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — GET /work-orders/{id} from another org is rejected (info disclosure)
+// ---------------------------------------------------------------------------
+
+/// An authenticated member of Org B fetches an Org A work order by id. The
+/// handler reads the row, sees it belongs to Org A, and rejects the caller
+/// (403) because they are not a member of Org A.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_work_order_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org_a = seed_org(&pool, "get-a").await;
+    let org_b = seed_org(&pool, "get-b").await;
+
+    // Org A owner (created_by) — a real user row for the FK.
+    let owner_a = TestUser::new();
+    let (_a_token, _) = create_authenticated_user(&app, &owner_a).await;
+    let owner_a_id = user_id_for(&pool, &owner_a.email).await;
+    seed_membership(&pool, org_a, owner_a_id, "manager").await;
+
+    let building_a = seed_building(&pool, org_a).await;
+    let wo_in_a = seed_work_order(&pool, org_a, building_a, owner_a_id).await;
+
+    // Attacker — a real authenticated member of Org B (NOT Org A).
+    let attacker = TestUser::new();
+    let (b_token, _) = create_authenticated_user(&app, &attacker).await;
+    let attacker_id = user_id_for(&pool, &attacker.email).await;
+    seed_membership(&pool, org_b, attacker_id, "manager").await;
+
+    let response = app
+        .execute(
+            app.get(&format!("/api/v1/work-orders/{}", wo_in_a))
+                .bearer(&b_token)
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::FORBIDDEN,
+        "#821: cross-tenant GET work order must be rejected (403), got {} body={}",
+        response.status,
+        response.text()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2 — PATCH /work-orders/{id} from another org is rejected + no mutation
+// ---------------------------------------------------------------------------
+
+/// A member of Org B attempts to update an Org A work order. The request is
+/// rejected (403) and the Org A row's title is unchanged.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn update_work_order_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org_a = seed_org(&pool, "upd-a").await;
+    let org_b = seed_org(&pool, "upd-b").await;
+
+    let owner_a = TestUser::new();
+    let (_a_token, _) = create_authenticated_user(&app, &owner_a).await;
+    let owner_a_id = user_id_for(&pool, &owner_a.email).await;
+    seed_membership(&pool, org_a, owner_a_id, "manager").await;
+
+    let building_a = seed_building(&pool, org_a).await;
+    let wo_in_a = seed_work_order(&pool, org_a, building_a, owner_a_id).await;
+
+    let attacker = TestUser::new();
+    let (b_token, _) = create_authenticated_user(&app, &attacker).await;
+    let attacker_id = user_id_for(&pool, &attacker.email).await;
+    seed_membership(&pool, org_b, attacker_id, "manager").await;
+
+    // The work-orders router registers PATCH (not PUT) for `/{id}`, and the
+    // common `RequestBuilder` has no PATCH helper, so build the request by hand.
+    let patch_req = axum::http::Request::builder()
+        .method(axum::http::Method::PATCH)
+        .uri(format!("/api/v1/work-orders/{}", wo_in_a))
+        .header(
+            axum::http::header::AUTHORIZATION,
+            format!("Bearer {}", b_token),
+        )
+        .header(axum::http::header::CONTENT_TYPE, "application/json")
+        .body(axum::body::Body::from(
+            json!({ "title": "hijacked-title" }).to_string(),
+        ))
+        .expect("build PATCH request");
+
+    let response = app.execute(patch_req).await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::FORBIDDEN,
+        "#821: cross-tenant PATCH work order must be rejected (403), got {} body={}",
+        response.status,
+        response.text()
+    );
+
+    assert_eq!(
+        work_order_title(&pool, wo_in_a).await,
+        "Original title",
+        "#821: Org A work order title must not be changed by cross-tenant PATCH"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3 — DELETE /work-orders/{id} from another org is rejected + row survives
+// ---------------------------------------------------------------------------
+
+/// A member of Org B attempts to delete an Org A work order. Rejected (403)
+/// and the row still exists.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn delete_work_order_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org_a = seed_org(&pool, "del-a").await;
+    let org_b = seed_org(&pool, "del-b").await;
+
+    let owner_a = TestUser::new();
+    let (_a_token, _) = create_authenticated_user(&app, &owner_a).await;
+    let owner_a_id = user_id_for(&pool, &owner_a.email).await;
+    seed_membership(&pool, org_a, owner_a_id, "manager").await;
+
+    let building_a = seed_building(&pool, org_a).await;
+    let wo_in_a = seed_work_order(&pool, org_a, building_a, owner_a_id).await;
+
+    let attacker = TestUser::new();
+    let (b_token, _) = create_authenticated_user(&app, &attacker).await;
+    let attacker_id = user_id_for(&pool, &attacker.email).await;
+    seed_membership(&pool, org_b, attacker_id, "manager").await;
+
+    let response = app
+        .execute(
+            app.delete(&format!("/api/v1/work-orders/{}", wo_in_a))
+                .bearer(&b_token)
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::FORBIDDEN,
+        "#821: cross-tenant DELETE work order must be rejected (403), got {} body={}",
+        response.status,
+        response.text()
+    );
+
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM work_orders WHERE id = $1")
+        .bind(wo_in_a)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        count, 1,
+        "#821: work order must survive cross-tenant DELETE"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 4 — POST /work-orders naming a foreign org is rejected + nothing created
+// ---------------------------------------------------------------------------
+
+/// A member of Org B posts a create request whose body names Org A as the
+/// owner. `verify_org_access` rejects it (403) and no work order is inserted
+/// into Org A.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_work_order_for_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org_a = seed_org(&pool, "crt-a").await;
+    let org_b = seed_org(&pool, "crt-b").await;
+
+    let owner_a = TestUser::new();
+    let (_a_token, _) = create_authenticated_user(&app, &owner_a).await;
+    let owner_a_id = user_id_for(&pool, &owner_a.email).await;
+    seed_membership(&pool, org_a, owner_a_id, "manager").await;
+    let building_a = seed_building(&pool, org_a).await;
+
+    let attacker = TestUser::new();
+    let (b_token, _) = create_authenticated_user(&app, &attacker).await;
+    let attacker_id = user_id_for(&pool, &attacker.email).await;
+    seed_membership(&pool, org_b, attacker_id, "manager").await;
+
+    let response = app
+        .execute(
+            app.post("/api/v1/work-orders")
+                .bearer(&b_token)
+                .json(json!({
+                    "organization_id": org_a,
+                    "building_id": building_a,
+                    "title": "cross-tenant inject",
+                    "description": "should be rejected",
+                }))
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::FORBIDDEN,
+        "#821: cross-tenant POST work order must be rejected (403), got {} body={}",
+        response.status,
+        response.text()
+    );
+
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM work_orders WHERE organization_id = $1")
+            .bind(org_a)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        count, 0,
+        "#821: no work order must be created in Org A by a cross-tenant POST"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 5 — same-org access still succeeds (no false-positive 403)
+// ---------------------------------------------------------------------------
+
+/// A member of Org A reads an Org A work order by id. The membership check
+/// passes and the handler returns 200 with the row — proving the fix does not
+/// over-block legitimate same-org access.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_work_order_same_org_succeeds(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org_a = seed_org(&pool, "ok-a").await;
+
+    let member = TestUser::new();
+    let (token, _) = create_authenticated_user(&app, &member).await;
+    let member_id = user_id_for(&pool, &member.email).await;
+    seed_membership(&pool, org_a, member_id, "manager").await;
+
+    let building_a = seed_building(&pool, org_a).await;
+    let wo_in_a = seed_work_order(&pool, org_a, building_a, member_id).await;
+
+    let response = app
+        .execute(
+            app.get(&format!("/api/v1/work-orders/{}", wo_in_a))
+                .bearer(&token)
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::OK,
+        "#821: same-org GET work order must succeed (200), got {} body={}",
+        response.status,
+        response.text()
+    );
+
+    let body = response.json_value();
+    assert_eq!(
+        body.get("id").and_then(|v| v.as_str()),
+        Some(wo_in_a.to_string().as_str()),
+        "#821: same-org GET must return the requested work order"
+    );
+}


### PR DESCRIPTION
Closes #821. Scopes work-order read/mutate-by-id handlers to the authenticated org (cross-tenant IDOR). Adds cross-org IDOR integration test (IG3). Recovered from a parallel implementer agent that committed but stalled before pushing.