### PR TITLE
refactor-ppt-web-untranslated-strings: i18n ppt-web status badge components

### DIFF
--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -1052,5 +1052,100 @@
     "errorDescription": "Chyba: {{message}}",
     "disconnectedDescription": "Aktualizace v reálném čase nejsou dostupné",
     "clickToReconnect": "Kliknutím se znovu připojíte"
+  },
+  "submissionStatus": {
+    "status": {
+      "draft": "Koncept",
+      "pending_validation": "Čeká na ověření",
+      "validated": "Ověřeno",
+      "submitted": "Odesláno",
+      "acknowledged": "Potvrzeno",
+      "processing": "Zpracovává se",
+      "accepted": "Přijato",
+      "rejected": "Zamítnuto",
+      "requires_correction": "Vyžaduje opravu",
+      "cancelled": "Zrušeno"
+    },
+    "description": {
+      "draft": "Podání se připravuje a dosud nebylo ověřeno.",
+      "pending_validation": "Podání se ověřuje vůči požadavkům portálu.",
+      "validated": "Podání prošlo ověřením a je připraveno k odeslání.",
+      "submitted": "Podání bylo odesláno na státní portál.",
+      "acknowledged": "Portál potvrdil přijetí podání.",
+      "processing": "Portál zpracovává podání.",
+      "accepted": "Podání bylo portálem přijato.",
+      "rejected": "Podání bylo zamítnuto. Zkontrolujte podrobnosti chyby a zkuste to znovu.",
+      "requires_correction": "Podání před přijetím vyžaduje opravy.",
+      "cancelled": "Podání bylo zrušeno."
+    },
+    "page": {
+      "backToDashboard": "Zpět na nástěnku",
+      "title": "Stav podání",
+      "reference": "Reference: {{reference}}",
+      "errorDetails": "Podrobnosti chyby",
+      "validationErrors": "Chyby ověření:",
+      "warnings": "Upozornění:",
+      "submissionDetails": "Podrobnosti podání",
+      "reportType": "Typ výkazu",
+      "reportPeriod": "Období výkazu",
+      "externalReference": "Externí reference",
+      "created": "Vytvořeno",
+      "validated": "Ověřeno",
+      "submitted": "Odesláno",
+      "acknowledged": "Potvrzeno",
+      "processed": "Zpracováno",
+      "submissionAttempts": "Počet pokusů o podání",
+      "nextRetry": "Naplánován další automatický pokus: {{date}}",
+      "reportDocument": "Dokument výkazu",
+      "viewReportPdf": "Zobrazit PDF výkazu",
+      "attachments": "Přílohy ({{count}})",
+      "auditTrail": "Audit ({{count}} událostí)",
+      "noAuditEvents": "Nezaznamenány žádné události auditu.",
+      "cancelSubmission": "Zrušit podání",
+      "validating": "Ověřuje se...",
+      "validate": "Ověřit",
+      "retrying": "Opakuje se...",
+      "retrySubmission": "Opakovat podání",
+      "retryFailed": "Opakování selhalo",
+      "validationFailed": "Ověření selhalo",
+      "cancelFailed": "Zrušení selhalo"
+    }
+  },
+  "ocrStatus": {
+    "compact": {
+      "completed": "OCR",
+      "processing": "Zpracovává se",
+      "pending": "Čeká",
+      "failed": "Selhalo",
+      "not_applicable": "N/A"
+    },
+    "full": {
+      "completed": "Text extrahován",
+      "processing": "Zpracovává se OCR...",
+      "pending": "OCR čeká",
+      "failed": "OCR selhalo",
+      "not_applicable": "Nepoužitelné"
+    },
+    "reprocessing": "Opakované zpracování...",
+    "retry": "Opakovat",
+    "retryTitle": "Opakovat zpracování OCR",
+    "processingTitle": "Zpracování OCR",
+    "extractingText": "Extrahuje se text z dokumentu... Může to chvíli trvat.",
+    "textExtractedOn": "Text extrahován {{date}}",
+    "processingFailed": "Zpracování OCR selhalo. Dokument může být nepodporovaný nebo poškozený.",
+    "clickRetry": "Klikněte na „Opakovat“ pro nový pokus.",
+    "queuedForExtraction": "Dokument je zařazen k extrakci textu."
+  },
+  "competitiveStatus": {
+    "features": {
+      "tours": "Virtuální prohlídky",
+      "pricing": "Cenová analýza",
+      "neighborhood": "Okolí",
+      "comparables": "Srovnatelné"
+    },
+    "competitive": "Konkurenční",
+    "title": "Konkurenční funkce",
+    "percentComplete": "Dokončeno {{percent}} %",
+    "viewAnalysis": "Zobrazit analýzu"
   }
 }

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -1047,5 +1047,100 @@
     "errorDescription": "Fehler: {{message}}",
     "disconnectedDescription": "Echtzeit-Updates sind nicht verfügbar",
     "clickToReconnect": "Zum erneuten Verbinden klicken"
