### PR TITLE
fix(epic-7a): wire mobile document detail + notify document-share recipients (#973)

### DIFF
--- a/backend/crates/common/src/notifications/mod.rs
+++ b/backend/crates/common/src/notifications/mod.rs
@@ -87,6 +87,8 @@ pub enum NotificationCategory {
     Community,
     /// Financial notifications (invoices, payments).
     Financial,
+    /// Document sharing notifications (Story 7A.5).
+    Documents,
     /// System maintenance and updates.
     System,
 }
@@ -101,6 +103,7 @@ impl NotificationCategory {
             NotificationCategory::Messages,
             NotificationCategory::Community,
             NotificationCategory::Financial,
+            NotificationCategory::Documents,
             NotificationCategory::System,
         ]
     }
@@ -114,6 +117,7 @@ impl NotificationCategory {
             NotificationCategory::Messages => "messages",
             NotificationCategory::Community => "community",
             NotificationCategory::Financial => "financial",
+            NotificationCategory::Documents => "documents",
             NotificationCategory::System => "system",
         }
     }
@@ -133,6 +137,10 @@ impl NotificationCategory {
             NotificationCategory::Community => &[NotificationChannel::InApp],
             // Financial defaults to all
             NotificationCategory::Financial => NotificationChannel::all(),
+            // Documents (share notifications) default to push and in-app
+            NotificationCategory::Documents => {
+                &[NotificationChannel::Push, NotificationChannel::InApp]
+            }
             // System defaults to email and in-app
             NotificationCategory::System => {
                 &[NotificationChannel::Email, NotificationChannel::InApp]
@@ -388,7 +396,7 @@ mod tests {
     #[test]
     fn test_notification_category_all() {
         let categories = NotificationCategory::all();
-        assert_eq!(categories.len(), 7);
+        assert_eq!(categories.len(), 8);
     }
 
     #[test]

--- a/backend/servers/api-server/src/routes/documents/shares.rs
+++ b/backend/servers/api-server/src/routes/documents/shares.rs
@@ -9,6 +9,7 @@ use axum::{
     Json, Router,
 };
 use common::errors::ErrorResponse;
+use common::notifications::{Notification, NotificationCategory};
 use db::models::{share_type, CreateShare, DocumentSummary, LogShareAccess};
 use uuid::Uuid;
 
@@ -212,7 +213,54 @@ async fn create_share(
                 .as_ref()
                 .map(|token| format!("/documents/shared/{}", token));
 
+            // Best-effort: notify the recipients of a non-link share (#973.2).
+            // LINK shares are pull-based (anyone with the URL) so there is no
+            // concrete recipient to notify. Recipient resolution runs on the
+            // same RLS connection so the reads are authorised under the
+            // manager's org context, mirroring the announcement publish path.
+            let recipients = resolve_share_recipients(
+                rls.conn(),
+                tenant.tenant_id,
+                &share.share_type,
+                share.target_id,
+                share.target_role.as_deref(),
+            )
+            .await;
+
             rls.release().await;
+
+            if !recipients.is_empty() {
+                let notification = Notification::new(
+                    Uuid::nil(),
+                    NotificationCategory::Documents,
+                    "Document shared with you",
+                    format!("\"{}\" has been shared with you", existing.title),
+                )
+                .with_action_url(format!("/documents/{}", existing.id))
+                .with_data(serde_json::json!({
+                    "document_id": existing.id,
+                    "share_id": share.id,
+                    "share_type": share.share_type,
+                    "shared_by": auth.user_id,
+                }));
+
+                let (sent, skipped, failed) = state
+                    .notification_pipeline
+                    .broadcast(&recipients, &notification, Some(existing.id))
+                    .await;
+
+                tracing::info!(
+                    document_id = %existing.id,
+                    share_id = %share.id,
+                    share_type = %share.share_type,
+                    recipients = recipients.len(),
+                    channels_sent = sent,
+                    channels_skipped = skipped,
+                    channels_failed = failed,
+                    "Document share created — recipient notifications dispatched"
+                );
+            }
+
             Ok((
                 StatusCode::CREATED,
                 Json(CreateShareResponse {
@@ -603,6 +651,90 @@ async fn access_protected_share(
         download_url,
         preview_url,
     }))
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/// Resolve a document share's targeting into the concrete set of recipient
+/// user ids (#973.2, Epic 7A.5 share-notification fan-out).
+///
+/// Must be called on a connection whose RLS context is the sharing manager's
+/// org, so the membership / unit / resident reads are authorised. Mirrors the
+/// announcement publish fan-out (`resolve_announcement_recipients`).
+///
+/// | share_type | recipients |
+/// |------------|------------|
+/// | `link`     | none (pull-based; anyone with the URL) |
+/// | `user`     | the single target user |
+/// | `role`     | active org members holding the target role |
+/// | `building` | active residents of units in the target building |
+///
+/// Resolution is best-effort: a query error is logged and treated as "no
+/// recipients" so a transient read failure never blocks the share itself.
+async fn resolve_share_recipients(
+    conn: &mut sqlx::PgConnection,
+    org_id: Uuid,
+    share_type_str: &str,
+    target_id: Option<Uuid>,
+    target_role: Option<&str>,
+) -> Vec<Uuid> {
+    let result: Result<Vec<(Uuid,)>, sqlx::Error> = match share_type_str {
+        share_type::USER => match target_id {
+            Some(uid) => Ok(vec![(uid,)]),
+            None => Ok(Vec::new()),
+        },
+        share_type::ROLE => match target_role {
+            Some(role) => {
+                sqlx::query_as(
+                    r#"
+                    SELECT DISTINCT user_id FROM user_memberships
+                    WHERE organization_id = $1
+                      AND revoked_at IS NULL
+                      AND role = $2
+                    "#,
+                )
+                .bind(org_id)
+                .bind(role)
+                .fetch_all(&mut *conn)
+                .await
+            }
+            None => Ok(Vec::new()),
+        },
+        share_type::BUILDING => match target_id {
+            Some(building_id) => {
+                sqlx::query_as(
+                    r#"
+                    SELECT DISTINCT ur.user_id
+                    FROM unit_residents ur
+                    JOIN units u ON u.id = ur.unit_id
+                    WHERE u.building_id = $1
+                      AND ur.end_date IS NULL
+                      AND ur.receives_notifications = TRUE
+                    "#,
+                )
+                .bind(building_id)
+                .fetch_all(&mut *conn)
+                .await
+            }
+            None => Ok(Vec::new()),
+        },
+        // LINK (and anything unexpected) has no concrete recipient.
+        _ => Ok(Vec::new()),
+    };
+
+    match result {
+        Ok(rows) => rows.into_iter().map(|(id,)| id).collect(),
+        Err(e) => {
+            tracing::error!(
+                share_type = %share_type_str,
+                error = %e,
+                "Failed to resolve share recipients; share created without notification fan-out"
+            );
+            Vec::new()
+        }
+    }
 }
 
 // ============================================================================

--- a/frontend/apps/mobile/src/App.tsx
+++ b/frontend/apps/mobile/src/App.tsx
@@ -232,7 +232,12 @@ function MainApp() {
       case 'Documents':
         return <DocumentsScreen onNavigate={handleNavigate} />;
       case 'DocumentDetail':
-        return <DocumentDetailScreen onBack={() => handleNavigate('Documents')} />;
+        return (
+          <DocumentDetailScreen
+            documentId={screenParams?.documentId as string | undefined}
+            onBack={() => handleNavigate('Documents')}
+          />
+        );
       case 'DocumentPreview':
         return screenParams?.document ? (
           <DocumentPreviewScreen

--- a/frontend/apps/mobile/src/screens/documents/DocumentDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentDetailScreen.tsx
@@ -1,26 +1,52 @@
 /**
  * DocumentDetailScreen (UC-08.4 + Story 7A.5).
  *
- * Single-document view with metadata, an "open" action that hands the URL off
- * to the platform viewer, and a "Share" button that opens DocumentShareSheet.
+ * Single-document view with metadata, an "open" action that fetches a
+ * short-lived presigned URL and hands it off to the platform viewer, and a
+ * "Share" button that opens DocumentShareSheet.
+ *
+ * Data comes from GET /api/v1/documents/{id} (wrapped as `{ document: ... }`).
+ * That payload carries no file URL, so the open action calls the presigned
+ * /preview endpoint (falling back to /download) — mirroring
+ * DocumentPreviewScreen.
  */
 
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Alert, Linking, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { apiRequest, useApiQuery } from '../../hooks/useApi';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 import { DocumentShareSheet } from './DocumentShareSheet';
-import type { Document } from './DocumentsScreen';
 
-const MOCK_DOCUMENT: Document = {
-  id: 'd1',
-  name: 'House Rules 2026.pdf',
-  type: 'pdf',
-  size: 1_245_678,
-  createdAt: '2026-03-12T08:30:00Z',
-  updatedAt: '2026-03-12T08:30:00Z',
-  parentId: null,
-  downloadUrl: 'https://example.com/house-rules-2026.pdf',
-};
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/**
+ * Shape of GET /api/v1/documents/{id}. The server wraps the document in a
+ * `document` key (DocumentDetailResponse) and flattens DocumentWithDetails, so
+ * the base Document fields sit alongside the *_name / share_count extras.
+ */
+interface ApiDocumentDetailResponse {
+  document: {
+    id: string;
+    title: string;
+    description?: string | null;
+    category: string;
+    file_name: string;
+    mime_type: string;
+    size_bytes: number;
+    created_at: string;
+    updated_at: string;
+    created_by_name?: string;
+    folder_name?: string | null;
+  };
+}
+
+/** Shape of UrlResponse from GET /api/v1/documents/{id}/preview|download. */
+interface PresignedUrlResponse {
+  url: string;
+  expires_at: string;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -28,31 +54,75 @@ function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+function getFileIcon(mimeType: string, fileName: string): string {
+  const mime = (mimeType ?? '').toLowerCase();
+  const name = (fileName ?? '').toLowerCase();
+  if (mime.includes('pdf') || name.endsWith('.pdf')) return '📄';
+  if (mime.startsWith('image/') || /\.(png|jpe?g|gif|webp)$/.test(name)) return '🖼️';
+  if (mime.includes('spreadsheet') || mime.includes('excel') || /\.(xlsx?|csv)$/.test(name))
+    return '📊';
+  return '🗂️';
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
 interface DocumentDetailScreenProps {
   documentId?: string;
-  document?: Document;
   onBack?: () => void;
 }
 
-export function DocumentDetailScreen({
-  document = MOCK_DOCUMENT,
-  onBack,
-}: DocumentDetailScreenProps) {
+export function DocumentDetailScreen({ documentId, onBack }: DocumentDetailScreenProps) {
   const [shareSheetVisible, setShareSheetVisible] = useState(false);
+  const [opening, setOpening] = useState(false);
 
-  const handleOpen = async () => {
-    if (!document.downloadUrl) {
-      Alert.alert('Unavailable', 'No file URL is associated with this document.');
-      return;
-    }
+  const { data, isLoading, error, refetch } = useApiQuery<ApiDocumentDetailResponse>(
+    ['documents', 'detail', documentId ?? ''],
+    `/api/v1/documents/${documentId ?? ''}`,
+    { staleTime: 60_000, enabled: !!documentId }
+  );
+
+  const document = data?.document;
+
+  const handleRetry = useCallback(() => {
+    void refetch();
+  }, [refetch]);
+
+  /**
+   * Fetch a presigned URL (preview, with download fallback) and hand it to the
+   * native viewer. The detail payload carries no file URL of its own.
+   */
+  const handleOpen = useCallback(async () => {
+    if (!documentId) return;
+    setOpening(true);
     try {
-      const supported = await Linking.canOpenURL(document.downloadUrl);
+      let presigned: PresignedUrlResponse;
+      try {
+        presigned = await apiRequest<PresignedUrlResponse>(
+          `/api/v1/documents/${documentId}/preview`
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : '';
+        const isUnsupported =
+          message.includes('PREVIEW_NOT_SUPPORTED') ||
+          message.includes('not supported') ||
+          message.includes('HTTP 400');
+        if (!isUnsupported) throw err;
+        presigned = await apiRequest<PresignedUrlResponse>(
+          `/api/v1/documents/${documentId}/download`
+        );
+      }
+
+      const supported = await Linking.canOpenURL(presigned.url);
       if (!supported) throw new Error('Cannot open URL');
-      await Linking.openURL(document.downloadUrl);
+      await Linking.openURL(presigned.url);
     } catch {
       Alert.alert('Could not open document', 'The file viewer is unavailable on this device.');
+    } finally {
+      setOpening(false);
     }
-  };
+  }, [documentId]);
+
+  const title = document?.title ?? '';
 
   return (
     <View style={s.container}>
@@ -62,51 +132,91 @@ export function DocumentDetailScreen({
             <Text style={styles.backLinkText}>← Documents</Text>
           </Pressable>
         )}
-        <Text style={s.headerTitle}>{document.name}</Text>
+        <Text style={s.headerTitle} numberOfLines={2}>
+          {title || 'Document'}
+        </Text>
       </View>
 
       <ScrollView style={s.scrollView}>
-        <View style={s.card}>
-          <View style={s.cardHeader}>
-            <Text style={styles.icon}>{document.type === 'pdf' ? '📄' : '🗂️'}</Text>
-            <Text style={[s.cardTitle, { marginLeft: 8 }]}>{document.name}</Text>
+        {isLoading && (
+          <View style={s.emptyState}>
+            <Text style={s.emptyTitle}>Loading…</Text>
           </View>
-          <View style={[s.cardFooter, { marginTop: 16 }]}>
-            {typeof document.size === 'number' && (
-              <Text style={s.cardMeta}>{formatBytes(document.size)}</Text>
-            )}
-            <Text style={s.cardMeta}>
-              Updated {new Date(document.updatedAt).toLocaleDateString()}
-            </Text>
+        )}
+
+        {error && !isLoading && (
+          <View style={s.emptyState}>
+            <Text style={s.emptyIcon}>⚠️</Text>
+            <Text style={s.emptyTitle}>Couldn’t load document</Text>
+            <Text style={s.emptyText}>{error.message}</Text>
+            <Pressable style={[s.primaryButton, styles.retryButton]} onPress={handleRetry}>
+              <Text style={s.primaryButtonText}>Retry</Text>
+            </Pressable>
           </View>
-        </View>
+        )}
 
-        <View style={s.card}>
-          <Text style={styles.sectionLabel}>Type</Text>
-          <Text style={styles.sectionValue}>{document.type.toUpperCase()}</Text>
-          <Text style={[styles.sectionLabel, { marginTop: 12 }]}>Created</Text>
-          <Text style={styles.sectionValue}>
-            {new Date(document.createdAt).toLocaleDateString()}
-          </Text>
-        </View>
+        {!isLoading && !error && !document && (
+          <View style={s.emptyState}>
+            <Text style={s.emptyIcon}>📄</Text>
+            <Text style={s.emptyTitle}>Document not found</Text>
+          </View>
+        )}
 
-        <Pressable style={s.primaryButton} onPress={handleOpen}>
-          <Text style={s.primaryButtonText}>Open document</Text>
-        </Pressable>
+        {!isLoading && !error && document && (
+          <>
+            <View style={s.card}>
+              <View style={s.cardHeader}>
+                <Text style={styles.icon}>
+                  {getFileIcon(document.mime_type, document.file_name)}
+                </Text>
+                <Text style={[s.cardTitle, { marginLeft: 8 }]} numberOfLines={2}>
+                  {document.title}
+                </Text>
+              </View>
+              <View style={[s.cardFooter, { marginTop: 16 }]}>
+                {typeof document.size_bytes === 'number' && document.size_bytes > 0 && (
+                  <Text style={s.cardMeta}>{formatBytes(document.size_bytes)}</Text>
+                )}
+                <Text style={s.cardMeta}>
+                  Updated {new Date(document.updated_at).toLocaleDateString()}
+                </Text>
+              </View>
+            </View>
 
-        <Pressable style={styles.shareButton} onPress={() => setShareSheetVisible(true)}>
-          <Text style={styles.shareButtonText}>🔗 Share</Text>
-        </Pressable>
+            <View style={s.card}>
+              <Text style={styles.sectionLabel}>Category</Text>
+              <Text style={styles.sectionValue}>{document.category}</Text>
+              <Text style={[styles.sectionLabel, { marginTop: 12 }]}>File</Text>
+              <Text style={styles.sectionValue}>{document.file_name}</Text>
+              <Text style={[styles.sectionLabel, { marginTop: 12 }]}>Created</Text>
+              <Text style={styles.sectionValue}>
+                {new Date(document.created_at).toLocaleDateString()}
+              </Text>
+            </View>
+
+            <Pressable
+              style={[s.primaryButton, opening && styles.buttonDisabled]}
+              onPress={() => void handleOpen()}
+              disabled={opening}
+            >
+              <Text style={s.primaryButtonText}>{opening ? 'Opening…' : 'Open document'}</Text>
+            </Pressable>
+
+            <Pressable style={styles.shareButton} onPress={() => setShareSheetVisible(true)}>
+              <Text style={styles.shareButtonText}>🔗 Share</Text>
+            </Pressable>
+
+            <DocumentShareSheet
+              documentId={document.id}
+              documentTitle={document.title}
+              visible={shareSheetVisible}
+              onClose={() => setShareSheetVisible(false)}
+            />
+          </>
+        )}
 
         <View style={s.bottomSpacer} />
       </ScrollView>
-
-      <DocumentShareSheet
-        documentId={document.id}
-        documentTitle={document.name}
-        visible={shareSheetVisible}
-        onClose={() => setShareSheetVisible(false)}
-      />
     </View>
   );
 }
@@ -114,7 +224,9 @@ export function DocumentDetailScreen({
 const styles = StyleSheet.create({
   backLink: { marginBottom: 8 },
   backLinkText: { color: colors.accent, fontSize: 14 },
+  retryButton: { marginTop: 16 },
   icon: { fontSize: 24 },
+  buttonDisabled: { opacity: 0.6 },
   sectionLabel: {
     fontSize: 12,
     color: colors.textMuted,


### PR DESCRIPTION
## Summary

Closes the two **fixable-now** Epic 7A (Document Management basic) gaps from the 2026-06-02 gap-sweep audit — the items that were truncated from the earlier triage pass.

**Verified locally:**
- Backend: `cargo check`, `cargo clippy -p api-server -p common -- -D warnings`, `cargo fmt --check`, `cargo test -p common` ✅
- Mobile: `pnpm --filter @ppt/mobile typecheck` ✅

### #973.1 — Mobile DocumentDetailScreen rendered MOCK_DOCUMENT (Story 7A.4)
`DocumentDetailScreen` now takes a `documentId`, fetches `GET /api/v1/documents/{id}` via `useApiQuery` with loading/error/empty states, and opens the file through the `/preview`→`/download` presigned-URL flow (mirroring `DocumentPreviewScreen`, since the detail payload carries no file URL). `App.tsx` forwards the route's `documentId` param.

### #973.2 — Document share sent no notification (Story 7A.5)
`create_share` now dispatches a best-effort notification to recipients after persisting the share:
- USER → target user; ROLE → org members holding that role; BUILDING → active residents (notifications-enabled)
- resolved on the manager's RLS connection, broadcast via the existing notification pipeline, logged, and **never fails the request** on error.
- Adds a `NotificationCategory::Documents` variant (with `all()`/`as_str()`/`default_channels()` + count test updated). This enum isn't referenced by the committed OpenAPI spec, so no spec/client regeneration is required.

Refs #973