### PR TITLE
bug-mediation-page-no-error-state: error state on mediation dispute fetch failure

### DIFF
--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -260,6 +260,12 @@
       "noTimelineEvents": "Zatím žádné události.",
       "mustBeParty": "Musíte být stranou nebo správcem, abyste se mohli zapojit do diskuse.",
       "noLongerActive": "Tento spor již není aktivní.",
+      "loadError": {
+        "title": "Nepodařilo se načíst spor",
+        "message": "Tento mediační případ se nepodařilo načíst. Zkuste to znovu.",
+        "retry": "Zkusit znovu",
+        "retrying": "Zkouším znovu…"
+      },
       "recordResolution": "Zaznamenat řešení",
       "onlyManagersCanResolve": "Řešení mohou zaznamenat pouze správci a mediátoři.",
       "escalateTitle": "Eskalovat spor",

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -260,6 +260,12 @@
       "noTimelineEvents": "Noch keine Ereignisse.",
       "mustBeParty": "Sie müssen Partei oder Verwalter sein, um an dieser Diskussion teilnehmen zu können.",
       "noLongerActive": "Diese Streitigkeit ist nicht mehr aktiv.",
+      "loadError": {
+        "title": "Streitfall konnte nicht geladen werden",
+        "message": "Dieser Mediationsfall konnte nicht geladen werden. Bitte versuchen Sie es erneut.",
+        "retry": "Erneut versuchen",
+        "retrying": "Wird wiederholt…"
+      },
       "recordResolution": "Lösung aufzeichnen",
       "onlyManagersCanResolve": "Nur Verwalter und Mediatoren können eine Lösung aufzeichnen.",
       "escalateTitle": "Streitigkeit eskalieren",

--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -322,6 +322,12 @@
       "noTimelineEvents": "No timeline events yet.",
       "mustBeParty": "You must be a party or manager to participate in this discussion.",
       "noLongerActive": "This dispute is no longer active.",
+      "loadError": {
+        "title": "Failed to load dispute",
+        "message": "We could not load this mediation case. Please try again.",
+        "retry": "Try again",
+        "retrying": "Retrying…"
+      },
       "recordResolution": "Record Resolution",
       "onlyManagersCanResolve": "Only managers and mediators can record a resolution.",
       "escalateTitle": "Escalate Dispute",

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -260,6 +260,12 @@
       "noTimelineEvents": "Még nincsenek idősor-események.",
       "mustBeParty": "A megbeszélésben való részvételhez félnek vagy kezelőnek kell lennie.",
       "noLongerActive": "Ez a vita már nem aktív.",
+      "loadError": {
+        "title": "A vita betöltése sikertelen",
+        "message": "Nem sikerült betölteni ezt a közvetítési ügyet. Kérjük, próbálja újra.",
+        "retry": "Próbálja újra",
+        "retrying": "Újrapróbálkozás…"
+      },
       "recordResolution": "Megoldás rögzítése",
       "onlyManagersCanResolve": "Megoldást csak kezelők és mediátorok rögzíthetnek.",
       "escalateTitle": "Vita eszkalálása",

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -260,6 +260,12 @@
       "noTimelineEvents": "Brak wydarzeń na osi czasu.",
       "mustBeParty": "Musisz być stroną lub zarządcą, aby uczestniczyć w tej dyskusji.",
       "noLongerActive": "Ten spór nie jest już aktywny.",
+      "loadError": {
+        "title": "Nie udało się załadować sporu",
+        "message": "Nie udało się załadować tej sprawy mediacyjnej. Spróbuj ponownie.",
+        "retry": "Spróbuj ponownie",
+        "retrying": "Ponawianie…"
+      },
       "recordResolution": "Zarejestruj rozwiązanie",
       "onlyManagersCanResolve": "Tylko zarządcy i mediatorzy mogą rejestrować rozwiązania.",
       "escalateTitle": "Eskaluj spór",

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -261,6 +261,12 @@
       "noTimelineEvents": "Zatiaľ žiadne udalosti.",
       "mustBeParty": "Musíte byť stranou alebo správcom, aby ste sa mohli zapojiť do diskusie.",
       "noLongerActive": "Tento spor už nie je aktívny.",
+      "loadError": {
+        "title": "Nepodarilo sa načítať spor",
+        "message": "Tento mediačný prípad sa nepodarilo načítať. Skúste to znova.",
+        "retry": "Skúsiť znova",
+        "retrying": "Skúšam znova…"
+      },
       "recordResolution": "Zaznamenať riešenie",
       "onlyManagersCanResolve": "Riešenie môžu zaznamenať iba správcovia a mediátori.",
       "escalateTitle": "Eskalovať spor",

