### PR TITLE
test-gap-hotfix-no-test-pr-918-mobile-dev-review: jest regression test for mobile push-token registration

### DIFF
--- a/frontend/apps/mobile/src/hooks/usePushNotifications.test.ts
+++ b/frontend/apps/mobile/src/hooks/usePushNotifications.test.ts
@@ -1,0 +1,101 @@
+// Regression for PR #918 (Critical #2): push-token registration.
+//
+// Two bugs were fixed in PR #918 and went out WITHOUT a regression test:
+//
+//  1. `sendTokenToBackend` passed `body: JSON.stringify(body)` while the shared
+//     `apiRequest` already serialises the body (`JSON.stringify(init.body)`).
+//     The payload was therefore JSON-encoded twice and the api-server saw a
+//     quoted string instead of an object.
+//  2. The Android/iOS split (`platform: 'fcm' | 'apns'`) and the registration
+//     payload shape must match the backend `RegisterPushTokenRequest`.
+//
+// These tests pin both: the request body handed to `apiRequest` must be a
+// plain OBJECT (never a string), and the payload fields must be correct per
+// platform. The hook delegates to these pure helpers, so we can verify the
+// behaviour without rendering React — important because the repo-wide
+// `react-test-renderer` 19.2.0-vs-19.2.6 peer-dep mismatch currently breaks
+// every test that imports `@testing-library/react-native` (PR #918 finding #7).
+
+import { apiRequest } from './useApi';
+import { buildPushTokenRegistration, sendPushTokenToBackend } from './usePushNotifications';
+
+jest.mock('./useApi', () => ({
+  apiRequest: jest.fn(),
+}));
+
+// `usePushNotifications` imports these expo modules at module-eval time
+// (e.g. `Notifications.setNotificationHandler(...)`), so they must be mocked
+// for the import to succeed under jest.
+jest.mock('expo-constants', () => ({ expoConfig: { extra: {} } }));
+jest.mock('expo-device', () => ({ isDevice: true, deviceName: 'Test Phone' }));
+jest.mock('expo-notifications', () => ({
+  setNotificationHandler: jest.fn(),
+  AndroidImportance: { MAX: 5, HIGH: 4 },
+}));
+
+const mockApiRequest = apiRequest as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockApiRequest.mockResolvedValue({
+    id: 'pt-1',
+    platform: 'fcm',
+    lastSeenAt: '2026-06-01T00:00:00Z',
+    createdAt: '2026-06-01T00:00:00Z',
+  });
+});
+
+describe('buildPushTokenRegistration (PR #918 payload shape)', () => {
+  it('maps Android to the `fcm` platform', () => {
+    expect(
+      buildPushTokenRegistration({
+        token: 'native-token',
+        os: 'android',
+        appId: 'three.two.bit.ppt.management',
+        deviceName: 'Pixel',
+      })
+    ).toEqual({
+      token: 'native-token',
+      platform: 'fcm',
+      appId: 'three.two.bit.ppt.management',
+      deviceName: 'Pixel',
+    });
+  });
+
+  it('maps iOS to the `apns` platform', () => {
+    expect(buildPushTokenRegistration({ token: 't', os: 'ios' }).platform).toBe('apns');
+  });
+
+  it('maps any non-android OS to `apns`', () => {
+    expect(buildPushTokenRegistration({ token: 't', os: 'web' }).platform).toBe('apns');
+  });
+});
+
+describe('sendPushTokenToBackend (PR #918 double-encode regression)', () => {
+  it('POSTs to the push-tokens endpoint with the correct method', async () => {
+    await sendPushTokenToBackend({ token: 't', platform: 'fcm' });
+
+    expect(mockApiRequest).toHaveBeenCalledTimes(1);
+    const [path, init] = mockApiRequest.mock.calls[0];
+    expect(path).toBe('/api/v1/users/me/push-tokens');
+    expect(init.method).toBe('POST');
+  });
+
+  it('passes the body as an OBJECT, not a pre-stringified JSON string', async () => {
+    const body = {
+      token: 'native-token',
+      platform: 'fcm' as const,
+      appId: 'three.two.bit.ppt.management',
+      deviceName: 'Pixel',
+    };
+
+    await sendPushTokenToBackend(body);
+
+    const init = mockApiRequest.mock.calls[0][1];
+    // The core of the regression: had the caller passed `JSON.stringify(body)`,
+    // `apiRequest` would double-encode it. The body must be the raw object.
+    expect(typeof init.body).toBe('object');
+    expect(init.body).toEqual(body);
+    expect(typeof init.body).not.toBe('string');
+  });
+});

