### PR TITLE
fix(security): scope emergency routes to authenticated tenant (closes #827)

### DIFF
--- a/backend/servers/api-server/src/routes/emergency.rs
+++ b/backend/servers/api-server/src/routes/emergency.rs
@@ -6,7 +6,7 @@ use api_core::extractors::AuthUser;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
-    response::IntoResponse,
+    response::{IntoResponse, Response},
     routing::{delete, get, post, put},
     Json, Router,
 };
@@ -23,6 +23,168 @@ use utoipa::IntoParams;
 use uuid::Uuid;
 
 use crate::state::AppState;
+
+// ============================================
+// Tenant-isolation helpers (issue #827)
+// ============================================
+//
+// Every emergency handler used to trust a client-supplied `organization_id`
+// (query param or JSON body) and pass it straight to the repository, so any
+// authenticated user could read or mutate another org's protocols, incidents,
+// broadcasts, contacts and drills simply by supplying the victim org's UUID.
+//
+// The fix mirrors the `verify_org_access` idiom in `routes/vendors.rs` (#825)
+// and `routes/financial.rs` (#802): the client-supplied org is never trusted on
+// its own; it is only accepted once the authenticated principal is confirmed to
+// be an active member of it. Cross-tenant callers get `403 FORBIDDEN` on the
+// org-keyed paths. The repository's by-id queries are already keyed on
+// `(id, organization_id)`, so once the org is verified a foreign UUID resolves
+// to `None` → `404`, leaving "missing" and "forbidden" indistinguishable.
+
+/// Membership check that maps DB errors to a `500` response but returns a plain
+/// bool for the membership outcome, letting the caller pick 403 vs 404.
+async fn is_org_member(state: &AppState, user_id: Uuid, org_id: Uuid) -> Result<bool, Response> {
+    state
+        .org_member_repo
+        .is_member(org_id, user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = ?e, "Failed to check org membership");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DATABASE_ERROR", "Database error")),
+            )
+                .into_response()
+        })
+}
+
+/// Verify the authenticated user is an active member of `org_id`. Returns a
+/// ready-to-send `403` response on mismatch, so callers can simply
+/// `if let Err(resp) = verify_org_access(..).await { return resp; }`.
+async fn verify_org_access(state: &AppState, user_id: Uuid, org_id: Uuid) -> Result<(), Response> {
+    if !is_org_member(state, user_id, org_id).await? {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "FORBIDDEN",
+                "You are not a member of this organization",
+            )),
+        )
+            .into_response());
+    }
+    Ok(())
+}
+
+/// Verify the authenticated user has at least manager-level authority in
+/// `org_id`. Used to gate mass-notification / incident-creation actions
+/// (broadcast + incident create — issue #827). Membership is checked first
+/// (403 for non-members), then role: org_admin / manager and the
+/// platform-level admin roles pass; ordinary residents/owners get `403`.
+async fn verify_org_manager(state: &AppState, user_id: Uuid, org_id: Uuid) -> Result<(), Response> {
+    verify_org_access(state, user_id, org_id).await?;
+
+    let role_type = state
+        .org_member_repo
+        .get_user_role_type(org_id, user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = ?e, "Failed to load org role");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DATABASE_ERROR", "Database error")),
+            )
+                .into_response()
+        })?;
+
+    let is_manager = matches!(
+        role_type.as_deref().map(str::to_lowercase).as_deref(),
+        Some("super_admin" | "superadmin" | "platform_admin" | "platformadmin")
+            | Some("org_admin" | "orgadmin")
+            | Some("manager")
+    );
+
+    if !is_manager {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "FORBIDDEN",
+                "Manager role required for this action",
+            )),
+        )
+            .into_response());
+    }
+    Ok(())
+}
+
+/// Verify the caller is a member of `org_id` AND that `incident_id` belongs to
+/// it. Used for the incident sub-resources (attachments / updates) whose repo
+/// methods key only on `incident_id` and therefore cannot self-scope. Returns
+/// `404` when the incident does not exist in the caller's org so a foreign
+/// incident UUID is indistinguishable from a missing one.
+async fn verify_incident_in_org(
+    state: &AppState,
+    user_id: Uuid,
+    org_id: Uuid,
+    incident_id: Uuid,
+) -> Result<(), Response> {
+    verify_org_access(state, user_id, org_id).await?;
+
+    let found = state
+        .emergency_repo
+        .find_incident_by_id(org_id, incident_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = ?e, "Failed to load incident");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", "Database error")),
+            )
+                .into_response()
+        })?;
+
+    if found.is_none() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("NOT_FOUND", "Incident not found")),
+        )
+            .into_response());
+    }
+    Ok(())
+}
+
+/// Verify the caller is a member of `org_id` AND that `broadcast_id` belongs to
+/// it. Used for the broadcast sub-resources (acknowledge / acknowledgments)
+/// whose repo methods key only on `broadcast_id`. `404` on cross-tenant.
+async fn verify_broadcast_in_org(
+    state: &AppState,
+    user_id: Uuid,
+    org_id: Uuid,
+    broadcast_id: Uuid,
+) -> Result<(), Response> {
+    verify_org_access(state, user_id, org_id).await?;
+
+    let found = state
+        .emergency_repo
+        .find_broadcast_by_id(org_id, broadcast_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = ?e, "Failed to load broadcast");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", "Database error")),
+            )
+                .into_response()
+        })?;
+
+    if found.is_none() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("NOT_FOUND", "Broadcast not found")),
+        )
+            .into_response());
+    }
+    Ok(())
+}
 
 // ============================================
 // Query Parameter Types
