### PR TITLE
gap-83-2-ota-xml-transport: guard Booking.com OTA XML listing-push (batch cap + non-negative availability)

### DIFF
--- a/backend/servers/api-server/src/routes/integrations/booking_channel.rs
+++ b/backend/servers/api-server/src/routes/integrations/booking_channel.rs
@@ -150,10 +150,22 @@ pub struct ConflictCheckResponse {
 ///
 /// On failure, returns `(error_code, human_message)` so the caller can build
 /// a `400` [`ErrorResponse`]. On success, returns `Ok(())`.
-fn validate_listing_push(
-    _request: &ListingPushRequest,
-) -> Result<(), (&'static str, &'static str)> {
-    // TODO(gap-83-2): no guards yet — see the failing tests below.
+fn validate_listing_push(request: &ListingPushRequest) -> Result<(), (&'static str, &'static str)> {
+    let total = request.availability.len() + request.rates.len();
+    if total > MAX_BATCH_SIZE {
+        return Err((
+            "BATCH_TOO_LARGE",
+            "A maximum of 500 availability + rate updates per request is allowed",
+        ));
+    }
+
+    if request.availability.iter().any(|a| a.available_count < 0) {
+        return Err((
+            "INVALID_AVAILABLE_COUNT",
+            "available_count must be non-negative",
+        ));
+    }
+
     Ok(())
 }
 
@@ -240,6 +252,21 @@ pub async fn push_booking_listing(
                 "FORBIDDEN",
                 "Insufficient permissions to manage integrations",
             )),
+        ));
+    }
+
+    // Validate the payload before any DB lookup or OTA XML generation so a
+    // malformed batch fails fast with a 400 instead of producing invalid XML.
+    if let Err((code, message)) = validate_listing_push(&request) {
+        tracing::warn!(
+            org_id = %path.org_id,
+            error_code = code,
+            "Rejecting Booking.com listing push: {}",
+            message
+        );
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(code, message)),
         ));
     }
 

--- a/backend/servers/api-server/src/routes/integrations/booking_channel.rs
+++ b/backend/servers/api-server/src/routes/integrations/booking_channel.rs
@@ -29,6 +29,17 @@ use crate::state::AppState;
 use common::errors::ErrorResponse;
 use common::TenantRole;
 
+/// Maximum number of availability/rate updates accepted in a single
+/// `listing-push` request.
+///
+/// Each entry becomes one `AvailStatusMessage` / `RateAmountMessage` in the
+/// generated OTA XML. Without a cap, an arbitrarily large list lets a caller
+/// build an unbounded XML body, risking OOM locally and timeouts upstream.
+/// Mirrors the `MAX_BATCH_SIZE` guard PR #607 added to the legacy
+/// `install.rs` push endpoints (issue #572) — applied here to the unified
+/// gap-83-2 OTA push surface, which had no such guard.
+pub const MAX_BATCH_SIZE: usize = 500;
+
 // ============================================================
 // Types
 // ============================================================
@@ -117,6 +128,33 @@ pub struct ConflictCheckResponse {
     pub checked_at: chrono::DateTime<chrono::Utc>,
     /// True if the query hit the 500-reservation cap — results may be incomplete.
     pub truncated: bool,
+}
+
+// ============================================================
+// Request validation
+// ============================================================
+
+/// Validate a [`ListingPushRequest`] before it is turned into OTA XML and
+/// pushed to Booking.com.
+///
+/// These guards protect the OTA XML transport from producing malformed or
+/// unbounded payloads:
+///
+/// * **Batch size** — the combined availability + rate update count must not
+///   exceed [`MAX_BATCH_SIZE`]. Each entry maps to one OTA message element;
+///   an unbounded list could OOM the encoder or time out upstream.
+/// * **Non-negative availability** — a negative `available_count` serialises
+///   to an invalid `BookingLimit` attribute in `OTA_HotelAvailNotifRQ`, which
+///   Booking.com rejects. This mirrors the `available_count >= 0` guard from
+///   PR #607.
+///
+/// On failure, returns `(error_code, human_message)` so the caller can build
+/// a `400` [`ErrorResponse`]. On success, returns `Ok(())`.
+fn validate_listing_push(
+    _request: &ListingPushRequest,
+) -> Result<(), (&'static str, &'static str)> {
+    // TODO(gap-83-2): no guards yet — see the failing tests below.
+    Ok(())
 }
 
 // ============================================================
