### PR TITLE
fix(security): scope rental connections to tenant & stop leaking OAuth tokens (closes #887, #804)

### DIFF
--- a/backend/crates/db/src/models/mod.rs
+++ b/backend/crates/db/src/models/mod.rs
@@ -311,10 +311,11 @@ pub use rental::{
     BookingWithGuests, BookingsResponse, CalendarBlock, CalendarEvent, CheckInReminder,
     ConnectionStatus, CreateBooking, CreateCalendarBlock, CreateGuest, CreateICalFeed,
     CreatePlatformConnection, GenerateReport, GuestSummary, ICalFeed, ICalFeedSummary,
-    NationalityStats, OAuthCallback, PlatformConnectionSummary, PlatformSyncStatus, RegisterGuest,
-    RentalBooking, RentalGuest, RentalGuestReport, RentalPlatformConnection, RentalStatistics,
-    ReportPreview, ReportSummary, SubmitReport, UnitAvailability, UpdateBooking,
-    UpdateBookingStatus, UpdateGuest, UpdateICalFeed, UpdatePlatformConnection,
+    NationalityStats, OAuthCallback, PlatformConnectionDetail, PlatformConnectionSummary,
+    PlatformSyncStatus, RegisterGuest, RentalBooking, RentalGuest, RentalGuestReport,
+    RentalPlatformConnection, RentalStatistics, ReportPreview, ReportSummary, SubmitReport,
+    UnitAvailability, UpdateBooking, UpdateBookingStatus, UpdateGuest, UpdateICalFeed,
+    UpdatePlatformConnection,
 };
 
 // Epic 19: Lease Management & Tenant Screening

--- a/backend/crates/db/src/models/rental.rs
+++ b/backend/crates/db/src/models/rental.rs
@@ -189,6 +189,62 @@ pub struct ConnectionStatus {
     pub external_listing_url: Option<String>,
 }
 
+/// Platform connection detail (token-free).
+///
+/// SECURITY (#887 / #804): the GET `/connections/{id}` endpoint must never
+/// serialize `access_token` / `refresh_token`. This DTO mirrors
+/// [`RentalPlatformConnection`] minus the OAuth secret fields and exposes a
+/// boolean `is_connected` derived from token presence instead. Build it via
+/// `PlatformConnectionDetail::from(connection)`.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct PlatformConnectionDetail {
+    pub id: Uuid,
+    pub organization_id: Uuid,
+    pub unit_id: Uuid,
+    pub platform: String,
+
+    /// True when an access token is stored (without exposing the token itself).
+    pub is_connected: bool,
+    pub token_expires_at: Option<DateTime<Utc>>,
+
+    pub external_property_id: Option<String>,
+    pub external_listing_url: Option<String>,
+
+    pub is_active: bool,
+    pub last_sync_at: Option<DateTime<Utc>>,
+    pub sync_error: Option<String>,
+
+    pub sync_calendar: bool,
+    pub sync_interval_minutes: i32,
+    pub block_other_platforms: bool,
+
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl From<RentalPlatformConnection> for PlatformConnectionDetail {
+    fn from(c: RentalPlatformConnection) -> Self {
+        Self {
+            id: c.id,
+            organization_id: c.organization_id,
+            unit_id: c.unit_id,
+            platform: c.platform,
+            is_connected: c.access_token.is_some(),
+            token_expires_at: c.token_expires_at,
+            external_property_id: c.external_property_id,
+            external_listing_url: c.external_listing_url,
+            is_active: c.is_active,
+            last_sync_at: c.last_sync_at,
+            sync_error: c.sync_error,
+            sync_calendar: c.sync_calendar,
+            sync_interval_minutes: c.sync_interval_minutes,
+            block_other_platforms: c.block_other_platforms,
+            created_at: c.created_at,
+            updated_at: c.updated_at,
+        }
+    }
+}
+
 /// Platform connection summary.
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize, ToSchema)]
 pub struct PlatformConnectionSummary {

--- a/backend/crates/db/src/repositories/rental.rs
+++ b/backend/crates/db/src/repositories/rental.rs
@@ -163,6 +163,29 @@ impl RentalRepository {
         Ok(conn)
     }
 
+    /// Find connection by ID scoped to an organization.
+    ///
+    /// SECURITY (#887 / #804): callers acting on behalf of an authenticated
+    /// tenant MUST use this instead of [`find_connection_by_id`] so a caller
+    /// from org B cannot read org A's connection (and its OAuth tokens).
+    /// Returns `None` when the connection does not exist OR belongs to a
+    /// different organization (the handler maps `None` → 404).
+    pub async fn find_connection_for_org(
+        &self,
+        org_id: Uuid,
+        id: Uuid,
+    ) -> Result<Option<RentalPlatformConnection>, SqlxError> {
+        let conn = sqlx::query_as::<_, RentalPlatformConnection>(
+            r#"SELECT * FROM rental_platform_connections WHERE id = $1 AND organization_id = $2"#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(conn)
+    }
+
     /// Find connection by unit and platform.
     pub async fn find_connection_by_unit_platform(
         &self,
@@ -208,6 +231,45 @@ impl RentalRepository {
         .bind(data.sync_interval_minutes)
         .bind(data.block_other_platforms)
         .fetch_one(&self.pool)
+        .await?;
+
+        Ok(conn)
+    }
+
+    /// Update connection scoped to an organization.
+    ///
+    /// SECURITY (#887 / #804): the `AND organization_id = $8` guard prevents a
+    /// tenant from mutating another org's connection. Returns `None` when no
+    /// row matched (missing or cross-org) so the handler can return 404.
+    pub async fn update_connection_for_org(
+        &self,
+        org_id: Uuid,
+        id: Uuid,
+        data: UpdatePlatformConnection,
+    ) -> Result<Option<RentalPlatformConnection>, SqlxError> {
+        let conn = sqlx::query_as::<_, RentalPlatformConnection>(
+            r#"
+            UPDATE rental_platform_connections SET
+                external_property_id = COALESCE($2, external_property_id),
+                external_listing_url = COALESCE($3, external_listing_url),
+                is_active = COALESCE($4, is_active),
+                sync_calendar = COALESCE($5, sync_calendar),
+                sync_interval_minutes = COALESCE($6, sync_interval_minutes),
+                block_other_platforms = COALESCE($7, block_other_platforms),
+                updated_at = NOW()
+            WHERE id = $1 AND organization_id = $8
+            RETURNING *
+            "#,
+        )
+        .bind(id)
+        .bind(&data.external_property_id)
+        .bind(&data.external_listing_url)
+        .bind(data.is_active)
+        .bind(data.sync_calendar)
+        .bind(data.sync_interval_minutes)
+        .bind(data.block_other_platforms)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
         .await?;
 
         Ok(conn)
@@ -307,6 +369,76 @@ impl RentalRepository {
             .await?;
 
         Ok(result.rows_affected() > 0)
+    }
+
+    /// Delete connection scoped to an organization.
+    ///
+    /// SECURITY (#887 / #804): the `AND organization_id = $2` guard prevents a
+    /// tenant from deleting another org's connection.
+    pub async fn delete_connection_for_org(
+        &self,
+        org_id: Uuid,
+        id: Uuid,
+    ) -> Result<bool, SqlxError> {
+        let result = sqlx::query(
+            r#"DELETE FROM rental_platform_connections WHERE id = $1 AND organization_id = $2"#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Get connection statuses for a unit scoped to an organization.
+    ///
+    /// SECURITY (#887 / #804): adds `AND organization_id = $2` so a caller
+    /// cannot enumerate another org's unit connections by guessing a unit UUID.
+    pub async fn get_connections_for_unit_in_org(
+        &self,
+        org_id: Uuid,
+        unit_id: Uuid,
+    ) -> Result<Vec<ConnectionStatus>, SqlxError> {
+        let connections = sqlx::query_as::<_, (Uuid, String, bool, bool, Option<chrono::DateTime<Utc>>, Option<String>, Option<String>)>(
+            r#"
+            SELECT id, platform::text, access_token IS NOT NULL, is_active, last_sync_at, sync_error, external_listing_url
+            FROM rental_platform_connections
+            WHERE unit_id = $1 AND organization_id = $2
+            ORDER BY platform
+            "#,
+        )
+        .bind(unit_id)
+        .bind(org_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let statuses = connections
+            .into_iter()
+            .map(
+                |(
+                    id,
+                    platform,
+                    is_connected,
+                    is_active,
+                    last_sync_at,
+                    sync_error,
+                    external_listing_url,
+                )| {
+                    ConnectionStatus {
+                        id,
+                        platform,
+                        is_connected,
+                        is_active,
+                        last_sync_at,
+                        sync_error,
+                        external_listing_url,
+                    }
+                },
+            )
+            .collect();
+
+        Ok(statuses)
     }
 
     /// Get connections for organization.
@@ -476,6 +608,25 @@ impl RentalRepository {
         Ok(booking)
     }
 
+    /// Find booking by ID scoped to an organization.
+    ///
+    /// SECURITY (#804): prevents reading another org's booking PII by UUID.
+    pub async fn find_booking_for_org(
+        &self,
+        org_id: Uuid,
+        id: Uuid,
+    ) -> Result<Option<RentalBooking>, SqlxError> {
+        let booking = sqlx::query_as::<_, RentalBooking>(
+            r#"SELECT * FROM rental_bookings WHERE id = $1 AND organization_id = $2"#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(booking)
+    }
+
     /// Find booking by external ID.
     pub async fn find_booking_by_external_id(
         &self,
@@ -555,6 +706,73 @@ impl RentalRepository {
         Ok(booking)
     }
 
+    /// Update booking scoped to an organization.
+    ///
+    /// SECURITY (#804): the `AND organization_id = $14` guard prevents a tenant
+    /// from mutating another org's booking. Returns `None` when no row matched.
+    pub async fn update_booking_for_org(
+        &self,
+        org_id: Uuid,
+        id: Uuid,
+        data: UpdateBooking,
+    ) -> Result<Option<RentalBooking>, SqlxError> {
+        let booking = sqlx::query_as::<_, RentalBooking>(
+            r#"
+            UPDATE rental_bookings SET
+                guest_name = COALESCE($2, guest_name),
+                guest_email = COALESCE($3, guest_email),
+                guest_phone = COALESCE($4, guest_phone),
+                guest_count = COALESCE($5, guest_count),
+                check_in = COALESCE($6, check_in),
+                check_out = COALESCE($7, check_out),
+                check_in_time = COALESCE($8, check_in_time),
+                check_out_time = COALESCE($9, check_out_time),
+                total_amount = COALESCE($10, total_amount),
+                currency = COALESCE($11, currency),
+                guest_notes = COALESCE($12, guest_notes),
+                internal_notes = COALESCE($13, internal_notes),
+                updated_at = NOW()
+            WHERE id = $1 AND organization_id = $14
+            RETURNING *
+            "#,
+        )
+        .bind(id)
+        .bind(&data.guest_name)
+        .bind(&data.guest_email)
+        .bind(&data.guest_phone)
+        .bind(data.guest_count)
+        .bind(data.check_in)
+        .bind(data.check_out)
+        .bind(data.check_in_time)
+        .bind(data.check_out_time)
+        .bind(data.total_amount)
+        .bind(&data.currency)
+        .bind(&data.guest_notes)
+        .bind(&data.internal_notes)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        // Only touch the calendar block if the booking belonged to this org.
+        if booking.is_some() && (data.check_in.is_some() || data.check_out.is_some()) {
+            sqlx::query(
+                r#"
+                UPDATE rental_calendar_blocks SET
+                    block_start = COALESCE($2, block_start),
+                    block_end = COALESCE($3, block_end)
+                WHERE booking_id = $1
+                "#,
+            )
+            .bind(id)
+            .bind(data.check_in)
+            .bind(data.check_out)
+            .execute(&self.pool)
+            .await?;
+        }
+
+        Ok(booking)
+    }
+
     /// Update booking status.
     pub async fn update_booking_status(
         &self,
@@ -580,6 +798,45 @@ impl RentalRepository {
 
         // Remove calendar block if cancelled
         if data.status == booking_status::CANCELLED {
+            sqlx::query(r#"DELETE FROM rental_calendar_blocks WHERE booking_id = $1"#)
+                .bind(id)
+                .execute(&self.pool)
+                .await?;
+        }
+
+        Ok(booking)
+    }
+
+    /// Update booking status scoped to an organization.
+    ///
+    /// SECURITY (#804): the `AND organization_id = $4` guard prevents a tenant
+    /// from changing another org's booking status. Returns `None` if no match.
+    pub async fn update_booking_status_for_org(
+        &self,
+        org_id: Uuid,
+        id: Uuid,
+        data: UpdateBookingStatus,
+    ) -> Result<Option<RentalBooking>, SqlxError> {
+        let booking = sqlx::query_as::<_, RentalBooking>(
+            r#"
+            UPDATE rental_bookings SET
+                status = $2,
+                cancelled_at = CASE WHEN $2 = 'cancelled' THEN NOW() ELSE cancelled_at END,
+                cancellation_reason = COALESCE($3, cancellation_reason),
+                updated_at = NOW()
+            WHERE id = $1 AND organization_id = $4
+            RETURNING *
+            "#,
+        )
+        .bind(id)
+        .bind(&data.status)
+        .bind(&data.cancellation_reason)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        // Remove calendar block if cancelled (only when the booking was ours).
+        if booking.is_some() && data.status == booking_status::CANCELLED {
             sqlx::query(r#"DELETE FROM rental_calendar_blocks WHERE booking_id = $1"#)
                 .bind(id)
                 .execute(&self.pool)
@@ -823,6 +1080,54 @@ impl RentalRepository {
         Ok(result.rows_affected() > 0)
     }
 
+    /// Delete calendar block scoped to an organization.
+    ///
+    /// SECURITY (#804): the `AND organization_id = $2` guard prevents a tenant
+    /// from deleting another org's calendar block.
+    pub async fn delete_calendar_block_for_org(
+        &self,
+        org_id: Uuid,
+        id: Uuid,
+    ) -> Result<bool, SqlxError> {
+        let result = sqlx::query(
+            r#"DELETE FROM rental_calendar_blocks WHERE id = $1 AND organization_id = $2 AND booking_id IS NULL"#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Verify a unit belongs to an organization.
+    ///
+    /// SECURITY (#804): used by unit-scoped read endpoints (calendar,
+    /// availability) so a caller cannot probe another org's unit by UUID.
+    pub async fn unit_belongs_to_org(
+        &self,
+        org_id: Uuid,
+        unit_id: Uuid,
+    ) -> Result<bool, SqlxError> {
+        // `units` has no `organization_id` column — org is reached through
+        // `buildings.organization_id` (see migration 00116 / 00140 RLS notes).
+        let (exists,): (bool,) = sqlx::query_as(
+            r#"
+            SELECT EXISTS(
+                SELECT 1 FROM units u
+                JOIN buildings b ON b.id = u.building_id
+                WHERE u.id = $1 AND b.organization_id = $2
+            )
+            "#,
+        )
+        .bind(unit_id)
+        .bind(org_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(exists)
+    }
+
     /// Get calendar events for unit in date range.
     pub async fn get_calendar_events(
         &self,
@@ -997,6 +1302,25 @@ impl RentalRepository {
         Ok(guest)
     }
 
+    /// Find guest by ID scoped to an organization.
+    ///
+    /// SECURITY (#804): prevents reading another org's guest PII by UUID.
+    pub async fn find_guest_for_org(
+        &self,
+        org_id: Uuid,
+        id: Uuid,
+    ) -> Result<Option<RentalGuest>, SqlxError> {
+        let guest = sqlx::query_as::<_, RentalGuest>(
+            r#"SELECT * FROM rental_guests WHERE id = $1 AND organization_id = $2"#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(guest)
+    }
+
     /// Update guest.
     pub async fn update_guest(
         &self,
@@ -1048,6 +1372,63 @@ impl RentalRepository {
         Ok(guest)
     }
 
+    /// Update guest scoped to an organization.
+    ///
+    /// SECURITY (#804): the `AND organization_id = $17` guard prevents a tenant
+    /// from mutating another org's guest. Returns `None` when no row matched.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn update_guest_for_org(
+        &self,
+        org_id: Uuid,
+        id: Uuid,
+        data: UpdateGuest,
+    ) -> Result<Option<RentalGuest>, SqlxError> {
+        let guest = sqlx::query_as::<_, RentalGuest>(
+            r#"
+            UPDATE rental_guests SET
+                first_name = COALESCE($2, first_name),
+                last_name = COALESCE($3, last_name),
+                date_of_birth = COALESCE($4, date_of_birth),
+                nationality = COALESCE($5, nationality),
+                id_type = COALESCE($6, id_type),
+                id_number = COALESCE($7, id_number),
+                id_issuing_country = COALESCE($8, id_issuing_country),
+                id_expiry_date = COALESCE($9, id_expiry_date),
+                id_document_url = COALESCE($10, id_document_url),
+                email = COALESCE($11, email),
+                phone = COALESCE($12, phone),
+                address_street = COALESCE($13, address_street),
+                address_city = COALESCE($14, address_city),
+                address_postal_code = COALESCE($15, address_postal_code),
+                address_country = COALESCE($16, address_country),
+                updated_at = NOW()
+            WHERE id = $1 AND organization_id = $17
+            RETURNING *
+            "#,
+        )
+        .bind(id)
+        .bind(&data.first_name)
+        .bind(&data.last_name)
+        .bind(data.date_of_birth)
+        .bind(&data.nationality)
+        .bind(&data.id_type)
+        .bind(&data.id_number)
+        .bind(&data.id_issuing_country)
+        .bind(data.id_expiry_date)
+        .bind(&data.id_document_url)
+        .bind(&data.email)
+        .bind(&data.phone)
+        .bind(&data.address_street)
+        .bind(&data.address_city)
+        .bind(&data.address_postal_code)
+        .bind(&data.address_country)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(guest)
+    }
+
     /// Register guest (mark as registered).
     pub async fn register_guest(&self, id: Uuid) -> Result<RentalGuest, SqlxError> {
         let guest = sqlx::query_as::<_, RentalGuest>(
@@ -1063,6 +1444,34 @@ impl RentalRepository {
         .bind(id)
         .bind(guest_status::REGISTERED)
         .fetch_one(&self.pool)
+        .await?;
+
+        Ok(guest)
+    }
+
+    /// Register guest scoped to an organization.
+    ///
+    /// SECURITY (#804): the `AND organization_id = $3` guard prevents a tenant
+    /// from registering another org's guest. Returns `None` when no row matched.
+    pub async fn register_guest_for_org(
+        &self,
+        org_id: Uuid,
+        id: Uuid,
+    ) -> Result<Option<RentalGuest>, SqlxError> {
+        let guest = sqlx::query_as::<_, RentalGuest>(
+            r#"
+            UPDATE rental_guests SET
+                status = $2,
+                registered_at = NOW(),
+                updated_at = NOW()
+            WHERE id = $1 AND organization_id = $3
+            RETURNING *
+            "#,
+        )
+        .bind(id)
+        .bind(guest_status::REGISTERED)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
         .await?;
 
         Ok(guest)
@@ -1111,6 +1520,49 @@ impl RentalRepository {
             guests,
             registration_complete,
         }))
+    }
+
+    /// Get booking with guests scoped to an organization.
+    ///
+    /// SECURITY (#804): resolves the booking via the org-scoped lookup so a
+    /// caller cannot read another org's booking + guest PII by UUID.
+    pub async fn get_booking_with_guests_for_org(
+        &self,
+        org_id: Uuid,
+        booking_id: Uuid,
+    ) -> Result<Option<BookingWithGuests>, SqlxError> {
+        let booking = match self.find_booking_for_org(org_id, booking_id).await? {
+            Some(b) => b,
+            None => return Ok(None),
+        };
+
+        let guests = self.get_guests_for_booking(booking_id).await?;
+
+        let registration_complete = !guests.is_empty()
+            && guests.iter().all(|g| {
+                g.status == guest_status::REGISTERED || g.status == guest_status::REPORTED
+            });
+
+        Ok(Some(BookingWithGuests {
+            booking,
+            guests,
+            registration_complete,
+        }))
+    }
+
+    /// Delete guest scoped to an organization.
+    ///
+    /// SECURITY (#804): the `AND organization_id = $2` guard prevents a tenant
+    /// from deleting another org's guest.
+    pub async fn delete_guest_for_org(&self, org_id: Uuid, id: Uuid) -> Result<bool, SqlxError> {
+        let result =
+            sqlx::query(r#"DELETE FROM rental_guests WHERE id = $1 AND organization_id = $2"#)
+                .bind(id)
+                .bind(org_id)
+                .execute(&self.pool)
+                .await?;
+
+        Ok(result.rows_affected() > 0)
     }
 
     /// Delete guest.
@@ -1275,6 +1727,79 @@ impl RentalRepository {
         .bind(id)
         .fetch_optional(&self.pool)
         .await?;
+
+        Ok(report)
+    }
+
+    /// Find report by ID scoped to an organization.
+    ///
+    /// SECURITY (#804): prevents reading another org's authority report by UUID.
+    pub async fn find_report_for_org(
+        &self,
+        org_id: Uuid,
+        id: Uuid,
+    ) -> Result<Option<RentalGuestReport>, SqlxError> {
+        let report = sqlx::query_as::<_, RentalGuestReport>(
+            r#"SELECT * FROM rental_guest_reports WHERE id = $1 AND organization_id = $2"#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(report)
+    }
+
+    /// Submit report scoped to an organization.
+    ///
+    /// SECURITY (#804): the `AND organization_id = $4` guard prevents a tenant
+    /// from submitting another org's report. Returns `None` when no row matched.
+    pub async fn submit_report_for_org(
+        &self,
+        org_id: Uuid,
+        id: Uuid,
+        user_id: Uuid,
+    ) -> Result<Option<RentalGuestReport>, SqlxError> {
+        let report = sqlx::query_as::<_, RentalGuestReport>(
+            r#"
+            UPDATE rental_guest_reports SET
+                status = $2,
+                submitted_at = NOW(),
+                submitted_by = $3,
+                updated_at = NOW()
+            WHERE id = $1 AND organization_id = $4
+            RETURNING *
+            "#,
+        )
+        .bind(id)
+        .bind(report_status::SUBMITTED)
+        .bind(user_id)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        // Mark guests as reported only when the report belonged to this org.
+        if report.is_some() {
+            sqlx::query(
+                r#"
+                UPDATE rental_guests SET
+                    status = 'reported',
+                    reported_at = NOW()
+                WHERE booking_id IN (
+                    SELECT b.id FROM rental_bookings b
+                    JOIN units u ON u.id = b.unit_id
+                    JOIN rental_guest_reports r ON r.building_id = u.building_id
+                    WHERE r.id = $1
+                        AND b.check_in >= r.period_start
+                        AND b.check_out <= r.period_end
+                )
+                AND status = 'registered'
+                "#,
+            )
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        }
 
         Ok(report)
     }
@@ -1464,6 +1989,77 @@ impl RentalRepository {
         .await?;
 
         Ok(feeds)
+    }
+
+    /// Get iCal feeds for a unit scoped to an organization.
+    ///
+    /// SECURITY (#804): adds `AND organization_id = $2` so a caller cannot
+    /// enumerate another org's feeds by guessing a unit UUID.
+    pub async fn get_ical_feeds_for_unit_in_org(
+        &self,
+        org_id: Uuid,
+        unit_id: Uuid,
+    ) -> Result<Vec<ICalFeed>, SqlxError> {
+        let feeds = sqlx::query_as::<_, ICalFeed>(
+            r#"SELECT * FROM rental_ical_feeds WHERE unit_id = $1 AND organization_id = $2 ORDER BY feed_name"#,
+        )
+        .bind(unit_id)
+        .bind(org_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(feeds)
+    }
+
+    /// Update iCal feed scoped to an organization.
+    ///
+    /// SECURITY (#804): the `AND organization_id = $5` guard prevents a tenant
+    /// from mutating another org's feed. Returns `None` when no row matched.
+    pub async fn update_ical_feed_for_org(
+        &self,
+        org_id: Uuid,
+        id: Uuid,
+        data: UpdateICalFeed,
+    ) -> Result<Option<ICalFeed>, SqlxError> {
+        let feed = sqlx::query_as::<_, ICalFeed>(
+            r#"
+            UPDATE rental_ical_feeds SET
+                feed_name = COALESCE($2, feed_name),
+                import_url = COALESCE($3, import_url),
+                is_active = COALESCE($4, is_active),
+                updated_at = NOW()
+            WHERE id = $1 AND organization_id = $5
+            RETURNING *
+            "#,
+        )
+        .bind(id)
+        .bind(&data.feed_name)
+        .bind(&data.import_url)
+        .bind(data.is_active)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(feed)
+    }
+
+    /// Delete iCal feed scoped to an organization.
+    ///
+    /// SECURITY (#804): the `AND organization_id = $2` guard prevents a tenant
+    /// from deleting another org's feed.
+    pub async fn delete_ical_feed_for_org(
+        &self,
+        org_id: Uuid,
+        id: Uuid,
+    ) -> Result<bool, SqlxError> {
+        let result =
+            sqlx::query(r#"DELETE FROM rental_ical_feeds WHERE id = $1 AND organization_id = $2"#)
+                .bind(id)
+                .bind(org_id)
+                .execute(&self.pool)
+                .await?;
+
+        Ok(result.rows_affected() > 0)
     }
 
     /// Update iCal feed.

--- a/backend/crates/db/src/repositories/rental.rs
+++ b/backend/crates/db/src/repositories/rental.rs
@@ -175,8 +175,22 @@ impl RentalRepository {
         org_id: Uuid,
         id: Uuid,
     ) -> Result<Option<RentalPlatformConnection>, SqlxError> {
+        // `platform` is the `rental_platform` enum; the model decodes it as
+        // `String`, so it must be cast with `platform::text` (a bare `SELECT *`
+        // panics with "mismatched types … not compatible with SQL type
+        // rental_platform"). All other columns map 1:1 to the model fields.
         let conn = sqlx::query_as::<_, RentalPlatformConnection>(
-            r#"SELECT * FROM rental_platform_connections WHERE id = $1 AND organization_id = $2"#,
+            r#"
+            SELECT
+                id, organization_id, unit_id, platform::text AS platform,
+                access_token, refresh_token, token_expires_at,
+                external_property_id, external_listing_url,
+                is_active, last_sync_at, sync_error,
+                sync_calendar, sync_interval_minutes, block_other_platforms,
+                created_at, updated_at
+            FROM rental_platform_connections
+            WHERE id = $1 AND organization_id = $2
+            "#,
         )
         .bind(id)
         .bind(org_id)
@@ -258,7 +272,13 @@ impl RentalRepository {
                 block_other_platforms = COALESCE($7, block_other_platforms),
                 updated_at = NOW()
             WHERE id = $1 AND organization_id = $8
-            RETURNING *
+            RETURNING
+                id, organization_id, unit_id, platform::text AS platform,
+                access_token, refresh_token, token_expires_at,
+                external_property_id, external_listing_url,
+                is_active, last_sync_at, sync_error,
+                sync_calendar, sync_interval_minutes, block_other_platforms,
+                created_at, updated_at
             "#,
         )
         .bind(id)

--- a/backend/servers/api-server/src/routes/rentals.rs
+++ b/backend/servers/api-server/src/routes/rentals.rs
@@ -13,10 +13,10 @@ use chrono::NaiveDate;
 use db::models::{
     BookingListQuery, BookingWithGuests, BookingsResponse, CalendarBlock, CalendarEvent,
     ConnectionStatus, CreateBooking, CreateCalendarBlock, CreateGuest, CreateICalFeed,
-    CreatePlatformConnection, GenerateReport, ICalFeed, PlatformConnectionSummary,
-    PlatformSyncStatus, RentalBooking, RentalGuest, RentalGuestReport, RentalPlatformConnection,
-    RentalStatistics, ReportPreview, ReportSummary, UpdateBooking, UpdateBookingStatus,
-    UpdateGuest, UpdateICalFeed, UpdatePlatformConnection,
+    CreatePlatformConnection, GenerateReport, ICalFeed, PlatformConnectionDetail,
+    PlatformConnectionSummary, PlatformSyncStatus, RentalBooking, RentalGuest, RentalGuestReport,
+    RentalPlatformConnection, RentalStatistics, ReportPreview, ReportSummary, UpdateBooking,
+    UpdateBookingStatus, UpdateGuest, UpdateICalFeed, UpdatePlatformConnection,
 };
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -68,6 +68,36 @@ pub fn router() -> Router<AppState> {
         .route("/ical/{id}", put(update_ical_feed))
         .route("/ical/{id}", delete(delete_ical_feed))
         .route("/units/{unit_id}/ical", get(get_unit_ical_feeds))
+}
+
+/// SECURITY (#804): assert that `unit_id` belongs to `org_id`.
+///
+/// Returns 404 (not 403) on a foreign/missing unit so the endpoint does not
+/// leak whether a given unit UUID exists in another organization.
+async fn ensure_unit_in_org(
+    state: &AppState,
+    org_id: Uuid,
+    unit_id: Uuid,
+) -> Result<(), (axum::http::StatusCode, String)> {
+    let owns = state
+        .rental_repo
+        .unit_belongs_to_org(org_id, unit_id)
+        .await
+        .map_err(|e| {
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to verify unit ownership: {}", e),
+            )
+        })?;
+
+    if owns {
+        Ok(())
+    } else {
+        Err((
+            axum::http::StatusCode::NOT_FOUND,
+            "Unit not found".to_string(),
+        ))
+    }
 }
 
 // ============================================
@@ -200,17 +230,22 @@ pub async fn create_connection(
     tag = "Rentals",
     params(("id" = Uuid, Path, description = "Connection ID")),
     responses(
-        (status = 200, description = "Connection details", body = RentalPlatformConnection),
+        (status = 200, description = "Connection details", body = PlatformConnectionDetail),
+        (status = 401, description = "Unauthorized"),
         (status = 404, description = "Connection not found")
     )
 )]
 pub async fn get_connection(
     State(state): State<AppState>,
+    TenantExtractor(tenant): TenantExtractor,
     Path(id): Path<Uuid>,
-) -> Result<Json<RentalPlatformConnection>, (axum::http::StatusCode, String)> {
+) -> Result<Json<PlatformConnectionDetail>, (axum::http::StatusCode, String)> {
+    // SECURITY (#887 / #804): scope the lookup to the authenticated tenant so a
+    // caller cannot read another org's connection, and return a token-free DTO
+    // so `access_token` / `refresh_token` are never serialized to the response.
     let connection = state
         .rental_repo
-        .find_connection_by_id(id)
+        .find_connection_for_org(tenant.tenant_id, id)
         .await
         .map_err(|e| {
             (
@@ -220,7 +255,7 @@ pub async fn get_connection(
         })?;
 
     match connection {
-        Some(c) => Ok(Json(c)),
+        Some(c) => Ok(Json(PlatformConnectionDetail::from(c))),
         None => Err((
             axum::http::StatusCode::NOT_FOUND,
             "Connection not found".to_string(),
@@ -236,20 +271,21 @@ pub async fn get_connection(
     params(("id" = Uuid, Path, description = "Connection ID")),
     request_body = UpdatePlatformConnection,
     responses(
-        (status = 200, description = "Connection updated", body = RentalPlatformConnection),
+        (status = 200, description = "Connection updated", body = PlatformConnectionDetail),
         (status = 401, description = "Unauthorized"),
         (status = 404, description = "Connection not found")
     )
 )]
 pub async fn update_connection(
     State(state): State<AppState>,
-    TenantExtractor(_tenant): TenantExtractor,
+    TenantExtractor(tenant): TenantExtractor,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdatePlatformConnection>,
-) -> Result<Json<RentalPlatformConnection>, (axum::http::StatusCode, String)> {
+) -> Result<Json<PlatformConnectionDetail>, (axum::http::StatusCode, String)> {
+    // SECURITY (#887 / #804): org-scoped update — cross-tenant ids return 404.
     let connection = state
         .rental_repo
-        .update_connection(id, data)
+        .update_connection_for_org(tenant.tenant_id, id, data)
         .await
         .map_err(|e| {
             (
@@ -258,7 +294,13 @@ pub async fn update_connection(
             )
         })?;
 
-    Ok(Json(connection))
+    match connection {
+        Some(c) => Ok(Json(PlatformConnectionDetail::from(c))),
+        None => Err((
+            axum::http::StatusCode::NOT_FOUND,
+            "Connection not found".to_string(),
+        )),
+    }
 }
 
 /// Delete platform connection.
@@ -275,15 +317,20 @@ pub async fn update_connection(
 )]
 pub async fn delete_connection(
     State(state): State<AppState>,
-    TenantExtractor(_tenant): TenantExtractor,
+    TenantExtractor(tenant): TenantExtractor,
     Path(id): Path<Uuid>,
 ) -> Result<axum::http::StatusCode, (axum::http::StatusCode, String)> {
-    let deleted = state.rental_repo.delete_connection(id).await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to delete connection: {}", e),
-        )
-    })?;
+    // SECURITY (#887 / #804): org-scoped delete — cross-tenant ids return 404.
+    let deleted = state
+        .rental_repo
+        .delete_connection_for_org(tenant.tenant_id, id)
+        .await
+        .map_err(|e| {
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to delete connection: {}", e),
+            )
+        })?;
 
     if !deleted {
         return Err((
@@ -308,12 +355,14 @@ pub async fn delete_connection(
 )]
 pub async fn get_unit_connections(
     State(state): State<AppState>,
-    TenantExtractor(_tenant): TenantExtractor,
+    TenantExtractor(tenant): TenantExtractor,
     Path(unit_id): Path<Uuid>,
 ) -> Result<Json<Vec<ConnectionStatus>>, (axum::http::StatusCode, String)> {
+    // SECURITY (#887 / #804): scope to the authenticated tenant so a caller
+    // cannot enumerate another org's unit connections by guessing a UUID.
     let connections = state
         .rental_repo
-        .get_connections_for_unit(unit_id)
+        .get_connections_for_unit_in_org(tenant.tenant_id, unit_id)
         .await
         .map_err(|e| {
             (
@@ -737,16 +786,20 @@ pub async fn create_booking(
     params(("id" = Uuid, Path, description = "Booking ID")),
     responses(
         (status = 200, description = "Booking details", body = RentalBooking),
+        (status = 401, description = "Unauthorized"),
         (status = 404, description = "Booking not found")
     )
 )]
 pub async fn get_booking(
     State(state): State<AppState>,
+    TenantExtractor(tenant): TenantExtractor,
     Path(id): Path<Uuid>,
 ) -> Result<Json<RentalBooking>, (axum::http::StatusCode, String)> {
+    // SECURITY (#804): scope to the authenticated tenant so a caller cannot
+    // read another org's booking PII by guessing a UUID.
     let booking = state
         .rental_repo
-        .find_booking_by_id(id)
+        .find_booking_for_org(tenant.tenant_id, id)
         .await
         .map_err(|e| {
             (
@@ -779,13 +832,14 @@ pub async fn get_booking(
 )]
 pub async fn update_booking(
     State(state): State<AppState>,
-    TenantExtractor(_tenant): TenantExtractor,
+    TenantExtractor(tenant): TenantExtractor,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateBooking>,
 ) -> Result<Json<RentalBooking>, (axum::http::StatusCode, String)> {
+    // SECURITY (#804): org-scoped update — cross-tenant ids return 404.
     let booking = state
         .rental_repo
-        .update_booking(id, data)
+        .update_booking_for_org(tenant.tenant_id, id, data)
         .await
         .map_err(|e| {
             (
@@ -794,7 +848,13 @@ pub async fn update_booking(
             )
         })?;
 
-    Ok(Json(booking))
+    match booking {
+        Some(b) => Ok(Json(b)),
+        None => Err((
+            axum::http::StatusCode::NOT_FOUND,
+            "Booking not found".to_string(),
+        )),
+    }
 }
 
 /// Update booking status.
@@ -812,13 +872,14 @@ pub async fn update_booking(
 )]
 pub async fn update_booking_status(
     State(state): State<AppState>,
-    TenantExtractor(_tenant): TenantExtractor,
+    TenantExtractor(tenant): TenantExtractor,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateBookingStatus>,
 ) -> Result<Json<RentalBooking>, (axum::http::StatusCode, String)> {
+    // SECURITY (#804): org-scoped status update — cross-tenant ids return 404.
     let booking = state
         .rental_repo
-        .update_booking_status(id, data)
+        .update_booking_status_for_org(tenant.tenant_id, id, data)
         .await
         .map_err(|e| {
             (
@@ -827,7 +888,13 @@ pub async fn update_booking_status(
             )
         })?;
 
-    Ok(Json(booking))
+    match booking {
+        Some(b) => Ok(Json(b)),
+        None => Err((
+            axum::http::StatusCode::NOT_FOUND,
+            "Booking not found".to_string(),
+        )),
+    }
 }
 
 /// Get booking with guests.
@@ -838,16 +905,20 @@ pub async fn update_booking_status(
     params(("id" = Uuid, Path, description = "Booking ID")),
     responses(
         (status = 200, description = "Booking with guests", body = BookingWithGuests),
+        (status = 401, description = "Unauthorized"),
         (status = 404, description = "Booking not found")
     )
 )]
 pub async fn get_booking_with_guests(
     State(state): State<AppState>,
+    TenantExtractor(tenant): TenantExtractor,
     Path(id): Path<Uuid>,
 ) -> Result<Json<BookingWithGuests>, (axum::http::StatusCode, String)> {
+    // SECURITY (#804): scope to the authenticated tenant so a caller cannot
+    // read another org's booking + guest PII by guessing a UUID.
     let result = state
         .rental_repo
-        .get_booking_with_guests(id)
+        .get_booking_with_guests_for_org(tenant.tenant_id, id)
         .await
         .map_err(|e| {
             (
@@ -893,10 +964,14 @@ pub struct CalendarQuery {
 )]
 pub async fn get_calendar(
     State(state): State<AppState>,
-    TenantExtractor(_tenant): TenantExtractor,
+    TenantExtractor(tenant): TenantExtractor,
     Path(unit_id): Path<Uuid>,
     Query(query): Query<CalendarQuery>,
 ) -> Result<Json<Vec<CalendarEvent>>, (axum::http::StatusCode, String)> {
+    // SECURITY (#804): verify the unit belongs to the caller's org before
+    // returning its calendar — otherwise any authed user could read any unit.
+    ensure_unit_in_org(&state, tenant.tenant_id, unit_id).await?;
+
     let events = state
         .rental_repo
         .get_calendar_events(unit_id, query.start_date, query.end_date)
@@ -943,10 +1018,13 @@ pub struct AvailabilityResponse {
 )]
 pub async fn check_availability(
     State(state): State<AppState>,
-    TenantExtractor(_tenant): TenantExtractor,
+    TenantExtractor(tenant): TenantExtractor,
     Path(unit_id): Path<Uuid>,
     Query(query): Query<AvailabilityQuery>,
 ) -> Result<Json<AvailabilityResponse>, (axum::http::StatusCode, String)> {
+    // SECURITY (#804): verify the unit belongs to the caller's org.
+    ensure_unit_in_org(&state, tenant.tenant_id, unit_id).await?;
+
     let available = state
         .rental_repo
         .check_availability(unit_id, query.start_date, query.end_date)
@@ -1009,12 +1087,13 @@ pub async fn create_calendar_block(
 )]
 pub async fn delete_calendar_block(
     State(state): State<AppState>,
-    TenantExtractor(_tenant): TenantExtractor,
+    TenantExtractor(tenant): TenantExtractor,
     Path(id): Path<Uuid>,
 ) -> Result<axum::http::StatusCode, (axum::http::StatusCode, String)> {
+    // SECURITY (#804): org-scoped delete — cross-tenant ids return 404.
     let deleted = state
         .rental_repo
-        .delete_calendar_block(id)
+        .delete_calendar_block_for_org(tenant.tenant_id, id)
         .await
         .map_err(|e| {
             (
@@ -1076,19 +1155,27 @@ pub async fn create_guest(
     params(("id" = Uuid, Path, description = "Guest ID")),
     responses(
         (status = 200, description = "Guest details", body = RentalGuest),
+        (status = 401, description = "Unauthorized"),
         (status = 404, description = "Guest not found")
     )
 )]
 pub async fn get_guest(
     State(state): State<AppState>,
+    TenantExtractor(tenant): TenantExtractor,
     Path(id): Path<Uuid>,
 ) -> Result<Json<RentalGuest>, (axum::http::StatusCode, String)> {
-    let guest = state.rental_repo.find_guest_by_id(id).await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to get guest: {}", e),
-        )
-    })?;
+    // SECURITY (#804): scope to the authenticated tenant so a caller cannot
+    // read another org's guest PII by guessing a UUID.
+    let guest = state
+        .rental_repo
+        .find_guest_for_org(tenant.tenant_id, id)
+        .await
+        .map_err(|e| {
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to get guest: {}", e),
+            )
+        })?;
 
     match guest {
         Some(g) => Ok(Json(g)),
@@ -1114,13 +1201,14 @@ pub async fn get_guest(
 )]
 pub async fn update_guest(
     State(state): State<AppState>,
-    TenantExtractor(_tenant): TenantExtractor,
+    TenantExtractor(tenant): TenantExtractor,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateGuest>,
 ) -> Result<Json<RentalGuest>, (axum::http::StatusCode, String)> {
+    // SECURITY (#804): org-scoped update — cross-tenant ids return 404.
     let guest = state
         .rental_repo
-        .update_guest(id, data)
+        .update_guest_for_org(tenant.tenant_id, id, data)
         .await
         .map_err(|e| {
             (
@@ -1129,7 +1217,13 @@ pub async fn update_guest(
             )
         })?;
 
-    Ok(Json(guest))
+    match guest {
+        Some(g) => Ok(Json(g)),
+        None => Err((
+            axum::http::StatusCode::NOT_FOUND,
+            "Guest not found".to_string(),
+        )),
+    }
 }
 
 /// Delete guest.
@@ -1146,15 +1240,20 @@ pub async fn update_guest(
 )]
 pub async fn delete_guest(
     State(state): State<AppState>,
-    TenantExtractor(_tenant): TenantExtractor,
+    TenantExtractor(tenant): TenantExtractor,
     Path(id): Path<Uuid>,
 ) -> Result<axum::http::StatusCode, (axum::http::StatusCode, String)> {
-    let deleted = state.rental_repo.delete_guest(id).await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to delete guest: {}", e),
-        )
-    })?;
+    // SECURITY (#804): org-scoped delete — cross-tenant ids return 404.
+    let deleted = state
+        .rental_repo
+        .delete_guest_for_org(tenant.tenant_id, id)
+        .await
+        .map_err(|e| {
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to delete guest: {}", e),
+            )
+        })?;
 
     if !deleted {
         return Err((
@@ -1180,17 +1279,28 @@ pub async fn delete_guest(
 )]
 pub async fn register_guest(
     State(state): State<AppState>,
-    TenantExtractor(_tenant): TenantExtractor,
+    TenantExtractor(tenant): TenantExtractor,
     Path(id): Path<Uuid>,
 ) -> Result<Json<RentalGuest>, (axum::http::StatusCode, String)> {
-    let guest = state.rental_repo.register_guest(id).await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to register guest: {}", e),
-        )
-    })?;
+    // SECURITY (#804): org-scoped register — cross-tenant ids return 404.
+    let guest = state
+        .rental_repo
+        .register_guest_for_org(tenant.tenant_id, id)
+        .await
+        .map_err(|e| {
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to register guest: {}", e),
+            )
+        })?;
 
-    Ok(Json(guest))
+    match guest {
+        Some(g) => Ok(Json(g)),
+        None => Err((
+            axum::http::StatusCode::NOT_FOUND,
+            "Guest not found".to_string(),
+        )),
+    }
 }
 
 /// Check-in reminders query params.
@@ -1364,19 +1474,27 @@ pub async fn create_report(
     params(("id" = Uuid, Path, description = "Report ID")),
     responses(
         (status = 200, description = "Report details", body = RentalGuestReport),
+        (status = 401, description = "Unauthorized"),
         (status = 404, description = "Report not found")
     )
 )]
 pub async fn get_report(
     State(state): State<AppState>,
+    TenantExtractor(tenant): TenantExtractor,
     Path(id): Path<Uuid>,
 ) -> Result<Json<RentalGuestReport>, (axum::http::StatusCode, String)> {
-    let report = state.rental_repo.find_report_by_id(id).await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to get report: {}", e),
-        )
-    })?;
+    // SECURITY (#804): scope to the authenticated tenant so a caller cannot
+    // read another org's authority report by guessing a UUID.
+    let report = state
+        .rental_repo
+        .find_report_for_org(tenant.tenant_id, id)
+        .await
+        .map_err(|e| {
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to get report: {}", e),
+            )
+        })?;
 
     match report {
         Some(r) => Ok(Json(r)),
@@ -1404,9 +1522,10 @@ pub async fn submit_report(
     TenantExtractor(tenant): TenantExtractor,
     Path(id): Path<Uuid>,
 ) -> Result<Json<RentalGuestReport>, (axum::http::StatusCode, String)> {
+    // SECURITY (#804): org-scoped submit — cross-tenant ids return 404.
     let report = state
         .rental_repo
-        .submit_report(id, tenant.user_id)
+        .submit_report_for_org(tenant.tenant_id, id, tenant.user_id)
         .await
         .map_err(|e| {
             (
@@ -1415,7 +1534,13 @@ pub async fn submit_report(
             )
         })?;
 
-    Ok(Json(report))
+    match report {
+        Some(r) => Ok(Json(r)),
+        None => Err((
+            axum::http::StatusCode::NOT_FOUND,
+            "Report not found".to_string(),
+        )),
+    }
 }
 
 // ============================================
@@ -1467,13 +1592,14 @@ pub async fn create_ical_feed(
 )]
 pub async fn update_ical_feed(
     State(state): State<AppState>,
-    TenantExtractor(_tenant): TenantExtractor,
+    TenantExtractor(tenant): TenantExtractor,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateICalFeed>,
 ) -> Result<Json<ICalFeed>, (axum::http::StatusCode, String)> {
+    // SECURITY (#804): org-scoped update — cross-tenant ids return 404.
     let feed = state
         .rental_repo
-        .update_ical_feed(id, data)
+        .update_ical_feed_for_org(tenant.tenant_id, id, data)
         .await
         .map_err(|e| {
             (
@@ -1482,7 +1608,13 @@ pub async fn update_ical_feed(
             )
         })?;
 
-    Ok(Json(feed))
+    match feed {
+        Some(f) => Ok(Json(f)),
+        None => Err((
+            axum::http::StatusCode::NOT_FOUND,
+            "Feed not found".to_string(),
+        )),
+    }
 }
 
 /// Delete iCal feed.
@@ -1499,15 +1631,20 @@ pub async fn update_ical_feed(
 )]
 pub async fn delete_ical_feed(
     State(state): State<AppState>,
-    TenantExtractor(_tenant): TenantExtractor,
+    TenantExtractor(tenant): TenantExtractor,
     Path(id): Path<Uuid>,
 ) -> Result<axum::http::StatusCode, (axum::http::StatusCode, String)> {
-    let deleted = state.rental_repo.delete_ical_feed(id).await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to delete feed: {}", e),
-        )
-    })?;
+    // SECURITY (#804): org-scoped delete — cross-tenant ids return 404.
+    let deleted = state
+        .rental_repo
+        .delete_ical_feed_for_org(tenant.tenant_id, id)
+        .await
+        .map_err(|e| {
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to delete feed: {}", e),
+            )
+        })?;
 
     if !deleted {
         return Err((
@@ -1532,12 +1669,14 @@ pub async fn delete_ical_feed(
 )]
 pub async fn get_unit_ical_feeds(
     State(state): State<AppState>,
-    TenantExtractor(_tenant): TenantExtractor,
+    TenantExtractor(tenant): TenantExtractor,
     Path(unit_id): Path<Uuid>,
 ) -> Result<Json<Vec<ICalFeed>>, (axum::http::StatusCode, String)> {
+    // SECURITY (#804): scope to the authenticated tenant so a caller cannot
+    // enumerate another org's feeds by guessing a unit UUID.
     let feeds = state
         .rental_repo
-        .get_ical_feeds_for_unit(unit_id)
+        .get_ical_feeds_for_unit_in_org(tenant.tenant_id, unit_id)
         .await
         .map_err(|e| {
             (

--- a/backend/servers/api-server/tests/rental_connection_token_leak_tests.rs
+++ b/backend/servers/api-server/tests/rental_connection_token_leak_tests.rs
@@ -1,0 +1,307 @@
+//! Regression tests for #887 / #804 — rental platform connection OAuth token
+//! leak + cross-tenant IDOR.
+//!
+//! Audit history (origin/dev): `GET /api/v1/rentals/connections/{id}` had **no**
+//! auth extractor and returned the raw `RentalPlatformConnection` row —
+//! including `access_token` / `refresh_token`. Any caller with a connection
+//! UUID could harvest OAuth tokens for any org. Sibling by-id reads
+//! (`bookings/{id}`, `guests/{id}`) were also unauthenticated, and the
+//! mutations extracted `TenantExtractor` but discarded `_tenant`, issuing
+//! id-only repo calls (cross-tenant write/IDOR).
+//!
+//! The fix:
+//!   1. Requires `TenantExtractor` (JWT + `X-Tenant-ID`) on every connection /
+//!      booking / guest / report read+mutate handler.
+//!   2. Routes by-id access through `*_for_org(org_id, id)` repo methods whose
+//!      WHERE clause carries `AND organization_id = $org` (cross-tenant → 404).
+//!   3. Returns a token-free `PlatformConnectionDetail` DTO from
+//!      `GET/PUT /connections/{id}` so tokens are never serialized.
+//!
+//! Tenant mechanism: `TenantExtractor` validates a bearer JWT (`AuthUser`) and
+//! then reads the tenant from the `X-Tenant-ID` header (TestApp does not wire
+//! `host_tenant_middleware`). We mint a JWT carrying the `Claims` shape the
+//! `AuthUser` extractor expects (`sub`, `exp`, `iat`, `token_type:"access"`,
+//! `email`, `name`), and supply the org via `X-Tenant-ID`.
+
+#[allow(dead_code)]
+mod common;
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use chrono::{Duration, Utc};
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::Serialize;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::TestApp;
+
+// Must match `TestConfig::default().jwt_secret` in tests/common/mod.rs — the
+// `AuthUser` extractor reads `JWT_SECRET` (set once from that value).
+const JWT_SECRET: &str = "test-secret-key-that-is-at-least-64-characters-long-for-testing-purposes";
+
+/// Mirror of `api_core::extractors::auth::Claims` (the on-the-wire access-token
+/// shape produced by `JwtService`).
+#[derive(Serialize)]
+struct AccessClaims {
+    sub: Uuid,
+    exp: i64,
+    iat: i64,
+    token_type: String,
+    tenant_id: Option<Uuid>,
+    role: Option<String>,
+    email: String,
+    name: String,
+}
+
+fn mint_access_token(user_id: Uuid, tenant_id: Uuid) -> String {
+    let now = Utc::now();
+    let claims = AccessClaims {
+        sub: user_id,
+        iat: now.timestamp(),
+        exp: (now + Duration::hours(1)).timestamp(),
+        token_type: "access".to_string(),
+        tenant_id: Some(tenant_id),
+        role: Some("manager".to_string()),
+        email: "rental-idor@test.local".to_string(),
+        name: "Rental IDOR Test".to_string(),
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(JWT_SECRET.as_bytes()),
+    )
+    .expect("mint access token")
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active') RETURNING id
+        "#,
+    )
+    .bind(format!("Rental IDOR Org {slug}"))
+    .bind(format!("rental-idor-org-{slug}"))
+    .bind(format!("{slug}@rental-idor.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'test_hash', 'Rental IDOR User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_building(pool: &PgPool, org_id: Uuid, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO buildings (organization_id, street, city, postal_code, country)
+        VALUES ($1, $2, 'Bratislava', '81101', 'Slovakia') RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(format!("{slug} Street 1"))
+    .fetch_one(pool)
+    .await
+    .expect("seed building")
+}
+
+async fn seed_unit(pool: &PgPool, building_id: Uuid, designation: &str) -> Uuid {
+    // `units` has no `organization_id`/`name` column — org is via the building,
+    // and the unit identifier is `designation`.
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO units (building_id, designation, floor)
+        VALUES ($1, $2, 1) RETURNING id
+        "#,
+    )
+    .bind(building_id)
+    .bind(designation)
+    .fetch_one(pool)
+    .await
+    .expect("seed unit")
+}
+
+/// Seed a connection with real OAuth tokens so we can assert they never leak.
+async fn seed_connection(pool: &PgPool, org_id: Uuid, unit_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO rental_platform_connections (
+            organization_id, unit_id, platform,
+            access_token, refresh_token, is_active
+        )
+        VALUES ($1, $2, 'airbnb', $3, $4, true)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(unit_id)
+    .bind(SECRET_ACCESS_TOKEN)
+    .bind(SECRET_REFRESH_TOKEN)
+    .fetch_one(pool)
+    .await
+    .expect("seed connection")
+}
+
+const SECRET_ACCESS_TOKEN: &str = "super-secret-access-token-DO-NOT-LEAK";
+const SECRET_REFRESH_TOKEN: &str = "super-secret-refresh-token-DO-NOT-LEAK";
+
+fn authed_get(uri: &str, token: &str, tenant: Uuid) -> Request<Body> {
+    Request::builder()
+        .method(Method::GET)
+        .uri(uri)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("X-Tenant-ID", tenant.to_string())
+        .body(Body::empty())
+        .unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// (a) cross-org caller cannot read another org's connection → 404
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_connection_from_other_org_is_not_found(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org_a = seed_org(&pool, "get-conn-a").await;
+    let org_b = seed_org(&pool, "get-conn-b").await;
+    let user_b = seed_user(&pool, "get-conn-b@rental-idor.test").await;
+    let building_a = seed_building(&pool, org_a, "get-conn-a").await;
+    let unit_a = seed_unit(&pool, building_a, "A-1").await;
+    let conn_in_a = seed_connection(&pool, org_a, unit_a).await;
+
+    // Org B caller (valid JWT, X-Tenant-ID=org_b) tries to read org A's connection.
+    let token_b = mint_access_token(user_b, org_b);
+    let uri = format!("/api/v1/rentals/connections/{conn_in_a}");
+    let resp = app.execute(authed_get(&uri, &token_b, org_b)).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::NOT_FOUND,
+        "cross-org connection read must be 404, got {}: {}",
+        resp.status,
+        resp.text()
+    );
+
+    // And no secret leaks even in the error body.
+    let body = resp.text();
+    assert!(
+        !body.contains(SECRET_ACCESS_TOKEN) && !body.contains(SECRET_REFRESH_TOKEN),
+        "cross-org 404 body must not contain OAuth tokens: {body}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (b) same-org SUCCESS case — proves real org context (must PASS)
+// (c) response body does NOT contain the token fields
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_connection_same_org_succeeds_without_leaking_tokens(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org_a = seed_org(&pool, "ok-conn-a").await;
+    let user_a = seed_user(&pool, "ok-conn-a@rental-idor.test").await;
+    let building_a = seed_building(&pool, org_a, "ok-conn-a").await;
+    let unit_a = seed_unit(&pool, building_a, "OK-1").await;
+    let conn_in_a = seed_connection(&pool, org_a, unit_a).await;
+
+    let token_a = mint_access_token(user_a, org_a);
+    let uri = format!("/api/v1/rentals/connections/{conn_in_a}");
+    let resp = app.execute(authed_get(&uri, &token_a, org_a)).await;
+
+    // (b) Same-org read must succeed — this proves the org context is real and
+    //     the scoped query returns the row (not a false 404).
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "same-org connection read must be 200, got {}: {}",
+        resp.status,
+        resp.text()
+    );
+
+    let body = resp.text();
+
+    // (c) The response must NOT contain the OAuth secret values, and the
+    //     token-free DTO must not even carry the `access_token`/`refresh_token`
+    //     keys.
+    assert!(
+        !body.contains(SECRET_ACCESS_TOKEN) && !body.contains(SECRET_REFRESH_TOKEN),
+        "connection response leaked an OAuth token value: {body}"
+    );
+
+    let json: serde_json::Value = serde_json::from_str(&body).expect("response is JSON");
+    assert!(
+        json.get("access_token").is_none(),
+        "response must not contain an access_token field: {body}"
+    );
+    assert!(
+        json.get("refresh_token").is_none(),
+        "response must not contain a refresh_token field: {body}"
+    );
+    // The token-free DTO still confirms a token is present via a boolean.
+    assert_eq!(
+        json.get("is_connected").and_then(|v| v.as_bool()),
+        Some(true),
+        "is_connected should reflect that a token is stored: {body}"
+    );
+    // And it correctly identifies the row.
+    assert_eq!(
+        json.get("id").and_then(|v| v.as_str()),
+        Some(conn_in_a.to_string().as_str()),
+        "response id must match the requested connection: {body}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (a, extra) unauthenticated read is rejected (no JWT at all)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_connection_without_auth_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org_a = seed_org(&pool, "noauth-a").await;
+    let building_a = seed_building(&pool, org_a, "noauth-a").await;
+    let unit_a = seed_unit(&pool, building_a, "NA-1").await;
+    let conn_in_a = seed_connection(&pool, org_a, unit_a).await;
+
+    let uri = format!("/api/v1/rentals/connections/{conn_in_a}");
+    let resp = app
+        .execute(
+            Request::builder()
+                .method(Method::GET)
+                .uri(&uri)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+
+    let code = resp.status.as_u16();
+    assert!(
+        (400..500).contains(&code),
+        "unauthenticated connection read must be 4xx, got {}",
+        resp.status
+    );
+    let body = resp.text();
+    assert!(
+        !body.contains(SECRET_ACCESS_TOKEN) && !body.contains(SECRET_REFRESH_TOKEN),
+        "unauthenticated response must not contain OAuth tokens: {body}"
+    );
+}


### PR DESCRIPTION
## Summary
- `GET /api/v1/rentals/connections/{id}` had **no** auth extractor and returned the raw `RentalPlatformConnection` row — including `access_token` / `refresh_token`. Any caller with a connection UUID could harvest OAuth tokens for any org (#887 P0 / #804 P0).
- Sibling by-id reads (`bookings/{id}`, `bookings/{id}/guests`, `guests/{id}`, `reports/{id}`) were also unauthenticated → guest PII disclosure.
- Mutations (`update_connection`, `delete_connection`, `update_booking`, `update_booking_status`, `update_guest`, `delete_guest`, `register_guest`, `delete_calendar_block`, `submit_report`, `update_ical_feed`, `delete_ical_feed`) extracted `TenantExtractor` but discarded `_tenant` and issued id-only repo calls → cross-tenant IDOR.

## Fix
1. **Auth + org-scope on every connection/booking/guest/report/iCal read+mutate handler.** Tenant is derived from `TenantExtractor` (the idiom these routes already used — JWT `AuthUser` + `X-Tenant-ID`), now actually *used*.
2. **By-id access is org-scoped.** New repo methods `find_connection_for_org`, `update_connection_for_org`, `delete_connection_for_org`, `get_connections_for_unit_in_org`, `find_booking_for_org`, `update_booking_for_org`, `update_booking_status_for_org`, `get_booking_with_guests_for_org`, `find_guest_for_org`, `update_guest_for_org`, `register_guest_for_org`, `delete_guest_for_org`, `find_report_for_org`, `submit_report_for_org`, `update_ical_feed_for_org`, `delete_ical_feed_for_org`, `get_ical_feeds_for_unit_in_org`, `delete_calendar_block_for_org` — each WHERE clause carries `AND organization_id = $org` so a cross-tenant id returns **404**. Unit-scoped reads (`calendar`, `availability`) gate on a new `unit_belongs_to_org` check (units reach org via `buildings.organization_id`).
3. **Stop leaking tokens.** `GET`/`PUT /connections/{id}` now return a new token-free `PlatformConnectionDetail` DTO (mirrors the connection minus `access_token`/`refresh_token`, exposes `is_connected: bool` instead).

## Org mechanism
`TenantExtractor` = bearer JWT (`AuthUser`) + `X-Tenant-ID` header → `tenant.tenant_id`. Same idiom used by the already-correct sibling handlers in this file (`get_statistics`, `list_connections`, `create_*`).

## Tested
- `cargo clippy -p api-server --lib -- -D warnings` → **exit 0**, clean (isolated `CARGO_TARGET_DIR=ct-887`).
- `cargo test -p api-server --test rental_connection_token_leak_tests` → **compiles clean**; the local `ppt-test-pg` postgres became unavailable mid-run (host disk-full event during the test build wedged Docker; recovering). The three tests are assertion-correct and were not reached due to `PoolTimedOut` (infra, not logic). A passing run will be posted as a comment once the DB recovers. Tests:
  - `get_connection_from_other_org_is_not_found` — cross-org read → 404, body has no tokens.
  - `get_connection_same_org_succeeds_without_leaking_tokens` — **same-org SUCCESS (200)**, asserts body has no `access_token`/`refresh_token` keys/values and `is_connected == true`.
  - `get_connection_without_auth_is_rejected` — no JWT → 4xx.

## Deferred (refs #887, #804 — not closed by this PR)
- Token **encryption-at-rest** (tokens are still stored app-level; callbacks already call `encrypt_if_available`).
- OAuth **callback state/nonce CSRF** binding (P2). The Airbnb/Booking callbacks deliberately still use the unscoped `find_connection_by_id` (no auth context — state-bound), which is the correct place for the P2 follow-up.

## Notes
Closes #887, closes #804.