### PR TITLE
fix(security): mandatory integration token encryption + bound OAuth state (closes #765)

### DIFF
--- a/backend/crates/integrations/src/crypto.rs
+++ b/backend/crates/integrations/src/crypto.rs
@@ -189,10 +189,56 @@ impl IntegrationCrypto {
     }
 }
 
+/// Encrypt a value, failing closed if encryption is not available.
+///
+/// Unlike [`encrypt_if_available`], this NEVER returns plaintext. It is the
+/// required path for persisting secrets (OAuth/access/refresh tokens, platform
+/// credentials): if `INTEGRATION_ENCRYPTION_KEY` is unset (`crypto` is `None`)
+/// or the encryption operation itself fails, an error is returned so the caller
+/// can refuse to store the secret rather than leaking it in plaintext.
+///
+/// On success the value carries the same "enc:" prefix used by
+/// [`encrypt_if_available`], so [`decrypt_if_available`] reads both transparently.
+///
+/// # Errors
+/// - [`CryptoError::KeyNotConfigured`] when `crypto` is `None`.
+/// - Propagates the underlying [`CryptoError`] when encryption fails.
+pub fn encrypt_required(
+    crypto: Option<&IntegrationCrypto>,
+    plaintext: &str,
+) -> Result<String, CryptoError> {
+    match crypto {
+        Some(c) => Ok(format!("{}{}", ENCRYPTED_PREFIX, c.encrypt(plaintext)?)),
+        None => Err(CryptoError::KeyNotConfigured(format!(
+            "{} must be set to store integration secrets; refusing to persist in plaintext",
+            ENCRYPTION_KEY_ENV
+        ))),
+    }
+}
+
+/// Encrypt an optional value, failing closed if encryption is not available.
+///
+/// Returns `Ok(None)` when the input is `None`. When the input is `Some`, the
+/// fail-closed semantics of [`encrypt_required`] apply.
+pub fn encrypt_optional_required(
+    crypto: Option<&IntegrationCrypto>,
+    plaintext: Option<&str>,
+) -> Result<Option<String>, CryptoError> {
+    match plaintext {
+        Some(text) => Ok(Some(encrypt_required(crypto, text)?)),
+        None => Ok(None),
+    }
+}
+
 /// Encrypt a value if crypto is available, otherwise return plaintext.
 ///
 /// Adds "enc:" prefix to encrypted values to distinguish them from plaintext.
 /// This allows graceful degradation in development environments and safe migration.
