### PR TITLE
test(db): auto_unpin_expired regression test; verify #969.5/#972.3 already landed

### DIFF
--- a/backend/crates/db/tests/announcement_tests.rs
+++ b/backend/crates/db/tests/announcement_tests.rs
@@ -657,13 +657,11 @@ async fn test_auto_unpin_expired() {
     assert_eq!(unpinned, vec![stale_id], "only the stale pin should unpin");
 
     // Stale announcement is fully unpinned (pinned flag + audit columns cleared).
-    let stale = sqlx::query(
-        "SELECT pinned, pinned_at, pinned_by FROM announcements WHERE id = $1",
-    )
-    .bind(stale_id)
-    .fetch_one(&db.pool)
-    .await
-    .unwrap();
+    let stale = sqlx::query("SELECT pinned, pinned_at, pinned_by FROM announcements WHERE id = $1")
+        .bind(stale_id)
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
     let stale_pinned: bool = stale.get("pinned");
     let stale_pinned_at: Option<chrono::DateTime<chrono::Utc>> = stale.get("pinned_at");
     let stale_pinned_by: Option<Uuid> = stale.get("pinned_by");

--- a/backend/crates/db/tests/announcement_tests.rs
+++ b/backend/crates/db/tests/announcement_tests.rs
@@ -603,6 +603,86 @@ async fn test_pin_announcement() {
     db.cleanup().await.unwrap();
 }
 
+/// Issue #972.7: announcements pinned longer than the cutoff are auto-unpinned
+/// by `auto_unpin_expired`, while recently-pinned ones are left untouched.
+#[tokio::test]
+#[ignore]
+async fn test_auto_unpin_expired() {
+    use db::repositories::AnnouncementRepository;
+
+    let db = TestDb::new().await.expect("Failed to connect to test DB");
+    db.cleanup().await.unwrap();
+    db.setup_as_super_admin().await.unwrap();
+
+    let org_id = db.create_test_org("Auto Unpin Org").await.unwrap();
+    let user_id = db
+        .create_test_user("unpin@test.com", "Unpin Author")
+        .await
+        .unwrap();
+
+    // Stale pin: pinned 40 days ago — should be unpinned with a 30-day cutoff.
+    let stale_id = db
+        .create_test_announcement(org_id, user_id, "Stale Pin", "Content")
+        .await
+        .unwrap();
+    sqlx::query(
+        "UPDATE announcements SET pinned = true, pinned_at = NOW() - INTERVAL '40 days', pinned_by = $1 WHERE id = $2",
+    )
+    .bind(user_id)
+    .bind(stale_id)
+    .execute(&db.pool)
+    .await
+    .unwrap();
+
+    // Fresh pin: pinned 1 day ago — should remain pinned.
+    let fresh_id = db
+        .create_test_announcement(org_id, user_id, "Fresh Pin", "Content")
+        .await
+        .unwrap();
+    sqlx::query(
+        "UPDATE announcements SET pinned = true, pinned_at = NOW() - INTERVAL '1 day', pinned_by = $1 WHERE id = $2",
+    )
+    .bind(user_id)
+    .bind(fresh_id)
+    .execute(&db.pool)
+    .await
+    .unwrap();
+
+    let repo = AnnouncementRepository::new(db.pool.clone());
+    let unpinned = repo
+        .auto_unpin_expired(chrono::Duration::days(30))
+        .await
+        .unwrap();
+
+    assert_eq!(unpinned, vec![stale_id], "only the stale pin should unpin");
+
+    // Stale announcement is fully unpinned (pinned flag + audit columns cleared).
+    let stale = sqlx::query(
+        "SELECT pinned, pinned_at, pinned_by FROM announcements WHERE id = $1",
+    )
+    .bind(stale_id)
+    .fetch_one(&db.pool)
+    .await
+    .unwrap();
+    let stale_pinned: bool = stale.get("pinned");
+    let stale_pinned_at: Option<chrono::DateTime<chrono::Utc>> = stale.get("pinned_at");
+    let stale_pinned_by: Option<Uuid> = stale.get("pinned_by");
+    assert!(!stale_pinned, "stale announcement should be unpinned");
+    assert!(stale_pinned_at.is_none(), "pinned_at should be cleared");
+    assert!(stale_pinned_by.is_none(), "pinned_by should be cleared");
+
+    // Fresh announcement is untouched.
+    let fresh_pinned: bool = sqlx::query("SELECT pinned FROM announcements WHERE id = $1")
+        .bind(fresh_id)
+        .fetch_one(&db.pool)
+        .await
+        .unwrap()
+        .get("pinned");
+    assert!(fresh_pinned, "fresh announcement should stay pinned");
+
+    db.cleanup().await.unwrap();
+}
+
 // ==================== RLS Table Coverage Test ====================
 
 /// Verify announcements tables have RLS enabled


### PR DESCRIPTION
## Summary

Gap-sweep for backend notification items from issues **#969** and **#972**. Two of the three assigned items were already fixed on `dev` since the 2026-06-02 evidence was captured; this PR closes the remaining gap (the missing regression test for #972.7) and documents the verification of the others.

## Items

- **#969.5** (Delete dead `FcmPushAdapter` no-op stub) — **already fixed on dev.** `grep -rn FcmPushAdapter backend` returns nothing. The orphaned `fcm_adapter_is_configured` test is gone, the `services/mod.rs` re-export (`backend/servers/api-server/src/services/mod.rs:30-32`) only exports `SmtpEmailAdapter` from `notification_pipeline`, and the module docs (`notification_pipeline.rs:7,22`) reference the real `FcmHttpAdapter`. No change needed.

- **#972.3** (Announcement comment notifications not dispatched) — **already fixed on dev.** `backend/servers/api-server/src/routes/announcements.rs:2348-2468` already captures `parent_author`, dedupes `[announcement.author_id, parent_author]` minus the actor, builds the `Notification` with the action URL + data payload, and best-effort dispatches via `notification_pipeline.broadcast(&recipients, &notification, Some(id))` after releasing the RLS conn. No change needed.

- **#972.7** (Pinned announcements never auto-unpin after 30 days) — **scheduler/repo wiring already on dev; added the missing regression test.** The config field (`scheduler.rs:42` `pin_max_age_days` default 30), `Scheduler::auto_unpin_expired_announcements` (`scheduler.rs:323`), its invocation in `run_scheduled_tasks` (`scheduler.rs:212`), the `announcements_unpinned` metric (`scheduler.rs:63`), and `AnnouncementRepository::auto_unpin_expired` (`crates/db/src/repositories/announcement.rs:1554`) were all present. The plan called for a DB-seeding regression test, which was absent — added `test_auto_unpin_expired` at `backend/crates/db/tests/announcement_tests.rs:606` (what+why: seeds a 40-day-old and a 1-day-old pinned announcement, asserts only the stale one is unpinned with `pinned`/`pinned_at`/`pinned_by` cleared, so a regression in the cutoff logic fails this test).

## Verify

- `cargo test -p db --test announcement_tests --no-run` → `Finished` (test compiles clean; it is `#[ignore]` + DB-backed like its siblings, so it needs a live Postgres to execute, which this environment lacks).
- Local `cargo clippy -p db --tests` was still building under heavy CPU contention from sibling worktrees at push time; CI `backend.yml` runs the authoritative `clippy -D warnings` + test gate. The change is a single integration test in an existing file, matching surrounding idioms.

Refs #969, #972