### PR TITLE
fix(reality-web): localize public-page headings & titles for cs/de (#955)

### DIFF
--- a/frontend/apps/reality-web/messages/cs.json
+++ b/frontend/apps/reality-web/messages/cs.json
@@ -310,17 +310,17 @@
       "pricing": "Cenové plány",
       "subtitle": "Prodávejte více s Reality Portálem",
       "title": "Pro makléře a agentury",
-      "heroTitle": "Sell more with Reality Portal",
-      "heroBadge": "For agents & agencies",
-      "heroIntro": "Tools, analytics and reach across millions of buyers and renters in one place."
+      "heroTitle": "Prodávejte více s Reality Portálem",
+      "heroBadge": "Pro makléře a agentury",
+      "heroIntro": "Nástroje, analytika a dosah na miliony kupujících a nájemců na jednom místě."
     },
     "help": {
       "categories": "Kategorie",
       "faq": "Často kladené otázky",
       "searchPlaceholder": "Vyhledávejte v centru nápovědy...",
       "title": "Centrum nápovědy",
-      "subtitle": "How can we help?",
-      "intro": "Search our help centre or contact us directly."
+      "subtitle": "Jak vám můžeme pomoci?",
+      "intro": "Prohledejte naše centrum nápovědy nebo nás kontaktujte přímo."
     },
     "journal": {
       "editorsPicks": "Výběr redakce",
@@ -346,7 +346,7 @@
       "clickHint": "Klikněte na čtvrť pro detailní statistiky.",
       "subtitle": "Bratislava – přehled",
       "title": "Mapa cen",
-      "h1": "Price map"
+      "h1": "Mapa cen"
     },
     "privacy": {
       "description": "Zavazujeme se chránit vaše osobní údaje v souladu s GDPR a platnými zákony. Úplné podmínky ochrany osobních údajů budou zveřejněny zde.",
@@ -370,10 +370,11 @@
     },
     "security": {
       "reportCta": "Nahlásit inzerát",
-      "subtitle": "How we keep listings, payments and your data safe — and what to watch out for.",
-      "title": "Security",
-      "h1": "Your security is our priority",
-      "scenariosHeading": "Common fraud scenarios"
+      "subtitle": "Pomáháme vám odhalit podvody a obchodovat s nemovitostmi v bezpečném prostředí.",
+      "title": "Bezpečnost",
+      "h1": "Vaše bezpečnost je naše priorita",
+      "scenariosHeading": "Časté podvodné scénáře",
+      "description": "Zjistěte, jak chráníme inzeráty, platby a vaše údaje na Reality Portálu."
     },
     "sell": {
       "steps": {
@@ -399,7 +400,7 @@
         }
       },
       "submit": "Zveřejnit inzerát",
-      "title": "Add listing",
+      "title": "Přidat inzerát",
       "stepLabel": "Step {step} of {total}: {stepTitle}",
       "asideTitle": "Steps",
       "back": "← Back",
