### PR TITLE
fix(security): replace vendor-portal demo stubs with honest 501s (closes #828)

### DIFF
--- a/backend/servers/api-server/src/routes/vendor_portal.rs
+++ b/backend/servers/api-server/src/routes/vendor_portal.rs
@@ -2,6 +2,47 @@
 //!
 //! Provides vendor-facing endpoints for job management, property access,
 //! work completion, invoicing, and performance tracking.
+//!
+//! # Authorization & data model (issue #828)
+//!
+//! Two security defects were closed here:
+//!
+//! 1. **Fabricated PII.** Every handler previously returned hard-coded sample
+//!    data — fake `VendorJob`s with invented `contact_phone` /
+//!    `building_address`, fake invoices, fake access codes — without ever
+//!    touching the database (`State(_state)` was unused). Any authenticated
+//!    staff principal received this fabricated PII as if it were live data.
+//!
+//! 2. **Unscoped access with no vendor identity.** The portal's request DTOs
+//!    (`VendorJob`, `PropertyAccessInfo`, `VendorProfile`, …) describe a
+//!    vendor-operations data model — a *vendor staff member* signed in to see
+//!    *their vendor company's* jobs, access codes, completions, and earnings.
+//!    That model has **no backing schema**: there is no `vendor_staff` /
+//!    `vendor_companies` table linking a `users` row to a `vendors` row, no
+//!    `vendor_jobs` table, no temporary-access-code store, and no
+//!    work-completion store. Without a vendor-identity mapping there is no
+//!    correct way to scope a request to "this caller's vendor" — returning
+//!    org-wide rows instead would expose every work order / invoice in the org
+//!    to any staff member through the vendor portal, which is a *new* leak.
+//!
+//! Until the vendor-identity schema lands (a `vendor_staff` membership table
+//! plus the per-job access-code / work-completion stores Epic 78 assumes),
+//! every handler returns `501 Not Implemented` — an honest, uniform signal
+//! that the feature has no persistence yet — rather than fabricating PII or
+//! leaking unscoped data. This mirrors the developer-portal fix in
+//! `routes/public_api.rs` (#851), which replaced fabricated API-key/usage
+//! responses with `501` for the same reason.
+//!
+//! The existing `require_vendor_principal` gate still runs first: a non-staff
+//! (public / reality-portal) principal is rejected with `403` before any
+//! further work, and `RequestPrincipal` itself rejects unauthenticated callers
+//! (`401`) and callers with no active membership in the resolved org (`403`).
+//!
+//! SECURITY (retained from #790): the previous `extract_vendor_context` helper
+//! deserialized the client-supplied `X-Tenant-Context` JSON header directly
+//! into a `TenantContext` with no JWT verification — any unauthenticated caller
+//! could forge tenancy. That helper is gone; every handler now goes through
+//! `RequestPrincipal` (verified bearer JWT + host-resolved tenant).
 
 use api_core::extractors::principal::RequestPrincipal;
 use axum::{
@@ -10,7 +51,6 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use chrono::Utc;
 use common::errors::ErrorResponse;
 use db::models::PrincipalKind;
 use db::models::{
@@ -19,7 +59,6 @@ use db::models::{
     VendorFeedback, VendorInvoiceWithTracking, VendorJob, VendorJobQuery, VendorJobSummary,
     VendorProfile, WorkCompletion,
 };
-use rust_decimal::Decimal;
 use serde::Deserialize;
 use utoipa::IntoParams;
 use uuid::Uuid;
@@ -29,22 +68,14 @@ use crate::state::AppState;
 // ============================================================================
 // Helper Functions
 // ============================================================================
-//
-// SECURITY: The previous `extract_vendor_context` helper deserialized the
-// client-supplied `X-Tenant-Context` JSON header directly into a
-// `TenantContext`. No JWT verification — any unauthenticated caller could
-// forge tenancy. That helper has been deleted; every handler now goes
-// through `RequestPrincipal` (verified bearer JWT + host-resolved tenant).
-//
-// P0-02: vendor-portal endpoints reject every request whose RequestPrincipal
-// is not a Staff (operator-side) principal — Public (reality portal users)
-// get 403 before any data is touched. A finer-grained "is this user actually
-// a vendor-role member of the org" check still needs to land (TODO
-// follow-up: query vendor_companies / vendor_staff) but the broad gate
-// already closes the cross-vendor data exposure where any logged-in resident
-// saw vendor job queues. (COMP-006, SEC-009)
 
 /// Reject any principal that isn't Staff/Platform.
+///
+/// First-line gate: a `Public` (reality-portal) principal must never reach a
+/// vendor-portal handler. Note this is *not* a vendor-identity check — see the
+/// module docs: the schema to bind a user to a specific vendor company does not
+/// exist yet, so finer-grained "is this caller a member of vendor X" scoping
+/// cannot be enforced and the handlers below fail closed with `501`.
 fn require_vendor_principal(
     principal: &RequestPrincipal,
 ) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
@@ -58,6 +89,25 @@ fn require_vendor_principal(
             )),
         )),
     }
