### PR TITLE
fix(api): add baseline security headers to API edge + SPA hosts (#954)

### DIFF
--- a/backend/crates/api-core/src/middleware/mod.rs
+++ b/backend/crates/api-core/src/middleware/mod.rs
@@ -4,6 +4,7 @@ pub mod authorization;
 pub mod feature_guard;
 pub mod host_tenant;
 pub mod rls_context;
+pub mod security_headers;
 pub mod tenant_filter;
 pub mod tenant_ops;
 
@@ -11,5 +12,6 @@ pub use authorization::*;
 pub use feature_guard::*;
 pub use host_tenant::*;
 pub use rls_context::*;
+pub use security_headers::*;
 pub use tenant_filter::*;
 pub use tenant_ops::*;

--- a/backend/crates/api-core/src/middleware/security_headers.rs
+++ b/backend/crates/api-core/src/middleware/security_headers.rs
@@ -1,0 +1,97 @@
+//! Baseline security response headers for the API edge (#954).
+//!
+//! Both api-server and reality-server previously shipped **zero** security
+//! headers on their JSON API responses — no HSTS, no `X-Content-Type-Options`,
+//! no framing/referrer policy — even though they sit behind TLS and carry auth
+//! credentials. The reality-web (Next.js) host already ships the full suite;
+//! this middleware brings the Rust API hosts up to the same baseline.
+//!
+//! It deliberately sets only the headers that make sense for a JSON API:
+//! - `Strict-Transport-Security` — close the first-request SSL-strip window.
+//! - `X-Content-Type-Options: nosniff` — never MIME-sniff a JSON body.
+//! - `X-Frame-Options: DENY` — an API has nothing to embed in a frame.
+//! - `Referrer-Policy` — conservative default.
+//!
+//! Content-Security-Policy is intentionally left to the HTML-serving edges
+//! (reality-web / the SPA nginx) — a JSON API renders no markup, so a CSP here
+//! would add bytes without protecting anything.
+
+use axum::{
+    extract::Request,
+    http::{header, HeaderValue},
+    middleware::Next,
+    response::Response,
+};
+
+/// HSTS value: 2 years + subdomains. Matches the reality-web baseline
+/// (`preload` is omitted here since the API hosts are not on the HSTS preload
+/// list; the SPA/edge owns the preloaded apex).
+const HSTS_VALUE: &str = "max-age=63072000; includeSubDomains";
+
+/// Axum middleware that attaches the baseline security headers to every
+/// response. Register with `axum::middleware::from_fn(security_headers)`.
+///
+/// Uses `insert` (override) rather than `entry`/append: these headers are never
+/// set by the API handlers themselves, and a single deterministic value is what
+/// we want at the edge.
+pub async fn security_headers(request: Request, next: Next) -> Response {
+    let mut response = next.run(request).await;
+    let headers = response.headers_mut();
+
+    headers.insert(
+        header::STRICT_TRANSPORT_SECURITY,
+        HeaderValue::from_static(HSTS_VALUE),
+    );
+    headers.insert(
+        header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
+    headers.insert(
+        header::REFERRER_POLICY,
+        HeaderValue::from_static("strict-origin-when-cross-origin"),
+    );
+
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::StatusCode, routing::get, Router};
+    use tower::ServiceExt; // for `oneshot`
+
+    async fn ok() -> &'static str {
+        "ok"
+    }
+
+    #[tokio::test]
+    async fn sets_all_baseline_headers() {
+        let app = Router::new()
+            .route("/health", get(ok))
+            .layer(axum::middleware::from_fn(security_headers));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let h = response.headers();
+        assert_eq!(
+            h.get(header::STRICT_TRANSPORT_SECURITY).unwrap(),
+            "max-age=63072000; includeSubDomains"
+        );
+        assert_eq!(h.get(header::X_CONTENT_TYPE_OPTIONS).unwrap(), "nosniff");
+        assert_eq!(h.get(header::X_FRAME_OPTIONS).unwrap(), "DENY");
+        assert_eq!(
+            h.get(header::REFERRER_POLICY).unwrap(),
+            "strict-origin-when-cross-origin"
+        );
+    }
+}

