### PR TITLE
fix(security): validate OAuth scopes on consent POST before code issuance (closes #756)

### DIFF
--- a/backend/servers/api-server/src/services/oauth.rs
+++ b/backend/servers/api-server/src/services/oauth.rs
@@ -375,6 +375,23 @@ impl OAuthService {
         code_challenge: Option<String>,
         code_challenge_method: Option<String>,
     ) -> Result<String, OAuthServiceError> {
+        // Re-validate the requested scopes against the client's registered grant
+        // before issuance. The consent POST path passes scopes straight from the
+        // submitted form, so without this gate a caller could request scopes the
+        // client was never authorized for (privilege escalation). Validating here
+        // covers every caller of `create_authorization_code`, not just the GET path.
+        let client = self
+            .repo
+            .find_active_client_by_client_id(client_id)
+            .await?
+            .ok_or_else(|| OAuthServiceError::InvalidClient("Client not found".to_string()))?;
+
+        for scope in scopes {
+            if !client.is_scope_allowed(scope) {
+                return Err(OAuthServiceError::InvalidScope(scope.clone()));
+            }
+        }
+
         // Generate authorization code
         let code = self.generate_secure_token();
         let code_hash = self.hash_token(&code);

--- a/backend/servers/api-server/tests/oauth_integration_tests.rs
+++ b/backend/servers/api-server/tests/oauth_integration_tests.rs
@@ -588,6 +588,89 @@ mod consent_revoke {
         assert_eq!(body["error"], "access_denied");
     }
 
+    /// Regression (issue #756): the consent POST must re-validate the requested
+    /// scopes against the client's registered grant before issuing a code.
+    /// The public client is seeded with `["profile"]` only, so a consent POST
+    /// asking for a scope outside that grant must be rejected with
+    /// `invalid_scope` (400) and must NOT issue an authorization code. A request
+    /// for the valid subset (`profile`) must still succeed.
+    #[sqlx::test(migrator = "db::MIGRATOR")]
+    async fn test_consent_post_rejects_scope_outside_client_grant(pool: PgPool) {
+        let app = TestApp::new(pool.clone()).await;
+        let user = TestUser::new();
+        let (access_token, _) = create_authenticated_user(&app, &user).await;
+        let (client_id, redirect_uri) = seed_public_client(&pool).await;
+        let (_verifier, challenge) = pkce_pair();
+
+        // `email` is NOT in the public client's `["profile"]` grant.
+        let escalation_form = form_body(&[
+            ("client_id", &client_id),
+            ("redirect_uri", &redirect_uri),
+            ("scope", "profile email"),
+            ("code_challenge", &challenge),
+            ("code_challenge_method", "S256"),
+            ("consent", "approve"),
+        ]);
+        let resp = app
+            .execute(form_request_with_auth(
+                "/api/v1/oauth/authorize",
+                &escalation_form,
+                &access_token,
+            ))
+            .await;
+        assert_eq!(
+            resp.status,
+            StatusCode::BAD_REQUEST,
+            "requesting a scope outside the client grant must be rejected. body={}",
+            resp.text()
+        );
+        let body = resp.json_value();
+        assert_eq!(body["error"], "invalid_scope");
+
+        // No authorization code may have been persisted for this client.
+        let code_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM oauth_authorization_codes WHERE client_id = $1",
+        )
+        .bind(&client_id)
+        .fetch_one(&pool)
+        .await
+        .expect("count auth codes");
+        assert_eq!(
+            code_count, 0,
+            "no authorization code must be issued when a scope is rejected"
+        );
+
+        // The valid subset (exactly the client's grant) must still succeed.
+        let valid_form = form_body(&[
+            ("client_id", &client_id),
+            ("redirect_uri", &redirect_uri),
+            ("scope", "profile"),
+            ("code_challenge", &challenge),
+            ("code_challenge_method", "S256"),
+            ("consent", "approve"),
+        ]);
+        let ok_resp = app
+            .execute(form_request_with_auth(
+                "/api/v1/oauth/authorize",
+                &valid_form,
+                &access_token,
+            ))
+            .await;
+        assert_eq!(
+            ok_resp.status,
+            StatusCode::OK,
+            "a consent POST for the valid scope subset must still succeed. body={}",
+            ok_resp.text()
+        );
+        assert!(
+            !ok_resp.json_value()["code"]
+                .as_str()
+                .unwrap_or("")
+                .is_empty(),
+            "a non-empty authorization code must be returned for the valid subset"
+        );
+    }
+
     /// After granting, the user can list their grants and then revoke the grant.
     /// After revocation the grant must no longer appear.
     #[sqlx::test(migrator = "db::MIGRATOR")]


### PR DESCRIPTION
Recovered from a session-cut agent. The consent POST path (`authorize_post` → `create_authorization_code`) issued codes with scopes taken straight from the submitted form, with no re-validation against the client's registered grant — a privilege-escalation gap (the GET consent path validated via `is_scope_allowed`; the POST path did not). 

**Fix:** `create_authorization_code` now loads the client and rejects any requested scope not in its grant (`InvalidScope`), covering every caller. PKCE/redirect_uri checks untouched.

**Test:** consent POST with a scope outside the client grant → 400 `invalid_scope` + no authorization code persisted; valid subset → succeeds.

Low-severity #756 follow-ups (introspect cross-client metadata, revoke-unauth) noted for later; not in scope here. CI is the verification gate (recovered WIP).