### PR TITLE
fix(voting): delegation/enum schema-drift in vote.rs (#1008) + eligibility & ballot-cast regression tests (#971)

### DIFF
--- a/backend/crates/db/src/repositories/vote.rs
+++ b/backend/crates/db/src/repositories/vote.rs
@@ -140,8 +140,8 @@ impl VoteRepository {
                 start_at, end_at, quorum_type, quorum_percentage,
                 allow_delegation, anonymous_voting, created_by
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-            RETURNING *
+            VALUES ($1, $2, $3, $4, $5, $6, $7::quorum_type, $8, $9, $10, $11)
+            RETURNING id, organization_id, building_id, title, description, start_at, end_at, status::text AS status, quorum_type::text AS quorum_type, quorum_percentage, allow_delegation, anonymous_voting, participation_count, eligible_count, quorum_met, results, results_calculated_at, created_by, published_by, published_at, cancelled_by, cancelled_at, cancellation_reason, created_at, updated_at
             "#,
         )
         .bind(data.organization_id)
@@ -174,7 +174,7 @@ impl VoteRepository {
     {
         let vote = sqlx::query_as::<_, Vote>(
             r#"
-            SELECT * FROM votes WHERE id = $1
+            SELECT id, organization_id, building_id, title, description, start_at, end_at, status::text AS status, quorum_type::text AS quorum_type, quorum_percentage, allow_delegation, anonymous_voting, participation_count, eligible_count, quorum_met, results, results_calculated_at, created_by, published_by, published_at, cancelled_by, cancelled_at, cancellation_reason, created_at, updated_at FROM votes WHERE id = $1
             "#,
         )
         .bind(id)
@@ -302,7 +302,7 @@ impl VoteRepository {
         // Get vote from RLS context
         let vote = sqlx::query_as::<_, Vote>(
             r#"
-            SELECT * FROM votes WHERE id = $1
+            SELECT id, organization_id, building_id, title, description, start_at, end_at, status::text AS status, quorum_type::text AS quorum_type, quorum_percentage, allow_delegation, anonymous_voting, participation_count, eligible_count, quorum_met, results, results_calculated_at, created_by, published_by, published_at, cancelled_by, cancelled_at, cancellation_reason, created_at, updated_at FROM votes WHERE id = $1
             "#,
         )
         .bind(vote_id)
@@ -414,8 +414,8 @@ impl VoteRepository {
                 start_at, end_at, quorum_type, quorum_percentage,
                 allow_delegation, anonymous_voting, created_by
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-            RETURNING *
+            VALUES ($1, $2, $3, $4, $5, $6, $7::quorum_type, $8, $9, $10, $11)
+            RETURNING id, organization_id, building_id, title, description, start_at, end_at, status::text AS status, quorum_type::text AS quorum_type, quorum_percentage, allow_delegation, anonymous_voting, participation_count, eligible_count, quorum_met, results, results_calculated_at, created_by, published_by, published_at, cancelled_by, cancelled_at, cancellation_reason, created_at, updated_at
             "#,
         )
         .bind(data.organization_id)
@@ -714,13 +714,13 @@ impl VoteRepository {
                 description = COALESCE($3, description),
                 start_at = COALESCE($4, start_at),
                 end_at = COALESCE($5, end_at),
-                quorum_type = COALESCE($6, quorum_type),
+                quorum_type = COALESCE($6::quorum_type, quorum_type),
                 quorum_percentage = COALESCE($7, quorum_percentage),
                 allow_delegation = COALESCE($8, allow_delegation),
                 anonymous_voting = COALESCE($9, anonymous_voting),
                 updated_at = NOW()
             WHERE id = $1 AND status = 'draft'
-            RETURNING *
+            RETURNING id, organization_id, building_id, title, description, start_at, end_at, status::text AS status, quorum_type::text AS quorum_type, quorum_percentage, allow_delegation, anonymous_voting, participation_count, eligible_count, quorum_met, results, results_calculated_at, created_by, published_by, published_at, cancelled_by, cancelled_at, cancellation_reason, created_at, updated_at
             "#,
         )
         .bind(id)
@@ -774,14 +774,14 @@ impl VoteRepository {
             r#"
             UPDATE votes
             SET
-                status = $2,
+                status = $2::vote_status,
                 start_at = $3,
                 eligible_count = $4,
                 published_by = $5,
                 published_at = NOW(),
                 updated_at = NOW()
             WHERE id = $1 AND status = 'draft'
-            RETURNING *
+            RETURNING id, organization_id, building_id, title, description, start_at, end_at, status::text AS status, quorum_type::text AS quorum_type, quorum_percentage, allow_delegation, anonymous_voting, participation_count, eligible_count, quorum_met, results, results_calculated_at, created_by, published_by, published_at, cancelled_by, cancelled_at, cancellation_reason, created_at, updated_at
             "#,
         )
         .bind(id)
@@ -826,7 +826,7 @@ impl VoteRepository {
                 cancellation_reason = $3,
                 updated_at = NOW()
             WHERE id = $1 AND status != 'closed'
-            RETURNING *
+            RETURNING id, organization_id, building_id, title, description, start_at, end_at, status::text AS status, quorum_type::text AS quorum_type, quorum_percentage, allow_delegation, anonymous_voting, participation_count, eligible_count, quorum_met, results, results_calculated_at, created_by, published_by, published_at, cancelled_by, cancelled_at, cancellation_reason, created_at, updated_at
             "#,
         )
         .bind(id)
@@ -866,7 +866,7 @@ impl VoteRepository {
                 results_calculated_at = NOW(),
                 updated_at = NOW()
             WHERE id = $1
-            RETURNING *
+            RETURNING id, organization_id, building_id, title, description, start_at, end_at, status::text AS status, quorum_type::text AS quorum_type, quorum_percentage, allow_delegation, anonymous_voting, participation_count, eligible_count, quorum_met, results, results_calculated_at, created_by, published_by, published_at, cancelled_by, cancelled_at, cancellation_reason, created_at, updated_at
             "#,
         )
         .bind(id)
@@ -900,7 +900,7 @@ impl VoteRepository {
             UPDATE votes
             SET status = 'active', updated_at = NOW()
             WHERE status = 'scheduled' AND start_at <= NOW()
-            RETURNING *
+            RETURNING id, organization_id, building_id, title, description, start_at, end_at, status::text AS status, quorum_type::text AS quorum_type, quorum_percentage, allow_delegation, anonymous_voting, participation_count, eligible_count, quorum_met, results, results_calculated_at, created_by, published_by, published_at, cancelled_by, cancelled_at, cancellation_reason, created_at, updated_at
             "#,
         )
         .fetch_all(&self.pool)
@@ -945,8 +945,8 @@ impl VoteRepository {
                 vote_id, question_text, description, question_type,
                 options, display_order, is_required
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7)
-            RETURNING *
+            VALUES ($1, $2, $3, $4::vote_question_type, $5, $6, $7)
+            RETURNING id, vote_id, question_text, description, question_type::text AS question_type, options, display_order, is_required, created_at, updated_at
             "#,
         )
         .bind(data.vote_id)
@@ -981,7 +981,7 @@ impl VoteRepository {
     pub async fn get_questions(&self, vote_id: Uuid) -> Result<Vec<VoteQuestion>, SqlxError> {
         let questions = sqlx::query_as::<_, VoteQuestion>(
             r#"
-            SELECT * FROM vote_questions
+            SELECT id, vote_id, question_text, description, question_type::text AS question_type, options, display_order, is_required, created_at, updated_at FROM vote_questions
             WHERE vote_id = $1
             ORDER BY display_order
             "#,
@@ -1015,7 +1015,7 @@ impl VoteRepository {
                 is_required = COALESCE($6, is_required),
                 updated_at = NOW()
             WHERE id = $1
-            RETURNING *
+            RETURNING id, vote_id, question_text, description, question_type::text AS question_type, options, display_order, is_required, created_at, updated_at
             "#,
         )
         .bind(id)
@@ -1837,8 +1837,8 @@ impl VoteRepository {
         let entry = sqlx::query_as::<_, VoteAuditLog>(
             r#"
             INSERT INTO vote_audit_log (vote_id, user_id, action, data_hash, data_snapshot, ip_address, user_agent)
-            VALUES ($1, $2, $3, $4, $5, $6::inet, $7)
-            RETURNING *
+            VALUES ($1, $2, $3::vote_audit_action, $4, $5, $6::inet, $7)
+            RETURNING id, vote_id, user_id, action::text AS action, data_hash, data_snapshot, ip_address::text AS ip_address, user_agent, created_at
             "#,
         )
         .bind(data.vote_id)
@@ -1866,8 +1866,8 @@ impl VoteRepository {
         let entry = sqlx::query_as::<_, VoteAuditLog>(
             r#"
             INSERT INTO vote_audit_log (vote_id, user_id, action, data_hash, data_snapshot, ip_address, user_agent)
-            VALUES ($1, $2, $3, $4, $5, $6::inet, $7)
-            RETURNING *
+            VALUES ($1, $2, $3::vote_audit_action, $4, $5, $6::inet, $7)
+            RETURNING id, vote_id, user_id, action::text AS action, data_hash, data_snapshot, ip_address::text AS ip_address, user_agent, created_at
             "#,
         )
         .bind(data.vote_id)
@@ -1887,7 +1887,7 @@ impl VoteRepository {
     pub async fn get_audit_log(&self, vote_id: Uuid) -> Result<Vec<VoteAuditLog>, SqlxError> {
         let entries = sqlx::query_as::<_, VoteAuditLog>(
             r#"
-            SELECT * FROM vote_audit_log
+            SELECT id, vote_id, user_id, action::text AS action, data_hash, data_snapshot, ip_address::text AS ip_address, user_agent, created_at FROM vote_audit_log
             WHERE vote_id = $1
             ORDER BY created_at
             "#,

--- a/backend/crates/db/src/repositories/vote.rs
+++ b/backend/crates/db/src/repositories/vote.rs
@@ -1206,7 +1206,7 @@ impl VoteRepository {
                 WHERE u.building_id = $1
                   AND ur.user_id = $2
                   AND ur.resident_type = 'owner'
-                  AND ur.move_out_date IS NULL
+                  AND ur.end_date IS NULL
 
                 UNION ALL
 
@@ -1221,10 +1221,10 @@ impl VoteRepository {
                 FROM units u
                 JOIN delegations d ON u.id = d.unit_id
                 WHERE u.building_id = $1
-                  AND d.delegate_id = $2
+                  AND d.delegate_user_id = $2
                   AND d.status = 'active'
-                  AND d.scope IN ('voting', 'full')
-                  AND (d.expires_at IS NULL OR d.expires_at > NOW())
+                  AND (d.scopes && ARRAY['voting','all']::delegation_scope[])
+                  AND (d.end_date IS NULL OR d.end_date >= CURRENT_DATE)
                   AND $3 = true
             )
             SELECT
@@ -1296,7 +1296,7 @@ impl VoteRepository {
             JOIN unit_residents ur ON u.id = ur.unit_id
             WHERE u.building_id = $1
               AND ur.resident_type = 'owner'
-              AND ur.move_out_date IS NULL
+              AND ur.end_date IS NULL
             "#,
         )
         .bind(vote.building_id)
@@ -1324,7 +1324,7 @@ impl VoteRepository {
             JOIN units u ON ur.unit_id = u.id
             WHERE u.building_id = $1
               AND ur.resident_type = 'owner'
-              AND ur.move_out_date IS NULL
+              AND ur.end_date IS NULL
             "#,
         )
         .bind(building_id)
@@ -1927,7 +1927,7 @@ impl VoteRepository {
             JOIN unit_residents ur ON u.id = ur.unit_id
             WHERE u.building_id = $2
               AND ur.resident_type = 'owner'
-              AND ur.move_out_date IS NULL
+              AND ur.end_date IS NULL
             ORDER BY u.designation
             "#,
         )

--- a/backend/crates/db/tests/vote_cast_regression_tests.rs
+++ b/backend/crates/db/tests/vote_cast_regression_tests.rs
@@ -1,0 +1,374 @@
+//! Regression tests for the RLS ballot-cast path (Epic 5, issue #971).
+//!
+//! These lock in the behaviour fixed by the #971 gap sweep on
+//! `VoteRepository::cast_vote_rls` / `get_poll_results_rls`
+//! (`crates/db/src/repositories/vote.rs`):
+//!
+//!   - #971.1 — the stored `vote_weight` reflects the unit's `ownership_share`
+//!     (folded into the INSERT as `COALESCE((SELECT ownership_share ...), 1.0)`),
+//!     not the old hard-coded `Decimal::from(1)`.
+//!   - #971.2 — a `ballot_cast` (or `ballot_updated`) `vote_audit_log` row is
+//!     written on the same RLS connection after the ballot INSERT.
+//!   - #971.5 — `participation_count` on the parent vote is recomputed after a
+//!     ballot is cast, so the live quorum indicator is accurate.
+//!   - #971.8 — `get_poll_results_rls` returns live, non-zero tallies for an
+//!     ACTIVE vote instead of zeroed cached results.
+//!
+//! They run against a real Postgres via `#[sqlx::test]`, which provisions an
+//! isolated migrated database per test. With no local Postgres they are
+//! skipped locally and run in CI (`backend.yml`). The audit insert needs the
+//! tenant GUC (`app.current_org_id`) in scope, so each test sets the request
+//! context on the connection it hands to `cast_vote_rls`.
+
+use db::models::vote::{audit_action, vote_status, CastVote, CreateVote, CreateVoteQuestion};
+use db::repositories::VoteRepository;
+use rust_decimal::Decimal;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("VoteCast {slug}"))
+    .bind(format!("vote-cast-{slug}"))
+    .bind(format!("{slug}@vote-cast.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'test_hash', 'Vote Cast User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_building(pool: &PgPool, org_id: Uuid, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO buildings (organization_id, name, street, city, postal_code, country)
+        VALUES ($1, $2, 'Test St 1', 'Bratislava', '81101', 'Slovakia')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .expect("seed building")
+}
+
+/// Seed a unit with an explicit ownership share so the weight assertion is
+/// meaningful (a value distinct from the legacy hard-coded `1.0`).
+async fn seed_unit(pool: &PgPool, building_id: Uuid, designation: &str, share: Decimal) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO units (building_id, designation, ownership_share)
+        VALUES ($1, $2, $3)
+        RETURNING id
+        "#,
+    )
+    .bind(building_id)
+    .bind(designation)
+    .bind(share)
+    .fetch_one(pool)
+    .await
+    .expect("seed unit")
+}
+
+/// Set the per-connection request context (org/user GUCs) so RLS insert
+/// policies — notably `vote_audit_log` — pass on the connection that
+/// `cast_vote_rls` runs both INSERTs on.
+async fn set_context(conn: &mut sqlx::PgConnection, org_id: Uuid, user_id: Uuid) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(false)
+        .execute(conn)
+        .await
+        .expect("set request context");
+}
+
+/// Create an ACTIVE vote with a known eligible_count + a single yes/no
+/// question, returning the vote id and the question id.
+async fn seed_active_vote(
+    repo: &VoteRepository,
+    pool: &PgPool,
+    org_id: Uuid,
+    building_id: Uuid,
+    created_by: Uuid,
+    eligible_count: i32,
+) -> (Uuid, Uuid) {
+    let vote = repo
+        .create_poll_rls(
+            pool,
+            CreateVote {
+                organization_id: org_id,
+                building_id,
+                title: "Roof renovation".to_string(),
+                description: None,
+                start_at: None,
+                end_at: chrono::Utc::now() + chrono::Duration::days(7),
+                quorum_type: "simple_majority".to_string(),
+                quorum_percentage: Some(50),
+                allow_delegation: Some(true),
+                anonymous_voting: Some(false),
+                created_by,
+            },
+        )
+        .await
+        .expect("create poll");
+
+    let question = repo
+        .add_question(CreateVoteQuestion {
+            vote_id: vote.id,
+            question_text: "Approve the roof renovation?".to_string(),
+            description: None,
+            question_type: db::models::vote::question_type::YES_NO.to_string(),
+            options: Vec::new(),
+            display_order: Some(0),
+            is_required: Some(true),
+        })
+        .await
+        .expect("add question");
+
+    // Flip the vote to ACTIVE and set an eligible_count so live-tally /
+    // participation_count assertions are well-defined.
+    sqlx::query("UPDATE votes SET status = $2::vote_status, eligible_count = $3 WHERE id = $1")
+        .bind(vote.id)
+        .bind(vote_status::ACTIVE)
+        .bind(eligible_count)
+        .execute(pool)
+        .await
+        .expect("activate vote");
+
+    (vote.id, question.id)
+}
+
+// ---------------------------------------------------------------------------
+// #971.1 — stored vote_weight == unit ownership_share
+// ---------------------------------------------------------------------------
+
+#[sqlx::test]
+async fn cast_vote_rls_stores_unit_ownership_share_as_weight(pool: PgPool) {
+    let repo = VoteRepository::new(pool.clone());
+    let org = seed_org(&pool, "weight").await;
+    let user = seed_user(&pool, "weight@vote-cast.test").await;
+    let building = seed_building(&pool, org, "Weight Building").await;
+    // Distinct from the legacy hard-coded 1.0 so the assertion is meaningful.
+    let share = Decimal::new(4250, 2); // 42.50
+    let unit = seed_unit(&pool, building, "W-1", share).await;
+
+    let (vote_id, question_id) = seed_active_vote(&repo, &pool, org, building, user, 4).await;
+
+    let mut conn = pool.acquire().await.expect("acquire");
+    set_context(&mut conn, org, user).await;
+
+    repo.cast_vote_rls(
+        &mut conn,
+        CastVote {
+            vote_id,
+            user_id: user,
+            unit_id: unit,
+            delegation_id: None,
+            answers: serde_json::json!({ question_id.to_string(): true }),
+        },
+    )
+    .await
+    .expect("cast vote");
+
+    let weight: Decimal = sqlx::query_scalar(
+        "SELECT vote_weight FROM vote_responses WHERE vote_id = $1 AND unit_id = $2",
+    )
+    .bind(vote_id)
+    .bind(unit)
+    .fetch_one(&pool)
+    .await
+    .expect("read vote_weight");
+
+    assert_eq!(
+        weight, share,
+        "stored vote_weight must equal the unit's ownership_share (#971.1), not the legacy 1.0"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #971.2 — a ballot_cast audit row exists after a cast
+// ---------------------------------------------------------------------------
+
+#[sqlx::test]
+async fn cast_vote_rls_writes_ballot_cast_audit_row(pool: PgPool) {
+    let repo = VoteRepository::new(pool.clone());
+    let org = seed_org(&pool, "audit").await;
+    let user = seed_user(&pool, "audit@vote-cast.test").await;
+    let building = seed_building(&pool, org, "Audit Building").await;
+    let unit = seed_unit(&pool, building, "A-1", Decimal::new(10000, 2)).await;
+
+    let (vote_id, question_id) = seed_active_vote(&repo, &pool, org, building, user, 2).await;
+
+    let mut conn = pool.acquire().await.expect("acquire");
+    set_context(&mut conn, org, user).await;
+
+    repo.cast_vote_rls(
+        &mut conn,
+        CastVote {
+            vote_id,
+            user_id: user,
+            unit_id: unit,
+            delegation_id: None,
+            answers: serde_json::json!({ question_id.to_string(): true }),
+        },
+    )
+    .await
+    .expect("cast vote");
+
+    // A non-delegated cast records action = ballot_cast (#971.2).
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM vote_audit_log WHERE vote_id = $1 AND action = $2::vote_audit_action",
+    )
+    .bind(vote_id)
+    .bind(audit_action::BALLOT_CAST)
+    .fetch_one(&pool)
+    .await
+    .expect("count audit rows");
+
+    assert_eq!(
+        count, 1,
+        "a ballot_cast audit row must be written on the RLS connection after the ballot INSERT (#971.2)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #971.5 — participation_count increments on an active vote after a cast
+// ---------------------------------------------------------------------------
+
+#[sqlx::test]
+async fn cast_vote_rls_increments_participation_count(pool: PgPool) {
+    let repo = VoteRepository::new(pool.clone());
+    let org = seed_org(&pool, "part").await;
+    let user = seed_user(&pool, "part@vote-cast.test").await;
+    let building = seed_building(&pool, org, "Participation Building").await;
+    let unit = seed_unit(&pool, building, "P-1", Decimal::new(5000, 2)).await;
+
+    let (vote_id, question_id) = seed_active_vote(&repo, &pool, org, building, user, 3).await;
+
+    // Freshly-activated vote: no ballots yet.
+    let before: i32 =
+        sqlx::query_scalar("SELECT COALESCE(participation_count, 0) FROM votes WHERE id = $1")
+            .bind(vote_id)
+            .fetch_one(&pool)
+            .await
+            .expect("read participation before");
+    assert_eq!(before, 0, "no ballots cast yet");
+
+    let mut conn = pool.acquire().await.expect("acquire");
+    set_context(&mut conn, org, user).await;
+
+    repo.cast_vote_rls(
+        &mut conn,
+        CastVote {
+            vote_id,
+            user_id: user,
+            unit_id: unit,
+            delegation_id: None,
+            answers: serde_json::json!({ question_id.to_string(): false }),
+        },
+    )
+    .await
+    .expect("cast vote");
+
+    let after: i32 =
+        sqlx::query_scalar("SELECT COALESCE(participation_count, 0) FROM votes WHERE id = $1")
+            .bind(vote_id)
+            .fetch_one(&pool)
+            .await
+            .expect("read participation after");
+
+    assert_eq!(
+        after, 1,
+        "participation_count must be recomputed to 1 after one ballot is cast (#971.5)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #971.8 — active-vote results are live (non-zero), not zeroed cached results
+// ---------------------------------------------------------------------------
+
+#[sqlx::test]
+async fn get_poll_results_rls_returns_live_tally_for_active_vote(pool: PgPool) {
+    let repo = VoteRepository::new(pool.clone());
+    let org = seed_org(&pool, "results").await;
+    let user = seed_user(&pool, "results@vote-cast.test").await;
+    let building = seed_building(&pool, org, "Results Building").await;
+    let unit = seed_unit(&pool, building, "R-1", Decimal::new(10000, 2)).await;
+
+    let (vote_id, question_id) = seed_active_vote(&repo, &pool, org, building, user, 4).await;
+
+    let mut conn = pool.acquire().await.expect("acquire");
+    set_context(&mut conn, org, user).await;
+
+    repo.cast_vote_rls(
+        &mut conn,
+        CastVote {
+            vote_id,
+            user_id: user,
+            unit_id: unit,
+            delegation_id: None,
+            answers: serde_json::json!({ question_id.to_string(): true }),
+        },
+    )
+    .await
+    .expect("cast vote");
+    drop(conn);
+
+    let results = repo
+        .get_poll_results_rls(&pool, vote_id)
+        .await
+        .expect("get poll results")
+        .expect("results present for active vote");
+
+    assert_eq!(
+        results.participation_count, 1,
+        "active-vote results must reflect the cast ballot, not zeroed cached results (#971.8)"
+    );
+    assert_eq!(
+        results.eligible_count, 4,
+        "eligible_count comes from the loaded vote row"
+    );
+    assert!(
+        !results.questions.is_empty(),
+        "active-vote results must include live per-question tallies (#971.8)"
+    );
+
+    // No RESULTS_CALCULATED audit row may be written by the active-vote arm —
+    // it uses compute_results (no audit write) to avoid spamming on every poll.
+    let calc_audits: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM vote_audit_log WHERE vote_id = $1 AND action = $2::vote_audit_action",
+    )
+    .bind(vote_id)
+    .bind(audit_action::RESULTS_CALCULATED)
+    .fetch_one(&pool)
+    .await
+    .expect("count results_calculated audits");
+    assert_eq!(
+        calc_audits, 0,
+        "polling active-vote results must NOT write a results_calculated audit row (#971.8)"
+    );
+}

--- a/backend/crates/db/tests/vote_delegation_eligibility_tests.rs
+++ b/backend/crates/db/tests/vote_delegation_eligibility_tests.rs
@@ -96,7 +96,12 @@ async fn insert_owner_resident(conn: &mut PgConnection, unit: Uuid, user: Uuid) 
 }
 
 /// Active vote with delegation allowed, open now, ending in the future.
-async fn insert_active_vote(conn: &mut PgConnection, org: Uuid, building: Uuid, creator: Uuid) -> Uuid {
+async fn insert_active_vote(
+    conn: &mut PgConnection,
+    org: Uuid,
+    building: Uuid,
+    creator: Uuid,
+) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(
         "INSERT INTO votes \
             (organization_id, building_id, title, start_at, end_at, status, \
@@ -230,7 +235,10 @@ async fn revoked_delegation_is_rejected_by_eligibility_and_cast_guard(pool: PgPo
         .await
         .expect("check_eligibility (active)");
     assert!(
-        before.eligible_units.iter().any(|u| u.unit_id == unit && u.is_delegated),
+        before
+            .eligible_units
+            .iter()
+            .any(|u| u.unit_id == unit && u.is_delegated),
         "delegate should be eligible while delegation is active"
     );
     assert!(
@@ -256,7 +264,10 @@ async fn revoked_delegation_is_rejected_by_eligibility_and_cast_guard(pool: PgPo
         .await
         .expect("check_eligibility (revoked)");
     assert!(
-        !after.eligible_units.iter().any(|u| u.unit_id == unit && u.is_delegated),
+        !after
+            .eligible_units
+            .iter()
+            .any(|u| u.unit_id == unit && u.is_delegated),
         "revoked delegation must not grant delegated eligibility; got {:?}",
         after.eligible_units
     );

--- a/backend/crates/db/tests/vote_delegation_eligibility_tests.rs
+++ b/backend/crates/db/tests/vote_delegation_eligibility_tests.rs
@@ -1,0 +1,267 @@
+//! Regression test for issue #1008 — voting-side schema drift.
+//!
+//! Several hand-written `sqlx::query` strings in the voting paths referenced
+//! columns that do not exist in the migrations:
+//!   - `delegations.delegate_id`        -> actual `delegate_user_id`
+//!   - `delegations.scope IN (...)`     -> actual `scopes delegation_scope[]`
+//!     (and the value `'full'` does not exist; the array value is `'all'`)
+//!   - `delegations.expires_at`         -> actual `end_date DATE`
+//!   - `unit_residents.move_out_date`   -> actual `end_date DATE`
+//!
+//! Because the backend ships no `.sqlx` offline metadata and uses
+//! runtime-checked query strings (not the `query!` macro), these compiled and
+//! passed clippy but ERROR'd at runtime against a real Postgres. This made:
+//!   - delegated-unit vote eligibility (`check_eligibility`) fail to plan, and
+//!   - the #971.3 cast-time delegation guard 500 instead of returning
+//!     403 DELEGATION_REVOKED.
+//!
+//! These tests run the real eligibility CTE and the real cast-time guard SQL
+//! against live Postgres, so they fail on the broken columns and pass once the
+//! columns are corrected. They are DB-gated (`#[sqlx::test]`); CI provisions
+//! Postgres and runs them.
+
+use db::repositories::VoteRepository;
+use db::DbPool;
+use sqlx::{PgConnection, PgPool};
+use uuid::Uuid;
+
+async fn set_ctx(conn: &mut PgConnection, org: Option<Uuid>, user: Option<Uuid>, su: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org)
+        .bind(user)
+        .bind(su)
+        .execute(conn)
+        .await
+        .expect("set_request_context");
+}
+
+async fn insert_org(conn: &mut PgConnection, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO organizations (name, slug, contact_email, status) \
+         VALUES ($1, $2, $3, 'active') RETURNING id",
+    )
+    .bind(format!("Issue 1008 {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@issue1008.test"))
+    .fetch_one(conn)
+    .await
+    .expect("insert org")
+}
+
+async fn insert_user(conn: &mut PgConnection, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO users (email, password_hash, name, status, email_verified_at) \
+         VALUES ($1, 'test_hash', 'U1008', 'active', NOW()) RETURNING id",
+    )
+    .bind(email)
+    .fetch_one(conn)
+    .await
+    .expect("insert user")
+}
+
+async fn insert_building(conn: &mut PgConnection, org: Uuid, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO buildings (organization_id, name, street, city, postal_code, country) \
+         VALUES ($1, $2, 'Addr', 'City', '00000', 'Country') RETURNING id",
+    )
+    .bind(org)
+    .bind(name)
+    .fetch_one(conn)
+    .await
+    .expect("insert building")
+}
+
+async fn insert_unit(conn: &mut PgConnection, building: Uuid, designation: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO units (building_id, designation) VALUES ($1, $2) RETURNING id",
+    )
+    .bind(building)
+    .bind(designation)
+    .fetch_one(conn)
+    .await
+    .expect("insert unit")
+}
+
+/// Owner resident with an open validity period (`end_date IS NULL` = current).
+async fn insert_owner_resident(conn: &mut PgConnection, unit: Uuid, user: Uuid) {
+    sqlx::query(
+        "INSERT INTO unit_residents (unit_id, user_id, resident_type) \
+         VALUES ($1, $2, 'owner')",
+    )
+    .bind(unit)
+    .bind(user)
+    .execute(conn)
+    .await
+    .expect("insert owner resident");
+}
+
+/// Active vote with delegation allowed, open now, ending in the future.
+async fn insert_active_vote(conn: &mut PgConnection, org: Uuid, building: Uuid, creator: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO votes \
+            (organization_id, building_id, title, start_at, end_at, status, \
+             allow_delegation, created_by, published_by, published_at) \
+         VALUES ($1, $2, 'Issue 1008 vote', NOW() - INTERVAL '1 hour', \
+                 NOW() + INTERVAL '7 days', 'active', TRUE, $3, $3, NOW()) \
+         RETURNING id",
+    )
+    .bind(org)
+    .bind(building)
+    .bind(creator)
+    .fetch_one(conn)
+    .await
+    .expect("insert active vote")
+}
+
+/// Active voting-scoped delegation of `unit` from `owner` to `delegate`.
+async fn insert_active_voting_delegation(
+    conn: &mut PgConnection,
+    owner: Uuid,
+    delegate: Uuid,
+    unit: Uuid,
+) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO delegations \
+            (owner_user_id, delegate_user_id, unit_id, scopes, status, start_date, end_date) \
+         VALUES ($1, $2, $3, ARRAY['voting']::delegation_scope[], 'active', CURRENT_DATE, NULL) \
+         RETURNING id",
+    )
+    .bind(owner)
+    .bind(delegate)
+    .bind(unit)
+    .fetch_one(conn)
+    .await
+    .expect("insert active voting delegation")
+}
+
+/// Mirror of the cast-time delegation re-validation guard in
+/// `api-server/src/routes/voting.rs` (#971.3). Returns whether an active
+/// matching delegation exists. The handler returns 403 DELEGATION_REVOKED when
+/// this is `false`.
+async fn cast_guard_delegation_valid(
+    pool: &DbPool,
+    delegation_id: Uuid,
+    delegate_user_id: Uuid,
+    unit_id: Uuid,
+) -> bool {
+    sqlx::query_scalar::<_, bool>(
+        r#"
+        SELECT EXISTS (
+            SELECT 1 FROM delegations
+            WHERE id = $1
+              AND delegate_user_id = $2
+              AND unit_id = $3
+              AND status = 'active'
+              AND (scopes && ARRAY['voting','all']::delegation_scope[])
+              AND (end_date IS NULL OR end_date >= CURRENT_DATE)
+        )
+        "#,
+    )
+    .bind(delegation_id)
+    .bind(delegate_user_id)
+    .bind(unit_id)
+    .fetch_one(pool)
+    .await
+    .expect("run cast-time delegation guard")
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn active_voting_delegation_makes_delegate_eligible(pool: PgPool) {
+    let mut sa = pool.acquire().await.unwrap();
+    set_ctx(&mut sa, None, None, true).await;
+
+    let org = insert_org(&mut sa, "elig").await;
+    let owner = insert_user(&mut sa, "owner-elig@issue1008.test").await;
+    let delegate = insert_user(&mut sa, "delegate-elig@issue1008.test").await;
+    let building = insert_building(&mut sa, org, "B-elig").await;
+    let unit = insert_unit(&mut sa, building, "1A").await;
+    insert_owner_resident(&mut sa, unit, owner).await;
+    let vote = insert_active_vote(&mut sa, org, building, owner).await;
+    insert_active_voting_delegation(&mut sa, owner, delegate, unit).await;
+    drop(sa);
+
+    let repo = VoteRepository::new(pool.clone());
+
+    // The delegate (who is NOT an owner resident) is eligible via the active
+    // voting delegation. Before the fix, the delegated-units CTE branch
+    // referenced delegate_id / scope / expires_at and errored at runtime.
+    let eligibility = repo
+        .check_eligibility(vote, delegate)
+        .await
+        .expect("check_eligibility for delegate");
+
+    let delegated: Vec<_> = eligibility
+        .eligible_units
+        .iter()
+        .filter(|u| u.unit_id == unit && u.is_delegated)
+        .collect();
+    assert_eq!(
+        delegated.len(),
+        1,
+        "delegate should have exactly one delegated eligible unit; got {:?}",
+        eligibility.eligible_units
+    );
+    assert!(
+        eligibility.can_vote,
+        "delegate with an active voting delegation should be able to vote"
+    );
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn revoked_delegation_is_rejected_by_eligibility_and_cast_guard(pool: PgPool) {
+    let mut sa = pool.acquire().await.unwrap();
+    set_ctx(&mut sa, None, None, true).await;
+
+    let org = insert_org(&mut sa, "revoke").await;
+    let owner = insert_user(&mut sa, "owner-revoke@issue1008.test").await;
+    let delegate = insert_user(&mut sa, "delegate-revoke@issue1008.test").await;
+    let building = insert_building(&mut sa, org, "B-revoke").await;
+    let unit = insert_unit(&mut sa, building, "2B").await;
+    insert_owner_resident(&mut sa, unit, owner).await;
+    let vote = insert_active_vote(&mut sa, org, building, owner).await;
+    let delegation = insert_active_voting_delegation(&mut sa, owner, delegate, unit).await;
+    drop(sa);
+
+    let repo = VoteRepository::new(pool.clone());
+
+    // While active: eligible + cast guard passes.
+    let before = repo
+        .check_eligibility(vote, delegate)
+        .await
+        .expect("check_eligibility (active)");
+    assert!(
+        before.eligible_units.iter().any(|u| u.unit_id == unit && u.is_delegated),
+        "delegate should be eligible while delegation is active"
+    );
+    assert!(
+        cast_guard_delegation_valid(&pool, delegation, delegate, unit).await,
+        "cast-time guard should accept an active delegation"
+    );
+
+    // Revoke the delegation.
+    {
+        let mut sa = pool.acquire().await.unwrap();
+        set_ctx(&mut sa, None, None, true).await;
+        sqlx::query("UPDATE delegations SET status = 'revoked', revoked_at = NOW() WHERE id = $1")
+            .bind(delegation)
+            .execute(&mut *sa)
+            .await
+            .expect("revoke delegation");
+    }
+
+    // After revoke: no delegated unit, and the cast-time guard rejects (the
+    // handler maps this `false` to 403 DELEGATION_REVOKED).
+    let after = repo
+        .check_eligibility(vote, delegate)
+        .await
+        .expect("check_eligibility (revoked)");
+    assert!(
+        !after.eligible_units.iter().any(|u| u.unit_id == unit && u.is_delegated),
+        "revoked delegation must not grant delegated eligibility; got {:?}",
+        after.eligible_units
+    );
+    assert!(
+        !cast_guard_delegation_valid(&pool, delegation, delegate, unit).await,
+        "cast-time guard must reject a revoked delegation (403 DELEGATION_REVOKED)"
+    );
+}

--- a/backend/servers/api-server/src/routes/voting.rs
+++ b/backend/servers/api-server/src/routes/voting.rs
@@ -1109,11 +1109,11 @@ async fn cast_vote(
             SELECT EXISTS (
                 SELECT 1 FROM delegations
                 WHERE id = $1
-                  AND delegate_id = $2
+                  AND delegate_user_id = $2
                   AND unit_id = $3
                   AND status = 'active'
-                  AND scope IN ('voting', 'full')
-                  AND (expires_at IS NULL OR expires_at > NOW())
+                  AND (scopes && ARRAY['voting','all']::delegation_scope[])
+                  AND (end_date IS NULL OR end_date >= CURRENT_DATE)
             )
             "#,
         )

--- a/backend/servers/api-server/src/services/scheduler.rs
+++ b/backend/servers/api-server/src/services/scheduler.rs
@@ -386,7 +386,7 @@ impl Scheduler {
                     SELECT DISTINCT ur.user_id
                     FROM unit_residents ur
                     JOIN units u ON ur.unit_id = u.id
-                    WHERE u.building_id = ANY($1) AND ur.move_out_date IS NULL
+                    WHERE u.building_id = ANY($1) AND ur.end_date IS NULL
                     "#,
                 )
                 .bind(&target_ids)
@@ -399,7 +399,7 @@ impl Scheduler {
                 let users: Vec<(uuid::Uuid,)> = sqlx::query_as(
                     r#"
                     SELECT DISTINCT user_id FROM unit_residents
-                    WHERE unit_id = ANY($1) AND move_out_date IS NULL
+                    WHERE unit_id = ANY($1) AND end_date IS NULL
                     "#,
                 )
                 .bind(&target_ids)
@@ -583,7 +583,7 @@ impl Scheduler {
             JOIN units u ON ur.unit_id = u.id
             WHERE u.building_id = $1
               AND ur.resident_type = 'owner'
-              AND ur.move_out_date IS NULL
+              AND ur.end_date IS NULL
             "#,
         )
         .bind(building_id)
@@ -658,7 +658,7 @@ impl Scheduler {
             JOIN units u ON ur.unit_id = u.id
             WHERE u.building_id = $1
               AND ur.resident_type = 'owner'
-              AND ur.move_out_date IS NULL
+              AND ur.end_date IS NULL
               AND NOT EXISTS (
                   SELECT 1 FROM vote_responses vr
                   WHERE vr.vote_id = $2 AND vr.unit_id = ur.unit_id
@@ -698,7 +698,7 @@ impl Scheduler {
             JOIN unit_residents ur ON ur.unit_id = u.id
             WHERE v.id = ANY($1)
               AND ur.resident_type = 'owner'
-              AND ur.move_out_date IS NULL
+              AND ur.end_date IS NULL
               AND NOT EXISTS (
                   SELECT 1 FROM vote_responses vr
                   WHERE vr.vote_id = v.id AND vr.unit_id = ur.unit_id


### PR DESCRIPTION
## Summary

Fixes the **voting-side** schema-drift bugs from #1008 — hand-written `sqlx`
query strings referencing columns that do not exist in the migrations. Because
the backend ships **no `.sqlx` offline metadata** and uses runtime-checked
`query`/`query_as` (not the `query!` macro), these compiled and passed clippy/CI
but **errored at runtime** against real Postgres.

This unblocks two gap-sweep items (#971) that were reported fixed but were
non-functional:

- **#971.3 (Story 5.4) — cast-time delegation re-validation guard.** The
  `voting.rs` guard is meant to return **403 `DELEGATION_REVOKED`** when a
  delegation was revoked/expired between eligibility load and ballot cast.
  Its query referenced non-existent columns, so it threw → **500** instead of
  enforcing. The security guard was non-functional.
- **#971.6 (Story 5.1) — publish-vote notifications.** `get_eligible_owner_user_ids`
  used `unit_residents.move_out_date` (does not exist), so the eligible-owner
  lookup errored (best-effort/logged → notifications silently never sent).

Scope is limited to the voting paths. The `users.first_name/last_name` sweep
(messaging etc.) is **out of scope** and tracked separately in #1008.

## Confirmed schema (from migrations)

- `delegations` (`00010_create_delegations.sql`): `delegate_user_id`,
  `scopes delegation_scope[]` (array; enum values `all, voting, documents,
  faults, financial` — **no `full`**), `status delegation_status`,
  `start_date DATE`, `end_date DATE`. No `delegate_id`, no singular `scope`,
  no `expires_at`.
- `unit_residents` (`00009_create_unit_residents.sql`): `end_date DATE`
  (NULL = current). No `move_out_date`.

Mirrors the canonical correct query in
`backend/crates/db/src/repositories/delegation.rs`.

## Corrected sites (before → after)

**`backend/crates/db/src/repositories/vote.rs`**
- `check_eligibility` owned-units branch: `ur.move_out_date IS NULL` → `ur.end_date IS NULL`
- `check_eligibility` delegated-units branch:
  - `d.delegate_id = $2` → `d.delegate_user_id = $2`
  - `d.scope IN ('voting','full')` → `(d.scopes && ARRAY['voting','all']::delegation_scope[])`
  - `d.expires_at IS NULL OR d.expires_at > NOW()` → `d.end_date IS NULL OR d.end_date >= CURRENT_DATE`
  - (kept `d.status = 'active'`)
- `count_eligible_units`: `ur.move_out_date IS NULL` → `ur.end_date IS NULL`
- `get_eligible_owner_user_ids` (#971.6): `ur.move_out_date IS NULL` → `ur.end_date IS NULL`
- `generate_report_data`: `ur.move_out_date IS NULL` → `ur.end_date IS NULL`

**`backend/servers/api-server/src/routes/voting.rs`** — #971.3 cast-time guard:
- `delegate_id = $2` → `delegate_user_id = $2`
- `scope IN ('voting','full')` → `(scopes && ARRAY['voting','all']::delegation_scope[])`
- `expires_at IS NULL OR expires_at > NOW()` → `end_date IS NULL OR end_date >= CURRENT_DATE`
- Still returns **403 `DELEGATION_REVOKED`** when no matching active row exists.

**`backend/servers/api-server/src/services/scheduler.rs`** — `unit_residents` joins:
- `get_recipients` (building target): `ur.move_out_date IS NULL` → `ur.end_date IS NULL`
- `get_recipients` (units target): `move_out_date IS NULL` → `end_date IS NULL`
- `get_vote_eligible_users`: `ur.move_out_date IS NULL` → `ur.end_date IS NULL`
- `get_users_not_voted` / `get_users_not_voted_batch`: `ur.move_out_date IS NULL` → `ur.end_date IS NULL`
- (left untouched: `user_memberships.expires_at` at L366 and `signature_requests.expires_at` — real columns, unrelated)

No SQL drift in `routes/delegations.rs` (the `delegate_id` hits there are `tracing` log field names reading the correct `delegate_user_id` value).

## Tests

New DB-gated regression test
`backend/crates/db/tests/vote_delegation_eligibility_tests.rs` (`#[sqlx::test]`):
1. `active_voting_delegation_makes_delegate_eligible` — seeds owner + unit +
   active vote + ACTIVE delegation `scopes={voting}`, asserts `check_eligibility`
   returns the delegated unit and `can_vote`.
2. `revoked_delegation_is_rejected_by_eligibility_and_cast_guard` — after
   `status='revoked'`, asserts no delegated eligibility and that the cast-time
   guard SQL (mirrored from `voting.rs`) returns `false` (→ 403 path).

These **require live Postgres to RUN** (they are `#[sqlx::test]`, DB-gated). I
do not have a local DB; verified via `cargo test -p db --test
vote_delegation_eligibility_tests --no-run` (compiles). **CI provisions
Postgres and runs them.**

## Verification

- `cargo build -p db` ✅
- `cargo build -p api-server` ✅
- `cargo clippy -p api-server --all-targets` ✅ — no new warnings in changed
  files; pre-existing warnings only in unrelated tests (`ws_integration_tests`
  `let_and_return`, `push_token_tests` `doc_lazy_continuation`).
- `cargo clippy -p db --tests` ✅ — clean.
- Reverted incidental `backend/Cargo.lock` workspace-version churn.

Refs #1008, #971.