### PR TITLE
fix(security): scope meter & energy routes to authenticated tenant (closes #803, closes #846)

### DIFF
--- a/backend/crates/db/src/repositories/energy.rs
+++ b/backend/crates/db/src/repositories/energy.rs
@@ -1119,6 +1119,18 @@ impl EnergyRepository {
     }
 
     /// Resolve a benchmark alert.
+    /// Get a single benchmark alert by id (used for tenant-ownership checks
+    /// before resolving it).
+    pub async fn get_benchmark_alert(
+        &self,
+        id: Uuid,
+    ) -> Result<Option<BenchmarkAlert>, sqlx::Error> {
+        sqlx::query_as("SELECT * FROM benchmark_alerts WHERE id = $1")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await
+    }
+
     pub async fn resolve_benchmark_alert(
         &self,
         id: Uuid,

--- a/backend/crates/db/src/repositories/meter.rs
+++ b/backend/crates/db/src/repositories/meter.rs
@@ -929,6 +929,20 @@ impl MeterRepository {
     }
 
     /// Resolve missing reading alert.
+    /// Get a single missing-reading alert by id (used for tenant-ownership
+    /// checks before resolving it).
+    pub async fn get_missing_alert(
+        &self,
+        id: Uuid,
+    ) -> Result<Option<MissingReadingAlert>, SqlxError> {
+        sqlx::query_as::<_, MissingReadingAlert>(
+            "SELECT * FROM missing_reading_alerts WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+    }
+
     pub async fn resolve_missing_alert(
         &self,
         id: Uuid,

--- a/backend/servers/api-server/src/routes/energy.rs
+++ b/backend/servers/api-server/src/routes/energy.rs
@@ -225,6 +225,90 @@ fn not_found_error(msg: &str) -> (StatusCode, Json<ErrorResponse>) {
     )
 }
 
+fn forbidden_error(msg: &str) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::FORBIDDEN,
+        Json(ErrorResponse::new("FORBIDDEN", msg)),
+    )
+}
+
+// ==================== Tenant-isolation helpers ====================
+//
+// SECURITY (issue #846): energy/ESG handlers previously trusted a
+// client-supplied `organization_id` and read EPC / carbon / benchmark data by
+// id/path with no ownership check. Every handler now derives or validates the
+// org against the authenticated principal via the `verify_org_access`
+// membership gate (mirrors `routes/financial.rs`) plus a
+// `verify_building_access` building->org gate (mirrors `routes/community.rs`).
+
+/// Verify the authenticated user is a member of `org_id`.
+async fn verify_org_access(
+    state: &AppState,
+    user_id: Uuid,
+    org_id: Uuid,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    let is_member = state
+        .org_member_repo
+        .is_member(org_id, user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = ?e, "Failed to check org membership");
+            internal_error("Database error")
+        })?;
+
+    if !is_member {
+        return Err(forbidden_error("You are not a member of this organization"));
+    }
+
+    Ok(())
+}
+
+/// Resolve the org that owns `building_id` and verify the caller is a member of
+/// it. Returns the building's organization_id. A 404 is returned for an unknown
+/// building so cross-tenant probing cannot distinguish missing from forbidden.
+async fn verify_building_access(
+    state: &AppState,
+    user_id: Uuid,
+    building_id: Uuid,
+) -> Result<Uuid, (StatusCode, Json<ErrorResponse>)> {
+    // Intentionally the non-RLS lookup: this IS the access check, run before
+    // any RLS context is established for the request (mirrors community.rs).
+    #[allow(deprecated)]
+    let building = state
+        .building_repo
+        .find_by_id(building_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = ?e, "Building lookup failed");
+            internal_error("Failed to verify building access")
+        })?
+        .ok_or_else(|| not_found_error("Building not found"))?;
+
+    verify_org_access(state, user_id, building.organization_id).await?;
+    Ok(building.organization_id)
+}
+
+/// Resolve the building/org that owns `unit_id` and verify the caller is a
+/// member of it. Returns the unit's organization_id.
+async fn verify_unit_access(
+    state: &AppState,
+    user_id: Uuid,
+    unit_id: Uuid,
+) -> Result<Uuid, (StatusCode, Json<ErrorResponse>)> {
+    #[allow(deprecated)]
+    let unit = state
+        .unit_repo
+        .find_by_id(unit_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = ?e, "Unit lookup failed");
+            internal_error("Failed to verify unit access")
+        })?
+        .ok_or_else(|| not_found_error("Unit not found"))?;
+
+    verify_building_access(state, user_id, unit.building_id).await
+}
+
 // ==================== EPC Handlers (Story 65.1) ====================
 
 /// Get EPC for a unit.
