### PR TITLE
ci: make trigger-deploy non-fatal so OIDC 403 stops reding dev image builds (#950)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -114,6 +114,8 @@ jobs:
             core.setOutput('token', token);
 
       - name: POST /api/deploy
+        # #950: deploy-trigger is best-effort; a 403 from the OIDC->scope mapping must not red the image build. Real fix = release:deploy scope grant on the deploy host.
+        continue-on-error: true
         env:
           DEPLOY_URL: https://onyx.rlt.sk
           # We deploy by BRANCH tag (e.g. `main`, `dev`), not by short SHA.

--- a/.github/workflows/docker-frontend.yml
+++ b/.github/workflows/docker-frontend.yml
@@ -116,6 +116,8 @@ jobs:
             core.setOutput('token', token);
 
       - name: POST /api/deploy
+        # #950: deploy-trigger is best-effort; a 403 from the OIDC->scope mapping must not red the image build. Real fix = release:deploy scope grant on the deploy host.
+        continue-on-error: true
         env:
           DEPLOY_URL: https://onyx.rlt.sk
           # See docker-build.yml's mirror of this step for the rationale on


### PR DESCRIPTION
## What

Adds `continue-on-error: true` to the `POST /api/deploy` step in both `docker-build.yml` and `docker-frontend.yml` so a deploy-trigger failure no longer marks the image build/push red.

## Why (#950)

The `trigger-deploy` job mints an OIDC token (audience `ppt-deploy`) and POSTs to `https://onyx.rlt.sk/api/deploy`. The deploy host currently returns **403** because the OIDC subject is not mapped to the `release:deploy` scope. With `curl -fsS`, that 403 fails the step, which fails the whole `trigger-deploy` job, which reds every dev image build — even though the image itself built and pushed fine.

This is the **repo-side mitigation** per the issue: it decouples build status from deploy status. A failed deploy-trigger is now best-effort and surfaces as a yellow/neutral step rather than reding the build.

The **real fix is infra** — granting the `release:deploy` OIDC scope to the GitHub Actions subject on the onyx deploy host. That is tracked separately.

## Scope

- `continue-on-error: true` is applied to **only** the `POST /api/deploy` step in each workflow. The OIDC token-mint step and the "Pick deploy target" step are left untouched, so token-mint/setup failures still surface.
- The image build/push jobs (`build`) remain fatal — only the deploy-trigger call is best-effort.
- YAML-only change; no cargo/backend impact.

Closes #950