### PR TITLE
test-gap-hotfix-no-test-pr-923-branch-protection-rebase: regression test for branch-protection round-trip

### DIFF
--- a/.github/workflows/branch-protection-setup.yml
+++ b/.github/workflows/branch-protection-setup.yml
@@ -41,11 +41,30 @@ on:
         required: false
         type: boolean
         default: false
+  # Self-test fixture: any change to this workflow or its extracted payload
+  # builder exercises the round-trip payload logic against fixtures that
+  # encode the #771/#923 "never weaken branch protection" contract, so a
+  # future refactor that re-introduces a hardcoded/weakening payload is
+  # caught in CI instead of silently downgrading `dev` protection on the
+  # next workflow_dispatch run.
+  push:
+    paths:
+      - '.github/workflows/branch-protection-setup.yml'
+      - '.github/workflows/scripts/branch-protection-payload.py'
+  pull_request:
+    paths:
+      - '.github/workflows/branch-protection-setup.yml'
+      - '.github/workflows/scripts/branch-protection-payload.py'
 
 jobs:
   apply-branch-protection:
     name: Register required status check on dev
     runs-on: ubuntu-latest
+    # Only run the live apply path on a manual dispatch. On the push /
+    # pull_request self-test trigger there is no GH_ADMIN_TOKEN and no
+    # dry_run input, and we must never mutate real branch protection from
+    # a PR — the `self-test` job below handles those events.
+    if: github.event_name == 'workflow_dispatch'
 
     permissions:
       # contents:read is enough to call the REST API with GH_ADMIN_TOKEN.
@@ -172,90 +191,17 @@ jobs:
           #     linear-history, conversation-resolution, etc. exactly as-is.
           # If no protection existed yet, fall back to a safe baseline (strict=true,
           # 1 approval, enforce_admins, no push restrictions).