+  },
+  "submissionStatus": {
+    "status": {
+      "draft": "Entwurf",
+      "pending_validation": "Validierung ausstehend",
+      "validated": "Validiert",
+      "submitted": "Eingereicht",
+      "acknowledged": "Bestätigt",
+      "processing": "In Bearbeitung",
+      "accepted": "Akzeptiert",
+      "rejected": "Abgelehnt",
+      "requires_correction": "Korrektur erforderlich",
+      "cancelled": "Storniert"
+    },
+    "description": {
+      "draft": "Die Einreichung wird vorbereitet und wurde noch nicht validiert.",
+      "pending_validation": "Die Einreichung wird anhand der Portalanforderungen validiert.",
+      "validated": "Die Einreichung hat die Validierung bestanden und ist versandbereit.",
+      "submitted": "Die Einreichung wurde an das Behördenportal gesendet.",
+      "acknowledged": "Das Portal hat den Eingang der Einreichung bestätigt.",
+      "processing": "Das Portal verarbeitet die Einreichung.",
+      "accepted": "Die Einreichung wurde vom Portal akzeptiert.",
+      "rejected": "Die Einreichung wurde abgelehnt. Prüfen Sie die Fehlerdetails und versuchen Sie es erneut.",
+      "requires_correction": "Die Einreichung erfordert Korrekturen, bevor sie akzeptiert werden kann.",
+      "cancelled": "Die Einreichung wurde storniert."
+    },
+    "page": {
+      "backToDashboard": "Zurück zum Dashboard",
+      "title": "Einreichungsstatus",
+      "reference": "Referenz: {{reference}}",
+      "errorDetails": "Fehlerdetails",
+      "validationErrors": "Validierungsfehler:",
+      "warnings": "Warnungen:",
+      "submissionDetails": "Einreichungsdetails",
+      "reportType": "Berichtstyp",
+      "reportPeriod": "Berichtszeitraum",
+      "externalReference": "Externe Referenz",
+      "created": "Erstellt",
+      "validated": "Validiert",
+      "submitted": "Eingereicht",
+      "acknowledged": "Bestätigt",
+      "processed": "Verarbeitet",
+      "submissionAttempts": "Einreichungsversuche",
+      "nextRetry": "Nächster automatischer Versuch geplant: {{date}}",
+      "reportDocument": "Berichtsdokument",
+      "viewReportPdf": "Bericht-PDF anzeigen",
+      "attachments": "Anhänge ({{count}})",
+      "auditTrail": "Prüfprotokoll ({{count}} Ereignisse)",
+      "noAuditEvents": "Keine Prüfereignisse aufgezeichnet.",
+      "cancelSubmission": "Einreichung stornieren",
+      "validating": "Wird validiert...",
+      "validate": "Validieren",
+      "retrying": "Wird wiederholt...",
+      "retrySubmission": "Einreichung wiederholen",
+      "retryFailed": "Wiederholung fehlgeschlagen",
+      "validationFailed": "Validierung fehlgeschlagen",
+      "cancelFailed": "Stornierung fehlgeschlagen"
+    }
+  },
+  "ocrStatus": {
+    "compact": {
+      "completed": "OCR",
+      "processing": "In Bearbeitung",
+      "pending": "Ausstehend",
+      "failed": "Fehlgeschlagen",
+      "not_applicable": "N/V"
+    },
+    "full": {
+      "completed": "Text extrahiert",
+      "processing": "OCR wird verarbeitet...",
+      "pending": "OCR ausstehend",
+      "failed": "OCR fehlgeschlagen",
+      "not_applicable": "Nicht zutreffend"
+    },
+    "reprocessing": "Erneute Verarbeitung...",
+    "retry": "Wiederholen",
+    "retryTitle": "OCR-Verarbeitung wiederholen",
+    "processingTitle": "OCR-Verarbeitung",
+    "extractingText": "Text wird aus dem Dokument extrahiert... Dies kann einen Moment dauern.",
+    "textExtractedOn": "Text extrahiert am {{date}}",
+    "processingFailed": "OCR-Verarbeitung fehlgeschlagen. Das Dokument wird möglicherweise nicht unterstützt oder ist beschädigt.",
+    "clickRetry": "Klicken Sie auf „Wiederholen“, um es erneut zu versuchen.",
+    "queuedForExtraction": "Das Dokument ist für die Textextraktion eingereiht."
+  },
+  "competitiveStatus": {
+    "features": {
+      "tours": "Virtuelle Touren",
+      "pricing": "Preisanalyse",
+      "neighborhood": "Nachbarschaft",
+      "comparables": "Vergleichsobjekte"
+    },
+    "competitive": "Wettbewerb",
+    "title": "Wettbewerbsfunktionen",
+    "percentComplete": "{{percent}} % abgeschlossen",
+    "viewAnalysis": "Analyse anzeigen"
   }
 }

--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -3338,5 +3338,100 @@
     "errorDescription": "Error: {{message}}",
     "disconnectedDescription": "Real-time updates are not available",
     "clickToReconnect": "Click to reconnect"
+  },
+  "submissionStatus": {
+    "status": {
+      "draft": "Draft",
+      "pending_validation": "Pending Validation",
+      "validated": "Validated",
+      "submitted": "Submitted",
+      "acknowledged": "Acknowledged",
+      "processing": "Processing",
+      "accepted": "Accepted",
+      "rejected": "Rejected",
+      "requires_correction": "Needs Correction",
+      "cancelled": "Cancelled"
+    },
+    "description": {
+      "draft": "The submission is being prepared and has not been validated yet.",
+      "pending_validation": "The submission is being validated against portal requirements.",
+      "validated": "The submission passed validation and is ready to be sent.",
+      "submitted": "The submission has been sent to the government portal.",
+      "acknowledged": "The portal has acknowledged receipt of the submission.",
+      "processing": "The portal is processing the submission.",
+      "accepted": "The submission has been accepted by the portal.",
+      "rejected": "The submission was rejected. Review the error details and retry.",
+      "requires_correction": "The submission requires corrections before it can be accepted.",
+      "cancelled": "The submission has been cancelled."
+    },
+    "page": {
+      "backToDashboard": "Back to Dashboard",
+      "title": "Submission Status",
+      "reference": "Reference: {{reference}}",
+      "errorDetails": "Error Details",
+      "validationErrors": "Validation Errors:",
+      "warnings": "Warnings:",
+      "submissionDetails": "Submission Details",
+      "reportType": "Report Type",
+      "reportPeriod": "Report Period",
+      "externalReference": "External Reference",
+      "created": "Created",
+      "validated": "Validated",
+      "submitted": "Submitted",
+      "acknowledged": "Acknowledged",
+      "processed": "Processed",
+      "submissionAttempts": "Submission Attempts",
+      "nextRetry": "Next automatic retry scheduled: {{date}}",
+      "reportDocument": "Report Document",
+      "viewReportPdf": "View Report PDF",
+      "attachments": "Attachments ({{count}})",
+      "auditTrail": "Audit Trail ({{count}} events)",
+      "noAuditEvents": "No audit events recorded.",
+      "cancelSubmission": "Cancel Submission",
+      "validating": "Validating...",
+      "validate": "Validate",
+      "retrying": "Retrying...",
+      "retrySubmission": "Retry Submission",
+      "retryFailed": "Retry failed",
+      "validationFailed": "Validation failed",
+      "cancelFailed": "Cancel failed"
+    }
+  },
+  "ocrStatus": {
+    "compact": {
+      "completed": "OCR",
+      "processing": "Processing",
+      "pending": "Pending",
+      "failed": "Failed",
+      "not_applicable": "N/A"
+    },
+    "full": {
+      "completed": "Text Extracted",
+      "processing": "Processing OCR...",
+      "pending": "OCR Pending",
+      "failed": "OCR Failed",
+      "not_applicable": "Not Applicable"
+    },
+    "reprocessing": "Reprocessing...",
+    "retry": "Retry",
+    "retryTitle": "Retry OCR processing",
+    "processingTitle": "OCR Processing",
+    "extractingText": "Extracting text from document... This may take a few moments.",
+    "textExtractedOn": "Text extracted on {{date}}",
+    "processingFailed": "OCR processing failed. The document may be unsupported or corrupted.",
+    "clickRetry": "Click \"Retry\" to try again.",
+    "queuedForExtraction": "Document is queued for text extraction."
+  },
+  "competitiveStatus": {
+    "features": {
+      "tours": "Virtual Tours",
+      "pricing": "Pricing Analysis",
+      "neighborhood": "Neighborhood",
+      "comparables": "Comparables"
+    },
+    "competitive": "Competitive",
+    "title": "Competitive Features",
+    "percentComplete": "{{percent}}% Complete",
+    "viewAnalysis": "View Analysis"
   }
 }

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -1020,5 +1020,100 @@
     "errorDescription": "Hiba: {{message}}",
     "disconnectedDescription": "A valós idejű frissítések nem érhetők el",
     "clickToReconnect": "Kattintson az újracsatlakozáshoz"
