### PR TITLE
bug-esignature-webhook-idempotency-guard: terminal-state idempotency guard for e-signature webhook

### DIFF
--- a/backend/crates/db/src/models/signature_request.rs
+++ b/backend/crates/db/src/models/signature_request.rs
@@ -44,6 +44,25 @@ impl std::fmt::Display for SignatureRequestStatus {
     }
 }
 
+impl SignatureRequestStatus {
+    /// Whether this status is terminal (finalized) — the request has reached
+    /// an outcome that must never be re-transitioned.
+    ///
+    /// E-signature providers deliver webhooks at-least-once, so a single
+    /// `completed` / `declined` event may arrive multiple times. Once a
+    /// request is in a terminal state, replaying a webhook must be a no-op:
+    /// it must not re-store the signed document, re-fire requester emails, or
+    /// flip signer status back and forth. Webhook handlers consult this guard
+    /// before applying any side effect (bug-esignature-webhook-idempotency-guard,
+    /// Story 84.2).
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Completed | Self::Declined | Self::Expired | Self::Cancelled
+        )
+    }
+}
+
 /// Status of an individual signer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
@@ -423,6 +442,19 @@ mod tests {
         signer.status = SignerStatus::Declined;
         assert!(signer.is_complete());
         assert!(!signer.has_signed());
+    }
+
+    #[test]
+    fn test_status_is_terminal() {
+        // Terminal (finalized) states — webhook replays must be no-ops.
+        assert!(SignatureRequestStatus::Completed.is_terminal());
+        assert!(SignatureRequestStatus::Declined.is_terminal());
+        assert!(SignatureRequestStatus::Expired.is_terminal());
+        assert!(SignatureRequestStatus::Cancelled.is_terminal());
+
+        // Non-terminal states — still progressing, webhooks may transition.
+        assert!(!SignatureRequestStatus::Pending.is_terminal());
+        assert!(!SignatureRequestStatus::InProgress.is_terminal());
     }
 
     #[test]

--- a/backend/servers/api-server/src/routes/signatures.rs
+++ b/backend/servers/api-server/src/routes/signatures.rs
@@ -695,6 +695,28 @@ pub async fn handle_webhook(
             )
         })?;
 
+    // Idempotency guard (bug-esignature-webhook-idempotency-guard, Story 84.2):
+    // e-signature providers deliver webhooks at-least-once, so a `completed` /
+    // `declined` event can arrive more than once. If the request is already in
+    // a terminal state, replaying the webhook must be a no-op — otherwise we
+    // would re-store the signed document, re-fire the requester completion /
+    // decline emails, and churn signer status on every duplicate delivery.
+    // Acknowledge with 200 so the provider stops retrying.
+    if signature_request.status.is_terminal() {
+        info!(
+            provider = %provider,
+            provider_request_id = %event.provider_request_id,
+            signature_request_id = %signature_request.id,
+            status = %signature_request.status,
+            event_type = %event.event_type,
+            "Ignoring duplicate webhook for already-finalized signature request"
+        );
+        return Ok(Json(WebhookResponse {
+            success: true,
+            message: "Signature request already finalized; webhook ignored".into(),
+        }));
+    }
+
     // Process signer-specific events and send appropriate email notifications (Story 84.2).
     let updated_request = if let (Some(signer_email), Some(signer_status)) =
         (&event.signer_email, &event.signer_status)