+          #
+          # The builder lives in scripts/branch-protection-payload.py so it can be
+          # regression-tested (see the `self-test` job in this workflow). It reads
+          # the same PROTECTION_JSON / PROTECTION_EXISTS / MERGED env vars set
+          # above. Keep this a single source of truth — do NOT re-inline the
+          # builder here, or the #771/#923 "never weaken protection" guarantee
+          # stops being tested.
           PAYLOAD=$(PROTECTION_JSON="$PROTECTION_JSON" \
             PROTECTION_EXISTS="$PROTECTION_EXISTS" \
-            MERGED="$MERGED" python3 -c "
-          import json, os
-
-          checks = [c.strip() for c in os.environ['MERGED'].strip().splitlines() if c.strip()]
-          exists = os.environ.get('PROTECTION_EXISTS') == 'true'
-
-          cur = {}
-          if exists:
-              raw = os.environ.get('PROTECTION_JSON', '').strip()
-              try:
-                  cur = json.loads(raw) if raw else {}
-              except json.JSONDecodeError:
-                  cur = {}
-
-          # --- required_status_checks: keep current strict (force to true), set checks ---
-          cur_rsc = cur.get('required_status_checks') or {}
-          # Never weaken strict: always require branches to be up to date before
-          # merge (strict=true). If the rule already had strict=true this is a
-          # no-op; if it was false we strengthen it. We never set strict=false.
-          rsc = {
-              'strict': True,
-              'checks': [{'context': c, 'app_id': -1} for c in checks],
-          }
-
-          # --- required_pull_request_reviews: preserve existing, else safe baseline ---
-          cur_prr = cur.get('required_pull_request_reviews')
-          if cur_prr:
-              prr = {
-                  'dismiss_stale_reviews': bool(cur_prr.get('dismiss_stale_reviews', False)),
-                  'require_code_owner_reviews': bool(cur_prr.get('require_code_owner_reviews', False)),
-                  'required_approving_review_count': int(cur_prr.get('required_approving_review_count', 1)),
-              }
-              # Preserve scoped review dismissal / bypass allowances if present.
-              if 'require_last_push_approval' in cur_prr:
-                  prr['require_last_push_approval'] = bool(cur_prr['require_last_push_approval'])
-          else:
-              prr = {
-                  'dismiss_stale_reviews': False,
-                  'require_code_owner_reviews': False,
-                  'required_approving_review_count': 1,
-              }
-
-          # --- enforce_admins: preserve, default to true ---
-          cur_ea = cur.get('enforce_admins')
-          if isinstance(cur_ea, dict):
-              enforce_admins = bool(cur_ea.get('enabled', True))
-          elif isinstance(cur_ea, bool):
-              enforce_admins = cur_ea
-          else:
-              enforce_admins = True
-
-          # --- restrictions: PRESERVE existing push restrictions, never null them ---
-          cur_restr = cur.get('restrictions')
-          if cur_restr:
-              restrictions = {
-                  'users': [u['login'] for u in cur_restr.get('users', [])],
-                  'teams': [t['slug'] for t in cur_restr.get('teams', [])],
-                  'apps': [a['slug'] for a in cur_restr.get('apps', [])],
-              }
-          else:
-              restrictions = None
-
-          payload = {
-              'required_status_checks': rsc,
-              'enforce_admins': enforce_admins,
-              'required_pull_request_reviews': prr,
-              'restrictions': restrictions,
-          }
-
-          # Preserve other boolean toggles only when the current rule has them on,
-          # so we never accidentally relax them.
-          for key in ('required_linear_history', 'allow_force_pushes',
-                      'allow_deletions', 'required_conversation_resolution',
-                      'block_creations', 'lock_branch'):
-              val = cur.get(key)
-              if isinstance(val, dict):
-                  val = val.get('enabled')
-              if val is not None:
-                  payload[key] = bool(val)
-
-          print(json.dumps(payload))
-          ")
+            MERGED="$MERGED" \
+            python3 .github/workflows/scripts/branch-protection-payload.py)
 
           echo "Payload to be sent (round-tripped from current protection):"
           echo "$PAYLOAD" | python3 -m json.tool --no-ensure-ascii 2>/dev/null || echo "$PAYLOAD"
@@ -347,3 +293,28 @@ jobs:
           echo "| Status | ${{ job.status }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Run \`gh api repos/\$REPO/branches/dev/protection\` to verify." >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------
+  # Self-test fixture for the round-trip payload builder (regression test
+  # for #771/#923 — the "never weaken branch protection" fix shipped
+  # without one).
+  #
+  # Runs branch-protection-payload.py against hand-written fixtures and
+  # asserts that stronger existing settings (extra approvals, code-owner
+  # reviews, push restrictions, linear history, conversation resolution,
+  # strict mode) are PRESERVED and only the new required check is appended.
+  # If a future edit re-inlines a hardcoded/weakening payload, this job
+  # fails BEFORE the live workflow downgrades real `dev` protection.
+  # ---------------------------------------------------------------------
+  self-test:
+    name: Self-test — branch-protection payload builder
+    runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run fixture-based payload-builder tests
+        run: |
+          set -euo pipefail
+          python3 .github/workflows/scripts/branch-protection-payload.py --self-test

