### PR TITLE
fix(security): require auth on voice OAuth exchange (closes #890)

### DIFF
--- a/backend/servers/api-server/src/routes/voice_webhooks.rs
+++ b/backend/servers/api-server/src/routes/voice_webhooks.rs
@@ -266,8 +266,12 @@ async fn google_actions_webhook(
 
 /// Exchange OAuth authorization code for tokens.
 ///
-/// This endpoint is called after the user completes account linking
-/// on the voice assistant platform.
+/// This endpoint completes account linking: it is invoked by the
+/// authenticated Property Management user (from the voice account-linking
+/// flow), **not** by the voice platform itself. It therefore requires a
+/// valid PM access token (`AuthUser`) and binds the resulting voice device
+/// to that user's identity and organization — never to random UUIDs
+/// (security fix #890).
 #[utoipa::path(
     post,
     path = "/api/v1/webhooks/voice/oauth/exchange",
@@ -275,17 +279,43 @@ async fn google_actions_webhook(
     responses(
         (status = 200, description = "Token exchange successful", body = VoiceOAuthExchangeResponse),
         (status = 400, description = "Invalid authorization code"),
+        (status = 401, description = "Unauthorized - missing or invalid PM access token"),
+        (status = 403, description = "Forbidden - no active organization context"),
         (status = 500, description = "Token exchange failed"),
     ),
+    security(("bearer_auth" = [])),
     tag = "Voice OAuth"
 )]
 async fn oauth_token_exchange(
     State(state): State<AppState>,
+    auth: api_core::AuthUser,
     Json(request): Json<VoiceOAuthExchangeRequest>,
 ) -> Result<Json<VoiceOAuthExchangeResponse>, (StatusCode, Json<ErrorResponse>)> {
     use integrations::{VoiceOAuthManager, VoicePlatform};
 
-    tracing::info!("OAuth token exchange for platform: {}", request.platform);
+    // Bind the linking to the authenticated PM user + their active org.
+    // Without an org context we cannot create a tenant-scoped voice device.
+    let user_id = auth.user_id;
+    let org_id = auth.tenant_id.ok_or_else(|| {
+        tracing::warn!(
+            user_id = %auth.user_id,
+            "Voice OAuth exchange rejected: no active organization context"
+        );
+        (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "NO_ORGANIZATION_CONTEXT",
+                "An active organization context is required to link a voice device",
+            )),
+        )
+    })?;
+
+    tracing::info!(
+        user_id = %user_id,
+        org_id = %org_id,
+        platform = %request.platform,
+        "OAuth token exchange for voice device linking"
+    );
 
     // Validate platform
     if request.platform != voice_platform::ALEXA
@@ -351,10 +381,12 @@ async fn oauth_token_exchange(
             .map(|rt| encrypt_if_available(crypto.as_ref(), rt));
 
         (access_encrypted, refresh_encrypted, tokens.expires_at)
-    } else {
-        // Platform not configured - use simulated tokens for development
+    } else if cfg!(debug_assertions) {
+        // Platform not configured - use simulated tokens for development only.
+        // Gated behind `debug_assertions` (security fix #890): release builds
+        // must never mint fake voice tokens.
         tracing::warn!(
-            "Voice OAuth not configured for platform {}, using simulated tokens",
+            "Voice OAuth not configured for platform {}, using simulated tokens (debug build)",
             request.platform
         );
         let simulated_access = format!("voice_access_{}_{}", request.platform, Uuid::new_v4());
@@ -364,13 +396,22 @@ async fn oauth_token_exchange(
             Some(encrypt_if_available(crypto.as_ref(), &simulated_refresh)),
             Some(Utc::now() + Duration::hours(1)),
         )
+    } else {
+        tracing::error!(
+            "Voice OAuth not configured for platform {} in a release build",
+            request.platform
+        );
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse::new(
+                "OAUTH_NOT_CONFIGURED",
+                "Voice OAuth is not configured for this platform",
+            )),
+        ));
     };
 
-    // For this webhook endpoint, we don't have tenant context
-    // The user_id and org_id should be extracted from the OAuth token claims
-    // For now, use placeholder values (in production, validate JWT/token)
-    let user_id = Uuid::new_v4();
-    let org_id = Uuid::new_v4();
+    // Device is bound to the authenticated PM user and their organization
+    // (derived above from the verified access token — never random UUIDs).
     let device_id = format!("{}_{}", request.platform, Uuid::new_v4());
 
     // Create the voice device with tokens