--- a/backend/servers/api-server/tests/esignature_webhook_idempotency_tests.rs
+++ b/backend/servers/api-server/tests/esignature_webhook_idempotency_tests.rs
@@ -165,7 +165,9 @@ async fn duplicate_completed_webhook_on_terminal_request_is_noop(pool: PgPool) {
     assert_eq!(body.get("success"), Some(&json!(true)));
     assert_eq!(
         body.get("message"),
-        Some(&json!("Signature request already finalized; webhook ignored")),
+        Some(&json!(
+            "Signature request already finalized; webhook ignored"
+        )),
         "expected the terminal-state guard message, got: {body}"
     );
 
@@ -175,13 +177,12 @@ async fn duplicate_completed_webhook_on_terminal_request_is_noop(pool: PgPool) {
         "signed",
         "duplicate webhook must not mutate signer status"
     );
-    let signed_doc: Option<Uuid> = sqlx::query_scalar(
-        r#"SELECT signed_document_id FROM signature_requests WHERE id = $1"#,
-    )
-    .bind(request_id)
-    .fetch_one(&pool)
-    .await
-    .expect("read signed_document_id");
+    let signed_doc: Option<Uuid> =
+        sqlx::query_scalar(r#"SELECT signed_document_id FROM signature_requests WHERE id = $1"#)
+            .bind(request_id)
+            .fetch_one(&pool)
+            .await
+            .expect("read signed_document_id");
     assert!(
         signed_doc.is_none(),
         "duplicate webhook must not store a signed document on a terminal request"

--- a/backend/servers/api-server/tests/esignature_webhook_idempotency_tests.rs
+++ b/backend/servers/api-server/tests/esignature_webhook_idempotency_tests.rs
@@ -1,0 +1,227 @@
+//! Regression tests for `bug-esignature-webhook-idempotency-guard` (Story 84.2).
+//!
+//! E-signature providers deliver webhooks at-least-once, so a single
+//! `completed` / `declined` event can arrive multiple times. Before the
+//! terminal-state idempotency guard, a duplicate delivery for an
+//! already-finalized signature request would re-run all side effects:
+//! re-store the signed document, churn signer status, and re-fire the
+//! requester completion/decline email.
+//!
+//! These tests POST a webhook to
+//! `/api/v1/signature-requests/webhook/{provider}` for a request that is
+//! already in a terminal state (`completed`) and assert:
+//!
+//! | Case | Expected |
+//! |------|----------|
+//! | W1 | Duplicate `completed` webhook → 200, "already finalized" ack, no signer mutation |
+//! | W2 | Duplicate `declined` signer event on a terminal request → 200, signer status untouched |
+//!
+//! The webhook endpoint is unauthenticated; authority comes from the
+//! `X-Webhook-Secret` header validated against `ESIGN_WEBHOOK_SECRET`. We pin
+//! that env var so the handler accepts our forged-but-authentic deliveries.
+
+#[allow(dead_code)]
+mod common;
+
+use axum::http::StatusCode;
+use common::TestApp;
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Shared webhook secret pinned for the duration of the test process.
+const TEST_WEBHOOK_SECRET: &str = "esign-webhook-idempotency-test-secret-0123456789";
+
+/// Ensure `ESIGN_WEBHOOK_SECRET` is set before the handler reads it.
+fn ensure_webhook_secret() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        std::env::set_var("ESIGN_WEBHOOK_SECRET", TEST_WEBHOOK_SECRET);
+    });
+}
+
+/// Seed org + user + document + a signature request in the given status with a
+/// single signer in the given signer status. Returns
+/// (request_id, provider, provider_request_id, signer_email).
+async fn seed_terminal_request(
+    pool: &PgPool,
+    status: &str,
+    signer_status: &str,
+) -> (Uuid, String, String, String) {
+    let slug = format!("esign-wh-{}", Uuid::new_v4());
+    let org_id = sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO organizations (name, slug, contact_email, status)
+           VALUES ('ESign WH Org', $1, 'esign-wh@example.com', 'active')
+           RETURNING id"#,
+    )
+    .bind(&slug)
+    .fetch_one(pool)
+    .await
+    .expect("seed org");
+
+    let user_id = sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO users (email, password_hash, name, status, email_verified_at)
+           VALUES ($1, 'test_hash', 'ESign User', 'active', NOW())
+           RETURNING id"#,
+    )
+    .bind(format!("esign-wh-{}@example.com", Uuid::new_v4()))
+    .fetch_one(pool)
+    .await
+    .expect("seed user");
+
+    let doc_id = sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO documents
+             (organization_id, title, category, file_key, file_name,
+              mime_type, size_bytes, access_scope, created_by)
+           VALUES ($1, 'Lease Agreement', 'contracts', 'k', 'lease.pdf',
+                   'application/pdf', 1, 'organization', $2)
+           RETURNING id"#,
+    )
+    .bind(org_id)
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed document");
+
+    let signer_email = format!("signer-{}@example.com", Uuid::new_v4());
+    let signers = json!([{
+        "email": signer_email,
+        "name": "Alice Buyer",
+        "order": 0,
+        "status": signer_status
+    }]);
+
+    let provider = "lightweight".to_string();
+    let provider_request_id = format!("prov-req-{}", Uuid::new_v4());
+
+    let request_id = sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO signature_requests
+             (document_id, organization_id, status, subject, message, signers,
+              provider, provider_request_id, created_by)
+           VALUES ($1, $2, $3::signature_request_status, 'Please sign the lease',
+                   'Sign at your earliest convenience', $4, $5, $6, $7)
+           RETURNING id"#,
+    )
+    .bind(doc_id)
+    .bind(org_id)
+    .bind(status)
+    .bind(&signers)
+    .bind(&provider)
+    .bind(&provider_request_id)
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed signature_request");
+
+    (request_id, provider, provider_request_id, signer_email)
+}
+
+/// Read the current signer status for the single seeded signer.
+async fn signer_status(pool: &PgPool, request_id: Uuid) -> String {
+    sqlx::query_scalar::<_, String>(
+        r#"SELECT signers->0->>'status' FROM signature_requests WHERE id = $1"#,
+    )
+    .bind(request_id)
+    .fetch_one(pool)
+    .await
+    .expect("read signer status")
+}
+
+// ===========================================================================
+// W1 — duplicate `completed` webhook on a completed request is a no-op
+// ===========================================================================
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn duplicate_completed_webhook_on_terminal_request_is_noop(pool: PgPool) {
+    ensure_webhook_secret();
+    let app = TestApp::new(pool.clone()).await;
+
+    // Request already finalized as `completed`, signer already `signed`.
+    let (request_id, provider, provider_request_id, signer_email) =
+        seed_terminal_request(&pool, "completed", "signed").await;
+
+    let before = signer_status(&pool, request_id).await;
+    assert_eq!(before, "signed", "precondition: signer is already signed");
+
+    let resp = app
+        .execute(
+            app.post(&format!("/api/v1/signature-requests/webhook/{}", provider))
+                .header("x-webhook-secret", TEST_WEBHOOK_SECRET)
+                .json(json!({
+                    "event_type": "completed",
+                    "provider_request_id": provider_request_id,
+                    "signer_email": signer_email,
+                    "signer_status": "signed",
+                    "signed_document_url": "https://provider.example/signed.pdf"
+                }))
+                .build(),
+        )
+        .await;
+
+    // Idempotent acknowledgement: 200, success, and the guard message so the
+    // provider stops retrying.
+    resp.assert_status(StatusCode::OK);
+    let body = resp.json_value();
+    assert_eq!(body.get("success"), Some(&json!(true)));
+    assert_eq!(
+        body.get("message"),
+        Some(&json!("Signature request already finalized; webhook ignored")),
+        "expected the terminal-state guard message, got: {body}"
+    );
+
+    // No side effects: signer status unchanged, no signed document linked.
+    assert_eq!(
+        signer_status(&pool, request_id).await,
+        "signed",
+        "duplicate webhook must not mutate signer status"
+    );
+    let signed_doc: Option<Uuid> = sqlx::query_scalar(
+        r#"SELECT signed_document_id FROM signature_requests WHERE id = $1"#,
+    )
+    .bind(request_id)
+    .fetch_one(&pool)
+    .await
+    .expect("read signed_document_id");
+    assert!(
+        signed_doc.is_none(),
+        "duplicate webhook must not store a signed document on a terminal request"
+    );
+}
+
+// ===========================================================================
+// W2 — a signer `declined` event on an already-terminal request is ignored
+// ===========================================================================
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn signer_event_on_terminal_request_does_not_retransition(pool: PgPool) {
+    ensure_webhook_secret();
+    let app = TestApp::new(pool.clone()).await;
+
+    // Request finalized as `completed`; signer recorded as `signed`. A late /
+    // duplicate `declined` event must not flip the signer back.
+    let (request_id, provider, provider_request_id, signer_email) =
+        seed_terminal_request(&pool, "completed", "signed").await;
+
+    let resp = app
+        .execute(
+            app.post(&format!("/api/v1/signature-requests/webhook/{}", provider))
+                .header("x-webhook-secret", TEST_WEBHOOK_SECRET)
+                .json(json!({
+                    "event_type": "signer_declined",
+                    "provider_request_id": provider_request_id,
+                    "signer_email": signer_email,
+                    "signer_status": "declined",
+                    "decline_reason": "changed my mind"
+                }))
+                .build(),
+        )
+        .await;
+
+    resp.assert_status(StatusCode::OK);
+
+    assert_eq!(
+        signer_status(&pool, request_id).await,
+        "signed",
+        "terminal request must not re-transition signer status on a late event"
+    );
+}


