### PR TITLE
bug-webhook-airbnb-dup-sync-jobs: dedup Airbnb webhook redeliveries before SYNC_EXTERNAL enqueue

### DIFF
--- a/backend/servers/api-server/src/routes/integrations/webhook.rs
+++ b/backend/servers/api-server/src/routes/integrations/webhook.rs
@@ -945,13 +945,7 @@ fn airbnb_dedup_key(event: &integrations::AirbnbWebhookEvent) -> String {
     hasher.update(b"|");
     hasher.update(event.listing_id.as_deref().unwrap_or("").as_bytes());
     hasher.update(b"|");
-    hasher.update(
-        event
-            .confirmation_code
-            .as_deref()
-            .unwrap_or("")
-            .as_bytes(),
-    );
+    hasher.update(event.confirmation_code.as_deref().unwrap_or("").as_bytes());
     hasher.update(b"|");
     hasher.update(event.timestamp.to_rfc3339().as_bytes());
     format!("synthetic:{}", hex::encode(hasher.finalize()))

--- a/backend/servers/api-server/src/routes/integrations/webhook.rs
+++ b/backend/servers/api-server/src/routes/integrations/webhook.rs
@@ -926,6 +926,37 @@ pub async fn handle_portal_webhook(
 
 // ==================== Gap 83-1: Airbnb Inbound Webhook ====================
 
+/// Compute the idempotency key for an inbound Airbnb webhook delivery.
+///
+/// Prefers the Airbnb-assigned `event_id`. When absent (older webhook schema
+/// versions omit it), derives a deterministic synthetic key from the stable,
+/// HMAC-signed fields of the delivery so that an at-least-once redelivery of
+/// the same payload maps to the same key and is suppressed by the dedup
+/// ledger. The `synthetic:` prefix keeps these keys from ever colliding with
+/// a real Airbnb `event_id`.
+fn airbnb_dedup_key(event: &integrations::AirbnbWebhookEvent) -> String {
+    if let Some(event_id) = event.event_id.as_deref() {
+        return event_id.to_string();
+    }
+
+    use sha2::Digest;
+    let mut hasher = Sha256::new();
+    hasher.update(format!("{:?}", event.event_type).as_bytes());
+    hasher.update(b"|");
+    hasher.update(event.listing_id.as_deref().unwrap_or("").as_bytes());
+    hasher.update(b"|");
+    hasher.update(
+        event
+            .confirmation_code
+            .as_deref()
+            .unwrap_or("")
+            .as_bytes(),
+    );
+    hasher.update(b"|");
+    hasher.update(event.timestamp.to_rfc3339().as_bytes());
+    format!("synthetic:{}", hex::encode(hasher.finalize()))
+}
+
 /// Receive and dispatch an inbound Airbnb webhook event.
 ///
 /// Airbnb signs every delivery with HMAC-SHA256 over the raw body using the
@@ -1002,65 +1033,63 @@ pub async fn handle_airbnb_webhook(
         )
     })?;
 
-    // 4. Persistent deduplication via Airbnb event_id (issue #711).
+    // 4. Persistent deduplication (issue #711, bug-webhook-airbnb-dup-sync-jobs).
     //
     // Airbnb guarantees at-least-once delivery. Without persistent dedup,
     // duplicate ReservationCreated/Updated deliveries enqueue racing
     // SYNC_EXTERNAL jobs, and ReservationCancelled deliveries hammer the
     // booking-status guard. Migration 00169 created
     // `airbnb_webhook_events(event_id PRIMARY KEY, event_type, received_at)`;
-    // we attempt to insert the event_id and bail out with 200 on conflict.
+    // we attempt to insert the delivery's dedup key and bail out with 200 on
+    // conflict (idempotent acknowledgement, no side effects).
     //