--- a/backend/servers/api-server/tests/voice_oauth_exchange_auth_tests.rs
+++ b/backend/servers/api-server/tests/voice_oauth_exchange_auth_tests.rs
@@ -1,0 +1,205 @@
+//! Regression tests for the unauthenticated voice OAuth exchange fix (#890).
+//!
+//! Audit history: `POST /api/v1/webhooks/voice/oauth/exchange`
+//! (`oauth_token_exchange`) accepted an `auth_code` + `platform` from any
+//! caller with **no authentication**, then minted a voice device bound to
+//! `Uuid::new_v4()` for both `user_id` and `org_id` — creating orphan,
+//! cross-tenant-unscoped voice devices.
+//!
+//! The fix adds the `AuthUser` extractor (PM access-token bearer auth) and
+//! derives `user_id` + `org_id` from the verified token claims, rejecting:
+//!   - requests with no/invalid bearer token  -> 401
+//!   - authenticated requests with no active org (no `tenant_id` claim) -> 403
+//!
+//! TestApp wiring caveat: `AuthUser` reads `tenant_id` directly from the JWT
+//! claims (no `host_tenant_middleware` needed), so we mint tokens carrying a
+//! custom `tenant_id` claim to exercise the authenticated paths.
+//!
+//! Success-path note: there is no `voice_assistant_devices` migration in the
+//! PPT schema, so a fully-authenticated request gets *past* the auth gate and
+//! then fails at the DB insert. The security contract is what we assert: a
+//! valid token is NOT rejected at the auth layer (status is never 401/403),
+//! while an unauthenticated or org-less request IS rejected before any work.
+
+#[allow(dead_code)]
+mod common;
+
+use axum::{
+    body::Body,
+    http::{header, Method, Request, StatusCode},
+};
+use chrono::{Duration, Utc};
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::Serialize;
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{TestApp, TestConfig};
+
+const EXCHANGE_URI: &str = "/api/v1/webhooks/voice/oauth/exchange";
+
+/// Mirror of `api_core::extractors::auth::Claims` — the shape `AuthUser`
+/// decodes. `tenant_id`/`role` are `Option` so we can mint a token with or
+/// without an active organization context.
+#[derive(Serialize)]
+struct AuthClaims {
+    sub: Uuid,
+    exp: i64,
+    iat: i64,
+    token_type: String,
+    tenant_id: Option<Uuid>,
+    role: Option<String>,
+    email: String,
+    name: String,
+}
+
+fn mint_access_token(secret: &str, user_id: Uuid, tenant_id: Option<Uuid>) -> String {
+    let now = Utc::now();
+    let claims = AuthClaims {
+        sub: user_id,
+        iat: now.timestamp(),
+        exp: (now + Duration::hours(1)).timestamp(),
+        token_type: "access".to_string(),
+        tenant_id,
+        role: Some("manager".to_string()),
+        email: "voice-link@example.test".to_string(),
+        name: "Voice Linker".to_string(),
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .expect("mint access token")
+}
+
+fn exchange_body() -> serde_json::Value {
+    json!({
+        "auth_code": "test-authorization-code",
+        "platform": "alexa",
+        "redirect_uri": "https://ppt.three-two-bit.com/api/v1/webhooks/voice/oauth/callback",
+        "state": null
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: no Authorization header -> 401, no device created.
+// ---------------------------------------------------------------------------
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn oauth_exchange_without_auth_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(EXCHANGE_URI)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(exchange_body().to_string()))
+        .unwrap();
+
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::UNAUTHORIZED,
+        "unauthenticated exchange must be 401, got {}: {}",
+        resp.status,
+        resp.text()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: garbage bearer token -> 401.
+// ---------------------------------------------------------------------------
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn oauth_exchange_invalid_token_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(EXCHANGE_URI)
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(header::AUTHORIZATION, "Bearer not-a-real-jwt")
+        .body(Body::from(exchange_body().to_string()))
+        .unwrap();
+
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::UNAUTHORIZED,
+        "invalid bearer token must be 401, got {}: {}",
+        resp.status,
+        resp.text()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: authenticated but no org context (no tenant_id claim) -> 403.
+// ---------------------------------------------------------------------------
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn oauth_exchange_without_org_context_is_forbidden(pool: PgPool) {
+    let config = TestConfig::default();
+    let secret = config.jwt_secret.clone();
+    let app = TestApp::with_config(pool.clone(), config).await;
+
+    let token = mint_access_token(&secret, Uuid::new_v4(), None);
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(EXCHANGE_URI)
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .body(Body::from(exchange_body().to_string()))
+        .unwrap();
+
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "org-less exchange must be 403, got {}: {}",
+        resp.status,
+        resp.text()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: valid token with an org context passes the auth gate.
+//
+// Proves the extractor admits a real authenticated principal: the response
+// status is NOT 401/403. (It does not reach a 200 because the PPT schema has
+// no `voice_assistant_devices` table, so the downstream DB insert fails — but
+// that is well past the security boundary this fix establishes.)
+// ---------------------------------------------------------------------------
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn oauth_exchange_with_valid_auth_passes_auth_gate(pool: PgPool) {
+    let config = TestConfig::default();
+    let secret = config.jwt_secret.clone();
+    let app = TestApp::with_config(pool.clone(), config).await;
+
+    let token = mint_access_token(&secret, Uuid::new_v4(), Some(Uuid::new_v4()));
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(EXCHANGE_URI)
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .body(Body::from(exchange_body().to_string()))
+        .unwrap();
+
+    let resp = app.execute(req).await;
+
+    assert_ne!(
+        resp.status,
+        StatusCode::UNAUTHORIZED,
+        "valid token must clear the auth gate, got 401: {}",
+        resp.text()
+    );
+    assert_ne!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "valid token with org context must clear the org gate, got 403: {}",
+        resp.text()
+    );
+}


### PR DESCRIPTION
## Summary
- `POST /api/v1/webhooks/voice/oauth/exchange` (`oauth_token_exchange`) was reachable with **no authentication** and bound the resulting voice device to random `Uuid::new_v4()` values for both `user_id` and `org_id` — creating orphan, tenant-unscoped voice devices (issue #890, Epic 93).
- This endpoint is the PM-user account-linking *completion* call (invoked by the authenticated PM client after the platform account-linking flow), not a platform webhook — so it now requires a valid PM access token.

## Endpoint / gap
`oauth_token_exchange` in `backend/servers/api-server/src/routes/voice_webhooks.rs` took only `Json(request)` (no auth extractor), then set `let user_id = Uuid::new_v4(); let org_id = Uuid::new_v4();` (P0 #1 unauthenticated, P0 #2 random user/org).

## Fix
1. Added the `api_core::AuthUser` bearer-token extractor (same pattern as the #872-hardened `integrations/oauth.rs` airbnb callback). Unauthenticated / invalid token now returns 401.
2. Derive `user_id` + `org_id` from the verified token claims; an authenticated request with no active organization (`tenant_id` claim absent) is rejected with 403 instead of inventing an org.
3. Gated the simulated-token dev fallback behind `cfg!(debug_assertions)` (suggested fix #3); release builds return 503 `OAUTH_NOT_CONFIGURED` rather than minting fake tokens.

Out of scope (noted as refs for #890): the P2 finding on `/verify` exposure/rate-limiting, and the `authenticate_voice_user` "find any active device for the platform" simplification used by the Alexa/Google webhooks — those are separate device-lookup concerns from the unauthenticated-exchange P0.

## Tested (Band A — fast check)
```
$ env CARGO_TARGET_DIR=~/.cargo-targets/ct-890 cargo check -p api-server
Finished `dev` profile ... (exit 0)
$ env CARGO_TARGET_DIR=~/.cargo-targets/ct-890 cargo clippy -p api-server --lib -- -D warnings
Finished `dev` profile ... (exit 0)
$ env CARGO_TARGET_DIR=~/.cargo-targets/ct-890 cargo test -p api-server --test voice_oauth_exchange_auth_tests --no-run
Finished `test` profile ... (exit 0) — test binary built
```

## Test
`backend/servers/api-server/tests/voice_oauth_exchange_auth_tests.rs`:
- `oauth_exchange_without_auth_is_rejected` → 401 (no token)
- `oauth_exchange_invalid_token_is_rejected` → 401 (garbage bearer)
- `oauth_exchange_without_org_context_is_forbidden` → 403 (valid token, no `tenant_id` claim)
- `oauth_exchange_with_valid_auth_passes_auth_gate` → asserts status is **not** 401/403 (valid JWT with `tenant_id` clears the auth + org gates; mints a real principal)

Success-case note: the PPT schema has **no `voice_assistant_devices` migration**, so the fully-authenticated request gets *past* the security boundary and then fails at the DB insert — the assertion verifies it is never rejected as 401/403, which is the security contract this PR establishes. The `#[sqlx::test]` suite runs against Postgres in `backend.yml` CI.

## Local DB caveat
Could not execute the `#[sqlx::test]` suite locally: this environment has no reachable Postgres (Docker daemon down; `docker run` blocked by sandbox). The test binary compiles clean and runs under `backend.yml` CI which provisions Postgres. fmt/clippy/check/test-compile all verified locally in an isolated `CARGO_TARGET_DIR` (per #849 stale-rlib guidance).

## CI parity (Band C — hot-path, security)
Will run via `.github/workflows/backend.yml` (cargo fmt + clippy + cargo test) on push — the change is `backend/**` only.