### PR TITLE
docs(screens): flip fault-detail/financial apiStatus after wiring landed in #989/#990

### DIFF
--- a/docs/screens/ppt/fault-detail.md
+++ b/docs/screens/ppt/fault-detail.md
@@ -9,7 +9,7 @@ implementations:
     component: FaultDetailPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: stub
+    apiStatus: complete
 endpoints: []
 relatedScreens:
   - id: ppt/faults-list
@@ -33,3 +33,4 @@ Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, e
 
 ## Agent Log
 - 2026-05-18 — agent: created stub for unmapped route.
+- 2026-06-03 — agent: confirmed FaultDetailPageRoute wired to useFault + triage/resolve/confirm/reopen/comment/attachment hooks (#970.1); apiStatus -> complete.

--- a/docs/screens/ppt/financial-invoices.md
+++ b/docs/screens/ppt/financial-invoices.md
@@ -9,7 +9,7 @@ implementations:
     component: InvoiceManagementPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: stub
+    apiStatus: partial
 endpoints: []
 relatedScreens:
   - id: ppt/financial
@@ -33,3 +33,4 @@ Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, e
 
 ## Agent Log
 - 2026-05-18 — agent: created stub for unmapped route.
+- 2026-06-03 — agent: confirmed InvoiceManagementPageRoute wired to listInvoices (status + pagination) + sendInvoice via TanStack Query (#975.2); apiStatus -> partial (no building_id/search params).

--- a/docs/screens/ppt/financial.md
+++ b/docs/screens/ppt/financial.md
@@ -9,7 +9,7 @@ implementations:
     component: FinancialDashboardPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: stub
+    apiStatus: partial
 endpoints: []
 relatedScreens: []
 sharedComponents: []
@@ -31,3 +31,4 @@ Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, e
 
 ## Agent Log
 - 2026-05-18 — agent: created stub for unmapped route.
+- 2026-06-03 — agent: confirmed FinancialDashboardPageRoute wired to getARAgingReport/getOverdueInvoices/listInvoices via TanStack Query (#975.1); apiStatus -> partial (no org-wide payments endpoint).


### PR DESCRIPTION
Frontend gap-sweep converging on `frontend/apps/ppt-web/src/App.tsx` + the hand-written api-client packages. Addresses #970, #972, #975, #976.

## Items

### #970.1 (critical) — Fault detail rendered hardcoded mock
- `frontend/packages/api-client/src/faults/types.ts:21` — corrected `FaultStatus` enum to the real backend values (`new`/`waiting_parts`, not `reported`/`on_hold`); extended `FaultWithDetails` to the full flattened+joined wire shape; fixed `FaultTimelineEntry` to `action/note/old_value/new_value/user_id/user_name/user_email/is_internal/created_at`. *Why:* the divergent types were the stated blocker for wiring the page.
- `frontend/apps/ppt-web/src/App.tsx` `FaultDetailPageRoute` — replaced `mockFault` with `useFault()` + `useTriageFault/useResolveFault/useConfirmFault/useReopenFault/useAddComment/useAddAttachment/useDeleteAttachment`; added module-level mappers `mapApiFaultToDetail` / `mapApiTimelineEntryToUi` / `mapApiFaultAttachmentToUi`; loading/error mirrors `FaultsPageRoute`; `isManager` from auth context. Updated `mapApiFaultStatusToUi` / `UI_FAULT_STATUS_TO_API` to the corrected enum.

### #972.1 (high) — Delete message wiring
- `frontend/packages/api-client/src/messaging/api.ts:105` — added `deleteMessage(threadId, messageId)` (DELETE `{baseUrl}/threads/{threadId}/messages/{messageId}`), modeled on `unblockUser`.
- `frontend/packages/api-client/src/messaging/hooks.ts` + `frontend/apps/ppt-web/src/features/messaging/hooks/useMessaging.ts` — `useDeleteMessage` mutation (invalidates thread + thread list).
- `App.tsx` `ThreadDetailPageRoute` — `onDeleteMessage={(messageId) => deleteMessage.mutate({ threadId, messageId })}`.
- *Depends on the sibling backend PR adding the DELETE route.*

### #972.2 (medium) — Search conversations wiring
- `frontend/packages/api-client/src/messaging/types.ts:105` — added `search?` to `ListThreadsParams`; `api.ts` `listThreads` forwards `search`.
- `App.tsx` `MessagesPageRoute` — widened `msgQueryParams` with `search?` and threaded `params.search` through `onFilterChange`.
- *Depends on the sibling backend PR adding the list-threads `search` param.*

### #975.1 (high) — Financial dashboard passed zeros
- `App.tsx` `FinancialDashboardPageRoute` — `useBuildings()` + `getARAgingReport` + `getOverdueInvoices` + `listInvoices` via TanStack Query; metrics + per-status invoice counts derived client-side; currency `EUR`; `isLoading` wired. `recentPayments` stays empty (no org-wide payments-list endpoint). Screen-map apiStatus stub→partial.

### #975.2 (high) — Invoice management no-ops
- `App.tsx` `InvoiceManagementPageRoute` — `listInvoices` query (status + pagination only; `ListInvoicesParams` has no `building_id`/`search`) + `sendInvoice` mutation (invalidates on success). `buildings=[]`. Screen-map apiStatus stub→partial.

### #976.1 (high) — Short-term rental pages unrouted
- `frontend/apps/ppt-web/src/routes/lazyRoutes.tsx` — lazy exports for the 7 rental pages.
- `App.tsx` — routed `/rentals`, `/rentals/connections`, `/rentals/bookings`, `/rentals/bookings/:bookingId`, `/rentals/calendar`, `/rentals/guests`, `/rentals/reports` (each `<ProtectedRoute>`); route wrappers call the generated `ShortTermRentalsService.*` via useQuery/useMutation and map `Rentals_*` → the pages' local types; added `nav.rentals` Link + `en.json` key. The generated rentals service has no calendar-events / tax-report / booking-grouped-guests endpoints, so those pages render empty data with working callbacks. New `docs/screens/ppt/rentals.md` (per-page entries noted as follow-up).

## Regression test (IG3)
`frontend/packages/api-client/src/messaging/api.test.ts` — pins `deleteMessage` (DELETE on the nested message route) and `listThreads({ search })` (forwards the `search` query param). Both fail on `dev` (method/param did not exist).

## Verify
- `pnpm --filter @ppt/web typecheck` — clean
- `pnpm --filter @ppt/api-client typecheck` — clean
- `pnpm check` (Biome) — 0 errors (14 warnings / 3 infos are pre-existing in untouched files)
- `pnpm --filter @ppt/api-client test` — 34 passed (incl. new messaging test)