### PR TITLE
fix(documents): localize DocumentDetail version-history copy (#1001)

### DIFF
--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -349,6 +349,14 @@
       "deleteErrorMessage": "Nepodařilo se smazat složku",
       "createError": "Vytvoření selhalo",
       "createErrorMessage": "Nepodařilo se vytvořit složku"
+    },
+    "versionHistory": {
+      "title": "Historie verzí",
+      "loading": "Načítání verzí…",
+      "loadError": "Historii verzí se nepodařilo načíst.",
+      "empty": "Pro tento dokument nejsou k dispozici žádné verze.",
+      "version": "Verze {{n}}",
+      "current": "Aktuální"
     }
   },
   "disputes": {

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -348,6 +348,14 @@
       "deleteErrorMessage": "Ordner konnte nicht gelöscht werden",
       "createError": "Erstellen fehlgeschlagen",
       "createErrorMessage": "Ordner konnte nicht erstellt werden"
+    },
+    "versionHistory": {
+      "title": "Versionsverlauf",
+      "loading": "Versionen werden geladen…",
+      "loadError": "Versionsverlauf konnte nicht geladen werden.",
+      "empty": "Für dieses Dokument sind keine Versionen verfügbar.",
+      "version": "Version {{n}}",
+      "current": "Aktuell"
     }
   },
   "disputes": {

--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -410,6 +410,14 @@
       "deleteErrorMessage": "Failed to delete folder",
       "createError": "Create failed",
       "createErrorMessage": "Failed to create folder"
+    },
+    "versionHistory": {
+      "title": "Version history",
+      "loading": "Loading versions…",
+      "loadError": "Failed to load version history.",
+      "empty": "No versions are available for this document.",
+      "version": "Version {{n}}",
+      "current": "Current"
     }
   },
   "disputes": {

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -348,6 +348,14 @@
       "deleteErrorMessage": "A mappa törlése nem sikerült",
       "createError": "Létrehozás sikertelen",
       "createErrorMessage": "A mappa létrehozása nem sikerült"
+    },
+    "versionHistory": {
+      "title": "Verziótörténet",
+      "loading": "Verziók betöltése…",
+      "loadError": "A verziótörténet betöltése nem sikerült.",
+      "empty": "Ehhez a dokumentumhoz nincsenek elérhető verziók.",
+      "version": "{{n}}. verzió",
+      "current": "Aktuális"
     }
   },
   "disputes": {

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -350,6 +350,14 @@
       "deleteErrorMessage": "Nie udało się usunąć folderu",
       "createError": "Tworzenie nie powiodło się",
       "createErrorMessage": "Nie udało się utworzyć folderu"
+    },
+    "versionHistory": {
+      "title": "Historia wersji",
+      "loading": "Ładowanie wersji…",
+      "loadError": "Nie udało się załadować historii wersji.",
+      "empty": "Brak dostępnych wersji dla tego dokumentu.",
+      "version": "Wersja {{n}}",
+      "current": "Bieżąca"
     }
   },
   "disputes": {

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -350,6 +350,14 @@
       "deleteErrorMessage": "Nepodarilo sa vymazať priečinok",
       "createError": "Vytvorenie zlyhalo",
       "createErrorMessage": "Nepodarilo sa vytvoriť priečinok"
+    },
+    "versionHistory": {
+      "title": "História verzií",
+      "loading": "Načítavam verzie…",
+      "loadError": "Históriu verzií sa nepodarilo načítať.",
+      "empty": "Pre tento dokument nie sú dostupné žiadne verzie.",
+      "version": "Verzia {{n}}",
+      "current": "Aktuálna"
     }
   },
   "disputes": {

--- a/frontend/apps/ppt-web/src/features/documents/pages/DocumentDetail.tsx
+++ b/frontend/apps/ppt-web/src/features/documents/pages/DocumentDetail.tsx
@@ -12,6 +12,7 @@ import {
   useReprocessOcr,
 } from '@ppt/api-client';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ClassificationUI } from '../components/ClassificationBadge';
 import { DocumentSharePanel } from '../components/DocumentSharePanel';
 import { DocumentSummary } from '../components/DocumentSummary';
@@ -72,6 +73,7 @@ export function DocumentDetail({ documentId }: DocumentDetailProps) {
   const versions = useDocumentVersions(documentId);
   const reprocessOcr = useReprocessOcr();
   const [showSharePanel, setShowSharePanel] = useState(false);
+  const { t } = useTranslation();
 
   if (isLoading) {
     return (
@@ -362,14 +364,24 @@ export function DocumentDetail({ documentId }: DocumentDetailProps) {
 
       {/* Version History (Story 7B.1) — list-only timeline */}
       <div className="version-history-section">
-        <h3 className="section-title">História verzií</h3>
+        <h3 className="section-title">{t('documents.versionHistory.title', 'Version history')}</h3>
 
-        {versions.isLoading && <p className="version-empty">Načítavam verzie…</p>}
+        {versions.isLoading && (
+          <p className="version-empty">
+            {t('documents.versionHistory.loading', 'Loading versions…')}
+          </p>
+        )}
 
-        {versions.error && <p className="version-empty">Históriu verzií sa nepodarilo načítať.</p>}
+        {versions.error && (
+          <p className="version-empty">
+            {t('documents.versionHistory.loadError', 'Failed to load version history.')}
+          </p>
+        )}
 
         {!versions.isLoading && !versions.error && versionRows.length === 0 && (
-          <p className="version-empty">Pre tento dokument nie sú dostupné žiadne verzie.</p>
+          <p className="version-empty">
+            {t('documents.versionHistory.empty', 'No versions are available for this document.')}
+          </p>
         )}
 
         {versionRows.length > 0 && (
@@ -379,8 +391,17 @@ export function DocumentDetail({ documentId }: DocumentDetailProps) {
                 <div className="version-marker" aria-hidden="true" />
                 <div className="version-body">
                   <div className="version-head">
-                    <span className="version-number">Verzia {v.versionNumber}</span>
-                    {v.isCurrent && <span className="version-current-badge">Aktuálna</span>}
+                    <span className="version-number">
+                      {t('documents.versionHistory.version', {
+                        defaultValue: 'Version {{n}}',
+                        n: v.versionNumber,
+                      })}
+                    </span>
+                    {v.isCurrent && (
+                      <span className="version-current-badge">
+                        {t('documents.versionHistory.current', 'Current')}
+                      </span>
+                    )}
                   </div>
                   <div className="version-meta">
                     {v.uploader && <span className="version-meta-item">{v.uploader}</span>}


### PR DESCRIPTION
## Summary
Closes #1001 (follow-up from post-merge review of PR #990).

The version-history section added to `DocumentDetail.tsx` rendered **hardcoded Slovak strings** (`"História verzií"`, `"Verzia {n}"`, `"Aktuálna"`, …) instead of going through react-i18next. ppt-web is localized (sk/cs/de/en/hu/pl), so those strings rendered as Slovak for every other locale — a user-visible defect.

## Change
- Added a `documents.versionHistory.*` namespace to all six ppt-web catalogs (`messages/{sk,cs,de,en,hu,pl}.json`) with translated copy.
- Consume them via `useTranslation()` in `DocumentDetail.tsx`, with ICU interpolation for the version number (`"Version {{n}}"`).

## Scope note
This PR localizes only the **version-history** strings flagged in the issue. The file contains other pre-existing hardcoded Slovak strings (error/empty/permission states) that predate this UI; left untouched to keep the fix focused. They could be a follow-up.

## Verification
- `biome check` ✅ (clean after format)
- `pnpm --filter @ppt/web typecheck` ✅ (tsc --noEmit, no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)