### PR TITLE
feat(api-server): e-signature /sign consumer with single-use nonce (#761 part 2)

### DIFF
--- a/backend/crates/db/migrations/00174_e_signature_nonces_consumed_at.sql
+++ b/backend/crates/db/migrations/00174_e_signature_nonces_consumed_at.sql
@@ -1,0 +1,29 @@
+-- Issue #761 part 2: ship the `/sign` consumer endpoint with consume-on-use.
+--
+-- Migration 00170 created `e_signature_nonces` with a UNIQUE (envelope_id,
+-- nonce) constraint and recorded a row at link-ISSUE time (`used_at` = when
+-- the invitation/reminder email was generated). That gave replay-prevention
+-- at the "issue twice" boundary but did NOT model single-use *consumption*:
+-- the row existed before the signer ever clicked, so the consumer could not
+-- tell "issued but not yet signed" from "already signed".
+--
+-- This migration splits the two states by adding a nullable `consumed_at`:
+--   * row INSERTed at issue  -> consumed_at IS NULL  (issued, awaiting signer)
+--   * /sign POST consumes it -> consumed_at = NOW()  (single-use spent)
+--
+-- The consumer flips NULL -> NOW() atomically
+--   (UPDATE ... WHERE envelope_id=$1 AND nonce=$2 AND consumed_at IS NULL),
+-- so a replay finds zero rows to update and is rejected with 409 CONFLICT.
+-- The existing UNIQUE (envelope_id, nonce) still rejects double-issue.
+ALTER TABLE e_signature_nonces
+    ADD COLUMN IF NOT EXISTS consumed_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN e_signature_nonces.consumed_at IS
+    'When the /sign consumer atomically consumed this nonce (single-use). NULL = issued (via build_signing_url) but not yet spent by a signer. Set NULL -> NOW() exactly once; a replay updates zero rows and is rejected 409.';
+
+-- Partial index over the hot consumer predicate: "is there an unconsumed nonce
+-- for this envelope?" Keeps the atomic UPDATE's WHERE clause index-backed
+-- without bloating the index with already-spent rows.
+CREATE INDEX IF NOT EXISTS idx_e_signature_nonces_unconsumed
+    ON e_signature_nonces (envelope_id, nonce)
+    WHERE consumed_at IS NULL;

--- a/backend/crates/db/src/repositories/e_signature_nonce.rs
+++ b/backend/crates/db/src/repositories/e_signature_nonce.rs
@@ -33,6 +33,36 @@ pub enum RecordNonceError {
     Database(#[from] SqlxError),
 }
 
+/// Read-only lifecycle state of a `(envelope_id, nonce)` pair, used by the
+/// `/sign` GET render-context handler to decide whether to show a signing
+/// form. Consumption itself goes through [`ESignatureNonceRepository::consume_nonce`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NonceState {
+    /// No row for this pair — the nonce was never issued for this envelope
+    /// (forged or for a different envelope). Map to 404/401.
+    NotIssued,
+    /// Issued (row exists, `consumed_at IS NULL`) and not yet spent — a
+    /// `/sign` POST may consume it.
+    Pending,
+    /// Already consumed (`consumed_at` set) — a replay. Map to 409 CONFLICT.
+    Consumed,
+}
+
+/// Result of an atomic single-use consume attempt via
+/// [`ESignatureNonceRepository::consume_nonce`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConsumeOutcome {
+    /// This call flipped `consumed_at` NULL -> NOW(); the signer may proceed.
+    Consumed,
+    /// The nonce was issued but a prior call already consumed it — replay.
+    /// Map to 409 CONFLICT.
+    AlreadyConsumed,
+    /// No row for this `(envelope_id, nonce)` pair — never issued. Map to
+    /// 401/404 (an unsigned/forged nonce that nonetheless passed HMAC would
+    /// be extraordinary, but we fail closed).
+    NotIssued,
+}
+
 impl ESignatureNonceRepository {
     /// Construct a new repository against the given pool.
     pub fn new(pool: PgPool) -> Self {
@@ -66,6 +96,76 @@ impl ESignatureNonceRepository {
                 Err(RecordNonceError::Replay)
             }
             Err(e) => Err(RecordNonceError::Database(e)),
+        }
+    }
+
+    /// Read the lifecycle state of a `(envelope_id, nonce)` pair WITHOUT
+    /// mutating it. Used by the `/sign` GET render-context handler so it can
+    /// distinguish "show the signing form" (Pending) from "already signed"
+    /// (Consumed) and "unknown link" (NotIssued).
+    pub async fn nonce_state(
+        &self,
+        envelope_id: Uuid,
+        nonce: Uuid,
+    ) -> Result<NonceState, SqlxError> {
+        // `consumed_at` is nullable; the outer Option is "row present?", the
+        // inner is "consumed?". A `::text` cast is unnecessary here — the
+        // column is a plain TIMESTAMPTZ, decoded directly.
+        let row: Option<(Option<chrono::DateTime<chrono::Utc>>,)> = sqlx::query_as(
+            r#"
+            SELECT consumed_at FROM e_signature_nonces
+            WHERE envelope_id = $1 AND nonce = $2
+            LIMIT 1
+            "#,
+        )
+        .bind(envelope_id)
+        .bind(nonce)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(match row {
+            None => NonceState::NotIssued,
+            Some((None,)) => NonceState::Pending,
+            Some((Some(_),)) => NonceState::Consumed,
+        })
+    }
+
+    /// Atomically consume an issued nonce (single-use).
+    ///
+    /// Flips `consumed_at` from `NULL` to `NOW()` in a single statement, so
+    /// two concurrent `/sign` POSTs racing on the same link cannot both win:
+    /// exactly one `UPDATE ... WHERE consumed_at IS NULL` matches a row, the
+    /// other matches zero. The loser, and every later replay, is reported as
+    /// [`ConsumeOutcome::AlreadyConsumed`] (→ 409). A pair that was never
+    /// issued is [`ConsumeOutcome::NotIssued`] (→ 401/404).
+    pub async fn consume_nonce(
+        &self,
+        envelope_id: Uuid,
+        nonce: Uuid,
+    ) -> Result<ConsumeOutcome, SqlxError> {
+        let consumed: Option<(Uuid,)> = sqlx::query_as(
+            r#"
+            UPDATE e_signature_nonces
+            SET consumed_at = NOW()
+            WHERE envelope_id = $1 AND nonce = $2 AND consumed_at IS NULL
+            RETURNING id
+            "#,
+        )
+        .bind(envelope_id)
+        .bind(nonce)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        if consumed.is_some() {
+            return Ok(ConsumeOutcome::Consumed);
+        }
+
+        // Zero rows updated: either the pair was never issued, or it was
+        // already consumed by a prior call. Distinguish for the caller.
+        if self.nonce_exists(envelope_id, nonce).await? {
+            Ok(ConsumeOutcome::AlreadyConsumed)
+        } else {
+            Ok(ConsumeOutcome::NotIssued)
         }
     }
 

