### PR TITLE
test-gap-booking-push-validation-untested: regression tests for legacy Booking.com push guards

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -167,7 +167,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "admin-core"
-version = "0.3.22"
+version = "0.3.43"
 dependencies = [
  "api-core",
  "async-trait",
@@ -340,7 +340,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-core"
-version = "0.3.22"
+version = "0.3.43"
 dependencies = [
  "async-trait",
  "axum",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "api-server"
-version = "0.3.22"
+version = "0.3.43"
 dependencies = [
  "admin-core",
  "aes-gcm",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.3.22"
+version = "0.3.43"
 dependencies = [
  "async-trait",
  "axum",
@@ -1998,7 +1998,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "db"
-version = "0.3.22"
+version = "0.3.43"
 dependencies = [
  "argon2",
  "async-trait",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "deploy-server"
-version = "0.3.22"
+version = "0.3.43"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3528,7 +3528,7 @@ dependencies = [
 
 [[package]]
 name = "integrations"
-version = "0.3.22"
+version = "0.3.43"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -5287,7 +5287,7 @@ dependencies = [
 
 [[package]]
 name = "reality-server"
-version = "0.3.22"
+version = "0.3.43"
 dependencies = [
  "anyhow",
  "api-core",
@@ -6769,7 +6769,7 @@ dependencies = [
 
 [[package]]
 name = "tenant-ops"
-version = "0.3.22"
+version = "0.3.43"
 dependencies = [
  "chrono",
  "common",

--- a/backend/servers/api-server/src/routes/integrations/install.rs
+++ b/backend/servers/api-server/src/routes/integrations/install.rs
@@ -46,10 +46,7 @@ fn validate_push_availability(
     request: &BookingPushAvailabilityRequest,
 ) -> Result<(), (&'static str, &'static str)> {
     if request.updates.is_empty() {
-        return Err((
-            "NO_UPDATES",
-            "At least one availability update is required",
-        ));
+        return Err(("NO_UPDATES", "At least one availability update is required"));
     }
 
     if request.updates.len() > MAX_BATCH_SIZE {
@@ -81,10 +78,7 @@ fn validate_push_rates(
     request: &BookingPushRatesRequest,
 ) -> Result<(), (&'static str, &'static str)> {
     if request.updates.is_empty() {
-        return Err((
-            "NO_UPDATES",
-            "At least one rate update is required",
-        ));
+        return Err(("NO_UPDATES", "At least one rate update is required"));
     }
 
     if request.updates.len() > MAX_BATCH_SIZE {
@@ -1305,12 +1299,8 @@ pub async fn push_booking_availability(
         ));
     }
 
-    validate_push_availability(&request).map_err(|(code, msg)| {
-        (
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse::new(code, msg)),
-        )
-    })?;
+    validate_push_availability(&request)
+        .map_err(|(code, msg)| (StatusCode::BAD_REQUEST, Json(ErrorResponse::new(code, msg))))?;
 
     let rental_repo = &state.rental_repo;
 
@@ -1448,12 +1438,8 @@ pub async fn push_booking_rates(
         ));
     }
 
-    validate_push_rates(&request).map_err(|(code, msg)| {
-        (
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse::new(code, msg)),
-        )
-    })?;
+    validate_push_rates(&request)
+        .map_err(|(code, msg)| (StatusCode::BAD_REQUEST, Json(ErrorResponse::new(code, msg))))?;
 
     let rental_repo = &state.rental_repo;
 

--- a/backend/servers/api-server/src/routes/integrations/install.rs
+++ b/backend/servers/api-server/src/routes/integrations/install.rs
@@ -24,6 +24,79 @@ use common::errors::ErrorResponse;
 
 const MAX_BATCH_SIZE: usize = 500;
 
+// ==================== Booking.com Push Validation ====================
+//
+// Pure request-shape guards for the legacy Booking.com push handlers
+// (issue #572, PR #607). Extracted from the inline handler bodies so the
+// batch-cap and non-negative `available_count` guards have a DB-free
+// regression test (see the `tests` module). The unified OTA `listing-push`
+// surface has its own equivalent guard in `booking_channel::validate_listing_push`
+// (PR #1045) — these are the *legacy* push-availability / push-rates guards.
+//
+// On failure each returns `(error_code, human_message)` so the caller can
+// build a `400` [`ErrorResponse`]; on success returns `Ok(())`.
+
+/// Validate a Booking.com push-availability request body.
+///
+/// Rejects:
+/// * an empty `updates` list (`NO_UPDATES`),
+/// * more than [`MAX_BATCH_SIZE`] updates (`BATCH_TOO_LARGE`),
+/// * any negative `available_count` (`INVALID_AVAILABLE_COUNT`).
+fn validate_push_availability(
+    request: &BookingPushAvailabilityRequest,
+) -> Result<(), (&'static str, &'static str)> {
+    if request.updates.is_empty() {
+        return Err((
+            "NO_UPDATES",
+            "At least one availability update is required",
+        ));
+    }
+
+    if request.updates.len() > MAX_BATCH_SIZE {
+        return Err((
+            "BATCH_TOO_LARGE",
+            "A maximum of 500 updates per request is allowed",
+        ));
+    }
+
+    if request.updates.iter().any(|u| u.available_count < 0) {
+        return Err((
+            "INVALID_AVAILABLE_COUNT",
+            "available_count must be non-negative",
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate a Booking.com push-rates request body.
+///
+/// Rejects:
+/// * an empty `updates` list (`NO_UPDATES`),
+/// * more than [`MAX_BATCH_SIZE`] updates (`BATCH_TOO_LARGE`).
+///
+/// Rate updates carry no `available_count`, so the non-negative guard does
+/// not apply here.
+fn validate_push_rates(
+    request: &BookingPushRatesRequest,
+) -> Result<(), (&'static str, &'static str)> {
+    if request.updates.is_empty() {
+        return Err((
+            "NO_UPDATES",
+            "At least one rate update is required",
+        ));
+    }
+
+    if request.updates.len() > MAX_BATCH_SIZE {
+        return Err((
+            "BATCH_TOO_LARGE",
+            "A maximum of 500 updates per request is allowed",
+        ));
+    }
+
+    Ok(())
+}
+
 // ==================== Airbnb Types ====================
 
 /// Airbnb connection status response.
@@ -1232,35 +1305,12 @@ pub async fn push_booking_availability(
         ));
     }
 
-    if request.updates.is_empty() {
-        return Err((
+    validate_push_availability(&request).map_err(|(code, msg)| {
+        (
             StatusCode::BAD_REQUEST,
-            Json(ErrorResponse::new(
-                "NO_UPDATES",
-                "At least one availability update is required",
-            )),
-        ));
-    }
-
-    if request.updates.len() > MAX_BATCH_SIZE {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse::new(
-                "BATCH_TOO_LARGE",
-                "A maximum of 500 updates per request is allowed",
-            )),
-        ));
-    }
-
-    if request.updates.iter().any(|u| u.available_count < 0) {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse::new(
-                "INVALID_AVAILABLE_COUNT",
-                "available_count must be non-negative",
-            )),
-        ));
-    }
+            Json(ErrorResponse::new(code, msg)),
+        )
+    })?;
 
     let rental_repo = &state.rental_repo;
 
@@ -1398,25 +1448,12 @@ pub async fn push_booking_rates(
         ));
     }
 
-    if request.updates.is_empty() {
-        return Err((
+    validate_push_rates(&request).map_err(|(code, msg)| {
+        (
             StatusCode::BAD_REQUEST,
-            Json(ErrorResponse::new(
-                "NO_UPDATES",
-                "At least one rate update is required",
-            )),
-        ));
-    }
-
-    if request.updates.len() > MAX_BATCH_SIZE {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse::new(
-                "BATCH_TOO_LARGE",
-                "A maximum of 500 updates per request is allowed",
-            )),
-        ));
-    }
+            Json(ErrorResponse::new(code, msg)),
+        )
+    })?;
 
     let rental_repo = &state.rental_repo;
 
