### PR TITLE
fix(leases): wire lease e-signing to the signature-request subsystem + drop orphaned methods (#977)

### DIFF
--- a/backend/crates/db/src/repositories/lease.rs
+++ b/backend/crates/db/src/repositories/lease.rs
@@ -871,11 +871,19 @@ impl LeaseRepository {
         Ok(lease)
     }
 
-    /// Send lease for signature with RLS context.
-    pub async fn send_for_signature_rls<'e, E>(
+    /// Mark a lease as sent for signature, binding it to the signature request
+    /// created in the hardened signature-request subsystem.
+    ///
+    /// Records the `signature_request_id` and transitions a `draft` lease to
+    /// `pending_signature`. The actual signing (landlord/tenant) and the
+    /// resulting status transitions are owned by the signature-request
+    /// subsystem (`routes::signatures`), not by lease-native logic — this is
+    /// Option A wiring for issue #977.
+    pub async fn mark_sent_for_signature_rls<'e, E>(
         &self,
         executor: E,
         id: Uuid,
+        signature_request_id: Uuid,
     ) -> Result<Lease, SqlxError>
     where
         E: Executor<'e, Database = Postgres>,
@@ -883,71 +891,15 @@ impl LeaseRepository {
         let lease = sqlx::query_as::<_, Lease>(
             r#"
             UPDATE leases SET
-                status = 'pending_signature',
-                updated_at = NOW()
-            WHERE id = $1 AND status = 'draft'
-            RETURNING *
-            "#,
-        )
-        .bind(id)
-        .fetch_one(executor)
-        .await?;
-
-        Ok(lease)
-    }
-
-    /// Record landlord signature with RLS context.
-    pub async fn record_landlord_signature_rls<'e, E>(
-        &self,
-        executor: E,
-        id: Uuid,
-    ) -> Result<Lease, SqlxError>
-    where
-        E: Executor<'e, Database = Postgres>,
-    {
-        let lease = sqlx::query_as::<_, Lease>(
-            r#"
-            UPDATE leases SET
-                landlord_signed_at = NOW(),
-                status = CASE
-                    WHEN tenant_signed_at IS NOT NULL THEN 'active'::lease_status
-                    ELSE status
-                END,
+                signature_request_id = $2,
+                status = CASE WHEN status = 'draft' THEN 'pending_signature' ELSE status END,
                 updated_at = NOW()
             WHERE id = $1
             RETURNING *
             "#,
         )
         .bind(id)
-        .fetch_one(executor)
-        .await?;
-
-        Ok(lease)
-    }
-
-    /// Record tenant signature with RLS context.
-    pub async fn record_tenant_signature_rls<'e, E>(
-        &self,
-        executor: E,
-        id: Uuid,
-    ) -> Result<Lease, SqlxError>
-    where
-        E: Executor<'e, Database = Postgres>,
-    {
-        let lease = sqlx::query_as::<_, Lease>(
-            r#"
-            UPDATE leases SET
-                tenant_signed_at = NOW(),
-                status = CASE
-                    WHEN landlord_signed_at IS NOT NULL THEN 'active'::lease_status
-                    ELSE status
-                END,
-                updated_at = NOW()
-            WHERE id = $1
-            RETURNING *
-            "#,
-        )
-        .bind(id)
+        .bind(signature_request_id)
         .fetch_one(executor)
         .await?;
 
@@ -1973,39 +1925,6 @@ impl LeaseRepository {
     )]
     pub async fn update_lease(&self, id: Uuid, data: UpdateLease) -> Result<Lease, SqlxError> {
         self.update_lease_rls(&self.pool, id, data).await
-    }
-
-    /// Send lease for signature.
-    ///
-    /// **Deprecated**: Use `send_for_signature_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use send_for_signature_rls with RlsConnection instead"
-    )]
-    pub async fn send_for_signature(&self, id: Uuid) -> Result<Lease, SqlxError> {
-        self.send_for_signature_rls(&self.pool, id).await
-    }
-
-    /// Record landlord signature.
-    ///
-    /// **Deprecated**: Use `record_landlord_signature_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use record_landlord_signature_rls with RlsConnection instead"
-    )]
-    pub async fn record_landlord_signature(&self, id: Uuid) -> Result<Lease, SqlxError> {
-        self.record_landlord_signature_rls(&self.pool, id).await
-    }
-
-    /// Record tenant signature.
-    ///
-    /// **Deprecated**: Use `record_tenant_signature_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use record_tenant_signature_rls with RlsConnection instead"
-    )]
-    pub async fn record_tenant_signature(&self, id: Uuid) -> Result<Lease, SqlxError> {
-        self.record_tenant_signature_rls(&self.pool, id).await
     }
 
     /// Terminate lease.