--- a/backend/crates/db/src/repositories/mod.rs
+++ b/backend/crates/db/src/repositories/mod.rs
@@ -85,7 +85,9 @@ pub use delegation::DelegationRepository;
 pub use device_push_token::DevicePushTokenRepository;
 pub use document::DocumentRepository;
 pub use document_template::DocumentTemplateRepository;
-pub use e_signature_nonce::{ESignatureNonceRepository, RecordNonceError};
+pub use e_signature_nonce::{
+    ConsumeOutcome, ESignatureNonceRepository, NonceState, RecordNonceError,
+};
 pub use facility::FacilityRepository;
 pub use fault::FaultRepository;
 pub use feature_flag::{

--- a/backend/servers/api-server/src/lib.rs
+++ b/backend/servers/api-server/src/lib.rs
@@ -165,6 +165,13 @@ pub fn route_table() -> Router<AppState> {
         .nest("/api/v1/templates", routes::templates::router())
         // E-Signature routes
         .nest("/api/v1/signature-requests", routes::signatures::router())
+        // Signer-facing public consumer endpoint (issue #761 part 2): the
+        // emailed HMAC link lands the signer here. No auth — all authority is
+        // in the verified token. GET render-context + POST record-signature.
+        .nest(
+            "/api/v1/signatures",
+            routes::signatures::public_sign_router(),
+        )
         // Messaging routes
         .nest("/api/v1/messages", routes::messaging::router())
         // Neighbor routes

--- a/backend/servers/api-server/src/routes/signatures.rs
+++ b/backend/servers/api-server/src/routes/signatures.rs
@@ -8,7 +8,7 @@ use std::sync::LazyLock;
 
 use api_core::{AuthUser, RlsConnection};
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::{HeaderMap, StatusCode},
     routing::{get, post},
     Json, Router,
@@ -17,12 +17,15 @@ use common::errors::ErrorResponse;
 use db::models::{
     CancelSignatureRequestRequest, CancelSignatureRequestResponse, CreateDocument,
     CreateSignatureRequest, CreateSignatureRequestResponse, ListSignatureRequestsResponse, Locale,
-    SendReminderRequest, SendReminderResponse, SignatureRequestResponse, SignatureWebhookEvent,
-    WebhookResponse,
+    SendReminderRequest, SendReminderResponse, SignatureRequestResponse, SignatureRequestStatus,
+    SignatureWebhookEvent, SignerStatus, WebhookResponse,
 };
-use integrations::{generate_storage_key, LightweightProvider};
+use db::repositories::{ConsumeOutcome, NonceState};
+use integrations::{generate_storage_key, ESignatureError, LightweightProvider};
+use serde::{Deserialize, Serialize};
 use subtle::ConstantTimeEq;
 use tracing::{error, info, warn};
+use utoipa::ToSchema;
 use uuid::Uuid;
 
 use crate::state::AppState;
@@ -1054,6 +1057,363 @@ async fn store_signed_document(
     }
 
     Ok(signed_doc.id)
+}
+
+// ===========================================================================
+// Signer-facing /sign consumer endpoint (Epic 84.2, issue #761 part 2)
+// ===========================================================================
+//
+// The invitation/reminder emails embed a HMAC-signed URL of the form
+// `{BASE_URL}/sign?token=<v1...>` (see `LightweightProvider::build_signing_url`).
+// The frontend signing page lifts that `token` and calls these endpoints:
+//
+//   GET  /api/v1/signatures/sign?token=...  -> render context (no mutation)
+//   POST /api/v1/signatures/sign?token=...  -> record the signature (consumes)
+//
+// Both are PUBLIC (no `AuthUser`): the signer is typically not a platform
+// user. ALL authority comes from the verifiable token. Defence in depth:
+//   1. HMAC + expiry          (`verify_token`)
+//   2. org binding            (token.org_id == request.organization_id)
+//   3. request lifecycle      (must be pending / in_progress)
+//   4. signer not yet complete (no re-sign after signed/declined)
+//   5. nonce single-use        (issued & unconsumed; POST consumes atomically)
+
+/// Query string carrying the HMAC signing token. Only `Deserialize` is needed
+/// (the `Query` extractor); these signer-facing routes are not registered in
+/// `ApiDoc`, mirroring the other inquiry/sign handlers.
+#[derive(Debug, Deserialize)]
+pub struct SignTokenQuery {
+    /// The `v1.` HMAC signing token from the emailed `/sign?token=` link.
+    pub token: String,
+}
+
+/// Render context returned by `GET /sign` so the frontend can show the
+/// document + signer details before the signer commits.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SignRenderContext {
+    /// The signature request id (envelope).
+    pub request_id: Uuid,
+    /// The document being signed.
+    pub document_id: Uuid,
+    /// Human-facing subject/title of the request (document title at creation).
+    pub subject: Option<String>,
+    /// Optional message the requester attached for signers.
+    pub message: Option<String>,
+    /// The signer's display name (from the request roster).
+    pub signer_name: String,
+    /// The signer's email (echoed from the verified token).
+    pub signer_email: String,
+    /// The signer's current status (e.g. `pending`, `viewed`).
+    pub signer_status: String,
+}
+
+/// Body for `POST /sign`. All fields optional so a bare `{}` is accepted;
+/// `typed_name` is captured as lightweight signing evidence in the log trail.
+#[derive(Debug, Default, Deserialize, ToSchema)]
+#[serde(default)]
+pub struct SubmitSignatureRequest {
+    /// The full name the signer typed to adopt their signature (evidence).
+    pub typed_name: Option<String>,
+}
+
+/// Response from `POST /sign`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SubmitSignatureResponse {
+    /// The request status AFTER recording this signature (`in_progress` while
+    /// other signers remain, `completed` once everyone has signed).
+    pub status: String,
+    /// Human-facing confirmation message.
+    pub message: String,
+}
+
+/// Public router for the signer-facing `/sign` endpoint. Merged at
+/// `/api/v1/signatures` in `route_table()`; carries NO auth extractor.
+pub fn public_sign_router() -> Router<AppState> {
+    Router::new().route("/sign", get(get_sign_context).post(submit_signature))
+}
+
+/// Map a token-verification error to a public HTTP status. We deliberately
+/// keep the body generic — never echo which check failed in a way that helps
+/// an attacker distinguish "bad MAC" from "unknown request".
+fn token_error_response(e: ESignatureError) -> (StatusCode, Json<ErrorResponse>) {
+    match e {
+        ESignatureError::TokenExpired => (
+            StatusCode::GONE,
+            Json(ErrorResponse::new(
+                "SIGNING_LINK_EXPIRED",
+                "This signing link has expired. Ask the sender for a new one.",
+            )),
+        ),
+        _ => (
+            StatusCode::UNAUTHORIZED,
+            Json(ErrorResponse::new(
+                "INVALID_SIGNING_LINK",
+                "This signing link is invalid.",
+            )),
+        ),
+    }
+}
+
+/// Shared verification for both GET and POST: verify the token's HMAC/expiry,
+/// load the request, and run the org / lifecycle / signer-state checks that
+/// do NOT mutate. Returns the verified token, the loaded request, and the
+/// matched signer's index so the caller can act on it.
+async fn verify_and_load(
+    state: &AppState,
+    token_str: &str,
+) -> Result<
+    (
+        integrations::SigningToken,
+        db::models::SignatureRequest,
+        usize,
+    ),
+    (StatusCode, Json<ErrorResponse>),
+> {
+    // (1) HMAC + expiry. `None` skips the explicit org arg here — we bind the
+    // org below against the loaded request, which is strictly stronger.
+    let token = ESIGN_PROVIDER
+        .verify_token(token_str, None)
+        .map_err(token_error_response)?;
+
+    // (2) Parse the embedded request id.
+    let request_id = Uuid::parse_str(&token.request_id).map_err(|_| {
+        (
+            StatusCode::UNAUTHORIZED,
+            Json(ErrorResponse::new(
+                "INVALID_SIGNING_LINK",
+                "This signing link is invalid.",
+            )),
+        )
+    })?;
+
+    // (3) Load the request on the bare pool (public endpoint — no user RLS
+    // context). `signature_requests` is ENABLE (not FORCE) RLS, so the
+    // service path reads it directly, exactly like the webhook handler.
+    let request = state
+        .signature_request_repo
+        .find_by_id(request_id)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DATABASE_ERROR", e.to_string())),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(ErrorResponse::new(
+                    "INVALID_SIGNING_LINK",
+                    "This signing link is invalid.",
+                )),
+            )
+        })?;
+
+    // (4) Org binding: the token's org must match the loaded request's org.
+    // Defends against a token minted for org A being used against a request
+    // whose id collides in org B (belt-and-braces; the HMAC already binds it).
+    if token.org_id != request.organization_id.to_string() {
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            Json(ErrorResponse::new(
+                "INVALID_SIGNING_LINK",
+                "This signing link is invalid.",
+            )),
+        ));
+    }
+
+    // (5) Request lifecycle: only an open request may be signed.
+    if !matches!(
+        request.status,
+        SignatureRequestStatus::Pending | SignatureRequestStatus::InProgress
+    ) {
+        return Err((
+            StatusCode::CONFLICT,
+            Json(ErrorResponse::new(
+                "REQUEST_NOT_OPEN",
+                "This signature request is no longer open for signing.",
+            )),
+        ));
+    }
+
+    // (6) Locate the signer by the token's (verified) email, case-insensitive.
+    let signer_idx = request
+        .signers
+        .iter()
+        .position(|s| s.email.eq_ignore_ascii_case(&token.signer_email))
+        .ok_or_else(|| {
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(ErrorResponse::new(
+                    "INVALID_SIGNING_LINK",
+                    "This signing link is invalid.",
+                )),
+            )
+        })?;
+
+    // (7) The signer must not have already completed (signed or declined).
+    // This is the invariant that makes a stale-but-unconsumed reminder nonce
+    // harmless: once the signer is complete, every /sign attempt is refused
+    // regardless of which reminder link is replayed.
+    if request.signers[signer_idx].is_complete() {
+        return Err((
+            StatusCode::CONFLICT,
+            Json(ErrorResponse::new(
+                "ALREADY_SIGNED",
+                "You have already responded to this signature request.",
+            )),
+        ));
+    }
+
+    Ok((token, request, signer_idx))
+}
+
+/// `GET /api/v1/signatures/sign?token=...` — render context for the signing
+/// page. Read-only: validates everything but does NOT consume the nonce, so
+/// the signer can load the page, reload it, and only spend the nonce on POST.
+pub async fn get_sign_context(
+    State(state): State<AppState>,
+    Query(query): Query<SignTokenQuery>,
+) -> Result<Json<SignRenderContext>, (StatusCode, Json<ErrorResponse>)> {
+    let (token, request, signer_idx) = verify_and_load(&state, &query.token).await?;
+
+    // Nonce must be issued and not yet consumed. A consumed nonce on an
+    // otherwise-open request means this exact link was already used.
+    match state
+        .e_signature_nonce_repo
+        .nonce_state(request.id, token.nonce)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DATABASE_ERROR", e.to_string())),
+            )
+        })? {
+        NonceState::Pending => {}
+        NonceState::Consumed => {
+            return Err((
+                StatusCode::CONFLICT,
+                Json(ErrorResponse::new(
+                    "LINK_ALREADY_USED",
+                    "This signing link has already been used.",
+                )),
+            ));
+        }
+        NonceState::NotIssued => {
+            return Err((
+                StatusCode::UNAUTHORIZED,
+                Json(ErrorResponse::new(
+                    "INVALID_SIGNING_LINK",
+                    "This signing link is invalid.",
+                )),
+            ));
+        }
+    }
+
+    let signer = &request.signers[signer_idx];
+    Ok(Json(SignRenderContext {
+        request_id: request.id,
+        document_id: request.document_id,
+        subject: request.subject.clone(),
+        message: request.message.clone(),
+        signer_name: signer.name.clone(),
+        signer_email: signer.email.clone(),
+        signer_status: signer.status.to_string(),
+    }))
+}
+
+/// `POST /api/v1/signatures/sign?token=...` — record the signature.
+///
+/// Atomically consumes the nonce (single-use) BEFORE mutating signer status,
+/// so a replay or a concurrent double-submit is rejected with 409 and never
+/// double-counts a signature.
+pub async fn submit_signature(
+    State(state): State<AppState>,
+    Query(query): Query<SignTokenQuery>,
+    body: Option<Json<SubmitSignatureRequest>>,
+) -> Result<Json<SubmitSignatureResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let (token, request, signer_idx) = verify_and_load(&state, &query.token).await?;
+    let typed_name = body.and_then(|b| b.0.typed_name);
+
+    // Single-use gate: flip the nonce NULL -> NOW() atomically. The winner of
+    // any race proceeds; everyone else (and every replay) is rejected here.
+    match state
+        .e_signature_nonce_repo
+        .consume_nonce(request.id, token.nonce)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DATABASE_ERROR", e.to_string())),
+            )
+        })? {
+        ConsumeOutcome::Consumed => {}
+        ConsumeOutcome::AlreadyConsumed => {
+            warn!(
+                signature_request_id = %request.id,
+                signer_email = %token.signer_email,
+                "Rejected /sign replay: nonce already consumed"
+            );
+            return Err((
+                StatusCode::CONFLICT,
+                Json(ErrorResponse::new(
+                    "LINK_ALREADY_USED",
+                    "This signing link has already been used.",
+                )),
+            ));
+        }
+        ConsumeOutcome::NotIssued => {
+            return Err((
+                StatusCode::UNAUTHORIZED,
+                Json(ErrorResponse::new(
+                    "INVALID_SIGNING_LINK",
+                    "This signing link is invalid.",
+                )),
+            ));
+        }
+    }
+
+    // Nonce is spent — record the signature. `update_signer_status` recomputes
+    // the request status (in_progress / completed) and the document's
+    // signature_status under the request's org context.
+    let signer_email = request.signers[signer_idx].email.clone();
+    let updated = state
+        .signature_request_repo
+        .update_signer_status(request.id, &signer_email, SignerStatus::Signed, None)
+        .await
+        .map_err(|e| {
+            error!(
+                signature_request_id = %request.id,
+                error = %e,
+                "Nonce consumed but failed to record signer status"
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(
+                    "DATABASE_ERROR",
+                    "Failed to record signature",
+                )),
+            )
+        })?;
+
+    info!(
+        signature_request_id = %request.id,
+        signer_email = %signer_email,
+        typed_name = ?typed_name,
+        new_status = %updated.status,
+        "Recorded signature via /sign"
+    );
+
+    let message = if matches!(updated.status, SignatureRequestStatus::Completed) {
+        "Thank you — all signatures have been collected.".to_string()
+    } else {
+        "Thank you — your signature has been recorded.".to_string()
+    };
+
+    Ok(Json(SubmitSignatureResponse {
+        status: updated.status.to_string(),
+        message,
+    }))
 }
 
 // Helper function to create document-scoped signature routes