@@ -497,15 +498,16 @@
     },
     "favorites": {
       "title": "Moje oblíbené",
-      "description": "Nemovitosti, které jste si uložili."
+      "description": "Nemovitosti, které jste si uložili.",
+      "h1": "Moje oblíbené"
     },
     "login": {
-      "title": "Sign in",
-      "description": "Sign in to your Reality Portal account."
+      "title": "Přihlášení",
+      "description": "Přihlaste se ke svému účtu na Reality Portálu."
     },
     "register": {
-      "title": "Create your account",
-      "description": "Save listings, set alerts and contact agents.",
+      "title": "Vytvoření účtu",
+      "description": "Ukládejte si inzeráty, nastavte upozornění a kontaktujte makléře.",
       "termsLabel": "I agree to the {termsLink} and the {privacyLink}.",
       "termsRequired": "You must accept the Terms of Service and Privacy Policy to register.",
       "termsLinkText": "Terms of Service",
@@ -566,6 +568,12 @@
       "requestNew": "Request a new reset link",
       "goToSignIn": "Go to sign in",
       "genericError": "Could not reset password. Please try again."
+    },
+    "compare": {
+      "title": "Porovnat nemovitosti",
+      "description": "Porovnejte nemovitosti vedle sebe a najděte ten správný domov.",
+      "h1": "Porovnat nemovitosti",
+      "subtitle": "Podívejte se, jak si vaše vybrané nemovitosti stojí vedle sebe."
     }
   },
   "search": {

--- a/frontend/apps/reality-web/messages/de.json
+++ b/frontend/apps/reality-web/messages/de.json
@@ -310,17 +310,17 @@
       "pricing": "Preispläne",
       "subtitle": "Verkaufen Sie mehr mit Reality Portal",
       "title": "Für Makler & Agenturen",
-      "heroTitle": "Sell more with Reality Portal",
-      "heroBadge": "For agents & agencies",
-      "heroIntro": "Tools, analytics and reach across millions of buyers and renters in one place."
+      "heroTitle": "Verkaufen Sie mehr mit Reality Portal",
+      "heroBadge": "Für Makler & Agenturen",
+      "heroIntro": "Werkzeuge, Analysen und Reichweite zu Millionen von Käufern und Mietern an einem Ort."
     },
     "help": {
       "categories": "Kategorien",
       "faq": "Häufig gestellte Fragen",
       "searchPlaceholder": "Im Hilfe-Center suchen...",
       "title": "Hilfe-Center",
-      "subtitle": "How can we help?",
-      "intro": "Search our help centre or contact us directly."
+      "subtitle": "Wie können wir helfen?",
+      "intro": "Durchsuchen Sie unser Hilfe-Center oder kontaktieren Sie uns direkt."
     },
     "journal": {
       "editorsPicks": "Redaktionsauswahl",
@@ -346,7 +346,7 @@
       "clickHint": "Klicken Sie auf einen Bezirk für detaillierte Statistiken.",
       "subtitle": "Bratislava – Übersicht",
       "title": "Preiskarte",
-      "h1": "Price map"
+      "h1": "Preiskarte"
     },
     "privacy": {
       "description": "Wir sind verpflichtet, Ihre personenbezogenen Daten gemäß DSGVO und geltendem Recht zu schützen. Die vollständigen Datenschutzbestimmungen werden hier veröffentlicht.",
@@ -370,10 +370,11 @@
     },
     "security": {
       "reportCta": "Inserat melden",
-      "subtitle": "How we keep listings, payments and your data safe — and what to watch out for.",
-      "title": "Security",
-      "h1": "Your security is our priority",
-      "scenariosHeading": "Common fraud scenarios"
+      "subtitle": "Wir helfen Ihnen, Betrug zu erkennen und Immobilien in einer sicheren Umgebung zu handeln.",
+      "title": "Sicherheit",
+      "h1": "Ihre Sicherheit ist unsere Priorität",
+      "scenariosHeading": "Häufige Betrugsszenarien",
+      "description": "Erfahren Sie, wie wir Inserate, Zahlungen und Ihre Daten auf Reality Portal schützen."
     },
     "sell": {
       "steps": {
@@ -399,7 +400,7 @@
         }
       },
       "submit": "Inserat veröffentlichen",
-      "title": "Add listing",
+      "title": "Inserat hinzufügen",
       "stepLabel": "Step {step} of {total}: {stepTitle}",
       "asideTitle": "Steps",
       "back": "← Back",
