### PR TITLE
fix(reality-server): address dev-review findings (closes #774, closes #896)

### DIFF
--- a/backend/servers/reality-server/src/routes/realtors.rs
+++ b/backend/servers/reality-server/src/routes/realtors.rs
@@ -214,23 +214,32 @@ pub async fn list_inquiries(
     principal: RequestPrincipal,
     Query(query): Query<InquiriesQuery>,
 ) -> Result<Json<InquiriesResponse>, (axum::http::StatusCode, String)> {
-    let inquiries = state
-        .reality_portal_repo
-        .get_realtor_inquiries(
+    let limit = query.limit.unwrap_or(20).clamp(1, 100);
+    let offset = query.offset.unwrap_or(0).max(0);
+
+    // Run the page query and the matching COUNT in parallel — the count must
+    // use the same status filter as the page so clients can compute
+    // `total / limit` for pagination. Returning `inquiries.len()` here (the
+    // previous behaviour, #774 item 3) silently lied on every non-final page:
+    // it reported the page size, not the real total.
+    let status_filter = query.status.clone();
+    let (inquiries, total) = tokio::try_join!(
+        state.reality_portal_repo.get_realtor_inquiries(
             principal.user_id,
             query.status,
-            query.limit.unwrap_or(20),
-            query.offset.unwrap_or(0),
+            limit,
+            offset,
+        ),
+        state
+            .reality_portal_repo
+            .count_realtor_inquiries(principal.user_id, status_filter),
+    )
+    .map_err(|e| {
+        (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to list inquiries: {}", e),
         )
-        .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to list inquiries: {}", e),
-            )
-        })?;
-
-    let total = inquiries.len() as i64;
+    })?;
 
     Ok(Json(InquiriesResponse { inquiries, total }))
 }

