### PR TITLE
fix(ppt-web): close frontend gaps from whole-app epic gap-sweep

### DIFF
--- a/docs/screens/ppt/fault-edit.md
+++ b/docs/screens/ppt/fault-edit.md
@@ -9,7 +9,7 @@ implementations:
     component: EditFaultPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: stub
+    apiStatus: complete
 endpoints: []
 relatedScreens:
   - id: ppt/fault-detail
@@ -33,3 +33,4 @@ Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, e
 
 ## Agent Log
 - 2026-05-18 — agent: created stub for unmapped route.
+- 2026-06-02 — agent (gap-sweep): wired EditFaultPageRoute to `useFault` (load initial data) + `useUpdateFault` + `useBuildings` in App.tsx (was initialData={{}} + no-op toast). apiStatus stub→complete.

--- a/docs/screens/ppt/fault-new.md
+++ b/docs/screens/ppt/fault-new.md
@@ -9,7 +9,7 @@ implementations:
     component: CreateFaultPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: stub
+    apiStatus: partial
 endpoints: []
 relatedScreens:
   - id: ppt/faults-list
@@ -35,3 +35,4 @@ Note: a `ppt/report-fault` screen-map already exists (mobile-oriented). This stu
 
 ## Agent Log
 - 2026-05-18 — agent: created stub for unmapped route.
+- 2026-06-02 — agent (gap-sweep): wired CreateFaultPageRoute to `useCreateFault` + `useBuildings` in App.tsx (was a no-op toast). Maps FaultFormData→CreateFaultRequest. apiStatus stub→partial — photo upload (File[]→useAddAttachment) still TODO.

--- a/docs/screens/ppt/privacy-settings.md
+++ b/docs/screens/ppt/privacy-settings.md
@@ -121,5 +121,6 @@ UC-23 GDPR + session management. The page bundles 4 distinct concerns: data expo
 
 <!-- newest entries on top -->
 
+- 2026-06-02 — agent (gap-sweep): fixed critical auth bug — page used bare `fetch('/api/v1/gdpr/*')` with no Authorization header (401 in prod). Added `features/privacy/gdprClient.ts` (base URL + bearer token) and routed all GDPR calls through it. Account deletion now sends the required `confirmation` (email) instead of `{}` (was always 400). Save now sends only backend-supported fields (profile_visibility, show_contact_info). Marketing/analytics consent still not persisted by backend — tracked as a follow-up issue; apiStatus stays `partial`.
 - 2026-05-09 — agent: design analyzed (pages/ppt-privacy-settings.html — 6 rows: loaded / export-3-state / delete-modal-2 / sessions-3 / consents-just-changed+audit / page-error); flipped ppt-web redesignStatus → in-progress; attached designSource; populated functionality checklist (8 sections covering 6 destructive/non-destructive flows), all states + 6 destructive-flow variants, design-specific notes (confirm-typed-name + GDPR čl. 17 ods. 3 + IP masking + auto-save consent UX); declared 6 sharedComponents; added 1 relatedScreen (accessibility-settings sibling)
 - 2026-05-08 — init: created from scan (source: sitemap)

--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -58,7 +58,8 @@
     "profile": "Profil",
     "accessibility": "Přístupnost",
     "privacy": "Soukromí",
