### PR TITLE
fix(deploy-server): require ESIGN secrets in preflight (#951)

### DIFF
--- a/backend/servers/deploy-server/src/infra/preflight.rs
+++ b/backend/servers/deploy-server/src/infra/preflight.rs
@@ -373,6 +373,8 @@ mod tests {
         std::env::set_var("PPT_JWT_SECRET", "a".repeat(32));
         std::env::set_var("PPT_TOTP_ENCRYPTION_KEY", "0".repeat(64));
         std::env::set_var("PPT_INTEGRATION_ENCRYPTION_KEY", "f".repeat(64));
+        std::env::set_var("PPT_ESIGN_TOKEN_SECRET", "e".repeat(32));
+        std::env::set_var("PPT_ESIGN_WEBHOOK_SECRET", "w");
         std::env::set_var("PPT_PM_CLIENT_SECRET", "z".repeat(32));
         let errors = check_env_vars();
         assert!(errors.is_empty(), "expected no errors, got {errors:?}");
@@ -385,6 +387,8 @@ mod tests {
         std::env::set_var("PPT_JWT_SECRET", "tooshort");
         std::env::set_var("PPT_TOTP_ENCRYPTION_KEY", "0".repeat(64));
         std::env::set_var("PPT_INTEGRATION_ENCRYPTION_KEY", "f".repeat(64));
+        std::env::set_var("PPT_ESIGN_TOKEN_SECRET", "e".repeat(32));
+        std::env::set_var("PPT_ESIGN_WEBHOOK_SECRET", "w");
         std::env::set_var("PPT_PM_CLIENT_SECRET", "z".repeat(32));
         let errors = check_env_vars();
         assert_eq!(errors.len(), 1);
@@ -399,6 +403,8 @@ mod tests {
         // 64 chars but not hex
         std::env::set_var("PPT_TOTP_ENCRYPTION_KEY", "z".repeat(64));
         std::env::set_var("PPT_INTEGRATION_ENCRYPTION_KEY", "f".repeat(64));
+        std::env::set_var("PPT_ESIGN_TOKEN_SECRET", "e".repeat(32));
+        std::env::set_var("PPT_ESIGN_WEBHOOK_SECRET", "w");
         std::env::set_var("PPT_PM_CLIENT_SECRET", "z".repeat(32));
         let errors = check_env_vars();
         assert_eq!(errors.len(), 1);
@@ -412,6 +418,8 @@ mod tests {
         std::env::set_var("PPT_JWT_SECRET", "a".repeat(32));
         std::env::set_var("PPT_TOTP_ENCRYPTION_KEY", "0".repeat(32)); // half the required length
         std::env::set_var("PPT_INTEGRATION_ENCRYPTION_KEY", "f".repeat(64));
+        std::env::set_var("PPT_ESIGN_TOKEN_SECRET", "e".repeat(32));
+        std::env::set_var("PPT_ESIGN_WEBHOOK_SECRET", "w");
         std::env::set_var("PPT_PM_CLIENT_SECRET", "z".repeat(32));
         let errors = check_env_vars();
         assert_eq!(errors.len(), 1);
@@ -427,6 +435,8 @@ mod tests {
         std::env::set_var("PPT_JWT_SECRET", "a".repeat(32));
         std::env::set_var("PPT_TOTP_ENCRYPTION_KEY", "0".repeat(64));
         std::env::set_var("PPT_INTEGRATION_ENCRYPTION_KEY", "f".repeat(64));
+        std::env::set_var("PPT_ESIGN_TOKEN_SECRET", "e".repeat(32));
+        std::env::set_var("PPT_ESIGN_WEBHOOK_SECRET", "w");
         std::env::set_var("PPT_PM_CLIENT_SECRET", "tooshort");
         let errors = check_env_vars();
         assert_eq!(errors.len(), 1);

--- a/backend/servers/deploy-server/src/infra/preflight.rs
+++ b/backend/servers/deploy-server/src/infra/preflight.rs
@@ -166,6 +166,12 @@ const REQUIRED_ENV: &[(&str, EnvCheck)] = &[
     // — exactly the up-front-failure contract this validator exists to
     // uphold.
     ("PPT_PM_CLIENT_SECRET", EnvCheck::MinLen(32)),
+    // E-signature secrets: `build_service_envs` requires both (token >= 32
+    // chars, webhook non-empty) and panics the api container without them.
+    // Validate up-front so a missing ESIGN secret fails preflight instead of
+    // crash-looping the deploy (issue #951 follow-up).
+    ("PPT_ESIGN_TOKEN_SECRET", EnvCheck::MinLen(32)),
+    ("PPT_ESIGN_WEBHOOK_SECRET", EnvCheck::NonEmpty),
 ];
 
 #[derive(Copy, Clone)]


### PR DESCRIPTION
## Summary

Closes the repo-side follow-up of #951. `build_service_envs` (blue_green.rs:173-182) requires `PPT_ESIGN_TOKEN_SECRET` (≥32 chars) and `PPT_ESIGN_WEBHOOK_SECRET` (non-empty) and **panics the api container** without them — but the preflight `REQUIRED_ENV` validator (`deploy-server/src/infra/preflight.rs`) omitted both. So a missing ESIGN secret passed preflight and only surfaced later as an api crash-loop on deploy, defeating the up-front-failure contract the validator exists to uphold.

Adds both to `REQUIRED_ENV` so a missing/short ESIGN secret fails preflight with a clear config error.

**Verified:** `cargo check -p deploy-server` + `cargo clippy -p deploy-server -- -D warnings` (clean). The existing `REQUIRED_ENV`-snapshot test is count-dynamic, so it still holds.

> The deploy-side half of #951 (injecting the secrets, PR #949) already merged to `dev`; the remaining operational step is populating `/etc/ppt-deploy/secrets.env` + rebuilding deploy-server (infra, not repo).

Refs #951