### PR TITLE
gap-83-2-booking-integration-ui: Booking.com connection management UI (ppt-web)

### DIFF
--- a/frontend/apps/ppt-web/src/features/integrations/components/BookingChannelPanel.tsx
+++ b/frontend/apps/ppt-web/src/features/integrations/components/BookingChannelPanel.tsx
@@ -1,0 +1,349 @@
+/**
+ * Booking.com Channel Panel (Gap 83.2)
+ *
+ * Connection management UI for the Booking.com channel-manager integration:
+ * connect/disconnect, availability/rate sync status, manual sync trigger, and
+ * cross-platform booking-conflict feed. Wires to the api-server
+ * `routes/integrations/{install,booking_channel}.rs` surface.
+ */
+
+import type { BookingConnectRequest } from '@ppt/api-client';
+import {
+  useBookingConflicts,
+  useBookingStatus,
+  useConnectBooking,
+  useDisconnectBooking,
+  useSyncBooking,
+} from '@ppt/api-client';
+import { useState } from 'react';
+import { ConfirmationDialog, useToast } from '../../../components';
+
+interface BookingChannelPanelProps {
+  organizationId: string;
+}
+
+function formatDateTime(value?: string | null): string {
+  if (!value) return 'Never';
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? value : d.toLocaleString();
+}
+
+export function BookingChannelPanel({ organizationId }: BookingChannelPanelProps) {
+  const { showToast } = useToast();
+
+  const { data: status, isLoading } = useBookingStatus(organizationId);
+  const connect = useConnectBooking(organizationId);
+  const disconnect = useDisconnectBooking(organizationId);
+  const sync = useSyncBooking(organizationId);
+
+  const connected = !!status?.connected;
+  const {
+    data: conflicts,
+    isLoading: conflictsLoading,
+    refetch: refetchConflicts,
+  } = useBookingConflicts(organizationId, connected);
+
+  const [showConnectDialog, setShowConnectDialog] = useState(false);
+  const [disconnectOpen, setDisconnectOpen] = useState(false);
+  const [form, setForm] = useState<BookingConnectRequest>({
+    hotel_id: '',
+    username: '',
+    password: '',
+  });
+
+  const resetForm = () => setForm({ hotel_id: '', username: '', password: '' });
+
+  const handleConnect = async () => {
+    try {
+      const res = await connect.mutateAsync(form);
+      showToast({ title: res.message || 'Booking.com connected', type: 'success' });
+      setShowConnectDialog(false);
+      resetForm();
+    } catch (error) {
+      showToast({
+        title: error instanceof Error ? error.message : 'Failed to connect Booking.com',
+        type: 'error',
+      });
+    }
+  };
+
+  const handleDisconnect = async () => {
+    try {
+      await disconnect.mutateAsync();
+      showToast({ title: 'Booking.com disconnected', type: 'success' });
+    } catch (error) {
+      showToast({
+        title: error instanceof Error ? error.message : 'Failed to disconnect',
+        type: 'error',
+      });
+    } finally {
+      setDisconnectOpen(false);
+    }
+  };
+
+  const handleSync = async () => {
+    try {
+      const res = await sync.mutateAsync();
+      if (res.success) {
+        showToast({
+          title: `Synced ${res.items_synced} item(s) from Booking.com`,
+          type: 'success',
+        });
+      } else {
+        showToast({ title: res.error || 'Sync reported an error', type: 'error' });
+      }
+    } catch (error) {
+      showToast({
+        title: error instanceof Error ? error.message : 'Failed to sync',
+        type: 'error',
+      });
+    }
+  };
+
+  if (isLoading) {
+    return <div className="text-sm text-muted-foreground">Loading Booking.com status…</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Connection status card */}
+      <div className="rounded-lg border p-5">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-center gap-4">
+            <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-blue-100 text-blue-700 font-semibold">
+              B
+            </div>
+            <div>
+              <div className="flex items-center gap-2">
+                <h3 className="text-lg font-semibold">Booking.com</h3>
+                <span
+                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                    connected ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-600'
+                  }`}
+                >
+                  {connected ? 'Connected' : 'Not connected'}
+                </span>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Channel-manager sync for availability, rates &amp; reservations
+              </p>
+            </div>
+          </div>
+
+          <div className="flex gap-2">
+            {connected ? (
+              <>
+                <button
+                  type="button"
+                  onClick={handleSync}
+                  disabled={sync.isPending}
+                  className="px-3 py-2 text-sm border rounded-md hover:bg-muted disabled:opacity-50"
+                >
+                  {sync.isPending ? 'Syncing…' : 'Sync now'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setDisconnectOpen(true)}
+                  className="px-3 py-2 text-sm border rounded-md text-red-600 hover:bg-red-50"
+                >
+                  Disconnect
+                </button>
+              </>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setShowConnectDialog(true)}
+                className="px-4 py-2 text-sm bg-primary text-primary-foreground rounded-md hover:bg-primary/90"
+              >
+                Connect
+              </button>
+            )}
+          </div>
+        </div>
+
+        {connected && (
+          <dl className="mt-5 grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <div>
+              <dt className="text-xs text-muted-foreground">Hotel ID</dt>
+              <dd className="text-sm font-medium">{status?.hotel_id || '—'}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-muted-foreground">Properties mapped</dt>
+              <dd className="text-sm font-medium">{status?.properties_count ?? 0}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-muted-foreground">Reservations</dt>
+              <dd className="text-sm font-medium">{status?.reservations_count ?? 0}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-muted-foreground">Last sync</dt>
+              <dd className="text-sm font-medium">{formatDateTime(status?.last_sync_at)}</dd>
+            </div>
+          </dl>
+        )}
+
+        {connected && status?.sync_error && (
+          <div className="mt-4 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+            Last sync error: {status.sync_error}
+          </div>
+        )}
+      </div>
+
+      {/* Conflict feed */}
+      {connected && (
+        <div className="rounded-lg border p-5">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-base font-semibold">Reservation conflicts</h3>
+              <p className="text-sm text-muted-foreground">
+                Overlapping bookings between Booking.com and other channels
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => refetchConflicts()}
+              disabled={conflictsLoading}
+              className="px-3 py-2 text-sm border rounded-md hover:bg-muted disabled:opacity-50"
+            >
+              {conflictsLoading ? 'Checking…' : 'Refresh'}
+            </button>
+          </div>
+
+          {conflictsLoading ? (
+            <p className="mt-4 text-sm text-muted-foreground">Checking for conflicts…</p>
+          ) : conflicts && conflicts.conflicts_found > 0 ? (
+            <div className="mt-4 space-y-3">
+              {conflicts.truncated && (
+                <div className="rounded-md bg-amber-50 px-3 py-2 text-xs text-amber-700">
+                  Results may be incomplete — the upstream reservation cap was reached.
+                </div>
+              )}
+              <ul className="divide-y rounded-md border">
+                {conflicts.conflicts.map((c) => (
+                  <li
+                    key={`${c.booking_reservation_id}-${c.conflicting_booking_id}`}
+                    className="flex items-center justify-between gap-4 px-4 py-3"
+                  >
+                    <div>
+                      <div className="text-sm font-medium">
+                        Booking.com reservation {c.booking_reservation_id}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        Conflicts with {c.conflicting_platform} · {c.overlap_start} →{' '}
+                        {c.overlap_end}
+                      </div>
+                    </div>
+                    <span className="inline-flex items-center rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700">
+                      Overlap
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : (
+            <p className="mt-4 text-sm text-muted-foreground">No conflicts detected.</p>
+          )}
+        </div>
+      )}
+
+      {/* Connect dialog */}
+      {showConnectDialog && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="w-full max-w-md bg-background rounded-lg shadow-lg p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-xl font-semibold">Connect Booking.com</h2>
+              <button
+                type="button"
+                onClick={() => {
+                  setShowConnectDialog(false);
+                  resetForm();
+                }}
+                className="text-muted-foreground hover:text-foreground"
+              >
+                X
+              </button>
+            </div>
+
+            <p className="text-sm text-muted-foreground mb-4">
+              Enter your Booking.com Supply XML (Connectivity) credentials. These authorize
+              availability and rate pushes for your hotel.
+            </p>
+
+            <div className="space-y-3">
+              <div>
+                <label htmlFor="booking-hotel-id" className="block text-sm font-medium mb-1">
+                  Hotel ID
+                </label>
+                <input
+                  id="booking-hotel-id"
+                  type="text"
+                  value={form.hotel_id}
+                  onChange={(e) => setForm((f) => ({ ...f, hotel_id: e.target.value }))}
+                  placeholder="e.g. 1234567"
+                  className="w-full px-3 py-2 border rounded-md bg-background"
+                />
+              </div>
+              <div>
+                <label htmlFor="booking-username" className="block text-sm font-medium mb-1">
+                  Username
+                </label>
+                <input
+                  id="booking-username"
+                  type="text"
+                  value={form.username}
+                  onChange={(e) => setForm((f) => ({ ...f, username: e.target.value }))}
+                  autoComplete="off"
+                  className="w-full px-3 py-2 border rounded-md bg-background"
+                />
+              </div>
+              <div>
+                <label htmlFor="booking-password" className="block text-sm font-medium mb-1">
+                  Password
+                </label>
+                <input
+                  id="booking-password"
+                  type="password"
+                  value={form.password}
+                  onChange={(e) => setForm((f) => ({ ...f, password: e.target.value }))}
+                  autoComplete="new-password"
+                  className="w-full px-3 py-2 border rounded-md bg-background"
+                />
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-2 pt-5">
+              <button
+                type="button"
+                onClick={() => {
+                  setShowConnectDialog(false);
+                  resetForm();
+                }}
+                className="px-4 py-2 text-sm border rounded-md hover:bg-muted"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleConnect}
+                disabled={connect.isPending || !form.hotel_id || !form.username || !form.password}
+                className="px-4 py-2 text-sm bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-50"
+              >
+                {connect.isPending ? 'Connecting…' : 'Connect'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <ConfirmationDialog
+        isOpen={disconnectOpen}
+        title="Disconnect Booking.com?"
+        message="This removes the stored credentials. Availability and rate sync will stop until you reconnect."
+        confirmLabel="Disconnect"
+        variant="danger"
+        onConfirm={handleDisconnect}
+        onCancel={() => setDisconnectOpen(false)}
+      />
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/integrations/components/index.ts
+++ b/frontend/apps/ppt-web/src/features/integrations/components/index.ts
@@ -6,6 +6,8 @@
 
 // Story 61.2: Accounting Export
 export { AccountingExportsList } from './AccountingExportsList';
+// Gap 83.2: Booking.com channel integration
+export { BookingChannelPanel } from './BookingChannelPanel';
 export { CalendarConnectDialog } from './CalendarConnectDialog';
 // Story 61.1: Calendar Integration
 export { CalendarConnectionsList } from './CalendarConnectionsList';

--- a/frontend/apps/ppt-web/src/features/integrations/pages/IntegrationsPage.tsx
+++ b/frontend/apps/ppt-web/src/features/integrations/pages/IntegrationsPage.tsx
@@ -7,6 +7,7 @@
 import { useState } from 'react';
 import {
   AccountingExportsList,
+  BookingChannelPanel,
   CalendarConnectionsList,
   ESignatureWorkflowsList,
   IntegrationsDashboard,
@@ -18,7 +19,7 @@ interface IntegrationsPageProps {
   organizationId: string;
 }
 
-type TabValue = 'calendars' | 'accounting' | 'esignatures' | 'video' | 'webhooks';
+type TabValue = 'calendars' | 'accounting' | 'esignatures' | 'video' | 'webhooks' | 'booking';
 
 const tabs: { value: TabValue; label: string }[] = [
   { value: 'calendars', label: 'Calendars' },
@@ -26,6 +27,7 @@ const tabs: { value: TabValue; label: string }[] = [
   { value: 'esignatures', label: 'E-Signatures' },
   { value: 'video', label: 'Video' },
   { value: 'webhooks', label: 'Webhooks' },
+  { value: 'booking', label: 'Booking.com' },
 ];
 
 export function IntegrationsPage({ organizationId }: IntegrationsPageProps) {
@@ -70,6 +72,8 @@ export function IntegrationsPage({ organizationId }: IntegrationsPageProps) {
           {activeTab === 'video' && <VideoMeetingsList organizationId={organizationId} />}
 
           {activeTab === 'webhooks' && <WebhookSubscriptionsList organizationId={organizationId} />}
+
+          {activeTab === 'booking' && <BookingChannelPanel organizationId={organizationId} />}
         </div>
       </div>
     </div>

--- a/frontend/packages/api-client/src/integrations/api.ts
+++ b/frontend/packages/api-client/src/integrations/api.ts
@@ -8,6 +8,12 @@ import type {
   AccountingExport,
   AccountingExportQuery,
   AccountingExportSettings,
+  BookingChannelStatus,
+  BookingConflictCheck,
+  BookingConnectRequest,
+  BookingConnectResponse,
+  BookingDisconnectResponse,
+  BookingSyncResult,
   CalendarConnection,
   CalendarEvent,
   CalendarEventsQuery,
@@ -399,4 +405,50 @@ export async function listWebhookLogs(id: string): Promise<WebhookDeliveryLog[]>
 
 export async function getWebhookStatistics(id: string): Promise<WebhookStatistics> {
   return apiRequest<WebhookStatistics>(`${API_BASE}/webhooks/${id}/stats`);
+}
+
+// ============================================
+// Booking.com Channel (Gap 83.2)
+// ============================================
+
+export async function getBookingStatus(organizationId: string): Promise<BookingChannelStatus> {
+  return apiRequest<BookingChannelStatus>(
+    `${API_BASE}/organizations/${organizationId}/booking/status`
+  );
+}
+
+export async function connectBooking(
+  organizationId: string,
+  data: BookingConnectRequest
+): Promise<BookingConnectResponse> {
+  return apiRequest<BookingConnectResponse>(
+    `${API_BASE}/organizations/${organizationId}/booking/connect`,
+    {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }
+  );
+}
+
+export async function disconnectBooking(
+  organizationId: string
+): Promise<BookingDisconnectResponse> {
+  return apiRequest<BookingDisconnectResponse>(
+    `${API_BASE}/organizations/${organizationId}/booking`,
+    {
+      method: 'DELETE',
+    }
+  );
+}
+
+export async function syncBooking(organizationId: string): Promise<BookingSyncResult> {
+  return apiRequest<BookingSyncResult>(`${API_BASE}/organizations/${organizationId}/booking/sync`, {
+    method: 'POST',
+  });
+}
+
+export async function getBookingConflicts(organizationId: string): Promise<BookingConflictCheck> {
+  return apiRequest<BookingConflictCheck>(
+    `${API_BASE}/organizations/${organizationId}/booking/conflicts`
+  );
 }

--- a/frontend/packages/api-client/src/integrations/hooks.ts
+++ b/frontend/packages/api-client/src/integrations/hooks.ts
@@ -9,6 +9,7 @@ import * as api from './api';
 import type {
   AccountingExportQuery,
   AccountingSystem,
+  BookingConnectRequest,
   CalendarEventsQuery,
   CalendarQuery,
   CreateAccountingExport,
@@ -56,6 +57,10 @@ export const integrationKeys = {
   webhook: (id: string) => [...integrationKeys.all, 'webhook', id] as const,
   webhookLogs: (id: string) => [...integrationKeys.all, 'webhook-logs', id] as const,
   webhookStats: (id: string) => [...integrationKeys.all, 'webhook-stats', id] as const,
+  // Booking.com (Gap 83.2)
+  bookingStatus: (orgId: string) => [...integrationKeys.all, 'booking-status', orgId] as const,
+  bookingConflicts: (orgId: string) =>
+    [...integrationKeys.all, 'booking-conflicts', orgId] as const,
 };
 
 // ============================================
@@ -491,5 +496,69 @@ export function useWebhookStatistics(id: string) {
     queryKey: integrationKeys.webhookStats(id),
     queryFn: () => api.getWebhookStatistics(id),
     enabled: !!id,
+  });
+}
+
+// ============================================
+// Booking.com Channel (Gap 83.2)
+// ============================================
+
+export function useBookingStatus(organizationId: string) {
+  return useQuery({
+    queryKey: integrationKeys.bookingStatus(organizationId),
+    queryFn: () => api.getBookingStatus(organizationId),
+    enabled: !!organizationId,
+  });
+}
+
+export function useConnectBooking(organizationId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: BookingConnectRequest) => api.connectBooking(organizationId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: integrationKeys.bookingStatus(organizationId),
+      });
+      queryClient.invalidateQueries({ queryKey: integrationKeys.statistics(organizationId) });
+    },
+  });
+}
+
+export function useDisconnectBooking(organizationId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.disconnectBooking(organizationId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: integrationKeys.bookingStatus(organizationId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: integrationKeys.bookingConflicts(organizationId),
+      });
+      queryClient.invalidateQueries({ queryKey: integrationKeys.statistics(organizationId) });
+    },
+  });
+}
+
+export function useSyncBooking(organizationId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.syncBooking(organizationId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: integrationKeys.bookingStatus(organizationId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: integrationKeys.bookingConflicts(organizationId),
+      });
+    },
+  });
+}
+
+export function useBookingConflicts(organizationId: string, enabled = true) {
+  return useQuery({
+    queryKey: integrationKeys.bookingConflicts(organizationId),
+    queryFn: () => api.getBookingConflicts(organizationId),
+    enabled: !!organizationId && enabled,
   });
 }

--- a/frontend/packages/api-client/src/integrations/types.ts
+++ b/frontend/packages/api-client/src/integrations/types.ts
@@ -475,3 +475,69 @@ export interface VideoMeetingQuery {
   status?: MeetingStatus;
   limit?: number;
 }
+
+// ============================================
+// Gap 83.2: Booking.com Channel Integration
+// ============================================
+//
+// NOTE: the Booking.com backend handlers (api-server
+// routes/integrations/{install,booking_channel}.rs) serialize with the
+// default serde casing (snake_case), so these wire types deliberately use
+// snake_case field names to match the JSON on the wire.
+
+/** Connection + sync status for a Booking.com channel connection. */
+export interface BookingChannelStatus {
+  connected: boolean;
+  hotel_id?: string | null;
+  last_sync_at?: string | null;
+  sync_error?: string | null;
+  properties_count: number;
+  reservations_count: number;
+}
+
+/** Request body for connecting a Booking.com hotel via Supply XML credentials. */
+export interface BookingConnectRequest {
+  hotel_id: string;
+  username: string;
+  password: string;
+}
+
+/** Response returned by the Booking.com connect endpoint. */
+export interface BookingConnectResponse {
+  success: boolean;
+  message: string;
+  hotel_id?: string;
+}
+
+/** Response returned by the Booking.com disconnect endpoint. */
+export interface BookingDisconnectResponse {
+  success: boolean;
+  message: string;
+}
+
+/** Result of a Booking.com sync operation. */
+export interface BookingSyncResult {
+  success: boolean;
+  items_synced: number;
+  synced_at: string;
+  error?: string | null;
+}
+
+/** A single cross-platform booking conflict (overlapping reservations). */
+export interface BookingConflict {
+  unit_id: string;
+  booking_reservation_id: string;
+  conflicting_platform: string;
+  conflicting_booking_id: string;
+  overlap_start: string;
+  overlap_end: string;
+}
+
+/** Response from the Booking.com conflict-detection endpoint. */
+export interface BookingConflictCheck {
+  conflicts_found: number;
+  conflicts: BookingConflict[];
+  checked_at: string;
+  /** True when the upstream query hit its reservation cap (results incomplete). */
+  truncated: boolean;
+}


### PR DESCRIPTION
## Task
Build Booking.com connection management UI in ppt-web: OAuth connect/disconnect, property mapping, availability/rate sync status, booking feed; wire to booking backend routes from PR #534 (83-2 Booking.com Integration).

## Owner
pm-frontend

## What landed
Adds a **Booking.com** tab to the existing ppt-web Integrations page (`features/integrations`), wiring the channel-manager backend surface that already exists in `backend/servers/api-server/src/routes/integrations/{install,booking_channel}.rs` (Gap 83-2):

- **Connection status card** — connected badge, hotel ID, properties-mapped count, reservations count, last-sync time, and last-sync error. (`GET /api/v1/integrations/organizations/{org_id}/booking/status`)
- **Connect dialog** — Supply XML (Connectivity) credentials: `hotel_id` / `username` / `password`. (`POST .../booking/connect`)
- **Disconnect** with a confirmation dialog. (`DELETE .../booking`)
- **Manual sync** trigger for availability/rates with toast feedback. (`POST .../booking/sync`)
- **Reservation-conflict feed** — cross-platform overlap detection with refresh and a truncation notice. (`GET .../booking/conflicts`)

`@ppt/api-client` gains the booking types, `fetch` wrappers, and TanStack Query hooks (`useBookingStatus`, `useConnectBooking`, `useDisconnectBooking`, `useSyncBooking`, `useBookingConflicts`) following the existing Epic-61 integrations module pattern.

### Implementation notes for the reviewer
- **Connect terminology:** the task says "OAuth connect", but the merged backend's Booking.com connect handler takes Supply-XML credentials (hotel_id/username/password), not an OAuth redirect (only Airbnb has an OAuth callback in `oauth.rs`). The UI implements the credential flow the backend actually exposes.
- **Property mapping:** the backend has no list/CRUD HTTP endpoint for room-type ↔ unit mappings (mappings are only accepted inline in push requests). The status card surfaces the mapped-property count; a dedicated mapping editor would require a new backend endpoint and is out of scope here.
- **Wire casing:** the Booking.com backend handlers serialize with default serde casing (**snake_case**), so the new TS wire types intentionally use snake_case field names (matches the actual JSON, unlike some older Epic-61 camelCase type declarations).
- **Type name:** `BookingStatus` collides with the facilities module's existing export, so the new status type is named `BookingChannelStatus`.

## Tested (Band A — fast check)
- `pnpm -F @ppt/api-client build` → exit 0
- `pnpm -F @ppt/web typecheck` → exit 0
- `biome check` on all 6 changed files → exit 0 (formatter applied)
- Note: ppt-web's per-app `lint` script invokes ESLint with no eslint config present (pre-existing repo misconfiguration); the authoritative linter is Biome per CLAUDE.md, which passes.

## Built (Band B — full build)
- `pnpm -F @ppt/web build` (Vite production build) → exit 0 (only pre-existing chunk-size / dynamic-import warnings)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change; new credential form posts to an existing authenticated, role-gated backend route).

## Remote-tested
skipped

## Scope drift
None — `scope-check.sh --owner pm-frontend` exit 0. All changes under `frontend/apps/ppt-web/` and `frontend/packages/api-client/`.

## Code-reuse review
None — `reuse-grep.sh` produced no warnings.

## Notes
- No new route was added (extends the existing Integrations page), and there is no existing `docs/screens/ppt/` entry for the Integrations page, so no screen-map update was applicable.

https://claude.ai/code/session_01F3Lzsdeor3xPB3LcD3MnVU

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3Lzsdeor3xPB3LcD3MnVU)_