### PR TITLE
fix(security): scope legal-document routes to authenticated tenant (refs #829)

### DIFF
--- a/backend/crates/db/src/repositories/legal.rs
+++ b/backend/crates/db/src/repositories/legal.rs
@@ -78,13 +78,18 @@ impl LegalRepository {
         .await
     }
 
-    /// Find a legal document by ID.
+    /// Find a legal document by ID, scoped to an organization.
+    ///
+    /// A foreign-org `id` returns `None` (→ HTTP 404), preventing cross-tenant
+    /// reads (IDOR, #829).
     pub async fn find_document_by_id(
         &self,
         id: Uuid,
+        org_id: Uuid,
     ) -> Result<Option<LegalDocument>, sqlx::Error> {
-        sqlx::query_as("SELECT * FROM legal_documents WHERE id = $1")
+        sqlx::query_as("SELECT * FROM legal_documents WHERE id = $1 AND organization_id = $2")
             .bind(id)
+            .bind(org_id)
             .fetch_optional(&self.pool)
             .await
     }
@@ -165,37 +170,42 @@ impl LegalRepository {
         .await
     }
 
-    /// Update a legal document.
+    /// Update a legal document, scoped to an organization.
+    ///
+    /// Returns `None` when no row in `org_id` matches `id` (→ HTTP 404),
+    /// so a cross-tenant `id` cannot be mutated (IDOR, #829).
     pub async fn update_document(
         &self,
         id: Uuid,
+        org_id: Uuid,
         data: UpdateLegalDocument,
-    ) -> Result<LegalDocument, sqlx::Error> {
+    ) -> Result<Option<LegalDocument>, sqlx::Error> {
         sqlx::query_as(
             r#"
             UPDATE legal_documents SET
-                building_id = COALESCE($2, building_id),
-                document_type = COALESCE($3, document_type),
-                title = COALESCE($4, title),
-                description = COALESCE($5, description),
-                parties = COALESCE($6, parties),
-                effective_date = COALESCE($7, effective_date),
-                expiry_date = COALESCE($8, expiry_date),
-                file_path = COALESCE($9, file_path),
-                file_name = COALESCE($10, file_name),
-                file_size = COALESCE($11, file_size),
-                mime_type = COALESCE($12, mime_type),
-                is_confidential = COALESCE($13, is_confidential),
-                retention_period_months = COALESCE($14, retention_period_months),
-                retention_expires_at = COALESCE($15, retention_expires_at),
-                tags = COALESCE($16, tags),
-                metadata = COALESCE($17, metadata),
+                building_id = COALESCE($3, building_id),
+                document_type = COALESCE($4, document_type),
+                title = COALESCE($5, title),
+                description = COALESCE($6, description),
+                parties = COALESCE($7, parties),
+                effective_date = COALESCE($8, effective_date),
+                expiry_date = COALESCE($9, expiry_date),
+                file_path = COALESCE($10, file_path),
+                file_name = COALESCE($11, file_name),
+                file_size = COALESCE($12, file_size),
+                mime_type = COALESCE($13, mime_type),
+                is_confidential = COALESCE($14, is_confidential),
+                retention_period_months = COALESCE($15, retention_period_months),
+                retention_expires_at = COALESCE($16, retention_expires_at),
+                tags = COALESCE($17, tags),
+                metadata = COALESCE($18, metadata),
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             RETURNING *
             "#,
         )
         .bind(id)
+        .bind(org_id)
         .bind(data.building_id)
         .bind(&data.document_type)
         .bind(&data.title)
@@ -212,29 +222,52 @@ impl LegalRepository {
         .bind(data.retention_expires_at)
         .bind(&data.tags)
         .bind(data.metadata.map(sqlx::types::Json))
-        .fetch_one(&self.pool)
+        .fetch_optional(&self.pool)
         .await
     }
 
-    /// Delete a legal document.
-    pub async fn delete_document(&self, id: Uuid) -> Result<bool, sqlx::Error> {
-        let result = sqlx::query("DELETE FROM legal_documents WHERE id = $1")
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
+    /// Delete a legal document, scoped to an organization.
+    pub async fn delete_document(&self, id: Uuid, org_id: Uuid) -> Result<bool, sqlx::Error> {
+        let result =
+            sqlx::query("DELETE FROM legal_documents WHERE id = $1 AND organization_id = $2")
+                .bind(id)
+                .bind(org_id)
+                .execute(&self.pool)
+                .await?;
         Ok(result.rows_affected() > 0)
     }
 
     // ==================== Document Versions ====================
 
-    /// Add a new version to a document.
+    /// Check that a document belongs to an organization.
+    ///
+    /// Used to org-scope child-resource (version) operations so a foreign-org
+    /// `document_id` cannot be read or written through (IDOR, #829).
+    async fn document_in_org(&self, document_id: Uuid, org_id: Uuid) -> Result<bool, sqlx::Error> {
+        let exists: Option<Uuid> = sqlx::query_scalar(
+            "SELECT id FROM legal_documents WHERE id = $1 AND organization_id = $2",
+        )
+        .bind(document_id)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(exists.is_some())
+    }
+
+    /// Add a new version to a document, scoped to an organization.
+    ///
+    /// Returns `None` when the parent document is not in `org_id` (→ HTTP 404).
     pub async fn add_document_version(
         &self,
         document_id: Uuid,
+        org_id: Uuid,
         user_id: Uuid,
         data: CreateLegalDocumentVersion,
-    ) -> Result<LegalDocumentVersion, sqlx::Error> {
-        sqlx::query_as(
+    ) -> Result<Option<LegalDocumentVersion>, sqlx::Error> {
+        if !self.document_in_org(document_id, org_id).await? {
+            return Ok(None);
+        }
+        let version: LegalDocumentVersion = sqlx::query_as(
             r#"
             INSERT INTO legal_document_versions
                 (document_id, version_number, file_path, file_name, file_size, mime_type,
@@ -255,15 +288,22 @@ impl LegalRepository {
         .bind(&data.change_notes)
         .bind(user_id)
         .fetch_one(&self.pool)
-        .await
+        .await?;
+        Ok(Some(version))
     }
 
-    /// List versions for a document.
+    /// List versions for a document, scoped to an organization.
+    ///
+    /// Returns `None` when the parent document is not in `org_id` (→ HTTP 404).
     pub async fn list_document_versions(
         &self,
         document_id: Uuid,
-    ) -> Result<Vec<LegalDocumentVersion>, sqlx::Error> {
-        sqlx::query_as(
+        org_id: Uuid,
+    ) -> Result<Option<Vec<LegalDocumentVersion>>, sqlx::Error> {
+        if !self.document_in_org(document_id, org_id).await? {
+            return Ok(None);
+        }
+        let versions = sqlx::query_as(
             r#"
             SELECT * FROM legal_document_versions
             WHERE document_id = $1
@@ -272,15 +312,20 @@ impl LegalRepository {
         )
         .bind(document_id)
         .fetch_all(&self.pool)
-        .await
+        .await?;
+        Ok(Some(versions))
     }
 
-    /// Get a specific version.
+    /// Get a specific version, scoped to an organization.
     pub async fn get_document_version(
         &self,
         document_id: Uuid,
+        org_id: Uuid,
         version_number: i32,
     ) -> Result<Option<LegalDocumentVersion>, sqlx::Error> {
+        if !self.document_in_org(document_id, org_id).await? {
+            return Ok(None);
+        }
         sqlx::query_as(
             r#"
             SELECT * FROM legal_document_versions
@@ -325,15 +370,21 @@ impl LegalRepository {
         .await
     }
 
-    /// Find a compliance requirement by ID.
+    /// Find a compliance requirement by ID, scoped to an organization.
+    ///
+    /// A foreign-org `id` returns `None` (→ HTTP 404) (IDOR, #829).
     pub async fn find_requirement_by_id(
         &self,
         id: Uuid,
+        org_id: Uuid,
     ) -> Result<Option<ComplianceRequirement>, sqlx::Error> {
-        sqlx::query_as("SELECT * FROM compliance_requirements WHERE id = $1")
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await
+        sqlx::query_as(
+            "SELECT * FROM compliance_requirements WHERE id = $1 AND organization_id = $2",
+        )
+        .bind(id)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await
     }
 
     /// List compliance requirements.
@@ -408,32 +459,36 @@ impl LegalRepository {
         .await
     }
 
-    /// Update a compliance requirement.
+    /// Update a compliance requirement, scoped to an organization.
+    ///
+    /// Returns `None` when no row in `org_id` matches `id` (→ HTTP 404) (IDOR, #829).
     pub async fn update_requirement(
         &self,
         id: Uuid,
+        org_id: Uuid,
         data: UpdateComplianceRequirement,
-    ) -> Result<ComplianceRequirement, sqlx::Error> {
+    ) -> Result<Option<ComplianceRequirement>, sqlx::Error> {
         sqlx::query_as(
             r#"
             UPDATE compliance_requirements SET
-                building_id = COALESCE($2, building_id),
-                name = COALESCE($3, name),
-                description = COALESCE($4, description),
-                category = COALESCE($5, category),
-                regulation_reference = COALESCE($6, regulation_reference),
-                frequency = COALESCE($7, frequency),
-                next_due_date = COALESCE($8, next_due_date),
-                status = COALESCE($9, status),
-                is_mandatory = COALESCE($10, is_mandatory),
-                responsible_party = COALESCE($11, responsible_party),
-                notes = COALESCE($12, notes),
+                building_id = COALESCE($3, building_id),
+                name = COALESCE($4, name),
+                description = COALESCE($5, description),
+                category = COALESCE($6, category),
+                regulation_reference = COALESCE($7, regulation_reference),
+                frequency = COALESCE($8, frequency),
+                next_due_date = COALESCE($9, next_due_date),
+                status = COALESCE($10, status),
+                is_mandatory = COALESCE($11, is_mandatory),
+                responsible_party = COALESCE($12, responsible_party),
+                notes = COALESCE($13, notes),
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             RETURNING *
             "#,
         )
         .bind(id)
+        .bind(org_id)
         .bind(data.building_id)
         .bind(&data.name)
         .bind(&data.description)
@@ -445,28 +500,53 @@ impl LegalRepository {
         .bind(data.is_mandatory)
         .bind(&data.responsible_party)
         .bind(&data.notes)
-        .fetch_one(&self.pool)
+        .fetch_optional(&self.pool)
         .await
     }
 
-    /// Delete a compliance requirement.
-    pub async fn delete_requirement(&self, id: Uuid) -> Result<bool, sqlx::Error> {
-        let result = sqlx::query("DELETE FROM compliance_requirements WHERE id = $1")
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
+    /// Delete a compliance requirement, scoped to an organization.
+    pub async fn delete_requirement(&self, id: Uuid, org_id: Uuid) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query(
+            "DELETE FROM compliance_requirements WHERE id = $1 AND organization_id = $2",
+        )
+        .bind(id)
+        .bind(org_id)
+        .execute(&self.pool)
+        .await?;
         Ok(result.rows_affected() > 0)
     }
 
     // ==================== Compliance Verifications ====================
 
-    /// Record a compliance verification.
+    /// Check that a compliance requirement belongs to an organization.
+    async fn requirement_in_org(
+        &self,
+        requirement_id: Uuid,
+        org_id: Uuid,
+    ) -> Result<bool, sqlx::Error> {
+        let exists: Option<Uuid> = sqlx::query_scalar(
+            "SELECT id FROM compliance_requirements WHERE id = $1 AND organization_id = $2",
+        )
+        .bind(requirement_id)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(exists.is_some())
+    }
+
+    /// Record a compliance verification, scoped to an organization.
+    ///
+    /// Returns `None` when the requirement is not in `org_id` (→ HTTP 404).
     pub async fn create_verification(
         &self,
         requirement_id: Uuid,
+        org_id: Uuid,
         user_id: Uuid,
         data: CreateComplianceVerification,
-    ) -> Result<ComplianceVerification, sqlx::Error> {
+    ) -> Result<Option<ComplianceVerification>, sqlx::Error> {
+        if !self.requirement_in_org(requirement_id, org_id).await? {
+            return Ok(None);
+        }
         // Record the verification
         let verification: ComplianceVerification = sqlx::query_as(
             r#"
@@ -507,15 +587,21 @@ impl LegalRepository {
         .execute(&self.pool)
         .await?;
 
-        Ok(verification)
+        Ok(Some(verification))
     }
 
-    /// List verifications for a requirement.
+    /// List verifications for a requirement, scoped to an organization.
+    ///
+    /// Returns `None` when the requirement is not in `org_id` (→ HTTP 404).
     pub async fn list_verifications(
         &self,
         requirement_id: Uuid,
-    ) -> Result<Vec<ComplianceVerification>, sqlx::Error> {
-        sqlx::query_as(
+        org_id: Uuid,
+    ) -> Result<Option<Vec<ComplianceVerification>>, sqlx::Error> {
+        if !self.requirement_in_org(requirement_id, org_id).await? {
+            return Ok(None);
+        }
+        let verifications = sqlx::query_as(
             r#"
             SELECT * FROM compliance_verifications
             WHERE requirement_id = $1
@@ -524,7 +610,8 @@ impl LegalRepository {
         )
         .bind(requirement_id)
         .fetch_all(&self.pool)
-        .await
+        .await?;
+        Ok(Some(verifications))
     }
 
     /// Get compliance statistics.
@@ -641,12 +728,31 @@ impl LegalRepository {
         Ok(notice)
     }
 
-    /// Find a legal notice by ID.
-    pub async fn find_notice_by_id(&self, id: Uuid) -> Result<Option<LegalNotice>, sqlx::Error> {
-        sqlx::query_as("SELECT * FROM legal_notices WHERE id = $1")
+    /// Find a legal notice by ID, scoped to an organization.
+    ///
+    /// A foreign-org `id` returns `None` (→ HTTP 404) (IDOR, #829).
+    pub async fn find_notice_by_id(
+        &self,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<Option<LegalNotice>, sqlx::Error> {
+        sqlx::query_as("SELECT * FROM legal_notices WHERE id = $1 AND organization_id = $2")
             .bind(id)
+            .bind(org_id)
             .fetch_optional(&self.pool)
             .await
+    }
+
+    /// Check that a legal notice belongs to an organization.
+    async fn notice_in_org(&self, notice_id: Uuid, org_id: Uuid) -> Result<bool, sqlx::Error> {
+        let exists: Option<Uuid> = sqlx::query_scalar(
+            "SELECT id FROM legal_notices WHERE id = $1 AND organization_id = $2",
+        )
+        .bind(notice_id)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(exists.is_some())
     }
 
     /// List legal notices.
@@ -719,43 +825,49 @@ impl LegalRepository {
         .await
     }
 
-    /// Update a legal notice.
+    /// Update a legal notice, scoped to an organization.
+    ///
+    /// Returns `None` when no row in `org_id` matches `id` (→ HTTP 404) (IDOR, #829).
     pub async fn update_notice(
         &self,
         id: Uuid,
+        org_id: Uuid,
         data: UpdateLegalNotice,
-    ) -> Result<LegalNotice, sqlx::Error> {
+    ) -> Result<Option<LegalNotice>, sqlx::Error> {
         sqlx::query_as(
             r#"
             UPDATE legal_notices SET
-                subject = COALESCE($2, subject),
-                content = COALESCE($3, content),
-                priority = COALESCE($4, priority),
-                delivery_method = COALESCE($5, delivery_method),
-                requires_acknowledgment = COALESCE($6, requires_acknowledgment),
-                acknowledgment_deadline = COALESCE($7, acknowledgment_deadline),
+                subject = COALESCE($3, subject),
+                content = COALESCE($4, content),
+                priority = COALESCE($5, priority),
+                delivery_method = COALESCE($6, delivery_method),
+                requires_acknowledgment = COALESCE($7, requires_acknowledgment),
+                acknowledgment_deadline = COALESCE($8, acknowledgment_deadline),
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             RETURNING *
             "#,
         )
         .bind(id)
+        .bind(org_id)
         .bind(&data.subject)
         .bind(&data.content)
         .bind(&data.priority)
         .bind(&data.delivery_method)
         .bind(data.requires_acknowledgment)
         .bind(data.acknowledgment_deadline)
-        .fetch_one(&self.pool)
+        .fetch_optional(&self.pool)
         .await
     }
 
-    /// Delete a legal notice.
-    pub async fn delete_notice(&self, id: Uuid) -> Result<bool, sqlx::Error> {
-        let result = sqlx::query("DELETE FROM legal_notices WHERE id = $1")
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
+    /// Delete a legal notice, scoped to an organization.
+    pub async fn delete_notice(&self, id: Uuid, org_id: Uuid) -> Result<bool, sqlx::Error> {
+        let result =
+            sqlx::query("DELETE FROM legal_notices WHERE id = $1 AND organization_id = $2")
+                .bind(id)
+                .bind(org_id)
+                .execute(&self.pool)
+                .await?;
         Ok(result.rows_affected() > 0)
     }
 
@@ -764,18 +876,27 @@ impl LegalRepository {
     /// Note: This is a synchronous database operation that marks all recipients as 'sent'.
     /// In production, actual email/mail delivery should be handled by a background job
     /// that can retry failures and update individual recipient statuses accordingly.
-    pub async fn send_notice(&self, id: Uuid) -> Result<LegalNotice, sqlx::Error> {
-        // Update notice sent_at
-        let notice: LegalNotice = sqlx::query_as(
+    pub async fn send_notice(
+        &self,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<Option<LegalNotice>, sqlx::Error> {
+        // Update notice sent_at (org-scoped — foreign-org notice → None → 404).
+        let notice: Option<LegalNotice> = sqlx::query_as(
             r#"
             UPDATE legal_notices SET sent_at = NOW(), updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             RETURNING *
             "#,
         )
         .bind(id)
-        .fetch_one(&self.pool)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
         .await?;
+
+        let Some(notice) = notice else {
+            return Ok(None);
+        };
 
         // Update recipients status to sent.
         // In a real system, this should be updated asynchronously after actual delivery.
@@ -791,17 +912,23 @@ impl LegalRepository {
         .execute(&self.pool)
         .await?;
 
-        Ok(notice)
+        Ok(Some(notice))
     }
 
     // ==================== Notice Recipients ====================
 
-    /// List recipients for a notice.
+    /// List recipients for a notice, scoped to an organization.
+    ///
+    /// Returns `None` when the parent notice is not in `org_id` (→ HTTP 404).
     pub async fn list_notice_recipients(
         &self,
         notice_id: Uuid,
-    ) -> Result<Vec<LegalNoticeRecipient>, sqlx::Error> {
-        sqlx::query_as(
+        org_id: Uuid,
+    ) -> Result<Option<Vec<LegalNoticeRecipient>>, sqlx::Error> {
+        if !self.notice_in_org(notice_id, org_id).await? {
+            return Ok(None);
+        }
+        let recipients = sqlx::query_as(
             r#"
             SELECT * FROM legal_notice_recipients
             WHERE notice_id = $1
@@ -810,17 +937,24 @@ impl LegalRepository {
         )
         .bind(notice_id)
         .fetch_all(&self.pool)
-        .await
+        .await?;
+        Ok(Some(recipients))
     }
 
-    /// Acknowledge a notice by recipient record ID.
+    /// Acknowledge a notice by recipient record ID, scoped to an organization.
     /// Uses the unique (notice_id, recipient_id) constraint to identify the recipient.
+    ///
+    /// Returns `None` when the parent notice is not in `org_id` (→ HTTP 404).
     pub async fn acknowledge_notice(
         &self,
         notice_id: Uuid,
         recipient_id: Uuid,
+        org_id: Uuid,
         data: AcknowledgeNotice,
-    ) -> Result<LegalNoticeRecipient, sqlx::Error> {
+    ) -> Result<Option<LegalNoticeRecipient>, sqlx::Error> {
+        if !self.notice_in_org(notice_id, org_id).await? {
+            return Ok(None);
+        }
         // The unique constraint on (notice_id, recipient_id) ensures this update
         // will only affect exactly one row.
         sqlx::query_as(
@@ -838,7 +972,7 @@ impl LegalRepository {
             data.acknowledgment_method
                 .unwrap_or_else(|| "manual".to_string()),
         )
-        .fetch_one(&self.pool)
+        .fetch_optional(&self.pool)
         .await
     }
 
@@ -931,15 +1065,26 @@ impl LegalRepository {
         .await
     }
 
-    /// Find a template by ID.
+    /// Find a template by ID, visible to an organization.
+    ///
+    /// Resolves the caller's own org templates and shared system templates
+    /// (`organization_id IS NULL`); a *different* org's private template
+    /// returns `None` (→ HTTP 404) (IDOR, #829).
     pub async fn find_template_by_id(
         &self,
         id: Uuid,
+        org_id: Uuid,
     ) -> Result<Option<ComplianceTemplate>, sqlx::Error> {
-        sqlx::query_as("SELECT * FROM compliance_templates WHERE id = $1")
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await
+        sqlx::query_as(
+            r#"
+            SELECT * FROM compliance_templates
+            WHERE id = $1 AND (organization_id = $2 OR organization_id IS NULL)
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await
     }
 
     /// List templates (organization-specific + system templates).
@@ -962,42 +1107,51 @@ impl LegalRepository {
         .await
     }
 
-    /// Update a template.
+    /// Update a template, scoped to an organization.
+    ///
+    /// Only the owning org's own (non-system) templates can be updated; a
+    /// foreign-org or system template returns `None` (→ HTTP 404) (IDOR, #829).
     pub async fn update_template(
         &self,
         id: Uuid,
+        org_id: Uuid,
         data: UpdateComplianceTemplate,
-    ) -> Result<ComplianceTemplate, sqlx::Error> {
+    ) -> Result<Option<ComplianceTemplate>, sqlx::Error> {
         sqlx::query_as(
             r#"
             UPDATE compliance_templates SET
-                name = COALESCE($2, name),
-                category = COALESCE($3, category),
-                description = COALESCE($4, description),
-                checklist_items = COALESCE($5, checklist_items),
-                frequency = COALESCE($6, frequency),
+                name = COALESCE($3, name),
+                category = COALESCE($4, category),
+                description = COALESCE($5, description),
+                checklist_items = COALESCE($6, checklist_items),
+                frequency = COALESCE($7, frequency),
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2 AND is_system = FALSE
             RETURNING *
             "#,
         )
         .bind(id)
+        .bind(org_id)
         .bind(&data.name)
         .bind(&data.category)
         .bind(&data.description)
         .bind(data.checklist_items.map(sqlx::types::Json))
         .bind(&data.frequency)
-        .fetch_one(&self.pool)
+        .fetch_optional(&self.pool)
         .await
     }
 
-    /// Delete a template.
-    pub async fn delete_template(&self, id: Uuid) -> Result<bool, sqlx::Error> {
-        let result =
-            sqlx::query("DELETE FROM compliance_templates WHERE id = $1 AND is_system = FALSE")
-                .bind(id)
-                .execute(&self.pool)
-                .await?;
+    /// Delete a template, scoped to an organization.
+    ///
+    /// Only the owning org's own (non-system) templates can be deleted.
+    pub async fn delete_template(&self, id: Uuid, org_id: Uuid) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query(
+            "DELETE FROM compliance_templates WHERE id = $1 AND organization_id = $2 AND is_system = FALSE",
+        )
+        .bind(id)
+        .bind(org_id)
+        .execute(&self.pool)
+        .await?;
         Ok(result.rows_affected() > 0)
     }
 
@@ -1008,7 +1162,7 @@ impl LegalRepository {
         data: ApplyTemplate,
     ) -> Result<Vec<ComplianceRequirement>, sqlx::Error> {
         let template = self
-            .find_template_by_id(data.template_id)
+            .find_template_by_id(data.template_id, org_id)
             .await?
             .ok_or_else(|| sqlx::Error::RowNotFound)?;
 

--- a/backend/servers/api-server/src/routes/legal.rs
+++ b/backend/servers/api-server/src/routes/legal.rs
@@ -249,6 +249,18 @@ pub struct PaginationQuery {
     pub offset: Option<i32>,
 }
 
+/// Resolve the caller's organization from the authenticated JWT `tenant_id`
+/// claim. Used to org-scope by-id reads/mutations so a foreign-org resource
+/// id surfaces as 404 rather than a cross-tenant leak (IDOR, #829).
+fn org_context(user: &AuthUser) -> Result<Uuid, (StatusCode, Json<ErrorResponse>)> {
+    user.tenant_id.ok_or_else(|| {
+        (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::forbidden("No organization context")),
+        )
+    })
+}
+
 // ==================== Legal Document Endpoints ====================
 
 async fn create_document(
@@ -310,12 +322,13 @@ async fn list_documents_summary(
 
 async fn get_document(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<Json<LegalDocument>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = org_context(&user)?;
     state
         .legal_repo
-        .find_document_by_id(id)
+        .find_document_by_id(id, org_id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get legal document: {:?}", e);
@@ -335,36 +348,48 @@ async fn get_document(
 
 async fn update_document(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateLegalDocument>,
 ) -> Result<Json<LegalDocument>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = org_context(&user)?;
     state
         .legal_repo
-        .update_document(id, data)
+        .update_document(id, org_id, data)
         .await
-        .map(Json)
         .map_err(|e| {
             tracing::error!("Failed to update legal document: {:?}", e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new("DB_ERROR", e.to_string())),
             )
+        })?
+        .map(Json)
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Document not found")),
+            )
         })
 }
 
 async fn delete_document(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let deleted = state.legal_repo.delete_document(id).await.map_err(|e| {
-        tracing::error!("Failed to delete legal document: {:?}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-        )
-    })?;
+    let org_id = org_context(&user)?;
+    let deleted = state
+        .legal_repo
+        .delete_document(id, org_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete legal document: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
+            )
+        })?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)
@@ -384,47 +409,62 @@ async fn add_version(
     Path(id): Path<Uuid>,
     Json(data): Json<CreateLegalDocumentVersion>,
 ) -> Result<(StatusCode, Json<LegalDocumentVersion>), (StatusCode, Json<ErrorResponse>)> {
+    let org_id = org_context(&user)?;
     state
         .legal_repo
-        .add_document_version(id, user.user_id, data)
+        .add_document_version(id, org_id, user.user_id, data)
         .await
-        .map(|v| (StatusCode::CREATED, Json(v)))
         .map_err(|e| {
             tracing::error!("Failed to add document version: {:?}", e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new("DB_ERROR", e.to_string())),
             )
+        })?
+        .map(|v| (StatusCode::CREATED, Json(v)))
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Document not found")),
+            )
         })
 }
 
 async fn list_versions(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Vec<LegalDocumentVersion>>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = org_context(&user)?;
     state
         .legal_repo
-        .list_document_versions(id)
+        .list_document_versions(id, org_id)
         .await
-        .map(Json)
         .map_err(|e| {
             tracing::error!("Failed to list document versions: {:?}", e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new("DB_ERROR", e.to_string())),
             )
+        })?
+        .map(Json)
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Document not found")),
+            )
         })
 }
 
 async fn get_version(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path((id, version)): Path<(Uuid, i32)>,
 ) -> Result<Json<LegalDocumentVersion>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = org_context(&user)?;
     state
         .legal_repo
-        .get_document_version(id, version)
+        .get_document_version(id, org_id, version)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get document version: {:?}", e);
@@ -522,12 +562,13 @@ async fn get_compliance_statistics(
 
 async fn get_requirement(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ComplianceRequirement>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = org_context(&user)?;
     state
         .legal_repo
-        .find_requirement_by_id(id)
+        .find_requirement_by_id(id, org_id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get compliance requirement: {:?}", e);
@@ -547,36 +588,48 @@ async fn get_requirement(
 
 async fn update_requirement(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateComplianceRequirement>,
 ) -> Result<Json<ComplianceRequirement>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = org_context(&user)?;
     state
         .legal_repo
-        .update_requirement(id, data)
+        .update_requirement(id, org_id, data)
         .await
-        .map(Json)
         .map_err(|e| {
             tracing::error!("Failed to update compliance requirement: {:?}", e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new("DB_ERROR", e.to_string())),
             )
+        })?
+        .map(Json)
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Requirement not found")),
+            )
         })
 }
 
 async fn delete_requirement(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let deleted = state.legal_repo.delete_requirement(id).await.map_err(|e| {
-        tracing::error!("Failed to delete compliance requirement: {:?}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-        )
-    })?;
+    let org_id = org_context(&user)?;
+    let deleted = state
+        .legal_repo
+        .delete_requirement(id, org_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete compliance requirement: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
+            )
+        })?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)
@@ -596,35 +649,49 @@ async fn create_verification(
     Path(id): Path<Uuid>,
     Json(data): Json<CreateComplianceVerification>,
 ) -> Result<(StatusCode, Json<ComplianceVerification>), (StatusCode, Json<ErrorResponse>)> {
+    let org_id = org_context(&user)?;
     state
         .legal_repo
-        .create_verification(id, user.user_id, data)
+        .create_verification(id, org_id, user.user_id, data)
         .await
-        .map(|v| (StatusCode::CREATED, Json(v)))
         .map_err(|e| {
             tracing::error!("Failed to create compliance verification: {:?}", e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new("DB_ERROR", e.to_string())),
             )
+        })?
+        .map(|v| (StatusCode::CREATED, Json(v)))
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Requirement not found")),
+            )
         })
 }
 
 async fn list_verifications(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Vec<ComplianceVerification>>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = org_context(&user)?;
     state
         .legal_repo
-        .list_verifications(id)
+        .list_verifications(id, org_id)
         .await
-        .map(Json)
         .map_err(|e| {
             tracing::error!("Failed to list compliance verifications: {:?}", e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new("DB_ERROR", e.to_string())),
+            )
+        })?
+        .map(Json)
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Requirement not found")),
             )
         })
 }
@@ -709,12 +776,13 @@ async fn get_notice_statistics(
 
 async fn get_notice(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<Json<LegalNotice>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = org_context(&user)?;
     state
         .legal_repo
-        .find_notice_by_id(id)
+        .find_notice_by_id(id, org_id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get legal notice: {:?}", e);
@@ -734,36 +802,48 @@ async fn get_notice(
 
 async fn update_notice(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateLegalNotice>,
 ) -> Result<Json<LegalNotice>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = org_context(&user)?;
     state
         .legal_repo
-        .update_notice(id, data)
+        .update_notice(id, org_id, data)
         .await
-        .map(Json)
         .map_err(|e| {
             tracing::error!("Failed to update legal notice: {:?}", e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new("DB_ERROR", e.to_string())),
             )
+        })?
+        .map(Json)
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Notice not found")),
+            )
         })
 }
 
 async fn delete_notice(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let deleted = state.legal_repo.delete_notice(id).await.map_err(|e| {
-        tracing::error!("Failed to delete legal notice: {:?}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-        )
-    })?;
+    let org_id = org_context(&user)?;
+    let deleted = state
+        .legal_repo
+        .delete_notice(id, org_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete legal notice: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
+            )
+        })?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)
@@ -777,19 +857,26 @@ async fn delete_notice(
 
 async fn send_notice(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<Json<LegalNotice>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = org_context(&user)?;
     state
         .legal_repo
-        .send_notice(id)
+        .send_notice(id, org_id)
         .await
-        .map(Json)
         .map_err(|e| {
             tracing::error!("Failed to send legal notice: {:?}", e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new("DB_ERROR", e.to_string())),
+            )
+        })?
+        .map(Json)
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Notice not found")),
             )
         })
 }
@@ -798,39 +885,56 @@ async fn send_notice(
 
 async fn list_recipients(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Vec<LegalNoticeRecipient>>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = org_context(&user)?;
     state
         .legal_repo
-        .list_notice_recipients(id)
+        .list_notice_recipients(id, org_id)
         .await
-        .map(Json)
         .map_err(|e| {
             tracing::error!("Failed to list notice recipients: {:?}", e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new("DB_ERROR", e.to_string())),
             )
+        })?
+        .map(Json)
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Notice not found")),
+            )
         })
 }
 
 async fn acknowledge_notice(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path((notice_id, recipient_id)): Path<(Uuid, Uuid)>,
     Json(data): Json<AcknowledgeNotice>,
 ) -> Result<Json<LegalNoticeRecipient>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = org_context(&user)?;
     state
         .legal_repo
-        .acknowledge_notice(notice_id, recipient_id, data)
+        .acknowledge_notice(notice_id, recipient_id, org_id, data)
         .await
-        .map(Json)
         .map_err(|e| {
             tracing::error!("Failed to acknowledge notice: {:?}", e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new("DB_ERROR", e.to_string())),
+            )
+        })?
+        .map(Json)
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new(
+                    "NOT_FOUND",
+                    "Notice or recipient not found",
+                )),
             )
         })
 }