+///
+/// # Security
+/// This helper deliberately degrades to plaintext when no key is configured and
+/// MUST NOT be used for persisting secrets such as OAuth tokens or platform
+/// credentials — use [`encrypt_required`] for those so the write fails closed.
 pub fn encrypt_if_available(crypto: Option<&IntegrationCrypto>, plaintext: &str) -> String {
     match crypto {
         Some(c) => match c.encrypt(plaintext) {
@@ -332,6 +378,53 @@ mod tests {
 
         // Decryption should fail authentication
         assert!(crypto.decrypt(&tampered).is_err());
+    }
+
+    #[test]
+    fn test_encrypt_required_fails_closed_without_key() {
+        // Issue #765: a missing encryption key must NOT silently fall back to
+        // plaintext when persisting secrets.
+        let result = encrypt_required(None, "super_secret_token");
+        assert!(matches!(result, Err(CryptoError::KeyNotConfigured(_))));
+    }
+
+    #[test]
+    fn test_encrypt_required_encrypts_with_key() {
+        let crypto = test_crypto();
+        let plaintext = "oauth_access_token";
+
+        let encrypted = encrypt_required(Some(&crypto), plaintext).unwrap();
+        // Never equal to plaintext, and carries the enc: prefix.
+        assert_ne!(encrypted, plaintext);
+        assert!(encrypted.starts_with(ENCRYPTED_PREFIX));
+
+        // decrypt_if_available reads it back transparently.
+        let decrypted = decrypt_if_available(Some(&crypto), &encrypted);
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn test_encrypt_optional_required_semantics() {
+        let crypto = test_crypto();
+
+        // None stays None even without a key.
+        assert!(encrypt_optional_required(None, None).unwrap().is_none());
+        assert!(encrypt_optional_required(Some(&crypto), None)
+            .unwrap()
+            .is_none());
+
+        // Some without a key fails closed.
+        assert!(matches!(
+            encrypt_optional_required(None, Some("refresh")),
+            Err(CryptoError::KeyNotConfigured(_))
+        ));
+
+        // Some with a key encrypts.
+        let encrypted = encrypt_optional_required(Some(&crypto), Some("refresh"))
+            .unwrap()
+            .unwrap();
+        assert!(encrypted.starts_with(ENCRYPTED_PREFIX));
+        assert_eq!(decrypt_if_available(Some(&crypto), &encrypted), "refresh");
     }
 
     #[test]

--- a/backend/crates/integrations/src/lib.rs
+++ b/backend/crates/integrations/src/lib.rs
@@ -79,7 +79,8 @@ pub use accounting::{
 
 // Encryption utilities for sensitive integration data
 pub use crypto::{
-    decrypt_if_available, encrypt_if_available, CryptoError, IntegrationCrypto, ENCRYPTION_KEY_ENV,
+    decrypt_if_available, encrypt_if_available, encrypt_optional_required, encrypt_required,
+    CryptoError, IntegrationCrypto, ENCRYPTION_KEY_ENV,
 };
 
 // Story 96.1: OAuth Token Management

--- a/backend/servers/api-server/src/routes/ai.rs
+++ b/backend/servers/api-server/src/routes/ai.rs
@@ -3053,7 +3053,10 @@ async fn exchange_voice_oauth_tokens(
     ),
     (StatusCode, Json<ErrorResponse>),
 > {
-    use integrations::{encrypt_if_available, IntegrationCrypto, VoiceOAuthManager, VoicePlatform};
+    use integrations::{
+        encrypt_optional_required, encrypt_required, IntegrationCrypto, VoiceOAuthManager,
+        VoicePlatform,
+    };
 
     // Parse the platform
     let voice_platform: VoicePlatform = platform.parse().map_err(|_| {
@@ -3106,13 +3109,40 @@ async fn exchange_voice_oauth_tokens(
             )
         })?;
 
-    // Encrypt tokens for storage
+    // Encrypt tokens for storage. Issue #765: encryption is MANDATORY — fail
+    // closed if INTEGRATION_ENCRYPTION_KEY is unset rather than persisting voice
+    // OAuth tokens in plaintext.
     let crypto = IntegrationCrypto::try_from_env();
-    let access_encrypted = encrypt_if_available(crypto.as_ref(), &tokens.access_token);
-    let refresh_encrypted = tokens
-        .refresh_token
-        .as_ref()
-        .map(|rt| encrypt_if_available(crypto.as_ref(), rt));
+    let access_encrypted =
+        encrypt_required(crypto.as_ref(), &tokens.access_token).map_err(|e| {
+            tracing::error!(
+                "Refusing to store voice OAuth token without encryption: {}",
+                e
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(
+                    "ENCRYPTION_REQUIRED",
+                    "Integration token encryption is not configured",
+                )),
+            )
+        })?;
+    let refresh_encrypted =
+        encrypt_optional_required(crypto.as_ref(), tokens.refresh_token.as_deref()).map_err(
+            |e| {
+                tracing::error!(
+                    "Refusing to store voice OAuth token without encryption: {}",
+                    e
+                );
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new(
+                        "ENCRYPTION_REQUIRED",
+                        "Integration token encryption is not configured",
+                    )),
+                )
+            },
+        )?;
 
     tracing::info!(
         "Successfully exchanged OAuth tokens for voice platform {}",

--- a/backend/servers/api-server/src/routes/integrations/install.rs
+++ b/backend/servers/api-server/src/routes/integrations/install.rs
@@ -11,8 +11,9 @@ use axum::{
 };
 use db::models::infrastructure::{job_type, queue, CreateBackgroundJob};
 use integrations::{
-    AirbnbClient, AirbnbOAuthConfig, AvailabilityUpdate, BookingClient, BookingCredentials,
-    IntegrationCrypto, PortalType, PropertyMapping, RateUpdate, RoomTypeMapping,
+    encrypt_optional_required, encrypt_required, AirbnbClient, AirbnbOAuthConfig,
+    AvailabilityUpdate, BookingClient, BookingCredentials, IntegrationCrypto, PortalType,
+    PropertyMapping, RateUpdate, RoomTypeMapping,
 };
 use serde::Deserialize;
 use utoipa::{IntoParams, ToSchema};
@@ -461,7 +462,10 @@ pub async fn connect_airbnb(
         redirect_uri,
     });
 
-    let oauth_state = format!("{}:{}", path.org_id, uuid::Uuid::new_v4());
+    // Issue #765: generate a server-bound, single-use OAuth state tied to the
+    // initiating org + user (persisted in Redis with a short TTL when available)
+    // instead of a stateless, forgeable `{org_id}:{uuid}` string.
+    let oauth_state = super::oauth_state::issue(&state, path.org_id, auth.user_id).await;
     tracing::debug!(oauth_state = %oauth_state, "Generated OAuth state parameter");
 
     let auth_url = client.generate_auth_url(&oauth_state);
@@ -1827,43 +1831,34 @@ pub async fn direct_connect_airbnb(
 
     let listings_count = listings.len() as i32;
 
-    // Optionally encrypt tokens before storage.
-    let (stored_access, stored_refresh) = match IntegrationCrypto::try_from_env() {
-        Some(crypto) => {
-            let encrypted_access = crypto.encrypt(&request.access_token).map_err(|e| {
-                tracing::error!(error = %e, "Failed to encrypt Airbnb access token");
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse::new(
-                        "CRYPTO_ERROR",
-                        "Failed to encrypt token",
-                    )),
-                )
-            })?;
-            let encrypted_refresh = request
-                .refresh_token
-                .as_deref()
-                .map(|rt| crypto.encrypt(rt))
-                .transpose()
-                .map_err(|e| {
-                    tracing::error!(error = %e, "Failed to encrypt Airbnb refresh token");
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(ErrorResponse::new(
-                            "CRYPTO_ERROR",
-                            "Failed to encrypt refresh token",
-                        )),
-                    )
-                })?;
-            (encrypted_access, encrypted_refresh)
-        }
-        None => {
-            tracing::warn!(
-                "INTEGRATION_ENCRYPTION_KEY is not set; Airbnb tokens will be stored in plaintext"
-            );
-            (request.access_token.clone(), request.refresh_token.clone())
-        }
-    };
+    // Encrypt tokens before storage. Issue #765: encryption is MANDATORY for
+    // persisted secrets — if INTEGRATION_ENCRYPTION_KEY is unset we fail closed
+    // rather than storing tokens in plaintext.
+    let crypto = IntegrationCrypto::try_from_env();
+    let stored_access = encrypt_required(crypto.as_ref(), &request.access_token).map_err(|e| {
+        tracing::error!(error = %e, "Refusing to store Airbnb access token without encryption");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "ENCRYPTION_REQUIRED",
+                "Integration token encryption is not configured",
+            )),
+        )
+    })?;
+    let stored_refresh = encrypt_optional_required(
+        crypto.as_ref(),
+        request.refresh_token.as_deref(),
+    )
+    .map_err(|e| {
+        tracing::error!(error = %e, "Refusing to store Airbnb refresh token without encryption");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "ENCRYPTION_REQUIRED",
+                "Integration token encryption is not configured",
+            )),
+        )
+    })?;
 
     let connection = state
         .rental_repo

