### PR TITLE
fix(security): audit OAuth client mutations with reason (closes #768, refs #800)

### DIFF
--- a/backend/crates/db/migrations/00173_audit_action_oauth_client_update.sql
+++ b/backend/crates/db/migrations/00173_audit_action_oauth_client_update.sql
@@ -1,0 +1,9 @@
+-- Migration: 00173_audit_action_oauth_client_update.sql
+-- Findings #768 / #800: privileged OAuth client mutations must be audited.
+-- The admin-web OAuth-clients screen requires an operator reason for scope
+-- edits, but `update_client` previously wrote no audit_log row and silently
+-- dropped the reason. Extend the `audit_action` Postgres ENUM with the
+-- `oauth_client_update` variant so the update handler can write an audit row
+-- (with the captured reason) like create/revoke/secret-regenerate already do.
+
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'oauth_client_update';

--- a/backend/crates/db/src/models/audit_log.rs
+++ b/backend/crates/db/src/models/audit_log.rs
@@ -56,6 +56,8 @@ pub enum AuditAction {
     OAuthRevoke,
     #[sqlx(rename = "oauth_client_create")]
     OAuthClientCreate,
+    #[sqlx(rename = "oauth_client_update")]
+    OAuthClientUpdate,
     #[sqlx(rename = "oauth_client_revoke")]
     OAuthClientRevoke,
     #[sqlx(rename = "oauth_client_secret_regenerate")]
@@ -120,6 +122,7 @@ impl AuditAction {
             Self::OAuthAuthorize => "OAuthAuthorize",
             Self::OAuthRevoke => "OAuthRevoke",
             Self::OAuthClientCreate => "OAuthClientCreate",
+            Self::OAuthClientUpdate => "OAuthClientUpdate",
             Self::OAuthClientRevoke => "OAuthClientRevoke",
             Self::OAuthClientSecretRegenerate => "OAuthClientSecretRegenerate",
             Self::OAuthTokenDeniedPrincipalKind => "OAuthTokenDeniedPrincipalKind",

--- a/backend/crates/db/src/models/oauth.rs
+++ b/backend/crates/db/src/models/oauth.rs
@@ -131,6 +131,12 @@ pub struct UpdateOAuthClient {
     pub scopes: Option<Vec<String>>,
     pub is_active: Option<bool>,
     pub rotate_refresh_tokens: Option<bool>,
+    /// Operator-supplied justification for the change. The admin-web UI
+    /// requires this when scopes are edited (privileged mutation) and
+    /// forwards it as `reason`; it is persisted to the audit log only and
+    /// is **not** written to the `oauth_clients` row.
+    #[serde(default)]
+    pub reason: Option<String>,
 }
 
 /// OAuth client summary for listing.

--- a/backend/servers/api-server/src/routes/oauth.rs
+++ b/backend/servers/api-server/src/routes/oauth.rs
@@ -813,10 +813,32 @@ pub async fn get_client(
 )]
 pub async fn update_client(
     _cap: RequireCapability,
+    principal: api_core::extractors::principal::RequestPrincipal,
     State(state): State<AppState>,
     axum::extract::Path(id): axum::extract::Path<Uuid>,
     Json(data): Json<UpdateOAuthClient>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    // Snapshot the pre-update client so the audit row can record the scope
+    // delta (old -> new), the security-relevant part of a privileged change.
+    let before = state.oauth_repo.find_client_by_id(id).await.map_err(|e| {
+        tracing::error!(error = %e, "Failed to load OAuth client before update");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to load client",
+            )),
+        )
+    })?;
+    let old_scopes: Option<Vec<String>> = before.as_ref().map(|c| c.scopes.0.clone());
+
+    // The operator reason is audit-trail-only — never persisted to the
+    // oauth_clients row — so capture it before handing `data` to the service.
+    let reason = data.reason.as_ref().and_then(|r| {
+        let trimmed = r.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    });
+
     let client = state
         .oauth_service
         .update_client(id, data)
