### PR TITLE
feat(reality): saved-search new-listing alert matching engine (#983)

### DIFF
--- a/backend/crates/db/src/repositories/reality_portal.rs
+++ b/backend/crates/db/src/repositories/reality_portal.rs
@@ -3,10 +3,11 @@
 //! Repository for agencies, realtors, inquiries, and property import.
 
 use crate::models::reality_portal::*;
+use crate::models::PublicListingQuery;
 use crate::DbPool;
-use chrono::{NaiveDate, Utc};
+use chrono::{DateTime, NaiveDate, Utc};
 use rust_decimal::Decimal;
-use sqlx::{Error as SqlxError, Row};
+use sqlx::{Error as SqlxError, Executor, Postgres, Row};
 use uuid::Uuid;
 
 /// Repository for Reality Portal Professional operations.
@@ -19,6 +20,142 @@ impl RealityPortalRepository {
     /// Create a new RealityPortalRepository.
     pub fn new(pool: DbPool) -> Self {
         Self { pool }
+    }
+
+    // ========================================================================
+    // Saved-search alert engine (Story 16.3, issue #983)
+    //
+    // These run on a caller-supplied connection so the background worker can
+    // set the global-read RLS context (`set_global_read_context`) once and
+    // read published listings across all orgs on the same connection.
+    // `portal_saved_searches` and `search_alert_queue` are not RLS-gated.
+    // ========================================================================
+
+    /// All alert-enabled saved searches, oldest-checked first.
+    pub async fn list_alertable_saved_searches<'e, E>(
+        &self,
+        executor: E,
+    ) -> Result<Vec<PortalSavedSearch>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        sqlx::query_as::<_, PortalSavedSearch>(
+            r#"
+            SELECT * FROM portal_saved_searches
+            WHERE alerts_enabled = true
+            ORDER BY last_matched_at ASC NULLS FIRST
+            LIMIT 5000
+            "#,
+        )
+        .fetch_all(executor)
+        .await
+    }
+
+    /// IDs of published listings matching a saved search's criteria, optionally
+    /// only those published after `since`. Mirrors the public `search_listings`
+    /// filter set so on-demand and alert matching agree. Requires the executor's
+    /// connection to be in global-read context to see cross-org published rows.
+    pub async fn find_new_match_listing_ids<'e, E>(
+        &self,
+        executor: E,
+        q: &PublicListingQuery,
+        since: Option<DateTime<Utc>>,
+        limit: i64,
+    ) -> Result<Vec<Uuid>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        sqlx::query_scalar::<_, Uuid>(
+            r#"
+            SELECT l.id
+            FROM listings l
+            WHERE l.status = 'active'
+                AND ($1::text IS NULL OR l.title ILIKE '%' || $1 || '%' OR l.description ILIKE '%' || $1 || '%' OR l.city ILIKE '%' || $1 || '%')
+                AND ($2::text IS NULL OR l.property_type = $2)
+                AND ($3::text IS NULL OR l.transaction_type = $3)
+                AND ($4::bigint IS NULL OR l.price >= $4)
+                AND ($5::bigint IS NULL OR l.price <= $5)
+                AND ($6::int IS NULL OR l.size_sqm >= $6)
+                AND ($7::int IS NULL OR l.size_sqm <= $7)
+                AND ($8::int IS NULL OR l.rooms >= $8)
+                AND ($9::int IS NULL OR l.rooms <= $9)
+                AND ($10::text IS NULL OR l.city ILIKE '%' || $10 || '%')
+                AND ($11::text IS NULL OR l.country = $11)
+                AND ($12::timestamptz IS NULL OR l.published_at > $12)
+            ORDER BY l.published_at DESC
+            LIMIT $13
+            "#,
+        )
+        .bind(&q.q)
+        .bind(&q.property_type)
+        .bind(&q.transaction_type)
+        .bind(q.price_min)
+        .bind(q.price_max)
+        .bind(q.area_min)
+        .bind(q.area_max)
+        .bind(q.rooms_min)
+        .bind(q.rooms_max)
+        .bind(&q.city)
+        .bind(&q.country)
+        .bind(since)
+        .bind(limit)
+        .fetch_all(executor)
+        .await
+    }
+
+    /// Enqueue a pending alert for later delivery.
+    pub async fn enqueue_search_alert<'e, E>(
+        &self,
+        executor: E,
+        saved_search_id: Uuid,
+        user_id: Uuid,
+        listing_ids: &[Uuid],
+        alert_type: &str,
+    ) -> Result<(), SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        sqlx::query(
+            r#"
+            INSERT INTO search_alert_queue
+                (saved_search_id, user_id, matching_listing_ids, alert_type, status)
+            VALUES ($1, $2, $3, $4, 'pending')
+            "#,
+        )
+        .bind(saved_search_id)
+        .bind(user_id)
+        .bind(listing_ids)
+        .bind(alert_type)
+        .execute(executor)
+        .await?;
+        Ok(())
+    }
+
+    /// Advance a saved search's match watermark (`last_matched_at = now()`) and
+    /// add `new_matches` to its running `match_count`.
+    pub async fn mark_saved_search_matched<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        new_matches: i64,
+    ) -> Result<(), SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        sqlx::query(
+            r#"
+            UPDATE portal_saved_searches
+            SET last_matched_at = now(),
+                match_count = match_count + $2,
+                updated_at = now()
+            WHERE id = $1
+            "#,
+        )
+        .bind(id)
+        .bind(new_matches as i32)
+        .execute(executor)
+        .await?;
+        Ok(())
     }
 
     // ========================================================================