--- a/backend/servers/api-server/src/routes/integrations/mod.rs
+++ b/backend/servers/api-server/src/routes/integrations/mod.rs
@@ -11,6 +11,7 @@
 pub mod booking_channel;
 pub mod install;
 pub mod oauth;
+pub mod oauth_state;
 pub mod sync;
 pub mod webhook;
 

--- a/backend/servers/api-server/src/routes/integrations/oauth.rs
+++ b/backend/servers/api-server/src/routes/integrations/oauth.rs
@@ -104,6 +104,30 @@ pub async fn airbnb_oauth_callback(
         ));
     }
 
+    // Issue #765: the OAuth `state` must be a real CSRF token — single-use and
+    // server-bound. Verify it against the value persisted when the flow was
+    // initiated and consume it so it cannot be replayed. When the state store
+    // (Redis) is unavailable we fall back to the stateless org-prefix check
+    // above plus the membership check below (defence in depth).
+    match super::oauth_state::verify_and_consume(&state, &query.state, path.org_id).await {
+        super::oauth_state::ConsumeOutcome::Consumed => {}
+        super::oauth_state::ConsumeOutcome::StoreUnavailable => {
+            tracing::warn!(
+                org_id = %path.org_id,
+                "OAuth state store unavailable; relying on stateless state + membership checks"
+            );
+        }
+        super::oauth_state::ConsumeOutcome::Rejected => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse::new(
+                    "INVALID_STATE",
+                    "OAuth state is invalid, expired, or already used",
+                )),
+            ));
+        }
+    }
+
     // Issue #765: prevent cross-org IDOR — the embedded-state org match above
     // is not an authorization check (the `state` value is client-visible and
     // forgeable). Require the authenticated caller to actually be a member of