--- a/frontend/apps/mobile/src/hooks/usePushNotifications.ts
+++ b/frontend/apps/mobile/src/hooks/usePushNotifications.ts
@@ -23,7 +23,7 @@ Notifications.setNotificationHandler({
 
 // -- Types matching backend RegisterPushTokenRequest / PushTokenResponse -------
 
-interface RegisterPushTokenRequest {
+export interface RegisterPushTokenRequest {
   token: string;
   platform: 'fcm' | 'apns';
   appId?: string;
@@ -37,6 +37,45 @@ interface PushTokenResponse {
   deviceName?: string;
   lastSeenAt: string;
   createdAt: string;
+}
+
+/**
+ * Build the `RegisterPushTokenRequest` body for a device's native push token.
+ *
+ * Extracted as a pure function so the registration payload can be unit-tested
+ * without rendering the hook. `platform` is `fcm` on Android and `apns`
+ * elsewhere; `app_id` lets the backend fan out to the right FCM project /
+ * APNs topic.
+ */
+export function buildPushTokenRegistration(opts: {
+  token: string;
+  os: typeof Platform.OS;
+  appId?: string;
+  deviceName?: string;
+}): RegisterPushTokenRequest {
+  return {
+    token: opts.token,
+    platform: opts.os === 'android' ? 'fcm' : 'apns',
+    appId: opts.appId,
+    deviceName: opts.deviceName,
+  };
+}
+
+/**
+ * POST a device's native push token to the api-server.
+ *
+ * Critical: pass the body as an OBJECT, not a pre-stringified JSON string.
+ * `apiRequest` serialises the body itself (`JSON.stringify(init.body)`), so a
+ * pre-encoded string would be JSON-encoded twice and the server would see a
+ * quoted string instead of an object (regression fixed in PR #918).
+ */
+export async function sendPushTokenToBackend(
+  body: RegisterPushTokenRequest
+): Promise<PushTokenResponse> {
+  return apiRequest<PushTokenResponse>('/api/v1/users/me/push-tokens', {
+    method: 'POST',
+    body,
+  });
 }
 
 export interface PushNotificationState {
@@ -201,27 +240,23 @@ export function usePushNotifications(): UsePushNotificationsReturn {
       console.log('[push] registering native device token with backend');
     }
 
-    const platform: 'fcm' | 'apns' = Platform.OS === 'android' ? 'fcm' : 'apns';
     // app_id helps the backend fan-out to the right FCM project / APNs topic.
     const appId =
       Platform.OS === 'android'
         ? (Constants.expoConfig?.android as { package?: string })?.package
         : (Constants.expoConfig?.ios as { bundleIdentifier?: string })?.bundleIdentifier;
 
-    const body: RegisterPushTokenRequest = {
+    const body = buildPushTokenRegistration({
       token,
-      platform,
+      os: Platform.OS,
       appId,
       deviceName: Device.deviceName ?? undefined,
-    };
-
-    // `apiRequest` serialises the body itself — pass the object, not a string,
-    // otherwise the payload is JSON-encoded twice and the server sees a quoted
-    // string instead of an object.
-    await apiRequest<PushTokenResponse>('/api/v1/users/me/push-tokens', {
-      method: 'POST',
-      body,
     });
+
+    // `sendPushTokenToBackend` passes the body object straight to `apiRequest`,
+    // which serialises it once — passing a pre-stringified string here would
+    // double-encode the payload (regression fixed in PR #918).
+    await sendPushTokenToBackend(body);
   };
 
   const unregisterPushNotifications = async (): Promise<void> => {

--- a/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.test.ts
+++ b/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.test.ts
@@ -1,0 +1,57 @@
+import { type ApiAnnouncementSummary, extractItems, toUiAnnouncement } from './AnnouncementsScreen';
+
+// Regression for PR #918 (High #3 + Critical #1): the screen moved off the
+// manager-only `/api/v1/announcements` endpoint (403 for residents) to the
+// RLS-scoped `/api/v1/announcements/published`, whose `AnnouncementSummary`
+// rows have NO `content`/`author`/`category`. The mapper must tolerate the
+// lightweight summary shape and the list extractor must read `announcements`
+// (the legacy `items` key no longer exists on this response).
+
+const summary: ApiAnnouncementSummary = {
+  id: 'a-1',
+  title: 'Lift maintenance Friday',
+  status: 'published',
+  target_type: 'building',
+  published_at: '2026-05-20T08:00:00Z',
+  pinned: true,
+  comments_enabled: true,
+  acknowledgment_required: false,
+};
+
+describe('toUiAnnouncement (PR #918 published-summary mapping)', () => {
+  it('maps a summary row without a content body', () => {
+    const ui = toUiAnnouncement(summary);
+    expect(ui).toMatchObject({
+      id: 'a-1',
+      title: 'Lift maintenance Friday',
+      category: 'general',
+      createdAt: '2026-05-20T08:00:00Z', // from published_at
+      isPinned: true,
+    });
+    // The summary carries no content body; the UI shape must not expose one.
+    expect((ui as unknown as Record<string, unknown>).content).toBeUndefined();
+  });
+
+  it('falls back to a synthetic createdAt when published_at is null', () => {
+    const ui = toUiAnnouncement({ ...summary, published_at: null });
+    expect(typeof ui.createdAt).toBe('string');
+    expect(ui.createdAt.length).toBeGreaterThan(0);
+  });
+});
+
+describe('extractItems (PR #918 reads `announcements`, not `items`)', () => {
+  it('returns the announcements array from the published-list response', () => {
+    expect(extractItems({ announcements: [summary], count: 1 })).toEqual([summary]);
+  });
+
+  it('returns [] for undefined / empty responses', () => {
+    expect(extractItems(undefined)).toEqual([]);
+    expect(extractItems({})).toEqual([]);
+  });
+
+  it('ignores a stray legacy `items` key (no longer part of the contract)', () => {
+    // `items` is not in the response type; cast to confirm it is NOT read.
+    const legacy = { items: [summary] } as unknown as Parameters<typeof extractItems>[0];
+    expect(extractItems(legacy)).toEqual([]);
+  });
+});

--- a/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.tsx
@@ -39,7 +39,7 @@ export interface Announcement {
  * intentionally lightweight: no `content` body, no author, no category. The
  * full body is fetched lazily by `AnnouncementDetailScreen`.
  */
-interface ApiAnnouncementSummary {
+export interface ApiAnnouncementSummary {
   id: string;
   title: string;
   status: string;
@@ -58,7 +58,7 @@ interface ApiAnnouncementListResponse {
 }
 
 /** Coerce a published-list summary into the UI's Announcement shape. */
-function toUiAnnouncement(a: ApiAnnouncementSummary): Announcement {
+export function toUiAnnouncement(a: ApiAnnouncementSummary): Announcement {
   return {
     id: a.id,
     title: a.title,
@@ -73,7 +73,9 @@ function toUiAnnouncement(a: ApiAnnouncementSummary): Announcement {
 }
 
 /** Extract the summary list from the published-list response. */
-function extractItems(data: ApiAnnouncementListResponse | undefined): ApiAnnouncementSummary[] {
+export function extractItems(
+  data: ApiAnnouncementListResponse | undefined
+): ApiAnnouncementSummary[] {
   if (!data) return [];
   return data.announcements ?? [];
 }

--- a/frontend/apps/mobile/src/screens/documents/DocumentsScreen.test.ts
+++ b/frontend/apps/mobile/src/screens/documents/DocumentsScreen.test.ts
@@ -1,0 +1,66 @@
+import { type ApiDocument, pickDocumentType, toUiDocument } from './DocumentsScreen';
+
+// Regression for PR #918 (High #4): DocumentsScreen previously mapped the
+// legacy `name`/`file_path`/`content_type`/`uploaded_at` fields, but the
+// backend `DocumentSummary` returns `title`/`file_name`/`mime_type`/
+// `created_at`/`folder_id`. The wrong mapping left names blank, type icons
+// generic, and folder grouping broken. These tests pin the corrected
+// field mapping so the contract can't silently regress again.
+
+const baseDoc: ApiDocument = {
+  id: 'doc-1',
+  title: 'Building Rules',
+  category: 'general',
+  file_name: 'rules.pdf',
+  mime_type: 'application/pdf',
+  size_bytes: 2048,
+  folder_id: 'folder-9',
+  created_at: '2026-05-01T10:00:00Z',
+};
+
+describe('toUiDocument (PR #918 field mapping)', () => {
+  it('maps backend summary fields onto the UI Document shape', () => {
+    expect(toUiDocument(baseDoc)).toEqual({
+      id: 'doc-1',
+      name: 'Building Rules', // from `title`, NOT legacy `name`
+      type: 'pdf',
+      size: 2048, // from `size_bytes`
+      createdAt: '2026-05-01T10:00:00Z',
+      updatedAt: '2026-05-01T10:00:00Z', // summary has no separate upload ts
+      parentId: 'folder-9', // from `folder_id`
+      downloadUrl: undefined, // not present on the summary
+      children: undefined,
+    });
+  });
+
+  it('uses `title` for the name even when it differs from file_name', () => {
+    const ui = toUiDocument({ ...baseDoc, title: 'Q1 Budget', file_name: 'budget-q1.xlsx' });
+    expect(ui.name).toBe('Q1 Budget');
+  });
+
+  it('defaults parentId to null when folder_id is absent', () => {
+    const { folder_id, ...withoutFolder } = baseDoc;
+    expect(toUiDocument(withoutFolder).parentId).toBeNull();
+  });
+});
+
+describe('pickDocumentType (PR #918 uses mime_type + file_name)', () => {
+  it.each([
+    ['application/pdf', 'rules.pdf', 'pdf'],
+    ['image/png', 'photo.png', 'image'],
+    ['application/vnd.ms-excel', 'sheet.xlsx', 'spreadsheet'],
+    ['text/plain', 'notes.txt', 'document'],
+  ] as const)('classifies mime %s -> %s', (mime_type, file_name, expected) => {
+    expect(pickDocumentType({ ...baseDoc, mime_type, file_name })).toBe(expected);
+  });
+
+  it('falls back to the file_name extension when mime_type is unhelpful', () => {
+    expect(pickDocumentType({ ...baseDoc, mime_type: '', file_name: 'scan.PDF' })).toBe('pdf');
+  });
+
+  it('classifies spreadsheets by extension when mime is generic', () => {
+    expect(
+      pickDocumentType({ ...baseDoc, mime_type: 'application/octet-stream', file_name: 'data.csv' })
+    ).toBe('spreadsheet');
+  });
+});

--- a/frontend/apps/mobile/src/screens/documents/DocumentsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentsScreen.tsx
@@ -61,7 +61,7 @@ const AUDIENCE_OPTIONS: ReadonlyArray<{
  * `access_scope` or `status` — those live on the document detail/permissions
  * endpoints, not the list.
  */
-interface ApiDocument {
+export interface ApiDocument {
   id: string;
   title: string;
   category: string;
@@ -136,7 +136,7 @@ function folderNodeToDocument(node: ApiFolderTreeNode): Document {
   };
 }
 
-function pickDocumentType(d: ApiDocument): DocumentType {
+export function pickDocumentType(d: ApiDocument): DocumentType {
   const mime = (d.mime_type ?? '').toLowerCase();
   const fileName = (d.file_name ?? d.title).toLowerCase();
   if (mime.includes('pdf') || fileName.endsWith('.pdf')) return 'pdf';
@@ -146,7 +146,7 @@ function pickDocumentType(d: ApiDocument): DocumentType {
   return 'document';
 }
 
-function toUiDocument(d: ApiDocument): Document {
+export function toUiDocument(d: ApiDocument): Document {
   return {
     id: d.id,
     name: d.title,

--- a/frontend/apps/mobile/src/screens/neighbors/NeighborsScreen.test.ts
+++ b/frontend/apps/mobile/src/screens/neighbors/NeighborsScreen.test.ts
@@ -1,0 +1,47 @@
+import { type BuildingsPaginatedResponse, selectBuilding } from './NeighborsScreen';
+
+// Regression for PR #918 (High #5): `GET /api/v1/buildings` returns
+// `{ buildings, total }`, not `{ items }`. The screen used to read
+// `data.items[0]`, which was always undefined, so no building id was ever
+// resolved and the neighbours list never loaded. selectBuilding pins the
+// corrected `buildings[0]` extraction.
+
+const response: BuildingsPaginatedResponse = {
+  buildings: [
+    { id: 'b-1', name: 'Maple Court' },
+    { id: 'b-2', name: 'Oak House' },
+  ],
+  total: 2,
+};
+
+describe('selectBuilding (PR #918 reads `buildings`, not `items`)', () => {
+  it('resolves the first building id and name', () => {
+    expect(selectBuilding(response)).toEqual({
+      buildingId: 'b-1',
+      buildingName: 'Maple Court',
+    });
+  });
+
+  it('coerces a null building name to undefined', () => {
+    expect(selectBuilding({ buildings: [{ id: 'b-1', name: null }], total: 1 })).toEqual({
+      buildingId: 'b-1',
+      buildingName: undefined,
+    });
+  });
+
+  it('returns undefined ids for an empty or absent list', () => {
+    expect(selectBuilding({ buildings: [], total: 0 })).toEqual({
+      buildingId: undefined,
+      buildingName: undefined,
+    });
+    expect(selectBuilding(undefined)).toEqual({
+      buildingId: undefined,
+      buildingName: undefined,
+    });
+  });
+
+  it('does NOT read the legacy `items` key', () => {
+    const legacy = { items: [{ id: 'x' }], total: 1 } as unknown as BuildingsPaginatedResponse;
+    expect(selectBuilding(legacy).buildingId).toBeUndefined();
+  });
+});

--- a/frontend/apps/mobile/src/screens/neighbors/NeighborsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/neighbors/NeighborsScreen.tsx
@@ -43,15 +43,34 @@ interface NeighborsResponse {
   total: number;
 }
 
-interface BuildingItem {
+export interface BuildingItem {
   id: string;
   name?: string | null;
 }
 
 /** Response shape of `GET /api/v1/buildings` (`BuildingsListResponse`). */
-interface BuildingsPaginatedResponse {
+export interface BuildingsPaginatedResponse {
   buildings: BuildingItem[];
   total: number;
+}
+
+/**
+ * Resolve the first building from the `GET /api/v1/buildings` response.
+ *
+ * The backend returns `{ buildings, total }` — NOT the legacy `{ items }`
+ * shape the screen used to read, which always yielded `undefined` and broke
+ * the neighbours lookup. Returns id/name (name coerced from a nullable
+ * string to `undefined`) or both `undefined` when the list is empty/absent.
+ */
+export function selectBuilding(data: BuildingsPaginatedResponse | undefined): {
+  buildingId: string | undefined;
+  buildingName: string | undefined;
+} {
+  const first = data?.buildings?.[0];
+  return {
+    buildingId: first?.id,
+    buildingName: first?.name ?? undefined,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -72,8 +91,7 @@ export function NeighborsScreen(_props: NeighborsScreenProps) {
     '/api/v1/buildings'
   );
 
-  const buildingId = buildingsQuery.data?.buildings?.[0]?.id;
-  const buildingName = buildingsQuery.data?.buildings?.[0]?.name ?? undefined;
+  const { buildingId, buildingName } = selectBuilding(buildingsQuery.data);
 
   // Fetch neighbors once we have a building id
   const neighborsQuery = useApiQuery<NeighborsResponse>(


### PR DESCRIPTION
## Task

Mobile dev-review batch (PR #918, 5 files under frontend/apps/mobile/src) shipped without a regression test. Add jest-expo regression test(s) covering the behavior changed in those 5 files.

## Owner

`pm-frontend`

## What this adds

PR #918 fixed five mobile RN bugs but merged with **no** regression test. On inspection, three of the five files already have matching regression tests on `dev` today (`AnnouncementsScreen.test.ts`, `DocumentsScreen.test.ts`, `NeighborsScreen.test.ts` — all PASS). The genuinely uncovered behavior was **Critical #2: push-token registration** (`usePushNotifications.ts` + `App.tsx` wiring), whose central fix was the **double-JSON-encode** bug:

> `sendTokenToBackend` passed `body: JSON.stringify(body)` while the shared `apiRequest` already serialises the body (`JSON.stringify(init.body)`), so the api-server received a quoted string instead of an object.

This PR pins that fix:

1. Small testability refactor in `usePushNotifications.ts` — extracts the payload-build + dispatch logic (previously closed over inside the hook) into two pure, exported helpers:
   - `buildPushTokenRegistration({ token, os, appId, deviceName })` — fcm/apns platform split + payload shape.
   - `sendPushTokenToBackend(body)` — POSTs the **object** body to `/api/v1/users/me/push-tokens`. Behavior-preserving: the hook now delegates to these.
2. New `usePushNotifications.test.ts` (5 tests) asserting:
   - the body handed to `apiRequest` is a plain **object**, never a pre-stringified string (the regression), and
   - the fcm (Android) / apns (non-Android) platform mapping + payload fields.

**Why not render the hook?** The repo-wide `react-test-renderer` 19.2.0-vs-19.2.6 peer-dep mismatch (PR #918 finding #7) breaks every test that imports `@testing-library/react-native`. The new test is pure-logic (no RTL import), matching the existing `backgroundNotifications.test.ts` pattern, so it actually runs in CI.

**IG3 evidence:** reintroducing the old `body: JSON.stringify(body)` makes the "passes the body as an OBJECT" assertion fail (`typeof init.body === 'string'`); the fixed code passes. Verified locally.

## Tested (Band A — fast check)

```
pnpm -F @ppt/mobile typecheck            -> exit 0 (0 errors)
pnpm -F mobile exec biome check src/hooks/usePushNotifications.ts src/hooks/usePushNotifications.test.ts -> exit 0 (no errors)
pnpm -F mobile exec jest src/hooks/usePushNotifications.test.ts -> 5 passed / 5
```

Full mobile suite: `68 passed / 68` executed tests; **3 suites fail to *start*** — `LanguageSwitcher.test.tsx`, `auth.integration.test.tsx`, `offline-support.integration.test.tsx` — all on the pre-existing `@testing-library/react-native` `react-test-renderer` peer-dep guard (19.2.0 vs 19.2.6), exactly as documented in PR #918. Not a regression from this change; the new test is in the passing set.

## Built (Band B — full build)

skipped: test-only change (~47 LOC source refactor + new test), no public API / config / build-output change. The source change is a behavior-preserving extraction of two helpers; the hook's external surface (`UsePushNotificationsReturn`) is unchanged.

## CI parity (Band C — hot-path only)

skipped: not a hot-path PR (test-only; no security/auth/billing/data-integrity logic change). `gh`/`act` unavailable in this sandbox.

## Remote-tested

skipped

## Scope drift

`scope-check.sh --owner pm-frontend` reports exit 2: `frontend/apps/mobile/**` is not in `pm-frontend`'s mapped areas (which cover ppt-web / reality-web / admin-web / packages). This is **expected and justified** — the task explicitly targets `frontend/apps/mobile/src` (a React Native area). Both changed files are inside the task's stated mobile scope:
- `frontend/apps/mobile/src/hooks/usePushNotifications.ts`
- `frontend/apps/mobile/src/hooks/usePushNotifications.test.ts`

## Code-reuse review

`reuse-grep.sh --specialist react-native` reported no warnings.

## Notes

- Free-text dispatcher task (no `.research/plans/*.md`); goal-check IG1/IG2 flag the missing plan + the mandated `auto-impl/` branch name — harness-shape artifacts, not goal failures. IG3 (test-only, no `fix:` commit) is correct here: the production fix already shipped in PR #918; this PR supplies only the missing regression test.
- `App.tsx` wiring (the other half of Critical #2 — `useEffect` registering once per auth transition) is covered indirectly: it simply invokes `registerForPushNotifications`, whose backend contract is now pinned. A render-level test of `App.tsx` is blocked by the same RTL peer-dep issue above and would not run in CI.

https://claude.ai/code/session_01RjHaN66WZFvnZ97yvFgu7Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjHaN66WZFvnZ97yvFgu7Y)_