@@ -262,6 +424,9 @@ async fn create_protocol(
     auth: AuthUser,
     Json(req): Json<CreateProtocolRequest>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, req.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .create_protocol(req.organization_id, auth.user_id, req.data)
@@ -281,9 +446,12 @@ async fn create_protocol(
 
 async fn list_protocols(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Query(query): Query<ProtocolListQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .list_protocols(query.organization_id, EmergencyProtocolQuery::from(&query))
@@ -303,10 +471,13 @@ async fn list_protocols(
 
 async fn get_protocol(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
     Query(query): Query<OrgQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .find_protocol_by_id(query.organization_id, id)
@@ -339,10 +510,13 @@ pub struct UpdateProtocolRequest {
 
 async fn update_protocol(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateProtocolRequest>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, req.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .update_protocol(req.organization_id, id, req.data)
@@ -367,10 +541,13 @@ async fn update_protocol(
 
 async fn delete_protocol(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
     Query(query): Query<OrgQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .delete_protocol(query.organization_id, id)
@@ -399,9 +576,12 @@ async fn delete_protocol(
 
 async fn create_contact(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Json(req): Json<CreateContactRequest>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, req.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .create_contact(req.organization_id, req.data)
@@ -421,9 +601,12 @@ async fn create_contact(
 
 async fn list_contacts(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Query(query): Query<ContactListQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .list_contacts(query.organization_id, EmergencyContactQuery::from(&query))
@@ -443,10 +626,13 @@ async fn list_contacts(
 
 async fn get_contact(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
     Query(query): Query<OrgQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .find_contact_by_id(query.organization_id, id)
@@ -479,10 +665,13 @@ pub struct UpdateContactRequest {
 
 async fn update_contact(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateContactRequest>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, req.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .update_contact(req.organization_id, id, req.data)
@@ -507,10 +696,13 @@ async fn update_contact(
 
 async fn delete_contact(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
     Query(query): Query<OrgQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .delete_contact(query.organization_id, id)
@@ -542,6 +734,9 @@ async fn create_incident(
     auth: AuthUser,
     Json(req): Json<CreateIncidentRequest>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_manager(&state, auth.user_id, req.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .create_incident(req.organization_id, auth.user_id, req.data)
@@ -561,9 +756,12 @@ async fn create_incident(
 
 async fn list_incidents(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Query(query): Query<IncidentListQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .list_incidents(query.organization_id, EmergencyIncidentQuery::from(&query))
@@ -583,9 +781,12 @@ async fn list_incidents(
 
 async fn get_active_incidents(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Query(query): Query<OrgQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .get_active_incidents(query.organization_id)
@@ -605,10 +806,13 @@ async fn get_active_incidents(
 
 async fn get_incident(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
     Query(query): Query<OrgQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .find_incident_by_id(query.organization_id, id)
@@ -641,10 +845,13 @@ pub struct UpdateIncidentRequest {
 
 async fn update_incident(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateIncidentRequest>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, req.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .update_incident(req.organization_id, id, req.data)
@@ -669,10 +876,13 @@ async fn update_incident(
 
 async fn acknowledge_incident(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
     Query(query): Query<OrgQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_manager(&state, auth.user_id, query.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .acknowledge_incident(query.organization_id, id)
@@ -710,6 +920,9 @@ async fn resolve_incident(
     Path(id): Path<Uuid>,
     Json(req): Json<ResolveIncidentRequest>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, req.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .resolve_incident(req.organization_id, id, auth.user_id, &req.resolution)
@@ -734,10 +947,13 @@ async fn resolve_incident(
 
 async fn close_incident(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
     Query(query): Query<OrgQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .close_incident(query.organization_id, id)
@@ -767,8 +983,13 @@ async fn add_incident_attachment(
     State(state): State<AppState>,
     auth: AuthUser,
     Path(id): Path<Uuid>,
+    Query(query): Query<OrgQuery>,
     Json(data): Json<AddIncidentAttachment>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_incident_in_org(&state, auth.user_id, query.organization_id, id).await
+    {
+        return resp;
+    }
     match state
         .emergency_repo
         .add_incident_attachment(id, auth.user_id, data)
@@ -788,9 +1009,14 @@ async fn add_incident_attachment(
 
 async fn list_incident_attachments(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
+    Query(query): Query<OrgQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_incident_in_org(&state, auth.user_id, query.organization_id, id).await
+    {
+        return resp;
+    }
     match state.emergency_repo.list_incident_attachments(id).await {
         Ok(attachments) => Json(attachments).into_response(),
         Err(e) => {
@@ -808,8 +1034,13 @@ async fn add_incident_update(
     State(state): State<AppState>,
     auth: AuthUser,
     Path(id): Path<Uuid>,
+    Query(query): Query<OrgQuery>,
     Json(data): Json<CreateIncidentUpdate>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_incident_in_org(&state, auth.user_id, query.organization_id, id).await
+    {
+        return resp;
+    }
     match state
         .emergency_repo
         .add_incident_update(id, auth.user_id, data)
@@ -829,9 +1060,14 @@ async fn add_incident_update(
 
 async fn list_incident_updates(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
+    Query(query): Query<OrgQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_incident_in_org(&state, auth.user_id, query.organization_id, id).await
+    {
+        return resp;
+    }
     match state.emergency_repo.list_incident_updates(id).await {
         Ok(updates) => Json(updates).into_response(),
         Err(e) => {
@@ -854,6 +1090,9 @@ async fn create_broadcast(
     auth: AuthUser,
     Json(req): Json<CreateBroadcastRequest>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_manager(&state, auth.user_id, req.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .create_broadcast(req.organization_id, auth.user_id, req.data)
@@ -873,9 +1112,12 @@ async fn create_broadcast(
 
 async fn list_broadcasts(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Query(query): Query<BroadcastListQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .list_broadcasts(query.organization_id, EmergencyBroadcastQuery::from(&query))
@@ -895,10 +1137,13 @@ async fn list_broadcasts(
 
 async fn get_broadcast(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
     Query(query): Query<OrgQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .find_broadcast_by_id(query.organization_id, id)
@@ -923,10 +1168,13 @@ async fn get_broadcast(
 
 async fn deactivate_broadcast(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
     Query(query): Query<OrgQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_manager(&state, auth.user_id, query.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .deactivate_broadcast(query.organization_id, id)
@@ -953,8 +1201,14 @@ async fn acknowledge_broadcast(
     State(state): State<AppState>,
     auth: AuthUser,
     Path(id): Path<Uuid>,
+    Query(query): Query<OrgQuery>,
     Json(data): Json<AcknowledgeBroadcast>,
 ) -> impl IntoResponse {
+    if let Err(resp) =
+        verify_broadcast_in_org(&state, auth.user_id, query.organization_id, id).await
+    {
+        return resp;
+    }
     match state
         .emergency_repo
         .acknowledge_broadcast(id, auth.user_id, data)
@@ -974,9 +1228,15 @@ async fn acknowledge_broadcast(
 
 async fn list_broadcast_acknowledgments(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
+    Query(query): Query<OrgQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) =
+        verify_broadcast_in_org(&state, auth.user_id, query.organization_id, id).await
+    {
+        return resp;
+    }
     match state
         .emergency_repo
         .list_broadcast_acknowledgments(id)
@@ -1003,6 +1263,9 @@ async fn create_drill(
     auth: AuthUser,
     Json(req): Json<CreateDrillRequest>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, req.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .create_drill(req.organization_id, auth.user_id, req.data)
@@ -1022,9 +1285,12 @@ async fn create_drill(
 
 async fn list_drills(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Query(query): Query<DrillListQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .list_drills(query.organization_id, EmergencyDrillQuery::from(&query))
@@ -1050,9 +1316,12 @@ struct UpcomingDrillsQuery {
 
 async fn get_upcoming_drills(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Query(query): Query<UpcomingDrillsQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
+        return resp;
+    }
     let days = query.days.unwrap_or(30);
     match state
         .emergency_repo
@@ -1073,10 +1342,13 @@ async fn get_upcoming_drills(
 
 async fn get_drill(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
     Query(query): Query<OrgQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .find_drill_by_id(query.organization_id, id)
@@ -1109,10 +1381,13 @@ pub struct UpdateDrillRequest {
 
 async fn update_drill(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateDrillRequest>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, req.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .update_drill(req.organization_id, id, req.data)
@@ -1137,10 +1412,13 @@ async fn update_drill(
 
 async fn start_drill(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
     Query(query): Query<OrgQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .start_drill(query.organization_id, id)
@@ -1176,10 +1454,13 @@ pub struct CompleteDrillRequest {
 
 async fn complete_drill(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
     Json(req): Json<CompleteDrillRequest>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, req.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .complete_drill(req.organization_id, id, req.data)
@@ -1207,10 +1488,13 @@ async fn complete_drill(
 
 async fn cancel_drill(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
     Query(query): Query<OrgQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .cancel_drill(query.organization_id, id)
@@ -1238,10 +1522,13 @@ async fn cancel_drill(
 
 async fn delete_drill(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(id): Path<Uuid>,
     Query(query): Query<OrgQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .delete_drill(query.organization_id, id)
@@ -1273,9 +1560,12 @@ async fn delete_drill(
 
 async fn get_statistics(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Query(query): Query<OrgQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .get_statistics(query.organization_id)
@@ -1295,9 +1585,12 @@ async fn get_statistics(
 
 async fn get_incidents_by_type(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Query(query): Query<OrgQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .get_incident_summary_by_type(query.organization_id)
@@ -1317,9 +1610,12 @@ async fn get_incidents_by_type(
 
 async fn get_incidents_by_severity(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Query(query): Query<OrgQuery>,
 ) -> impl IntoResponse {
+    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
+        return resp;
+    }
     match state
         .emergency_repo
         .get_incident_summary_by_severity(query.organization_id)

--- a/backend/servers/api-server/tests/emergency_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/emergency_cross_org_idor_tests.rs
@@ -1,0 +1,387 @@
+//! Regression tests for the cross-tenant IDOR fix on the emergency endpoints
+//! (`/api/v1/emergency/*`, Epic 23 — issue #827).
+//!
+//! Audit history: every emergency handler trusted a client-supplied
+//! `organization_id` (query param or JSON body) and passed it straight to the
+//! repository, performing no membership check. Any authenticated user could
+//! read or mutate another org's protocols, contacts, incidents, broadcasts and
+//! drills simply by supplying the victim org's UUID, and `create_broadcast` /
+//! `create_incident` (mass-notification + incident lifecycle) were not gated to
+//! managers.
+//!
+//! The fix threads the authenticated `user_id` through a `verify_org_access`
+//! membership check on every org-keyed path (403 for non-members) and gates the
+//! broadcast/incident-create + lifecycle actions behind `verify_org_manager`
+//! (403 for ordinary members). The repository's by-id queries are already keyed
+//! on `(id, organization_id)`, so once the org is verified a foreign UUID
+//! resolves to `None` → `404`.
+//!
+//! These tests exercise the HTTP surface end-to-end with real HS256 JWTs:
+//!   1. Seed two orgs (A, B), a member user in each, and a protocol in Org A.
+//!   2. Org B's member probes Org A's resources → rejected (403); no leak/write.
+//!   3. Org A's member reads/writes its own org → allowed (2xx) — proving the
+//!      test establishes real org/tenant context (the membership row), so the
+//!      cross-org rejection is NOT a trivial "no context" pass.
+
+#[allow(dead_code)]
+mod common;
+
+use axum::http::StatusCode;
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{TestApp, TestConfig};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active') RETURNING id
+        "#,
+    )
+    .bind(format!("EmergencyIDOR Org {slug}"))
+    .bind(format!("emergency-idor-org-{slug}"))
+    .bind(format!("{slug}@emergency-idor.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'test_hash', 'EmergencyIDOR User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Make `user_id` an active member of `org_id` with the given role.
+async fn seed_membership(pool: &PgPool, org_id: Uuid, user_id: Uuid, role_type: &str) {
+    sqlx::query(
+        r#"
+        INSERT INTO organization_members (organization_id, user_id, role_type, status, joined_at)
+        VALUES ($1, $2, $3, 'active', NOW())
+        "#,
+    )
+    .bind(org_id)
+    .bind(user_id)
+    .bind(role_type)
+    .execute(pool)
+    .await
+    .expect("seed membership");
+}
+
+/// Seed an emergency protocol in `org_id` and return its id.
+async fn seed_protocol(pool: &PgPool, org_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO emergency_protocols (organization_id, name, protocol_type)
+        VALUES ($1, 'Fire Evacuation', 'fire')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed protocol")
+}
+
+/// Seed a building in `org_id` (emergency_broadcasts.building_id is NOT NULL).
+async fn seed_building(pool: &PgPool, org_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO buildings (organization_id, street, city, postal_code, name)
+        VALUES ($1, 'Main St 1', 'Bratislava', '81101', 'HQ')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed building")
+}
+
+/// Mint a real HS256 access token for `user_id`, signed with the same secret
+/// the TestApp configures into `JWT_SECRET`.
+fn mint_token(user_id: Uuid, email: &str) -> String {
+    use api_server::services::JwtService;
+    let config = TestConfig::default();
+    let jwt = JwtService::new(&config.jwt_secret).expect("jwt service");
+    jwt.generate_access_token(user_id, email, "EmergencyIDOR User", None, None)
+        .expect("mint access token")
+}
+
+// ---------------------------------------------------------------------------
+// T1 — cross-org list_protocols is rejected (information disclosure)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_protocols_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "lst-a").await;
+    let org_b = seed_org(&pool, "lst-b").await;
+    let user_b = seed_user(&pool, "lst-b@emergency-idor.test").await;
+    seed_membership(&pool, org_b, user_b, "org_admin").await;
+    let _protocol_a = seed_protocol(&pool, org_a).await;
+
+    let token_b = mint_token(user_b, "lst-b@emergency-idor.test");
+    let uri = format!("/api/v1/emergency/protocols?organization_id={org_a}");
+    let resp = app.execute(app.get(&uri).bearer(&token_b).build()).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "Org B member must not list Org A protocols: {}",
+        resp.text()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T2 — cross-org get_protocol by UUID is rejected (IDOR)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_protocol_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "get-a").await;
+    let org_b = seed_org(&pool, "get-b").await;
+    let user_b = seed_user(&pool, "get-b@emergency-idor.test").await;
+    seed_membership(&pool, org_b, user_b, "org_admin").await;
+    let protocol_a = seed_protocol(&pool, org_a).await;
+
+    let token_b = mint_token(user_b, "get-b@emergency-idor.test");
+    // Attacker supplies the VICTIM org id together with the victim protocol id.
+    let uri = format!("/api/v1/emergency/protocols/{protocol_a}?organization_id={org_a}");
+    let resp = app.execute(app.get(&uri).bearer(&token_b).build()).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "Org B member must not read Org A protocol: {}",
+        resp.text()
+    );
+    assert_ne!(
+        resp.status,
+        StatusCode::OK,
+        "Org A protocol must not be readable by Org B"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T3 — cross-org create_protocol (attacker-supplied org_id) is rejected
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_protocol_for_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "crt-a").await;
+    let org_b = seed_org(&pool, "crt-b").await;
+    let user_b = seed_user(&pool, "crt-b@emergency-idor.test").await;
+    seed_membership(&pool, org_b, user_b, "org_admin").await;
+
+    let token_b = mint_token(user_b, "crt-b@emergency-idor.test");
+    let body = json!({
+        "organization_id": org_a,
+        "name": "Injected Protocol",
+        "protocol_type": "fire",
+        "steps": [],
+    });
+    let resp = app
+        .execute(
+            app.post("/api/v1/emergency/protocols")
+                .bearer(&token_b)
+                .json(body)
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "Org B member must not create a protocol in Org A: {}",
+        resp.text()
+    );
+
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM emergency_protocols WHERE organization_id = $1")
+            .bind(org_a)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(count, 0, "no protocol may be created via cross-tenant POST");
+}
+
+// ---------------------------------------------------------------------------
+// T4 — cross-org delete_protocol by UUID is rejected (mutate IDOR)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn delete_protocol_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "del-a").await;
+    let org_b = seed_org(&pool, "del-b").await;
+    let user_b = seed_user(&pool, "del-b@emergency-idor.test").await;
+    seed_membership(&pool, org_b, user_b, "org_admin").await;
+    let protocol_a = seed_protocol(&pool, org_a).await;
+
+    let token_b = mint_token(user_b, "del-b@emergency-idor.test");
+    let uri = format!("/api/v1/emergency/protocols/{protocol_a}?organization_id={org_a}");
+    let resp = app.execute(app.delete(&uri).bearer(&token_b).build()).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "Org B member must not delete Org A protocol: {}",
+        resp.text()
+    );
+
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM emergency_protocols WHERE id = $1")
+        .bind(protocol_a)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count, 1, "Org A protocol must not be deleted cross-tenant");
+}
+
+// ---------------------------------------------------------------------------
+// T5 — create_broadcast requires manager role (ordinary member rejected)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_broadcast_as_plain_member_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "bc-a").await;
+    // A genuine member of Org A, but only a `resident` — not a manager.
+    let resident = seed_user(&pool, "bc-resident@emergency-idor.test").await;
+    seed_membership(&pool, org_a, resident, "resident").await;
+
+    let building_id = seed_building(&pool, org_a).await;
+
+    let token = mint_token(resident, "bc-resident@emergency-idor.test");
+    let body = json!({
+        "organization_id": org_a,
+        "building_id": building_id,
+        "title": "Evacuate now",
+        "message": "Leave the building",
+        "severity": "critical",
+    });
+    let resp = app
+        .execute(
+            app.post("/api/v1/emergency/broadcasts")
+                .bearer(&token)
+                .json(body)
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "a non-manager member must not create an emergency broadcast: {}",
+        resp.text()
+    );
+
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM emergency_broadcasts WHERE organization_id = $1")
+            .bind(org_a)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(count, 0, "no broadcast may be created by a non-manager");
+}
+
+// ---------------------------------------------------------------------------
+// T6 — SAME-ORG SUCCESS: legitimate member reads its own org's protocol.
+//
+// This is the load-bearing positive case. It proves the harness establishes
+// real org/tenant context (an active organization_members row), so the
+// cross-org rejections above fail for the RIGHT reason (membership mismatch),
+// not because the request lacked any context.
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_protocol_for_own_org_succeeds(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "own-a").await;
+    let user_a = seed_user(&pool, "own-a@emergency-idor.test").await;
+    seed_membership(&pool, org_a, user_a, "org_admin").await;
+    let protocol_a = seed_protocol(&pool, org_a).await;
+
+    let token_a = mint_token(user_a, "own-a@emergency-idor.test");
+    let uri = format!("/api/v1/emergency/protocols/{protocol_a}?organization_id={org_a}");
+    let resp = app.execute(app.get(&uri).bearer(&token_a).build()).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "Org A member must be able to read its own protocol: {}",
+        resp.text()
+    );
+    let protocol = resp.json_value();
+    assert_eq!(
+        protocol.get("id").and_then(|v| v.as_str()),
+        Some(protocol_a.to_string().as_str()),
+        "expected the owning org's protocol, got {protocol}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T7 — SAME-ORG SUCCESS: a manager member CAN create a broadcast in its org.
+//
+// Companion positive case for the manager gate (T5): confirms the gate admits
+// the right role rather than rejecting everything.
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_broadcast_as_manager_succeeds(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "bcok-a").await;
+    let manager = seed_user(&pool, "bcok-mgr@emergency-idor.test").await;
+    seed_membership(&pool, org_a, manager, "manager").await;
+
+    // emergency_broadcasts.building_id is NOT NULL — seed one for the org.
+    let building_id = seed_building(&pool, org_a).await;
+
+    let token = mint_token(manager, "bcok-mgr@emergency-idor.test");
+    let body = json!({
+        "organization_id": org_a,
+        "building_id": building_id,
+        "title": "Evacuate now",
+        "message": "Leave the building",
+        "severity": "critical",
+    });
+    let resp = app
+        .execute(
+            app.post("/api/v1/emergency/broadcasts")
+                .bearer(&token)
+                .json(body)
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::CREATED,
+        "a manager must be able to create an emergency broadcast: {}",
+        resp.text()
+    );
+
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM emergency_broadcasts WHERE organization_id = $1")
+            .bind(org_a)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(count, 1, "manager's broadcast must be persisted");
+}


### PR DESCRIPTION
## Task

Issue #827 — Epic 23 Emergency Management cross-tenant IDOR. Every handler in `routes/emergency.rs` carried only `AuthUser` and passed a **client-supplied `organization_id`** (query param / JSON body) straight to the repository with no membership check. Any authenticated user could read or mutate another org's protocols, contacts, incidents, broadcasts and drills by supplying the victim org's UUID; `create_broadcast` / `create_incident` (mass-notification + incident lifecycle) were not role-gated.

## Owner

pm-security

## Fix

Mirrors the `verify_org_access` idiom shipped for vendors (#825) and financial (#802) — the same `AuthUser` + `org_member_repo.is_member` mechanism emergency.rs already had available, so no extractor/middleware change.

- **Membership gate on every org-keyed handler** (`verify_org_access(&state, auth.user_id, org_id)`): protocols, contacts, incidents, broadcasts, drills, statistics — list/create/read/update/delete/lifecycle. Non-members get `403`. The repo's by-id queries are already keyed on `(id, organization_id)`, so once the org is verified a foreign UUID resolves to `404`.
- **Manager-role gate** (`verify_org_manager`) on the mass-notification / incident-control actions the issue calls out: `create_incident`, `acknowledge_incident`, `create_broadcast`, `deactivate_broadcast`. Role is read from `org_member_repo.get_user_role_type` against the verified org; `org_admin` / `manager` / platform admins pass, ordinary members get `403`.
- **Sub-resources keyed only on `incident_id` / `broadcast_id`** (incident attachments + updates, broadcast acknowledge + acknowledgments) had no org param at all. Added an `OrgQuery` + `verify_incident_in_org` / `verify_broadcast_in_org` helpers that confirm membership AND that the parent row belongs to that org (`404` on cross-tenant).

Org-context mechanism: `AuthUser.user_id` + `org_member_repo.is_member` / `get_user_role_type` (NOT `X-Tenant-ID` / `ResolvedTenant`), matching the rest of emergency.rs.

## Tested (Band A — fast check)

Postgres via local container; isolated `CARGO_TARGET_DIR` (the shared target dir was being clobbered mid-run by a parallel agent's in-flight `db` edit — produced a stale `db.rlib` and false cross-tenant 200s until `cargo clean -p db && rebuild`).

```
cargo fmt --all                                            # exit 0
cargo clippy -p api-server --lib -- -D warnings            # exit 0
cargo test -p api-server --test emergency_cross_org_idor_tests   # 7 passed; 0 failed
```

New regression test `emergency_cross_org_idor_tests.rs` (real HS256 JWTs, two orgs):
- `list_protocols_from_other_org_is_rejected` → 403
- `get_protocol_from_other_org_is_rejected` → 403 (and not 200)
- `create_protocol_for_other_org_is_rejected` → 403, no row written
- `delete_protocol_from_other_org_is_rejected` → 403, row survives
- `create_broadcast_as_plain_member_is_rejected` → 403 (manager gate), no row
- **`get_protocol_for_own_org_succeeds` → 200** (load-bearing same-org SUCCESS: proves the test establishes real `organization_members` context, so the rejections fail for the right reason)
- **`create_broadcast_as_manager_succeeds` → 201** (manager gate admits the right role)

## Built (Band B)

`cargo clippy -p api-server --lib` compiled the full lib clean (exit 0).

## CI parity (Band C)

skipped — full `just test` shares the contended target dir; ran the relevant test target + clippy directly in an isolated target instead.

## Notes

- No repo/db changes; the emergency repo's by-id methods were already org-scoped, the bug was purely in the handlers trusting the client org.
- Heads-up for reviewers/CI: origin/dev currently shows transient `db`-vs-route arity mismatches in `multi_currency.rs` / `violations.rs` when the shared `db.rlib` is stale; a clean `db` rebuild resolves it (this PR does not touch those files).