### PR TITLE
fix(security): scope multi-currency & violations reads to authenticated tenant (closes #850)

### DIFF
--- a/backend/crates/db/src/repositories/multi_currency.rs
+++ b/backend/crates/db/src/repositories/multi_currency.rs
@@ -205,10 +205,11 @@ impl MultiCurrencyRepository {
         Ok(config)
     }
 
-    /// Get property currency configuration
+    /// Get property currency configuration scoped to an organization.
     pub async fn get_property_currency_config(
         &self,
         building_id: Uuid,
+        org_id: Uuid,
     ) -> Result<Option<PropertyCurrencyConfig>, AppError> {
         let config = sqlx::query_as::<_, PropertyCurrencyConfig>(
             r#"
@@ -217,10 +218,11 @@ impl MultiCurrencyRepository {
                    requires_local_reporting, local_accounting_format,
                    created_at, updated_at
             FROM property_currency_config
-            WHERE building_id = $1
+            WHERE building_id = $1 AND organization_id = $2
             "#,
         )
         .bind(building_id)
+        .bind(org_id)
         .fetch_optional(&self.pool)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;

--- a/backend/crates/db/src/repositories/violations.rs
+++ b/backend/crates/db/src/repositories/violations.rs
@@ -72,11 +72,19 @@ impl ViolationRepository {
     }
 
     /// Get a community rule by ID.
-    pub async fn get_rule(&self, rule_id: Uuid) -> Result<Option<CommunityRule>, sqlx::Error> {
-        sqlx::query_as::<_, CommunityRule>("SELECT * FROM community_rules WHERE id = $1")
-            .bind(rule_id)
-            .fetch_optional(&self.pool)
-            .await
+    /// Get a single community rule scoped to an organization (tenant-safe read).
+    pub async fn get_rule_for_org(
+        &self,
+        rule_id: Uuid,
+        org_id: Uuid,
+    ) -> Result<Option<CommunityRule>, sqlx::Error> {
+        sqlx::query_as::<_, CommunityRule>(
+            "SELECT * FROM community_rules WHERE id = $1 AND organization_id = $2",
+        )
+        .bind(rule_id)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await
     }
 
     /// List community rules for an organization.
@@ -231,14 +239,19 @@ impl ViolationRepository {
     }
 
     /// Get a violation by ID.
-    pub async fn get_violation(
+    /// Get a single violation scoped to an organization (tenant-safe read).
+    pub async fn get_violation_for_org(
         &self,
         violation_id: Uuid,
+        org_id: Uuid,
     ) -> Result<Option<Violation>, sqlx::Error> {
-        sqlx::query_as::<_, Violation>("SELECT * FROM violations WHERE id = $1")
-            .bind(violation_id)
-            .fetch_optional(&self.pool)
-            .await
+        sqlx::query_as::<_, Violation>(
+            "SELECT * FROM violations WHERE id = $1 AND organization_id = $2",
+        )
+        .bind(violation_id)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await
     }
 
     /// List violations with filters.
@@ -477,14 +490,19 @@ impl ViolationRepository {
     }
 
     /// Get an enforcement action by ID.
-    pub async fn get_enforcement_action(
+    /// Get a single enforcement action scoped to an organization (tenant-safe read).
+    pub async fn get_enforcement_action_for_org(
         &self,
         action_id: Uuid,
+        org_id: Uuid,
     ) -> Result<Option<EnforcementAction>, sqlx::Error> {
-        sqlx::query_as::<_, EnforcementAction>("SELECT * FROM enforcement_actions WHERE id = $1")
-            .bind(action_id)
-            .fetch_optional(&self.pool)
-            .await
+        sqlx::query_as::<_, EnforcementAction>(
+            "SELECT * FROM enforcement_actions WHERE id = $1 AND organization_id = $2",
+        )
+        .bind(action_id)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await
     }
 
     /// List enforcement actions.
@@ -637,6 +655,21 @@ impl ViolationRepository {
             .bind(appeal_id)
             .fetch_optional(&self.pool)
             .await
+    }
+
+    /// Get a single appeal scoped to an organization (tenant-safe read).
+    pub async fn get_appeal_for_org(
+        &self,
+        appeal_id: Uuid,
+        org_id: Uuid,
+    ) -> Result<Option<ViolationAppeal>, sqlx::Error> {
+        sqlx::query_as::<_, ViolationAppeal>(
+            "SELECT * FROM violation_appeals WHERE id = $1 AND organization_id = $2",
+        )
+        .bind(appeal_id)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await
     }
 
     /// List appeals.

--- a/backend/servers/api-server/src/routes/multi_currency.rs
+++ b/backend/servers/api-server/src/routes/multi_currency.rs
@@ -226,12 +226,19 @@ async fn create_property_currency_config(
 /// Get property currency configuration
 async fn get_property_currency_config(
     State(s): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(building_id): Path<Uuid>,
 ) -> ApiResult<Json<serde_json::Value>> {
+    let org_id = user.tenant_id.ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::bad_request("Tenant context required")),
+        )
+    })?;
+
     match s
         .multi_currency_repo
-        .get_property_currency_config(building_id)
+        .get_property_currency_config(building_id, org_id)
         .await
     {
         Ok(Some(config)) => Ok(Json(to_json_value(config)?)),

--- a/backend/servers/api-server/src/routes/violations.rs
+++ b/backend/servers/api-server/src/routes/violations.rs
@@ -114,12 +114,16 @@ async fn create_rule(
 
 async fn get_rule(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(rule_id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::violations::CommunityRule>> {
+    let org_id = user
+        .tenant_id
+        .ok_or_else(|| forbidden_error("No organization context"))?;
+
     state
         .violation_repo
-        .get_rule(rule_id)
+        .get_rule_for_org(rule_id, org_id)
         .await
         .map_err(|e| internal_error(&format!("Failed to get rule: {}", e)))?
         .ok_or_else(|| not_found_error("Rule not found"))
@@ -208,12 +212,16 @@ async fn create_violation(
 
 async fn get_violation(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(violation_id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::violations::Violation>> {
+    let org_id = user
+        .tenant_id
+        .ok_or_else(|| forbidden_error("No organization context"))?;
+
     state
         .violation_repo
-        .get_violation(violation_id)
+        .get_violation_for_org(violation_id, org_id)
         .await
         .map_err(|e| internal_error(&format!("Failed to get violation: {}", e)))?
         .ok_or_else(|| not_found_error("Violation not found"))
@@ -343,12 +351,16 @@ async fn create_action(
 
 async fn get_action(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path((_violation_id, action_id)): Path<(Uuid, Uuid)>,
 ) -> ApiResult<Json<db::models::violations::EnforcementAction>> {
+    let org_id = user
+        .tenant_id
+        .ok_or_else(|| forbidden_error("No organization context"))?;
+
     state
         .violation_repo
-        .get_enforcement_action(action_id)
+        .get_enforcement_action_for_org(action_id, org_id)
         .await
         .map_err(|e| internal_error(&format!("Failed to get action: {}", e)))?
         .ok_or_else(|| not_found_error("Action not found"))
@@ -462,12 +474,16 @@ async fn create_appeal(
 
 async fn get_appeal(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(appeal_id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::violations::ViolationAppeal>> {
+    let org_id = user
+        .tenant_id
+        .ok_or_else(|| forbidden_error("No organization context"))?;
+
     state
         .violation_repo
-        .get_appeal(appeal_id)
+        .get_appeal_for_org(appeal_id, org_id)
         .await
         .map_err(|e| internal_error(&format!("Failed to get appeal: {}", e)))?
         .ok_or_else(|| not_found_error("Appeal not found"))

--- a/backend/servers/api-server/tests/multi_currency_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/multi_currency_cross_org_idor_tests.rs
@@ -1,0 +1,197 @@
+//! Regression tests for the cross-org IDOR fix on multi-currency reads (#850).
+//!
+//! Audit history: `get_property_currency_config` in
+//! `servers/api-server/src/routes/multi_currency.rs` authenticated the caller
+//! but loaded the property currency config by `building_id` only — the repo
+//! query was `... WHERE building_id = $1`, with no organization predicate. Any
+//! authenticated user who knew (or guessed) another org's `building_id` could
+//! read that org's currency/tax configuration. The UPDATE path already scoped
+//! by `organization_id`; the read path did not.
+//!
+//! The fix threads the verified `org_id` (JWT `tenant_id`) into the repository
+//! so the SQL is org-scoped:
+//!   `... WHERE building_id = $1 AND organization_id = $2`
+//! A foreign-org row therefore surfaces as `None` → HTTP 404, never a
+//! cross-tenant read.
+//!
+//! Tenancy here comes straight from the JWT `tenant_id` claim, which `AuthUser`
+//! reads without a DB membership lookup. That lets these tests mint a real
+//! access token per org and drive the handler end-to-end:
+//!   - Org A's token reading Org A's property config -> 200 (same-org succeeds).
+//!   - Org B's token reading Org A's property config -> 404 (cross-org blocked).
+
+#[allow(dead_code)]
+mod common;
+
+use axum::http::StatusCode;
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::Serialize;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{TestApp, TestConfig};
+
+// ---------------------------------------------------------------------------
+// JWT minting (matches api_core::extractors::auth::Claims)
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct TestClaims {
+    sub: Uuid,
+    exp: i64,
+    iat: i64,
+    token_type: String,
+    tenant_id: Option<Uuid>,
+    role: Option<String>,
+    email: String,
+    name: String,
+}
+
+/// Mint an access token bound to `org_id` (the JWT `tenant_id` claim), signed
+/// with the same secret `TestApp` configures.
+fn access_token(user_id: Uuid, org_id: Uuid) -> String {
+    let now = chrono::Utc::now().timestamp();
+    let claims = TestClaims {
+        sub: user_id,
+        exp: now + 3600,
+        iat: now,
+        token_type: "access".to_string(),
+        tenant_id: Some(org_id),
+        role: Some("manager".to_string()),
+        email: "idor-test@multi-currency.test".to_string(),
+        name: "MultiCurrency IDOR User".to_string(),
+    };
+    let secret = TestConfig::default().jwt_secret;
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .expect("encode test JWT")
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active') RETURNING id
+        "#,
+    )
+    .bind(format!("MultiCurrencyIDOR Org {slug}"))
+    .bind(format!("mc-idor-{slug}"))
+    .bind(format!("{slug}@mc-idor.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'test_hash', 'MultiCurrencyIDOR User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_building(pool: &PgPool, org_id: Uuid, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO buildings (organization_id, street, city, postal_code, country)
+        VALUES ($1, $2, 'Bratislava', '81101', 'Slovakia') RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(format!("{slug} Street 1"))
+    .fetch_one(pool)
+    .await
+    .expect("seed building")
+}
+
+async fn seed_property_currency_config(pool: &PgPool, org_id: Uuid, building_id: Uuid) {
+    sqlx::query(
+        r#"
+        INSERT INTO property_currency_config (building_id, organization_id, default_currency, country)
+        VALUES ($1, $2, 'EUR', 'SK')
+        "#,
+    )
+    .bind(building_id)
+    .bind(org_id)
+    .execute(pool)
+    .await
+    .expect("seed property currency config");
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: same-org read succeeds
+// ---------------------------------------------------------------------------
+
+/// A user whose JWT `tenant_id` matches the building's organization can read
+/// the property currency config.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_property_currency_config_same_org_succeeds(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let user = seed_user(&pool, "same-org@mc-idor.test").await;
+    let org_a = seed_org(&pool, "same-a").await;
+    let building_id = seed_building(&pool, org_a, "same-a").await;
+    seed_property_currency_config(&pool, org_a, building_id).await;
+
+    let token = access_token(user, org_a);
+    let req = app
+        .get(&format!("/api/v1/multi-currency/properties/{building_id}"))
+        .bearer(&token)
+        .build();
+    let resp = app.execute(req).await;
+
+    resp.assert_status(StatusCode::OK);
+    let body = resp.json_value();
+    assert_eq!(
+        body["building_id"].as_str(),
+        Some(building_id.to_string().as_str()),
+        "same-org read must return the requested property config"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: cross-org read is blocked (404)
+// ---------------------------------------------------------------------------
+
+/// A user from Org B cannot read Org A's property currency config by
+/// building id — the org-scoped query finds no row and the handler returns
+/// 404 (the core #850 IDOR).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_property_currency_config_cross_org_is_not_found(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let user_b = seed_user(&pool, "attacker@mc-idor.test").await;
+    let org_a = seed_org(&pool, "x-a").await;
+    let org_b = seed_org(&pool, "x-b").await;
+    let building_id = seed_building(&pool, org_a, "x-a").await;
+    seed_property_currency_config(&pool, org_a, building_id).await;
+
+    // Org B token targeting Org A's building.
+    let token = access_token(user_b, org_b);
+    let req = app
+        .get(&format!("/api/v1/multi-currency/properties/{building_id}"))
+        .bearer(&token)
+        .build();
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::NOT_FOUND,
+        "cross-org property config read must be 404, got {} (body: {})",
+        resp.status,
+        resp.text()
+    );
+}

--- a/backend/servers/api-server/tests/violations_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/violations_cross_org_idor_tests.rs
@@ -1,0 +1,183 @@
+//! Regression tests for the cross-org IDOR fix on violation reads (#850).
+//!
+//! Audit history: `get_violation` in
+//! `servers/api-server/src/routes/violations.rs` authenticated the caller but
+//! called `get_violation(id)` whose repo query was
+//! `SELECT * FROM violations WHERE id = $1` — no organization predicate. Any
+//! authenticated user who knew (or guessed) another org's `violation_id` could
+//! read that org's violation record (and likewise for `get_rule`, `get_action`,
+//! `get_appeal`). `list_violations` correctly scoped by `organization_id`; the
+//! by-id reads did not.
+//!
+//! The fix adds `_for_org` repository variants
+//!   `SELECT * FROM violations WHERE id = $1 AND organization_id = $2`
+//! and threads the verified `org_id` (JWT `tenant_id`) into them. A foreign-org
+//! row therefore surfaces as `None` → HTTP 404, never a cross-tenant read.
+//!
+//! Tenancy here comes straight from the JWT `tenant_id` claim, which `AuthUser`
+//! reads without a DB membership lookup. That lets these tests mint a real
+//! access token per org and drive the handler end-to-end:
+//!   - Org A's token reading Org A's violation -> 200 (same-org succeeds).
+//!   - Org B's token reading Org A's violation -> 404 (cross-org blocked).
+
+#[allow(dead_code)]
+mod common;
+
+use axum::http::StatusCode;
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::Serialize;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{TestApp, TestConfig};
+
+// ---------------------------------------------------------------------------
+// JWT minting (matches api_core::extractors::auth::Claims)
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct TestClaims {
+    sub: Uuid,
+    exp: i64,
+    iat: i64,
+    token_type: String,
+    tenant_id: Option<Uuid>,
+    role: Option<String>,
+    email: String,
+    name: String,
+}
+
+/// Mint an access token bound to `org_id` (the JWT `tenant_id` claim), signed
+/// with the same secret `TestApp` configures.
+fn access_token(user_id: Uuid, org_id: Uuid) -> String {
+    let now = chrono::Utc::now().timestamp();
+    let claims = TestClaims {
+        sub: user_id,
+        exp: now + 3600,
+        iat: now,
+        token_type: "access".to_string(),
+        tenant_id: Some(org_id),
+        role: Some("manager".to_string()),
+        email: "idor-test@violations.test".to_string(),
+        name: "Violations IDOR User".to_string(),
+    };
+    let secret = TestConfig::default().jwt_secret;
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .expect("encode test JWT")
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active') RETURNING id
+        "#,
+    )
+    .bind(format!("ViolationsIDOR Org {slug}"))
+    .bind(format!("vio-idor-{slug}"))
+    .bind(format!("{slug}@vio-idor.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'test_hash', 'ViolationsIDOR User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_violation(pool: &PgPool, org_id: Uuid, number: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO violations (
+            organization_id, violation_number, category, title, description, occurred_at
+        )
+        VALUES ($1, $2, 'noise', 'Loud party', 'Excessive noise after 22:00', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(number)
+    .fetch_one(pool)
+    .await
+    .expect("seed violation")
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: same-org read succeeds
+// ---------------------------------------------------------------------------
+
+/// A user whose JWT `tenant_id` matches the violation's organization can read
+/// it.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_violation_same_org_succeeds(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let user = seed_user(&pool, "same-org@vio-idor.test").await;
+    let org_a = seed_org(&pool, "same-a").await;
+    let violation_id = seed_violation(&pool, org_a, "VIO-SAME-0001").await;
+
+    let token = access_token(user, org_a);
+    let req = app
+        .get(&format!("/api/v1/violations/{violation_id}"))
+        .bearer(&token)
+        .build();
+    let resp = app.execute(req).await;
+
+    resp.assert_status(StatusCode::OK);
+    let body = resp.json_value();
+    assert_eq!(
+        body["id"].as_str(),
+        Some(violation_id.to_string().as_str()),
+        "same-org read must return the requested violation"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: cross-org read is blocked (404)
+// ---------------------------------------------------------------------------
+
+/// A user from Org B cannot read Org A's violation by id — the org-scoped
+/// query finds no row and the handler returns 404 (the core #850 IDOR).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_violation_cross_org_is_not_found(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let user_b = seed_user(&pool, "attacker@vio-idor.test").await;
+    let org_a = seed_org(&pool, "x-a").await;
+    let org_b = seed_org(&pool, "x-b").await;
+    let violation_id = seed_violation(&pool, org_a, "VIO-X-0001").await;
+
+    // Org B token targeting Org A's violation.
+    let token = access_token(user_b, org_b);
+    let req = app
+        .get(&format!("/api/v1/violations/{violation_id}"))
+        .bearer(&token)
+        .build();
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::NOT_FOUND,
+        "cross-org violation read must be 404, got {} (body: {})",
+        resp.status,
+        resp.text()
+    );
+}


### PR DESCRIPTION
## Summary

Closes #850 (remaining IDOR slice on Epics 61 + 42).

Two by-id read paths authenticated the caller but loaded resources without an organization predicate, allowing any authenticated user to read another org's data by guessing a UUID. The UPDATE paths were already org-scoped — these reads were not.

- `routes/multi_currency.rs` — `get_property_currency_config` now extracts `org_id` from the JWT `tenant_id` and passes it to the repo, mirroring the existing `update_property_currency_config` org check. Repo query changed to `WHERE building_id = $1 AND organization_id = $2`.
- `routes/violations.rs` — `get_violation`, `get_rule`, `get_action`, `get_appeal` now scope by org via new `*_for_org(id, org_id)` repo variants (`WHERE id = $1 AND organization_id = $2`), matching the `reserve_funds` `get_fund(org_id, fund_id)` idiom. The now-unused insecure `get_violation`/`get_rule`/`get_enforcement_action` repo methods were removed; `get_appeal` is retained (still used internally by `decide_appeal`).

Foreign-org rows now surface as `None` → HTTP 404 (no cross-tenant read).

## Org mechanism

Both route groups resolve org from the server-trusted JWT `tenant_id` claim via `AuthUser` (no client-supplied org header, no DB membership lookup). So the `_for_org` / org-predicate idiom is the correct mechanism here, not `verify_org_access` (which validates a client-supplied `organization_id`).

## Tested (Band A — fast check)

```
$ cargo fmt --all                                   # exit 0
$ cargo clippy -p api-server --lib -- -D warnings    # exit 0 (Finished, no warnings)
$ DATABASE_URL=... cargo test -p api-server \
    --test multi_currency_cross_org_idor_tests \
    --test violations_cross_org_idor_tests
running 2 tests
test get_property_currency_config_cross_org_is_not_found ... ok
test get_property_currency_config_same_org_succeeds ... ok
test result: ok. 2 passed; 0 failed

running 2 tests
test get_violation_cross_org_is_not_found ... ok
test get_violation_same_org_succeeds ... ok
test result: ok. 2 passed; 0 failed
```

Each suite includes a **same-org success (200)** case alongside the cross-org **404** case, proving real tenant context is established end-to-end (token minted with the resource's org → 200; token minted with a different org → 404).

## Notes / deferred

- Data residency (Epic 146, P2 stub) deferred — non-trivial (requires persisting config per org or returning 501); out of scope for this IDOR slice.
- These queries use runtime `query_as` (not compile-time macros), so no `.sqlx` offline cache regeneration was needed.