@@ -877,12 +981,13 @@ async fn list_templates(
 
 async fn get_template(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ComplianceTemplate>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = org_context(&user)?;
     state
         .legal_repo
-        .find_template_by_id(id)
+        .find_template_by_id(id, org_id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get compliance template: {:?}", e);
@@ -902,36 +1007,51 @@ async fn get_template(
 
 async fn update_template(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateComplianceTemplate>,
 ) -> Result<Json<ComplianceTemplate>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = org_context(&user)?;
     state
         .legal_repo
-        .update_template(id, data)
+        .update_template(id, org_id, data)
         .await
-        .map(Json)
         .map_err(|e| {
             tracing::error!("Failed to update compliance template: {:?}", e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new("DB_ERROR", e.to_string())),
             )
+        })?
+        .map(Json)
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new(
+                    "NOT_FOUND",
+                    "Template not found (or is system template)",
+                )),
+            )
         })
 }
 
 async fn delete_template(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let deleted = state.legal_repo.delete_template(id).await.map_err(|e| {
-        tracing::error!("Failed to delete compliance template: {:?}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-        )
-    })?;
+    let org_id = org_context(&user)?;
+    let deleted = state
+        .legal_repo
+        .delete_template(id, org_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete compliance template: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
+            )
+        })?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)
@@ -948,12 +1068,13 @@ async fn delete_template(
 
 async fn apply_template(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Json(payload): Json<ApplyTemplateRequest>,
 ) -> Result<(StatusCode, Json<Vec<ComplianceRequirement>>), (StatusCode, Json<ErrorResponse>)> {
+    let org_id = org_context(&user)?;
     state
         .legal_repo
-        .apply_template(payload.organization_id, payload.data)
+        .apply_template(org_id, payload.data)
         .await
         .map(|r| (StatusCode::CREATED, Json(r)))
         .map_err(|e| {

--- a/backend/servers/api-server/tests/legal_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/legal_cross_org_idor_tests.rs
@@ -1,0 +1,303 @@
+//! Regression tests for the cross-org IDOR fix on legal-document endpoints (#829).
+//!
+//! Audit history: the by-id handlers in
+//! `servers/api-server/src/routes/legal.rs` (`get_document`, `update_document`,
+//! `delete_document`, and the sibling requirement/notice/template handlers)
+//! extracted nothing from the caller and called the repository with only the
+//! resource UUID — e.g. `find_document_by_id(id)`. Any authenticated user who
+//! knew (or guessed) another org's document id could read, update, or delete
+//! that org's legal documents (P0/P1 IDOR — confidential contracts, GDPR
+//! notices, compliance PII).
+//!
+//! The fix derives the verified `org_id` from the JWT `tenant_id` claim (the
+//! same idiom as `violations.rs` / `reserve_funds.rs`) and threads it into the
+//! repository so the SQL is org-scoped:
+//!   `SELECT * FROM legal_documents WHERE id = $1 AND organization_id = $2`.
+//! A foreign-org row therefore surfaces as `None` → HTTP 404, never a
+//! cross-tenant read or write.
+//!
+//! Like the reserve-fund suite, legal tenancy comes straight from the JWT
+//! `tenant_id` claim, which `AuthUser` reads without a DB membership lookup.
+//! That lets these tests mint a real access token per org and drive the
+//! handlers end-to-end:
+//!   - Org A's token reading Org A's document -> 200 (same-org succeeds).
+//!   - Org B's token reading Org A's document -> 404 (cross-org is blocked).
+
+#[allow(dead_code)]
+mod common;
+
+use axum::http::{Method, StatusCode};
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::Serialize;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{RequestBuilder, TestApp, TestConfig};
+
+// ---------------------------------------------------------------------------
+// JWT minting (matches api_core::extractors::auth::Claims)
+// ---------------------------------------------------------------------------
+//
+// NOTE: `JwtService` emits the org claim as `org_id`, which does NOT map to
+// `Claims.tenant_id`. We therefore mint a custom claims struct whose field is
+// literally `tenant_id`, matching what `AuthUser` reads.
+
+#[derive(Serialize)]
+struct TestClaims {
+    sub: Uuid,
+    exp: i64,
+    iat: i64,
+    token_type: String,
+    tenant_id: Option<Uuid>,
+    role: Option<String>,
+    email: String,
+    name: String,
+}
+
+/// Mint an access token bound to `org_id` (the JWT `tenant_id` claim), signed
+/// with the same secret `TestApp` configures.
+fn access_token(user_id: Uuid, org_id: Option<Uuid>) -> String {
+    let now = chrono::Utc::now().timestamp();
+    let claims = TestClaims {
+        sub: user_id,
+        exp: now + 3600,
+        iat: now,
+        token_type: "access".to_string(),
+        tenant_id: org_id,
+        role: Some("manager".to_string()),
+        email: "idor-test@legal.test".to_string(),
+        name: "Legal IDOR User".to_string(),
+    };
+    let secret = TestConfig::default().jwt_secret;
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .expect("encode test JWT")
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active') RETURNING id
+        "#,
+    )
+    .bind(format!("LegalIDOR Org {slug}"))
+    .bind(format!("legal-idor-{slug}"))
+    .bind(format!("{slug}@legal-idor.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'test_hash', 'LegalIDOR User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_document(pool: &PgPool, org_id: Uuid, created_by: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO legal_documents (organization_id, document_type, title, created_by)
+        VALUES ($1, 'contract', 'Cross-org Confidential Contract', $2)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(created_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed document")
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: same-org read succeeds (proves real org context is wired)
+// ---------------------------------------------------------------------------
+
+/// A user whose JWT `tenant_id` matches the document's organization can read it.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_document_same_org_succeeds(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let user = seed_user(&pool, "same-org@legal-idor.test").await;
+    let org_a = seed_org(&pool, "same-a").await;
+    let doc_id = seed_document(&pool, org_a, user).await;
+
+    let token = access_token(user, Some(org_a));
+    let req = app
+        .get(&format!("/api/v1/legal/documents/{doc_id}"))
+        .bearer(&token)
+        .build();
+    let resp = app.execute(req).await;
+
+    resp.assert_status(StatusCode::OK);
+    let body = resp.json_value();
+    assert_eq!(
+        body["id"].as_str(),
+        Some(doc_id.to_string().as_str()),
+        "same-org read must return the requested document"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: cross-org read is blocked (404)
+// ---------------------------------------------------------------------------
+
+/// A user from Org B cannot read Org A's document by id — the org-scoped query
+/// finds no row and the handler returns 404 (the core #829 IDOR).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_document_cross_org_is_not_found(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let user_a = seed_user(&pool, "owner@legal-idor.test").await;
+    let user_b = seed_user(&pool, "attacker@legal-idor.test").await;
+    let org_a = seed_org(&pool, "x-a").await;
+    let org_b = seed_org(&pool, "x-b").await;
+    let doc_id = seed_document(&pool, org_a, user_a).await;
+
+    // Org B token targeting Org A's document.
+    let token = access_token(user_b, Some(org_b));
+    let req = app
+        .get(&format!("/api/v1/legal/documents/{doc_id}"))
+        .bearer(&token)
+        .build();
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::NOT_FOUND,
+        "cross-org document read must be 404, got {} (body: {})",
+        resp.status,
+        resp.text()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: cross-org update is blocked and does not mutate the row
+// ---------------------------------------------------------------------------
+
+/// A cross-org `PATCH` must not rename another org's document.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn update_document_cross_org_does_not_mutate(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let user_a = seed_user(&pool, "upd-owner@legal-idor.test").await;
+    let user_b = seed_user(&pool, "upd-attacker@legal-idor.test").await;
+    let org_a = seed_org(&pool, "u-a").await;
+    let org_b = seed_org(&pool, "u-b").await;
+    let doc_id = seed_document(&pool, org_a, user_a).await;
+
+    let token = access_token(user_b, Some(org_b));
+    let req = RequestBuilder::new(Method::PATCH, &format!("/api/v1/legal/documents/{doc_id}"))
+        .bearer(&token)
+        .json(serde_json::json!({ "title": "Hijacked Document" }))
+        .build();
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::NOT_FOUND,
+        "cross-org document update must be 404, got {} (body: {})",
+        resp.status,
+        resp.text()
+    );
+
+    // The document title must be unchanged.
+    let title: String = sqlx::query_scalar("SELECT title FROM legal_documents WHERE id = $1")
+        .bind(doc_id)
+        .fetch_one(&pool)
+        .await
+        .expect("fetch document title");
+    assert_eq!(
+        title, "Cross-org Confidential Contract",
+        "cross-org update must not mutate the document"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: cross-org delete is blocked and does not remove the row
+// ---------------------------------------------------------------------------
+
+/// A cross-org `DELETE` must not remove another org's document.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn delete_document_cross_org_does_not_delete(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let user_a = seed_user(&pool, "del-owner@legal-idor.test").await;
+    let user_b = seed_user(&pool, "del-attacker@legal-idor.test").await;
+    let org_a = seed_org(&pool, "d-a").await;
+    let org_b = seed_org(&pool, "d-b").await;
+    let doc_id = seed_document(&pool, org_a, user_a).await;
+
+    let token = access_token(user_b, Some(org_b));
+    let req = app
+        .delete(&format!("/api/v1/legal/documents/{doc_id}"))
+        .bearer(&token)
+        .build();
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::NOT_FOUND,
+        "cross-org document delete must be 404, got {} (body: {})",
+        resp.status,
+        resp.text()
+    );
+
+    // The document must still exist.
+    let still_there: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM legal_documents WHERE id = $1")
+        .bind(doc_id)
+        .fetch_one(&pool)
+        .await
+        .expect("count document");
+    assert_eq!(
+        still_there, 1,
+        "cross-org delete must not remove the document"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: a token with no tenant_id claim is rejected (org-context guard)
+// ---------------------------------------------------------------------------
+
+/// Without an organization context the handler cannot scope the query, so it
+/// must refuse with 403 rather than fall back to an unscoped read.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_document_without_tenant_claim_is_forbidden(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let user = seed_user(&pool, "no-org@legal-idor.test").await;
+    let org_a = seed_org(&pool, "n-a").await;
+    let doc_id = seed_document(&pool, org_a, user).await;
+
+    // Token carries no tenant_id claim.
+    let token = access_token(user, None);
+    let req = app
+        .get(&format!("/api/v1/legal/documents/{doc_id}"))
+        .bearer(&token)
+        .build();
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "request without org context must be 403, got {} (body: {})",
+        resp.status,
+        resp.text()
+    );
+}


### PR DESCRIPTION
## Summary

Closes the remaining cross-tenant IDOR gap from #829 (Epic 25 — Legal). The by-id read/mutate handlers in `routes/legal.rs` previously called the repository with only the resource UUID (e.g. `find_document_by_id(id)`, `update_document(id, …)`, `delete_document(id)`), with **no organization predicate**. Any authenticated user who knew/guessed another org's document/requirement/notice/template id could read, update, or delete that org's confidential legal data (contracts, GDPR notices, compliance PII).

The fix derives the org from the authenticated JWT `tenant_id` claim — the same idiom the already-merged `violations.rs` / `reserve_funds.rs` use (`user.tenant_id.ok_or_else(forbidden)`) — and threads it into every by-id repository method so the SQL is org-scoped (`… WHERE id = $1 AND organization_id = $2`). A foreign-org row now surfaces as `None` → HTTP 404; a token with no `tenant_id` is rejected 403.

Scoped handlers/repo methods: documents (get/update/delete + versions: add/list/get), requirements (get/update/delete + verifications: create/list), notices (get/update/delete/send + recipients: list/acknowledge), templates (get/update/delete/apply). Child resources (versions, verifications, recipients) are guarded via a parent-in-org check. `apply_template` now uses the JWT org instead of trusting the request body.

## Scope of #829 (multi-epic)

#829 spans Epics 20/24/25/26. Per the issue's prior sweeps, **work_orders (Epic 20) was already fixed in #877**, and **budgets (24) / subscriptions (26) already use RLS** — verified those remain in place on `dev`. This PR addresses the one remaining actionable gap: legal (Epic 25). Using `refs #829` (not `closes`) since other parts merged separately.

## Owner
pm-security

## Tested (Band A — fast check)
Isolated `CARGO_TARGET_DIR` against a local Postgres 16 container:

```
$ cargo check -p db          # exit 0
$ cargo check -p api-server  # exit 0
$ cargo test -p api-server --test legal_cross_org_idor_tests
running 5 tests
test get_document_same_org_succeeds ... ok
test get_document_without_tenant_claim_is_forbidden ... ok
test get_document_cross_org_is_not_found ... ok
test delete_document_cross_org_does_not_delete ... ok
test update_document_cross_org_does_not_mutate ... ok
test result: ok. 5 passed; 0 failed
```

The suite includes a **same-org success case** (Org A's token reads Org A's document → 200), proving real org context is wired — not just blanket 404s.

## Built (Band B — full build)
```
$ cargo clippy -p api-server --lib -- -D warnings   # exit 0, clean
$ cargo clippy -p db --lib -- -D warnings           # exit 0, clean
$ cargo fmt --all                                   # clean
```

## CI parity (Band C — hot-path)
Security/IDOR change. Verified via the per-crate clippy `-D warnings` + the new integration test above (CI `backend.yml` runs fmt/clippy/test).

## Notes
- New repo signatures return `Option<…>` for by-id update/mutate so the handler can map a missing (or cross-org) row to 404 rather than a DB error.
- `ApplyTemplateRequest.organization_id` is retained for wire compatibility but no longer trusted; the org comes from the JWT.