+  },
+  "submissionStatus": {
+    "status": {
+      "draft": "Vázlat",
+      "pending_validation": "Ellenőrzésre vár",
+      "validated": "Ellenőrizve",
+      "submitted": "Beküldve",
+      "acknowledged": "Visszaigazolva",
+      "processing": "Feldolgozás alatt",
+      "accepted": "Elfogadva",
+      "rejected": "Elutasítva",
+      "requires_correction": "Javítás szükséges",
+      "cancelled": "Visszavonva"
+    },
+    "description": {
+      "draft": "A beküldés előkészítés alatt áll, és még nem került ellenőrzésre.",
+      "pending_validation": "A beküldést a portál követelményei alapján ellenőrzik.",
+      "validated": "A beküldés átment az ellenőrzésen, és készen áll a küldésre.",
+      "submitted": "A beküldést elküldték a kormányzati portálra.",
+      "acknowledged": "A portál visszaigazolta a beküldés átvételét.",
+      "processing": "A portál feldolgozza a beküldést.",
+      "accepted": "A beküldést a portál elfogadta.",
+      "rejected": "A beküldést elutasították. Tekintse át a hiba részleteit, és próbálja újra.",
+      "requires_correction": "A beküldés elfogadás előtt javításokat igényel.",
+      "cancelled": "A beküldést visszavonták."
+    },
+    "page": {
+      "backToDashboard": "Vissza az irányítópultra",
+      "title": "Beküldés állapota",
+      "reference": "Hivatkozás: {{reference}}",
+      "errorDetails": "Hiba részletei",
+      "validationErrors": "Ellenőrzési hibák:",
+      "warnings": "Figyelmeztetések:",
+      "submissionDetails": "Beküldés részletei",
+      "reportType": "Jelentés típusa",
+      "reportPeriod": "Jelentési időszak",
+      "externalReference": "Külső hivatkozás",
+      "created": "Létrehozva",
+      "validated": "Ellenőrizve",
+      "submitted": "Beküldve",
+      "acknowledged": "Visszaigazolva",
+      "processed": "Feldolgozva",
+      "submissionAttempts": "Beküldési kísérletek",
+      "nextRetry": "Következő automatikus újrapróbálkozás ütemezve: {{date}}",
+      "reportDocument": "Jelentés dokumentuma",
+      "viewReportPdf": "Jelentés PDF megtekintése",
+      "attachments": "Mellékletek ({{count}})",
+      "auditTrail": "Naplózás ({{count}} esemény)",
+      "noAuditEvents": "Nincs rögzített naplóesemény.",
+      "cancelSubmission": "Beküldés visszavonása",
+      "validating": "Ellenőrzés...",
+      "validate": "Ellenőrzés",
+      "retrying": "Újrapróbálkozás...",
+      "retrySubmission": "Beküldés újrapróbálása",
+      "retryFailed": "Az újrapróbálkozás sikertelen",
+      "validationFailed": "Az ellenőrzés sikertelen",
+      "cancelFailed": "A visszavonás sikertelen"
+    }
+  },
+  "ocrStatus": {
+    "compact": {
+      "completed": "OCR",
+      "processing": "Feldolgozás",
+      "pending": "Függőben",
+      "failed": "Sikertelen",
+      "not_applicable": "N/A"
+    },
+    "full": {
+      "completed": "Szöveg kinyerve",
+      "processing": "OCR feldolgozása...",
+      "pending": "OCR függőben",
+      "failed": "OCR sikertelen",
+      "not_applicable": "Nem alkalmazható"
+    },
+    "reprocessing": "Ismételt feldolgozás...",
+    "retry": "Újra",
+    "retryTitle": "OCR feldolgozás újrapróbálása",
+    "processingTitle": "OCR feldolgozás",
+    "extractingText": "Szöveg kinyerése a dokumentumból... Ez eltarthat egy ideig.",
+    "textExtractedOn": "Szöveg kinyerve: {{date}}",
+    "processingFailed": "Az OCR feldolgozás sikertelen. A dokumentum nem támogatott vagy sérült lehet.",
+    "clickRetry": "Kattintson az „Újra” gombra az ismételt próbálkozáshoz.",
+    "queuedForExtraction": "A dokumentum sorban áll a szövegkinyeréshez."
+  },
+  "competitiveStatus": {
+    "features": {
+      "tours": "Virtuális túrák",
+      "pricing": "Árelemzés",
+      "neighborhood": "Környék",
+      "comparables": "Összehasonlíthatók"
+    },
+    "competitive": "Versenyképes",
+    "title": "Versenyképességi funkciók",
+    "percentComplete": "{{percent}}% kész",
+    "viewAnalysis": "Elemzés megtekintése"
   }
 }

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -1026,5 +1026,100 @@
     "errorDescription": "Błąd: {{message}}",
     "disconnectedDescription": "Aktualizacje w czasie rzeczywistym są niedostępne",
     "clickToReconnect": "Kliknij, aby połączyć ponownie"
