### PR TITLE
fix: clear remaining review-tail findings (#764, #698, #767, #751)

### DIFF
--- a/.github/workflows/eas-build-android.yml
+++ b/.github/workflows/eas-build-android.yml
@@ -101,6 +101,28 @@ jobs:
         working-directory: frontend/apps/mobile
         run: pnpm typecheck
 
+      # issue #767 (#6) — fail fast before invoking EAS when the required
+      # repo/org secrets are absent. Without this the build proceeds to
+      # `eas build` and fails deep in the EAS pipeline with an opaque auth
+      # error. Note: the real production API_BASE_URL / WS_BASE_URL live in the
+      # EAS *project* secret store (not GitHub secrets) — they cannot be
+      # verified here, so this only guards the GitHub-level prerequisites.
+      - name: Verify required EAS secrets
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          EXPO_PROJECT_ID: ${{ secrets.EXPO_PROJECT_ID }}
+        run: |
+          missing=""
+          [ -z "$EXPO_TOKEN" ] && missing="$missing EXPO_TOKEN"
+          [ -z "$EXPO_PROJECT_ID" ] && missing="$missing EXPO_PROJECT_ID"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing required GitHub secret(s):$missing"
+            echo "Set them under repo/org Settings → Secrets and variables → Actions."
+            echo "See the header of this workflow for the one-time setup checklist."
+            exit 1
+          fi
+          echo "Required EAS secrets present."
+
       - name: Setup EAS
         uses: expo/expo-github-action@v8
         with:

--- a/.github/workflows/eas-build-ios.yml
+++ b/.github/workflows/eas-build-ios.yml
@@ -96,6 +96,28 @@ jobs:
         working-directory: frontend
         run: pnpm lint
 
+      # issue #767 (#6) — fail fast before invoking EAS when the required
+      # repo/org secrets are absent. Without this the build proceeds to
+      # `eas build` and fails deep in the EAS pipeline with an opaque auth
+      # error. Note: the real production API_BASE_URL / WS_BASE_URL live in the
+      # EAS *project* secret store (not GitHub secrets) — they cannot be
+      # verified here, so this only guards the GitHub-level prerequisites.
+      - name: Verify required EAS secrets
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          EXPO_PROJECT_ID: ${{ secrets.EXPO_PROJECT_ID }}
+        run: |
+          missing=""
+          [ -z "$EXPO_TOKEN" ] && missing="$missing EXPO_TOKEN"
+          [ -z "$EXPO_PROJECT_ID" ] && missing="$missing EXPO_PROJECT_ID"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing required GitHub secret(s):$missing"
+            echo "Set them under repo/org Settings → Secrets and variables → Actions."
+            echo "See the header of this workflow for the one-time setup checklist."
+            exit 1
+          fi
+          echo "Required EAS secrets present."
+
       - name: Setup EAS
         uses: expo/expo-github-action@v8
         with:

--- a/backend/servers/api-server/src/routes/admin/mfa/mod.rs
+++ b/backend/servers/api-server/src/routes/admin/mfa/mod.rs
@@ -7,16 +7,19 @@
 //! Endpoints:
 //!   * `POST /admin/mfa/enroll/start`   — generate TOTP secret, return QR URI
 //!   * `POST /admin/mfa/enroll/verify`  — confirm code, activate, issue recovery codes
+//!   * `POST /admin/mfa/verify`         — TOTP step-up for enrolled users (opens recency window)
 //!   * `POST /admin/mfa/recovery/use`   — consume a recovery code (lockout fallback)
 //!   * `POST /admin/mfa/disable`        — clear enrollment (requires fresh MFA or recovery code)
 
 mod disable;
 mod enroll;
 mod recovery;
+mod verify;
 
 pub use disable::disable_mfa;
 pub use enroll::{start_enroll, verify_enroll};
 pub use recovery::use_recovery;
+pub use verify::verify_step_up;
 
 use axum::{routing::post, Router};
 
@@ -27,6 +30,7 @@ pub fn router() -> Router<AppState> {
     Router::new()
         .route("/enroll/start", post(start_enroll))
         .route("/enroll/verify", post(verify_enroll))
+        .route("/verify", post(verify_step_up))
         .route("/recovery/use", post(use_recovery))
         .route("/disable", post(disable_mfa))
 }

--- a/backend/servers/api-server/src/routes/admin/mfa/verify.rs
+++ b/backend/servers/api-server/src/routes/admin/mfa/verify.rs
@@ -1,0 +1,173 @@
+//! Admin MFA step-up (TOTP) verification. Phase 6 (B6) follow-up (#764).
+//!
+//! `POST /admin/mfa/verify` is the interactive TOTP step-up for an *already
+//! enrolled* platform principal. When a capability-gated admin call returns
+//! `401 mfa_required`, the admin-web `MfaChallengeProvider` prompts for a
+//! 6-digit code and POSTs it here. On success the server records a
+//! `two_factor_auth_verifications` row (`method = 'totp'`) so the 15-minute
+//! recency window opens and the original mutation can be retried.
+//!
+//! This is distinct from:
+//!   * `POST /api/v1/auth/mfa/verify` — *setup completion* (enables MFA, issues
+//!     recovery codes, 409s if already enabled, never opens a recency window).
+//!   * `POST /admin/mfa/recovery/use` — lockout fallback via single-use code.
+//!
+//! Before this endpoint existed an enrolled admin could only satisfy the
+//! recency gate by burning a recovery code, which is wrong: recovery codes are
+//! a one-time lockout escape hatch, not the day-to-day step-up path.
+
+use std::sync::Arc;
+
+use axum::{extract::State, http::StatusCode, response::IntoResponse, Extension, Json};
+use serde::{Deserialize, Serialize};
+
+use admin_core::{AuditOutcome, AuditWriter, Capability};
+use api_core::extractors::principal::RequestPrincipal;
+
+use crate::state::AppState;
+
+/// Request body for `POST /admin/mfa/verify`.
+#[derive(Debug, Deserialize)]
+pub struct VerifyStepUpRequest {
+    /// 6-digit TOTP code from the authenticator app.
+    pub code: String,
+}
+
+/// Response for `POST /admin/mfa/verify`.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerifyStepUpResponse {
+    pub message: String,
+}
+
+/// Verify a TOTP code for an enrolled platform principal and open the
+/// 15-minute MFA recency window.
+///
+/// Side-effects on success:
+///   1. Inserts a `two_factor_auth_verifications` row (`method = 'totp'`).
+///   2. Audits the event.
+pub async fn verify_step_up(
+    principal: RequestPrincipal,
+    State(state): State<AppState>,
+    Extension(audit): Extension<Arc<dyn AuditWriter>>,
+    Json(req): Json<VerifyStepUpRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
+    let user_id = principal.user_id;
+
+    // Platform-kind guard. Mirrors the rest of the admin MFA router — the
+    // RequireCapability gate is not in play here because satisfying that gate
+    // is the entire purpose of this call.
+    if !principal.is_platform() {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "not_platform_principal",
+                "message": "Admin MFA step-up is for platform principals only."
+            })),
+        ));
+    }
+
+    // Load the enrollment + encrypted secret. Must be enabled — an
+    // un-enrolled user has no secret to verify against and must enroll first.
+    let row: Option<(String, bool)> =
+        sqlx::query_as("SELECT secret, enabled FROM user_2fa WHERE user_id = $1")
+            .bind(user_id)
+            .fetch_optional(&state.db)
+            .await
+            .map_err(|e| {
+                tracing::error!(error = %e, "mfa/verify: fetch user_2fa failed");
+                internal()
+            })?;
+
+    let (encrypted_secret, enabled) = row.ok_or_else(|| {
+        (
+            StatusCode::PRECONDITION_FAILED,
+            Json(serde_json::json!({
+                "error": "mfa_not_enrolled",
+                "message": "MFA is not enrolled. Complete enrollment before step-up."
+            })),
+        )
+    })?;
+
+    if !enabled {
+        return Err((
+            StatusCode::PRECONDITION_FAILED,
+            Json(serde_json::json!({
+                "error": "mfa_not_enrolled",
+                "message": "MFA is not enrolled. Complete enrollment before step-up."
+            })),
+        ));
+    }
+
+    // Decrypt + verify the code.
+    let secret = state
+        .totp_service
+        .decrypt_secret(&encrypted_secret)
+        .map_err(|e| {
+            tracing::error!(error = %e, "mfa/verify: decrypt failed");
+            internal()
+        })?;
+
+    let valid = state
+        .totp_service
+        .verify_code(&secret, req.code.trim())
+        .unwrap_or(false);
+
+    if !valid {
+        let _ = audit
+            .record(
+                Some(user_id),
+                Capability::UsersWrite,
+                AuditOutcome::Denied,
+                Some("mfa_step_up_invalid"),
+                Some(user_id),
+                None,
+                None,
+                None,
+            )
+            .await;
+        return Err((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(serde_json::json!({
+                "error": "invalid_code",
+                "message": "The TOTP code is invalid. Check your authenticator app and try again."
+            })),
+        ));
+    }
+
+    // Open the 15-minute MFA recency window. Same row shape the recency check
+    // (`admin_core::PgMfaRecency` / `capabilities.rs`) reads from.
+    sqlx::query("INSERT INTO two_factor_auth_verifications (user_id, method) VALUES ($1, 'totp')")
+        .bind(user_id)
+        .execute(&state.db)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "mfa/verify: insert verification failed");
+            internal()
+        })?;
+
+    let _ = audit
+        .record(
+            Some(user_id),
+            Capability::UsersWrite,
+            AuditOutcome::Allowed,
+            Some("mfa_step_up"),
+            Some(user_id),
+            None,
+            None,
+            None,
+        )
+        .await;
+
+    tracing::info!(user_id = %user_id, "admin mfa step-up verified");
+    Ok(Json(VerifyStepUpResponse {
+        message: "MFA verified. The 15-minute verification window is now open.".into(),
+    }))
+}
+
+fn internal() -> (StatusCode, Json<serde_json::Value>) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(serde_json::json!({ "error": "internal" })),
+    )
+}

