### PR TITLE
gap-85-3-rn-fcm-push-config: RN FCM push config

### DIFF
--- a/frontend/apps/mobile/src/hooks/usePushNotifications.ts
+++ b/frontend/apps/mobile/src/hooks/usePushNotifications.ts
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Linking, Platform } from 'react-native';
 import { createDeepLink } from '../qrcode/DeepLinkHandler';
 import { colors } from '../screens/shared/screenStyles';
+import { consumeLaunchNotification, syncBadgeFromData } from '../services/backgroundNotifications';
 import { apiRequest } from './useApi';
 
 // Configure notification handling
@@ -72,6 +73,9 @@ export function usePushNotifications(): UsePushNotificationsReturn {
     notificationListener.current = Notifications.addNotificationReceivedListener(
       (notif: Notifications.Notification) => {
         setNotification(notif);
+        // Mirror any badge count carried by the (possibly FCM data-only)
+        // payload onto the app icon — iOS does not auto-apply it.
+        void syncBadgeFromData(notif.request.content.data);
       }
     );
 
@@ -82,6 +86,14 @@ export function usePushNotifications(): UsePushNotificationsReturn {
         handleNotificationNavigation(data);
       }
     );
+
+    // Cold-start: if the app was launched from a killed state by tapping a
+    // push, the response listener above never fires. Route that launch
+    // notification through the same handler once on mount.
+    void consumeLaunchNotification((data) => {
+      void syncBadgeFromData(data);
+      handleNotificationNavigation(data as Record<string, unknown>);
+    });
 
     // Check if already registered
     checkRegistrationStatus();

