### PR TITLE
fix(staging): relative redirects, admin favicon, drop X-Powered-By (#957)

### DIFF
--- a/docker/nginx/admin-web.nginx.conf.template
+++ b/docker/nginx/admin-web.nginx.conf.template
@@ -13,6 +13,10 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Emit relative redirects (#957) — see ppt-web template. Avoids leaking the
+    # internal :8080 port / https->http downgrade in implicit slash redirects.
+    absolute_redirect off;
+
     gzip on;
     gzip_vary on;
     gzip_min_length 1024;

--- a/docker/nginx/ppt-web.nginx.conf.template
+++ b/docker/nginx/ppt-web.nginx.conf.template
@@ -11,6 +11,13 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Emit relative redirects (#957). Without this, nginx's implicit
+    # trailing-slash redirect for `/api` -> `/api/` builds an ABSOLUTE Location
+    # from the listen socket (`http://host:8080/api/`), leaking the internal
+    # port and downgrading https->http. A relative `Location: /api/` is resolved
+    # by the browser against the original scheme+host.
+    absolute_redirect off;
+
     # Gzip compression
     gzip on;
     gzip_vary on;

--- a/frontend/apps/admin-web/public/favicon.svg
+++ b/frontend/apps/admin-web/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#2563eb"/>
+  <path d="M16 48V20l16-8 16 8v28h-8V32H24v16h-8z" fill="#ffffff"/>
+  <rect x="28" y="20" width="8" height="6" fill="#2563eb"/>
+</svg>

--- a/frontend/apps/reality-web/next.config.js
+++ b/frontend/apps/reality-web/next.config.js
@@ -93,6 +93,10 @@ const nextConfig = {
   // Standalone output for Docker deployment
   output: 'standalone',
 
+  // Don't advertise the framework via `X-Powered-By: Next.js` (#957). No
+  // version is leaked, but the Rust API hosts omit any banner — match them.
+  poweredByHeader: false,
+
   // Enable React strict mode
   reactStrictMode: true,
 


### PR DESCRIPTION
## Summary
Addresses the #957 low-severity staging roundup. Fixes 3 of the 4 items; item 2 is working-as-designed (see below).

### 1. `/api` 301 leaks internal upstream ✅
`https://staging.ppt.rlt.sk/api` → `301 Location: http://staging.ppt.rlt.sk:8080/api/` (leaks internal :8080, downgrades https→http). nginx built an **absolute** Location for the implicit trailing-slash redirect from its listen socket. Added `absolute_redirect off;` to both `ppt-web` and `admin-web` templates so the redirect is relative (`Location: /api/`), resolved by the browser against the original scheme+host.

### 3. admin-web favicon 404 ✅
The admin shell links `<link rel="icon" href="/favicon.svg">` but no asset existed. Added `frontend/apps/admin-web/public/favicon.svg` (mirrors ppt-web; Vite copies `public/` to the dist root).

### 4. reality-web `X-Powered-By: Next.js` ✅
Set `poweredByHeader: false` in `next.config.js`. Matches the Rust API hosts, which emit no banner.

### 2. `favorites/ids` returns `200 []` without auth — **working as designed** ⚠️
Not changed. The handler uses `OptionalRequestPrincipal` **deliberately**, with a documented rationale: the endpoint is a favorite-hydration helper callable from anonymous SSR pages (returns `[]` for anon), while still propagating `401/403` for a *present-but-invalid* token (the "stolen-but-revoked token" defense, leak #10/#11). Forcing it to `401` like its siblings would break the documented anonymous-SSR contract for a purely cosmetic consistency gain (the issue confirms no data leak — empty list). Rationale also posted on the issue.

## Verification
- nginx/favicon are config/asset only.
- `next.config.js` is a one-field config change (covered by frontend CI: biome + typecheck + build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)