--- a/backend/servers/api-server/tests/admin_mfa_step_up_tests.rs
+++ b/backend/servers/api-server/tests/admin_mfa_step_up_tests.rs
@@ -1,0 +1,256 @@
+//! Integration tests for `POST /api/v1/admin/mfa/verify` (TOTP step-up).
+//!
+//! Issue #764: an already-enrolled platform principal hitting a
+//! capability-gated route gets `401 mfa_required`. Before this endpoint
+//! existed the admin-web `MfaWrapper` POSTed the 6-digit code to
+//! `/api/v1/auth/mfa/verify` — the *setup-completion* handler, which 409s for
+//! enrolled users and never inserts a `two_factor_auth_verifications` row, so
+//! the 15-minute recency gate could never be satisfied via TOTP. This endpoint
+//! is the dedicated step-up path; on success it inserts a `method = 'totp'`
+//! verification row.
+//!
+//! Scenarios mirror the contract in
+//! `backend/servers/api-server/src/routes/admin/mfa/verify.rs`:
+//!   1. Happy path — valid TOTP → 200, exactly one `two_factor_auth_verifications`
+//!      row (`method = 'totp'`), audit row outcome=allowed + target `mfa_step_up`.
+//!   2. Invalid code — 422 `invalid_code`, no verification row, audit Denied.
+//!   3. Not enrolled — 412 `mfa_not_enrolled`, no verification row.
+//!
+//! All tests are gated `#[ignore = "requires postgres + migrations"]` per the
+//! established convention.
+
+#[allow(dead_code)]
+mod common;
+
+use axum::http::StatusCode;
+use serde_json::json;
+use sqlx::PgPool;
+use totp_rs::{Algorithm, Secret, TOTP};
+use uuid::Uuid;
+
+use api_server::services::{JwtService, TotpService};
+use common::TestApp;
+
+const TEST_JWT_SECRET: &str =
+    "test-secret-key-that-is-at-least-64-characters-long-for-testing-purposes";
+const TEST_ISSUER: &str = "Property Management";
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+async fn seed_user(pool: &PgPool, email: &str, kind: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'h', 'MFA StepUp Test', 'active', NOW(), $2)
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .bind(kind)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Seed an *enrolled* user_2fa row and return the plaintext base32 secret so
+/// the test can generate a live TOTP for it.
+async fn enroll_user_2fa(pool: &PgPool, user_id: Uuid) -> String {
+    let totp = TotpService::new(TEST_ISSUER.to_string());
+    let secret = totp.generate_secret().expect("gen secret");
+    let encrypted = totp.encrypt_secret(&secret).expect("encrypt secret");
+    sqlx::query(
+        r#"
+        INSERT INTO user_2fa (user_id, secret, enabled, enabled_at, backup_codes, backup_codes_remaining)
+        VALUES ($1, $2, true, NOW(), '[]'::jsonb, 0)
+        ON CONFLICT (user_id) DO UPDATE SET secret = EXCLUDED.secret, enabled = true, enabled_at = NOW()
+        "#,
+    )
+    .bind(user_id)
+    .bind(&encrypted)
+    .execute(pool)
+    .await
+    .expect("seed user_2fa");
+    secret
+}
+
+/// Generate the current valid 6-digit TOTP for a base32 secret, matching the
+/// SHA1 / 6-digit / 30-second parameters used by `TotpService::verify_code`.
+fn current_totp(secret: &str) -> String {
+    let bytes = Secret::Encoded(secret.to_string())
+        .to_bytes()
+        .expect("decode secret");
+    let totp = TOTP::new(
+        Algorithm::SHA1,
+        6,
+        1,
+        30,
+        bytes,
+        Some(TEST_ISSUER.to_string()),
+        "".to_string(),
+    )
+    .expect("build totp");
+    totp.generate_current().expect("generate current code")
+}
+
+fn mint_token(user_id: Uuid, kind: &str) -> String {
+    let svc = JwtService::new(TEST_JWT_SECRET).expect("jwt service");
+    svc.generate_access_token_with_kind(
+        user_id,
+        "mfa-stepup@test.local",
+        "MFA StepUp Test",
+        None,
+        None,
+        Some(kind.to_string()),
+    )
+    .expect("mint token")
+}
+
+fn set_env_once() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        if std::env::var("RUST_ENV").is_err() {
+            std::env::set_var("RUST_ENV", "development");
+        }
+    });
+}
+
+async fn verification_count(pool: &PgPool, user_id: Uuid) -> i64 {
+    sqlx::query_scalar(
+        "SELECT COUNT(*) FROM two_factor_auth_verifications WHERE user_id = $1 AND method = 'totp'",
+    )
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+// ─── tests ──────────────────────────────────────────────────────────────────
+
+/// (1) Happy path: a valid current TOTP opens the recency window via a
+/// `method = 'totp'` verification row and audits an allowed `mfa_step_up`.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+#[ignore = "requires postgres + migrations"]
+async fn happy_path_totp_opens_window(pool: PgPool) {
+    set_env_once();
+    let app = TestApp::new(pool.clone()).await;
+
+    let user = seed_user(&pool, "happy-stepup@mfa-test.local", "platform").await;
+    let secret = enroll_user_2fa(&pool, user).await;
+    let token = mint_token(user, "platform");
+    let code = current_totp(&secret);
+
+    let req = app
+        .post("/api/v1/admin/mfa/verify")
+        .bearer(&token)
+        .json(json!({ "code": code }))
+        .build();
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "expected 200, got {} body {}",
+        resp.status,
+        resp.text()
+    );
+
+    assert_eq!(
+        verification_count(&pool, user).await,
+        1,
+        "exactly one totp verification row must be inserted"
+    );
+
+    let audit_allowed: i64 = sqlx::query_scalar(
+        r#"SELECT COUNT(*) FROM audit_logs
+           WHERE user_id = $1
+             AND resource_type = 'mfa_step_up'
+             AND details->>'outcome' = 'allowed'"#,
+    )
+    .bind(user)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(
+        audit_allowed >= 1,
+        "expected at least one allowed audit row, got {audit_allowed}"
+    );
+}
+
+/// (2) Invalid code: a non-matching code yields 422 `invalid_code`, opens no
+/// window, and audits a Denied `mfa_step_up_invalid` row.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+#[ignore = "requires postgres + migrations"]
+async fn invalid_code_is_rejected_and_audited(pool: PgPool) {
+    set_env_once();
+    let app = TestApp::new(pool.clone()).await;
+
+    let user = seed_user(&pool, "invalid-stepup@mfa-test.local", "platform").await;
+    let _secret = enroll_user_2fa(&pool, user).await;
+    let token = mint_token(user, "platform");
+
+    let req = app
+        .post("/api/v1/admin/mfa/verify")
+        .bearer(&token)
+        .json(json!({ "code": "000000" }))
+        .build();
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "expected 422, got {} body {}",
+        resp.status,
+        resp.text()
+    );
+    let body = resp.json_value();
+    assert_eq!(
+        body.get("error").and_then(|v| v.as_str()),
+        Some("invalid_code"),
+        "expected invalid_code, got {body}"
+    );
+
+    assert_eq!(
+        verification_count(&pool, user).await,
+        0,
+        "no verification row must be inserted on invalid code"
+    );
+}
+
+/// (3) Not enrolled: an un-enrolled platform principal gets 412
+/// `mfa_not_enrolled` and no window is opened.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+#[ignore = "requires postgres + migrations"]
+async fn not_enrolled_is_rejected(pool: PgPool) {
+    set_env_once();
+    let app = TestApp::new(pool.clone()).await;
+
+    let user = seed_user(&pool, "noenroll-stepup@mfa-test.local", "platform").await;
+    let token = mint_token(user, "platform");
+
+    let req = app
+        .post("/api/v1/admin/mfa/verify")
+        .bearer(&token)
+        .json(json!({ "code": "123456" }))
+        .build();
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::PRECONDITION_FAILED,
+        "expected 412, got {} body {}",
+        resp.status,
+        resp.text()
+    );
+    let body = resp.json_value();
+    assert_eq!(
+        body.get("error").and_then(|v| v.as_str()),
+        Some("mfa_not_enrolled"),
+        "expected mfa_not_enrolled, got {body}"
+    );
+
+    assert_eq!(
+        verification_count(&pool, user).await,
+        0,
+        "no verification row for un-enrolled user"
+    );
+}

