### PR TITLE
gap-8a-3-fcm-rn-property-push: route push-notification taps to entity detail screens

### DIFF
--- a/frontend/apps/mobile/src/hooks/usePushNotifications.ts
+++ b/frontend/apps/mobile/src/hooks/usePushNotifications.ts
@@ -3,9 +3,13 @@ import * as Device from 'expo-device';
 import * as Notifications from 'expo-notifications';
 import { useEffect, useRef, useState } from 'react';
 import { Linking, Platform } from 'react-native';
-import { createDeepLink } from '../qrcode/DeepLinkHandler';
 import { colors } from '../screens/shared/screenStyles';
-import { consumeLaunchNotification, syncBadgeFromData } from '../services/backgroundNotifications';
+import {
+  consumeLaunchNotification,
+  deepLinkForNotification,
+  type PushNotificationData,
+  syncBadgeFromData,
+} from '../services/backgroundNotifications';
 import { apiRequest } from './useApi';
 
 // Configure notification handling
@@ -114,44 +118,12 @@ export function usePushNotifications(): UsePushNotificationsReturn {
   };
 
   const handleNotificationNavigation = (data: Record<string, unknown>) => {
-    // Handle deep linking based on notification data
-    const { type, id } = data;
-    const idString = id ? String(id) : undefined;
-
-    // Map notification types to screen names and create deep links
-    let deepLinkUrl: string;
-
-    switch (type) {
-      case 'announcement':
-        deepLinkUrl = idString
-          ? createDeepLink('Announcements', { id: idString })
-          : createDeepLink('Announcements');
-        break;
-      case 'fault':
-        deepLinkUrl = idString
-          ? createDeepLink('Faults', { id: idString })
-          : createDeepLink('Faults');
-        break;
-      case 'vote':
-        deepLinkUrl = idString
-          ? createDeepLink('Voting', { id: idString })
-          : createDeepLink('Voting');
-        break;
-      case 'message':
-        deepLinkUrl = idString
-          ? createDeepLink('Messages', { id: idString })
-          : createDeepLink('Messages');
-        break;
-      case 'outage':
-        deepLinkUrl = idString
-          ? createDeepLink('Outages', { id: idString })
-          : createDeepLink('Outages');
-        break;
-      default:
-        deepLinkUrl = createDeepLink('Dashboard');
-    }
-
-    Linking.openURL(deepLinkUrl);
+    // Map the notification's {type, id} payload to a `ppt://` deep link and
+    // hand it to the OS Linking layer; `deepLinkManager` (initialised in
+    // App.tsx) picks up the `url` event and routes to the screen. Mapping
+    // logic lives in `backgroundNotifications.deepLinkForNotification` so the
+    // foreground, runtime-tap, and cold-start paths route identically.
+    Linking.openURL(deepLinkForNotification(data as PushNotificationData));
   };
 
   const registerForPushNotifications = async (): Promise<string | null> => {

--- a/frontend/apps/mobile/src/qrcode/DeepLinkHandler.ts
+++ b/frontend/apps/mobile/src/qrcode/DeepLinkHandler.ts
@@ -148,8 +148,18 @@ export function createDeepLink(
   params?: Record<string, string>,
   query?: Record<string, string>
 ): string {
-  // Find route for screen
-  const route = DEEP_LINK_ROUTES.find((r) => r.screen === screen);
+  // Find a route for the screen. When the caller supplies params (e.g. an
+  // entity `id` from a tapped push), prefer the route whose `params` cover
+  // those keys so we build the *detail* path (`announcements/:id`) rather than
+  // the bare list path (`announcements`) — otherwise the id is silently
+  // dropped and the tap always lands on the list screen.
+  const paramKeys = params ? Object.keys(params).filter((k) => params[k]) : [];
+  const route =
+    (paramKeys.length > 0
+      ? DEEP_LINK_ROUTES.find(
+          (r) => r.screen === screen && paramKeys.every((k) => r.params?.includes(k))
+        )
+      : undefined) ?? DEEP_LINK_ROUTES.find((r) => r.screen === screen);
 
   if (!route) {
     // Default to simple path

--- a/frontend/apps/mobile/src/services/backgroundNotifications.test.ts
+++ b/frontend/apps/mobile/src/services/backgroundNotifications.test.ts
@@ -7,6 +7,7 @@
 import * as Notifications from 'expo-notifications';
 import {
   consumeLaunchNotification,
+  deepLinkForNotification,
   extractNotificationData,
   syncBadgeFromData,
 } from './backgroundNotifications';
@@ -80,6 +81,32 @@ describe('consumeLaunchNotification', () => {
 
     await expect(consumeLaunchNotification(handler)).resolves.toBeUndefined();
     expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe('deepLinkForNotification', () => {
+  it('routes a typed push with an id to the matching detail deep link', () => {
+    expect(deepLinkForNotification({ type: 'announcement', id: '42' })).toBe(
+      'ppt://announcements/42'
+    );
+    expect(deepLinkForNotification({ type: 'fault', id: 7 })).toBe('ppt://faults/7');
+    expect(deepLinkForNotification({ type: 'vote', id: '9' })).toBe('ppt://voting/9');
+    expect(deepLinkForNotification({ type: 'message', id: '3' })).toBe('ppt://messages/3');
+    expect(deepLinkForNotification({ type: 'outage', id: '5' })).toBe('ppt://outages/5');
+  });
+
+  it('routes a typed push without an id to the list deep link', () => {
+    expect(deepLinkForNotification({ type: 'announcement' })).toBe('ppt://announcements');
+    expect(deepLinkForNotification({ type: 'fault' })).toBe('ppt://faults');
+  });
+
+  it('falls back to the dashboard for an unknown type', () => {
+    expect(deepLinkForNotification({ type: 'wat', id: '1' })).toBe('ppt://dashboard');
+  });
+
+  it('falls back to the dashboard for a missing type or null payload', () => {
+    expect(deepLinkForNotification({ id: '1' })).toBe('ppt://dashboard');
+    expect(deepLinkForNotification(null)).toBe('ppt://dashboard');
   });
 });
 

--- a/frontend/apps/mobile/src/services/backgroundNotifications.ts
+++ b/frontend/apps/mobile/src/services/backgroundNotifications.ts
@@ -17,15 +17,20 @@
  *      exactly once on startup and hands the notification's data payload to a
  *      caller-supplied handler. The actual screen routing is owned by the
  *      navigation/deep-link layer — this module deliberately does NOT import
- *      `Linking` or the deep-link helper so the two concerns stay decoupled.
+ *      `Linking` so the two concerns stay decoupled.
  *
  *   2. `syncBadgeFromData()` keeps the app-icon badge in sync with the
  *      `badge` field a backgrounded data-notification may carry, since iOS
  *      only auto-applies the badge for *alert* notifications, not data-only
  *      ones routed through FCM.
+ *
+ *   3. `deepLinkForNotification()` maps a push `{type,id}` payload to the
+ *      `ppt://` deep link that opens the matching screen, shared by every
+ *      tap entry point in `usePushNotifications`.
  */
 
 import * as Notifications from 'expo-notifications';
+import { createDeepLink } from '../qrcode/DeepLinkHandler';
 
 /** Shape of the data payload our backend attaches to every push. */
 export interface PushNotificationData {
@@ -74,6 +79,36 @@ export async function consumeLaunchNotification(handler: LaunchNotificationHandl
       console.warn('[push] failed to read launch notification', err);
     }
   }
+}
+
+/**
+ * Map a push notification's `{ type, id }` data payload to the `ppt://` deep
+ * link that opens the matching screen when the notification is tapped.
+ *
+ * Shared by the foreground tap handler, the runtime-tap handler, and the
+ * cold-start launch handler in `usePushNotifications` so all three entry
+ * points route identically. Unknown / missing types fall back to the
+ * Dashboard so a tap is never a dead end.
+ */
+export function deepLinkForNotification(data: PushNotificationData | null): string {
+  const type = data?.type;
+  const idString = data?.id != null ? String(data.id) : undefined;
+
+  // Each push `type` maps to a list screen; when an entity `id` is present we
+  // pass it through so the deep-link layer can open the detail screen.
+  const screenForType: Record<string, string> = {
+    announcement: 'Announcements',
+    fault: 'Faults',
+    vote: 'Voting',
+    message: 'Messages',
+    outage: 'Outages',
+  };
+
+  const screen = type ? screenForType[type] : undefined;
+  if (!screen) {
+    return createDeepLink('Dashboard');
+  }
+  return idString ? createDeepLink(screen, { id: idString }) : createDeepLink(screen);
 }
 
 /**


### PR DESCRIPTION
## Task
Wire FCM push notifications in the React Native Property Management app (frontend/apps/mobile): register FCM token via PUT /api/v1/push-tokens, handle notification tap-open to relevant screen, handle foreground notifications via expo-notifications.

## Owner
pm-frontend (specialist: react-native)

## Finding: the FCM pipeline already exists
The core deliverables of this task already landed in merged PR #961 (`gap-85-3-rn-fcm-push-config`):
- **Token registration** — `usePushNotifications` obtains the native FCM (Android) / APNs (iOS) token via `getDevicePushTokenAsync()` and registers it with the backend. The real backend contract is `POST /api/v1/users/me/push-tokens` (router in `backend/servers/api-server/src/routes/push_tokens.rs`), not `PUT /api/v1/push-tokens` as the task text approximated — there is no `PUT /api/v1/push-tokens` endpoint. The existing client already matches the real route.
- **Foreground notifications** — `Notifications.setNotificationHandler` + `addNotificationReceivedListener`.
- **Tap-open** — `addNotificationResponseReceivedListener` + cold-start `consumeLaunchNotification`, routed through `Linking.openURL` → `deepLinkManager` (initialised in `App.tsx`).

## What this PR adds (closing the real gaps)
1. **Bug fix in the tap-open path** — `createDeepLink` always selected the *first* route for a screen, so a detail push like `{type:'announcement', id:'42'}` was downgraded to the bare list path `ppt://announcements` and the id was silently dropped — taps never opened the specific entity. It now prefers the route whose `params` cover the supplied keys, producing `ppt://announcements/42`.
2. **Refactor for testability** — extracted the `{type,id}` → `ppt://` deep-link mapping out of the hook into a pure `deepLinkForNotification()` helper in `backgroundNotifications.ts`, shared by the foreground, runtime-tap, and cold-start handlers so all three route identically.
3. **Tests** — added unit coverage for `deepLinkForNotification` (detail, list, unknown-type, missing/null payload). This is the first test for the notification-tap mapping; PR #961 only tested badge/launch handling.

## Tested (Band A — fast check)
- `pnpm -F @ppt/mobile typecheck` → exit 0
- `pnpm -F @ppt/mobile exec jest src/services/backgroundNotifications.test.ts` → 14 passed (10 pre-existing + 4 new), exit 0
- `npx @biomejs/biome check <changed files>` → 0 errors, exit 0

Full mobile suite (`pnpm -F @ppt/mobile test`): 25 tests pass. 3 suites (auth/offline integration + LanguageSwitcher) error before running on a pre-existing `react-test-renderer` peer-dep mismatch (19.2.6 vs expected 19.2.0) — verified identical failure on clean `dev` (via `git stash`), so not introduced here.

## Built (Band B — full build)
Skipped: change is < 50 LOC of substantive logic, no public API / config / migration touched. (Metro/expo prebuild requires native toolchain not available in the routine sandbox.)

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change). Push-token *registration* logic was untouched; this PR only changes client-side deep-link routing.

## Remote-tested
Skipped (no ppt-bridge MCP in session).

## Scope drift
`scope-check.sh --owner pm-frontend` flags `frontend/apps/mobile/**` as out-of-area because `owner-areas.json` maps that path to `pm-mobile`, while the dispatcher labeled this task `pm-frontend`. All four changed files are inside `frontend/apps/mobile/src/` — squarely the `react-native` specialist's owned area. The drift is an owner_role-hint mislabel, not actual out-of-area code:
- `frontend/apps/mobile/src/services/backgroundNotifications.ts`
- `frontend/apps/mobile/src/services/backgroundNotifications.test.ts`
- `frontend/apps/mobile/src/hooks/usePushNotifications.ts`
- `frontend/apps/mobile/src/qrcode/DeepLinkHandler.ts`

## Code-reuse review
`reuse-grep.sh --specialist react-native` → no warnings. This PR *reduces* duplication (removed the inline `switch` in the hook in favour of the shared helper).

## Notes
- iOS-native APNs entitlement / capability wiring is not exercisable in this Linux sandbox (needs macOS + Xcode). It is unchanged by this PR and out of scope for the Android/Expo FCM logic touched here.
- No backend changes — the `POST /api/v1/users/me/push-tokens` route already exists.

https://claude.ai/code/session_01B9Ch1AzokCL8STsvK2X9ij

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9Ch1AzokCL8STsvK2X9ij)_