### PR TITLE
test-gap-hotfix-no-test-pr-943-mobile-dev-review-tail: jest regression test

### DIFF
--- a/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.test.ts
+++ b/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.test.ts
@@ -1,4 +1,11 @@
-import { type ApiAnnouncementSummary, extractItems, toUiAnnouncement } from './AnnouncementsScreen';
+import {
+  type Announcement,
+  type ApiAnnouncementSummary,
+  derivePinnedItems,
+  extractItems,
+  filterMainList,
+  toUiAnnouncement,
+} from './AnnouncementsScreen';
 
 // Regression for PR #918 (High #3 + Critical #1): the screen moved off the
 // manager-only `/api/v1/announcements` endpoint (403 for residents) to the
@@ -53,5 +60,77 @@ describe('extractItems (PR #918 reads `announcements`, not `items`)', () => {
     // `items` is not in the response type; cast to confirm it is NOT read.
     const legacy = { items: [summary] } as unknown as Parameters<typeof extractItems>[0];
     expect(extractItems(legacy)).toEqual([]);
+  });
+});
+
+// Regression for PR #943 (#767 dev-review tail): the screen dropped the
+// dedicated `?pinned=true` query and now derives the sticky pinned band
+// client-side from the single published list, and partitions the main feed
+// from that same list. These behaviours used to be inlined in the component
+// body (untested); PR #943 shipped without pinning them. The two helpers
+// below pin the client-side derivation so it cannot silently regress.
+
+const ui = (over: Partial<Announcement> & Pick<Announcement, 'id'>): Announcement => ({
+  title: over.title ?? over.id,
+  category: 'general',
+  createdAt: '2026-05-01T00:00:00Z',
+  author: 'Building Management',
+  isRead: false,
+  isPinned: false,
+  attachments: [],
+  commentsCount: 0,
+  ...over,
+});
+
+describe('derivePinnedItems (PR #943 client-side pinned band)', () => {
+  it('keeps only pinned rows', () => {
+    const items = [
+      ui({ id: 'a', isPinned: true }),
+      ui({ id: 'b', isPinned: false }),
+      ui({ id: 'c', isPinned: true }),
+    ];
+    expect(derivePinnedItems(items).map((a) => a.id)).toEqual(['a', 'c']);
+  });
+
+  it('returns [] when nothing is pinned', () => {
+    expect(derivePinnedItems([ui({ id: 'a' }), ui({ id: 'b' })])).toEqual([]);
+  });
+});
+
+describe('filterMainList (PR #943 main feed partitioning)', () => {
+  const items = [
+    ui({ id: 'pin', isPinned: true, createdAt: '2026-05-05T00:00:00Z' }),
+    ui({
+      id: 'old',
+      title: 'Lift maintenance',
+      category: 'maintenance',
+      createdAt: '2026-05-01T00:00:00Z',
+    }),
+    ui({
+      id: 'new',
+      title: 'Garden event',
+      category: 'event',
+      createdAt: '2026-05-03T00:00:00Z',
+    }),
+  ];
+
+  it('excludes pinned items from the main feed', () => {
+    expect(filterMainList(items, 'all', '').map((a) => a.id)).not.toContain('pin');
+  });
+
+  it('sorts the remaining items newest-first', () => {
+    expect(filterMainList(items, 'all', '').map((a) => a.id)).toEqual(['new', 'old']);
+  });
+
+  it('applies the active category filter', () => {
+    expect(filterMainList(items, 'maintenance', '').map((a) => a.id)).toEqual(['old']);
+  });
+
+  it('matches the search query against the TITLE only (no content body since #943)', () => {
+    expect(filterMainList(items, 'all', 'garden').map((a) => a.id)).toEqual(['new']);
+    // Case-insensitive.
+    expect(filterMainList(items, 'all', 'LIFT').map((a) => a.id)).toEqual(['old']);
+    // A term that matched the old `content` body must NOT match now.
+    expect(filterMainList(items, 'all', 'no-such-title')).toEqual([]);
   });
 });

--- a/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.tsx
@@ -80,6 +80,38 @@ export function extractItems(
   return data.announcements ?? [];
 }
 
