### PR TITLE
bug-mobile-voting-unsafe-cast: guard VotingScreen against unsafe API response cast

### DIFF
--- a/frontend/apps/mobile/src/screens/voting/VotingScreen.test.ts
+++ b/frontend/apps/mobile/src/screens/voting/VotingScreen.test.ts
@@ -1,0 +1,44 @@
+import { parseVoteSummaries } from './VotingScreen';
+
+const validSummary = {
+  id: 'vote-1',
+  building_id: 'b-1',
+  title: 'Roof repair budget',
+  status: 'open',
+  end_at: '2026-07-01T00:00:00Z',
+  quorum_type: 'simple',
+};
+
+describe('parseVoteSummaries', () => {
+  it('accepts a bare array of summaries', () => {
+    expect(parseVoteSummaries([validSummary])).toEqual([validSummary]);
+  });
+
+  it('accepts the wrapped `{ votes: [...] }` shape', () => {
+    expect(parseVoteSummaries({ votes: [validSummary], total: 1 })).toEqual([validSummary]);
+  });
+
+  // Regression: the previous `data as unknown as ApiVoteSummary[]` double-cast
+  // let these shapes through and crashed at `.map(toUiVote)` render time.
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a number', 42],
+    ['a string', 'unexpected'],
+    ['an object without votes', { error: 'boom' }],
+    ['an object whose votes is not an array', { votes: 'nope' }],
+  ])('returns [] for an unexpected top-level shape: %s', (_label, input) => {
+    expect(parseVoteSummaries(input)).toEqual([]);
+  });
+
+  it('drops malformed entries instead of throwing', () => {
+    const mixed = [
+      validSummary,
+      null,
+      'garbage',
+      { id: 'no-title' }, // missing title/status/end_at
+      { ...validSummary, id: 123 }, // wrong field type
+    ];
+    expect(parseVoteSummaries(mixed)).toEqual([validSummary]);
+  });
+});

--- a/frontend/apps/mobile/src/screens/voting/VotingScreen.tsx
+++ b/frontend/apps/mobile/src/screens/voting/VotingScreen.tsx
@@ -44,6 +44,41 @@ interface ApiVoteSummary {
   quorum_met?: boolean | null;
 }
 
