### PR TITLE
test-gap-hotfix-no-test-pr-918-mobile-dev-review: regression tests for PR #918 mobile dev-review fixes

### DIFF
--- a/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.test.ts
+++ b/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.test.ts
@@ -1,0 +1,57 @@
+import { type ApiAnnouncementSummary, extractItems, toUiAnnouncement } from './AnnouncementsScreen';
+
+// Regression for PR #918 (High #3 + Critical #1): the screen moved off the
+// manager-only `/api/v1/announcements` endpoint (403 for residents) to the
+// RLS-scoped `/api/v1/announcements/published`, whose `AnnouncementSummary`
+// rows have NO `content`/`author`/`category`. The mapper must tolerate the
+// lightweight summary shape and the list extractor must read `announcements`
+// (the legacy `items` key no longer exists on this response).
+
+const summary: ApiAnnouncementSummary = {
+  id: 'a-1',
+  title: 'Lift maintenance Friday',
+  status: 'published',
+  target_type: 'building',
+  published_at: '2026-05-20T08:00:00Z',
+  pinned: true,
+  comments_enabled: true,
+  acknowledgment_required: false,
+};
+
+describe('toUiAnnouncement (PR #918 published-summary mapping)', () => {
+  it('maps a summary row without a content body', () => {
+    const ui = toUiAnnouncement(summary);
+    expect(ui).toMatchObject({
+      id: 'a-1',
+      title: 'Lift maintenance Friday',
+      category: 'general',
+      createdAt: '2026-05-20T08:00:00Z', // from published_at
+      isPinned: true,
+    });
+    // The summary carries no content body; the UI shape must not expose one.
+    expect((ui as unknown as Record<string, unknown>).content).toBeUndefined();
+  });
+
+  it('falls back to a synthetic createdAt when published_at is null', () => {
+    const ui = toUiAnnouncement({ ...summary, published_at: null });
+    expect(typeof ui.createdAt).toBe('string');
+    expect(ui.createdAt.length).toBeGreaterThan(0);
+  });
+});
+
+describe('extractItems (PR #918 reads `announcements`, not `items`)', () => {
+  it('returns the announcements array from the published-list response', () => {
+    expect(extractItems({ announcements: [summary], count: 1 })).toEqual([summary]);
+  });
+
+  it('returns [] for undefined / empty responses', () => {
+    expect(extractItems(undefined)).toEqual([]);
+    expect(extractItems({})).toEqual([]);
+  });
+
+  it('ignores a stray legacy `items` key (no longer part of the contract)', () => {
+    // `items` is not in the response type; cast to confirm it is NOT read.
+    const legacy = { items: [summary] } as unknown as Parameters<typeof extractItems>[0];
+    expect(extractItems(legacy)).toEqual([]);
+  });
+});