+  },
+  "submissionStatus": {
+    "status": {
+      "draft": "Wersja robocza",
+      "pending_validation": "Oczekuje na weryfikację",
+      "validated": "Zweryfikowano",
+      "submitted": "Wysłano",
+      "acknowledged": "Potwierdzono",
+      "processing": "Przetwarzanie",
+      "accepted": "Zaakceptowano",
+      "rejected": "Odrzucono",
+      "requires_correction": "Wymaga poprawy",
+      "cancelled": "Anulowano"
+    },
+    "description": {
+      "draft": "Zgłoszenie jest przygotowywane i nie zostało jeszcze zweryfikowane.",
+      "pending_validation": "Zgłoszenie jest weryfikowane pod kątem wymagań portalu.",
+      "validated": "Zgłoszenie przeszło weryfikację i jest gotowe do wysłania.",
+      "submitted": "Zgłoszenie zostało wysłane do portalu rządowego.",
+      "acknowledged": "Portal potwierdził otrzymanie zgłoszenia.",
+      "processing": "Portal przetwarza zgłoszenie.",
+      "accepted": "Zgłoszenie zostało zaakceptowane przez portal.",
+      "rejected": "Zgłoszenie zostało odrzucone. Sprawdź szczegóły błędu i spróbuj ponownie.",
+      "requires_correction": "Zgłoszenie wymaga poprawek przed zaakceptowaniem.",
+      "cancelled": "Zgłoszenie zostało anulowane."
+    },
+    "page": {
+      "backToDashboard": "Powrót do panelu",
+      "title": "Status zgłoszenia",
+      "reference": "Numer referencyjny: {{reference}}",
+      "errorDetails": "Szczegóły błędu",
+      "validationErrors": "Błędy weryfikacji:",
+      "warnings": "Ostrzeżenia:",
+      "submissionDetails": "Szczegóły zgłoszenia",
+      "reportType": "Typ raportu",
+      "reportPeriod": "Okres raportu",
+      "externalReference": "Zewnętrzny numer referencyjny",
+      "created": "Utworzono",
+      "validated": "Zweryfikowano",
+      "submitted": "Wysłano",
+      "acknowledged": "Potwierdzono",
+      "processed": "Przetworzono",
+      "submissionAttempts": "Liczba prób zgłoszenia",
+      "nextRetry": "Zaplanowano kolejną automatyczną próbę: {{date}}",
+      "reportDocument": "Dokument raportu",
+      "viewReportPdf": "Wyświetl PDF raportu",
+      "attachments": "Załączniki ({{count}})",
+      "auditTrail": "Dziennik audytu ({{count}} zdarzeń)",
+      "noAuditEvents": "Brak zarejestrowanych zdarzeń audytu.",
+      "cancelSubmission": "Anuluj zgłoszenie",
+      "validating": "Weryfikowanie...",
+      "validate": "Zweryfikuj",
+      "retrying": "Ponawianie...",
+      "retrySubmission": "Ponów zgłoszenie",
+      "retryFailed": "Ponowienie nie powiodło się",
+      "validationFailed": "Weryfikacja nie powiodła się",
+      "cancelFailed": "Anulowanie nie powiodło się"
+    }
+  },
+  "ocrStatus": {
+    "compact": {
+      "completed": "OCR",
+      "processing": "Przetwarzanie",
+      "pending": "Oczekuje",
+      "failed": "Niepowodzenie",
+      "not_applicable": "Nd."
+    },
+    "full": {
+      "completed": "Tekst wyodrębniony",
+      "processing": "Przetwarzanie OCR...",
+      "pending": "OCR oczekuje",
+      "failed": "OCR nie powiódł się",
+      "not_applicable": "Nie dotyczy"
+    },
+    "reprocessing": "Ponowne przetwarzanie...",
+    "retry": "Ponów",
+    "retryTitle": "Ponów przetwarzanie OCR",
+    "processingTitle": "Przetwarzanie OCR",
+    "extractingText": "Wyodrębnianie tekstu z dokumentu... Może to chwilę potrwać.",
+    "textExtractedOn": "Tekst wyodrębniono {{date}}",
+    "processingFailed": "Przetwarzanie OCR nie powiodło się. Dokument może być nieobsługiwany lub uszkodzony.",
+    "clickRetry": "Kliknij „Ponów”, aby spróbować ponownie.",
+    "queuedForExtraction": "Dokument oczekuje w kolejce na wyodrębnienie tekstu."
+  },
+  "competitiveStatus": {
+    "features": {
+      "tours": "Wirtualne spacery",
+      "pricing": "Analiza cenowa",
+      "neighborhood": "Okolica",
+      "comparables": "Porównywalne"
+    },
+    "competitive": "Konkurencyjne",
+    "title": "Funkcje konkurencyjne",
+    "percentComplete": "Ukończono {{percent}}%",
+    "viewAnalysis": "Wyświetl analizę"
   }
 }

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -1053,5 +1053,100 @@
     "errorDescription": "Chyba: {{message}}",
     "disconnectedDescription": "Aktualizácie v reálnom čase nie sú dostupné",
     "clickToReconnect": "Kliknutím sa znova pripojíte"
+  },
+  "submissionStatus": {
+    "status": {
+      "draft": "Koncept",
+      "pending_validation": "Čaká na overenie",
+      "validated": "Overené",
+      "submitted": "Odoslané",
+      "acknowledged": "Potvrdené",
+      "processing": "Spracúva sa",
+      "accepted": "Prijaté",
+      "rejected": "Zamietnuté",
+      "requires_correction": "Vyžaduje opravu",
+      "cancelled": "Zrušené"
+    },
+    "description": {
+      "draft": "Podanie sa pripravuje a zatiaľ nebolo overené.",
+      "pending_validation": "Podanie sa overuje voči požiadavkám portálu.",
+      "validated": "Podanie prešlo overením a je pripravené na odoslanie.",
+      "submitted": "Podanie bolo odoslané na štátny portál.",
+      "acknowledged": "Portál potvrdil prijatie podania.",
+      "processing": "Portál spracúva podanie.",
+      "accepted": "Podanie bolo portálom prijaté.",
+      "rejected": "Podanie bolo zamietnuté. Skontrolujte podrobnosti chyby a skúste znova.",
+      "requires_correction": "Podanie pred prijatím vyžaduje opravy.",
+      "cancelled": "Podanie bolo zrušené."
+    },
+    "page": {
+      "backToDashboard": "Späť na nástenku",
+      "title": "Stav podania",
+      "reference": "Referencia: {{reference}}",
+      "errorDetails": "Podrobnosti chyby",
+      "validationErrors": "Chyby overenia:",
+      "warnings": "Upozornenia:",
+      "submissionDetails": "Podrobnosti podania",
+      "reportType": "Typ výkazu",
+      "reportPeriod": "Obdobie výkazu",
+      "externalReference": "Externá referencia",
+      "created": "Vytvorené",
+      "validated": "Overené",
+      "submitted": "Odoslané",
+      "acknowledged": "Potvrdené",
+      "processed": "Spracované",
+      "submissionAttempts": "Počet pokusov o podanie",
+      "nextRetry": "Naplánovaný ďalší automatický pokus: {{date}}",
+      "reportDocument": "Dokument výkazu",
+      "viewReportPdf": "Zobraziť PDF výkazu",
+      "attachments": "Prílohy ({{count}})",
+      "auditTrail": "Audit ({{count}} udalostí)",
+      "noAuditEvents": "Nezaznamenané žiadne udalosti auditu.",
+      "cancelSubmission": "Zrušiť podanie",
+      "validating": "Overuje sa...",
+      "validate": "Overiť",
+      "retrying": "Opakuje sa...",
+      "retrySubmission": "Opakovať podanie",
+      "retryFailed": "Opakovanie zlyhalo",
+      "validationFailed": "Overenie zlyhalo",
+      "cancelFailed": "Zrušenie zlyhalo"
+    }
+  },
+  "ocrStatus": {
+    "compact": {
+      "completed": "OCR",
+      "processing": "Spracúva sa",
+      "pending": "Čaká",
+      "failed": "Zlyhalo",
+      "not_applicable": "N/A"
+    },
+    "full": {
+      "completed": "Text extrahovaný",
+      "processing": "Spracúva sa OCR...",
+      "pending": "OCR čaká",
+      "failed": "OCR zlyhalo",
+      "not_applicable": "Neaplikovateľné"
+    },
+    "reprocessing": "Opakované spracovanie...",
+    "retry": "Opakovať",
+    "retryTitle": "Opakovať spracovanie OCR",
+    "processingTitle": "Spracovanie OCR",
+    "extractingText": "Extrahuje sa text z dokumentu... Môže to chvíľu trvať.",
+    "textExtractedOn": "Text extrahovaný {{date}}",
+    "processingFailed": "Spracovanie OCR zlyhalo. Dokument môže byť nepodporovaný alebo poškodený.",
+    "clickRetry": "Kliknite na „Opakovať“ pre opätovný pokus.",
+    "queuedForExtraction": "Dokument je zaradený na extrakciu textu."
+  },
+  "competitiveStatus": {
+    "features": {
+      "tours": "Virtuálne prehliadky",
+      "pricing": "Cenová analýza",
+      "neighborhood": "Okolie",
+      "comparables": "Porovnateľné"
+    },
+    "competitive": "Konkurenčné",
+    "title": "Konkurenčné funkcie",
+    "percentComplete": "Dokončené {{percent}} %",
+    "viewAnalysis": "Zobraziť analýzu"
   }
 }