+/** Narrow an unknown value to a well-formed `ApiVoteSummary`.
+ *
+ *  The list endpoint is consumed without a generated client, so the response
+ *  shape is `unknown` at runtime. A blind cast (previously
+ *  `data as unknown as ApiVoteSummary[]`) made `.map(toUiVote)` crash the
+ *  whole screen the moment the backend returned an unexpected shape — a
+ *  non-array, an array of nulls, or summaries missing `id`/`title`/`status`.
+ *  Validate the required string fields here and drop anything malformed. */
+function isApiVoteSummary(value: unknown): value is ApiVoteSummary {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.id === 'string' &&
+    typeof v.title === 'string' &&
+    typeof v.status === 'string' &&
+    typeof v.end_at === 'string'
+  );
+}
+
+/** Safely normalise the `/api/v1/voting` response into a validated summary
+ *  list. Accepts either a bare array or `{ votes: [...] }` (the shape varies
+ *  by backend version) and tolerates any other/garbage shape by returning an
+ *  empty list rather than throwing. Malformed individual entries are dropped
+ *  so one bad row can't take down the whole screen. */
+export function parseVoteSummaries(data: unknown): ApiVoteSummary[] {
+  const candidates: unknown[] = Array.isArray(data)
+    ? data
+    : typeof data === 'object' &&
+        data !== null &&
+        Array.isArray((data as { votes?: unknown }).votes)
+      ? (data as { votes: unknown[] }).votes
+      : [];
+  return candidates.filter(isApiVoteSummary);
+}
+
 /** Map the api-server's status string onto the UI's narrowed enum. */
 function toUiStatus(status: string): VoteStatus {
   switch (status) {
@@ -84,11 +119,6 @@ interface VotingScreenProps {
   onNavigate?: (screen: string, params?: Record<string, unknown>) => void;
 }
 
-interface ApiVoteListResponse {
-  votes: ApiVoteSummary[];
-  total?: number;
-}
-
 export function VotingScreen({ onNavigate }: VotingScreenProps) {
   const { t } = useTranslation();
   const [filter, setFilter] = useState<'all' | 'active' | 'closed'>('all');
@@ -96,18 +126,17 @@ export function VotingScreen({ onNavigate }: VotingScreenProps) {
   // Voting routes use `RlsConnection` and require both Authorization and
   // X-Tenant-ID — both are sent by `useApiQuery` (the latter pulled from
   // the JWT's `tenant_id` claim).
-  const { data, isLoading, error, refetch, isFetching } = useApiQuery<ApiVoteListResponse>(
+  const { data, isLoading, error, refetch, isFetching } = useApiQuery<unknown>(
     ['voting', 'list'],
     '/api/v1/voting',
     { staleTime: 30_000 }
   );
 
   // The list endpoint may return either an array or `{ votes: [...] }`
-  // depending on backend version — accept both.
-  const apiVotes: ApiVoteSummary[] = Array.isArray(data)
-    ? (data as unknown as ApiVoteSummary[])
-    : (data?.votes ?? []);
-  const votes: Vote[] = apiVotes.map(toUiVote);
+  // depending on backend version — accept both, and reject anything else
+  // (or any malformed row) so an unexpected response shape renders the empty
+  // state instead of crashing the screen at `.map()` time.
+  const votes: Vote[] = parseVoteSummaries(data).map(toUiVote);
 
   const onRefresh = useCallback(async () => {
     await refetch();


### PR DESCRIPTION
## Task
Mobile VotingScreen double-casts the API result across the type boundary, causing a render-time crash on an unexpected response shape. Replace the unsafe double-cast with safe parsing/validation (guard the shape; render a fallback/error instead of crashing).

## Owner
pm-frontend (react-native — frontend/apps/mobile)

## Root cause
`frontend/apps/mobile/src/screens/voting/VotingScreen.tsx` consumed `GET /api/v1/voting` and then did:

```ts
const apiVotes: ApiVoteSummary[] = Array.isArray(data)
  ? (data as unknown as ApiVoteSummary[])   // blind double-cast
  : (data?.votes ?? []);
const votes = apiVotes.map(toUiVote);
```

The `data as unknown as ApiVoteSummary[]` double-cast asserts the element type without checking it, and the `data?.votes ?? []` branch passes `data.votes` straight through even when it is not an array. So a response like `{ "votes": "..." }` (or any other unexpected shape) reaches `.map(toUiVote)` and throws a `TypeError` at render time, crashing the whole screen.

## Fix
- Query is now typed `useApiQuery<unknown>` (the response is genuinely untyped at runtime — no generated client for this route).
- New `parseVoteSummaries(data: unknown)` normaliser:
  - accepts a bare array OR the `{ votes: [...] }` wrapper (both backend versions),
  - returns `[]` for any other top-level shape (null/number/string/object-without-votes/votes-not-an-array),
  - drops individual malformed rows via the `isApiVoteSummary` type guard (requires string `id`/`title`/`status`/`end_at`).
- On bad data the screen now renders the existing empty state instead of crashing. The existing `error` branch still handles fetch errors.

No new dependencies (zod is not a mobile dep; a plain runtime guard is used).

## Tested (Band A — fast check)
- `pnpm -F mobile typecheck` → exit 0
- `pnpm biome check apps/mobile/src/screens/voting/VotingScreen.tsx apps/mobile/src/screens/voting/VotingScreen.test.ts` → exit 0 (mobile has no per-package `lint` script; Biome runs at workspace root)
- `pnpm -F mobile test -- VotingScreen` → 9 passed, exit 0

Regression evidence (IG3): a fixture reproducing the old double-cast logic throws on `{ votes: 'nope' }` (TypeError at `.map`); the new `parseVoteSummaries` returns `[]` for the same input. The `'an object whose votes is not an array'` test case is the failing-on-main guard.

## Built (Band B — full build)
skipped: change <50 LOC of substantive logic, no public API/migration/config touch (component-internal helper + test only)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Notes
- `parseVoteSummaries` is exported solely for unit testing.
- Scope-drift check: clean (only `frontend/apps/mobile/src/screens/voting/**`). Code-reuse check: clean.

https://claude.ai/code/session_01HwQ7o9smrF2A2BLVXb1gHq

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwQ7o9smrF2A2BLVXb1gHq)_