@@ -830,7 +852,50 @@ pub async fn update_client(
         })?;
 
     match client {
-        Some(c) => Ok(Json(c)),
+        Some(c) => {
+            // Audit log — privileged mutation. Use the trusted server-side
+            // principal, capture the scope delta, and persist the operator
+            // reason supplied by the admin-web UI. Previously this handler
+            // wrote no audit row at all (findings #768 / #800).
+            let new_scopes = c.scopes.clone();
+            let scopes_changed = old_scopes
+                .as_ref()
+                .map(|old| {
+                    let mut a = old.clone();
+                    let mut b = new_scopes.clone();
+                    a.sort();
+                    b.sort();
+                    a != b
+                })
+                .unwrap_or(false);
+            let user_id: Option<Uuid> = Some(principal.user_id);
+            if let Err(e) = state
+                .audit_log_repo
+                .create(CreateAuditLog {
+                    user_id,
+                    action: AuditAction::OAuthClientUpdate,
+                    resource_type: Some("oauth_client".to_string()),
+                    resource_id: Some(id),
+                    org_id: None,
+                    details: Some(serde_json::json!({
+                        "client_id": c.client_id,
+                        "name": c.name,
+                        "scopes": new_scopes,
+                        "scopes_changed": scopes_changed,
+                        "reason": reason,
+                    })),
+                    old_values: old_scopes.map(|s| serde_json::json!({ "scopes": s })),
+                    new_values: Some(serde_json::json!({ "scopes": new_scopes })),
+                    ip_address: None,
+                    user_agent: None,
+                })
+                .await
+            {
+                tracing::warn!(error = %e, "Failed to create audit log for OAuth client update");
+            }
+
+            Ok(Json(c))
+        }
         None => Err((
             StatusCode::NOT_FOUND,
             Json(ErrorResponse::new("CLIENT_NOT_FOUND", "Client not found")),

--- a/backend/servers/api-server/tests/oauth_integration_tests.rs
+++ b/backend/servers/api-server/tests/oauth_integration_tests.rs
@@ -2401,3 +2401,183 @@ mod provider_security {
         );
     }
 }
+
+// ─── module: admin_client_audit ─────────────────────────────────────────────
+//
+// Findings #768 / #800: privileged OAuth-client mutations on the admin surface
+// must be audited. `update_client` (PATCH /api/v1/admin/oauth/clients/{id})
+// previously wrote NO audit_log row at all and silently dropped the operator
+// `reason` the admin-web UI requires for scope edits. These tests pin the
+// regression: an `oauth_client_update` row is written, and the supplied
+// `reason` is persisted into its `details`.
+#[cfg(test)]
+mod admin_client_audit {
+    use super::*;
+    use api_server::services::JwtService;
+
+    const TEST_JWT_SECRET: &str =
+        "test-secret-key-that-is-at-least-64-characters-long-for-testing-purposes";
+
+    /// Seed a platform-principal user. Returns the new user id.
+    async fn seed_platform_user(pool: &PgPool, email: &str) -> Uuid {
+        sqlx::query_scalar::<_, Uuid>(
+            r#"
+            INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+            VALUES ($1, 'h', 'OAuth Admin Test', 'active', NOW(), 'platform')
+            RETURNING id
+            "#,
+        )
+        .bind(email)
+        .fetch_one(pool)
+        .await
+        .expect("seed platform user")
+    }
+
+    /// Mark the user as MFA-enrolled (the capability gate's step 2.5 wall).
+    async fn enroll_mfa(pool: &PgPool, user_id: Uuid) {
+        sqlx::query(
+            r#"
+            INSERT INTO user_2fa (user_id, secret, enabled, enabled_at, backup_codes, backup_codes_remaining)
+            VALUES ($1, 'unused-secret', true, NOW(), '[]'::jsonb, 0)
+            ON CONFLICT (user_id) DO UPDATE SET enabled = true, enabled_at = NOW()
+            "#,
+        )
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .expect("enroll mfa");
+    }
+
+    /// Grant `oauth_client_write` to the user with `mfa_required = false` so
+    /// the capability extractor's recent-MFA recency check is skipped (we are
+    /// not exercising MFA here — only the audit behaviour of update_client).
+    async fn grant_oauth_client_write(pool: &PgPool, user_id: Uuid, granted_by: Uuid) {
+        sqlx::query(
+            r#"
+            INSERT INTO capability_grants
+                (user_id, capability, granted_by, expires_at, mfa_required, note)
+            VALUES ($1, 'oauth_client_write', $2, NULL, false, 'ci-audit-test')
+            "#,
+        )
+        .bind(user_id)
+        .bind(granted_by)
+        .execute(pool)
+        .await
+        .expect("grant oauth_client_write");
+    }
+
+    /// Look up the internal UUID of a seeded client by its `client_id`.
+    async fn client_uuid(pool: &PgPool, client_id: &str) -> Uuid {
+        sqlx::query_scalar::<_, Uuid>("SELECT id FROM oauth_clients WHERE client_id = $1")
+            .bind(client_id)
+            .fetch_one(pool)
+            .await
+            .expect("client uuid")
+    }
+
+    /// Mint a platform-kind bearer JWT validated by `TestApp`'s JWT secret.
+    fn mint_platform_token(user_id: Uuid, email: &str) -> String {
+        let svc = JwtService::new(TEST_JWT_SECRET).expect("jwt service");
+        svc.generate_access_token_with_kind(
+            user_id,
+            email,
+            "OAuth Admin Test",
+            None,
+            None,
+            Some("platform".to_string()),
+        )
+        .expect("mint token")
+    }
+
+    /// Build a PATCH request (the test RequestBuilder has no `patch` helper).
+    fn patch_request(uri: &str, token: &str, body: serde_json::Value) -> Request<Body> {
+        Request::builder()
+            .method(Method::PATCH)
+            .uri(uri)
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    /// Updating a client's scopes via the admin route must write exactly one
+    /// `oauth_client_update` audit row, attributed to the acting operator,
+    /// with the supplied `reason` persisted in `details.reason`.
+    #[sqlx::test(migrator = "db::MIGRATOR")]
+    #[ignore = "requires postgres + migrations"]
+    async fn update_client_scope_change_writes_audit_with_reason(pool: PgPool) {
+        let app = TestApp::new(pool.clone()).await;
+
+        let admin = seed_platform_user(&pool, "oauth-audit-admin@test.local").await;
+        let granter = seed_platform_user(&pool, "oauth-audit-granter@test.local").await;
+        enroll_mfa(&pool, admin).await;
+        grant_oauth_client_write(&pool, admin, granter).await;
+        let token = mint_platform_token(admin, "oauth-audit-admin@test.local");
+
+        let (client_id, _secret, _redirect) = seed_confidential_client(&pool).await;
+        let id = client_uuid(&pool, &client_id).await;
+
+        let before = count_audit_rows(&pool, admin, "oauth_client_update").await;
+
+        let reason = "Granting calendar scope per ticket OPS-4821";
+        let req = patch_request(
+            &format!("/api/v1/admin/oauth/clients/{id}"),
+            &token,
+            serde_json::json!({
+                "name": "CI Conf (renamed)",
+                "scopes": ["profile", "email", "openid"],
+                "reason": reason,
+            }),
+        );
+        let resp = app.execute(req).await;
+        assert_eq!(
+            resp.status,
+            StatusCode::OK,
+            "update_client must succeed for a granted platform principal (got {}): {}",
+            resp.status,
+            resp.text()
+        );
+
+        // Exactly one audit row was added for this action.
+        let after = count_audit_rows(&pool, admin, "oauth_client_update").await;
+        assert_eq!(
+            after,
+            before + 1,
+            "exactly one oauth_client_update audit row must be written on update_client"
+        );
+
+        // The supplied reason is persisted into the audit row's details, and
+        // the scope change is recorded.
+        let row: (serde_json::Value, Option<Uuid>) = sqlx::query_as(
+            r#"
+            SELECT details, resource_id
+            FROM audit_logs
+            WHERE user_id = $1 AND action::text = 'oauth_client_update'
+            ORDER BY created_at DESC
+            LIMIT 1
+            "#,
+        )
+        .bind(admin)
+        .fetch_one(&pool)
+        .await
+        .expect("fetch audit row");
+
+        assert_eq!(
+            row.0.get("reason").and_then(|v| v.as_str()),
+            Some(reason),
+            "audit details.reason must persist the operator reason, got {}",
+            row.0
+        );
+        assert_eq!(
+            row.0.get("scopes_changed").and_then(|v| v.as_bool()),
+            Some(true),
+            "audit must flag scopes_changed=true, got {}",
+            row.0
+        );
+        assert_eq!(
+            row.1,
+            Some(id),
+            "audit resource_id must reference the updated client UUID"
+        );
+    }
+}


### PR DESCRIPTION
## What

`update_client` (PATCH `/api/v1/admin/oauth/clients/{id}`) wrote **no** audit-log entry and silently dropped the operator `reason` the admin-web OAuth-clients UI requires for scope edits. Privileged OAuth scope changes were therefore unauditable — while the sibling mutations (`register_client`, `revoke_client`, `regenerate_client_secret`) already emit audit rows.

This is finding #1 of #768 / #800 (Epic 10B platform-UX review).

## Changes

- **DTO** (`db/models/oauth.rs`): add `reason: Option<String>` to `UpdateOAuthClient` — audit-trail-only, never written to the `oauth_clients` row (the repo binds fields by name, so the new field is inert in SQL).
- **AuditAction** (`db/models/audit_log.rs`): add `OAuthClientUpdate` variant + exhaust `canonical_name`.
- **Migration** `00173_audit_action_oauth_client_update.sql`: `ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'oauth_client_update'`.
- **Handler** (`api-server/routes/oauth.rs`): `update_client` now takes the trusted `RequestPrincipal`, snapshots pre-update scopes, trims/captures the operator reason, and writes an `oauth_client_update` audit row via the existing `audit_log_repo` — actor, `client_id`, scope delta (`old_values`/`new_values` + `scopes_changed`), and `reason` in `details`. Matches the register/revoke/secret-regenerate idiom (best-effort, `tracing::warn!` on audit-write failure).

## Unaudited → now audited

| Mutation | Before | After |
|----------|--------|-------|
| `update_client` (PATCH) | **no audit row, reason dropped** | `oauth_client_update` row + reason + scope delta |
| create / revoke / secret-regenerate | already audited | unchanged |

## Test

`oauth_integration_tests::admin_client_audit::update_client_scope_change_writes_audit_with_reason` — seeds a platform principal with an `oauth_client_write` grant (`mfa_required=false`) + MFA enrollment, PATCHes a seeded client's scopes with a reason, and asserts exactly one `oauth_client_update` audit row is written with `details.reason` persisted, `scopes_changed=true`, and `resource_id` = client UUID. Gated `#[ignore = "requires postgres + migrations"]` per the file convention (CI runs `-- --ignored`).

## Verify (isolated target dir, Docker down → compile-only)

- `cargo fmt --all` — clean
- `cargo clippy -p api-server -- -D warnings` — clean
- `cargo test -p api-server --no-run` — all test binaries built (incl. `oauth_integration_tests`)

## Out of scope (follow-ups)

- #768 finding #4: capture a `reason` on `register_client` — the admin-web UI only sends a reason on scope edits today, so create/revoke audit rows have no reason to persist yet.
- #800 broader Epic-10B items: system-announcement over-gating (`site_settings_write` vs `_read`), onboarding admin page using user-progress API ungated by capability, health-threshold edits with no audit reason.