--- a/frontend/apps/admin-web/src/components/MfaWrapper.tsx
+++ b/frontend/apps/admin-web/src/components/MfaWrapper.tsx
@@ -6,9 +6,15 @@
  * from ppt-web's MfaWrapper — uses `useAdminAuth().token` for the bearer
  * instead of ppt-web's `AuthContext.getAccessToken`.
  *
- * Endpoint: POST /api/v1/auth/mfa/verify (api-server). On 200 the user is
- * freshly MFA-verified for RECENT_MFA_WINDOW (15 min) and the api-client
- * retries the original mutation transparently.
+ * Endpoint: POST /api/v1/admin/mfa/verify (api-server). This is the TOTP
+ * *step-up* endpoint for already-enrolled platform principals — it inserts a
+ * `two_factor_auth_verifications` row so the RECENT_MFA_WINDOW (15 min)
+ * recency gate opens, and the api-client retries the original mutation
+ * transparently.
+ *
+ * NOTE: do NOT point this at `/api/v1/auth/mfa/verify` — that endpoint is the
+ * setup-completion flow (enables MFA, issues recovery codes, 409s if already
+ * enrolled) and never opens the recency window. Pointing here was issue #764.
  */
 
 import { MfaChallengeProvider } from '@ppt/admin-ui';
