### PR TITLE
test-gap-80-2-dispute-filing-ac-coverage: regression tests for dispute-filing surface

### DIFF
--- a/frontend/apps/ppt-web/src/features/disputes/components/EvidenceUploader.test.tsx
+++ b/frontend/apps/ppt-web/src/features/disputes/components/EvidenceUploader.test.tsx
@@ -1,0 +1,202 @@
+/// <reference types="vitest/globals" />
+/**
+ * EvidenceUploader component tests (Epic 80, Story 80.2 — AC-2).
+ *
+ * Regression coverage for the dispute-filing evidence surface:
+ *  - accepted file types / extensions exposed on the input
+ *  - per-file type + size validation (error status, no preview)
+ *  - MAX_FILES cap (drop zone hidden, extra files dropped)
+ *  - remove + description editing callbacks
+ *  - status indicators (uploading / uploaded / error)
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { EvidenceUploader, type PendingEvidence } from './EvidenceUploader';
+
+// jsdom has no real object-URL support — stub it so image previews don't throw.
+const mockCreateObjectURL = vi.fn(() => 'blob:mock-url');
+const mockRevokeObjectURL = vi.fn();
+URL.createObjectURL = mockCreateObjectURL;
+URL.revokeObjectURL = mockRevokeObjectURL;
+
+function makeFile(name: string, type: string, sizeBytes = 1024): File {
+  const file = new File(['x'], name, { type });
+  // jsdom derives size from the blob parts; override for size-limit tests.
+  Object.defineProperty(file, 'size', { value: sizeBytes });
+  return file;
+}
+
+function selectFiles(files: File[]) {
+  const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+  Object.defineProperty(input, 'files', { value: files, configurable: true });
+  fireEvent.change(input);
+}
+
+describe('EvidenceUploader', () => {
+  const onChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the drop zone with the accepted-format hint when empty', () => {
+    render(<EvidenceUploader files={[]} onChange={onChange} />);
+
+    expect(
+      screen.getByRole('button', { name: /drop evidence files here or click to browse/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/JPG, PNG, PDF, MP3, MP4/i)).toBeInTheDocument();
+  });
+
+  it('exposes the accepted extensions and multiple attribute on the file input', () => {
+    render(<EvidenceUploader files={[]} onChange={onChange} />);
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(input).toHaveAttribute('accept', '.jpg,.jpeg,.png,.webp,.mp3,.mp4,.pdf');
+    expect(input).toHaveAttribute('multiple');
+  });
+
+  it('accepts a valid file with pending status and creates an image preview', () => {
+    render(<EvidenceUploader files={[]} onChange={onChange} />);
+
+    selectFiles([makeFile('photo.jpg', 'image/jpeg')]);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const next: PendingEvidence[] = onChange.mock.calls[0][0];
+    expect(next).toHaveLength(1);
+    expect(next[0].status).toBe('pending');
+    expect(next[0].error).toBeUndefined();
+    expect(next[0].preview).toBe('blob:mock-url');
+    expect(mockCreateObjectURL).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks an unsupported file type as error and skips the preview', () => {
+    render(<EvidenceUploader files={[]} onChange={onChange} />);
+
+    selectFiles([makeFile('virus.exe', 'application/x-msdownload')]);
+
+    const next: PendingEvidence[] = onChange.mock.calls[0][0];
+    expect(next[0].status).toBe('error');
+    expect(next[0].error).toMatch(/unsupported file type/i);
+    expect(next[0].preview).toBeUndefined();
+    expect(mockCreateObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('marks a file exceeding the 50 MB limit as error', () => {
+    render(<EvidenceUploader files={[]} onChange={onChange} />);
+
+    selectFiles([makeFile('huge.pdf', 'application/pdf', 51 * 1024 * 1024)]);
+
+    const next: PendingEvidence[] = onChange.mock.calls[0][0];
+    expect(next[0].status).toBe('error');
+    expect(next[0].error).toMatch(/max 50 MB/i);
+  });
+
+  it('caps the queue at 10 files and hides the drop zone when full', () => {
+    const full: PendingEvidence[] = Array.from({ length: 10 }, (_, i) => ({
+      id: `ev-${i}`,
+      file: makeFile(`f${i}.pdf`, 'application/pdf'),
+      description: '',
+      status: 'pending',
+    }));
+
+    render(<EvidenceUploader files={full} onChange={onChange} />);
+
+    // Drop zone is gone once the cap is reached (the hidden file input itself
+    // stays mounted; only the clickable drop zone is conditional).
+    expect(
+      screen.queryByRole('button', { name: /drop evidence files here/i })
+    ).not.toBeInTheDocument();
+    // All 10 queued files are still listed.
+    expect(screen.getByRole('list', { name: /evidence files/i })).toBeInTheDocument();
+  });
+
+  it('drops files beyond the remaining slots', () => {
+    const existing: PendingEvidence[] = Array.from({ length: 9 }, (_, i) => ({
+      id: `ev-${i}`,
+      file: makeFile(`f${i}.pdf`, 'application/pdf'),
+      description: '',
+      status: 'pending',
+    }));
+
+    render(<EvidenceUploader files={existing} onChange={onChange} />);
+
+    // Two incoming files, but only one slot remains.
+    selectFiles([makeFile('a.pdf', 'application/pdf'), makeFile('b.pdf', 'application/pdf')]);
+
+    const next: PendingEvidence[] = onChange.mock.calls[0][0];
+    expect(next).toHaveLength(10);
+  });
+
+  it('removes a queued file and revokes its object URL', () => {
+    const files: PendingEvidence[] = [
+      {
+        id: 'ev-1',
+        file: makeFile('photo.jpg', 'image/jpeg'),
+        description: '',
+        preview: 'blob:mock-url',
+        status: 'pending',
+      },
+    ];
+
+    render(<EvidenceUploader files={files} onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /remove photo\.jpg/i }));
+
+    expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it('edits a per-file description through onChange', () => {
+    const files: PendingEvidence[] = [
+      {
+        id: 'ev-1',
+        file: makeFile('clip.mp4', 'video/mp4'),
+        description: '',
+        status: 'pending',
+      },
+    ];
+
+    render(<EvidenceUploader files={files} onChange={onChange} />);
+
+    fireEvent.change(screen.getByLabelText(/description for clip\.mp4/i), {
+      target: { value: 'noise recording' },
+    });
+
+    const next: PendingEvidence[] = onChange.mock.calls[0][0];
+    expect(next[0].description).toBe('noise recording');
+  });
+
+  it('shows the error message for an errored file and omits its description input', () => {
+    const files: PendingEvidence[] = [
+      {
+        id: 'ev-1',
+        file: makeFile('bad.exe', 'application/x-msdownload'),
+        description: '',
+        status: 'error',
+        error: 'Unsupported file type: application/x-msdownload',
+      },
+    ];
+
+    render(<EvidenceUploader files={files} onChange={onChange} />);
+
+    expect(screen.getByText(/unsupported file type/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/description for bad\.exe/i)).not.toBeInTheDocument();
+  });
+
+  it('renders an uploading spinner and a disabled remove button mid-upload', () => {
+    const files: PendingEvidence[] = [
+      {
+        id: 'ev-1',
+        file: makeFile('doc.pdf', 'application/pdf'),
+        description: '',
+        status: 'uploading',
+      },
+    ];
+
+    render(<EvidenceUploader files={files} onChange={onChange} />);
+
+    expect(screen.getByLabelText(/uploading/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /remove doc\.pdf/i })).toBeDisabled();
+  });
+});

--- a/frontend/apps/ppt-web/src/features/disputes/pages/FileDisputePage.test.tsx
+++ b/frontend/apps/ppt-web/src/features/disputes/pages/FileDisputePage.test.tsx
@@ -1,0 +1,180 @@
+/// <reference types="vitest/globals" />
+/**
+ * FileDisputePage form tests (Epic 80, Story 80.2).
+ *
+ * Regression coverage for the dispute-filing surface acceptance criteria:
+ *  - AC-1: dispute-type radio-card grid renders all 6 categories + is required
+ *  - AC-3: subject (min 5) + description (min 30) validation, char counter
+ *  - AC-1/AC-3: required unit selector
+ *  - AC-5: valid submit forwards { values, evidence } to onSubmit; the submit
+ *          button is disabled (shows "Filing…") while isSubmitting is true
+ *  - navigation: Cancel / Back route to /disputes
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { type DisputeFormValues, FileDisputePage } from './FileDisputePage';
+
+// jsdom lacks object-URL support used by the embedded EvidenceUploader.
+URL.createObjectURL = vi.fn(() => 'blob:mock-url');
+URL.revokeObjectURL = vi.fn();
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const UNITS = [
+  { id: 'unit-1', label: 'Unit 1A' },
+  { id: 'unit-2', label: 'Unit 2B' },
+];
+
+function renderPage(props: Partial<React.ComponentProps<typeof FileDisputePage>> = {}) {
+  const onSubmit = props.onSubmit ?? vi.fn();
+  render(
+    <MemoryRouter>
+      <FileDisputePage units={UNITS} onSubmit={onSubmit} {...props} />
+    </MemoryRouter>
+  );
+  return { onSubmit };
+}
+
+/** Fill the three required fields with valid values. */
+function fillValidForm() {
+  fireEvent.click(screen.getByRole('radio', { name: /noise/i }));
+  fireEvent.change(screen.getByLabelText(/^unit/i), { target: { value: 'unit-1' } });
+  fireEvent.change(screen.getByLabelText(/^subject/i), {
+    target: { value: 'Loud parties past midnight' },
+  });
+  fireEvent.change(screen.getByLabelText(/^description/i), {
+    target: { value: 'Repeated loud music and shouting well past the 22:00 quiet hours.' },
+  });
+}
+
+describe('FileDisputePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── AC-1: dispute type selector ──
+  it('renders all six dispute-type radio cards', () => {
+    renderPage();
+    for (const label of [
+      /noise/i,
+      /property damage/i,
+      /payment \/ fees/i,
+      /lease terms/i,
+      /maintenance/i,
+      /^other$/i,
+    ]) {
+      expect(screen.getByRole('radio', { name: label })).toBeInTheDocument();
+    }
+  });
+
+  it('marks the type radiogroup as required', () => {
+    renderPage();
+    expect(screen.getByRole('radiogroup', { name: /dispute type/i })).toHaveAttribute(
+      'aria-required',
+      'true'
+    );
+  });
+
+  it('blocks submit and shows the type error when no type is chosen', async () => {
+    const { onSubmit } = renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /file dispute/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/please select a dispute type/i)).toBeInTheDocument();
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  // ── AC-3: subject + description validation ──
+  it('rejects a too-short subject and description', async () => {
+    const { onSubmit } = renderPage();
+
+    fireEvent.click(screen.getByRole('radio', { name: /noise/i }));
+    fireEvent.change(screen.getByLabelText(/^unit/i), { target: { value: 'unit-1' } });
+    fireEvent.change(screen.getByLabelText(/^subject/i), { target: { value: 'hi' } });
+    fireEvent.change(screen.getByLabelText(/^description/i), { target: { value: 'too short' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /file dispute/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/subject must be at least 5 characters/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/description must be at least 30 characters/i)).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('requires a unit to be selected', async () => {
+    const { onSubmit } = renderPage();
+
+    fireEvent.click(screen.getByRole('radio', { name: /noise/i }));
+    fireEvent.change(screen.getByLabelText(/^subject/i), {
+      target: { value: 'A valid subject line' },
+    });
+    fireEvent.change(screen.getByLabelText(/^description/i), {
+      target: { value: 'A sufficiently long description that clears the thirty-char minimum.' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /file dispute/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/please select a unit/i)).toBeInTheDocument();
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('updates the description character counter as the user types', () => {
+    renderPage();
+    fireEvent.change(screen.getByLabelText(/^description/i), {
+      target: { value: 'hello world' },
+    });
+    expect(screen.getByText('11 / 5000')).toBeInTheDocument();
+  });
+
+  // ── AC-5: submit ──
+  it('forwards the validated values and evidence array to onSubmit', async () => {
+    const { onSubmit } = renderPage();
+
+    fillValidForm();
+    fireEvent.click(screen.getByRole('button', { name: /file dispute/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+    const payload = onSubmit.mock.calls[0][0] as {
+      values: DisputeFormValues;
+      evidence: unknown[];
+    };
+    expect(payload.values).toMatchObject({
+      type: 'noise',
+      unitId: 'unit-1',
+      subject: 'Loud parties past midnight',
+    });
+    expect(payload.values.description.length).toBeGreaterThanOrEqual(30);
+    expect(Array.isArray(payload.evidence)).toBe(true);
+  });
+
+  it('disables the submit button and shows a filing spinner while submitting', () => {
+    renderPage({ isSubmitting: true });
+    const button = screen.getByRole('button', { name: /filing/i });
+    expect(button).toBeDisabled();
+  });
+
+  // ── Navigation ──
+  it('navigates back to the disputes list from Cancel', () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/disputes');
+  });
+
+  it('navigates back to the disputes list from the Back link', () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /back to disputes/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/disputes');
+  });
+});


### PR DESCRIPTION
## Task
Verify full acceptance-criteria coverage for the dispute-filing flow (story 80-2) and add missing regression tests for the filing surface.

## Owner
pm-frontend

## AC coverage audit
The live filing surface is the `/disputes/new` route: `FileDisputePage` (form) + `EvidenceUploader` (evidence), wired in `App.tsx#FileDisputePageRoute`. Per `docs/screens/ppt/file-dispute.md` agent log, the implemented ACs are:

- **AC-1** dispute-type selector + required validation — `FileDisputePage` radio-card grid + zod `type` enum. **Was untested.**
- **AC-2** evidence upload (type/size validation, max files, remove, descriptions) — `EvidenceUploader`. **Was untested.**
- **AC-3** subject (min 5) + description (min 30) fields, char counter, required unit — `FileDisputePage`. **Was untested.**
- **AC-5** submit forwards `{ values, evidence }`; submit disabled while in-flight; Cancel/Back nav — `FileDisputePage` + route wrapper. **Was untested.**

Finding: the dispute-filing surface had **zero** tests before this PR (only mediation/timeline components in the disputes feature were covered). This PR closes that gap. (AC-4 "draft auto-save / `useDraftStorage`" remains unimplemented per the screen-map agent log — out of scope for a test-coverage task; no code to test.)

## Changes
- `EvidenceUploader.test.tsx` — 11 tests (AC-2): accepted extensions/`multiple` attr, valid-file pending status + image preview, unsupported-type error, 50 MB size cap, MAX_FILES cap + drop-zone hiding, slot overflow drop, remove + `revokeObjectURL`, description editing, error message render, mid-upload spinner + disabled remove.
- `FileDisputePage.test.tsx` — 10 tests (AC-1/3/5 + nav): all 6 radio cards, required radiogroup, type-missing block, subject/description min-length, required unit, char counter, valid-submit payload shape, submitting-disabled state, Cancel + Back navigation.

Test patterns mirror the existing `PhotoUploader.test.tsx` (object-URL stub, `new File` + `Object.defineProperty` size) and `MediationResolutionForm.test.tsx` (RHF + zod assertions). No new helpers/components — tests only.

## Tested (Band A — fast check)
- `vitest run EvidenceUploader.test.tsx FileDisputePage.test.tsx` → **2 files / 21 tests passed**, exit 0
- `pnpm -F @ppt/web typecheck` (`tsc --noEmit`) → exit 0
- `biome check` (both new files) → exit 0 (after applying the `useImportType` safe fix)

Note: the app's `lint` npm script invokes a stale ESLint 10 config that errors repo-wide (pre-existing, unrelated to this change); CI uses `biome check`, which is clean here.

## Built (Band B — full build)
Skipped: test-only change (no production code, no public API/config touch).

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (test-only; no security/auth/billing/data-integrity change).

## Remote-tested
Skipped (no ppt-bridge MCP this session).

## Notes
Pure test-coverage task. `scope_drift=false` (both files under ppt-web frontend = pm-frontend area). `code_reuse_warn=none`. No source behavior changed; these tests pass against current `dev` and lock in the AC-1/2/3/5 behavior against regression.

https://claude.ai/code/session_018cvrGtMRxYhwNHGwom6JhS

---
_Generated by [Claude Code](https://claude.ai/code/session_018cvrGtMRxYhwNHGwom6JhS)_