### PR TITLE
security-pkce-oauth-authcode-pr-908-closed: verify PKCE enforcement on OAuth auth-code flow

### DIFF
--- a/backend/servers/api-server/src/services/oauth.rs
+++ b/backend/servers/api-server/src/services/oauth.rs
@@ -321,10 +321,15 @@ impl OAuthService {
             .await?
             .ok_or_else(|| OAuthServiceError::InvalidClient("Client not found".to_string()))?;
 
-        // PKCE is required for public (non-confidential) clients per RFC 7636 / OAuth 2.1
-        if !client.is_confidential && code_challenge.is_none() {
+        // PKCE is required for the authorization-code flow for ALL clients
+        // (public and confidential) per OAuth 2.1 §4.1.1 / RFC 7636. A
+        // confidential client secret is not a substitute for PKCE: PKCE
+        // protects the authorization-code in transit against interception,
+        // which a client secret presented later at the token endpoint does
+        // not. Reject any authorize request without a code_challenge.
+        if code_challenge.is_none() {
             return Err(OAuthServiceError::InvalidRequest(
-                "PKCE code_challenge required for public clients".to_string(),
+                "PKCE code_challenge is required for the authorization-code flow".to_string(),
             ));
         }
 
@@ -452,20 +457,27 @@ impl OAuthService {
             return Err(OAuthServiceError::InvalidGrant);
         }
 
-        // Validate PKCE if code challenge was provided
-        if let Some(ref challenge) = auth_code.code_challenge {
-            let verifier = request
-                .code_verifier
-                .as_ref()
-                .ok_or_else(|| OAuthServiceError::InvalidCodeVerifier)?;
+        // Validate PKCE. PKCE is mandatory for every authorization-code flow
+        // (enforced at the authorize stage in `validate_authorize_request`), so
+        // a stored code with no challenge must never be exchangeable — treat its
+        // absence as invalid_grant (defense in depth against codes minted before
+        // enforcement or via a bypassed authorize path). A present challenge
+        // requires a matching code_verifier.
+        let challenge = auth_code
+            .code_challenge
+            .as_deref()
+            .ok_or(OAuthServiceError::InvalidGrant)?;
+        let verifier = request
+            .code_verifier
+            .as_ref()
+            .ok_or(OAuthServiceError::InvalidCodeVerifier)?;
 
-            if !self.verify_pkce(
-                verifier,
-                challenge,
-                auth_code.code_challenge_method.as_deref(),
-            ) {
-                return Err(OAuthServiceError::InvalidCodeVerifier);
-            }
+        if !self.verify_pkce(
+            verifier,
+            challenge,
+            auth_code.code_challenge_method.as_deref(),
+        ) {
+            return Err(OAuthServiceError::InvalidCodeVerifier);
         }
 
         // Get client for rotation settings and principal_kind enforcement (Phase 6 C17)

--- a/backend/servers/api-server/tests/oauth_integration_tests.rs
+++ b/backend/servers/api-server/tests/oauth_integration_tests.rs
@@ -392,6 +392,41 @@ mod pkce_flow {
         assert_eq!(body["error"], "invalid_request");
     }
 
+    /// Regression (issue #823, PR #908): PKCE is mandatory for the
+    /// authorization-code flow for *all* clients, not just public ones
+    /// (OAuth 2.1 §4.1.1 / RFC 7636). Previously `validate_authorize_request`
+    /// only required `code_challenge` when `!is_confidential`, so a confidential
+    /// client could obtain an authorization code with no PKCE binding — a code
+    /// then exchangeable at `/token` with no `code_verifier` at all (the token
+    /// path only checked the verifier `if let Some(challenge)`). A confidential
+    /// client authorizing without `code_challenge` must now be rejected with
+    /// 400 `invalid_request`.
+    #[sqlx::test(migrator = "db::MIGRATOR")]
+    async fn test_confidential_client_requires_pkce(pool: PgPool) {
+        let app = TestApp::new(pool.clone()).await;
+        let user = TestUser::new();
+        let (access_token, _) = create_authenticated_user(&app, &user).await;
+        let (client_id, _client_secret, redirect_uri) = seed_confidential_client(&pool).await;
+
+        // No code_challenge supplied.
+        let uri = format!(
+            "/api/v1/oauth/authorize?response_type=code&client_id={}&redirect_uri={}&scope=profile",
+            urlencoding::encode(&client_id),
+            urlencoding::encode(&redirect_uri),
+        );
+        // Authenticated (issue #820) so the request reaches PKCE validation.
+        let req = get_request_with_auth(&uri, &access_token);
+        let resp = app.execute(req).await;
+        assert_eq!(
+            resp.status,
+            StatusCode::BAD_REQUEST,
+            "confidential client without PKCE must be rejected. body={}",
+            resp.text()
+        );
+        let body = resp.json_value();
+        assert_eq!(body["error"], "invalid_request");
+    }
+
     /// Regression (issue #820): the authorize consent GET advertises bearer
     /// auth + a 401 in its OpenAPI but previously took no auth extractor, so it
     /// served the consent page (client name, scopes, redirect URI) to any


### PR DESCRIPTION
Auto: PR #908 (fix(security): require PKCE on OAuth authorization-code flow, closes #823) was closed unmerged — verify whether PKCE enforcement still pending.

Auto-generated by the PPT research dispatcher (Phase 2 PR-create for an implementer branch pushed without a PR).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwQ7o9smrF2A2BLVXb1gHq)_