--- a/backend/servers/reality-server/tests/inquiry_pagination_tests.rs
+++ b/backend/servers/reality-server/tests/inquiry_pagination_tests.rs
@@ -1,0 +1,184 @@
+//! Pagination regression tests for the realtor inquiries list (#774 item 3).
+//!
+//! # Background
+//!
+//! `GET /api/v1/realtors/inquiries` (and the mirror `GET /api/v1/inquiries`)
+//! returned `total = inquiries.len()` — i.e. the size of the *current page*,
+//! not the real total. On every non-final page the client saw a `total` equal
+//! to `limit`, so `total / limit` pagination silently broke.
+//!
+//! The fix wires the route to [`RealityPortalRepository::count_realtor_inquiries`],
+//! which counts with the same status filter as
+//! [`RealityPortalRepository::get_realtor_inquiries`]. These tests exercise the
+//! repository contract the route now depends on:
+//!
+//! | Case | Setup | Expected |
+//! |------|-------|----------|
+//! | C1 | 5 inquiries, page of 2 | page len 2, **count 5** |
+//! | C2 | status filter | count matches the filtered subset, not the page |
+//!
+//! Uses `#[sqlx::test(migrator = "db::MIGRATOR")]` — the same harness as the
+//! IDOR suite in this directory.
+
+use db::models::CreateListingInquiry;
+use db::repositories::RealityPortalRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Insert a minimal `organizations` row (required by `listings` FK).
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Pag Org {slug}"))
+    .bind(format!("pag-org-{slug}"))
+    .bind(format!("{slug}@pag.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed_org failed")
+}
+
+/// Insert a minimal public-principal `users` row (a Reality Portal realtor).
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users
+            (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'Pag Test User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed_user failed")
+}
+
+/// Insert a minimal active `listings` row owned by `created_by`.
+async fn seed_listing(pool: &PgPool, org_id: Uuid, created_by: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO listings
+            (organization_id, created_by, status, transaction_type,
+             title, property_type, price, currency,
+             street, city, postal_code, country)
+        VALUES ($1, $2, 'active', 'sale',
+                'Pag Test Listing', 'apartment', 100000.00, 'EUR',
+                'Test Street 1', 'Bratislava', '81101', 'SK')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(created_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed_listing failed")
+}
+
+/// Create N inquiries addressed to `realtor_id` via the repository (the same
+/// path production uses), each with the given inquiry_type/status default.
+async fn seed_inquiries(
+    repo: &RealityPortalRepository,
+    listing_id: Uuid,
+    realtor_id: Uuid,
+    n: usize,
+) {
+    for i in 0..n {
+        repo.create_inquiry(
+            listing_id,
+            realtor_id,
+            None,
+            CreateListingInquiry {
+                name: format!("Buyer {i}"),
+                email: format!("buyer{i}@pag.test"),
+                phone: None,
+                message: "Is this still available?".to_string(),
+                inquiry_type: Some("info".to_string()),
+                preferred_contact: Some("email".to_string()),
+                preferred_time: None,
+            },
+        )
+        .await
+        .expect("create_inquiry failed");
+    }
+}
+
+// ============================================================================
+// C1 — count reflects the full total, not the current page length
+// ============================================================================
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn count_returns_full_total_not_page_len(pool: PgPool) {
+    let org = seed_org(&pool, "pag-c1").await;
+    let realtor = seed_user(&pool, "realtor-c1@pag.test").await;
+    let listing = seed_listing(&pool, org, realtor).await;
+
+    let repo = RealityPortalRepository::new(pool.clone());
+    seed_inquiries(&repo, listing, realtor, 5).await;
+
+    // First page of 2.
+    let page = repo
+        .get_realtor_inquiries(realtor, None, 2, 0)
+        .await
+        .expect("get_realtor_inquiries failed");
+    assert_eq!(page.len(), 2, "C1: page should hold exactly `limit` rows");
+
+    // The real total must be 5, NOT the page length of 2 (the old bug).
+    let total = repo
+        .count_realtor_inquiries(realtor, None)
+        .await
+        .expect("count_realtor_inquiries failed");
+    assert_eq!(
+        total, 5,
+        "C1: count must report the full total (5), not the page length (2)"
+    );
+}
+
+// ============================================================================
+// C2 — count respects the same status filter as the page query
+// ============================================================================
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn count_respects_status_filter(pool: PgPool) {
+    let org = seed_org(&pool, "pag-c2").await;
+    let realtor = seed_user(&pool, "realtor-c2@pag.test").await;
+    let listing = seed_listing(&pool, org, realtor).await;
+
+    let repo = RealityPortalRepository::new(pool.clone());
+    seed_inquiries(&repo, listing, realtor, 3).await;
+
+    // Flip one inquiry to 'read' so the status partitions the set.
+    let first = repo
+        .get_realtor_inquiries(realtor, None, 1, 0)
+        .await
+        .expect("get_realtor_inquiries failed");
+    let target = first[0].id;
+    let owned = repo
+        .mark_inquiry_read_for_realtor(target, realtor)
+        .await
+        .expect("mark_inquiry_read_for_realtor failed");
+    assert!(owned, "C2: realtor owns the inquiry");
+
+    // Unfiltered total is still 3.
+    let total_all = repo
+        .count_realtor_inquiries(realtor, None)
+        .await
+        .expect("count all failed");
+    assert_eq!(total_all, 3, "C2: unfiltered count must be 3");
+
+    // 'new' count drops to 2; 'read' count is 1.
+    let total_new = repo
+        .count_realtor_inquiries(realtor, Some("new".to_string()))
+        .await
+        .expect("count new failed");
+    let total_read = repo
+        .count_realtor_inquiries(realtor, Some("read".to_string()))
+        .await
+        .expect("count read failed");
+    assert_eq!(total_new, 2, "C2: 'new' count must be 2 after one was read");
+    assert_eq!(total_read, 1, "C2: 'read' count must be 1");
+}


### PR DESCRIPTION
Triage + fix pass over the two reality-server umbrella review issues. Reality-server is the public listings / SSO-consumer server (port 8081); public endpoints are intentionally unauthenticated.

## Live finding fixed

**#774 item 3 — `GET /api/v1/realtors/inquiries` pagination `total` was wrong**
`backend/servers/reality-server/src/routes/realtors.rs` `list_inquiries` returned `total = inquiries.len()` (the current page length), so `total / limit` pagination silently broke on every non-final page (a full page always reported `total == limit`). Wired it to the existing `RealityPortalRepository::count_realtor_inquiries`, running the page query and the count in parallel with the **same status filter** — mirroring the already-fixed mirror handler `GET /api/v1/inquiries` (`routes/inquiries.rs`). Also added `clamp(1,100)` / `max(0)` bounds on limit/offset to match that handler.

### Regression tests
`backend/servers/reality-server/tests/inquiry_pagination_tests.rs` (new, repo-layer, `#[sqlx::test]` harness matching `inquiry_idor_tests.rs`):
- `count_returns_full_total_not_page_len` — 5 inquiries, page of 2 → page len 2 but **count 5**.
- `count_respects_status_filter` — count tracks the same status filter as the page (`new` vs `read`).

## Findings verified already-fixed (no change needed)

**#774**
- Item 1/2 (reality-api-client inquiry hooks, buyer `/inquiries` UI): frontend / generated-client scope, not reality-server Rust — out of scope for this PR.
- Item 4 (message length 5000 vs 2000): route + handler both cap at 5000 (`routes/inquiries.rs` `MAX_INQUIRY_MESSAGE_LEN`, `respond_to_inquiry`); no mismatch remains.
- Item 6/7 (GET inquiry marks read; empty messages array): mark-read is ownership-scoped (`get_inquiry_for_realtor` + `mark_inquiry_read_for_realtor`); empty `messages` is a documented placeholder, not a bug.
- Item 8 (`mark_inquiry_read` footgun / IDOR): already fixed (#497/#519) — both `routes/realtors.rs` and `routes/inquiries.rs` use `mark_inquiry_read_for_realtor(id, principal.user_id)`; covered by `inquiry_idor_tests.rs`.
- `metrics` / `AssertSqlSafe` delta: `price_map.rs` interpolates only a fixed `interval` literal from a closed match (`1 month`…`5 years`) into `sqlx::AssertSqlSafe` — not user-controlled, no injection.

**#896** (all P2/P3 verify/confirm notes — code already satisfies them)
- `submit_report` existence-oracle: `routes/reports.rs` gates the listing check on `status = 'active'` (round-9 audit comment) so it cannot probe draft/archived listings; input length + attachment-URL (http(s)-only, `<=2048`) caps in place. Anonymous report is intentional per screen-map; rate-limiting is an infra/moderation-layer concern, noted but out of code scope.
- Article slug enumeration: `routes/articles.rs` list + detail + comments all gate on `a.published_at <= NOW()`, so drafts/unpublished cannot be read by slug.
- `agent_reviews` duplicate/spam: `routes/agent_reviews.rs` uses `ON CONFLICT (realtor_id, reviewer_user_id) DO NOTHING` and sets `verified_buyer` server-side from a prior responded inquiry — no client-spoofable trust flag, no duplicates.
- `compare` cross-status leak: `routes/compare.rs` `LEFT JOIN listings ... AND l.status = 'active'` (H4 audit) and add-to-compare gates existence on `status = 'active'` — no draft/archived data leak.

## Verify
- `command cargo fmt --all` — clean (pre-commit hook re-checked, OK)
- `cargo clippy -p reality-server -- -D warnings` (isolated target) — clean
- `cargo test -p reality-server --no-run` (isolated target) — compiles; new test binary built. Docker down locally → tests run in CI.