+/**
+ * Derive the pinned sticky-band items from the published list (PR #943).
+ *
+ * PR #943 dropped the dedicated `?pinned=true` query and now derives pinned
+ * items client-side from the same published list, keeping only `isPinned`
+ * rows. This is the band shown above the main feed.
+ */
+export function derivePinnedItems(items: Announcement[]): Announcement[] {
+  return items.filter((a) => a.isPinned);
+}
+
+/**
+ * Build the main (non-pinned) feed from the published list (PR #943).
+ *
+ * Excludes pinned items (they live in the sticky band), applies the active
+ * category filter, matches the search query against the TITLE only (the
+ * published summary has no `content` body since PR #943), and sorts
+ * newest-first by `createdAt`.
+ */
+export function filterMainList(
+  items: Announcement[],
+  filter: 'all' | AnnouncementCategory,
+  searchQuery: string
+): Announcement[] {
+  const q = searchQuery.toLowerCase();
+  return items
+    .filter((a) => !a.isPinned)
+    .filter((a) => (filter === 'all' ? true : a.category === filter))
+    .filter((a) => q === '' || a.title.toLowerCase().includes(q))
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+}
+
 interface AnnouncementsScreenProps {
   onNavigate?: (screen: string, params?: Record<string, unknown>) => void;
 }
@@ -107,10 +139,11 @@ export function AnnouncementsScreen({ onNavigate }: AnnouncementsScreenProps) {
     .map(toUiAnnouncement)
     .map((a) => ({ ...a, isRead: readIds.has(a.id) ? true : a.isRead }));
 
-  const pinnedItems: Announcement[] = extractItems(pinnedData)
-    .map(toUiAnnouncement)
-    .map((a) => ({ ...a, isRead: readIds.has(a.id) ? true : a.isRead }))
-    .filter((a) => a.isPinned);
+  const pinnedItems: Announcement[] = derivePinnedItems(
+    extractItems(pinnedData)
+      .map(toUiAnnouncement)
+      .map((a) => ({ ...a, isRead: readIds.has(a.id) ? true : a.isRead }))
+  );
 
   const onRefresh = useCallback(async () => {
     await refetch();
@@ -173,11 +206,7 @@ export function AnnouncementsScreen({ onNavigate }: AnnouncementsScreenProps) {
   };
 
   // Main list excludes pinned items (they appear in the sticky band above)
-  const filteredAnnouncements = allRaw
-    .filter((a) => !a.isPinned)
-    .filter((a) => (filter === 'all' ? true : a.category === filter))
-    .filter((a) => searchQuery === '' || a.title.toLowerCase().includes(searchQuery.toLowerCase()))
-    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  const filteredAnnouncements = filterMainList(allRaw, filter, searchQuery);
 
   const unreadCount = allRaw.filter((a) => !a.isRead).length;
 


### PR DESCRIPTION
Regression test for the #943 mobile dev-review tail fix. Test-only.

## Context
PR #943 (`fix(mobile): address dev-review findings (#767)`) reworked `AnnouncementsScreen` to derive the pinned sticky band and the main feed client-side from the single `/api/v1/announcements/published` list — replacing the old dedicated `?pinned=true` query. That partitioning logic was inlined in the component body and shipped without a regression test.

## Change
- Extracted two pure helpers from the component body (behaviour-preserving): `derivePinnedItems` and `filterMainList`.
- Added jest-expo regression tests pinning the #943 behaviours:
  - `derivePinnedItems` keeps only `isPinned` rows.
  - `filterMainList` excludes pinned items, sorts newest-first, applies the category filter, and matches the search query against the **title only** (the published summary no longer carries a `content` body).

Pure-logic test (no `@testing-library/react-native` import) to dodge the known `react-test-renderer` peer-dep mismatch, matching the existing `usePushNotifications.test.ts` / `DocumentsScreen.test.ts` pattern.

## Verification
- `pnpm -F @ppt/mobile typecheck` — exit 0
- `pnpm -F mobile exec jest src/screens/announcements/AnnouncementsScreen.test.ts` — 11 passed (5 existing + 6 new)
- `biome check` on both files — clean

https://claude.ai/code/session_01B1zLPWsXzQCqtbHf3DmSdn

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1zLPWsXzQCqtbHf3DmSdn)_