### PR TITLE
gap-85-3-rn-universal-links: RN universal links / App Links

### DIFF
--- a/frontend/apps/mobile/.env.development
+++ b/frontend/apps/mobile/.env.development
@@ -9,3 +9,6 @@ API_BASE_URL=http://localhost:8080
 WS_BASE_URL=ws://localhost:8080
 ENVIRONMENT=development
 DEBUG_MODE=true
+# gap-85-3: Universal Links / App Links host (iOS associatedDomains +
+# Android https intentFilter). Must serve /.well-known/{apple-app-site-association,assetlinks.json}.
+APP_LINK_HOST=app.ppt.example.com

--- a/frontend/apps/mobile/.env.example
+++ b/frontend/apps/mobile/.env.example
@@ -23,3 +23,8 @@ API_BASE_URL=http://localhost:8080
 WS_BASE_URL=ws://localhost:8080
 ENVIRONMENT=development
 DEBUG_MODE=true
+# gap-85-3: HTTPS host for Universal Links (iOS) / App Links (Android).
+# Drives ios.associatedDomains, the Android https intentFilter, and the JS
+# route matcher (src/qrcode/universalLinks.ts). The matching well-known files
+# (apple-app-site-association, assetlinks.json) must be served from this host.
+APP_LINK_HOST=app.ppt.example.com

--- a/frontend/apps/mobile/.env.production
+++ b/frontend/apps/mobile/.env.production
@@ -15,3 +15,7 @@ API_BASE_URL=__SET_BY_CI__
 WS_BASE_URL=__SET_BY_CI__
 ENVIRONMENT=production
 DEBUG_MODE=false
+# gap-85-3: Universal Links / App Links host (iOS associatedDomains +
+# Android https intentFilter). CI should override with the real production
+# host before building; the well-known files must be served from this host.
+APP_LINK_HOST=app.ppt.example.com

--- a/frontend/apps/mobile/.env.staging
+++ b/frontend/apps/mobile/.env.staging
@@ -9,3 +9,6 @@ API_BASE_URL=https://staging-api.ppt.example.com
 WS_BASE_URL=wss://staging-api.ppt.example.com
 ENVIRONMENT=staging
 DEBUG_MODE=true
+# gap-85-3: Universal Links / App Links host (iOS associatedDomains +
+# Android https intentFilter). Must serve /.well-known/{apple-app-site-association,assetlinks.json}.
+APP_LINK_HOST=staging-app.ppt.example.com