+}
+
+/// Uniform "not implemented" response for vendor-portal endpoints whose
+/// persistence / identity model does not exist yet (closes #828).
+///
+/// These handlers previously fabricated sample data (including PII) instead of
+/// querying the database. Until the vendor-identity schema (`vendor_staff`
+/// membership + per-job access-code / work-completion stores) lands, every
+/// endpoint returns `501` so callers get an honest signal rather than
+/// fabricated or unscoped data. Mirrors `routes/public_api.rs::not_implemented`
+/// (#851).
+fn not_implemented(feature: &str) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        Json(ErrorResponse::new(
+            "NOT_IMPLEMENTED",
+            format!("{feature} is not implemented yet (no vendor-identity schema; see issue #828)"),
+        )),
+    )
 }
 
 /// Query parameters for invoice listing.
@@ -119,8 +169,9 @@ pub fn router() -> Router<AppState> {
     path = "/api/v1/vendor-portal/dashboard/stats",
     tag = "Vendor Portal",
     responses(
-        (status = 200, description = "Dashboard statistics", body = VendorDashboardStats),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Not a staff principal"),
+        (status = 501, description = "Not implemented (no vendor-identity schema)"),
     )
 )]
 async fn get_dashboard_stats(
@@ -128,16 +179,7 @@ async fn get_dashboard_stats(
     principal: RequestPrincipal,
 ) -> Result<Json<VendorDashboardStats>, (StatusCode, Json<ErrorResponse>)> {
     require_vendor_principal(&principal)?;
-    let stats = VendorDashboardStats {
-        today_jobs: 3,
-        upcoming_jobs: 12,
-        pending_action_jobs: 2,
-        completed_this_month: 28,
-        total_earnings_this_month: Decimal::new(450000, 2),
-        average_rating: Some(Decimal::new(47, 1)),
-    };
-
-    Ok(Json(stats))
+    Err(not_implemented("Vendor dashboard statistics"))
 }
 
 // ==================== Job Handlers (Story 78.1) ====================
@@ -149,8 +191,9 @@ async fn get_dashboard_stats(
     tag = "Vendor Portal",
     params(VendorJobQuery),
     responses(
-        (status = 200, description = "List of jobs", body = Vec<VendorJobSummary>),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Not a staff principal"),
+        (status = 501, description = "Not implemented (no vendor-identity schema)"),
     )
 )]
 async fn list_jobs(
@@ -159,32 +202,7 @@ async fn list_jobs(
     Query(_query): Query<VendorJobQuery>,
 ) -> Result<Json<Vec<VendorJobSummary>>, (StatusCode, Json<ErrorResponse>)> {
     require_vendor_principal(&principal)?;
-    let jobs = vec![
-        VendorJobSummary {
-            id: Uuid::new_v4(),
-            work_order_id: Uuid::new_v4(),
-            title: "Fix leaky faucet".to_string(),
-            building_name: "Sunset Apartments".to_string(),
-            unit_number: Some("304".to_string()),
-            scheduled_date: Some(Utc::now().date_naive()),
-            status: "scheduled".to_string(),
-            priority: "medium".to_string(),
-            service_type: "plumbing".to_string(),
-        },
-        VendorJobSummary {
-            id: Uuid::new_v4(),
-            work_order_id: Uuid::new_v4(),
-            title: "HVAC maintenance".to_string(),
-            building_name: "Downtown Tower".to_string(),
-            unit_number: None,
-            scheduled_date: Some(Utc::now().date_naive()),
-            status: "pending".to_string(),
-            priority: "high".to_string(),
-            service_type: "hvac".to_string(),
-        },
-    ];
-
-    Ok(Json(jobs))
+    Err(not_implemented("Vendor job listing"))
 }
 
 /// Get job details.
@@ -196,42 +214,18 @@ async fn list_jobs(
         ("job_id" = Uuid, Path, description = "Job ID")
     ),
     responses(
-        (status = 200, description = "Job details", body = VendorJob),
         (status = 401, description = "Unauthorized"),
-        (status = 404, description = "Job not found"),
+        (status = 403, description = "Not a staff principal"),
+        (status = 501, description = "Not implemented (no vendor-identity schema)"),
     )
 )]
 async fn get_job_details(
     State(_state): State<AppState>,
     principal: RequestPrincipal,
-    Path(job_id): Path<Uuid>,
+    Path(_job_id): Path<Uuid>,
 ) -> Result<Json<VendorJob>, (StatusCode, Json<ErrorResponse>)> {
     require_vendor_principal(&principal)?;
-    let job = VendorJob {
-        id: job_id,
-        work_order_id: Uuid::new_v4(),
-        vendor_id: Uuid::new_v4(),
-        building_id: Uuid::new_v4(),
-        unit_id: Some(Uuid::new_v4()),
-        title: "Fix leaky faucet".to_string(),
-        description: Some("Kitchen faucet is dripping constantly".to_string()),
-        scheduled_date: Some(Utc::now().date_naive()),
-        scheduled_time: Some("10:00".to_string()),
-        estimated_duration_hours: Some(Decimal::new(2, 0)),
-        status: "scheduled".to_string(),
-        priority: "medium".to_string(),
-        service_type: "plumbing".to_string(),
-        building_name: "Sunset Apartments".to_string(),
-        building_address: "123 Sunset Blvd".to_string(),
-        unit_number: Some("304".to_string()),
-        contact_name: Some("John Smith".to_string()),
-        contact_phone: Some("+1-555-123-4567".to_string()),
-        special_instructions: Some("Ring doorbell twice".to_string()),
-        created_at: Some(Utc::now()),
-        updated_at: Some(Utc::now()),
-    };
-
-    Ok(Json(job))
+    Err(not_implemented("Vendor job details"))
 }
 
 /// Accept a job.
