### PR TITLE
fix(api-server): close backend gap-sweep remainder (Epics 2B/4/5/6/10B)

### DIFF
--- a/backend/crates/db/src/repositories/announcement.rs
+++ b/backend/crates/db/src/repositories/announcement.rs
@@ -1544,6 +1544,37 @@ impl AnnouncementRepository {
         self.unpin_rls(&self.pool, id).await
     }
 
+    /// Auto-unpin announcements that have been pinned longer than `max_age`
+    /// (Story 6.4 / issue #972.7). Returns the IDs of the announcements that
+    /// were unpinned.
+    ///
+    /// Runs from the background scheduler without user context — like
+    /// `publish_scheduled`, these are privileged/admin-level maintenance
+    /// operations and use the internal pool directly (no RLS enforcement).
+    pub async fn auto_unpin_expired(
+        &self,
+        max_age: chrono::Duration,
+    ) -> Result<Vec<Uuid>, SqlxError> {
+        // Build the Postgres interval from whole seconds via `make_interval`
+        // (matches the codebase's `make_interval`/`|| ' days'` convention and
+        // avoids relying on chrono<->interval Encode impls).
+        let max_age_secs = max_age.num_seconds().max(0) as f64;
+
+        let rows: Vec<(Uuid,)> = sqlx::query_as(
+            r#"
+            UPDATE announcements
+            SET pinned = false, pinned_at = NULL, pinned_by = NULL, updated_at = NOW()
+            WHERE pinned = true AND pinned_at < NOW() - make_interval(secs => $1)
+            RETURNING id
+            "#,
+        )
+        .bind(max_age_secs)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
+
     // ------------------------------------------------------------------------
     // Attachments
     // ------------------------------------------------------------------------

--- a/backend/crates/db/src/repositories/fault.rs
+++ b/backend/crates/db/src/repositories/fault.rs
@@ -191,6 +191,33 @@ impl FaultRepository {
         Ok(fault)
     }
 
+    /// Find a fault by idempotency key with RLS context (Story 4.1, #970).
+    ///
+    /// Use this with an `RlsConnection` so the lookup is scoped to the caller's
+    /// tenant by the `faults_tenant_isolation` RLS policy. Unlike the
+    /// pool-based [`find_by_idempotency_key`](Self::find_by_idempotency_key),
+    /// this prevents a key collision across organizations from leaking another
+    /// tenant's fault during offline-create idempotency replay.
+    pub async fn find_by_idempotency_key_rls<'e, E>(
+        &self,
+        executor: E,
+        key: &str,
+    ) -> Result<Option<Fault>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let fault = sqlx::query_as::<_, Fault>(
+            r#"
+            SELECT * FROM faults WHERE idempotency_key = $1
+            "#,
+        )
+        .bind(key)
+        .fetch_optional(executor)
+        .await?;
+
+        Ok(fault)
+    }
+
     /// Find a fault by ID, scoped to a specific organization.
     ///
     /// SECURITY (#770): explicitly threads `organization_id` into the WHERE

--- a/backend/crates/db/src/repositories/messaging.rs
+++ b/backend/crates/db/src/repositories/messaging.rs
@@ -124,6 +124,7 @@ impl MessagingRepository {
         organization_id: Uuid,
         limit: Option<i64>,
         offset: Option<i64>,
+        search: Option<&str>,
     ) -> Result<Vec<ThreadWithPreview>, SqlxError>
     where
         E: Executor<'e, Database = Postgres>,
@@ -182,12 +183,14 @@ impl MessagingRepository {
             LEFT JOIN unread_counts uc ON uc.thread_id = t.id
             WHERE $1 = ANY(t.participant_ids)
               AND t.organization_id = $2
+              AND ($3::text IS NULL OR (u.first_name ILIKE '%'||$3||'%' OR u.last_name ILIKE '%'||$3||'%'))
             ORDER BY t.last_message_at DESC NULLS LAST, t.created_at DESC
-            LIMIT $3 OFFSET $4
+            LIMIT $4 OFFSET $5
             "#,
         )
         .bind(user_id)
         .bind(organization_id)
+        .bind(search)
         .bind(limit)
         .bind(offset)
         .fetch_all(executor)