@@ -143,19 +167,25 @@ pub async fn airbnb_oauth_callback(
         )
     })?;
 
-    // Encrypt tokens before storage
-    let crypto = integrations::IntegrationCrypto::from_env().ok();
-    let (encrypted_access, encrypted_refresh) = match &crypto {
-        Some(c) => (
-            c.encrypt(&tokens.access_token)
-                .unwrap_or(tokens.access_token.clone()),
-            tokens
-                .refresh_token
-                .as_ref()
-                .map(|rt| c.encrypt(rt).unwrap_or(rt.clone())),
-        ),
-        None => (tokens.access_token.clone(), tokens.refresh_token.clone()),
+    // Encrypt tokens before storage. Issue #765: encryption is MANDATORY — if
+    // INTEGRATION_ENCRYPTION_KEY is unset we fail closed rather than persisting
+    // OAuth tokens in plaintext.
+    let crypto = integrations::IntegrationCrypto::try_from_env();
+    let encryption_unavailable = |e: integrations::CryptoError| {
+        tracing::error!(error = %e, "Refusing to store Airbnb OAuth tokens without encryption");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "ENCRYPTION_REQUIRED",
+                "Integration token encryption is not configured",
+            )),
+        )
     };
+    let encrypted_access = integrations::encrypt_required(crypto.as_ref(), &tokens.access_token)
+        .map_err(encryption_unavailable)?;
+    let encrypted_refresh =
+        integrations::encrypt_optional_required(crypto.as_ref(), tokens.refresh_token.as_deref())
+            .map_err(encryption_unavailable)?;
 
     let rental_repo = &state.rental_repo;
     let connection = rental_repo

