### PR TITLE
fix(security): standardize listings tenant extraction + real global-publish authz (closes #851, #809)

### DIFF
--- a/backend/servers/api-server/src/routes/listings.rs
+++ b/backend/servers/api-server/src/routes/listings.rs
@@ -3,12 +3,13 @@
 
 use crate::services::SyndicationService;
 use crate::state::AppState;
-use api_core::extractors::{AuthUser, RlsConnection, TenantExtractor};
+use api_core::extractors::{RlsConnection, TenantExtractor};
 use axum::{
     extract::{Path, Query, State},
     routing::{delete, get, post, put},
     Json, Router,
 };
+use common::TenantRole;
 use db::models::{
     listing_status, property_type as prop_type, AuditAction, CreateAuditLog, CreateListing,
     CreateListingFromUnit, CreateListingPhoto, CreateSyndication, Listing, ListingListQuery,
@@ -1088,9 +1089,13 @@ pub async fn get_organization_syndication_stats(
 // and 00136). They are deliberately separate from `/{id}/publish` (which
 // queues external-portal syndication jobs — Epic 105).
 //
-// Auth: stub gate — `AuthUser` extractor + an org-id ownership check via the
-// repository (UPDATE WHERE organization_id = $caller_org). Real capability
-// gating (`Capability::ListingsPublish`) lands in Phase 5.
+// Auth (closes #851, #809): these handlers use the same `TenantExtractor`
+// every other listings handler uses (consistent org/role extraction from the
+// JWT), and gate the global-publish action behind manager role — publishing a
+// listing to the cross-org global portal is a management action, not something
+// any org member (e.g. a resident) may do. The repository UPDATE remains
+// org-scoped (UPDATE WHERE organization_id = $caller_org) as a second
+// defensive layer against cross-tenant writes.
 
 /// Mark a listing as published to the global reality portal.
 ///
@@ -1105,24 +1110,25 @@ pub async fn get_organization_syndication_stats(
     responses(
         (status = 200, description = "Listing published to global portal", body = Listing),
         (status = 401, description = "Unauthorized"),
-        (status = 403, description = "Listing belongs to another organization"),
+        (status = 403, description = "Manager role required, or listing belongs to another organization"),
         (status = 404, description = "Listing not found")
     )
 )]
 pub async fn global_publish(
     State(state): State<AppState>,
-    auth: AuthUser,
+    TenantExtractor(tenant): TenantExtractor,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Listing>, (axum::http::StatusCode, String)> {
-    // Stub auth gate (Phase 5 replaces this with capability-based authz):
-    // the user must be authenticated AND must have a tenant in their token.
-    // The repository UPDATE is org-scoped (WHERE organization_id = $org), so
-    // an attempt to publish another org's listing returns Ok(None) → 404,
-    // not 200. We rely on that as the second defensive layer.
-    let org_id = auth.tenant_id.ok_or((
-        axum::http::StatusCode::FORBIDDEN,
-        "No tenant context".to_string(),
-    ))?;
+    // Authz (closes #809): publishing to the cross-org global portal is a
+    // manager action. `has_role` is hierarchical, so OrgAdmin / PlatformAdmin /
+    // SuperAdmin (all above Manager) also pass.
+    if !tenant.has_role(TenantRole::Manager) {
+        return Err((
+            axum::http::StatusCode::FORBIDDEN,
+            "Manager role required to publish listings to the global portal".to_string(),
+        ));
+    }
+    let org_id = tenant.tenant_id;
 
     let previous = state
         .listing_repo
@@ -1159,7 +1165,7 @@ pub async fn global_publish(
     let audit_result = state
         .audit_log_repo
         .create(CreateAuditLog {
-            user_id: Some(auth.user_id),
+            user_id: Some(tenant.user_id),
             action: AuditAction::ResourceUpdated,
             resource_type: Some("listing".to_string()),
             resource_id: Some(id),
@@ -1206,19 +1212,24 @@ pub async fn global_publish(
     responses(
         (status = 200, description = "Listing withdrawn from global portal", body = Listing),
         (status = 401, description = "Unauthorized"),
-        (status = 403, description = "Listing belongs to another organization"),
+        (status = 403, description = "Manager role required, or listing belongs to another organization"),
         (status = 404, description = "Listing not found")
     )
 )]
 pub async fn global_unpublish(
     State(state): State<AppState>,
-    auth: AuthUser,
+    TenantExtractor(tenant): TenantExtractor,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Listing>, (axum::http::StatusCode, String)> {
-    let org_id = auth.tenant_id.ok_or((
-        axum::http::StatusCode::FORBIDDEN,
-        "No tenant context".to_string(),
-    ))?;
+    // Authz (closes #809): withdrawing from the global portal is the inverse
+    // management action and is gated identically to `global_publish`.
+    if !tenant.has_role(TenantRole::Manager) {
+        return Err((
+            axum::http::StatusCode::FORBIDDEN,
+            "Manager role required to withdraw listings from the global portal".to_string(),
+        ));
+    }
+    let org_id = tenant.tenant_id;
 
     let previous = state
         .listing_repo
@@ -1253,7 +1264,7 @@ pub async fn global_unpublish(
     let audit_result = state
         .audit_log_repo
         .create(CreateAuditLog {
-            user_id: Some(auth.user_id),
+            user_id: Some(tenant.user_id),
             action: AuditAction::ResourceUpdated,
             resource_type: Some("listing".to_string()),
             resource_id: Some(id),

--- a/backend/servers/api-server/src/routes/public_api.rs
+++ b/backend/servers/api-server/src/routes/public_api.rs
@@ -43,6 +43,25 @@ fn generate_secure_secret(prefix: &str) -> String {
     format!("{}_{}", prefix, hex::encode(bytes))
 }
 
+/// Uniform "not implemented" error for developer-portal endpoints whose
+/// persistence layer does not exist yet (closes #851).
+///
+/// These handlers previously diverged: some fabricated a success response
+/// (e.g. `create_api_key` minted a real-looking secret, `revoke_api_key`
+/// returned `204` without revoking anything), while others returned `404`.
+/// That advertised live behavior the server can't honor. Until the developer
+/// account / API-key repository lands, every such endpoint returns `501` so
+/// callers get an honest, uniform signal instead of a misleading 2xx/404.
+fn not_implemented(feature: &str) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        Json(ErrorResponse::new(
+            "NOT_IMPLEMENTED",
+            format!("{feature} is not implemented yet"),
+        )),
+    )
+}
+
 /// Create public API / developer portal router.
 pub fn router() -> Router<AppState> {
     Router::new()
@@ -143,29 +162,12 @@ pub struct SuspendDeveloperRequest {
 )]
 async fn create_developer_account(
     State(_state): State<AppState>,
-    user: AuthUser,
-    Json(payload): Json<CreateDeveloperAccount>,
+    _user: AuthUser,
+    Json(_payload): Json<CreateDeveloperAccount>,
 ) -> Result<(StatusCode, Json<DeveloperAccount>), (StatusCode, Json<ErrorResponse>)> {
-    // Implementation would create developer account
-    let account = DeveloperAccount {
-        id: Uuid::new_v4(),
-        user_id: user.user_id,
-        organization_id: user.tenant_id,
-        company_name: payload.company_name,
-        website: payload.website,
-        description: payload.description,
-        contact_email: payload.contact_email,
-        contact_name: payload.contact_name,
-        tier: "free".to_string(),
-        is_verified: Some(false),
-        is_active: Some(true),
-        metadata: payload.metadata,
-        created_at: Some(Utc::now()),
-        updated_at: Some(Utc::now()),
-        verified_at: None,
-    };
-
-    Ok((StatusCode::CREATED, Json(account)))
+    // No developer-account persistence exists yet; previously this fabricated
+    // a CREATED account that was never stored (closes #851).
+    Err(not_implemented("Developer account creation"))
 }
 
 /// Get current user's developer account.
@@ -183,14 +185,7 @@ async fn get_my_developer_account(
     State(_state): State<AppState>,
     _user: AuthUser,
 ) -> Result<Json<DeveloperAccount>, (StatusCode, Json<ErrorResponse>)> {
-    // Implementation would fetch developer account
-    Err((
-        StatusCode::NOT_FOUND,
-        Json(ErrorResponse::new(
-            "NOT_FOUND",
-            "Developer account not found. Please create one first.",
-        )),
-    ))
+    Err(not_implemented("Developer account lookup"))
 }
 
 /// Update current user's developer account.
@@ -199,13 +194,7 @@ async fn update_my_developer_account(
     _user: AuthUser,
     Json(_payload): Json<UpdateDeveloperAccount>,
 ) -> Result<Json<DeveloperAccount>, (StatusCode, Json<ErrorResponse>)> {
-    Err((
-        StatusCode::NOT_FOUND,
-        Json(ErrorResponse::new(
-            "NOT_FOUND",
-            "Developer account not found",
-        )),
-    ))
+    Err(not_implemented("Developer account update"))
 }
 
 /// Get usage summary for current developer.
@@ -213,13 +202,7 @@ async fn get_my_usage_summary(
     State(_state): State<AppState>,
     _user: AuthUser,
 ) -> Result<Json<DeveloperUsageSummary>, (StatusCode, Json<ErrorResponse>)> {
-    Err((
-        StatusCode::NOT_FOUND,
-        Json(ErrorResponse::new(
-            "NOT_FOUND",
-            "Developer account not found",
-        )),
-    ))
+    Err(not_implemented("Developer usage summary"))
 }
 
 // ==================== API Key Endpoints (Story 69.1) ====================
@@ -241,7 +224,7 @@ async fn create_api_key(
     _user: AuthUser,
     Json(payload): Json<CreateApiKey>,
 ) -> Result<(StatusCode, Json<CreateApiKeyResponse>), (StatusCode, Json<ErrorResponse>)> {
-    // Validate scopes
+    // Validate scopes up front so obviously-bad requests still get a 400.
     for scope in &payload.scopes {
         if !db::models::api_key_scope::ALL.contains(&scope.as_str()) {
             return Err((
@@ -254,21 +237,11 @@ async fn create_api_key(
         }
     }
 
-    // Generate API key with prefix for identification
-    let key_prefix = format!("ppt_{}", &Uuid::new_v4().to_string()[..8]);
-    let secret = generate_secure_secret(&key_prefix);
-
-    let response = CreateApiKeyResponse {
-        id: Uuid::new_v4(),
-        name: payload.name,
-        key_prefix: key_prefix.clone(),
-        secret: secret.clone(),
-        scopes: payload.scopes,
-        expires_at: payload.expires_at,
-        created_at: Utc::now(),
-    };
-
-    Ok((StatusCode::CREATED, Json(response)))
+    // Previously this minted a real-looking, cryptographically-secure secret
+    // and returned 201 — but the key was never persisted, so it could never
+    // authenticate anything. Returning the fake secret was misleading and a
+    // latent security footgun. Fail honestly until persistence exists (#851).
+    Err(not_implemented("API key creation"))
 }
 
 /// List all API keys for current developer.
@@ -287,7 +260,7 @@ async fn list_api_keys(
     _user: AuthUser,
     Query(_query): Query<ApiKeyQuery>,
 ) -> Result<Json<Vec<ApiKeyDisplay>>, (StatusCode, Json<ErrorResponse>)> {
-    Ok(Json(vec![]))
+    Err(not_implemented("API key listing"))
 }
 
 /// Get API key details.
@@ -296,10 +269,7 @@ async fn get_api_key(
     _user: AuthUser,
     Path(_id): Path<Uuid>,
 ) -> Result<Json<ApiKeyDisplay>, (StatusCode, Json<ErrorResponse>)> {
-    Err((
-        StatusCode::NOT_FOUND,
-        Json(ErrorResponse::new("NOT_FOUND", "API key not found")),
-    ))
+    Err(not_implemented("API key lookup"))
 }
 
 /// Update an API key.
@@ -309,10 +279,7 @@ async fn update_api_key(
     Path(_id): Path<Uuid>,
     Json(_payload): Json<UpdateApiKey>,
 ) -> Result<Json<ApiKeyDisplay>, (StatusCode, Json<ErrorResponse>)> {
-    Err((
-        StatusCode::NOT_FOUND,
-        Json(ErrorResponse::new("NOT_FOUND", "API key not found")),
-    ))
+    Err(not_implemented("API key update"))
 }
 
 /// Revoke an API key.
@@ -334,8 +301,9 @@ async fn revoke_api_key(
     _user: AuthUser,
     Path(_id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    // Implementation would revoke the key
-    Ok(StatusCode::NO_CONTENT)
+    // Previously returned 204 without revoking anything — a silent no-op that
+    // told the caller a key was revoked when nothing happened (closes #851).
+    Err(not_implemented("API key revocation"))
 }
 
 /// Rotate an API key (create new, expire old).
@@ -357,11 +325,7 @@ async fn rotate_api_key(
     _user: AuthUser,
     Path(_id): Path<Uuid>,
 ) -> Result<Json<RotateApiKeyResponse>, (StatusCode, Json<ErrorResponse>)> {
-    // Implementation would rotate the key
-    Err((
-        StatusCode::NOT_FOUND,
-        Json(ErrorResponse::new("NOT_FOUND", "API key not found")),
-    ))
+    Err(not_implemented("API key rotation"))
 }
 
 /// Get usage statistics for an API key.
@@ -371,7 +335,7 @@ async fn get_api_key_usage(
     Path(_id): Path<Uuid>,
     Query(_query): Query<DateRangeQuery>,
 ) -> Result<Json<Vec<ApiKeyUsageStats>>, (StatusCode, Json<ErrorResponse>)> {
-    Ok(Json(vec![]))
+    Err(not_implemented("API key usage statistics"))
 }
 
 // ==================== API Documentation Endpoints (Story 69.2) ====================

--- a/backend/servers/api-server/tests/listings_global_publish_authz_tests.rs
+++ b/backend/servers/api-server/tests/listings_global_publish_authz_tests.rs
@@ -1,0 +1,287 @@
+//! Authz + tenant-isolation regression for the listings global-publish
+//! endpoints (#851, #809).
+//!
+//! Before the fix:
+//! - `global_publish` / `global_unpublish` used a bare `AuthUser` + a "Phase 5
+//!   replaces this" stub gate that accepted ANY authenticated org member
+//!   (e.g. a resident) as long as their token carried a tenant. The fix
+//!   standardizes them onto the same `TenantExtractor` the rest of
+//!   `listings.rs` uses and gates the action behind manager role.
+//! - The repository UPDATE is org-scoped, so a caller from org B publishing
+//!   org A's listing must NOT succeed.
+//!
+//! These tests mint real JWTs (the same `Claims` shape the `AuthUser`
+//! extractor decodes) so the role + tenant come from the token, exactly as in
+//! production. `JwtService` emits an `org_id` claim that does NOT map onto the
+//! `tenant_id` field the extractor reads, so we encode our own claims struct
+//! carrying `tenant_id` + `role` directly (see the note in
+//! reserve_funds_cross_org_idor_tests.rs).
+
+#[allow(dead_code)]
+mod common;
+
+use axum::{
+    body::Body,
+    http::{header, Method, Request, StatusCode},
+};
+use chrono::Utc;
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::Serialize;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::TestApp;
+
+/// Same secret `TestConfig::default()` stamps into `JWT_SECRET`, so tokens we
+/// mint here validate against the `AuthUser` extractor's cached verifier.
+const JWT_SECRET: &str = "test-secret-key-that-is-at-least-64-characters-long-for-testing-purposes";
+
+/// Minimal mirror of `api_core::extractors::auth::Claims` (the access-token
+/// wire shape the extractor decodes). `role` is serialized as snake_case to
+/// match `TenantRole`'s serde representation.
+#[derive(Serialize)]
+struct TestClaims {
+    sub: Uuid,
+    exp: i64,
+    iat: i64,
+    token_type: String,
+    tenant_id: Option<Uuid>,
+    role: Option<String>,
+    email: String,
+    name: String,
+}
+
+/// Mint a real access JWT for `user_id` in `org_id` with `role`
+/// (snake_case, e.g. "manager" / "resident").
+fn mint_token(user_id: Uuid, org_id: Uuid, role: &str) -> String {
+    let now = Utc::now().timestamp();
+    let claims = TestClaims {
+        sub: user_id,
+        iat: now,
+        exp: now + 3600,
+        token_type: "access".to_string(),
+        tenant_id: Some(org_id),
+        role: Some(role.to_string()),
+        email: format!("{user_id}@listings-authz.test"),
+        name: "Listings Authz Test".to_string(),
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(JWT_SECRET.as_bytes()),
+    )
+    .expect("mint jwt")
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO organizations (name, slug, contact_email, status)
+           VALUES ($1, $2, $3, 'active') RETURNING id"#,
+    )
+    .bind(format!("ListingsAuthz {slug}"))
+    .bind(format!("listings-authz-{slug}-{}", Uuid::new_v4()))
+    .bind(format!("{slug}-{}@listings-authz.test", Uuid::new_v4()))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO users (email, password_hash, name, status, email_verified_at)
+           VALUES ($1, 'x', 'Authz User', 'active', NOW()) RETURNING id"#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Seed a draft listing in `org_id` created by `user_id`. Returns its id.
+async fn seed_listing(pool: &PgPool, org_id: Uuid, user_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        // `size_sqm` / `latitude` / `longitude` are populated because the
+        // `Listing` model decodes them via `#[sqlx(try_from = "Decimal")]`,
+        // which does not tolerate NULL (a separate, pre-existing repo quirk
+        // unrelated to this auth fix). Setting them keeps the success-path
+        // `find_by_id_and_org` decode clean so the test exercises the authz +
+        // org-scoping behavior we actually care about.
+        r#"INSERT INTO listings
+               (organization_id, created_by, status, transaction_type, title,
+                property_type, size_sqm, rooms, street, city, postal_code,
+                country, latitude, longitude, price, currency)
+           VALUES ($1, $2, 'active', 'sale', 'Test Listing', 'apartment',
+                   75.5, 3, 'Main 1', 'Bratislava', '81101', 'SK',
+                   48.1486, 17.1077, 100000, 'EUR')
+           RETURNING id"#,
+    )
+    .bind(org_id)
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed listing")
+}
+
+fn authed(method: Method, uri: &str, org: Uuid, token: &str) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .header("X-Tenant-ID", org.to_string())
+        .body(Body::empty())
+        .unwrap()
+}
+
+async fn is_published(pool: &PgPool, listing_id: Uuid) -> bool {
+    sqlx::query_scalar::<_, bool>("SELECT is_published FROM listings WHERE id = $1")
+        .bind(listing_id)
+        .fetch_one(pool)
+        .await
+        .expect("read is_published")
+}
+
+// ---------------------------------------------------------------------------
+// #809 — role gate: a non-manager (resident) must be rejected with 403.
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn resident_cannot_global_publish(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org = seed_org(&pool, "resident-pub").await;
+    let user = seed_user(
+        &pool,
+        &format!("res-{}@listings-authz.test", Uuid::new_v4()),
+    )
+    .await;
+    let listing = seed_listing(&pool, org, user).await;
+
+    let token = mint_token(user, org, "resident");
+    let resp = app
+        .execute(authed(
+            Method::POST,
+            &format!("/api/v1/listings/{listing}/global-publish"),
+            org,
+            &token,
+        ))
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "resident global-publish must be 403, got {} (body: {})",
+        resp.status,
+        String::from_utf8_lossy(&resp.body)
+    );
+    assert!(
+        !is_published(&pool, listing).await,
+        "listing must remain unpublished after a rejected publish"
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn resident_cannot_global_unpublish(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org = seed_org(&pool, "resident-unpub").await;
+    let user = seed_user(
+        &pool,
+        &format!("res-{}@listings-authz.test", Uuid::new_v4()),
+    )
+    .await;
+    let listing = seed_listing(&pool, org, user).await;
+
+    let token = mint_token(user, org, "resident");
+    let resp = app
+        .execute(authed(
+            Method::POST,
+            &format!("/api/v1/listings/{listing}/global-unpublish"),
+            org,
+            &token,
+        ))
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "resident global-unpublish must be 403, got {}",
+        resp.status
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #851 — cross-tenant: a manager in org B must NOT publish org A's listing.
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn manager_cannot_global_publish_other_orgs_listing(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org_a = seed_org(&pool, "xorg-a").await;
+    let org_b = seed_org(&pool, "xorg-b").await;
+    let user_a = seed_user(&pool, &format!("a-{}@listings-authz.test", Uuid::new_v4())).await;
+    let user_b = seed_user(&pool, &format!("b-{}@listings-authz.test", Uuid::new_v4())).await;
+    let listing_in_a = seed_listing(&pool, org_a, user_a).await;
+
+    // Manager of org B targeting org A's listing, with B's tenant context.
+    let token_b = mint_token(user_b, org_b, "manager");
+    let resp = app
+        .execute(authed(
+            Method::POST,
+            &format!("/api/v1/listings/{listing_in_a}/global-publish"),
+            org_b,
+            &token_b,
+        ))
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::NOT_FOUND,
+        "cross-org global-publish must 404 (org-scoped lookup finds nothing), got {}",
+        resp.status
+    );
+    assert!(
+        !is_published(&pool, listing_in_a).await,
+        "org A's listing must NOT be published by an org B manager"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Same-org success: a manager publishing their OWN org's listing succeeds and
+// the row is actually flipped (proves real org context, not a stub).
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn manager_can_global_publish_own_listing(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org = seed_org(&pool, "own-pub").await;
+    let user = seed_user(
+        &pool,
+        &format!("mgr-{}@listings-authz.test", Uuid::new_v4()),
+    )
+    .await;
+    let listing = seed_listing(&pool, org, user).await;
+
+    let token = mint_token(user, org, "manager");
+    let resp = app
+        .execute(authed(
+            Method::POST,
+            &format!("/api/v1/listings/{listing}/global-publish"),
+            org,
+            &token,
+        ))
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "manager publishing own listing must be 200, got {} (body: {})",
+        resp.status,
+        String::from_utf8_lossy(&resp.body)
+    );
+    assert!(
+        is_published(&pool, listing).await,
+        "listing must be marked published after a successful global-publish"
+    );
+}


### PR DESCRIPTION
## Summary
- **#809** — `global_publish` / `global_unpublish` carried a stub auth gate ("Phase 5 replaces this") that accepted **any** authenticated org member (e.g. a resident) as long as their token had a tenant. Replaced with a real manager-role check using the same idiom as #799 (building create/archive) and #808.
- **#851** — Standardized tenant extraction: both global handlers now use the same `TenantExtractor` (org + role from JWT) that every other handler in `listings.rs` uses, instead of a bare `AuthUser.tenant_id`. The repository UPDATE stays org-scoped (`WHERE organization_id = $caller_org`) as a second defensive layer.
- **#851** — `public_api.rs` developer-portal stubs diverged (some fabricated success — `create_api_key` minted a real-looking secret never stored, `revoke_api_key` returned 204 without revoking; others returned 404/empty). They are now **501 Not Implemented** uniformly across the account + API-key management endpoints, so OpenAPI no longer advertises behavior the server can't honor. There was no DB layer (no `api_key_repo` on `AppState`), so there was **no cross-tenant read** to scope.

## Handlers changed
- `listings.rs`: `global_publish`, `global_unpublish` (extractor + manager-role gate; audit `user_id` now from `tenant`).
- `public_api.rs`: `create_developer_account`, `get_my_developer_account`, `update_my_developer_account`, `get_my_usage_summary`, `create_api_key`, `list_api_keys`, `get_api_key`, `update_api_key`, `revoke_api_key`, `rotate_api_key`, `get_api_key_usage` → uniform `501` via a new `not_implemented(feature)` helper. (Read-only docs endpoints — changelog/openapi/endpoints — left as sample data; not part of the auth concern.)

## Idiom used
`!tenant.has_role(TenantRole::Manager) → 403`, matching #799's `RlsConnection::has_role` precedent (`TenantContext::has_role` is hierarchical, so OrgAdmin/PlatformAdmin/SuperAdmin also pass).

## Tested (Band A) — isolated `CARGO_TARGET_DIR`
```
$ env CARGO_TARGET_DIR=~/.cargo-targets/ct-851 cargo fmt --all          # exit 0
$ env CARGO_TARGET_DIR=~/.cargo-targets/ct-851 cargo clippy -p api-server --lib -- -D warnings   # exit 0, Finished, no warnings
$ env CARGO_TARGET_DIR=~/.cargo-targets/ct-851 DATABASE_URL=postgres://... cargo test -p api-server --test listings_global_publish_authz_tests
running 4 tests
test resident_cannot_global_unpublish ... ok
test manager_can_global_publish_own_listing ... ok
test manager_cannot_global_publish_other_orgs_listing ... ok
test resident_cannot_global_publish ... ok
test result: ok. 4 passed; 0 failed
```
> Note: the repo's `.zshrc` forces `CARGO_TARGET_DIR` to a shared `/Volumes/CargoSD/target` — this caused stale-binary linkage mid-task (a resident appeared to pass the gate because the old stub binary was linked). Passing `CARGO_TARGET_DIR` inline (`env CARGO_TARGET_DIR=…`) is required to honor the isolated dir.

## IG3 — regression test
`backend/servers/api-server/tests/listings_global_publish_authz_tests.rs` mints real access JWTs (the `Claims` wire shape the `AuthUser` extractor decodes — `JwtService`'s `org_id` claim does NOT map to `tenant_id`, so a custom claims struct carries `tenant_id` + snake_case `role` directly). Cases:
- `resident_cannot_global_publish` / `resident_cannot_global_unpublish` → 403 (role gate).
- `manager_cannot_global_publish_other_orgs_listing` → 404, org A's row stays unpublished (no cross-tenant publish).
- `manager_can_global_publish_own_listing` → **200 and the row is actually flipped to `is_published=true`** (proves real org context / success path).

## Out-of-scope / deferred
- **Portal-sync idempotency (#809):** non-trivial — lives in `SyndicationService`/`create_publish_jobs` job system. Deferred; **refs #809** (not closed by this PR).
- Pre-existing repo quirk noted in the test: `Listing`'s `#[sqlx(try_from = "Decimal")]` on `Option<Decimal>` fields (`size_sqm`/`latitude`/`longitude`) does not tolerate NULL on the `find_by_id_and_org` decode path. Unrelated to auth; the test seeds those columns to avoid tripping it.