@@ -244,10 +238,9 @@ async fn get_job_details(
     ),
     request_body = AcceptJobRequest,
     responses(
-        (status = 200, description = "Job accepted"),
         (status = 401, description = "Unauthorized"),
-        (status = 404, description = "Job not found"),
-        (status = 409, description = "Job already accepted or declined"),
+        (status = 403, description = "Not a staff principal"),
+        (status = 501, description = "Not implemented (no vendor-identity schema)"),
     )
 )]
 async fn accept_job(
@@ -257,7 +250,7 @@ async fn accept_job(
     Json(_request): Json<AcceptJobRequest>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     require_vendor_principal(&principal)?;
-    Ok(StatusCode::OK)
+    Err(not_implemented("Accept job"))
 }
 
 /// Decline a job.
@@ -270,10 +263,9 @@ async fn accept_job(
     ),
     request_body = DeclineJobRequest,
     responses(
-        (status = 200, description = "Job declined"),
         (status = 401, description = "Unauthorized"),
-        (status = 404, description = "Job not found"),
-        (status = 409, description = "Job already accepted or completed"),
+        (status = 403, description = "Not a staff principal"),
+        (status = 501, description = "Not implemented (no vendor-identity schema)"),
     )
 )]
 async fn decline_job(
@@ -283,7 +275,7 @@ async fn decline_job(
     Json(_request): Json<DeclineJobRequest>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     require_vendor_principal(&principal)?;
-    Ok(StatusCode::OK)
+    Err(not_implemented("Decline job"))
 }
 
 /// Propose alternative time for a job.
@@ -296,9 +288,9 @@ async fn decline_job(
     ),
     request_body = db::models::ProposeAlternativeTime,
     responses(
-        (status = 200, description = "Alternative time proposed"),
         (status = 401, description = "Unauthorized"),
-        (status = 404, description = "Job not found"),
+        (status = 403, description = "Not a staff principal"),
+        (status = 501, description = "Not implemented (no vendor-identity schema)"),
     )
 )]
 async fn propose_alternative_time(
@@ -308,7 +300,7 @@ async fn propose_alternative_time(
     Json(_request): Json<db::models::ProposeAlternativeTime>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     require_vendor_principal(&principal)?;
-    Ok(StatusCode::OK)
+    Err(not_implemented("Propose alternative time"))
 }
 
 // ==================== Property Access Handlers (Story 78.2) ====================
@@ -322,33 +314,18 @@ async fn propose_alternative_time(
         ("job_id" = Uuid, Path, description = "Job ID")
     ),
     responses(
-        (status = 200, description = "Access information", body = PropertyAccessInfo),
         (status = 401, description = "Unauthorized"),
-        (status = 404, description = "Job not found"),
+        (status = 403, description = "Not a staff principal"),
+        (status = 501, description = "Not implemented (no access-code store)"),
     )
 )]
 async fn get_access_info(
     State(_state): State<AppState>,
     principal: RequestPrincipal,
-    Path(job_id): Path<Uuid>,
+    Path(_job_id): Path<Uuid>,
 ) -> Result<Json<PropertyAccessInfo>, (StatusCode, Json<ErrorResponse>)> {
     require_vendor_principal(&principal)?;
-    let access_info = PropertyAccessInfo {
-        job_id,
-        building_id: Uuid::new_v4(),
-        unit_id: Some(Uuid::new_v4()),
-        access_method: "key_box".to_string(),
-        access_code: Some("1234".to_string()),
-        key_box_location: Some("Next to main entrance, behind planter".to_string()),
-        smart_lock_info: None,
-        contact_name: Some("John Smith".to_string()),
-        contact_phone: Some("+1-555-123-4567".to_string()),
-        special_instructions: Some("Call before entering".to_string()),
-        access_valid_from: Some(Utc::now()),
-        access_valid_until: Some(Utc::now() + chrono::Duration::hours(8)),
-    };
-
-    Ok(Json(access_info))
+    Err(not_implemented("Property access information"))
 }
 
 /// Generate temporary access code.
