### PR TITLE
gap-79-1-announcements-faults-api-wiring: inline error/retry states for announcements & faults lists

### DIFF
--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -242,6 +242,7 @@
   },
   "faults": {
     "title": "Hlášení závad",
+    "failedToLoad": "Nepodařilo se načíst závady",
     "newFault": "Nová závada",
     "reportFault": "Nahlásit závadu",
     "description": "Popis",

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -241,6 +241,7 @@
   },
   "faults": {
     "title": "Störungsmeldungen",
+    "failedToLoad": "Störungen konnten nicht geladen werden",
     "newFault": "Neue Störung",
     "reportFault": "Störung melden",
     "description": "Beschreibung",

--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -260,6 +260,7 @@
   },
   "faults": {
     "title": "Fault Reports",
+    "failedToLoad": "Failed to load faults",
     "newFault": "New Fault",
     "reportFault": "Report Fault",
     "description": "Description",

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -241,6 +241,7 @@
   },
   "faults": {
     "title": "Hibajelentések",
+    "failedToLoad": "Nem sikerült betölteni a hibákat",
     "newFault": "Új hiba",
     "reportFault": "Hiba jelentése",
     "description": "Leírás",

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -243,6 +243,7 @@
   },
   "faults": {
     "title": "Zgłoszenia usterek",
+    "failedToLoad": "Nie udało się załadować usterek",
     "newFault": "Nowa usterka",
     "reportFault": "Zgłoś usterkę",
     "description": "Opis",

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -243,6 +243,7 @@
   },
   "faults": {
     "title": "Hlásenia porúch",
+    "failedToLoad": "Nepodarilo sa načítať poruchy",
     "newFault": "Nová porucha",
     "reportFault": "Nahlásiť poruchu",
     "description": "Popis",

--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -1658,7 +1658,7 @@ function AnnouncementsPageRoute() {
     pageSize: 10,
   });
 
-  const { data, isLoading, error } = useAnnouncements(listParams);
+  const { data, isLoading, error, refetch } = useAnnouncements(listParams);
   // Story 6.4 — separate query for the sticky pinned band; immune to list filters.
   // Routes through the shared hook (#486 / #516) so the URL + staleTime + pageSize
   // can't drift between this callsite and other consumers (mobile).