@@ -2071,4 +2108,133 @@ pub async fn enqueue_airbnb_availability_sync(
             message: "Availability sync job queued successfully".to_string(),
         }),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    //! Regression tests for the legacy Booking.com push request guards
+    //! (issue #572, PR #607): the `MAX_BATCH_SIZE` batch-cap and the
+    //! non-negative `available_count` validation on the `push-availability`
+    //! / `push-rates` endpoints. These guards previously had no coverage —
+    //! the unified `listing-push` surface (PR #1045) tests its own
+    //! `booking_channel::validate_listing_push`, not these handlers.
+    use super::*;
+    use chrono::NaiveDate;
+
+    /// Build `avail` availability-update DTOs, all with a non-negative count.
+    fn avail_updates(avail: usize) -> Vec<AvailabilityUpdateDto> {
+        (0..avail)
+            .map(|i| AvailabilityUpdateDto {
+                room_type_id: "DBL".to_string(),
+                date: NaiveDate::from_ymd_opt(2025, 6, 1).unwrap()
+                    + chrono::Duration::days(i as i64),
+                available_count: 1,
+                stop_sell: false,
+                cta: false,
+                ctd: false,
+                min_los: None,
+                max_los: None,
+            })
+            .collect()
+    }
+
+    /// Build a minimal availability push request with `avail` updates.
+    fn make_availability_request(avail: usize) -> BookingPushAvailabilityRequest {
+        BookingPushAvailabilityRequest {
+            room_mappings: Vec::new(),
+            updates: avail_updates(avail),
+        }
+    }
+
+    /// Build a minimal rates push request with `rates` updates.
+    fn make_rates_request(rates: usize) -> BookingPushRatesRequest {
+        BookingPushRatesRequest {
+            updates: (0..rates)
+                .map(|i| RateUpdateDto {
+                    room_type_id: "DBL".to_string(),
+                    rate_plan_code: "STD".to_string(),
+                    date: NaiveDate::from_ymd_opt(2025, 6, 1).unwrap()
+                        + chrono::Duration::days(i as i64),
+                    base_rate: rust_decimal::Decimal::new(10000, 2),
+                    currency: "EUR".to_string(),
+                    extra_person_rate: None,
+                    extra_child_rate: None,
+                })
+                .collect(),
+        }
+    }
+
+    // ---- push-availability guards ----
+
+    #[test]
+    fn availability_accepts_valid_batch() {
+        let req = make_availability_request(10);
+        assert!(validate_push_availability(&req).is_ok());
+    }
+
+    #[test]
+    fn availability_accepts_max_batch_boundary() {
+        // Exactly MAX_BATCH_SIZE updates must be allowed (boundary).
+        let req = make_availability_request(MAX_BATCH_SIZE);
+        assert!(validate_push_availability(&req).is_ok());
+    }
+
+    #[test]
+    fn availability_rejects_empty_updates() {
+        let req = make_availability_request(0);
+        let err = validate_push_availability(&req).unwrap_err();
+        assert_eq!(err.0, "NO_UPDATES");
+    }
+
+    #[test]
+    fn availability_rejects_oversized_batch() {
+        // One over the cap -> BATCH_TOO_LARGE (400).
+        let req = make_availability_request(MAX_BATCH_SIZE + 1);
+        let err = validate_push_availability(&req).unwrap_err();
+        assert_eq!(err.0, "BATCH_TOO_LARGE");
+    }
+
+    #[test]
+    fn availability_rejects_negative_available_count() {
+        let mut req = make_availability_request(3);
+        req.updates[2].available_count = -1;
+        let err = validate_push_availability(&req).unwrap_err();
+        assert_eq!(err.0, "INVALID_AVAILABLE_COUNT");
+    }
+
+    #[test]
+    fn availability_zero_available_count_is_allowed() {
+        // Zero (sold out) is non-negative and must pass the guard.
+        let mut req = make_availability_request(1);
+        req.updates[0].available_count = 0;
+        assert!(validate_push_availability(&req).is_ok());
+    }
+
+    // ---- push-rates guards ----
+
+    #[test]
+    fn rates_accepts_valid_batch() {
+        let req = make_rates_request(10);
+        assert!(validate_push_rates(&req).is_ok());
+    }
+
+    #[test]
+    fn rates_accepts_max_batch_boundary() {
+        let req = make_rates_request(MAX_BATCH_SIZE);
+        assert!(validate_push_rates(&req).is_ok());
+    }
+
+    #[test]
+    fn rates_rejects_empty_updates() {
+        let req = make_rates_request(0);
+        let err = validate_push_rates(&req).unwrap_err();
+        assert_eq!(err.0, "NO_UPDATES");
+    }
+
+    #[test]
+    fn rates_rejects_oversized_batch() {
+        let req = make_rates_request(MAX_BATCH_SIZE + 1);
+        let err = validate_push_rates(&req).unwrap_err();
+        assert_eq!(err.0, "BATCH_TOO_LARGE");
+    }
 }