--- a/frontend/apps/mobile/app.config.ts
+++ b/frontend/apps/mobile/app.config.ts
@@ -131,6 +131,20 @@ export default ({ config }: ConfigContext): ExpoConfig => {
   // EAS Cloud injects via GOOGLE_SERVICES_JSON secret; omitted for plain local dev.
   const googleServicesFile = hasGoogleServicesJson() ? './google-services.json' : undefined;
 
+  // -------------------------------------------------------------------------
+  // gap-85-3: Universal Links (iOS) / App Links (Android) host.
+  // -------------------------------------------------------------------------
+  // The HTTPS host that the app associates with deep links. Single source of
+  // truth is the `APP_LINK_HOST` env var (per-env in .env.<env>), falling back
+  // to the convention placeholder domain. This SAME host must be used in:
+  //   - iOS `associatedDomains` (`applinks:<host>`) below
+  //   - the Android `https` intentFilter below
+  //   - the served well-known files:
+  //       public/.well-known/apple-app-site-association
+  //       public/.well-known/assetlinks.json
+  //   - the JS route matcher (src/qrcode/universalLinks.ts → extra.appLinkHost)
+  const appLinkHost = envVars.APP_LINK_HOST ?? process.env.APP_LINK_HOST ?? 'app.ppt.example.com';
+
   return {
     ...config,
     name: config.name ?? 'PPT Management',
@@ -153,6 +167,14 @@ export default ({ config }: ConfigContext): ExpoConfig => {
        * App Store Connect API key set once in EAS (Key ID + Issuer ID + p8).
        */
       buildNumber: config.ios?.buildNumber ?? '1',
+      /**
+       * gap-85-3: Universal Links entitlement.
+       * `applinks:<host>` lets iOS route HTTPS taps on `https://<host>/...` to
+       * the app when the apple-app-site-association file is served from that
+       * host (see public/.well-known/apple-app-site-association). Expo writes
+       * this into the generated `<app>.entitlements` at prebuild time.
+       */
+      associatedDomains: [...(config.ios?.associatedDomains ?? []), `applinks:${appLinkHost}`],
       infoPlist: {
         ...(config.ios?.infoPlist ?? {}),
         API_BASE_URL: apiBaseUrl,
@@ -243,9 +265,12 @@ export default ({ config }: ConfigContext): ExpoConfig => {
           category: ['BROWSABLE', 'DEFAULT'],
         },
         {
+          // gap-85-3: HTTPS App Link. autoVerify drives Android to fetch
+          // https://<host>/.well-known/assetlinks.json and verify the signing
+          // SHA-256 before claiming the link without a chooser dialog.
           action: 'VIEW',
           autoVerify: true,
-          data: [{ scheme: 'https', host: 'app.ppt.example.com', pathPrefix: '/' }],
+          data: [{ scheme: 'https', host: appLinkHost, pathPrefix: '/' }],
           category: ['BROWSABLE', 'DEFAULT'],
         },
       ],
@@ -273,6 +298,9 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       WS_BASE_URL: wsBaseUrl,
       ENVIRONMENT: environment,
       DEBUG_MODE: debugMode,
+      // gap-85-3: HTTPS host the app claims for universal links / App Links.
+      // Read in JS via src/qrcode/universalLinks.ts → getAppLinkHost().
+      appLinkHost,
       /**
        * EAS 85.2: EAS project ID at runtime for update channel routing.
        * Populated from EXPO_PROJECT_ID env var (set in CI via GitHub secret).

--- a/frontend/apps/mobile/public/.well-known/README.md
+++ b/frontend/apps/mobile/public/.well-known/README.md
@@ -1,0 +1,46 @@
+# Universal Links / App Links well-known files
+
+gap-85-3 — these two files make tapping an `https://<APP_LINK_HOST>/<path>`
+link open the **PPT Management** app (`three.two.bit.ppt.management`) directly
+instead of the browser.
+
+## What lives here
+
+| File | Platform | Verifies |
+|------|----------|----------|
+| `apple-app-site-association` | iOS (Universal Links) | App bundle ↔ domain association |
+| `assetlinks.json` | Android (App Links) | Signing cert ↔ domain association |
+
+## Hosting requirement (NOT served by the app)
+
+These files are **served by the web host** that owns `APP_LINK_HOST`
+(default convention: `app.ppt.example.com`; real value injected per-env via
+`APP_LINK_HOST` in `.env.<env>` / EAS). They must be reachable at, with
+`Content-Type: application/json` and **no redirect**:
+
+```
+https://<APP_LINK_HOST>/.well-known/apple-app-site-association
+https://<APP_LINK_HOST>/.well-known/assetlinks.json
+```
+
+The `apple-app-site-association` file MUST be served **without** a `.json`
+extension (Apple requirement). Deploy these by copying this directory to the
+web host's document root (`reality-web` / api-server static, or the CDN that
+fronts `APP_LINK_HOST`).
+
+## Placeholders to replace before production
+
+Both files ship with build-time placeholders that CI / release must replace:
+
+- `__APPLE_TEAM_ID__` — the Apple Developer Team ID (10 chars, e.g. `A1B2C3D4E5`).
+  Find it in App Store Connect → Membership, or `eas credentials -p ios`.
+- `__ANDROID_SIGNING_SHA256__` — the SHA-256 fingerprint of the **upload /
+  signing** keystore, colon-separated upper-hex
+  (e.g. `14:6D:E9:83:C5:73:06:50:D8:EE:B9:95:2F:34:FC:64:16:A0:83:42:E6:1D:BE:A8:8A:04:96:B2:3F:CF:44:E5`).
+  For EAS-managed signing: `eas credentials -p android` → "Download / view"
+  shows the SHA-256. For Play App Signing: Play Console → App integrity →
+  "App signing key certificate" SHA-256.
+
+> Android `autoVerify` and iOS associated-domain verification will silently
+> fail (link opens the browser) if these placeholders are not replaced or the
+> files are not served exactly as above.

--- a/frontend/apps/mobile/public/.well-known/apple-app-site-association
+++ b/frontend/apps/mobile/public/.well-known/apple-app-site-association
@@ -1,0 +1,44 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appIDs": ["__APPLE_TEAM_ID__.three.two.bit.ppt.management"],
+        "appID": "__APPLE_TEAM_ID__.three.two.bit.ppt.management",
+        "paths": [
+          "/dashboard",
+          "/dashboard/*",
+          "/faults",
+          "/faults/*",
+          "/fault/report",
+          "/announcements",
+          "/announcements/*",
+          "/voting",
+          "/voting/*",
+          "/documents",
+          "/documents/*",
+          "/outages",
+          "/outages/*",
+          "/messages",
+          "/messages/*",
+          "/settings",
+          "/settings/*"
+        ],
+        "components": [
+          { "/": "/dashboard*" },
+          { "/": "/faults*" },
+          { "/": "/fault/report*" },
+          { "/": "/announcements*" },
+          { "/": "/voting*" },
+          { "/": "/documents*" },
+          { "/": "/outages*" },
+          { "/": "/messages*" },
+          { "/": "/settings*" }
+        ]
+      }
+    ]
+  },
+  "webcredentials": {
+    "apps": ["__APPLE_TEAM_ID__.three.two.bit.ppt.management"]
+  }
+}

--- a/frontend/apps/mobile/public/.well-known/assetlinks.json
+++ b/frontend/apps/mobile/public/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "three.two.bit.ppt.management",
+      "sha256_cert_fingerprints": [
+        "__ANDROID_SIGNING_SHA256__"
+      ]
+    }
+  }
+]

--- a/frontend/apps/mobile/public/.well-known/assetlinks.json
+++ b/frontend/apps/mobile/public/.well-known/assetlinks.json
@@ -4,9 +4,7 @@
     "target": {
       "namespace": "android_app",
       "package_name": "three.two.bit.ppt.management",
-      "sha256_cert_fingerprints": [
-        "__ANDROID_SIGNING_SHA256__"
-      ]
+      "sha256_cert_fingerprints": ["__ANDROID_SIGNING_SHA256__"]
     }
   }
 ]

--- a/frontend/apps/mobile/src/App.tsx
+++ b/frontend/apps/mobile/src/App.tsx
@@ -7,6 +7,7 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { OfflineBanner, SyncProgressToast, SyncStatusBadge } from './components/sync';
 import { AuthProvider, useAuth } from './contexts';
 import { useOfflineSupport, usePushNotifications } from './hooks';
+import { deepLinkManager, type ParsedDeepLink } from './qrcode';
 import { colors } from './screens/shared/screenStyles';
 import './i18n'; // Initialize i18n
 import {
@@ -85,6 +86,44 @@ type Screen =
   | 'LeaseDetail'
   | 'More';
 
+/**
+ * gap-85-3: translate a parsed deep link (custom scheme OR universal link)
+ * into the in-app screen name + params understood by `handleNavigate`.
+ *
+ * The DeepLinkHandler route table keys detail params as `id`; the App screens
+ * expect domain-specific param names (`announcementId`, `voteId`,
+ * `documentId`). When an `:id` is present we route to the matching *Detail
+ * screen; otherwise we land on the list screen.
+ */
+function resolveDeepLinkTarget(
+  link: ParsedDeepLink
+): { screen: Screen; params?: Record<string, unknown> } | null {
+  if (!link.success || !link.screen) {
+    return null;
+  }
+  const id = link.params?.id;
+  switch (link.screen) {
+    case 'Announcements':
+      return id
+        ? { screen: 'AnnouncementDetail', params: { announcementId: id } }
+        : { screen: 'Announcements' };
+    case 'Voting':
+      return id ? { screen: 'VoteDetail', params: { voteId: id } } : { screen: 'Voting' };
+    case 'Documents':
+      return id
+        ? { screen: 'DocumentDetail', params: { documentId: id } }
+        : { screen: 'Documents' };
+    case 'Messages':
+      return id ? { screen: 'ThreadDetail', params: { threadId: id } } : { screen: 'Messages' };
+    case 'WidgetSettings':
+      return { screen: 'Settings' };
+    default:
+      // Faults, ReportFault, Outages, Settings, Dashboard map 1:1. Pass any
+      // remaining route params through verbatim.
+      return { screen: link.screen as Screen, params: link.params };
+  }
+}
+
 function MainApp() {
   const { t } = useTranslation();
   const { isAuthenticated, isLoading } = useAuth();
@@ -120,6 +159,26 @@ function MainApp() {
     setCurrentScreen(screen as Screen);
     setScreenParams(params);
   }, []);
+
+  // gap-85-3: route incoming deep links (custom scheme + universal/App Links).
+  // The manager handles the cold-start initial URL, runtime `url` events, and
+  // queues auth-required links until the user is authenticated.
+  useEffect(() => {
+    const unsubscribe = deepLinkManager.addHandler((link) => {
+      const target = resolveDeepLinkTarget(link);
+      if (target) {
+        handleNavigate(target.screen, target.params);
+      }
+    });
+    void deepLinkManager.initialize();
+    return unsubscribe;
+  }, [handleNavigate]);
+
+  // Keep the manager's auth gate in sync so auth-required links queued while
+  // logged out are dispatched the moment the user authenticates.
+  useEffect(() => {
+    deepLinkManager.setAuthenticated(isAuthenticated);
+  }, [isAuthenticated]);
 
   if (isLoading) {
     return (
@@ -327,20 +386,13 @@ function MainApp() {
       </View>
 
       {/* Sync progress toast */}
-      <SyncProgressToast
-        visible={isSyncingWithProgress || showSyncToast}
-        progress={
-          syncProgress?.total
-            ? Math.round(((syncProgress?.current || 0) / syncProgress.total) * 100)
-            : 0
-        }
-        total={syncProgress?.total || 0}
-        current={syncProgress?.current || 0}
-        failed={syncProgress?.failed || 0}
-        isComplete={syncProgress?.isComplete || false}
-        onDismiss={() => setShowSyncToast(false)}
-        onRetry={handleRetrySync}
-      />
+      {isSyncingWithProgress && showSyncToast && syncProgress && (
+        <SyncProgressToast
+          progress={syncProgress}
+          onRetry={handleRetrySync}
+          onDismiss={() => setShowSyncToast(false)}
+        />
+      )}
 
       <StatusBar style="auto" />
     </View>
@@ -348,32 +400,37 @@ function MainApp() {
 }
 
 interface MoreMenuProps {
-  onNavigate: (screen: string) => void;
+  onNavigate: (screen: string, params?: Record<string, unknown>) => void;
 }
 
-const MORE_ITEMS: ReadonlyArray<{ icon: string; label: string; screen: string }> = [
-  { icon: '🔔', label: 'Notifications', screen: 'Notifications' },
-  { icon: '💬', label: 'Messages', screen: 'Messages' },
-  { icon: '🏘️', label: 'Neighbours', screen: 'Neighbors' },
-  { icon: '📏', label: 'Meters', screen: 'Meters' },
-  { icon: '👥', label: 'Person-months', screen: 'PersonMonths' },
-  { icon: '⚡', label: 'Outages', screen: 'Outages' },
-  { icon: '📰', label: 'News', screen: 'News' },
-  { icon: '📝', label: 'Forms', screen: 'Forms' },
-  { icon: '🏢', label: 'Buildings', screen: 'Buildings' },
-  { icon: '📑', label: 'Leases', screen: 'Leases' },
-  { icon: '👤', label: 'Profile', screen: 'Profile' },
-];
-
 function MoreMenu({ onNavigate }: MoreMenuProps) {
+  const { t } = useTranslation();
+  const items: { icon: string; label: string; screen: string }[] = [
+    { icon: '📬', label: t('tabs.messages'), screen: 'Messages' },
+    { icon: '👥', label: t('tabs.neighbors'), screen: 'Neighbors' },
+    { icon: '🔔', label: t('tabs.notifications'), screen: 'Notifications' },
+    { icon: '📅', label: t('tabs.personMonths'), screen: 'PersonMonths' },
+    { icon: '⚠️', label: t('tabs.outages'), screen: 'Outages' },
+    { icon: '📰', label: t('tabs.newsFeed'), screen: 'News' },
+    { icon: '📝', label: t('tabs.forms'), screen: 'Forms' },
+    { icon: '🏢', label: t('tabs.buildings'), screen: 'Buildings' },
+    { icon: '📄', label: t('tabs.leases'), screen: 'Leases' },
+    { icon: '📊', label: t('tabs.meters'), screen: 'Meters' },
+    { icon: '👤', label: t('tabs.profile'), screen: 'Profile' },
+  ];
+
   return (
     <View style={moreStyles.container}>
       <View style={moreStyles.header}>
-        <Text style={moreStyles.title}>More</Text>
-        <Text style={moreStyles.subtitle}>Everything else available in the app.</Text>
+        <Text style={moreStyles.title}>{t('tabs.more')}</Text>
+        <Text style={moreStyles.subtitle}>{t('tabs.moreSubtitle')}</Text>
       </View>
-      {MORE_ITEMS.map((item) => (
-        <Pressable key={item.screen} style={moreStyles.row} onPress={() => onNavigate(item.screen)}>
+      {items.map((item) => (
+        <Pressable
+          key={item.screen}
+          style={moreStyles.row}
+          onPress={() => onNavigate(item.screen)}
+        >
           <Text style={moreStyles.rowIcon}>{item.icon}</Text>
           <Text style={moreStyles.rowLabel}>{item.label}</Text>
           <Text style={moreStyles.rowChevron}>›</Text>

--- a/frontend/apps/mobile/src/App.tsx
+++ b/frontend/apps/mobile/src/App.tsx
@@ -386,13 +386,20 @@ function MainApp() {
       </View>
 
       {/* Sync progress toast */}
-      {isSyncingWithProgress && showSyncToast && syncProgress && (
-        <SyncProgressToast
-          progress={syncProgress}
-          onRetry={handleRetrySync}
-          onDismiss={() => setShowSyncToast(false)}
-        />
-      )}
+      <SyncProgressToast
+        visible={isSyncingWithProgress || showSyncToast}
+        progress={
+          syncProgress?.total
+            ? Math.round(((syncProgress?.current || 0) / syncProgress.total) * 100)
+            : 0
+        }
+        total={syncProgress?.total || 0}
+        current={syncProgress?.current || 0}
+        failed={syncProgress?.failed || 0}
+        isComplete={syncProgress?.isComplete || false}
+        onDismiss={() => setShowSyncToast(false)}
+        onRetry={handleRetrySync}
+      />
 
       <StatusBar style="auto" />
     </View>
@@ -400,37 +407,32 @@ function MainApp() {
 }
 
 interface MoreMenuProps {
-  onNavigate: (screen: string, params?: Record<string, unknown>) => void;
+  onNavigate: (screen: string) => void;
 }
 
-function MoreMenu({ onNavigate }: MoreMenuProps) {
-  const { t } = useTranslation();
-  const items: { icon: string; label: string; screen: string }[] = [
-    { icon: '📬', label: t('tabs.messages'), screen: 'Messages' },
-    { icon: '👥', label: t('tabs.neighbors'), screen: 'Neighbors' },
-    { icon: '🔔', label: t('tabs.notifications'), screen: 'Notifications' },
-    { icon: '📅', label: t('tabs.personMonths'), screen: 'PersonMonths' },
-    { icon: '⚠️', label: t('tabs.outages'), screen: 'Outages' },
-    { icon: '📰', label: t('tabs.newsFeed'), screen: 'News' },
-    { icon: '📝', label: t('tabs.forms'), screen: 'Forms' },
-    { icon: '🏢', label: t('tabs.buildings'), screen: 'Buildings' },
-    { icon: '📄', label: t('tabs.leases'), screen: 'Leases' },
-    { icon: '📊', label: t('tabs.meters'), screen: 'Meters' },
-    { icon: '👤', label: t('tabs.profile'), screen: 'Profile' },
-  ];
+const MORE_ITEMS: ReadonlyArray<{ icon: string; label: string; screen: string }> = [
+  { icon: '🔔', label: 'Notifications', screen: 'Notifications' },
+  { icon: '💬', label: 'Messages', screen: 'Messages' },
+  { icon: '🏘️', label: 'Neighbours', screen: 'Neighbors' },
+  { icon: '📏', label: 'Meters', screen: 'Meters' },
+  { icon: '👥', label: 'Person-months', screen: 'PersonMonths' },
+  { icon: '⚡', label: 'Outages', screen: 'Outages' },
+  { icon: '📰', label: 'News', screen: 'News' },
+  { icon: '📝', label: 'Forms', screen: 'Forms' },
+  { icon: '🏢', label: 'Buildings', screen: 'Buildings' },
+  { icon: '📑', label: 'Leases', screen: 'Leases' },
+  { icon: '👤', label: 'Profile', screen: 'Profile' },
+];
 
+function MoreMenu({ onNavigate }: MoreMenuProps) {
   return (
     <View style={moreStyles.container}>
       <View style={moreStyles.header}>
-        <Text style={moreStyles.title}>{t('tabs.more')}</Text>
-        <Text style={moreStyles.subtitle}>{t('tabs.moreSubtitle')}</Text>
+        <Text style={moreStyles.title}>More</Text>
+        <Text style={moreStyles.subtitle}>Everything else available in the app.</Text>
       </View>
-      {items.map((item) => (
-        <Pressable
-          key={item.screen}
-          style={moreStyles.row}
-          onPress={() => onNavigate(item.screen)}
-        >
+      {MORE_ITEMS.map((item) => (
+        <Pressable key={item.screen} style={moreStyles.row} onPress={() => onNavigate(item.screen)}>
           <Text style={moreStyles.rowIcon}>{item.icon}</Text>
           <Text style={moreStyles.rowLabel}>{item.label}</Text>
           <Text style={moreStyles.rowChevron}>›</Text>

--- a/frontend/apps/mobile/src/qrcode/DeepLinkHandler.ts
+++ b/frontend/apps/mobile/src/qrcode/DeepLinkHandler.ts
@@ -2,8 +2,11 @@
  * Deep link handling for QR codes and external links.
  *
  * Epic 49 - Story 49.3: QR Code Scanning
+ * gap-85-3: extended to accept HTTPS universal links (iOS) / App Links
+ *           (Android) in addition to the legacy `ppt://` custom scheme.
  */
 import { Linking } from 'react-native';
+import { normalizeLinkUrl } from './universalLinks';
 
 /**
  * Deep link route configuration.
@@ -64,13 +67,17 @@ export interface ParsedDeepLink {
  */
 export function parseDeepLink(url: string): ParsedDeepLink {
   try {
-    if (!url.startsWith('ppt://')) {
+    // Accept both the legacy `ppt://` custom scheme and HTTPS universal links
+    // (iOS) / App Links (Android). `normalizeLinkUrl` returns the canonical
+    // `<path>?<query>` form, or null when the URL is not one this app owns.
+    const normalized = normalizeLinkUrl(url);
+    if (normalized === null) {
       return { success: false, error: 'Not a PPT deep link' };
     }
 
-    const parsed = new URL(url);
-    const pathParts = parsed.pathname.replace(/^\//, '').split('/').filter(Boolean);
-    const path = pathParts.join('/');
+    const [rawPath, rawQuery] = normalized.split('?', 2);
+    const path = rawPath.split('/').filter(Boolean).join('/');
+    const searchParams = new URLSearchParams(rawQuery ?? '');
 
     // Find matching route
     for (const route of DEEP_LINK_ROUTES) {
@@ -78,7 +85,7 @@ export function parseDeepLink(url: string): ParsedDeepLink {
       if (match) {
         // Extract query parameters
         const query: Record<string, string> = {};
-        parsed.searchParams.forEach((value, key) => {
+        searchParams.forEach((value, key) => {
           query[key] = value;
         });
 

--- a/frontend/apps/mobile/src/qrcode/index.ts
+++ b/frontend/apps/mobile/src/qrcode/index.ts
@@ -8,3 +8,4 @@ export * from './DeepLinkHandler';
 export * from './QRCodeGenerator';
 export * from './QRCodeScanner';
 export type * from './types';
+export * from './universalLinks';

--- a/frontend/apps/mobile/src/qrcode/universalLinks.test.ts
+++ b/frontend/apps/mobile/src/qrcode/universalLinks.test.ts
@@ -1,0 +1,68 @@
+/**
+ * gap-85-3: regression tests for universal-link (iOS) / App-Link (Android)
+ * URL normalisation and end-to-end deep-link parsing.
+ */
+import { parseDeepLink } from './DeepLinkHandler';
+import { DEFAULT_APP_LINK_HOST, normalizeLinkUrl } from './universalLinks';
+
+describe('normalizeLinkUrl', () => {
+  it('normalises a custom-scheme link with path + query', () => {
+    expect(normalizeLinkUrl('ppt://faults/123?source=qr')).toBe('faults/123?source=qr');
+  });
+
+  it('normalises the ppt-management scheme', () => {
+    expect(normalizeLinkUrl('ppt-management://documents/9')).toBe('documents/9');
+  });
+
+  it('normalises an HTTPS universal link on the associated host', () => {
+    expect(normalizeLinkUrl(`https://${DEFAULT_APP_LINK_HOST}/faults/123?source=email`)).toBe(
+      'faults/123?source=email'
+    );
+  });
+
+  it('rejects an HTTPS link on a foreign host', () => {
+    expect(normalizeLinkUrl('https://evil.example.org/faults/123')).toBeNull();
+  });
+
+  it('rejects an unsupported scheme', () => {
+    expect(normalizeLinkUrl('mailto:someone@example.com')).toBeNull();
+  });
+
+  it('rejects a malformed URL', () => {
+    expect(normalizeLinkUrl('not a url')).toBeNull();
+  });
+});
+
+describe('parseDeepLink — universal links', () => {
+  it('parses an HTTPS universal link to the matching screen + params', () => {
+    const result = parseDeepLink(`https://${DEFAULT_APP_LINK_HOST}/faults/42`);
+    expect(result.success).toBe(true);
+    expect(result.screen).toBe('Faults');
+    expect(result.params).toEqual({ id: '42' });
+    expect(result.requiresAuth).toBe(true);
+  });
+
+  it('parses query parameters from a universal link', () => {
+    const result = parseDeepLink(`https://${DEFAULT_APP_LINK_HOST}/documents?tab=shared`);
+    expect(result.success).toBe(true);
+    expect(result.screen).toBe('Documents');
+    expect(result.query).toEqual({ tab: 'shared' });
+  });
+
+  it('still parses the legacy ppt:// custom scheme', () => {
+    const result = parseDeepLink('ppt://announcements/7');
+    expect(result.success).toBe(true);
+    expect(result.screen).toBe('Announcements');
+    expect(result.params).toEqual({ id: '7' });
+  });
+
+  it('fails for an HTTPS link on a non-associated host', () => {
+    const result = parseDeepLink('https://phishing.example.net/faults/42');
+    expect(result.success).toBe(false);
+  });
+
+  it('fails for an unknown route on the associated host', () => {
+    const result = parseDeepLink(`https://${DEFAULT_APP_LINK_HOST}/unknown/path`);
+    expect(result.success).toBe(false);
+  });
+});

--- a/frontend/apps/mobile/src/qrcode/universalLinks.ts
+++ b/frontend/apps/mobile/src/qrcode/universalLinks.ts
@@ -1,0 +1,93 @@
+/**
+ * Universal Links (iOS) / App Links (Android) configuration.
+ *
+ * gap-85-3: Configure HTTPS deep links so that tapping an
+ * `https://<app-host>/<path>` URL on a device with the app installed opens
+ * the corresponding in-app screen instead of the browser.
+ *
+ * The host(s) below MUST match:
+ *   - iOS:     `ios.associatedDomains` in app.config.ts (`applinks:<host>`)
+ *              and the `apple-app-site-association` file served at
+ *              `https://<host>/.well-known/apple-app-site-association`.
+ *   - Android: the `https` `intentFilters` host in app.config.ts and the
+ *              `assetlinks.json` served at
+ *              `https://<host>/.well-known/assetlinks.json`.
+ *
+ * Single source of truth for the host comes from the `APP_LINK_HOST` env var
+ * (loaded by app.config.ts into `Constants.expoConfig.extra.appLinkHost`),
+ * falling back to the convention placeholder domain used across the env files.
+ */
+import Constants from 'expo-constants';
+
+/**
+ * Convention placeholder host. Real hosts are injected per-environment via the
+ * `APP_LINK_HOST` env var (see .env.<env> and app.config.ts).
+ */
+export const DEFAULT_APP_LINK_HOST = 'app.ppt.example.com';
+
+/**
+ * The HTTPS host this build associates universal links / App Links with.
+ * Read from Expo config (single source of truth: app.config.ts → extra).
+ */
+export function getAppLinkHost(): string {
+  const fromExtra = Constants.expoConfig?.extra?.appLinkHost as string | undefined;
+  return fromExtra && fromExtra.length > 0 ? fromExtra : DEFAULT_APP_LINK_HOST;
+}
+
+/**
+ * Returns the set of hosts an incoming universal link may legitimately use.
+ * Includes the configured host. Kept as an array so additional hosts (e.g. a
+ * `www.` alias or a short-link domain) can be appended without touching the
+ * parsing logic.
+ */
+export function getAppLinkHosts(): string[] {
+  return [getAppLinkHost()];
+}
+
+/**
+ * Custom URL scheme for non-HTTPS deep links (QR codes, push payloads, etc).
+ * Matches `scheme` in app.config.ts and the legacy `ppt://` links.
+ */
+export const APP_SCHEMES = ['ppt', 'ppt-management'] as const;
+
+/**
+ * Normalise any supported deep-link URL (custom scheme OR universal link) to
+ * the canonical `<path>?<query>` form the route matcher understands.
+ *
+ * - `ppt://faults/123?x=1`                        -> `faults/123?x=1`
+ * - `ppt-management://faults/123`                 -> `faults/123`
+ * - `https://app.ppt.example.com/faults/123?x=1`  -> `faults/123?x=1`
+ *
+ * Returns `null` when the URL is not a deep link this app owns (wrong scheme,
+ * or an HTTPS URL whose host is not an associated App-Link host).
+ */
+export function normalizeLinkUrl(url: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+
+  const scheme = parsed.protocol.replace(/:$/, '');
+
+  if ((APP_SCHEMES as readonly string[]).includes(scheme)) {
+    // Custom-scheme URLs put the first path segment in the host slot
+    // (e.g. `ppt://faults/123` → host=`faults`, pathname=`/123`).
+    const host = parsed.host ?? '';
+    const rest = parsed.pathname.replace(/^\//, '');
+    const path = [host, rest].filter(Boolean).join('/');
+    return appendQuery(path, parsed.search);
+  }
+
+  if (scheme === 'https' && getAppLinkHosts().includes(parsed.host)) {
+    const path = parsed.pathname.replace(/^\//, '');
+    return appendQuery(path, parsed.search);
+  }
+
+  return null;
+}
+
+function appendQuery(path: string, search: string): string {
+  return search && search.length > 1 ? `${path}${search}` : path;
+}


### PR DESCRIPTION
## Task
Configure universal links (iOS) and App Links (Android) for the React Native Property Management app (frontend/apps/mobile): apple-app-site-association JSON, assetlinks.json, metro/app config entitlements, and deep-link handler routing.

## Owner
`pm-frontend` (specialist: `react-native`)

## What changed (scoped to `frontend/apps/mobile`)
- **`public/.well-known/apple-app-site-association`** — iOS Universal Links association for bundle `three.two.bit.ppt.management` (paths for dashboard/faults/announcements/voting/documents/outages/messages/settings). Ships with `__APPLE_TEAM_ID__` placeholder.
- **`public/.well-known/assetlinks.json`** — Android App Links Digital Asset Links for package `three.two.bit.ppt.management`. Ships with `__ANDROID_SIGNING_SHA256__` placeholder.
- **`public/.well-known/README.md`** — hosting + placeholder-replacement instructions (files must be served by the `APP_LINK_HOST` web host, not the app).
- **`app.config.ts`** — added iOS `associatedDomains` (`applinks:<host>`); the Android `https` `intentFilter` now uses a configurable `appLinkHost` (was hardcoded); host exposed via `extra.appLinkHost`. Single source of truth = `APP_LINK_HOST` env var.
- **`.env.{development,staging,production,example}`** — added `APP_LINK_HOST`.
- **`src/qrcode/universalLinks.ts`** (new) — `normalizeLinkUrl()` accepts both the legacy `ppt://`/`ppt-management://` custom schemes and HTTPS universal links, host-allowlisted against `getAppLinkHost()`.
- **`src/qrcode/DeepLinkHandler.ts`** — `parseDeepLink()` now routes via `normalizeLinkUrl` instead of hardcoding `ppt://`, so HTTPS universal/App links resolve to the same route table. Reused the existing `DeepLinkManager` (no reimplementation).
- **`src/App.tsx`** — wired `deepLinkManager` into routing: initialize on mount (handles cold-start initial URL + runtime `url` events), map parsed links to in-app screens via `resolveDeepLinkTarget`, and sync the auth gate so auth-required links queued while logged out fire on login.
- **`src/qrcode/universalLinks.test.ts`** (new) — 11 regression tests.

Push notification (FCM / expo-notifications) wiring was intentionally NOT touched — owned by sibling task `gap-85-3-rn-fcm-push-config`.

## Tested (Band A — fast check)
- `pnpm -F mobile typecheck` → exit 0
- `npx biome check apps/mobile/src/qrcode apps/mobile/src/App.tsx apps/mobile/app.config.ts` → exit 0 (autofixed export-sort; `mobile` has no `lint` script — repo lint is Biome)
- `npx jest src/qrcode/universalLinks.test.ts` → 11 passed, exit 0

## Built (Band B — full build)
Skipped a device/emulator build: `expo prebuild` / native compile needs the Android SDK/Xcode, not available in this cloud trigger env. `app.config.ts` standalone tsc surfaces only a single pre-existing typing quirk on the `withLegacyStoragePermissions` plugin entry (unrelated to this change; the file is excluded from the repo `tsc` typecheck by design). Config additions (`associatedDomains`, `appLinkHost`) are plain strings/arrays and type-clean.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity logic). Note: link parsing is host-allowlisted so foreign HTTPS hosts cannot deep-link into the app (covered by tests).

## Remote-tested
skipped (no ppt-bridge MCP in session)

## Scope drift
`scope-check.sh --owner pm-frontend` returned exit 2 (drift) because `owner-areas.json` maps `frontend/apps/mobile/**` to `pm-mobile`, not `pm-frontend`. The drift is expected and justified: the task explicitly targets the React Native app under `frontend/apps/mobile`, which the `react-native` specialist owns. All changed paths are inside `frontend/apps/mobile/`. The owner_role hint (`pm-frontend`) is simply broader than the area map; no out-of-scope files were touched.

## Code-reuse review
`reuse-grep.sh --specialist react-native` → no warnings. Reused existing `DeepLinkManager` / `parseDeepLink` rather than adding a parallel handler.

## Notes
- The well-known files carry build-time placeholders (`__APPLE_TEAM_ID__`, `__ANDROID_SIGNING_SHA256__`) that release/CI must replace from EAS credentials before App Link verification will succeed — see `public/.well-known/README.md`.
- `apple-app-site-association` must be served without a `.json` extension and from the `APP_LINK_HOST` document root (deployment owned by the web/CDN host, not the app bundle).

https://claude.ai/code/session_011pgA6gdeNaSWpQw7CK3AE9

---
_Generated by [Claude Code](https://claude.ai/code/session_011pgA6gdeNaSWpQw7CK3AE9)_