@@ -240,9 +324,11 @@ fn not_found_error(msg: &str) -> (StatusCode, Json<ErrorResponse>) {
 )]
 async fn get_unit_epc(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(unit_id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::energy::EnergyPerformanceCertificate>> {
+    verify_unit_access(&state, auth.user_id, unit_id).await?;
+
     let repo = &state.energy_repo;
 
     match repo.get_epc_for_unit(unit_id).await {
@@ -270,12 +356,26 @@ async fn get_unit_epc(
 async fn create_unit_epc(
     State(state): State<AppState>,
     auth: AuthUser,
-    Path(_unit_id): Path<Uuid>,
+    Path(unit_id): Path<Uuid>,
     Json(payload): Json<CreateEpcRequest>,
 ) -> ApiResult<(
     StatusCode,
     Json<db::models::energy::EnergyPerformanceCertificate>,
 )> {
+    // Caller must own the target org AND the unit being written (body
+    // `unit_id`, which is what gets persisted) must belong to that org. The
+    // path and body unit ids must agree to avoid a confused-deputy write.
+    if payload.data.unit_id != unit_id {
+        return Err(forbidden_error("Path unit_id does not match body unit_id"));
+    }
+    verify_org_access(&state, auth.user_id, payload.organization_id).await?;
+    let unit_org = verify_unit_access(&state, auth.user_id, payload.data.unit_id).await?;
+    if unit_org != payload.organization_id {
+        return Err(forbidden_error(
+            "Unit does not belong to the specified organization",
+        ));
+    }
+
     let repo = &state.energy_repo;
 
     repo.create_epc(payload.organization_id, auth.user_id, payload.data)
@@ -301,10 +401,12 @@ async fn create_unit_epc(
 )]
 async fn update_unit_epc(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(unit_id): Path<Uuid>,
     Json(payload): Json<UpdateEpcRequest>,
 ) -> ApiResult<Json<db::models::energy::EnergyPerformanceCertificate>> {
+    verify_unit_access(&state, auth.user_id, unit_id).await?;
+
     let repo = &state.energy_repo;
 
     // First get the EPC for this unit
@@ -338,10 +440,12 @@ async fn update_unit_epc(
 )]
 async fn list_building_epcs(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(building_id): Path<Uuid>,
     Query(query): Query<ListQuery>,
 ) -> ApiResult<Json<db::models::energy::ListEpcsResponse>> {
+    verify_building_access(&state, auth.user_id, building_id).await?;
+
     let repo = &state.energy_repo;
     let limit = query.limit.min(MAX_LIST_LIMIT);
 
@@ -367,13 +471,16 @@ async fn list_building_epcs(
 )]
 async fn get_epc(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::energy::EnergyPerformanceCertificate>> {
     let repo = &state.energy_repo;
 
     match repo.get_epc(id).await {
-        Ok(Some(epc)) => Ok(Json(epc)),
+        Ok(Some(epc)) => {
+            verify_org_access(&state, auth.user_id, epc.organization_id).await?;
+            Ok(Json(epc))
+        }
         Ok(None) => Err(not_found_error("EPC not found")),
         Err(e) => {
             tracing::error!("Failed to get EPC: {:?}", e);
@@ -395,10 +502,21 @@ async fn get_epc(
 )]
 async fn delete_epc(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
 ) -> ApiResult<StatusCode> {
     let repo = &state.energy_repo;
+
+    // Verify the EPC belongs to the caller's org before deleting.
+    let epc = repo
+        .get_epc(id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get EPC: {:?}", e);
+            internal_error("Failed to get EPC")
+        })?
+        .ok_or_else(|| not_found_error("EPC not found"))?;
+    verify_org_access(&state, auth.user_id, epc.organization_id).await?;
 
     match repo.delete_epc(id).await {
         Ok(true) => Ok(StatusCode::NO_CONTENT),
@@ -425,10 +543,12 @@ async fn delete_epc(
 )]
 async fn get_carbon_dashboard(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(building_id): Path<Uuid>,
     Query(query): Query<CarbonDashboardQuery>,
 ) -> ApiResult<Json<db::models::energy::CarbonDashboard>> {
+    verify_building_access(&state, auth.user_id, building_id).await?;
+
     let repo = &state.energy_repo;
     let year = query.year.unwrap_or_else(|| chrono::Utc::now().year());
 
@@ -457,9 +577,23 @@ async fn get_carbon_dashboard(
 async fn record_emission(
     State(state): State<AppState>,
     auth: AuthUser,
-    Path(_building_id): Path<Uuid>,
+    Path(building_id): Path<Uuid>,
     Json(payload): Json<CreateEmissionRequest>,
 ) -> ApiResult<(StatusCode, Json<db::models::energy::CarbonEmission>)> {
+    if payload.data.building_id != building_id {
+        return Err(forbidden_error(
+            "Path building_id does not match body building_id",
+        ));
+    }
+    verify_org_access(&state, auth.user_id, payload.organization_id).await?;
+    let building_org =
+        verify_building_access(&state, auth.user_id, payload.data.building_id).await?;
+    if building_org != payload.organization_id {
+        return Err(forbidden_error(
+            "Building does not belong to the specified organization",
+        ));
+    }
+
     let repo = &state.energy_repo;
 
     repo.create_emission(payload.organization_id, auth.user_id, payload.data)
@@ -483,10 +617,12 @@ async fn record_emission(
 )]
 async fn list_emissions(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(building_id): Path<Uuid>,
     Query(query): Query<EmissionsQuery>,
 ) -> ApiResult<Json<db::models::energy::ListEmissionsResponse>> {
+    verify_building_access(&state, auth.user_id, building_id).await?;
+
     let repo = &state.energy_repo;
     let limit = query.limit.min(MAX_LIST_LIMIT);
 
@@ -513,10 +649,24 @@ async fn list_emissions(
 )]
 async fn set_carbon_target(
     State(state): State<AppState>,
-    _auth: AuthUser,
-    Path(_building_id): Path<Uuid>,
+    auth: AuthUser,
+    Path(building_id): Path<Uuid>,
     Json(payload): Json<SetCarbonTargetRequest>,
 ) -> ApiResult<(StatusCode, Json<db::models::energy::CarbonTarget>)> {
+    if payload.data.building_id != building_id {
+        return Err(forbidden_error(
+            "Path building_id does not match body building_id",
+        ));
+    }
+    verify_org_access(&state, auth.user_id, payload.organization_id).await?;
+    let building_org =
+        verify_building_access(&state, auth.user_id, payload.data.building_id).await?;
+    if building_org != payload.organization_id {
+        return Err(forbidden_error(
+            "Building does not belong to the specified organization",
+        ));
+    }
+
     let repo = &state.energy_repo;
 
     repo.set_carbon_target(payload.organization_id, payload.data)
@@ -541,10 +691,12 @@ async fn set_carbon_target(
 )]
 async fn export_carbon_report(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(building_id): Path<Uuid>,
     Query(query): Query<CarbonDashboardQuery>,
 ) -> ApiResult<Json<db::models::energy::CarbonDashboard>> {
+    verify_building_access(&state, auth.user_id, building_id).await?;
+
     // For now, return JSON; PDF generation would be added later
     let repo = &state.energy_repo;
     let year = query.year.unwrap_or_else(|| chrono::Utc::now().year());
@@ -574,13 +726,16 @@ async fn export_carbon_report(
 )]
 async fn get_sustainability_score(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(listing_id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::energy::SustainabilityScore>> {
     let repo = &state.energy_repo;
 
     match repo.get_sustainability_score(listing_id).await {
-        Ok(Some(score)) => Ok(Json(score)),
+        Ok(Some(score)) => {
+            verify_org_access(&state, auth.user_id, score.organization_id).await?;
+            Ok(Json(score))
+        }
         Ok(None) => Err(not_found_error("Sustainability score not found")),
         Err(e) => {
             tracing::error!("Failed to get sustainability score: {:?}", e);
@@ -603,10 +758,12 @@ async fn get_sustainability_score(
 )]
 async fn create_sustainability_score(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(_listing_id): Path<Uuid>,
     Json(payload): Json<CreateSustainabilityScoreRequest>,
 ) -> ApiResult<(StatusCode, Json<db::models::energy::SustainabilityScore>)> {
+    verify_org_access(&state, auth.user_id, payload.organization_id).await?;
+
     let repo = &state.energy_repo;
 
     repo.upsert_sustainability_score(payload.organization_id, payload.data)
@@ -632,11 +789,22 @@ async fn create_sustainability_score(
 )]
 async fn update_sustainability_score(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(listing_id): Path<Uuid>,
     Json(payload): Json<UpdateSustainabilityScoreRequest>,
 ) -> ApiResult<Json<db::models::energy::SustainabilityScore>> {
     let repo = &state.energy_repo;
+
+    // Verify the existing score belongs to the caller's org before updating.
+    let existing = repo
+        .get_sustainability_score(listing_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get sustainability score: {:?}", e);
+            internal_error("Failed to get sustainability score")
+        })?
+        .ok_or_else(|| not_found_error("Sustainability score not found"))?;
+    verify_org_access(&state, auth.user_id, existing.organization_id).await?;
 
     match repo
         .update_sustainability_score(listing_id, payload.data)
@@ -663,9 +831,11 @@ async fn update_sustainability_score(
 )]
 async fn search_sustainable_listings(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Query(query): Query<SustainabilitySearchQuery>,
 ) -> ApiResult<Json<Vec<Uuid>>> {
+    verify_org_access(&state, auth.user_id, query.organization_id).await?;
+
     let repo = &state.energy_repo;
     let limit = query.limit.min(MAX_LIST_LIMIT);
 
@@ -701,10 +871,12 @@ async fn search_sustainable_listings(
 )]
 async fn get_benchmark_dashboard(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(building_id): Path<Uuid>,
     Query(query): Query<BenchmarkQuery>,
 ) -> ApiResult<Json<db::models::energy::BenchmarkDashboard>> {
+    verify_building_access(&state, auth.user_id, building_id).await?;
+
     let repo = &state.energy_repo;
 
     match repo.get_benchmark_dashboard(building_id, query).await {
@@ -731,10 +903,24 @@ async fn get_benchmark_dashboard(
 )]
 async fn calculate_benchmark(
     State(state): State<AppState>,
-    _auth: AuthUser,
-    Path(_building_id): Path<Uuid>,
+    auth: AuthUser,
+    Path(building_id): Path<Uuid>,
     Json(payload): Json<CalculateBenchmarkRequest>,
 ) -> ApiResult<(StatusCode, Json<db::models::energy::BuildingBenchmark>)> {
+    if payload.data.building_id != building_id {
+        return Err(forbidden_error(
+            "Path building_id does not match body building_id",
+        ));
+    }
+    verify_org_access(&state, auth.user_id, payload.organization_id).await?;
+    let building_org =
+        verify_building_access(&state, auth.user_id, payload.data.building_id).await?;
+    if building_org != payload.organization_id {
+        return Err(forbidden_error(
+            "Building does not belong to the specified organization",
+        ));
+    }
+
     let repo = &state.energy_repo;
 
     repo.calculate_benchmark(payload.organization_id, payload.data)
@@ -758,10 +944,12 @@ async fn calculate_benchmark(
 )]
 async fn list_benchmark_alerts(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(building_id): Path<Uuid>,
     Query(query): Query<BenchmarkAlertsQuery>,
 ) -> ApiResult<Json<db::models::energy::ListBenchmarkAlertsResponse>> {
+    verify_building_access(&state, auth.user_id, building_id).await?;
+
     let repo = &state.energy_repo;
 
     repo.list_benchmark_alerts(building_id, query)
@@ -790,6 +978,17 @@ async fn resolve_benchmark_alert(
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::energy::BenchmarkAlert>> {
     let repo = &state.energy_repo;
+
+    // Verify the alert belongs to the caller's org before resolving.
+    let alert = repo
+        .get_benchmark_alert(id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get benchmark alert: {:?}", e);
+            internal_error("Failed to get benchmark alert")
+        })?
+        .ok_or_else(|| not_found_error("Alert not found"))?;
+    verify_org_access(&state, auth.user_id, alert.organization_id).await?;
 
     match repo.resolve_benchmark_alert(id, auth.user_id).await {
         Ok(alert) => Ok(Json(alert)),

--- a/backend/servers/api-server/src/routes/meters.rs
+++ b/backend/servers/api-server/src/routes/meters.rs
@@ -232,6 +232,158 @@ fn not_found_error(msg: &str) -> (StatusCode, Json<ErrorResponse>) {
     )
 }
 
+fn forbidden_error(msg: &str) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::FORBIDDEN,
+        Json(ErrorResponse::new("FORBIDDEN", msg)),
+    )
+}
+
+// ==================== Tenant-isolation helpers ====================
+//
+// SECURITY (issues #803, #846): meter handlers previously trusted a
+// client-supplied `organization_id` (request body / query param) and read
+// resources by id/path with no ownership check, letting any authenticated
+// caller register, read, or mutate another org's meters. Every handler now
+// derives or validates the org against the authenticated principal via the
+// `verify_org_access` membership gate (mirrors the `verify_org_access` idiom
+// in `routes/financial.rs` / `routes/integrations/sync.rs`), plus a
+// `verify_building_access` building→org gate (mirrors `routes/community.rs`).
+
+/// Verify the authenticated user is a member of `org_id`.
+async fn verify_org_access(
+    state: &AppState,
+    user_id: Uuid,
+    org_id: Uuid,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    let is_member = state
+        .org_member_repo
+        .is_member(org_id, user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = ?e, "Failed to check org membership");
+            internal_error("Database error")
+        })?;
+
+    if !is_member {
+        return Err(forbidden_error("You are not a member of this organization"));
+    }
+
+    Ok(())
+}
+
+/// Resolve the organization that owns `building_id` and verify the caller is a
+/// member of it. Returns the building's organization_id on success. A 404 is
+/// returned for an unknown building so cross-tenant probing cannot distinguish
+/// "missing" from "forbidden".
+async fn verify_building_access(
+    state: &AppState,
+    user_id: Uuid,
+    building_id: Uuid,
+) -> Result<Uuid, (StatusCode, Json<ErrorResponse>)> {
+    // Intentionally the non-RLS lookup: this IS the access check, run before
+    // any RLS context is established for the request (mirrors community.rs).
+    #[allow(deprecated)]
+    let building = state
+        .building_repo
+        .find_by_id(building_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = ?e, "Building lookup failed");
+            internal_error("Failed to verify building access")
+        })?
+        .ok_or_else(|| not_found_error("Building not found"))?;
+
+    verify_org_access(state, user_id, building.organization_id).await?;
+    Ok(building.organization_id)
+}
+
+/// Resolve the building/org that owns `unit_id` and verify the caller is a
+/// member of it. Returns the unit's organization_id on success.
+async fn verify_unit_access(
+    state: &AppState,
+    user_id: Uuid,
+    unit_id: Uuid,
+) -> Result<Uuid, (StatusCode, Json<ErrorResponse>)> {
+    #[allow(deprecated)]
+    let unit = state
+        .unit_repo
+        .find_by_id(unit_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = ?e, "Unit lookup failed");
+            internal_error("Failed to verify unit access")
+        })?
+        .ok_or_else(|| not_found_error("Unit not found"))?;
+
+    verify_building_access(state, user_id, unit.building_id).await
+}
+
+/// Resolve the meter by id, verify the caller is a member of its owning org,
+/// and return the meter. A 404 is returned for an unknown meter or a
+/// cross-tenant caller (no missing/forbidden distinction).
+async fn verify_meter_access(
+    state: &AppState,
+    user_id: Uuid,
+    meter_id: Uuid,
+) -> Result<db::models::Meter, (StatusCode, Json<ErrorResponse>)> {
+    let meter = state
+        .meter_repo
+        .get_meter(meter_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = ?e, "Meter lookup failed");
+            internal_error("Failed to verify meter access")
+        })?
+        .ok_or_else(|| not_found_error("Meter not found"))?;
+
+    let is_member = state
+        .org_member_repo
+        .is_member(meter.organization_id, user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = ?e, "Failed to check org membership");
+            internal_error("Database error")
+        })?;
+    if !is_member {
+        return Err(not_found_error("Meter not found"));
+    }
+
+    Ok(meter)
+}
+
+/// Resolve the utility bill by id and verify the caller is a member of its
+/// owning org. A 404 is returned for an unknown bill or a cross-tenant caller.
+async fn verify_bill_access(
+    state: &AppState,
+    user_id: Uuid,
+    bill_id: Uuid,
+) -> Result<db::models::UtilityBill, (StatusCode, Json<ErrorResponse>)> {
+    let bill = state
+        .meter_repo
+        .get_utility_bill(bill_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = ?e, "Utility bill lookup failed");
+            internal_error("Failed to verify utility bill access")
+        })?
+        .ok_or_else(|| not_found_error("Utility bill not found"))?;
+
+    let is_member = state
+        .org_member_repo
+        .is_member(bill.organization_id, user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = ?e, "Failed to check org membership");
+            internal_error("Database error")
+        })?;
+    if !is_member {
+        return Err(not_found_error("Utility bill not found"));
+    }
+
+    Ok(bill)
+}
+
 // ==================== Meter Handlers ====================
 
 /// Register a new meter.