--- a/backend/servers/api-server/src/routes/integrations/oauth_state.rs
+++ b/backend/servers/api-server/src/routes/integrations/oauth_state.rs
@@ -1,0 +1,158 @@
+//! Server-bound OAuth `state` parameter store (Issue #765).
+//!
+//! The OAuth `state` parameter must be a real CSRF token: single-use and tied
+//! to the session/user that initiated the authorization flow. Previously the
+//! Airbnb flow used a stateless `{org_id}:{uuid}` string that the server never
+//! persisted, so it could not detect forgery or replay — any value with the
+//! right org prefix was accepted.
+//!
+//! This module persists a generated state in Redis (short TTL) bound to the
+//! initiating `org_id` + `user_id`, and verifies + consumes it on callback so a
+//! state can be used at most once. When Redis is unavailable the caller falls
+//! back to the stateless org-binding + `verify_org_access` checks (defence in
+//! depth), and we log that single-use enforcement is degraded.
+
+use uuid::Uuid;
+
+use crate::state::AppState;
+
+/// TTL for a pending OAuth state, in seconds. An authorization round-trip is
+/// interactive and short; 10 minutes is generous while keeping the replay
+/// window small.
+const OAUTH_STATE_TTL_SECS: u64 = 600;
+
+/// Redis key namespace for pending OAuth states.
+const KEY_PREFIX: &str = "integrations:oauth:state:";
+
+/// The server-side record bound to a generated OAuth state.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct OAuthStateRecord {
+    pub org_id: Uuid,
+    pub user_id: Uuid,
+}
+
+fn redis_key(state: &str) -> String {
+    format!("{KEY_PREFIX}{state}")
+}
+
+/// Generate a new OAuth state and persist it (if Redis is available) bound to
+/// the initiating org + user.
+///
+/// The returned string keeps the `{org_id}:{uuid}` shape so the existing
+/// stateless org-prefix check continues to work as a second layer. When Redis
+/// is configured the random component is the single-use token; when it is not,
+/// the value is still returned but cannot be enforced as single-use.
+pub async fn issue(state: &AppState, org_id: Uuid, user_id: Uuid) -> String {
+    let nonce = Uuid::new_v4();
+    let oauth_state = format!("{org_id}:{nonce}");
+
+    if let Some(redis) = &state.redis_client {
+        let record = OAuthStateRecord { org_id, user_id };
+        match redis
+            .set(
+                &redis_key(&oauth_state),
+                &record,
+                Some(OAUTH_STATE_TTL_SECS),
+            )
+            .await
+        {
+            Ok(()) => {
+                tracing::debug!(org_id = %org_id, "Persisted single-use OAuth state");
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "Failed to persist OAuth state in Redis; single-use enforcement degraded"
+                );
+            }
+        }
+    } else {
+        tracing::warn!("Redis not configured; OAuth state single-use enforcement is unavailable");
+    }
+
+    oauth_state
+}
+
+/// Outcome of verifying + consuming an OAuth state on callback.
+pub enum ConsumeOutcome {
+    /// State was found, matched the org, and has now been consumed (deleted).
+    Consumed,
+    /// State did not match (forged/replayed/expired) — reject the callback.
+    Rejected,
+    /// Redis is unavailable, so single-use enforcement could not run. Callers
+    /// fall back to stateless org-binding + `verify_org_access`.
+    StoreUnavailable,
+}
+
+/// Verify a state on callback and consume it so it cannot be reused.
+///
+/// Returns [`ConsumeOutcome::Consumed`] only if the stored record exists and
+/// its `org_id` matches the callback's path org. The key is deleted on a match
+/// to guarantee single use. A non-matching `org_id` deletes the key and
+/// rejects (prevents replay across orgs).
+pub async fn verify_and_consume(
+    state: &AppState,
+    oauth_state: &str,
+    org_id: Uuid,
+) -> ConsumeOutcome {
+    let Some(redis) = &state.redis_client else {
+        return ConsumeOutcome::StoreUnavailable;
+    };
+
+    let key = redis_key(oauth_state);
+    let record: Option<OAuthStateRecord> = match redis.get(&key).await {
+        Ok(r) => r,
+        Err(e) => {
+            // A Redis read error must not silently pass the check; treat as
+            // unavailable so the stateless fallback decides.
+            tracing::warn!(error = %e, "Failed to read OAuth state from Redis");
+            return ConsumeOutcome::StoreUnavailable;
+        }
+    };
+
+    match record {
+        Some(rec) => {
+            // Always consume the key once seen, on match or mismatch, to
+            // prevent reuse / replay.
+            let _ = redis.delete(&key).await;
+            if rec.org_id == org_id {
+                ConsumeOutcome::Consumed
+            } else {
+                tracing::warn!(
+                    stored_org = %rec.org_id,
+                    path_org = %org_id,
+                    "OAuth state org mismatch on callback"
+                );
+                ConsumeOutcome::Rejected
+            }
+        }
+        None => {
+            tracing::warn!("OAuth state not found or already consumed (possible replay)");
+            ConsumeOutcome::Rejected
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redis_key_is_namespaced() {
+        let key = redis_key("org:nonce");
+        assert_eq!(key, "integrations:oauth:state:org:nonce");
+        assert!(key.starts_with(KEY_PREFIX));
+    }
+
+    #[test]
+    fn state_record_roundtrips_through_json() {
+        let org_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let rec = OAuthStateRecord { org_id, user_id };
+
+        let json = serde_json::to_string(&rec).unwrap();
+        let back: OAuthStateRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.org_id, org_id);
+        assert_eq!(back.user_id, user_id);
+    }
+}

--- a/backend/servers/api-server/src/routes/rentals.rs
+++ b/backend/servers/api-server/src/routes/rentals.rs
@@ -393,7 +393,10 @@ pub async fn airbnb_callback(
     State(state): State<AppState>,
     Query(params): Query<OAuthCallbackQuery>,
 ) -> Result<axum::response::Redirect, (axum::http::StatusCode, String)> {
-    use integrations::{encrypt_if_available, AirbnbClient, AirbnbOAuthConfig, IntegrationCrypto};
+    use integrations::{
+        encrypt_optional_required, encrypt_required, AirbnbClient, AirbnbOAuthConfig,
+        IntegrationCrypto,
+    };
 
     // Check for OAuth error
     if let Some(error) = params.error {
@@ -494,13 +497,28 @@ pub async fn airbnb_callback(
         )
     })?;
 
-    // Encrypt tokens for storage
+    // Encrypt tokens for storage. Issue #765: encryption is MANDATORY — fail
+    // closed if INTEGRATION_ENCRYPTION_KEY is unset rather than storing tokens
+    // in plaintext.
     let crypto = IntegrationCrypto::try_from_env();
-    let access_encrypted = encrypt_if_available(crypto.as_ref(), &tokens.access_token);
-    let refresh_encrypted = tokens
-        .refresh_token
-        .as_ref()
-        .map(|rt| encrypt_if_available(crypto.as_ref(), rt));
+    let access_encrypted =
+        encrypt_required(crypto.as_ref(), &tokens.access_token).map_err(|e| {
+            tracing::error!("Refusing to store Airbnb token without encryption: {}", e);
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "Integration token encryption is not configured".to_string(),
+            )
+        })?;
+    let refresh_encrypted =
+        encrypt_optional_required(crypto.as_ref(), tokens.refresh_token.as_deref()).map_err(
+            |e| {
+                tracing::error!("Refusing to store Airbnb token without encryption: {}", e);
+                (
+                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                    "Integration token encryption is not configured".to_string(),
+                )
+            },
+        )?;
 
     // Update connection with tokens and mark as connected
     state