@@ -1763,6 +1763,10 @@ function AnnouncementsPageRoute() {
       announcements={announcements}
       total={total}
       isLoading={isLoading}
+      isError={!!error}
+      onRetry={() => {
+        void refetch();
+      }}
       pinnedAnnouncements={pinnedAnnouncements}
       onNavigateToCreate={() => navigate('/announcements/new')}
       onNavigateToView={(id) => navigate(`/announcements/${id}`)}
@@ -2478,7 +2482,7 @@ function FaultsPageRoute() {
   const { showToast } = useToast();
   const [faultQuery, setFaultQuery] = useState<FaultListQuery>({ page: 1, limit: 10 });
 
-  const { data, isLoading, error } = useFaults(faultQuery);
+  const { data, isLoading, error, refetch } = useFaults(faultQuery);
 
   useEffect(() => {
     if (error) {
@@ -2521,6 +2525,10 @@ function FaultsPageRoute() {
       faults={faults}
       total={total}
       isLoading={isLoading}
+      isError={!!error}
+      onRetry={() => {
+        void refetch();
+      }}
       onNavigateToCreate={() => navigate('/faults/new')}
       onNavigateToView={(id) => navigate(`/faults/${id}`)}
       onNavigateToEdit={(id) => navigate(`/faults/${id}/edit`)}

--- a/frontend/apps/ppt-web/src/features/announcements/components/AnnouncementList.tsx
+++ b/frontend/apps/ppt-web/src/features/announcements/components/AnnouncementList.tsx
@@ -13,6 +13,10 @@ interface AnnouncementListProps {
   page: number;
   pageSize: number;
   isLoading?: boolean;
+  /** True when the list query failed. Renders an inline error state. */
+  isError?: boolean;
+  /** Retry the failed list query. */
+  onRetry?: () => void;
   /** Pinned published announcements shown in the sticky band above the list (Story 6.4) */
   pinnedAnnouncements?: AnnouncementSummary[];
   onPageChange: (page: number) => void;
@@ -33,6 +37,8 @@ export function AnnouncementList({
   page,
   pageSize,
   isLoading,
+  isError,
+  onRetry,
   pinnedAnnouncements = [],
   onPageChange,
   onStatusFilter,
@@ -105,7 +111,23 @@ export function AnnouncementList({
       </div>
 
       {/* List */}
-      {isLoading ? (
+      {isError ? (
+        <div
+          role="alert"
+          className="text-center py-12 border border-red-200 bg-red-50 rounded-md text-red-700"
+        >
+          <p className="font-medium">Failed to load announcements.</p>
+          {onRetry && (
+            <button
+              type="button"
+              onClick={onRetry}
+              className="mt-3 px-3 py-1 border border-red-300 rounded text-red-700 hover:bg-red-100"
+            >
+              Retry
+            </button>
+          )}
+        </div>
+      ) : isLoading ? (
         <div className="flex items-center justify-center py-12">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
         </div>

--- a/frontend/apps/ppt-web/src/features/announcements/components/AnnouncementList.tsx
+++ b/frontend/apps/ppt-web/src/features/announcements/components/AnnouncementList.tsx
@@ -4,6 +4,7 @@ import type {
   AnnouncementTargetType,
 } from '@ppt/api-client';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { AnnouncementCard } from './AnnouncementCard';
 import { PinnedAnnouncementsBand } from './PinnedAnnouncementsBand';
 
@@ -51,6 +52,7 @@ export function AnnouncementList({
   onPin,
   onCreate,
 }: AnnouncementListProps) {
+  const { t } = useTranslation();
   const [statusFilter, setStatusFilter] = useState<AnnouncementStatus | ''>('');
   const [targetTypeFilter, setTargetTypeFilter] = useState<AnnouncementTargetType | ''>('');
 
@@ -116,14 +118,16 @@ export function AnnouncementList({
           role="alert"
           className="text-center py-12 border border-red-200 bg-red-50 rounded-md text-red-700"
         >
-          <p className="font-medium">Failed to load announcements.</p>
+          <p className="font-medium">
+            {t('announcements.failedToLoad', { defaultValue: 'Failed to load announcements' })}
+          </p>
           {onRetry && (
             <button
               type="button"
               onClick={onRetry}
               className="mt-3 px-3 py-1 border border-red-300 rounded text-red-700 hover:bg-red-100"
             >
-              Retry
+              {t('common.retry', { defaultValue: 'Retry' })}
             </button>
           )}
         </div>

--- a/frontend/apps/ppt-web/src/features/announcements/pages/AnnouncementsPage.test.tsx
+++ b/frontend/apps/ppt-web/src/features/announcements/pages/AnnouncementsPage.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * AnnouncementsPage state-wiring regression test (gap-79-1).
+ * Verifies the loading / error / empty triad threaded from the route's
+ * TanStack Query hook (isLoading / isError / onRetry) reaches the UI.
+ */
+
+/// <reference types="vitest/globals" />
+import { fireEvent, render, screen } from '@testing-library/react';
+import { AnnouncementsPage } from './AnnouncementsPage';
+
+const noop = () => {};
+
+const baseProps = {
+  announcements: [],
+  total: 0,
+  onNavigateToCreate: noop,
+  onNavigateToView: noop,
+  onNavigateToEdit: noop,
+  onDelete: noop,
+  onPublish: noop,
+  onArchive: noop,
+  onPin: noop,
+  onFilterChange: noop,
+};
+
+describe('AnnouncementsPage state wiring', () => {
+  it('renders the empty state when not loading and no error', () => {
+    render(<AnnouncementsPage {...baseProps} isLoading={false} />);
+    expect(screen.getByText('No announcements found.')).toBeInTheDocument();
+  });
+
+  it('renders an inline error state (not the empty state) when isError is true', () => {
+    render(<AnnouncementsPage {...baseProps} isError />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Failed to load announcements.');
+    expect(screen.queryByText('No announcements found.')).not.toBeInTheDocument();
+  });
+
+  it('invokes onRetry from the error state retry button', () => {
+    const onRetry = vi.fn();
+    render(<AnnouncementsPage {...baseProps} isError onRetry={onRetry} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not show the empty state while loading', () => {
+    render(<AnnouncementsPage {...baseProps} isLoading />);
+    expect(screen.queryByText('No announcements found.')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/apps/ppt-web/src/features/announcements/pages/AnnouncementsPage.test.tsx
+++ b/frontend/apps/ppt-web/src/features/announcements/pages/AnnouncementsPage.test.tsx
@@ -31,7 +31,7 @@ describe('AnnouncementsPage state wiring', () => {
 
   it('renders an inline error state (not the empty state) when isError is true', () => {
     render(<AnnouncementsPage {...baseProps} isError />);
-    expect(screen.getByRole('alert')).toHaveTextContent('Failed to load announcements.');
+    expect(screen.getByRole('alert')).toHaveTextContent('Failed to load announcements');
     expect(screen.queryByText('No announcements found.')).not.toBeInTheDocument();
   });
 

--- a/frontend/apps/ppt-web/src/features/announcements/pages/AnnouncementsPage.tsx
+++ b/frontend/apps/ppt-web/src/features/announcements/pages/AnnouncementsPage.tsx
@@ -11,6 +11,10 @@ interface AnnouncementsPageProps {
   announcements: AnnouncementSummary[];
   total: number;
   isLoading?: boolean;
+  /** True when the announcements list query failed (surfaces an inline error state). */
+  isError?: boolean;
+  /** Retry the failed announcements list query. */
+  onRetry?: () => void;
   /** Pinned published announcements for the sticky band (Story 6.4). Fetched
    *  separately in the route wrapper so the band is immune to list filters. */
   pinnedAnnouncements?: AnnouncementSummary[];
@@ -28,6 +32,8 @@ export function AnnouncementsPage({
   announcements,
   total,
   isLoading,
+  isError,
+  onRetry,
   pinnedAnnouncements = [],
   onNavigateToCreate,
   onNavigateToView,
@@ -69,6 +75,8 @@ export function AnnouncementsPage({
         page={page}
         pageSize={pageSize}
         isLoading={isLoading}
+        isError={isError}
+        onRetry={onRetry}
         pinnedAnnouncements={pinnedAnnouncements}
         onPageChange={handlePageChange}
         onStatusFilter={handleStatusFilter}

--- a/frontend/apps/ppt-web/src/features/faults/components/FaultList.tsx
+++ b/frontend/apps/ppt-web/src/features/faults/components/FaultList.tsx
@@ -4,6 +4,7 @@
  */
 
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { FaultCategory, FaultPriority, FaultStatus, FaultSummary } from './FaultCard';
 import { FaultCard } from './FaultCard';
 
@@ -80,6 +81,7 @@ export function FaultList({
   onTriage,
   onCreate,
 }: FaultListProps) {
+  const { t } = useTranslation();
   const [searchQuery, setSearchQuery] = useState('');
   const totalPages = Math.ceil(total / pageSize);
 
@@ -157,14 +159,16 @@ export function FaultList({
           role="alert"
           className="text-center py-8 border border-red-200 bg-red-50 rounded-lg text-red-700"
         >
-          <p className="font-medium">Failed to load faults.</p>
+          <p className="font-medium">
+            {t('faults.failedToLoad', { defaultValue: 'Failed to load faults' })}
+          </p>
           {onRetry && (
             <button
               type="button"
               onClick={onRetry}
               className="mt-3 px-3 py-1 border border-red-300 rounded text-red-700 hover:bg-red-100"
             >
-              Retry
+              {t('common.retry', { defaultValue: 'Retry' })}
             </button>
           )}
         </div>

--- a/frontend/apps/ppt-web/src/features/faults/components/FaultList.tsx
+++ b/frontend/apps/ppt-web/src/features/faults/components/FaultList.tsx
@@ -13,6 +13,10 @@ interface FaultListProps {
   page: number;
   pageSize: number;
   isLoading?: boolean;
+  /** True when the list query failed. Renders an inline error state. */
+  isError?: boolean;
+  /** Retry the failed list query. */
+  onRetry?: () => void;
   onPageChange: (page: number) => void;
   onStatusFilter: (status?: FaultStatus) => void;
   onPriorityFilter: (priority?: FaultPriority) => void;
@@ -64,6 +68,8 @@ export function FaultList({
   page,
   pageSize,
   isLoading,
+  isError,
+  onRetry,
   onPageChange,
   onStatusFilter,
   onPriorityFilter,
@@ -145,6 +151,25 @@ export function FaultList({
         </select>
       </div>
 
+      {/* Error */}
+      {!isLoading && isError && (
+        <div
+          role="alert"
+          className="text-center py-8 border border-red-200 bg-red-50 rounded-lg text-red-700"
+        >
+          <p className="font-medium">Failed to load faults.</p>
+          {onRetry && (
+            <button
+              type="button"
+              onClick={onRetry}
+              className="mt-3 px-3 py-1 border border-red-300 rounded text-red-700 hover:bg-red-100"
+            >
+              Retry
+            </button>
+          )}
+        </div>
+      )}
+
       {/* Loading */}
       {isLoading && (
         <div className="flex justify-center py-8">
@@ -153,11 +178,11 @@ export function FaultList({
       )}
 
       {/* List */}
-      {!isLoading && faults.length === 0 && (
+      {!isLoading && !isError && faults.length === 0 && (
         <div className="text-center py-8 text-gray-500">No faults found.</div>
       )}
 
-      {!isLoading && faults.length > 0 && (
+      {!isLoading && !isError && faults.length > 0 && (
         <div className="space-y-3">
           {faults.map((fault) => (
             <FaultCard

--- a/frontend/apps/ppt-web/src/features/faults/pages/FaultsPage.test.tsx
+++ b/frontend/apps/ppt-web/src/features/faults/pages/FaultsPage.test.tsx
@@ -28,7 +28,7 @@ describe('FaultsPage state wiring', () => {
 
   it('renders an inline error state (not the empty state) when isError is true', () => {
     render(<FaultsPage {...baseProps} isError />);
-    expect(screen.getByRole('alert')).toHaveTextContent('Failed to load faults.');
+    expect(screen.getByRole('alert')).toHaveTextContent('Failed to load faults');
     expect(screen.queryByText('No faults found.')).not.toBeInTheDocument();
   });
 

--- a/frontend/apps/ppt-web/src/features/faults/pages/FaultsPage.test.tsx
+++ b/frontend/apps/ppt-web/src/features/faults/pages/FaultsPage.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * FaultsPage state-wiring regression test (gap-79-1).
+ * Verifies the loading / error / empty triad threaded from the route's
+ * TanStack Query hook (isLoading / isError / onRetry) reaches the UI.
+ */
+
+/// <reference types="vitest/globals" />
+import { fireEvent, render, screen } from '@testing-library/react';
+import { FaultsPage } from './FaultsPage';
+
+const noop = () => {};
+
+const baseProps = {
+  faults: [],
+  total: 0,
+  onNavigateToCreate: noop,
+  onNavigateToView: noop,
+  onNavigateToEdit: noop,
+  onNavigateToTriage: noop,
+  onFilterChange: noop,
+};
+
+describe('FaultsPage state wiring', () => {
+  it('renders the empty state when not loading and no error', () => {
+    render(<FaultsPage {...baseProps} isLoading={false} />);
+    expect(screen.getByText('No faults found.')).toBeInTheDocument();
+  });
+
+  it('renders an inline error state (not the empty state) when isError is true', () => {
+    render(<FaultsPage {...baseProps} isError />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Failed to load faults.');
+    expect(screen.queryByText('No faults found.')).not.toBeInTheDocument();
+  });
+
+  it('invokes onRetry from the error state retry button', () => {
+    const onRetry = vi.fn();
+    render(<FaultsPage {...baseProps} isError onRetry={onRetry} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not show the empty state while loading', () => {
+    render(<FaultsPage {...baseProps} isLoading />);
+    expect(screen.queryByText('No faults found.')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/apps/ppt-web/src/features/faults/pages/FaultsPage.tsx
+++ b/frontend/apps/ppt-web/src/features/faults/pages/FaultsPage.tsx
@@ -25,6 +25,10 @@ interface FaultsPageProps {
   faults: FaultSummary[];
   total: number;
   isLoading?: boolean;
+  /** True when the faults list query failed (surfaces an inline error state). */
+  isError?: boolean;
+  /** Retry the failed faults list query. */
+  onRetry?: () => void;
   onNavigateToCreate: () => void;
   onNavigateToView: (id: string) => void;
   onNavigateToEdit: (id: string) => void;
@@ -36,6 +40,8 @@ export function FaultsPage({
   faults,
   total,
   isLoading,
+  isError,
+  onRetry,
   onNavigateToCreate,
   onNavigateToView,
   onNavigateToEdit,
@@ -87,6 +93,8 @@ export function FaultsPage({
         page={page}
         pageSize={pageSize}
         isLoading={isLoading}
+        isError={isError}
+        onRetry={onRetry}
         onPageChange={handlePageChange}
         onStatusFilter={handleStatusFilter}
         onPriorityFilter={handlePriorityFilter}


### PR DESCRIPTION
## Task
Fully wire AnnouncementsPage and FaultsPage in ppt-web to their TanStack Query API hooks (story 79-1).

## Owner
pm-frontend

## What this PR does
Completes the loading / error / empty triad for the announcements and faults lists in ppt-web:

- Adds `isError` / `onRetry` props to `AnnouncementsPage`, `FaultsPage` and their `AnnouncementList` / `FaultList` children, rendering an inline `role="alert"` error block with a `Retry` button.
- **Wires the route wrappers** `AnnouncementsPageRoute` and `FaultsPageRoute` in `App.tsx` to feed `isError={!!error}` and `onRetry={() => void refetch()}` from the `useAnnouncements` / `useFaults` TanStack Query hooks into the pages, so the new error/retry UI is actually driven by query state (previously the props defaulted to `undefined`).
- i18n: the inline error strings now use `t('announcements.failedToLoad')` / `t('faults.failedToLoad')` and `t('common.retry')`; added the `faults.failedToLoad` key across all six locales (en, sk, cs, de, pl, hu).
- Adds/updates regression tests (`AnnouncementsPage.test.tsx`, `FaultsPage.test.tsx`) covering the loading / error / empty states and the retry callback.

## Tested (Band A — fast check)
- `pnpm -F @ppt/web typecheck` -> exit 0
- `biome check` on all changed files -> exit 0
- `vitest run AnnouncementsPage.test.tsx FaultsPage.test.tsx` -> 8 passed

## Scope drift
None — all changes inside `frontend/apps/ppt-web`.

https://claude.ai/code/session_01Kre3mEK52941iWP26F51rx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kre3mEK52941iWP26F51rx)_