### PR TITLE
fix(backend): scheduler retry budget + OAuth introspect/revoke hardening (refs #789, #823)

### DIFF
--- a/backend/crates/db/src/models/oauth.rs
+++ b/backend/crates/db/src/models/oauth.rs
@@ -495,6 +495,12 @@ pub struct RevokeTokenRequest {
     pub token: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token_type_hint: Option<String>,
+    /// Client ID for authentication (RFC 7009 §2.1; alternative to Basic auth).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_id: Option<String>,
+    /// Client secret for authentication (alternative to Basic auth).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_secret: Option<String>,
 }
 
 /// OAuth error response.

--- a/backend/crates/db/src/repositories/background_jobs.rs
+++ b/backend/crates/db/src/repositories/background_jobs.rs
@@ -369,14 +369,32 @@ impl BackgroundJobRepository {
         Ok(jobs)
     }
 
-    /// Reset stuck jobs back to pending.
+    /// Reset stuck jobs, honoring the per-job retry budget.
+    ///
+    /// A job is "stuck" when it has been `running` longer than
+    /// `timeout_minutes`. `claim_background_job` already incremented `attempts`
+    /// when the job was claimed, so the comparison is against the attempts
+    /// already consumed:
+    ///
+    /// - jobs that still have budget (`attempts < max_attempts`) are reset to
+    ///   `pending` so a healthy worker can pick them up again;
+    /// - jobs that have exhausted their budget (`attempts >= max_attempts`) are
+    ///   routed to the terminal `timed_out` state with `completed_at` set, so a
+    ///   job that hangs on every run can no longer loop forever.
+    ///
+    /// Returns the total number of stuck jobs that were transitioned (reset +
+    /// timed out).
     pub async fn reset_stuck_jobs(&self, timeout_minutes: i32) -> Result<i64, SqlxError> {
         let result = sqlx::query(
             r#"
             UPDATE background_jobs
-            SET status = 'pending',
-                worker_id = NULL,
-                started_at = NULL,
+            SET status = CASE
+                    WHEN attempts < max_attempts THEN 'pending'::background_job_status
+                    ELSE 'timed_out'::background_job_status
+                END,
+                worker_id = CASE WHEN attempts < max_attempts THEN NULL ELSE worker_id END,
+                started_at = CASE WHEN attempts < max_attempts THEN NULL ELSE started_at END,
+                completed_at = CASE WHEN attempts < max_attempts THEN completed_at ELSE NOW() END,
                 error_message = 'Job reset due to timeout'
             WHERE status = 'running'
               AND started_at < NOW() - ($1 || ' minutes')::INTERVAL

--- a/backend/crates/db/src/repositories/background_jobs.rs
+++ b/backend/crates/db/src/repositories/background_jobs.rs
@@ -74,13 +74,20 @@ impl BackgroundJobRepository {
         let job_types_arr: Option<Vec<String>> =
             job_types.map(|jt| jt.iter().map(|s| s.to_string()).collect());
 
-        let job =
-            sqlx::query_as::<_, BackgroundJob>("SELECT * FROM claim_background_job($1, $2, $3)")
-                .bind(queue)
-                .bind(worker_id)
-                .bind(job_types_arr)
-                .fetch_optional(&self.pool)
-                .await?;
+        // `claim_background_job` returns the composite `background_jobs` type.
+        // When no job is claimable the function returns a NULL composite, which
+        // `SELECT * FROM ...` expands into a single all-NULL row. Without the
+        // `WHERE id IS NOT NULL` guard that row reaches the decoder and fails
+        // with `UnexpectedNullError` on the non-nullable `id`; with it, an empty
+        // claim collapses to zero rows so `fetch_optional` yields `None`.
+        let job = sqlx::query_as::<_, BackgroundJob>(
+            "SELECT * FROM claim_background_job($1, $2, $3) WHERE id IS NOT NULL",
+        )
+        .bind(queue)
+        .bind(worker_id)
+        .bind(job_types_arr)
+        .fetch_optional(&self.pool)
+        .await?;
 
         Ok(job)
     }

--- a/backend/crates/db/tests/background_jobs_stuck_retry_budget_tests.rs
+++ b/backend/crates/db/tests/background_jobs_stuck_retry_budget_tests.rs
@@ -1,0 +1,146 @@
+//! Regression test for issue #789 (round 6) — the stuck-job reaper used to
+//! reset every timed-out `running` job straight back to `pending`, ignoring the
+//! per-job retry budget (`attempts` / `max_attempts`). A job that hangs on
+//! every run therefore looped forever: claim -> hang -> reset -> claim -> ...
+//!
+//! After the fix `reset_stuck_jobs` only recycles jobs that still have budget
+//! (`attempts < max_attempts`); jobs that have exhausted their attempts are
+//! routed to the terminal `timed_out` state with `completed_at` set, so they
+//! can never be re-claimed.
+//!
+//! These tests drive the real repository method against Postgres, so they fail
+//! on `main` (the exhausted job comes back as `pending`) and pass once the
+//! attempt-budget guard is in place.
+
+use db::models::infrastructure::{BackgroundJobStatus, CreateBackgroundJob};
+use db::repositories::BackgroundJobRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Seed a single background job, then force it into a "stuck running" state with
+/// the requested attempt counters and a `started_at` far enough in the past to
+/// be picked up by `reset_stuck_jobs`. Runs under super-admin RLS context so the
+/// `background_jobs_system_update` policy is satisfied.
+async fn seed_stuck_job(pool: &PgPool, attempts: i32, max_attempts: i32) -> Uuid {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(Option::<Uuid>::None)
+        .bind(Option::<Uuid>::None)
+        .bind(true)
+        .execute(pool)
+        .await
+        .expect("set super-admin context");
+
+    let repo = BackgroundJobRepository::new(pool.clone());
+    let job = repo
+        .create(
+            CreateBackgroundJob {
+                job_type: "test_stuck".to_string(),
+                priority: None,
+                payload: serde_json::json!({}),
+                scheduled_at: None,
+                queue: Some("test-stuck-queue".to_string()),
+                max_attempts: Some(max_attempts),
+                org_id: None,
+            },
+            None,
+        )
+        .await
+        .expect("create job");
+
+    // Simulate a worker that claimed the job (attempts already incremented) and
+    // then hung: status = running, started_at well past the timeout window.
+    sqlx::query(
+        r#"
+        UPDATE background_jobs
+        SET status = 'running',
+            attempts = $2,
+            worker_id = 'worker-hung',
+            started_at = NOW() - INTERVAL '60 minutes',
+            completed_at = NULL
+        WHERE id = $1
+        "#,
+    )
+    .bind(job.id)
+    .bind(attempts)
+    .execute(pool)
+    .await
+    .expect("force stuck running state");
+
+    job.id
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn stuck_job_with_remaining_budget_is_reset_to_pending(pool: PgPool) {
+    // attempts (1) < max_attempts (3): still retriable.
+    let job_id = seed_stuck_job(&pool, 1, 3).await;
+    let repo = BackgroundJobRepository::new(pool.clone());
+
+    let affected = repo.reset_stuck_jobs(10).await.expect("reset stuck jobs");
+    assert_eq!(affected, 1, "the stuck job should be transitioned");
+
+    let job = repo
+        .find_by_id(job_id)
+        .await
+        .expect("find job")
+        .expect("job exists");
+
+    assert_eq!(
+        job.status,
+        BackgroundJobStatus::Pending,
+        "a job with remaining attempts must be recycled to pending"
+    );
+    assert!(
+        job.worker_id.is_none(),
+        "worker_id must be cleared on reset"
+    );
+    assert!(
+        job.started_at.is_none(),
+        "started_at must be cleared on reset"
+    );
+    assert!(
+        job.completed_at.is_none(),
+        "a recycled job is not finished, so completed_at stays null"
+    );
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn stuck_job_with_exhausted_budget_is_timed_out_not_recycled(pool: PgPool) {
+    // attempts (3) == max_attempts (3): budget exhausted. On `main` this came
+    // back as `pending` and looped forever; the fix sends it to `timed_out`.
+    let job_id = seed_stuck_job(&pool, 3, 3).await;
+    let repo = BackgroundJobRepository::new(pool.clone());
+
+    let affected = repo.reset_stuck_jobs(10).await.expect("reset stuck jobs");
+    assert_eq!(affected, 1, "the exhausted job should be transitioned");
+
+    let job = repo
+        .find_by_id(job_id)
+        .await
+        .expect("find job")
+        .expect("job exists");
+
+    assert_eq!(
+        job.status,
+        BackgroundJobStatus::TimedOut,
+        "an attempt-exhausted job must be terminated, not recycled to pending"
+    );
+    assert_ne!(
+        job.status,
+        BackgroundJobStatus::Pending,
+        "the infinite-retry loop regression must not reappear"
+    );
+    assert!(
+        job.completed_at.is_some(),
+        "a terminated job must have completed_at set"
+    );
+
+    // A terminal job is invisible to the claimer, so it cannot loop again.
+    let reclaimed = repo
+        .claim_job("test-stuck-queue", "worker-next", None)
+        .await
+        .expect("claim attempt");
+    assert!(
+        reclaimed.is_none(),
+        "a timed-out job must not be re-claimable"
+    );
+}

--- a/backend/servers/api-server/src/routes/oauth.rs
+++ b/backend/servers/api-server/src/routes/oauth.rs
@@ -465,6 +465,12 @@ pub async fn token(
 // ==================== Token Revocation ====================
 
 /// Revoke a token (RFC 7009).
+///
+/// Requires client authentication (RFC 7009 §2.1): confidential clients must
+/// present a valid `client_secret`, public clients authenticate by `client_id`
+/// alone. The token is only revoked if it was issued to the authenticating
+/// client — this prevents an unauthenticated caller (or another client) from
+/// revoking arbitrary tokens, which would otherwise be a trivial DoS.
 #[utoipa::path(
     post,
     path = "/api/v1/oauth/revoke",
@@ -472,20 +478,99 @@ pub async fn token(
     request_body = RevokeTokenRequest,
     responses(
         (status = 200, description = "Token revoked"),
-        (status = 400, description = "Invalid request", body = OAuthError)
+        (status = 400, description = "Invalid request", body = OAuthError),
+        (status = 401, description = "Invalid client", body = OAuthError)
     )
 )]
 pub async fn revoke(
     State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
     Form(request): Form<RevokeTokenRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<OAuthError>)> {
+    let client_id = authenticate_revocation_client(
+        &state,
+        &headers,
+        &request.client_id,
+        &request.client_secret,
+    )
+    .await?;
+
     state
         .oauth_service
-        .revoke_token(&request.token, request.token_type_hint.as_deref())
+        .revoke_token(
+            &request.token,
+            request.token_type_hint.as_deref(),
+            &client_id,
+        )
         .await
         .map_err(|e| (StatusCode::BAD_REQUEST, Json(e.into())))?;
 
     Ok(StatusCode::OK)
+}
+
+/// Authenticate the client calling the revocation endpoint and return its
+/// `client_id`. Mirrors the `/token` endpoint policy: confidential clients must
+/// supply a valid secret; public clients authenticate by `client_id` only.
+async fn authenticate_revocation_client(
+    state: &AppState,
+    headers: &axum::http::HeaderMap,
+    form_client_id: &Option<String>,
+    form_client_secret: &Option<String>,
+) -> Result<String, (StatusCode, Json<OAuthError>)> {
+    // Basic-auth credentials take precedence over form fields, matching
+    // `/introspect` and `extract_client_credentials`.
+    let creds = extract_client_credentials(headers, form_client_id, form_client_secret);
+    let (client_id, supplied_secret) = match creds {
+        Some((id, secret)) => (id, Some(secret)),
+        None => {
+            let id = form_client_id.clone().ok_or_else(|| {
+                (
+                    StatusCode::UNAUTHORIZED,
+                    Json(OAuthError::invalid_client("client authentication required")),
+                )
+            })?;
+            (id, None)
+        }
+    };
+
+    let client = state
+        .oauth_service
+        .get_client(&client_id)
+        .await
+        .map_err(|e| (StatusCode::UNAUTHORIZED, Json(e.into())))?
+        .ok_or_else(|| {
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(OAuthError::invalid_client("unknown or inactive client")),
+            )
+        })?;
+
+    if client.is_confidential {
+        let secret = supplied_secret.ok_or_else(|| {
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(OAuthError::invalid_client(
+                    "client_secret required for confidential clients",
+                )),
+            )
+        })?;
+        state
+            .oauth_service
+            .validate_client_credentials(&client_id, &secret)
+            .await
+            .map_err(|e| (StatusCode::UNAUTHORIZED, Json(e.into())))?;
+    } else if let Some(secret) = supplied_secret {
+        // Public client that supplied a secret anyway — validate it so a
+        // misconfigured client surfaces the mismatch instead of silently
+        // succeeding.
+        state
+            .oauth_service
+            .validate_client_credentials(&client_id, &secret)
+            .await
+            .map_err(|e| (StatusCode::UNAUTHORIZED, Json(e.into())))?;
+    }
+
+    Ok(client_id)
 }
 
 // ==================== Token Introspection ====================
@@ -540,9 +625,12 @@ pub async fn introspect(
             )
         })?;
 
+    // Bind the response to the authenticated client: a token belonging to a
+    // different client is reported as inactive (RFC 7662 §2.2), so a client
+    // cannot enumerate another client's token metadata.
     let response = state
         .oauth_service
-        .introspect_token(&request.token)
+        .introspect_token(&request.token, &client_id)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(e.into())))?;
 