--- a/frontend/apps/ppt-web/src/features/disputes/pages/MediationWorkspacePage.test.tsx
+++ b/frontend/apps/ppt-web/src/features/disputes/pages/MediationWorkspacePage.test.tsx
@@ -1,0 +1,112 @@
+/// <reference types="vitest/globals" />
+/**
+ * MediationWorkspacePage tests (bug-mediation-page-no-error-state).
+ *
+ * Regression: when the dispute fetch query errors the page used to fall
+ * through to rendering the workspace with an "unknown" status placeholder.
+ * It must instead show an explicit error banner (role="alert") with a retry
+ * affordance.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MediationWorkspacePage } from './MediationWorkspacePage';
+
+vi.mock('@ppt/api-client', () => ({
+  useDispute: vi.fn(),
+  useMediationSessions: vi.fn(() => ({ data: [], isLoading: false })),
+  useResolveDispute: vi.fn(() => ({ isPending: false, mutateAsync: vi.fn() })),
+  useEscalateDispute: vi.fn(() => ({ isPending: false, mutateAsync: vi.fn() })),
+  useAssignMediator: vi.fn(() => ({ isPending: false, mutateAsync: vi.fn() })),
+  useScheduleSession: vi.fn(() => ({ isPending: false, mutateAsync: vi.fn() })),
+  useUpdateSession: vi.fn(() => ({ isPending: false, mutateAsync: vi.fn() })),
+  useCancelSession: vi.fn(() => ({ isPending: false, mutateAsync: vi.fn() })),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'disputes.mediation.backToDispute': 'Back to Dispute',
+        'disputes.mediation.loadError.title': 'Failed to load dispute',
+        'disputes.mediation.loadError.message': 'We could not load this case.',
+        'disputes.mediation.loadError.retry': 'Try again',
+        'disputes.mediation.loadError.retrying': 'Retrying',
+        'common.loading': 'Loading',
+      };
+      return map[key] ?? key;
+    },
+    i18n: { language: 'en' },
+  }),
+}));
+
+// Child components reach for other api-client hooks via their own imports;
+// stub them so the page renders in isolation.
+vi.mock('../components/MediationTimelineView', () => ({
+  MediationTimelineView: () => null,
+}));
+vi.mock('../components/MediationChatThread', () => ({ MediationChatThread: () => null }));
+vi.mock('../components/MediationSessionsPanel', () => ({ MediationSessionsPanel: () => null }));
+
+import { useDispute } from '@ppt/api-client';
+
+const mockUseDispute = vi.mocked(useDispute);
+
+function renderPage() {
+  return render(
+    <MediationWorkspacePage
+      disputeId="dsp-1"
+      organizationId="org-1"
+      onBack={vi.fn()}
+      onToastSuccess={vi.fn()}
+      onToastError={vi.fn()}
+    />
+  );
+}
+
+describe('MediationWorkspacePage error state', () => {
+  it('renders an alert banner with retry when the dispute fetch errors', () => {
+    mockUseDispute.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      isFetching: false,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useDispute>);
+
+    renderPage();
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('Failed to load dispute');
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
+    // Must NOT fall through to the workspace title / unknown placeholder.
+    expect(screen.queryByText('disputes.mediation.title')).not.toBeInTheDocument();
+  });
+
+  it('calls refetch when the retry button is clicked', () => {
+    const refetch = vi.fn();
+    mockUseDispute.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      isFetching: false,
+      refetch,
+    } as unknown as ReturnType<typeof useDispute>);
+
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not show the error banner while loading', () => {
+    mockUseDispute.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      isFetching: true,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useDispute>);
+
+    renderPage();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.getByRole('status', { name: 'Loading' })).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/ppt-web/src/features/disputes/pages/MediationWorkspacePage.tsx
+++ b/frontend/apps/ppt-web/src/features/disputes/pages/MediationWorkspacePage.tsx
@@ -72,7 +72,13 @@ export function MediationWorkspacePage({
     undefined
   );
 
-  const { data: dispute, isLoading: disputeLoading } = useDispute(disputeId);
+  const {
+    data: dispute,
+    isLoading: disputeLoading,
+    isError: disputeError,
+    refetch: refetchDispute,
+    isFetching: disputeFetching,
+  } = useDispute(disputeId);
   const { data: sessions = [], isLoading: sessionsLoading } = useMediationSessions(disputeId);
 
   const resolveDispute = useResolveDispute(organizationId);
@@ -189,6 +195,51 @@ export function MediationWorkspacePage({
           aria-label={t('common.loading')}
           className="animate-spin rounded-full h-10 w-10 border-b-2 border-violet-600"
         />
+      </div>
+    );
+  }
+
+  // Fetch failed and we have no dispute to fall back on: show an explicit
+  // error banner with a retry affordance instead of rendering the page with
+  // 'unknown' status and empty placeholders.
+  if (disputeError && !dispute) {
+    return (
+      <div className="max-w-5xl mx-auto px-4 py-8">
+        <button
+          type="button"
+          onClick={onBack}
+          className="text-sm text-violet-600 hover:text-violet-800 mb-4 flex items-center gap-1"
+        >
+          {t('disputes.mediation.backToDispute')}
+        </button>
+        <div role="alert" className="bg-red-50 border border-red-200 rounded-xl p-8 text-center">
+          <svg
+            className="w-12 h-12 text-red-400 mx-auto mb-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
+            />
+          </svg>
+          <p className="text-gray-900 font-medium">{t('disputes.mediation.loadError.title')}</p>
+          <p className="text-gray-500 text-sm mt-1">{t('disputes.mediation.loadError.message')}</p>
+          <button
+            type="button"
+            onClick={() => refetchDispute()}
+            disabled={disputeFetching}
+            className="mt-5 inline-flex items-center px-4 py-2 text-sm bg-violet-600 text-white rounded-lg hover:bg-violet-700 font-medium disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {disputeFetching
+              ? t('disputes.mediation.loadError.retrying')
+              : t('disputes.mediation.loadError.retry')}
+          </button>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Task
MediationWorkspacePage shows empty/unknown state instead of error UI on dispute fetch failure. Add a proper error state (role="alert" banner / retry affordance) when the dispute fetch query errors, instead of falling through to the empty/unknown placeholder.

## Owner
pm-frontend

## What changed
- `MediationWorkspacePage.tsx`: destructure `isError`, `refetch`, `isFetching` from `useDispute(...)`. When the dispute query errors and there is no cached dispute, render a `role="alert"` error banner with a title/message and a Retry button (`refetch()`, disabled + "retrying" label while `isFetching`). Previously the page fell through and rendered the workspace with `disputeStatus = 'unknown'` and empty placeholders.
- Added `disputes.mediation.loadError` i18n keys (`title`, `message`, `retry`, `retrying`) to all six locales (en, sk, cs, de, pl, hu).
- Added regression test `MediationWorkspacePage.test.tsx` (3 cases: error banner + retry rendered; retry click calls `refetch`; banner not shown while loading).

The error UI mirrors the existing pattern used in `reports/pages/ScheduleDetailPage.tsx` (warning-triangle icon + title + message), with the addition of a retry affordance.

## TDD evidence (IG3)
Split into a `test:` commit (29694c9) and a `fix:` commit (2158bbb). Verified the test fails on the unfixed page: stashing the page change makes the two error-state assertions fail with `Unable to find an accessible element with the role "alert"`; the loading-state assertion still passes. With the fix applied all 3 pass.

## Tested (Band A — fast check)
- `pnpm -F @ppt/web typecheck` (`tsc --noEmit`) — exit 0.
- `pnpm exec biome check` on all 8 changed files — exit 0 (Biome is the project linter per CLAUDE.md; ran autofix for JSX formatting).
- `vitest run src/features/disputes/pages/MediationWorkspacePage.test.tsx` — 3/3 passed. Full `@ppt/web` suite: 481/481 passed.

> Note: `pnpm -F @ppt/web lint` (`eslint . --ext ts,tsx`) fails with "ESLint couldn't find an eslint.config file" — this is a pre-existing breakage on `dev` (confirmed by stashing all changes and re-running), unrelated to this PR. The repo's configured linter is Biome.

## Built (Band B — full build)
Skipped: change is small (~50 LOC of substantive code + i18n keys), no public API surface or build-config change.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (UI-only error-state, no security/auth/billing/data-integrity change).

## Remote-tested
Skipped (no ppt-bridge MCP in this session).

## Scope drift
None — scope-check.sh (`--owner pm-frontend`) exit 0; all changes under `frontend/apps/ppt-web/`.

## Code-reuse review
None — reuse-grep.sh exit 0 (no new auth/crypto/http helpers).

## Notes
- The remote branch was first created from `dev` via MCP; the local two-commit branch (test: + fix:) was then pushed over it, so the PR preserves the TDD commit structure.
- goal-check.sh reports IG1/IG2/IG4/IG5/IG6 failures: these are plan-file/`impl/`-branch-name checks specific to the research-flow plan workflow and do not apply to this directly-dispatched bug task (branch `auto-impl/*`, no `.research/plans/<slug>.md`). The mandatory verify gate (Step 3) passed.

https://claude.ai/code/session_01HwQ7o9smrF2A2BLVXb1gHq

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwQ7o9smrF2A2BLVXb1gHq)_