### PR DESCRIPTION
## Task
Add a terminal-state idempotency guard to the e-signature webhook handler (story 84-2) so duplicate webhook deliveries cannot re-transition an already-finalized signature.

## Owner
pm-backend

## Approach
E-signature providers deliver webhooks at-least-once, so a single `completed` / `declined` event may arrive multiple times. Before this change, a duplicate delivery for an already-finalized request re-ran every side effect in `handle_webhook`: re-stored the signed document, churned signer status via `update_signer_status`, and re-fired the requester completion / decline email.

Fix:
- Add `SignatureRequestStatus::is_terminal()` — true for `Completed | Declined | Expired | Cancelled`.
- In `handle_webhook`, right after the signature request is loaded (and before any side effect), short-circuit with an idempotent `200` ack when the request is already terminal.

### Reuse note (Airbnb 00169 ledger)
The reviewer hint pointed at the Airbnb `airbnb_webhook_events` `ON CONFLICT DO NOTHING` event-id ledger (migration 00169). That pattern keys on a globally-unique provider `event_id`, but the e-signature `SignatureWebhookEvent` payload has no event-id field (only `event_type` + `provider_request_id`). A terminal-state guard on the existing `signature_requests.status` column is the natural fit here, reuses an existing column, and needs no migration — so I deliberately did not introduce a new ledger table.