@@ -497,15 +498,16 @@
     },
     "favorites": {
       "title": "Meine Favoriten",
-      "description": "Immobilien, die Sie gespeichert haben."
+      "description": "Immobilien, die Sie gespeichert haben.",
+      "h1": "Meine Favoriten"
     },
     "login": {
-      "title": "Sign in",
-      "description": "Sign in to your Reality Portal account."
+      "title": "Anmelden",
+      "description": "Melden Sie sich bei Ihrem Reality-Portal-Konto an."
     },
     "register": {
-      "title": "Create your account",
-      "description": "Save listings, set alerts and contact agents.",
+      "title": "Konto erstellen",
+      "description": "Speichern Sie Inserate, richten Sie Benachrichtigungen ein und kontaktieren Sie Makler.",
       "termsLabel": "I agree to the {termsLink} and the {privacyLink}.",
       "termsRequired": "You must accept the Terms of Service and Privacy Policy to register.",
       "termsLinkText": "Terms of Service",
@@ -566,6 +568,12 @@
       "requestNew": "Request a new reset link",
       "goToSignIn": "Go to sign in",
       "genericError": "Could not reset password. Please try again."
+    },
+    "compare": {
+      "title": "Immobilien vergleichen",
+      "description": "Vergleichen Sie Immobilien nebeneinander und finden Sie Ihr perfektes Zuhause.",
+      "h1": "Immobilien vergleichen",
+      "subtitle": "Sehen Sie, wie sich Ihre ausgewählten Immobilien im Vergleich schlagen."
     }
   },
   "search": {

--- a/frontend/apps/reality-web/messages/en.json
+++ b/frontend/apps/reality-web/messages/en.json
@@ -373,7 +373,8 @@
       "subtitle": "We help you spot fraud and trade properties in a safe environment.",
       "title": "Security",
       "h1": "Your security is our priority",
-      "scenariosHeading": "Common fraud scenarios"
+      "scenariosHeading": "Common fraud scenarios",
+      "description": "Learn how we keep listings, payments and your data safe on Reality Portal."
     },
     "sell": {
       "steps": {
@@ -497,7 +498,8 @@
     },
     "favorites": {
       "title": "My Favorites",
-      "description": "Properties you have saved for later."
+      "description": "Properties you have saved for later.",
+      "h1": "My Favorites"
     },
     "login": {
       "title": "Sign in",
@@ -566,6 +568,12 @@
       "requestNew": "Request a new reset link",
       "goToSignIn": "Go to sign in",
       "genericError": "Could not reset password. Please try again."
+    },
+    "compare": {
+      "title": "Compare properties",
+      "description": "Compare properties side by side to find your perfect home.",
+      "h1": "Compare properties",
+      "subtitle": "See how your selected properties stack up against each other."
     }
   },
   "search": {

--- a/frontend/apps/reality-web/messages/sk.json
+++ b/frontend/apps/reality-web/messages/sk.json
@@ -373,7 +373,8 @@
       "subtitle": "Pomáhame vám rozpoznať podvody a obchodovať s nehnuteľnosťami v bezpečnom prostredí.",
       "title": "Bezpečnosť",
       "h1": "Vaša bezpečnosť je naša priorita",
-      "scenariosHeading": "Časté podvodné scenáre"
+      "scenariosHeading": "Časté podvodné scenáre",
+      "description": "Zistite, ako chránime ponuky, platby a vaše údaje na Reality Portáli."
     },
     "sell": {
       "steps": {
@@ -497,7 +498,8 @@
     },
     "favorites": {
       "title": "Moje obľúbené",
-      "description": "Nehnuteľnosti, ktoré ste si uložili."
+      "description": "Nehnuteľnosti, ktoré ste si uložili.",
+      "h1": "Moje obľúbené"
     },
     "login": {
       "title": "Prihlásenie",
@@ -566,6 +568,12 @@
       "requestNew": "Vyžiadať nový odkaz",
       "goToSignIn": "Prejsť na prihlásenie",
       "genericError": "Nepodarilo sa obnoviť heslo. Skúste znova."
+    },
+    "compare": {
+      "title": "Porovnať nehnuteľnosti",
+      "description": "Porovnajte nehnuteľnosti vedľa seba a nájdite ten správny domov.",
+      "h1": "Porovnať nehnuteľnosti",
+      "subtitle": "Pozrite sa, ako si vaše vybrané nehnuteľnosti stoja vedľa seba."
     }
   },
   "search": {

--- a/frontend/apps/reality-web/src/app/[locale]/compare/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/compare/page.tsx
@@ -5,15 +5,15 @@
  * Epic 51 - Story 51.3: Share Comparison
  */
 
-import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
 
 import { ComparisonUrlHandler, ComparisonView } from '../../../components/comparison';
 import { Header } from '../../../components/ui';
+import { pageMetadata } from '../../../lib/page-metadata';
 
-export const metadata: Metadata = {
-  title: 'Compare Properties | Reality Portal',
-  description: 'Compare properties side by side to find your perfect home.',
-};
+// Was a hardcoded English `metadata` object (#955). Use the shared helper so the
+// title is localized and carries the site " — Reality Portal" suffix.
+export const generateMetadata = pageMetadata('compare');
 
 interface ComparePageProps {
   searchParams: Promise<{ ids?: string }>;
@@ -22,6 +22,7 @@ interface ComparePageProps {
 export default async function ComparePage({ searchParams }: ComparePageProps) {
   const params = await searchParams;
   const sharedIds = params.ids?.split(',').filter(Boolean) ?? [];
+  const t = await getTranslations('pages.compare');
 
   return (
     <>
@@ -29,10 +30,8 @@ export default async function ComparePage({ searchParams }: ComparePageProps) {
       <main className="min-h-screen bg-gray-50">
         <div className="mx-auto max-w-[1200px] px-6">
           <div className="border-b border-gray-200 bg-white py-8 -mx-6 px-6 mb-6">
-            <h1 className="text-[28px] font-bold text-gray-900 mb-2">Compare Properties</h1>
-            <p className="text-gray-500">
-              See how your selected properties stack up against each other.
-            </p>
+            <h1 className="text-[28px] font-bold text-gray-900 mb-2">{t('h1')}</h1>
+            <p className="text-gray-500">{t('subtitle')}</p>
           </div>
           {/* Handle shared URL ids parameter */}
           <ComparisonUrlHandler sharedIds={sharedIds} />

--- a/frontend/apps/reality-web/src/app/[locale]/favorites/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/favorites/page.tsx
@@ -8,6 +8,7 @@
 
 import { useFavorites, useRemoveFavorite } from '@ppt/reality-api-client';
 import Link from 'next/link';
+import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 import { ProtectedRoute } from '@/components/auth';
 import { ListingCard } from '@/components/listings';
@@ -195,12 +196,13 @@ function FavoritesContent() {
 }
 
 export default function FavoritesPage() {
+  const t = useTranslations('pages.favorites');
   return (
     <div className="page-container">
       <Header />
       <main className="main">
         <div className="container">
-          <h1 className="page-title">My Favorites</h1>
+          <h1 className="page-title">{t('h1')}</h1>
           <ProtectedRoute>
             <FavoritesContent />
           </ProtectedRoute>

--- a/frontend/apps/reality-web/src/app/[locale]/security/layout.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/security/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const generateMetadata = pageMetadata('security');
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}


### PR DESCRIPTION
## Summary
Addresses #955. Multiple reality-web public pages rendered English headings/titles for **cs**/**de** (some in all locales) while the rest of the page was localized.

### Structural fixes (affected all locales)
- **/compare** used a hardcoded English `metadata` object and hardcoded `<h1>`/subtitle. Now uses `pageMetadata('compare')` + `getTranslations('pages.compare')`, with new `pages.compare.*` keys in all four catalogs. (Also fixes the ` | ` vs site `—` title separator, since `pageMetadata` applies the standard ` — Reality Portal` suffix.)
- **/favorites** hardcoded `<h1>My Favorites</h1>`. Now `t('pages.favorites.h1')` via `useTranslations`.
- **/security** had no `layout.tsx`/metadata, so it inherited the homepage title. Added `security/layout.tsx` with `pageMetadata('security')` and a `pages.security.description` key.

### Translation fixes (cs/de held untranslated English)
Translated the heading/title keys that fell back to English in cs/de: `sell.title`, `forAgents.{heroTitle,heroBadge,heroIntro}`, `priceMap.h1`, `help.{subtitle,intro}`, `security.{title,h1,subtitle,scenariosHeading}`, `login.{title,description}`, `register.{title,description}`.

## Scope / follow-up
This pass covers the **headings & titles** the issue enumerates. The larger form-field subtrees — `sell.steps.*` and the `register.*` form labels/validation messages — are still English in cs/de and are a separate localization-completeness task (noted here so they aren't forgotten).

## Verification
- `pnpm check` (Biome): pass (only pre-existing warnings).
- `pnpm typecheck`: pass.
- Catalog edits are minimal/surgical (the catalogs round-trip byte-for-byte through `JSON.stringify(…, 2)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)