### PR TITLE
fix(sso): point Reality SSO callback at api.<apex> so OAuth code exchange reaches reality-server (#952)

### DIFF
--- a/backend/servers/api-server/src/bin/seed.rs
+++ b/backend/servers/api-server/src/bin/seed.rs
@@ -30,8 +30,13 @@ use dialoguer::{Confirm, Input, Password};
 /// staging Reality Portal apexes. Operators with custom apex hostnames can
 /// override via repeated `--reality-portal-redirect-uri` flags.
 const DEFAULT_REALITY_PORTAL_REDIRECT_URIS: &[&str] = &[
-    "https://rlt.sk/api/v1/sso/callback",
-    "https://staging.rlt.sk/api/v1/sso/callback",
+    // The SSO callback lands on reality-server (:8081), which is exposed on the
+    // `api.` subdomain — the bare apex serves the Next.js reality-web app and
+    // has no `/api/v1/sso/*` handler, so an apex callback 404s the OAuth
+    // code-exchange (#952). Keep these in sync with deploy-server's
+    // `SSO_CALLBACK_URL` (see `blue_green.rs`).
+    "https://api.rlt.sk/api/v1/sso/callback",
+    "https://api.staging.rlt.sk/api/v1/sso/callback",
 ];
 
 /// UPSERT the `reality-portal` row in `oauth_clients` with the given secret.

--- a/backend/servers/deploy-server/src/infra/blue_green.rs
+++ b/backend/servers/deploy-server/src/infra/blue_green.rs
@@ -276,13 +276,15 @@ pub fn build_service_envs(
     // env config.
     reality_env.push(format!("PM_API_URL={api_base_url}"));
     // `SSO_CALLBACK_URL` defaults to `http://localhost:8081/api/v1/sso/callback`
-    // — that endpoint is on reality-server itself, exposed publicly at
-    // `<reality_apex>/api/v1/sso/callback` so the user's browser can reach
-    // it after the OAuth redirect from api-server. Without overriding the
+    // — that endpoint is on reality-server itself. It must be exposed publicly
+    // at `api.<reality_apex>/api/v1/sso/callback` (the `api.` subdomain proxies
+    // to reality-server :8081 via Caddy). The apex host itself serves the
+    // Next.js reality-web app, which has no `/api/v1/sso/*` handler and would
+    // 404 the OAuth code-exchange callback (#952). Without overriding the
     // default, the redirect from PM SSO would point at localhost in the
     // user's browser → broken login.
     reality_env.push(format!(
-        "SSO_CALLBACK_URL=https://{}/api/v1/sso/callback",
+        "SSO_CALLBACK_URL=https://api.{}/api/v1/sso/callback",
         target.reality_apex
     ));
     reality_env.push(format!("PLATFORM_HOST={platform_hosts}"));


### PR DESCRIPTION
## Problem (#952)

The Reality SSO OAuth callback (`/api/v1/sso/callback`) was being registered/seeded against the **bare reality apex** host (e.g. `https://rlt.sk/...`). That apex host serves the **Next.js reality-web** app, which has **no `/api/v1/sso/*` route handler** — so when api-server redirected the browser back with the OAuth `code`, the callback **404'd** and SSO login broke.

## Fix (Owner decision: Option A)

Repoint the SSO callback at the **`api.<apex>`** subdomain, which Caddy already proxies to **reality-server (:8081)** — the service that actually owns `/api/v1/sso/callback`. The `api.<reality_apex>` route is already registered in `blue_green.rs` (reality-server backend), so no new routing is required.

Two consistent changes:

1. **`backend/servers/deploy-server/src/infra/blue_green.rs`** — the env injected into reality-server now sets
   `SSO_CALLBACK_URL=https://api.{reality_apex}/api/v1/sso/callback` (was `https://{reality_apex}/...`).
2. **`backend/servers/api-server/src/bin/seed.rs`** — the seeded `reality-portal` OAuth client `redirect_uris` now use the `api.` subdomain:
   - prod:    `https://rlt.sk/api/v1/sso/callback` → `https://api.rlt.sk/api/v1/sso/callback`
   - staging: `https://staging.rlt.sk/api/v1/sso/callback` → `https://api.staging.rlt.sk/api/v1/sso/callback`

Localhost/dev defaults left unchanged. The per-worktree dev deploy path (`api/worktree.rs`) is **not** an apex case and is left as-is (in Shared mode the `wt-*.dev.rlt.sk/api/*` path-route already proxies to reality-server).

## ⚠️ Operational follow-up REQUIRED

This changes the **registered OAuth `redirect_uri`** for the `reality-portal` client. To avoid breaking SSO, in **each environment**:

- The provider-side / api-server `oauth_clients.redirect_uris` for `reality-portal` **MUST be re-seeded** (run the seed bin / migration that upserts the client) so the stored `redirect_uri` matches the new callback. A mismatch causes the OAuth `redirect_uri` validation to reject the exchange.
- Any externally-issued client config that pins the old apex callback must be updated to the new `api.<apex>` value.

**New values to register (prod + staging):**
- `https://api.rlt.sk/api/v1/sso/callback`
- `https://api.staging.rlt.sk/api/v1/sso/callback`

## Verify

`cd backend && cargo fmt --all && cargo build -p api-server -p deploy-server && cargo clippy -p api-server -p deploy-server` — build + clippy exit 0, no new warnings. Cargo.lock version churn reverted.