@@ -43,7 +49,7 @@ export function MfaWrapper({ children }: { children: ReactNode }) {
         const headers: Record<string, string> = { 'Content-Type': 'application/json' };
         if (token) headers.Authorization = `Bearer ${token}`;
         try {
-          const response = await fetch('/api/v1/auth/mfa/verify', {
+          const response = await fetch('/api/v1/admin/mfa/verify', {
             method: 'POST',
             headers,
             body: JSON.stringify({ code }),

--- a/mobile-native/iosApp/iosApp/App/AppDelegate.swift
+++ b/mobile-native/iosApp/iosApp/App/AppDelegate.swift
@@ -1,0 +1,75 @@
+import UIKit
+import UserNotifications
+
+/// UIKit application delegate for the otherwise-pure-SwiftUI Reality Portal app.
+///
+/// SwiftUI's `App` lifecycle does not expose the APNs callbacks
+/// (`application(_:didRegisterForRemoteNotificationsWithDeviceToken:)`) nor a
+/// place to set the `UNUserNotificationCenter` delegate. Without a delegate,
+/// foreground notifications are silently dropped (no banner/sound) and taps on
+/// notifications are never routed. Issue #698 finding 2.
+///
+/// This delegate is installed via `@UIApplicationDelegateAdaptor` in
+/// `RealityPortalApp`. It keeps the service layer (`PushNotificationManager`)
+/// UIKit-free by forwarding events through `NotificationCenter` — the same
+/// decoupling pattern already used for APNs registration requests.
+final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        // Become the notification-center delegate so foreground presentation
+        // and tap-handling callbacks fire. PushNotificationManager owns
+        // category registration + preferences; this object only bridges the
+        // OS-level delegate callbacks.
+        UNUserNotificationCenter.current().delegate = self
+        return true
+    }
+
+    // MARK: - APNs token callbacks
+
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        NotificationCenter.default.post(
+            name: .pushNotificationManagerDidRegister,
+            object: nil,
+            userInfo: ["deviceToken": deviceToken]
+        )
+    }
+
+    func application(
+        _ application: UIApplication,
+        didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+        NotificationCenter.default.post(
+            name: .pushNotificationManagerDidFailToRegister,
+            object: nil,
+            userInfo: ["error": error]
+        )
+    }
+
+    // MARK: - UNUserNotificationCenterDelegate
+
+    /// Present banners/sounds even when the app is in the foreground.
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .list, .sound, .badge])
+    }
+
+    /// Handle taps on a delivered notification. Routing is left to the app's
+    /// navigation layer; for now we simply acknowledge so the system does not
+    /// log an unhandled-response warning.
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        completionHandler()
+    }
+}