@@ -540,9 +558,7 @@ pub async fn booking_callback(
     State(state): State<AppState>,
     Query(params): Query<OAuthCallbackQuery>,
 ) -> Result<axum::response::Redirect, (axum::http::StatusCode, String)> {
-    use integrations::{
-        encrypt_if_available, BookingClient, BookingCredentials, IntegrationCrypto,
-    };
+    use integrations::{encrypt_required, BookingClient, BookingCredentials, IntegrationCrypto};
 
     // Check for OAuth error
     if let Some(error) = params.error {
@@ -645,9 +661,20 @@ pub async fn booking_callback(
         ));
     }
 
-    // Encrypt authorization code for storage
+    // Encrypt authorization code for storage. Issue #765: encryption is
+    // MANDATORY for persisted Booking.com credentials — fail closed if
+    // INTEGRATION_ENCRYPTION_KEY is unset.
     let crypto = IntegrationCrypto::try_from_env();
-    let code_encrypted = encrypt_if_available(crypto.as_ref(), &code);
+    let code_encrypted = encrypt_required(crypto.as_ref(), &code).map_err(|e| {
+        tracing::error!(
+            "Refusing to store Booking.com credentials without encryption: {}",
+            e
+        );
+        (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            "Integration credential encryption is not configured".to_string(),
+        )
+    })?;
 
     // Update connection with credentials and mark as connected
     state

--- a/backend/servers/api-server/src/routes/voice_webhooks.rs
+++ b/backend/servers/api-server/src/routes/voice_webhooks.rs
@@ -27,7 +27,7 @@ use db::models::{
     VoiceTokenRefreshRequest, VoiceTokenRefreshResult, WebhookVerificationResult,
 };
 use hmac::{Hmac, KeyInit, Mac};
-use integrations::{encrypt_if_available, IntegrationCrypto};
+use integrations::{encrypt_optional_required, encrypt_required, CryptoError, IntegrationCrypto};
 use serde::Deserialize;
 use sha2::Sha256;
 use sqlx::PgConnection;
@@ -35,6 +35,21 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 type HmacSha256 = Hmac<Sha256>;
+
+/// Map a fail-closed encryption error to an HTTP 500.
+///
+/// Issue #765: persisted voice OAuth tokens must always be encrypted; when
+/// `INTEGRATION_ENCRYPTION_KEY` is unset we refuse to store them in plaintext.
+fn voice_encryption_required(e: CryptoError) -> (StatusCode, Json<ErrorResponse>) {
+    tracing::error!(error = %e, "Refusing to store voice OAuth token without encryption");
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse::new(
+            "ENCRYPTION_REQUIRED",
+            "Integration token encryption is not configured",
+        )),
+    )
+}
 
 // ============================================================================
 // Router
@@ -374,11 +389,12 @@ async fn oauth_token_exchange(
                 )
             })?;
 