-    "admin": "Administrace"
+    "admin": "Administrace",
+    "aiChat": "AI asistent"
   },
   "auth": {
     "signIn": "Přihlásit se",

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -58,7 +58,8 @@
     "profile": "Profil",
     "accessibility": "Barrierefreiheit",
     "privacy": "Datenschutz",
-    "admin": "Administration"
+    "admin": "Administration",
+    "aiChat": "KI-Assistent"
   },
   "auth": {
     "signIn": "Anmelden",

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -58,7 +58,8 @@
     "profile": "Profil",
     "accessibility": "Akadálymentesítés",
     "privacy": "Adatvédelem",
-    "admin": "Adminisztráció"
+    "admin": "Adminisztráció",
+    "aiChat": "AI asszisztens"
   },
   "auth": {
     "signIn": "Bejelentkezés",

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -58,7 +58,8 @@
     "profile": "Profil",
     "accessibility": "Dostępność",
     "privacy": "Prywatność",
-    "admin": "Administracja"
+    "admin": "Administracja",
+    "aiChat": "Asystent AI"
   },
   "auth": {
     "signIn": "Zaloguj się",

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -59,7 +59,8 @@
     "profile": "Profil",
     "accessibility": "Prístupnosť",
     "privacy": "Súkromie",
-    "admin": "Administrácia"
+    "admin": "Administrácia",
+    "aiChat": "AI asistent"
   },
   "auth": {
     "signIn": "Prihlásiť sa",

--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -34,6 +34,7 @@ import {
   useConfirmFault,
   useCreateAnnouncementComment,
   useCreateDispute,
+  useCreateFault,
   useCreateOutage,
   useDeleteAnnouncement,
   useDeleteAnnouncementComment,
@@ -59,6 +60,7 @@ import {
   useStartOutage,
   useTriageFault,
   useUpdateDisputeStatus,
+  useUpdateFault,
   useUpdateOutage,
   useUpdateScheduleCron,
 } from '@ppt/api-client';
@@ -131,25 +133,36 @@ import type {
 // Lazy-loaded route components for code splitting (Epic 130)
 import {
   AccessibilitySettingsPage,
+  AiChatPage,
   AnnouncementsPage,
   ArticleDetailPage,
   AuthCallbackPage,
+  AutomationRulesPage,
+  BookFacilityPage,
   BudgetManagementPage,
+  BuildingDetailPage,
+  BuildingsPage,
   ChangePasswordPage,
   CreateAnnouncementPage,
+  CreateFacilityPage,
   CreateFaultPage,
   CreateGroupPage,
   CreateOutagePage,
+  CreateRulePage,
   DisputeDetailPage,
   DisputesPage,
   DocumentDetailPage,
   DocumentsPage,
   DocumentUploadPage,
   EditAnnouncementPage,
+  EditFacilityPage,
   EditFaultPage,
   EditOutagePage,
+  EditRulePage,
   EmergencyContactDirectoryPage,
   EventsPage,
+  ExecutionMonitoringPage,
+  FacilitiesPage,
   FaultDetailPage,
   FaultsPage,
   FeedPage,
@@ -165,6 +178,7 @@ import {
   MarketplacePage,
   MediationWorkspacePage,
   MessagesPage,
+  MyBookingsPage,
   NeighborDetailPage,
   NeighborsPage,
   NeighborsPrivacySettingsPage,
@@ -174,6 +188,7 @@ import {
   OAuthGrantsPage,
   OutagesPage,
   PaymentManagementPage,
+  PendingBookingsPage,
   PrivacySettingsPage,
   ProfileEditPage,
   RegisterPage,
@@ -182,6 +197,7 @@ import {
   ScheduleDetailPage,
   ServerErrorPage,
   SessionExpiredPage,
+  TemplateLibraryPage,
   ThreadDetailPage,
   TwoFactorAuthPage,
   ViewAnnouncementPage,
@@ -430,7 +446,9 @@ function AppNavigation() {
   return (
     <nav className="app-nav" aria-label="Main navigation">
       <Link to="/">{t('nav.home')}</Link>
+      <Link to="/buildings">{t('nav.buildings')}</Link>
       <Link to="/documents">{t('nav.documents')}</Link>
+      <Link to="/ai-assistant">{t('nav.aiChat')}</Link>
       <Link to="/news">{t('nav.news')}</Link>
       <Link to="/emergency">{t('nav.emergency')}</Link>
       <Link to="/disputes">{t('nav.disputes')}</Link>
@@ -811,6 +829,125 @@ function App() {
                                   }
                                 />
 
+                                {/* Buildings management (Epic 3, Story 3.1) — gap-sweep */}
+                                <Route
+                                  path="/buildings"
+                                  element={
+                                    <ProtectedRoute>
+                                      <BuildingsPageRoute />
+                                    </ProtectedRoute>
+                                  }
+                                />
+                                <Route
+                                  path="/buildings/:buildingId"
+                                  element={
+                                    <ProtectedRoute>
+                                      <BuildingDetailPageRoute />
+                                    </ProtectedRoute>
+                                  }
+                                />
+                                {/* Facilities & bookings (Epic 3, Story 3.7) — gap-sweep.
+                                  Pages self-resolve params via useParams/useNavigate. */}
+                                <Route
+                                  path="/buildings/:buildingId/facilities"
+                                  element={
+                                    <ProtectedRoute>
+                                      <FacilitiesPage />
+                                    </ProtectedRoute>
+                                  }
+                                />
+                                <Route
+                                  path="/buildings/:buildingId/facilities/new"
+                                  element={
+                                    <ProtectedRoute>
+                                      <CreateFacilityPage />
+                                    </ProtectedRoute>
+                                  }
+                                />
+                                <Route
+                                  path="/buildings/:buildingId/facilities/:facilityId/edit"
+                                  element={
+                                    <ProtectedRoute>
+                                      <EditFacilityPage />
+                                    </ProtectedRoute>
+                                  }
+                                />
+                                <Route
+                                  path="/buildings/:buildingId/facilities/:facilityId/book"
+                                  element={
+                                    <ProtectedRoute>
+                                      <BookFacilityPage />
+                                    </ProtectedRoute>
+                                  }
+                                />
+                                <Route
+                                  path="/buildings/:buildingId/facilities/pending"
+                                  element={
+                                    <ProtectedRoute>
+                                      <PendingBookingsPage />
+                                    </ProtectedRoute>
+                                  }
+                                />
+                                <Route
+                                  path="/facilities/bookings/my"
+                                  element={
+                                    <ProtectedRoute>
+                                      <MyBookingsPage />
+                                    </ProtectedRoute>
+                                  }
+                                />
+                                {/* AI Assistant chat (Epic 13, Story 13.1) — gap-sweep */}
+                                <Route
+                                  path="/ai-assistant"
+                                  element={
+                                    <ProtectedRoute>
+                                      <AiChatPage />
+                                    </ProtectedRoute>
+                                  }
+                                />
+                                {/* Workflow Automation (Epic 13) — gap-sweep.
+                                  Paths match the pages' hard-coded navigate() targets. */}
+                                <Route
+                                  path="/automations/rules"
+                                  element={
+                                    <ProtectedRoute>
+                                      <AutomationRulesPage />
+                                    </ProtectedRoute>
+                                  }
+                                />
+                                <Route
+                                  path="/automations/rules/new"
+                                  element={
+                                    <ProtectedRoute>
+                                      <CreateRulePage />
+                                    </ProtectedRoute>
+                                  }
+                                />
+                                <Route
+                                  path="/automations/rules/:id/edit"
+                                  element={
+                                    <ProtectedRoute>
+                                      <EditRulePage />
+                                    </ProtectedRoute>
+                                  }
+                                />
+                                <Route
+                                  path="/automations/templates"
+                                  element={
+                                    <ProtectedRoute>
+                                      <TemplateLibraryPage />
+                                    </ProtectedRoute>
+                                  }
+                                />
+                                <Route
+                                  path="/automations/executions"
+                                  element={
+                                    <ProtectedRoute>
+                                      <ExecutionMonitoringPage />
+                                    </ProtectedRoute>
+                                  }
+                                />
+
                                 {/* Phase 5 admin is at admin.rlt.sk now;
                                   see frontend/apps/admin-web. */}
 
@@ -841,6 +978,26 @@ function DocumentsPageRoute() {
   const { user } = useAuth();
   const organizationId = user?.organizationId ?? 'default-org';
   return <DocumentsPage organizationId={organizationId} />;
+}
+
+/** Route wrapper for buildings list (Epic 3, Story 3.1) — gap-sweep */
+function BuildingsPageRoute() {
+  const navigate = useNavigate();
+  return (
+    <BuildingsPage
+      onNavigateToView={(id) => navigate(`/buildings/${id}`)}
+      onNavigateToEdit={(id) => navigate(`/buildings/${id}`)}
+    />
+  );
+}
+
+/** Route wrapper for building detail (Epic 3, Story 3.1) — gap-sweep */
+function BuildingDetailPageRoute() {
+  const { buildingId } = useParams<{ buildingId: string }>();
+  if (!buildingId) {
+    return <div>Building not found</div>;
+  }
+  return <BuildingDetailPage buildingId={buildingId} />;
 }
 
 /** Route wrapper for folder-tree page (gap-7a-2) */
@@ -2541,14 +2698,39 @@ function FaultsPageRoute() {
 function CreateFaultPageRoute() {
   const navigate = useNavigate();
   const { showToast } = useToast();
+  const { data: buildingsData } = useBuildings();
+  const createFault = useCreateFault();
+
+  const buildings = (buildingsData?.items ?? []).map((b) => ({ id: b.id, name: b.name }));
 
   return (
     <CreateFaultPage
-      buildings={[]}
+      buildings={buildings}
       units={[]}
-      onSubmit={() => {
-        showToast({ type: 'success', title: 'Created', message: 'Fault reported' });
-        navigate('/faults');
+      isSubmitting={createFault.isPending}
+      onSubmit={async (data) => {
+        try {
+          // Map FaultFormData (camelCase) -> CreateFaultRequest (snake_case).
+          // NOTE: photos (File[]) are not sent here — base64/upload wiring via
+          // useAddAttachment is a separate follow-up (see fault-new screen-map).
+          const created = await createFault.mutateAsync({
+            building_id: data.buildingId,
+            unit_id: data.unitId,
+            title: data.title,
+            description: data.description,
+            location_description: data.locationDescription,
+            category: data.category,
+            priority: data.priority,
+          });
+          showToast({ type: 'success', title: 'Created', message: 'Fault reported' });
+          navigate(created?.id ? `/faults/${created.id}` : '/faults');
+        } catch (err) {
+          showToast({
+            type: 'error',
+            title: 'Failed to report fault',
+            message: err instanceof Error ? err.message : 'Please try again.',
+          });
+        }
       }}
       onCancel={() => navigate('/faults')}
     />
@@ -2644,20 +2826,52 @@ function EditFaultPageRoute() {
   const { faultId } = useParams<{ faultId: string }>();
   const navigate = useNavigate();
   const { showToast } = useToast();
+  const { data, isLoading } = useFault(faultId ?? '');
+  const { data: buildingsData } = useBuildings();
+  const updateFault = useUpdateFault(faultId ?? '');
 
   if (!faultId) {
     return <div>Fault not found</div>;
   }
+  if (isLoading || !data) {
+    return <div className="p-6">Loading…</div>;
+  }
+
+  const fault = data.fault;
+  const buildings = (buildingsData?.items ?? []).map((b) => ({ id: b.id, name: b.name }));
 
   return (
     <EditFaultPage
       faultId={faultId}
-      initialData={{}}
-      buildings={[]}
+      initialData={{
+        buildingId: fault.building_id,
+        unitId: fault.unit_id,
+        title: fault.title,
+        description: fault.description,
+        locationDescription: fault.location_description,
+        category: fault.category,
+        priority: fault.priority,
+      }}
+      buildings={buildings}
       units={[]}
-      onSubmit={() => {
-        showToast({ type: 'success', title: 'Updated', message: 'Fault updated' });
-        navigate(`/faults/${faultId}`);
+      isSubmitting={updateFault.isPending}
+      onSubmit={async (formData) => {
+        try {
+          await updateFault.mutateAsync({
+            title: formData.title,
+            description: formData.description,
+            location_description: formData.locationDescription,
+            category: formData.category,
+          });
+          showToast({ type: 'success', title: 'Updated', message: 'Fault updated' });
+          navigate(`/faults/${faultId}`);
+        } catch (err) {
+          showToast({
+            type: 'error',
+            title: 'Failed to update fault',
+            message: err instanceof Error ? err.message : 'Please try again.',
+          });
+        }
       }}
       onCancel={() => navigate(`/faults/${faultId}`)}
     />

--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -2845,10 +2845,10 @@ function EditFaultPageRoute() {
       faultId={faultId}
       initialData={{
         buildingId: fault.building_id,
-        unitId: fault.unit_id,
+        unitId: fault.unit_id ?? undefined,
         title: fault.title,
         description: fault.description,
-        locationDescription: fault.location_description,
+        locationDescription: fault.location_description ?? undefined,
         category: fault.category,
         priority: fault.priority,
       }}

--- a/frontend/apps/ppt-web/src/features/documents/pages/DocumentDetail.tsx
+++ b/frontend/apps/ppt-web/src/features/documents/pages/DocumentDetail.tsx
@@ -11,14 +11,20 @@ import {
   useDocumentVersions,
   useReprocessOcr,
 } from '@ppt/api-client';
-import { useState } from 'react';
+import { lazy, Suspense, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ClassificationUI } from '../components/ClassificationBadge';
-import { DocumentPreviewModal } from '../components/DocumentPreviewModal';
 import { DocumentSharePanel } from '../components/DocumentSharePanel';
 import { DocumentSummary } from '../components/DocumentSummary';
 import { OcrProcessingStatus } from '../components/OcrStatusBadge';
 import { useDocumentDownload } from '../hooks/useDocumentDownload';
+
+// Lazy-loaded so PDF.js (react-pdf, references DOMMatrix at module load) is
+// only pulled in when the preview actually opens — keeps it out of the initial
+// bundle and out of the jsdom module graph for tests that render this page.
+const DocumentPreviewModal = lazy(() =>
+  import('../components/DocumentPreviewModal').then((m) => ({ default: m.DocumentPreviewModal }))
+);
 
 /** Human-readable labels for the access_scope values returned by the backend (7a-3). */
 const AUDIENCE_LABELS: Record<AccessScope, string> = {
@@ -310,13 +316,15 @@ export function DocumentDetail({ documentId }: DocumentDetailProps) {
         )}
 
         {showPreview && (
-          <DocumentPreviewModal
-            documentId={doc.id}
-            title={doc.title}
-            fileName={doc.file_name}
-            mimeType={doc.mime_type}
-            onClose={() => setShowPreview(false)}
-          />
+          <Suspense fallback={null}>
+            <DocumentPreviewModal
+              documentId={doc.id}
+              title={doc.title}
+              fileName={doc.file_name}
+              mimeType={doc.mime_type}
+              onClose={() => setShowPreview(false)}
+            />
+          </Suspense>
         )}
       </div>
 

--- a/frontend/apps/ppt-web/src/features/documents/pages/DocumentDetail.tsx
+++ b/frontend/apps/ppt-web/src/features/documents/pages/DocumentDetail.tsx
@@ -14,9 +14,11 @@ import {
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ClassificationUI } from '../components/ClassificationBadge';
+import { DocumentPreviewModal } from '../components/DocumentPreviewModal';
 import { DocumentSharePanel } from '../components/DocumentSharePanel';
 import { DocumentSummary } from '../components/DocumentSummary';
 import { OcrProcessingStatus } from '../components/OcrStatusBadge';
+import { useDocumentDownload } from '../hooks/useDocumentDownload';
 
 /** Human-readable labels for the access_scope values returned by the backend (7a-3). */
 const AUDIENCE_LABELS: Record<AccessScope, string> = {
@@ -74,6 +76,13 @@ export function DocumentDetail({ documentId }: DocumentDetailProps) {
   const reprocessOcr = useReprocessOcr();
   const [showSharePanel, setShowSharePanel] = useState(false);
   const { t } = useTranslation();
+  const [showPreview, setShowPreview] = useState(false);
+  // Hook order must stay unconditional (called before the early returns); the
+  // file name is resolved lazily inside the hook when download() runs.
+  const { download, isDownloading } = useDocumentDownload(
+    documentId,
+    data?.document?.file_name ?? ''
+  );
 
   if (isLoading) {
     return (
@@ -232,10 +241,10 @@ export function DocumentDetail({ documentId }: DocumentDetailProps) {
 
         {/* Document Actions */}
         <div className="document-actions">
-          <a
-            href={`/api/v1/documents/${doc.id}/download`}
-            target="_blank"
-            rel="noopener noreferrer"
+          <button
+            type="button"
+            onClick={() => download()}
+            disabled={isDownloading}
             className="action-btn primary"
           >
             <svg
@@ -251,14 +260,9 @@ export function DocumentDetail({ documentId }: DocumentDetailProps) {
               <polyline points="7 10 12 15 17 10" />
               <line x1="12" y1="15" x2="12" y2="3" />
             </svg>
-            Download
-          </a>
-          <a
-            href={`/api/v1/documents/${doc.id}/preview`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="action-btn"
-          >
+            {isDownloading ? 'Downloading…' : 'Download'}
+          </button>
+          <button type="button" onClick={() => setShowPreview(true)} className="action-btn">
             <svg
               width="16"
               height="16"
@@ -272,7 +276,7 @@ export function DocumentDetail({ documentId }: DocumentDetailProps) {
               <circle cx="12" cy="12" r="3" />
             </svg>
             Preview
-          </a>
+          </button>
           <button
             type="button"
             className={`action-btn${showSharePanel ? ' active' : ''}`}
@@ -303,6 +307,16 @@ export function DocumentDetail({ documentId }: DocumentDetailProps) {
           <div id="doc-share-panel" className="share-panel-wrapper">
             <DocumentSharePanel documentId={doc.id} documentTitle={doc.title} />
           </div>
+        )}
+
+        {showPreview && (
+          <DocumentPreviewModal
+            documentId={doc.id}
+            title={doc.title}
+            fileName={doc.file_name}
+            mimeType={doc.mime_type}
+            onClose={() => setShowPreview(false)}
+          />
         )}
       </div>
 

--- a/frontend/apps/ppt-web/src/features/documents/pages/DocumentDetail.versions.test.tsx
+++ b/frontend/apps/ppt-web/src/features/documents/pages/DocumentDetail.versions.test.tsx
@@ -48,6 +48,11 @@ vi.mock('../components/DocumentSummary', () => ({
 vi.mock('../components/OcrStatusBadge', () => ({
   OcrProcessingStatus: () => null,
 }));
+// Download hook calls useToast (needs a ToastProvider) and is unrelated to the
+// version-history logic under test — mock it like the other leaf dependencies.
+vi.mock('../hooks/useDocumentDownload', () => ({
+  useDocumentDownload: () => ({ download: vi.fn(), isDownloading: false }),
+}));
 
 // Minimal i18next-compatible `t`: honours `defaultValue` and the second-arg
 // fallback string, and interpolates `{{name}}` placeholders — matching the

--- a/frontend/apps/ppt-web/src/features/privacy/gdprClient.ts
+++ b/frontend/apps/ppt-web/src/features/privacy/gdprClient.ts
@@ -1,0 +1,31 @@
+/**
+ * Authenticated fetch helper for the user-facing GDPR endpoints
+ * (/api/v1/gdpr/*). Mirrors the conventions in features/auth/authApiClient.ts:
+ * a configurable base URL (VITE_API_BASE_URL) plus the bearer token read from
+ * localStorage. Every GDPR handler requires the `AuthUser` extractor, so a bare
+ * `fetch` with no Authorization header returns 401 in production (gap-sweep).
+ */
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '';
+const ACCESS_TOKEN_KEY = 'ppt_access_token';
+
+function readAccessToken(): string | undefined {
+  try {
+    return localStorage.getItem(ACCESS_TOKEN_KEY) ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Issue an authenticated request against an API path. Attaches the bearer
+ * token (when present) and resolves the configured API base URL.
+ */
+export function gdprFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  const token = readAccessToken();
+  const headers = new Headers(init.headers);
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+  return fetch(`${API_BASE_URL}${path}`, { ...init, headers });
+}

--- a/frontend/apps/ppt-web/src/features/privacy/pages/PrivacySettingsPage.tsx
+++ b/frontend/apps/ppt-web/src/features/privacy/pages/PrivacySettingsPage.tsx
@@ -4,6 +4,8 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
+import { useAuth } from '../../../contexts';
+import { gdprFetch } from '../gdprClient';
 
 interface PrivacySettings {
   profile_visibility: 'visible' | 'hidden' | 'contacts_only';
@@ -19,6 +21,7 @@ interface DataExportRequest {
 }
 
 export function PrivacySettingsPage() {
+  const { user } = useAuth();
   const [settings, setSettings] = useState<PrivacySettings | null>(null);
   const [exportRequests, setExportRequests] = useState<DataExportRequest[]>([]);
   const [loading, setLoading] = useState(true);
@@ -32,8 +35,8 @@ export function PrivacySettingsPage() {
 
     try {
       const [settingsRes, historyRes] = await Promise.all([
-        fetch('/api/v1/gdpr/privacy'),
-        fetch('/api/v1/gdpr/export/history'),
+        gdprFetch('/api/v1/gdpr/privacy'),
+        gdprFetch('/api/v1/gdpr/export/history'),
       ]);
 
       if (!settingsRes.ok) {
@@ -64,10 +67,16 @@ export function PrivacySettingsPage() {
     setSuccess(null);
 
     try {
-      const response = await fetch('/api/v1/gdpr/privacy', {
+      // Backend (UpdatePrivacySettingsRequest) only persists these two fields;
+      // sending the full `settings` object silently drops marketing/analytics
+      // consent. Send only the supported fields so the request is honest.
+      const response = await gdprFetch('/api/v1/gdpr/privacy', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(settings),
+        body: JSON.stringify({
+          profile_visibility: settings.profile_visibility,
+          show_contact_info: settings.show_contact_info,
+        }),
       });
 
       if (!response.ok) {
@@ -86,7 +95,7 @@ export function PrivacySettingsPage() {
     setError(null);
 
     try {
-      const response = await fetch('/api/v1/gdpr/export/request', {
+      const response = await gdprFetch('/api/v1/gdpr/export/request', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ format: 'json' }),
@@ -105,34 +114,41 @@ export function PrivacySettingsPage() {
   }, [loadSettings]);
 
   const handleRequestDeletion = useCallback(async () => {
-    if (
-      !confirm(
-        'Are you sure you want to request account deletion? ' +
-          'This will schedule your account and all associated data for deletion. ' +
-          'This action cannot be undone after the grace period.'
-      )
-    ) {
+    // The backend (RequestDataDeletion) requires a `confirmation` string that
+    // must match the account email — an empty body always 400s. Ask the user
+    // to retype their email as the GDPR-grade confirmation step.
+    const confirmation = window.prompt(
+      'This will schedule your account and all associated data for permanent ' +
+        'deletion after a 30-day grace period. This cannot be undone after the ' +
+        'grace period.\n\nType your account email address to confirm:'
+    );
+    if (!confirmation) {
+      return;
+    }
+    if (user?.email && confirmation.trim().toLowerCase() !== user.email.toLowerCase()) {
+      setError('The email you entered does not match your account email.');
       return;
     }
 
     setError(null);
 
     try {
-      const response = await fetch('/api/v1/gdpr/deletion/request', {
+      const response = await gdprFetch('/api/v1/gdpr/deletion/request', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({}),
+        body: JSON.stringify({ confirmation: confirmation.trim() }),
       });
 
       if (!response.ok) {
-        throw new Error('Failed to request account deletion');
+        const errorData = await response.text();
+        throw new Error(errorData || 'Failed to request account deletion');
       }
 
       setSuccess('Account deletion requested. You have 30 days to cancel this request.');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to request deletion');
     }
-  }, []);
+  }, [user]);
 
   if (loading) {
     return <div className="privacy-loading">Loading privacy settings...</div>;

--- a/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
+++ b/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
@@ -212,6 +212,56 @@ export const ScheduleDetailPage = lazy(() =>
   import('../features/reports').then((m) => ({ default: m.ScheduleDetailPage }))
 );
 
+// Buildings feature (Epic 3, Story 3.1) — built + API-wired, now routed (gap-sweep)
+export const BuildingsPage = lazy(() =>
+  import('../features/buildings').then((m) => ({ default: m.BuildingsPage }))
+);
+export const BuildingDetailPage = lazy(() =>
+  import('../features/buildings').then((m) => ({ default: m.BuildingDetailPage }))
+);
+
+// Facilities & bookings feature (Epic 3, Story 3.7) — API-wired, now routed (gap-sweep)
+export const FacilitiesPage = lazy(() =>
+  import('../features/facilities').then((m) => ({ default: m.FacilitiesPage }))
+);
+export const CreateFacilityPage = lazy(() =>
+  import('../features/facilities').then((m) => ({ default: m.CreateFacilityPage }))
+);
+export const EditFacilityPage = lazy(() =>
+  import('../features/facilities').then((m) => ({ default: m.EditFacilityPage }))
+);
+export const BookFacilityPage = lazy(() =>
+  import('../features/facilities').then((m) => ({ default: m.BookFacilityPage }))
+);
+export const MyBookingsPage = lazy(() =>
+  import('../features/facilities').then((m) => ({ default: m.MyBookingsPage }))
+);
+export const PendingBookingsPage = lazy(() =>
+  import('../features/facilities').then((m) => ({ default: m.PendingBookingsPage }))
+);
+
+// AI Assistant chat (Epic 13, Story 13.1) — built, now routed (gap-sweep)
+export const AiChatPage = lazy(() =>
+  import('../features/ai-chat').then((m) => ({ default: m.AiChatPage }))
+);
+
+// Workflow Automation (Epic 13) — built + API-wired, now routed (gap-sweep)
+export const AutomationRulesPage = lazy(() =>
+  import('../features/workflow-automation').then((m) => ({ default: m.AutomationRulesPage }))
+);
+export const CreateRulePage = lazy(() =>
+  import('../features/workflow-automation').then((m) => ({ default: m.CreateRulePage }))
+);
+export const EditRulePage = lazy(() =>
+  import('../features/workflow-automation').then((m) => ({ default: m.EditRulePage }))
+);
+export const TemplateLibraryPage = lazy(() =>
+  import('../features/workflow-automation').then((m) => ({ default: m.TemplateLibraryPage }))
+);
+export const ExecutionMonitoringPage = lazy(() =>
+  import('../features/workflow-automation').then((m) => ({ default: m.ExecutionMonitoringPage }))
+);
+
 // Command Palette (Epic 129) - loaded eagerly since it's used globally
 // CommandPaletteDialog and CommandPaletteProvider are NOT lazy loaded
 // because they need to be available immediately for keyboard shortcuts


### PR DESCRIPTION
## Whole-app gap sweep vs Epics & use-cases

A multi-agent audit mapped all 25 epics' acceptance criteria (`_bmad-output/epics.md`) against the actual code + screen-map status, then adversarially verified each finding. Result: **81 candidate gaps → 38 confirmed fixable-now, 40 needs-issue, 3 rejected (already exist)**.

This PR lands the **self-contained frontend fixes** (everything verifiable here without a DB/backend). The remaining 68 gaps (backend correctness/security, mobile, reality-web, and larger frontend features) are filed as **21 epic-grouped GitHub issues** (#966–#986, label `gap-sweep`), each with `file:line` evidence and a verified fix plan.

### Fixed in this PR (verified: `pnpm typecheck` + `biome check` + `vitest`)

**Routing — features were built + API-wired but never mounted:**
- Buildings management list/detail (Epic 3.1) + nav link
- Facilities & bookings, all 6 routes (Epic 3.7)
- AI Assistant chat `/ai-assistant` (Epic 13) + nav link
- Workflow Automation rules/templates/executions (Epic 13)

**Fault flows — route wrappers were no-op toasts (Epic 4):**
- Create-fault now calls `useCreateFault` (+ `useBuildings`), maps form→request
- Edit-fault loads via `useFault`, persists via `useUpdateFault`

**GDPR privacy (Epic 9, critical):**
- `PrivacySettingsPage` used bare `fetch()` (no `Authorization` → 401 in prod); routed through a new authenticated `gdprClient`
- Account deletion now sends the required `confirmation` (email) instead of `{}` (was always 400)
- Save sends only backend-supported fields

**Documents (Epic 7A):**
- `DocumentDetail` download/preview were raw `<a href>` to auth-required JSON endpoints; now use the existing `useDocumentDownload` hook + `DocumentPreviewModal`

Screen-maps updated for `fault-new`, `fault-edit`, `privacy-settings`; `nav.aiChat` i18n key backfilled (sk/cs/de/pl/hu).

### Filed as issues (not in this PR)
21 epic-grouped issues #966–#986. Highlights worth prioritising:
- **#971 Epic 5 Voting** — live ballot-cast path (`cast_vote_rls`) ignores ownership weight, writes no audit entry, doesn't re-validate revoked delegations (correctness + compliance).
- **#970 Epic 4 Faults** — manager mutations missing org/role guards; offline-create not idempotent.
- **#975 Epic 11 Financial** & **#981 Epic 3** — several unwired ppt-web pages + missing backend reports.

### Notes
- Backend gaps were intentionally **not** fixed here: this environment has no `.sqlx` offline data / DB and a cold Rust compile, so backend changes (esp. the voting security fixes) can't be verified — they're filed with precise plans instead.
- Pre-existing `src/test/shared-auth.test.ts` (4 failures, `@ppt/shared` localStorage) fail on `dev` too — untouched by this branch.
