### PR TITLE
test(gap-80-1): dispute filing API integration tests

### DIFF
--- a/backend/crates/db/tests/dispute_lifecycle_tests.rs
+++ b/backend/crates/db/tests/dispute_lifecycle_tests.rs
@@ -1,0 +1,391 @@
+//! Dispute filing API integration tests (gap-80-1, Epic 77 / Story 77.1).
+//!
+//! Complements the focused `dispute_cross_tenant_tests.rs` (issue #520) and the
+//! HTTP-layer `dispute_cross_org_idor_tests.rs` (#760 / #834) with repository
+//! integration coverage of:
+//!
+//! - the create + status-transition lifecycle (file → under_review → mediation
+//!   → resolved → closed) end to end through `DisputeRepository`,
+//! - RLS tenant isolation — a caller in org B cannot read or drive a dispute
+//!   filed in org A (`find_by_id_with_details_for_org` / `update_status` /
+//!   `withdraw` are all org-scoped),
+//! - the dispute status state machine — every legal transition succeeds and a
+//!   representative set of illegal ones is rejected with `BadRequest`,
+//! - evidence persistence + activity-trail side effects.
+//!
+//! These run against a real Postgres via `#[sqlx::test]`, which provisions an
+//! isolated migrated database per test. With no local Postgres they are
+//! skipped locally and run in CI (`backend.yml`) — Band A/B locally, Band C in
+//! CI (see PR body).
+
+use db::models::disputes::{dispute_state_machine, dispute_status};
+use db::models::{AddEvidence, FileDispute, UpdateDisputeStatus};
+use db::repositories::DisputeRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("DisputeLifecycle {slug}"))
+    .bind(format!("dispute-lifecycle-{slug}"))
+    .bind(format!("{slug}@dispute-lifecycle.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'test_hash', 'Dispute Lifecycle User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+fn file_req(org_id: Uuid, filed_by: Uuid, respondents: Vec<Uuid>) -> FileDispute {
+    FileDispute {
+        organization_id: org_id,
+        building_id: None,
+        unit_id: None,
+        category: "noise".into(),
+        title: "Loud neighbours".into(),
+        description: "Repeated loud music after midnight.".into(),
+        desired_resolution: Some("Quiet hours respected".into()),
+        respondent_ids: respondents,
+        filed_by,
+    }
+}
+
+fn transition(dispute_id: Uuid, org_id: Uuid, by: Uuid, status: &str) -> UpdateDisputeStatus {
+    UpdateDisputeStatus {
+        dispute_id,
+        organization_id: org_id,
+        status: status.into(),
+        reason: None,
+        updated_by: by,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Full create + status-transition lifecycle
+// ---------------------------------------------------------------------------
+
+/// File a dispute, then drive it through the canonical happy-path lifecycle
+/// `filed → under_review → mediation → resolved → closed`. Each step must
+/// succeed and the persisted status must reflect the transition.
+#[sqlx::test]
+async fn file_then_full_status_lifecycle(pool: PgPool) {
+    let org = seed_org(&pool, "lc").await;
+    let complainant = seed_user(&pool, "complainant@dispute-lifecycle.test").await;
+    let respondent = seed_user(&pool, "respondent@dispute-lifecycle.test").await;
+
+    let repo = DisputeRepository::new(pool.clone());
+
+    // Create — the new dispute starts in `filed` with a generated reference.
+    let dispute = repo
+        .file_dispute(org, file_req(org, complainant, vec![respondent]))
+        .await
+        .expect("file dispute");
+    assert_eq!(dispute.status, dispute_status::FILED);
+    assert!(dispute.reference_number.starts_with("DSP-"));
+    assert_eq!(dispute.organization_id, org);
+
+    // Filing seeds the complainant + respondent as parties and a
+    // `dispute_filed` activity.
+    let parties = repo.list_parties(dispute.id).await.expect("list parties");
+    assert_eq!(parties.len(), 2, "complainant + respondent are seeded");
+    let activities = repo
+        .list_activities(dispute.id, 50, 0)
+        .await
+        .expect("list activities");
+    assert!(
+        activities
+            .iter()
+            .any(|a| a.activity_type == "dispute_filed"),
+        "filing records a dispute_filed activity"
+    );
+
+    // Walk the lifecycle.
+    for next in [
+        dispute_status::UNDER_REVIEW,
+        dispute_status::MEDIATION,
+        dispute_status::RESOLVED,
+        dispute_status::CLOSED,
+    ] {
+        let updated = repo
+            .update_status(transition(dispute.id, org, complainant, next))
+            .await
+            .unwrap_or_else(|e| panic!("transition to {next} should succeed: {e:?}"));
+        assert_eq!(updated.status, next, "status persisted as {next}");
+    }
+
+    // Every transition recorded a status_changed activity (4 transitions).
+    let activities = repo
+        .list_activities(dispute.id, 50, 0)
+        .await
+        .expect("list activities");
+    let status_changes = activities
+        .iter()
+        .filter(|a| a.activity_type == "status_changed")
+        .count();
+    assert_eq!(status_changes, 4, "one status_changed per transition");
+}
+
+// ---------------------------------------------------------------------------
+// 2. RLS tenant isolation — cross-tenant access denied
+// ---------------------------------------------------------------------------
+
+/// A caller in org B must not be able to read or act on a dispute filed in
+/// org A. All three org-scoped repo entry points
+/// (`find_by_id_with_details_for_org`, `update_status`, `withdraw`) must deny
+/// the foreign org while the owning org succeeds.
+#[sqlx::test]
+async fn cross_tenant_access_is_denied(pool: PgPool) {
+    let org_a = seed_org(&pool, "iso-a").await;
+    let org_b = seed_org(&pool, "iso-b").await;
+    let user_a = seed_user(&pool, "iso-a@dispute-lifecycle.test").await;
+    let user_b = seed_user(&pool, "iso-b@dispute-lifecycle.test").await;
+
+    let repo = DisputeRepository::new(pool.clone());
+
+    let dispute = repo
+        .file_dispute(org_a, file_req(org_a, user_a, vec![]))
+        .await
+        .expect("file dispute in org A");
+
+    // READ: org B cannot see org A's dispute; org A can.
+    assert!(
+        repo.find_by_id_with_details_for_org(dispute.id, org_b)
+            .await
+            .expect("query ok")
+            .is_none(),
+        "org B must not read org A's dispute"
+    );
+    assert!(
+        repo.find_by_id_with_details_for_org(dispute.id, org_a)
+            .await
+            .expect("query ok")
+            .is_some(),
+        "org A reads its own dispute"
+    );
+
+    // ACT (status): org B's transition must fail; the row stays in `filed`.
+    let cross = repo
+        .update_status(transition(
+            dispute.id,
+            org_b,
+            user_b,
+            dispute_status::UNDER_REVIEW,
+        ))
+        .await;
+    assert!(cross.is_err(), "cross-tenant update_status must fail");
+    assert_eq!(
+        repo.find_by_id_with_details_for_org(dispute.id, org_a)
+            .await
+            .expect("query ok")
+            .expect("exists")
+            .dispute
+            .status,
+        dispute_status::FILED,
+        "cross-tenant attempt must not mutate the row"
+    );
+
+    // ACT (withdraw): org B's withdraw must NotFound; org A's succeeds.
+    let cross_wd = repo.withdraw(dispute.id, org_b, user_b).await;
+    assert!(
+        matches!(cross_wd, Err(common::errors::AppError::NotFound(_))),
+        "cross-tenant withdraw must be NotFound, got {cross_wd:?}"
+    );
+    repo.withdraw(dispute.id, org_a, user_a)
+        .await
+        .expect("org A withdraws its own dispute");
+    assert_eq!(
+        repo.find_by_id_with_details_for_org(dispute.id, org_a)
+            .await
+            .expect("query ok")
+            .expect("exists")
+            .dispute
+            .status,
+        dispute_status::WITHDRAWN,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Dispute status-machine transitions (legal + illegal)
+// ---------------------------------------------------------------------------
+
+/// `update_status` enforces the state machine: a legal transition succeeds and
+/// an illegal one (e.g. `filed → resolved`, skipping review) is rejected with
+/// `BadRequest`, leaving the row untouched.
+#[sqlx::test]
+async fn status_machine_rejects_illegal_transitions(pool: PgPool) {
+    let org = seed_org(&pool, "sm").await;
+    let user = seed_user(&pool, "sm@dispute-lifecycle.test").await;
+    let repo = DisputeRepository::new(pool.clone());
+
+    let dispute = repo
+        .file_dispute(org, file_req(org, user, vec![]))
+        .await
+        .expect("file dispute");
+
+    // filed → resolved is NOT a legal transition (must go via under_review).
+    assert!(
+        !dispute_state_machine::is_valid_transition(
+            dispute_status::FILED,
+            dispute_status::RESOLVED
+        ),
+        "state machine: filed→resolved is illegal"
+    );
+    let illegal = repo
+        .update_status(transition(dispute.id, org, user, dispute_status::RESOLVED))
+        .await;
+    assert!(
+        matches!(illegal, Err(common::errors::AppError::BadRequest(_))),
+        "filed→resolved must be rejected with BadRequest, got {illegal:?}"
+    );
+    assert_eq!(
+        repo.find_by_id_with_details_for_org(dispute.id, org)
+            .await
+            .expect("query ok")
+            .expect("exists")
+            .dispute
+            .status,
+        dispute_status::FILED,
+        "rejected transition leaves status unchanged"
+    );
+
+    // An unknown status value is also rejected (guard before the state check).
+    let unknown = repo
+        .update_status(transition(dispute.id, org, user, "banana"))
+        .await;
+    assert!(
+        matches!(unknown, Err(common::errors::AppError::BadRequest(_))),
+        "unknown status must be rejected, got {unknown:?}"
+    );
+
+    // A legal transition from filed succeeds.
+    let ok = repo
+        .update_status(transition(
+            dispute.id,
+            org,
+            user,
+            dispute_status::UNDER_REVIEW,
+        ))
+        .await
+        .expect("filed→under_review is legal");
+    assert_eq!(ok.status, dispute_status::UNDER_REVIEW);
+
+    // From a terminal-ish state: resolved → closed is the only legal move.
+    repo.update_status(transition(dispute.id, org, user, dispute_status::RESOLVED))
+        .await
+        .expect("under_review→resolved is legal");
+    let bad_from_resolved = repo
+        .update_status(transition(dispute.id, org, user, dispute_status::MEDIATION))
+        .await;
+    assert!(
+        matches!(
+            bad_from_resolved,
+            Err(common::errors::AppError::BadRequest(_))
+        ),
+        "resolved→mediation must be rejected, got {bad_from_resolved:?}"
+    );
+    repo.update_status(transition(dispute.id, org, user, dispute_status::CLOSED))
+        .await
+        .expect("resolved→closed is legal");
+}
+
+// ---------------------------------------------------------------------------
+// 4. Evidence persistence + activity trail
+// ---------------------------------------------------------------------------
+
+/// Adding evidence persists the row, exposes it via `list_evidence`, bumps the
+/// dispute's evidence_count, and records an `evidence_added` activity. (The
+/// HTTP-layer auth guard on the evidence-upload route is covered in the
+/// api-server test `dispute_evidence_auth_tests.rs`.)
+#[sqlx::test]
+async fn add_evidence_persists_and_records_activity(pool: PgPool) {
+    let org = seed_org(&pool, "ev").await;
+    let user = seed_user(&pool, "ev@dispute-lifecycle.test").await;
+    let repo = DisputeRepository::new(pool.clone());
+
+    let dispute = repo
+        .file_dispute(org, file_req(org, user, vec![]))
+        .await
+        .expect("file dispute");
+
+    let evidence = repo
+        .add_evidence(AddEvidence {
+            dispute_id: dispute.id,
+            uploaded_by: user,
+            filename: "noise-recording.mp3".into(),
+            original_filename: "recording (1).mp3".into(),
+            content_type: "audio/mpeg".into(),
+            size_bytes: 1024,
+            storage_url: "s3://evidence/noise-recording.mp3".into(),
+            description: Some("Recording of the noise".into()),
+        })
+        .await
+        .expect("add evidence");
+    assert_eq!(evidence.dispute_id, dispute.id);
+    assert_eq!(evidence.uploaded_by, user);
+
+    let listed = repo.list_evidence(dispute.id).await.expect("list evidence");
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].id, evidence.id);
+
+    let details = repo
+        .find_by_id_with_details_for_org(dispute.id, org)
+        .await
+        .expect("query ok")
+        .expect("exists");
+    assert_eq!(
+        details.evidence_count, 1,
+        "evidence_count reflects the upload"
+    );
+
+    let activities = repo
+        .list_activities(dispute.id, 50, 0)
+        .await
+        .expect("list activities");
+    assert!(
+        activities
+            .iter()
+            .any(|a| a.activity_type == "evidence_added"),
+        "adding evidence records an evidence_added activity"
+    );
+
+    // delete_evidence is dispute-scoped: a wrong dispute id deletes nothing.
+    let other = repo
+        .file_dispute(org, file_req(org, user, vec![]))
+        .await
+        .expect("file second dispute");
+    let wrong_scope = repo
+        .delete_evidence(other.id, evidence.id)
+        .await
+        .expect("delete query ok");
+    assert!(
+        !wrong_scope,
+        "evidence is not deletable via a foreign dispute id"
+    );
+    let right_scope = repo
+        .delete_evidence(dispute.id, evidence.id)
+        .await
+        .expect("delete query ok");
+    assert!(right_scope, "evidence is deletable via its own dispute id");
+}

--- a/backend/servers/api-server/tests/dispute_evidence_auth_tests.rs
+++ b/backend/servers/api-server/tests/dispute_evidence_auth_tests.rs
@@ -1,0 +1,157 @@
+//! Auth-guard tests for the dispute evidence-upload endpoint (gap-80-1,
+//! Epic 77 / Story 77.1).
+//!
+//! The `POST /api/v1/disputes/{id}/evidence` handler takes an `AuthUser`
+//! extractor, so an unauthenticated request must be rejected *before* any row
+//! is written to `dispute_evidence`. These tests pin that contract at the HTTP
+//! surface and assert the side-effect-free outcome (no evidence row created).
+//!
+//! TestApp wiring caveat (same as `dispute_cross_org_idor_tests.rs`): `TestApp`
+//! mounts the router without `host_tenant_middleware`, so any request lacking a
+//! fully-provisioned Bearer JWT is rejected with 4xx before the handler body
+//! runs. The security contract — no evidence persisted without auth — still
+//! holds and is what we assert.
+
+#[allow(dead_code)]
+mod common;
+
+use axum::body::Body;
+use axum::http::{header, Method, Request, StatusCode};
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::TestApp;
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active') RETURNING id
+        "#,
+    )
+    .bind(format!("DisputeEvidence Org {slug}"))
+    .bind(format!("dispute-evidence-{slug}"))
+    .bind(format!("{slug}@dispute-evidence.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'test_hash', 'DisputeEvidence User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_dispute(pool: &PgPool, org_id: Uuid, filed_by: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO disputes (
+            organization_id, reference_number, category,
+            title, description, status, priority, filed_by
+        )
+        VALUES ($1, $2, 'noise', 'Evidence dispute', 'Has evidence',
+                'under_review', 'medium', $3)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(format!("DISP-EV-{}", Uuid::new_v4()))
+    .bind(filed_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed dispute")
+}
+
+async fn evidence_count(pool: &PgPool, dispute_id: Uuid) -> i64 {
+    sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM dispute_evidence WHERE dispute_id = $1")
+        .bind(dispute_id)
+        .fetch_one(pool)
+        .await
+        .expect("count evidence")
+}
+
+fn assert_rejected(status: StatusCode, ctx: &str) {
+    let code = status.as_u16();
+    assert!(
+        (400..500).contains(&code),
+        "{ctx}: expected 4xx rejection, got {status}"
+    );
+}
+
+fn evidence_body() -> serde_json::Value {
+    json!({
+        "data": {
+            "dispute_id": Uuid::nil(),
+            "uploaded_by": Uuid::nil(),
+            "filename": "evil.pdf",
+            "original_filename": "evil.pdf",
+            "content_type": "application/pdf",
+            "size_bytes": 10,
+            "storage_url": "s3://evidence/evil.pdf",
+            "description": "unauthenticated upload attempt"
+        }
+    })
+}
+
+/// An unauthenticated POST to the evidence-upload endpoint is rejected and no
+/// evidence row is persisted.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn add_evidence_without_auth_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let user_id = seed_user(&pool, "no-auth@dispute-evidence.test").await;
+    let org_id = seed_org(&pool, "no-auth").await;
+    let dispute_id = seed_dispute(&pool, org_id, user_id).await;
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(format!("/api/v1/disputes/{dispute_id}/evidence"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(evidence_body().to_string()))
+        .unwrap();
+    let resp = app.execute(req).await;
+
+    assert_rejected(resp.status, "POST /evidence without auth");
+    assert_eq!(
+        evidence_count(&pool, dispute_id).await,
+        0,
+        "no evidence row may be created without authentication"
+    );
+}
+
+/// A POST carrying a malformed/forged bearer token is rejected and no evidence
+/// row is persisted (the `AuthUser` extractor validates the JWT signature).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn add_evidence_with_bogus_bearer_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let user_id = seed_user(&pool, "bogus@dispute-evidence.test").await;
+    let org_id = seed_org(&pool, "bogus").await;
+    let dispute_id = seed_dispute(&pool, org_id, user_id).await;
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(format!("/api/v1/disputes/{dispute_id}/evidence"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(header::AUTHORIZATION, "Bearer not-a-real-jwt")
+        .body(Body::from(evidence_body().to_string()))
+        .unwrap();
+    let resp = app.execute(req).await;
+
+    assert_rejected(resp.status, "POST /evidence with bogus bearer");
+    assert_eq!(
+        evidence_count(&pool, dispute_id).await,
+        0,
+        "a forged bearer must not create an evidence row"
+    );
+}


### PR DESCRIPTION
## What changed

Adds integration-test coverage for the dispute filing API (Epic 77 / Story 77.1). **Test-only** — no production code touched.

Two new test files:

### `backend/crates/db/tests/dispute_lifecycle_tests.rs` (`#[sqlx::test]`, repo layer)
- **Full create + status-transition lifecycle** — `file_dispute` (asserts `filed` start, `DSP-` reference, seeded complainant+respondent parties, `dispute_filed` activity) then drives `filed → under_review → mediation → resolved → closed`, asserting each persisted status and that one `status_changed` activity is recorded per transition.
- **RLS tenant isolation / cross-tenant denied** — a dispute filed in org A; org B cannot read it (`find_by_id_with_details_for_org` → `None`), cannot transition it (`update_status` errors, row stays `filed`), and cannot withdraw it (`withdraw` → `NotFound`); the owning org A succeeds at all three.
- **Status state-machine** — illegal `filed → resolved` rejected with `BadRequest` (row unchanged), unknown status value rejected, legal `filed → under_review` and `under_review → resolved → closed` succeed, and `resolved → mediation` rejected.
- **Evidence persistence + activity trail** — `add_evidence` persists, surfaces via `list_evidence`, bumps `evidence_count`, records `evidence_added`; `delete_evidence` is dispute-scoped (foreign dispute id deletes nothing).

### `backend/servers/api-server/tests/dispute_evidence_auth_tests.rs` (`#[sqlx::test]`, HTTP via `TestApp`)
- **Evidence-upload auth guard** — `POST /api/v1/disputes/{id}/evidence` carries an `AuthUser` extractor. Unauthenticated and forged-bearer requests are rejected (4xx) with **no `dispute_evidence` row written** (asserted via a direct count).

## Tests

| Coverage area (task) | Where |
|---|---|
| create + status-transition lifecycle | `dispute_lifecycle_tests::file_then_full_status_lifecycle` |
| RLS tenant isolation (cross-tenant denied) | `dispute_lifecycle_tests::cross_tenant_access_is_denied` |
| dispute status-machine transitions | `dispute_lifecycle_tests::status_machine_rejects_illegal_transitions` |
| evidence-upload auth guard | `dispute_evidence_auth_tests::{add_evidence_without_auth_is_rejected, add_evidence_with_bogus_bearer_is_rejected}` |
| (bonus) evidence persistence + activity | `dispute_lifecycle_tests::add_evidence_persists_and_records_activity` |

## Verify bands

- **Band A (Tested, offline):** `cargo fmt --all -- --check` → exit 0; `cargo clippy -p db --tests -- -D warnings` → exit 0.
- **Band B (Built):** `cargo test -p db --test dispute_lifecycle_tests --no-run` → exit 0; `cargo test -p api-server --test dispute_evidence_auth_tests --no-run` → exit 0. Both new test binaries compile.
- **Band C (CI-parity):** the `#[sqlx::test]` tests need a live Postgres, which this session has no local Docker/Postgres for, so they are **executed in CI** (`backend.yml` provisions Postgres). They are not `#[ignore]` — `#[sqlx::test]` provisions an isolated migrated DB per test and is the repo convention (mirrors `dispute_cross_tenant_tests.rs` / `dispute_cross_org_idor_tests.rs`). Same Band A/B/C convention as PRs #931/#932.

## Scope drift

None. `scope-check.sh --owner pm-backend` → exit 0. Only two new test files added; `backend/Cargo.lock` was reverted (build had rewritten a pre-existing, unrelated workspace-version drift `0.3.0`→`0.3.7`) to keep the PR strictly test-scoped.

## Code reuse

Reuses the existing repo test conventions: `#[sqlx::test]` fixtures mirroring `dispute_cross_tenant_tests.rs`, the `TestApp` HTTP harness + `common` module from `dispute_cross_org_idor_tests.rs`, and the existing `db::models::disputes` constants (`dispute_status`, `dispute_state_machine`) rather than re-deriving the state machine in the test. No new production seams were introduced.

https://claude.ai/code/session_01FVATs19YUYXs9R3cQqSPVw

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVATs19YUYXs9R3cQqSPVw)_