@@ -361,26 +338,19 @@ async fn get_access_info(
     ),
     request_body = GenerateAccessCode,
     responses(
-        (status = 200, description = "Access code generated", body = AccessCodeResponse),
         (status = 401, description = "Unauthorized"),
-        (status = 404, description = "Job not found"),
+        (status = 403, description = "Not a staff principal"),
+        (status = 501, description = "Not implemented (no access-code store)"),
     )
 )]
 async fn generate_access_code(
     State(_state): State<AppState>,
     principal: RequestPrincipal,
     Path(_job_id): Path<Uuid>,
-    Json(request): Json<GenerateAccessCode>,
+    Json(_request): Json<GenerateAccessCode>,
 ) -> Result<Json<AccessCodeResponse>, (StatusCode, Json<ErrorResponse>)> {
     require_vendor_principal(&principal)?;
-    let now = Utc::now();
-    let response = AccessCodeResponse {
-        code: "847291".to_string(),
-        valid_from: now,
-        valid_until: now + chrono::Duration::hours(request.valid_hours as i64),
-    };
-
-    Ok(Json(response))
+    Err(not_implemented("Access code generation"))
 }
 
 // ==================== Work Completion Handlers (Story 78.3) ====================
@@ -395,35 +365,19 @@ async fn generate_access_code(
     ),
     request_body = SubmitWorkCompletion,
     responses(
-        (status = 200, description = "Work completion submitted", body = WorkCompletion),
         (status = 401, description = "Unauthorized"),
-        (status = 404, description = "Job not found"),
-        (status = 409, description = "Job already completed"),
+        (status = 403, description = "Not a staff principal"),
+        (status = 501, description = "Not implemented (no work-completion store)"),
     )
 )]
 async fn submit_work_completion(
     State(_state): State<AppState>,
     principal: RequestPrincipal,
-    Path(job_id): Path<Uuid>,
-    Json(request): Json<SubmitWorkCompletion>,
+    Path(_job_id): Path<Uuid>,
+    Json(_request): Json<SubmitWorkCompletion>,
 ) -> Result<Json<WorkCompletion>, (StatusCode, Json<ErrorResponse>)> {
     require_vendor_principal(&principal)?;
-    let materials_total: Decimal = request.materials_used.iter().map(|m| m.total_cost).sum();
-
-    let completion = WorkCompletion {
-        job_id,
-        completed_at: Utc::now(),
-        before_photos: request.before_photos,
-        after_photos: request.after_photos,
-        time_spent_hours: request.time_spent_hours,
-        materials_used: request.materials_used,
-        notes: request.notes,
-        labor_cost: request.labor_cost,
-        materials_cost: materials_total,
-        total_cost: request.labor_cost + materials_total,
-    };
-
-    Ok(Json(completion))
+    Err(not_implemented("Work completion submission"))
 }
 
 /// Get work completion details for a job.
@@ -435,31 +389,18 @@ async fn submit_work_completion(
         ("job_id" = Uuid, Path, description = "Job ID")
     ),
     responses(
-        (status = 200, description = "Work completion details", body = WorkCompletion),
         (status = 401, description = "Unauthorized"),
-        (status = 404, description = "Job or completion not found"),
+        (status = 403, description = "Not a staff principal"),
+        (status = 501, description = "Not implemented (no work-completion store)"),
     )
 )]
 async fn get_work_completion(
     State(_state): State<AppState>,
     principal: RequestPrincipal,
-    Path(job_id): Path<Uuid>,
+    Path(_job_id): Path<Uuid>,
 ) -> Result<Json<WorkCompletion>, (StatusCode, Json<ErrorResponse>)> {
     require_vendor_principal(&principal)?;
-    let completion = WorkCompletion {
-        job_id,
-        completed_at: Utc::now(),
-        before_photos: vec!["photo1.jpg".to_string()],
-        after_photos: vec!["photo2.jpg".to_string()],
-        time_spent_hours: Decimal::new(2, 0),
-        materials_used: vec![],
-        notes: Some("Replaced washer and tightened fittings".to_string()),
-        labor_cost: Decimal::new(15000, 2),
-        materials_cost: Decimal::new(2500, 2),
-        total_cost: Decimal::new(17500, 2),
-    };
-
-    Ok(Json(completion))
+    Err(not_implemented("Work completion details"))
 }
 
 /// List vendor invoices.
