### PR TITLE
fix(security): enforce expiry + password on public document shares (closes #807)

### DIFF
--- a/backend/crates/db/src/repositories/document.rs
+++ b/backend/crates/db/src/repositories/document.rs
@@ -576,7 +576,14 @@ impl DocumentRepository {
     {
         sqlx::query_as::<_, Document>(
             r#"
-            SELECT * FROM documents
+            SELECT
+                id, organization_id, folder_id, title, description,
+                category::text AS category, file_key, file_name, mime_type,
+                size_bytes, access_scope::text AS access_scope,
+                access_target_ids, access_roles, created_by, created_at,
+                updated_at, deleted_at, version_number, parent_document_id,
+                is_current_version, template_id, generation_metadata
+            FROM documents
             WHERE id = $1 AND deleted_at IS NULL
             "#,
         )
@@ -1221,7 +1228,10 @@ impl DocumentRepository {
                 share_token, password_hash, expires_at
             )
             VALUES ($1, $2::document_share_type, $3, $4, $5, $6, $7, $8)
-            RETURNING *
+            RETURNING
+                id, document_id, share_type::text AS share_type, target_id,
+                target_role, shared_by, share_token, password_hash, expires_at,
+                revoked_at, created_at
             "#,
         )
         .bind(data.document_id)
@@ -1247,7 +1257,11 @@ impl DocumentRepository {
     {
         sqlx::query_as::<_, DocumentShare>(
             r#"
-            SELECT * FROM document_shares
+            SELECT
+                id, document_id, share_type::text AS share_type, target_id,
+                target_role, shared_by, share_token, password_hash, expires_at,
+                revoked_at, created_at
+            FROM document_shares
             WHERE id = $1 AND revoked_at IS NULL
             "#,
         )
@@ -1267,7 +1281,11 @@ impl DocumentRepository {
     {
         sqlx::query_as::<_, DocumentShare>(
             r#"
-            SELECT * FROM document_shares
+            SELECT
+                id, document_id, share_type::text AS share_type, target_id,
+                target_role, shared_by, share_token, password_hash, expires_at,
+                revoked_at, created_at
+            FROM document_shares
             WHERE share_token = $1
               AND revoked_at IS NULL
               AND (expires_at IS NULL OR expires_at > NOW())

--- a/backend/servers/api-server/tests/document_share_access_tests.rs
+++ b/backend/servers/api-server/tests/document_share_access_tests.rs
@@ -1,0 +1,436 @@
+//! Public document-share access integration tests (Epic 7B, issue #807).
+//!
+//! The public share-access routes are mounted at the router root (merged, not
+//! nested under `/api/v1/documents`):
+//!
+//! - `GET  /shared/{token}`         — open a share (no password)
+//! - `POST /shared/{token}/access`  — open a password-protected share
+//!
+//! These tests pin the security contract for those public, unauthenticated
+//! routes:
+//!
+//! - An **expired** share token (`expires_at < now()`) is rejected with 404,
+//!   not served. Expiry is enforced in the SQL predicate of
+//!   `find_share_by_token` (`AND (expires_at IS NULL OR expires_at > NOW())`);
+//!   a regression that drops that predicate would surface here.
+//! - A **valid, non-expired** link share is served (200) with download/preview
+//!   URLs.
+//! - A **password-protected** share returns 401 on the no-password GET route,
+//!   rejects a wrong password (401) on the POST route, and serves the document
+//!   (200) for the correct password.
+//! - A **revoked** share is rejected with 404.
+//!
+//! Shares are seeded with raw SQL; the password hash is produced with the same
+//! `argon2` default the create-share handler uses, so `verify_share_password`
+//! accepts it.
+
+#[allow(dead_code)]
+mod common;
+
+use argon2::{password_hash::PasswordHasher, Argon2};
+use axum::{
+    body::Body,
+    http::{header, Method, Request, StatusCode},
+};
+use chrono::{DateTime, Duration, Utc};
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{cleanup_test_user, create_authenticated_user, TestApp, TestUser};
+
+// ============================================================================
+// Seed helpers
+// ============================================================================
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO organizations (name, slug, contact_email, status) \
+         VALUES ($1, $2, $3, 'active') RETURNING id",
+    )
+    .bind(format!("ShareTest {slug}"))
+    .bind(format!("share-test-{slug}"))
+    .bind(format!("{slug}@share-test.example"))
+    .fetch_one(pool)
+    .await
+    .expect("seed_org")
+}
+
+async fn add_org_member(pool: &PgPool, org_id: Uuid, user_id: Uuid) {
+    sqlx::query(
+        "INSERT INTO organization_members \
+             (id, organization_id, user_id, role_type, status, created_at) \
+         VALUES ($1, $2, $3, 'admin', 'active', NOW()) ON CONFLICT DO NOTHING",
+    )
+    .bind(Uuid::new_v4())
+    .bind(org_id)
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .expect("add_org_member");
+}
+
+async fn user_id_for(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(email)
+        .fetch_one(pool)
+        .await
+        .expect("user_id_for")
+}
+
+/// Insert a `documents` row directly and return its id.
+async fn seed_document(pool: &PgPool, org_id: Uuid, created_by: Uuid, title: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO documents \
+             (organization_id, title, category, file_key, file_name, mime_type, \
+              size_bytes, access_scope, created_by) \
+         VALUES ($1, $2, 'reports', $3, 'report.pdf', 'application/pdf', 1024, \
+                 'organization', $4) \
+         RETURNING id",
+    )
+    .bind(org_id)
+    .bind(title)
+    .bind(format!("{org_id}/test/{}.pdf", Uuid::new_v4()))
+    .bind(created_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed_document")
+}
+
+/// Hash a password exactly as the share-create handler does (`argon2`
+/// default, PHC string), so `verify_share_password` accepts it.
+fn hash_password(password: &str) -> String {
+    Argon2::default()
+        .hash_password(password.as_bytes())
+        .expect("hash_password")
+        .to_string()
+}
+
+/// Insert a `link`-type share row directly and return its `share_token`.
+///
+/// Done with raw SQL (rather than `DocumentRepository::create_share`) so the
+/// test does not depend on the deprecated repo method's `RETURNING *` decode
+/// path. The expiry / revocation / password columns are written verbatim,
+/// which is exactly what the public read path filters on.
+async fn seed_link_share(
+    pool: &PgPool,
+    document_id: Uuid,
+    shared_by: Uuid,
+    password: Option<&str>,
+    expires_at: Option<DateTime<Utc>>,
+) -> String {
+    let token: String = format!("tok{}", Uuid::new_v4().simple());
+    let password_hash = password.map(hash_password);
+    sqlx::query(
+        "INSERT INTO document_shares \
+             (document_id, share_type, shared_by, share_token, password_hash, expires_at) \
+         VALUES ($1, 'link'::document_share_type, $2, $3, $4, $5)",
+    )
+    .bind(document_id)
+    .bind(shared_by)
+    .bind(&token)
+    .bind(password_hash)
+    .bind(expires_at)
+    .execute(pool)
+    .await
+    .expect("seed_link_share");
+    token
+}
+
+/// Full setup: org + authenticated user (as creator) + document. Returns
+/// `(pool-ready org_id, user_id, document_id)`.
+async fn setup(app: &TestApp, pool: &PgPool, user: &TestUser, title: &str) -> (Uuid, Uuid, Uuid) {
+    cleanup_test_user(pool, &user.email).await;
+    let (_token, _) = create_authenticated_user(app, user).await;
+    let user_id = user_id_for(pool, &user.email).await;
+    let org_id = seed_org(pool, &Uuid::new_v4().to_string()[..8]).await;
+    add_org_member(pool, org_id, user_id).await;
+    let doc_id = seed_document(pool, org_id, user_id, title).await;
+    (org_id, user_id, doc_id)
+}
+
+// ============================================================================
+// Expiry enforcement (issue #807)
+// ============================================================================
+
+/// An expired share token must NOT serve the document. The SQL predicate
+/// `expires_at > NOW()` filters it out, so the handler sees `None` → 404.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn test_expired_share_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    let (_org, user_id, doc_id) = setup(&app, &pool, &user, "Expired Share Doc").await;
+
+    // expires_at one hour in the PAST
+    let token = seed_link_share(
+        &pool,
+        doc_id,
+        user_id,
+        None,
+        Some(Utc::now() - Duration::hours(1)),
+    )
+    .await;
+
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri(format!("/shared/{token}"))
+        .body(Body::empty())
+        .unwrap();
+    let response = app.execute(request).await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::NOT_FOUND,
+        "expired share must be rejected with 404; got {}. Body: {}",
+        response.status,
+        response.text()
+    );
+
+    cleanup_test_user(&pool, &user.email).await;
+}
+
+/// A valid, non-expired link share serves the document with 200 + URLs.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn test_valid_share_succeeds(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    let (_org, user_id, doc_id) = setup(&app, &pool, &user, "Valid Share Doc").await;
+
+    // expires_at one hour in the FUTURE
+    let token = seed_link_share(
+        &pool,
+        doc_id,
+        user_id,
+        None,
+        Some(Utc::now() + Duration::hours(1)),
+    )
+    .await;
+
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri(format!("/shared/{token}"))
+        .body(Body::empty())
+        .unwrap();
+    let response = app.execute(request).await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::OK,
+        "valid share must succeed with 200; got {}. Body: {}",
+        response.status,
+        response.text()
+    );
+
+    let body = response.json_value();
+    assert_eq!(
+        body["document"]["id"].as_str(),
+        Some(doc_id.to_string().as_str()),
+        "response must reference the shared document"
+    );
+    assert!(
+        body["download_url"].as_str().is_some(),
+        "response must contain a download_url"
+    );
+
+    cleanup_test_user(&pool, &user.email).await;
+}
+
+/// A link share with `expires_at = NULL` (never expires) succeeds.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn test_non_expiring_share_succeeds(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    let (_org, user_id, doc_id) = setup(&app, &pool, &user, "No-Expiry Share Doc").await;
+
+    let token = seed_link_share(&pool, doc_id, user_id, None, None).await;
+
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri(format!("/shared/{token}"))
+        .body(Body::empty())
+        .unwrap();
+    let response = app.execute(request).await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::OK,
+        "non-expiring share must succeed with 200; got {}. Body: {}",
+        response.status,
+        response.text()
+    );
+
+    cleanup_test_user(&pool, &user.email).await;
+}
+
+// ============================================================================
+// Password enforcement (issue #807)
+// ============================================================================
+
+/// The no-password GET route must NOT serve a password-protected share — it
+/// returns 401 PASSWORD_REQUIRED and never leaks the document URLs.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn test_password_protected_share_requires_password_on_get(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    let (_org, user_id, doc_id) = setup(&app, &pool, &user, "Pwd Share Doc").await;
+
+    let token = seed_link_share(
+        &pool,
+        doc_id,
+        user_id,
+        Some("s3cret-pass"),
+        Some(Utc::now() + Duration::hours(1)),
+    )
+    .await;
+
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri(format!("/shared/{token}"))
+        .body(Body::empty())
+        .unwrap();
+    let response = app.execute(request).await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::UNAUTHORIZED,
+        "password-protected share must return 401 on the GET route; got {}. Body: {}",
+        response.status,
+        response.text()
+    );
+    let body = response.json_value();
+    assert_eq!(
+        body["code"].as_str(),
+        Some("PASSWORD_REQUIRED"),
+        "error code must be PASSWORD_REQUIRED"
+    );
+    assert!(
+        body.get("download_url").is_none(),
+        "password-protected GET must not leak a download_url"
+    );
+
+    cleanup_test_user(&pool, &user.email).await;
+}
+
+/// The POST access route rejects a wrong password with 401.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn test_wrong_password_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    let (_org, user_id, doc_id) = setup(&app, &pool, &user, "Wrong Pwd Doc").await;
+
+    let token = seed_link_share(
+        &pool,
+        doc_id,
+        user_id,
+        Some("correct-horse"),
+        Some(Utc::now() + Duration::hours(1)),
+    )
+    .await;
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri(format!("/shared/{token}/access"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(
+            json!({ "password": "wrong-battery" }).to_string(),
+        ))
+        .unwrap();
+    let response = app.execute(request).await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::UNAUTHORIZED,
+        "wrong password must be rejected with 401; got {}. Body: {}",
+        response.status,
+        response.text()
+    );
+
+    cleanup_test_user(&pool, &user.email).await;
+}
+
+/// The POST access route serves the document for the correct password.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn test_correct_password_succeeds(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    let (_org, user_id, doc_id) = setup(&app, &pool, &user, "Correct Pwd Doc").await;
+
+    let token = seed_link_share(
+        &pool,
+        doc_id,
+        user_id,
+        Some("correct-horse"),
+        Some(Utc::now() + Duration::hours(1)),
+    )
+    .await;
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri(format!("/shared/{token}/access"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(
+            json!({ "password": "correct-horse" }).to_string(),
+        ))
+        .unwrap();
+    let response = app.execute(request).await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::OK,
+        "correct password must serve the document with 200; got {}. Body: {}",
+        response.status,
+        response.text()
+    );
+    let body = response.json_value();
+    assert_eq!(
+        body["document"]["id"].as_str(),
+        Some(doc_id.to_string().as_str()),
+        "response must reference the shared document"
+    );
+
+    cleanup_test_user(&pool, &user.email).await;
+}
+
+// ============================================================================
+// Revocation (defense-in-depth — shares the same SQL predicate as expiry)
+// ============================================================================
+
+/// A revoked share is filtered out (`revoked_at IS NULL`) → 404.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn test_revoked_share_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    let (_org, user_id, doc_id) = setup(&app, &pool, &user, "Revoked Share Doc").await;
+
+    let token = seed_link_share(
+        &pool,
+        doc_id,
+        user_id,
+        None,
+        Some(Utc::now() + Duration::hours(1)),
+    )
+    .await;
+
+    sqlx::query("UPDATE document_shares SET revoked_at = NOW() WHERE share_token = $1")
+        .bind(&token)
+        .execute(&pool)
+        .await
+        .expect("revoke share");
+
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri(format!("/shared/{token}"))
+        .body(Body::empty())
+        .unwrap();
+    let response = app.execute(request).await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::NOT_FOUND,
+        "revoked share must be rejected with 404; got {}. Body: {}",
+        response.status,
+        response.text()
+    );
+
+    cleanup_test_user(&pool, &user.email).await;
+}