@@ -207,19 +210,29 @@ impl MessagingRepository {
         executor: E,
         user_id: Uuid,
         organization_id: Uuid,
+        search: Option<&str>,
     ) -> Result<i64, SqlxError>
     where
         E: Executor<'e, Database = Postgres>,
     {
         let (count,): (i64,) = sqlx::query_as(
             r#"
-            SELECT COUNT(*) FROM message_threads
-            WHERE $1 = ANY(participant_ids)
-              AND organization_id = $2
+            SELECT COUNT(*)
+            FROM message_threads t
+            CROSS JOIN LATERAL (
+                SELECT id, first_name, last_name, email
+                FROM users
+                WHERE id = ANY(t.participant_ids) AND id != $1
+                LIMIT 1
+            ) u
+            WHERE $1 = ANY(t.participant_ids)
+              AND t.organization_id = $2
+              AND ($3::text IS NULL OR (u.first_name ILIKE '%'||$3||'%' OR u.last_name ILIKE '%'||$3||'%'))
             "#,
         )
         .bind(user_id)
         .bind(organization_id)
+        .bind(search)
         .fetch_one(executor)
         .await?;
 
@@ -687,7 +700,7 @@ impl MessagingRepository {
         limit: Option<i64>,
         offset: Option<i64>,
     ) -> Result<Vec<ThreadWithPreview>, SqlxError> {
-        self.list_threads_rls(&self.pool, user_id, organization_id, limit, offset)
+        self.list_threads_rls(&self.pool, user_id, organization_id, limit, offset, None)
             .await
     }
 
@@ -703,7 +716,7 @@ impl MessagingRepository {
         user_id: Uuid,
         organization_id: Uuid,
     ) -> Result<i64, SqlxError> {
-        self.count_threads_rls(&self.pool, user_id, organization_id)
+        self.count_threads_rls(&self.pool, user_id, organization_id, None)
             .await
     }
 

--- a/backend/crates/db/src/repositories/organization_member.rs
+++ b/backend/crates/db/src/repositories/organization_member.rs
@@ -429,7 +429,10 @@ impl OrganizationMemberRepository {
             FROM organization_members om
             INNER JOIN organizations o ON o.id = om.organization_id
             LEFT JOIN roles r ON r.id = om.role_id
-            WHERE om.user_id = $1 AND om.status != 'removed' AND o.status != 'deleted'
+            WHERE om.user_id = $1
+              AND om.status != 'removed'
+              AND o.status != 'deleted'
+              AND o.status != 'suspended'
             ORDER BY om.joined_at DESC
             "#,
         )

--- a/backend/crates/db/src/repositories/vote.rs
+++ b/backend/crates/db/src/repositories/vote.rs
@@ -187,14 +187,16 @@ impl VoteRepository {
     /// Cast a vote with RLS context (Story 5.3).
     ///
     /// Use this method with an `RlsConnection` to ensure RLS policies are enforced.
-    pub async fn cast_vote_rls<'e, E>(
+    ///
+    /// Takes a `&mut PgConnection` (rather than a generic by-value executor) so
+    /// that the ballot INSERT and the immutable audit-log INSERT both run on the
+    /// SAME RLS-scoped connection, keeping the tenant context (`app.current_org_id`)
+    /// in scope for the `vote_audit_log` insert policy (Story 5.7).
+    pub async fn cast_vote_rls(
         &self,
-        executor: E,
+        executor: &mut sqlx::PgConnection,
         data: CastVote,
-    ) -> Result<VoteReceipt, SqlxError>
-    where
-        E: Executor<'e, Database = Postgres>,
-    {
+    ) -> Result<VoteReceipt, SqlxError> {
         // Generate hash for ballot integrity
         let hash_input = format!(
             "{}:{}:{}:{}:{}",
@@ -206,20 +208,23 @@ impl VoteRepository {
         );
         let response_hash = hex::encode(Sha256::digest(hash_input.as_bytes()));
 
-        // Get vote weight from unit ownership_share
-        // Note: For RLS version, we use a default weight of 1.0
-        // The calling code should provide the weight if needed
-        let vote_weight = Decimal::from(1);
-
         let is_delegated = data.delegation_id.is_some();
 
+        // Fold the ownership-weight lookup into the INSERT as a scalar subquery so
+        // the stored vote_weight reflects the unit's ownership_share (Story 5.2),
+        // mirroring the legacy `COALESCE(ownership_share, 1.0)` semantics. The
+        // subquery degrades safely to 1.0 if the units row is not visible/found.
         let response = sqlx::query_as::<_, VoteResponse>(
             r#"
             INSERT INTO vote_responses (
                 vote_id, user_id, unit_id, delegation_id, is_delegated,
                 answers, vote_weight, response_hash
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            VALUES (
+                $1, $2, $3, $4, $5, $6,
+                COALESCE((SELECT ownership_share FROM units WHERE id = $3), 1.0),
+                $7
+            )
             ON CONFLICT (vote_id, unit_id) DO UPDATE
             SET
                 user_id = EXCLUDED.user_id,
@@ -237,10 +242,38 @@ impl VoteRepository {
         .bind(data.delegation_id)
         .bind(is_delegated)
         .bind(&data.answers)
-        .bind(vote_weight)
         .bind(&response_hash)
-        .fetch_one(executor)
+        .fetch_one(&mut *executor)
         .await?;
+
+        // Write the immutable audit entry on the SAME RLS executor (Story 5.7).
+        let audit_action = if is_delegated {
+            audit_action::BALLOT_UPDATED
+        } else {
+            audit_action::BALLOT_CAST
+        };
+
+        Self::create_audit_entry_rls(
+            &mut *executor,
+            CreateVoteAuditLog {
+                vote_id: data.vote_id,
+                user_id: Some(data.user_id),
+                action: audit_action.to_string(),
+                data: serde_json::json!({
+                    "unit_id": data.unit_id,
+                    "response_hash": response_hash,
+                    "is_delegated": is_delegated,
+                }),
+                ip_address: None,
+                user_agent: None,
+            },
+        )
+        .await?;
+
+        // The RLS executor borrow has ended; recompute participation_count on the
+        // pool so the live quorum/participation indicator reflects this ballot
+        // while the vote is still active (Story 5.6).
+        self.update_participation_count(data.vote_id).await?;
 
         // Generate confirmation number (first 8 chars of hash)
         let confirmation_number = response_hash[..8].to_uppercase();
@@ -291,18 +324,15 @@ impl VoteRepository {
                     });
                 Ok(Some(results))
             }
-            Some(_) => {
-                // Vote not closed yet - for RLS version, return empty results
-                // Full calculation requires multiple queries
-                Ok(Some(VoteResults {
-                    vote_id,
-                    participation_count: 0,
-                    eligible_count: 0,
-                    participation_rate: 0.0,
-                    quorum_met: false,
-                    questions: Vec::new(),
-                    calculated_at: Utc::now(),
-                }))
+            Some(v) => {
+                // Vote not closed yet - compute live tallies so an active-vote
+                // results dashboard sees real participation/per-question data
+                // (Story 5.6). Uses compute_results (no audit write) on self.pool,
+                // reusing the already-loaded vote row. RLS scoping for this branch
+                // relies on route-level authorization (the RLS executor only gated
+                // the initial vote lookup above).
+                let results = self.compute_results(&v).await?;
+                Ok(Some(results))
             }
             None => Ok(None),
         }
@@ -1276,6 +1306,34 @@ impl VoteRepository {
         Ok(count.0 as i32)
     }
 
+    /// Get the user IDs of eligible owners for a building (Story 5.1).
+    ///
+    /// Returns the distinct owner residents of the building's units — the
+    /// recipients of a `VoteStarted` notification when a vote is published.
+    /// Mirrors the scheduler's eligible-users query (scheduler.rs) so immediate
+    /// and scheduled publishes notify the same audience. Note this counts user
+    /// IDs, not units (unlike `count_eligible_units`).
+    pub async fn get_eligible_owner_user_ids(
+        &self,
+        building_id: Uuid,
+    ) -> Result<Vec<Uuid>, SqlxError> {
+        let users: Vec<(Uuid,)> = sqlx::query_as(
+            r#"
+            SELECT DISTINCT ur.user_id
+            FROM unit_residents ur
+            JOIN units u ON ur.unit_id = u.id
+            WHERE u.building_id = $1
+              AND ur.resident_type = 'owner'
+              AND ur.move_out_date IS NULL
+            "#,
+        )
+        .bind(building_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(users.into_iter().map(|(id,)| id).collect())
+    }
+
     /// Update participation count for a vote.
     async fn update_participation_count(&self, vote_id: Uuid) -> Result<(), SqlxError> {
         sqlx::query(
@@ -1493,13 +1551,17 @@ impl VoteRepository {
     // Results (Story 5.5)
     // ========================================================================
 
-    /// Calculate results for a vote.
-    #[allow(deprecated)]
-    pub async fn calculate_results(&self, vote_id: Uuid) -> Result<VoteResults, SqlxError> {
-        let vote = self
-            .find_by_id(vote_id)
-            .await?
-            .ok_or(SqlxError::RowNotFound)?;
+    /// Compute live tallies for a vote WITHOUT writing an audit entry.
+    ///
+    /// Pure read path shared by [`calculate_results`](Self::calculate_results)
+    /// (which appends a `RESULTS_CALCULATED` audit entry afterwards) and the
+    /// active-vote arm of [`get_poll_results_rls`](Self::get_poll_results_rls)
+    /// (a read that must NOT spam the audit log on every dashboard poll).
+    ///
+    /// Queries `self.pool`, not the RLS executor, so callers must enforce
+    /// route-level authorization before exposing the results (Story 5.6).
+    async fn compute_results(&self, vote: &Vote) -> Result<VoteResults, SqlxError> {
+        let vote_id = vote.id;
         let questions = self.get_questions(vote_id).await?;
 
         // Get all responses
@@ -1521,7 +1583,7 @@ impl VoteRepository {
         };
 
         // Calculate quorum
-        let quorum_met = self.check_quorum(&vote, participation_count, eligible_count);
+        let quorum_met = self.check_quorum(vote, participation_count, eligible_count);
 
         // Calculate results for each question
         let mut question_results = Vec::new();
@@ -1533,21 +1595,6 @@ impl VoteRepository {
             question_results.push(result);
         }
 
-        // Create audit log entry
-        self.create_audit_entry(CreateVoteAuditLog {
-            vote_id,
-            user_id: None,
-            action: audit_action::RESULTS_CALCULATED.to_string(),
-            data: serde_json::json!({
-                "participation_count": participation_count,
-                "participation_rate": participation_rate,
-                "quorum_met": quorum_met,
-            }),
-            ip_address: None,
-            user_agent: None,
-        })
-        .await?;
-
         Ok(VoteResults {
             vote_id,
             participation_count,
@@ -1557,6 +1604,34 @@ impl VoteRepository {
             questions: question_results,
             calculated_at: Utc::now(),
         })
+    }
+
+    /// Calculate results for a vote.
+    #[allow(deprecated)]
+    pub async fn calculate_results(&self, vote_id: Uuid) -> Result<VoteResults, SqlxError> {
+        let vote = self
+            .find_by_id(vote_id)
+            .await?
+            .ok_or(SqlxError::RowNotFound)?;
+
+        let results = self.compute_results(&vote).await?;
+
+        // Create audit log entry
+        self.create_audit_entry(CreateVoteAuditLog {
+            vote_id,
+            user_id: None,
+            action: audit_action::RESULTS_CALCULATED.to_string(),
+            data: serde_json::json!({
+                "participation_count": results.participation_count,
+                "participation_rate": results.participation_rate,
+                "quorum_met": results.quorum_met,
+            }),
+            ip_address: None,
+            user_agent: None,
+        })
+        .await?;
+
+        Ok(results)
     }
 
     /// Check if quorum is met.
@@ -1741,6 +1816,43 @@ impl VoteRepository {
     // ========================================================================
     // Audit Log
     // ========================================================================
+
+    /// Create an audit log entry on a caller-supplied executor.
+    ///
+    /// Executor-generic mirror of [`create_audit_entry`](Self::create_audit_entry)
+    /// that runs the INSERT on the passed executor instead of `self.pool`. Used by
+    /// the RLS ballot-cast path so the audit row is written under the same RLS
+    /// session context (`app.current_org_id`) as the ballot itself (Story 5.7).
+    pub async fn create_audit_entry_rls<'e, E>(
+        executor: E,
+        data: CreateVoteAuditLog,
+    ) -> Result<VoteAuditLog, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        // Generate hash of the data
+        let data_str = serde_json::to_string(&data.data).unwrap_or_default();
+        let data_hash = hex::encode(Sha256::digest(data_str.as_bytes()));
+
+        let entry = sqlx::query_as::<_, VoteAuditLog>(
+            r#"
+            INSERT INTO vote_audit_log (vote_id, user_id, action, data_hash, data_snapshot, ip_address, user_agent)
+            VALUES ($1, $2, $3, $4, $5, $6::inet, $7)
+            RETURNING *
+            "#,
+        )
+        .bind(data.vote_id)
+        .bind(data.user_id)
+        .bind(&data.action)
+        .bind(&data_hash)
+        .bind(&data.data)
+        .bind(&data.ip_address)
+        .bind(&data.user_agent)
+        .fetch_one(executor)
+        .await?;
+
+        Ok(entry)
+    }
 
     /// Create an audit log entry.
     pub async fn create_audit_entry(

--- a/backend/servers/api-server/src/main.rs
+++ b/backend/servers/api-server/src/main.rs
@@ -152,6 +152,7 @@ fn parse_default_origins() -> Vec<HeaderValue> {
         routes::organizations::get_organization_branding,
         routes::organizations::update_organization_branding,
         routes::organizations::export_organization_data,
+        routes::messaging::delete_message,
     ),
     components(schemas(
         routes::health::HealthResponse,
@@ -429,6 +430,10 @@ async fn main() -> anyhow::Result<()> {
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(3),
+        pin_max_age_days: std::env::var("PIN_MAX_AGE_DAYS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(30),
     };
     let scheduler_pool = state.db.clone();
     let announcement_repo = AnnouncementRepository::new(scheduler_pool.clone());

--- a/backend/servers/api-server/src/routes/admin/agencies.rs
+++ b/backend/servers/api-server/src/routes/admin/agencies.rs
@@ -119,6 +119,12 @@ pub struct AgencyDetailResponse {
     pub name: String,
     pub slug: String,
     pub status: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+    pub member_count: i64,
+    pub active_member_count: i64,
+    pub building_count: i64,
+    pub unit_count: i64,
 }
 
 /// GET /admin/agencies/:id
@@ -139,6 +145,12 @@ async fn get_agency(
         name: detail.name,
         slug: detail.slug,
         status: detail.status,
+        created_at: detail.created_at,
+        updated_at: detail.updated_at,
+        member_count: detail.metrics.member_count,
+        active_member_count: detail.metrics.active_member_count,
+        building_count: detail.metrics.building_count,
+        unit_count: detail.metrics.unit_count,
     }))
 }
 
@@ -164,6 +176,32 @@ async fn suspend_agency(
         .suspend_organization(id, principal.user_id, &body.reason)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    // Cascade the suspension: revoke every org member's sessions so the block
+    // takes effect immediately rather than waiting for token expiry. Mirrors
+    // the cascade in `platform_admin::suspend_organization`. Failures here are
+    // logged but do not fail the request — the org is already suspended and the
+    // auth path also drops suspended-org memberships at login/refresh.
+    let user_ids = state
+        .platform_admin_repo
+        .get_org_member_user_ids(id)
+        .await
+        .unwrap_or_default();
+
+    for user_id in &user_ids {
+        if let Err(e) = state
+            .session_repo
+            .revoke_all_user_tokens(*user_id, None)
+            .await
+        {
+            tracing::warn!(
+                user_id = %user_id,
+                error = %e,
+                "Failed to revoke sessions for suspended org member"
+            );
+        }
+    }
+
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/backend/servers/api-server/src/routes/announcements.rs
+++ b/backend/servers/api-server/src/routes/announcements.rs
@@ -2342,7 +2342,10 @@ async fn create_comment(
         ));
     }
 
-    // If parent_id is provided, verify it exists and belongs to same announcement
+    // If parent_id is provided, verify it exists and belongs to same announcement.
+    // Capture the parent comment's author so we can notify them about the reply
+    // before `parent` drops at the end of this block (Story 6.3 AC).
+    let mut parent_author: Option<Uuid> = None;
     if let Some(parent_id) = req.parent_id {
         match state
             .announcement_repo
@@ -2371,6 +2374,7 @@ async fn create_comment(
                         )),
                     ));
                 }
+                parent_author = Some(parent.user_id);
             }
             Ok(None) => {
                 rls.release().await;
@@ -2417,6 +2421,52 @@ async fn create_comment(
                 user_id = %auth.user_id,
                 "Comment created"
             );
+
+            // Story 6.3 AC: notify the announcement author and, for replies,
+            // the parent comment's author. Exclude the actor (commenter). The
+            // RLS connection is released above; the pipeline does not need it
+            // (matches the publish_announcement ordering).
+            let mut recipients: Vec<Uuid> = Vec::new();
+            for candidate in [Some(announcement.author_id), parent_author]
+                .into_iter()
+                .flatten()
+            {
+                if candidate != auth.user_id && !recipients.contains(&candidate) {
+                    recipients.push(candidate);
+                }
+            }
+
+            if !recipients.is_empty() {
+                // Short snippet of the comment body for the notification preview.
+                let snippet: String = comment.content.chars().take(140).collect();
+                let notification = Notification::new(
+                    Uuid::nil(),
+                    NotificationCategory::Announcements,
+                    format!("New comment on {}", announcement.title),
+                    snippet,
+                )
+                .with_action_url(format!("/announcements/{}", id))
+                .with_data(serde_json::json!({
+                    "announcement_id": id,
+                    "comment_id": comment.id,
+                }));
+
+                let (sent, skipped, failed) = state
+                    .notification_pipeline
+                    .broadcast(&recipients, &notification, Some(id))
+                    .await;
+
+                tracing::info!(
+                    comment_id = %comment.id,
+                    announcement_id = %id,
+                    recipients = recipients.len(),
+                    sent,
+                    skipped,
+                    failed,
+                    "Dispatched comment notifications"
+                );
+            }
+
             Ok((StatusCode::CREATED, Json(comment)))
         }
         Err(e) => {

--- a/backend/servers/api-server/src/routes/faults.rs
+++ b/backend/servers/api-server/src/routes/faults.rs
@@ -360,6 +360,42 @@ async fn create_fault(
         idempotency_key: req.idempotency_key,
     };
 
+    // Idempotent offline create (#970): if the client supplied an idempotency
+    // key and a fault with that key already exists in this tenant, return the
+    // existing fault instead of inserting a duplicate. The lookup runs on the
+    // RLS-scoped connection (NOT the org-unscoped pool-based finder) so a key
+    // collision across organizations cannot leak another tenant's fault.
+    if let Some(ref key) = data.idempotency_key {
+        match state
+            .fault_repo
+            .find_by_idempotency_key_rls(&mut **rls.conn(), key)
+            .await
+        {
+            Ok(Some(existing)) => {
+                rls.release().await;
+                return Ok((
+                    StatusCode::OK,
+                    Json(CreateFaultResponse {
+                        id: existing.id,
+                        message: "Fault already exists".to_string(),
+                    }),
+                ));
+            }
+            Ok(None) => {}
+            Err(e) => {
+                tracing::error!("Failed to check fault idempotency key: {}", e);
+                rls.release().await;
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new(
+                        "INTERNAL_ERROR",
+                        "Failed to create fault",
+                    )),
+                ));
+            }
+        }
+    }
+
     let fault = state
         .fault_repo
         .create_rls(&mut **rls.conn(), data)
@@ -570,10 +606,13 @@ async fn get_fault(
 )]
 async fn update_fault(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateFaultRequest>,
 ) -> Result<Json<FaultActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let tenant_id = require_tenant_id(&principal)?;
+
     // Check fault exists and can be edited
     let existing = match state.fault_repo.find_by_id_rls(&mut **rls.conn(), id).await {
         Ok(Some(f)) => f,
@@ -593,6 +632,15 @@ async fn update_fault(
             ));
         }
     };
+
+    // SECURITY (#970): only the reporter who filed the fault or a manager in
+    // the tenant may edit it. Any other tenant member must be rejected.
+    if existing.reporter_id != principal.user_id {
+        if let Err(e) = require_manager(&state, principal.user_id, tenant_id).await {
+            rls.release().await;
+            return Err(e);
+        }
+    }
 
     if !existing.can_reporter_edit() {
         rls.release().await;
@@ -1285,9 +1333,14 @@ async fn delete_attachment(
 )]
 async fn get_ai_suggestion(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<AiSuggestionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    // SECURITY (#970): AI triage suggestions are a manager-tier workflow action.
+    let tenant_id = require_tenant_id(&principal)?;
+    require_manager(&state, principal.user_id, tenant_id).await?;
+
     // Get fault to analyze
     let fault = match state.fault_repo.find_by_id_rls(&mut **rls.conn(), id).await {
         Ok(Some(f)) => f,

--- a/backend/servers/api-server/src/routes/messaging.rs
+++ b/backend/servers/api-server/src/routes/messaging.rs
@@ -102,6 +102,8 @@ pub struct SendMessageRequest {
 pub struct ListThreadsQuery {
     pub limit: Option<i64>,
     pub offset: Option<i64>,
+    /// Optional case-insensitive filter on the other participant's name.
+    pub search: Option<String>,
 }
 
 /// Query for listing messages.
@@ -123,6 +125,10 @@ pub fn router() -> Router<AppState> {
         .route("/threads", post(start_thread))
         .route("/threads/{id}", get(get_thread))
         .route("/threads/{id}/messages", post(send_message))
+        .route(
+            "/threads/{id}/messages/{message_id}",
+            delete(delete_message),
+        )
         .route("/threads/{id}/read", post(mark_thread_read))
         // Block endpoints
         .route("/users/blocked", get(list_blocked_users))
@@ -156,6 +162,13 @@ async fn list_threads(
     let user_id = rls.user_id();
     let tenant_id = rls.tenant_id();
 
+    // Treat an empty/whitespace-only search string as no filter.
+    let search = query
+        .search
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+
     let threads = repo
         .list_threads_rls(
             &mut **rls.conn(),
@@ -163,6 +176,7 @@ async fn list_threads(
             tenant_id,
             query.limit,
             query.offset,
+            search,
         )
         .await
         .map_err(|e| {
@@ -174,7 +188,7 @@ async fn list_threads(
         })?;
 
     let total = repo
-        .count_threads_rls(&mut **rls.conn(), user_id, tenant_id)
+        .count_threads_rls(&mut **rls.conn(), user_id, tenant_id, search)
         .await
         .map_err(|e| {
             tracing::error!("Failed to count threads: {:?}", e);
@@ -645,6 +659,127 @@ async fn send_message(
     Ok(Json(SendMessageResponse {
         message: "Message sent successfully".to_string(),
         sent_message: message,
+    }))
+}
+
+/// Delete a message in a thread (soft delete).
+///
+/// Only the sender of a message may delete it. The message must belong to the
+/// given thread, the thread must belong to the caller's tenant, and the caller
+/// must be a participant.
+#[utoipa::path(
+    delete,
+    path = "/api/v1/messages/threads/{id}/messages/{message_id}",
+    params(
+        ("id" = Uuid, Path, description = "Thread ID"),
+        ("message_id" = Uuid, Path, description = "Message ID"),
+    ),
+    responses(
+        (status = 200, description = "Message deleted successfully", body = MessageSuccessResponse),
+        (status = 403, description = "Not a participant or not the sender", body = ErrorResponse),
+        (status = 404, description = "Thread or message not found", body = ErrorResponse),
+    ),
+    tag = "messaging"
+)]
+pub async fn delete_message(
+    State(state): State<AppState>,
+    mut rls: RlsConnection,
+    Path((id, message_id)): Path<(Uuid, Uuid)>,
+) -> Result<Json<MessageSuccessResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let repo = MessagingRepository::new(state.db.clone());
+    let user_id = rls.user_id();
+    let tenant_id = rls.tenant_id();
+
+    // Get thread and verify it exists
+    let thread = repo
+        .get_thread_rls(&mut **rls.conn(), id)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
+            )
+        })?;
+
+    let thread = thread.ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("NOT_FOUND", "Thread not found")),
+        )
+    })?;
+
+    // Security: Verify thread belongs to current tenant (Critical 1.1 fix)
+    if thread.organization_id != tenant_id {
+        rls.release().await;
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "FORBIDDEN",
+                "Access denied to this thread",
+            )),
+        ));
+    }
+
+    if !thread.participant_ids.contains(&user_id) {
+        rls.release().await;
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "NOT_PARTICIPANT",
+                "You are not a participant in this thread",
+            )),
+        ));
+    }
+
+    // Fetch the target message and verify it belongs to this thread and that
+    // the caller is its sender.
+    let target: Option<(Uuid, Uuid)> = sqlx::query_as(
+        r#"
+        SELECT thread_id, sender_id FROM messages WHERE id = $1
+        "#,
+    )
+    .bind(message_id)
+    .fetch_optional(&mut **rls.conn())
+    .await
+    .map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new("DB_ERROR", e.to_string())),
+        )
+    })?;
+
+    let (msg_thread_id, msg_sender_id) = target.ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("NOT_FOUND", "Message not found")),
+        )
+    })?;
+
+    if msg_thread_id != id || msg_sender_id != user_id {
+        rls.release().await;
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "FORBIDDEN",
+                "You can only delete your own messages",
+            )),
+        ));
+    }
+
+    repo.delete_message_rls(&mut **rls.conn(), message_id, user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete message: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
+            )
+        })?;
+
+    rls.release().await;
+
+    Ok(Json(MessageSuccessResponse {
+        message: "Message deleted successfully".to_string(),
     }))
 }
 