--- a/.github/workflows/scripts/branch-protection-payload.py
+++ b/.github/workflows/scripts/branch-protection-payload.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Build the branch-protection PUT payload for branch-protection-setup.yml.
+
+WHY THIS EXISTS (single source of truth + regression test)
+----------------------------------------------------------
+PR #923 ("don't weaken branch protection; rebase lockfiles from base",
+closes #771) replaced a HARDCODED branch-protection payload with a
+round-trip builder: it starts from the branch's CURRENT protection and
+only *adds/strengthens*, so running the setup workflow can never silently
+revert a stronger rule (extra approvals, code-owner reviews, push
+restrictions, linear history, conversation resolution, strict mode).
+
+That fix shipped with no test. This module extracts the payload-builder
+logic out of the inline `python3 -c "..."` heredoc in
+`.github/workflows/branch-protection-setup.yml` so that:
+
+  1. the workflow imports ONE implementation (no copy drift), and
+  2. `--self-test` exercises that implementation against fixtures that
+     encode the exact #771/#923 regression — a future edit that
+     re-introduces a hardcoded/weakening payload fails CI here instead
+     of silently downgrading `dev` protection on the next dispatch run.
+
+CONTRACT (mirrors the workflow's documented intent)
+---------------------------------------------------
+Given the CURRENT protection object (as returned by
+`GET /repos/{o}/{r}/branches/{b}/protection`) and the merged list of
+required status-check contexts, produce the body for
+`PUT .../branches/{b}/protection` such that:
+
+  * required_status_checks.strict is ALWAYS true (never weaken; strengthen
+    false -> true), and .checks is exactly the merged context list.
+  * required_pull_request_reviews is PRESERVED when present (approval
+    count, dismiss-stale, code-owner, require_last_push_approval), else a
+    safe baseline (1 approval).
+  * enforce_admins is preserved (dict {enabled} or bool), default true.
+  * restrictions (push restrictions) are PRESERVED, never nulled, when
+    present; null only when the current rule had none.
+  * the boolean toggles required_linear_history, allow_force_pushes,
+    allow_deletions, required_conversation_resolution, block_creations,
+    lock_branch are carried over only when present on the current rule.
+
+USAGE
+-----
+  # Build mode (used by the workflow):
+  #   reads current protection JSON from $PROTECTION_JSON (empty/absent =>
+  #   no existing protection), merged contexts (newline-delimited) from
+  #   $MERGED, and $PROTECTION_EXISTS in {"true","false"}; prints the
+  #   payload JSON to stdout.
+  PROTECTION_EXISTS=true PROTECTION_JSON='{...}' MERGED=$'a\nb' \
+      python3 branch-protection-payload.py
+
+  # Self-test mode (used by CI):
+  python3 branch-protection-payload.py --self-test
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def build_payload(current: dict | None, checks: list[str]) -> dict:
+    """Round-trip the current protection into a PUT payload.
+
+    `current` is the parsed current protection object (or None / {} when no
+    protection exists yet). `checks` is the merged list of required
+    status-check contexts. Returns the PUT body as a dict.
+    """
+    cur = current or {}
+
+    # --- required_status_checks: force strict=true, set the merged checks ---
+    # Never weaken strict: always require branches to be up to date before
+    # merge. If the rule already had strict=true this is a no-op; if it was
+    # false we strengthen it. We never set strict=false.
+    rsc = {
+        "strict": True,
+        "checks": [{"context": c, "app_id": -1} for c in checks],
+    }
+
+    # --- required_pull_request_reviews: preserve existing, else safe baseline ---
+    cur_prr = cur.get("required_pull_request_reviews")
+    if cur_prr:
+        prr = {
+            "dismiss_stale_reviews": bool(cur_prr.get("dismiss_stale_reviews", False)),
+            "require_code_owner_reviews": bool(
+                cur_prr.get("require_code_owner_reviews", False)
+            ),
+            "required_approving_review_count": int(
+                cur_prr.get("required_approving_review_count", 1)
+            ),
+        }
+        # Preserve scoped review dismissal / bypass allowances if present.
+        if "require_last_push_approval" in cur_prr:
+            prr["require_last_push_approval"] = bool(
+                cur_prr["require_last_push_approval"]
+            )
+    else:
+        prr = {
+            "dismiss_stale_reviews": False,
+            "require_code_owner_reviews": False,
+            "required_approving_review_count": 1,
+        }
+
+    # --- enforce_admins: preserve (dict {enabled} or bool), default true ---
+    cur_ea = cur.get("enforce_admins")
+    if isinstance(cur_ea, dict):
+        enforce_admins = bool(cur_ea.get("enabled", True))
+    elif isinstance(cur_ea, bool):
+        enforce_admins = cur_ea
+    else:
+        enforce_admins = True
+
+    # --- restrictions: PRESERVE existing push restrictions, never null them ---
+    cur_restr = cur.get("restrictions")
+    if cur_restr:
+        restrictions = {
+            "users": [u["login"] for u in cur_restr.get("users", [])],
+            "teams": [t["slug"] for t in cur_restr.get("teams", [])],
+            "apps": [a["slug"] for a in cur_restr.get("apps", [])],
+        }
+    else:
+        restrictions = None
+
+    payload = {
+        "required_status_checks": rsc,
+        "enforce_admins": enforce_admins,
+        "required_pull_request_reviews": prr,
+        "restrictions": restrictions,
+    }
+
+    # Preserve other boolean toggles only when the current rule has them on,
+    # so we never accidentally relax them.
+    for key in (
+        "required_linear_history",
+        "allow_force_pushes",
+        "allow_deletions",
+        "required_conversation_resolution",
+        "block_creations",
+        "lock_branch",
+    ):
+        val = cur.get(key)
+        if isinstance(val, dict):
+            val = val.get("enabled")
+        if val is not None:
+            payload[key] = bool(val)
+
+    return payload
+
+
+def _build_from_env() -> dict:
+    """Build a payload from the same env vars the workflow sets."""
+    checks = [
+        c.strip() for c in os.environ.get("MERGED", "").strip().splitlines() if c.strip()
+    ]
+    exists = os.environ.get("PROTECTION_EXISTS") == "true"
+    cur: dict = {}
+    if exists:
+        raw = os.environ.get("PROTECTION_JSON", "").strip()
+        try:
+            cur = json.loads(raw) if raw else {}
+        except json.JSONDecodeError:
+            cur = {}
+    return build_payload(cur, checks)
+
+
+# ---------------------------------------------------------------------------
+# Self-test fixtures
+#
+# Each fixture pins one slice of the #771/#923 contract. `_check` raises
+# AssertionError with an actionable message on mismatch.
+# ---------------------------------------------------------------------------
+
+NEW_CHECK = "security-gate-conclusion"
+
+
+def _check(name: str, cond: bool, detail: str) -> None:
+    status = "ok  " if cond else "FAIL"
+    print(f"{status} {name}: {detail}")
+    if not cond:
+        raise AssertionError(f"{name}: {detail}")
+
+
+def _self_test() -> int:
+    # --- Fixture 1: the #771 regression — a STRONGER existing rule must be
+    # fully preserved, with only the new check appended and strict forced on.
+    strong = {
+        "required_status_checks": {
+            "strict": True,
+            "checks": [{"context": "backend", "app_id": -1}],
+        },
+        "required_pull_request_reviews": {
+            "dismiss_stale_reviews": True,
+            "require_code_owner_reviews": True,
+            "required_approving_review_count": 2,
+            "require_last_push_approval": True,
+        },
+        "enforce_admins": {"enabled": True},
+        "restrictions": {
+            "users": [{"login": "alice"}],
+            "teams": [{"slug": "maintainers"}],
+            "apps": [],
+        },
+        "required_linear_history": {"enabled": True},
+        "required_conversation_resolution": {"enabled": True},
+        "allow_force_pushes": {"enabled": False},
+    }
+    p = build_payload(strong, ["backend", NEW_CHECK])
+    prr = p["required_pull_request_reviews"]
+    _check(
+        "strong/approvals-preserved",
+        prr["required_approving_review_count"] == 2,
+        "2 required approvals carried over (regression: was hardcoded to 1)",
+    )
+    _check(
+        "strong/code-owner-preserved",
+        prr["require_code_owner_reviews"] is True,
+        "code-owner reviews kept on",
+    )
+    _check(
+        "strong/last-push-approval-preserved",
+        prr.get("require_last_push_approval") is True,
+        "require_last_push_approval carried over",
+    )
+    _check(
+        "strong/restrictions-preserved",
+        p["restrictions"] == {"users": ["alice"], "teams": ["maintainers"], "apps": []},
+        "push restrictions flattened to login/slug and NOT nulled",
+    )
+    _check(
+        "strong/linear-history-preserved",
+        p.get("required_linear_history") is True,
+        "linear history toggle carried over",
+    )
+    _check(
+        "strong/conversation-resolution-preserved",
+        p.get("required_conversation_resolution") is True,
+        "conversation resolution carried over",
+    )
+    _check(
+        "strong/enforce-admins-preserved",
+        p["enforce_admins"] is True,
+        "enforce_admins (dict form) carried over",
+    )
+    contexts = [c["context"] for c in p["required_status_checks"]["checks"]]
+    _check(
+        "strong/new-check-appended",
+        NEW_CHECK in contexts and "backend" in contexts,
+        f"existing 'backend' kept and '{NEW_CHECK}' appended -> {contexts}",
+    )
+
+    # --- Fixture 2: strict MUST be strengthened, never weakened. A rule that
+    # currently has strict=false comes back strict=true.
+    weak_strict = {
+        "required_status_checks": {"strict": False, "checks": []},
+    }
+    p2 = build_payload(weak_strict, [NEW_CHECK])
+    _check(
+        "strict/strengthened",
+        p2["required_status_checks"]["strict"] is True,
+        "strict=false strengthened to strict=true (never weakened)",
+    )
+
+    # --- Fixture 3: no existing protection -> safe baseline. ---
+    p3 = build_payload({}, [NEW_CHECK])
+    _check(
+        "baseline/strict-true",
+        p3["required_status_checks"]["strict"] is True,
+        "baseline strict=true",
+    )
+    _check(
+        "baseline/one-approval",
+        p3["required_pull_request_reviews"]["required_approving_review_count"] == 1,
+        "baseline requires 1 approval",
+    )
+    _check(
+        "baseline/enforce-admins",
+        p3["enforce_admins"] is True,
+        "baseline enforce_admins=true",
+    )
+    _check(
+        "baseline/no-restrictions",
+        p3["restrictions"] is None,
+        "baseline restrictions=null (no push restrictions to invent)",
+    )
+    _check(
+        "baseline/no-extra-toggles",
+        "required_linear_history" not in p3 and "lock_branch" not in p3,
+        "baseline does not fabricate optional toggles",
+    )
+
+    # --- Fixture 4: enforce_admins given as a bare bool is honoured. ---
+    p4 = build_payload({"enforce_admins": False}, [NEW_CHECK])
+    _check(
+        "enforce-admins/bool-false",
+        p4["enforce_admins"] is False,
+        "enforce_admins given as bool False is preserved (not forced true)",
+    )
+
+    # --- Fixture 5: env round-trip path (what the workflow actually calls)
+    # must equal the direct build for the same inputs. ---
+    os.environ["PROTECTION_EXISTS"] = "true"
+    os.environ["PROTECTION_JSON"] = json.dumps(strong)
+    os.environ["MERGED"] = "backend\n" + NEW_CHECK
+    env_payload = _build_from_env()
+    _check(
+        "env/round-trip-matches",
+        env_payload == build_payload(strong, ["backend", NEW_CHECK]),
+        "env-driven build equals direct build (workflow code path is exercised)",
+    )
+
+    # --- Fixture 6: malformed PROTECTION_JSON with exists=true degrades to
+    # baseline rather than crashing the workflow. ---
+    os.environ["PROTECTION_EXISTS"] = "true"
+    os.environ["PROTECTION_JSON"] = "{not valid json"
+    os.environ["MERGED"] = NEW_CHECK
+    bad = _build_from_env()
+    _check(
+        "env/malformed-json-baseline",
+        bad["required_status_checks"]["strict"] is True
+        and bad["restrictions"] is None,
+        "unparseable current protection falls back to safe baseline",
+    )
+
+    print("\nALL FIXTURES PASSED")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if "--self-test" in argv[1:]:
+        return _self_test()
+    print(json.dumps(_build_from_env()))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Task
Add missing integration/regression test covering the CI branch-protection + auto-rebase workflow change shipped in PR #923 (closes #771) without a test.

## Owner
pm-devops

## What PR #923 changed (and why it was risky untested)
PR #923 replaced the **hardcoded** branch-protection payload in `branch-protection-setup.yml` with a **round-trip builder**: it starts from the branch's CURRENT protection (fetched via the API) and only *adds/strengthens* — so re-running the setup workflow can never silently revert a stronger `dev` rule (extra approvals, code-owner reviews, push restrictions, linear history, conversation resolution, strict mode). It also flipped `--theirs`→`--ours` in `auto-rebase-stale-drafts.yml` so lockfile conflicts resolve from base during a rebase. Both were YAML/embedded-Python and shipped with no test.

## What this PR adds
- **`.github/workflows/scripts/branch-protection-payload.py`** — the payload builder extracted out of the inline `python3 -c "…"` heredoc, made the **single source of truth**. The workflow now invokes this script (same `PROTECTION_JSON` / `PROTECTION_EXISTS` / `MERGED` env contract) instead of re-inlining the logic, so the tested code path *is* the production code path.
- A `--self-test` fixture suite in that script pinning the #771/#923 contract: a stronger existing rule (2 approvals + code-owner + `require_last_push_approval` + push restrictions + linear history + conversation resolution + strict) is fully preserved and only `security-gate-conclusion` is appended; `strict=false` is strengthened to `true` (never weakened); no-protection falls back to the safe baseline; bool/dict `enforce_admins` forms honoured; malformed current-protection JSON degrades to baseline rather than crashing.
- A `self-test` job wired into `branch-protection-setup.yml` (runs on `push`/`pull_request` touching the workflow or the builder script). The live `apply-branch-protection` job is now gated `if: github.event_name == 'workflow_dispatch'` so the self-test trigger never attempts a real API mutation.

The auto-rebase `--ours` flip is a one-line git-semantics change with no isolatable unit surface; its intent is captured in the workflow's safety comment. The substantive, regression-prone logic (the payload builder) is what this test locks down.

## Tested (Band A — fast check)
- `python3 .github/workflows/scripts/branch-protection-payload.py --self-test` → exit 0 (17 fixtures, `ALL FIXTURES PASSED`)
- `python3 -m py_compile .github/workflows/scripts/branch-protection-payload.py` → exit 0
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/branch-protection-setup.yml'))"` → OK (triggers: pull_request, push, workflow_dispatch; jobs: apply-branch-protection, self-test)
- Build-mode smoke (env path) → emits a correct round-tripped payload (strict=true, 2 approvals preserved, restrictions flattened, new check appended).

## IG3 — fails-on-regression proof
Re-introduced the pre-#923 hardcoded weakening builder (strict=false, 1 approval, restrictions=null) in a throwaway copy and ran `--self-test`: **exit 1**, `FAIL strong/approvals-preserved`. Against the shipped #923 fix the suite passes. The test genuinely guards the regression.

## Built (Band B — full build)
Skipped: CI-config-only change, no compiled artifact. Python compile + YAML parse + full self-test cover the surface.

## CI parity (Band C — hot-path only)
Skipped: no security/auth/billing/data-integrity application code. (Note: this self-test job will itself run on this PR since it touches the workflow + script paths.)

## Remote-tested
skipped

## Notes
- `scope_drift=false` (all paths under `.github/**`, in pm-devops scope), `code_reuse_warn=none`.
- This is a pure test-gap task: there is intentionally a `test:` commit only and no `fix:` commit — the fix already shipped in PR #923; this PR adds the missing regression test.

https://claude.ai/code/session_01R5YAgoAhWSvDbsV22mQuWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5YAgoAhWSvDbsV22mQuWT)_