### PR TITLE
security-pkce-oauth-authcode-pr-908-closed: regression test — challenge-less authz codes are non-exchangeable (PKCE)

### DIFF
--- a/backend/servers/api-server/tests/oauth_integration_tests.rs
+++ b/backend/servers/api-server/tests/oauth_integration_tests.rs
@@ -1929,6 +1929,145 @@ mod provider_security {
         assert_eq!(err["error"], "invalid_grant");
     }
 
+    /// Defense-in-depth regression (issue #823 / superseded PR #908, landed in
+    /// #1025): PKCE is enforced at the *authorize* stage, but the token endpoint
+    /// must independently refuse to exchange any stored authorization code that
+    /// has **no** `code_challenge` bound to it — see the comment in
+    /// `OAuthService::exchange_code_for_tokens`. Such a challenge-less code can
+    /// only exist if it was minted before PKCE enforcement, or via a future bug
+    /// that bypasses `validate_authorize_request`. Because the live authorize
+    /// path now always requires a `code_challenge`, the only way to exercise
+    /// this second layer is to insert the row directly.
+    ///
+    /// Both attempts — with and without a `code_verifier` — must be rejected
+    /// with `invalid_grant`, and no tokens must be issued.
+    #[sqlx::test(migrator = "db::MIGRATOR")]
+    async fn test_challengeless_stored_code_not_exchangeable(pool: PgPool) {
+        let app = TestApp::new(pool.clone()).await;
+        let user = TestUser::new();
+        let (_access_token, _) = create_authenticated_user(&app, &user).await;
+        let (client_id, client_secret, redirect_uri) = seed_confidential_client(&pool).await;
+
+        // Look up the freshly-created user's id so the seeded code references a
+        // real principal (FK on oauth_authorization_codes.user_id).
+        let user_id: Uuid = sqlx::query_scalar("SELECT id FROM users WHERE email = $1")
+            .bind(&user.email)
+            .fetch_one(&pool)
+            .await
+            .expect("fetch seeded user id");
+
+        // Mint a raw authorization code and store its SHA-256 hash with a NULL
+        // code_challenge — i.e. a code with no PKCE binding. This mirrors how
+        // OAuthService hashes codes (`hash_token` = hex(sha256(code))).
+        let raw_code = format!("legacy-code-{}", Uuid::new_v4());
+        let code_hash = {
+            let mut hasher = Sha256::new();
+            hasher.update(raw_code.as_bytes());
+            hex::encode(hasher.finalize())
+        };
+
+        sqlx::query(
+            r#"
+            INSERT INTO oauth_authorization_codes
+                (user_id, client_id, code_hash, scopes, redirect_uri,
+                 code_challenge, code_challenge_method, expires_at)
+            VALUES
+                ($1, $2, $3, '["profile"]'::jsonb, $4,
+                 NULL, NULL, NOW() + INTERVAL '10 minutes')
+            "#,
+        )
+        .bind(user_id)
+        .bind(&client_id)
+        .bind(&code_hash)
+        .bind(&redirect_uri)
+        .execute(&pool)
+        .await
+        .expect("seed challenge-less authorization code");
+
+        // Attempt 1: exchange WITHOUT a code_verifier.
+        let token_form_no_verifier = form_body(&[
+            ("grant_type", "authorization_code"),
+            ("code", &raw_code),
+            ("redirect_uri", &redirect_uri),
+            ("client_id", &client_id),
+            ("client_secret", &client_secret),
+        ]);
+        let resp = app
+            .execute(form_request("/api/v1/oauth/token", &token_form_no_verifier))
+            .await;
+        assert_eq!(
+            resp.status,
+            StatusCode::BAD_REQUEST,
+            "challenge-less code must not be exchangeable (no verifier). body={}",
+            resp.text()
+        );
+        assert_eq!(resp.json_value()["error"], "invalid_grant");
+
+        // The first exchange attempt atomically consumed the code, so a re-seed
+        // is needed to prove the second (with-verifier) path independently.
+        let raw_code2 = format!("legacy-code-{}", Uuid::new_v4());
+        let code_hash2 = {
+            let mut hasher = Sha256::new();
+            hasher.update(raw_code2.as_bytes());
+            hex::encode(hasher.finalize())
+        };
+        sqlx::query(
+            r#"
+            INSERT INTO oauth_authorization_codes
+                (user_id, client_id, code_hash, scopes, redirect_uri,
+                 code_challenge, code_challenge_method, expires_at)
+            VALUES
+                ($1, $2, $3, '["profile"]'::jsonb, $4,
+                 NULL, NULL, NOW() + INTERVAL '10 minutes')
+            "#,
+        )
+        .bind(user_id)
+        .bind(&client_id)
+        .bind(&code_hash2)
+        .bind(&redirect_uri)
+        .execute(&pool)
+        .await
+        .expect("re-seed challenge-less authorization code");
+
+        // Attempt 2: exchange WITH an arbitrary code_verifier. A challenge-less
+        // stored code must still be rejected — the verifier has nothing valid to
+        // match against, so the token endpoint refuses it rather than treating
+        // "no challenge" as "PKCE not required".
+        let token_form_with_verifier = form_body(&[
+            ("grant_type", "authorization_code"),
+            ("code", &raw_code2),
+            ("redirect_uri", &redirect_uri),
+            ("client_id", &client_id),
+            ("client_secret", &client_secret),
+            ("code_verifier", "any-verifier-the-attacker-supplies"),
+        ]);
+        let resp2 = app
+            .execute(form_request(
+                "/api/v1/oauth/token",
+                &token_form_with_verifier,
+            ))
+            .await;
+        assert_eq!(
+            resp2.status,
+            StatusCode::BAD_REQUEST,
+            "challenge-less code must not be exchangeable (with verifier). body={}",
+            resp2.text()
+        );
+        assert_eq!(resp2.json_value()["error"], "invalid_grant");
+
+        // And no access tokens may have been minted for this user as a result.
+        let issued: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM oauth_access_tokens WHERE user_id = $1")
+                .bind(user_id)
+                .fetch_one(&pool)
+                .await
+                .expect("count access tokens");
+        assert_eq!(
+            issued, 0,
+            "no access token must be issued from a challenge-less authorization code"
+        );
+    }
+
     // ── B. Revoked-token introspection ───────────────────────────────────────
 
     /// Introspecting a revoked access token must return active=false.


