### PR TITLE
bug-mobile-voting-hardcoded-locale: localize voting screen dates with active i18n locale

### DIFF
--- a/frontend/apps/mobile/src/screens/voting/VotingScreen.test.ts
+++ b/frontend/apps/mobile/src/screens/voting/VotingScreen.test.ts
@@ -1,4 +1,4 @@
-import { parseVoteSummaries } from './VotingScreen';
+import { formatVoteDate, parseVoteSummaries } from './VotingScreen';
 
 const validSummary = {
   id: 'vote-1',
@@ -40,5 +40,33 @@ describe('parseVoteSummaries', () => {
       { ...validSummary, id: 123 }, // wrong field type
     ];
     expect(parseVoteSummaries(mixed)).toEqual([validSummary]);
+  });
+});
+
+describe('formatVoteDate', () => {
+  const iso = '2026-07-01T00:00:00Z';
+
+  // Regression: the screen hardcoded 'en-US', so vote dates never localised.
+  // The formatter must honour the locale it is handed (i18n.language at the
+  // call site) rather than a fixed locale.
+  it('formats using the locale it is passed', () => {
+    const enUS = formatVoteDate(iso, 'en-US');
+    const de = formatVoteDate(iso, 'de-DE');
+
+    // Both produce a non-empty, parseable string for the same instant…
+    expect(enUS).toBeTruthy();
+    expect(de).toBeTruthy();
+    // …and locale-specific month abbreviations differ between en and de
+    // (e.g. "Jul" vs "Juli"), proving the locale argument is actually used.
+    expect(de).not.toBe(enUS);
+  });
+
+  it.each([
+    ['en-US', /2026/],
+    ['sk', /2026/],
+    ['cs', /2026/],
+    ['de', /2026/],
+  ])('includes the year for locale %s', (locale, yearMatcher) => {
+    expect(formatVoteDate(iso, locale as string)).toMatch(yearMatcher as RegExp);
   });
 });

--- a/frontend/apps/mobile/src/screens/voting/VotingScreen.tsx
+++ b/frontend/apps/mobile/src/screens/voting/VotingScreen.tsx
@@ -79,6 +79,21 @@ export function parseVoteSummaries(data: unknown): ApiVoteSummary[] {
   return candidates.filter(isApiVoteSummary);
 }
 
+/** Format a vote date for display using the app's active i18n locale.
+ *
+ *  Previously hardcoded `'en-US'`, so vote dates never localised regardless of
+ *  the user's selected language. Pass `i18n.language` (the react-i18next active
+ *  language, e.g. `'sk'`, `'cs'`, `'de'`, `'en'`) so the rendered date matches
+ *  the rest of the UI. Exported so the formatting can be unit-tested without
+ *  rendering the screen. */
+export function formatVoteDate(dateString: string, locale: string): string {
+  return new Date(dateString).toLocaleDateString(locale, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
 /** Map the api-server's status string onto the UI's narrowed enum. */
 function toUiStatus(status: string): VoteStatus {
   switch (status) {
@@ -120,7 +135,7 @@ interface VotingScreenProps {
 }
 
 export function VotingScreen({ onNavigate }: VotingScreenProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [filter, setFilter] = useState<'all' | 'active' | 'closed'>('all');
 
   // Voting routes use `RlsConnection` and require both Authorization and
@@ -155,10 +170,7 @@ export function VotingScreen({ onNavigate }: VotingScreenProps) {
     }
   };
 
-  const formatDate = (dateString: string): string => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-  };
+  const formatDate = (dateString: string): string => formatVoteDate(dateString, i18n.language);
 
   const getTimeRemaining = (endsAt: string): string => {
     const end = new Date(endsAt);


### PR DESCRIPTION
## Task
Mobile VotingScreen hardcodes 'en-US' in toLocaleDateString — vote dates never localize. In frontend/apps/mobile (VotingScreen, `toLocaleDateString('en-US', ...)`), replace the hardcoded locale with the app's active i18n locale (use the i18next/react-i18next current language, e.g. `i18n.language`). Add/adjust a unit test if feasible. Keep scope to the mobile voting screen.

## Owner
pm-frontend

## Changes
- Extracted a pure, exported `formatVoteDate(dateString, locale)` helper in `VotingScreen.tsx` (so it's unit-testable without rendering the screen).
- `VotingScreen` now pulls `i18n` from `useTranslation()` and calls `formatVoteDate(dateString, i18n.language)` — matching the existing pattern already used in `AnnouncementDetailScreen.tsx`.
- Removed the hardcoded `'en-US'`.
- Added `formatVoteDate` unit tests proving locale-sensitive output (en vs de differ) and year presence across `en-US`/`sk`/`cs`/`de`.

Scope is limited to the voting screen. Other screens (Documents, Outages, Dashboard, Announcements list, Faults, etc.) have the same `'en-US'` hardcode but are intentionally out of scope for this task.

## Tested (Band A — fast check)
- `pnpm -F @ppt/mobile typecheck` → exit 0 (tsc --noEmit clean)
- `pnpm exec biome check apps/mobile/src/screens/voting/VotingScreen.tsx apps/mobile/src/screens/voting/VotingScreen.test.ts` → exit 0 (No fixes applied)
- `pnpm exec jest src/screens/voting/VotingScreen.test.ts` → 14 passed (incl. 5 new formatVoteDate cases)

## Built (Band B — full build)
Skipped: change <50 LOC, no public API/config touch (small per-screen bugfix).

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (UI date formatting; no security/auth/billing/data-integrity change).

## Notes
- Scope drift: false — only `frontend/apps/mobile/src/screens/voting/*` touched (within pm-frontend area).
- Code-reuse: none — reuses the established `i18n.language` + `toLocaleDateString` pattern from `AnnouncementDetailScreen.tsx`; no new auth/crypto/http helpers added.

https://claude.ai/code/session_01HoqWfPhxS8ZLYWQM56SiEM

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoqWfPhxS8ZLYWQM56SiEM)_