### PR TITLE
test-gap-hotfix-no-test-pr-874-portal-webhooks: HTTP-level fail-closed regression test

### DIFF
--- a/backend/servers/api-server/tests/portal_webhook_signature_tests.rs
+++ b/backend/servers/api-server/tests/portal_webhook_signature_tests.rs
@@ -25,6 +25,7 @@
 //! under `SQLX_OFFLINE=true` with no DB the harness skips them, and CI runs
 //! them against an ephemeral migrated database.
 
+#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/portal_webhook_signature_tests.rs
+++ b/backend/servers/api-server/tests/portal_webhook_signature_tests.rs
@@ -1,0 +1,188 @@
+//! HTTP-level regression tests for the portal-webhook fail-closed fix (#833,
+//! shipped in PR #874).
+//!
+//! PR #874 inverted the portal webhook signature contract so the receivers
+//! fail **closed**: an unverified or invalid-signature webhook is rejected with
+//! `401`, and only a correctly HMAC-SHA256-signed webhook is accepted. That PR
+//! added unit tests for the `require_portal_webhook_verification` helper in
+//! isolation, but no test exercised the contract end-to-end through the wired
+//! Axum route stack (`POST /api/v1/webhooks/portals/...`). These tests close
+//! that gap by driving the real router (`create_router` via `TestApp`) so the
+//! route mount, the security gate ordering (verification runs *before* body
+//! parsing and any DB access), and the `401` vs `200` outcomes are all pinned.
+//!
+//! Why this proves fail-closed:
+//! - The rejection (`401`) happens in the security gate before the handler
+//!   touches the listing repo, so a forged webhook never reaches the database.
+//! - A valid signature gets *past* the gate; the handler then looks up the
+//!   syndication. With no matching syndication seeded it returns `200` with
+//!   `{"success": false, "message": "Syndication not found"}` — a `200` that is
+//!   only reachable once verification has passed. That distinguishes "accepted
+//!   the signature" (200, the fix working) from "rejected the signature"
+//!   (401, the pre-fix forged path).
+//!
+//! These tests need a `PgPool` because `TestApp` builds the full `AppState`;
+//! under `SQLX_OFFLINE=true` with no DB the harness skips them, and CI runs
+//! them against an ephemeral migrated database.
+
+mod common;
+
+use axum::http::StatusCode;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use common::TestApp;
+use hmac::{Hmac, KeyInit, Mac};
+use sha2::Sha256;
+use sqlx::PgPool;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// The portal the `reality-portal` routes verify against. The route handler
+/// passes the canonical `"reality_portal"` (underscore) to the verifier, so the
+/// env var the verifier reads is `REALITY_PORTAL_WEBHOOK_SECRET`.
+const PORTAL_SECRET_ENV: &str = "REALITY_PORTAL_WEBHOOK_SECRET";
+const SIG_HEADER: &str = "X-Webhook-Signature";
+const VIEWS_URI: &str = "/api/v1/webhooks/portals/reality-portal/views";
+
+/// `std::env::{set_var, remove_var}` are not safe to interleave with `getenv`
+/// on glibc, and integration tests in this binary may run concurrently. Every
+/// test that mutates the webhook-secret env serializes behind this mutex.
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Compute the `sha256=<base64>` header value the verifier expects for `body`.
+fn sign(secret: &str, body: &[u8]) -> String {
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).expect("hmac key");
+    mac.update(body);
+    format!("sha256={}", BASE64.encode(mac.finalize().into_bytes()))
+}
+
+/// Fail-closed: with NO secret configured the route rejects any webhook (even a
+/// well-formed body) with `401` — never silently accepts an unverified payload.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn unconfigured_secret_rejects_webhook(pool: PgPool) {
+    let _guard = ENV_LOCK.lock().unwrap();
+    std::env::remove_var(PORTAL_SECRET_ENV);
+
+    let app = TestApp::new(pool).await;
+
+    let body = serde_json::json!({ "external_id": "ext-1", "views_count": 7 });
+    let req = app
+        .post(VIEWS_URI)
+        .header(SIG_HEADER, "sha256=AAAA")
+        .json(body)
+        .build();
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::UNAUTHORIZED,
+        "no secret configured must fail closed with 401, not accept the webhook. Body: {}",
+        resp.text()
+    );
+}
+
+/// Fail-closed: with a secret configured but an INVALID signature, the route
+/// rejects with `401` before parsing the body or touching the database.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn invalid_signature_is_rejected(pool: PgPool) {
+    let _guard = ENV_LOCK.lock().unwrap();
+    std::env::set_var(PORTAL_SECRET_ENV, "super-secret-key");
+
+    let app = TestApp::new(pool).await;
+
+    let body = serde_json::json!({ "external_id": "ext-1", "views_count": 7 });
+    let req = app
+        .post(VIEWS_URI)
+        .header(SIG_HEADER, "sha256=Zm9yZ2Vk") // "forged", not a valid HMAC
+        .json(body)
+        .build();
+    let resp = app.execute(req).await;
+
+    std::env::remove_var(PORTAL_SECRET_ENV);
+
+    assert_eq!(
+        resp.status,
+        StatusCode::UNAUTHORIZED,
+        "an invalid signature must be rejected with 401. Body: {}",
+        resp.text()
+    );
+}
+
+/// Fail-closed: with a secret configured but the signature header MISSING
+/// entirely, the route rejects with `401`.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn missing_signature_header_is_rejected(pool: PgPool) {
+    let _guard = ENV_LOCK.lock().unwrap();
+    std::env::set_var(PORTAL_SECRET_ENV, "super-secret-key");
+
+    let app = TestApp::new(pool).await;
+
+    let body = serde_json::json!({ "external_id": "ext-1", "views_count": 7 });
+    let req = app.post(VIEWS_URI).json(body).build(); // no signature header
+    let resp = app.execute(req).await;
+
+    std::env::remove_var(PORTAL_SECRET_ENV);
+
+    assert_eq!(
+        resp.status,
+        StatusCode::UNAUTHORIZED,
+        "a missing signature header must be rejected with 401. Body: {}",
+        resp.text()
+    );
+}
+
+/// Accept path: a correctly HMAC-SHA256-signed webhook gets PAST the security
+/// gate. The body must be signed exactly as serialized on the wire, so we build
+/// the JSON string once, sign those bytes, and send the same bytes as the body.
+///
+/// With no matching syndication seeded, the handler returns `200` with
+/// `success: false` — a `200` that is only reachable once verification passed.
+/// The assertion that matters for this regression is "not 401": the valid
+/// signature was accepted rather than rejected as forged.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn valid_signature_is_accepted(pool: PgPool) {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let secret = "super-secret-key";
+    std::env::set_var(PORTAL_SECRET_ENV, secret);
+
+    let app = TestApp::new(pool).await;
+
+    // Serialize the body once and sign those exact bytes — the verifier HMACs
+    // the raw request body, so signature and payload must be byte-identical.
+    let body = serde_json::to_string(&serde_json::json!({
+        "external_id": "ext-unknown",
+        "views_count": 3,
+    }))
+    .unwrap();
+    let signature = sign(secret, body.as_bytes());
+
+    let req = axum::http::Request::builder()
+        .method(axum::http::Method::POST)
+        .uri(VIEWS_URI)
+        .header(axum::http::header::CONTENT_TYPE, "application/json")
+        .header(SIG_HEADER, signature)
+        .body(axum::body::Body::from(body))
+        .expect("build signed request");
+    let resp = app.execute(req).await;
+
+    std::env::remove_var(PORTAL_SECRET_ENV);
+
+    assert_ne!(
+        resp.status,
+        StatusCode::UNAUTHORIZED,
+        "a correctly-signed webhook must be accepted (got past the signature \
+         gate), not rejected as forged. Body: {}",
+        resp.text()
+    );
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "an accepted (but unmatched) webhook returns 200 with success=false. Body: {}",
+        resp.text()
+    );
+    let json = resp.json_value();
+    assert_eq!(
+        json.get("success").and_then(|v| v.as_bool()),
+        Some(false),
+        "unmatched syndication is acknowledged with success=false: {json}"
+    );
+}