--- a/backend/servers/api-server/src/services/oauth.rs
+++ b/backend/servers/api-server/src/services/oauth.rs
@@ -614,15 +614,25 @@ impl OAuthService {
     // ==================== Token Operations ====================
 
     /// Validate and introspect an access token.
+    /// Introspect a token on behalf of an authenticated client.
+    ///
+    /// `authenticated_client_id` is the client that authenticated to the
+    /// introspection endpoint. RFC 7662 §2.2 lets the server tailor the
+    /// response to the requester; we bind the metadata to the calling client so
+    /// one client cannot enumerate another client's token contents (scopes,
+    /// subject, expiry). A token that belongs to a different client is reported
+    /// as `inactive` — indistinguishable from an unknown/expired token, which
+    /// also avoids leaking token existence across client boundaries.
     pub async fn introspect_token(
         &self,
         token: &str,
+        authenticated_client_id: &str,
     ) -> Result<IntrospectionResponse, OAuthServiceError> {
         let token_hash = self.hash_token(token);
 
         // Try access token first
         if let Some(access_token) = self.repo.find_access_token_by_hash(&token_hash).await? {
-            if !access_token.is_valid() {
+            if !access_token.is_valid() || access_token.client_id != authenticated_client_id {
                 return Ok(IntrospectionResponse::inactive());
             }
 
@@ -640,7 +650,7 @@ impl OAuthService {
 
         // Try refresh token
         if let Some(refresh_token) = self.repo.find_refresh_token_by_hash(&token_hash).await? {
-            if !refresh_token.is_valid() {
+            if !refresh_token.is_valid() || refresh_token.client_id != authenticated_client_id {
                 return Ok(IntrospectionResponse::inactive());
             }
 
@@ -659,21 +669,37 @@ impl OAuthService {
         Ok(IntrospectionResponse::inactive())
     }
 
-    /// Revoke a token.
+    /// Revoke a token on behalf of an authenticated client.
+    ///
+    /// `authenticated_client_id` is the client that authenticated to the
+    /// revocation endpoint. RFC 7009 §2.1 requires that the server "first
+    /// validate the client credentials ... and then verify whether the token
+    /// was issued to the client making the revocation request." A token that
+    /// belongs to a different client is left untouched — this closes the
+    /// unauthenticated cross-client revocation / DoS hole where any party that
+    /// learned a token could revoke it. Returning `Ok(())` regardless keeps the
+    /// RFC-mandated behaviour of not disclosing whether the token existed.
     pub async fn revoke_token(
         &self,
         token: &str,
         _token_type_hint: Option<&str>,
+        authenticated_client_id: &str,
     ) -> Result<(), OAuthServiceError> {
         let token_hash = self.hash_token(token);
 
-        // Try to revoke as access token
-        if self.repo.revoke_access_token_by_hash(&token_hash).await? {
+        // Try to revoke as access token — only if it belongs to this client.
+        if let Some(access_token) = self.repo.find_access_token_by_hash(&token_hash).await? {
+            if access_token.client_id == authenticated_client_id {
+                self.repo.revoke_access_token_by_hash(&token_hash).await?;
+            }
             return Ok(());
         }
 
-        // Try to revoke as refresh token
-        if self.repo.revoke_refresh_token_by_hash(&token_hash).await? {
+        // Try to revoke as refresh token — only if it belongs to this client.
+        if let Some(refresh_token) = self.repo.find_refresh_token_by_hash(&token_hash).await? {
+            if refresh_token.client_id == authenticated_client_id {
+                self.repo.revoke_refresh_token_by_hash(&token_hash).await?;
+            }
             return Ok(());
         }
 

--- a/backend/servers/api-server/tests/oauth_integration_tests.rs
+++ b/backend/servers/api-server/tests/oauth_integration_tests.rs
@@ -1028,8 +1028,13 @@ mod refresh_rotation {
         // Obtain an initial refresh token via the full auth flow.
         let (_at, rt) = auth_flow(&app, &user_at, &client_id, &client_secret, &redirect_uri).await;
 
-        // Explicitly revoke the refresh token via RFC 7009.
-        let revoke_body = form_body(&[("token", &rt), ("token_type_hint", "refresh_token")]);
+        // Explicitly revoke the refresh token via RFC 7009 (client-authenticated).
+        let revoke_body = form_body(&[
+            ("token", &rt),
+            ("token_type_hint", "refresh_token"),
+            ("client_id", &client_id),
+            ("client_secret", &client_secret),
+        ]);
         let revoke_resp = app
             .execute(form_request("/api/v1/oauth/revoke", &revoke_body))
             .await;
@@ -1415,8 +1420,13 @@ mod audit_trail {
             .expect("access_token")
             .to_string();
 
-        // Revoke the access token (RFC 7009)
-        let revoke_body = form_body(&[("token", &oauth_at), ("token_type_hint", "access_token")]);
+        // Revoke the access token (RFC 7009, client-authenticated)
+        let revoke_body = form_body(&[
+            ("token", &oauth_at),
+            ("token_type_hint", "access_token"),
+            ("client_id", &client_id),
+            ("client_secret", &client_secret),
+        ]);
         let revoke_resp = app
             .execute(form_request("/api/v1/oauth/revoke", &revoke_body))
             .await;
@@ -1487,8 +1497,13 @@ mod audit_trail {
             .expect("refresh_token")
             .to_string();
 
-        // Revoke the refresh token via RFC 7009.
-        let revoke_body = form_body(&[("token", &oauth_rt), ("token_type_hint", "refresh_token")]);
+        // Revoke the refresh token via RFC 7009 (client-authenticated).
+        let revoke_body = form_body(&[
+            ("token", &oauth_rt),
+            ("token_type_hint", "refresh_token"),
+            ("client_id", &client_id),
+            ("client_secret", &client_secret),
+        ]);
         let revoke_resp = app
             .execute(form_request("/api/v1/oauth/revoke", &revoke_body))
             .await;
@@ -1896,8 +1911,13 @@ mod provider_security {
         let (oauth_at, _rt) =
             auth_flow_confidential(&app, &user_at, &client_id, &client_secret, &redirect_uri).await;
 
-        // Revoke the access token via RFC 7009
-        let revoke_body = form_body(&[("token", &oauth_at), ("token_type_hint", "access_token")]);
+        // Revoke the access token via RFC 7009 (client-authenticated)
+        let revoke_body = form_body(&[
+            ("token", &oauth_at),
+            ("token_type_hint", "access_token"),
+            ("client_id", &client_id),
+            ("client_secret", &client_secret),
+        ]);
         let revoke_resp = app
             .execute(form_request("/api/v1/oauth/revoke", &revoke_body))
             .await;
@@ -1940,8 +1960,13 @@ mod provider_security {
         let (_at, rt) =
             auth_flow_confidential(&app, &user_at, &client_id, &client_secret, &redirect_uri).await;
 
-        // Revoke the refresh token via RFC 7009
-        let revoke_body = form_body(&[("token", &rt), ("token_type_hint", "refresh_token")]);
+        // Revoke the refresh token via RFC 7009 (client-authenticated)
+        let revoke_body = form_body(&[
+            ("token", &rt),
+            ("token_type_hint", "refresh_token"),
+            ("client_id", &client_id),
+            ("client_secret", &client_secret),
+        ]);
         let revoke_resp = app
             .execute(form_request("/api/v1/oauth/revoke", &revoke_body))
             .await;
@@ -2481,6 +2506,159 @@ mod provider_security {
             err["error"], "invalid_client",
             "error must be invalid_client for deactivated client, got {}",
             err
+        );
+    }
+
+    // ── C. Revocation endpoint authentication (#823 / RFC 7009 §2.1) ─────────
+
+    /// The revocation endpoint must require client authentication. An
+    /// unauthenticated caller (no client_id / client_secret) must be rejected
+    /// with 401 and MUST NOT revoke the token. Before the fix the endpoint took
+    /// any token from any caller and revoked it — a trivial unauthenticated DoS.
+    #[sqlx::test(migrator = "db::MIGRATOR")]
+    async fn test_revoke_without_client_auth_is_rejected_and_no_op(pool: PgPool) {
+        let app = TestApp::new(pool.clone()).await;
+        let user = TestUser::new();
+        let (user_at, _) = create_authenticated_user(&app, &user).await;
+        let (client_id, client_secret, redirect_uri) = seed_confidential_client(&pool).await;
+
+        let (oauth_at, _rt) =
+            auth_flow_confidential(&app, &user_at, &client_id, &client_secret, &redirect_uri).await;
+
+        // Revoke WITHOUT any client credentials.
+        let revoke_body = form_body(&[("token", &oauth_at), ("token_type_hint", "access_token")]);
+        let resp = app
+            .execute(form_request("/api/v1/oauth/revoke", &revoke_body))
+            .await;
+        assert_eq!(
+            resp.status,
+            StatusCode::UNAUTHORIZED,
+            "unauthenticated revoke must return 401. body={}",
+            resp.text()
+        );
+
+        // The token must still be active — the unauthenticated call must be a
+        // no-op, not a successful revocation.
+        let introspect_body = form_body(&[
+            ("token", &oauth_at),
+            ("client_id", &client_id),
+            ("client_secret", &client_secret),
+        ]);
+        let intro = app
+            .execute(form_request("/api/v1/oauth/introspect", &introspect_body))
+            .await
+            .json_value();
+        assert_eq!(
+            intro["active"], true,
+            "token must remain active after an unauthenticated revoke attempt, got {}",
+            intro
+        );
+    }
+
+    /// A client must not be able to revoke another client's token. The
+    /// revocation endpoint authenticates the caller, but the token belongs to a
+    /// different client, so the revoke must be a no-op (200 per RFC 7009, but
+    /// the victim token stays active).
+    #[sqlx::test(migrator = "db::MIGRATOR")]
+    async fn test_revoke_cross_client_token_is_no_op(pool: PgPool) {
+        let app = TestApp::new(pool.clone()).await;
+        let user = TestUser::new();
+        let (user_at, _) = create_authenticated_user(&app, &user).await;
+
+        // Victim client issues a token.
+        let (victim_id, victim_secret, victim_redirect) = seed_confidential_client(&pool).await;
+        let (victim_at, _rt) =
+            auth_flow_confidential(&app, &user_at, &victim_id, &victim_secret, &victim_redirect)
+                .await;
+
+        // Attacker client authenticates with its OWN valid credentials and tries
+        // to revoke the victim's token.
+        let (attacker_id, attacker_secret, _attacker_redirect) =
+            seed_confidential_client(&pool).await;
+        let revoke_body = form_body(&[
+            ("token", &victim_at),
+            ("token_type_hint", "access_token"),
+            ("client_id", &attacker_id),
+            ("client_secret", &attacker_secret),
+        ]);
+        let resp = app
+            .execute(form_request("/api/v1/oauth/revoke", &revoke_body))
+            .await;
+        assert_eq!(
+            resp.status,
+            StatusCode::OK,
+            "RFC 7009 returns 200 even when the token is not the caller's. body={}",
+            resp.text()
+        );
+
+        // Victim token must still be active — the cross-client revoke is a no-op.
+        let introspect_body = form_body(&[
+            ("token", &victim_at),
+            ("client_id", &victim_id),
+            ("client_secret", &victim_secret),
+        ]);
+        let intro = app
+            .execute(form_request("/api/v1/oauth/introspect", &introspect_body))
+            .await
+            .json_value();
+        assert_eq!(
+            intro["active"], true,
+            "another client must not be able to revoke this token, got {}",
+            intro
+        );
+    }
+
+    /// Introspection must be bound to the authenticating client. A client that
+    /// authenticates correctly but introspects a token belonging to a different
+    /// client must get `active=false` (RFC 7662 §2.2) — no cross-client metadata
+    /// leak (scope / sub / expiry).
+    #[sqlx::test(migrator = "db::MIGRATOR")]
+    async fn test_introspect_cross_client_token_reports_inactive(pool: PgPool) {
+        let app = TestApp::new(pool.clone()).await;
+        let user = TestUser::new();
+        let (user_at, _) = create_authenticated_user(&app, &user).await;
+
+        // Owner client issues a token.
+        let (owner_id, owner_secret, owner_redirect) = seed_confidential_client(&pool).await;
+        let (owner_at, _rt) =
+            auth_flow_confidential(&app, &user_at, &owner_id, &owner_secret, &owner_redirect).await;
+
+        // Sanity: the owner sees its own token as active.
+        let owner_introspect = form_body(&[
+            ("token", &owner_at),
+            ("client_id", &owner_id),
+            ("client_secret", &owner_secret),
+        ]);
+        let owner_intro = app
+            .execute(form_request("/api/v1/oauth/introspect", &owner_introspect))
+            .await
+            .json_value();
+        assert_eq!(
+            owner_intro["active"], true,
+            "owner must see its own token active, got {}",
+            owner_intro
+        );
+
+        // A different (validly authenticated) client introspects the same token.
+        let (other_id, other_secret, _other_redirect) = seed_confidential_client(&pool).await;
+        let other_introspect = form_body(&[
+            ("token", &owner_at),
+            ("client_id", &other_id),
+            ("client_secret", &other_secret),
+        ]);
+        let other_intro = app
+            .execute(form_request("/api/v1/oauth/introspect", &other_introspect))
+            .await
+            .json_value();
+        assert_eq!(
+            other_intro["active"], false,
+            "a token belonging to another client must introspect as inactive, got {}",
+            other_intro
+        );
+        assert!(
+            other_intro["scope"].is_null() && other_intro["sub"].is_null(),
+            "no token metadata may leak across clients, got {}",
+            other_intro
         );
     }
 }


### PR DESCRIPTION
## Summary

Two remaining live backend review residuals from umbrellas #789 and #823. Most of both umbrellas was already fixed on `dev`; this PR closes the concrete remaining items.

### 1. Scheduler stuck-job retry budget (#789 round 6) — P2 — **fixed**

`BackgroundJobRepository::reset_stuck_jobs` reset **every** timed-out `running` job back to `pending` without consulting the attempt budget. Because `claim_background_job` increments `attempts` on claim, a job that hangs on every run consumed an attempt each cycle but was endlessly recycled — an infinite retry loop.

Now:
- jobs with `attempts < max_attempts` are recycled to `pending` (worker/started cleared) for a healthy retry;
- jobs with `attempts >= max_attempts` are routed to the terminal `timed_out` state (the enum already had it) with `completed_at` set, so the claimer can never pick them up again.

Regression tests: `backend/crates/db/tests/background_jobs_stuck_retry_budget_tests.rs` — one test per branch, including a re-claim assertion proving the exhausted job is no longer claimable. These drive the real repo against Postgres and fail on `main` (exhausted job returns as `pending`).

### 2. OAuth introspect / revoke hardening (#823) — **both fixed (genuine findings)**

**Revoke** (`POST /oauth/revoke`, RFC 7009) had **no client authentication at all** — any caller who obtained or guessed a token could revoke it (a real unauthenticated DoS, not RFC-permitted). Fixed:
- the endpoint now authenticates the client (confidential clients must present a valid `client_secret`; public clients authenticate by `client_id`), mirroring the `/token` endpoint policy;
- the token is only revoked if it was issued to the authenticating client; a cross-client token is a no-op and returns 200 (RFC 7009 §2.1, no existence disclosure).

**Introspect** (`POST /oauth/introspect`, RFC 7662) was client-authenticated but returned full metadata for **any** token regardless of owner — a cross-client metadata leak (scope/sub/expiry). Per RFC 7662 §2.2 the response is now bound to the calling client; a token belonging to another client reports `active=false`. Low-risk hardening, done because the same client-binding plumbing was already needed for revoke.

`RevokeTokenRequest` gains `client_id`/`client_secret` fields (form/Basic-auth, matching introspect). Existing revoke integration tests updated to authenticate; new regression tests added:
- `test_revoke_without_client_auth_is_rejected_and_no_op` (401 + token stays active)
- `test_revoke_cross_client_token_is_no_op`
- `test_introspect_cross_client_token_reports_inactive`

#### Deferred / no-op from these umbrellas
None deferred from the two live items — both were genuine and are fixed. The other rounds-6–10 items in #789 and the #823 P1 notes (authorize_get auth, PKCE-required, redirect_uri binding) were already addressed on `dev` (verified: `authorize_get` now requires bearer + `validate_access_token`).

## Verification

Isolated target dir (`$HOME/.cargo-targets/ct-resid`, cleaned up after):
- `cargo fmt --all` — clean
- `cargo clippy -p api-server -p db -- -D warnings` — clean
- `cargo test -p db --no-run` and `cargo test -p api-server --test oauth_integration_tests --no-run` — compile OK
- Test **execution** skipped: local Docker/Postgres is down (`PoolTimedOut` on connect), per task guidance compile-only is acceptable. CI will run them against a live DB.

refs #789, #823