### PR TITLE
fix(api-server): close account-enumeration oracles on login & register (#956)

### DIFF
--- a/backend/servers/api-server/src/routes/auth.rs
+++ b/backend/servers/api-server/src/routes/auth.rs
@@ -52,14 +52,22 @@ pub struct RegisterRequest {
 }
 
 /// Register response.
+///
+/// Intentionally generic and identical for both a fresh registration and an
+/// attempt to register an already-existing email (#956). It carries no
+/// account-specific data (notably no user id), so the response cannot be used
+/// to enumerate registered accounts.
 #[derive(Debug, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RegisterResponse {
-    /// Success message
+    /// Generic success message
     pub message: String,
-    /// User ID
-    pub user_id: String,
 }
+
+/// Generic, account-agnostic message returned by `register` regardless of
+/// whether the email was already registered. Keeps the success and
+/// already-exists paths byte-for-byte identical (#956).
+const REGISTER_GENERIC_MESSAGE: &str = "Check your email to verify your account";
 
 /// Register endpoint.
 #[utoipa::path(
@@ -68,9 +76,10 @@ pub struct RegisterResponse {
     tag = "Authentication",
     request_body = RegisterRequest,
     responses(
-        (status = 201, description = "Registration successful", body = RegisterResponse),
-        (status = 400, description = "Invalid input", body = ErrorResponse),
-        (status = 409, description = "Email already exists", body = ErrorResponse)
+        // A 201 with a generic body is returned whether or not the email is
+        // already registered, to avoid account enumeration (#956).
+        (status = 201, description = "Registration accepted", body = RegisterResponse),
+        (status = 400, description = "Invalid input", body = ErrorResponse)
     )
 )]
 pub async fn register(
@@ -112,16 +121,23 @@ pub async fn register(
         ));
     }
 
-    // Check if email already exists
+    // Check if email already exists. We must NOT signal this back to the
+    // caller (no 409 / EMAIL_EXISTS) — a distinct response for an existing
+    // address is an account-enumeration oracle. Instead we short-circuit with
+    // the exact same generic 201 a fresh registration returns, and notify the
+    // real account holder out-of-band (logged here; an out-of-band "someone
+    // tried to register with your email" notification is a future enhancement).
     match state.user_repo.email_exists(&req.email).await {
         Ok(true) => {
-            // Don't reveal whether account is verified or not
-            return Err((
-                StatusCode::CONFLICT,
-                Json(ErrorResponse::new(
-                    "EMAIL_EXISTS",
-                    "An account with this email already exists",
-                )),
+            tracing::info!(
+                email_hash = %common::email_log_hash(&req.email),
+                "Registration attempted for an already-registered email; returning generic response"
+            );
+            return Ok((
+                StatusCode::CREATED,
+                Json(RegisterResponse {
+                    message: REGISTER_GENERIC_MESSAGE.to_string(),
+                }),
             ));
         }
         Ok(false) => {}
@@ -218,8 +234,7 @@ pub async fn register(
     Ok((
         StatusCode::CREATED,
         Json(RegisterResponse {
-            message: "Check your email to verify your account".to_string(),
-            user_id: user.id.to_string(),
+            message: REGISTER_GENERIC_MESSAGE.to_string(),
         }),
     ))
 }
@@ -609,20 +624,6 @@ pub async fn login(
         ));
     }
 
-    if !user.is_verified() {
-        let _ = state
-            .session_repo
-            .record_login_attempt(&req.email, &ip_address, false)
-            .await;
-        return Err((
-            StatusCode::UNAUTHORIZED,
-            Json(ErrorResponse::new(
-                "EMAIL_NOT_VERIFIED",
-                "Please verify your email first",
-            )),
-        ));
-    }
-
     // Verify password
     let password_valid = match state
         .auth_service
@@ -656,6 +657,26 @@ pub async fn login(
             Json(ErrorResponse::new(
                 "INVALID_CREDENTIALS",
                 "Invalid email or password",
+            )),
+        ));
+    }
+
+    // Email-verification gate. This MUST come *after* the password check:
+    // returning EMAIL_NOT_VERIFIED before verifying the password turns login
+    // into an account-enumeration oracle (an attacker learns an email is
+    // registered-but-unverified without knowing the password). With a wrong
+    // password the caller already got the generic INVALID_CREDENTIALS above
+    // regardless of verification state (#956).
+    if !user.is_verified() {
+        let _ = state
+            .session_repo
+            .record_login_attempt(&req.email, &ip_address, false)
+            .await;
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            Json(ErrorResponse::new(
+                "EMAIL_NOT_VERIFIED",
+                "Please verify your email first",
             )),
         ));
     }