--- a/frontend/apps/mobile/src/services/backgroundNotifications.test.ts
+++ b/frontend/apps/mobile/src/services/backgroundNotifications.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for background / cold-start FCM push handling.
+ *
+ * Epic 85 - Story 85.3.
+ */
+
+import * as Notifications from 'expo-notifications';
+import {
+  consumeLaunchNotification,
+  extractNotificationData,
+  syncBadgeFromData,
+} from './backgroundNotifications';
+
+jest.mock('expo-notifications', () => ({
+  getLastNotificationResponseAsync: jest.fn(),
+  setBadgeCountAsync: jest.fn(),
+}));
+
+const mockGetLast = Notifications.getLastNotificationResponseAsync as jest.Mock;
+const mockSetBadge = Notifications.setBadgeCountAsync as jest.Mock;
+
+function makeResponse(data: unknown): Notifications.NotificationResponse {
+  return {
+    actionIdentifier: 'default',
+    notification: {
+      date: 0,
+      request: {
+        identifier: 'id',
+        // biome-ignore lint/suspicious/noExplicitAny: test fixture intentionally loose
+        content: { data } as any,
+        trigger: null,
+      },
+    },
+  } as Notifications.NotificationResponse;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('extractNotificationData', () => {
+  it('returns the data payload from a valid response', () => {
+    expect(extractNotificationData(makeResponse({ type: 'fault', id: '7' }))).toEqual({
+      type: 'fault',
+      id: '7',
+    });
+  });
+
+  it('returns null for a null response', () => {
+    expect(extractNotificationData(null)).toBeNull();
+  });
+
+  it('returns null when data is missing', () => {
+    expect(extractNotificationData(makeResponse(undefined))).toBeNull();
+  });
+});
+
+describe('consumeLaunchNotification', () => {
+  it('invokes the handler with the launch payload when present', async () => {
+    mockGetLast.mockResolvedValue(makeResponse({ type: 'announcement', id: '42' }));
+    const handler = jest.fn();
+
+    await consumeLaunchNotification(handler);
+
+    expect(handler).toHaveBeenCalledWith({ type: 'announcement', id: '42' });
+  });
+
+  it('does nothing when the app was not launched from a notification', async () => {
+    mockGetLast.mockResolvedValue(null);
+    const handler = jest.fn();
+
+    await consumeLaunchNotification(handler);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('swallows errors so app boot is never blocked', async () => {
+    mockGetLast.mockRejectedValue(new Error('boom'));
+    const handler = jest.fn();
+
+    await expect(consumeLaunchNotification(handler)).resolves.toBeUndefined();
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe('syncBadgeFromData', () => {
+  it('applies a valid badge count', async () => {
+    await syncBadgeFromData({ badge: 5 });
+    expect(mockSetBadge).toHaveBeenCalledWith(5);
+  });
+
+  it('ignores a missing badge', async () => {
+    await syncBadgeFromData({ type: 'fault' });
+    expect(mockSetBadge).not.toHaveBeenCalled();
+  });
+
+  it('ignores a negative badge', async () => {
+    await syncBadgeFromData({ badge: -1 });
+    expect(mockSetBadge).not.toHaveBeenCalled();
+  });
+
+  it('ignores null data', async () => {
+    await syncBadgeFromData(null);
+    expect(mockSetBadge).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/apps/mobile/src/services/backgroundNotifications.ts
+++ b/frontend/apps/mobile/src/services/backgroundNotifications.ts
@@ -1,0 +1,97 @@
+/**
+ * Background / cold-start FCM push handling.
+ *
+ * Epic 85 - Story 85.3: FCM push notification configuration.
+ *
+ * The `usePushNotifications` hook covers the two *runtime* cases:
+ *   - a notification received while the app is in the foreground
+ *     (`addNotificationReceivedListener`), and
+ *   - a notification tapped while the app is running/backgrounded
+ *     (`addNotificationResponseReceivedListener`).
+ *
+ * Neither of those listeners fires when the app is launched from a fully
+ * killed state by tapping a push (the OS starts a fresh JS context after the
+ * event already happened). This module fills that gap:
+ *
+ *   1. `consumeLaunchNotification()` polls `getLastNotificationResponseAsync`
+ *      exactly once on startup and hands the notification's data payload to a
+ *      caller-supplied handler. The actual screen routing is owned by the
+ *      navigation/deep-link layer — this module deliberately does NOT import
+ *      `Linking` or the deep-link helper so the two concerns stay decoupled.
+ *
+ *   2. `syncBadgeFromData()` keeps the app-icon badge in sync with the
+ *      `badge` field a backgrounded data-notification may carry, since iOS
+ *      only auto-applies the badge for *alert* notifications, not data-only
+ *      ones routed through FCM.
+ */
+
+import * as Notifications from 'expo-notifications';
+
+/** Shape of the data payload our backend attaches to every push. */
+export interface PushNotificationData {
+  /** Domain entity the push refers to (announcement, fault, vote, …). */
+  type?: string;
+  /** Entity id, used by the routing layer to open a detail screen. */
+  id?: string | number;
+  /** Optional badge count the OS should display for the app icon. */
+  badge?: number;
+  [key: string]: unknown;
+}
+
+/** Handler invoked with the data payload of a cold-start launch push. */
+export type LaunchNotificationHandler = (data: PushNotificationData) => void;
+
+/**
+ * Extracts the data payload from a notification response, or `null` when the
+ * response/notification is malformed.
+ */
+export function extractNotificationData(
+  response: Notifications.NotificationResponse | null
+): PushNotificationData | null {
+  const data = response?.notification?.request?.content?.data;
+  if (!data || typeof data !== 'object') {
+    return null;
+  }
+  return data as PushNotificationData;
+}
+
+/**
+ * If the app was launched from a killed state by tapping a push, hand the
+ * notification's data payload to `handler`. No-op when launched normally.
+ *
+ * Safe to call unconditionally on startup; failures are swallowed so a missing
+ * launch notification never blocks app boot.
+ */
+export async function consumeLaunchNotification(
+  handler: LaunchNotificationHandler
+): Promise<void> {
+  try {
+    const response = await Notifications.getLastNotificationResponseAsync();
+    const data = extractNotificationData(response);
+    if (data) {
+      handler(data);
+    }
+  } catch (err) {
+    if (__DEV__) {
+      console.warn('[push] failed to read launch notification', err);
+    }
+  }
+}
+
+/**
+ * Apply the `badge` count carried by a (possibly background-delivered) data
+ * notification to the app icon. iOS does not auto-apply badges for data-only
+ * FCM messages, so the client mirrors it explicitly.
+ */
+export async function syncBadgeFromData(data: PushNotificationData | null): Promise<void> {
+  if (!data || typeof data.badge !== 'number' || data.badge < 0) {
+    return;
+  }
+  try {
+    await Notifications.setBadgeCountAsync(data.badge);
+  } catch (err) {
+    if (__DEV__) {
+      console.warn('[push] failed to sync badge count', err);
+    }
+  }
+}

--- a/frontend/apps/mobile/src/services/backgroundNotifications.ts
+++ b/frontend/apps/mobile/src/services/backgroundNotifications.ts
@@ -62,9 +62,7 @@ export function extractNotificationData(
  * Safe to call unconditionally on startup; failures are swallowed so a missing
  * launch notification never blocks app boot.
  */
-export async function consumeLaunchNotification(
-  handler: LaunchNotificationHandler
-): Promise<void> {
+export async function consumeLaunchNotification(handler: LaunchNotificationHandler): Promise<void> {
   try {
     const response = await Notifications.getLastNotificationResponseAsync();
     const data = extractNotificationData(response);

--- a/frontend/apps/mobile/src/services/index.ts
+++ b/frontend/apps/mobile/src/services/index.ts
@@ -1,0 +1,6 @@
+export type { LaunchNotificationHandler, PushNotificationData } from './backgroundNotifications';
+export {
+  consumeLaunchNotification,
+  extractNotificationData,
+  syncBadgeFromData,
+} from './backgroundNotifications';

--- a/frontend/apps/mobile/src/types/expo-modules.d.ts
+++ b/frontend/apps/mobile/src/types/expo-modules.d.ts
@@ -222,6 +222,26 @@ declare module 'expo-notifications' {
     data: string;
   }
   export function getDevicePushTokenAsync(): Promise<DevicePushToken>;
+
+  /**
+   * Returns the notification response that launched the app from a killed
+   * (cold-start) state, or `null` when the app was launched normally. The
+   * runtime-listener `addNotificationResponseReceivedListener` does NOT fire
+   * for the cold-start case, so this must be polled once on startup.
+   */
+  export function getLastNotificationResponseAsync(): Promise<NotificationResponse | null>;
+
+  /**
+   * Registers a background task (defined via `expo-task-manager`'s
+   * `defineTask`) to be invoked by the OS when a data notification is
+   * delivered while the app is backgrounded or killed.
+   */
+  export function registerTaskAsync(taskName: string): Promise<void>;
+
+  /**
+   * Unregisters a previously-registered background notification task.
+   */
+  export function unregisterTaskAsync(taskName: string): Promise<void>;
 }
 
 declare module '@react-native-async-storage/async-storage' {


### PR DESCRIPTION
## Task
Configure FCM push notifications for the React Native Property Management app (frontend/apps/mobile): add expo-notifications, wire FCM token registration, background/foreground message handling, and notification-tap routing to the relevant screen.

## Owner
pm-frontend (specialist: react-native)

## Key finding: most of this was already shipped
Investigating before coding, most of the requested FCM wiring already exists from Epic 85 stories 85.1/85.2:
- `expo-notifications` is already a dependency (`package.json`).
- `app.config.ts` already registers the `expo-notifications` plugin (icon/color), sets `android.googleServicesFile` for FCM, declares `POST_NOTIFICATIONS`, and ships `google-services.json.template`.
- `src/hooks/usePushNotifications.ts` already does: notification handler config, **FCM/APNs device-token registration with the backend** (`POST /api/v1/users/me/push-tokens`), Android channels, **foreground** received-listener, and **tap routing** while running (`addNotificationResponseReceivedListener` → `handleNotificationNavigation`).
- `App.tsx` already calls `registerForPushNotifications()` on auth.

So token registration + foreground + running-tap routing were done. This PR closes the one genuine remaining gap: **background / cold-start handling**.

## What this PR adds
New `src/services/backgroundNotifications.ts` (+ barrel `index.ts`):
- `consumeLaunchNotification(handler)` — polls `getLastNotificationResponseAsync()` once on mount. The runtime response-listener does NOT fire when the app is launched from a **killed** state by tapping a push; this routes that cold-start payload through the existing `handleNotificationNavigation`.
- `syncBadgeFromData(data)` — mirrors a `badge` count carried by a (possibly data-only FCM) payload onto the app icon, since iOS does not auto-apply badges for data notifications.
- `extractNotificationData(response)` — null-safe payload extraction.

`usePushNotifications.ts` (12 lines): calls `syncBadgeFromData` from the foreground received-listener and runs `consumeLaunchNotification` on mount, routing cold-start taps through the **existing** navigation handler (no duplication of deep-link logic).

`types/expo-modules.d.ts`: added hand-rolled declarations for `getLastNotificationResponseAsync`, `registerTaskAsync`, `unregisterTaskAsync` (repo declares Expo types manually — no @types installed).

## Scope discipline
- All changes confined to push-notification wiring under `frontend/apps/mobile/src/`.
- **Did NOT touch** deep-link / universal-link config (`app.config.ts` intentFilters, `qrcode/DeepLinkHandler`, `Linking`) — that is owned by the sibling task `gap-85-3-rn-universal-links`. Cold-start routing reuses the existing in-hook handler rather than re-implementing link logic.

## Tested (Band A — fast check)
NOT RUN — degraded cloud env. `frontend/node_modules` is not installed (no `tsc`, `biome`, or `jest` binary present), so `pnpm -F mobile typecheck` / `lint` / `test` could not execute. Code was written to match existing strict-TS + Biome conventions (hand-typed Expo decls, `__DEV__` guards, `void` on fire-and-forget promises, no unused imports). A regression test (`backgroundNotifications.test.ts`, 10 cases mocking `expo-notifications`) is included and follows the repo's jest-expo setup, but could not be executed here. CI (`frontend.yml`) will be the first real green/red signal.

## Built (Band B — full build)
skipped: tooling unavailable in this env (see above).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Notes
- A fully background **data-only** FCM message handler (OS-invoked while killed) would additionally need `expo-task-manager` + `Notifications.registerTaskAsync('...')` with a `TaskManager.defineTask`. That package is **not** in the workspace and could not be added offline (no lockfile regen). I added the `registerTaskAsync`/`unregisterTaskAsync` type decls so it's a drop-in follow-up, but did not add the native dep. Flagging as a follow-up rather than landing an un-installable dependency.
- The local commit was rebased onto latest `dev`; only the 5 files above are changed.

https://claude.ai/code/session_011pgA6gdeNaSWpQw7CK3AE9

---
_Generated by [Claude Code](https://claude.ai/code/session_011pgA6gdeNaSWpQw7CK3AE9)_