### PR TITLE
fix(security): SSO consumer review findings (closes #820)

### DIFF
--- a/backend/servers/reality-server/src/state.rs
+++ b/backend/servers/reality-server/src/state.rs
@@ -399,6 +399,22 @@ impl SessionService {
 }
 
 /// SSO token service for mobile deep-link flow.
+///
+/// ## Durability (issue #820, P1 — deliberate follow-up)
+///
+/// Tokens live in an in-process `Mutex<HashMap>`, so they are **not durable
+/// across reality-server instances**. The mobile deep-link flow therefore
+/// requires the `/sso/mobile/token` mint and the `/sso/mobile/validate`
+/// redeem to hit the same instance (sticky routing). Migrating to a shared
+/// store (Redis) is tracked as a follow-up; reality-server has no Redis
+/// dependency today, so adding one is out of scope for the #820 security
+/// review. The security properties below hold regardless of durability:
+///
+/// - **One-time use:** `validate_and_consume_token` removes the entry before
+///   returning it, so a token can be redeemed at most once.
+/// - **Short TTL:** tokens are minted with a 5-minute lifetime and rejected
+///   past `expires_at`.
+/// - **Unforgeable:** the token value is a random v4 UUID.
 #[derive(Clone)]
 pub struct SsoTokenService {
     // Short-lived tokens for mobile SSO
@@ -431,9 +447,18 @@ impl SsoTokenService {
         duration: chrono::Duration,
     ) -> Result<String, anyhow::Error> {
         let token = uuid::Uuid::new_v4().to_string();
-        let expires_at = chrono::Utc::now() + duration;
+        let now = chrono::Utc::now();
+        let expires_at = now + duration;
 
-        self.tokens.lock().await.insert(
+        let mut tokens = self.tokens.lock().await;
+        // Amortized eviction (issue #820): tokens that are minted but never
+        // redeemed (abandoned deep-links, replay probes) would otherwise
+        // accumulate in the map forever, since `validate_and_consume_token`
+        // only removes a token when it is actually presented. Sweep expired
+        // entries on every mint so the map stays bounded by the number of
+        // *live* (<= 5-minute-old) tokens rather than total tokens ever issued.
+        tokens.retain(|_, t| t.expires_at >= now);
+        tokens.insert(
             token.clone(),
             MobileSsoToken {
                 user_info: user_info.clone(),
@@ -459,6 +484,15 @@ impl SsoTokenService {
         }
 
         Ok(sso_token.user_info)
+    }
+
+    /// Number of tokens currently held (live + not-yet-swept expired).
+    ///
+    /// Test/observability helper — lets callers assert the store does not grow
+    /// unboundedly across mints (issue #820 eviction regression test).
+    #[cfg(test)]
+    pub(crate) async fn len(&self) -> usize {
+        self.tokens.lock().await.len()
     }
 }
 
@@ -931,5 +965,82 @@ impl Clone for OAuthTokens {
             token_type: self.token_type.clone(),
             expires_in: self.expires_in,
         }
+    }
+}
+
+// ==================== Mobile SSO token store tests (issue #820) ====================
+
+#[cfg(test)]
+mod sso_token_service_tests {
+    use super::SsoTokenService;
+    use crate::routes::sso::SsoUserInfo;
+
+    fn user(id: &str) -> SsoUserInfo {
+        SsoUserInfo {
+            user_id: id.to_string(),
+            email: format!("{id}@example.com"),
+            name: format!("User {id}"),
+            avatar_url: None,
+        }
+    }
+
+    /// A freshly minted token validates exactly once, then is gone.
+    #[tokio::test]
+    async fn mobile_token_is_one_time_use() {
+        let svc = SsoTokenService::new();
+        let token = svc
+            .create_mobile_token(&user("u1"), chrono::Duration::minutes(5))
+            .await
+            .expect("mint");
+
+        let first = svc.validate_and_consume_token(&token).await;
+        assert!(first.is_ok(), "first redemption should succeed");
+        assert_eq!(first.unwrap().user_id, "u1");
+
+        let second = svc.validate_and_consume_token(&token).await;
+        assert!(
+            second.is_err(),
+            "second redemption of the same token must be rejected"
+        );
+    }
+
+    /// An expired token is rejected on redemption (short-TTL enforcement).
+    #[tokio::test]
+    async fn mobile_token_expired_is_rejected() {
+        let svc = SsoTokenService::new();
+        // Mint already-expired (negative duration).
+        let token = svc
+            .create_mobile_token(&user("u2"), chrono::Duration::seconds(-1))
+            .await
+            .expect("mint");
+
+        let result = svc.validate_and_consume_token(&token).await;
+        assert!(result.is_err(), "expired token must be rejected");
+    }
+
+    /// Regression (issue #820): minting new tokens must sweep expired,
+    /// never-redeemed tokens so the in-memory map cannot grow unboundedly.
+    #[tokio::test]
+    async fn mobile_token_mint_evicts_expired_entries() {
+        let svc = SsoTokenService::new();
+
+        // Insert 5 already-expired tokens that are never redeemed.
+        for i in 0..5 {
+            svc.create_mobile_token(&user(&format!("old{i}")), chrono::Duration::seconds(-1))
+                .await
+                .expect("mint expired");
+        }
+        // Each subsequent mint runs the sweep first, so after a single live
+        // mint the only surviving entry is the live one — the 5 expired,
+        // abandoned tokens are evicted rather than leaked.
+        svc.create_mobile_token(&user("live"), chrono::Duration::minutes(5))
+            .await
+            .expect("mint live");
+
+        assert_eq!(
+            svc.len().await,
+            1,
+            "expired, never-redeemed tokens must be swept on mint"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Triage + fix for the Epic 10A-SSO Cross-Platform SSO Consumer review (#820), covering reality-server `sso.rs` (SSO consumer) and api-server `oauth.rs` (OAuth provider). Most findings were already resolved on `dev`; this lands the one genuine, in-scope, low-risk fix and documents the rest with evidence.

## Fixed (this PR)

**reality-server mobile SSO token store — `backend/servers/reality-server/src/state.rs`**
- Expired-but-never-redeemed mobile SSO tokens accumulated in the in-memory `Mutex<HashMap>` indefinitely: `validate_and_consume_token` only removes a token when it is actually presented, so abandoned deep-links and replay probes leaked entries forever (unbounded memory growth / DoS surface).
- `create_mobile_token` now sweeps expired entries (`retain`) on every mint, bounding the map by *live* (<= 5-minute) tokens.
- Added 3 unit tests: one-time use, expiry rejection, and the eviction-on-mint regression. All pass (`cargo test -p reality-server --lib sso_token_service_tests` → 3 passed).

## Already fixed on `dev` (no change needed)

- **P1 — `oauth.rs` `authorize_get` served the consent page without auth.** Resolved by #912: the handler now extracts + validates the bearer token before doing any work, with a `test_authorize_get_requires_auth` regression test.
- **P2 — SSO redirect allowlist.** `ensure_redirect_uri_allowed` runs at both login and callback, allows same-origin relative paths, restricts to http(s), and matches on origin against `allowed_redirect_origins`. PKCE (S256), server-generated `state` for CSRF, 10-minute pending-session expiry, and a `HttpOnly; Secure; SameSite=Strict` cookie scoped to `/api/v1/sso` with a cookie-injection guard are all present.
- **P2 — portal/PM boundary.** `exchange_pm_token` / `sync_session` introspect the PM token first and map *only* to portal roles; portal sessions never carry PM `TenantExtractor` scopes.

## Deliberate follow-up (out of scope — documented in code)

- **P1 — durability of in-memory stores.** Pending PKCE sessions (`sso_sessions`) and mobile SSO tokens live in-process, so a multi-instance reality-server needs sticky routing. reality-server has **no Redis dependency today**; introducing one is net-new infrastructure beyond a security review, so this is documented on `SsoTokenService` as a follow-up rather than migrated. (Note: `SessionService` — the actual user sessions — is already DB-backed and durable.)
- **ppt-web `POST /api/v1/auth/sso/callback` (frontend-discovered lead).** The api-server has no such route; ppt-web carries incomplete SSO-callback scaffolding (Story 79.2, `AuthCallbackPage`) with no login initiator wired up. This is feature completion spanning frontend + backend, not a reality-server/oauth security finding, and belongs to the 79.x SSO-completion track.

## Verification

- `command cargo fmt --all` — clean
- `cargo clippy -p reality-server -- -D warnings` (isolated target dir) — clean
- `cargo test -p reality-server --no-run` — compiles; new unit suite runs green (Docker not required for the in-memory store tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)