### PR TITLE
feat(reality-server): buyer-axis my-inquiries listing (#763 part 1)

### DIFF
--- a/backend/crates/db/src/repositories/reality_portal.rs
+++ b/backend/crates/db/src/repositories/reality_portal.rs
@@ -744,6 +744,54 @@ impl RealityPortalRepository {
         .await
     }
 
+    /// Get inquiries submitted by a buyer (the authenticated `user_id` that
+    /// created them). This is the buyer-axis counterpart to
+    /// [`get_realtor_inquiries`](Self::get_realtor_inquiries): the realtor view
+    /// scopes on `realtor_id`, the buyer view scopes on `user_id`.
+    pub async fn get_buyer_inquiries(
+        &self,
+        user_id: Uuid,
+        status: Option<String>,
+        limit: i32,
+        offset: i32,
+    ) -> Result<Vec<ListingInquiry>, SqlxError> {
+        sqlx::query_as::<_, ListingInquiry>(
+            r#"
+            SELECT * FROM listing_inquiries
+            WHERE user_id = $1 AND ($2::text IS NULL OR status = $2)
+            ORDER BY created_at DESC
+            LIMIT $3 OFFSET $4
+            "#,
+        )
+        .bind(user_id)
+        .bind(&status)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    /// Count inquiries submitted by a buyer (matching the same filter as
+    /// [`get_buyer_inquiries`](Self::get_buyer_inquiries)). Exposes the true
+    /// `total` to paginated routes instead of the current page's `len()`
+    /// (the bug fixed for the realtor axis in PR #919).
+    pub async fn count_buyer_inquiries(
+        &self,
+        user_id: Uuid,
+        status: Option<String>,
+    ) -> Result<i64, SqlxError> {
+        sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT COUNT(*) FROM listing_inquiries
+            WHERE user_id = $1 AND ($2::text IS NULL OR status = $2)
+            "#,
+        )
+        .bind(user_id)
+        .bind(&status)
+        .fetch_one(&self.pool)
+        .await
+    }
+
     /// Get a single inquiry by id, scoped to the owning realtor.
     ///
     /// Single-row query — replaces the previous list-then-filter pattern in

--- a/backend/servers/reality-server/src/routes/inquiries.rs
+++ b/backend/servers/reality-server/src/routes/inquiries.rs
@@ -62,6 +62,9 @@ pub fn router() -> Router<AppState> {
         .route("/viewing/{listing_id}", post(request_viewing))
         // Authenticated routes
         .route("/", get(list_my_inquiries))
+        // Buyer-axis listing: inquiries the authenticated buyer submitted.
+        // Must be registered before `/{id}` so `mine` is not captured as an id.
+        .route("/mine", get(list_buyer_inquiries))
         .route("/{id}", get(get_inquiry))
         .route("/{id}/read", put(mark_as_read))
         .route("/{id}/respond", post(respond_to_inquiry))
@@ -489,6 +492,56 @@ pub async fn list_my_inquiries(
             .count_realtor_inquiries(principal.user_id, status_filter),
     )
     .map_err(|e| crate::util::errors::db_error("list inquiries", e))?;
+
+    Ok(Json(InquiryListResponse {
+        inquiries,
+        total,
+        page,
+        limit,
+    }))
+}
+
+/// List inquiries the authenticated buyer submitted.
+///
+/// Buyer-axis counterpart to [`list_my_inquiries`] (which is realtor-scoped):
+/// returns only inquiries whose `user_id` matches the calling principal, so a
+/// buyer sees the inquiries they sent and never another buyer's. `total` is the
+/// FULL filtered count (not the current page length) so clients can paginate —
+/// the page-length-as-total bug fixed for the realtor axis in PR #919.
+#[utoipa::path(
+    get,
+    path = "/api/v1/inquiries/mine",
+    tag = "Inquiries",
+    params(InquiryListQuery),
+    responses(
+        (status = 200, description = "Buyer's inquiry list", body = InquiryListResponse),
+        (status = 401, description = "Unauthorized")
+    )
+)]
+pub async fn list_buyer_inquiries(
+    State(state): State<AppState>,
+    principal: RequestPrincipal,
+    Query(query): Query<InquiryListQuery>,
+) -> Result<Json<InquiryListResponse>, (axum::http::StatusCode, String)> {
+    let page = query.page.unwrap_or(1).max(1);
+    let limit = query.limit.unwrap_or(20).clamp(1, 100);
+    let offset = (page - 1) * limit;
+
+    // Page query and matching COUNT run in parallel; both use the same filter
+    // so `total / limit` paginates correctly.
+    let status_filter = query.status.clone();
+    let (inquiries, total) = tokio::try_join!(
+        state.reality_portal_repo.get_buyer_inquiries(
+            principal.user_id,
+            query.status,
+            limit,
+            offset,
+        ),
+        state
+            .reality_portal_repo
+            .count_buyer_inquiries(principal.user_id, status_filter),
+    )
+    .map_err(|e| crate::util::errors::db_error("list buyer inquiries", e))?;
 
     Ok(Json(InquiryListResponse {
         inquiries,

--- a/backend/servers/reality-server/tests/buyer_inquiries_tests.rs
+++ b/backend/servers/reality-server/tests/buyer_inquiries_tests.rs
@@ -1,0 +1,209 @@
+//! Buyer-axis inquiry listing tests (closes #763 part 1).
+//!
+//! # Background
+//!
+//! Inquiries were only realtor-scoped: `list_my_inquiries` →
+//! `get_realtor_inquiries`/`count_realtor_inquiries` filter on `realtor_id`.
+//! A buyer (the authenticated `user_id` who submitted the inquiry) had no way
+//! to list the inquiries they sent. The new `GET /api/v1/inquiries/mine`
+//! endpoint is backed by `get_buyer_inquiries`/`count_buyer_inquiries`, which
+//! scope on `user_id`.
+//!
+//! # Test strategy
+//!
+//! We exercise the repository layer directly via [`RealityPortalRepository`]
+//! (the same harness as `inquiry_idor_tests.rs`). Three invariants:
+//!
+//! | Case | Expected |
+//! |------|----------|
+//! | B1 | Buyer A's listing returns only A's inquiries (own visibility) |
+//! | B2 | Buyer B's inquiries are hidden from buyer A (isolation) |
+//! | B3 | `count_buyer_inquiries` returns the FULL count, not the page length (PR #919 regression) |
+
+use db::repositories::RealityPortalRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+// ============================================================================
+// Seed helpers (mirror inquiry_idor_tests.rs)
+// ============================================================================
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Buyer Org {slug}"))
+    .bind(format!("buyer-org-{slug}"))
+    .bind(format!("{slug}@buyer.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed_org failed")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users
+            (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'Buyer Test User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed_user failed")
+}
+
+async fn seed_listing(pool: &PgPool, org_id: Uuid, created_by: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO listings
+            (organization_id, created_by, status, transaction_type,
+             title, property_type, price, currency,
+             street, city, postal_code, country)
+        VALUES ($1, $2, 'active', 'sale',
+                'Buyer Test Listing', 'apartment', 100000.00, 'EUR',
+                'Test Street 1', 'Bratislava', '81101', 'SK')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(created_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed_listing failed")
+}
+
+/// Insert a `listing_inquiries` row addressed to `realtor_id` and submitted by
+/// `buyer_id` (the authenticated `user_id`).
+async fn seed_buyer_inquiry(
+    pool: &PgPool,
+    listing_id: Uuid,
+    realtor_id: Uuid,
+    buyer_id: Uuid,
+) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO listing_inquiries
+            (listing_id, realtor_id, user_id, name, email, message,
+             inquiry_type, preferred_contact)
+        VALUES ($1, $2, $3, 'Buyer', 'buyer@buyer.test',
+                'Is this still available?', 'info', 'email')
+        RETURNING id
+        "#,
+    )
+    .bind(listing_id)
+    .bind(realtor_id)
+    .bind(buyer_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed_buyer_inquiry failed")
+}
+
+// ============================================================================
+// B1 — Buyer sees only their own inquiries
+// ============================================================================
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn buyer_sees_only_own_inquiries(pool: PgPool) {
+    let org = seed_org(&pool, "b1").await;
+    let realtor = seed_user(&pool, "realtor-b1@buyer.test").await;
+    let buyer_a = seed_user(&pool, "buyer-a-b1@buyer.test").await;
+    let buyer_b = seed_user(&pool, "buyer-b-b1@buyer.test").await;
+    let listing = seed_listing(&pool, org, realtor).await;
+
+    // Two inquiries from A, one from B.
+    seed_buyer_inquiry(&pool, listing, realtor, buyer_a).await;
+    seed_buyer_inquiry(&pool, listing, realtor, buyer_a).await;
+    seed_buyer_inquiry(&pool, listing, realtor, buyer_b).await;
+
+    let repo = RealityPortalRepository::new(pool.clone());
+
+    let a_inquiries = repo
+        .get_buyer_inquiries(buyer_a, None, 20, 0)
+        .await
+        .expect("get_buyer_inquiries(A) failed");
+
+    assert_eq!(
+        a_inquiries.len(),
+        2,
+        "B1: buyer A must see exactly their own 2 inquiries"
+    );
+    assert!(
+        a_inquiries.iter().all(|i| i.user_id == Some(buyer_a)),
+        "B1: every returned inquiry must belong to buyer A"
+    );
+}
+
+// ============================================================================
+// B2 — Another buyer's inquiries are hidden (isolation)
+// ============================================================================
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn other_buyers_inquiries_hidden(pool: PgPool) {
+    let org = seed_org(&pool, "b2").await;
+    let realtor = seed_user(&pool, "realtor-b2@buyer.test").await;
+    let buyer_a = seed_user(&pool, "buyer-a-b2@buyer.test").await;
+    let buyer_b = seed_user(&pool, "buyer-b-b2@buyer.test").await;
+    let listing = seed_listing(&pool, org, realtor).await;
+
+    // Only buyer B has inquiries.
+    let b_inquiry = seed_buyer_inquiry(&pool, listing, realtor, buyer_b).await;
+
+    let repo = RealityPortalRepository::new(pool.clone());
+
+    let a_inquiries = repo
+        .get_buyer_inquiries(buyer_a, None, 20, 0)
+        .await
+        .expect("get_buyer_inquiries(A) failed");
+
+    assert!(
+        a_inquiries.is_empty(),
+        "B2: buyer A must NOT see buyer B's inquiries; got {:?}",
+        a_inquiries.iter().map(|i| i.id).collect::<Vec<_>>()
+    );
+    assert!(
+        !a_inquiries.iter().any(|i| i.id == b_inquiry),
+        "B2: buyer B's inquiry leaked into buyer A's listing"
+    );
+}
+
+// ============================================================================
+// B3 — Pagination total is the FULL count, not the page length (PR #919)
+// ============================================================================
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn pagination_total_is_full_count(pool: PgPool) {
+    let org = seed_org(&pool, "b3").await;
+    let realtor = seed_user(&pool, "realtor-b3@buyer.test").await;
+    let buyer = seed_user(&pool, "buyer-b3@buyer.test").await;
+    let listing = seed_listing(&pool, org, realtor).await;
+
+    // 5 inquiries from this buyer.
+    for _ in 0..5 {
+        seed_buyer_inquiry(&pool, listing, realtor, buyer).await;
+    }
+
+    let repo = RealityPortalRepository::new(pool.clone());
+
+    // Page 1 with limit 2 → 2 rows on the page, but total must be 5.
+    let page = repo
+        .get_buyer_inquiries(buyer, None, 2, 0)
+        .await
+        .expect("get_buyer_inquiries page failed");
+    let total = repo
+        .count_buyer_inquiries(buyer, None)
+        .await
+        .expect("count_buyer_inquiries failed");
+
+    assert_eq!(page.len(), 2, "B3: page must hold `limit` (2) rows");
+    assert_eq!(
+        total, 5,
+        "B3: total must be the FULL filtered count (5), not the page length (2)"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #763 (part 1). Adds the buyer-axis "my inquiries" listing to reality-server. Inquiries were only realtor-scoped (`list_my_inquiries` → `get_realtor_inquiries`/`count_realtor_inquiries`, both filtering on `realtor_id`); a buyer had no endpoint to see the inquiries they submitted.

## Changes

- **repo** (`reality_portal.rs`): `get_buyer_inquiries` + `count_buyer_inquiries`, scoped on `listing_inquiries.user_id` (the authenticated submitter). The count is the **full filtered total**, not the current page length — the page-length-as-total bug fixed for the realtor axis in #919.
- **route** (`inquiries.rs`): `GET /api/v1/inquiries/mine`, scoped to `principal.user_id`. Registered **before** `/{id}` so `mine` is not captured as an inquiry id. Page query + matching COUNT run in parallel with the same filter.
- **tests** (`buyer_inquiries_tests.rs`): repository-layer, same `#[sqlx::test]` harness as `inquiry_idor_tests.rs`:
  - B1 — buyer sees only their own inquiries
  - B2 — another buyer's inquiries are hidden
  - B3 — pagination `total` is the full count (5), not the page length (2)

## Verification

- `cargo fmt`, `cargo build`, and `cargo test --no-run` green (compiled against a clean target dir). Docker unavailable locally; the `#[sqlx::test]` cases run in CI.