### PR TITLE
fix(security): scope fault routes to authenticated tenant (closes #770)

### DIFF
--- a/backend/crates/db/src/repositories/fault.rs
+++ b/backend/crates/db/src/repositories/fault.rs
@@ -191,6 +191,52 @@ impl FaultRepository {
         Ok(fault)
     }
 
+    /// Find a fault by ID, scoped to a specific organization.
+    ///
+    /// SECURITY (#770): explicitly threads `organization_id` into the WHERE
+    /// clause so a caller in org B cannot read/act on org A's fault by
+    /// enumerating its UUID. Returns `None` (→ 404) for a cross-tenant id.
+    /// Use this for the legacy pool-based mutate-by-id handlers
+    /// (assign/resolve/confirm/reopen, comments, attachments) that do NOT
+    /// run under an `RlsConnection` and therefore are not protected by the
+    /// `faults_tenant_isolation` RLS policy.
+    pub async fn find_by_id_for_org(
+        &self,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<Option<Fault>, SqlxError> {
+        // The enum columns (category/priority/status) are cast to text so the
+        // row decodes into the `String`-typed `Fault` model regardless of
+        // whether the connection has the PG enum types registered (matches the
+        // `::text` idiom used by the statistics queries below).
+        let fault = sqlx::query_as::<_, Fault>(
+            r#"
+            SELECT
+                id, organization_id, building_id, unit_id, reporter_id,
+                title, description, location_description,
+                category::text AS category,
+                priority::text AS priority,
+                status::text AS status,
+                ai_category::text AS ai_category,
+                ai_priority::text AS ai_priority,
+                ai_confidence, ai_processed_at,
+                assigned_to, assigned_at, triaged_by, triaged_at,
+                resolved_at, resolved_by, resolution_notes,
+                confirmed_at, confirmed_by, rating, feedback,
+                scheduled_date, estimated_completion, idempotency_key,
+                created_at, updated_at
+            FROM faults
+            WHERE id = $1 AND organization_id = $2
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(fault)
+    }
+
     /// Update fault details with RLS context (reporter can edit before triage).
     pub async fn update_rls<'e, E>(
         &self,
@@ -350,8 +396,10 @@ impl FaultRepository {
             r#"
             SELECT
                 f.id, f.organization_id, f.building_id, f.unit_id, f.reporter_id,
-                f.title, f.description, f.location_description, f.category, f.priority, f.status,
-                f.ai_category, f.ai_priority, f.ai_confidence, f.ai_processed_at,
+                f.title, f.description, f.location_description,
+                f.category::text AS category, f.priority::text AS priority, f.status::text AS status,
+                f.ai_category::text AS ai_category, f.ai_priority::text AS ai_priority,
+                f.ai_confidence, f.ai_processed_at,
                 f.assigned_to, f.assigned_at, f.triaged_by, f.triaged_at,
                 f.resolved_at, f.resolved_by, f.resolution_notes,
                 f.confirmed_at, f.confirmed_by, f.rating, f.feedback,
@@ -377,52 +425,105 @@ impl FaultRepository {
         .fetch_optional(&self.pool)
         .await?;
 
-        Ok(result.map(|row| {
-            let fault = Fault {
-                id: row.id,
-                organization_id: row.organization_id,
-                building_id: row.building_id,
-                unit_id: row.unit_id,
-                reporter_id: row.reporter_id,
-                title: row.title,
-                description: row.description,
-                location_description: row.location_description,
-                category: row.category,
-                priority: row.priority,
-                status: row.status,
-                ai_category: row.ai_category,
-                ai_priority: row.ai_priority,
-                ai_confidence: row.ai_confidence,
-                ai_processed_at: row.ai_processed_at,
-                assigned_to: row.assigned_to,
-                assigned_at: row.assigned_at,
-                triaged_by: row.triaged_by,
-                triaged_at: row.triaged_at,
-                resolved_at: row.resolved_at,
-                resolved_by: row.resolved_by,
-                resolution_notes: row.resolution_notes,
-                confirmed_at: row.confirmed_at,
-                confirmed_by: row.confirmed_by,
-                rating: row.rating,
-                feedback: row.feedback,
-                scheduled_date: row.scheduled_date,
-                estimated_completion: row.estimated_completion,
-                idempotency_key: row.idempotency_key,
-                created_at: row.created_at,
-                updated_at: row.updated_at,
-            };
-            FaultWithDetails {
-                fault,
-                reporter_name: row.reporter_name,
-                reporter_email: row.reporter_email,
-                building_name: row.building_name,
-                building_address: row.building_address,
-                unit_designation: row.unit_designation,
-                assigned_to_name: row.assigned_to_name,
-                attachment_count: row.attachment_count,
-                comment_count: row.comment_count,
-            }
-        }))
+        Ok(result.map(Self::details_row_to_model))
+    }
+
+    /// Find fault with full details, scoped to a specific organization.
+    ///
+    /// SECURITY (#770): the `get_fault` handler runs WITHOUT an
+    /// `RlsConnection`, so the unscoped `find_by_id_with_details` leaked any
+    /// org's fault (and its reporter PII / timeline / attachment counts) to a
+    /// caller who guessed the UUID — a cross-tenant IDOR. This variant adds an
+    /// explicit `f.organization_id = $2` predicate so a cross-tenant id
+    /// resolves to `None` (→ 404).
+    pub async fn find_by_id_with_details_for_org(
+        &self,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<Option<FaultWithDetails>, SqlxError> {
+        let result = sqlx::query_as::<_, FaultDetailsRow>(
+            r#"
+            SELECT
+                f.id, f.organization_id, f.building_id, f.unit_id, f.reporter_id,
+                f.title, f.description, f.location_description,
+                f.category::text AS category, f.priority::text AS priority, f.status::text AS status,
+                f.ai_category::text AS ai_category, f.ai_priority::text AS ai_priority,
+                f.ai_confidence, f.ai_processed_at,
+                f.assigned_to, f.assigned_at, f.triaged_by, f.triaged_at,
+                f.resolved_at, f.resolved_by, f.resolution_notes,
+                f.confirmed_at, f.confirmed_by, f.rating, f.feedback,
+                f.scheduled_date, f.estimated_completion, f.idempotency_key,
+                f.created_at, f.updated_at,
+                u.name as reporter_name,
+                u.email as reporter_email,
+                COALESCE(b.name, b.street) as building_name,
+                b.street || ', ' || b.city as building_address,
+                un.designation as unit_designation,
+                au.name as assigned_to_name,
+                (SELECT COUNT(*) FROM fault_attachments WHERE fault_id = f.id) as attachment_count,
+                (SELECT COUNT(*) FROM fault_timeline WHERE fault_id = f.id AND action = 'comment') as comment_count
+            FROM faults f
+            JOIN users u ON f.reporter_id = u.id
+            JOIN buildings b ON f.building_id = b.id
+            LEFT JOIN units un ON f.unit_id = un.id
+            LEFT JOIN users au ON f.assigned_to = au.id
+            WHERE f.id = $1 AND f.organization_id = $2
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(result.map(Self::details_row_to_model))
+    }
+
+    /// Map a raw [`FaultDetailsRow`] into the public [`FaultWithDetails`] model.
+    fn details_row_to_model(row: FaultDetailsRow) -> FaultWithDetails {
+        let fault = Fault {
+            id: row.id,
+            organization_id: row.organization_id,
+            building_id: row.building_id,
+            unit_id: row.unit_id,
+            reporter_id: row.reporter_id,
+            title: row.title,
+            description: row.description,
+            location_description: row.location_description,
+            category: row.category,
+            priority: row.priority,
+            status: row.status,
+            ai_category: row.ai_category,
+            ai_priority: row.ai_priority,
+            ai_confidence: row.ai_confidence,
+            ai_processed_at: row.ai_processed_at,
+            assigned_to: row.assigned_to,
+            assigned_at: row.assigned_at,
+            triaged_by: row.triaged_by,
+            triaged_at: row.triaged_at,
+            resolved_at: row.resolved_at,
+            resolved_by: row.resolved_by,
+            resolution_notes: row.resolution_notes,
+            confirmed_at: row.confirmed_at,
+            confirmed_by: row.confirmed_by,
+            rating: row.rating,
+            feedback: row.feedback,
+            scheduled_date: row.scheduled_date,
+            estimated_completion: row.estimated_completion,
+            idempotency_key: row.idempotency_key,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+        };
+        FaultWithDetails {
+            fault,
+            reporter_name: row.reporter_name,
+            reporter_email: row.reporter_email,
+            building_name: row.building_name,
+            building_address: row.building_address,
+            unit_designation: row.unit_designation,
+            assigned_to_name: row.assigned_to_name,
+            attachment_count: row.attachment_count,
+            comment_count: row.comment_count,
+        }
     }
 
     /// List faults with filters (Story 4.3).

--- a/backend/servers/api-server/src/routes/faults.rs
+++ b/backend/servers/api-server/src/routes/faults.rs
@@ -52,6 +52,63 @@ fn require_tenant_id(
     })
 }
 
+/// Assert the fault `id` belongs to `tenant_id`, returning 404 otherwise.
+///
+/// SECURITY (#770): the legacy pool-based mutate-by-id repository methods
+/// (`assign`, `resolve`, `confirm`, `reopen`, comments, attachments) run
+/// OUTSIDE an `RlsConnection`, so they are NOT protected by the
+/// `faults_tenant_isolation` RLS policy and would otherwise act on any org's
+/// fault by UUID. This pre-flight guard scopes the row to the caller's org
+/// before the mutation runs, collapsing a cross-tenant id to a 404.
+async fn require_fault_in_org(
+    state: &AppState,
+    id: Uuid,
+    tenant_id: Uuid,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    match state.fault_repo.find_by_id_for_org(id, tenant_id).await {
+        Ok(Some(_)) => Ok(()),
+        Ok(None) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("NOT_FOUND", "Fault not found")),
+        )),
+        Err(e) => {
+            tracing::error!("Failed to load fault for org scope check: {}", e);
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to load fault")),
+            ))
+        }
+    }
+}
+
+/// Require the caller to hold a manager-tier role in `tenant_id`.
+///
+/// SECURITY (#770): triage/assign/resolve are workflow actions that any tenant
+/// member could previously invoke. This gate restricts them to managers via
+/// the canonical `is_manager_in_org` membership lookup (same set used by
+/// `get_fault`/`list_comments` for internal-note visibility).
+async fn require_manager(
+    state: &AppState,
+    user_id: Uuid,
+    tenant_id: Uuid,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    let is_manager = MembershipRepository::new(state.db.clone())
+        .is_manager_in_org(user_id, tenant_id)
+        .await
+        .unwrap_or(false);
+    if is_manager {
+        Ok(())
+    } else {
+        Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "FORBIDDEN",
+                "Manager role required for this action",
+            )),
+        ))
+    }
+}
+
 // ============================================================================
 // Response Types
 // ============================================================================