### PR DESCRIPTION
## Task
PR #908 (`fix(security): require PKCE on OAuth authorization-code flow, closes #823`) was closed unmerged — verify whether PKCE enforcement is still pending. Investigate the current state of OAuth authorization-code PKCE enforcement in the backend; if PKCE is NOT enforced, implement enforcement (reject authorization-code grants lacking a valid PKCE code_verifier/code_challenge per RFC 7636/RFC 9700) with tests; if it IS already enforced on dev, add/strengthen regression tests proving it and document the finding.

## Finding (why PR #908 was closed)

PKCE enforcement on the OAuth authorization-code flow is **already present and merged on `dev`**. PR #908 was closed-unmerged because its work was **superseded by PR #1025** (`fix(security): require PKCE on OAuth authorization-code flow for all clients`), which is the commit `9ea8349` on `dev`. There is no pending enforcement gap.

Current enforcement (in `backend/servers/api-server/src/services/oauth.rs`):

- **Authorize stage** — `validate_authorize_request` rejects any authorize request with no `code_challenge`, for **all** clients (public *and* confidential), returning `invalid_request` (OAuth 2.1 §4.1.1 / RFC 7636). This is the exact fix from #823: previously the challenge was only required for public clients.
- **Token stage** — `exchange_code_for_tokens` requires the stored code to have a `code_challenge` AND the request to supply a matching `code_verifier`; absence of either yields `invalid_grant`. Only `S256` is accepted (`verify_pkce` returns `false` for `plain` or any other method).
- The `/token` route (`routes/oauth.rs`) drives both layers end-to-end.

