### PR TITLE
test-gap-hotfix-no-test-pr-992-mobile-doc-detail: deep-link payload regression test

### DIFF
--- a/frontend/apps/mobile/src/App.tsx
+++ b/frontend/apps/mobile/src/App.tsx
@@ -7,8 +7,9 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { OfflineBanner, SyncProgressToast, SyncStatusBadge } from './components/sync';
 import { AuthProvider, useAuth } from './contexts';
 import { useOfflineSupport, usePushNotifications } from './hooks';
-import { deepLinkManager, type ParsedDeepLink } from './qrcode';
+import { deepLinkManager } from './qrcode';
 import { colors } from './screens/shared/screenStyles';
+import { resolveDeepLinkTarget, type Screen } from './services/deepLinkRouting';
 import './i18n'; // Initialize i18n
 import {
   AnnouncementDetailScreen,
@@ -53,76 +54,6 @@ const queryClient = new QueryClient({
 });
 
 const API_BASE_URL = (Constants.expoConfig?.extra?.apiUrl as string) || 'http://localhost:8080';
-
-type Screen =
-  | 'Dashboard'
-  | 'Faults'
-  | 'ReportFault'
-  | 'Announcements'
-  | 'AnnouncementDetail'
-  | 'Voting'
-  | 'VoteDetail'
-  | 'Documents'
-  | 'DocumentDetail'
-  | 'DocumentPreview'
-  | 'DocumentUpload'
-  | 'DocumentPermissions'
-  | 'Messages'
-  | 'ThreadDetail'
-  | 'Settings'
-  | 'MeterReading'
-  | 'Meters'
-  | 'MeterDetail'
-  | 'Profile'
-  | 'TwoFactor'
-  | 'Neighbors'
-  | 'Notifications'
-  | 'PersonMonths'
-  | 'Outages'
-  | 'News'
-  | 'Forms'
-  | 'Buildings'
-  | 'Leases'
-  | 'LeaseDetail'
-  | 'More';
-
-/**
- * gap-85-3: translate a parsed deep link (custom scheme OR universal link)
- * into the in-app screen name + params understood by `handleNavigate`.
- *
- * The DeepLinkHandler route table keys detail params as `id`; the App screens
- * expect domain-specific param names (`announcementId`, `voteId`,
- * `documentId`). When an `:id` is present we route to the matching *Detail
- * screen; otherwise we land on the list screen.
- */
-function resolveDeepLinkTarget(
-  link: ParsedDeepLink
-): { screen: Screen; params?: Record<string, unknown> } | null {
-  if (!link.success || !link.screen) {
-    return null;
-  }
-  const id = link.params?.id;
-  switch (link.screen) {
-    case 'Announcements':
-      return id
-        ? { screen: 'AnnouncementDetail', params: { announcementId: id } }
-        : { screen: 'Announcements' };
-    case 'Voting':
-      return id ? { screen: 'VoteDetail', params: { voteId: id } } : { screen: 'Voting' };
-    case 'Documents':
-      return id
-        ? { screen: 'DocumentDetail', params: { documentId: id } }
-        : { screen: 'Documents' };
-    case 'Messages':
-      return id ? { screen: 'ThreadDetail', params: { threadId: id } } : { screen: 'Messages' };
-    case 'WidgetSettings':
-      return { screen: 'Settings' };
-    default:
-      // Faults, ReportFault, Outages, Settings, Dashboard map 1:1. Pass any
-      // remaining route params through verbatim.
-      return { screen: link.screen as Screen, params: link.params };
-  }
-}
 
 function MainApp() {
   const { t } = useTranslation();

--- a/frontend/apps/mobile/src/services/deepLinkRouting.test.ts
+++ b/frontend/apps/mobile/src/services/deepLinkRouting.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Regression tests for the deep-link → in-app screen+params mapping.
+ *
+ * Pins the document-detail deep-link payload path wired in PR #992: a parsed
+ * `Documents` deep link carrying an `id` must resolve to the `DocumentDetail`
+ * screen with `params: { documentId: id }` — the exact shape `App.tsx` hands
+ * to `handleNavigate` and that `DocumentDetailScreen` reads as `documentId`.
+ *
+ * Pure-logic test (no `@testing-library/react-native`), matching the
+ * `backgroundNotifications.test.ts` style — the routing was extracted from the
+ * `App` component (gap-85-3) so it can be exercised without mounting the tree.
+ */
+
+import type { ParsedDeepLink } from '../qrcode';
+import { resolveDeepLinkTarget } from './deepLinkRouting';
+
+function link(partial: Partial<ParsedDeepLink>): ParsedDeepLink {
+  return { success: true, ...partial };
+}
+
+describe('resolveDeepLinkTarget — document-detail payload (PR #992)', () => {
+  it('routes a Documents deep link with an id to DocumentDetail + documentId param', () => {
+    const target = resolveDeepLinkTarget(link({ screen: 'Documents', params: { id: 'doc-123' } }));
+
+    expect(target).toEqual({
+      screen: 'DocumentDetail',
+      params: { documentId: 'doc-123' },
+    });
+  });
+
+  it('uses the param key `documentId` (the key DocumentDetailScreen reads)', () => {
+    const target = resolveDeepLinkTarget(link({ screen: 'Documents', params: { id: 'abc' } }));
+
+    // Guards against a silent regression where the payload key drifts (e.g.
+    // back to `id`), which would leave DocumentDetailScreen with no id and the
+    // detail query disabled.
+    expect(target?.params).toHaveProperty('documentId', 'abc');
+    expect(target?.params).not.toHaveProperty('id');
+  });
+
+  it('routes a Documents deep link without an id to the Documents list', () => {
+    const target = resolveDeepLinkTarget(link({ screen: 'Documents' }));
+
+    expect(target).toEqual({ screen: 'Documents' });
+    expect(target?.params).toBeUndefined();
+  });
+});
+
+describe('resolveDeepLinkTarget — guards & sibling detail routes', () => {
+  it('returns null for an unsuccessful parse', () => {
+    expect(resolveDeepLinkTarget(link({ success: false, screen: 'Documents' }))).toBeNull();
+  });
+
+  it('returns null when no screen was resolved', () => {
+    expect(resolveDeepLinkTarget(link({ screen: undefined }))).toBeNull();
+  });
+
+  it('maps the other detail screens to their domain-specific param keys', () => {
+    expect(resolveDeepLinkTarget(link({ screen: 'Announcements', params: { id: '42' } }))).toEqual({
+      screen: 'AnnouncementDetail',
+      params: { announcementId: '42' },
+    });
+
+    expect(resolveDeepLinkTarget(link({ screen: 'Voting', params: { id: '9' } }))).toEqual({
+      screen: 'VoteDetail',
+      params: { voteId: '9' },
+    });
+
+    expect(resolveDeepLinkTarget(link({ screen: 'Messages', params: { id: '3' } }))).toEqual({
+      screen: 'ThreadDetail',
+      params: { threadId: '3' },
+    });
+  });
+
+  it('passes 1:1 routes through verbatim with their params', () => {
+    expect(resolveDeepLinkTarget(link({ screen: 'Faults', params: { id: '7' } }))).toEqual({
+      screen: 'Faults',
+      params: { id: '7' },
+    });
+  });
+
+  it('folds WidgetSettings onto the Settings screen', () => {
+    expect(resolveDeepLinkTarget(link({ screen: 'WidgetSettings' }))).toEqual({
+      screen: 'Settings',
+    });
+  });
+});

--- a/frontend/apps/mobile/src/services/deepLinkRouting.ts
+++ b/frontend/apps/mobile/src/services/deepLinkRouting.ts
@@ -1,0 +1,85 @@
+/**
+ * Deep-link routing (pure logic).
+ *
+ * Extracted from `App.tsx` (gap-85-3) so the parsed-deep-link → in-app
+ * screen+params mapping can be unit-tested without mounting the RN tree.
+ * Mirrors the `backgroundNotifications.deepLinkForNotification` split: the
+ * navigation layer (`App`) just calls this and hands the result to
+ * `handleNavigate`.
+ */
+
+import type { ParsedDeepLink } from '../qrcode';
+
+/**
+ * In-app screen names understood by `handleNavigate`. Kept in sync with the
+ * `Screen` union in `App.tsx`.
+ */
+export type Screen =
+  | 'Dashboard'
+  | 'Faults'
+  | 'ReportFault'
+  | 'Announcements'
+  | 'AnnouncementDetail'
+  | 'Voting'
+  | 'VoteDetail'
+  | 'Documents'
+  | 'DocumentDetail'
+  | 'DocumentPreview'
+  | 'DocumentUpload'
+  | 'DocumentPermissions'
+  | 'Messages'
+  | 'ThreadDetail'
+  | 'Settings'
+  | 'MeterReading'
+  | 'Meters'
+  | 'MeterDetail'
+  | 'Profile'
+  | 'TwoFactor'
+  | 'Neighbors'
+  | 'Notifications'
+  | 'PersonMonths'
+  | 'Outages'
+  | 'News'
+  | 'Forms'
+  | 'Buildings'
+  | 'Leases'
+  | 'LeaseDetail'
+  | 'More';
+
+/**
+ * gap-85-3: translate a parsed deep link (custom scheme OR universal link)
+ * into the in-app screen name + params understood by `handleNavigate`.
+ *
+ * The DeepLinkHandler route table keys detail params as `id`; the App screens
+ * expect domain-specific param names (`announcementId`, `voteId`,
+ * `documentId`). When an `:id` is present we route to the matching *Detail
+ * screen; otherwise we land on the list screen.
+ */
+export function resolveDeepLinkTarget(
+  link: ParsedDeepLink
+): { screen: Screen; params?: Record<string, unknown> } | null {
+  if (!link.success || !link.screen) {
+    return null;
+  }
+  const id = link.params?.id;
+  switch (link.screen) {
+    case 'Announcements':
+      return id
+        ? { screen: 'AnnouncementDetail', params: { announcementId: id } }
+        : { screen: 'Announcements' };
+    case 'Voting':
+      return id ? { screen: 'VoteDetail', params: { voteId: id } } : { screen: 'Voting' };
+    case 'Documents':
+      return id
+        ? { screen: 'DocumentDetail', params: { documentId: id } }
+        : { screen: 'Documents' };
+    case 'Messages':
+      return id ? { screen: 'ThreadDetail', params: { threadId: id } } : { screen: 'Messages' };
+    case 'WidgetSettings':
+      return { screen: 'Settings' };
+    default:
+      // Faults, ReportFault, Outages, Settings, Dashboard map 1:1. Pass any
+      // remaining route params through verbatim.
+      return { screen: link.screen as Screen, params: link.params };
+  }
+}

--- a/frontend/apps/mobile/src/services/index.ts
+++ b/frontend/apps/mobile/src/services/index.ts
@@ -4,3 +4,5 @@ export {
   extractNotificationData,
   syncBadgeFromData,
 } from './backgroundNotifications';
+export type { Screen } from './deepLinkRouting';
+export { resolveDeepLinkTarget } from './deepLinkRouting';


### PR DESCRIPTION
Regression test for the #992 mobile document-detail deep-link payload path. Test-only.

## What
PR #992 wired the mobile document-detail deep-link payload path (`Documents/:id` deep link → `DocumentDetail` screen with `params: { documentId: id }`, consumed by `App.tsx` → `DocumentDetailScreen`) but shipped without a regression test for the payload mapping.

This adds a jest-expo **pure-logic** test pinning that mapping. To make the logic testable without mounting the RN tree, `resolveDeepLinkTarget` (and its `Screen` type) were extracted verbatim from `App.tsx` into `src/services/deepLinkRouting.ts` — a minimal, behavior-preserving move mirroring the `usePushNotifications` / `backgroundNotifications.deepLinkForNotification` split. `App.tsx` now imports the helper; runtime behavior is unchanged.

## Tests
`src/services/deepLinkRouting.test.ts` (8 cases):
- Documents deep link with `id` → `DocumentDetail` + `{ documentId }` (the #992 path)
- payload key is `documentId` (not `id`) — guards the exact regression
- Documents deep link without id → `Documents` list
- guards: unsuccessful parse / no screen → `null`
- sibling detail routes (Announcements/Voting/Messages) keep their domain param keys
- 1:1 passthrough routes + `WidgetSettings` → `Settings`

Avoids `@testing-library/react-native` (known react-test-renderer peer-dep break); follows the `backgroundNotifications.test.ts` pure-logic pattern.

## Verification (in worktree off `origin/dev`)
- `pnpm -F @ppt/mobile typecheck` → exit 0
- `pnpm -F mobile exec jest src/services/deepLinkRouting.test.ts` → 8 passed
- `biome check` on changed files → clean

Test-only; no production behavior change beyond the testability extraction.

https://claude.ai/code/session_01B1zLPWsXzQCqtbHf3DmSdn

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1zLPWsXzQCqtbHf3DmSdn)_