### PR TITLE
fix(db): correct users.first_name/last_name schema drift → name (#1008 remainder)

### DIFF
--- a/backend/crates/db/src/repositories/data_export.rs
+++ b/backend/crates/db/src/repositories/data_export.rs
@@ -348,9 +348,14 @@ impl DataExportRepository {
             chrono::DateTime<Utc>,
         )> = sqlx::query_as(
             r#"
-            SELECT id, email, first_name, last_name, phone_number,
-                   COALESCE(language, 'en') as language,
-                   profile_visibility, show_contact_info, email_verified,
+            -- Issue #1008: `users` has a single `name` column (no first/last),
+            -- `phone` (not phone_number), `locale` (not language), and
+            -- `email_verified_at` (not a bool email_verified). Map them onto the
+            -- ProfileExport shape: full name in first_name, last_name NULL.
+            SELECT id, email, name AS first_name, NULL::text AS last_name, phone AS phone_number,
+                   COALESCE(locale, 'en') as language,
+                   profile_visibility, show_contact_info,
+                   (email_verified_at IS NOT NULL) AS email_verified,
                    created_at, updated_at
             FROM users WHERE id = $1
             "#,

--- a/backend/crates/db/src/repositories/document.rs
+++ b/backend/crates/db/src/repositories/document.rs
@@ -1647,7 +1647,7 @@ impl DocumentRepository {
                 d.mime_type,
                 d.size_bytes,
                 d.created_by,
-                CONCAT(u.first_name, ' ', u.last_name) as created_by_name,
+                u.name as created_by_name,
                 d.created_at,
                 doc.root_id,
                 doc.title
@@ -1722,7 +1722,7 @@ impl DocumentRepository {
                 d.mime_type,
                 d.size_bytes,
                 d.created_by,
-                CONCAT(u.first_name, ' ', u.last_name) as created_by_name,
+                u.name as created_by_name,
                 d.created_at
             FROM documents d
             JOIN users u ON u.id = d.created_by
@@ -1865,7 +1865,7 @@ impl DocumentRepository {
                 d.mime_type,
                 d.size_bytes,
                 d.created_by,
-                CONCAT(u.first_name, ' ', u.last_name) as created_by_name,
+                u.name as created_by_name,
                 d.created_at
             FROM documents d
             JOIN users u ON u.id = d.created_by
@@ -1920,7 +1920,7 @@ impl DocumentRepository {
                 d.mime_type,
                 d.size_bytes,
                 d.created_by,
-                CONCAT(u.first_name, ' ', u.last_name) as created_by_name,
+                u.name as created_by_name,
                 d.created_at
             FROM documents d
             JOIN users u ON u.id = d.created_by

--- a/backend/crates/db/src/repositories/document_template.rs
+++ b/backend/crates/db/src/repositories/document_template.rs
@@ -66,7 +66,7 @@ impl DocumentTemplateRepository {
             r#"
             SELECT
                 t.*,
-                CONCAT(u.first_name, ' ', u.last_name) as created_by_name
+                u.name as created_by_name
             FROM document_templates t
             JOIN users u ON u.id = t.created_by
             WHERE t.id = $1 AND t.deleted_at IS NULL

--- a/backend/crates/db/src/repositories/form.rs
+++ b/backend/crates/db/src/repositories/form.rs
@@ -113,19 +113,17 @@ impl FormRepository {
         .await?;
 
         let created_by_name = sqlx::query_scalar::<_, String>(
-            "SELECT COALESCE(first_name || ' ' || last_name, email) FROM users WHERE id = $1",
+            "SELECT COALESCE(name, email) FROM users WHERE id = $1",
         )
         .bind(form.created_by)
         .fetch_optional(&self.pool)
         .await?;
 
         let published_by_name = if let Some(published_by) = form.published_by {
-            sqlx::query_scalar::<_, String>(
-                "SELECT COALESCE(first_name || ' ' || last_name, email) FROM users WHERE id = $1",
-            )
-            .bind(published_by)
-            .fetch_optional(&self.pool)
-            .await?
+            sqlx::query_scalar::<_, String>("SELECT COALESCE(name, email) FROM users WHERE id = $1")
+                .bind(published_by)
+                .fetch_optional(&self.pool)
+                .await?
         } else {
             None
         };
@@ -182,7 +180,7 @@ impl FormRepository {
                 SELECT f.id, f.title, f.description, f.category, f.status, f.target_type,
                        f.require_signatures, f.submission_deadline, f.published_at, f.created_at,
                        COALESCE((SELECT COUNT(*) FROM form_submissions WHERE form_id = f.id), 0) as submission_count,
-                       u.first_name || ' ' || u.last_name as created_by_name
+                       u.name as created_by_name
                 FROM forms f LEFT JOIN users u ON u.id = f.created_by
                 WHERE f.organization_id = $1 AND f.deleted_at IS NULL
                   AND ($2::text IS NULL OR f.status = $2) AND ($3::text IS NULL OR f.category = $3)
@@ -196,7 +194,7 @@ impl FormRepository {
                 SELECT f.id, f.title, f.description, f.category, f.status, f.target_type,
                        f.require_signatures, f.submission_deadline, f.published_at, f.created_at,
                        COALESCE((SELECT COUNT(*) FROM form_submissions WHERE form_id = f.id), 0) as submission_count,
-                       u.first_name || ' ' || u.last_name as created_by_name
+                       u.name as created_by_name
                 FROM forms f LEFT JOIN users u ON u.id = f.created_by
                 WHERE f.organization_id = $1 AND f.deleted_at IS NULL
                   AND ($2::text IS NULL OR f.status = $2) AND ($3::text IS NULL OR f.category = $3)
@@ -210,7 +208,7 @@ impl FormRepository {
                 SELECT f.id, f.title, f.description, f.category, f.status, f.target_type,
                        f.require_signatures, f.submission_deadline, f.published_at, f.created_at,
                        COALESCE((SELECT COUNT(*) FROM form_submissions WHERE form_id = f.id), 0) as submission_count,
-                       u.first_name || ' ' || u.last_name as created_by_name
+                       u.name as created_by_name
                 FROM forms f LEFT JOIN users u ON u.id = f.created_by
                 WHERE f.organization_id = $1 AND f.deleted_at IS NULL
                   AND ($2::text IS NULL OR f.status = $2) AND ($3::text IS NULL OR f.category = $3)
@@ -224,7 +222,7 @@ impl FormRepository {
                 SELECT f.id, f.title, f.description, f.category, f.status, f.target_type,
                        f.require_signatures, f.submission_deadline, f.published_at, f.created_at,
                        COALESCE((SELECT COUNT(*) FROM form_submissions WHERE form_id = f.id), 0) as submission_count,
-                       u.first_name || ' ' || u.last_name as created_by_name
+                       u.name as created_by_name
                 FROM forms f LEFT JOIN users u ON u.id = f.created_by
                 WHERE f.organization_id = $1 AND f.deleted_at IS NULL
                   AND ($2::text IS NULL OR f.status = $2) AND ($3::text IS NULL OR f.category = $3)
@@ -238,7 +236,7 @@ impl FormRepository {
                 SELECT f.id, f.title, f.description, f.category, f.status, f.target_type,
                        f.require_signatures, f.submission_deadline, f.published_at, f.created_at,
                        COALESCE((SELECT COUNT(*) FROM form_submissions WHERE form_id = f.id), 0) as submission_count,
-                       u.first_name || ' ' || u.last_name as created_by_name
+                       u.name as created_by_name
                 FROM forms f LEFT JOIN users u ON u.id = f.created_by
                 WHERE f.organization_id = $1 AND f.deleted_at IS NULL
                   AND ($2::text IS NULL OR f.status = $2) AND ($3::text IS NULL OR f.category = $3)
@@ -252,7 +250,7 @@ impl FormRepository {
                 SELECT f.id, f.title, f.description, f.category, f.status, f.target_type,
                        f.require_signatures, f.submission_deadline, f.published_at, f.created_at,
                        COALESCE((SELECT COUNT(*) FROM form_submissions WHERE form_id = f.id), 0) as submission_count,
-                       u.first_name || ' ' || u.last_name as created_by_name
+                       u.name as created_by_name
                 FROM forms f LEFT JOIN users u ON u.id = f.created_by
                 WHERE f.organization_id = $1 AND f.deleted_at IS NULL
                   AND ($2::text IS NULL OR f.status = $2) AND ($3::text IS NULL OR f.category = $3)
@@ -266,7 +264,7 @@ impl FormRepository {
                 SELECT f.id, f.title, f.description, f.category, f.status, f.target_type,
                        f.require_signatures, f.submission_deadline, f.published_at, f.created_at,
                        COALESCE((SELECT COUNT(*) FROM form_submissions WHERE form_id = f.id), 0) as submission_count,
-                       u.first_name || ' ' || u.last_name as created_by_name
+                       u.name as created_by_name
                 FROM forms f LEFT JOIN users u ON u.id = f.created_by
                 WHERE f.organization_id = $1 AND f.deleted_at IS NULL
                   AND ($2::text IS NULL OR f.status = $2) AND ($3::text IS NULL OR f.category = $3)
@@ -280,7 +278,7 @@ impl FormRepository {
                 SELECT f.id, f.title, f.description, f.category, f.status, f.target_type,
                        f.require_signatures, f.submission_deadline, f.published_at, f.created_at,
                        COALESCE((SELECT COUNT(*) FROM form_submissions WHERE form_id = f.id), 0) as submission_count,
-                       u.first_name || ' ' || u.last_name as created_by_name
+                       u.name as created_by_name
                 FROM forms f LEFT JOIN users u ON u.id = f.created_by
                 WHERE f.organization_id = $1 AND f.deleted_at IS NULL
                   AND ($2::text IS NULL OR f.status = $2) AND ($3::text IS NULL OR f.category = $3)
@@ -295,7 +293,7 @@ impl FormRepository {
                 SELECT f.id, f.title, f.description, f.category, f.status, f.target_type,
                        f.require_signatures, f.submission_deadline, f.published_at, f.created_at,
                        COALESCE((SELECT COUNT(*) FROM form_submissions WHERE form_id = f.id), 0) as submission_count,
-                       u.first_name || ' ' || u.last_name as created_by_name
+                       u.name as created_by_name
                 FROM forms f LEFT JOIN users u ON u.id = f.created_by
                 WHERE f.organization_id = $1 AND f.deleted_at IS NULL
                   AND ($2::text IS NULL OR f.status = $2) AND ($3::text IS NULL OR f.category = $3)
@@ -310,7 +308,7 @@ impl FormRepository {
                 SELECT f.id, f.title, f.description, f.category, f.status, f.target_type,
                        f.require_signatures, f.submission_deadline, f.published_at, f.created_at,
                        COALESCE((SELECT COUNT(*) FROM form_submissions WHERE form_id = f.id), 0) as submission_count,
-                       u.first_name || ' ' || u.last_name as created_by_name
+                       u.name as created_by_name
                 FROM forms f LEFT JOIN users u ON u.id = f.created_by
                 WHERE f.organization_id = $1 AND f.deleted_at IS NULL
                   AND ($2::text IS NULL OR f.status = $2) AND ($3::text IS NULL OR f.category = $3)
@@ -705,8 +703,8 @@ impl FormRepository {
             SELECT
                 s.*,
                 f.title as form_title,
-                u.first_name || ' ' || u.last_name as submitted_by_name,
-                r.first_name || ' ' || r.last_name as reviewed_by_name,
+                u.name as submitted_by_name,
+                r.name as reviewed_by_name,
                 un.unit_number,
                 b.name as building_name
             FROM form_submissions s
@@ -796,7 +794,7 @@ impl FormRepository {
                 s.form_id,
                 f.title as form_title,
                 s.submitted_by,
-                u.first_name || ' ' || u.last_name as submitted_by_name,
+                u.name as submitted_by_name,
                 s.submitted_at,
                 s.status,
                 s.signature_data IS NOT NULL as has_signature,
@@ -979,7 +977,7 @@ impl FormRepository {
                     (SELECT COUNT(*) FROM form_submissions WHERE form_id = f.id),
                     0
                 ) as submission_count,
-                u.first_name || ' ' || u.last_name as created_by_name
+                u.name as created_by_name
             FROM forms f
             LEFT JOIN users u ON u.id = f.created_by
             WHERE f.organization_id = $1

--- a/backend/crates/db/src/repositories/messaging.rs
+++ b/backend/crates/db/src/repositories/messaging.rs
@@ -162,8 +162,11 @@ impl MessagingRepository {
                 t.updated_at,
                 -- Other participant (the one that's not the current user)
                 u.id as other_user_id,
-                u.first_name as other_first_name,
-                u.last_name as other_last_name,
+                -- Issue #1008: `users` has a single `name` column, not
+                -- first_name/last_name. Map the full name into *_first_name and
+                -- leave *_last_name empty to preserve the ParticipantInfo shape.
+                u.name as other_first_name,
+                '' as other_last_name,
                 u.email as other_email,
                 -- Last message
                 tm.message_id as last_message_id,
@@ -174,7 +177,7 @@ impl MessagingRepository {
                 COALESCE(uc.unread, 0) as unread_count
             FROM message_threads t
             CROSS JOIN LATERAL (
-                SELECT id, first_name, last_name, email
+                SELECT id, name, email
                 FROM users
                 WHERE id = ANY(t.participant_ids) AND id != $1
                 LIMIT 1
@@ -183,7 +186,7 @@ impl MessagingRepository {
             LEFT JOIN unread_counts uc ON uc.thread_id = t.id
             WHERE $1 = ANY(t.participant_ids)
               AND t.organization_id = $2
-              AND ($3::text IS NULL OR (u.first_name ILIKE '%'||$3||'%' OR u.last_name ILIKE '%'||$3||'%'))
+              AND ($3::text IS NULL OR u.name ILIKE '%'||$3||'%')
             ORDER BY t.last_message_at DESC NULLS LAST, t.created_at DESC
             LIMIT $4 OFFSET $5
             "#,
@@ -220,14 +223,14 @@ impl MessagingRepository {
             SELECT COUNT(*)
             FROM message_threads t
             CROSS JOIN LATERAL (
-                SELECT id, first_name, last_name, email
+                SELECT id, name, email
                 FROM users
                 WHERE id = ANY(t.participant_ids) AND id != $1
                 LIMIT 1
             ) u
             WHERE $1 = ANY(t.participant_ids)
               AND t.organization_id = $2
-              AND ($3::text IS NULL OR (u.first_name ILIKE '%'||$3||'%' OR u.last_name ILIKE '%'||$3||'%'))
+              AND ($3::text IS NULL OR u.name ILIKE '%'||$3||'%')
             "#,
         )
         .bind(user_id)
@@ -317,8 +320,8 @@ impl MessagingRepository {
                 m.read_at,
                 m.deleted_at,
                 m.created_at,
-                u.first_name as sender_first_name,
-                u.last_name as sender_last_name,
+                u.name as sender_first_name, -- #1008: users has only `name`
+                '' as sender_last_name,
                 u.email as sender_email
             FROM messages m
             JOIN users u ON u.id = m.sender_id
@@ -568,8 +571,8 @@ impl MessagingRepository {
                 b.blocker_id,
                 b.blocked_id,
                 b.created_at,
-                u.first_name as blocked_first_name,
-                u.last_name as blocked_last_name,
+                u.name as blocked_first_name, -- #1008: users has only `name`
+                '' as blocked_last_name,
                 u.email as blocked_email
             FROM user_blocks b
             JOIN users u ON u.id = b.blocked_id

--- a/backend/crates/db/src/repositories/platform_admin.rs
+++ b/backend/crates/db/src/repositories/platform_admin.rs
@@ -292,9 +292,11 @@ impl PlatformAdminRepository {
 
         if query.is_some() {
             param_idx += 1;
+            // Issue #1008: `users` has a single `name` column (no
+            // display_name/first_name/last_name); search email + name.
             conditions.push(format!(
-                "(LOWER(u.email) LIKE '%' || LOWER(${}::text) || '%' OR LOWER(u.display_name) LIKE '%' || LOWER(${}::text) || '%' OR LOWER(u.first_name) LIKE '%' || LOWER(${}::text) || '%' OR LOWER(u.last_name) LIKE '%' || LOWER(${}::text) || '%')",
-                param_idx, param_idx, param_idx, param_idx
+                "(LOWER(u.email) LIKE '%' || LOWER(${}::text) || '%' OR LOWER(u.name) LIKE '%' || LOWER(${}::text) || '%')",
+                param_idx, param_idx
             ));
         }
 
@@ -308,8 +310,10 @@ impl PlatformAdminRepository {
 
         let data_query = format!(
             r#"
-            SELECT u.id, u.email, u.display_name, u.first_name, u.last_name, u.status,
-                   u.email_verified, u.created_at, u.updated_at, u.last_login_at
+            SELECT u.id, u.email, u.name AS display_name, NULL::text AS first_name,
+                   NULL::text AS last_name, u.status,
+                   (u.email_verified_at IS NOT NULL) AS email_verified,
+                   u.created_at, u.updated_at, NULL::timestamptz AS last_login_at
             FROM users u
             WHERE {}
             ORDER BY u.created_at DESC
@@ -350,8 +354,10 @@ impl PlatformAdminRepository {
     ) -> Result<Option<SupportUserInfo>, SqlxError> {
         let user = sqlx::query_as::<_, SupportUserInfo>(
             r#"
-            SELECT id, email, display_name, first_name, last_name, status,
-                   email_verified, created_at, updated_at, last_login_at
+            SELECT id, email, name AS display_name, NULL::text AS first_name,
+                   NULL::text AS last_name, status,
+                   (email_verified_at IS NOT NULL) AS email_verified,
+                   created_at, updated_at, NULL::timestamptz AS last_login_at
             FROM users
             WHERE id = $1
             "#,

--- a/backend/crates/db/src/repositories/registry.rs
+++ b/backend/crates/db/src/repositories/registry.rs
@@ -107,20 +107,17 @@ impl RegistryRepository {
         .fetch_optional(&self.pool)
         .await?;
 
-        let owner_name: Option<String> = sqlx::query_scalar(
-            "SELECT COALESCE(first_name || ' ' || last_name, email) FROM users WHERE id = $1",
-        )
-        .bind(registration.owner_id)
-        .fetch_optional(&self.pool)
-        .await?;
+        let owner_name: Option<String> =
+            sqlx::query_scalar("SELECT COALESCE(name, email) FROM users WHERE id = $1")
+                .bind(registration.owner_id)
+                .fetch_optional(&self.pool)
+                .await?;
 
         let reviewed_by_name = if let Some(reviewed_by) = registration.reviewed_by {
-            sqlx::query_scalar::<_, String>(
-                "SELECT COALESCE(first_name || ' ' || last_name, email) FROM users WHERE id = $1",
-            )
-            .bind(reviewed_by)
-            .fetch_optional(&self.pool)
-            .await?
+            sqlx::query_scalar::<_, String>("SELECT COALESCE(name, email) FROM users WHERE id = $1")
+                .bind(reviewed_by)
+                .fetch_optional(&self.pool)
+                .await?
         } else {
             None
         };
@@ -168,7 +165,7 @@ impl RegistryRepository {
         let registrations = sqlx::query_as::<_, PetRegistrationSummary>(
             r#"
             SELECT pr.id, pr.unit_id, u.unit_number,
-                   pr.owner_id, COALESCE(usr.first_name || ' ' || usr.last_name, usr.email) as owner_name,
+                   pr.owner_id, COALESCE(usr.name, usr.email) as owner_name,
                    pr.pet_name, pr.pet_type, pr.breed, pr.pet_size, pr.status, pr.created_at
             FROM pet_registrations pr
             JOIN units u ON u.id = pr.unit_id
@@ -366,20 +363,17 @@ impl RegistryRepository {
         .fetch_optional(&self.pool)
         .await?;
 
-        let owner_name: Option<String> = sqlx::query_scalar(
-            "SELECT COALESCE(first_name || ' ' || last_name, email) FROM users WHERE id = $1",
-        )
-        .bind(registration.owner_id)
-        .fetch_optional(&self.pool)
-        .await?;
+        let owner_name: Option<String> =
+            sqlx::query_scalar("SELECT COALESCE(name, email) FROM users WHERE id = $1")
+                .bind(registration.owner_id)
+                .fetch_optional(&self.pool)
+                .await?;
 
         let reviewed_by_name = if let Some(reviewed_by) = registration.reviewed_by {
-            sqlx::query_scalar::<_, String>(
-                "SELECT COALESCE(first_name || ' ' || last_name, email) FROM users WHERE id = $1",
-            )
-            .bind(reviewed_by)
-            .fetch_optional(&self.pool)
-            .await?
+            sqlx::query_scalar::<_, String>("SELECT COALESCE(name, email) FROM users WHERE id = $1")
+                .bind(reviewed_by)
+                .fetch_optional(&self.pool)
+                .await?
         } else {
             None
         };
@@ -437,7 +431,7 @@ impl RegistryRepository {
         let registrations = sqlx::query_as::<_, VehicleRegistrationSummary>(
             r#"
             SELECT vr.id, vr.unit_id, u.unit_number,
-                   vr.owner_id, COALESCE(usr.first_name || ' ' || usr.last_name, usr.email) as owner_name,
+                   vr.owner_id, COALESCE(usr.name, usr.email) as owner_name,
                    vr.vehicle_type, vr.make, vr.model, vr.license_plate, vr.status,
                    ps.spot_number as parking_spot_number, vr.created_at
             FROM vehicle_registrations vr

--- a/backend/servers/api-server/src/routes/messaging.rs
+++ b/backend/servers/api-server/src/routes/messaging.rs
@@ -1067,10 +1067,11 @@ async fn get_other_participant(
             )
         })?;
 
-    // Get user info
+    // Get user info. Issue #1008: `users` has a single `name` column — map it
+    // into first_name and leave last_name empty to keep the ParticipantInfo shape.
     let user = sqlx::query_as::<_, (Uuid, String, String, String)>(
         r#"
-        SELECT id, first_name, last_name, email FROM users WHERE id = $1
+        SELECT id, name AS first_name, '' AS last_name, email FROM users WHERE id = $1
         "#,
     )
     .bind(other_user_id)


### PR DESCRIPTION
## Summary
Addresses the **broader sweep** of #1008. The `users` table has a single `name` column — there is no `first_name`/`last_name` (migration `00001_create_users.sql`). Several hand-written `sqlx::query`/`query_as` strings referenced `users.first_name`/`last_name` (and, in the export/admin paths, `display_name`/`phone_number`/`language`/`email_verified`/`last_login_at`, none of which exist). Because the backend uses **runtime-checked query strings with no `.sqlx` offline metadata**, `cargo build`/`clippy`/CI never catch these — they throw only at runtime against Postgres.

The **voting side** (`vote.rs`, `voting.rs`, `scheduler.rs`) is handled by **#1009** — those files are intentionally untouched here to avoid conflicts.

## Sites fixed (all API-shape-preserving)
| File | Fix |
|------|-----|
| `db/repositories/messaging.rs` | thread list/count (`other_*`), message sender (`sender_*`), blocked user (`blocked_*`): `u.name` → `*_first_name`, `''` → `*_last_name`; thread-name **search** filters on `u.name` (was a guaranteed 500 + dead search) |
| `api-server/routes/messaging.rs` | participant lookup `SELECT name AS first_name, '' AS last_name` |
| `db/repositories/registry.rs` | pet/vehicle owner-name `COALESCE(name, email)` (×6) |
| `db/repositories/document.rs` | version-history `created_by_name` = `u.name` (×4) |
| `db/repositories/document_template.rs` | `created_by_name` = `u.name` |
| `db/repositories/form.rs` | `created_by_name`/`submitted_by_name`/`reviewed_by_name` = `u.name`/`r.name` (×16) |
| `db/repositories/data_export.rs` | GDPR `ProfileExport`: `name`→first_name, NULL last_name, `phone`→phone_number, `locale`→language, `email_verified_at IS NOT NULL`→email_verified |
| `db/repositories/platform_admin.rs` | `SupportUserInfo`: `name`→display_name, NULL first/last & last_login_at, `email_verified_at IS NOT NULL`→email_verified; search on email + name |

`rental.rs`/`models/rental.rs` are **untouched** — `rental_guests` legitimately has `first_name`/`last_name` (migration `00051`).

## Design note — why API-preserving
`ParticipantInfo`, `ProfileExport`, and `SupportUserInfo` are serialized response models that already expose `first_name`/`last_name`. Rather than a cross-stack rename (which would ripple to the generated TS client + frontend), this PR maps the single `name` into the existing fields (full name in `first_name`, empty/NULL `last_name`). This **removes the runtime errors and restores correct name display/search** without changing the API contract. A proper single-`name` model refactor would be a sensible follow-up.

## Durable fix (recommended follow-up, from the issue)
Generate + commit `.sqlx` offline metadata (`cargo sqlx prepare --workspace`) and fail CI if stale, so column drift becomes a **compile** error. That needs a running Postgres and is out of scope here.

## Verification
- `cargo fmt -p db -p api-server --check` ✅
- `cargo check -p db -p api-server` ✅ (exit 0)
- Every changed query manually verified against the migration schema (`users` columns: `id, email, password_hash, name, phone, status, email_verified_at, locale, profile_visibility, show_contact_info, …`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)