--- a/backend/servers/api-server/tests/esignature_sign_consumer_tests.rs
+++ b/backend/servers/api-server/tests/esignature_sign_consumer_tests.rs
@@ -21,6 +21,7 @@
 //! once (LazyLock); we pin that secret here and mint tokens with a provider
 //! that shares it, so server-side verification matches.
 
+#[allow(dead_code)]
 mod common;
 
 use std::time::Duration;
@@ -28,7 +29,7 @@ use std::time::Duration;
 use axum::http::StatusCode;
 use common::TestApp;
 use db::repositories::ESignatureNonceRepository;
-use integrations::{LightweightConfig, LightweightProvider, SigningToken};
+use integrations::{LightweightConfig, LightweightProvider};
 use sqlx::PgPool;
 use uuid::Uuid;
 

--- a/backend/servers/api-server/tests/esignature_sign_consumer_tests.rs
+++ b/backend/servers/api-server/tests/esignature_sign_consumer_tests.rs
@@ -1,0 +1,310 @@
+//! HTTP-level tests for the signer-facing `/sign` consumer endpoint
+//! (issue #761 part 2).
+//!
+//! These exercise the full router (`create_router`) end to end:
+//!
+//!   GET  /api/v1/signatures/sign?token=...  — render context (no consume)
+//!   POST /api/v1/signatures/sign?token=...  — record signature (consumes)
+//!
+//! Invariants asserted:
+//!
+//! | Case | Expected |
+//! |------|----------|
+//! | S1 | A valid link renders context, then signs once (200 → completed) |
+//! | S2 | Replaying the POST after a successful sign is rejected (409) |
+//! | S3 | A token with a tampered HMAC is rejected (401) |
+//! | S4 | An expired token is rejected (410) |
+//! | S5 | A nonce that was never issued is rejected (401) |
+//!
+//! The endpoint is unauthenticated — all authority is in the HMAC token. The
+//! server's `ESIGN_PROVIDER` reads `ESIGN_TOKEN_SECRET` from the environment
+//! once (LazyLock); we pin that secret here and mint tokens with a provider
+//! that shares it, so server-side verification matches.
+
+mod common;
+
+use std::time::Duration;
+
+use axum::http::StatusCode;
+use common::TestApp;
+use db::repositories::ESignatureNonceRepository;
+use integrations::{LightweightConfig, LightweightProvider, SigningToken};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Fixed HMAC secret shared by the in-test token minter and the server's
+/// `ESIGN_PROVIDER`. ≥32 bytes to clear the production floor.
+const TEST_ESIGN_SECRET: &str = "esign-sign-consumer-test-secret-0123456789";
+
+/// Ensure `ESIGN_TOKEN_SECRET` is set before the server's `ESIGN_PROVIDER`
+/// LazyLock is first touched (i.e. before the first `/sign` request).
+fn ensure_esign_secret() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        if std::env::var("ESIGN_TOKEN_SECRET").is_err() {
+            std::env::set_var("ESIGN_TOKEN_SECRET", TEST_ESIGN_SECRET);
+        }
+    });
+}
+
+/// Build a provider that mints tokens with the same secret the server uses.
+/// `ttl` lets a test mint an already-expiring token (S4).
+fn minter(ttl_secs: u64) -> LightweightProvider {
+    LightweightProvider::new(LightweightConfig {
+        token_secret: TEST_ESIGN_SECRET.as_bytes().to_vec(),
+        previous_token_secret: None,
+        base_url: "http://localhost:3000".to_string(),
+        webhook_url: None,
+        token_ttl_secs: ttl_secs,
+    })
+}
+
+/// Seed org + user + document + a pending signature request with one signer.
+/// Returns (request_id, org_id, signer_email).
+async fn seed_request_with_signer(pool: &PgPool, signer_email: &str) -> (Uuid, Uuid, String) {
+    let slug = format!("esign-sign-{}", Uuid::new_v4());
+    let org_id = sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO organizations (name, slug, contact_email, status)
+           VALUES ('ESign Sign Org', $1, 'esign-sign@example.com', 'active')
+           RETURNING id"#,
+    )
+    .bind(&slug)
+    .fetch_one(pool)
+    .await
+    .expect("seed org");
+
+    let user_id = sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO users (email, password_hash, name, status, email_verified_at)
+           VALUES ($1, 'test_hash', 'ESign User', 'active', NOW())
+           RETURNING id"#,
+    )
+    .bind(format!("esign-{}@example.com", Uuid::new_v4()))
+    .fetch_one(pool)
+    .await
+    .expect("seed user");
+
+    let doc_id = sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO documents
+             (organization_id, title, category, file_key, file_name,
+              mime_type, size_bytes, access_scope, created_by)
+           VALUES ($1, 'Lease Agreement', 'contracts', 'k', 'lease.pdf',
+                   'application/pdf', 1, 'organization', $2)
+           RETURNING id"#,
+    )
+    .bind(org_id)
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed document");
+
+    // Single signer, JSONB roster. `status: sent` mirrors a freshly-emailed
+    // invitation; `is_complete()` is false so signing is allowed.
+    let signers = serde_json::json!([{
+        "email": signer_email,
+        "name": "Alice Buyer",
+        "order": 0,
+        "status": "sent"
+    }]);
+
+    let request_id = sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO signature_requests
+             (document_id, organization_id, status, subject, message, signers, created_by)
+           VALUES ($1, $2, 'pending', 'Please sign the lease',
+                   'Sign at your earliest convenience', $3, $4)
+           RETURNING id"#,
+    )
+    .bind(doc_id)
+    .bind(org_id)
+    .bind(&signers)
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed signature_request");
+
+    (request_id, org_id, signer_email.to_string())
+}
+
+/// Mint a signing token for the request and record its nonce as ISSUED
+/// (mirrors what `create_signature_request` / `send_reminder` do at send
+/// time). Returns the encoded token string.
+async fn issue_token(
+    pool: &PgPool,
+    provider: &LightweightProvider,
+    request_id: Uuid,
+    org_id: Uuid,
+    signer_email: &str,
+) -> String {
+    let signed = provider
+        .build_signing_url(
+            signer_email,
+            &request_id.to_string(),
+            &org_id.to_string(),
+            "sent",
+        )
+        .expect("build signing url");
+
+    ESignatureNonceRepository::new(pool.clone())
+        .record_nonce(request_id, signed.nonce)
+        .await
+        .expect("record nonce (issue)");
+
+    // Extract the encoded token from the `?token=` query.
+    signed
+        .url
+        .split("token=")
+        .nth(1)
+        .expect("token in url")
+        .to_string()
+}
+
+// ===========================================================================
+// S1 + S2 — happy path renders + signs once; replay rejected
+// ===========================================================================
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn valid_link_renders_and_signs_once_then_replay_rejected(pool: PgPool) {
+    ensure_esign_secret();
+    let app = TestApp::new(pool.clone()).await;
+    let email = "alice@example.com";
+    let (request_id, org_id, _) = seed_request_with_signer(&pool, email).await;
+    let token = issue_token(&pool, &minter(3600), request_id, org_id, email).await;
+
+    // GET render context — read-only, no consume.
+    let get_resp = app
+        .execute(
+            app.get(&format!("/api/v1/signatures/sign?token={token}"))
+                .build(),
+        )
+        .await;
+    get_resp.assert_status(StatusCode::OK);
+    let ctx = get_resp.json_value();
+    assert_eq!(ctx["request_id"], request_id.to_string());
+    assert_eq!(ctx["signer_email"], email);
+
+    // A second GET must STILL be OK — GET never consumes the nonce.
+    app.execute(
+        app.get(&format!("/api/v1/signatures/sign?token={token}"))
+            .build(),
+    )
+    .await
+    .assert_status(StatusCode::OK);
+
+    // POST — record the signature. One signer total, so the request completes.
+    let post_resp = app
+        .execute(
+            app.post(&format!("/api/v1/signatures/sign?token={token}"))
+                .json(serde_json::json!({ "typed_name": "Alice Buyer" }))
+                .build(),
+        )
+        .await;
+    post_resp.assert_status(StatusCode::OK);
+    assert_eq!(post_resp.json_value()["status"], "completed");
+
+    // S2: replay the SAME token → 409 (nonce already consumed).
+    app.execute(
+        app.post(&format!("/api/v1/signatures/sign?token={token}"))
+            .json(serde_json::json!({}))
+            .build(),
+    )
+    .await
+    .assert_status(StatusCode::CONFLICT);
+
+    // And the request is recorded as completed in the DB.
+    let status: String = sqlx::query_scalar::<_, String>(
+        "SELECT status::text FROM signature_requests WHERE id = $1",
+    )
+    .bind(request_id)
+    .fetch_one(&pool)
+    .await
+    .expect("read request status");
+    assert_eq!(status, "completed");
+}
+
+// ===========================================================================
+// S3 — tampered HMAC rejected
+// ===========================================================================
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn tampered_token_rejected(pool: PgPool) {
+    ensure_esign_secret();
+    let app = TestApp::new(pool.clone()).await;
+    let email = "bob@example.com";
+    let (request_id, org_id, _) = seed_request_with_signer(&pool, email).await;
+    let token = issue_token(&pool, &minter(3600), request_id, org_id, email).await;
+
+    // Flip the last character of the base64url payload — the MAC no longer
+    // matches the (decoded) fields.
+    let mut chars: Vec<char> = token.chars().collect();
+    let last = chars.len() - 1;
+    chars[last] = if chars[last] == 'A' { 'B' } else { 'A' };
+    let tampered: String = chars.into_iter().collect();
+
+    app.execute(
+        app.get(&format!("/api/v1/signatures/sign?token={tampered}"))
+            .build(),
+    )
+    .await
+    .assert_status(StatusCode::UNAUTHORIZED);
+}
+
+// ===========================================================================
+// S4 — expired token rejected (410 GONE)
+// ===========================================================================
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn expired_token_rejected(pool: PgPool) {
+    ensure_esign_secret();
+    let app = TestApp::new(pool.clone()).await;
+    let email = "carol@example.com";
+    let (request_id, org_id, _) = seed_request_with_signer(&pool, email).await;
+
+    // ttl = 0 → expires_at == issue time. Sleep just past it so verify sees
+    // `now > expires_at`.
+    let token = issue_token(&pool, &minter(0), request_id, org_id, email).await;
+    tokio::time::sleep(Duration::from_millis(1100)).await;
+
+    app.execute(
+        app.get(&format!("/api/v1/signatures/sign?token={token}"))
+            .build(),
+    )
+    .await
+    .assert_status(StatusCode::GONE);
+}
+
+// ===========================================================================
+// S5 — valid HMAC but nonce never issued → rejected
+// ===========================================================================
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn unissued_nonce_rejected(pool: PgPool) {
+    ensure_esign_secret();
+    let app = TestApp::new(pool.clone()).await;
+    let email = "dave@example.com";
+    let (request_id, org_id, _) = seed_request_with_signer(&pool, email).await;
+
+    // Mint a perfectly valid token but do NOT record its nonce — simulating a
+    // forged-but-somehow-signed link, or one whose issuance row was never
+    // written. The consumer must fail closed.
+    let provider = minter(3600);
+    let signed = provider
+        .build_signing_url(email, &request_id.to_string(), &org_id.to_string(), "sent")
+        .expect("build url");
+    let token = signed.url.split("token=").nth(1).unwrap().to_string();
+
+    // GET → 401 (nonce not issued).
+    app.execute(
+        app.get(&format!("/api/v1/signatures/sign?token={token}"))
+            .build(),
+    )
+    .await
+    .assert_status(StatusCode::UNAUTHORIZED);
+
+    // POST → also 401.
+    app.execute(
+        app.post(&format!("/api/v1/signatures/sign?token={token}"))
+            .json(serde_json::json!({}))
+            .build(),
+    )
+    .await
+    .assert_status(StatusCode::UNAUTHORIZED);
+}