-        let access_encrypted = encrypt_if_available(crypto.as_ref(), &tokens.access_token);
-        let refresh_encrypted = tokens
-            .refresh_token
-            .as_ref()
-            .map(|rt| encrypt_if_available(crypto.as_ref(), rt));
+        // Issue #765: encryption is MANDATORY — fail closed if no key is set.
+        let access_encrypted = encrypt_required(crypto.as_ref(), &tokens.access_token)
+            .map_err(voice_encryption_required)?;
+        let refresh_encrypted =
+            encrypt_optional_required(crypto.as_ref(), tokens.refresh_token.as_deref())
+                .map_err(voice_encryption_required)?;
 
         (access_encrypted, refresh_encrypted, tokens.expires_at)
     } else if cfg!(debug_assertions) {
@@ -392,8 +408,12 @@ async fn oauth_token_exchange(
         let simulated_access = format!("voice_access_{}_{}", request.platform, Uuid::new_v4());
         let simulated_refresh = format!("voice_refresh_{}_{}", request.platform, Uuid::new_v4());
         (
-            encrypt_if_available(crypto.as_ref(), &simulated_access),
-            Some(encrypt_if_available(crypto.as_ref(), &simulated_refresh)),
+            encrypt_required(crypto.as_ref(), &simulated_access)
+                .map_err(voice_encryption_required)?,
+            Some(
+                encrypt_required(crypto.as_ref(), &simulated_refresh)
+                    .map_err(voice_encryption_required)?,
+            ),
             Some(Utc::now() + Duration::hours(1)),
         )
     } else {
@@ -526,46 +546,48 @@ async fn oauth_token_refresh(
         )
     })?;
 
-    let (new_access_encrypted, new_refresh_encrypted, new_expires_at) =
-        if oauth_manager.has_platform(voice_platform) {
-            // Decrypt the refresh token
-            let refresh_token = decrypt_if_available(crypto.as_ref(), refresh_token_encrypted);
+    let (new_access_encrypted, new_refresh_encrypted, new_expires_at) = if oauth_manager
+        .has_platform(voice_platform)
+    {
+        // Decrypt the refresh token
+        let refresh_token = decrypt_if_available(crypto.as_ref(), refresh_token_encrypted);
 
-            // Refresh the tokens using OAuth client
-            let tokens = oauth_manager
-                .refresh_token(voice_platform, &refresh_token)
-                .await
-                .map_err(|e| {
-                    tracing::error!("Token refresh failed: {}", e);
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(ErrorResponse::new(
-                            "TOKEN_REFRESH_FAILED",
-                            format!("Failed to refresh token: {}", e),
-                        )),
-                    )
-                })?;
+        // Refresh the tokens using OAuth client
+        let tokens = oauth_manager
+            .refresh_token(voice_platform, &refresh_token)
+            .await
+            .map_err(|e| {
+                tracing::error!("Token refresh failed: {}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new(
+                        "TOKEN_REFRESH_FAILED",
+                        format!("Failed to refresh token: {}", e),
+                    )),
+                )
+            })?;
 
-            let access_encrypted = encrypt_if_available(crypto.as_ref(), &tokens.access_token);
-            let refresh_encrypted = tokens
-                .refresh_token
-                .as_ref()
-                .map(|rt| encrypt_if_available(crypto.as_ref(), rt));
+        // Issue #765: encryption is MANDATORY — fail closed if no key is set.
+        let access_encrypted = encrypt_required(crypto.as_ref(), &tokens.access_token)
+            .map_err(voice_encryption_required)?;
+        let refresh_encrypted =
+            encrypt_optional_required(crypto.as_ref(), tokens.refresh_token.as_deref())
+                .map_err(voice_encryption_required)?;
 
-            (access_encrypted, refresh_encrypted, tokens.expires_at)
-        } else {
-            // Platform not configured - use simulated tokens for development
-            tracing::warn!(
-                "Voice OAuth not configured for platform {}, using simulated refresh",
-                device.platform
-            );
-            let new_access = format!("voice_access_refreshed_{}", Uuid::new_v4());
-            (
-                encrypt_if_available(crypto.as_ref(), &new_access),
-                None,
-                Some(Utc::now() + Duration::hours(1)),
-            )
-        };
+        (access_encrypted, refresh_encrypted, tokens.expires_at)
+    } else {
+        // Platform not configured - use simulated tokens for development
+        tracing::warn!(
+            "Voice OAuth not configured for platform {}, using simulated refresh",
+            device.platform
+        );
+        let new_access = format!("voice_access_refreshed_{}", Uuid::new_v4());
+        (
+            encrypt_required(crypto.as_ref(), &new_access).map_err(voice_encryption_required)?,
+            None,
+            Some(Utc::now() + Duration::hours(1)),
+        )
+    };
 
     // Update the device tokens
     state
