### PR TITLE
feat(organizations): async full org data export → S3 + emailed link (#979)

### DIFF
--- a/backend/crates/integrations/src/storage.rs
+++ b/backend/crates/integrations/src/storage.rs
@@ -626,6 +626,51 @@ impl StorageService {
         Ok(key.to_string())
     }
 
+    /// Upload a **system-generated** artifact (e.g. an organization data export
+    /// or tenant backup tarball) to S3.
+    ///
+    /// Unlike [`upload`](Self::upload), this does NOT enforce the user-content
+    /// MIME allowlist — the bytes are produced by the server itself, not
+    /// uploaded by an end user, so the allowlist (which exists to constrain
+    /// user uploads) does not apply. The size cap is still enforced. Use this
+    /// ONLY for trusted, server-produced content (issue #979).
+    pub async fn upload_system_artifact(
+        &self,
+        key: &str,
+        content: Vec<u8>,
+        content_type: &str,
+    ) -> Result<String, StorageError> {
+        let client = self.get_s3_client()?;
+        let size = content.len();
+
+        if size as i64 > MAX_UPLOAD_SIZE_BYTES {
+            return Err(StorageError::FileTooLarge(
+                size as i64,
+                MAX_UPLOAD_SIZE_BYTES,
+            ));
+        }
+
+        let body = ByteStream::from(content);
+        client
+            .put_object()
+            .bucket(&self.config.bucket)
+            .key(key)
+            .body(body)
+            .content_type(content_type)
+            .send()
+            .await
+            .map_err(|e| StorageError::UploadError(format!("S3 PutObject failed: {}", e)))?;
+
+        tracing::info!(
+            key = %key,
+            content_type = %content_type,
+            size_bytes = %size,
+            "Uploaded system artifact to S3"
+        );
+
+        Ok(key.to_string())
+    }
+
     /// Download a file from S3 (Story 103.1).
     ///
     /// # Arguments

--- a/backend/servers/api-server/src/routes/organizations/settings.rs
+++ b/backend/servers/api-server/src/routes/organizations/settings.rs
@@ -11,6 +11,7 @@ use axum::{
 use common::errors::ErrorResponse;
 use db::models::UpdateOrganization;
 use serde::{Deserialize, Serialize};
+use tenant_ops::{export_tenant, TenantDataManifest};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -654,9 +655,16 @@ pub struct ExportRole {
 /// Organization export query parameters.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct ExportQuery {
-    /// Export format (json or csv)
+    /// Export format (json or csv) for the synchronous response.
     #[serde(default = "default_format")]
     pub format: String,
+    /// Issue #979: when true, runs a **full** multi-table export as a
+    /// background job (reusing the tenant-ops exporter), uploads the resulting
+    /// `.tar.gz` to S3, and emails the requester a 7-day download link.
+    /// Returns `202 Accepted` immediately. When false/absent, the legacy
+    /// synchronous members+roles JSON/CSV body is returned unchanged.
+    #[serde(default)]
+    pub background: bool,
 }
 
 fn default_format() -> String {
@@ -784,6 +792,133 @@ pub async fn export_organization_data(
                 "You do not have permission to export organization data",
             )),
         ));