### PR DESCRIPTION
## Summary

Hardens + adds regression coverage for the public document-share access path (issue #807, Epic 7B P1 "Public share routes").

- Verified that expiry and password are enforced before serving a shared document:
  - `find_share_by_token` (used by both `GET /shared/{token}` and `POST /shared/{token}/access`) already filters with `AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at > NOW())`, so expired/revoked tokens never reach the document.
  - The GET route rejects password-protected shares with 401 `PASSWORD_REQUIRED`; the POST route enforces the password via `verify_share_password`.
- **Fixed a latent 500 on the success path.** While writing the regression tests, every *valid* (matching) share returned 500, not 200: `find_share_by_token_rls`, `find_share_by_id_rls`, `create_share_rls` (`RETURNING`) and `find_by_id_rls` used `SELECT *` / `RETURNING *`, which return the `document_share_type` / `document_category` / `document_access_scope` Postgres enums. Those don't decode into the `String` struct fields, so the public share read path 500'd for any servable share. Replaced with explicit column projections that cast the enum columns to `::text`.
- Added `backend/servers/api-server/tests/document_share_access_tests.rs` (7 tests).

## Closes
Closes #807 (P1 public-share-routes item). Other #807 sub-items (monolith split re-mount verification, intelligence tenant-scoping, templates/signatures cross-check) are separate and NOT addressed here.

## Tested (Band A — fast check)
```
$ DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres \
  cargo test -p api-server --test document_share_access_tests
test result: ok. 7 passed; 0 failed; 0 ignored; finished in 61.30s
```
Tests:
- `test_expired_share_is_rejected` — expired token -> 404
- `test_revoked_share_is_rejected` — revoked token -> 404
- `test_valid_share_succeeds` — valid non-expired link -> 200 + URLs (success case)
- `test_non_expiring_share_succeeds` — `expires_at = NULL` -> 200
- `test_password_protected_share_requires_password_on_get` — 401 `PASSWORD_REQUIRED`, no URL leak
- `test_wrong_password_is_rejected` — wrong password -> 401
- `test_correct_password_succeeds` — correct password -> 200

```
$ cargo fmt --all                                        # exit 0
$ cargo clippy -p api-server --lib -- -D warnings        # exit 0, no warnings
$ cargo clippy -p db --lib --tests -- -D warnings        # exit 0, no warnings
```

## Built (Band B — full build)
skipped: change is a small repo-layer query fix + a new test file; covered by clippy + test compile above.

## CI parity (Band C — hot-path only)
Hot-path (security). Local equivalents of the backend CI job ran green: `cargo fmt --all`, `cargo clippy -p api-server --lib -- -D warnings`, `cargo clippy -p db --lib --tests -- -D warnings`, and the new integration test (7/7). No sqlx offline cache change — all touched queries use runtime `query_as`, not the `query!`/`query_as!` macros.

## Notes for the reviewer
- The `#[utoipa::path]` annotations on these handlers document the path as `/api/v1/documents/shared/{token}`, but `public_router()` is mounted via `.merge()` at the router root, so the **actual** routes are `/shared/{token}` and `/shared/{token}/access`. The tests use the real paths. The OpenAPI annotation mismatch is pre-existing and out of scope here.
- The deprecated `find_share_by_token` (`#[allow(deprecated)]` in the handlers) delegates to `find_share_by_token_rls`, so it inherits the expiry/revocation predicate. Migrating the public handlers off the deprecated method is a larger RLS-context change left out of scope.

## Out-of-scope items noticed
- `backend/servers/api-server/tests/integration/` (mod.rs + submodules incl. `document_access_tests.rs`) is not wired to any top-level test entrypoint, so it never compiles — and its `documents` schema is stale (uses `name`/`file_path`/`access_level`). Worth either deleting or wiring + fixing in a follow-up.