### PR DESCRIPTION
## Task
Add the missing backend regression test(s) proving the legacy `install.rs` booking push availability/rates endpoints' batch-cap (MAX_BATCH_SIZE) and non-negative `available_count` validation guards reject malformed requests with the correct 400 error codes.

## Owner
pm-backend (specialist: rust-backend)

## What & why
The legacy Booking.com push handlers `push_booking_availability` / `push_booking_rates` in `backend/servers/api-server/src/routes/integrations/install.rs` carried inline `MAX_BATCH_SIZE` batch-cap and non-negative `available_count` guards (issue #572, PR #607) with **no regression test**. PR #1045 added tests for the *unified* OTA `listing-push` surface (`booking_channel::validate_listing_push`) but not for these legacy endpoints — verified `install.rs` had zero `#[cfg(test)]` coverage.

This PR:
- Extracts the inline guards into two pure functions `validate_push_availability` / `validate_push_rates` (behavior-preserving refactor) so they're testable without a DB, and rewires both handlers to call them.
- Adds a `#[cfg(test)]` module with 10 tests covering: valid batch, exact `MAX_BATCH_SIZE` boundary, oversized batch → `BATCH_TOO_LARGE`, empty → `NO_UPDATES`, negative count → `INVALID_AVAILABLE_COUNT`, and zero-count-allowed.

Does **not** duplicate PR #1045's `validate_listing_push` tests — this targets the other (legacy) surface.

## Tested (Band A — fast check)
- `SQLX_OFFLINE=true cargo check -p api-server` → exit 0
- `SQLX_OFFLINE=true cargo test -p api-server --lib install::` → exit 0 (10 passed; 0 failed)

## Built (Band B — full build)
- `SQLX_OFFLINE=true cargo clippy -p api-server --lib -- -D warnings` → exit 0 (install.rs clean)
- Note: `cargo clippy -p api-server --lib --tests` fails on a **pre-existing, unrelated** `clippy::items-after-test-module` lint in `routes/admin/mod.rs` (not touched by this PR; present on `dev`).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (test-only + behavior-preserving refactor of existing validation; no security/auth/billing/data-integrity change).

## Remote-tested
skipped

## Scope drift
None — `scope-check.sh --owner pm-backend` → exit 0. Only `install.rs` + a mechanical `Cargo.lock` workspace version sync (0.3.22 → 0.3.43) refreshed by the build.

## Code-reuse review
None — `reuse-grep.sh --specialist rust-backend` → exit 0. The new `validate_push_*` helpers are install.rs-local and intentionally mirror (not duplicate) `booking_channel::validate_listing_push`, which validates a different request type for the unified surface.

https://claude.ai/code/session_01R5YAgoAhWSvDbsV22mQuWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5YAgoAhWSvDbsV22mQuWT)_