### PR TITLE
fix(documents): honor membership expiry in document-share role fan-out (#1000)

### DIFF
--- a/backend/servers/api-server/src/routes/documents/shares.rs
+++ b/backend/servers/api-server/src/routes/documents/shares.rs
@@ -688,10 +688,16 @@ async fn resolve_share_recipients(
         share_type::ROLE => match target_role {
             Some(role) => {
                 sqlx::query_as(
+                    // Issue #1000: exclude expired memberships, matching the
+                    // announcement targeting predicate in `announcement.rs`
+                    // (`list_published_rls`/`count_published_rls`). A user whose
+                    // membership lapsed (but was never explicitly revoked) no
+                    // longer has org access and must not be fanned out to.
                     r#"
                     SELECT DISTINCT user_id FROM user_memberships
                     WHERE organization_id = $1
                       AND revoked_at IS NULL
+                      AND (expires_at IS NULL OR expires_at > NOW())
                       AND role = $2
                     "#,
                 )


### PR DESCRIPTION
## Summary
Closes #1000 (follow-up from post-merge review of PR #992).

The `ROLE` branch of `resolve_share_recipients` in `backend/servers/api-server/src/routes/documents/shares.rs` resolved recipients with only `revoked_at IS NULL`, but **not** membership expiry. A user whose org membership has lapsed (`expires_at` in the past) but was never explicitly revoked still received document-share notifications for that role — even though they may no longer have org access.

This matches the announcement-targeting predicate landed in #944 (`announcement.rs` `list_published_rls`/`count_published_rls`), which uses the stricter `revoked_at IS NULL AND (expires_at IS NULL OR expires_at > NOW())`. The two role-resolution paths now agree.

## Change
Added `AND (expires_at IS NULL OR expires_at > NOW())` to the `ROLE` recipient query.

## Notes
- `user_memberships.expires_at` confirmed present (migration `00128_user_memberships.sql:18`) and indexed by `idx_user_memberships_active (user_id, organization_id) WHERE revoked_at IS NULL`.
- The secondary point in the issue (USER/ROLE arms not consulting per-user notification preference, unlike the BUILDING arm's `receives_notifications`) is left as-is: the downstream notification pipeline filters by per-category preference, so the fan-out set is intentionally broad. Noted here for the reviewer.

## Verification
- `cargo fmt -p api-server --check` ✅
- `cargo check -p api-server` ✅ (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)