## Files
- `backend/crates/db/src/models/signature_request.rs` — `is_terminal()` helper + unit test
- `backend/servers/api-server/src/routes/signatures.rs` — guard in `handle_webhook`
- `backend/servers/api-server/tests/esignature_webhook_idempotency_tests.rs` — HTTP regression tests (new)

## Tested (Band A — fast check)
- `SQLX_OFFLINE=true cargo check -p db -p api-server` — exit 0 (compiles incl. new integration test binary)
- `SQLX_OFFLINE=true cargo test -p db --lib models::signature_request` — exit 0, 4 passed incl. `test_status_is_terminal`

## Built (Band B — full build)
skipped: change is small (~30 LOC handler + helper, +227 LOC new test); no public API/migration/config touch. (`is_terminal` is an additive helper; no schema or wire change.)

## CI parity (Band C — hot-path only)
The DB-backed regression tests (`esignature_webhook_idempotency_tests.rs`, W1/W2) require a live Postgres (`#[sqlx::test(migrator = "db::MIGRATOR")]`) and cannot run on the DB-less implementer runner. They will run in `backend.yml` CI, which provisions Postgres. Locally verified compile + the no-DB model unit test.

## Remote-tested
skipped (no ppt-bridge MCP in this session)

## Notes
- scope_drift=false (diff stays within pm-backend areas), code_reuse_warn=none.
- IG goal-check reports shape mismatches expected for a dispatcher auto-impl task (no `.research/plans/<slug>.md`, branch prefix `auto-impl/` not `impl/`, single combined commit instead of separate test:/fix:). The regression tests are present; the verify gate (the authoritative quality bar) passed.

https://claude.ai/code/session_01E7kkv8dxo3sopwvwxguqbj

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7kkv8dxo3sopwvwxguqbj)_