--- a/backend/servers/api-server/src/routes/voting.rs
+++ b/backend/servers/api-server/src/routes/voting.rs
@@ -10,6 +10,7 @@ use axum::{
 };
 use chrono::{DateTime, NaiveDate, Utc};
 use common::errors::ErrorResponse;
+use common::notifications::{Notification, NotificationCategory};
 use db::models::{
     CancelVote, CastVote, CreateVote, CreateVoteComment, CreateVoteQuestion, HideVoteComment,
     PublishVote, QuestionOption, UpdateVote, UpdateVoteQuestion, Vote, VoteAuditLog,
@@ -535,6 +536,57 @@ async fn publish_vote(
             )
         })?;
 
+    // Story 5.1: notify eligible owners when a vote is published. Only dispatch
+    // on immediate publishes (status == ACTIVE); SCHEDULED votes are handled by
+    // the scheduler's activation path at start time, so gating avoids a
+    // double-notification. Best-effort: log on error, never fail the publish.
+    if vote.status == db::models::vote_status::ACTIVE {
+        match state
+            .vote_repo
+            .get_eligible_owner_user_ids(vote.building_id)
+            .await
+        {
+            Ok(eligible_ids) if !eligible_ids.is_empty() => {
+                let notification = Notification::new(
+                    Uuid::nil(),
+                    NotificationCategory::Votes,
+                    format!("New Vote: {}", vote.title),
+                    format!(
+                        "A new vote has started: \"{}\". Deadline: {}",
+                        vote.title,
+                        vote.end_at.format("%Y-%m-%d %H:%M")
+                    ),
+                )
+                .with_action_url(format!("/voting/{}", vote.id))
+                .with_data(serde_json::json!({
+                    "vote_id": vote.id,
+                    "organization_id": vote.organization_id,
+                    "building_id": vote.building_id,
+                    "end_at": vote.end_at.to_rfc3339(),
+                }));
+
+                let results = state
+                    .notification_pipeline
+                    .dispatch_to_users(&eligible_ids, &notification, Some(vote.id), None)
+                    .await;
+
+                tracing::info!(
+                    vote_id = %vote.id,
+                    recipients = results.len(),
+                    "Vote published — VoteStarted notifications dispatched"
+                );
+            }
+            Ok(_) => {}
+            Err(e) => {
+                tracing::error!(
+                    vote_id = %vote.id,
+                    error = %e,
+                    "Failed to load eligible owners for vote-published notification"
+                );
+            }
+        }
+    }
+
     rls.release().await;
     Ok(Json(vote))
 }