--- a/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.tsx
@@ -39,7 +39,7 @@ export interface Announcement {
  * intentionally lightweight: no `content` body, no author, no category. The
  * full body is fetched lazily by `AnnouncementDetailScreen`.
  */
-interface ApiAnnouncementSummary {
+export interface ApiAnnouncementSummary {
   id: string;
   title: string;
   status: string;
@@ -58,7 +58,7 @@ interface ApiAnnouncementListResponse {
 }
 
 /** Coerce a published-list summary into the UI's Announcement shape. */
-function toUiAnnouncement(a: ApiAnnouncementSummary): Announcement {
+export function toUiAnnouncement(a: ApiAnnouncementSummary): Announcement {
   return {
     id: a.id,
     title: a.title,
@@ -73,7 +73,9 @@ function toUiAnnouncement(a: ApiAnnouncementSummary): Announcement {
 }
 
 /** Extract the summary list from the published-list response. */
-function extractItems(data: ApiAnnouncementListResponse | undefined): ApiAnnouncementSummary[] {
+export function extractItems(
+  data: ApiAnnouncementListResponse | undefined
+): ApiAnnouncementSummary[] {
   if (!data) return [];
   return data.announcements ?? [];
 }

--- a/frontend/apps/mobile/src/screens/documents/DocumentsScreen.test.ts
+++ b/frontend/apps/mobile/src/screens/documents/DocumentsScreen.test.ts
@@ -1,0 +1,66 @@
+import { type ApiDocument, pickDocumentType, toUiDocument } from './DocumentsScreen';
+
+// Regression for PR #918 (High #4): DocumentsScreen previously mapped the
+// legacy `name`/`file_path`/`content_type`/`uploaded_at` fields, but the
+// backend `DocumentSummary` returns `title`/`file_name`/`mime_type`/
+// `created_at`/`folder_id`. The wrong mapping left names blank, type icons
+// generic, and folder grouping broken. These tests pin the corrected
+// field mapping so the contract can't silently regress again.
+
+const baseDoc: ApiDocument = {
+  id: 'doc-1',
+  title: 'Building Rules',
+  category: 'general',
+  file_name: 'rules.pdf',
+  mime_type: 'application/pdf',
+  size_bytes: 2048,
+  folder_id: 'folder-9',
+  created_at: '2026-05-01T10:00:00Z',
+};
+
+describe('toUiDocument (PR #918 field mapping)', () => {
+  it('maps backend summary fields onto the UI Document shape', () => {
+    expect(toUiDocument(baseDoc)).toEqual({
+      id: 'doc-1',
+      name: 'Building Rules', // from `title`, NOT legacy `name`
+      type: 'pdf',
+      size: 2048, // from `size_bytes`
+      createdAt: '2026-05-01T10:00:00Z',
+      updatedAt: '2026-05-01T10:00:00Z', // summary has no separate upload ts
+      parentId: 'folder-9', // from `folder_id`
+      downloadUrl: undefined, // not present on the summary
+      children: undefined,
+    });
+  });
+
+  it('uses `title` for the name even when it differs from file_name', () => {
+    const ui = toUiDocument({ ...baseDoc, title: 'Q1 Budget', file_name: 'budget-q1.xlsx' });
+    expect(ui.name).toBe('Q1 Budget');
+  });
+
+  it('defaults parentId to null when folder_id is absent', () => {
+    const { folder_id, ...withoutFolder } = baseDoc;
+    expect(toUiDocument(withoutFolder).parentId).toBeNull();
+  });
+});
+
+describe('pickDocumentType (PR #918 uses mime_type + file_name)', () => {
+  it.each([
+    ['application/pdf', 'rules.pdf', 'pdf'],
+    ['image/png', 'photo.png', 'image'],
+    ['application/vnd.ms-excel', 'sheet.xlsx', 'spreadsheet'],
+    ['text/plain', 'notes.txt', 'document'],
+  ] as const)('classifies mime %s -> %s', (mime_type, file_name, expected) => {
+    expect(pickDocumentType({ ...baseDoc, mime_type, file_name })).toBe(expected);
+  });
+
+  it('falls back to the file_name extension when mime_type is unhelpful', () => {
+    expect(pickDocumentType({ ...baseDoc, mime_type: '', file_name: 'scan.PDF' })).toBe('pdf');
+  });
+
+  it('classifies spreadsheets by extension when mime is generic', () => {
+    expect(
+      pickDocumentType({ ...baseDoc, mime_type: 'application/octet-stream', file_name: 'data.csv' })
+    ).toBe('spreadsheet');
+  });
+});

--- a/frontend/apps/mobile/src/screens/documents/DocumentsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentsScreen.tsx
@@ -61,7 +61,7 @@ const AUDIENCE_OPTIONS: ReadonlyArray<{
  * `access_scope` or `status` — those live on the document detail/permissions
  * endpoints, not the list.
  */
-interface ApiDocument {
+export interface ApiDocument {
   id: string;
   title: string;
   category: string;
@@ -136,7 +136,7 @@ function folderNodeToDocument(node: ApiFolderTreeNode): Document {
   };
 }
 
-function pickDocumentType(d: ApiDocument): DocumentType {
+export function pickDocumentType(d: ApiDocument): DocumentType {
   const mime = (d.mime_type ?? '').toLowerCase();
   const fileName = (d.file_name ?? d.title).toLowerCase();
   if (mime.includes('pdf') || fileName.endsWith('.pdf')) return 'pdf';
@@ -146,7 +146,7 @@ function pickDocumentType(d: ApiDocument): DocumentType {
   return 'document';
 }
 
-function toUiDocument(d: ApiDocument): Document {
+export function toUiDocument(d: ApiDocument): Document {
   return {
     id: d.id,
     name: d.title,

--- a/frontend/apps/mobile/src/screens/neighbors/NeighborsScreen.test.ts
+++ b/frontend/apps/mobile/src/screens/neighbors/NeighborsScreen.test.ts
@@ -1,0 +1,47 @@
+import { type BuildingsPaginatedResponse, selectBuilding } from './NeighborsScreen';
+
+// Regression for PR #918 (High #5): `GET /api/v1/buildings` returns
+// `{ buildings, total }`, not `{ items }`. The screen used to read
+// `data.items[0]`, which was always undefined, so no building id was ever
+// resolved and the neighbours list never loaded. selectBuilding pins the
+// corrected `buildings[0]` extraction.
+
+const response: BuildingsPaginatedResponse = {
+  buildings: [
+    { id: 'b-1', name: 'Maple Court' },
+    { id: 'b-2', name: 'Oak House' },
+  ],
+  total: 2,
+};
+
+describe('selectBuilding (PR #918 reads `buildings`, not `items`)', () => {
+  it('resolves the first building id and name', () => {
+    expect(selectBuilding(response)).toEqual({
+      buildingId: 'b-1',
+      buildingName: 'Maple Court',
+    });
+  });
+
+  it('coerces a null building name to undefined', () => {
+    expect(selectBuilding({ buildings: [{ id: 'b-1', name: null }], total: 1 })).toEqual({
+      buildingId: 'b-1',
+      buildingName: undefined,
+    });
+  });
+
+  it('returns undefined ids for an empty or absent list', () => {
+    expect(selectBuilding({ buildings: [], total: 0 })).toEqual({
+      buildingId: undefined,
+      buildingName: undefined,
+    });
+    expect(selectBuilding(undefined)).toEqual({
+      buildingId: undefined,
+      buildingName: undefined,
+    });
+  });
+
+  it('does NOT read the legacy `items` key', () => {
+    const legacy = { items: [{ id: 'x' }], total: 1 } as unknown as BuildingsPaginatedResponse;
+    expect(selectBuilding(legacy).buildingId).toBeUndefined();
+  });
+});

--- a/frontend/apps/mobile/src/screens/neighbors/NeighborsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/neighbors/NeighborsScreen.tsx
@@ -43,15 +43,34 @@ interface NeighborsResponse {
   total: number;
 }
 
-interface BuildingItem {
+export interface BuildingItem {
   id: string;
   name?: string | null;
 }
 
 /** Response shape of `GET /api/v1/buildings` (`BuildingsListResponse`). */
-interface BuildingsPaginatedResponse {
+export interface BuildingsPaginatedResponse {
   buildings: BuildingItem[];
   total: number;
+}
+
+/**
+ * Resolve the first building from the `GET /api/v1/buildings` response.
+ *
+ * The backend returns `{ buildings, total }` — NOT the legacy `{ items }`
+ * shape the screen used to read, which always yielded `undefined` and broke
+ * the neighbours lookup. Returns id/name (name coerced from a nullable
+ * string to `undefined`) or both `undefined` when the list is empty/absent.
+ */
+export function selectBuilding(data: BuildingsPaginatedResponse | undefined): {
+  buildingId: string | undefined;
+  buildingName: string | undefined;
+} {
+  const first = data?.buildings?.[0];
+  return {
+    buildingId: first?.id,
+    buildingName: first?.name ?? undefined,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -72,8 +91,7 @@ export function NeighborsScreen(_props: NeighborsScreenProps) {
     '/api/v1/buildings'
   );
 
-  const buildingId = buildingsQuery.data?.buildings?.[0]?.id;
-  const buildingName = buildingsQuery.data?.buildings?.[0]?.name ?? undefined;
+  const { buildingId, buildingName } = selectBuilding(buildingsQuery.data);
 
   // Fetch neighbors once we have a building id
   const neighborsQuery = useApiQuery<NeighborsResponse>(


### PR DESCRIPTION
## Task
Mobile dev-review batch (PR #918, 5 files under frontend/apps/mobile/src) shipped without a regression test. Add a focused regression test (jest-expo) covering the behavior changed by PR #918's mobile dev-review fixes.

## Owner
pm-frontend

## What changed
PR #918 ("fix(mobile): address dev-review findings (#767)") corrected several mobile data-contract bugs but landed with no test. This PR backfills focused jest-expo regression tests for the data-mapping fixes, mirroring the existing logic-only `VotingScreen.test.ts` pattern (no rendering — avoids the known `react-test-renderer` 19.2.0 vs 19.2.6 peer mismatch that breaks render-based suites).

Tests added (18 cases, 3 suites):
- `DocumentsScreen.test.ts` — High #4: backend `DocumentSummary` maps `title`/`file_name`/`mime_type`/`created_at`/`folder_id` (not legacy `name`/`file_path`/`content_type`/`uploaded_at`). Covers `toUiDocument` + `pickDocumentType`.
- `AnnouncementsScreen.test.ts` — Critical #1 + High #3: the published-list `AnnouncementSummary` shape has no `content`/`author`/`category`; `extractItems` reads `announcements` (legacy `items` is gone). Covers `toUiAnnouncement` + `extractItems`.
- `NeighborsScreen.test.ts` — High #5: `GET /api/v1/buildings` returns `{ buildings, total }`, not `{ items }`. Covers the extracted `selectBuilding` helper.

Minimal production change to make the pure mappers testable:
- Added `export` to the existing transform functions / API-shape interfaces.
- Extracted `NeighborsScreen`'s inline first-building selection into a behavior-preserving pure `selectBuilding(data)` helper (same `buildings[0]` logic PR #918 introduced).

No production behavior changed.

## IG3 — failing-on-old-behavior check
Reverting the documents mapping to the pre-#918 buggy field (`name` instead of `title`) makes `DocumentsScreen.test.ts` fail (exit 1, 2 cases). Restored after verification.

## Tested (Band A — fast check)
- `pnpm -F @ppt/mobile exec jest <3 new files>` → exit 0 (18 passed, 3 suites)
- `pnpm -F @ppt/mobile typecheck` → exit 0
- `pnpm -F @ppt/mobile exec biome check <6 changed files>` → exit 0 (1 pre-existing `setDownloading` warning in DocumentsScreen, untouched — same one PR #918 noted)

## Built (Band B — full build)
skipped: test-only change (<50 LOC production, just `export` keywords + a behavior-preserving helper extraction; no public API/config touch)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Notes
- Repo-wide `pnpm -F @ppt/mobile test` remains environmentally broken on the `react-test-renderer` peer-dep mismatch (finding #7 in PR #918) — these logic-only `.test.ts` files do not import the renderer and run clean, exactly like `VotingScreen.test.ts`.
- Critical #2 (push-token double-encode + wiring in `App.tsx`/`usePushNotifications.ts`) is hook/effect behavior that needs a render harness; left uncovered here to avoid the broken renderer path. The three data-mapping fixes are the highest-value contained regressions.

https://claude.ai/code/session_01R3UnDQwr5dg5ATPvUwJZv8

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3UnDQwr5dg5ATPvUwJZv8)_