### PR TITLE
fix(security): org-scope disputes & enhanced tenant screening reads (closes #760, closes #834)

### DIFF
--- a/backend/crates/db/src/repositories/dispute.rs
+++ b/backend/crates/db/src/repositories/dispute.rs
@@ -140,9 +140,17 @@ impl DisputeRepository {
         Ok(disputes)
     }
 
-    pub async fn find_by_id_with_details(
+    /// Fetch a dispute with details, scoped to the caller's organization.
+    ///
+    /// Issue #760 / #834 (cross-tenant IDOR): the previous
+    /// `find_by_id_with_details` looked the dispute up by primary key alone,
+    /// relying on RLS that the management API pool does not enforce. The
+    /// `organization_id = $2` predicate closes the leak — a caller targeting a
+    /// dispute in another org gets `None` (surfaced as 404), never the row.
+    pub async fn find_by_id_with_details_for_org(
         &self,
         id: Uuid,
+        org_id: Uuid,
     ) -> Result<Option<DisputeWithDetails>, AppError> {
         // Get dispute
         let dispute = sqlx::query_as::<_, Dispute>(
@@ -152,10 +160,11 @@ impl DisputeRepository {
                    assigned_to, resolved_at, resolution_notes, mediation_notes,
                    created_at, updated_at
             FROM disputes
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             "#,
         )
         .bind(id)
+        .bind(org_id)
         .fetch_optional(&self.pool)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
@@ -450,12 +459,26 @@ impl DisputeRepository {
         Ok(dispute)
     }
 
-    pub async fn withdraw(&self, id: Uuid, user_id: Uuid) -> Result<(), AppError> {
-        sqlx::query("UPDATE disputes SET status = 'withdrawn' WHERE id = $1")
-            .bind(id)
-            .execute(&self.pool)
-            .await
-            .map_err(|e| AppError::Database(e.to_string()))?;
+    /// Withdraw a dispute, scoped to the caller's organization.
+    ///
+    /// Issue #760 / #834: the UPDATE is gated by `organization_id = $2` so a
+    /// caller from another org cannot withdraw a foreign dispute by guessing
+    /// its UUID. Returns `NotFound` when no row in the caller's org matches —
+    /// the handler maps this to 404 so the response is not a cross-tenant
+    /// existence oracle.
+    pub async fn withdraw(&self, id: Uuid, org_id: Uuid, user_id: Uuid) -> Result<(), AppError> {
+        let result = sqlx::query(
+            "UPDATE disputes SET status = 'withdrawn' WHERE id = $1 AND organization_id = $2",
+        )
+        .bind(id)
+        .bind(org_id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        if result.rows_affected() == 0 {
+            return Err(AppError::NotFound("Dispute not found".to_string()));
+        }
 
         self.record_activity(
             id,

--- a/backend/crates/db/src/repositories/enhanced_tenant_screening.rs
+++ b/backend/crates/db/src/repositories/enhanced_tenant_screening.rs
@@ -90,15 +90,23 @@ impl EnhancedTenantScreeningRepository {
         .await
     }
 
-    /// Get AI risk scoring model by ID.
+    /// Get AI risk scoring model by ID, scoped to the owning organization.
+    ///
+    /// Issue #834 (cross-tenant PII): models carry provider weighting / scoring
+    /// configuration. The `organization_id = $2` predicate stops a caller from
+    /// another org reading a foreign model by guessing its UUID.
     pub async fn get_risk_model(
         &self,
+        org_id: Uuid,
         id: Uuid,
     ) -> Result<Option<AiRiskScoringModel>, sqlx::Error> {
-        sqlx::query_as("SELECT * FROM ai_risk_scoring_models WHERE id = $1")
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await
+        sqlx::query_as(
+            "SELECT * FROM ai_risk_scoring_models WHERE id = $1 AND organization_id = $2",
+        )
+        .bind(id)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await
     }
 
     /// Get active AI risk scoring model for organization.
@@ -192,15 +200,23 @@ impl EnhancedTenantScreeningRepository {
         .await
     }
 
-    /// Get provider config by ID.
+    /// Get provider config by ID, scoped to the owning organization.
+    ///
+    /// Issue #834: provider configs hold third-party integration settings
+    /// (endpoints, rate limits, cost). Scope by org so a foreign caller cannot
+    /// read another tenant's provider wiring by UUID.
     pub async fn get_provider_config(
         &self,
+        org_id: Uuid,
         id: Uuid,
     ) -> Result<Option<ScreeningProviderConfig>, sqlx::Error> {
-        sqlx::query_as("SELECT * FROM screening_provider_configs WHERE id = $1")
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await
+        sqlx::query_as(
+            "SELECT * FROM screening_provider_configs WHERE id = $1 AND organization_id = $2",
+        )
+        .bind(id)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await
     }
 
     /// List provider configs for organization.
@@ -316,14 +332,23 @@ impl EnhancedTenantScreeningRepository {
     }
 
     /// Get AI result by screening ID.
+    /// Get the AI result for a screening, scoped to the owning organization.
+    ///
+    /// Issue #834 (cross-tenant PII): AI results carry risk scores and
+    /// recommendations. Scoping by `organization_id` closes the IDOR where any
+    /// org could read another org's result by guessing the screening UUID.
     pub async fn get_ai_result_by_screening(
         &self,
+        org_id: Uuid,
         screening_id: Uuid,
     ) -> Result<Option<ScreeningAiResult>, sqlx::Error> {
-        sqlx::query_as("SELECT * FROM screening_ai_results WHERE screening_id = $1")
-            .bind(screening_id)
-            .fetch_optional(&self.pool)
-            .await
+        sqlx::query_as(
+            "SELECT * FROM screening_ai_results WHERE screening_id = $1 AND organization_id = $2",
+        )
+        .bind(screening_id)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await
     }
 
     /// Get AI result by ID.
@@ -471,14 +496,21 @@ impl EnhancedTenantScreeningRepository {
     }
 
     /// Get credit result by screening ID.
+    /// Get the credit result for a screening, scoped to the owning organization.
+    ///
+    /// Issue #834: credit results are sensitive PII (FICO scores, accounts).
     pub async fn get_credit_result_by_screening(
         &self,
+        org_id: Uuid,
         screening_id: Uuid,
     ) -> Result<Option<ScreeningCreditResult>, sqlx::Error> {
-        sqlx::query_as("SELECT * FROM screening_credit_results WHERE screening_id = $1")
-            .bind(screening_id)
-            .fetch_optional(&self.pool)
-            .await
+        sqlx::query_as(
+            "SELECT * FROM screening_credit_results WHERE screening_id = $1 AND organization_id = $2",
+        )
+        .bind(screening_id)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await
     }
 
     // =========================================================================
@@ -522,15 +554,22 @@ impl EnhancedTenantScreeningRepository {
         .await
     }
 
-    /// Get background result by screening ID.
+    /// Get background result by screening ID, scoped to the owning organization.
+    ///
+    /// Issue #834: background results are sensitive PII (criminal records,
+    /// identity verification).
     pub async fn get_background_result_by_screening(
         &self,
+        org_id: Uuid,
         screening_id: Uuid,
     ) -> Result<Option<ScreeningBackgroundResult>, sqlx::Error> {
-        sqlx::query_as("SELECT * FROM screening_background_results WHERE screening_id = $1")
-            .bind(screening_id)
-            .fetch_optional(&self.pool)
-            .await
+        sqlx::query_as(
+            "SELECT * FROM screening_background_results WHERE screening_id = $1 AND organization_id = $2",
+        )
+        .bind(screening_id)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await
     }
 
     // =========================================================================
@@ -567,15 +606,21 @@ impl EnhancedTenantScreeningRepository {
         .await
     }
 
-    /// Get eviction result by screening ID.
+    /// Get eviction result by screening ID, scoped to the owning organization.
+    ///
+    /// Issue #834: eviction history is sensitive PII.
     pub async fn get_eviction_result_by_screening(
         &self,
+        org_id: Uuid,
         screening_id: Uuid,
     ) -> Result<Option<ScreeningEvictionResult>, sqlx::Error> {
-        sqlx::query_as("SELECT * FROM screening_eviction_results WHERE screening_id = $1")
-            .bind(screening_id)
-            .fetch_optional(&self.pool)
-            .await
+        sqlx::query_as(
+            "SELECT * FROM screening_eviction_results WHERE screening_id = $1 AND organization_id = $2",
+        )
+        .bind(screening_id)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await
     }
 
     // =========================================================================
@@ -711,14 +756,19 @@ impl EnhancedTenantScreeningRepository {
     }
 
     /// Get reports for screening.
+    /// Get reports for a screening, scoped to the owning organization.
+    ///
+    /// Issue #834: screening reports aggregate the sensitive PII above.
     pub async fn get_reports_by_screening(
         &self,
+        org_id: Uuid,
         screening_id: Uuid,
     ) -> Result<Vec<ScreeningReport>, sqlx::Error> {
         sqlx::query_as(
-            "SELECT * FROM screening_reports WHERE screening_id = $1 AND deleted_at IS NULL ORDER BY generated_at DESC",
+            "SELECT * FROM screening_reports WHERE screening_id = $1 AND organization_id = $2 AND deleted_at IS NULL ORDER BY generated_at DESC",
         )
         .bind(screening_id)
+        .bind(org_id)
         .fetch_all(&self.pool)
         .await
     }
@@ -773,22 +823,34 @@ impl EnhancedTenantScreeningRepository {
         .await
     }
 
-    /// Get complete screening data.
+    /// Get complete screening data, scoped to the owning organization.
+    ///
+    /// Issue #834: this aggregates every sensitive screening artefact, so each
+    /// component lookup is org-scoped. `get_risk_factors` keys off the
+    /// AI-result id, which is itself org-scoped above, so it needs no separate
+    /// org predicate.
     pub async fn get_complete_screening_data(
         &self,
+        org_id: Uuid,
         screening_id: Uuid,
     ) -> Result<CompleteScreeningData, sqlx::Error> {
-        let ai_result = self.get_ai_result_by_screening(screening_id).await?;
+        let ai_result = self
+            .get_ai_result_by_screening(org_id, screening_id)
+            .await?;
         let risk_factors = if let Some(ref ai) = ai_result {
             self.get_risk_factors(ai.id).await?
         } else {
             vec![]
         };
-        let credit_result = self.get_credit_result_by_screening(screening_id).await?;
-        let background_result = self
-            .get_background_result_by_screening(screening_id)
+        let credit_result = self
+            .get_credit_result_by_screening(org_id, screening_id)
             .await?;
-        let eviction_result = self.get_eviction_result_by_screening(screening_id).await?;
+        let background_result = self
+            .get_background_result_by_screening(org_id, screening_id)
+            .await?;
+        let eviction_result = self
+            .get_eviction_result_by_screening(org_id, screening_id)
+            .await?;
 
         Ok(CompleteScreeningData {
             ai_result,

--- a/backend/servers/api-server/src/routes/disputes.rs
+++ b/backend/servers/api-server/src/routes/disputes.rs
@@ -355,14 +355,29 @@ async fn get_statistics(
 }
 
 /// Get a specific dispute by ID.
+///
+/// Issue #760 / #834:
+///   * The lookup is scoped to the caller's JWT tenant, so a dispute owned by
+///     another org returns 404 (no cross-tenant IDOR).
+///   * `mediation_notes` is confidential — it is only returned to a
+///     manager/admin or the assigned mediator. For every other party it is
+///     redacted to `None`, even though they may read the rest of the dispute.
 async fn get_dispute(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<Json<DisputeWithDetails>, (StatusCode, Json<ErrorResponse>)> {
-    state
+    // Derive the org from the verified JWT so the read cannot cross tenants.
+    let organization_id = user.tenant_id.ok_or_else(|| {
+        (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new("FORBIDDEN", "No organization context")),
+        )
+    })?;
+
+    let mut details = state
         .dispute_repo
-        .find_by_id_with_details(id)
+        .find_by_id_with_details_for_org(id, organization_id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get dispute: {:?}", e);
@@ -371,13 +386,42 @@ async fn get_dispute(
                 Json(ErrorResponse::new("DB_ERROR", "Failed to get dispute")),
             )
         })?
-        .map(Json)
         .ok_or_else(|| {
             (
                 StatusCode::NOT_FOUND,
                 Json(ErrorResponse::new("NOT_FOUND", "Dispute not found")),
             )
-        })
+        })?;
+
+    // Confidentiality gate for mediation_notes: visible to managers/admins and
+    // the assigned mediator only. Writes are already restricted in
+    // `update_mediation_notes`; without this read gate the notes leaked to any
+    // org member that could read the dispute.
+    let is_manager = user
+        .role
+        .as_ref()
+        .is_some_and(|r| r.is_manager() || r.is_admin());
+
+    if !is_manager && details.dispute.mediation_notes.is_some() {
+        let is_mediator = state
+            .dispute_repo
+            .find_party_by_user(id, user.user_id)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to verify mediator access: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("DB_ERROR", "Failed to get dispute")),
+                )
+            })?
+            .is_some_and(|p| p.role == db::models::disputes::party_role::MEDIATOR);
+
+        if !is_mediator {
+            details.dispute.mediation_notes = None;
+        }
+    }
+
+    Ok(Json(details))
 }
 
 /// Update dispute status — enforces the state machine.
@@ -626,23 +670,39 @@ async fn update_mediation_notes(
 }
 
 /// Withdraw a dispute.
+///
+/// Issue #760 / #834: the withdraw is scoped to the caller's JWT tenant, so a
+/// dispute owned by another org returns 404 and is never mutated.
 async fn withdraw_dispute(
     State(state): State<AppState>,
     user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    state
+    let organization_id = user.tenant_id.ok_or_else(|| {
+        (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new("FORBIDDEN", "No organization context")),
+        )
+    })?;
+
+    match state
         .dispute_repo
-        .withdraw(id, user.user_id)
+        .withdraw(id, organization_id, user.user_id)
         .await
-        .map(|_| StatusCode::NO_CONTENT)
-        .map_err(|e| {
+    {
+        Ok(()) => Ok(StatusCode::NO_CONTENT),
+        Err(common::errors::AppError::NotFound(_)) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("NOT_FOUND", "Dispute not found")),
+        )),
+        Err(e) => {
             tracing::error!("Failed to withdraw dispute: {:?}", e);
-            (
+            Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new("DB_ERROR", "Failed to withdraw dispute")),
-            )
-        })
+            ))
+        }
+    }
 }
 
 /// List parties for a dispute.