--- a/mobile-native/iosApp/iosApp/App/RealityPortalApp.swift
+++ b/mobile-native/iosApp/iosApp/App/RealityPortalApp.swift
@@ -20,6 +20,13 @@ import shared
 /// Epic 82 - Story 82.5: Inquiries and Account (PushNotificationManager)
 @main
 struct RealityPortalApp: App {
+    // MARK: - App Delegate
+
+    // SwiftUI's App lifecycle does not surface APNs callbacks or expose a place
+    // to set the UNUserNotificationCenter delegate; the adaptor installs a
+    // UIKit AppDelegate that does both. Issue #698 finding 2.
+    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+
     // MARK: - State Objects
 
     @State private var navigationCoordinator = NavigationCoordinator()
@@ -101,6 +108,27 @@ struct RealityPortalApp: App {
             UIApplication.shared.registerForRemoteNotifications()
         }
 
+        // Bridge the APNs token callbacks delivered to `AppDelegate` back into
+        // `PushNotificationManager`. The manager stays UIKit-free; the delegate
+        // posts the raw token / error via NotificationCenter. Issue #698.
+        NotificationCenter.default.addObserver(
+            forName: .pushNotificationManagerDidRegister,
+            object: nil,
+            queue: .main
+        ) { note in
+            guard let token = note.userInfo?["deviceToken"] as? Data else { return }
+            pushNotificationManager.didRegisterForRemoteNotifications(deviceToken: token)
+        }
+
+        NotificationCenter.default.addObserver(
+            forName: .pushNotificationManagerDidFailToRegister,
+            object: nil,
+            queue: .main
+        ) { note in
+            guard let error = note.userInfo?["error"] as? Error else { return }
+            pushNotificationManager.didFailToRegisterForRemoteNotifications(error: error)
+        }
+
         // Restore navigation state from the previous launch.
         restorationService.restore(
             into: navigationCoordinator,
@@ -127,22 +155,6 @@ struct RealityPortalApp: App {
         @unknown default:
             break
         }
-    }
-
-    // MARK: - APNs Token Handling
-
-    /// Forward an APNs device token to the `PushNotificationManager`.
-    ///
-    /// In a pure SwiftUI lifecycle app, hook this via `UIApplicationDelegateAdaptor`
-    /// if an explicit AppDelegate is added. The notification-center bridge in
-    /// `configureApp()` handles APNs registration requests from the service layer.
-    func didRegisterForRemoteNotifications(deviceToken: Data) {
-        pushNotificationManager.didRegisterForRemoteNotifications(deviceToken: deviceToken)
-    }
-
-    /// Forward an APNs registration failure to the `PushNotificationManager`.
-    func didFailToRegisterForRemoteNotifications(error: Error) {
-        pushNotificationManager.didFailToRegisterForRemoteNotifications(error: error)
     }
 
     // MARK: - Incoming URL Handling

--- a/mobile-native/iosApp/iosApp/Core/Services/PushNotificationManager.swift
+++ b/mobile-native/iosApp/iosApp/Core/Services/PushNotificationManager.swift
@@ -303,4 +303,16 @@ extension Notification.Name {
     static let pushNotificationManagerRequestsRegistration = Notification.Name(
         "three.two.bit.ppt.reality.PushNotificationManagerRequestsRegistration"
     )
+
+    /// Posted by `AppDelegate` when APNs delivers a device token. `userInfo`
+    /// carries the raw token under the `"deviceToken"` key (`Data`).
+    static let pushNotificationManagerDidRegister = Notification.Name(
+        "three.two.bit.ppt.reality.PushNotificationManagerDidRegister"
+    )
+
+    /// Posted by `AppDelegate` when APNs registration fails. `userInfo` carries
+    /// the failure under the `"error"` key (`Error`).
+    static let pushNotificationManagerDidFailToRegister = Notification.Name(
+        "three.two.bit.ppt.reality.PushNotificationManagerDidFailToRegister"
+    )
 }

--- a/mobile-native/iosApp/iosApp/Features/Inquiries/InquiryDetailView.swift
+++ b/mobile-native/iosApp/iosApp/Features/Inquiries/InquiryDetailView.swift
@@ -23,10 +23,22 @@ struct InquiryDetailView: View {
     @State private var replyText = ""
     @State private var isSendingReply = false
 
-    private var inquiryRepository: InquiryRepository {
-        DependencyContainer.shared.makeAuthenticatedInquiryRepository(
+    // Cached repository — a computed `var` would re-run
+    // `makeAuthenticatedInquiryRepository` (allocating a new repository) on
+    // every `body` re-evaluation and every async access, so `loadInquiry` and
+    // `sendReply` could end up using different instances. Lazily initialized
+    // once and reused thereafter. See issue #698 finding 3.
+    @State private var inquiryRepository: InquiryRepository?
+
+    private func resolveRepository() -> InquiryRepository {
+        if let repo = inquiryRepository {
+            return repo
+        }
+        let repo = DependencyContainer.shared.makeAuthenticatedInquiryRepository(
             sessionToken: authManager.getSessionToken()
         )
+        inquiryRepository = repo
+        return repo
     }
 
     var body: some View {
@@ -197,7 +209,7 @@ struct InquiryDetailView: View {
         isLoading = true
         errorMessage = nil
 
-        let result = await inquiryRepository.getInquiry(inquiryId: inquiryId)
+        let result = await resolveRepository().getInquiry(inquiryId: inquiryId)
 
         if let fetched = result.getOrNull() {
             inquiry = fetched
@@ -213,7 +225,7 @@ struct InquiryDetailView: View {
         guard !trimmed.isEmpty else { return }
 
         isSendingReply = true
-        let result = await inquiryRepository.replyToInquiry(
+        let result = await resolveRepository().replyToInquiry(
             inquiryId: inquiryId,
             message: trimmed
         )

--- a/mobile-native/iosApp/iosApp/Features/Inquiries/SendInquiryView.swift
+++ b/mobile-native/iosApp/iosApp/Features/Inquiries/SendInquiryView.swift
@@ -25,10 +25,22 @@ struct SendInquiryView: View {
     @State private var errorMessage: String?
     @State private var didSend = false
 
-    private var inquiryRepository: InquiryRepository {
-        DependencyContainer.shared.makeAuthenticatedInquiryRepository(
+    // Cached repository — a computed `var` would re-run
+    // `makeAuthenticatedInquiryRepository` (allocating a new repository) on
+    // every `body` re-evaluation and every async access, so `loadInquiry` and
+    // `send` could end up using different instances. Lazily initialized once in
+    // `.onAppear` and reused thereafter. See issue #698 finding 3.
+    @State private var inquiryRepository: InquiryRepository?
+
+    private func resolveRepository() -> InquiryRepository {
+        if let repo = inquiryRepository {
+            return repo
+        }
+        let repo = DependencyContainer.shared.makeAuthenticatedInquiryRepository(
             sessionToken: authManager.getSessionToken()
         )
+        inquiryRepository = repo
+        return repo
     }
 
     private var isFormValid: Bool {
@@ -38,81 +50,84 @@ struct SendInquiryView: View {
         !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
+    // NOTE: this view is navigated to via the `.newInquiry(listingId)` route
+    // from `MainTabView`, which already runs inside the app's root navigation
+    // hierarchy. It must NOT wrap its content in its own `NavigationStack` — a
+    // nested stack duplicates the back button, drops the inline title, and can
+    // ignore `.navigationBarTitleDisplayMode(.inline)`. See issue #698 finding 1.
     var body: some View {
-        NavigationStack {
-            Form {
-                // Contact details section
-                Section(String(localized: "section_contact_details")) {
-                    TextField(String(localized: "label_name_required"), text: $name)
-                        .textContentType(.name)
-                        .autocorrectionDisabled()
+        Form {
+            // Contact details section
+            Section(String(localized: "section_contact_details")) {
+                TextField(String(localized: "label_name_required"), text: $name)
+                    .textContentType(.name)
+                    .autocorrectionDisabled()
 
-                    TextField(String(localized: "label_email_required"), text: $email)
-                        .textContentType(.emailAddress)
-                        .keyboardType(.emailAddress)
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
+                TextField(String(localized: "label_email_required"), text: $email)
+                    .textContentType(.emailAddress)
+                    .keyboardType(.emailAddress)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
 
-                    TextField(String(localized: "label_phone_optional"), text: $phone)
-                        .textContentType(.telephoneNumber)
-                        .keyboardType(.phonePad)
-                }
+                TextField(String(localized: "label_phone_optional"), text: $phone)
+                    .textContentType(.telephoneNumber)
+                    .keyboardType(.phonePad)
+            }
 
-                // Message section
-                Section(String(localized: "section_your_message")) {
-                    TextField(String(localized: "inquiry_message_placeholder"), text: $message, axis: .vertical)
-                        .lineLimit(4...8)
-                        .frame(minHeight: 80, alignment: .topLeading)
-                }
+            // Message section
+            Section(String(localized: "section_your_message")) {
+                TextField(String(localized: "inquiry_message_placeholder"), text: $message, axis: .vertical)
+                    .lineLimit(4...8)
+                    .frame(minHeight: 80, alignment: .topLeading)
+            }
 
-                // Error feedback
-                if let errorMessage {
-                    Section {
-                        Label(errorMessage, systemImage: "exclamationmark.circle.fill")
-                            .foregroundStyle(.red)
-                            .font(.callout)
-                    }
-                }
-
-                // Submit button
+            // Error feedback
+            if let errorMessage {
                 Section {
-                    Button {
-                        Task { await send() }
-                    } label: {
-                        HStack {
-                            Spacer()
-                            if isSending {
-                                ProgressView()
-                            } else {
-                                Text(String(localized: "send_inquiry"))
-                                    .fontWeight(.semibold)
-                            }
-                            Spacer()
+                    Label(errorMessage, systemImage: "exclamationmark.circle.fill")
+                        .foregroundStyle(.red)
+                        .font(.callout)
+                }
+            }
+
+            // Submit button
+            Section {
+                Button {
+                    Task { await send() }
+                } label: {
+                    HStack {
+                        Spacer()
+                        if isSending {
+                            ProgressView()
+                        } else {
+                            Text(String(localized: "send_inquiry"))
+                                .fontWeight(.semibold)
                         }
-                    }
-                    .disabled(!isFormValid || isSending)
-                }
-            }
-            .navigationTitle(String(localized: "send_inquiry"))
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(String(localized: "cancel")) {
-                        dismiss()
+                        Spacer()
                     }
                 }
+                .disabled(!isFormValid || isSending)
             }
-            .alert(String(localized: "inquiry_sent"), isPresented: $didSend) {
-                Button(String(localized: "ok")) {
+        }
+        .navigationTitle(String(localized: "send_inquiry"))
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button(String(localized: "cancel")) {
                     dismiss()
-                    coordinator.selectedTab = .inquiries
                 }
-            } message: {
-                Text(String(localized: "inquiry_sent_confirmation"))
             }
-            .onAppear {
-                prefillFromAuthManager()
+        }
+        .alert(String(localized: "inquiry_sent"), isPresented: $didSend) {
+            Button(String(localized: "ok")) {
+                dismiss()
+                coordinator.selectedTab = .inquiries
             }
+        } message: {
+            Text(String(localized: "inquiry_sent_confirmation"))
+        }
+        .onAppear {
+            prefillFromAuthManager()
         }
     }
 
@@ -143,7 +158,7 @@ struct SendInquiryView: View {
             phone: trimmedPhone.isEmpty ? nil : trimmedPhone
         )
 
-        let result = await inquiryRepository.createInquiry(request: request)
+        let result = await resolveRepository().createInquiry(request: request)
 
         if result.getOrNull() != nil {
             didSend = true

--- a/mobile-native/iosApp/iosApp/Resources/Info.plist
+++ b/mobile-native/iosApp/iosApp/Resources/Info.plist
@@ -72,6 +72,8 @@
     <string>Reality Portal needs access to your photos to upload profile pictures or share listings.</string>
     <key>NSCameraUsageDescription</key>
     <string>Reality Portal needs camera access to take photos for your profile or inquiries.</string>
+    <key>NSUserNotificationUsageDescription</key>
+    <string>Receive alerts for new property listings, price drops, and replies to your inquiries.</string>
     <key>NSAppTransportSecurity</key>
     <dict>
         <key>NSAllowsArbitraryLoads</key>

--- a/mobile-native/iosApp/iosAppTests/RealityPortalTests.swift
+++ b/mobile-native/iosApp/iosAppTests/RealityPortalTests.swift
@@ -697,6 +697,15 @@ final class PushNotificationManagerTests: XCTestCase {
 
     override func tearDown() {
         keychain.deleteAll()
+        // testDisablingNewListingsPersists writes a preference into
+        // UserDefaults.standard (PushNotificationManager reads preferences from
+        // the standard suite and does not accept an injected suite). Remove it
+        // so a leftover `false` cannot make order-dependent tests in other
+        // suites — which assume `newListings` defaults to `true` — fail
+        // non-deterministically. Issue #698 finding 4.
+        for key in NotificationPreferenceKey.allCases {
+            UserDefaults.standard.removeObject(forKey: key.rawValue)
+        }
         super.tearDown()
     }
 


### PR DESCRIPTION
Clears the **remaining** (partially-fixed) review findings across four issues. Earlier PRs handled the contained code bugs (#767 → PR #918, #751 → PR #916, #764 #1 → PR #855); this PR is the leftover tail.

## Fixes by issue

### #764 — Admin MFA & Auth Hardening (live items #2)
- **Missing TOTP step-up endpoint (backend).** `POST /api/v1/admin/mfa/verify` added. An already-enrolled platform principal hitting a capability-gated route gets `401 mfa_required`, but there was **no** TOTP endpoint to satisfy the 15-minute recency gate — only single-use recovery codes opened the window. The new endpoint verifies the TOTP against the stored secret and inserts a `two_factor_auth_verifications` row (`method='totp'`), exactly what `admin_core::PgMfaRecency` / `capabilities.rs` reads. Postgres-gated integration tests added (happy/invalid/not-enrolled).
- **admin-web wrong endpoint (frontend).** `MfaWrapper`'s verify callback POSTed to `/api/v1/auth/mfa/verify` — the *setup-completion* handler that 409s for enrolled users and never opens a recency window. Repointed at the new `/api/v1/admin/mfa/verify`. These two land together (frontend depends on the new route).

### #698 — iOS InquiryDetailView/SendInquiryView follow-ups (closes #698)
- Finding 1: removed the nested `NavigationStack` from `SendInquiryView` (it's pushed onto the root nav stack).
- Finding 2: added `NSUserNotificationUsageDescription` to `Resources/Info.plist`; wired `UNUserNotificationCenterDelegate` via a new `AppDelegate` (`@UIApplicationDelegateAdaptor`) — presents foreground banners and bridges APNs token callbacks back into `PushNotificationManager` (the SwiftUI lifecycle exposed neither); removed the orphaned token handlers on the App.
- Finding 3: cached `InquiryRepository` in `@State` (lazy `resolveRepository()`) in both views instead of a computed `var` that re-allocated per access.
- Finding 4: `PushNotificationManagerTests.tearDown` now clears `NotificationPreferenceKey` entries from `UserDefaults.standard`.

### #767 — Mobile RN (medium #6)
- Added a fail-fast **"Verify required EAS secrets"** preflight step to both EAS build workflows (`EXPO_TOKEN`, `EXPO_PROJECT_ID`) so a misconfigured run fails with a clear message instead of deep in the EAS pipeline.

## Verified already-fixed / deferred

- **#767 #8 (config/api.ts drift):** already consistent — `config/api.ts` reads exactly the four keys (`API_BASE_URL`, `WS_BASE_URL`, `ENVIRONMENT`, `DEBUG_MODE`) that `app.config.ts` writes into `extra`. No change needed.
- **#767 #7 (Expo SDK 55/56 skew):** deferred. `expo` core is `~55`, but `expo-clipboard`/`expo-constants`/`expo-image-picker`/`jest-expo` are on the `56` line. Aligning a major SDK skew is risky without an on-device build matrix — left as a follow-up.
- **#751 (SSO callback → non-existent backend route):** deferred. The client posts to `POST /api/v1/auth/sso/callback`, which no backend route serves (only an OAuth-provider redirect URI exists in seed config). This is the Story 79.x SSO feature, explicitly out of scope. All other #751 api-client items (announcements contract, document auth/204) were fixed in PR #916.
- **#764 #1 (RequestPrincipal refresh-JWT):** already fixed by PR #855.

## Verification
- Backend: `cargo clippy -p api-server -- -D warnings` clean; new test target compiles (`--no-run`) — postgres-gated, not run here. Isolated `CARGO_TARGET_DIR` per repo rules, cleaned up after.
- Frontend: pre-commit ran `biome lint` + workspace `typecheck` — green. admin-web vitest: only pre-existing unrelated failure (`CapabilitiesAdminPage` capability-count, fails on `dev` without this change).
- iOS: Swift files parse clean (`swiftc -parse`). Full Xcode build not runnable here — the `.xcodeproj` is created manually in Xcode (see `xcschemes/INSTALL.md`) and isn't checked in, so the new `AppDelegate.swift` must be added to the iosApp target's sources when the project is regenerated.