--- a/backend/servers/api-server/tests/auth_enumeration_tests.rs
+++ b/backend/servers/api-server/tests/auth_enumeration_tests.rs
@@ -1,0 +1,207 @@
+//! Account-enumeration regression tests for the api-server auth endpoints (#956).
+//!
+//! These cover two oracles that let an attacker probe which emails are
+//! registered without valid credentials:
+//!
+//! 1. **Login** previously checked `is_verified()` *before* verifying the
+//!    password, so a registered-but-unverified email returned
+//!    `EMAIL_NOT_VERIFIED` even for a wrong password — distinguishable from the
+//!    `INVALID_CREDENTIALS` an unknown email gets. The fix verifies the password
+//!    first; `EMAIL_NOT_VERIFIED` is only surfaced once the password is correct.
+//! 2. **Register** previously returned `409 EMAIL_EXISTS` for an existing email
+//!    (vs `201` + a real `userId` for a new one). The fix returns an identical
+//!    generic `201` for both and never echoes a user id.
+//!
+//! Lives at the top level of `tests/` (unlike the dead `tests/integration/`
+//! subtree, which has no `tests/integration.rs` entry point and is never
+//! compiled or run by `cargo test`).
+
+mod common;
+
+use common::{cleanup_test_user, verify_user_email, TestApp, TestUser};
+use serde_json::json;
+use sqlx::PgPool;
+
+// ============================================================================
+// Login enumeration
+// ============================================================================
+
+/// A wrong password against a registered-but-unverified account must return the
+/// generic `INVALID_CREDENTIALS`, NOT `EMAIL_NOT_VERIFIED` (which would confirm
+/// the email is registered). This is the core fix for #956.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn login_unverified_wrong_password_returns_generic_invalid_credentials(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    cleanup_test_user(&pool, &user.email).await;
+
+    // Register but DO NOT verify.
+    let reg = app
+        .post("/api/v1/auth/register")
+        .json(user.registration_body())
+        .build();
+    app.execute(reg).await;
+
+    // Wrong password on the unverified account.
+    let login = app
+        .post("/api/v1/auth/login")
+        .json(json!({ "email": user.email, "password": "WrongPassword123!" }))
+        .build();
+    let response = app.execute(login).await;
+
+    response.assert_status(axum::http::StatusCode::UNAUTHORIZED);
+    let body = response.json_value();
+    assert_eq!(
+        body["code"].as_str().unwrap(),
+        "INVALID_CREDENTIALS",
+        "a wrong password must not reveal verification state (no EMAIL_NOT_VERIFIED oracle)"
+    );
+
+    cleanup_test_user(&pool, &user.email).await;
+}
+
+/// An unknown email returns the same generic `INVALID_CREDENTIALS` — the
+/// response must be indistinguishable from the unverified-wrong-password case.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn login_unknown_email_returns_generic_invalid_credentials(pool: PgPool) {
+    let app = TestApp::new(pool).await;
+
+    let login = app
+        .post("/api/v1/auth/login")
+        .json(json!({ "email": "definitely-not-registered@example.com", "password": "AnyPassword123!" }))
+        .build();
+    let response = app.execute(login).await;
+
+    response.assert_status(axum::http::StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        response.json_value()["code"].as_str().unwrap(),
+        "INVALID_CREDENTIALS"
+    );
+}
+
+/// The verification gate is preserved: with the CORRECT password, an unverified
+/// account is still blocked with `EMAIL_NOT_VERIFIED` (after the password has
+/// been verified, so it leaks nothing an authenticated caller doesn't know).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn login_unverified_correct_password_still_blocks_with_email_not_verified(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    cleanup_test_user(&pool, &user.email).await;
+
+    let reg = app
+        .post("/api/v1/auth/register")
+        .json(user.registration_body())
+        .build();
+    app.execute(reg).await;
+
+    // Correct password, still unverified.
+    let login = app
+        .post("/api/v1/auth/login")
+        .json(user.login_body())
+        .build();
+    let response = app.execute(login).await;
+
+    response.assert_status(axum::http::StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        response.json_value()["code"].as_str().unwrap(),
+        "EMAIL_NOT_VERIFIED",
+        "a correct password on an unverified account should still surface the verification gate"
+    );
+
+    cleanup_test_user(&pool, &user.email).await;
+}
+
+/// A verified account with the correct password logs in successfully — the
+/// reorder must not regress the happy path.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn login_verified_correct_password_succeeds(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    cleanup_test_user(&pool, &user.email).await;
+
+    let reg = app
+        .post("/api/v1/auth/register")
+        .json(user.registration_body())
+        .build();
+    app.execute(reg).await;
+    verify_user_email(&pool, &user.email).await;
+
+    let login = app
+        .post("/api/v1/auth/login")
+        .json(user.login_body())
+        .build();
+    let response = app.execute(login).await;
+
+    response.assert_status(axum::http::StatusCode::OK);
+    response.assert_json_field("accessToken");
+
+    cleanup_test_user(&pool, &user.email).await;
+}
+
+// ============================================================================
+// Register enumeration
+// ============================================================================
+
+/// A fresh registration returns `201` with a generic message and no user id.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn register_new_email_does_not_echo_user_id(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    cleanup_test_user(&pool, &user.email).await;
+
+    let reg = app
+        .post("/api/v1/auth/register")
+        .json(user.registration_body())
+        .build();
+    let response = app.execute(reg).await;
+
+    response.assert_status(axum::http::StatusCode::CREATED);
+    let body = response.json_value();
+    response.assert_json_field("message");
+    assert!(
+        body.get("userId").is_none() && body.get("user_id").is_none(),
+        "register must not echo a user id (enumeration vector): {body}"
+    );
+
+    cleanup_test_user(&pool, &user.email).await;
+}
+
+/// Registering an already-registered email returns the SAME generic `201`
+/// response as a fresh registration — no `409`, no `EMAIL_EXISTS`, and a
+/// byte-for-byte identical body.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn register_existing_email_is_indistinguishable_from_new(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    cleanup_test_user(&pool, &user.email).await;
+
+    // First registration.
+    let first = app
+        .post("/api/v1/auth/register")
+        .json(user.registration_body())
+        .build();
+    let first_resp = app.execute(first).await;
+    first_resp.assert_status(axum::http::StatusCode::CREATED);
+    let first_body = first_resp.json_value();
+
+    // Second registration with the same email.
+    let second = app
+        .post("/api/v1/auth/register")
+        .json(user.registration_body())
+        .build();
+    let second_resp = app.execute(second).await;
+
+    second_resp.assert_status(axum::http::StatusCode::CREATED);
+    let second_body = second_resp.json_value();
+
+    assert!(
+        second_body.get("code").is_none(),
+        "existing-email registration must not return an EMAIL_EXISTS code: {second_body}"
+    );
+    assert_eq!(
+        first_body, second_body,
+        "existing-email response must be identical to a fresh registration"
+    );
+
+    cleanup_test_user(&pool, &user.email).await;
+}