@@ -469,8 +410,9 @@ async fn get_work_completion(
     tag = "Vendor Portal",
     params(InvoiceQuery),
     responses(
-        (status = 200, description = "List of invoices", body = Vec<VendorInvoiceWithTracking>),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Not a staff principal"),
+        (status = 501, description = "Not implemented (no vendor-identity schema)"),
     )
 )]
 async fn list_invoices(
@@ -479,34 +421,7 @@ async fn list_invoices(
     Query(_query): Query<InvoiceQuery>,
 ) -> Result<Json<Vec<VendorInvoiceWithTracking>>, (StatusCode, Json<ErrorResponse>)> {
     require_vendor_principal(&principal)?;
-    let invoices = vec![
-        VendorInvoiceWithTracking {
-            id: Uuid::new_v4(),
-            invoice_number: "INV-2024-001".to_string(),
-            job_id: Some(Uuid::new_v4()),
-            job_title: Some("Fix leaky faucet".to_string()),
-            invoice_date: Utc::now().date_naive(),
-            due_date: Some(Utc::now().date_naive() + chrono::Duration::days(30)),
-            total_amount: Decimal::new(17500, 2),
-            paid_amount: Decimal::ZERO,
-            status: "pending".to_string(),
-            payment_expected_date: Some(Utc::now().date_naive() + chrono::Duration::days(14)),
-        },
-        VendorInvoiceWithTracking {
-            id: Uuid::new_v4(),
-            invoice_number: "INV-2024-002".to_string(),
-            job_id: Some(Uuid::new_v4()),
-            job_title: Some("HVAC maintenance".to_string()),
-            invoice_date: Utc::now().date_naive() - chrono::Duration::days(15),
-            due_date: Some(Utc::now().date_naive() + chrono::Duration::days(15)),
-            total_amount: Decimal::new(45000, 2),
-            paid_amount: Decimal::new(45000, 2),
-            status: "paid".to_string(),
-            payment_expected_date: None,
-        },
-    ];
-
-    Ok(Json(invoices))
+    Err(not_implemented("Vendor invoice listing"))
 }
 
 // ==================== Profile & Feedback Handlers (Story 78.4) ====================
@@ -517,8 +432,9 @@ async fn list_invoices(
     path = "/api/v1/vendor-portal/profile",
     tag = "Vendor Portal",
     responses(
-        (status = 200, description = "Vendor profile", body = VendorProfile),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Not a staff principal"),
+        (status = 501, description = "Not implemented (no vendor-identity schema)"),
     )
 )]
 async fn get_profile(
@@ -526,27 +442,7 @@ async fn get_profile(
     principal: RequestPrincipal,
 ) -> Result<Json<VendorProfile>, (StatusCode, Json<ErrorResponse>)> {
     require_vendor_principal(&principal)?;
-    let profile = VendorProfile {
-        id: Uuid::new_v4(),
-        company_name: "ABC Plumbing Services".to_string(),
-        contact_name: Some("Mike Johnson".to_string()),
-        phone: Some("+1-555-987-6543".to_string()),
-        email: Some("mike@abcplumbing.com".to_string()),
-        services: vec!["plumbing".to_string(), "hvac".to_string()],
-        average_rating: Some(Decimal::new(47, 1)),
-        quality_rating: Some(Decimal::new(48, 1)),
-        timeliness_rating: Some(Decimal::new(46, 1)),
-        communication_rating: Some(Decimal::new(49, 1)),
-        total_jobs: 156,
-        completed_jobs: 152,
-        completion_rate: Some(Decimal::new(974, 1)),
-        average_response_time_hours: Some(Decimal::new(25, 1)),
-        badges: vec!["reliable".to_string(), "top_rated".to_string()],
-        is_preferred: true,
-        member_since: Some(Utc::now() - chrono::Duration::days(365 * 2)),
-    };
-
-    Ok(Json(profile))
+    Err(not_implemented("Vendor profile"))
 }
 
 /// List feedback for vendor.
@@ -556,8 +452,9 @@ async fn get_profile(
     tag = "Vendor Portal",
     params(FeedbackQuery),
     responses(
-        (status = 200, description = "List of feedback", body = Vec<VendorFeedback>),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Not a staff principal"),
+        (status = 501, description = "Not implemented (no vendor-identity schema)"),
     )
 )]
 async fn list_feedback(
@@ -566,38 +463,7 @@ async fn list_feedback(
     Query(_query): Query<FeedbackQuery>,
 ) -> Result<Json<Vec<VendorFeedback>>, (StatusCode, Json<ErrorResponse>)> {
     require_vendor_principal(&principal)?;
-    let feedback = vec![
-        VendorFeedback {
-            id: Uuid::new_v4(),
-            job_id: Uuid::new_v4(),
-            job_title: "Fix leaky faucet".to_string(),
-            building_name: "Sunset Apartments".to_string(),
-            rating: 5,
-            quality_rating: Some(5),
-            timeliness_rating: Some(5),
-            communication_rating: Some(5),
-            review_text: Some(
-                "Excellent work! Fixed the issue quickly and professionally.".to_string(),
-            ),
-            reviewer_name: Some("Property Manager".to_string()),
-            created_at: Utc::now() - chrono::Duration::days(7),
-        },
-        VendorFeedback {
-            id: Uuid::new_v4(),
-            job_id: Uuid::new_v4(),
-            job_title: "HVAC maintenance".to_string(),
-            building_name: "Downtown Tower".to_string(),
-            rating: 4,
-            quality_rating: Some(5),
-            timeliness_rating: Some(4),
-            communication_rating: Some(4),
-            review_text: Some("Good service, arrived a bit late but did great work.".to_string()),
-            reviewer_name: Some("Building Superintendent".to_string()),
-            created_at: Utc::now() - chrono::Duration::days(14),
-        },
-    ];
-
-    Ok(Json(feedback))
+    Err(not_implemented("Vendor feedback listing"))
 }
 
 /// Get vendor earnings summary.
@@ -607,28 +473,16 @@ async fn list_feedback(
     tag = "Vendor Portal",
     params(EarningsQuery),
     responses(
-        (status = 200, description = "Earnings summary", body = VendorEarningsSummary),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Not a staff principal"),
+        (status = 501, description = "Not implemented (no vendor-identity schema)"),
     )
 )]
 async fn get_earnings_summary(
     State(_state): State<AppState>,
     principal: RequestPrincipal,
-    Query(query): Query<EarningsQuery>,
+    Query(_query): Query<EarningsQuery>,
 ) -> Result<Json<VendorEarningsSummary>, (StatusCode, Json<ErrorResponse>)> {
     require_vendor_principal(&principal)?;
-    let months = query.period_months.unwrap_or(1);
-    let today = Utc::now().date_naive();
-    let period_start = today - chrono::Duration::days(months as i64 * 30);
-
-    let summary = VendorEarningsSummary {
-        period_start,
-        period_end: today,
-        total_jobs: 28,
-        total_earnings: Decimal::new(450000, 2),
-        paid_amount: Decimal::new(380000, 2),
-        pending_amount: Decimal::new(70000, 2),
-    };
-
-    Ok(Json(summary))
+    Err(not_implemented("Vendor earnings summary"))
 }