@@ -894,15 +916,18 @@ fn verify_hmac_signature(signature: &str, body: &str) -> Result<bool, String> {
 /// Authenticate user via OAuth access token.
 async fn authenticate_voice_user(
     conn: &mut PgConnection,
-    access_token: &str,
+    // Reserved for real OAuth/JWT validation; not used by the simplified
+    // platform lookup below. Issue #765 removed the dead plaintext-encryption of
+    // this value (it was computed and discarded).
+    _access_token: &str,
     platform: &str,
 ) -> Result<db::models::VoiceAssistantDevice, (StatusCode, Json<ErrorResponse>)> {
     // In production, validate the access token and extract user ID
     // For now, find device by platform that has matching token pattern
 
-    // Look for device with this token (simplified - production would validate JWT/OAuth)
-    let crypto = IntegrationCrypto::try_from_env();
-    let _encrypted_token = encrypt_if_available(crypto.as_ref(), access_token);
+    // Look for device with this token (simplified - production would validate JWT/OAuth).
+    // Note: this is a read-only lookup, not a persistence path, so no encryption
+    // of the access token is performed here.
 
     // Try to find a device - for demo, just find any active device for the platform
     // In production, you would validate the token and look up the associated user


### PR DESCRIPTION
## Summary

Hardens two P1 security findings in the integrations OAuth area (#765). Both were verified against current `dev` before fixing.

### Finding 1 — Plaintext token fallback (now fails closed)
Integration/OAuth secrets were stored in **plaintext** whenever `INTEGRATION_ENCRYPTION_KEY` was unset — and silently on any encryption error (`encrypt(...).unwrap_or(plaintext)`). The system never failed closed.

**Fix:** new `encrypt_required` / `encrypt_optional_required` helpers in `crates/integrations/src/crypto.rs` that **never** return plaintext — they `Err` on a missing key or crypto failure, and carry the same `enc:` prefix `decrypt_if_available` already reads. Every token/credential write now uses the fail-closed path and returns `500 ENCRYPTION_REQUIRED` instead of persisting plaintext:

- Airbnb direct-connect — `integrations/install.rs`
- Airbnb OAuth callback — `integrations/oauth.rs`
- Airbnb + Booking.com rental callbacks — `rentals.rs`
- Voice OAuth exchange + refresh — `voice_webhooks.rs`
- Voice OAuth token exchange — `ai.rs`

Also removed a dead plaintext-encrypt of the inbound access token in `authenticate_voice_user` (the value was computed and discarded).

### Finding 2 — OAuth `state` not server-bound (CSRF)
The Airbnb `state` was a stateless `{org_id}:{uuid}` string the server never persisted, so it was not a real CSRF token (any value with the right org prefix was accepted; replayable).

**Fix:** new `routes/integrations/oauth_state.rs`. `connect_airbnb` now issues a **single-use** state persisted in Redis (10-min TTL) bound to the initiating org + user; the callback **verifies + consumes** it, rejecting reuse/replay/forgery with `400 INVALID_STATE`. When Redis is unavailable it logs and falls back to the existing stateless org-prefix + `verify_org_access` checks (defence in depth).

The cross-org IDOR part of #765 (`verify_org_access`) was already fixed by #872 and is left intact.

## Tests
- `crypto::tests` — `encrypt_required` / `encrypt_optional_required` refuse without a key (fail-closed regression); encrypt-with-key + `decrypt_if_available` round-trip.
- `oauth_state::tests` — key namespacing + state record JSON round-trip.

## Verification (isolated target dir, Docker down → compile-only for DB-backed suites)
- `cargo fmt --all` — clean
- `cargo clippy -p api-server -- -D warnings` — clean
- `cargo clippy -p integrations -- -D warnings` — clean
- `cargo test -p integrations --lib crypto::` — 11 passed (incl. 3 new fail-closed tests)
- `cargo test -p api-server --lib integrations::oauth_state` — 2 passed; full api-server lib compiles as a test build

closes #765