@@ -247,9 +399,28 @@ fn not_found_error(msg: &str) -> (StatusCode, Json<ErrorResponse>) {
 )]
 async fn register_meter(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Json(payload): Json<RegisterMeterRequest>,
 ) -> ApiResult<(StatusCode, Json<db::models::Meter>)> {
+    // Trust the authenticated principal, not the client-supplied org: the
+    // caller must be a member of the target org AND own the target building.
+    verify_org_access(&state, auth.user_id, payload.organization_id).await?;
+    let building_org =
+        verify_building_access(&state, auth.user_id, payload.data.building_id).await?;
+    if building_org != payload.organization_id {
+        return Err(forbidden_error(
+            "Building does not belong to the specified organization",
+        ));
+    }
+    if let Some(unit_id) = payload.data.unit_id {
+        let unit_org = verify_unit_access(&state, auth.user_id, unit_id).await?;
+        if unit_org != payload.organization_id {
+            return Err(forbidden_error(
+                "Unit does not belong to the specified organization",
+            ));
+        }
+    }
+
     let repo = &state.meter_repo;
 
     repo.register_meter(payload.organization_id, payload.data)
@@ -273,10 +444,12 @@ async fn register_meter(
 )]
 async fn list_meters(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(building_id): Path<Uuid>,
     Query(query): Query<ListMetersQuery>,
 ) -> ApiResult<Json<db::models::ListMetersResponse>> {
+    verify_building_access(&state, auth.user_id, building_id).await?;
+
     let repo = &state.meter_repo;
     let limit = query.limit.min(MAX_LIST_LIMIT);
 
@@ -302,9 +475,11 @@ async fn list_meters(
 )]
 async fn get_meter(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::MeterResponse>> {
+    verify_meter_access(&state, auth.user_id, id).await?;
+
     let repo = &state.meter_repo;
 
     match repo.get_meter_with_readings(id, 10).await {
@@ -331,14 +506,24 @@ async fn get_meter(
 )]
 async fn replace_meter(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
     Json(payload): Json<ReplaceMeterRequest>,
 ) -> ApiResult<(StatusCode, Json<db::models::Meter>)> {
+    // The replacement inherits org/building/unit from the existing meter, so
+    // the only authoritative org is the meter's own. Verify ownership and
+    // ignore any client-supplied org mismatch.
+    let meter = verify_meter_access(&state, auth.user_id, id).await?;
+    if meter.organization_id != payload.organization_id {
+        return Err(forbidden_error(
+            "organization_id does not match the meter's organization",
+        ));
+    }
+
     let repo = &state.meter_repo;
 
     match repo
-        .replace_meter(id, payload.organization_id, payload.data)
+        .replace_meter(id, meter.organization_id, payload.data)
         .await
     {
         Ok(meter) => Ok((StatusCode::CREATED, Json(meter))),
@@ -362,9 +547,11 @@ async fn replace_meter(
 )]
 async fn list_unit_meters(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(unit_id): Path<Uuid>,
 ) -> ApiResult<Json<Vec<db::models::Meter>>> {
+    verify_unit_access(&state, auth.user_id, unit_id).await?;
+
     let repo = &state.meter_repo;
 
     repo.list_meters_for_unit(unit_id)
@@ -394,6 +581,8 @@ async fn submit_reading(
     auth: AuthUser,
     Json(payload): Json<SubmitReading>,
 ) -> ApiResult<(StatusCode, Json<db::models::MeterReading>)> {
+    verify_meter_access(&state, auth.user_id, payload.meter_id).await?;
+
     let repo = &state.meter_repo;
 
     repo.submit_reading(auth.user_id, payload)
@@ -418,13 +607,16 @@ async fn submit_reading(
 )]
 async fn get_reading(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::MeterReading>> {
     let repo = &state.meter_repo;
 
     match repo.get_reading(id).await {
-        Ok(Some(reading)) => Ok(Json(reading)),
+        Ok(Some(reading)) => {
+            verify_meter_access(&state, auth.user_id, reading.meter_id).await?;
+            Ok(Json(reading))
+        }
         Ok(None) => Err(not_found_error("Reading not found")),
         Err(e) => {
             tracing::error!("Failed to get reading: {:?}", e);
@@ -448,10 +640,12 @@ async fn get_reading(
 )]
 async fn list_readings(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(meter_id): Path<Uuid>,
     Query(query): Query<ListReadingsQuery>,
 ) -> ApiResult<Json<db::models::ListReadingsResponse>> {
+    verify_meter_access(&state, auth.user_id, meter_id).await?;
+
     let repo = &state.meter_repo;
     let limit = query.limit.min(MAX_LIST_LIMIT);
 
@@ -479,9 +673,11 @@ async fn list_readings(
 )]
 async fn create_submission_window(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Json(payload): Json<CreateSubmissionWindowRequest>,
 ) -> ApiResult<(StatusCode, Json<db::models::ReadingSubmissionWindow>)> {
+    verify_org_access(&state, auth.user_id, payload.organization_id).await?;
+
     let repo = &state.meter_repo;
 
     repo.create_submission_window(payload.organization_id, payload.data)
@@ -506,9 +702,11 @@ async fn create_submission_window(
 )]
 async fn get_open_window(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(building_id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::ReadingSubmissionWindow>> {
+    verify_building_access(&state, auth.user_id, building_id).await?;
+
     let repo = &state.meter_repo;
 
     match repo.get_open_submission_window(building_id).await {
@@ -543,6 +741,17 @@ async fn validate_reading(
 ) -> ApiResult<Json<db::models::MeterReading>> {
     let repo = &state.meter_repo;
 
+    // Resolve the reading's meter and verify org ownership before validating.
+    let reading = repo
+        .get_reading(id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get reading: {:?}", e);
+            internal_error("Failed to get reading")
+        })?
+        .ok_or_else(|| not_found_error("Reading not found"))?;
+    verify_meter_access(&state, auth.user_id, reading.meter_id).await?;
+
     match repo.validate_reading(id, auth.user_id, payload).await {
         Ok(Some(reading)) => Ok(Json(reading)),
         Ok(None) => Err(not_found_error("Reading not found")),
@@ -565,9 +774,19 @@ async fn validate_reading(
 )]
 async fn get_pending_readings(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Query(query): Query<PendingReadingsQuery>,
 ) -> ApiResult<Json<Vec<db::models::MeterReading>>> {
+    verify_org_access(&state, auth.user_id, query.organization_id).await?;
+    if let Some(building_id) = query.building_id {
+        let building_org = verify_building_access(&state, auth.user_id, building_id).await?;
+        if building_org != query.organization_id {
+            return Err(forbidden_error(
+                "Building does not belong to the specified organization",
+            ));
+        }
+    }
+
     let repo = &state.meter_repo;
 
     repo.get_pending_readings(query.organization_id, query.building_id)
@@ -591,9 +810,11 @@ async fn get_pending_readings(
 )]
 async fn get_validation_rules(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Query(query): Query<ValidationRulesQuery>,
 ) -> ApiResult<Json<Vec<db::models::ReadingValidationRule>>> {
+    verify_org_access(&state, auth.user_id, query.organization_id).await?;
+
     let repo = &state.meter_repo;
 
     repo.get_validation_rules(query.organization_id)
@@ -623,6 +844,8 @@ async fn create_utility_bill(
     auth: AuthUser,
     Json(payload): Json<CreateUtilityBillRequest>,
 ) -> ApiResult<(StatusCode, Json<db::models::UtilityBill>)> {
+    verify_org_access(&state, auth.user_id, payload.organization_id).await?;
+
     let repo = &state.meter_repo;
 
     repo.create_utility_bill(payload.organization_id, auth.user_id, payload.data)
@@ -647,9 +870,11 @@ async fn create_utility_bill(
 )]
 async fn get_utility_bill(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::UtilityBillResponse>> {
+    verify_bill_access(&state, auth.user_id, id).await?;
+
     let repo = &state.meter_repo;
 
     match repo.get_utility_bill_with_distributions(id).await {
@@ -680,6 +905,8 @@ async fn distribute_bill(
     Path(id): Path<Uuid>,
     Json(payload): Json<DistributeUtilityBill>,
 ) -> ApiResult<Json<db::models::UtilityBillResponse>> {
+    verify_bill_access(&state, auth.user_id, id).await?;
+
     let repo = &state.meter_repo;
 
     match repo
@@ -710,10 +937,12 @@ async fn distribute_bill(
 )]
 async fn get_consumption_history(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(meter_id): Path<Uuid>,
     Query(query): Query<ConsumptionQuery>,
 ) -> ApiResult<Json<db::models::ConsumptionHistoryResponse>> {
+    verify_meter_access(&state, auth.user_id, meter_id).await?;
+
     let repo = &state.meter_repo;
 
     match repo
@@ -741,10 +970,12 @@ async fn get_consumption_history(
 )]
 async fn get_consumption_aggregates(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(meter_id): Path<Uuid>,
     Query(query): Query<AggregatesQuery>,
 ) -> ApiResult<Json<Vec<db::models::ConsumptionAggregate>>> {
+    verify_meter_access(&state, auth.user_id, meter_id).await?;
+
     let repo = &state.meter_repo;
 
     repo.get_consumption_aggregates(meter_id, query.year)
@@ -770,9 +1001,11 @@ async fn get_consumption_aggregates(
 )]
 async fn list_providers(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Query(query): Query<ProvidersQuery>,
 ) -> ApiResult<Json<Vec<db::models::SmartMeterProvider>>> {
+    verify_org_access(&state, auth.user_id, query.organization_id).await?;
+
     let repo = &state.meter_repo;
 
     repo.get_smart_meter_providers(query.organization_id)
@@ -797,13 +1030,16 @@ async fn list_providers(
 )]
 async fn get_provider(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::SmartMeterProvider>> {
     let repo = &state.meter_repo;
 
     match repo.get_smart_meter_provider(id).await {
-        Ok(Some(provider)) => Ok(Json(provider)),
+        Ok(Some(provider)) => {
+            verify_org_access(&state, auth.user_id, provider.organization_id).await?;
+            Ok(Json(provider))
+        }
         Ok(None) => Err(not_found_error("Provider not found")),
         Err(e) => {
             tracing::error!("Failed to get provider: {:?}", e);
@@ -825,9 +1061,11 @@ async fn get_provider(
 )]
 async fn ingest_smart_reading(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Json(payload): Json<IngestReadingRequest>,
 ) -> ApiResult<StatusCode> {
+    verify_org_access(&state, auth.user_id, payload.organization_id).await?;
+
     let repo = &state.meter_repo;
 
     // Find meter by number
@@ -870,9 +1108,11 @@ async fn ingest_smart_reading(
 )]
 async fn list_missing_alerts(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Query(query): Query<AlertsQuery>,
 ) -> ApiResult<Json<Vec<db::models::MissingReadingAlert>>> {
+    verify_org_access(&state, auth.user_id, query.organization_id).await?;
+
     let repo = &state.meter_repo;
 
     repo.get_missing_reading_alerts(query.organization_id, query.unresolved_only)
@@ -903,6 +1143,17 @@ async fn resolve_alert(
     Json(payload): Json<ResolveAlertRequest>,
 ) -> ApiResult<Json<db::models::MissingReadingAlert>> {
     let repo = &state.meter_repo;
+
+    // Resolve the alert's meter and verify org ownership before resolving.
+    let alert = repo
+        .get_missing_alert(id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get alert: {:?}", e);
+            internal_error("Failed to get alert")
+        })?
+        .ok_or_else(|| not_found_error("Alert not found"))?;
+    verify_meter_access(&state, auth.user_id, alert.meter_id).await?;
 
     match repo
         .resolve_missing_alert(id, auth.user_id, payload.notes.as_deref())

--- a/backend/servers/api-server/tests/meters_energy_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/meters_energy_cross_org_idor_tests.rs
@@ -1,0 +1,354 @@
+//! Regression tests for the cross-tenant IDOR / forged-org fixes on the meter
+//! (`/api/v1/meters/*`, Epic 12 — issue #803) and energy/ESG
+//! (`/api/v1/energy/*`, Epic 65 — issue #846) endpoints.
+//!
+//! Audit history: every meter and energy handler either discarded its
+//! `AuthUser` (the `_auth` binding) or accepted a client-supplied
+//! `organization_id` (JSON body / query param) without checking that the
+//! caller is actually a member of that org, and read resources by UUID/path
+//! with no ownership check. The combination let a foreign authenticated
+//! caller:
+//!   * register a meter against an attacker-chosen org,
+//!   * read any meter / reading / consumption by UUID,
+//!   * list another org's building/unit meters,
+//!   * read another org's EPC / carbon / benchmark data by building/unit path.
+//!
+//! The fix derives or validates the org against the authenticated principal
+//! via a `verify_org_access` membership gate (mirrors `routes/financial.rs`)
+//! plus a `verify_building_access` building->org gate (mirrors
+//! `routes/community.rs`). Cross-tenant requests are rejected (403 for
+//! org-keyed reads/writes, 404 for by-ID/path probes); same-org access works.
+//!
+//! NOTE: Epic 65 (energy) has repository code but no schema migration for its
+//! tables, so only the *rejection* path (which short-circuits in the tenant
+//! gate before any energy query) is asserted for energy; the same-org success
+//! path is proven on the meter endpoints whose tables do exist.
+
+#[allow(dead_code)]
+mod common;
+
+use axum::http::StatusCode;
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{TestApp, TestConfig};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active') RETURNING id
+        "#,
+    )
+    .bind(format!("MeterIDOR Org {slug}"))
+    .bind(format!("meter-idor-org-{slug}"))
+    .bind(format!("{slug}@meter-idor.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'test_hash', 'MeterIDOR User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Make `user_id` an active member of `org_id`.
+async fn seed_membership(pool: &PgPool, org_id: Uuid, user_id: Uuid) {
+    sqlx::query(
+        r#"
+        INSERT INTO organization_members (organization_id, user_id, role_type, status, joined_at)
+        VALUES ($1, $2, 'org_admin', 'active', NOW())
+        "#,
+    )
+    .bind(org_id)
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .expect("seed membership");
+}
+
+async fn seed_building(pool: &PgPool, org_id: Uuid, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO buildings (organization_id, street, city, postal_code, country)
+        VALUES ($1, $2, 'Bratislava', '81101', 'Slovakia') RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(format!("{slug} Street 1"))
+    .fetch_one(pool)
+    .await
+    .expect("seed building")
+}
+
+async fn seed_meter(pool: &PgPool, org_id: Uuid, building_id: Uuid, number: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO meters (
+            organization_id, building_id, meter_number, meter_type,
+            initial_reading, current_reading, unit_of_measure, is_active
+        )
+        VALUES ($1, $2, $3, 'electricity', 0, 0, 'kWh', true)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(building_id)
+    .bind(number)
+    .fetch_one(pool)
+    .await
+    .expect("seed meter")
+}
+
+/// Mint a real HS256 access token for `user_id`, signed with the same secret
+/// the TestApp configures into `JWT_SECRET`.
+fn mint_token(user_id: Uuid, email: &str) -> String {
+    use api_server::services::JwtService;
+    let config = TestConfig::default();
+    let jwt = JwtService::new(&config.jwt_secret).expect("jwt service");
+    jwt.generate_access_token(user_id, email, "MeterIDOR User", None, None)
+        .expect("mint access token")
+}
+
+fn assert_rejected(status: StatusCode, ctx: &str) {
+    let code = status.as_u16();
+    assert!(
+        (400..500).contains(&code),
+        "{ctx}: cross-tenant/unauthenticated request must be rejected with 4xx, got {status}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #803 — meters: unauthenticated get_meter is rejected
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_meter_without_auth_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "noauth-a").await;
+    let building_a = seed_building(&pool, org_a, "noauth-a").await;
+    let meter_a = seed_meter(&pool, org_a, building_a, "NOAUTH-1").await;
+
+    let uri = format!("/api/v1/meters/{meter_a}");
+    let resp = app.execute(app.get(&uri).build()).await;
+
+    assert_rejected(resp.status, "get_meter without bearer token");
+}
+
+// ---------------------------------------------------------------------------
+// #803 — meters: cross-org get_meter by UUID is rejected (IDOR)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_meter_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "get-a").await;
+    let org_b = seed_org(&pool, "get-b").await;
+    let user_b = seed_user(&pool, "get-b@meter-idor.test").await;
+    seed_membership(&pool, org_b, user_b).await;
+    let building_a = seed_building(&pool, org_a, "get-a").await;
+    let meter_a = seed_meter(&pool, org_a, building_a, "GET-1").await;
+
+    let token_b = mint_token(user_b, "get-b@meter-idor.test");
+    let uri = format!("/api/v1/meters/{meter_a}");
+    let resp = app.execute(app.get(&uri).bearer(&token_b).build()).await;
+
+    assert_rejected(resp.status, "get_meter cross-tenant");
+    assert_ne!(
+        resp.status,
+        StatusCode::OK,
+        "Org A meter must not be readable by Org B"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #803 — meters: cross-org list_meters (building path) is rejected
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_meters_for_other_orgs_building_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "lst-a").await;
+    let org_b = seed_org(&pool, "lst-b").await;
+    let user_b = seed_user(&pool, "lst-b@meter-idor.test").await;
+    seed_membership(&pool, org_b, user_b).await;
+    let building_a = seed_building(&pool, org_a, "lst-a").await;
+    let _meter_a = seed_meter(&pool, org_a, building_a, "LST-1").await;
+
+    let token_b = mint_token(user_b, "lst-b@meter-idor.test");
+    let uri = format!("/api/v1/meters/buildings/{building_a}");
+    let resp = app.execute(app.get(&uri).bearer(&token_b).build()).await;
+
+    assert_rejected(resp.status, "list_meters cross-tenant building");
+    assert_ne!(resp.status, StatusCode::OK);
+}
+
+// ---------------------------------------------------------------------------
+// #803 — meters: register_meter with attacker-supplied org_id is rejected
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn register_meter_for_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "reg-a").await;
+    let org_b = seed_org(&pool, "reg-b").await;
+    let user_b = seed_user(&pool, "reg-b@meter-idor.test").await;
+    seed_membership(&pool, org_b, user_b).await;
+    let building_a = seed_building(&pool, org_a, "reg-a").await;
+
+    let token_b = mint_token(user_b, "reg-b@meter-idor.test");
+    let body = json!({
+        "organization_id": org_a,
+        "building_id": building_a,
+        "meter_number": "ATTACKER-1",
+        "meter_type": "electricity",
+        "initial_reading": "0",
+        "unit_of_measure": "kWh",
+    });
+    let resp = app
+        .execute(
+            app.post("/api/v1/meters")
+                .bearer(&token_b)
+                .json(body)
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "Org B member must not register a meter against Org A: {}",
+        resp.text()
+    );
+
+    // No meter row should have been created for Org A via the forged request.
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM meters WHERE meter_number = 'ATTACKER-1'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(count, 0, "no meter may be registered via cross-tenant POST");
+}
+
+// ---------------------------------------------------------------------------
+// #803 — meters: legitimate same-org get_meter succeeds
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_meter_for_own_org_succeeds(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "own-a").await;
+    let user_a = seed_user(&pool, "own-a@meter-idor.test").await;
+    seed_membership(&pool, org_a, user_a).await;
+    let building_a = seed_building(&pool, org_a, "own-a").await;
+    let meter_a = seed_meter(&pool, org_a, building_a, "OWN-1").await;
+
+    let token_a = mint_token(user_a, "own-a@meter-idor.test");
+    let uri = format!("/api/v1/meters/{meter_a}");
+    let resp = app.execute(app.get(&uri).bearer(&token_a).build()).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "Org A member must be able to read its own meter: {}",
+        resp.text()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #846 — energy: cross-org get_unit_epc (unit path) is rejected (IDOR)
+//
+// The tenant gate (verify_unit_access) runs before any energy-table query, so
+// a foreign caller is rejected regardless of whether the EPC row exists.
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_unit_epc_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "epc-a").await;
+    let org_b = seed_org(&pool, "epc-b").await;
+    let user_b = seed_user(&pool, "epc-b@meter-idor.test").await;
+    seed_membership(&pool, org_b, user_b).await;
+    let building_a = seed_building(&pool, org_a, "epc-a").await;
+    let unit_a = sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO units (
+            building_id, designation, floor, unit_type,
+            size_sqm, rooms, ownership_share, occupancy_status, status, settings
+        )
+        VALUES ($1, 'EPC-1A', 1, 'apartment', 50.0, 2, 100.00, 'unknown', 'active', '{}'::jsonb)
+        RETURNING id
+        "#,
+    )
+    .bind(building_a)
+    .fetch_one(&pool)
+    .await
+    .expect("seed unit");
+
+    let token_b = mint_token(user_b, "epc-b@meter-idor.test");
+    let uri = format!("/api/v1/energy/units/{unit_a}/epc");
+    let resp = app.execute(app.get(&uri).bearer(&token_b).build()).await;
+
+    assert_rejected(resp.status, "get_unit_epc cross-tenant");
+    assert_ne!(
+        resp.status,
+        StatusCode::OK,
+        "Org A unit EPC must not be readable by Org B"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #846 — energy: cross-org get_benchmark_dashboard (building path) is rejected
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_benchmark_dashboard_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "bm-a").await;
+    let org_b = seed_org(&pool, "bm-b").await;
+    let user_b = seed_user(&pool, "bm-b@meter-idor.test").await;
+    seed_membership(&pool, org_b, user_b).await;
+    let building_a = seed_building(&pool, org_a, "bm-a").await;
+
+    let token_b = mint_token(user_b, "bm-b@meter-idor.test");
+    let uri = format!("/api/v1/energy/buildings/{building_a}/benchmark");
+    let resp = app.execute(app.get(&uri).bearer(&token_b).build()).await;
+
+    assert_rejected(resp.status, "get_benchmark_dashboard cross-tenant");
+    assert_ne!(
+        resp.status,
+        StatusCode::OK,
+        "Org A benchmark dashboard must not be readable by Org B"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #846 — energy: unauthenticated benchmark dashboard is rejected
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_benchmark_dashboard_without_auth_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "bm-noauth-a").await;
+    let building_a = seed_building(&pool, org_a, "bm-noauth-a").await;
+
+    let uri = format!("/api/v1/energy/buildings/{building_a}/benchmark");
+    let resp = app.execute(app.get(&uri).build()).await;
+
+    assert_rejected(resp.status, "get_benchmark_dashboard without bearer token");
+}


### PR DESCRIPTION
## Summary

Closes the cross-tenant IDOR / forged-`organization_id` holes on the meter (Epic 12, #803) and energy/ESG (Epic 65, #846) HTTP surfaces. Both endpoints discarded their `AuthUser` (the `_auth` binding) or trusted a client-supplied `organization_id`, and read resources by id/path with no ownership check — letting any authenticated caller register/read/mutate another org's meters, readings, EPCs, carbon and benchmark data.

Every handler now derives or validates the org against the authenticated principal, reusing the existing sibling idioms verbatim:
- `verify_org_access(&state, user_id, org_id)` membership gate — mirrors `routes/financial.rs` / `routes/integrations/sync.rs` (uses `state.org_member_repo.is_member`).
- `verify_building_access(&state, user_id, building_id) -> org_id` building→org gate — mirrors `routes/community.rs` (loads building via `building_repo.find_by_id`, `#[allow(deprecated)]` because this IS the pre-RLS access check, exactly as community.rs documents).
- `verify_unit_access` (unit→building→org) and by-id `verify_meter_access` / `verify_bill_access` resolve the owning org then run the membership check. Cross-tenant by-id probes return 404 (no missing/forbidden distinction); org-keyed reads/writes return 403.

Client-supplied `organization_id` is no longer trusted: it must match the authenticated membership AND the path building/unit must belong to that org.

## Handlers changed

**`routes/meters.rs` (#803):** register_meter, list_meters, get_meter, replace_meter, list_unit_meters, submit_reading, get_reading, list_readings, create_submission_window, get_open_window, validate_reading, get_pending_readings, get_validation_rules, create_utility_bill, get_utility_bill, distribute_bill, get_consumption_history, get_consumption_aggregates, list_providers, get_provider, ingest_smart_reading, list_missing_alerts, resolve_alert.

**`routes/energy.rs` (#846):** get_unit_epc, create_unit_epc, update_unit_epc, list_building_epcs, get_epc, delete_epc, get_carbon_dashboard, record_emission, list_emissions, set_carbon_target, export_carbon_report, get_sustainability_score, create_sustainability_score, update_sustainability_score, search_sustainable_listings, get_benchmark_dashboard, calculate_benchmark, list_benchmark_alerts, resolve_benchmark_alert.

**`crates/db/src/repositories/meter.rs` / `energy.rs`:** added read-only `get_missing_alert` / `get_benchmark_alert` by-id getters so the resolve handlers can verify ownership before mutating (runtime `query_as`, no sqlx-offline regen needed).

## Tested (Band A)

```
$ cargo clippy -p api-server --lib -- -D warnings
Finished `dev` profile in 4m02s   # exit 0, no warnings

$ DATABASE_URL=postgres://…@127.0.0.1:5432/postgres \
    cargo test -p api-server --test meters_energy_cross_org_idor_tests
test result: ok. 8 passed; 0 failed; 0 ignored   # exit 0

$ cargo fmt --all   # clean
```

New test target `tests/meters_energy_cross_org_idor_tests.rs` (built with `-Dwarnings`, no unused imports). Covers: unauthenticated rejected; cross-org `get_meter` / `list_meters` / `get_unit_epc` / `get_benchmark_dashboard` rejected; forged-org `register_meter` rejected + no row written; same-org `get_meter` succeeds.

## IG3 — failing on main (two-commit TDD)

```
6a001ac  fix(security): scope meter & energy routes to authenticated tenant
e8f259e  test(api-server): cross-org IDOR regressions for meters & energy
```
Against the pre-fix code the same suite fails with the IDOR signatures — cross-tenant `get_meter` → 200 OK, `register_meter` → 201 (meter created for Org A), `get_benchmark_dashboard` → reaches the repo instead of 403/404. With the fix applied all 8 pass.

## Notes

- Epic 65 (energy) has repo code but **no schema migration** for its tables, so the energy tests assert the *rejection* path only (the tenant gate short-circuits before any energy query); same-org success is proven on the meter endpoints, whose tables exist. Out-of-scope follow-up: add the missing energy migrations.
- `resolve_alert` / `resolve_benchmark_alert` are manager-side mutations not explicitly flagged in either issue but were gated for completeness (resolve alert → meter → org; benchmark alert → org).