--- a/backend/servers/api-server/tests/vendor_portal_stub_removal_tests.rs
+++ b/backend/servers/api-server/tests/vendor_portal_stub_removal_tests.rs
@@ -1,0 +1,251 @@
+//! Regression tests for the vendor-portal stub-removal fix (Epic 78, issue #828).
+//!
+//! Audit history: every `/api/v1/vendor-portal/*` handler returned hard-coded
+//! sample data — fabricated `VendorJob`s with invented `contact_phone` /
+//! `building_address`, fake invoices, fake access codes — without ever touching
+//! the database (`State(_state)` was unused). Any authenticated staff principal
+//! received this fabricated PII as if it were live data, and there was no
+//! vendor-identity scoping (no `vendor_staff` schema exists to bind a user to a
+//! specific vendor company).
+//!
+//! The fix removes all fabricated responses: behind the `require_vendor_principal`
+//! gate every handler now returns `501 Not Implemented` (mirroring the
+//! developer-portal fix in `routes/public_api.rs`, #851) until the
+//! vendor-identity schema lands.
+//!
+//! Two layers of assertion:
+//!
+//!   * **HTTP** — exercises the live router. `create_router` (and thus `TestApp`)
+//!     does NOT layer `host_tenant_middleware`, so `RequestPrincipal` routes get
+//!     no `ResolvedTenant` and authenticated callers are rejected with a 4xx
+//!     (`403 tenant not resolved`). The security-meaningful invariant we pin
+//!     here is the one the bug violated: **the endpoints never return a `200`
+//!     carrying fabricated PII** (no `contact_phone` / `building_address`),
+//!     and an unauthenticated caller is rejected with `401`.
+//!
+//!   * **Repository** — the scoping primitive a future vendor-scoped portal must
+//!     build on. `WorkOrderRepository::list` is org-scoped: a member of Org B
+//!     must not see Org A's jobs, and Org A sees its own. (Repo-layer because
+//!     the IDOR fix lives in the WHERE clause; see
+//!     `ai_llm_cross_tenant_idor_tests.rs` for the same rationale.)
+
+#[allow(dead_code)]
+mod common;
+
+use axum::http::StatusCode;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{TestApp, TestConfig};
+use db::models::WorkOrderQuery;
+use db::repositories::WorkOrderRepository;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active') RETURNING id
+        "#,
+    )
+    .bind(format!("VendorPortal Org {slug}"))
+    .bind(format!("vendor-portal-org-{slug}"))
+    .bind(format!("{slug}@vendor-portal.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'test_hash', 'VendorPortal User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_membership(pool: &PgPool, org_id: Uuid, user_id: Uuid) {
+    sqlx::query(
+        r#"
+        INSERT INTO organization_members (organization_id, user_id, role_type, status, joined_at)
+        VALUES ($1, $2, 'org_admin', 'active', NOW())
+        "#,
+    )
+    .bind(org_id)
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .expect("seed membership");
+}
+
+/// Seed a building in `org_id` and return its id (work orders require one).
+async fn seed_building(pool: &PgPool, org_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO buildings (organization_id, street, city, postal_code, country)
+        VALUES ($1, '123 Sunset Blvd', 'Bratislava', '81101', 'SK')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed building")
+}
+
+/// Seed a work order ("job") in `org_id` / `building_id`.
+async fn seed_work_order(pool: &PgPool, org_id: Uuid, building_id: Uuid, creator: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO work_orders
+            (organization_id, building_id, title, description, priority, work_type,
+             status, source, created_by)
+        VALUES ($1, $2, 'Fix leaky faucet', 'Kitchen faucet drips', 'medium',
+                'corrective', 'open', 'manual', $3)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(building_id)
+    .bind(creator)
+    .fetch_one(pool)
+    .await
+    .expect("seed work order")
+}
+
+fn mint_token(user_id: Uuid, email: &str) -> String {
+    use api_server::services::JwtService;
+    let config = TestConfig::default();
+    let jwt = JwtService::new(&config.jwt_secret).expect("jwt service");
+    jwt.generate_access_token(user_id, email, "VendorPortal User", None, None)
+        .expect("mint access token")
+}
+
+// ---------------------------------------------------------------------------
+// HTTP — fabricated PII / data is never returned (the #828 bug)
+// ---------------------------------------------------------------------------
+
+/// Before the fix, `get_job_details` returned a `200` with a fabricated
+/// `VendorJob` (fake `contact_phone`, `building_address`). After the fix the
+/// endpoint must NEVER serve a `200` with such data — an authenticated caller
+/// gets a 4xx (no resolved tenant under TestApp) and an unauthenticated caller
+/// gets `401`.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn job_details_never_returns_fabricated_pii(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "pii-a").await;
+    let user_a = seed_user(&pool, "pii-a@vendor-portal.test").await;
+    seed_membership(&pool, org_a, user_a).await;
+
+    let job_id = Uuid::new_v4();
+    let uri = format!("/api/v1/vendor-portal/jobs/{job_id}");
+
+    // Authenticated staff member: must be rejected (no fabricated 200).
+    let token = mint_token(user_a, "pii-a@vendor-portal.test");
+    let resp = app.execute(app.get(&uri).bearer(&token).build()).await;
+    assert_ne!(
+        resp.status,
+        StatusCode::OK,
+        "vendor-portal job details must not return a 200 with fabricated PII: {}",
+        resp.text()
+    );
+    let body = resp.text();
+    assert!(
+        !body.contains("555-123-4567") && !body.contains("Sunset Blvd"),
+        "response must not leak the old hard-coded sample PII, got: {body}"
+    );
+
+    // Unauthenticated: rejected with 401.
+    let resp = app.execute(app.get(&uri).build()).await;
+    assert_eq!(
+        resp.status,
+        StatusCode::UNAUTHORIZED,
+        "unauthenticated vendor-portal access must be 401: {}",
+        resp.text()
+    );
+}
+
+/// `list_jobs` and `list_invoices` previously returned `200` with a fabricated
+/// array. Neither may return a `200` body anymore.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_endpoints_never_return_fabricated_arrays(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "lst-a").await;
+    let user_a = seed_user(&pool, "lst-a@vendor-portal.test").await;
+    seed_membership(&pool, org_a, user_a).await;
+    let token = mint_token(user_a, "lst-a@vendor-portal.test");
+
+    for uri in [
+        "/api/v1/vendor-portal/jobs",
+        "/api/v1/vendor-portal/invoices",
+        "/api/v1/vendor-portal/dashboard/stats",
+        "/api/v1/vendor-portal/profile",
+    ] {
+        let resp = app.execute(app.get(uri).bearer(&token).build()).await;
+        assert_ne!(
+            resp.status,
+            StatusCode::OK,
+            "{uri} must not return a fabricated 200 body: {}",
+            resp.text()
+        );
+        let body = resp.text();
+        assert!(
+            !body.contains("Sunset Apartments") && !body.contains("INV-2024-001"),
+            "{uri} must not leak old hard-coded sample data, got: {body}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Repository — org scoping is the primitive a vendor-scoped portal builds on
+// ---------------------------------------------------------------------------
+
+/// A member of Org B must not see Org A's jobs (work orders), and Org A sees
+/// its own. This pins the org-scoping contract `WorkOrderRepository::list`
+/// enforces — the foundation a future vendor-identity-scoped portal listing
+/// will sit on. Without it, the portal would have no correct way to keep one
+/// party's jobs from another's.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn work_orders_are_org_scoped(pool: PgPool) {
+    let org_a = seed_org(&pool, "scope-a").await;
+    let org_b = seed_org(&pool, "scope-b").await;
+    let user_a = seed_user(&pool, "scope-a@vendor-portal.test").await;
+    let building_a = seed_building(&pool, org_a).await;
+    let job_a = seed_work_order(&pool, org_a, building_a, user_a).await;
+
+    let repo = WorkOrderRepository::new(pool.clone());
+
+    // Org B sees NOTHING of Org A's jobs.
+    let b_jobs = repo
+        .list(org_b, WorkOrderQuery::default())
+        .await
+        .expect("list org_b work orders");
+    assert!(
+        b_jobs.iter().all(|w| w.id != job_a),
+        "Org B must not see Org A's job {job_a}"
+    );
+    assert!(
+        b_jobs.is_empty(),
+        "Org B has no jobs of its own; expected an empty list, got {} rows",
+        b_jobs.len()
+    );
+
+    // Org A sees its own job (the legitimate success case).
+    let a_jobs = repo
+        .list(org_a, WorkOrderQuery::default())
+        .await
+        .expect("list org_a work orders");
+    assert!(
+        a_jobs.iter().any(|w| w.id == job_a),
+        "Org A must see its own job {job_a}"
+    );
+}


### PR DESCRIPTION
## Task
Epic 78 Vendor Operations Portal code review (#828): vendor-portal handlers returned **hard-coded fake** data (e.g. `get_job_details` with sample PII `contact_phone` / `building_address`) instead of querying the DB (`State(_state)` unused), and no vendor-company membership check beyond the broad `require_vendor_principal()` Staff/Platform gate.

## Owner
pm-security / pm-backend

## What changed and why
Investigation found the issue's premise — scope each request to the caller's vendor via `vendor_companies` / `vendor_staff` — has **no backing schema**. There is:
- no `vendor_staff` / `vendor_companies` table linking a `users` row to a `vendors` row (vendors are org-scoped only),
- no `vendor_jobs` table (portal "jobs" don't map cleanly onto `work_orders` — no `service_type` / `unit_number` / per-job contact),
- no temporary-access-code store, no work-completion store.

Without a vendor-identity mapping there is **no correct way** to scope a request to "this caller's vendor". Returning org-wide rows instead would expose every work order / invoice in the org through the portal — a *new* leak. Forcing the portal DTOs onto `work_orders` would re-introduce fabricated values.

So, mirroring the developer-portal stub removal (#851), **every handler now returns `501 Not Implemented`** behind the existing `require_vendor_principal` gate, instead of fabricating PII / serving unscoped data. The security bug (fabricated PII + unscoped access) is removed; the feature is honestly marked not-yet-implemented pending the vendor-identity schema.

### Handlers (all → 501, after the Staff/Platform gate)
dashboard stats, list jobs, job details, accept/decline/propose-time, access info, generate access code, submit/get work completion, list invoices, profile, feedback, earnings.

### Vendor-auth mechanism
- `RequestPrincipal` (verified bearer JWT + host-resolved tenant) rejects unauthenticated (`401`) and no-active-membership-in-org (`403`).
- `require_vendor_principal` rejects `Public` (reality-portal) principals (`403`) before any work.
- Finer-grained per-vendor scoping is a documented follow-up requiring a `vendor_staff` schema.

## Tested (Band A — fast check)
- `cargo clippy -p api-server --lib -- -D warnings` → exit 0 (clean)
- `cargo test -p api-server --test vendor_portal_stub_removal_tests --no-run` → exit 0 (compiles)
- `cargo fmt --all -- --check` → exit 0

New `vendor_portal_stub_removal_tests.rs`:
- **HTTP**: vendor-portal endpoints never return a `200` carrying the old hard-coded sample PII (`555-123-4567`, `Sunset Blvd`, `Sunset Apartments`, `INV-2024-001`); unauthenticated access → `401`.
- **Repository**: `WorkOrderRepository::list` is org-scoped — Org B cannot see Org A's jobs (empty), Org A sees its own (success case). Repo-layer per `ai_llm_cross_tenant_idor_tests.rs`, since `TestApp`'s `create_router` omits `host_tenant_middleware` so `RequestPrincipal` routes can only assert a 4xx at the HTTP layer.

> Note: `#[sqlx::test]` tests require a live Postgres (`DATABASE_URL`), provided by CI `backend.yml`. They were not executed locally (no DB / Docker run blocked in sandbox); the targets compile clean.

## Built (Band B — full build)
Skipped full release build; change is a net **-146 LOC** simplification (removes fabricated data) with no public API surface change (route table and DTOs unchanged; only response bodies). Clippy lib check covers compile correctness.

## CI parity (Band C — hot-path only)
Security-relevant change. Local equivalents of the backend CI gate were run: `cargo fmt --all -- --check` (exit 0) and `cargo clippy -p api-server --lib -- -D warnings` (exit 0). Full `cargo test` deferred to CI (needs DB).

## Notes
- `closes #828`. Follow-up needed before the portal can serve real data: a `vendor_staff` membership table (user → vendor) plus per-job access-code and work-completion stores Epic 78 assumes.