### PR TITLE
fix: address dev-review rounds 1-5 findings (#788)

### DIFF
--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -59,6 +59,7 @@ import {
   Routes,
   useNavigate,
   useParams,
+  useSearchParams,
 } from 'react-router-dom';
 import {
   AnnouncerProvider,
@@ -2053,10 +2054,15 @@ function NewMessagePageRoute() {
   const navigate = useNavigate();
   const { showToast } = useToast();
   const { t } = useTranslation();
+  const [searchParams] = useSearchParams();
 
-  // Fetch potential recipients from neighbors.
-  // buildingId is not part of the auth token; the hook handles undefined gracefully.
-  const { recipients, isLoading: isLoadingRecipients } = useMessageRecipients(undefined);
+  // Fetch potential recipients from the user's building neighbors. Without a
+  // building id the recipients query stays disabled and the list is always
+  // empty — making the page unusable. Mirror the NeighborsPage convention and
+  // use the first building the user has access to (building-selector deferred).
+  const { data: buildingsData, isLoading: isLoadingBuildings } = useBuildings();
+  const buildingId = buildingsData?.items?.[0]?.id;
+  const { recipients, isLoading: isLoadingRecipients } = useMessageRecipients(buildingId);
   const startThread = useStartThread();
 
   const handleNewMsgSubmit = async (data: import('./features/messaging').CreateThreadRequest) => {
@@ -2081,7 +2087,10 @@ function NewMessagePageRoute() {
   return (
     <NewMessagePage
       recipients={recipients}
-      isLoadingRecipients={isLoadingRecipients}
+      initialRecipientIds={
+        searchParams.get('recipientId') ? [searchParams.get('recipientId') as string] : undefined
+      }
+      isLoadingRecipients={isLoadingRecipients || isLoadingBuildings}
       isSubmitting={startThread.isPending}
       onSubmit={handleNewMsgSubmit}
       onCancel={() => navigate('/messages')}

--- a/frontend/apps/ppt-web/src/features/buildings/components/BuildingCard.tsx
+++ b/frontend/apps/ppt-web/src/features/buildings/components/BuildingCard.tsx
@@ -7,6 +7,7 @@
  */
 
 import type { Building, BuildingStatus, BuildingType } from '@ppt/api-client';
+import { isSafeImageUrl } from '@ppt/shared';
 
 interface BuildingCardProps {
   building: Building;
@@ -38,14 +39,18 @@ const TYPE_LABELS: Record<BuildingType, string> = {
 export function BuildingCard({ building, onView, onEdit }: BuildingCardProps) {
   const { id, name, address, type, status, unitCount, floorCount, photoUrl } = building;
 
+  // Only render server-provided photo URLs that pass the http(s)/relative
+  // allowlist — guards against injected javascript:/data: image sources.
+  const safePhotoUrl = isSafeImageUrl(photoUrl) ? photoUrl : undefined;
+
   const addressLine = [address.street, address.city, address.postalCode].filter(Boolean).join(', ');
 
   return (
     <div className="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow">
       {/* Building Image */}
       <div className="h-48 bg-gray-200 relative">
-        {photoUrl ? (
-          <img src={photoUrl} alt={name} className="w-full h-full object-cover" />
+        {safePhotoUrl ? (
+          <img src={safePhotoUrl} alt={name} className="w-full h-full object-cover" />
         ) : (
           <div className="w-full h-full flex items-center justify-center text-gray-400">
             <svg

--- a/frontend/apps/ppt-web/src/features/buildings/hooks/useBuildings.ts
+++ b/frontend/apps/ppt-web/src/features/buildings/hooks/useBuildings.ts
@@ -19,22 +19,29 @@ const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '';
 
 /**
  * Creates a buildings API client with current auth token.
+ *
+ * `createBuildingsApi` bakes the `Authorization: Bearer <token>` header into
+ * the returned client at construction time, so the client must be re-created
+ * whenever the token rotates — see {@link useBuildingsApi}.
  */
-function getBuildingsApi() {
+function getBuildingsApi(accessToken: string | undefined) {
   return createBuildingsApi({
     baseUrl: API_BASE_URL,
-    accessToken: getToken() ?? undefined,
+    accessToken,
   });
 }
 
 /**
  * Hook to get buildings API hooks with current auth context.
  *
- * Creates memoized API client and returns TanStack Query hooks
- * for buildings operations.
+ * Creates a memoized API client and returns TanStack Query hooks for buildings
+ * operations. The memo is keyed on the current access token so a token refresh
+ * (rotation) rebuilds the client with the fresh Bearer header instead of
+ * sending a stale token for the rest of the component's lifetime.
  */
 export function useBuildingsApi() {
-  const api = useMemo(() => getBuildingsApi(), []);
+  const token = getToken() ?? undefined;
+  const api = useMemo(() => getBuildingsApi(token), [token]);
   return useMemo(() => createBuildingHooks(api), [api]);
 }
 

--- a/frontend/apps/ppt-web/src/features/buildings/pages/BuildingDetailPage.tsx
+++ b/frontend/apps/ppt-web/src/features/buildings/pages/BuildingDetailPage.tsx
@@ -7,6 +7,7 @@
  */
 
 import type { BuildingStatus, BuildingType } from '@ppt/api-client';
+import { isSafeImageUrl } from '@ppt/shared';
 import { Link } from 'react-router-dom';
 import { useBuilding, useBuildingCommonAreas, useBuildingFloors } from '../hooks';
 
@@ -105,7 +106,7 @@ export function BuildingDetailPage({ buildingId }: BuildingDetailPageProps) {
       <div className="bg-white rounded-lg shadow-md overflow-hidden mb-6">
         {/* Building Image */}
         <div className="h-64 bg-gray-200 relative">
-          {building.photoUrl ? (
+          {isSafeImageUrl(building.photoUrl) ? (
             <img
               src={building.photoUrl}
               alt={building.name}

--- a/frontend/apps/ppt-web/src/features/messaging/hooks/useMessaging.ts
+++ b/frontend/apps/ppt-web/src/features/messaging/hooks/useMessaging.ts
@@ -34,17 +34,22 @@ import type {
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '';
 
-function getMessagingApi() {
+// NOTE: `createMessagingApi` / `createNeighborsApi` bake the
+// `Authorization: Bearer <token>` header into the returned client at
+// construction time. Callers must re-create the client whenever the token
+// rotates (the `useMemo` deps below are keyed on the token), otherwise a stale
+// Bearer token is sent for the rest of the component's lifetime.
+function getMessagingApi(accessToken: string | undefined) {
   return createMessagingApi({
     baseUrl: API_BASE_URL,
-    accessToken: getToken() ?? undefined,
+    accessToken,
   });
 }
 
-function getNeighborsApi() {
+function getNeighborsApi(accessToken: string | undefined) {
   return createNeighborsApi({
     baseUrl: API_BASE_URL,
-    accessToken: getToken() ?? undefined,
+    accessToken,
   });
 }
 
@@ -141,7 +146,8 @@ export function mapApiThreadDetailToUi(detail: ThreadDetailResponse): ThreadWith
  * Returns TanStack Query hooks for the messaging API.
  */
 export function useMessagingApi() {
-  const api = useMemo(() => getMessagingApi(), []);
+  const token = getToken() ?? undefined;
+  const api = useMemo(() => getMessagingApi(token), [token]);
   return useMemo(() => createMessagingHooks(api), [api]);
 }
 
@@ -214,7 +220,8 @@ export function useMessageRecipients(buildingId?: string): {
   recipients: RecipientOption[];
   isLoading: boolean;
 } {
-  const api = useMemo(() => getNeighborsApi(), []);
+  const token = getToken() ?? undefined;
+  const api = useMemo(() => getNeighborsApi(token), [token]);
   const hooks = useMemo(() => createNeighborHooks(api), [api]);
   const { data, isLoading } = hooks.useNeighbors(buildingId ?? '', !!buildingId);
 

--- a/frontend/apps/ppt-web/src/features/messaging/pages/NewMessagePage.tsx
+++ b/frontend/apps/ppt-web/src/features/messaging/pages/NewMessagePage.tsx
@@ -12,6 +12,8 @@ import type { CreateThreadRequest, RecipientOption } from '../types';
 
 interface NewMessagePageProps {
   recipients: RecipientOption[];
+  /** Recipient ids to preselect (e.g. when arriving from "Contact" on a neighbor). */
+  initialRecipientIds?: string[];
   isLoadingRecipients?: boolean;
   isSubmitting?: boolean;
   onSubmit: (data: CreateThreadRequest) => void;
@@ -20,13 +22,16 @@ interface NewMessagePageProps {
 
 export function NewMessagePage({
   recipients,
+  initialRecipientIds,
   isLoadingRecipients,
   isSubmitting,
   onSubmit,
   onCancel,
 }: NewMessagePageProps) {
   const { t } = useTranslation();
-  const [selectedRecipientIds, setSelectedRecipientIds] = useState<string[]>([]);
+  const [selectedRecipientIds, setSelectedRecipientIds] = useState<string[]>(
+    initialRecipientIds ?? []
+  );
   const [subject, setSubject] = useState('');
   const [message, setMessage] = useState('');
   const [errors, setErrors] = useState<{

--- a/frontend/apps/ppt-web/src/test/shared-auth.test.ts
+++ b/frontend/apps/ppt-web/src/test/shared-auth.test.ts
@@ -20,6 +20,7 @@ import {
   hasRolePermission,
   isTokenExpired,
   ROLES,
+  sanitizeReturnUrl,
   setReturnUrl,
 } from '@ppt/shared';
 
@@ -291,6 +292,43 @@ describe('@ppt/shared - auth', () => {
 
     it('returns null when nothing was stored', () => {
       expect(getAndClearReturnUrl()).toBeNull();
+    });
+
+    it('drops off-origin / open-redirect URLs on write', () => {
+      setReturnUrl('https://evil.com/phish');
+      expect(getAndClearReturnUrl()).toBeNull();
+      setReturnUrl('//evil.com');
+      expect(getAndClearReturnUrl()).toBeNull();
+      setReturnUrl('javascript:alert(1)');
+      expect(getAndClearReturnUrl()).toBeNull();
+    });
+
+    it('sanitizes a tampered stored value on read', () => {
+      sessionStorage.setItem('auth_return_url', '//evil.com/path');
+      expect(getAndClearReturnUrl()).toBeNull();
+    });
+  });
+
+  describe('sanitizeReturnUrl', () => {
+    it('accepts same-origin rooted paths', () => {
+      expect(sanitizeReturnUrl('/dashboard')).toBe('/dashboard');
+      expect(sanitizeReturnUrl('/buildings/42?tab=faults')).toBe('/buildings/42?tab=faults');
+    });
+
+    it('rejects off-origin, protocol-relative, scheme, and relative URLs', () => {
+      expect(sanitizeReturnUrl('https://evil.com')).toBeNull();
+      expect(sanitizeReturnUrl('//evil.com')).toBeNull();
+      expect(sanitizeReturnUrl('/\\evil.com')).toBeNull();
+      expect(sanitizeReturnUrl('javascript:alert(1)')).toBeNull();
+      expect(sanitizeReturnUrl('dashboard')).toBeNull();
+      expect(sanitizeReturnUrl('')).toBeNull();
+      expect(sanitizeReturnUrl(null)).toBeNull();
+      expect(sanitizeReturnUrl(undefined)).toBeNull();
+    });
+
+    it('rejects control-character smuggling', () => {
+      expect(sanitizeReturnUrl('/\tevil')).toBeNull();
+      expect(sanitizeReturnUrl('/\nevil')).toBeNull();
     });
   });
 });

--- a/frontend/packages/shared/src/auth.ts
+++ b/frontend/packages/shared/src/auth.ts
@@ -343,12 +343,46 @@ export function hasAnyRole(userRole: string, roles: Role[]): boolean {
 // ============================================
 
 /**
+ * Validate that a stored return URL is a safe, same-origin relative path.
+ *
+ * Open-redirect protection: the post-login redirect target comes from the URL /
+ * sessionStorage and is fed straight into `navigate()`. An attacker who can seed
+ * the return URL (e.g. `?returnUrl=https://evil.com`) could otherwise bounce a
+ * freshly-authenticated user off-site. Only accept root-relative in-app paths:
+ *
+ * - must start with a single `/` (rooted, same-origin),
+ * - must NOT start with `//` or `/\` (protocol-relative → off-origin),
+ * - must NOT contain a scheme such as `javascript:` / `data:` (those never start
+ *   with `/`, so the leading-slash rule already rejects them, but we also strip
+ *   control chars defensively).
+ *
+ * Returns the sanitized path, or `null` if the value is not a safe relative path.
+ */
+export function sanitizeReturnUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  // Reject anything containing control characters (incl. \t \n \r) used to
+  // smuggle past naive prefix checks.
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: deliberately matching control chars to reject them
+  if (/[\u0000-\u001f\u007f-\u009f]/.test(url)) return null;
+  // Must be a rooted, same-origin path.
+  if (!url.startsWith('/')) return null;
+  // Reject protocol-relative URLs (`//host`, `/\host`) that resolve off-origin.
+  if (url.startsWith('//') || url.startsWith('/\\')) return null;
+  return url;
+}
+
+/**
  * Store return URL for post-login redirect.
+ *
+ * The URL is sanitized to a same-origin relative path; unsafe values
+ * (absolute/off-origin/scheme URLs) are dropped rather than stored.
  */
 export function setReturnUrl(url: string): void {
   if (typeof sessionStorage === 'undefined') return;
+  const safe = sanitizeReturnUrl(url);
+  if (safe === null) return;
   try {
-    sessionStorage.setItem('auth_return_url', url);
+    sessionStorage.setItem('auth_return_url', safe);
   } catch {
     // Storage blocked or full
   }
@@ -356,13 +390,16 @@ export function setReturnUrl(url: string): void {
 
 /**
  * Get and clear the stored return URL.
+ *
+ * Re-validates on read (defense in depth) so a value written by an older build
+ * or tampered storage can never become an open-redirect target.
  */
 export function getAndClearReturnUrl(): string | null {
   if (typeof sessionStorage === 'undefined') return null;
   try {
     const url = sessionStorage.getItem('auth_return_url');
     sessionStorage.removeItem('auth_return_url');
-    return url;
+    return sanitizeReturnUrl(url);
   } catch {
     return null;
   }

--- a/frontend/packages/shared/src/index.ts
+++ b/frontend/packages/shared/src/index.ts
@@ -39,6 +39,7 @@ export {
   // Roles
   ROLES,
   type Role,
+  sanitizeReturnUrl,
   // Session
   setReturnUrl,
   setSsoState,
@@ -106,6 +107,8 @@ export {
   // Composite
   combineValidators,
   getPasswordStrength,
+  // Image URL allowlist
+  isSafeImageUrl,
   isValidCompanyId,
   // Email
   isValidEmail,

--- a/frontend/packages/shared/src/validation.ts
+++ b/frontend/packages/shared/src/validation.ts
@@ -176,6 +176,31 @@ export function validateUrl(url: string): ValidationResult {
   return { valid: true };
 }
 
+/**
+ * Returns `true` when `url` is safe to use as an `<img src>` value.
+ *
+ * Allowlist (defense in depth against injected URLs from API/user data):
+ *  - absolute `http:` / `https:` URLs,
+ *  - root-relative paths (`/...`), excluding protocol-relative `//host`.
+ *
+ * Everything else — `javascript:`, `data:`, `blob:`, `file:`, `vbscript:`,
+ * bare/relative strings — is rejected. While browsers do not execute
+ * `javascript:` in `img src`, restricting to an explicit allowlist prevents
+ * data-exfiltration and tracking-pixel style abuse via attacker-controlled
+ * image URLs.
+ */
+export function isSafeImageUrl(url: string | null | undefined): boolean {
+  if (!url) return false;
+  // Root-relative (same-origin) path, but not protocol-relative `//host`.
+  if (url.startsWith('/')) return !url.startsWith('//');
+  try {
+    const { protocol } = new URL(url);
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 // ============================================
 // Numeric Validation
 // ============================================

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/api/ApiClient.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/api/ApiClient.kt
@@ -36,6 +36,13 @@ class ApiClient(
         tenantId?.let { header("X-Tenant-ID", it) }
     }
 
+    /**
+     * Percent-encode a value before splicing it into a request path so that ids containing `/`,
+     * `?`, `#`, or `..` cannot smuggle extra path segments or query parameters into the request
+     * (path-injection).
+     */
+    private fun pathSegment(value: String): String = value.encodeURLPathPart()
+
     suspend fun healthCheck(): String {
         return client.get("$baseUrl/health") { configureRequest() }.toString()
     }
@@ -73,7 +80,8 @@ class ApiClient(
      */
     suspend fun getListing(id: String): Result<ListingDetail> {
         return try {
-            val response = client.get("$baseUrl/api/v1/listings/$id") { configureRequest() }
+            val response =
+                client.get("$baseUrl/api/v1/listings/${pathSegment(id)}") { configureRequest() }
             if (response.status.isSuccess()) {
                 Result.success(response.body())
             } else if (response.status == HttpStatusCode.NotFound) {
@@ -117,7 +125,7 @@ class ApiClient(
     suspend fun addFavorite(listingId: String): Result<AddFavoriteResponse> {
         return try {
             val response =
-                client.post("$baseUrl/api/v1/favorites/$listingId") {
+                client.post("$baseUrl/api/v1/favorites/${pathSegment(listingId)}") {
                     configureRequest()
                     // Empty typed body — `AddFavoriteBody` serializes to `{}` via
                     // ContentNegotiation, keeping this call on the same pipeline as every other.
@@ -147,7 +155,9 @@ class ApiClient(
     suspend fun removeFavorite(listingId: String): Result<Unit> {
         return try {
             val response =
-                client.delete("$baseUrl/api/v1/favorites/$listingId") { configureRequest() }
+                client.delete("$baseUrl/api/v1/favorites/${pathSegment(listingId)}") {
+                    configureRequest()
+                }
             if (response.status.isSuccess()) {
                 Result.success(Unit)
             } else if (response.status == HttpStatusCode.Unauthorized) {

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/FavoritesRepository.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/FavoritesRepository.kt
@@ -21,6 +21,14 @@ class FavoritesRepository(
         sessionToken?.let { header(HttpHeaders.Authorization, "Bearer $it") }
     }
 
+    /**
+     * URL-encode a value before splicing it into a request path. Without this, an attacker- or
+     * caller-supplied id containing `/`, `?`, `#`, or `..` could smuggle extra path segments or
+     * query parameters into the request (path-injection). [encodeURLPathPart] percent-encodes
+     * everything that is not valid inside a single path segment.
+     */
+    private fun pathSegment(value: String): String = value.encodeURLPathPart()
+
     // --- Favorites ---
 
     /** Get user's favorite listings. */
@@ -49,7 +57,7 @@ class FavoritesRepository(
     suspend fun addFavorite(listingId: String): Result<AddFavoriteResponse> {
         return try {
             val response =
-                client.post("$baseUrl/api/v1/favorites/$listingId") {
+                client.post("$baseUrl/api/v1/favorites/${pathSegment(listingId)}") {
                     configureRequest()
                     // Empty typed body — server's `AddFavorite` is `{notes?: String}`; we omit it.
                     // Using the @Serializable `AddFavoriteBody` keeps the call on the
@@ -76,7 +84,9 @@ class FavoritesRepository(
     suspend fun removeFavorite(listingId: String): Result<Unit> {
         return try {
             val response =
-                client.delete("$baseUrl/api/v1/favorites/$listingId") { configureRequest() }
+                client.delete("$baseUrl/api/v1/favorites/${pathSegment(listingId)}") {
+                    configureRequest()
+                }
 
             if (response.status.isSuccess()) {
                 Result.success(Unit)
@@ -104,7 +114,9 @@ class FavoritesRepository(
     suspend fun isFavorite(listingId: String): Result<Boolean> {
         return try {
             val response =
-                client.get("$baseUrl/api/v1/favorites/$listingId/check") { configureRequest() }
+                client.get("$baseUrl/api/v1/favorites/${pathSegment(listingId)}/check") {
+                    configureRequest()
+                }
 
             when {
                 response.status.isSuccess() -> {
@@ -172,7 +184,7 @@ class FavoritesRepository(
     ): Result<SavedSearch> {
         return try {
             val response =
-                client.patch("$baseUrl/api/v1/saved-searches/$searchId") {
+                client.patch("$baseUrl/api/v1/saved-searches/${pathSegment(searchId)}") {
                     configureRequest()
                     setBody(request)
                 }
@@ -197,7 +209,9 @@ class FavoritesRepository(
     suspend fun deleteSavedSearch(searchId: String): Result<Unit> {
         return try {
             val response =
-                client.delete("$baseUrl/api/v1/saved-searches/$searchId") { configureRequest() }
+                client.delete("$baseUrl/api/v1/saved-searches/${pathSegment(searchId)}") {
+                    configureRequest()
+                }
 
             if (response.status.isSuccess()) {
                 Result.success(Unit)

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoritesRepositoryTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoritesRepositoryTest.kt
@@ -86,4 +86,38 @@ class FavoritesRepositoryTest {
             "expected FavoritesException, got ${ex?.let { it::class }}",
         )
     }
+
+    /**
+     * Round-1 review (#788): listing ids are spliced into the request path and must be
+     * percent-encoded so a hostile id cannot smuggle extra path segments or query parameters
+     * (path-injection). A `/`-bearing id must NOT escape its segment.
+     */
+    @Test
+    fun isFavorite_url_encodes_listing_id_path_segment() = runTest {
+        var capturedPath: String? = null
+        val engine = MockEngine { request ->
+            capturedPath = request.url.encodedPath
+            respond(
+                content = ByteReadChannel("""{"is_favorited": false}"""),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = HttpClient(engine) { install(ContentNegotiation) { json(json) } }
+        val repo =
+            FavoritesRepository(
+                baseUrl = "https://example.test",
+                sessionToken = "test-token",
+                client = client,
+            )
+
+        repo.isFavorite("../admin/secret")
+
+        // The `/` characters must be percent-encoded; the path stays anchored under /favorites/.
+        assertEquals(
+            "/api/v1/favorites/..%2Fadmin%2Fsecret/check",
+            capturedPath,
+            "listingId must be percent-encoded into a single path segment",
+        )
+    }
 }


### PR DESCRIPTION
Triages the **dev-review rounds 1–5** findings from #788 across `mobile-native/` (Kotlin) and `frontend/apps/ppt-web/` (React). No api-server changes.

## Fixed

**Round 1 — mobile-native (Medium):** path-injection via unencoded ids.
`ApiClient` and `FavoritesRepository` spliced caller-supplied ids
(`$listingId` / `$id` / `$searchId`) straight into request paths. An id with
`/ ? # ..` could smuggle extra path segments/query params. Now percent-encoded
via `encodeURLPathPart`. Regression test added.

**Round 2 — ppt-web auth (High):** post-login open redirect.
`setReturnUrl` stored any URL and `getAndClearReturnUrl` passed it to
`navigate()`. Added `sanitizeReturnUrl` in `@ppt/shared` — same-origin rooted
paths only; rejects absolute / protocol-relative (`//host`) / scheme
(`javascript:`) / control-char URLs. Sanitizes on **both write and read**
(defense in depth, catches tampered/old stored values). Tests added.

**Round 4 — ppt-web buildings (Medium):** stale Bearer token.
`useBuildingsApi` built its client with `useMemo([], …)`, baking the
`Authorization` header at first mount; a token rotation left the stale token in
place. Memo now keyed on the current token so the client rebuilds on refresh.
Same fix applied to `useMessagingApi` / `useMessageRecipients` (Round 5 Medium).

**Round 4 — ppt-web buildings (Low):** `photoUrl` rendered into `<img src>`
without validation. Added `isSafeImageUrl` (`@ppt/shared`, http(s)/relative
allowlist), applied in `BuildingCard` + `BuildingDetailPage`.

**Round 5 — ppt-web messaging (Medium):** empty recipient list.
`NewMessagePageRoute` called `useMessageRecipients(undefined)`, permanently
disabling the neighbors query → recipients always empty → New Message page
unusable. Wired to the user's first building (mirrors `NeighborsPageRoute`) and
honor `?recipientId=` for preselection.

## Already fixed / out of scope

- **Round 1 (Low) — 401 on favorite check:** already correct. Server always
  returns 200 with `{is_favorited}`; 401 → `false` only for the unauthenticated
  case (documented in `FavoritesRepository`).
- **Round 2 (Medium) — logout cache purge (#712 partial):** `AUTHED_QUERY_KEY_ROOTS`
  already covers every auth-scoped root (all `queryKeys` factory namespaces +
  ad-hoc `developer/ocr/actionQueue/executionLogs/executionStats/ai-chat`).
  Verified by grepping all `queryKey:` roots in ppt-web — none missing.
- **Round 3 (Medium/Low) — voting action-queue + dispute UI:** `useActionQueue`
  is entirely mock-data driven (no `/action-queue` backend endpoint), and the
  dispute-resolution vote UI is a `notImplemented` stub. These are
  feature-completion tasks requiring backend work, not contained bugs.
- **Round 5 — "attachments dropped":** `NewMessagePage` has no attachment input
  and the messaging API maps `content` only; adding attachments is new
  feature+API work, out of scope for this triage.

## Verification

- **ppt-web:** `biome check` clean, `tsc --noEmit` clean (whole workspace via
  pre-commit), `vitest run` — **458 passed** (incl. new `sanitizeReturnUrl` tests).
- **mobile-native:** `:shared:compileKotlinIosSimulatorArm64` +
  `:shared:compileTestKotlinIosSimulatorArm64` + `linkDebugTestIosSimulatorArm64`
  all **compiled and linked** (main + new test). Test *execution*
  (`iosSimulatorArm64Test`) and Android compile could not run — no iOS simulator
  SDK / no Android SDK in this environment. Kotlin Spotless pre-commit passed.

Partially closes #788 (rounds 1, 2, 4, 5 actionable items).
