### PR TITLE
test-gap-screen-map-drift-pr-922-ppt: add docs/screens/ppt updates for PR #922 App.tsx drift

### DIFF
--- a/docs/screens/ppt/auth-callback.md
+++ b/docs/screens/ppt/auth-callback.md
@@ -71,10 +71,12 @@ Intermediate page in the SSO login flow. The user never navigates here directly 
 - **State nonce lifecycle**: `setSsoState(crypto.randomUUID())` must be called by the SSO initiation path (Login page SSO buttons) before the provider redirect. `getAndClearSsoState()` in this page consumes and removes the nonce atomically so it cannot be replayed.
 - **`redirectUri` must match exactly** what the backend registered with the SSO provider. Derived from `window.location.origin + '/auth/callback'`.
 - **`biome-ignore lint/correctness/useExhaustiveDependencies`** on the mount-only `useEffect` is intentional — `loginWithSsoCode` and `navigate` are stable refs; `searchParams` changes every render but the exchange must run only once.
+- **Return-URL is open-redirect hardened** (PR #922, dev-review round 2): the post-exchange redirect via `getAndClearReturnUrl()` now passes through `sanitizeReturnUrl()` in `@ppt/shared` (same-origin rooted paths only; absolute/protocol-relative/scheme/control-char values are dropped to `null` → falls back to `/dashboard`). This complements the state-nonce check as a second open-redirect guard on the SSO return path.
 
 ## Agent Log
 
 <!-- newest entries on top -->
 
+- 2026-06-03 — agent: test-gap-screen-map-drift-pr-922-ppt — noted PR #922 (dev-review round 2) return-URL hardening: post-SSO redirect via `getAndClearReturnUrl()` now sanitized by `sanitizeReturnUrl` in `@ppt/shared`, a second open-redirect guard alongside the state nonce. No frontmatter change (still in-progress/stub — backend endpoint pending).
 - 2026-05-27 — agent: gap-79-2 review fixes — created screen-map (ppt/auth-callback); buildStatus=in-progress, apiStatus=stub (backend endpoint not yet implemented); added state nonce validation (OIDC §3.1.2.7) and loginWithSsoCode catch block (partial write rollback) per reviewer findings on PR#568
 - 2026-05-27 — agent: gap-79-2-login-flow-impl-v2 — new route /auth/callback; AuthCallbackPage wired; loginWithSsoCode added to AuthContext

--- a/docs/screens/ppt/login.md
+++ b/docs/screens/ppt/login.md
@@ -133,11 +133,13 @@ UC-14 single sign-in entry point. Email + password is primary; magic-link, TOTP,
 - Service-status link in network-error banner ("<a>Stav služby</a>") should point to a public statuspage URL — TBD at deploy.
 - DE strings: "Anmeldung läuft…" is longer than "Prihlasujeme…" — submit button must wrap or use icon-only spinner on narrow widths.
 - Mobile (RN) login is `n/a` per current screen-map — flag if a mobile login UI gets requested; this design is web-only.
+- Post-login return-URL handling is now open-redirect hardened (PR #922, dev-review round 2). The `getAndClearReturnUrl()` / `setReturnUrl()` helpers in `@ppt/shared` both run `sanitizeReturnUrl()` — same-origin rooted paths only; absolute (`https://evil.com`), protocol-relative (`//host`, `/\host`), scheme (`javascript:`), and control-char URLs are rejected on BOTH write and read (defense in depth catches tampered/old stored values). The login redirect target fed into `navigate()` can no longer bounce a freshly-authenticated user off-site.
 
 ## Agent Log
 
 <!-- newest entries on top -->
 
+- 2026-06-03 — agent: test-gap-screen-map-drift-pr-922-ppt — reconciled drift from PR #922 (dev-review round 2): `@ppt/shared` `setReturnUrl`/`getAndClearReturnUrl` now sanitize via new `sanitizeReturnUrl` (same-origin rooted paths only; rejects absolute/protocol-relative/scheme/control-char URLs on write AND read) — closes post-login open-redirect. No frontmatter change (shipped/complete).
 - 2026-05-27 — agent: gap-79-2-login-flow-wiring — wired TanStack Query cache clear (queryClient.clear()) into logout() for session cleanup; loginWithSsoCode already present; apiStatus promoted to complete
 - 2026-05-24 — agent: gap-79-2 login-flow-wiring — removed local RETURN_URL_KEY constant and inline getAndClearReturnUrl; now imports getAndClearReturnUrl from @ppt/shared for consistent return-URL handling across auth flows
 - 2026-05-09 — agent: design analyzed (pages/ppt-login.html — 4 rows: loaded+magic / TOTP+SMS / loading+empty / 3 errors); flipped ppt-web redesignStatus → in-progress; attached designSource; populated functionality checklist (12 sections covering 6 distinct UI states), all states with full variants, design-specific notes; declared 6 sharedComponents; added 1 relatedScreen

--- a/docs/screens/ppt/messages-new.md
+++ b/docs/screens/ppt/messages-new.md
@@ -31,16 +31,23 @@ Wired to real API in 2026-05-24 (Epic 6, Story 6.5). NewMessagePageRoute uses
 and `useStartThread` to open a new conversation. On success, navigates to the
 new thread's detail page.
 
-Note: buildingId is not available in the auth token; the recipient list is empty
-until the neighbors API is called with a building context. A follow-up task should
-pass buildingId from the user's building context once that data flows through auth.
+The recipient list is now resolved from the user's first accessible building
+(via `useBuildings`, mirroring the NeighborsPage convention) — the previous
+`useMessageRecipients(undefined)` call left the neighbors query permanently
+disabled, so the recipient list was always empty and the page unusable
+(fixed in PR #922, dev-review round 5). The route also honors a `?recipientId=`
+query param to preselect a recipient (e.g. arriving from "Contact" on a
+neighbor). A dedicated building selector is still deferred until building
+context flows through auth.
 
 ## Notes
 
 ### Specific (recent)
 - 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:491`.
 - 2026-05-24 — api-integration: wired to POST /messages/threads (useStartThread) + GET neighbors for recipient list; API only supports single recipient per thread.
+- 2026-06-03 — bugfix (PR #922): recipient list now sourced from the user's first building via `useBuildings` (was `useMessageRecipients(undefined)` → empty/unusable). Added `?recipientId=` preselection passed through as `initialRecipientIds`. Loading state now also waits on the buildings query.
 
 ## Agent Log
-- 2026-05-18 — agent: created stub for unmapped route.
+- 2026-06-03 — agent: test-gap-screen-map-drift-pr-922-ppt — reconciled drift from PR #922 (dev-review rounds 1-5). NewMessagePageRoute now resolves buildingId via useBuildings + honors ?recipientId= preselection; updated Specific notes. buildStatus/apiStatus unchanged (shipped/complete).
 - 2026-05-24 — agent: promoted apiStatus stub→integrated; wired NewMessagePageRoute to useStartThread/useMessageRecipients hooks.
+- 2026-05-18 — agent: created stub for unmapped route.

--- a/docs/screens/ppt/session-expired.md
+++ b/docs/screens/ppt/session-expired.md
@@ -33,11 +33,13 @@ Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, e
 ## Notes
 
 ### Specific (recent)
+- 2026-06-03 — drift (PR #922, dev-review round 2): the `setReturnUrl` call into `@ppt/shared` now sanitizes via `sanitizeReturnUrl` on write — an off-origin / scheme / protocol-relative return URL captured at session-expiry is dropped rather than stored, so the eventual post-login redirect can't be hijacked.
 - 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:544`.
 
 ## Agent Log
 
 <!-- newest entries on top -->
 
+- 2026-06-03 — agent: test-gap-screen-map-drift-pr-922-ppt — noted PR #922 return-URL sanitization in `@ppt/shared` `setReturnUrl` (open-redirect hardening). No frontmatter change (still shipped).
 - 2026-05-24 — agent: gap-79-2 login-flow-wiring — removed local RETURN_URL_KEY constant; now imports setReturnUrl from @ppt/shared to align return-URL storage with LoginPage and prevent key drift
 - 2026-05-18 — agent: created stub for unmapped route.


### PR DESCRIPTION
Auto: Screen-map drift — PR #922 modified ppt-web App.tsx (dev-review rounds 1-5 fixes) without a docs/screens/ppt update. This branch backfills the screen-map docs.

Auto-generated by the PPT research dispatcher (Phase 2 PR-create for an implementer branch pushed without a PR).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwQ7o9smrF2A2BLVXb1gHq)_