--- a/backend/servers/reality-server/src/lib.rs
+++ b/backend/servers/reality-server/src/lib.rs
@@ -18,5 +18,6 @@ pub mod extractors;
 pub mod handlers;
 pub mod observability;
 pub mod routes;
+pub mod services;
 pub mod state;
 pub mod util;

--- a/backend/servers/reality-server/src/main.rs
+++ b/backend/servers/reality-server/src/main.rs
@@ -32,6 +32,7 @@ pub mod extractors;
 mod handlers;
 mod observability;
 mod routes;
+mod services;
 pub mod state;
 mod util;
 
@@ -414,6 +415,15 @@ async fn main() -> anyhow::Result<()> {
     let host_tenant_config = api_core::middleware::HostTenantConfig::new(db.clone());
     let tenant_resolution_cache = host_tenant_config.cache.clone();
     let tenant_rate_limiters = host_tenant_config.rate_limiters.clone();
+
+    // Story 16.3 / #983: start the saved-search alert matching engine. It polls
+    // alert-enabled saved searches against newly published listings and enqueues
+    // alerts. Disabled-safe via SAVED_SEARCH_ALERT_* env.
+    let alert_worker = services::SavedSearchAlertWorker::new(
+        db.clone(),
+        services::SavedSearchAlertConfig::from_env(),
+    );
+    let _alert_worker_handle = alert_worker.start();
 
     // Create application state
     let state = AppState::new(db, tenant_resolution_cache, tenant_rate_limiters);

--- a/backend/servers/reality-server/src/services/mod.rs
+++ b/backend/servers/reality-server/src/services/mod.rs
@@ -1,0 +1,5 @@
+//! Background services for reality-server.
+
+pub mod saved_search_alerts;
+
+pub use saved_search_alerts::{SavedSearchAlertConfig, SavedSearchAlertWorker};

--- a/backend/servers/reality-server/src/services/saved_search_alerts.rs
+++ b/backend/servers/reality-server/src/services/saved_search_alerts.rs
@@ -1,0 +1,203 @@
+//! Saved-search alert matching engine — Story 16.3 (issue #983).
+//!
+//! Before this worker, saved-search matching only ran on demand
+//! (`POST /saved-searches/{id}/run`); nothing iterated alert-enabled searches
+//! against newly published listings, so "new listing matches your search →
+//! you're notified" was unimplemented. This background worker periodically:
+//!
+//! 1. opens a connection in **global-read** RLS context (so it can see
+//!    published listings across all orgs — the same context the public portal
+//!    request path uses),
+//! 2. for each alert-enabled saved search, finds listings published since the
+//!    search's `last_matched_at` watermark that match its criteria,
+//!    3. enqueues a pending row in `search_alert_queue` and advances the
+//!    watermark (`last_matched_at`, `match_count`).
+//!
+//! On a search's first sighting (no watermark) it only sets the watermark — it
+//! does not alert on the entire back-catalogue.
+//!
+//! Out of scope (documented follow-ups, blocked on missing infrastructure):
+//! - **Delivery**: turning queued `search_alert_queue` rows into emails/in-app
+//!   notifications. reality-server has no notification/email transport today;
+//!   delivery needs either a cross-server call to api-server's notification
+//!   pipeline or a dedicated drainer. The queue is the hand-off point.
+//! - **Favorite price-drop alerts (16.2)**: `portal_favorites` and
+//!   `listing_price_history` are `FORCE ROW LEVEL SECURITY` org-isolated, so a
+//!   context-less worker reads nothing; that half needs per-org / super-admin
+//!   context, a deliberate privilege decision.
+
+use std::time::Duration;
+
+use db::models::PublicListingQuery;
+use db::{repositories::RealityPortalRepository, DbPool};
+use tokio::time::interval;
+use tracing::Instrument;
+
+/// Configuration for the saved-search alert worker.
+#[derive(Debug, Clone)]
+pub struct SavedSearchAlertConfig {
+    pub enabled: bool,
+    pub poll_interval_secs: u64,
+    /// Max matching listings recorded per search per run (alert payload cap).
+    pub match_limit: i64,
+}
+
+impl Default for SavedSearchAlertConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            poll_interval_secs: 3600,
+            match_limit: 100,
+        }
+    }
+}
+
+impl SavedSearchAlertConfig {
+    /// Build from environment:
+    /// - `SAVED_SEARCH_ALERT_ENABLED` (default `true`)
+    /// - `SAVED_SEARCH_ALERT_INTERVAL_SECS` (default `3600`)
+    pub fn from_env() -> Self {
+        let default = Self::default();
+        let enabled = std::env::var("SAVED_SEARCH_ALERT_ENABLED")
+            .map(|v| v != "false" && v != "0")
+            .unwrap_or(default.enabled);
+        let poll_interval_secs = std::env::var("SAVED_SEARCH_ALERT_INTERVAL_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(default.poll_interval_secs);
+        Self {
+            enabled,
+            poll_interval_secs,
+            ..default
+        }
+    }
+}
+
+/// Background worker that matches alert-enabled saved searches against newly
+/// published listings and enqueues alerts.
+pub struct SavedSearchAlertWorker {
+    db: DbPool,
+    repo: RealityPortalRepository,
+    config: SavedSearchAlertConfig,
+}
+
+impl SavedSearchAlertWorker {
+    pub fn new(db: DbPool, config: SavedSearchAlertConfig) -> Self {
+        let repo = RealityPortalRepository::new(db.clone());
+        Self { db, repo, config }
+    }
+
+    /// Spawn the background task and return its `JoinHandle`.
+    pub fn start(self) -> tokio::task::JoinHandle<()> {
+        let poll_secs = self.config.poll_interval_secs;
+        tokio::spawn(
+            async move {
+                if !self.config.enabled {
+                    tracing::info!("[#983] SavedSearchAlertWorker disabled — not starting");
+                    return;
+                }
+                tracing::info!(
+                    poll_interval_secs = self.config.poll_interval_secs,
+                    "[#983] SavedSearchAlertWorker started"
+                );
+                let mut ticker = interval(Duration::from_secs(self.config.poll_interval_secs));
+                loop {
+                    ticker.tick().await;
+                    self.run_once().await;
+                }
+            }
+            .instrument(tracing::info_span!(
+                "bg.saved_search_alerts",
+                poll_secs = poll_secs
+            )),
+        )
+    }
+
+    /// One matching pass over all alert-enabled saved searches.
+    async fn run_once(&self) {
+        // A dedicated connection in global-read context: lets the matching query
+        // see published listings across orgs. The pool's after_release hook
+        // clears the context when the connection is returned.
+        let mut conn = match self.db.acquire().await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::error!(error = %e, "[#983] could not acquire DB connection");
+                return;
+            }
+        };
+        if let Err(e) = db::tenant_context::set_global_read_context(&mut *conn, true).await {
+            tracing::error!(error = %e, "[#983] failed to set global-read context");
+            return;
+        }
+
+        let searches = match self.repo.list_alertable_saved_searches(&mut *conn).await {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!(error = %e, "[#983] failed to list alertable saved searches");
+                return;
+            }
+        };
+
+        let mut queued = 0usize;
+        for search in searches {
+            // First sighting: establish the watermark, don't alert on history.
+            let Some(since) = search.last_matched_at else {
+                let _ = self
+                    .repo
+                    .mark_saved_search_matched(&mut *conn, search.id, 0)
+                    .await;
+                continue;
+            };
+
+            let query: PublicListingQuery = match serde_json::from_value(search.criteria.clone()) {
+                Ok(q) => q,
+                Err(e) => {
+                    tracing::warn!(id = %search.id, error = %e, "[#983] unparseable saved-search criteria; skipping");
+                    continue;
+                }
+            };
+
+            let ids = match self
+                .repo
+                .find_new_match_listing_ids(
+                    &mut *conn,
+                    &query,
+                    Some(since),
+                    self.config.match_limit,
+                )
+                .await
+            {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(id = %search.id, error = %e, "[#983] match query failed; skipping");
+                    continue;
+                }
+            };
+
+            if ids.is_empty() {
+                continue;
+            }
+
+            if let Err(e) = self
+                .repo
+                .enqueue_search_alert(&mut *conn, search.id, search.user_id, &ids, "new_listing")
+                .await
+            {
+                tracing::warn!(id = %search.id, error = %e, "[#983] failed to enqueue alert; skipping watermark advance");
+                continue;
+            }
+            let _ = self
+                .repo
+                .mark_saved_search_matched(&mut *conn, search.id, ids.len() as i64)
+                .await;
+            queued += 1;
+        }
+
+        if queued > 0 {
+            tracing::info!(
+                searches_alerted = queued,
+                "[#983] saved-search alerts queued"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Addresses the core gap in #983 (Epic 16 / Story 16.3): saved-search matching only ran **on demand** (`POST /saved-searches/{id}/run`). Nothing iterated alert-enabled searches against newly published listings — no scheduler, no publish-time hook — so *"a new listing matches your saved search → you're notified"* was unimplemented.

## What changed
New **`SavedSearchAlertWorker`** on reality-server, spawned in `main` (disabled-safe via `SAVED_SEARCH_ALERT_ENABLED` / `SAVED_SEARCH_ALERT_INTERVAL_SECS`, default on / hourly). Each pass:
1. opens a connection in **global-read RLS context** (`db::tenant_context::set_global_read_context`) so it can see published listings across all orgs — the same context the public portal request path uses (`portal_saved_searches` / `search_alert_queue` are not RLS-gated);
2. for each alert-enabled saved search, finds listings **published since its `last_matched_at` watermark** matching its `criteria` (reusing the public `search_listings` filter set, so on-demand and alert matching agree);
3. enqueues a pending `search_alert_queue` row and advances the watermark (`last_matched_at`, `match_count`).

First sighting (no watermark) only **sets** the watermark — it does not alert on the entire back-catalogue.

New executor-based repo methods on `RealityPortalRepository`: `list_alertable_saved_searches`, `find_new_match_listing_ids`, `enqueue_search_alert`, `mark_saved_search_matched` (all take a caller-supplied connection so the worker can set global-read context once and reuse it).

## Scope & documented follow-ups (blocked on missing infrastructure)
This PR is the **matching engine** — the substantive missing piece. Two halves are intentionally deferred and documented in the worker's module docs:
- **Delivery** — draining `search_alert_queue` into email/in-app notifications. reality-server has **no notification/email transport**; delivery needs a cross-server call to api-server's notification pipeline or a dedicated drainer. The queue is the hand-off point.
- **Favorite price-drop alerts (16.2)** — `portal_favorites` and `listing_price_history` are `FORCE ROW LEVEL SECURITY` org-isolated; a context-less worker reads nothing. That half needs per-org / super-admin context (a deliberate privilege decision).

## Why scoped this way
Verified against migrations + RLS policies (not assumed): `portal_saved_searches`/`search_alert_queue` have no RLS (worker can read/write), `listings` is readable under global-read, but the favorites/price-history tables are org-FORCE-RLS. Shipping the matching engine now is correct and safe; the deferred halves require infra decisions.

## Verification
- `cargo fmt -p db -p reality-server` ✅
- `cargo clippy -p db -p reality-server -- -D warnings` ✅ (exit 0, clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)