-    // If `event_id` is absent we cannot dedup; fall through to processing
-    // as before — Airbnb sends event_id on first-class events, and lower-
-    // priority types (MessageReceived / ReviewReceived) are not the
-    // high-stakes paths.
-    if let Some(ref event_id) = event.event_id {
-        let event_type_label = format!("{:?}", event.event_type);
-        let insert = sqlx::query(
-            "INSERT INTO airbnb_webhook_events (event_id, event_type) \
-             VALUES ($1, $2) ON CONFLICT (event_id) DO NOTHING",
-        )
-        .bind(event_id)
-        .bind(&event_type_label)
-        .execute(&state.db)
-        .await;
+    // The dedup key is the Airbnb-assigned `event_id` when present. Older
+    // webhook schema versions omit it; in that case we derive a *synthetic*
+    // key from the stable, signed fields of the delivery (event type +
+    // listing id + confirmation code + timestamp). Airbnb redelivers the
+    // byte-identical signed payload, so a redelivery yields the same
+    // synthetic key and is suppressed — closing the previously-unguarded
+    // event_id-absent path that could still double-enqueue SYNC_EXTERNAL.
+    let dedup_key = airbnb_dedup_key(&event);
+    let event_type_label = format!("{:?}", event.event_type);
+    let insert = sqlx::query(
+        "INSERT INTO airbnb_webhook_events (event_id, event_type) \
+         VALUES ($1, $2) ON CONFLICT (event_id) DO NOTHING",
+    )
+    .bind(&dedup_key)
+    .bind(&event_type_label)
+    .execute(&state.db)
+    .await;
 
-        match insert {
-            Ok(result) if result.rows_affected() == 0 => {
-                tracing::info!(
-                    event_id = %event_id,
-                    event_type = %event_type_label,
-                    "Airbnb webhook: duplicate delivery suppressed by dedup ledger"
-                );
-                return Ok(StatusCode::OK);
-            }
-            Ok(_) => {
-                tracing::debug!(
-                    event_id = %event_id,
-                    event_type = %event_type_label,
-                    "Airbnb webhook: event_id recorded in dedup ledger"
-                );
-            }
-            Err(e) => {
-                // Best-effort: if the ledger insert fails (DB blip, table
-                // not yet migrated on a stale env, etc.) we degrade to the
-                // pre-#711 behaviour and process the event. Failing closed
-                // here would let a transient DB issue silently drop real
-                // reservation updates, which is worse than a rare double-
-                // processing (downstream handlers are idempotent upserts).
-                tracing::warn!(
-                    error = %e,
-                    event_id = %event_id,
-                    "Airbnb webhook: dedup ledger insert failed, processing anyway"
-                );
-            }
+    match insert {
+        Ok(result) if result.rows_affected() == 0 => {
+            tracing::info!(
+                dedup_key = %dedup_key,
+                event_type = %event_type_label,
+                "Airbnb webhook: duplicate delivery suppressed by dedup ledger"
+            );
+            return Ok(StatusCode::OK);
         }
-    } else {
-        tracing::debug!(
-            event_type = ?event.event_type,
-            "Airbnb webhook: event without event_id, dedup skipped"
-        );
+        Ok(_) => {
+            tracing::debug!(
+                dedup_key = %dedup_key,
+                event_type = %event_type_label,
+                "Airbnb webhook: delivery recorded in dedup ledger"
+            );
+        }
+        Err(e) => {
+            // Best-effort: if the ledger insert fails (DB blip, table
+            // not yet migrated on a stale env, etc.) we degrade to the
+            // pre-#711 behaviour and process the event. Failing closed
+            // here would let a transient DB issue silently drop real
+            // reservation updates, which is worse than a rare double-
+            // processing (downstream handlers are idempotent upserts).
+            tracing::warn!(
+                error = %e,
+                dedup_key = %dedup_key,
+                "Airbnb webhook: dedup ledger insert failed, processing anyway"
+            );
+        }
     }
 
     // 5. Dispatch by event type.
@@ -1080,11 +1109,12 @@ pub async fn handle_airbnb_webhook(
                             "trigger": "webhook",
                             "event_id": event.event_id,
                         });
-                        // TODO: Airbnb delivers webhooks at-least-once; a rapid sequence of
-                        // events for the same listing will enqueue duplicate sync jobs.
-                        // Deduplication should be handled at the worker level (idempotent
-                        // upsert) or by checking for an already-queued SYNC_EXTERNAL job
-                        // for this (org_id, connection_id) before inserting.
+                        // Idempotency note: at-least-once redeliveries are
+                        // suppressed up-front by the dedup ledger in step 4
+                        // (Airbnb event_id, or a synthetic key for legacy
+                        // deliveries that omit it), so reaching this point
+                        // means a first-seen delivery and the SYNC_EXTERNAL
+                        // job is enqueued exactly once per delivery.
                         let job_data = CreateBackgroundJob {
                             job_type: job_type::SYNC_EXTERNAL.to_string(),
                             priority: Some(1),
@@ -1275,5 +1305,83 @@ mod airbnb_webhook_tests {
         assert!(event.is_ok(), "parse failed: {:?}", event.err());
         let ev = event.unwrap();
         assert!(ev.event_id.is_none());
+    }
+
+    // ---- Dedup-key regression tests (bug-webhook-airbnb-dup-sync-jobs) ----
+    //
+    // The dedup key is what makes the `airbnb_webhook_events` ledger
+    // (INSERT ... ON CONFLICT DO NOTHING) suppress at-least-once
+    // redeliveries before any SYNC_EXTERNAL job is enqueued. A redelivery
+    // MUST map to the same key as the original delivery, otherwise the
+    // ledger lets it through and a duplicate sync job is created.
+
+    fn parse(body: &str) -> integrations::AirbnbWebhookEvent {
+        AirbnbClient::parse_webhook_event(body).expect("valid event")
+    }
+
+    const RESERVATION_WITH_ID: &str = r#"{
+        "event_type": "reservation_created",
+        "event_id": "evt_abc123",
+        "listing_id": "listing_42",
+        "confirmation_code": "HMABC123",
+        "timestamp": "2026-01-01T00:00:00Z",
+        "payload": {}
+    }"#;
+
+    const RESERVATION_NO_ID: &str = r#"{
+        "event_type": "reservation_created",
+        "listing_id": "listing_42",
+        "confirmation_code": "HMABC123",
+        "timestamp": "2026-01-01T00:00:00Z",
+        "payload": {}
+    }"#;
+
+    #[test]
+    fn dedup_key_uses_event_id_verbatim_when_present() {
+        let key = super::airbnb_dedup_key(&parse(RESERVATION_WITH_ID));
+        assert_eq!(key, "evt_abc123");
+    }
+
+    #[test]
+    fn dedup_key_redelivery_with_event_id_is_stable() {
+        // Same event_id redelivered => identical key => ledger conflict =>
+        // no second SYNC_EXTERNAL enqueue.
+        let first = super::airbnb_dedup_key(&parse(RESERVATION_WITH_ID));
+        let redelivery = super::airbnb_dedup_key(&parse(RESERVATION_WITH_ID));
+        assert_eq!(first, redelivery);
+    }
+
+    #[test]
+    fn dedup_key_synthetic_when_event_id_absent() {
+        let key = super::airbnb_dedup_key(&parse(RESERVATION_NO_ID));
+        assert!(
+            key.starts_with("synthetic:"),
+            "expected synthetic key, got {key}"
+        );
+        // Synthetic keys can never collide with a real Airbnb event_id.
+        assert_ne!(key, "evt_abc123");
+    }
+
+    #[test]
+    fn dedup_key_synthetic_redelivery_is_stable() {
+        // The previously-unguarded path: an event WITHOUT event_id, redelivered
+        // byte-for-byte, must still produce the same key so the duplicate
+        // SYNC_EXTERNAL enqueue is suppressed.
+        let first = super::airbnb_dedup_key(&parse(RESERVATION_NO_ID));
+        let redelivery = super::airbnb_dedup_key(&parse(RESERVATION_NO_ID));
+        assert_eq!(first, redelivery);
+    }
+
+    #[test]
+    fn dedup_key_synthetic_differs_for_distinct_deliveries() {
+        let a = super::airbnb_dedup_key(&parse(RESERVATION_NO_ID));
+        // Different listing => different delivery => different key.
+        let other = RESERVATION_NO_ID.replace("listing_42", "listing_99");
+        let b = super::airbnb_dedup_key(&parse(&other));
+        assert_ne!(a, b);
+        // Different timestamp => different delivery => different key.
+        let later = RESERVATION_NO_ID.replace("00:00:00Z", "00:05:00Z");
+        let c = super::airbnb_dedup_key(&parse(&later));
+        assert_ne!(a, c);
     }
 }