### PR DESCRIPTION
## Task
Portal webhook fail-closed fix (PR #874) shipped without a regression test for unverified-signature rejection. Add a regression test that proves an unverified/invalid-signature portal webhook is rejected (fail-closed) and a valid-signature one is accepted.

## Owner
pm-backend

## Finding (important)
PR #874 (the #833 fail-closed fix) **did** ship with unit tests after all: `routes/portal_webhooks.rs` already contains a `#[cfg(test)] mod tests` with `rejects_when_no_secret_configured`, `rejects_invalid_signature_when_secret_set`, `rejects_missing_signature_header_when_secret_set`, and `accepts_valid_signature_when_secret_set`. Those run green on `dev` (verified locally, 4 passed).

Those tests exercise the `require_portal_webhook_verification` helper **in isolation**. What was genuinely missing was an **HTTP-level** test proving the contract holds through the wired Axum route stack — i.e. that `POST /api/v1/webhooks/portals/...` actually rejects forged webhooks at the route (before any DB access) and accepts correctly-signed ones. This PR adds that complementary coverage; it is additive, not a duplicate of the in-module unit tests.

## What changed
New file `backend/servers/api-server/tests/portal_webhook_signature_tests.rs` — drives the real router via the `common::TestApp` harness (`create_router` + `oneshot`) with four `#[sqlx::test]` cases against the mounted `reality-portal/views` route:
- unconfigured secret -> `401` (fail closed; never accept an unverified webhook)
- invalid signature -> `401`
- missing signature header -> `401`
- valid HMAC-SHA256 signature -> accepted past the gate (`200` with `success=false` on unmatched syndication — a 200 only reachable once verification passed)

## Tested (Band A — fast check)
- `SQLX_OFFLINE=true cargo check -p api-server` -> exit 0
- `SQLX_OFFLINE=true cargo test -p api-server --lib portal_webhooks` -> exit 0 (4 existing unit tests pass — baseline)
- `SQLX_OFFLINE=true cargo test -p api-server --test portal_webhook_signature_tests --no-run` -> exit 0 (new test compiles clean; only pre-existing dead-code warnings in shared `common/mod.rs`)

The four new cases use `#[sqlx::test(migrator = "db::MIGRATOR")]`, so they execute against an ephemeral migrated Postgres in CI. No local DB is available here, so per the skill's verify bands they were compiled (`--no-run`) but not run locally. The rejection-path assertions (401) do not depend on seeded DB rows.

## Built (Band B — full build)
skipped: test-only change, no production code, no public API/config touch.

## CI parity (Band C — hot-path only)
skipped: no production-code change. The verification logic itself is unchanged; this PR only adds a test. CI will run the new `#[sqlx::test]` cases against Postgres.

## Remote-tested
skipped (no ppt-bridge MCP in session).

## Notes
- `scope-check.sh --owner pm-backend` -> exit 0 (no scope drift).
- `reuse-grep.sh --specialist rust-backend` -> no warnings.
- goal-check IG1/IG2/IG4-6 are N/A for this dispatcher action-list task (no `.research/plans/<slug>.md` plan file; branch is `auto-impl/*` per dispatcher mandate). IG3 is a `test:`-only commit by design — this PR is itself the regression test for an already-merged fix, so there is no paired `fix:` commit.

https://claude.ai/code/session_01R3UnDQwr5dg5ATPvUwJZv8

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3UnDQwr5dg5ATPvUwJZv8)_