### PR TITLE
fix(security): scope vendor routes to authenticated tenant (closes #825)

### DIFF
--- a/backend/crates/db/src/repositories/vendor.rs
+++ b/backend/crates/db/src/repositories/vendor.rs
@@ -294,6 +294,19 @@ impl VendorRepository {
         Ok(result.rows_affected() > 0)
     }
 
+    /// Resolve the `vendor_id` that owns `contact_id`, if any. Used by the
+    /// route layer to derive the owning org for tenant-isolation checks
+    /// (issue #825) before deleting a contact.
+    pub async fn find_contact_vendor_id(
+        &self,
+        contact_id: Uuid,
+    ) -> Result<Option<Uuid>, sqlx::Error> {
+        sqlx::query_scalar("SELECT vendor_id FROM vendor_contacts WHERE id = $1")
+            .bind(contact_id)
+            .fetch_optional(&self.pool)
+            .await
+    }
+
     // ==================== Vendor Contracts ====================
 
     /// Create a contract.

--- a/backend/servers/api-server/src/routes/vendors.rs
+++ b/backend/servers/api-server/src/routes/vendors.rs
@@ -22,6 +22,160 @@ use uuid::Uuid;
 
 use crate::state::AppState;
 
+/// Verify the authenticated user is a member of `org_id`.
+///
+/// This is the tenant-isolation gate for the org-keyed vendor routes
+/// (list / create / statistics — issue #825). The client-supplied
+/// `organization_id` (query param or JSON body) is never trusted on its own;
+/// it is only accepted once confirmed to belong to the authenticated
+/// principal. Cross-tenant callers receive `403 FORBIDDEN`.
+///
+/// Mirrors the `verify_org_access` idiom in `routes/financial.rs` (#802) and
+/// `routes/integrations/sync.rs`.
+async fn verify_org_access(
+    state: &AppState,
+    user_id: Uuid,
+    org_id: Uuid,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    if !is_member_or_not_found(state, user_id, org_id).await? {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "FORBIDDEN",
+                "You are not a member of this organization",
+            )),
+        ));
+    }
+    Ok(())
+}
+
+/// Membership check that maps DB errors to a 500 but returns a plain bool for
+/// the membership outcome, letting the caller choose 403 vs 404 semantics.
+async fn is_member_or_not_found(
+    state: &AppState,
+    user_id: Uuid,
+    org_id: Uuid,
+) -> Result<bool, (StatusCode, Json<ErrorResponse>)> {
+    state
+        .org_member_repo
+        .is_member(org_id, user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = ?e, "Failed to check org membership");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DATABASE_ERROR", "Database error")),
+            )
+        })
+}
+
+/// Resolve the vendor by id and verify the authenticated user belongs to its
+/// owning org. Returns `404` when the vendor does not exist OR the user is not
+/// a member (so cross-tenant probing cannot distinguish "missing" from
+/// "forbidden"). Mirrors `verify_account_access` in `routes/financial.rs`.
+async fn verify_vendor_access(
+    state: &AppState,
+    user_id: Uuid,
+    vendor_id: Uuid,
+) -> Result<Vendor, (StatusCode, Json<ErrorResponse>)> {
+    let vendor = state
+        .vendor_repo
+        .find_by_id(vendor_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to load vendor: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", "Failed to load vendor")),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Vendor not found")),
+            )
+        })?;
+
+    if !is_member_or_not_found(state, user_id, vendor.organization_id).await? {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("NOT_FOUND", "Vendor not found")),
+        ));
+    }
+
+    Ok(vendor)
+}
+
+/// Resolve the contract by id and verify org membership. `404` on missing or
+/// cross-tenant.
+async fn verify_contract_access(
+    state: &AppState,
+    user_id: Uuid,
+    contract_id: Uuid,
+) -> Result<VendorContract, (StatusCode, Json<ErrorResponse>)> {
+    let contract = state
+        .vendor_repo
+        .find_contract_by_id(contract_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to load contract: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", "Failed to load contract")),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Contract not found")),
+            )
+        })?;
+
+    if !is_member_or_not_found(state, user_id, contract.organization_id).await? {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("NOT_FOUND", "Contract not found")),
+        ));
+    }
+
+    Ok(contract)
+}
+
+/// Resolve the invoice by id and verify org membership. `404` on missing or
+/// cross-tenant.
+async fn verify_invoice_access(
+    state: &AppState,
+    user_id: Uuid,
+    invoice_id: Uuid,
+) -> Result<VendorInvoice, (StatusCode, Json<ErrorResponse>)> {
+    let invoice = state
+        .vendor_repo
+        .find_invoice_by_id(invoice_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to load invoice: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", "Failed to load invoice")),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Invoice not found")),
+            )
+        })?;
+
+    if !is_member_or_not_found(state, user_id, invoice.organization_id).await? {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("NOT_FOUND", "Invoice not found")),
+        ));
+    }
+
+    Ok(invoice)
+}
+
 /// Create vendors router.
 pub fn router() -> Router<AppState> {
     Router::new()
@@ -218,9 +372,10 @@ pub struct PaginationQuery {
 
 async fn create_vendor(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Json(payload): Json<CreateVendorRequest>,
 ) -> Result<(StatusCode, Json<Vendor>), (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, user.user_id, payload.organization_id).await?;
     state
         .vendor_repo
         .create(payload.organization_id, payload.data)
@@ -237,9 +392,10 @@ async fn create_vendor(
 
 async fn list_vendors(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Query(query): Query<ListVendorsQuery>,
 ) -> Result<Json<Vec<Vendor>>, (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, user.user_id, query.organization_id).await?;
     state
         .vendor_repo
         .list(query.organization_id, (&query).into())
@@ -256,9 +412,10 @@ async fn list_vendors(
 
 async fn list_vendors_with_details(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Query(query): Query<ListVendorsQuery>,
 ) -> Result<Json<Vec<VendorWithDetails>>, (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, user.user_id, query.organization_id).await?;
     state
         .vendor_repo
         .list_with_details(query.organization_id, (&query).into())
@@ -275,9 +432,10 @@ async fn list_vendors_with_details(
 
 async fn get_statistics(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Query(query): Query<OrgQuery>,
 ) -> Result<Json<VendorStatistics>, (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, user.user_id, query.organization_id).await?;
     state
         .vendor_repo
         .get_statistics(query.organization_id)
@@ -294,35 +452,20 @@ async fn get_statistics(
 
 async fn get_vendor(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Vendor>, (StatusCode, Json<ErrorResponse>)> {
-    state
-        .vendor_repo
-        .find_by_id(id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to get vendor: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to get vendor")),
-            )
-        })?
-        .map(Json)
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Vendor not found")),
-            )
-        })
+    let vendor = verify_vendor_access(&state, user.user_id, id).await?;
+    Ok(Json(vendor))
 }
 
 async fn update_vendor(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateVendor>,
 ) -> Result<Json<Vendor>, (StatusCode, Json<ErrorResponse>)> {
+    verify_vendor_access(&state, user.user_id, id).await?;
     state
         .vendor_repo
         .update(id, data)
@@ -339,9 +482,10 @@ async fn update_vendor(
 
 async fn delete_vendor(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    verify_vendor_access(&state, user.user_id, id).await?;
     let deleted = state.vendor_repo.delete(id).await.map_err(|e| {
         tracing::error!("Failed to delete vendor: {:?}", e);
         (
@@ -362,10 +506,11 @@ async fn delete_vendor(
 
 async fn set_preferred(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
     Json(data): Json<PreferredRequest>,
 ) -> Result<Json<Vendor>, (StatusCode, Json<ErrorResponse>)> {
+    verify_vendor_access(&state, user.user_id, id).await?;
     state
         .vendor_repo
         .set_preferred(id, data.is_preferred)
@@ -384,10 +529,11 @@ async fn set_preferred(
 
 async fn add_contact(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
     Json(data): Json<CreateVendorContact>,
 ) -> Result<(StatusCode, Json<VendorContact>), (StatusCode, Json<ErrorResponse>)> {
+    verify_vendor_access(&state, user.user_id, id).await?;
     state
         .vendor_repo
         .add_contact(id, data)
@@ -404,9 +550,10 @@ async fn add_contact(
 
 async fn list_contacts(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Vec<VendorContact>>, (StatusCode, Json<ErrorResponse>)> {
+    verify_vendor_access(&state, user.user_id, id).await?;
     state
         .vendor_repo
         .list_contacts(id)
@@ -423,9 +570,30 @@ async fn list_contacts(
 
 async fn delete_contact(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(contact_id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    // Resolve the owning vendor and verify tenant membership before deleting,
+    // so a foreign caller cannot delete another org's contact by id (#825).
+    let vendor_id = state
+        .vendor_repo
+        .find_contact_vendor_id(contact_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to resolve contact: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", "Failed to resolve contact")),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Contact not found")),
+            )
+        })?;
+    verify_vendor_access(&state, user.user_id, vendor_id).await?;
+
     let deleted = state
         .vendor_repo
         .delete_contact(contact_id)
@@ -456,6 +624,7 @@ async fn add_rating(
     Path(id): Path<Uuid>,
     Json(data): Json<CreateVendorRating>,
 ) -> Result<(StatusCode, Json<VendorRating>), (StatusCode, Json<ErrorResponse>)> {
+    verify_vendor_access(&state, user.user_id, id).await?;
     state
         .vendor_repo
         .add_rating(id, user.user_id, data)
@@ -472,10 +641,11 @@ async fn add_rating(
 
 async fn list_ratings(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<Vec<VendorRating>>, (StatusCode, Json<ErrorResponse>)> {
+    verify_vendor_access(&state, user.user_id, id).await?;
     state
         .vendor_repo
         .list_ratings(id, query.limit.unwrap_or(50), query.offset.unwrap_or(0))
@@ -494,9 +664,10 @@ async fn list_ratings(
 
 async fn create_contract(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Json(payload): Json<CreateContractRequest>,
 ) -> Result<(StatusCode, Json<VendorContract>), (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, user.user_id, payload.organization_id).await?;
     state
         .vendor_repo
         .create_contract(payload.organization_id, payload.data)
@@ -513,9 +684,10 @@ async fn create_contract(
 
 async fn list_contracts(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Query(query): Query<ListContractsQuery>,
 ) -> Result<Json<Vec<VendorContract>>, (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, user.user_id, query.organization_id).await?;
     state
         .vendor_repo
         .list_contracts(query.organization_id, (&query).into())
@@ -532,9 +704,10 @@ async fn list_contracts(
 
 async fn get_expiring_contracts(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Query(query): Query<ExpiringQuery>,
 ) -> Result<Json<Vec<ExpiringContract>>, (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, user.user_id, query.organization_id).await?;
     state
         .vendor_repo
         .get_expiring_contracts(query.organization_id, query.days.unwrap_or(30))
@@ -554,35 +727,20 @@ async fn get_expiring_contracts(
 
 async fn get_contract(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<Json<VendorContract>, (StatusCode, Json<ErrorResponse>)> {
-    state
-        .vendor_repo
-        .find_contract_by_id(id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to get contract: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to get contract")),
-            )
-        })?
-        .map(Json)
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Contract not found")),
-            )
-        })
+    let contract = verify_contract_access(&state, user.user_id, id).await?;
+    Ok(Json(contract))
 }
 
 async fn update_contract(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateVendorContract>,
 ) -> Result<Json<VendorContract>, (StatusCode, Json<ErrorResponse>)> {
+    verify_contract_access(&state, user.user_id, id).await?;
     state
         .vendor_repo
         .update_contract(id, data)
@@ -599,9 +757,10 @@ async fn update_contract(
 
 async fn delete_contract(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    verify_contract_access(&state, user.user_id, id).await?;
     let deleted = state.vendor_repo.delete_contract(id).await.map_err(|e| {
         tracing::error!("Failed to delete contract: {:?}", e);
         (
@@ -627,6 +786,7 @@ async fn create_invoice(
     user: AuthUser,
     Json(payload): Json<CreateInvoiceRequest>,
 ) -> Result<(StatusCode, Json<VendorInvoice>), (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, user.user_id, payload.organization_id).await?;
     state
         .vendor_repo
         .create_invoice(payload.organization_id, user.user_id, payload.data)
@@ -643,9 +803,10 @@ async fn create_invoice(
 
 async fn list_invoices(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Query(query): Query<ListInvoicesQuery>,
 ) -> Result<Json<Vec<VendorInvoice>>, (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, user.user_id, query.organization_id).await?;
     state
         .vendor_repo
         .list_invoices(query.organization_id, (&query).into())
@@ -662,9 +823,10 @@ async fn list_invoices(
 
 async fn get_overdue_invoices(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Query(query): Query<OrgQuery>,
 ) -> Result<Json<Vec<VendorInvoice>>, (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, user.user_id, query.organization_id).await?;
     state
         .vendor_repo
         .get_overdue_invoices(query.organization_id)
@@ -684,9 +846,10 @@ async fn get_overdue_invoices(
 
 async fn get_invoice_summary(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Query(query): Query<InvoiceSummaryQuery>,
 ) -> Result<Json<Vec<InvoiceSummary>>, (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, user.user_id, query.organization_id).await?;
     state
         .vendor_repo
         .get_invoice_summary(query.organization_id, query.start_date, query.end_date)
@@ -706,35 +869,20 @@ async fn get_invoice_summary(
 
 async fn get_invoice(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<Json<VendorInvoice>, (StatusCode, Json<ErrorResponse>)> {
-    state
-        .vendor_repo
-        .find_invoice_by_id(id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to get invoice: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to get invoice")),
-            )
-        })?
-        .map(Json)
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Invoice not found")),
-            )
-        })
+    let invoice = verify_invoice_access(&state, user.user_id, id).await?;
+    Ok(Json(invoice))
 }
 
 async fn update_invoice(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateVendorInvoice>,
 ) -> Result<Json<VendorInvoice>, (StatusCode, Json<ErrorResponse>)> {
+    verify_invoice_access(&state, user.user_id, id).await?;
     state
         .vendor_repo
         .update_invoice(id, data)
@@ -751,9 +899,10 @@ async fn update_invoice(
 
 async fn delete_invoice(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    verify_invoice_access(&state, user.user_id, id).await?;
     let deleted = state.vendor_repo.delete_invoice(id).await.map_err(|e| {
         tracing::error!("Failed to delete invoice: {:?}", e);
         (
@@ -777,6 +926,7 @@ async fn approve_invoice(
     user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<Json<VendorInvoice>, (StatusCode, Json<ErrorResponse>)> {
+    verify_invoice_access(&state, user.user_id, id).await?;
     state
         .vendor_repo
         .approve_invoice(id, user.user_id)
@@ -797,6 +947,7 @@ async fn reject_invoice(
     Path(id): Path<Uuid>,
     Json(data): Json<RejectRequest>,
 ) -> Result<Json<VendorInvoice>, (StatusCode, Json<ErrorResponse>)> {
+    verify_invoice_access(&state, user.user_id, id).await?;
     state
         .vendor_repo
         .reject_invoice(id, user.user_id, &data.reason)
@@ -813,10 +964,11 @@ async fn reject_invoice(
 
 async fn record_payment(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
     Json(data): Json<RecordPaymentRequest>,
 ) -> Result<Json<VendorInvoice>, (StatusCode, Json<ErrorResponse>)> {
+    verify_invoice_access(&state, user.user_id, id).await?;
     state
         .vendor_repo
         .record_payment(

--- a/backend/servers/api-server/tests/vendor_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/vendor_cross_org_idor_tests.rs
@@ -1,0 +1,326 @@
+//! Regression tests for the cross-tenant IDOR fix on the vendor endpoints
+//! (`/api/v1/vendors/*`, Epic 21 — issue #825).
+//!
+//! Audit history: every vendor handler carried `AuthUser` but performed no
+//! org scoping. By-id reads/mutations (`get_vendor`, `update_vendor`,
+//! `delete_vendor`, `get_contract`, `get_invoice`, approve/reject, …) called
+//! `find_by_id(id)` with no membership check, and the org-keyed list/create
+//! paths accepted a client-supplied `organization_id` without confirming the
+//! caller belongs to it. A foreign caller could read/mutate any other org's
+//! vendor, contract or invoice by UUID, or list/write into an arbitrary org.
+//!
+//! The fix threads the authenticated `user_id` through a `verify_org_access`
+//! membership check on the org-keyed paths, and re-derives the org from the
+//! fetched row (`verify_vendor_access` / `verify_contract_access` /
+//! `verify_invoice_access`) for by-id resources — returning `404` on
+//! cross-tenant probes so "missing" and "forbidden" are indistinguishable, and
+//! `403` on org-keyed reads/writes.
+//!
+//! These tests exercise the HTTP surface end-to-end with real HS256 JWTs:
+//!   1. Seed two orgs (A, B), a member user in each, and a vendor in Org A.
+//!   2. Org B's member probes Org A's vendor → rejected (4xx); no leak / write.
+//!   3. Org A's member reads its own vendor → allowed (2xx).
+
+#[allow(dead_code)]
+mod common;
+
+use axum::http::{Method, StatusCode};
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{RequestBuilder, TestApp, TestConfig};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active') RETURNING id
+        "#,
+    )
+    .bind(format!("VendorIDOR Org {slug}"))
+    .bind(format!("vendor-idor-org-{slug}"))
+    .bind(format!("{slug}@vendor-idor.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'test_hash', 'VendorIDOR User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Make `user_id` an active member of `org_id`.
+async fn seed_membership(pool: &PgPool, org_id: Uuid, user_id: Uuid) {
+    sqlx::query(
+        r#"
+        INSERT INTO organization_members (organization_id, user_id, role_type, status, joined_at)
+        VALUES ($1, $2, 'org_admin', 'active', NOW())
+        "#,
+    )
+    .bind(org_id)
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .expect("seed membership");
+}
+
+/// Seed a vendor in `org_id` and return its id.
+async fn seed_vendor(pool: &PgPool, org_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO vendors (organization_id, company_name, status)
+        VALUES ($1, 'Acme Plumbing', 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed vendor")
+}
+
+/// Mint a real HS256 access token for `user_id`, signed with the same secret
+/// the TestApp configures into `JWT_SECRET`.
+fn mint_token(user_id: Uuid, email: &str) -> String {
+    use api_server::services::JwtService;
+    let config = TestConfig::default();
+    let jwt = JwtService::new(&config.jwt_secret).expect("jwt service");
+    jwt.generate_access_token(user_id, email, "VendorIDOR User", None, None)
+        .expect("mint access token")
+}
+
+fn assert_rejected(status: StatusCode, ctx: &str) {
+    let code = status.as_u16();
+    assert!(
+        (400..500).contains(&code),
+        "{ctx}: cross-tenant/unauthenticated request must be rejected with 4xx, got {status}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T1 — unauthenticated get_vendor is rejected
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_vendor_without_auth_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "noauth-a").await;
+    let vendor_a = seed_vendor(&pool, org_a).await;
+
+    let uri = format!("/api/v1/vendors/{vendor_a}");
+    let resp = app.execute(app.get(&uri).build()).await;
+
+    assert_rejected(resp.status, "get_vendor without bearer token");
+}
+
+// ---------------------------------------------------------------------------
+// T2 — cross-org list_vendors is rejected (information disclosure)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_vendors_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "lst-a").await;
+    let org_b = seed_org(&pool, "lst-b").await;
+    let user_b = seed_user(&pool, "lst-b@vendor-idor.test").await;
+    seed_membership(&pool, org_b, user_b).await;
+    let _vendor_a = seed_vendor(&pool, org_a).await;
+
+    // User B (member of Org B only) asks for Org A's vendors.
+    let token_b = mint_token(user_b, "lst-b@vendor-idor.test");
+    let uri = format!("/api/v1/vendors?organization_id={org_a}");
+    let resp = app.execute(app.get(&uri).bearer(&token_b).build()).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "Org B member must not list Org A vendors: {}",
+        resp.text()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T3 — cross-org get_vendor by UUID is rejected (IDOR)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_vendor_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "get-a").await;
+    let org_b = seed_org(&pool, "get-b").await;
+    let user_b = seed_user(&pool, "get-b@vendor-idor.test").await;
+    seed_membership(&pool, org_b, user_b).await;
+    let vendor_a = seed_vendor(&pool, org_a).await;
+
+    let token_b = mint_token(user_b, "get-b@vendor-idor.test");
+    let uri = format!("/api/v1/vendors/{vendor_a}");
+    let resp = app.execute(app.get(&uri).bearer(&token_b).build()).await;
+
+    assert_rejected(resp.status, "get_vendor cross-tenant");
+    // Specifically: must not 200 with Org A's vendor.
+    assert_ne!(
+        resp.status,
+        StatusCode::OK,
+        "Org A vendor must not be readable by Org B"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T4 — cross-org delete_vendor by UUID is rejected (mutate IDOR)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn delete_vendor_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "del-a").await;
+    let org_b = seed_org(&pool, "del-b").await;
+    let user_b = seed_user(&pool, "del-b@vendor-idor.test").await;
+    seed_membership(&pool, org_b, user_b).await;
+    let vendor_a = seed_vendor(&pool, org_a).await;
+
+    let token_b = mint_token(user_b, "del-b@vendor-idor.test");
+    let uri = format!("/api/v1/vendors/{vendor_a}");
+    let resp = app.execute(app.delete(&uri).bearer(&token_b).build()).await;
+
+    assert_rejected(resp.status, "delete_vendor cross-tenant");
+    assert_ne!(
+        resp.status,
+        StatusCode::NO_CONTENT,
+        "Org A vendor must not be deletable by Org B"
+    );
+
+    // The vendor row must still exist.
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM vendors WHERE id = $1")
+        .bind(vendor_a)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count, 1, "Org A vendor must not be deleted cross-tenant");
+}
+
+// ---------------------------------------------------------------------------
+// T5 — cross-org update_vendor (attacker-supplied id) is rejected (mutate IDOR)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn update_vendor_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "upd-a").await;
+    let org_b = seed_org(&pool, "upd-b").await;
+    let user_b = seed_user(&pool, "upd-b@vendor-idor.test").await;
+    seed_membership(&pool, org_b, user_b).await;
+    let vendor_a = seed_vendor(&pool, org_a).await;
+
+    let token_b = mint_token(user_b, "upd-b@vendor-idor.test");
+    let uri = format!("/api/v1/vendors/{vendor_a}");
+    let body = json!({ "company_name": "Hijacked Inc" });
+    let resp = app
+        .execute(
+            RequestBuilder::new(Method::PATCH, &uri)
+                .bearer(&token_b)
+                .json(body)
+                .build(),
+        )
+        .await;
+
+    assert_rejected(resp.status, "update_vendor cross-tenant");
+
+    // The vendor name must be unchanged.
+    let name: String = sqlx::query_scalar("SELECT company_name FROM vendors WHERE id = $1")
+        .bind(vendor_a)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        name, "Acme Plumbing",
+        "Org A vendor must not be mutated cross-tenant"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T6 — cross-org create_vendor (attacker-supplied org_id) is rejected
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_vendor_for_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "crt-a").await;
+    let org_b = seed_org(&pool, "crt-b").await;
+    let user_b = seed_user(&pool, "crt-b@vendor-idor.test").await;
+    seed_membership(&pool, org_b, user_b).await;
+
+    let token_b = mint_token(user_b, "crt-b@vendor-idor.test");
+    let body = json!({
+        "organization_id": org_a,
+        "company_name": "Injected Vendor",
+        "services": [],
+    });
+    let resp = app
+        .execute(
+            app.post("/api/v1/vendors")
+                .bearer(&token_b)
+                .json(body)
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "Org B member must not create a vendor in Org A: {}",
+        resp.text()
+    );
+
+    // No vendor row should have been created for Org A.
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM vendors WHERE organization_id = $1")
+        .bind(org_a)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count, 0, "no vendor may be created via cross-tenant POST");
+}
+
+// ---------------------------------------------------------------------------
+// T7 — legitimate same-org access succeeds
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_vendor_for_own_org_succeeds(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "own-a").await;
+    let user_a = seed_user(&pool, "own-a@vendor-idor.test").await;
+    seed_membership(&pool, org_a, user_a).await;
+    let vendor_a = seed_vendor(&pool, org_a).await;
+
+    let token_a = mint_token(user_a, "own-a@vendor-idor.test");
+    let uri = format!("/api/v1/vendors/{vendor_a}");
+    let resp = app.execute(app.get(&uri).bearer(&token_a).build()).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "Org A member must be able to read its own vendor: {}",
+        resp.text()
+    );
+    let vendor = resp.json_value();
+    assert_eq!(
+        vendor.get("id").and_then(|v| v.as_str()),
+        Some(vendor_a.to_string().as_str()),
+        "expected the owning org's vendor, got {vendor}"
+    );
+}


### PR DESCRIPTION
## Task

Issue #825 (Epic 21 — Vendor Management): every handler in `routes/vendors.rs` carried `AuthUser` but performed **no org scoping**. By-id reads/mutations (`get_vendor`, `update_vendor`, `delete_vendor`, `set_preferred`, contacts, ratings, `get_contract`/`update`/`delete`, `get_invoice`/`update`/`delete`/`approve`/`reject`/`record_payment`) called `find_by_id(id)` with no membership check (cross-org IDOR), and org-keyed list/create paths accepted a client-supplied `organization_id` without confirming the caller belongs to it.

## Fix

Reused the **existing `verify_org_access` idiom** from `routes/financial.rs` (#802) / `routes/integrations/sync.rs`:

- **Org-keyed paths** (`create_vendor`, `list_vendors`, `list_vendors_with_details`, `get_statistics`, `create_contract`, `list_contracts`, `get_expiring_contracts`, `create_invoice`, `list_invoices`, `get_overdue_invoices`, `get_invoice_summary`) → `verify_org_access(&state, user.user_id, organization_id)` against the client-supplied org → **403** for non-members. Org is verified, never trusted.
- **By-id resources** → `verify_vendor_access` / `verify_contract_access` / `verify_invoice_access` re-derive the org from the fetched row and check membership, returning **404** on cross-tenant probes (mirrors `verify_account_access`). Covers get/update/delete/set_preferred/contacts/ratings/contract get-update-delete/invoice get-update-delete-approve-reject-record_payment.
- **`delete_contact`** (path is `contact_id`, no org on the row): added repo helper `find_contact_vendor_id` to resolve the owning vendor, then `verify_vendor_access`.

No client-supplied `organization_id` is trusted on its own anymore.

### Deferred
- **P2 (manager approval role check)** on invoice approve/reject: out of scope here — no role-helper idiom exists in `financial.rs`/`work_orders.rs` to mirror, and the P1 IDOR (cross-tenant) is fully closed. Left for a follow-up that introduces a shared role gate.

## Owner
pm-security

## Tested (Band A)
- `cargo fmt --all` → exit 0
- `cargo clippy -p api-server --lib -- -D warnings` → Finished, 0 warnings
- `cargo test -p api-server --test vendor_cross_org_idor_tests` → **7 passed; 0 failed**

New IG3 test `tests/vendor_cross_org_idor_tests.rs` (fails on `dev` before this fix):
- get_vendor without auth → rejected
- list_vendors cross-org → 403
- get_vendor cross-org by UUID → not-200 (404)
- delete_vendor cross-org → row still present
- update_vendor cross-org → name unchanged
- create_vendor with attacker org_id → 403, no row created
- get_vendor same-org → 200

## Built (Band B)
Covered by the clippy lib check + integration test compile/run above (release build skipped — security route change, no build-output/config impact).

## CI parity (Band C)
Backend CI runs `cargo fmt` / `clippy -D warnings` / `cargo test` — all replicated locally and green.

## Remote-tested
skipped

## Notes
`find_contact_vendor_id` uses runtime `query_scalar` (not the sqlx macro), so no `.sqlx` offline-cache regeneration is needed.