--- a/backend/servers/api-server/tests/airbnb_webhook_dedup_tests.rs
+++ b/backend/servers/api-server/tests/airbnb_webhook_dedup_tests.rs
@@ -47,7 +47,10 @@ async fn first_delivery_records_and_redelivery_is_suppressed(pool: PgPool) {
 
     // First delivery: ledger row created → handler would enqueue SYNC_EXTERNAL.
     let first = try_record_delivery(&pool, key, "ReservationCreated").await;
-    assert_eq!(first, 1, "first delivery must insert exactly one ledger row");
+    assert_eq!(
+        first, 1,
+        "first delivery must insert exactly one ledger row"
+    );
 
     // Redelivery (same event_id): conflict → 0 rows → handler returns 200
     // WITHOUT enqueuing a second SYNC_EXTERNAL job.
@@ -88,8 +91,14 @@ async fn synthetic_key_redelivery_is_suppressed(pool: PgPool) {
 async fn distinct_deliveries_each_record(pool: PgPool) {
     // Two genuinely different deliveries (different keys) must both record,
     // so legitimate back-to-back events still each enqueue their sync job.
-    assert_eq!(try_record_delivery(&pool, "evt_a", "ReservationUpdated").await, 1);
-    assert_eq!(try_record_delivery(&pool, "evt_b", "ReservationUpdated").await, 1);
+    assert_eq!(
+        try_record_delivery(&pool, "evt_a", "ReservationUpdated").await,
+        1
+    );
+    assert_eq!(
+        try_record_delivery(&pool, "evt_b", "ReservationUpdated").await,
+        1
+    );
     assert_eq!(ledger_count(&pool, "evt_a").await, 1);
     assert_eq!(ledger_count(&pool, "evt_b").await, 1);
 }

--- a/backend/servers/api-server/tests/airbnb_webhook_dedup_tests.rs
+++ b/backend/servers/api-server/tests/airbnb_webhook_dedup_tests.rs
@@ -1,0 +1,95 @@
+//! Regression tests for `bug-webhook-airbnb-dup-sync-jobs`.
+//!
+//! Airbnb delivers webhooks at-least-once. The inbound handler
+//! (`routes/integrations/webhook.rs::handle_airbnb_webhook`) guards against
+//! redelivery by INSERTing the delivery's dedup key into the
+//! `airbnb_webhook_events` ledger with `ON CONFLICT (event_id) DO NOTHING`
+//! and returning 200 without side effects when no row is inserted — i.e. the
+//! SYNC_EXTERNAL job is enqueued exactly once per distinct delivery.
+//!
+//! These tests exercise the exact SQL the handler runs against an ephemeral
+//! migrated database (migration `00169_airbnb_webhook_events`), proving that
+//! a redelivery does NOT produce a second ledger row and therefore would NOT
+//! enqueue a second SYNC_EXTERNAL job. They require a `DATABASE_URL`; under
+//! `SQLX_OFFLINE=true` with no DB the harness skips them.
+
+use sqlx::{PgPool, Row};
+
+/// Mirror of the dedup INSERT performed by `handle_airbnb_webhook` (step 4).
+/// Returns the number of rows affected — 1 for a first-seen delivery, 0 for a
+/// redelivery (conflict). In the handler, a 0 means "duplicate → return 200
+/// without enqueuing".
+async fn try_record_delivery(pool: &PgPool, dedup_key: &str, event_type: &str) -> u64 {
+    sqlx::query(
+        "INSERT INTO airbnb_webhook_events (event_id, event_type) \
+         VALUES ($1, $2) ON CONFLICT (event_id) DO NOTHING",
+    )
+    .bind(dedup_key)
+    .bind(event_type)
+    .execute(pool)
+    .await
+    .expect("ledger insert should not error")
+    .rows_affected()
+}
+
+async fn ledger_count(pool: &PgPool, dedup_key: &str) -> i64 {
+    sqlx::query("SELECT COUNT(*) AS n FROM airbnb_webhook_events WHERE event_id = $1")
+        .bind(dedup_key)
+        .fetch_one(pool)
+        .await
+        .expect("count query")
+        .get::<i64, _>("n")
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn first_delivery_records_and_redelivery_is_suppressed(pool: PgPool) {
+    let key = "evt_reservation_created_001";
+
+    // First delivery: ledger row created → handler would enqueue SYNC_EXTERNAL.
+    let first = try_record_delivery(&pool, key, "ReservationCreated").await;
+    assert_eq!(first, 1, "first delivery must insert exactly one ledger row");
+
+    // Redelivery (same event_id): conflict → 0 rows → handler returns 200
+    // WITHOUT enqueuing a second SYNC_EXTERNAL job.
+    let redelivery = try_record_delivery(&pool, key, "ReservationCreated").await;
+    assert_eq!(
+        redelivery, 0,
+        "redelivery must be suppressed (ON CONFLICT DO NOTHING)"
+    );
+
+    // Exactly one ledger row exists for this delivery — i.e. one enqueue.
+    assert_eq!(
+        ledger_count(&pool, key).await,
+        1,
+        "redelivery must not create a second ledger row"
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn synthetic_key_redelivery_is_suppressed(pool: PgPool) {
+    // Legacy deliveries omit event_id; the handler derives a synthetic key.
+    // A byte-identical redelivery yields the same synthetic key, so it is
+    // suppressed exactly like an event_id-bearing redelivery.
+    let synthetic_key = "synthetic:deadbeefcafef00d";
+
+    assert_eq!(
+        try_record_delivery(&pool, synthetic_key, "ReservationCreated").await,
+        1
+    );
+    assert_eq!(
+        try_record_delivery(&pool, synthetic_key, "ReservationCreated").await,
+        0,
+        "synthetic-key redelivery must be suppressed"
+    );
+    assert_eq!(ledger_count(&pool, synthetic_key).await, 1);
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn distinct_deliveries_each_record(pool: PgPool) {
+    // Two genuinely different deliveries (different keys) must both record,
+    // so legitimate back-to-back events still each enqueue their sync job.
+    assert_eq!(try_record_delivery(&pool, "evt_a", "ReservationUpdated").await, 1);
+    assert_eq!(try_record_delivery(&pool, "evt_b", "ReservationUpdated").await, 1);
+    assert_eq!(ledger_count(&pool, "evt_a").await, 1);
+    assert_eq!(ledger_count(&pool, "evt_b").await, 1);
+}


### PR DESCRIPTION
## Task
The Airbnb webhook handler, under at-least-once delivery, enqueues duplicate SYNC_EXTERNAL jobs for redelivered webhooks. Add idempotency/dedup so a redelivered webhook does not enqueue a second SYNC_EXTERNAL job (e.g. dedup on the webhook delivery id / external event id before enqueue).

## Owner
pm-backend (rust-backend)

## Root cause / fix
An `event_id` dedup ledger (`airbnb_webhook_events`, migration `00169`) was already added under issue #711, but it only guarded deliveries that **carry** an `event_id`. Legacy deliveries that omit `event_id` fell through the `else` branch and still enqueued a `SYNC_EXTERNAL` job on every redelivery — the residual bug, flagged by a stale `TODO` right above the enqueue.

This PR introduces `airbnb_dedup_key(&event)`:
- uses the Airbnb-assigned `event_id` verbatim when present;
- otherwise derives a deterministic synthetic key from the HMAC-signed delivery fields (`event_type | listing_id | confirmation_code | timestamp`), prefixed `synthetic:` so it can never collide with a real `event_id`.

Both paths now flow through the single `INSERT ... ON CONFLICT (event_id) DO NOTHING` gate. Since Airbnb redelivers the byte-identical signed payload, a redelivery yields the same key, hits the conflict, returns `200` with no side effects, and never reaches the enqueue. The stale `TODO` is removed and replaced with an accurate idempotency note. No migration change (existing table reused).

## Tested (Band A — fast check)
- `SQLX_OFFLINE=true cargo check -p api-server` — exit 0
- `SQLX_OFFLINE=true cargo test -p api-server --lib dedup_key` — exit 0 (5 passed, 0 failed)
- `SQLX_OFFLINE=true cargo clippy -p api-server -- -D warnings` — exit 0 (clean)

New unit tests prove redelivery determinism: same `event_id` -> same key; legacy (no `event_id`) redelivery -> same synthetic key; distinct deliveries (different listing/timestamp) -> different keys.

New `#[sqlx::test(migrator = "db::MIGRATOR")]` integration suite (`tests/airbnb_webhook_dedup_tests.rs`) runs the handler's exact dedup SQL against an ephemeral migrated DB and asserts a redelivery inserts **0** rows (hence no second enqueue), while distinct deliveries each record. Compiles clean (`cargo test --test airbnb_webhook_dedup_tests --no-run` exit 0); runs in CI where `DATABASE_URL` is present.

## Built (Band B — full build)
Skipped Band B full release build: change is < 50 LOC of substantive logic, no public API/route/config surface change, reuses existing migration. Band A check + clippy + unit tests cover it.

## CI parity (Band C — hot-path only)
Webhook ingest is hot-path-adjacent. Equivalent of the backend CI job run locally: `cargo check`, `cargo clippy -- -D warnings`, and unit tests all green (see Tested). The DB-backed `#[sqlx::test]` suite will additionally run under CI's Postgres.

Note: a pre-existing `clippy::items_after_test_module` lint fires on `src/routes/admin/mod.rs` (untouched by this PR, present on `dev` HEAD) only under `clippy --tests`; not introduced here.

## Remote-tested
skipped (no ppt-bridge MCP in session)

## Notes
- Scope drift: false (diff confined to `backend/servers/api-server/`, owned by pm-backend).
- Code reuse: none flagged (reuse-grep clean; reuses the existing ledger + migration rather than adding new infra).
- Behaviour on ledger DB error is unchanged best-effort: log + process (downstream sync is an idempotent upsert), as established by #711.

https://claude.ai/code/session_01HwQ7o9smrF2A2BLVXb1gHq

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwQ7o9smrF2A2BLVXb1gHq)_