### PR TITLE
fix(ppt-web): prevent stale aria-live message resurrection in Announcer

### DIFF
--- a/frontend/apps/ppt-web/src/components/Announcer.test.tsx
+++ b/frontend/apps/ppt-web/src/components/Announcer.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Announcer tests — stale-message resurrection regression.
+ *
+ * Bug: the deferred "set" timeout (clear-then-set, +100ms) was not tracked in a
+ * ref, so a rapid second announce() left the first announce's deferred set
+ * pending. That pending set then fired AFTER the newer message had been shown,
+ * resurrecting the stale message in the aria-live region.
+ *
+ * Fix: track the deferred set timeout per channel and clear the pending one
+ * (alongside the clear timeout) before scheduling a new set.
+ */
+/// <reference types="vitest/globals" />
+
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AnnouncerProvider, useAnnouncer } from './Announcer';
+
+let announce: ReturnType<typeof useAnnouncer>['announce'];
+
+function Capture() {
+  announce = useAnnouncer().announce;
+  return null;
+}
+
+function renderAnnouncer() {
+  return render(
+    <AnnouncerProvider>
+      <Capture />
+    </AnnouncerProvider>
+  );
+}
+
+const polite = () => screen.getByRole('status');
+
+describe('AnnouncerProvider', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it('does not resurrect a stale message when announce() is called rapidly', () => {
+    renderAnnouncer();
+
+    // First announce at t=0 schedules its deferred set at t=100.
+    act(() => {
+      announce('first message');
+    });
+
+    // Second announce at t=50 (within the 100ms window) schedules its deferred
+    // set at t=150. In the buggy code the first deferred set (t=100) was left
+    // untracked, so it still fires at t=100 and flashes the stale message into
+    // the live region before the second message lands — a stale announcement.
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    act(() => {
+      announce('second message');
+    });
+
+    // Advance to t=100: only the (cancelled-in-fix) first deferred set is due.
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+
+    // With the fix the stale "first message" set was cancelled, so the live
+    // region must never have shown it here.
+    expect(polite().textContent).not.toBe('first message');
+
+    // Advance to t=150: the second deferred set fires.
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    expect(polite().textContent).toBe('second message');
+  });
+
+  it('shows the latest message and clears it after the announce window', () => {
+    renderAnnouncer();
+
+    act(() => {
+      announce('hello');
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(polite().textContent).toBe('hello');
+
+    // After the 3000ms clear timeout the region empties.
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(polite().textContent).toBe('');
+  });
+
+  it('keeps polite and assertive channels independent', () => {
+    renderAnnouncer();
+
+    act(() => {
+      announce('be polite', 'polite');
+      announce('urgent!', 'assertive');
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(screen.getByRole('status').textContent).toBe('be polite');
+    expect(screen.getByRole('alert').textContent).toBe('urgent!');
+  });
+});

--- a/frontend/apps/ppt-web/src/components/Announcer.tsx
+++ b/frontend/apps/ppt-web/src/components/Announcer.tsx
@@ -9,7 +9,15 @@
  * announce('Form submitted successfully');
  */
 
-import { createContext, type ReactNode, useCallback, useContext, useRef, useState } from 'react';
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 interface AnnouncerContextValue {
   /**
@@ -34,31 +42,54 @@ export function AnnouncerProvider({ children }: AnnouncerProviderProps) {
   const [politeMessage, setPoliteMessage] = useState('');
   const [assertiveMessage, setAssertiveMessage] = useState('');
 
-  // Use refs to store timeout IDs for cleanup
-  const politeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const assertiveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Use refs to store timeout IDs for cleanup.
+  // We must track BOTH the deferred "set" timeout and the "clear" timeout per
+  // channel. If the "set" timeout is left untracked, a rapid second announce()
+  // can leave a previous deferred set pending, which then fires after the newer
+  // message was already shown — resurrecting a stale screen-reader message.
+  const politeSetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const politeClearTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const assertiveSetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const assertiveClearTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const announce = useCallback((message: string, politeness: 'polite' | 'assertive' = 'polite') => {
-    // Clear existing timeout
     if (politeness === 'polite') {
-      if (politeTimeoutRef.current) {
-        clearTimeout(politeTimeoutRef.current);
+      // Cancel any pending set/clear from a prior announce so an in-flight
+      // deferred set cannot resurrect a stale message over this one.
+      if (politeSetTimeoutRef.current) {
+        clearTimeout(politeSetTimeoutRef.current);
       }
-      // Clear then set to trigger screen reader
+      if (politeClearTimeoutRef.current) {
+        clearTimeout(politeClearTimeoutRef.current);
+      }
+      // Clear then set to trigger screen reader.
       setPoliteMessage('');
-      setTimeout(() => setPoliteMessage(message), 100);
+      politeSetTimeoutRef.current = setTimeout(() => setPoliteMessage(message), 100);
 
-      // Clear message after it's been announced
-      politeTimeoutRef.current = setTimeout(() => setPoliteMessage(''), 3000);
+      // Clear message after it's been announced.
+      politeClearTimeoutRef.current = setTimeout(() => setPoliteMessage(''), 3000);
     } else {
-      if (assertiveTimeoutRef.current) {
-        clearTimeout(assertiveTimeoutRef.current);
+      if (assertiveSetTimeoutRef.current) {
+        clearTimeout(assertiveSetTimeoutRef.current);
+      }
+      if (assertiveClearTimeoutRef.current) {
+        clearTimeout(assertiveClearTimeoutRef.current);
       }
       setAssertiveMessage('');
-      setTimeout(() => setAssertiveMessage(message), 100);
+      assertiveSetTimeoutRef.current = setTimeout(() => setAssertiveMessage(message), 100);
 
-      assertiveTimeoutRef.current = setTimeout(() => setAssertiveMessage(''), 3000);
+      assertiveClearTimeoutRef.current = setTimeout(() => setAssertiveMessage(''), 3000);
     }
+  }, []);
+
+  // Clear any pending timeouts on unmount to avoid setState-after-unmount.
+  useEffect(() => {
+    return () => {
+      if (politeSetTimeoutRef.current) clearTimeout(politeSetTimeoutRef.current);
+      if (politeClearTimeoutRef.current) clearTimeout(politeClearTimeoutRef.current);
+      if (assertiveSetTimeoutRef.current) clearTimeout(assertiveSetTimeoutRef.current);
+      if (assertiveClearTimeoutRef.current) clearTimeout(assertiveClearTimeoutRef.current);
+    };
   }, []);
 
   return (


### PR DESCRIPTION
## Problem

The `AnnouncerProvider` (`frontend/apps/ppt-web/src/components/Announcer.tsx`) uses a clear-then-set pattern to nudge screen readers into re-reading an `aria-live` region:

```ts
setPoliteMessage('');
setTimeout(() => setPoliteMessage(message), 100); // <-- handle NOT tracked
politeTimeoutRef.current = setTimeout(() => setPoliteMessage(''), 3000);
```

Only the **clear** timeout (+3000ms) was stored in a ref. The deferred **set** timeout (+100ms) was untracked. When `announce()` was called twice in quick succession (within the 100ms window), the first deferred set stayed pending and fired anyway — flashing the stale, superseded message into the live region before the newer message landed. To a screen reader, that is a resurrected stale announcement.

## Fix

- Track **both** the deferred set and the clear timeout per channel (polite + assertive).
- Cancel both pending handles before scheduling a new set, so an in-flight stale set can no longer fire.
- Clear all pending timeouts on unmount (avoids setState-after-unmount).

## Test (IG3)

Added `Announcer.test.tsx` with a focused vitest using fake timers that reproduces the resurrection: two rapid `announce()` calls, then asserts the live region never shows the stale first message and ultimately settles on the latest one. Plus coverage for the clear-after-window behavior and polite/assertive channel independence.

Verified the resurrection test **fails on the pre-fix code** (live region shows `first message`) and **passes with the fix**.

## Verify (Band A)
- `pnpm -F @ppt/web exec vitest run src/components/Announcer.test.tsx` — 3 passed
- `pnpm -F @ppt/web typecheck` — clean
- `biome check` on changed files — clean

https://claude.ai/code/session_01HoqWfPhxS8ZLYWQM56SiEM

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoqWfPhxS8ZLYWQM56SiEM)_