### PR TITLE
bug-report-schedule-update-no-cron-column: route report-schedule cron through dedicated column

### DIFF
--- a/backend/crates/db/src/models/report_schedule.rs
+++ b/backend/crates/db/src/models/report_schedule.rs
@@ -37,7 +37,7 @@ pub mod report_execution_status {
 ///
 /// Maps to the `report_schedules` table created by migration
 /// `00162_create_report_schedules_executions.sql`, with the
-/// `cron_expression` column added by `00163_report_schedules_add_cron_expression.sql`.
+/// `cron_expression` column added by `00166_report_schedules_add_cron_expression.sql`.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ReportSchedule {
     pub id: Uuid,

--- a/backend/crates/db/src/repositories/report_schedule.rs
+++ b/backend/crates/db/src/repositories/report_schedule.rs
@@ -3,7 +3,7 @@
 //! Real SQLx implementation backed by the `report_schedules` and
 //! `report_executions` tables added in migration
 //! `00162_create_report_schedules_executions.sql`. The `cron_expression`
-//! column is added by `00163_report_schedules_add_cron_expression.sql`.
+//! column is added by `00166_report_schedules_add_cron_expression.sql`.
 
 use crate::models::report_schedule::{
     report_execution_status, report_schedule_status, ExecutionDownloadUrl, ExecutionHistoryQuery,
@@ -13,6 +13,30 @@ use crate::DbPool;
 use chrono::{Duration, Utc};
 use common::errors::AppError;
 use uuid::Uuid;
+
+/// Canonical projection for `report_schedules` rows.
+///
+/// Every `SELECT` / `RETURNING` that maps into [`ReportScheduleRow`] must list
+/// exactly these columns — `query_as` resolves `FromRow` fields by name at
+/// runtime, so omitting one (historically `cron_expression`, issue #616) makes
+/// the query fail with "no column found for name: …" only when a live DB is
+/// hit. Defined with `concat!` so it is a compile-time `&'static str`
+/// (required by sqlx 0.9's `SqlSafeStr` bound) and so every query below shares
+/// the same column list. The tests at the bottom of this module guard the
+/// projection without needing a database.
+macro_rules! report_schedule_columns {
+    () => {
+        "id, report_id, organization_id, name, frequency, \
+         day_of_week, day_of_month, time, timezone, format, \
+         recipients, is_active, status, \
+         last_run_at, next_run_at, created_at, updated_at, \
+         cron_expression"
+    };
+}
+
+/// The bare column projection, used by the parity tests below.
+#[cfg(test)]
+const REPORT_SCHEDULE_COLUMNS: &str = report_schedule_columns!();
 
 /// Repository for report schedule and execution operations.
 #[derive(Clone)]
@@ -35,17 +59,11 @@ impl ReportScheduleRepository {
     /// Prefer `get_by_id_scoped` in request handlers so the caller's
     /// `organization_id` is enforced in the WHERE clause.
     pub async fn get_by_id(&self, id: Uuid) -> Result<Option<ReportSchedule>, AppError> {
-        let row = sqlx::query_as::<_, ReportScheduleRow>(
-            r#"
-            SELECT id, report_id, organization_id, name, frequency,
-                   day_of_week, day_of_month, time, timezone, format,
-                   recipients, is_active, status,
-                   last_run_at, next_run_at, created_at, updated_at,
-                   cron_expression
-            FROM report_schedules
-            WHERE id = $1
-            "#,
-        )
+        let row = sqlx::query_as::<_, ReportScheduleRow>(concat!(
+            "SELECT ",
+            report_schedule_columns!(),
+            " FROM report_schedules WHERE id = $1"
+        ))
         .bind(id)
         .fetch_optional(&self.pool)
         .await
@@ -66,17 +84,11 @@ impl ReportScheduleRepository {
         id: Uuid,
         caller_org_id: Uuid,
     ) -> Result<Option<ReportSchedule>, AppError> {
-        let row = sqlx::query_as::<_, ReportScheduleRow>(
-            r#"
-            SELECT id, report_id, organization_id, name, frequency,
-                   day_of_week, day_of_month, time, timezone, format,
-                   recipients, is_active, status,
-                   last_run_at, next_run_at, created_at, updated_at
-            FROM report_schedules
-            WHERE id              = $1
-              AND organization_id = $2
-            "#,
-        )
+        let row = sqlx::query_as::<_, ReportScheduleRow>(concat!(
+            "SELECT ",
+            report_schedule_columns!(),
+            " FROM report_schedules WHERE id = $1 AND organization_id = $2"
+        ))
         .bind(id)
         .bind(caller_org_id)
         .fetch_optional(&self.pool)
@@ -100,21 +112,13 @@ impl ReportScheduleRepository {
     /// Returns `NotFound` when the `id` does not exist **or** belongs to a
     /// different organisation, giving the same opaque response in both cases.
     pub async fn pause(&self, id: Uuid, caller_org_id: Uuid) -> Result<ReportSchedule, AppError> {
-        let row = sqlx::query_as::<_, ReportScheduleRow>(
-            r#"
-            UPDATE report_schedules
-            SET is_active  = false,
-                status     = $1,
-                updated_at = NOW()
-            WHERE id              = $2
-              AND organization_id = $3
-            RETURNING id, report_id, organization_id, name, frequency,
-                      day_of_week, day_of_month, time, timezone, format,
-                      recipients, is_active, status,
-                      last_run_at, next_run_at, created_at, updated_at,
-                      cron_expression
-            "#,
-        )
+        let row = sqlx::query_as::<_, ReportScheduleRow>(concat!(
+            "UPDATE report_schedules \
+             SET is_active = false, status = $1, updated_at = NOW() \
+             WHERE id = $2 AND organization_id = $3 \
+             RETURNING ",
+            report_schedule_columns!()
+        ))
         .bind(report_schedule_status::PAUSED)
         .bind(id)
         .bind(caller_org_id)
@@ -140,21 +144,13 @@ impl ReportScheduleRepository {
     /// Returns `NotFound` when the `id` does not exist **or** belongs to a
     /// different organisation, giving the same opaque response in both cases.
     pub async fn resume(&self, id: Uuid, caller_org_id: Uuid) -> Result<ReportSchedule, AppError> {
-        let row = sqlx::query_as::<_, ReportScheduleRow>(
-            r#"
-            UPDATE report_schedules
-            SET is_active  = true,
-                status     = $1,
-                updated_at = NOW()
-            WHERE id              = $2
-              AND organization_id = $3
-            RETURNING id, report_id, organization_id, name, frequency,
-                      day_of_week, day_of_month, time, timezone, format,
-                      recipients, is_active, status,
-                      last_run_at, next_run_at, created_at, updated_at,
-                      cron_expression
-            "#,
-        )
+        let row = sqlx::query_as::<_, ReportScheduleRow>(concat!(
+            "UPDATE report_schedules \
+             SET is_active = true, status = $1, updated_at = NOW() \
+             WHERE id = $2 AND organization_id = $3 \
+             RETURNING ",
+            report_schedule_columns!()
+        ))
         .bind(report_schedule_status::ACTIVE)
         .bind(id)
         .bind(caller_org_id)
@@ -473,7 +469,7 @@ impl ReportScheduleRepository {
     ///
     /// All parameters are optional; only non-`None` values are applied. The
     /// cron expression is persisted to the dedicated `cron_expression` column
-    /// added by migration `00163_report_schedules_add_cron_expression.sql`
+    /// added by migration `00166_report_schedules_add_cron_expression.sql`
     /// (NOT the legacy `time` HH:MM column).
     ///
     /// # Cross-tenant safety (closes #624)
@@ -505,23 +501,17 @@ impl ReportScheduleRepository {
             serde_json::Value::Array(v.into_iter().map(serde_json::Value::String).collect())
         });
 
-        let row = sqlx::query_as::<_, ReportScheduleRow>(
-            r#"
-            UPDATE report_schedules
-            SET cron_expression = COALESCE($3, cron_expression),
-                recipients      = COALESCE($4, recipients),
-                is_active       = COALESCE($5, is_active),
-                status          = COALESCE($6, status),
-                updated_at      = NOW()
-            WHERE id              = $1
-              AND organization_id = $2
-            RETURNING id, report_id, organization_id, name, frequency,
-                      day_of_week, day_of_month, time, timezone, format,
-                      recipients, is_active, status,
-                      last_run_at, next_run_at, created_at, updated_at,
-                      cron_expression
-            "#,
-        )
+        let row = sqlx::query_as::<_, ReportScheduleRow>(concat!(
+            "UPDATE report_schedules \
+             SET cron_expression = COALESCE($3, cron_expression), \
+                 recipients      = COALESCE($4, recipients), \
+                 is_active       = COALESCE($5, is_active), \
+                 status          = COALESCE($6, status), \
+                 updated_at      = NOW() \
+             WHERE id = $1 AND organization_id = $2 \
+             RETURNING ",
+            report_schedule_columns!()
+        ))
         .bind(id)
         .bind(caller_org_id)
         .bind(cron_expression.as_deref())
@@ -547,5 +537,67 @@ impl ReportScheduleRepository {
         })?;
 
         Ok(ReportSchedule::from(row))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::REPORT_SCHEDULE_COLUMNS;
+
+    /// Every column that [`super::ReportScheduleRow`] maps from `FromRow` must
+    /// appear in the canonical projection. `query_as` resolves fields by name
+    /// at runtime, so a missing column only surfaces as a DB error in
+    /// production. This test is the no-DB guard for issue #616, where the
+    /// `cron_expression` column was added to the row struct but dropped from
+    /// the `get_by_id_scoped` SELECT — making cron edits silently fail to
+    /// round-trip through the dedicated column.
+    #[test]
+    fn column_projection_covers_every_row_field() {
+        // Field list mirrors `ReportScheduleRow`. If a field is added there,
+        // add it here and to REPORT_SCHEDULE_COLUMNS — the test fails loudly
+        // until both are in sync.
+        let expected = [
+            "id",
+            "report_id",
+            "organization_id",
+            "name",
+            "frequency",
+            "day_of_week",
+            "day_of_month",
+            "time",
+            "timezone",
+            "format",
+            "recipients",
+            "is_active",
+            "status",
+            "last_run_at",
+            "next_run_at",
+            "created_at",
+            "updated_at",
+            "cron_expression",
+        ];
+
+        let actual: Vec<&str> = REPORT_SCHEDULE_COLUMNS
+            .split(',')
+            .map(|c| c.trim())
+            .collect();
+
+        assert_eq!(
+            actual, expected,
+            "REPORT_SCHEDULE_COLUMNS must list every ReportScheduleRow field, \
+             in order, including cron_expression (issue #616)"
+        );
+    }
+
+    /// Explicit guard for the exact regression in issue #616.
+    #[test]
+    fn projection_includes_cron_expression() {
+        assert!(
+            REPORT_SCHEDULE_COLUMNS
+                .split(',')
+                .any(|c| c.trim() == "cron_expression"),
+            "cron_expression must be selected so report-schedule edits round-trip \
+             through the dedicated column, not the legacy `time` field (issue #616)"
+        );
     }
 }


### PR DESCRIPTION
## Task
Report schedule cron edits round-trip through the overloaded `time` field; add a dedicated cron_expression column + migration and route schedule update through it (issue #616, story 81-1).

## Owner
pm-backend

## Findings (what was already done vs. what was broken)
The dedicated `cron_expression` column and its migration **already exist on `dev`**:
- Migration `backend/crates/db/migrations/00166_report_schedules_add_cron_expression.sql` adds the column (forward-only, `ADD COLUMN IF NOT EXISTS`, backfills cron-shaped values out of `time`, keeps `time` for back-compat).
- `ReportScheduleRow` / `ReportSchedule` already carry `cron_expression`.
- The update path (`PUT /api/v1/reports/schedules/{id}` -> `update_schedule()`) already validates a 5-field cron and writes to the `cron_expression` column (not `time`).

The remaining real bug: `ReportScheduleRepository::get_by_id_scoped` SELECTed only the 17 legacy columns, **omitting `cron_expression`**. Because `query_as` resolves `FromRow` fields by column name at runtime, that scoped read fails with `no column found for name: cron_expression` against a live DB — so an edited schedule could not be read back through the scoped path, and cron never round-tripped to the caller.

## Fix
- Add `cron_expression` to the `get_by_id_scoped` projection.
- Extract the canonical projection into a `report_schedule_columns!` macro shared by all five SELECT/RETURNING queries (`get_by_id`, `get_by_id_scoped`, `pause`, `resume`, `update_schedule`). `concat!` keeps it a compile-time `&'static str` so it satisfies sqlx 0.9's `SqlSafeStr` bound, and eliminates the "one query forgot a column" drift class structurally.
- Add two no-DB regression tests guarding that the projection lists every `ReportScheduleRow` field, including `cron_expression`.
- Fix stale doc-comment migration numbers (`00163` -> `00166`).

No new migration is needed — 00166 already lands the column on `dev`; existing rows stay valid (nullable column, backfilled).

## Tested (Band A — fast check)
```
SQLX_OFFLINE=true cargo check -p db                      -> exit 0
SQLX_OFFLINE=true cargo test  -p db --lib report_schedule -> exit 0
  running 2 tests
  test ...::projection_includes_cron_expression ... ok
  test ...::column_projection_covers_every_row_field ... ok
  test result: ok. 2 passed; 0 failed
```

## Built (Band B — full build)
```
SQLX_OFFLINE=true cargo clippy -p db --lib -> exit 0 (no warnings)
```
(No SQLx compile-time macros are used in this repo file — all queries are `query_as::<_, T>` runtime-checked — so `.sqlx` offline data is unaffected and `sqlx prepare --check` needs no regeneration.)

## CI parity (Band C — hot-path only)
Data-layer / cross-tenant-adjacent change: covered by the clippy `-D warnings`-equivalent run above plus Band A. No auth/billing surface touched.

## Remote-tested
skipped (no ppt-bridge MCP in session)

## Notes
- A live-DB round-trip integration test (the existing `#[ignore]` `TestDb` harness) would also cover this, but those don't run in the offline verify gate; the added unit tests are the no-DB regression guard that runs in CI.
- scope_drift=false (both files under `backend/**` = pm-backend area); code_reuse_warn=none.

https://claude.ai/code/session_01E7kkv8dxo3sopwvwxguqbj

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7kkv8dxo3sopwvwxguqbj)_