### PR TITLE
test(deploy-server): guard api-server startup env contract (#951 follow-up)

### DIFF
--- a/backend/servers/deploy-server/src/infra/blue_green.rs
+++ b/backend/servers/deploy-server/src/infra/blue_green.rs
@@ -102,6 +102,28 @@ impl BlueGreenSpec {
     }
 }
 
+/// The env-var KEYS the `api-server` container requires at startup outside
+/// `RUST_ENV=development`. Mirrors the panics in `api-server/src/main.rs`:
+/// `DATABASE_URL` and `JWT_SECRET` (the core bootstrap), the two encryption
+/// keys (`TOTP_ENCRYPTION_KEY`, `INTEGRATION_ENCRYPTION_KEY`), and the
+/// e-signature secrets (`ESIGN_TOKEN_SECRET`, `ESIGN_WEBHOOK_SECRET`).
+///
+/// This is the shared contract between api-server's startup config and the
+/// deploy-server's [`build_service_envs`] (issue #951): `build_service_envs`
+/// MUST inject every one of these onto the `api` service, or the container
+/// crash-loops on deploy (which is exactly what bit the ESIGN rollout). The
+/// `api_env_contains_all_required_startup_vars` test guards the contract so a
+/// newly-required secret can't silently reach a deploy un-injected — add the
+/// var here and the test fails until `build_service_envs` templates it.
+pub const API_REQUIRED_STARTUP_ENV: &[&str] = &[
+    "DATABASE_URL",
+    "JWT_SECRET",
+    "TOTP_ENCRYPTION_KEY",
+    "INTEGRATION_ENCRYPTION_KEY",
+    "ESIGN_TOKEN_SECRET",
+    "ESIGN_WEBHOOK_SECRET",
+];
+
 /// Build the per-service environment map for a target deploy.
 ///
 /// Reads shared secrets from the deploy-server's own environment
@@ -316,6 +338,71 @@ pub fn build_service_envs(
     // `BlueGreenDeployer::deploy` once the next color is known.
     envs.insert("admin-web".into(), vec![]);
     Ok(envs)
+}
+
+#[cfg(test)]
+mod build_service_envs_tests {
+    use super::*;
+
+    fn test_target() -> crate::config::Target {
+        crate::config::Target {
+            docker_socket: "/var/run/docker.sock".into(),
+            caddy_url: "http://localhost:2019".into(),
+            reality_apex: "staging.rlt.sk".into(),
+            ppt_apex: "staging.ppt.rlt.sk".into(),
+            idle_timeout: None,
+            promote_strategy: None,
+            rollback_mode: "manual".into(),
+            health_grace: None,
+        }
+    }
+
+    fn set_all_required_secrets() {
+        // Deploy-server-side secrets `build_service_envs` reads, satisfying its
+        // length/hex validation.
+        std::env::set_var("POSTGRES_PASSWORD", "test-postgres-password");
+        std::env::set_var("PPT_JWT_SECRET", "x".repeat(32));
+        std::env::set_var("PPT_TOTP_ENCRYPTION_KEY", "a".repeat(64));
+        std::env::set_var("PPT_INTEGRATION_ENCRYPTION_KEY", "b".repeat(64));
+        std::env::set_var("PPT_PM_CLIENT_SECRET", "c".repeat(32));
+        std::env::set_var("PPT_ESIGN_TOKEN_SECRET", "d".repeat(32));
+        std::env::set_var("PPT_ESIGN_WEBHOOK_SECRET", "webhook-secret");
+    }
+
+    /// Issue #951: every secret the api-server requires at startup
+    /// (`API_REQUIRED_STARTUP_ENV`) must be injected onto the `api` container by
+    /// `build_service_envs`, or the container crash-loops on deploy — and when
+    /// any required deploy-server secret is absent, `build_service_envs` must
+    /// fail fast with a `Config` error rather than start empty-valued containers.
+    ///
+    /// Both halves are in one test because they mutate process-wide env vars and
+    /// would race if run as separate (parallel) tests.
+    #[test]
+    fn build_service_envs_enforces_api_startup_contract() {
+        set_all_required_secrets();
+
+        let envs = build_service_envs("staging", &test_target())
+            .expect("build_service_envs should succeed with all secrets set");
+        let api_env = envs.get("api").expect("`api` service env must exist");
+
+        for key in API_REQUIRED_STARTUP_ENV {
+            assert!(
+                api_env.iter().any(|kv| kv.starts_with(&format!("{key}="))),
+                "the `api` container env is missing `{key}`, which api-server requires at \
+                 startup (issue #951). Add it to `build_service_envs` so the deploy doesn't \
+                 crash-loop the api container."
+            );
+        }
+
+        // Missing required secret -> fail fast with a Config error.
+        std::env::remove_var("PPT_ESIGN_TOKEN_SECRET");
+        let err = build_service_envs("staging", &test_target())
+            .expect_err("must error when a required secret is missing");
+        assert!(
+            matches!(err, crate::DeployError::Config(_)),
+            "expected a Config error, got {err:?}"
+        );
+    }
 }
 
 impl BlueGreenDeployer {


### PR DESCRIPTION
## Summary
Follow-up to #951. PR #949 (merged) fixed the immediate problem — the deploy-server now injects `ESIGN_TOKEN_SECRET`/`ESIGN_WEBHOOK_SECRET` into the api container. But the **underlying class of bug** the issue called out had no guard:

> Add a guard so newly-required backend env vars are caught before they reach a deploy (e.g. a checked list shared between api-server config and deploy-server `build_service_envs`).

When api-server gains a new startup-required env var (like the ESIGN secrets did, migration `00170`), but `build_service_envs` isn't updated to inject it, the api container **crash-loops on deploy** (`UNHEALTHY`, blue/green aborts) — and nothing catches it until the deploy fails.

## Change
- `API_REQUIRED_STARTUP_ENV`: a documented, shared list of the env-var **keys** api-server requires at startup outside `RUST_ENV=development`, mirroring the panics in `api-server/src/main.rs` (`DATABASE_URL`, `JWT_SECRET`, `TOTP_ENCRYPTION_KEY`, `INTEGRATION_ENCRYPTION_KEY`, `ESIGN_TOKEN_SECRET`, `ESIGN_WEBHOOK_SECRET`).
- A unit test (`build_service_envs_enforces_api_startup_contract`) that:
  1. asserts `build_service_envs` templates **every** key in that list onto the `api` service, and
  2. asserts a missing required secret fails fast with a `Config` error rather than starting empty-valued containers.

Adding a new required secret to the contract now **fails CI** until `build_service_envs` wires it — turning a deploy-time crash-loop into a compile/test-time failure.

## Verification
- `cargo fmt -p deploy-server --check` ✅
- `cargo test -p deploy-server` ✅ — `build_service_envs_enforces_api_startup_contract ... ok` (1 passed)

## Note
This is the first test in `blue_green.rs`. A CI smoke-deploy (the issue's other suggested option) is heavier infra and left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)