Existing test coverage (`tests/oauth_integration_tests.rs`) is already strong: `test_public_client_requires_pkce`, `test_confidential_client_requires_pkce` (the #823 regression), `test_pkce_wrong_verifier_rejected`, `test_pkce_missing_verifier_rejected`, `test_pkce_plain_method_rejected*`, plus full happy-path S256 flows for public and confidential clients.

## What this PR adds

This is the "already enforced → strengthen regression tests + document" path. Every existing test proves PKCE at the **authorize** stage (which now always sets a `code_challenge`). None proved the independent **token-endpoint defense-in-depth** layer documented in the `exchange_code_for_tokens` comment: a *stored* authorization code with a NULL `code_challenge` (mintable only before enforcement, or via a future bug that bypasses `validate_authorize_request`) must never be exchangeable.

New test `provider_security::test_challengeless_stored_code_not_exchangeable`:
1. Seeds an `oauth_authorization_codes` row directly with `code_challenge = NULL` (the only way to reach this branch now that authorize always requires a challenge).
2. Asserts the `/token` exchange is rejected with `invalid_grant` **both** without a `code_verifier` and with an arbitrary one.
3. Asserts no `oauth_access_tokens` row is issued for the user.

**Test-only change** — no production code is modified (enforcement already shipped via #1025).

## Owner
pm-security

## Tested (Band A — fast check)
- `SQLX_OFFLINE=true cargo check -p api-server --tests` → exit 0 (compiles clean against the real schema + Axum router types).
- DB-backed test execution (`#[sqlx::test]`) could not run locally: cloud-mode environment has **no Postgres and no Docker**, and the `ppt-bridge` MCP is **not connected** in this session. The test exercises the live `/token` HTTP path via `TestApp` and the real `db::MIGRATOR` schema; it will run on CI's backend-test job (which provisions Postgres).

## Built (Band B — full build)
- N/A for a test-only addition (no public API / migration / config change). Compilation of the test target verified above.

## CI parity (Band C — hot-path)
`act` not installed — ran the workflow commands manually:
- `cargo fmt --all -- --check` → exit 0.
- `cargo clippy -p api-server --tests -- -D warnings` → fails on a **pre-existing** lint unrelated to this change: `clippy::items_after_test_module` at `src/routes/admin/mod.rs:76` (a file not in this diff; triggered by a newer local clippy 1.94.0). My diff is fmt-clean and `cargo check --tests` is green.
- Backend-test job (Postgres-backed `cargo test`) will run on CI.

## Remote-tested
skipped — ppt-bridge MCP not connected.

## Scope drift
`scope-check.sh --owner pm-security` returns exit 2, flagging `backend/servers/api-server/tests/oauth_integration_tests.rs`. This is a **false positive** of the owner-area globs: an OAuth/PKCE security regression test is unambiguously within pm-security's domain. No production or off-area code is touched (the entire diff is one added test in this file). Reviewer to confirm.

## Code-reuse review
`reuse-grep.sh --specialist rust-backend` → no warnings. The test reuses the existing in-file SHA-256 code-hashing pattern (matching `OAuthService::hash_token`) and the existing `seed_confidential_client` / `form_body` / `form_request` helpers; no new shared helpers introduced.

## Notes
- Branch `auto-impl/security-pkce-oauth-authcode-pr-908-clos` previously held the (now-merged-as-#1025) enforcement work; it was force-updated (with lease) to a fresh branch off current `dev` carrying only the new regression test, since the prior content is already in `dev`.

https://claude.ai/code/session_01ACnVs3vLweZfRw7kVzHmwD

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACnVs3vLweZfRw7kVzHmwD)_