### PR TITLE
fix(mobile): address dev-review findings (#767)

### DIFF
--- a/frontend/apps/mobile/src/App.tsx
+++ b/frontend/apps/mobile/src/App.tsx
@@ -1,12 +1,12 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Constants from 'expo-constants';
 import { StatusBar } from 'expo-status-bar';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { OfflineBanner, SyncProgressToast, SyncStatusBadge } from './components/sync';
 import { AuthProvider, useAuth } from './contexts';
-import { useOfflineSupport } from './hooks';
+import { useOfflineSupport, usePushNotifications } from './hooks';
 import { colors } from './screens/shared/screenStyles';
 import './i18n'; // Initialize i18n
 import {
@@ -90,7 +90,21 @@ function MainApp() {
   const { isAuthenticated, isLoading } = useAuth();
   const { isConnected, queuedActionsCount, isSyncing, syncProgress, processQueue } =
     useOfflineSupport();
+  const { registerForPushNotifications } = usePushNotifications();
   const [showSyncToast, setShowSyncToast] = useState(false);
+
+  // Register this device's push token with the backend once authenticated.
+  // Without this the registration hook was never invoked, so no device ever
+  // received pushes. Errors are surfaced inside the hook and ignored here —
+  // a missing push token must not block the app. Keyed on `isAuthenticated`
+  // only: `registerForPushNotifications` is re-created each render, so adding
+  // it to the deps would re-register on every render.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: register once per auth transition; the callback is intentionally excluded
+  useEffect(() => {
+    if (isAuthenticated) {
+      void registerForPushNotifications();
+    }
+  }, [isAuthenticated]);
 
   // Show sync toast when sync progress starts
   const handleRetrySync = useCallback(() => {

--- a/frontend/apps/mobile/src/hooks/usePushNotifications.ts
+++ b/frontend/apps/mobile/src/hooks/usePushNotifications.ts
@@ -231,9 +231,12 @@ export function usePushNotifications(): UsePushNotificationsReturn {
       deviceName: Device.deviceName ?? undefined,
     };
 
+    // `apiRequest` serialises the body itself — pass the object, not a string,
+    // otherwise the payload is JSON-encoded twice and the server sees a quoted
+    // string instead of an object.
     await apiRequest<PushTokenResponse>('/api/v1/users/me/push-tokens', {
       method: 'POST',
-      body: JSON.stringify(body),
+      body,
     });
   };
 

--- a/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.tsx
@@ -23,7 +23,6 @@ export interface AnnouncementAttachment {
 export interface Announcement {
   id: string;
   title: string;
-  content: string;
   category: AnnouncementCategory;
   createdAt: string;
   author: string;
@@ -33,32 +32,38 @@ export interface Announcement {
   commentsCount: number;
 }
 
-/** API shape returned by `GET /api/v1/announcements`. */
-interface ApiAnnouncement {
+/**
+ * API shape of an item in `GET /api/v1/announcements/published`.
+ *
+ * The published-list endpoint returns `AnnouncementSummary` rows, which are
+ * intentionally lightweight: no `content` body, no author, no category. The
+ * full body is fetched lazily by `AnnouncementDetailScreen`.
+ */
+interface ApiAnnouncementSummary {
   id: string;
   title: string;
-  content: string;
   status: string;
-  pinned: boolean;
+  target_type: string;
   published_at?: string | null;
-  created_at: string;
-  updated_at: string;
+  pinned: boolean;
+  comments_enabled: boolean;
+  acknowledgment_required: boolean;
 }
 
+/** Response shape of `GET /api/v1/announcements/published`. */
 interface ApiAnnouncementListResponse {
-  announcements?: ApiAnnouncement[];
-  items?: ApiAnnouncement[];
+  announcements?: ApiAnnouncementSummary[];
+  count?: number;
   total?: number;
 }
 
-/** Coerce the api-server response into the UI's Announcement shape. */
-function toUiAnnouncement(a: ApiAnnouncement): Announcement {
+/** Coerce a published-list summary into the UI's Announcement shape. */
+function toUiAnnouncement(a: ApiAnnouncementSummary): Announcement {
   return {
     id: a.id,
     title: a.title,
-    content: a.content,
     category: 'general',
-    createdAt: a.published_at ?? a.created_at,
+    createdAt: a.published_at ?? new Date().toISOString(),
     author: 'Building Management',
     isRead: false,
     isPinned: a.pinned,
@@ -67,10 +72,10 @@ function toUiAnnouncement(a: ApiAnnouncement): Announcement {
   };
 }
 
-/** Normalise both paginated (`items`) and legacy (`announcements`) list shapes. */
-function extractItems(data: ApiAnnouncementListResponse | undefined): ApiAnnouncement[] {
+/** Extract the summary list from the published-list response. */
+function extractItems(data: ApiAnnouncementListResponse | undefined): ApiAnnouncementSummary[] {
   if (!data) return [];
-  return data.items ?? data.announcements ?? [];
+  return data.announcements ?? [];
 }
 
 interface AnnouncementsScreenProps {
@@ -82,20 +87,19 @@ export function AnnouncementsScreen({ onNavigate }: AnnouncementsScreenProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [readIds, setReadIds] = useState<Set<string>>(new Set());
 
-  // Main list (all published)
+  // Resident-facing published list. The manager-only `/api/v1/announcements`
+  // endpoint 403s for residents — the published endpoint is RLS-scoped and
+  // readable by any authenticated tenant member.
   const { data, isLoading, error, refetch, isFetching } = useApiQuery<ApiAnnouncementListResponse>(
     ['announcements', 'list'],
-    '/api/v1/announcements?status=published',
+    '/api/v1/announcements/published',
     { staleTime: 60_000 }
   );
 
-  // Story 6.4 — pinned published announcements for the sticky band.
-  // This query is separate so the band is immune to category/search filters.
-  const { data: pinnedData } = useApiQuery<ApiAnnouncementListResponse>(
-    ['announcements', 'pinned'],
-    '/api/v1/announcements?status=published&pinned=true&pageSize=20',
-    { staleTime: 5 * 60_000 }
-  );
+  // Story 6.4 — pinned items are derived client-side from the published list
+  // (the published endpoint already orders `pinned DESC`). A dedicated query
+  // is unnecessary and the endpoint does not accept a `pinned` filter.
+  const pinnedData = data;
 
   const allRaw: Announcement[] = extractItems(data)
     .map(toUiAnnouncement)
@@ -103,7 +107,8 @@ export function AnnouncementsScreen({ onNavigate }: AnnouncementsScreenProps) {
 
   const pinnedItems: Announcement[] = extractItems(pinnedData)
     .map(toUiAnnouncement)
-    .map((a) => ({ ...a, isRead: readIds.has(a.id) ? true : a.isRead }));
+    .map((a) => ({ ...a, isRead: readIds.has(a.id) ? true : a.isRead }))
+    .filter((a) => a.isPinned);
 
   const onRefresh = useCallback(async () => {
     await refetch();
@@ -169,12 +174,7 @@ export function AnnouncementsScreen({ onNavigate }: AnnouncementsScreenProps) {
   const filteredAnnouncements = allRaw
     .filter((a) => !a.isPinned)
     .filter((a) => (filter === 'all' ? true : a.category === filter))
-    .filter(
-      (a) =>
-        searchQuery === '' ||
-        a.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        a.content.toLowerCase().includes(searchQuery.toLowerCase())
-    )
+    .filter((a) => searchQuery === '' || a.title.toLowerCase().includes(searchQuery.toLowerCase()))
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 
   const unreadCount = allRaw.filter((a) => !a.isRead).length;
@@ -294,9 +294,6 @@ export function AnnouncementsScreen({ onNavigate }: AnnouncementsScreenProps) {
               </View>
 
               <Text style={styles.announcementTitle}>{announcement.title}</Text>
-              <Text style={styles.announcementPreview} numberOfLines={2}>
-                {announcement.content}
-              </Text>
 
               <View style={styles.announcementFooter}>
                 <Text style={styles.authorText}>By {announcement.author}</Text>

--- a/frontend/apps/mobile/src/screens/documents/DocumentsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentsScreen.tsx
@@ -50,32 +50,38 @@ const AUDIENCE_OPTIONS: ReadonlyArray<{
   { value: 'public', label: 'Public', color: '#047857', bg: '#d1fae5', icon: '🌍' },
 ] as const;
 
-/** Subset of `Document` returned by `GET /api/v1/documents`. */
+/**
+ * Item shape of `GET /api/v1/documents` (`DocumentSummary` on the server).
+ *
+ * Fields mirror the backend exactly: `title` (not `name`), `file_name`
+ * (not `file_path`), `mime_type` (not `content_type`), and `created_at`
+ * (the summary has no separate upload timestamp). The summary carries no
+ * `access_scope` or `status` — those live on the document detail/permissions
+ * endpoints, not the list.
+ */
 interface ApiDocument {
   id: string;
-  name: string;
-  file_path?: string | null;
-  size_bytes?: number | null;
-  content_type?: string | null;
-  uploaded_at?: string | null;
+  title: string;
+  category: string;
+  file_name: string;
+  mime_type: string;
+  size_bytes: number;
+  folder_id?: string | null;
   created_at: string;
-  /** RLS-enforced audience scope (gap-7a-3). */
-  access_scope?: AccessScope;
-  /** Publication status: absent means published (backward compat). */
-  status?: DocumentStatus;
 }
 
 interface ApiDocumentListResponse {
   documents: ApiDocument[];
+  count?: number;
   total?: number;
 }
 
 function pickDocumentType(d: ApiDocument): DocumentType {
-  const ct = (d.content_type ?? '').toLowerCase();
-  const name = d.name.toLowerCase();
-  if (ct.includes('pdf') || name.endsWith('.pdf')) return 'pdf';
-  if (ct.startsWith('image/') || /\.(png|jpe?g|gif|webp)$/.test(name)) return 'image';
-  if (ct.includes('spreadsheet') || ct.includes('excel') || /\.(xlsx?|csv)$/.test(name))
+  const mime = (d.mime_type ?? '').toLowerCase();
+  const fileName = (d.file_name ?? d.title).toLowerCase();
+  if (mime.includes('pdf') || fileName.endsWith('.pdf')) return 'pdf';
+  if (mime.startsWith('image/') || /\.(png|jpe?g|gif|webp)$/.test(fileName)) return 'image';
+  if (mime.includes('spreadsheet') || mime.includes('excel') || /\.(xlsx?|csv)$/.test(fileName))
     return 'spreadsheet';
   return 'document';
 }
@@ -83,16 +89,14 @@ function pickDocumentType(d: ApiDocument): DocumentType {
 function toUiDocument(d: ApiDocument): Document {
   return {
     id: d.id,
-    name: d.name,
+    name: d.title,
     type: pickDocumentType(d),
     size: d.size_bytes ?? undefined,
     createdAt: d.created_at,
-    updatedAt: d.uploaded_at ?? d.created_at,
-    parentId: null,
-    downloadUrl: d.file_path ?? undefined,
+    updatedAt: d.created_at,
+    parentId: d.folder_id ?? null,
+    downloadUrl: undefined,
     children: undefined,
-    accessScope: d.access_scope,
-    status: d.status,
   };
 }
 

--- a/frontend/apps/mobile/src/screens/neighbors/NeighborsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/neighbors/NeighborsScreen.tsx
@@ -45,11 +45,12 @@ interface NeighborsResponse {
 
 interface BuildingItem {
   id: string;
-  name: string;
+  name?: string | null;
 }
 
+/** Response shape of `GET /api/v1/buildings` (`BuildingsListResponse`). */
 interface BuildingsPaginatedResponse {
-  items: BuildingItem[];
+  buildings: BuildingItem[];
   total: number;
 }
 
@@ -61,7 +62,7 @@ interface NeighborsScreenProps {
   onNavigate?: (screen: string, params?: Record<string, unknown>) => void;
 }
 
-export function NeighborsScreen({ onNavigate }: NeighborsScreenProps) {
+export function NeighborsScreen(_props: NeighborsScreenProps) {
   const [search, setSearch] = useState('');
   const [refreshKey, setRefreshKey] = useState(0);
 
@@ -71,8 +72,8 @@ export function NeighborsScreen({ onNavigate }: NeighborsScreenProps) {
     '/api/v1/buildings'
   );
 
-  const buildingId = buildingsQuery.data?.items?.[0]?.id;
-  const buildingName = buildingsQuery.data?.items?.[0]?.name;
+  const buildingId = buildingsQuery.data?.buildings?.[0]?.id;
+  const buildingName = buildingsQuery.data?.buildings?.[0]?.name ?? undefined;
 
   // Fetch neighbors once we have a building id
   const neighborsQuery = useApiQuery<NeighborsResponse>(
@@ -174,12 +175,11 @@ export function NeighborsScreen({ onNavigate }: NeighborsScreenProps) {
             </Text>
           </View>
         ) : (
+          // The list row shows the full neighbour record (name, unit, phone,
+          // email). There is no NeighborDetail screen, so the row is a static
+          // card rather than a dead navigation target.
           filtered.map((neighbor) => (
-            <Pressable
-              key={neighbor.user_id}
-              style={[s.card, styles.row]}
-              onPress={() => onNavigate?.('NeighborDetail', { neighborId: neighbor.user_id })}
-            >
+            <View key={neighbor.user_id} style={[s.card, styles.row]}>
               <View style={styles.avatar}>
                 <Text style={styles.avatarText}>{initials(neighbor.display_name)}</Text>
               </View>
@@ -192,13 +192,9 @@ export function NeighborsScreen({ onNavigate }: NeighborsScreenProps) {
                 {neighbor.phone && <Text style={styles.contact}>📞 {neighbor.phone}</Text>}
                 {neighbor.email && <Text style={styles.contact}>✉️ {neighbor.email}</Text>}
               </View>
-            </Pressable>
+            </View>
           ))
         )}
-
-        <Pressable style={s.primaryButton} onPress={() => onNavigate?.('InviteNeighbor')}>
-          <Text style={s.primaryButtonText}>Invite a neighbour</Text>
-        </Pressable>
 
         <View style={s.bottomSpacer} />
       </ScrollView>


### PR DESCRIPTION
## Summary

Triages umbrella issue #767 (Mobile RN Property Management app dev review) and fixes the contained, verified findings. Each finding below was spot-checked against the **current** backend contract before acting — several review notes were already addressed on `dev`.

## Findings fixed

### Critical #1 — Announcements used manager-only endpoint (403 for residents)
`AnnouncementsScreen` called `GET /api/v1/announcements?status=published`, which routes to `list_announcements` — gated behind `is_manager()` (`announcements.rs:472`), so residents got 403. Switched to `GET /api/v1/announcements/published` (the RLS-scoped, any-authenticated-user endpoint).

### High #3 — List expected `content`, backend summary has none
The published endpoint returns `AnnouncementSummary` (`id, title, status, target_type, published_at, pinned, comments_enabled, acknowledgment_required`) — no `content`, `category`, or `author`. Updated the API type, dropped the card content-preview and content-based search (title search retained), and derive the pinned band from the same list (`pinned DESC` is already the server order). The full body is still fetched lazily by `AnnouncementDetailScreen`.

### High #4 — Documents field mapping wrong
`DocumentsScreen` mapped `name`/`file_path`/`content_type`/`uploaded_at`, but the backend `DocumentSummary` returns `title`/`file_name`/`mime_type`/`created_at`/`folder_id`. Corrected the mapping so names, type icons, and sizes render correctly.

### High #5 — Neighbors used `buildings.items`; dead `NeighborDetail` route
- `GET /api/v1/buildings` returns `{ buildings, total, offset, limit }`, not `{ items }` — so no building id was ever resolved. Now reads `data.buildings[0]`.
- Tapping a neighbour navigated to `NeighborDetail`, which has no screen and no `case` in `App.tsx` (fell through to Dashboard). The `InviteNeighbor` button was equally dead. Removed both; the row already shows the full neighbour record (name, unit, phone, email).

### Critical #2 — Push tokens: double JSON encode + never wired in App
- `sendTokenToBackend` passed `body: JSON.stringify(body)` while the shared `apiRequest` already serialises the body → payload encoded twice. Now passes the object directly.
- `usePushNotifications` was exported but never consumed, so registration never fired. Wired it into the authenticated `MainApp` (registers once per auth transition; errors handled inside the hook).

## Already-fixed / out-of-scope (no change)

- **Critical #2 (route missing):** the `/api/v1/users/me/push-tokens` route now exists and is registered (PR #836). Only the double-encode + wiring remained.
- **Findings #1/#3 partial staleness:** the screen had already moved off the legacy `items` shape and added a `content` field client-side; the real gap (wrong endpoint + summary has no `content`) is what's fixed here.
- **Medium #6 (EAS secrets CI check), #7 (Expo SDK 55/56 skew), Low #8 (config/api.ts drift):** build/config concerns, not contained code bugs. #7 is corroborated by the test runner failing on a `react-test-renderer` 19.2.0-vs-19.2.6 peer mismatch (see Verification).

## Verification (frontend toolchain, no cargo)

- `pnpm install --frozen-lockfile` — OK
- `pnpm --filter mobile exec biome check src` — no errors (6 pre-existing warnings, all in `useOfflineSupport.ts` / `DocumentsScreen` `setDownloading`, untouched)
- `pnpm --filter mobile typecheck` — **0 errors**
- `pnpm --filter mobile test` — **environmentally broken**: all 3 suites fail to *start* on `@testing-library/react-native`'s peer-dep guard (`Incorrect version of "react-test-renderer" ... Expected "19.2.0", but found "19.2.6"`). No test imports the changed files; this is the SDK package skew from finding #7, not a regression.

Closes the contained portion of #767.