@@ -635,6 +673,81 @@ mod tests {
         let json = serde_json::to_value(&response).unwrap();
         assert_eq!(json["conflicts_found"], 1);
         assert_eq!(json["conflicts"][0]["conflicting_platform"], "airbnb");
+    }
+
+    /// Build a minimal valid `ListingPushRequest` with the given counts of
+    /// availability and rate entries (all entries non-negative).
+    fn make_request(avail: usize, rates: usize) -> ListingPushRequest {
+        ListingPushRequest {
+            unit_id: Uuid::new_v4(),
+            room_type_id: "DBL".to_string(),
+            availability: (0..avail)
+                .map(|i| RoomAvailabilityEntry {
+                    room_type_id: "DBL".to_string(),
+                    date: NaiveDate::from_ymd_opt(2025, 6, 1).unwrap()
+                        + chrono::Duration::days(i as i64),
+                    available_count: 1,
+                    stop_sell: false,
+                })
+                .collect(),
+            rates: (0..rates)
+                .map(|i| RoomRateEntry {
+                    room_type_id: "DBL".to_string(),
+                    rate_plan_code: "STD".to_string(),
+                    date: NaiveDate::from_ymd_opt(2025, 6, 1).unwrap()
+                        + chrono::Duration::days(i as i64),
+                    base_rate: rust_decimal::Decimal::new(10000, 2),
+                    currency: "EUR".to_string(),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn test_validate_listing_push_accepts_valid_batch() {
+        let req = make_request(10, 10);
+        assert!(validate_listing_push(&req).is_ok());
+    }
+
+    #[test]
+    fn test_validate_listing_push_accepts_max_batch_boundary() {
+        // Exactly MAX_BATCH_SIZE combined entries is allowed.
+        let req = make_request(MAX_BATCH_SIZE, 0);
+        assert!(validate_listing_push(&req).is_ok());
+        let req = make_request(MAX_BATCH_SIZE / 2, MAX_BATCH_SIZE - MAX_BATCH_SIZE / 2);
+        assert!(validate_listing_push(&req).is_ok());
+    }
+
+    #[test]
+    fn test_validate_listing_push_rejects_oversized_batch() {
+        // availability + rates combined exceeding the cap -> BATCH_TOO_LARGE.
+        let req = make_request(MAX_BATCH_SIZE, 1);
+        let err = validate_listing_push(&req).unwrap_err();
+        assert_eq!(err.0, "BATCH_TOO_LARGE");
+    }
+
+    #[test]
+    fn test_validate_listing_push_rejects_negative_available_count() {
+        let mut req = make_request(2, 0);
+        req.availability[1].available_count = -1;
+        let err = validate_listing_push(&req).unwrap_err();
+        assert_eq!(err.0, "INVALID_AVAILABLE_COUNT");
+    }
+
+    #[test]
+    fn test_validate_listing_push_zero_available_count_is_valid() {
+        // 0 means sold out — a valid OTA `BookingLimit`, not a rejection.
+        let mut req = make_request(1, 0);
+        req.availability[0].available_count = 0;
+        assert!(validate_listing_push(&req).is_ok());
+    }
+
+    #[test]
+    fn test_validate_listing_push_empty_request_is_valid() {
+        // No availability and no rates is a no-op push, not an error here;
+        // the handler simply pushes nothing.
+        let req = make_request(0, 0);
+        assert!(validate_listing_push(&req).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Task
Implement the OTA XML parsing/generation transport for Booking.com rate/availability push (story 83-2, AC-5) — validation guards landed in PR #607, XML transport still missing.

## Owner
pm-backend

## What this actually changes (scope finding)

Investigation showed the OTA **XML transport itself is already implemented**:
- `backend/crates/integrations/src/booking.rs` has the full `ota_xml` submodule (quick-xml based `OTA_HotelAvailNotifRQ` / `OTA_HotelRateAmountNotifRQ` generation, `OTA_HotelResNotifRS` build, namespace-safe response/reservation parsing) — landed in #1010.
- `backend/servers/api-server/src/routes/integrations/booking_channel.rs` wires the `POST .../booking/listing-push` endpoint (AC-5 rate/availability push) onto that transport via `push_availability` / `push_rates`.

PR #607 added `MAX_BATCH_SIZE = 500` and `available_count >= 0` guards (issue #572) — but **only to the legacy `install.rs` push handlers**. The unified gap-83-2 `listing-push` OTA surface had **no such guards**, so a malformed request (negative count or an unbounded batch) would flow straight into OTA XML generation and emit an invalid `OTA_HotelAvailNotifRQ` payload to Booking.com.

This PR closes that gap: it brings the OTA XML push surface to validation parity with #607.

- New `pub const MAX_BATCH_SIZE: usize = 500`.
- New `validate_listing_push()` — rejects `>500` combined availability+rate updates (`BATCH_TOO_LARGE`) and any negative `available_count` (`INVALID_AVAILABLE_COUNT`) with a `400` **before** any DB lookup or XML generation.
- Wired into `push_booking_listing`.
- 6 new unit tests (valid batch, max-boundary, oversized → `BATCH_TOO_LARGE`, negative → `INVALID_AVAILABLE_COUNT`, `available_count=0` is valid sold-out, empty request is valid).

TDD: the `test:` commit lands the tests against a no-op stub (2 negative-path tests red); the `fix:` commit implements the guard (green).

## Tested (Band A — fast check)
- `cargo check -p api-server` → exit 0
- `cargo test -p api-server --lib booking_channel` → 10 passed, 0 failed
- `cargo test -p api-server --lib` (full lib suite) → 218 passed, 0 failed

## Built (Band B — full build)
- `cargo clippy -p api-server --lib` → exit 0, no warnings
- `cargo fmt -p api-server` → clean

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (input-validation guard on an integration push endpoint; no auth/billing/data-integrity change)

## Remote-tested
skipped

## Scope drift
None — `scope-check.sh --owner pm-backend` → exit 0. Single file touched (`booking_channel.rs`), inside pm-backend's area.

## Code-reuse review
None — `reuse-grep.sh --specialist rust-backend` → exit 0. The guard mirrors the existing `install.rs` pattern (constant + per-handler validation) rather than introducing a duplicate shared helper, matching the existing codebase convention.

## Notes
- The XML transport (build + parse) was already complete; the deliverable here is the missing validation guard that protects that transport on the AC-5 push endpoint. No transport re-implementation was needed or done.
- IG goal-check: IG3 (TDD evidence) passes. IG1 (no `.research/plans/<slug>.md`) and IG2 (branch `auto-impl/*` vs `impl/*`) report FAIL only because this is a dispatcher-spawned gap task, not a plan-driven flow — not correctness issues.

https://claude.ai/code/session_01UQuKivbyuXbFrPhMDuNNgd

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQuKivbyuXbFrPhMDuNNgd)_