### PR TITLE
fix(frontend): align api-client contracts + auth hydration race (#751)

### DIFF
--- a/frontend/apps/ppt-web/src/pages/AuthCallbackPage.tsx
+++ b/frontend/apps/ppt-web/src/pages/AuthCallbackPage.tsx
@@ -58,7 +58,7 @@ export function AuthCallbackPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const { loginWithSsoCode, isAuthenticated } = useAuth();
+  const { loginWithSsoCode, isAuthenticated, isLoading } = useAuth();
 
   const [status, setStatus] = useState<CallbackStatus>('pending');
   const [errorMessage, setErrorMessage] = useState<string>('');
@@ -66,10 +66,18 @@ export function AuthCallbackPage() {
   // Guard against double-invocation in React StrictMode.
   const exchangeStarted = useRef(false);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional mount-only run; loginWithSsoCode/navigate are stable; searchParams changes every render
+  // biome-ignore lint/correctness/useExhaustiveDependencies: loginWithSsoCode/navigate are stable; searchParams changes every render; we deliberately re-run when isLoading flips false so the exchange waits for hydration
   useEffect(() => {
-    // If already authenticated (e.g. browser back after successful SSO),
-    // just redirect without re-exchanging.
+    // Wait for AuthProvider to finish hydrating stored session state (#751).
+    // Running before hydration completes risks treating an already-authenticated
+    // user as a fresh callback (isAuthenticated still false) and, after the
+    // one-shot state-nonce check below clears the nonce, surfacing a spurious
+    // "state mismatch" error instead of just redirecting.
+    if (isLoading) return;
+
+    // If already authenticated (e.g. browser back after successful SSO,
+    // or a valid stored session restored during hydration), just redirect
+    // without re-exchanging.
     if (isAuthenticated) {
       const returnUrl = getAndClearReturnUrl();
       navigate(returnUrl || '/dashboard', { replace: true });
@@ -140,7 +148,7 @@ export function AuthCallbackPage() {
     };
 
     exchange();
-  }, []);
+  }, [isLoading, isAuthenticated]);
 
   // ── Pending state ─────────────────────────────────────────────────────────
   if (status === 'pending') {

--- a/frontend/packages/api-client/src/announcements/hooks.test.ts
+++ b/frontend/packages/api-client/src/announcements/hooks.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Contract tests for the announcement list client (#751).
+ *
+ * The backend `ListAnnouncementsQuery` expects `limit` / `offset` /
+ * `target_type` / `from_date` / `to_date` and returns
+ * `{ announcements, count, total }` with snake_case summary fields. The client
+ * exposes the UI-friendly `page` / `pageSize` / `targetType` shape. These tests
+ * pin the request-param translation and the response normalisation so the two
+ * contracts can't silently drift apart again (lists rendering empty).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  type BackendAnnouncementListResponse,
+  buildAnnouncementQuery,
+  toPaginatedResponse,
+} from './hooks';
+
+describe('buildAnnouncementQuery', () => {
+  it('returns an empty string when no params are given', () => {
+    expect(buildAnnouncementQuery()).toBe('');
+  });
+
+  it('translates page/pageSize to backend limit/offset', () => {
+    const sp = new URLSearchParams(buildAnnouncementQuery({ page: 3, pageSize: 20 }).slice(1));
+    expect(sp.get('limit')).toBe('20');
+    // page 3 @ 20 per page → offset 40
+    expect(sp.get('offset')).toBe('40');
+  });
+
+  it('maps camelCase filters to snake_case backend names', () => {
+    const sp = new URLSearchParams(
+      buildAnnouncementQuery({
+        targetType: 'building',
+        authorId: 'author-1',
+        fromDate: '2026-01-01',
+        toDate: '2026-02-01',
+      }).slice(1)
+    );
+    expect(sp.get('target_type')).toBe('building');
+    expect(sp.get('author_id')).toBe('author-1');
+    expect(sp.get('from_date')).toBe('2026-01-01');
+    expect(sp.get('to_date')).toBe('2026-02-01');
+    // The old camelCase keys must NOT be sent.
+    expect(sp.get('targetType')).toBeNull();
+    expect(sp.get('fromDate')).toBeNull();
+  });
+
+  it('does not emit offset when only pageSize is given', () => {
+    const sp = new URLSearchParams(buildAnnouncementQuery({ pageSize: 10 }).slice(1));
+    expect(sp.get('limit')).toBe('10');
+    expect(sp.get('offset')).toBeNull();
+  });
+});
+
+describe('toPaginatedResponse', () => {
+  const raw: BackendAnnouncementListResponse = {
+    announcements: [
+      {
+        id: 'a1',
+        title: 'Hello',
+        status: 'published',
+        target_type: 'all',
+        published_at: '2026-01-01T00:00:00Z',
+        pinned: true,
+        comments_enabled: false,
+        acknowledgment_required: true,
+      },
+    ],
+    count: 1,
+    total: 42,
+  };
+
+  it('maps snake_case summary fields to the camelCase UI shape', () => {
+    const result = toPaginatedResponse(raw, { page: 2, pageSize: 10 });
+    expect(result.items[0]).toEqual({
+      id: 'a1',
+      title: 'Hello',
+      status: 'published',
+      targetType: 'all',
+      publishedAt: '2026-01-01T00:00:00Z',
+      pinned: true,
+      commentsEnabled: false,
+      acknowledgmentRequired: true,
+    });
+  });
+
+  it('derives total / page / pageSize / totalPages', () => {
+    const result = toPaginatedResponse(raw, { page: 2, pageSize: 10 });
+    expect(result.total).toBe(42);
+    expect(result.page).toBe(2);
+    expect(result.pageSize).toBe(10);
+    expect(result.totalPages).toBe(5); // ceil(42 / 10)
+  });
+
+  it('tolerates a missing announcements array', () => {
+    const result = toPaginatedResponse({ count: 0, total: 0 } as BackendAnnouncementListResponse);
+    expect(result.items).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+});

--- a/frontend/packages/api-client/src/announcements/hooks.ts
+++ b/frontend/packages/api-client/src/announcements/hooks.ts
@@ -32,19 +32,96 @@ const ANNOUNCEMENTS_BASE = '/api/v1/announcements';
 
 const fetchJson = authenticatedFetchJson;
 
-function buildAnnouncementQuery(params?: ListAnnouncementsParams): string {
+/**
+ * Default page size used when a caller passes `page` but no explicit
+ * `pageSize`, so `page`→`offset` translation has a stable basis.
+ */
+const DEFAULT_PAGE_SIZE = 10;
+
+/**
+ * Build the announcement list query string against the *backend* contract.
+ *
+ * The backend (`ListAnnouncementsQuery`) expects `limit` / `offset` /
+ * `target_type` / `from_date` / `to_date` (snake_case, limit/offset paging),
+ * not the UI-friendly `page` / `pageSize` / `targetType` / `fromDate` /
+ * `toDate` we expose on `ListAnnouncementsParams`. Previously these were sent
+ * verbatim, so the server ignored every filter and paging param (#751).
+ */
+export function buildAnnouncementQuery(params?: ListAnnouncementsParams): string {
   if (!params) return '';
   const sp = new URLSearchParams();
-  if (params.page) sp.set('page', params.page.toString());
-  if (params.pageSize) sp.set('pageSize', params.pageSize.toString());
+  const pageSize = params.pageSize ?? (params.page ? DEFAULT_PAGE_SIZE : undefined);
+  if (pageSize !== undefined) sp.set('limit', pageSize.toString());
+  if (params.page && pageSize !== undefined) {
+    // 1-based page → 0-based offset
+    const offset = (Math.max(1, params.page) - 1) * pageSize;
+    sp.set('offset', offset.toString());
+  }
   if (params.status) sp.set('status', params.status);
-  if (params.targetType) sp.set('targetType', params.targetType);
-  if (params.authorId) sp.set('authorId', params.authorId);
+  if (params.targetType) sp.set('target_type', params.targetType);
+  if (params.authorId) sp.set('author_id', params.authorId);
   if (params.pinned !== undefined) sp.set('pinned', params.pinned.toString());
-  if (params.fromDate) sp.set('fromDate', params.fromDate);
-  if (params.toDate) sp.set('toDate', params.toDate);
+  if (params.fromDate) sp.set('from_date', params.fromDate);
+  if (params.toDate) sp.set('to_date', params.toDate);
   const q = sp.toString();
   return q ? `?${q}` : '';
+}
+
+/**
+ * Raw backend list response shape (`AnnouncementListResponse`): announcements
+ * are serialized snake_case (no `serde(rename_all = "camelCase")` on
+ * `AnnouncementSummary`) and pagination is `{ count, total }` — not the
+ * `{ items, page, pageSize, totalPages }` the UI consumes. We normalize here
+ * so callers keep getting `PaginatedResponse<AnnouncementSummary>` (#751).
+ */
+interface BackendAnnouncementSummary {
+  id: string;
+  title: string;
+  status: AnnouncementSummary['status'];
+  target_type: AnnouncementSummary['targetType'];
+  published_at?: string | null;
+  pinned: boolean;
+  comments_enabled: boolean;
+  acknowledgment_required: boolean;
+}
+
+export interface BackendAnnouncementListResponse {
+  announcements: BackendAnnouncementSummary[];
+  count: number;
+  total: number;
+}
+
+function mapSummary(s: BackendAnnouncementSummary): AnnouncementSummary {
+  return {
+    id: s.id,
+    title: s.title,
+    status: s.status,
+    targetType: s.target_type,
+    publishedAt: s.published_at ?? undefined,
+    pinned: s.pinned,
+    commentsEnabled: s.comments_enabled,
+    acknowledgmentRequired: s.acknowledgment_required,
+  };
+}
+
+/**
+ * Normalize a raw backend list response into the UI's `PaginatedResponse`.
+ * `page` / `pageSize` echo the request params (the backend reports neither);
+ * `totalPages` is derived from `total` and the effective page size.
+ */
+export function toPaginatedResponse(
+  raw: BackendAnnouncementListResponse,
+  params?: ListAnnouncementsParams
+): PaginatedResponse<AnnouncementSummary> {
+  const pageSize = params?.pageSize ?? DEFAULT_PAGE_SIZE;
+  const page = params?.page ?? 1;
+  return {
+    items: (raw.announcements ?? []).map(mapSummary),
+    total: raw.total ?? 0,
+    page,
+    pageSize,
+    totalPages: pageSize > 0 ? Math.ceil((raw.total ?? 0) / pageSize) : 0,
+  };
 }
 
 // Query keys factory for cache management
@@ -348,10 +425,12 @@ export type AnnouncementHooks = ReturnType<typeof createAnnouncementHooks>;
 export function useAnnouncements(params?: ListAnnouncementsParams) {
   return useQuery<PaginatedResponse<AnnouncementSummary>>({
     queryKey: announcementKeys.list(params),
-    queryFn: () =>
-      fetchJson<PaginatedResponse<AnnouncementSummary>>(
+    queryFn: async () => {
+      const raw = await fetchJson<BackendAnnouncementListResponse>(
         `${ANNOUNCEMENTS_BASE}${buildAnnouncementQuery(params)}`
-      ),
+      );
+      return toPaginatedResponse(raw, params);
+    },
   });
 }
 
@@ -366,10 +445,12 @@ export function usePinnedAnnouncements() {
   const params: ListAnnouncementsParams = { pinned: true, status: 'published', pageSize: 20 };
   return useQuery<PaginatedResponse<AnnouncementSummary>>({
     queryKey: announcementKeys.list(params),
-    queryFn: () =>
-      fetchJson<PaginatedResponse<AnnouncementSummary>>(
+    queryFn: async () => {
+      const raw = await fetchJson<BackendAnnouncementListResponse>(
         `${ANNOUNCEMENTS_BASE}${buildAnnouncementQuery(params)}`
-      ),
+      );
+      return toPaginatedResponse(raw, params);
+    },
     staleTime: 5 * 60 * 1000,
   });
 }

--- a/frontend/packages/api-client/src/documents/api.test.ts
+++ b/frontend/packages/api-client/src/documents/api.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Regression tests for the document API client (#751).
+ *
+ * Two findings are pinned here:
+ *  - the document transport now routes through the shared authenticated
+ *    `fetch` wrapper, so every request carries `Authorization: Bearer …`
+ *    (previously it only set `Content-Type` and 401'd for protected routes);
+ *  - `deleteFolder` / `revokeDocumentShare` hit endpoints that return
+ *    `204 No Content` — they must resolve (to `undefined`) instead of
+ *    rejecting while trying to parse an empty body.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearTokenProvider, setTokenProvider } from '../auth/token-provider';
+import { deleteFolder, listDocuments, revokeDocumentShare } from './api';
+
+function mockOkResponse(body: unknown, status = 200): Response {
+  return {
+    ok: true,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+function mock204Response(): Response {
+  return {
+    ok: true,
+    status: 204,
+    json: async () => {
+      throw new Error('no body');
+    },
+  } as unknown as Response;
+}
+
+describe('documents api client', () => {
+  beforeEach(() => {
+    setTokenProvider(() => 'doc-token');
+    vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    clearTokenProvider();
+    vi.restoreAllMocks();
+  });
+
+  it('attaches the bearer token from the registered provider', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(mockOkResponse({ documents: [], total: 0 }));
+    await listDocuments();
+    const headers = (vi.mocked(fetch).mock.calls[0][1] as RequestInit).headers as Record<
+      string,
+      string
+    >;
+    expect(headers.Authorization).toBe('Bearer doc-token');
+  });
+
+  it('resolves to undefined on a 204 delete-folder response', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(mock204Response());
+    await expect(deleteFolder('folder-1', true)).resolves.toBeUndefined();
+  });
+
+  it('resolves to undefined on a 204 revoke-share response', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(mock204Response());
+    await expect(revokeDocumentShare('doc-1', 'share-1')).resolves.toBeUndefined();
+  });
+});

--- a/frontend/packages/api-client/src/documents/api.ts
+++ b/frontend/packages/api-client/src/documents/api.ts
@@ -2,6 +2,8 @@
  * Document API client (Epic 39).
  */
 
+import { getToken } from '../auth';
+import { authenticatedFetchJson } from '../lib/fetch';
 import type {
   ClassificationFeedback,
   ClassificationHistoryEntry,
@@ -26,21 +28,19 @@ import type {
 
 const API_BASE = '/api/v1/documents';
 
+/**
+ * All document requests go through the shared authenticated transport
+ * (`authenticatedFetchJson`) so they:
+ *   - carry the `Authorization: Bearer …` header from the registered token
+ *     provider — document routes are auth-protected and previously 401'd
+ *     because this local transport never set the header (#751),
+ *   - handle `204 No Content` uniformly (e.g. `deleteFolder`,
+ *     `revokeDocumentShare`) without trying to `JSON.parse` an empty body,
+ *   - share the same 401/MFA-retry and error-normalisation behaviour as the
+ *     rest of the client.
+ */
 async function fetchApi<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const response = await fetch(url, {
-    ...options,
-    headers: {
-      'Content-Type': 'application/json',
-      ...options.headers,
-    },
-  });
-
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({ message: 'Request failed' }));
-    throw new Error(error.message || `HTTP ${response.status}`);
-  }
-
-  return response.json();
+  return authenticatedFetchJson<T>(url, options);
 }
 
 // Document CRUD
@@ -139,8 +139,11 @@ export async function updateFolder(
   });
 }
 
-export async function deleteFolder(id: string, cascade = false): Promise<{ message: string }> {
-  return fetchApi(`${API_BASE}/folders/${id}?cascade=${cascade}`, {
+// Backend `delete_folder` returns 204 No Content — the shared transport
+// resolves to `undefined`, so the return type is `void` (was `{ message }`,
+// which would have rejected on the empty 204 body, #751).
+export async function deleteFolder(id: string, cascade = false): Promise<void> {
+  await fetchApi(`${API_BASE}/folders/${id}?cascade=${cascade}`, {
     method: 'DELETE',
   });
 }
@@ -284,17 +287,13 @@ export async function uploadDocument(
 
     xhr.open('POST', `${API_BASE}/upload`);
 
-    // Attach Authorization header if an access token is available
-    try {
-      const token =
-        typeof window !== 'undefined' && window.localStorage
-          ? window.localStorage.getItem('token')
-          : null;
-      if (token) {
-        xhr.setRequestHeader('Authorization', `Bearer ${token}`);
-      }
-    } catch {
-      // If accessing storage fails, proceed without auth header
+    // Attach the bearer token from the registered token provider — the same
+    // source the rest of the client uses. (Previously read the wrong
+    // localStorage key `'token'` directly, so uploads went out unauthenticated
+    // and 401'd, #751.)
+    const token = getToken();
+    if (token) {
+      xhr.setRequestHeader('Authorization', `Bearer ${token}`);
     }
 
     xhr.send(formData);


### PR DESCRIPTION
Triage of umbrella review **#751 — Current dev review: frontend/web/API-client findings**. Each finding was spot-checked against current `dev` before acting.

## Fixed (frontend-contained)

### High — Document client transport omits bearer auth
`frontend/packages/api-client/src/documents/api.ts`
- Local `fetchApi` now delegates to the shared `authenticatedFetchJson` (`../lib/fetch`), so every document request (browse, folders, move, preview/download, share) carries `Authorization: Bearer …` from the registered token provider. Previously it set only `Content-Type`, so protected routes 401'd.
- `uploadDocument` (XHR path) now reads the token via `getToken()` instead of the wrong localStorage key `'token'` (the real key is `ppt_access_token`), so uploads are authenticated too.

### Medium — delete/revoke clients parsed JSON from 204 responses
`frontend/packages/api-client/src/documents/api.ts`
- The shared transport already returns `undefined` on `204 No Content`, fixing the false-failure UX for `deleteFolder` / `revokeDocumentShare`. `deleteFolder` return type corrected to `Promise<void>` (was `Promise<{ message }>`, which would reject on the empty body).

### High — Announcement list client did not match backend query/response
`frontend/packages/api-client/src/announcements/hooks.ts`
- `buildAnnouncementQuery` now emits the backend contract: `page`/`pageSize` → `limit`/`offset`, and `targetType`/`authorId`/`fromDate`/`toDate` → `target_type`/`author_id`/`from_date`/`to_date`.
- Responses (`{ announcements, count, total }`, snake_case summary fields — backend `AnnouncementSummary` has no `rename_all = "camelCase"`) are normalised via `toPaginatedResponse` into the `PaginatedResponse<AnnouncementSummary>` the UI consumes (`data.items` / `data.total` in `App.tsx`), mapping summary fields to camelCase. Fixes empty-rendering announcement pages.

### Medium — OAuth callback raced auth hydration
`frontend/apps/ppt-web/src/pages/AuthCallbackPage.tsx`
- The mount effect now waits for `AuthProvider` hydration (`isLoading`) before processing the callback and re-runs when hydration completes. An already-authenticated stored session now redirects cleanly instead of hitting the one-shot state-nonce check and surfacing a spurious "state mismatch".

### Tests
- `frontend/packages/api-client/src/documents/api.test.ts` — asserts the bearer header is attached and 204 endpoints resolve to `undefined`.
- `frontend/packages/api-client/src/announcements/hooks.test.ts` — pins the query-param translation and response normalisation (contract test against a sample backend response shape).

## Out of scope / not fixed

### High — SSO callback posts to an endpoint that does not exist
The client targets `POST /api/v1/auth/sso/callback`, but the api-server auth router exposes no such route (verified: `backend/servers/api-server/src/routes/auth.rs` has `/login`, `/refresh`, `/logout`, `/me`, … but no `/sso/callback`; `oauth.rs` is the *provider* side for reality-server SSO, the other direction). This is a **backend gap** requiring a Rust route + integration coverage — out of scope for this frontend-only PR. Recommend a separate backend task.

### Note — unused class-based announcements API has the same mismatch
`frontend/packages/api-client/src/announcements/api.ts` (`createAnnouncementHooks` / `AnnouncementsApi`) has the same param/response mismatch, but it is not consumed by any app (the live path is the standalone hooks fixed here). Left untouched to keep this change cohesive; can be aligned or removed as dead code separately.

## Verification
- `pnpm biome check` (changed + new files): clean
- `pnpm -r typecheck` (pre-commit hook, full workspace): clean
- `pnpm --filter @ppt/api-client test`: 32 passed (10 new)
- `pnpm --filter @ppt/web test`: 453 passed

#751 can be partially closed once merged (4 of 5 findings resolved; the SSO-route High remains as a backend follow-up).