--- a/backend/servers/api-server/tests/auth_enumeration_tests.rs
+++ b/backend/servers/api-server/tests/auth_enumeration_tests.rs
@@ -16,6 +16,10 @@
 //! subtree, which has no `tests/integration.rs` entry point and is never
 //! compiled or run by `cargo test`).
 
+// Each integration-test binary compiles `common` independently and uses only a
+// subset of its helpers; without this the rest trip `-D dead_code` under CI's
+// `RUSTFLAGS=-Dwarnings`. Matches every other test file in this directory.
+#[allow(dead_code)]
 mod common;
 
 use common::{cleanup_test_user, verify_user_email, TestApp, TestUser};


### PR DESCRIPTION
## Summary
Fixes #956. Two auth endpoints leaked account existence to an unauthenticated caller.

### Login oracle
`POST /api/v1/auth/login` checked `is_verified()` **before** verifying the password, so a registered-but-unverified email returned `401 EMAIL_NOT_VERIFIED` even for a *wrong* password — distinguishable from the `401 INVALID_CREDENTIALS` an unknown email gets. An attacker could enumerate registered-but-unverified emails without knowing any password.

**Fix:** the verification gate now runs **after** the password check. A wrong password always yields the generic `INVALID_CREDENTIALS` regardless of verification state; `EMAIL_NOT_VERIFIED` is only surfaced once the password is correct (i.e. only to someone who already proved knowledge of the credential).

### Register oracle
`POST /api/v1/auth/register` returned `409 EMAIL_EXISTS` for an existing email vs `201` + a real `userId` for a new one.

**Fix:** returns an **identical generic 201** for both new and existing emails, and never echoes a user id (`user_id` dropped from `RegisterResponse`). The success and already-exists bodies are byte-for-byte identical. Notifying the existing account holder out-of-band is logged as a future enhancement.

This mirrors the already-generic `forgot-password` response.

## Tests
Adds `tests/auth_enumeration_tests.rs` — a **live** top-level test file. (Note: the existing `tests/integration/` subtree has no `tests/integration.rs` entry point, so Cargo never compiles or runs it — its `auth_tests.rs` is dead code, which is why the prior oracle behavior went uncaught. Wiring that suite back in is out of scope here.)

New tests cover:
- unverified + wrong password → `INVALID_CREDENTIALS` (the fix)
- unknown email → `INVALID_CREDENTIALS` (indistinguishable)
- unverified + correct password → `EMAIL_NOT_VERIFIED` (gate preserved)
- verified + correct password → 200 (happy path not regressed)
- register new email → 201, no `userId`
- register existing email → identical 201 body, no `EMAIL_EXISTS`

## Notes / follow-ups
- `reality-server` portal register (`/api/v1/users/register`) has the same `409 EMAIL_EXISTS` + `userId` pattern — a sibling fix worth a separate issue (out of scope; this issue scoped to api-server).
- The `login` handler's `ACCOUNT_SUSPENDED` branch still precedes the password check (a narrower oracle); left as-is to keep this change focused on the reported finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)