+    }
+
+    // Issue #979: full async export. Spawn a detached background job that
+    // produces a complete per-table `.tar.gz` (via the tenant-ops exporter),
+    // uploads it to S3, and emails the requester a 7-day presigned link. We
+    // return 202 immediately rather than blocking the request. The permission
+    // check above has already authorised this user to export this org, so the
+    // job runs against the service-role pool (RLS-bypassing) for the same org.
+    if query.background {
+        // Release the RLS connection before the long-running work.
+        rls.release().await;
+
+        let pool = state.db.clone();
+        let storage = state.storage_service.clone();
+        let email = state.email_service.clone();
+        let user_repo = state.user_repo.clone();
+        let org_id = id;
+
+        tokio::spawn(async move {
+            let to_email = match user_repo.find_by_id(user_id).await {
+                Ok(Some(u)) => u.email,
+                _ => {
+                    tracing::error!(user_id = %user_id, "[#979] org export: requester not found; aborting");
+                    return;
+                }
+            };
+            let Some(storage) = storage else {
+                tracing::error!("[#979] org export: storage not configured; cannot deliver export");
+                return;
+            };
+
+            // Load the tenant-data manifest (env-overridable, mirrors the
+            // admin tenant-lifecycle export path).
+            let manifest_path = std::env::var("PPT_TENANT_MANIFEST_PATH")
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|_| TenantDataManifest::default_path());
+            let manifest = match TenantDataManifest::load(&manifest_path) {
+                Ok(m) => m,
+                Err(e) => {
+                    tracing::error!(error = %e, path = ?manifest_path, "[#979] org export: manifest load failed");
+                    return;
+                }
+            };
+
+            let out_dir = std::env::temp_dir().join(format!("ppt-org-export-{}", Uuid::new_v4()));
+            let export = match export_tenant(&pool, org_id, &manifest, &out_dir).await {
+                Ok(e) => e,
+                Err(e) => {
+                    tracing::error!(error = %e, org = %org_id, "[#979] org export: export_tenant failed");
+                    let _ = std::fs::remove_dir_all(&out_dir);
+                    return;
+                }
+            };
+
+            let bytes = match std::fs::read(&export.tarball_path) {
+                Ok(b) => b,
+                Err(e) => {
+                    tracing::error!(error = %e, "[#979] org export: reading tarball failed");
+                    let _ = std::fs::remove_dir_all(&out_dir);
+                    return;
+                }
+            };
+
+            let key = format!("exports/org-{}/{}-export.tar.gz", org_id, Uuid::new_v4());
+            let upload = storage
+                .upload_system_artifact(&key, bytes, "application/gzip")
+                .await;
+            let _ = std::fs::remove_dir_all(&out_dir);
+            if let Err(e) = upload {
+                tracing::error!(error = %e, "[#979] org export: S3 upload failed");
+                return;
+            }
+
+            // 7-day presigned download link.
+            let presigned = match storage
+                .generate_download_url(
+                    &key,
+                    "organization-export.tar.gz",
+                    "application/gzip",
+                    Some(7 * 24 * 3600),
+                )
+                .await
+            {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::error!(error = %e, "[#979] org export: presign failed");
+                    return;
+                }
+            };
+
+            let expires = presigned.expires_at.to_rfc3339();
+            let html = format!(
+                "<p>Your organization data export is ready.</p>\
+                 <p><a href=\"{url}\">Download the export</a> — link valid until {expires}.</p>",
+                url = presigned.url,
+            );
+            let text = format!(
+                "Your organization data export is ready.\nDownload (valid until {expires}): {url}",
+                url = presigned.url,
+            );
+            match email
+                .send_html_email(
+                    &to_email,
+                    "Your organization data export is ready",
+                    &html,
+                    &text,
+                )
+                .await
+            {
+                Ok(()) => tracing::info!(
+                    org = %org_id,
+                    rows = export.rows_exported,
+                    tables = export.tables_exported,
+                    "[#979] org export delivered via emailed link"
+                ),
+                Err(e) => tracing::error!(error = %e, "[#979] org export: email send failed"),
+            }
+        });
+
+        return Ok((
+            StatusCode::ACCEPTED,
+            Json(serde_json::json!({
+                "status": "accepted",
+                "message": "Export started. A download link will be emailed when it is ready."
+            })),
+        )
+            .into_response());
     }
 
     // Get organization using RLS


### PR DESCRIPTION
## Summary
Addresses #979 (Epic 2A / Story 2A.7). The org self-service export endpoint returned only a **synchronous members+roles JSON** (ignoring `format=csv` for anything richer); the AC requires a **background job that exports all org data and emails a download link**.

## Change (additive — no contract break)
`GET /api/v1/organizations/{id}/export?background=true`:
1. Runs the existing permission check (`organization:export`, or `organization:read` + `users:read`).
2. Releases the RLS connection and **spawns a detached job** that:
   - runs the **tenant-ops exporter** → a full per-table `.tar.gz` (the same exporter used by the admin tenant-lifecycle route),
   - uploads it to S3 via a new `StorageService::upload_system_artifact`,
   - generates a **7-day presigned** download URL,
   - **emails** the requester the link.
3. Returns **`202 Accepted`** immediately.

When `background` is absent/false the **legacy synchronous JSON/CSV response is unchanged**, so existing callers keep working.

## Notes / decisions
- **`upload_system_artifact`**: the public `upload` enforces a user-content MIME allowlist (no gzip). System-generated exports aren't user uploads, so this new method skips the allowlist but keeps the size cap — narrowly documented for trusted server output.
- Manifest is loaded via `PPT_TENANT_MANIFEST_PATH` (falls back to the repo default), mirroring `admin_tenant_lifecycle`'s proven pattern — so it works in the deployed image the same way tenant export already does.
- No background-job queue consumer exists in this codebase (`claim_job` is only used in tests), so a detached `tokio::spawn` is used — exactly the "enqueue a tokio background job" the issue proposed.

## Follow-ups (called out, out of scope here)
- A job-status polling endpoint (the emailed link is the AC's specified delivery mechanism).
- Multipart upload for exports exceeding the 50 MB single-`put_object` cap.

## Verification
- `cargo fmt -p api-server -p integrations` ✅
- `cargo clippy -p api-server -p integrations -- -D warnings` ✅ (exit 0, clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)