### PR TITLE
gap-7a-4-mobile-document-preview: test + refactor mobile preview presign fallback

### DIFF
--- a/frontend/apps/mobile/src/screens/documents/DocumentDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentDetailScreen.tsx
@@ -15,6 +15,7 @@ import { useCallback, useState } from 'react';
 import { Alert, Linking, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { apiRequest, useApiQuery } from '../../hooks/useApi';
 import { colors, screenStyles as s } from '../shared/screenStyles';
+import { isPreviewUnsupportedError } from './DocumentPreviewScreen';
 import { DocumentShareSheet } from './DocumentShareSheet';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -101,12 +102,7 @@ export function DocumentDetailScreen({ documentId, onBack }: DocumentDetailScree
           `/api/v1/documents/${documentId}/preview`
         );
       } catch (err) {
-        const message = err instanceof Error ? err.message : '';
-        const isUnsupported =
-          message.includes('PREVIEW_NOT_SUPPORTED') ||
-          message.includes('not supported') ||
-          message.includes('HTTP 400');
-        if (!isUnsupported) throw err;
+        if (!isPreviewUnsupportedError(err)) throw err;
         presigned = await apiRequest<PresignedUrlResponse>(
           `/api/v1/documents/${documentId}/download`
         );

--- a/frontend/apps/mobile/src/screens/documents/DocumentPreviewScreen.test.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentPreviewScreen.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * Regression tests for DocumentPreviewScreen — Story 7A.4 (mobile slice).
+ *
+ * The load-bearing logic in the document download + preview flow is the
+ * decision of whether a failed GET /api/v1/documents/{id}/preview should fall
+ * back to GET /api/v1/documents/{id}/download (file-type not previewable) or be
+ * surfaced as a hard error (auth/network/5xx). That classifier —
+ * `isPreviewUnsupportedError` — is shared between DocumentPreviewScreen and
+ * DocumentDetailScreen, so a regression here would break the fallback on both.
+ *
+ * These tests pin the classifier directly (no RN render tree), which keeps them
+ * runnable regardless of the @testing-library/react-native peer-dep state.
+ */
+
+import { isPreviewUnsupportedError } from './DocumentPreviewScreen';
+
+describe('isPreviewUnsupportedError', () => {
+  it.each([
+    ['the explicit backend code', 'PREVIEW_NOT_SUPPORTED'],
+    ['a human-readable "not supported" message', 'Preview is not supported for this type'],
+    ['a raw HTTP 400 status', 'HTTP 400 Bad Request'],
+  ])('returns true for an unsupported-preview error: %s', (_label, message) => {
+    expect(isPreviewUnsupportedError(new Error(message))).toBe(true);
+  });
+
+  it.each([
+    ['an auth error', 'HTTP 401 Unauthorized'],
+    ['a forbidden error', 'HTTP 403 Forbidden'],
+    ['a server error', 'HTTP 500 Internal Server Error'],
+    ['a network error', 'Network request failed'],
+  ])('returns false for a hard failure that must surface: %s', (_label, message) => {
+    expect(isPreviewUnsupportedError(new Error(message))).toBe(false);
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a bare string', 'PREVIEW_NOT_SUPPORTED'],
+    ['a plain object', { message: 'PREVIEW_NOT_SUPPORTED' }],
+  ])('returns false for non-Error throwables: %s', (_label, value) => {
+    // Only real Error instances carry a trusted `.message`; anything else is
+    // treated as a hard failure rather than silently falling back to download.
+    expect(isPreviewUnsupportedError(value)).toBe(false);
+  });
+});

--- a/frontend/apps/mobile/src/screens/documents/DocumentPreviewScreen.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentPreviewScreen.tsx
@@ -62,6 +62,24 @@ function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+/**
+ * Decide whether a failed /preview request means "this file type can't be
+ * previewed, fall back to /download" (true) versus a genuine error to surface
+ * (false). The backend signals an unsupported preview with PREVIEW_NOT_SUPPORTED
+ * / HTTP 400; anything else (auth, network, 5xx) is a hard failure.
+ *
+ * Exported so the fallback decision can be unit-tested independently of the
+ * RN render tree, and reused by DocumentDetailScreen's open action.
+ */
+export function isPreviewUnsupportedError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : '';
+  return (
+    message.includes('PREVIEW_NOT_SUPPORTED') ||
+    message.includes('not supported') ||
+    message.includes('HTTP 400')
+  );
+}
+
 function getFileIcon(type: Document['type']): string {
   switch (type) {
     case 'pdf':
@@ -111,13 +129,7 @@ export function DocumentPreviewScreen({ document, onBack }: DocumentPreviewScree
       });
     } catch (err) {
       // PREVIEW_NOT_SUPPORTED (400) → fall back to download endpoint
-      const message = err instanceof Error ? err.message : '';
-      const isUnsupported =
-        message.includes('PREVIEW_NOT_SUPPORTED') ||
-        message.includes('not supported') ||
-        message.includes('HTTP 400');
-
-      if (isUnsupported) {
+      if (isPreviewUnsupportedError(err)) {
         try {
           const fallback = await apiRequest<PresignedUrlResponse>(
             `/api/v1/documents/${document.id}/download`


### PR DESCRIPTION
## Task

Implement the mobile (React Native) document download + preview slice for story 7a-4: an RN screen wired to the existing backend download/presign routes; web slice shipped, mobile is the remaining gap.

## Finding: the screen was already shipped

On `dev`, `frontend/apps/mobile/src/screens/documents/DocumentPreviewScreen.tsx` already exists and is fully wired:
- registered in `App.tsx` navigation (`DocumentPreview` route);
- navigated to from `DocumentsScreen` on document tap (`_onNavigate('DocumentPreview', { document })`);
- calls `GET /api/v1/documents/{id}/preview` for a presigned URL, opens it in the native viewer via `Linking.openURL`, falls back to `GET .../download` on `PREVIEW_NOT_SUPPORTED`/HTTP 400, and shares via `expo-sharing`;
- all `documents.preview.*` i18n keys present across **all 6 locales** (en, sk, cs, de, hu, pl — verified).

So the UI gap was effectively closed already. The genuine remaining gap was the **absence of any test** for this slice (no `*.test.*` under `screens/documents/`).

## What landed

1. Extracted the inline preview-fallback classifier into an exported pure helper `isPreviewUnsupportedError(err)` on `DocumentPreviewScreen.tsx`.
2. Reused it in `DocumentDetailScreen.tsx`, removing the **duplicated** `PREVIEW_NOT_SUPPORTED || 'not supported' || 'HTTP 400'` check that existed in both files (code-reuse win, behaviour-preserving).
3. Added `DocumentPreviewScreen.test.tsx` — 11 cases pinning the preview→download fallback decision (unsupported codes ⇒ fall back; auth/network/5xx ⇒ surface; non-Error throwables ⇒ treated as hard failure, not silent fallback).

The test targets the pure classifier rather than a full render because **all `@testing-library/react-native` component tests are currently red in this workspace** due to a pre-existing peer-dep mismatch (`react-test-renderer` 19.2.6 vs expected 19.2.0) — confirmed against the existing `LanguageSwitcher.test.tsx`, which fails identically on `dev`. This keeps the new test runnable.

## Owner
pm-frontend

## Tested (Band A — fast check)
- `pnpm -F mobile typecheck` → exit 0 (clean)
- `biome check` on the 3 changed files → exit 0 ("Checked 3 files, No fixes applied")
- `jest DocumentPreviewScreen.test.tsx` → **11 passed, 1 suite passed**

## Built (Band B — full build)
Skipped: change is small (~50 LOC, mostly the new test + a helper extraction), no public API/config/build-output change.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change; this is mobile UI test + a behaviour-preserving refactor).

## Scope drift
`scope-check.sh --owner pm-frontend` exits 2 because `owner-areas.json` for `pm-frontend` omits `frontend/apps/mobile/**` (it lists ppt-web/reality-web/admin-web/packages). All 3 changed files are inside `frontend/apps/mobile/src/screens/documents/` — exactly this task's intended area per the `react-native` specialist spec. This is an owner-areas mapping gap, not a real out-of-area edit. Reviewer to confirm.

Offending paths (all in mobile app, expected):
- `frontend/apps/mobile/src/screens/documents/DocumentPreviewScreen.tsx`
- `frontend/apps/mobile/src/screens/documents/DocumentDetailScreen.tsx`
- `frontend/apps/mobile/src/screens/documents/DocumentPreviewScreen.test.tsx`

## Code-reuse review
`reuse-grep.sh --specialist react-native` → empty (no warnings). The change in fact removes a duplication.

## Notes
Behaviour-preserving refactor + new test only — no change to the preview/download/share runtime flow.

https://claude.ai/code/session_01Kre3mEK52941iWP26F51rx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kre3mEK52941iWP26F51rx)_