--- a/backend/servers/api-server/src/main.rs
+++ b/backend/servers/api-server/src/main.rs
@@ -524,6 +524,11 @@ async fn main() -> anyhow::Result<()> {
         // this per-route via `DefaultBodyLimit::max(...)` and stream
         // chunks instead of buffering full payloads. Cap here: 16 MiB.
         .layer(DefaultBodyLimit::max(16 * 1024 * 1024))
+        // Baseline security headers (HSTS, nosniff, frame-deny, referrer) on
+        // every response — the API edge previously shipped none (#954).
+        .layer(axum::middleware::from_fn(
+            api_core::middleware::security_headers,
+        ))
         // Middleware
         .layer(TraceLayer::new_for_http())
         // Phase 1: Host-resolution (tenant-resolution) middleware. Runs FIRST

--- a/backend/servers/reality-server/src/main.rs
+++ b/backend/servers/reality-server/src/main.rs
@@ -476,6 +476,11 @@ async fn main() -> anyhow::Result<()> {
         // and accepts no large uploads; 4 MiB is more than enough for
         // JSON+forms.
         .layer(DefaultBodyLimit::max(4 * 1024 * 1024))
+        // Baseline security headers (HSTS, nosniff, frame-deny, referrer) on
+        // every response — the API edge previously shipped none (#954).
+        .layer(axum::middleware::from_fn(
+            api_core::middleware::security_headers,
+        ))
         // Middleware
         .layer(TraceLayer::new_for_http())
         // CORS configuration - origins configurable via CORS_ALLOWED_ORIGINS env var

--- a/docker/nginx/admin-web.nginx.conf.template
+++ b/docker/nginx/admin-web.nginx.conf.template
@@ -36,6 +36,12 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Cache-Control "no-store" always;
+    # HSTS — was missing (#954). The super-admin console is served TLS-only.
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+    # CSP — was missing (#954). frame-ancestors 'none' mirrors X-Frame-Options
+    # DENY (admin must never be framed); connect-src kept permissive (https:/wss:)
+    # for same-origin /api proxying and external telemetry.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
 
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
@@ -44,6 +50,7 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
     }
 
     location /health {

--- a/docker/nginx/ppt-web.nginx.conf.template
+++ b/docker/nginx/ppt-web.nginx.conf.template
@@ -34,6 +34,12 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    # HSTS — was missing (#954). This host is served TLS-only behind Caddy.
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+    # CSP — was missing (#954). frame-ancestors 'self' mirrors the SAMEORIGIN
+    # policy above; connect-src is kept permissive (https:/wss:) so same-origin
+    # /api + /ws proxying and any external uploads/telemetry keep working.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
 
     # Cache static assets (include security headers since add_header in location overrides parent)
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
@@ -43,6 +49,7 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
     }
 
     # Health check endpoint


### PR DESCRIPTION
## Summary
Fixes #954. Security headers were inconsistent across the edge:

- **API hosts** (`api-server`, `reality-server`) shipped **zero** security headers — no HSTS, no `X-Content-Type-Options`, no framing/referrer policy — despite being TLS-only and credential-bearing.
- **SPA hosts** (`ppt-web`, `admin-web` nginx) had the basics but **no HSTS and no CSP** — notably the super-admin console.

The reality-web (Next.js) host already ships the full suite; this brings everything up to that baseline.

## Changes
- **`api_core::middleware::security_headers`** (new axum `from_fn` middleware) sets on every response:
  - `Strict-Transport-Security: max-age=63072000; includeSubDomains`
  - `X-Content-Type-Options: nosniff`
  - `X-Frame-Options: DENY`
  - `Referrer-Policy: strict-origin-when-cross-origin`
  
  Applied to both `api-server` and `reality-server` routers. CSP is intentionally **not** set on the JSON API (it renders no markup, so a CSP would add bytes without protecting anything).
- **`docker/nginx/{ppt-web,admin-web}.nginx.conf.template`** gain HSTS and a CSP. `frame-ancestors` mirrors each host's existing `X-Frame-Options` (`'self'` for ppt-web/SAMEORIGIN, `'none'` for admin/DENY). `connect-src` is kept permissive (`'self' https: wss:`) so same-origin `/api` + `/ws` proxying and external uploads/telemetry keep working.

## Tests
- Unit test on the middleware (`api-core`) asserts all four headers are present on a response.
- nginx templates are config-only (rendered via `envsubst` at container start).

## Notes
- HSTS `preload` is omitted on the API hosts (they're not on the preload list; the SPA/edge owns the preloaded apex).
- The CSP is deliberately conservative on `connect-src`/`img-src` to avoid breaking the SPAs; it can be tightened after a staging walkthrough confirms no violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)