--- a/frontend/apps/ppt-web/src/features/competitive/components/CompetitiveStatusBadge.tsx
+++ b/frontend/apps/ppt-web/src/features/competitive/components/CompetitiveStatusBadge.tsx
@@ -5,6 +5,8 @@
  * Shows the status of competitive features for a listing.
  */
 
+import { useTranslation } from 'react-i18next';
+
 export interface CompetitiveFeaturesStatus {
   listingId: string;
   hasVirtualTours: boolean;
@@ -33,10 +35,11 @@ export function CompetitiveStatusBadge({
   compact = false,
   className = '',
 }: CompetitiveStatusBadgeProps) {
+  const { t } = useTranslation();
   const features = [
     {
       key: 'tours',
-      label: 'Virtual Tours',
+      label: t('competitiveStatus.features.tours'),
       active: status.hasVirtualTours,
       count: status.virtualTourCount,
       icon: (
@@ -52,7 +55,7 @@ export function CompetitiveStatusBadge({
     },
     {
       key: 'pricing',
-      label: 'Pricing Analysis',
+      label: t('competitiveStatus.features.pricing'),
       active: status.hasPricingAnalysis && status.pricingAnalysisValid,
       icon: (
         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -67,7 +70,7 @@ export function CompetitiveStatusBadge({
     },
     {
       key: 'neighborhood',
-      label: 'Neighborhood',
+      label: t('competitiveStatus.features.neighborhood'),
       active: status.hasNeighborhoodInsights && status.neighborhoodInsightsValid,
       icon: (
         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -88,7 +91,7 @@ export function CompetitiveStatusBadge({
     },
     {
       key: 'comparables',
-      label: 'Comparables',
+      label: t('competitiveStatus.features.comparables'),
       active: status.hasComparables,
       count: status.comparablesCount,
       icon: (
@@ -119,7 +122,7 @@ export function CompetitiveStatusBadge({
         } ${className}`}
       >
         <span className="font-medium">{completionPercent}%</span>
-        <span className="text-xs">Competitive</span>
+        <span className="text-xs">{t('competitiveStatus.competitive')}</span>
       </button>
     );
   }
@@ -128,7 +131,7 @@ export function CompetitiveStatusBadge({
     <div className={`bg-white rounded-lg shadow-sm border p-4 ${className}`}>
       {/* Header */}
       <div className="flex items-center justify-between mb-4">
-        <h3 className="text-sm font-semibold text-gray-900">Competitive Features</h3>
+        <h3 className="text-sm font-semibold text-gray-900">{t('competitiveStatus.title')}</h3>
         <span
           className={`px-2 py-1 text-xs font-medium rounded-full ${
             completionPercent === 100
@@ -138,7 +141,7 @@ export function CompetitiveStatusBadge({
                 : 'bg-gray-100 text-gray-600'
           }`}
         >
-          {completionPercent}% Complete
+          {t('competitiveStatus.percentComplete', { percent: completionPercent })}
         </span>
       </div>
 
@@ -204,7 +207,7 @@ export function CompetitiveStatusBadge({
           onClick={onViewDetails}
           className="w-full mt-4 px-4 py-2 text-sm font-medium text-blue-600 bg-blue-50 hover:bg-blue-100 rounded-lg transition-colors"
         >
-          View Analysis
+          {t('competitiveStatus.viewAnalysis')}
         </button>
       )}
     </div>

--- a/frontend/apps/ppt-web/src/features/documents/components/OcrStatusBadge.tsx
+++ b/frontend/apps/ppt-web/src/features/documents/components/OcrStatusBadge.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { OcrStatus } from '@ppt/api-client';
+import { useTranslation } from 'react-i18next';
 
 interface OcrStatusBadgeProps {
   status: OcrStatus;
@@ -19,36 +20,38 @@ export function OcrStatusBadge({
   onReprocess,
   isReprocessing = false,
 }: OcrStatusBadgeProps) {
+  const { t } = useTranslation();
   // Get status configuration
   const getStatusConfig = (s: OcrStatus) => {
+    const variant = compact ? 'compact' : 'full';
     switch (s) {
       case 'completed':
         return {
-          label: compact ? 'OCR' : 'Text Extracted',
+          label: t(`ocrStatus.${variant}.completed`),
           className: 'status-completed',
           icon: '✓',
         };
       case 'processing':
         return {
-          label: compact ? 'Processing' : 'Processing OCR...',
+          label: t(`ocrStatus.${variant}.processing`),
           className: 'status-processing',
           icon: '⟳',
         };
       case 'pending':
         return {
-          label: compact ? 'Pending' : 'OCR Pending',
+          label: t(`ocrStatus.${variant}.pending`),
           className: 'status-pending',
           icon: '○',
         };
       case 'failed':
         return {
-          label: compact ? 'Failed' : 'OCR Failed',
+          label: t(`ocrStatus.${variant}.failed`),
           className: 'status-failed',
           icon: '✕',
         };
       case 'not_applicable':
         return {
-          label: compact ? 'N/A' : 'Not Applicable',
+          label: t(`ocrStatus.${variant}.not_applicable`),
           className: 'status-na',
           icon: '—',
         };
@@ -68,7 +71,9 @@ export function OcrStatusBadge({
       <span className={`status-icon ${isReprocessing ? 'spinning' : ''}`}>
         {isReprocessing ? '⟳' : config.icon}
       </span>
-      <span className="status-label">{isReprocessing ? 'Reprocessing...' : config.label}</span>
+      <span className="status-label">
+        {isReprocessing ? t('ocrStatus.reprocessing') : config.label}
+      </span>
 
       {/* Reprocess button for failed status */}
       {status === 'failed' && onReprocess && !isReprocessing && (
@@ -79,9 +84,9 @@ export function OcrStatusBadge({
             onReprocess();
           }}
           className="reprocess-button"
-          title="Retry OCR processing"
+          title={t('ocrStatus.retryTitle')}
         >
-          Retry
+          {t('ocrStatus.retry')}
         </button>
       )}
 
@@ -182,6 +187,7 @@ export function OcrProcessingStatus({
   onReprocess,
   isReprocessing,
 }: OcrProcessingStatusProps) {
+  const { t } = useTranslation();
   const formatDate = (dateString: string): string => {
     const date = new Date(dateString);
     return date.toLocaleString('en-US', {
@@ -196,7 +202,7 @@ export function OcrProcessingStatus({
   return (
     <div className="ocr-processing-status">
       <div className="status-header">
-        <h4 className="status-title">OCR Processing</h4>
+        <h4 className="status-title">{t('ocrStatus.processingTitle')}</h4>
         <OcrStatusBadge status={status} onReprocess={onReprocess} isReprocessing={isReprocessing} />
       </div>
 
@@ -205,26 +211,24 @@ export function OcrProcessingStatus({
           <div className="progress-bar">
             <div className="progress-bar-fill" />
           </div>
-          <p className="processing-text">
-            Extracting text from document... This may take a few moments.
-          </p>
+          <p className="processing-text">{t('ocrStatus.extractingText')}</p>
         </div>
       )}
 
       {status === 'completed' && processedAt && (
-        <p className="processed-date">Text extracted on {formatDate(processedAt)}</p>
+        <p className="processed-date">
+          {t('ocrStatus.textExtractedOn', { date: formatDate(processedAt) })}
+        </p>
       )}
 
       {status === 'failed' && (
         <p className="error-text">
-          OCR processing failed. The document may be unsupported or corrupted.
-          {onReprocess && ' Click "Retry" to try again.'}
+          {t('ocrStatus.processingFailed')}
+          {onReprocess && ` ${t('ocrStatus.clickRetry')}`}
         </p>
       )}
 
-      {status === 'pending' && (
-        <p className="pending-text">Document is queued for text extraction.</p>
-      )}
+      {status === 'pending' && <p className="pending-text">{t('ocrStatus.queuedForExtraction')}</p>}
 
       <style>{`
         .ocr-processing-status {

--- a/frontend/apps/ppt-web/src/features/government-portal/components/SubmissionStatusBadge.tsx
+++ b/frontend/apps/ppt-web/src/features/government-portal/components/SubmissionStatusBadge.tsx
@@ -4,6 +4,7 @@
  */
 
 import type { SubmissionStatus } from '@ppt/api-client';
+import { useTranslation } from 'react-i18next';
 
 interface SubmissionStatusBadgeProps {
   status: SubmissionStatus;
@@ -13,14 +14,15 @@ interface SubmissionStatusBadgeProps {
 }
 
 interface StatusConfig {
-  label: string;
+  /** i18n key under `submissionStatus.status` for the badge label */
+  labelKey: string;
   className: string;
   icon: React.ReactNode;
 }
 
 const statusConfig: Record<SubmissionStatus, StatusConfig> = {
   draft: {
-    label: 'Draft',
+    labelKey: 'draft',
     className: 'bg-gray-100 text-gray-700',
     icon: (
       <svg
@@ -40,7 +42,7 @@ const statusConfig: Record<SubmissionStatus, StatusConfig> = {
     ),
   },
   pending_validation: {
-    label: 'Pending Validation',
+    labelKey: 'pending_validation',
     className: 'bg-blue-100 text-blue-700',
     icon: (
       <svg
@@ -60,7 +62,7 @@ const statusConfig: Record<SubmissionStatus, StatusConfig> = {
     ),
   },
   validated: {
-    label: 'Validated',
+    labelKey: 'validated',
     className: 'bg-cyan-100 text-cyan-700',
     icon: (
       <svg
@@ -80,7 +82,7 @@ const statusConfig: Record<SubmissionStatus, StatusConfig> = {
     ),
   },
   submitted: {
-    label: 'Submitted',
+    labelKey: 'submitted',
     className: 'bg-indigo-100 text-indigo-700',
     icon: (
       <svg
@@ -100,7 +102,7 @@ const statusConfig: Record<SubmissionStatus, StatusConfig> = {
     ),
   },
   acknowledged: {
-    label: 'Acknowledged',
+    labelKey: 'acknowledged',
     className: 'bg-purple-100 text-purple-700',
     icon: (
       <svg
@@ -115,7 +117,7 @@ const statusConfig: Record<SubmissionStatus, StatusConfig> = {
     ),
   },
   processing: {
-    label: 'Processing',
+    labelKey: 'processing',
     className: 'bg-yellow-100 text-yellow-700',
     icon: (
       <svg
@@ -135,7 +137,7 @@ const statusConfig: Record<SubmissionStatus, StatusConfig> = {
     ),
   },
   accepted: {
-    label: 'Accepted',
+    labelKey: 'accepted',
     className: 'bg-green-100 text-green-700',
     icon: (
       <svg
@@ -155,7 +157,7 @@ const statusConfig: Record<SubmissionStatus, StatusConfig> = {
     ),
   },
   rejected: {
-    label: 'Rejected',
+    labelKey: 'rejected',
     className: 'bg-red-100 text-red-700',
     icon: (
       <svg
@@ -175,7 +177,7 @@ const statusConfig: Record<SubmissionStatus, StatusConfig> = {
     ),
   },
   requires_correction: {
-    label: 'Needs Correction',
+    labelKey: 'requires_correction',
     className: 'bg-orange-100 text-orange-700',
     icon: (
       <svg
@@ -195,7 +197,7 @@ const statusConfig: Record<SubmissionStatus, StatusConfig> = {
     ),
   },
   cancelled: {
-    label: 'Cancelled',
+    labelKey: 'cancelled',
     className: 'bg-gray-100 text-gray-500',
     icon: (
       <svg
@@ -221,6 +223,7 @@ export function SubmissionStatusBadge({
   showIcon = true,
   size = 'md',
 }: SubmissionStatusBadgeProps) {
+  const { t } = useTranslation();
   const config = statusConfig[status];
 
   const sizeClasses = {
@@ -234,7 +237,7 @@ export function SubmissionStatusBadge({
       className={`inline-flex items-center rounded-full font-medium ${config.className} ${sizeClasses[size]}`}
     >
       {showIcon && config.icon}
-      {config.label}
+      {t(`submissionStatus.status.${config.labelKey}`)}
     </span>
   );
 }

--- a/frontend/apps/ppt-web/src/features/government-portal/pages/SubmissionStatusPage.tsx
+++ b/frontend/apps/ppt-web/src/features/government-portal/pages/SubmissionStatusPage.tsx
@@ -13,6 +13,7 @@ import type {
   SubmissionStatus,
 } from '@ppt/api-client';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { SubmissionStatusBadge } from '../components/SubmissionStatusBadge';
 
 interface SubmissionStatusPageProps {
@@ -50,6 +51,7 @@ export function SubmissionStatusPage({
   onCancel,
   onBack,
 }: SubmissionStatusPageProps) {
+  const { t } = useTranslation();
   const [showErrorDetails, setShowErrorDetails] = useState(false);
   const [showAuditTrail, setShowAuditTrail] = useState(false);
   const [cancelError, setCancelError] = useState<string | null>(null);
@@ -83,7 +85,7 @@ export function SubmissionStatusPage({
     try {
       await onRetry(submission.id);
     } catch (err) {
-      setActionError(err instanceof Error ? err.message : 'Retry failed');
+      setActionError(err instanceof Error ? err.message : t('submissionStatus.page.retryFailed'));
     }
   };
 
@@ -92,7 +94,9 @@ export function SubmissionStatusPage({
     try {
       await onValidate(submission.id);
     } catch (err) {
-      setActionError(err instanceof Error ? err.message : 'Validation failed');
+      setActionError(
+        err instanceof Error ? err.message : t('submissionStatus.page.validationFailed')
+      );
     }
   };
 
@@ -101,25 +105,12 @@ export function SubmissionStatusPage({
     try {
       await onCancel(submission.id);
     } catch (err) {
-      setCancelError(err instanceof Error ? err.message : 'Cancel failed');
+      setCancelError(err instanceof Error ? err.message : t('submissionStatus.page.cancelFailed'));
     }
   };
 
-  const getStatusDescription = (status: SubmissionStatus): string => {
-    const descriptions: Record<SubmissionStatus, string> = {
-      draft: 'The submission is being prepared and has not been validated yet.',
-      pending_validation: 'The submission is being validated against portal requirements.',
-      validated: 'The submission passed validation and is ready to be sent.',
-      submitted: 'The submission has been sent to the government portal.',
-      acknowledged: 'The portal has acknowledged receipt of the submission.',
-      processing: 'The portal is processing the submission.',
-      accepted: 'The submission has been accepted by the portal.',
-      rejected: 'The submission was rejected. Review the error details and retry.',
-      requires_correction: 'The submission requires corrections before it can be accepted.',
-      cancelled: 'The submission has been cancelled.',
-    };
-    return descriptions[status];
-  };
+  const getStatusDescription = (status: SubmissionStatus): string =>
+    t(`submissionStatus.description.${status}`);
 
   if (isLoading) {
     return (
@@ -160,13 +151,17 @@ export function SubmissionStatusPage({
               d="M15 19l-7-7 7-7"
             />
           </svg>
-          Back to Dashboard
+          {t('submissionStatus.page.backToDashboard')}
         </button>
 
         <div className="flex items-start justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-gray-900">Submission Status</h1>
-            <p className="mt-1 text-gray-500">Reference: {submission.submissionReference}</p>
+            <h1 className="text-2xl font-bold text-gray-900">{t('submissionStatus.page.title')}</h1>
+            <p className="mt-1 text-gray-500">
+              {t('submissionStatus.page.reference', {
+                reference: submission.submissionReference,
+              })}
+            </p>
           </div>
           <SubmissionStatusBadge status={submission.status} size="lg" />
         </div>
@@ -224,7 +219,9 @@ export function SubmissionStatusPage({
                     d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
                   />
                 </svg>
-                <span className="font-medium text-red-900">Error Details</span>
+                <span className="font-medium text-red-900">
+                  {t('submissionStatus.page.errorDetails')}
+                </span>
               </div>
               <svg
                 className={`h-5 w-5 text-red-500 transition-transform ${showErrorDetails ? 'rotate-180' : ''}`}
@@ -249,7 +246,9 @@ export function SubmissionStatusPage({
                 </pre>
                 {submission.validationResult && !submission.validationResult.isValid && (
                   <div className="mt-4">
-                    <h4 className="text-sm font-medium text-red-900 mb-2">Validation Errors:</h4>
+                    <h4 className="text-sm font-medium text-red-900 mb-2">
+                      {t('submissionStatus.page.validationErrors')}
+                    </h4>
                     <ul className="space-y-2">
                       {submission.validationResult.errors.map((error) => (
                         <li
@@ -283,7 +282,9 @@ export function SubmissionStatusPage({
                 {submission.validationResult?.warnings &&
                   submission.validationResult.warnings.length > 0 && (
                     <div className="mt-4">
-                      <h4 className="text-sm font-medium text-yellow-900 mb-2">Warnings:</h4>
+                      <h4 className="text-sm font-medium text-yellow-900 mb-2">
+                        {t('submissionStatus.page.warnings')}
+                      </h4>
                       <ul className="space-y-2">
                         {submission.validationResult.warnings.map((warning) => (
                           <li
@@ -321,45 +322,65 @@ export function SubmissionStatusPage({
 
       {/* Submission Details */}
       <div className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Submission Details</h2>
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">
+          {t('submissionStatus.page.submissionDetails')}
+        </h2>
         <div className="grid grid-cols-2 md:grid-cols-3 gap-6">
           <div>
-            <p className="text-sm font-medium text-gray-500">Report Type</p>
+            <p className="text-sm font-medium text-gray-500">
+              {t('submissionStatus.page.reportType')}
+            </p>
             <p className="text-gray-900">{submission.reportType}</p>
           </div>
           <div>
-            <p className="text-sm font-medium text-gray-500">Report Period</p>
+            <p className="text-sm font-medium text-gray-500">
+              {t('submissionStatus.page.reportPeriod')}
+            </p>
             <p className="text-gray-900">
               {formatShortDate(submission.reportPeriodStart)} -{' '}
               {formatShortDate(submission.reportPeriodEnd)}
             </p>
           </div>
           <div>
-            <p className="text-sm font-medium text-gray-500">External Reference</p>
+            <p className="text-sm font-medium text-gray-500">
+              {t('submissionStatus.page.externalReference')}
+            </p>
             <p className="text-gray-900">{submission.externalReference || '—'}</p>
           </div>
           <div>
-            <p className="text-sm font-medium text-gray-500">Created</p>
+            <p className="text-sm font-medium text-gray-500">
+              {t('submissionStatus.page.created')}
+            </p>
             <p className="text-gray-900">{formatDate(submission.createdAt)}</p>
           </div>
           <div>
-            <p className="text-sm font-medium text-gray-500">Validated</p>
+            <p className="text-sm font-medium text-gray-500">
+              {t('submissionStatus.page.validated')}
+            </p>
             <p className="text-gray-900">{formatDate(submission.validatedAt)}</p>
           </div>
           <div>
-            <p className="text-sm font-medium text-gray-500">Submitted</p>
+            <p className="text-sm font-medium text-gray-500">
+              {t('submissionStatus.page.submitted')}
+            </p>
             <p className="text-gray-900">{formatDate(submission.submittedAt)}</p>
           </div>
           <div>
-            <p className="text-sm font-medium text-gray-500">Acknowledged</p>
+            <p className="text-sm font-medium text-gray-500">
+              {t('submissionStatus.page.acknowledged')}
+            </p>
             <p className="text-gray-900">{formatDate(submission.acknowledgedAt)}</p>
           </div>
           <div>
-            <p className="text-sm font-medium text-gray-500">Processed</p>
+            <p className="text-sm font-medium text-gray-500">
+              {t('submissionStatus.page.processed')}
+            </p>
             <p className="text-gray-900">{formatDate(submission.processedAt)}</p>
           </div>
           <div>
-            <p className="text-sm font-medium text-gray-500">Submission Attempts</p>
+            <p className="text-sm font-medium text-gray-500">
+              {t('submissionStatus.page.submissionAttempts')}
+            </p>
             <p className="text-gray-900">{submission.submissionAttempts}</p>
           </div>
         </div>
@@ -368,7 +389,9 @@ export function SubmissionStatusPage({
         {submission.nextRetryAt && (
           <div className="mt-4 p-3 bg-yellow-50 rounded-lg">
             <p className="text-sm text-yellow-800">
-              Next automatic retry scheduled: {formatDate(submission.nextRetryAt)}
+              {t('submissionStatus.page.nextRetry', {
+                date: formatDate(submission.nextRetryAt),
+              })}
             </p>
           </div>
         )}
@@ -377,7 +400,9 @@ export function SubmissionStatusPage({
       {/* Report PDF */}
       {submission.reportPdfUrl && (
         <div className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">Report Document</h2>
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">
+            {t('submissionStatus.page.reportDocument')}
+          </h2>
           <a
             href={submission.reportPdfUrl}
             target="_blank"
@@ -398,7 +423,7 @@ export function SubmissionStatusPage({
                 d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"
               />
             </svg>
-            View Report PDF
+            {t('submissionStatus.page.viewReportPdf')}
           </a>
         </div>
       )}
@@ -407,7 +432,7 @@ export function SubmissionStatusPage({
       {attachments.length > 0 && (
         <div className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
           <h2 className="text-lg font-semibold text-gray-900 mb-4">
-            Attachments ({attachments.length})
+            {t('submissionStatus.page.attachments', { count: attachments.length })}
           </h2>
           <div className="space-y-2">
             {attachments.map((attachment) => (
@@ -468,7 +493,7 @@ export function SubmissionStatusPage({
           className="w-full flex items-center justify-between p-4 text-left hover:bg-gray-50 transition-colors"
         >
           <h2 className="text-lg font-semibold text-gray-900">
-            Audit Trail ({auditTrail.length} events)
+            {t('submissionStatus.page.auditTrail', { count: auditTrail.length })}
           </h2>
           <svg
             className={`h-5 w-5 text-gray-400 transition-transform ${showAuditTrail ? 'rotate-180' : ''}`}
@@ -484,7 +509,9 @@ export function SubmissionStatusPage({
         {showAuditTrail && (
           <div className="border-t border-gray-200">
             {auditTrail.length === 0 ? (
-              <div className="p-4 text-center text-gray-500">No audit events recorded.</div>
+              <div className="p-4 text-center text-gray-500">
+                {t('submissionStatus.page.noAuditEvents')}
+              </div>
             ) : (
               <div className="divide-y divide-gray-100">
                 {auditTrail.map((event) => (
@@ -523,7 +550,7 @@ export function SubmissionStatusPage({
               onClick={handleCancel}
               className="px-4 py-2 text-red-600 hover:text-red-800 hover:bg-red-50 rounded-md transition-colors"
             >
-              Cancel Submission
+              {t('submissionStatus.page.cancelSubmission')}
             </button>
           )}
         </div>
@@ -558,7 +585,7 @@ export function SubmissionStatusPage({
                       d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
                     />
                   </svg>
-                  Validating...
+                  {t('submissionStatus.page.validating')}
                 </>
               ) : (
                 <>
@@ -576,7 +603,7 @@ export function SubmissionStatusPage({
                       d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
                     />
                   </svg>
-                  Validate
+                  {t('submissionStatus.page.validate')}
                 </>
               )}
             </button>
@@ -611,7 +638,7 @@ export function SubmissionStatusPage({
                       d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
                     />
                   </svg>
-                  Retrying...
+                  {t('submissionStatus.page.retrying')}
                 </>
               ) : (
                 <>
@@ -629,7 +656,7 @@ export function SubmissionStatusPage({
                       d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
                     />
                   </svg>
-                  Retry Submission
+                  {t('submissionStatus.page.retrySubmission')}
                 </>
               )}
             </button>


### PR DESCRIPTION
## Task
ppt-web status/auth components hardcode English in an otherwise i18n'd app. Replace hardcoded English strings in ppt-web status/auth components with i18n (react-i18next) keys, adding the keys to all locale files.

## Owner
pm-frontend

## Context / scope note
The **auth + ConnectionStatus** half of this task already shipped in PR #1032 and #1046 (merged to `dev` on 2026-06-03/04). PR #1032 explicitly deferred the remaining ppt-web **status badge** components as a follow-up. This PR is exactly that follow-up — net-new work, not yet on `dev`.

## What changed
- **`SubmissionStatusBadge.tsx`** — the 10 hardcoded status labels (`Draft`, `Pending Validation`, …) now resolve via `t('submissionStatus.status.<status>')` through a `labelKey` map.
- **`SubmissionStatusPage.tsx`** — all headings, field labels, buttons, status descriptions, retry/validate/cancel states and the audit-trail/attachment strings now resolve via `t('submissionStatus.page.*' / '.description.*')`.
- **`OcrStatusBadge.tsx`** (`OcrStatusBadge` + `OcrProcessingStatus`) — compact/full status labels, reprocess button, processing/extraction/error/pending copy via `t('ocrStatus.*')`.
- **`CompetitiveStatusBadge.tsx`** — feature labels, completion %, header and CTA via `t('competitiveStatus.*')`.
- **Locale files** — added new top-level namespaces `submissionStatus`, `ocrStatus`, `competitiveStatus`, **fully translated** for all six locales the app ships (`en, sk, cs, de, pl, hu`). All six diffs are strictly append-only.

## Tested (Band A — fast check)
- `pnpm -F @ppt/web typecheck` → `tsc --noEmit`, exit 0
- `pnpm exec biome check <4 components> messages/*.json` → exit 0 (Biome is the project's CI linter; the package `lint` script points at an unconfigured eslint and fails on `dev` too — pre-existing, unrelated)
- `pnpm -F @ppt/web test:run` → 38 files / 512 tests passed

## Built (Band B — full build)
- `pnpm -F @ppt/web build` (Vite production build) → exit 0. Pre-existing chunk-size / dynamic-import advisories only; unrelated to this change.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (pure i18n string refactor — no security/auth-logic/billing/data-integrity change).

## Remote-tested
skipped

## Notes
- Scope-check (`--owner pm-frontend`) → exit 0, no drift; all 10 files are under `frontend/apps/ppt-web/`.
- Code-reuse grep → no warnings (only the existing `useTranslation` hook was added).
- Still hardcoded (left for a further follow-up to keep this reviewable): `developer/RateLimitStatus.tsx`, `financial/InvoiceStatusChart.tsx`, and the `settings.sessions` block.
- Branch note: an earlier stale branch `auto-impl/refactor-ppt-web-untranslated-strings` (base from the already-merged #1032 tip) was abandoned because `dev` had advanced far past it; this PR uses a fresh branch cut from current `dev` so the diff is exactly the 10 net-new files.

https://claude.ai/code/session_01DFsRB5VH8Sju3ADp6i3gUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFsRB5VH8Sju3ADp6i3gUa)_