### PR DESCRIPTION
## Summary

Closes #761 (part 2). The HMAC-signed-link infra existed (migration 00170, `e_signature_nonce` repo, signing-URL generation in `routes/signatures.rs`) but there was **no `/sign` endpoint** and nonces were recorded at link-issue time and **never consumed** — a captured signing link could be replayed for the full 7-day token TTL.

This adds the signer-facing consumer endpoint and makes the nonce genuinely single-use.

## Changes

### Migration `00174` — consume-on-use
`e_signature_nonces` gets a nullable `consumed_at`. Issue inserts a row (`consumed_at NULL`); `/sign` flips `NULL → NOW()` **atomically**, so a replay updates zero rows and is rejected. Partial index over the unconsumed predicate. The existing `UNIQUE (envelope_id, nonce)` still rejects double-issue, so the repo replay test is unchanged.

### Repo (`e_signature_nonce.rs`)
- `nonce_state` — read-only lifecycle (`NotIssued` / `Pending` / `Consumed`) for the GET preview.
- `consume_nonce` — atomic single-use `UPDATE … WHERE consumed_at IS NULL RETURNING`, returning `ConsumeOutcome` (`Consumed` / `AlreadyConsumed` / `NotIssued`). Two racing POSTs: exactly one wins.

### Route (`signatures.rs`) — public `GET`/`POST /api/v1/signatures/sign?token=`
No auth — all authority is in the verified token. Defence in depth, shared by both verbs:
1. HMAC + expiry (`verify_token`)
2. org binding (`token.org_id == request.organization_id`)
3. request lifecycle (must be `pending`/`in_progress`)
4. signer not already complete (makes a stale-but-unconsumed reminder nonce harmless once the signer has signed)
5. nonce single-use

`GET` renders the signing context **without** consuming. `POST` consumes the nonce **before** recording the signature (`update_signer_status` → recomputes request + document status), so a replay or concurrent double-submit can't double-count.

### Tests (`esignature_sign_consumer_tests.rs`, full router via `create_router`)
- valid link renders, signs once → `completed`; a second GET stays OK (GET never consumes)
- replay POST → **409**
- tampered HMAC → **401**
- expired token → **410**
- valid HMAC but un-issued nonce → **401**

## Verification

- `cargo fmt`, `cargo build`, `cargo test --no-run` green against a clean target dir. Docker unavailable locally; `#[sqlx::test]` cases run in CI. Existing `esignature_nonce_replay_tests.rs` and `esignature.rs` HMAC unit tests remain valid.