--- a/backend/servers/api-server/src/routes/enhanced_tenant_screening.rs
+++ b/backend/servers/api-server/src/routes/enhanced_tenant_screening.rs
@@ -126,12 +126,16 @@ async fn get_risk_model(
     auth: AuthUser,
     Path(id): Path<Uuid>,
 ) -> impl IntoResponse {
-    let _ = match get_org_id(&auth) {
+    let org_id = match get_org_id(&auth) {
         Ok(id) => id,
         Err(e) => return e.into_response(),
     };
 
-    match s.enhanced_tenant_screening_repo.get_risk_model(id).await {
+    match s
+        .enhanced_tenant_screening_repo
+        .get_risk_model(org_id, id)
+        .await
+    {
         Ok(Some(model)) => Json(model).into_response(),
         Ok(None) => (StatusCode::NOT_FOUND, "Risk model not found").into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
@@ -225,14 +229,14 @@ async fn get_provider_config(
     auth: AuthUser,
     Path(id): Path<Uuid>,
 ) -> impl IntoResponse {
-    let _ = match get_org_id(&auth) {
+    let org_id = match get_org_id(&auth) {
         Ok(id) => id,
         Err(e) => return e.into_response(),
     };
 
     match s
         .enhanced_tenant_screening_repo
-        .get_provider_config(id)
+        .get_provider_config(org_id, id)
         .await
     {
         Ok(Some(config)) => Json(config).into_response(),
@@ -328,14 +332,14 @@ async fn get_ai_result(
     auth: AuthUser,
     Path(screening_id): Path<Uuid>,
 ) -> impl IntoResponse {
-    let _ = match get_org_id(&auth) {
+    let org_id = match get_org_id(&auth) {
         Ok(id) => id,
         Err(e) => return e.into_response(),
     };
 
     match s
         .enhanced_tenant_screening_repo
-        .get_ai_result_by_screening(screening_id)
+        .get_ai_result_by_screening(org_id, screening_id)
         .await
     {
         Ok(Some(result)) => Json(result).into_response(),
@@ -350,15 +354,15 @@ async fn get_risk_factors(
     auth: AuthUser,
     Path(screening_id): Path<Uuid>,
 ) -> impl IntoResponse {
-    let _ = match get_org_id(&auth) {
+    let org_id = match get_org_id(&auth) {
         Ok(id) => id,
         Err(e) => return e.into_response(),
     };
 
-    // First get the AI result to get its ID
+    // First get the (org-scoped) AI result to get its ID
     match s
         .enhanced_tenant_screening_repo
-        .get_ai_result_by_screening(screening_id)
+        .get_ai_result_by_screening(org_id, screening_id)
         .await
     {
         Ok(Some(ai_result)) => {
@@ -382,14 +386,14 @@ async fn get_complete_screening_data(
     auth: AuthUser,
     Path(screening_id): Path<Uuid>,
 ) -> impl IntoResponse {
-    let _ = match get_org_id(&auth) {
+    let org_id = match get_org_id(&auth) {
         Ok(id) => id,
         Err(e) => return e.into_response(),
     };
 
     match s
         .enhanced_tenant_screening_repo
-        .get_complete_screening_data(screening_id)
+        .get_complete_screening_data(org_id, screening_id)
         .await
     {
         Ok(data) => Json(data).into_response(),
@@ -412,7 +416,7 @@ async fn run_ai_scoring(
     let model = if let Some(model_id) = req.model_id {
         match s
             .enhanced_tenant_screening_repo
-            .get_risk_model(model_id)
+            .get_risk_model(org_id, model_id)
             .await
         {
             Ok(Some(m)) => m,
@@ -442,19 +446,19 @@ async fn run_ai_scoring(
     // Get credit, background, and eviction results to compute component scores
     let credit = s
         .enhanced_tenant_screening_repo
-        .get_credit_result_by_screening(req.screening_id)
+        .get_credit_result_by_screening(org_id, req.screening_id)
         .await
         .ok()
         .flatten();
     let background = s
         .enhanced_tenant_screening_repo
-        .get_background_result_by_screening(req.screening_id)
+        .get_background_result_by_screening(org_id, req.screening_id)
         .await
         .ok()
         .flatten();
     let eviction = s
         .enhanced_tenant_screening_repo
-        .get_eviction_result_by_screening(req.screening_id)
+        .get_eviction_result_by_screening(org_id, req.screening_id)
         .await
         .ok()
         .flatten();
@@ -515,14 +519,14 @@ async fn get_credit_result(
     auth: AuthUser,
     Path(screening_id): Path<Uuid>,
 ) -> impl IntoResponse {
-    let _ = match get_org_id(&auth) {
+    let org_id = match get_org_id(&auth) {
         Ok(id) => id,
         Err(e) => return e.into_response(),
     };
 
     match s
         .enhanced_tenant_screening_repo
-        .get_credit_result_by_screening(screening_id)
+        .get_credit_result_by_screening(org_id, screening_id)
         .await
     {
         Ok(Some(result)) => Json(result).into_response(),
@@ -562,14 +566,14 @@ async fn get_background_result(
     auth: AuthUser,
     Path(screening_id): Path<Uuid>,
 ) -> impl IntoResponse {
-    let _ = match get_org_id(&auth) {
+    let org_id = match get_org_id(&auth) {
         Ok(id) => id,
         Err(e) => return e.into_response(),
     };
 
     match s
         .enhanced_tenant_screening_repo
-        .get_background_result_by_screening(screening_id)
+        .get_background_result_by_screening(org_id, screening_id)
         .await
     {
         Ok(Some(result)) => Json(result).into_response(),
@@ -609,14 +613,14 @@ async fn get_eviction_result(
     auth: AuthUser,
     Path(screening_id): Path<Uuid>,
 ) -> impl IntoResponse {
-    let _ = match get_org_id(&auth) {
+    let org_id = match get_org_id(&auth) {
         Ok(id) => id,
         Err(e) => return e.into_response(),
     };
 
     match s
         .enhanced_tenant_screening_repo
-        .get_eviction_result_by_screening(screening_id)
+        .get_eviction_result_by_screening(org_id, screening_id)
         .await
     {
         Ok(Some(result)) => Json(result).into_response(),
@@ -726,14 +730,14 @@ async fn get_reports(
     auth: AuthUser,
     Path(screening_id): Path<Uuid>,
 ) -> impl IntoResponse {
-    let _ = match get_org_id(&auth) {
+    let org_id = match get_org_id(&auth) {
         Ok(id) => id,
         Err(e) => return e.into_response(),
     };
 
     match s
         .enhanced_tenant_screening_repo
-        .get_reports_by_screening(screening_id)
+        .get_reports_by_screening(org_id, screening_id)
         .await
     {
         Ok(reports) => Json(reports).into_response(),

--- a/backend/servers/api-server/tests/dispute_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/dispute_cross_org_idor_tests.rs
@@ -34,6 +34,8 @@ use serde_json::json;
 use sqlx::PgPool;
 use uuid::Uuid;
 
+use db::repositories::DisputeRepository;
+
 use common::TestApp;
 
 // ---------------------------------------------------------------------------
@@ -260,4 +262,128 @@ async fn update_mediation_notes_cross_org_claim_rejected(pool: PgPool) {
     let resp = app.execute(req).await;
 
     assert_rejected(resp.status, "PATCH /mediation-notes cross-org X-Tenant-ID");
+}
+
+// ---------------------------------------------------------------------------
+// Repository-layer contract tests (issue #760 / #834)
+//
+// The HTTP tests above prove cross-org mutations never reach the row, but the
+// TestApp harness cannot mint a JWT carrying `tenant_id` for the happy path.
+// These repo tests pin the org-scope contract directly — including the
+// positive (owning org reads its dispute) case the task requires.
+// ---------------------------------------------------------------------------
+
+/// Seed a dispute carrying mediation_notes; returns its id.
+async fn seed_dispute_with_notes(pool: &PgPool, org_id: Uuid, filed_by: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO disputes (
+            organization_id, reference_number, category, title, description,
+            status, priority, filed_by, mediation_notes
+        )
+        VALUES ($1, $2, 'noise', 'Notes dispute', 'Has confidential notes',
+                'under_review', 'medium', $3, 'CONFIDENTIAL mediation notes')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(format!("DISP-NOTES-{}", Uuid::new_v4()))
+    .bind(filed_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed dispute with notes")
+}
+
+// R1 — find_by_id_with_details_for_org: owner reads, foreign org gets None.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn find_by_id_for_org_is_scoped_to_owning_org(pool: PgPool) {
+    let org_a = seed_org(&pool, "repo-find-a").await;
+    let org_b = seed_org(&pool, "repo-find-b").await;
+    let user_a = seed_user(&pool, "repo-find-a@dispute-idor.test").await;
+    let dispute_a = seed_dispute(&pool, org_a, user_a).await;
+
+    let repo = DisputeRepository::new(pool.clone());
+
+    // The owning org reads its dispute (positive case).
+    let own = repo
+        .find_by_id_with_details_for_org(dispute_a, org_a)
+        .await
+        .expect("find with right org");
+    assert!(own.is_some(), "org A must read its own dispute by id");
+    assert_eq!(own.unwrap().dispute.id, dispute_a);
+
+    // A foreign org gets nothing (closed IDOR → handler returns 404).
+    let cross = repo
+        .find_by_id_with_details_for_org(dispute_a, org_b)
+        .await
+        .expect("find with wrong org");
+    assert!(cross.is_none(), "org B must not read org A's dispute by id");
+}
+
+// R2 — withdraw: owner withdraws, foreign org is NotFound and the row stands.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn withdraw_is_scoped_to_owning_org(pool: PgPool) {
+    let org_a = seed_org(&pool, "repo-wd-a").await;
+    let org_b = seed_org(&pool, "repo-wd-b").await;
+    let user_a = seed_user(&pool, "repo-wd-a@dispute-idor.test").await;
+    let dispute_a = seed_dispute(&pool, org_a, user_a).await;
+
+    let repo = DisputeRepository::new(pool.clone());
+
+    // A foreign org cannot withdraw — NotFound, and the status is unchanged.
+    let cross = repo.withdraw(dispute_a, org_b, user_a).await;
+    assert!(
+        matches!(cross, Err(::common::errors::AppError::NotFound(_))),
+        "org B withdraw must fail with NotFound, got {cross:?}"
+    );
+    assert_eq!(
+        dispute_status(&pool, dispute_a).await,
+        "under_review",
+        "cross-org withdraw must not mutate the row"
+    );
+
+    // The owning org withdraws successfully (positive case).
+    repo.withdraw(dispute_a, org_a, user_a)
+        .await
+        .expect("org A withdraws its own dispute");
+    assert_eq!(
+        dispute_status(&pool, dispute_a).await,
+        "withdrawn",
+        "org A withdraw must set status=withdrawn"
+    );
+}
+
+// R3 — mediation_notes are present in the row for the owning org. The HTTP
+// confidentiality gate (manager/mediator only) is applied in the handler; this
+// pins that the data exists and is org-scoped so the gate has something to
+// redact.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn mediation_notes_present_for_owning_org(pool: PgPool) {
+    let org_a = seed_org(&pool, "repo-notes-a").await;
+    let org_b = seed_org(&pool, "repo-notes-b").await;
+    let user_a = seed_user(&pool, "repo-notes-a@dispute-idor.test").await;
+    let dispute_a = seed_dispute_with_notes(&pool, org_a, user_a).await;
+
+    let repo = DisputeRepository::new(pool.clone());
+
+    let own = repo
+        .find_by_id_with_details_for_org(dispute_a, org_a)
+        .await
+        .expect("find with right org")
+        .expect("dispute exists for owner");
+    assert_eq!(
+        own.dispute.mediation_notes.as_deref(),
+        Some("CONFIDENTIAL mediation notes"),
+        "owning org must see mediation_notes at the repo layer"
+    );
+
+    // Foreign org cannot reach the dispute at all.
+    let cross = repo
+        .find_by_id_with_details_for_org(dispute_a, org_b)
+        .await
+        .expect("find with wrong org");
+    assert!(
+        cross.is_none(),
+        "org B must not read org A's dispute (and thus never its notes)"
+    );
 }

--- a/backend/servers/api-server/tests/enhanced_screening_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/enhanced_screening_cross_org_idor_tests.rs
@@ -1,0 +1,308 @@
+//! Regression tests for the cross-tenant IDOR / PII leak fix on the enhanced
+//! tenant screening endpoints (Epic 135 — issue #834, extends #760).
+//!
+//! Audit history: every get-by-id / get-by-screening repository method looked
+//! its row up by UUID alone (`WHERE id = $1` / `WHERE screening_id = $1`),
+//! while the route handlers fetched the caller's org from the JWT and then
+//! discarded it (`let _ = get_org_id(...)`). A caller from another org could
+//! therefore read a foreign org's risk model, provider config, AI risk score,
+//! credit / background / eviction result, or aggregated report by guessing the
+//! UUID — a disclosure of sensitive PII.
+//!
+//! The fix threads the JWT tenant into each repository call so the SQL WHERE
+//! clause is `... AND organization_id = $N`, and the handlers pass the real
+//! org id. Cross-org reads now return `None` (surfaced as 404); the owning
+//! org still reads its own rows.
+//!
+//! These tests pin the contract at the repository layer (the authority the
+//! handlers scope to), exercising both the positive case (owner reads its row)
+//! and the negative case (foreign org gets nothing) without depending on the
+//! TestApp auth harness — which cannot mint a JWT carrying `tenant_id` for the
+//! happy path because `JwtService` emits an `org_id` claim under a different
+//! name than the `AuthUser` extractor reads.
+
+#[allow(dead_code)]
+mod common;
+
+use rust_decimal::Decimal;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use db::models::enhanced_tenant_screening::{
+    CreateAiRiskScoringModel, CreateScreeningProviderConfig, ScreeningProviderType,
+};
+use db::repositories::EnhancedTenantScreeningRepository;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active') RETURNING id
+        "#,
+    )
+    .bind(format!("ScreeningIDOR Org {slug}"))
+    .bind(format!("screening-idor-{slug}"))
+    .bind(format!("{slug}@screening-idor.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'test_hash', 'ScreeningIDOR User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+fn sample_model(name: &str) -> CreateAiRiskScoringModel {
+    CreateAiRiskScoringModel {
+        name: name.to_string(),
+        description: None,
+        credit_history_weight: None,
+        rental_history_weight: None,
+        income_stability_weight: None,
+        employment_stability_weight: None,
+        eviction_history_weight: None,
+        criminal_background_weight: None,
+        identity_verification_weight: None,
+        reference_quality_weight: None,
+        excellent_threshold: None,
+        good_threshold: None,
+        fair_threshold: None,
+        poor_threshold: None,
+        auto_approve_threshold: None,
+        auto_reject_threshold: None,
+    }
+}
+
+fn sample_provider(name: &str) -> CreateScreeningProviderConfig {
+    CreateScreeningProviderConfig {
+        provider_name: name.to_string(),
+        provider_type: ScreeningProviderType::CreditBureau,
+        api_endpoint: Some("https://example.test/api".to_string()),
+        api_key: None,
+        api_secret: None,
+        rate_limit_per_hour: None,
+        priority: None,
+        cost_per_check: Some(Decimal::new(199, 2)),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Seed the full chain required for a screening_ai_results row.
+// organizations -> buildings -> units -> tenant_applications -> tenant_screenings
+// ---------------------------------------------------------------------------
+
+async fn seed_screening(pool: &PgPool, org_id: Uuid, slug: &str) -> Uuid {
+    let building_id = sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO buildings (organization_id, street, city, postal_code, country)
+        VALUES ($1, $2, 'Bratislava', '81101', 'Slovakia') RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(format!("{slug} Street 1"))
+    .fetch_one(pool)
+    .await
+    .expect("seed building");
+
+    let unit_id = sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO units (
+            building_id, designation, floor, unit_type,
+            size_sqm, rooms, ownership_share, occupancy_status, status, settings
+        )
+        VALUES ($1, $2, 1, 'apartment', 50.0, 2, 100.00, 'unknown', 'active', '{}'::jsonb)
+        RETURNING id
+        "#,
+    )
+    .bind(building_id)
+    .bind(format!("{slug}-1A"))
+    .fetch_one(pool)
+    .await
+    .expect("seed unit");
+
+    let application_id = sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO tenant_applications (
+            organization_id, unit_id, applicant_name, applicant_email, status
+        )
+        VALUES ($1, $2, 'Applicant', $3, 'draft') RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(unit_id)
+    .bind(format!("{slug}@applicant.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed application");
+
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO tenant_screenings (
+            application_id, organization_id, screening_type, status
+        )
+        VALUES ($1, $2, 'credit_check', 'completed') RETURNING id
+        "#,
+    )
+    .bind(application_id)
+    .bind(org_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed screening")
+}
+
+/// Insert a screening_ai_results row for `screening_id` in `org_id`.
+async fn seed_ai_result(pool: &PgPool, org_id: Uuid, screening_id: Uuid, model_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO screening_ai_results (
+            screening_id, organization_id, model_id,
+            ai_risk_score, risk_category, recommendation
+        )
+        VALUES ($1, $2, $3, 72, 'good', 'approve') RETURNING id
+        "#,
+    )
+    .bind(screening_id)
+    .bind(org_id)
+    .bind(model_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed ai result")
+}
+
+// ---------------------------------------------------------------------------
+// T1 — risk models are scoped to the owning org (positive + negative)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn repo_risk_model_is_scoped_to_owning_org(pool: PgPool) {
+    let org_a = seed_org(&pool, "model-a").await;
+    let org_b = seed_org(&pool, "model-b").await;
+    let user_a = seed_user(&pool, "model-a@screening-idor.test").await;
+
+    let repo = EnhancedTenantScreeningRepository::new(pool.clone());
+    let model_a = repo
+        .create_risk_model(org_a, user_a, sample_model("Model A"))
+        .await
+        .expect("create model A");
+
+    // The owning org reads its model.
+    let own = repo
+        .get_risk_model(org_a, model_a.id)
+        .await
+        .expect("get model with right org");
+    assert!(own.is_some(), "org A must read its own risk model by id");
+    assert_eq!(own.unwrap().id, model_a.id);
+
+    // A foreign org gets nothing (closed IDOR).
+    let cross = repo
+        .get_risk_model(org_b, model_a.id)
+        .await
+        .expect("get model with wrong org");
+    assert!(
+        cross.is_none(),
+        "org B must not read org A's risk model by id"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T2 — provider configs are scoped to the owning org (positive + negative)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn repo_provider_config_is_scoped_to_owning_org(pool: PgPool) {
+    let org_a = seed_org(&pool, "prov-a").await;
+    let org_b = seed_org(&pool, "prov-b").await;
+
+    let repo = EnhancedTenantScreeningRepository::new(pool.clone());
+    let config_a = repo
+        .create_provider_config(org_a, sample_provider("Provider A"))
+        .await
+        .expect("create provider A");
+
+    let own = repo
+        .get_provider_config(org_a, config_a.id)
+        .await
+        .expect("get config with right org");
+    assert!(own.is_some(), "org A must read its own provider config");
+    assert_eq!(own.unwrap().id, config_a.id);
+
+    let cross = repo
+        .get_provider_config(org_b, config_a.id)
+        .await
+        .expect("get config with wrong org");
+    assert!(
+        cross.is_none(),
+        "org B must not read org A's provider config by id"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T3 — AI risk results (sensitive PII) are scoped to the owning org
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn repo_ai_result_is_scoped_to_owning_org(pool: PgPool) {
+    let org_a = seed_org(&pool, "ai-a").await;
+    let org_b = seed_org(&pool, "ai-b").await;
+
+    let user_a = seed_user(&pool, "ai-a@screening-idor.test").await;
+    let repo = EnhancedTenantScreeningRepository::new(pool.clone());
+    let model_a = repo
+        .create_risk_model(org_a, user_a, sample_model("AI Model A"))
+        .await
+        .expect("create model A");
+    let screening_a = seed_screening(&pool, org_a, "ai-a").await;
+    let _result_a = seed_ai_result(&pool, org_a, screening_a, model_a.id).await;
+
+    // The owning org reads the AI result for its screening.
+    let own = repo
+        .get_ai_result_by_screening(org_a, screening_a)
+        .await
+        .expect("get ai result with right org");
+    assert!(own.is_some(), "org A must read its own screening AI result");
+    assert_eq!(own.unwrap().screening_id, screening_a);
+
+    // A foreign org gets nothing — the risk score / recommendation never leaks.
+    let cross = repo
+        .get_ai_result_by_screening(org_b, screening_a)
+        .await
+        .expect("get ai result with wrong org");
+    assert!(
+        cross.is_none(),
+        "org B must not read org A's screening AI result"
+    );
+
+    // The complete-data aggregate is likewise closed for the foreign org.
+    let cross_complete = repo
+        .get_complete_screening_data(org_b, screening_a)
+        .await
+        .expect("complete data with wrong org");
+    assert!(
+        cross_complete.ai_result.is_none(),
+        "org B must not get org A's AI result via the complete-data aggregate"
+    );
+
+    // ...and open for the owner.
+    let own_complete = repo
+        .get_complete_screening_data(org_a, screening_a)
+        .await
+        .expect("complete data with right org");
+    assert!(
+        own_complete.ai_result.is_some(),
+        "org A must read its own complete screening data"
+    );
+}


### PR DESCRIPTION
Cross-org IDOR on dispute and enhanced-tenant-screening read/mutate paths. Repo getters filter by organization_id; routes resolve org from the authenticated principal. Tests: dispute_cross_org_idor + enhanced_screening_cross_org_idor (same-org success + cross-org 404).

WIP recovered after a session-limit cutoff; CI is the verification gate.