@@ -451,7 +508,16 @@ async fn get_fault(
         .await
         .unwrap_or(false);
 
-    let fault = match state.fault_repo.find_by_id_with_details(id).await {
+    // SECURITY (#770): scope the lookup to the caller's organization. The
+    // previous `find_by_id_with_details(id)` ran on the raw pool with no org
+    // predicate, so a caller in org B could read org A's fault (reporter PII,
+    // timeline, attachment counts) by enumerating the UUID — a cross-tenant
+    // IDOR. The `_for_org` variant returns None (→ 404) for a cross-tenant id.
+    let fault = match state
+        .fault_repo
+        .find_by_id_with_details_for_org(id, tenant_id)
+        .await
+    {
         Ok(Some(f)) => f,
         Ok(None) => {
             return Err((
@@ -594,7 +660,8 @@ async fn triage_fault(
     Path(id): Path<Uuid>,
     Json(req): Json<TriageFaultRequest>,
 ) -> Result<Json<FaultActionResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
+    let tenant_id = require_tenant_id(&principal)?;
+    require_manager(&state, principal.user_id, tenant_id).await?;
 
     // Check fault exists
     let existing = match state.fault_repo.find_by_id_rls(&mut **rls.conn(), id).await {
@@ -675,7 +742,9 @@ async fn assign_fault(
     Path(id): Path<Uuid>,
     Json(req): Json<AssignFaultRequest>,
 ) -> Result<Json<FaultActionResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
+    let tenant_id = require_tenant_id(&principal)?;
+    require_manager(&state, principal.user_id, tenant_id).await?;
+    require_fault_in_org(&state, id, tenant_id).await?;
 
     let data = AssignFault {
         assigned_to: req.assigned_to,
@@ -724,7 +793,8 @@ async fn update_status(
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateStatusRequest>,
 ) -> Result<Json<FaultActionResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
+    let tenant_id = require_tenant_id(&principal)?;
+    require_manager(&state, principal.user_id, tenant_id).await?;
 
     // Get current fault to obtain current status
     let existing = match state.fault_repo.find_by_id_rls(&mut **rls.conn(), id).await {
@@ -801,7 +871,9 @@ async fn resolve_fault(
     Path(id): Path<Uuid>,
     Json(req): Json<ResolveFaultRequest>,
 ) -> Result<Json<FaultActionResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
+    let tenant_id = require_tenant_id(&principal)?;
+    require_manager(&state, principal.user_id, tenant_id).await?;
+    require_fault_in_org(&state, id, tenant_id).await?;
 
     let data = ResolveFault {
         resolution_notes: req.resolution_notes,
@@ -849,7 +921,8 @@ async fn confirm_fault(
     Path(id): Path<Uuid>,
     Json(req): Json<ConfirmFaultRequest>,
 ) -> Result<Json<FaultActionResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
+    let tenant_id = require_tenant_id(&principal)?;
+    require_fault_in_org(&state, id, tenant_id).await?;
 
     let data = ConfirmFault {
         rating: req.rating,
@@ -897,7 +970,8 @@ async fn reopen_fault(
     Path(id): Path<Uuid>,
     Json(req): Json<ReopenFaultRequest>,
 ) -> Result<Json<FaultActionResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
+    let tenant_id = require_tenant_id(&principal)?;
+    require_fault_in_org(&state, id, tenant_id).await?;
 
     let data = ReopenFault { reason: req.reason };
 
@@ -940,6 +1014,10 @@ async fn list_comments(
     Path(id): Path<Uuid>,
 ) -> Result<Json<TimelineResponse>, (StatusCode, Json<ErrorResponse>)> {
     let tenant_id = require_tenant_id(&principal)?;
+    // SECURITY (#770): scope the timeline read to the caller's org. The
+    // `list_timeline` query runs on the raw pool (no RLS), so without this
+    // guard a caller could read another org's fault timeline by UUID.
+    require_fault_in_org(&state, id, tenant_id).await?;
     // P0-07: real role lookup (see get_fault above).
     let is_manager = MembershipRepository::new(state.db.clone())
         .is_manager_in_org(principal.user_id, tenant_id)
@@ -981,11 +1059,25 @@ async fn add_comment(
     Path(id): Path<Uuid>,
     Json(req): Json<AddCommentRequest>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
+    let tenant_id = require_tenant_id(&principal)?;
+    require_fault_in_org(&state, id, tenant_id).await?;
+
+    // SECURITY (#770): internal notes are manager-only. Read filtering was
+    // already gated in P0-07; the write path was not. A non-manager asking to
+    // mark a comment internal is downgraded to a normal comment rather than
+    // silently creating a manager-visibility note (least surprise + no leak).
+    let is_internal = if req.is_internal {
+        MembershipRepository::new(state.db.clone())
+            .is_manager_in_org(principal.user_id, tenant_id)
+            .await
+            .unwrap_or(false)
+    } else {
+        false
+    };
 
     let data = AddFaultComment {
         note: req.note,
-        is_internal: req.is_internal,
+        is_internal,
     };
 
     state
@@ -1026,7 +1118,8 @@ async fn add_work_note(
     Path(id): Path<Uuid>,
     Json(req): Json<AddWorkNoteRequest>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
+    let tenant_id = require_tenant_id(&principal)?;
+    require_fault_in_org(&state, id, tenant_id).await?;
 
     let data = AddWorkNote { note: req.note };
 
@@ -1062,8 +1155,14 @@ async fn add_work_note(
 )]
 async fn list_attachments(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(id): Path<Uuid>,
 ) -> Result<Json<AttachmentsResponse>, (StatusCode, Json<ErrorResponse>)> {
+    // SECURITY (#770): the attachment list runs on the raw pool (no RLS), so
+    // scope it to the caller's org before returning storage URLs / metadata.
+    let tenant_id = require_tenant_id(&principal)?;
+    require_fault_in_org(&state, id, tenant_id).await?;
+
     match state.fault_repo.list_attachments(id).await {
         Ok(attachments) => Ok(Json(AttachmentsResponse { attachments })),
         Err(e) => {
@@ -1099,7 +1198,8 @@ async fn add_attachment(
     Path(id): Path<Uuid>,
     Json(req): Json<AddAttachmentRequest>,
 ) -> Result<(StatusCode, Json<FaultAttachment>), (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
+    let tenant_id = require_tenant_id(&principal)?;
+    require_fault_in_org(&state, id, tenant_id).await?;
 
     let data = CreateFaultAttachment {
         fault_id: id,
@@ -1145,8 +1245,16 @@ async fn add_attachment(
 )]
 async fn delete_attachment(
     State(state): State<AppState>,
-    Path((_id, attachment_id)): Path<(Uuid, Uuid)>,
+    principal: RequestPrincipal,
+    Path((id, attachment_id)): Path<(Uuid, Uuid)>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    // SECURITY (#770): scope the delete to the caller's org via the parent
+    // fault. `delete_attachment` runs on the raw pool with no org predicate,
+    // so without this guard any caller could delete another org's attachment
+    // by enumerating its UUID.
+    let tenant_id = require_tenant_id(&principal)?;
+    require_fault_in_org(&state, id, tenant_id).await?;
+
     match state.fault_repo.delete_attachment(attachment_id).await {
         Ok(_) => Ok(StatusCode::NO_CONTENT),
         Err(e) => {

--- a/backend/servers/api-server/tests/faults_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/faults_cross_org_idor_tests.rs
@@ -1,0 +1,188 @@
+//! Regression tests for the cross-tenant IDOR fix on the fault
+//! read-and-mutate-by-id paths (issue #770).
+//!
+//! Audit history: `get_fault` extracted a verified `RequestPrincipal` but then
+//! called `fault_repo.find_by_id_with_details(id)` — a query on the raw pool
+//! with NO `organization_id` predicate and NOT running under an
+//! `RlsConnection`. A caller in org B could therefore read org A's fault
+//! (reporter PII, building address, timeline + attachment counts) by guessing
+//! or enumerating the fault UUID. The legacy pool-based mutate-by-id handlers
+//! (assign/resolve/confirm/reopen, comments, attachments) shared the same gap.
+//!
+//! The fix adds `_for_org` repository variants that thread the principal's
+//! `effective_org` into the SQL WHERE clause (the same idiom the violations and
+//! AI/LLM routers already use, see `ai_llm_cross_tenant_idor_tests.rs`).
+//!
+//! Why repo-layer and not HTTP-layer: `TestApp` mounts the router WITHOUT
+//! `host_tenant_middleware`, so `RequestPrincipal` can never resolve an
+//! `effective_org` in tests. The IDOR fix itself lives in the repository's
+//! WHERE clause, so the security contract is asserted there directly: the
+//! scoped method must NOT return another org's row even though the raw
+//! (pre-fix) query would. Each test also runs the unscoped lookup to
+//! demonstrate the leak the `_for_org` variant closes.
+
+use db::repositories::FaultRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active') RETURNING id
+        "#,
+    )
+    .bind(format!("FaultIDOR Org {slug}"))
+    .bind(format!("fault-idor-org-{slug}"))
+    .bind(format!("{slug}@fault-idor.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'test_hash', 'FaultIDOR User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_building(pool: &PgPool, org_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO buildings (organization_id, name, street, city, postal_code, country, status)
+        VALUES ($1, 'FaultIDOR Building', 'Test Street 1', 'Test City', '12345', 'SK', 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed building")
+}
+
+async fn seed_fault(pool: &PgPool, org_id: Uuid) -> Uuid {
+    let user_id = seed_user(pool, &format!("reporter-{org_id}@fault-idor.test")).await;
+    let building_id = seed_building(pool, org_id).await;
+
+    // Insert directly with explicit enum casts. (The production `create_rls`
+    // path relies on a `query_as` bind that decodes fine at runtime but the
+    // raw text-bind here needs the cast to satisfy the enum-typed columns.)
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO faults (
+            organization_id, building_id, reporter_id,
+            title, description, location_description, category, priority
+        )
+        VALUES (
+            $1, $2, $3,
+            'Leaking pipe', 'Water under the kitchen sink', 'Kitchen',
+            'plumbing'::fault_category, 'high'::fault_priority
+        )
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(building_id)
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed fault")
+}
+
+// ---------------------------------------------------------------------------
+// (1) get_fault path: find_by_id_with_details_for_org is tenant-scoped.
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn find_by_id_with_details_for_org_blocks_cross_tenant_read(pool: PgPool) {
+    let repo = FaultRepository::new(pool.clone());
+
+    let org_a = seed_org(&pool, "details-a").await;
+    let org_b = seed_org(&pool, "details-b").await;
+    let fault_in_a = seed_fault(&pool, org_a).await;
+
+    // Same-org read SUCCEEDS — proves the org predicate does not over-filter.
+    let same_org = repo
+        .find_by_id_with_details_for_org(fault_in_a, org_a)
+        .await
+        .expect("query ok");
+    assert!(
+        same_org.is_some(),
+        "org A must be able to read its own fault details"
+    );
+
+    // Cross-org read returns None (→ 404). The IDOR is blocked.
+    let cross_org = repo
+        .find_by_id_with_details_for_org(fault_in_a, org_b)
+        .await
+        .expect("query ok");
+    assert!(
+        cross_org.is_none(),
+        "org B must NOT be able to read org A's fault details"
+    );
+
+    // Sanity: the unscoped query (the vulnerable pre-fix `find_by_id_with_details`
+    // path) leaks the row regardless of org.
+    let leaked = repo
+        .find_by_id_with_details(fault_in_a)
+        .await
+        .expect("query ok");
+    assert!(
+        leaked.is_some(),
+        "sanity: the unscoped query (pre-fix path) does leak the fault"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (2) mutate-by-id paths: find_by_id_for_org guards assign/resolve/confirm/
+//     reopen/comments/attachments before the pool-based mutation runs.
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn find_by_id_for_org_blocks_cross_tenant_mutate(pool: PgPool) {
+    let repo = FaultRepository::new(pool.clone());
+
+    let org_a = seed_org(&pool, "mutate-a").await;
+    let org_b = seed_org(&pool, "mutate-b").await;
+    let fault_in_a = seed_fault(&pool, org_a).await;
+
+    // Same-org guard SUCCEEDS — the action proceeds for the owning org.
+    let same_org = repo
+        .find_by_id_for_org(fault_in_a, org_a)
+        .await
+        .expect("query ok");
+    assert!(
+        same_org.is_some(),
+        "org A must pass the org-scope guard for its own fault"
+    );
+
+    // Cross-org guard returns None — the handler maps this to 404 and the
+    // assign/resolve/confirm/reopen/comment/attachment mutation never runs.
+    let cross_org = repo
+        .find_by_id_for_org(fault_in_a, org_b)
+        .await
+        .expect("query ok");
+    assert!(
+        cross_org.is_none(),
+        "org B must NOT pass the org-scope guard for org A's fault"
+    );
+
+    // A fully random id is also rejected for the owning org.
+    let missing = repo
+        .find_by_id_for_org(Uuid::new_v4(), org_a)
+        .await
+        .expect("query ok");
+    assert!(missing.is_none(), "unknown fault id must resolve to None");
+}


### PR DESCRIPTION
## Summary

Closes the cross-tenant IDOR on the fault read/mutate-by-id endpoints (issue #770). `get_fault` (and the legacy pool-based sibling handlers) looked rows up by UUID with **no** organization predicate and **not** under an `RlsConnection`, so a caller in org B could read or act on org A's faults (reporter PII, building address, timeline/attachment data) by enumerating the id.

## Org mechanism

`backend/servers/api-server/src/routes/faults.rs` resolves tenancy via `RequestPrincipal::effective_org` (`require_tenant_id`). Handlers that already loaded the fault through `find_by_id_rls` under an `RlsConnection` were protected by the `faults_tenant_isolation` RLS policy; the unscoped pool handlers were not. Fix follows the established `_for_org` idiom (violations.rs, ai_llm).

## Changes

`backend/crates/db/src/repositories/fault.rs`
- New `find_by_id_for_org(id, org_id) -> Option<Fault>` — org-scoped guard for the pool-based mutate-by-id handlers.
- New `find_by_id_with_details_for_org(id, org_id) -> Option<FaultWithDetails>` — org-scoped variant of the details query backing `get_fault`.
- Extracted shared `FaultDetailsRow -> FaultWithDetails` mapping into `details_row_to_model`.
- Enum columns (`category`/`priority`/`status`/`ai_category`/`ai_priority`) cast to `::text` in the new queries (and the existing details query) so they decode into the `String`-typed models without relying on connection-level enum registration — matches the repo's existing statistics-query idiom.

`backend/servers/api-server/src/routes/faults.rs`
- `get_fault` now calls `find_by_id_with_details_for_org(id, tenant_id)` — cross-tenant id -> 404. **(core fix)**
- Added `require_fault_in_org` org-scope pre-flight guard to the unscoped handlers: `assign_fault`, `resolve_fault`, `confirm_fault`, `reopen_fault`, `list_comments`, `add_comment`, `add_work_note`, `list_attachments`, `add_attachment`, `delete_attachment`. `list_attachments`/`delete_attachment` gained a `RequestPrincipal` extractor (they had none).
- Added `require_manager` (reusing `MembershipRepository::is_manager_in_org`) on the workflow actions: `triage_fault`, `assign_fault`, `update_status`, `resolve_fault`.
- `add_comment`: `is_internal` write now gated to managers (internal-note write-gate; read filtering was already fixed in P0-07).

## Tested (Band A)

Isolated target dir (`--target-dir ~/.cargo-targets/ct-770`) to avoid the shared-target-dir false-pass trap.

```
$ cargo fmt --all                                              # exit 0
$ cargo clippy -p api-server -p db --lib -- -D warnings        # exit 0, no warnings
$ cargo test -p api-server --test faults_cross_org_idor_tests  # exit 0
running 2 tests
test find_by_id_for_org_blocks_cross_tenant_mutate ... ok
test find_by_id_with_details_for_org_blocks_cross_tenant_read ... ok
test result: ok. 2 passed; 0 failed
```

The IDOR regression test (`faults_cross_org_idor_tests.rs`) asserts at the repo layer (TestApp has no `host_tenant_middleware`, so `effective_org` can't resolve over HTTP — same caveat as `ai_llm_cross_tenant_idor_tests.rs`): a **same-org read/guard SUCCEEDS** (proves real org context, not blanket denial) and a **cross-org lookup returns None (-> 404)**, with a sanity assertion that the unscoped pre-fix path leaks the row.

## CI parity

`backend.yml` (fmt + clippy + cargo test) will run on these `backend/**` changes; replicated locally above.

## Notes / deferred

- No status-transition state machine added (#770 Medium 3) — out of scope for the IDOR/authz fix; arbitrary status jumps still possible via `update_status`. Noted for follow-up.
- `FaultStatistics` mobile contract drift (#770 Medium 6) and AI-heuristic items (Low 8) untouched — unrelated to tenant scoping.