### PR TITLE
fix(security): scope infra/operations/owner-analytics reads (#901)

### DIFF
--- a/backend/crates/db/src/repositories/owner_analytics.rs
+++ b/backend/crates/db/src/repositories/owner_analytics.rs
@@ -19,13 +19,76 @@ impl OwnerAnalyticsRepository {
         Self { pool }
     }
 
+    // ======================== Tenant-isolation guards ========================
+
+    /// Verify that `unit_id` belongs to a building owned by `org_id`.
+    /// Returns `AppError::NotFound` when the unit is absent or in another org —
+    /// callers surface this as a 404 so cross-tenant probing cannot distinguish
+    /// "wrong org" from "does not exist".
+    async fn assert_unit_in_org(&self, unit_id: Uuid, org_id: Uuid) -> Result<(), AppError> {
+        let exists: bool = sqlx::query_scalar(
+            r#"
+            SELECT EXISTS (
+                SELECT 1
+                FROM units u
+                JOIN buildings b ON b.id = u.building_id
+                WHERE u.id = $1 AND b.organization_id = $2
+            )
+            "#,
+        )
+        .bind(unit_id)
+        .bind(org_id)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        if exists {
+            Ok(())
+        } else {
+            Err(AppError::NotFound("Unit not found".to_string()))
+        }
+    }
+
+    /// Verify that `valuation_id` belongs to a unit in a building owned by `org_id`.
+    async fn assert_valuation_in_org(
+        &self,
+        valuation_id: Uuid,
+        org_id: Uuid,
+    ) -> Result<(), AppError> {
+        let exists: bool = sqlx::query_scalar(
+            r#"
+            SELECT EXISTS (
+                SELECT 1
+                FROM property_valuations pv
+                JOIN units u ON u.id = pv.unit_id
+                JOIN buildings b ON b.id = u.building_id
+                WHERE pv.id = $1 AND b.organization_id = $2
+            )
+            "#,
+        )
+        .bind(valuation_id)
+        .bind(org_id)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        if exists {
+            Ok(())
+        } else {
+            Err(AppError::NotFound("Valuation not found".to_string()))
+        }
+    }
+
     // ======================== Property Valuations (Story 74.1) ========================
 
     pub async fn create_valuation(
         &self,
-        _org_id: Uuid,
+        org_id: Uuid,
         req: CreatePropertyValuation,
     ) -> Result<PropertyValuation, AppError> {
+        // Enforce tenant isolation: the unit must belong to the caller's org.
+        self.assert_unit_in_org(req.unit_id, org_id).await?;
+
         // Calculate low and high values (±5%)
         let value_low = req.estimated_value * Decimal::new(95, 2);
         let value_high = req.estimated_value * Decimal::new(105, 2);
@@ -63,19 +126,23 @@ impl OwnerAnalyticsRepository {
     pub async fn get_latest_valuation(
         &self,
         unit_id: Uuid,
-        _org_id: Uuid,
+        org_id: Uuid,
     ) -> Result<Option<PropertyValuation>, AppError> {
         let valuation = sqlx::query_as::<_, PropertyValuation>(
             r#"
-            SELECT id, unit_id, valuation_date, value_low, value_high, estimated_value,
-                   valuation_method, confidence_score, notes, created_at
-            FROM property_valuations
-            WHERE unit_id = $1
-            ORDER BY valuation_date DESC
+            SELECT pv.id, pv.unit_id, pv.valuation_date, pv.value_low, pv.value_high,
+                   pv.estimated_value, pv.valuation_method, pv.confidence_score, pv.notes,
+                   pv.created_at
+            FROM property_valuations pv
+            JOIN units u ON u.id = pv.unit_id
+            JOIN buildings b ON b.id = u.building_id
+            WHERE pv.unit_id = $1 AND b.organization_id = $2
+            ORDER BY pv.valuation_date DESC
             LIMIT 1
             "#,
         )
         .bind(unit_id)
+        .bind(org_id)
         .fetch_optional(&self.pool)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
@@ -86,17 +153,21 @@ impl OwnerAnalyticsRepository {
     pub async fn get_valuation_with_comparables(
         &self,
         valuation_id: Uuid,
-        _org_id: Uuid,
+        org_id: Uuid,
     ) -> Result<Option<PropertyValuationWithComparables>, AppError> {
         let valuation = sqlx::query_as::<_, PropertyValuation>(
             r#"
-            SELECT id, unit_id, valuation_date, value_low, value_high, estimated_value,
-                   valuation_method, confidence_score, notes, created_at
-            FROM property_valuations
-            WHERE id = $1
+            SELECT pv.id, pv.unit_id, pv.valuation_date, pv.value_low, pv.value_high,
+                   pv.estimated_value, pv.valuation_method, pv.confidence_score, pv.notes,
+                   pv.created_at
+            FROM property_valuations pv
+            JOIN units u ON u.id = pv.unit_id
+            JOIN buildings b ON b.id = u.building_id
+            WHERE pv.id = $1 AND b.organization_id = $2
             "#,
         )
         .bind(valuation_id)
+        .bind(org_id)
         .fetch_optional(&self.pool)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
@@ -129,8 +200,12 @@ impl OwnerAnalyticsRepository {
     pub async fn add_comparable(
         &self,
         valuation_id: Uuid,
+        org_id: Uuid,
         req: AddComparableProperty,
     ) -> Result<ComparableProperty, AppError> {
+        // Enforce tenant isolation: the valuation must belong to the caller's org.
+        self.assert_valuation_in_org(valuation_id, org_id).await?;
+
         let comparable = sqlx::query_as::<_, ComparableProperty>(
             r#"
             INSERT INTO comparable_properties (valuation_id, address, sale_price, size_sqm,
@@ -157,20 +232,24 @@ impl OwnerAnalyticsRepository {
 
     pub async fn get_value_history(
         &self,
+        org_id: Uuid,
         q: ValueHistoryQuery,
     ) -> Result<Vec<PropertyValueHistory>, AppError> {
         let limit = q.limit.unwrap_or(12) as i64;
 
         let history = sqlx::query_as::<_, PropertyValueHistory>(
             r#"
-            SELECT id, unit_id, value, recorded_at
-            FROM property_value_history
-            WHERE unit_id = $1
-            ORDER BY recorded_at DESC
-            LIMIT $2
+            SELECT pvh.id, pvh.unit_id, pvh.value, pvh.recorded_at
+            FROM property_value_history pvh
+            JOIN units u ON u.id = pvh.unit_id
+            JOIN buildings b ON b.id = u.building_id
+            WHERE pvh.unit_id = $1 AND b.organization_id = $2
+            ORDER BY pvh.recorded_at DESC
+            LIMIT $3
             "#,
         )
         .bind(q.unit_id)
+        .bind(org_id)
         .bind(limit)
         .fetch_all(&self.pool)
         .await
@@ -182,13 +261,13 @@ impl OwnerAnalyticsRepository {
     pub async fn get_value_trend(
         &self,
         unit_id: Uuid,
-        _org_id: Uuid,
+        org_id: Uuid,
     ) -> Result<Option<ValueTrendAnalysis>, AppError> {
         let query = ValueHistoryQuery {
             unit_id,
             limit: Some(12),
         };
-        let history = self.get_value_history(query).await?;
+        let history = self.get_value_history(org_id, query).await?;
 
         if history.is_empty() {
             return Ok(None);
@@ -218,9 +297,12 @@ impl OwnerAnalyticsRepository {
 
     pub async fn calculate_roi(
         &self,
-        _org_id: Uuid,
+        org_id: Uuid,
         req: CalculateROIRequest,
     ) -> Result<PropertyROI, AppError> {
+        // Enforce tenant isolation: the unit must belong to the caller's org.
+        self.assert_unit_in_org(req.unit_id, org_id).await?;
+
         // Get total income for the period
         let total_income: Decimal = sqlx::query_scalar(
             r#"
@@ -281,10 +363,13 @@ impl OwnerAnalyticsRepository {
     pub async fn get_cash_flow_breakdown(
         &self,
         unit_id: Uuid,
-        _org_id: Uuid,
+        org_id: Uuid,
         from: chrono::NaiveDate,
         to: chrono::NaiveDate,
     ) -> Result<CashFlowBreakdown, AppError> {
+        // Enforce tenant isolation: the unit must belong to the caller's org.
+        self.assert_unit_in_org(unit_id, org_id).await?;
+
         // Get rental income
         let rental_income: Decimal = sqlx::query_scalar(
             r#"
@@ -468,7 +553,7 @@ impl OwnerAnalyticsRepository {
 
     pub async fn compare_properties(
         &self,
-        _org_id: Uuid,
+        org_id: Uuid,
         req: PortfolioComparisonRequest,
     ) -> Result<ComparisonMetrics, AppError> {
         let mut properties = Vec::new();
@@ -478,6 +563,10 @@ impl OwnerAnalyticsRepository {
         let mut highest_value = Decimal::MIN;
 
         for &unit_id in &req.unit_ids {
+            // Enforce tenant isolation: every requested unit must belong to the
+            // caller's org, otherwise a caller could probe cross-tenant values.
+            self.assert_unit_in_org(unit_id, org_id).await?;
+
             // Get valuation
             let valuation = sqlx::query_scalar::<_, Decimal>(
                 r#"
@@ -632,16 +721,20 @@ impl OwnerAnalyticsRepository {
     pub async fn submit_expense_for_approval(
         &self,
         submitted_by: Uuid,
-        _org_id: Uuid,
+        org_id: Uuid,
         req: SubmitExpenseForApproval,
     ) -> Result<ExpenseApprovalResponse, AppError> {
-        // Check for auto-approval rules
+        // Enforce tenant isolation: the unit must belong to the caller's org.
+        self.assert_unit_in_org(req.unit_id, org_id).await?;
+
+        // Check for auto-approval rules (scoped to this org).
         let matching_rule = sqlx::query_as::<_, ExpenseAutoApprovalRule>(
             r#"
             SELECT id, organization_id, owner_id, unit_id, max_amount_per_expense,
                    max_monthly_total, allowed_categories, is_active, created_at, updated_at
             FROM expense_auto_approval_rules
             WHERE (unit_id = $1 OR unit_id IS NULL)
+              AND organization_id = $4
               AND is_active = true
               AND max_amount_per_expense >= $2
               AND $3 = ANY(allowed_categories)
@@ -652,6 +745,7 @@ impl OwnerAnalyticsRepository {
         .bind(req.unit_id)
         .bind(req.amount)
         .bind(&req.category)
+        .bind(org_id)
         .fetch_optional(&self.pool)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
@@ -716,20 +810,27 @@ impl OwnerAnalyticsRepository {
 
     pub async fn list_expense_requests(
         &self,
-        _org_id: Uuid,
+        org_id: Uuid,
         q: ExpenseRequestsQuery,
     ) -> Result<ListExpenseRequestsResponse, AppError> {
         let limit = q.limit.unwrap_or(50) as i64;
         let offset = q.offset.unwrap_or(0) as i64;
 
+        // Scope every expense request to units in buildings owned by `org_id`,
+        // so a caller cannot read another tenant's expense history (or probe by
+        // passing a foreign unit_id as `property_id`).
         let requests = sqlx::query_as::<_, ExpenseApprovalRequest>(
             r#"
-            SELECT id, unit_id, submitted_by, amount, category, description, status,
-                   auto_approval_rule_id, reviewed_by, review_notes, created_at, updated_at
-            FROM expense_approval_requests
-            WHERE ($1::uuid IS NULL OR unit_id = $1)
-              AND ($2::text IS NULL OR status = $2)
-            ORDER BY created_at DESC
+            SELECT ear.id, ear.unit_id, ear.submitted_by, ear.amount, ear.category,
+                   ear.description, ear.status, ear.auto_approval_rule_id, ear.reviewed_by,
+                   ear.review_notes, ear.created_at, ear.updated_at
+            FROM expense_approval_requests ear
+            JOIN units u ON u.id = ear.unit_id
+            JOIN buildings b ON b.id = u.building_id
+            WHERE b.organization_id = $5
+              AND ($1::uuid IS NULL OR ear.unit_id = $1)
+              AND ($2::text IS NULL OR ear.status = $2)
+            ORDER BY ear.created_at DESC
             LIMIT $3 OFFSET $4
             "#,
         )
@@ -737,6 +838,7 @@ impl OwnerAnalyticsRepository {
         .bind(&q.status)
         .bind(limit)
         .bind(offset)
+        .bind(org_id)
         .fetch_all(&self.pool)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
@@ -744,13 +846,17 @@ impl OwnerAnalyticsRepository {
         let total: i64 = sqlx::query_scalar(
             r#"
             SELECT COUNT(*)
-            FROM expense_approval_requests
-            WHERE ($1::uuid IS NULL OR unit_id = $1)
-              AND ($2::text IS NULL OR status = $2)
+            FROM expense_approval_requests ear
+            JOIN units u ON u.id = ear.unit_id
+            JOIN buildings b ON b.id = u.building_id
+            WHERE b.organization_id = $3
+              AND ($1::uuid IS NULL OR ear.unit_id = $1)
+              AND ($2::text IS NULL OR ear.status = $2)
             "#,
         )
         .bind(q.property_id)
         .bind(&q.status)
+        .bind(org_id)
         .fetch_one(&self.pool)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
@@ -762,6 +868,7 @@ impl OwnerAnalyticsRepository {
         &self,
         id: Uuid,
         reviewed_by: Uuid,
+        org_id: Uuid,
         req: ReviewExpenseRequest,
     ) -> Result<ExpenseApprovalRequest, AppError> {
         let status = match req.decision {
@@ -770,23 +877,32 @@ impl OwnerAnalyticsRepository {
             ExpenseApprovalDecision::NeedsInfo => "needs_info",
         };
 
+        // Scope the UPDATE to expense requests whose unit lives in a building
+        // owned by `org_id`. A reviewer in another tenant therefore cannot
+        // approve/reject this org's expenses (the row simply won't match).
         let expense = sqlx::query_as::<_, ExpenseApprovalRequest>(
             r#"
-            UPDATE expense_approval_requests
+            UPDATE expense_approval_requests ear
             SET status = $2, reviewed_by = $3, review_notes = $4
-            WHERE id = $1
-            RETURNING id, unit_id, submitted_by, amount, category, description, status,
-                      auto_approval_rule_id, reviewed_by, review_notes, created_at, updated_at
+            FROM units u, buildings b
+            WHERE ear.id = $1
+              AND u.id = ear.unit_id
+              AND b.id = u.building_id
+              AND b.organization_id = $5
+            RETURNING ear.id, ear.unit_id, ear.submitted_by, ear.amount, ear.category,
+                      ear.description, ear.status, ear.auto_approval_rule_id, ear.reviewed_by,
+                      ear.review_notes, ear.created_at, ear.updated_at
             "#,
         )
         .bind(id)
         .bind(status)
         .bind(reviewed_by)
         .bind(&req.notes)
-        .fetch_one(&self.pool)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
-        Ok(expense)
+        expense.ok_or_else(|| AppError::NotFound("Expense request not found".to_string()))
     }
 }

--- a/backend/servers/api-server/src/routes/infrastructure.rs
+++ b/backend/servers/api-server/src/routes/infrastructure.rs
@@ -2,6 +2,7 @@
 //!
 //! Routes for distributed tracing, feature flags, background jobs, and health monitoring.
 
+use api_core::extractors::AuthUser;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -27,6 +28,27 @@ use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 
 use crate::state::AppState;
+
+/// Reject any caller that is not a platform administrator.
+///
+/// Infrastructure routes expose platform-wide internals — distributed traces
+/// (which carry cross-tenant `user_id` / `org_id`), feature flags, background
+/// jobs and host health/metrics. They are not tenant-scoped resources, so the
+/// only safe gate is the platform-admin capability, mirroring the operations
+/// routes (Epic 73). Returns 403 for authenticated non-admins.
+fn require_platform_admin(auth: &AuthUser) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    if auth.is_platform_admin() {
+        Ok(())
+    } else {
+        Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "FORBIDDEN",
+                "Only platform administrators can access infrastructure endpoints",
+            )),
+        ))
+    }
+}
 
 /// Create infrastructure router.
 pub fn router() -> Router<AppState> {
@@ -216,7 +238,9 @@ fn default_limit() -> i64 {
 )]
 pub async fn get_dashboard(
     State(state): State<AppState>,
+    auth: AuthUser,
 ) -> Result<Json<InfrastructureDashboard>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     // Calculate actual uptime (Story 88.1)
     let uptime_seconds = state.boot_time.elapsed().as_secs() as i64;
 
@@ -306,8 +330,10 @@ pub async fn get_dashboard(
 )]
 pub async fn list_traces(
     State(state): State<AppState>,
+    auth: AuthUser,
     Query(query): Query<TraceQueryParams>,
 ) -> Result<Json<PaginatedResponse<Trace>>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     let trace_query = TraceQuery {
         service_name: query.service_name,
         operation_name: query.operation_name,
@@ -361,8 +387,10 @@ pub async fn list_traces(
 )]
 pub async fn get_trace(
     State(state): State<AppState>,
+    auth: AuthUser,
     Path(path): Path<TraceIdPath>,
 ) -> Result<Json<TraceWithSpans>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     // Get the trace
     let trace = match state.infrastructure_repo.get_trace(path.trace_id).await {
         Ok(Some(t)) => t,
@@ -418,8 +446,10 @@ pub async fn get_trace(
 )]
 pub async fn get_trace_spans(
     State(state): State<AppState>,
+    auth: AuthUser,
     Path(path): Path<TraceIdPath>,
 ) -> Result<Json<Vec<Span>>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     // Check if trace exists
     match state.infrastructure_repo.get_trace(path.trace_id).await {
         Ok(Some(_)) => {}
@@ -477,8 +507,10 @@ pub async fn get_trace_spans(
 )]
 pub async fn list_feature_flags(
     State(state): State<AppState>,
+    auth: AuthUser,
     Query(query): Query<FlagQueryParams>,
 ) -> Result<Json<PaginatedResponse<FeatureFlag>>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     match state
         .infrastructure_repo
         .list_feature_flags(
@@ -528,10 +560,11 @@ pub async fn list_feature_flags(
 )]
 pub async fn create_feature_flag(
     State(state): State<AppState>,
+    auth: AuthUser,
     Json(data): Json<CreateFeatureFlag>,
 ) -> Result<(StatusCode, Json<FeatureFlag>), (StatusCode, Json<ErrorResponse>)> {
-    // For now, use a placeholder user ID - in production, extract from auth context
-    let created_by = Uuid::nil();
+    require_platform_admin(&auth)?;
+    let created_by = auth.user_id;
 
     match state
         .infrastructure_repo
@@ -576,8 +609,10 @@ pub async fn create_feature_flag(
 )]
 pub async fn get_feature_flag(
     State(state): State<AppState>,
+    auth: AuthUser,
     Path(path): Path<FlagIdPath>,
 ) -> Result<Json<FeatureFlag>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     match state.infrastructure_repo.get_feature_flag(path.id).await {
         Ok(Some(flag)) => Ok(Json(flag)),
         Ok(None) => Err((
@@ -613,10 +648,12 @@ pub async fn get_feature_flag(
 )]
 pub async fn update_feature_flag(
     State(state): State<AppState>,
+    auth: AuthUser,
     Path(path): Path<FlagIdPath>,
     Json(data): Json<UpdateFeatureFlag>,
 ) -> Result<Json<FeatureFlag>, (StatusCode, Json<ErrorResponse>)> {
-    let updated_by = Uuid::nil(); // Placeholder
+    require_platform_admin(&auth)?;
+    let updated_by = auth.user_id;
 
     match state
         .infrastructure_repo
@@ -656,9 +693,11 @@ pub async fn update_feature_flag(
 )]
 pub async fn delete_feature_flag(
     State(state): State<AppState>,
+    auth: AuthUser,
     Path(path): Path<FlagIdPath>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let deleted_by = Uuid::nil(); // Placeholder
+    require_platform_admin(&auth)?;
+    let deleted_by = auth.user_id;
 
     match state
         .infrastructure_repo
@@ -699,10 +738,12 @@ pub async fn delete_feature_flag(
 )]
 pub async fn toggle_feature_flag(
     State(state): State<AppState>,
+    auth: AuthUser,
     Path(path): Path<FlagIdPath>,
     Json(data): Json<ToggleFlagRequest>,
 ) -> Result<Json<FeatureFlag>, (StatusCode, Json<ErrorResponse>)> {
-    let toggled_by = Uuid::nil(); // Placeholder
+    require_platform_admin(&auth)?;
+    let toggled_by = auth.user_id;
 
     match state
         .infrastructure_repo
@@ -744,8 +785,10 @@ pub async fn toggle_feature_flag(
 )]
 pub async fn list_flag_overrides(
     State(state): State<AppState>,
+    auth: AuthUser,
     Path(path): Path<FlagIdPath>,
 ) -> Result<Json<Vec<FeatureFlagOverride>>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     // First check if flag exists
     match state.infrastructure_repo.get_feature_flag(path.id).await {
         Ok(None) => {
@@ -798,9 +841,11 @@ pub async fn list_flag_overrides(
 )]
 pub async fn create_flag_override(
     State(state): State<AppState>,
+    auth: AuthUser,
     Path(path): Path<FlagIdPath>,
     Json(data): Json<CreateOverrideRequest>,
 ) -> Result<(StatusCode, Json<FeatureFlagOverride>), (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     // Check if flag exists
     match state.infrastructure_repo.get_feature_flag(path.id).await {
         Ok(None) => {
@@ -838,7 +883,7 @@ pub async fn create_flag_override(
         }
     };
 
-    let created_by = Uuid::nil(); // Placeholder
+    let created_by = auth.user_id;
 
     match state
         .infrastructure_repo
@@ -881,9 +926,11 @@ pub async fn create_flag_override(
 )]
 pub async fn delete_flag_override(
     State(state): State<AppState>,
+    auth: AuthUser,
     Path(path): Path<OverrideIdPath>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let deleted_by = Uuid::nil(); // Placeholder
+    require_platform_admin(&auth)?;
+    let deleted_by = auth.user_id;
 
     match state
         .infrastructure_repo
@@ -925,8 +972,10 @@ pub async fn delete_flag_override(
 )]
 pub async fn get_flag_audit_log(
     State(state): State<AppState>,
+    auth: AuthUser,
     Path(path): Path<FlagIdPath>,
 ) -> Result<Json<Vec<FeatureFlagAuditLog>>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     // Check if flag exists
     match state.infrastructure_repo.get_feature_flag(path.id).await {
         Ok(None) => {
@@ -982,8 +1031,10 @@ pub async fn get_flag_audit_log(
 )]
 pub async fn evaluate_feature_flag(
     State(state): State<AppState>,
+    auth: AuthUser,
     Json(data): Json<EvaluateFeatureFlag>,
 ) -> Result<Json<FeatureFlagEvaluation>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     match state
         .infrastructure_repo
         .evaluate_feature_flag(&data.key, data.user_id, data.org_id)
@@ -1032,8 +1083,10 @@ pub async fn evaluate_feature_flag(
 )]
 pub async fn list_jobs(
     State(state): State<AppState>,
+    auth: AuthUser,
     Query(query): Query<JobQueryParams>,
 ) -> Result<Json<PaginatedResponse<BackgroundJob>>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     use db::models::infrastructure::{BackgroundJobQuery, BackgroundJobStatus};
 
     let job_query = BackgroundJobQuery {
@@ -1085,8 +1138,10 @@ pub async fn list_jobs(
 )]
 pub async fn create_job(
     State(state): State<AppState>,
+    auth: AuthUser,
     Json(data): Json<CreateBackgroundJob>,
 ) -> Result<(StatusCode, Json<BackgroundJob>), (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     match state.background_job_repo.create(data, None).await {
         Ok(job) => Ok((StatusCode::CREATED, Json(job))),
         Err(e) => {
@@ -1114,8 +1169,10 @@ pub async fn create_job(
 )]
 pub async fn get_job(
     State(state): State<AppState>,
+    auth: AuthUser,
     Path(path): Path<JobIdPath>,
 ) -> Result<Json<BackgroundJob>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     match state.background_job_repo.find_by_id(path.id).await {
         Ok(Some(job)) => Ok(Json(job)),
         Ok(None) => Err((
@@ -1149,9 +1206,11 @@ pub async fn get_job(
 )]
 pub async fn retry_job(
     State(state): State<AppState>,
+    auth: AuthUser,
     Path(path): Path<JobIdPath>,
     Json(data): Json<RetryBackgroundJob>,
 ) -> Result<Json<BackgroundJob>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     match state
         .background_job_repo
         .retry_job(
@@ -1195,8 +1254,10 @@ pub async fn retry_job(
 )]
 pub async fn cancel_job(
     State(state): State<AppState>,
+    auth: AuthUser,
     Path(path): Path<JobIdPath>,
 ) -> Result<Json<BackgroundJob>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     match state.background_job_repo.cancel_job(path.id).await {
         Ok(Some(job)) => Ok(Json(job)),
         Ok(None) => Err((
@@ -1231,8 +1292,10 @@ pub async fn cancel_job(
 )]
 pub async fn get_job_executions(
     State(state): State<AppState>,
+    auth: AuthUser,
     Path(path): Path<JobIdPath>,
 ) -> Result<Json<Vec<BackgroundJobExecution>>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     match state.background_job_repo.get_executions(path.id).await {
         Ok(executions) => Ok(Json(executions)),
         Err(e) => {
@@ -1261,7 +1324,9 @@ pub async fn get_job_executions(
 )]
 pub async fn get_queue_stats(
     State(state): State<AppState>,
+    auth: AuthUser,
 ) -> Result<Json<Vec<BackgroundJobQueueStats>>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     match state.background_job_repo.get_all_queue_stats().await {
         Ok(stats) => Ok(Json(stats)),
         Err(e) => {
@@ -1290,7 +1355,9 @@ pub async fn get_queue_stats(
 )]
 pub async fn get_job_type_stats(
     State(state): State<AppState>,
+    auth: AuthUser,
 ) -> Result<Json<Vec<BackgroundJobTypeStats>>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     match state.infrastructure_repo.get_job_type_stats().await {
         Ok(stats) => Ok(Json(stats)),
         Err(e) => {
@@ -1320,7 +1387,9 @@ pub async fn get_job_type_stats(
 )]
 pub async fn get_detailed_health(
     State(state): State<AppState>,
+    auth: AuthUser,
 ) -> Result<Json<SystemHealth>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     // Calculate actual uptime (Story 88.1)
     let uptime_seconds = state.boot_time.elapsed().as_secs() as i64;
 
@@ -1390,7 +1459,9 @@ pub async fn get_detailed_health(
 )]
 pub async fn list_health_checks(
     State(state): State<AppState>,
+    auth: AuthUser,
 ) -> Result<Json<Vec<HealthCheckConfig>>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     match state.infrastructure_repo.list_health_checks().await {
         Ok(configs) => Ok(Json(configs)),
         Err(e) => {
@@ -1421,8 +1492,10 @@ pub async fn list_health_checks(
 )]
 pub async fn get_health_check(
     State(state): State<AppState>,
+    auth: AuthUser,
     Path(path): Path<HealthCheckIdPath>,
 ) -> Result<Json<HealthCheckConfig>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     match state.infrastructure_repo.get_health_check(path.id).await {
         Ok(Some(config)) => Ok(Json(config)),
         Ok(None) => Err((
@@ -1457,8 +1530,10 @@ pub async fn get_health_check(
 )]
 pub async fn get_health_check_results(
     State(state): State<AppState>,
+    auth: AuthUser,
     Path(path): Path<HealthCheckIdPath>,
 ) -> Result<Json<Vec<HealthCheckResult>>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     match state
         .infrastructure_repo
         .get_health_check_results(path.id, 100)
@@ -1494,8 +1569,10 @@ pub async fn get_health_check_results(
 )]
 pub async fn list_alerts(
     State(state): State<AppState>,
+    auth: AuthUser,
     Query(query): Query<AlertQueryParams>,
 ) -> Result<Json<PaginatedResponse<HealthAlert>>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     match state
         .infrastructure_repo
         .list_alerts(
@@ -1543,8 +1620,10 @@ pub async fn list_alerts(
 )]
 pub async fn get_alert(
     State(state): State<AppState>,
+    auth: AuthUser,
     Path(path): Path<AlertIdPath>,
 ) -> Result<Json<HealthAlert>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     match state.infrastructure_repo.get_alert(path.id).await {
         Ok(Some(alert)) => Ok(Json(alert)),
         Ok(None) => Err((
@@ -1577,10 +1656,12 @@ pub async fn get_alert(
 )]
 pub async fn acknowledge_alert(
     State(state): State<AppState>,
+    auth: AuthUser,
     Path(path): Path<AlertIdPath>,
     Json(data): Json<AcknowledgeAlert>,
 ) -> Result<Json<HealthAlert>, (StatusCode, Json<ErrorResponse>)> {
-    let acknowledged_by = Uuid::nil(); // Placeholder
+    require_platform_admin(&auth)?;
+    let acknowledged_by = auth.user_id;
 
     match state
         .infrastructure_repo
@@ -1624,9 +1705,11 @@ pub async fn acknowledge_alert(
 )]
 pub async fn resolve_alert(
     State(state): State<AppState>,
+    auth: AuthUser,
     Path(path): Path<AlertIdPath>,
     Json(data): Json<ResolveAlert>,
 ) -> Result<Json<HealthAlert>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     match state
         .infrastructure_repo
         .resolve_alert(path.id, data.note.as_deref())
@@ -1666,7 +1749,9 @@ pub async fn resolve_alert(
 )]
 pub async fn list_alert_rules(
     State(state): State<AppState>,
+    auth: AuthUser,
 ) -> Result<Json<Vec<HealthAlertRule>>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     match state.infrastructure_repo.list_alert_rules().await {
         Ok(rules) => Ok(Json(rules)),
         Err(e) => {
@@ -1697,8 +1782,10 @@ pub async fn list_alert_rules(
 )]
 pub async fn create_alert_rule(
     State(state): State<AppState>,
+    auth: AuthUser,
     Json(data): Json<CreateHealthAlertRule>,
 ) -> Result<(StatusCode, Json<HealthAlertRule>), (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     match state.infrastructure_repo.create_alert_rule(data).await {
         Ok(rule) => Ok((StatusCode::CREATED, Json(rule))),
         Err(e) => {
@@ -1729,8 +1816,10 @@ pub async fn create_alert_rule(
 )]
 pub async fn get_alert_rule(
     State(state): State<AppState>,
+    auth: AuthUser,
     Path(path): Path<AlertRuleIdPath>,
 ) -> Result<Json<HealthAlertRule>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     match state.infrastructure_repo.get_alert_rule(path.id).await {
         Ok(Some(rule)) => Ok(Json(rule)),
         Ok(None) => Err((
@@ -1766,9 +1855,11 @@ pub async fn get_alert_rule(
 )]
 pub async fn update_alert_rule(
     State(state): State<AppState>,
+    auth: AuthUser,
     Path(path): Path<AlertRuleIdPath>,
     Json(data): Json<UpdateHealthAlertRule>,
 ) -> Result<Json<HealthAlertRule>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     match state
         .infrastructure_repo
         .update_alert_rule(path.id, data)
@@ -1807,8 +1898,10 @@ pub async fn update_alert_rule(
 )]
 pub async fn delete_alert_rule(
     State(state): State<AppState>,
+    auth: AuthUser,
     Path(path): Path<AlertRuleIdPath>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     match state.infrastructure_repo.delete_alert_rule(path.id).await {
         Ok(true) => Ok(StatusCode::NO_CONTENT),
         Ok(false) => Err((
@@ -1844,9 +1937,11 @@ pub async fn delete_alert_rule(
 )]
 pub async fn toggle_alert_rule(
     State(state): State<AppState>,
+    auth: AuthUser,
     Path(path): Path<AlertRuleIdPath>,
     Json(data): Json<ToggleAlertRuleRequest>,
 ) -> Result<Json<HealthAlertRule>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&auth)?;
     match state
         .infrastructure_repo
         .toggle_alert_rule(path.id, data.enabled)

--- a/backend/servers/api-server/src/routes/migration.rs
+++ b/backend/servers/api-server/src/routes/migration.rs
@@ -23,6 +23,24 @@ use db::models::{
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+/// Reject any caller that is not a platform administrator.
+///
+/// Platform migration import/export moves entire-org datasets (buildings,
+/// units, residents, financials) and is therefore high-blast-radius. Until the
+/// handlers are backed by real, audited persistence (refs #901), gate the whole
+/// surface behind the platform-admin capability so ordinary tenant users cannot
+/// trigger bulk import/export. Returns 403 for authenticated non-admins.
+fn require_platform_admin(user: &AuthUser) -> Result<(), (StatusCode, String)> {
+    if user.is_platform_admin() {
+        Ok(())
+    } else {
+        Err((
+            StatusCode::FORBIDDEN,
+            "Only platform administrators can access migration endpoints".to_string(),
+        ))
+    }
+}
+
 /// Create the migration router.
 pub fn router() -> Router<AppState> {
     Router::new()
@@ -95,6 +113,7 @@ async fn list_templates(
     user: AuthUser,
     Query(query): Query<ListTemplatesQuery>,
 ) -> Result<Json<ListTemplatesResponse>, (StatusCode, String)> {
+    require_platform_admin(&user)?;
     let org_id = user.tenant_id.ok_or((
         StatusCode::BAD_REQUEST,
         "Organization context required".to_string(),
@@ -114,8 +133,9 @@ async fn list_templates(
 /// List system-provided templates.
 async fn list_system_templates(
     State(_state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
 ) -> Result<Json<Vec<ImportTemplateSummary>>, (StatusCode, String)> {
+    require_platform_admin(&user)?;
     let templates: Vec<ImportTemplateSummary> = vec![
         ImportTemplateSummary {
             id: Uuid::new_v4(),
@@ -173,6 +193,7 @@ async fn create_template(
     user: AuthUser,
     Json(req): Json<CreateTemplateRequest>,
 ) -> Result<Json<ImportTemplateSummary>, (StatusCode, String)> {
+    require_platform_admin(&user)?;
     let org_id = user.tenant_id.ok_or((
         StatusCode::BAD_REQUEST,
         "Organization context required".to_string(),
@@ -227,6 +248,7 @@ async fn get_template(
     user: AuthUser,
     Path(template_id): Path<Uuid>,
 ) -> Result<Json<TemplateDetailResponse>, (StatusCode, String)> {
+    require_platform_admin(&user)?;
     let _org_id = user.tenant_id.ok_or((
         StatusCode::BAD_REQUEST,
         "Organization context required".to_string(),
@@ -256,6 +278,7 @@ async fn update_template(
     Path(template_id): Path<Uuid>,
     Json(req): Json<UpdateImportTemplate>,
 ) -> Result<Json<ImportTemplateSummary>, (StatusCode, String)> {
+    require_platform_admin(&user)?;
     let org_id = user.tenant_id.ok_or((
         StatusCode::BAD_REQUEST,
         "Organization context required".to_string(),
@@ -289,6 +312,7 @@ async fn delete_template(
     user: AuthUser,
     Path(template_id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, String)> {
+    require_platform_admin(&user)?;
     let org_id = user.tenant_id.ok_or((
         StatusCode::BAD_REQUEST,
         "Organization context required".to_string(),
@@ -334,6 +358,7 @@ async fn download_template(
     Path(template_id): Path<Uuid>,
     Query(query): Query<DownloadTemplateQuery>,
 ) -> Result<Json<TemplateDownloadResponse>, (StatusCode, String)> {
+    require_platform_admin(&user)?;
     let _org_id = user.tenant_id.ok_or((
         StatusCode::BAD_REQUEST,
         "Organization context required".to_string(),
@@ -368,6 +393,7 @@ async fn duplicate_template(
     user: AuthUser,
     Path(template_id): Path<Uuid>,
 ) -> Result<Json<ImportTemplateSummary>, (StatusCode, String)> {
+    require_platform_admin(&user)?;
     let org_id = user.tenant_id.ok_or((
         StatusCode::BAD_REQUEST,
         "Organization context required".to_string(),
@@ -468,6 +494,7 @@ async fn upload_import_file(
     user: AuthUser,
     mut multipart: Multipart,
 ) -> Result<Json<UploadImportResponse>, (StatusCode, String)> {
+    require_platform_admin(&user)?;
     let org_id = user.tenant_id.ok_or((
         StatusCode::BAD_REQUEST,
         "Organization context required".to_string(),
@@ -578,6 +605,7 @@ async fn list_import_jobs(
     user: AuthUser,
     Query(query): Query<ListImportJobsQuery>,
 ) -> Result<Json<ListImportJobsResponse>, (StatusCode, String)> {
+    require_platform_admin(&user)?;
     let _org_id = user.tenant_id.ok_or((
         StatusCode::BAD_REQUEST,
         "Organization context required".to_string(),
@@ -623,6 +651,7 @@ async fn get_import_job_status(
     user: AuthUser,
     Path(job_id): Path<Uuid>,
 ) -> Result<Json<ImportJobStatusResponse>, (StatusCode, String)> {
+    require_platform_admin(&user)?;
     let _org_id = user.tenant_id.ok_or((
         StatusCode::BAD_REQUEST,
         "Organization context required".to_string(),
@@ -661,6 +690,7 @@ async fn cancel_import_job(
     user: AuthUser,
     Path(job_id): Path<Uuid>,
 ) -> Result<Json<ImportJobStatusResponse>, (StatusCode, String)> {
+    require_platform_admin(&user)?;
     let org_id = user.tenant_id.ok_or((
         StatusCode::BAD_REQUEST,
         "Organization context required".to_string(),
@@ -700,6 +730,7 @@ async fn retry_import_job(
     user: AuthUser,
     Path(job_id): Path<Uuid>,
 ) -> Result<Json<ImportJobStatusResponse>, (StatusCode, String)> {
+    require_platform_admin(&user)?;
     let org_id = user.tenant_id.ok_or((
         StatusCode::BAD_REQUEST,
         "Organization context required".to_string(),
@@ -749,6 +780,7 @@ async fn get_import_job_errors(
     Path(job_id): Path<Uuid>,
     Query(pagination): Query<MigrationPagination>,
 ) -> Result<Json<ImportJobErrorsResponse>, (StatusCode, String)> {
+    require_platform_admin(&user)?;
     let _org_id = user.tenant_id.ok_or((
         StatusCode::BAD_REQUEST,
         "Organization context required".to_string(),
@@ -806,6 +838,7 @@ async fn request_migration_export(
     user: AuthUser,
     Json(req): Json<RequestMigrationExportRequest>,
 ) -> Result<Json<MigrationExportResponse>, (StatusCode, String)> {
+    require_platform_admin(&user)?;
     let org_id = user.tenant_id.ok_or((
         StatusCode::BAD_REQUEST,
         "Organization context required".to_string(),
@@ -847,6 +880,7 @@ async fn get_export_status(
     user: AuthUser,
     Path(export_id): Path<Uuid>,
 ) -> Result<Json<MigrationExportStatusResponse>, (StatusCode, String)> {
+    require_platform_admin(&user)?;
     let _org_id = user.tenant_id.ok_or((
         StatusCode::BAD_REQUEST,
         "Organization context required".to_string(),
@@ -894,6 +928,7 @@ async fn download_export(
     user: AuthUser,
     Path(export_id): Path<Uuid>,
 ) -> Result<Json<ExportDownloadResponse>, (StatusCode, String)> {
+    require_platform_admin(&user)?;
     let org_id = user.tenant_id.ok_or((
         StatusCode::BAD_REQUEST,
         "Organization context required".to_string(),
@@ -945,6 +980,7 @@ async fn get_export_history(
     user: AuthUser,
     Query(_pagination): Query<MigrationPagination>,
 ) -> Result<Json<Vec<ExportHistoryEntry>>, (StatusCode, String)> {
+    require_platform_admin(&user)?;
     let _org_id = user.tenant_id.ok_or((
         StatusCode::BAD_REQUEST,
         "Organization context required".to_string(),
@@ -987,6 +1023,7 @@ async fn get_export_categories(
     State(_state): State<AppState>,
     user: AuthUser,
 ) -> Result<Json<ExportCategoriesResponse>, (StatusCode, String)> {
+    require_platform_admin(&user)?;
     let _org_id = user.tenant_id.ok_or((
         StatusCode::BAD_REQUEST,
         "Organization context required".to_string(),
@@ -1065,6 +1102,7 @@ async fn get_import_preview(
     user: AuthUser,
     Path(job_id): Path<Uuid>,
 ) -> Result<Json<ImportPreviewResult>, (StatusCode, String)> {
+    require_platform_admin(&user)?;
     let _org_id = user.tenant_id.ok_or((
         StatusCode::BAD_REQUEST,
         "Organization context required".to_string(),
@@ -1161,6 +1199,7 @@ async fn approve_import(
     Path(job_id): Path<Uuid>,
     Json(req): Json<ApproveImportRequest>,
 ) -> Result<Json<ApproveImportResponse>, (StatusCode, String)> {
+    require_platform_admin(&user)?;
     let org_id = user.tenant_id.ok_or((
         StatusCode::BAD_REQUEST,
         "Organization context required".to_string(),
@@ -1194,6 +1233,7 @@ async fn validate_import(
     user: AuthUser,
     Path(job_id): Path<Uuid>,
 ) -> Result<Json<ImportJobStatusResponse>, (StatusCode, String)> {
+    require_platform_admin(&user)?;
     let org_id = user.tenant_id.ok_or((
         StatusCode::BAD_REQUEST,
         "Organization context required".to_string(),

--- a/backend/servers/api-server/src/routes/owner_analytics.rs
+++ b/backend/servers/api-server/src/routes/owner_analytics.rs
@@ -136,15 +136,18 @@ async fn get_unit_valuation(
 
 async fn create_valuation(
     State(s): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(_uid): Path<Uuid>,
     Json(r): Json<CreateValuationRequest>,
 ) -> ApiResult<Json<serde_json::Value>> {
-    match s
-        .owner_analytics_repo
-        .create_valuation(r.organization_id, r.data)
-        .await
-    {
+    // Derive the org from the authenticated session, never trust the body.
+    let org = user.tenant_id.ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::bad_request("Tenant context required")),
+        )
+    })?;
+    match s.owner_analytics_repo.create_valuation(org, r.data).await {
         Ok(v) => Ok(Json(to_json_value(v)?)),
         Err(e) => Err((
             StatusCode::BAD_REQUEST,
@@ -183,11 +186,17 @@ async fn get_valuation_with_comparables(
 
 async fn add_comparable(
     State(s): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(vid): Path<Uuid>,
     Json(r): Json<AddComparableProperty>,
 ) -> ApiResult<Json<serde_json::Value>> {
-    match s.owner_analytics_repo.add_comparable(vid, r).await {
+    let org = user.tenant_id.ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::bad_request("Tenant context required")),
+        )
+    })?;
+    match s.owner_analytics_repo.add_comparable(vid, org, r).await {
         Ok(c) => Ok(Json(to_json_value(c)?)),
         Err(e) => Err((
             StatusCode::BAD_REQUEST,
@@ -198,16 +207,25 @@ async fn add_comparable(
 
 async fn get_value_history(
     State(s): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(uid): Path<Uuid>,
     Query(p): Query<ValueHistoryParams>,
 ) -> ApiResult<Json<serde_json::Value>> {
+    let org = user.tenant_id.ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::bad_request("Tenant context required")),
+        )
+    })?;
     match s
         .owner_analytics_repo
-        .get_value_history(ValueHistoryQuery {
-            unit_id: uid,
-            limit: p.limit,
-        })
+        .get_value_history(
+            org,
+            ValueHistoryQuery {
+                unit_id: uid,
+                limit: p.limit,
+            },
+        )
         .await
     {
         Ok(h) => Ok(Json(to_json_value(h)?)),
@@ -244,15 +262,17 @@ async fn get_value_trend(
 
 async fn calculate_roi(
     State(s): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(_uid): Path<Uuid>,
     Json(r): Json<CalculateROIWithOrg>,
 ) -> ApiResult<Json<serde_json::Value>> {
-    match s
-        .owner_analytics_repo
-        .calculate_roi(r.organization_id, r.data)
-        .await
-    {
+    let org = user.tenant_id.ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::bad_request("Tenant context required")),
+        )
+    })?;
+    match s.owner_analytics_repo.calculate_roi(org, r.data).await {
         Ok(roi) => Ok(Json(to_json_value(roi)?)),
         Err(e) => Err((
             StatusCode::BAD_REQUEST,
@@ -380,9 +400,15 @@ async fn create_auto_approval_rule(
     user: AuthUser,
     Json(r): Json<CreateRuleRequest>,
 ) -> ApiResult<Json<serde_json::Value>> {
+    let org = user.tenant_id.ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::bad_request("Tenant context required")),
+        )
+    })?;
     match s
         .owner_analytics_repo
-        .create_auto_approval_rule(user.user_id, r.organization_id, r.data)
+        .create_auto_approval_rule(user.user_id, org, r.data)
         .await
     {
         Ok(rule) => Ok(Json(to_json_value(rule)?)),
@@ -435,9 +461,15 @@ async fn submit_expense(
     user: AuthUser,
     Json(r): Json<SubmitExpenseRequest>,
 ) -> ApiResult<Json<serde_json::Value>> {
+    let org = user.tenant_id.ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::bad_request("Tenant context required")),
+        )
+    })?;
     match s
         .owner_analytics_repo
-        .submit_expense_for_approval(user.user_id, r.organization_id, r.data)
+        .submit_expense_for_approval(user.user_id, org, r.data)
         .await
     {
         Ok(resp) => Ok(Json(to_json_value(resp)?)),
@@ -474,9 +506,15 @@ async fn review_expense(
     Path(id): Path<Uuid>,
     Json(r): Json<ReviewExpenseRequest>,
 ) -> ApiResult<Json<serde_json::Value>> {
+    let org = user.tenant_id.ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::bad_request("Tenant context required")),
+        )
+    })?;
     match s
         .owner_analytics_repo
-        .review_expense(id, user.user_id, r)
+        .review_expense(id, user.user_id, org, r)
         .await
     {
         Ok(e) => Ok(Json(to_json_value(e)?)),

--- a/backend/servers/api-server/tests/infra_migration_platform_admin_tests.rs
+++ b/backend/servers/api-server/tests/infra_migration_platform_admin_tests.rs
@@ -73,7 +73,12 @@ fn infrastructure_cases() -> Vec<(Method, String, Option<&'static str>)> {
         (
             Method::POST,
             format!("{base}/feature-flags"),
-            Some(r#"{"key":"x","name":"x","description":"x","enabled":true}"#),
+            // Well-formed body so the request reaches the platform-admin gate
+            // (an invalid body would 422 at extraction, masking whether the
+            // 403 authz check actually fires).
+            Some(
+                r#"{"key":"x","name":"x","description":"x","enabled":true,"default_value":true,"value_type":"Boolean","environment":"dev"}"#,
+            ),
         ),
         (Method::GET, format!("{base}/jobs"), None),
         (Method::GET, format!("{base}/health/detailed"), None),
@@ -93,7 +98,10 @@ fn migration_cases() -> Vec<(Method, String, Option<&'static str>)> {
         (
             Method::POST,
             format!("{base}/export"),
-            Some(r#"{"categories":[],"privacy_options":{}}"#),
+            // Omit privacy_options so its `#[serde(default)]` applies; a literal
+            // `{}` would force serde to require its non-default bool fields and
+            // 422 before the platform-admin gate is reached.
+            Some(r#"{"categories":["buildings"]}"#),
         ),
         (Method::GET, format!("{base}/export/history"), None),
     ]

--- a/backend/servers/api-server/tests/infra_migration_platform_admin_tests.rs
+++ b/backend/servers/api-server/tests/infra_migration_platform_admin_tests.rs
@@ -1,0 +1,164 @@
+//! Regression: infrastructure (Epic 71/72) and platform-migration (Epic 66)
+//! endpoints must be gated behind the platform-admin capability (#901).
+//!
+//! Before the fix:
+//!   * `infrastructure.rs` handlers took no `AuthUser` extractor at all, so the
+//!     distributed-trace store (carrying cross-tenant `user_id` / `org_id`),
+//!     feature flags, background jobs and host health/metrics were readable and
+//!     mutable by *anyone*, authenticated or not.
+//!   * `migration.rs` import/export handlers extracted `AuthUser` but performed
+//!     no capability check, so any tenant user could drive bulk org-wide
+//!     data import/export (and receive fabricated stub payloads).
+//!
+//! The fix:
+//!   * Every infrastructure handler (except the Prometheus scrape endpoint)
+//!     now extracts `AuthUser` and calls `require_platform_admin`.
+//!   * Every migration import/export handler now calls `require_platform_admin`.
+//!
+//! This test proves, for a representative sample of both surfaces:
+//!   1. an unauthenticated request is rejected (401) — auth is now required;
+//!   2. an authenticated *non-admin* request is rejected with 403 and does NOT
+//!      receive a 200 with fabricated data.
+//!
+//! A freshly registered user (`create_authenticated_user`) is an ordinary
+//! tenant user, never a platform admin, so it exercises the 403 path.
+
+#[allow(dead_code)]
+mod common;
+
+use axum::{
+    body::Body,
+    http::{header, Method, Request, StatusCode},
+};
+use sqlx::PgPool;
+
+use common::{create_authenticated_user, TestApp, TestUser};
+
+const UUID: &str = "00000000-0000-0000-0000-000000000001";
+
+fn anon(method: Method, uri: &str, body: Option<&str>) -> Request<Body> {
+    let b = Request::builder().method(method).uri(uri);
+    match body {
+        Some(j) => b
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(j.to_string()))
+            .unwrap(),
+        None => b.body(Body::empty()).unwrap(),
+    }
+}
+
+fn authed(token: &str, method: Method, uri: &str, body: Option<&str>) -> Request<Body> {
+    let b = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header(header::AUTHORIZATION, format!("Bearer {token}"));
+    match body {
+        Some(j) => b
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(j.to_string()))
+            .unwrap(),
+        None => b.body(Body::empty()).unwrap(),
+    }
+}
+
+/// Representative slice across tracing, feature flags, jobs, health and the
+/// dashboard — the four infrastructure sub-domains.
+fn infrastructure_cases() -> Vec<(Method, String, Option<&'static str>)> {
+    let base = "/api/v1/infrastructure";
+    vec![
+        (Method::GET, format!("{base}/dashboard"), None),
+        (Method::GET, format!("{base}/traces"), None),
+        (Method::GET, format!("{base}/traces/{UUID}"), None),
+        (Method::GET, format!("{base}/feature-flags"), None),
+        (
+            Method::POST,
+            format!("{base}/feature-flags"),
+            Some(r#"{"key":"x","name":"x","description":"x","enabled":true}"#),
+        ),
+        (Method::GET, format!("{base}/jobs"), None),
+        (Method::GET, format!("{base}/health/detailed"), None),
+        (Method::GET, format!("{base}/health/alerts"), None),
+    ]
+}
+
+/// Representative slice across templates, import jobs and export — the
+/// high-blast-radius migration surface.
+fn migration_cases() -> Vec<(Method, String, Option<&'static str>)> {
+    let base = "/api/v1/migration";
+    vec![
+        (Method::GET, format!("{base}/templates"), None),
+        (Method::GET, format!("{base}/templates/system"), None),
+        (Method::GET, format!("{base}/import/jobs"), None),
+        (Method::GET, format!("{base}/import/jobs/{UUID}"), None),
+        (
+            Method::POST,
+            format!("{base}/export"),
+            Some(r#"{"categories":[],"privacy_options":{}}"#),
+        ),
+        (Method::GET, format!("{base}/export/history"), None),
+    ]
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn infrastructure_endpoints_require_auth(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    for (method, uri, body) in infrastructure_cases() {
+        let resp = app.execute(anon(method.clone(), &uri, body)).await;
+        assert_eq!(
+            resp.status,
+            StatusCode::UNAUTHORIZED,
+            "{method} {uri} must require auth (401), got {}",
+            resp.status
+        );
+    }
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn infrastructure_endpoints_reject_non_platform_admin(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (token, _r) = create_authenticated_user(&app, &TestUser::new()).await;
+
+    for (method, uri, body) in infrastructure_cases() {
+        let resp = app
+            .execute(authed(&token, method.clone(), &uri, body))
+            .await;
+        assert_eq!(
+            resp.status,
+            StatusCode::FORBIDDEN,
+            "{method} {uri} must reject non-admin (403, NOT a fabricated 200), got {}",
+            resp.status
+        );
+    }
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn migration_endpoints_require_auth(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    for (method, uri, body) in migration_cases() {
+        let resp = app.execute(anon(method.clone(), &uri, body)).await;
+        assert_eq!(
+            resp.status,
+            StatusCode::UNAUTHORIZED,
+            "{method} {uri} must require auth (401), got {}",
+            resp.status
+        );
+    }
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn migration_endpoints_reject_non_platform_admin(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (token, _r) = create_authenticated_user(&app, &TestUser::new()).await;
+
+    for (method, uri, body) in migration_cases() {
+        let resp = app
+            .execute(authed(&token, method.clone(), &uri, body))
+            .await;
+        assert_eq!(
+            resp.status,
+            StatusCode::FORBIDDEN,
+            "{method} {uri} must reject non-admin (403, NOT a fabricated 200), got {}",
+            resp.status
+        );
+    }
+}

--- a/backend/servers/api-server/tests/owner_analytics_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/owner_analytics_cross_org_idor_tests.rs
@@ -23,6 +23,8 @@
 mod common;
 
 use axum::http::StatusCode;
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::Serialize;
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -118,13 +120,44 @@ async fn seed_valuation(pool: &PgPool, unit_id: Uuid) -> Uuid {
     .expect("seed valuation")
 }
 
-/// Mint a real HS256 access token whose `org_id` claim becomes `AuthUser.tenant_id`.
+/// Claims shape matching `api_core::extractors::auth::Claims`. We mint with this
+/// rather than `JwtService` — which serializes the org as the `org_id` claim —
+/// so the `tenant_id` claim populates `AuthUser.tenant_id`. Without it the
+/// owner-analytics handlers see no tenant context (400 "Tenant context
+/// required") and the same-org success case wrongly fails.
+#[derive(Serialize)]
+struct TestClaims {
+    sub: Uuid,
+    exp: i64,
+    iat: i64,
+    token_type: String,
+    tenant_id: Option<Uuid>,
+    role: Option<String>,
+    email: String,
+    name: String,
+}
+
+/// Mint an HS256 access token for `user_id`, scoped to `org_id` via the JWT
+/// `tenant_id` claim, signed with the same secret `TestApp` configures.
 fn mint_token(user_id: Uuid, email: &str, org_id: Uuid) -> String {
-    use api_server::services::JwtService;
-    let config = TestConfig::default();
-    let jwt = JwtService::new(&config.jwt_secret).expect("jwt service");
-    jwt.generate_access_token(user_id, email, "OwnerIDOR User", Some(org_id), None)
-        .expect("mint access token")
+    let now = chrono::Utc::now().timestamp();
+    let claims = TestClaims {
+        sub: user_id,
+        exp: now + 3600,
+        iat: now,
+        token_type: "access".to_string(),
+        tenant_id: Some(org_id),
+        role: Some("manager".to_string()),
+        email: email.to_string(),
+        name: "OwnerIDOR User".to_string(),
+    };
+    let secret = TestConfig::default().jwt_secret;
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .expect("encode test JWT")
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/servers/api-server/tests/owner_analytics_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/owner_analytics_cross_org_idor_tests.rs
@@ -1,0 +1,246 @@
+//! Regression tests for the cross-tenant IDOR fix on the owner-analytics
+//! endpoints (`/api/v1/owner-analytics/*`, Epic 74 — issue #901).
+//!
+//! Audit history: the `OwnerAnalyticsRepository` queries plumbed an `org_id`
+//! parameter through but never used it — every read/mutate was keyed solely on
+//! `unit_id` / `valuation_id` (`WHERE unit_id = $1`). The api-server connects
+//! with a BYPASSRLS role (see migration 00165), so the table-level RLS policies
+//! added in 00116 do NOT catch this at runtime. The net effect: any
+//! authenticated user could read another org's property valuations, value
+//! history, ROI / cash-flow, and expense data by guessing a `unit_id`.
+//!
+//! The fix threads the caller's `tenant_id` (from the JWT) into every query and
+//! constrains it via `units -> buildings.organization_id`, so a unit in another
+//! org simply does not match (surfaced as 404 / empty, never the foreign row).
+//!
+//! These tests exercise the HTTP surface end-to-end with real HS256 JWTs:
+//!   1. Seed two orgs (A, B), each with a building + unit; a valuation in A's
+//!      unit; and a member user in each org (tenant_id carried in the token).
+//!   2. Org B's member probes Org A's unit/valuation → must NOT 200.
+//!   3. Org A's member reads its own unit's valuation → 200 with the row.
+
+#[allow(dead_code)]
+mod common;
+
+use axum::http::StatusCode;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{TestApp, TestConfig};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active') RETURNING id
+        "#,
+    )
+    .bind(format!("OwnerIDOR Org {slug}"))
+    .bind(format!("owner-idor-org-{slug}-{}", Uuid::new_v4()))
+    .bind(format!("{slug}-{}@owner-idor.test", Uuid::new_v4()))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'test_hash', 'OwnerIDOR User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_membership(pool: &PgPool, org_id: Uuid, user_id: Uuid) {
+    sqlx::query(
+        r#"
+        INSERT INTO organization_members (organization_id, user_id, role_type, status, joined_at)
+        VALUES ($1, $2, 'org_admin', 'active', NOW())
+        "#,
+    )
+    .bind(org_id)
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .expect("seed membership");
+}
+
+async fn seed_building(pool: &PgPool, org_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO buildings (organization_id, street, city, postal_code, country)
+        VALUES ($1, 'Test St 1', 'Bratislava', '81101', 'Slovakia')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed building")
+}
+
+async fn seed_unit(pool: &PgPool, building_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO units (building_id, designation, floor, unit_type)
+        VALUES ($1, '3B', 3, 'apartment')
+        RETURNING id
+        "#,
+    )
+    .bind(building_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed unit")
+}
+
+async fn seed_valuation(pool: &PgPool, unit_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO property_valuations
+            (unit_id, value_low, value_high, estimated_value, valuation_method, confidence_score)
+        VALUES ($1, 95000, 105000, 100000, 'avm', 85)
+        RETURNING id
+        "#,
+    )
+    .bind(unit_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed valuation")
+}
+
+/// Mint a real HS256 access token whose `org_id` claim becomes `AuthUser.tenant_id`.
+fn mint_token(user_id: Uuid, email: &str, org_id: Uuid) -> String {
+    use api_server::services::JwtService;
+    let config = TestConfig::default();
+    let jwt = JwtService::new(&config.jwt_secret).expect("jwt service");
+    jwt.generate_access_token(user_id, email, "OwnerIDOR User", Some(org_id), None)
+        .expect("mint access token")
+}
+
+// ---------------------------------------------------------------------------
+// T1 — cross-org unit valuation read is rejected (IDOR)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn unit_valuation_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "valuation-a").await;
+    let org_b = seed_org(&pool, "valuation-b").await;
+    let user_b = seed_user(&pool, &format!("val-b-{}@owner-idor.test", Uuid::new_v4())).await;
+    seed_membership(&pool, org_b, user_b).await;
+
+    let building_a = seed_building(&pool, org_a).await;
+    let unit_a = seed_unit(&pool, building_a).await;
+    let _val_a = seed_valuation(&pool, unit_a).await;
+
+    // User B (org B) probes Org A's unit valuation.
+    let token_b = mint_token(user_b, "val-b@owner-idor.test", org_b);
+    let uri = format!("/api/v1/owner-analytics/units/{unit_a}/valuation");
+    let resp = app.execute(app.get(&uri).bearer(&token_b).build()).await;
+
+    assert_ne!(
+        resp.status,
+        StatusCode::OK,
+        "Org A unit valuation must NOT be readable by Org B (got 200): {}",
+        resp.text()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T2 — cross-org value-history read is rejected and returns no rows
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn value_history_from_other_org_is_empty(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "hist-a").await;
+    let org_b = seed_org(&pool, "hist-b").await;
+    let user_b = seed_user(&pool, &format!("hist-b-{}@owner-idor.test", Uuid::new_v4())).await;
+    seed_membership(&pool, org_b, user_b).await;
+
+    let building_a = seed_building(&pool, org_a).await;
+    let unit_a = seed_unit(&pool, building_a).await;
+    // create_valuation also writes a value-history row.
+    let _val_a = seed_valuation(&pool, unit_a).await;
+    sqlx::query("INSERT INTO property_value_history (unit_id, value) VALUES ($1, 100000)")
+        .bind(unit_a)
+        .execute(&pool)
+        .await
+        .expect("seed history");
+
+    let token_b = mint_token(user_b, "hist-b@owner-idor.test", org_b);
+    let uri = format!("/api/v1/owner-analytics/units/{unit_a}/value-history");
+    let resp = app.execute(app.get(&uri).bearer(&token_b).build()).await;
+
+    // The list endpoint returns 200 with a JSON array; the org-scoping must make
+    // that array empty for a foreign caller (no rows leak across the tenant
+    // boundary). Either a non-200 OR an empty array is acceptable; a populated
+    // array is the bug.
+    if resp.status == StatusCode::OK {
+        let body = resp.json_value();
+        let len = body.as_array().map(|a| a.len()).unwrap_or(0);
+        assert_eq!(
+            len, 0,
+            "Org A value history must not leak to Org B; got {len} rows: {body}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// T3 — legitimate same-org valuation read succeeds (fix does not over-block)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn unit_valuation_same_org_succeeds(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "legit-a").await;
+    let user_a = seed_user(
+        &pool,
+        &format!("legit-a-{}@owner-idor.test", Uuid::new_v4()),
+    )
+    .await;
+    seed_membership(&pool, org_a, user_a).await;
+
+    let building_a = seed_building(&pool, org_a).await;
+    let unit_a = seed_unit(&pool, building_a).await;
+    let _val_a = seed_valuation(&pool, unit_a).await;
+
+    let token_a = mint_token(user_a, "legit-a@owner-idor.test", org_a);
+    let uri = format!("/api/v1/owner-analytics/units/{unit_a}/valuation");
+    let resp = app.execute(app.get(&uri).bearer(&token_a).build()).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "Org A member must read its own unit valuation (got {}): {}",
+        resp.status,
+        resp.text()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T4 — unauthenticated read is rejected
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn unit_valuation_without_auth_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let uri = format!("/api/v1/owner-analytics/units/{}/valuation", Uuid::new_v4());
+    let resp = app.execute(app.get(&uri).build()).await;
+    assert_eq!(
+        resp.status,
+        StatusCode::UNAUTHORIZED,
+        "missing bearer token must be 401, got {}",
+        resp.status
+    );
+}


### PR DESCRIPTION
## Task

Investigate #901 (Epics 71 Infrastructure, 72 Operations, 74 Owner Analytics + data-migration tooling) and fix cross-tenant IDOR / missing org-scoping in `infrastructure.rs`, `operations.rs`, `owner_analytics.rs`, `migration.rs`.

## Per-handler classification & evidence

### `owner_analytics.rs` (Epic 74) — FIXED (cross-tenant IDOR)
The `OwnerAnalyticsRepository` plumbed an `org_id` through every method but **never used it** — queries were keyed solely on `unit_id` / `valuation_id` (`WHERE unit_id = $1`). The api-server connects with a **BYPASSRLS** role (see migration `00165` comment), so the RLS policies added in `00116` do **not** catch this at runtime. Net effect: any authenticated user could read/mutate another org's valuations, value history, ROI/cash-flow, comparables and expense data by supplying a foreign `unit_id` / `valuation_id`, and several routes (`create_valuation`, `calculate_roi`, `submit_expense`, `create_auto_approval_rule`) trusted an attacker-supplied `organization_id` from the request body.

Fix:
- Repo: every unit/valuation-keyed query now joins `units -> buildings` and constrains `b.organization_id = $org`; added `assert_unit_in_org` / `assert_valuation_in_org` guards for mutating paths; expense list/review/submit scoped to the org; auto-approval-rule lookup scoped to org.
- Routes: derive org from `user.tenant_id` (JWT), never the request body; require tenant context (400 if absent).

### `infrastructure.rs` (Epic 71/72) — FIXED (missing auth + IDOR)
38 handlers took **no `AuthUser` extractor at all** — distributed traces (carrying cross-tenant `user_id`/`org_id`), feature flags, background jobs and host health/metrics were fully **unauthenticated** and (for traces) cross-org via a client-supplied `org_id` query param.

Fix: added `require_platform_admin` and threaded `AuthUser` into all 37 non-scrape handlers (mirrors the operations.rs precedent). The Prometheus scrape endpoint (`/health/metrics`) is intentionally left ungated (network-layer protected scrape target). Also replaced 7 `Uuid::nil()` audit-trail placeholders with the real `auth.user_id`.

### `migration.rs` (Epic 66 — P1 in issue) — GATED (501/real-impl deferred)
All 23 handlers returned **fabricated stub data** (`generate_sample_templates`, hardcoded `vec![...]`, "In a real implementation…" x40, no DB) and only extracted `AuthUser` with no capability check, so any tenant user could drive org-wide bulk import/export.

Fix: gated all 22 data import/export handlers behind `require_platform_admin` (the static category-catalog endpoint is left open). The handlers remain stubs — real persistence is follow-up work (refs #901). This closes the high-blast-radius exposure now.

### `operations.rs` (Epic 73) — ALREADY-FIXED
All 39 handlers already gate on `auth.is_platform_admin()` (39/39). No change.

## Owner
pm-security

## Tested (Band A — fast check)
- `cargo clippy -p api-server --lib -- -D warnings` → exit 0 (`Finished`, no warnings)
- `cargo test -p api-server --test owner_analytics_cross_org_idor_tests --test infra_migration_platform_admin_tests --no-run` → exit 0 (both test binaries linked)
- `cargo fmt` → clean (pre-commit hook passed)

Local Docker/Postgres is down, so the new `#[sqlx::test]` tests are compiled here and **executed in CI** (provisioned Postgres). New tests:
- `owner_analytics_cross_org_idor_tests.rs` — cross-org valuation/value-history reads rejected; **legit same-org read returns 200**; unauthenticated → 401.
- `infra_migration_platform_admin_tests.rs` — infrastructure + migration endpoints: unauthenticated → 401, authenticated non-admin → **403 (not a fabricated 200)**.

## Built (Band B — full build)
Covered by the `-p api-server --lib` clippy build above (release build skipped; this is a route/repo change, no build-output config touched).

## CI parity (Band C — hot-path)
Hot-path (security/IDOR). The repo SQL changes use runtime `sqlx::query`/`query_as` (not the `query!` macro), so no offline-cache regen is needed. Full `cargo test` + clippy across the workspace will run in CI.

## Notes
- No change to `operations.rs` (already gated) — scope stays tight to the four issue files + repo + 2 tests.
- `migration.rs` handlers are still stubs behind the admin gate; real persistence is a follow-up (refs #901).