@@ -1047,6 +1099,55 @@ async fn cast_vote(
         ));
     }
 
+    // Re-validate the delegation at cast time (Story 5.4): a delegation that was
+    // active when eligibility was loaded may have since been revoked or expired.
+    // Run the check on the same RLS connection so it sees the same tenant context.
+    if let Some(delegation_id) = req.delegation_id {
+        let user_id = rls.user_id();
+        let is_valid: bool = match sqlx::query_scalar::<_, bool>(
+            r#"
+            SELECT EXISTS (
+                SELECT 1 FROM delegations
+                WHERE id = $1
+                  AND delegate_id = $2
+                  AND unit_id = $3
+                  AND status = 'active'
+                  AND scope IN ('voting', 'full')
+                  AND (expires_at IS NULL OR expires_at > NOW())
+            )
+            "#,
+        )
+        .bind(delegation_id)
+        .bind(user_id)
+        .bind(req.unit_id)
+        .fetch_one(&mut **rls.conn())
+        .await
+        {
+            Ok(exists) => exists,
+            Err(e) => {
+                rls.release().await;
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new(
+                        "DATABASE_ERROR",
+                        format!("Failed to validate delegation: {}", e),
+                    )),
+                ));
+            }
+        };
+
+        if !is_valid {
+            rls.release().await;
+            return Err((
+                StatusCode::FORBIDDEN,
+                Json(ErrorResponse::new(
+                    "DELEGATION_REVOKED",
+                    "Delegation revoked",
+                )),
+            ));
+        }
+    }
+
     let data = CastVote {
         vote_id: id,
         user_id: rls.user_id(),
@@ -1057,7 +1158,7 @@ async fn cast_vote(
 
     let receipt = state
         .vote_repo
-        .cast_vote_rls(&mut **rls.conn(), data)
+        .cast_vote_rls(rls.conn(), data)
         .await
         .map_err(|e| {
             (

--- a/backend/servers/api-server/src/services/mod.rs
+++ b/backend/servers/api-server/src/services/mod.rs
@@ -28,7 +28,7 @@ pub use jwt::JwtService;
 pub use notification::{NotificationService, NotificationServiceConfig};
 #[allow(unused_imports)]
 pub use notification_pipeline::{
-    FcmPushAdapter, NotificationPipeline, PipelineConfig, PreferenceRouter, SmtpEmailAdapter,
+    NotificationPipeline, PipelineConfig, PreferenceRouter, SmtpEmailAdapter,
 };
 pub use oauth::{OAuthService, OAuthServiceError};
 #[allow(unused_imports)]

--- a/backend/servers/api-server/src/services/notification_pipeline.rs
+++ b/backend/servers/api-server/src/services/notification_pipeline.rs
@@ -4,7 +4,7 @@
 //! - **2b-1** Channel infrastructure: `NotificationPipeline` + `DeliveryRequest` dispatch
 //! - **2b-2** Preference routing: `PreferenceRouter` checks per-user, per-channel settings
 //! - **2b-3** Delivery tracking: in-memory + logging; ready to swap for a DB adapter
-//! - **2b-4** Transport adapters: `SmtpEmailAdapter`, `FcmPushAdapter` (stub), `DbInAppAdapter`
+//! - **2b-4** Transport adapters: `SmtpEmailAdapter`, `FcmHttpAdapter`, `DbInAppAdapter`
 //! - **2b-5** Pipeline integration: `NotificationPipeline::dispatch` / `dispatch_to_users`
 //!
 //! ## Architecture
@@ -19,7 +19,7 @@
 //!    │
 //!    └─ For each enabled channel:
 //!         ├─ email  ─► impl EmailTransport (SmtpEmailAdapter)
-//!         ├─ push   ─► impl PushTransport  (FcmPushAdapter)
+//!         ├─ push   ─► impl PushTransport  (FcmHttpAdapter)
 //!         └─ in_app ─► impl InAppTransport (DbInAppAdapter)
 //!              │
 //!              ▼
@@ -100,74 +100,6 @@ impl EmailTransport for SmtpEmailAdapter {
             )
             .await
             .map_err(|e| NotificationError::EmailFailed(e.to_string()))
-    }
-}
-
-// ============================================================================
-// Story 2b-4b — Push transport adapter (FCM stub)
-// ============================================================================
-
-/// FCM / APNs push notification adapter.
-///
-/// **Current status:** stub that logs intent; a real FCM HTTP v1 or APNs
-/// implementation should replace `send_to_fcm` / `send_to_apns` in a
-/// follow-up PR without changing the trait boundary.
-#[derive(Clone, Default)]
-pub struct FcmPushAdapter {
-    /// FCM server key (None = disabled / not configured)
-    fcm_server_key: Option<String>,
-}
-
-impl FcmPushAdapter {
-    /// Create a new adapter.  Pass `None` to run in log-only (no real push) mode.
-    pub fn new(fcm_server_key: Option<String>) -> Self {
-        Self { fcm_server_key }
-    }
-
-    /// Load from environment variable `FCM_SERVER_KEY`.
-    pub fn from_env() -> Self {
-        Self::new(std::env::var("FCM_SERVER_KEY").ok())
-    }
-
-    /// Returns `true` when push delivery is enabled (FCM key is set).
-    pub fn is_configured(&self) -> bool {
-        self.fcm_server_key.is_some()
-    }
-}
-
-#[async_trait]
-impl PushTransport for FcmPushAdapter {
-    async fn send(
-        &self,
-        user_id: Uuid,
-        device_tokens: &[String],
-        notification: &Notification,
-    ) -> TransportResult {
-        if !self.is_configured() {
-            // Issue #484: previously returned Ok(()) which caused the
-            // pipeline to mark the delivery as `Sent`. Return the
-            // explicit `PushNotConfigured` error so callers see a
-            // `Skipped` outcome and `sent` counters are not inflated.
-            tracing::info!(
-                user_id = %user_id,
-                token_count = device_tokens.len(),
-                title = %notification.title,
-                category = %notification.category,
-                "[Epic 2B] Push notification (FCM not configured — skipped)"
-            );
-            return Err(NotificationError::PushNotConfigured);
-        }
-
-        // TODO (follow-up): call FCM HTTP v1 API for each device_token
-        // For now, log that we would send and return Ok.
-        tracing::info!(
-            user_id = %user_id,
-            token_count = device_tokens.len(),
-            title = %notification.title,
-            "[Epic 2B] Push notification queued (FCM stub — real send pending)"
-        );
-
-        Ok(())
     }
 }
 
@@ -705,15 +637,6 @@ mod tests {
         assert_eq!(SmtpEmailAdapter::parse_locale("de"), Locale::German);
         assert_eq!(SmtpEmailAdapter::parse_locale("en"), Locale::English);
         assert_eq!(SmtpEmailAdapter::parse_locale("unknown"), Locale::English);
-    }
-
-    #[test]
-    fn fcm_adapter_is_configured() {
-        let without_key = FcmPushAdapter::new(None);
-        assert!(!without_key.is_configured());
-
-        let with_key = FcmPushAdapter::new(Some("server-key-abc".to_string()));
-        assert!(with_key.is_configured());
     }
 
     #[test]

--- a/backend/servers/api-server/src/services/scheduler.rs
+++ b/backend/servers/api-server/src/services/scheduler.rs
@@ -37,6 +37,9 @@ pub struct SchedulerConfig {
     pub payment_reminder_days_before: i64,
     /// Days before signature request expiry to send reminder (default: 3).
     pub signature_reminder_days_before: i64,
+    /// Maximum age (in days) a pinned announcement is kept pinned before the
+    /// scheduler auto-unpins it (default: 30, issue #972.7).
+    pub pin_max_age_days: i64,
 }
 
 impl Default for SchedulerConfig {
@@ -48,6 +51,7 @@ impl Default for SchedulerConfig {
             meter_reminder_days_before: 3,
             payment_reminder_days_before: 7,
             signature_reminder_days_before: 3,
+            pin_max_age_days: 30,
         }
     }
 }
@@ -56,6 +60,7 @@ impl Default for SchedulerConfig {
 #[derive(Debug, Default)]
 pub struct SchedulerMetrics {
     pub announcements_published: u64,
+    pub announcements_unpinned: u64,
     pub votes_activated: u64,
     pub votes_closed: u64,
     pub vote_reminders_sent: u64,
@@ -149,6 +154,7 @@ impl Scheduler {
         let guard = self.metrics.lock().unwrap();
         SchedulerMetrics {
             announcements_published: guard.announcements_published,
+            announcements_unpinned: guard.announcements_unpinned,
             votes_activated: guard.votes_activated,
             votes_closed: guard.votes_closed,
             vote_reminders_sent: guard.vote_reminders_sent,
@@ -199,6 +205,12 @@ impl Scheduler {
         // Story 106.1: Publish scheduled announcements and send notifications
         if let Err(e) = self.publish_scheduled_announcements().await {
             tracing::error!("Failed to publish scheduled announcements: {}", e);
+            self.increment_errors();
+        }
+
+        // Story 6.4 (issue #972.7): Auto-unpin announcements pinned too long
+        if let Err(e) = self.auto_unpin_expired_announcements().await {
+            tracing::error!("Failed to auto-unpin expired announcements: {}", e);
             self.increment_errors();
         }
 
@@ -301,6 +313,29 @@ impl Scheduler {
                     "Scheduled announcement published"
                 );
             }
+        }
+
+        Ok(())
+    }
+
+    /// Auto-unpin announcements that have been pinned longer than the
+    /// configured maximum age (Story 6.4 / issue #972.7).
+    async fn auto_unpin_expired_announcements(&self) -> Result<(), sqlx::Error> {
+        // Note: Scheduler runs in background without user context.
+        // These operations are privileged/admin-level and don't need RLS enforcement.
+        let max_age = chrono::Duration::days(self.config.pin_max_age_days);
+        let unpinned = self.announcement_repo.auto_unpin_expired(max_age).await?;
+
+        if !unpinned.is_empty() {
+            tracing::info!(
+                "Auto-unpinned {} announcement(s) pinned longer than {} day(s): {:?}",
+                unpinned.len(),
+                self.config.pin_max_age_days,
+                unpinned
+            );
+
+            let mut metrics = self.metrics.lock().unwrap();
+            metrics.announcements_unpinned += unpinned.len() as u64;
         }
 
         Ok(())
@@ -982,9 +1017,17 @@ mod tests {
     }
 
     #[test]
+    fn test_scheduler_config_pin_max_age_default() {
+        // Issue #972.7: pinned announcements auto-unpin after 30 days by default.
+        let config = SchedulerConfig::default();
+        assert_eq!(config.pin_max_age_days, 30);
+    }
+
+    #[test]
     fn test_scheduler_metrics_default() {
         let metrics = SchedulerMetrics::default();
         assert_eq!(metrics.announcements_published, 0);
+        assert_eq!(metrics.announcements_unpinned, 0);
         assert_eq!(metrics.votes_closed, 0);
         assert_eq!(metrics.errors, 0);
     }

--- a/backend/servers/api-server/tests/voting_tests.rs
+++ b/backend/servers/api-server/tests/voting_tests.rs
@@ -133,6 +133,43 @@ mod authorization {
 
         assert_eq!(response.status, StatusCode::UNAUTHORIZED);
     }
+
+    /// A delegated cast (delegation_id present) still requires authentication —
+    /// the delegation re-validation guard (Story 5.4) runs only after the
+    /// `RlsConnection` extractor succeeds, so an unauthenticated request is
+    /// rejected before the guard is reached.
+    #[sqlx::test]
+    async fn test_cast_delegated_vote_without_auth_is_rejected(pool: PgPool) {
+        let app = TestApp::new(pool).await;
+
+        let body = json!({
+            "unit_id": Uuid::new_v4(),
+            "delegation_id": Uuid::new_v4(),
+            "answers": {}
+        });
+        let request = json_request(
+            Method::POST,
+            &format!("/api/v1/voting/{}/cast", Uuid::new_v4()),
+            body,
+        );
+        let response = app.execute(request).await;
+
+        assert_eq!(response.status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[sqlx::test]
+    async fn test_get_results_without_auth_is_rejected(pool: PgPool) {
+        let app = TestApp::new(pool).await;
+
+        let response = app
+            .execute(empty_request(
+                Method::GET,
+                &format!("/api/v1/voting/{}/results", Uuid::new_v4()),
+            ))
+            .await;
+
+        assert_eq!(response.status, StatusCode::UNAUTHORIZED);
+    }
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Implements the self-contained **fixable-now** backend gaps from the 2026-06-02 whole-app gap-sweep audit (the remainder not landed in the original gap-sweep PR). Each change follows the adversarially-verified "sharpened fix plan" in its issue.

**Verified locally** (backend uses runtime sqlx, so no DB needed to compile):
- `cargo check -p api-server -p db` ✅
- `cargo clippy -p api-server -p db -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅

## Changes by issue

### Voting — Epic 5 (#971)
- **#971.1** `cast_vote_rls` derives `vote_weight` from the unit's `ownership_share` (inline `COALESCE` subquery) instead of hardcoding `1.0` — weighted voting now works.
- **#971.2** ballot casts write an immutable `BALLOT_CAST`/`BALLOT_UPDATED` audit entry on the same RLS connection (new `create_audit_entry_rls` helper).
- **#971.3** delegation is re-validated at cast time (active + scope + unexpired) → revoked delegate gets **403 `DELEGATION_REVOKED`**.
- **#971.5** `participation_count` updated on each cast → accurate live quorum bar.
- **#971.6** publishing an immediately-active vote notifies eligible owners via the notification pipeline.
- **#971.8** active-vote `/results` returns live tallies (`compute_results` helper) instead of an empty struct, **without** writing a `RESULTS_CALCULATED` audit row on every read.

### Faults — Epic 4 (#970)
- **#970.2** `create_fault` is idempotent: offline retry with the same key returns the existing fault (200) instead of a 500 from the UNIQUE violation (RLS-scoped lookup).
- **#970.4** `update_fault` (reporter-or-manager) and `get_ai_suggestion` (manager) gain the org-scope/role guards their siblings already have.

### Announcements / Messaging — Epic 6 (#972)
- **#972.3** posting a comment notifies the announcement author + parent-comment author (replies), excluding the actor.
- **#972.7** scheduler auto-unpins announcements pinned longer than `PIN_MAX_AGE_DAYS` (default 30).
- **#972.1** (backend half) `DELETE /messages/threads/{id}/messages/{message_id}` (sender-only).
- **#972.2** (backend half) thread list/count gain an optional `search` filter (ILIKE on the other participant's name).

> The frontend halves of #972.1/#972.2 (client method + wiring) land in the companion frontend gap-sweep PR.

### Notifications — Epic 2B (#969)
- **#969.5** delete the dead `FcmPushAdapter` stub that reported `Sent` without sending; `FcmHttpAdapter` remains the real adapter.

### Platform admin — Epic 10B (#968)
- **#968.1** suspending an org cascades: revokes all member sessions **and** excludes suspended-org memberships from login/refresh token minting.
- **#968.3** (backend half) `AgencyDetailResponse` widened with `created_at`/`updated_at` + member/building/unit counts for the admin drill-in.

## Tests
- Added negative-path HTTP tests to `voting_tests.rs` (auth rejection for delegated cast / results). Deeper repo-level assertions (stored `vote_weight`, audit row, participation count) require the tenant+RLS integration fixture and run in CI's DB-backed job.

## Notes for reviewers
- `cast_vote_rls` signature changed from a generic `E: Executor` to `&mut PgConnection` so the ballot INSERT and the audit INSERT share one RLS connection. The sole caller already passed a `&mut PgConnection`.
- #971.6 uses `common::notifications::Notification` (the type `dispatch_to_users` accepts), matching the `announcements.rs` pattern.

Refs #968 #969 #970 #971 #972