### PR TITLE
dx-documentsbrowse-folder-preselect: pre-select current folder in MoveFolderDialog

### DIFF
--- a/frontend/apps/ppt-web/src/features/documents/components/DocumentsBrowse.tsx
+++ b/frontend/apps/ppt-web/src/features/documents/components/DocumentsBrowse.tsx
@@ -508,7 +508,7 @@ export function DocumentsBrowse({
         <MoveFolderDialog
           documentTitles={[moveTarget.title]}
           buildingId={buildingId}
-          currentFolderId={null} /* TODO: pre-select once DocumentSummary exposes folder_id */
+          currentFolderId={moveTarget.folder_id ?? null}
           onConfirm={handleMoveConfirm}
           onCancel={() => setMoveTarget(null)}
           isPending={isMovePending}

--- a/frontend/apps/ppt-web/src/features/documents/components/MoveFolderDialog.preselect.test.tsx
+++ b/frontend/apps/ppt-web/src/features/documents/components/MoveFolderDialog.preselect.test.tsx
@@ -1,0 +1,81 @@
+/// <reference types="vitest/globals" />
+/**
+ * Regression test for dx-documentsbrowse-folder-preselect.
+ *
+ * DocumentsBrowse previously hard-coded `currentFolderId={null}` because
+ * DocumentSummary did not carry `folder_id`. Now that the field is threaded
+ * through, MoveFolderDialog must open with the document's current folder
+ * pre-selected (destination label + selected tree row), so the "Move" button
+ * stays disabled until the user actually changes the target.
+ */
+
+import type { FolderTreeNode } from '@ppt/api-client';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the folder-tree query so the dialog renders a deterministic tree.
+const useFolderTreeMock = vi.fn();
+vi.mock('@ppt/api-client', () => ({
+  useFolderTree: (buildingId?: string) => useFolderTreeMock(buildingId),
+}));
+
+import { MoveFolderDialog } from './MoveFolderDialog';
+
+function node(id: string, name: string, children: FolderTreeNode[] = []): FolderTreeNode {
+  return {
+    folder: { id, name } as FolderTreeNode['folder'],
+    children,
+    document_count: 0,
+  };
+}
+
+const TREE: FolderTreeNode[] = [
+  node('a', 'Rok 2025', [node('a1', 'Faktúry')]),
+  node('b', 'Zápisnice'),
+];
+
+describe('MoveFolderDialog pre-select', () => {
+  beforeEach(() => {
+    useFolderTreeMock.mockReset();
+    useFolderTreeMock.mockReturnValue({ data: { tree: TREE }, isLoading: false, error: null });
+  });
+
+  it('pre-selects the document current folder and disables Move until changed', () => {
+    render(
+      <MoveFolderDialog
+        documentTitles={['Faktura.pdf']}
+        currentFolderId="a1"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    );
+
+    // The folder name button for the current folder is marked pressed
+    // (aria-pressed=true) — i.e. the dialog opened pre-selected on it.
+    const selected = screen.getByRole('button', { name: 'Faktúry', pressed: true });
+    expect(selected).toBeInTheDocument();
+
+    // Destination label reflects the pre-selected folder, not "root".
+    expect(screen.queryByText('Koreň (bez priečinka)')).not.toBeInTheDocument();
+
+    // No net change yet → confirm button disabled.
+    const confirm = screen.getByRole('button', { name: 'Presunúť sem' });
+    expect(confirm).toBeDisabled();
+  });
+
+  it('falls back to root selection when the document has no folder', () => {
+    render(
+      <MoveFolderDialog
+        documentTitles={['Faktura.pdf']}
+        currentFolderId={null}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    );
+
+    const rootOption = screen.getByRole('button', {
+      name: /Všetky dokumenty \(bez priečinka\)/,
+    });
+    expect(rootOption).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/frontend/packages/api-client/src/documents/types.ts
+++ b/frontend/packages/api-client/src/documents/types.ts
@@ -39,6 +39,8 @@ export interface DocumentSummary {
   title: string;
   description?: string;
   category: string;
+  /** Owning folder id; absent/null means the document lives at the root. */
+  folder_id?: string | null;
   file_name: string;
   mime_type: string;
   size_bytes: number;


### PR DESCRIPTION
## Task
DocumentsBrowse MoveFolderDialog cannot pre-select current folder (DocumentSummary lacks folder_id). Thread the document's folder_id through DocumentSummary so MoveFolderDialog opens with the current folder pre-selected.

## Owner
pm-frontend (specialist: react-web)

## What changed
- `frontend/packages/api-client/src/documents/types.ts` — added `folder_id?: string | null` to the `DocumentSummary` interface. The backend `DocumentSummary` (backend/crates/db/src/models/document.rs) already serializes `folder_id: Option<Uuid>`, so the field was already on the wire — only the frontend type was missing it.
- `frontend/apps/ppt-web/src/features/documents/components/DocumentsBrowse.tsx` — replaced the hard-coded `currentFolderId={null}` TODO with `currentFolderId={moveTarget.folder_id ?? null}`, so the move dialog opens pre-selected on the document's current folder.
- `frontend/apps/ppt-web/src/features/documents/components/MoveFolderDialog.preselect.test.tsx` — new regression test: asserts the dialog opens pre-selected on the document's folder (Move button disabled until changed) and falls back to root selection when the doc has no folder.

`MoveFolderDialog` already accepted a `currentFolderId` prop and seeded its internal selection from it — no dialog changes were needed. `FolderTreePage` already pre-selects via the active `selectedFolderId`, so it was intentionally left untouched.

## Tested (Band A — fast check)
- `pnpm -F @ppt/api-client build` → exit 0 (tsc)
- `pnpm -F @ppt/web typecheck` (tsc --noEmit) → exit 0
- `npx biome check` on the two changed source files → exit 0 (clean). Per-app `lint` script uses a stale eslint v9 config repo-wide; the project standard is Biome (CLAUDE.md), which is clean on the changed files.
- `npx vitest run` (full @ppt/web suite) → 34 files / 483 tests passed (was 481 before; +2 from the new test)

## Built (Band B — full build)
skipped: change <50 LOC (one type field + one-line wiring + a test), no public-API/config build-output impact.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped

## Scope drift
none — scope-check.sh (owner pm-frontend) exit 0.

## Code-reuse review
none — reuse-grep.sh exit 0, no warnings.

## Notes
Pure frontend type-plumbing fix; no backend change required because the API already returns `folder_id`.

https://claude.ai/code/session_01E3DYUbvgCFXsREUVK1J34t

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3DYUbvgCFXsREUVK1J34t)_