--- a/backend/servers/api-server/src/routes/leases.rs
+++ b/backend/servers/api-server/src/routes/leases.rs
@@ -52,6 +52,8 @@ pub fn router() -> Router<AppState> {
         .route("/{id}", put(update_lease))
         .route("/{id}/terminate", post(terminate_lease))
         .route("/{id}/renew", post(renew_lease))
+        // E-signing (issue #977): wire to the hardened signature-request subsystem
+        .route("/{id}/send-for-signature", post(send_lease_for_signature))
         // Lease Amendments
         .route("/{id}/amendments", post(create_amendment))
         .route("/{id}/amendments", get(list_amendments))
@@ -808,6 +810,177 @@ async fn terminate_lease(
 
     rls.release().await;
     result
+}
+
+/// Request body for sending a lease out for e-signature (issue #977).
+///
+/// The lease's generated agreement must already exist as a row in the
+/// `documents` table; its id is supplied here. The endpoint then delegates to
+/// the hardened signature-request subsystem to create the signing workflow.
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct SendLeaseForSignatureRequest {
+    /// Id of the generated lease-agreement document (a `documents` row).
+    pub document_id: Uuid,
+    /// Landlord's email for the signing invitation. Defaults to the
+    /// authenticated requester's email when omitted.
+    #[serde(default)]
+    pub landlord_email: Option<String>,
+    /// Days until the signature request expires (default: 30).
+    #[serde(default)]
+    pub expires_in_days: Option<i32>,
+}
+
+/// Send a lease out for e-signature (issue #977, Option A).
+///
+/// Wires leases into the existing hardened signature-request subsystem
+/// (`routes::signatures`) rather than a lease-native signing flow: it resolves
+/// the lease's generated document and creates a signature request for it with
+/// the landlord and tenant as signers, reusing the one HMAC-signed-link / nonce
+/// / email path. The lease is then bound to the created request and moved to
+/// `pending_signature`.
+///
+/// Document resolution caveat: a lease currently has no FK to a `documents`
+/// row (only a `document_url` text column), and lease-agreement generation is
+/// not yet wired to persist a `documents` row. So this endpoint requires the
+/// caller to pass the generated document's id and returns `400` if absent.
+async fn send_lease_for_signature(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    mut rls: RlsConnection,
+    Path(id): Path<Uuid>,
+    Json(payload): Json<SendLeaseForSignatureRequest>,
+) -> Result<(StatusCode, Json<db::models::SignatureRequest>), (StatusCode, Json<ErrorResponse>)> {
+    // Sending a lease out for signature is a manager action (same gate as
+    // review_application). Without this, any org member could trigger signing.
+    if !rls.is_super_admin() && !rls.has_role(TenantRole::Manager) {
+        rls.release().await;
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "FORBIDDEN",
+                "Only managers can send a lease for signature",
+            )),
+        ));
+    }
+
+    // Load the lease (RLS-scoped) to derive the tenant signer and confirm it
+    // exists within the caller's organisation.
+    let lease = match state
+        .lease_repo
+        .find_lease_by_id_rls(&mut **rls.conn(), id)
+        .await
+    {
+        Ok(Some(l)) => l,
+        Ok(None) => {
+            rls.release().await;
+            return Err((
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Lease not found")),
+            ));
+        }
+        Err(e) => {
+            tracing::error!("Failed to load lease for signature: {:?}", e);
+            rls.release().await;
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", "Failed to load lease")),
+            ));
+        }
+    };
+
+    // Build the signer set: landlord (the requesting manager, unless an explicit
+    // landlord_email is given) + tenant (from the lease record).
+    let landlord_email = payload
+        .landlord_email
+        .clone()
+        .unwrap_or_else(|| auth.email.clone());
+    if landlord_email.trim().is_empty() {
+        rls.release().await;
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(
+                "VALIDATION_ERROR",
+                "A landlord email is required to send the lease for signature",
+            )),
+        ));
+    }
+    if lease.tenant_email.trim().is_empty() {
+        rls.release().await;
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(
+                "VALIDATION_ERROR",
+                "Lease has no tenant email; cannot create a signing request",
+            )),
+        ));
+    }
+
+    let signers = vec![
+        db::models::CreateSigner {
+            email: landlord_email,
+            name: lease.landlord_name.clone(),
+            order: 0,
+        },
+        db::models::CreateSigner {
+            email: lease.tenant_email.clone(),
+            name: lease.tenant_name.clone(),
+            order: 0,
+        },
+    ];
+
+    let create_request = db::models::CreateSignatureRequest {
+        signers,
+        subject: Some(format!("Lease agreement for {}", lease.tenant_name)),
+        message: None,
+        provider: None,
+        expires_in_days: payload.expires_in_days,
+    };
+
+    // Delegate to the single hardened signature-request creation path. This
+    // owns document existence/dedup checks plus HMAC link + nonce + email; we do
+    // NOT duplicate any of that here. The caller owns the rls lifecycle.
+    let response = match crate::routes::signatures::create_signature_request_for_document(
+        &state,
+        &auth,
+        &mut rls,
+        payload.document_id,
+        create_request,
+    )
+    .await
+    {
+        Ok(resp) => resp,
+        Err(e) => {
+            rls.release().await;
+            return Err(e);
+        }
+    };
+
+    let signature_request_id = response.signature_request.id;
+
+    // Bind the lease to the created request and transition draft ->
+    // pending_signature. The actual signing transitions are owned by the
+    // signature subsystem, not lease-native logic.
+    if let Err(e) = state
+        .lease_repo
+        .mark_sent_for_signature_rls(&mut **rls.conn(), id, signature_request_id)
+        .await
+    {
+        // The signature request was already created; surface a clear error but
+        // do not roll it back (the manager can retry binding via a follow-up).
+        tracing::error!("Failed to mark lease as sent for signature: {:?}", e);
+        rls.release().await;
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DB_ERROR",
+                "Signature request created but failed to update lease status",
+            )),
+        ));
+    }
+
+    rls.release().await;
+
+    Ok((StatusCode::CREATED, Json(response.signature_request)))
 }
 
 async fn renew_lease(

--- a/backend/servers/api-server/src/routes/signatures.rs
+++ b/backend/servers/api-server/src/routes/signatures.rs
@@ -68,9 +68,30 @@ pub async fn create_signature_request(
     Path(document_id): Path<Uuid>,
     Json(request): Json<CreateSignatureRequest>,
 ) -> Result<(StatusCode, Json<CreateSignatureRequestResponse>), (StatusCode, Json<ErrorResponse>)> {
+    let result =
+        create_signature_request_for_document(&state, &auth, &mut rls, document_id, request).await;
+    rls.release().await;
+    result.map(|resp| (StatusCode::CREATED, Json(resp)))
+}
+
+/// Core signature-request creation flow, shared by the document-scoped HTTP
+/// handler and other subsystems (e.g. lease e-signing in `routes::leases`).
+///
+/// This is the single hardened path that owns the HMAC-signed-link + nonce +
+/// email logic (issue #527 / #673). Callers must NOT duplicate that logic — they
+/// resolve a `document_id` and delegate here. The caller owns the
+/// [`RlsConnection`] lifecycle and is responsible for calling `rls.release()`
+/// after this returns (this function does not release it, so the caller can keep
+/// using the connection for follow-up work in the same request).
+pub(crate) async fn create_signature_request_for_document(
+    state: &AppState,
+    auth: &AuthUser,
+    rls: &mut RlsConnection,
+    document_id: Uuid,
+    request: CreateSignatureRequest,
+) -> Result<CreateSignatureRequestResponse, (StatusCode, Json<ErrorResponse>)> {
     // Validate request
     if request.signers.is_empty() {
-        rls.release().await;
         return Err((
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -88,14 +109,12 @@ pub async fn create_signature_request(
     {
         Ok(Some(doc)) => doc,
         Ok(None) => {
-            rls.release().await;
             return Err((
                 StatusCode::NOT_FOUND,
                 Json(ErrorResponse::new("NOT_FOUND", "Document not found")),
             ));
         }
         Err(e) => {
-            rls.release().await;
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new("DATABASE_ERROR", e.to_string())),
@@ -111,7 +130,6 @@ pub async fn create_signature_request(
     {
         Ok(reqs) => reqs,
         Err(e) => {
-            rls.release().await;
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new("DATABASE_ERROR", e.to_string())),
@@ -126,7 +144,6 @@ pub async fn create_signature_request(
                 | db::models::SignatureRequestStatus::InProgress
         )
     }) {
-        rls.release().await;
         return Err((
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -145,15 +162,12 @@ pub async fn create_signature_request(
     {
         Ok(req) => req,
         Err(e) => {
-            rls.release().await;
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new("DATABASE_ERROR", e.to_string())),
             ));
         }
     };
-
-    rls.release().await;
 
     info!(
         signature_request_id = %signature_request.id,
@@ -247,13 +261,10 @@ pub async fn create_signature_request(
         }
     }
 
-    Ok((
-        StatusCode::CREATED,
-        Json(CreateSignatureRequestResponse {
-            signature_request,
-            message: "Signature request created. Signers will receive email invitations.".into(),
-        }),
-    ))
+    Ok(CreateSignatureRequestResponse {
+        signature_request,
+        message: "Signature request created. Signers will receive email invitations.".into(),
+    })
 }
 
 /// List signature requests for a document.

--- a/backend/servers/api-server/tests/lease_send_for_signature_rbac_tests.rs
+++ b/backend/servers/api-server/tests/lease_send_for_signature_rbac_tests.rs
@@ -1,0 +1,119 @@
+//! Real-JWT RBAC regression for lease e-signing (#977).
+//!
+//! `send_lease_for_signature`
+//! (`POST /api/v1/leases/{id}/send-for-signature`) wires leases into the
+//! hardened signature-request subsystem (Option A). Sending a lease out for
+//! signature is a manager action, gated with the same role check as
+//! `review_application`: a **resident** must be rejected with 403 before
+//! reaching the repository; a **manager** must pass the role gate (proven by
+//! NOT getting a 403 — a random lease/document id then fails downstream, but
+//! crucially not with 403).
+//!
+//! Mirrors `lease_review_rbac_tests`.
+
+#[allow(dead_code)]
+mod common;
+
+use axum::{
+    body::Body,
+    http::{header, Method, Request, StatusCode},
+};
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{create_authenticated_user, TestApp, TestUser};
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO organizations (name, slug, contact_email, status)
+           VALUES ($1, $2, $3, 'active') RETURNING id"#,
+    )
+    .bind(format!("LeaseSign {slug}"))
+    .bind(format!("lease-sign-{slug}-{}", Uuid::new_v4()))
+    .bind(format!("{slug}-{}@lease-sign.test", Uuid::new_v4()))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_membership(pool: &PgPool, org_id: Uuid, user_id: Uuid, role: &str) {
+    sqlx::query(
+        r#"INSERT INTO organization_members
+               (id, organization_id, user_id, role_type, status, created_at)
+           VALUES ($1, $2, $3, $4, 'active', NOW()) ON CONFLICT DO NOTHING"#,
+    )
+    .bind(Uuid::new_v4())
+    .bind(org_id)
+    .bind(user_id)
+    .bind(role)
+    .execute(pool)
+    .await
+    .expect("seed membership");
+}
+
+async fn user_id_for(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(email)
+        .fetch_one(pool)
+        .await
+        .expect("user id")
+}
+
+/// Authenticate a user and make them a member of `org` with `role`.
+/// Returns the bearer token.
+async fn member_token(pool: &PgPool, app: &TestApp, org: Uuid, role: &str) -> String {
+    let user = TestUser::new();
+    let (token, _refresh) = create_authenticated_user(app, &user).await;
+    let uid = user_id_for(pool, &user.email).await;
+    seed_membership(pool, org, uid, role).await;
+    token
+}
+
+fn send_req(token: &str, org: Uuid, lease_id: Uuid) -> Request<Body> {
+    Request::builder()
+        .method(Method::POST)
+        .uri(format!("/api/v1/leases/{lease_id}/send-for-signature"))
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .header("X-Tenant-ID", org.to_string())
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(
+            json!({ "document_id": Uuid::new_v4() }).to_string(),
+        ))
+        .unwrap()
+}
+
+/// A resident must NOT be able to send a lease for signature.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn resident_cannot_send_lease_for_signature(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org = seed_org(&pool, "res").await;
+    let token = member_token(&pool, &app, org, "resident").await;
+
+    let resp = app.execute(send_req(&token, org, Uuid::new_v4())).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "a resident sending a lease for signature must get 403, got {}",
+        resp.status
+    );
+}
+
+/// A manager passes the role gate (does not get 403). The random lease id won't
+/// be found, so the handler returns 404 downstream — but crucially NOT 403,
+/// proving managers are allowed through the gate.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn manager_passes_send_for_signature_role_gate(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org = seed_org(&pool, "mgr").await;
+    let token = member_token(&pool, &app, org, "manager").await;
+
+    let resp = app.execute(send_req(&token, org, Uuid::new_v4())).await;
+
+    assert_ne!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "a manager must pass the send-for-signature role gate, got 403"
+    );
+}


### PR DESCRIPTION
## Issue #977 item 1 — Lease e-signing had repo methods but no HTTP route

Owner decision: **Option A** — wire leases to the existing hardened signature-request subsystem (`routes/signatures.rs`, `signature_requests`, `LightweightProvider`), **not** a lease-native signing flow. Then delete the orphaned lease e-sign repo methods as dead code.

### Why Option A
There must be exactly **one** signing path. The signature-request subsystem already owns the HMAC-signed-link integrity, the one-shot nonce persistence (`e_signature_nonces`, #673), cross-tenant replay protection (org_id bound into the HMAC, #527), the `/sign` consumer, reminders, cancel, and webhooks. The orphaned lease methods (`send_for_signature_rls`, `record_landlord_signature_rls`, `record_tenant_signature_rls`) were a parallel, weaker flow that just flipped `leases.status`/`*_signed_at` with no link integrity, no nonce, no emails. Wiring leases into the hardened path avoids a competing weaker mechanism.

### New endpoint
`POST /api/v1/leases/{id}/send-for-signature`

- Auth: `AuthUser` + `RlsConnection`, gated behind the **manager/owner** role check (same gate as `review_application`, #806) — `is_super_admin() || has_role(Manager)`, else `403`.
- Loads the lease (RLS-scoped), derives signers: **landlord** (the requesting manager's email, or an explicit `landlord_email` in the body) + **tenant** (`tenant_email`/`tenant_name` from the lease).
- Delegates to the **reused** signature-request creation path. `create_signature_request`'s body was extracted into a shared `create_signature_request_for_document(state, auth, rls, document_id, request)`; both the existing document handler and the new lease handler call it — the HMAC/nonce/email logic is **not** duplicated.
- On success, binds the lease to the created request (`signature_request_id`) and transitions `draft -> pending_signature` via a new `mark_sent_for_signature_rls`. Returns the created `SignatureRequest`.

### Document-resolution caveat
A lease has **no FK to a `documents` row** — only a `document_url` text column and `signature_request_id`. Lease-agreement generation (`services/document_generation.rs`) is an LLM text generator and does not persist a `documents` row tied to the lease. Since the signature subsystem signs a `documents` row, the endpoint **requires the caller to pass the generated document's `document_id`** in the request body and returns a clear `400`/`404` if it is missing/not found (existence + dedup checks are enforced inside the shared path). Auto-resolving/generating the lease document and persisting a `documents` row is left as a follow-up.

### Dead code removed (grep-proven, no callers)
Removed from `crates/db/src/repositories/lease.rs`:
- `send_for_signature_rls`, `record_landlord_signature_rls`, `record_tenant_signature_rls` (+ their 3 deprecated non-RLS wrappers `send_for_signature` / `record_landlord_signature` / `record_tenant_signature`).

`grep -rn` across the whole backend found **zero** callers outside `lease.rs` itself for all six. Replaced with the single `mark_sent_for_signature_rls` used by the new route. The `landlord_signed_at` / `tenant_signed_at` columns and `pending_signature` const are **kept** (still referenced by the model and the statistics query) — only the dead transition methods were deleted.

### Tests
Added `lease_send_for_signature_rbac_tests.rs` (mirrors `lease_review_rbac_tests`): a resident gets `403`; a manager passes the gate (not `403`). Real-JWT + `X-Tenant-ID`, DB-backed via `#[sqlx::test]`.

### Verify
- `cargo fmt --all` clean
- `cargo build -p api-server` — exit 0
- `cargo clippy -p api-server --all-targets` — exit 0, no new warnings in changed files (only pre-existing doc-list warnings in unrelated `report_schedule_sibling_scope_tests.rs`)
- New test target compiles (`cargo test ... --no-run` exit 0)

### Follow-up notes
- OpenAPI/client regen: sibling lease + signature handlers carry **no** `#[utoipa::path]` attrs and are not in the `main.rs` `paths()` registry, so this endpoint matches that convention and is not yet in the spec. Adding it to TypeSpec + regenerating `@ppt/api-client` is a follow-up.
- Auto-resolving the lease's generated document into a `documents` row (so the body needn't carry `document_id`) is a follow-up.