### PR TITLE
bug-reality-web-listing-metadata-ssr-throw: guard listing generateMetadata against malformed 200 body

### DIFF
--- a/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/metadata.test.ts
+++ b/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/metadata.test.ts
@@ -1,0 +1,93 @@
+/**
+ * buildListingMetadata Tests
+ *
+ * Regression guard for the SSR crash where a malformed/partial 200 body
+ * (truthy but not a real ListingDetail) made generateMetadata throw while
+ * reading nested fields (listing.address.city, listing.description.slice).
+ * buildListingMetadata must degrade to safe fallback metadata instead.
+ */
+
+import type { ListingDetail } from '@ppt/reality-api-client';
+import { describe, expect, it } from 'vitest';
+import { buildListingMetadata } from './metadata';
+
+const FALLBACK_TITLE = 'Listing Not Found - Reality Portal';
+
+const validListing: ListingDetail = {
+  id: 'listing-1',
+  slug: 'beautiful-apartment',
+  title: 'Beautiful Apartment',
+  propertyType: 'apartment',
+  transactionType: 'sale',
+  status: 'active',
+  price: 150000,
+  currency: 'EUR',
+  area: 75,
+  address: { city: 'Bratislava', country: 'SK' },
+  isFeatured: false,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  description: 'A lovely place to live with plenty of light.',
+  features: {},
+  photos: [],
+  agent: { id: 'a1', name: 'Agent', email: 'a@example.com' },
+  viewCount: 0,
+  favoriteCount: 0,
+  primaryPhoto: {
+    id: 'p1',
+    url: 'https://cdn.example.com/p1.jpg',
+    thumbnailUrl: 'https://cdn.example.com/p1-thumb.jpg',
+    isPrimary: true,
+    order: 0,
+  },
+};
+
+describe('buildListingMetadata', () => {
+  it('builds full metadata from a valid listing', () => {
+    const meta = buildListingMetadata(validListing);
+    expect(meta.title).toBe('Beautiful Apartment - Bratislava | Reality Portal');
+    expect(meta.description).toBe('A lovely place to live with plenty of light.');
+    expect(meta.openGraph?.images).toEqual(['https://cdn.example.com/p1.jpg']);
+  });
+
+  it('falls back when the body is null/undefined (not-found / network failure)', () => {
+    expect(buildListingMetadata(null).title).toBe(FALLBACK_TITLE);
+    expect(buildListingMetadata(undefined).title).toBe(FALLBACK_TITLE);
+  });
+
+  // The core regression: malformed but truthy 200 bodies must NOT throw.
+  it('falls back on an empty object body without throwing', () => {
+    expect(() => buildListingMetadata({})).not.toThrow();
+    expect(buildListingMetadata({}).title).toBe(FALLBACK_TITLE);
+  });
+
+  it('falls back when address is missing (would have thrown on .city)', () => {
+    const malformed = { title: 'Has title but no address' };
+    expect(() => buildListingMetadata(malformed)).not.toThrow();
+    expect(buildListingMetadata(malformed).title).toBe(FALLBACK_TITLE);
+  });
+
+  it('falls back when title is missing', () => {
+    const malformed = { address: { city: 'Bratislava', country: 'SK' } };
+    expect(buildListingMetadata(malformed).title).toBe(FALLBACK_TITLE);
+  });
+
+  it('falls back on non-object bodies (string / number / array)', () => {
+    expect(buildListingMetadata('oops').title).toBe(FALLBACK_TITLE);
+    expect(buildListingMetadata(42).title).toBe(FALLBACK_TITLE);
+    expect(buildListingMetadata([]).title).toBe(FALLBACK_TITLE);
+  });
+
+  it('tolerates a missing/malformed description (would have thrown on .slice)', () => {
+    const noDescription = { ...validListing, description: undefined as unknown as string };
+    expect(() => buildListingMetadata(noDescription)).not.toThrow();
+    const meta = buildListingMetadata(noDescription);
+    expect(meta.title).toBe('Beautiful Apartment - Bratislava | Reality Portal');
+    expect(meta.description).toBeUndefined();
+  });
+
+  it('omits og images when primaryPhoto is missing or malformed', () => {
+    const noPhoto = { ...validListing, primaryPhoto: undefined };
+    expect(buildListingMetadata(noPhoto).openGraph?.images).toEqual([]);
+  });
+});

--- a/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/metadata.ts
+++ b/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/metadata.ts
@@ -1,0 +1,52 @@
+/**
+ * Listing detail metadata helpers.
+ *
+ * Kept in a standalone module (no component / next-intl imports) so the
+ * defensive metadata logic can be unit-tested in isolation.
+ */
+
+import type { ListingDetail } from '@ppt/reality-api-client';
+import type { Metadata } from 'next';
+
+/** Metadata used when the listing can't be resolved or is malformed. */
+export const FALLBACK_METADATA: Metadata = {
+  title: 'Listing Not Found - Reality Portal',
+};
+
+/**
+ * Build listing metadata defensively.
+ *
+ * `getListing` returns the raw JSON body of any 200 response, so a malformed
+ * or partial 200 (e.g. `{}`, or a body missing `title` / `address` /
+ * `description`) is truthy but does not match `ListingDetail`. Reading nested
+ * fields off such a body (`listing.address.city`, `listing.description.slice`)
+ * would throw during SSR and crash the request. Treat the body as `unknown`
+ * and fall back to safe default metadata whenever a required field is missing
+ * or the wrong shape.
+ */
+export function buildListingMetadata(listing: unknown): Metadata {
+  if (!listing || typeof listing !== 'object') {
+    return FALLBACK_METADATA;
+  }
+
+  const l = listing as Partial<ListingDetail>;
+  const city = l.address?.city;
+  if (typeof l.title !== 'string' || typeof city !== 'string') {
+    return FALLBACK_METADATA;
+  }
+
+  const title = `${l.title} - ${city} | Reality Portal`;
+  const description = typeof l.description === 'string' ? l.description.slice(0, 160) : undefined;
+  const images = typeof l.primaryPhoto?.url === 'string' ? [l.primaryPhoto.url] : [];
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: 'website',
+      images,
+    },
+  };
+}

--- a/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/page.tsx
@@ -12,6 +12,7 @@ import type { ListingDetail } from '@ppt/reality-api-client';
 import type { Metadata } from 'next';
 import { headers } from 'next/headers';
 import { ListingDetailContent, ListingNotFound } from '@/components/listings';
+import { buildListingMetadata } from './metadata';
 
 function inferApiBaseFromHost(host: string): string | null {
   const bareHost = host.split(':')[0]?.toLowerCase();
@@ -83,25 +84,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const host = await resolveHost();
   const listing = await getListing(slug, host);
 
-  if (!listing) {
-    return {
-      title: 'Listing Not Found - Reality Portal',
-    };
-  }
-
-  const title = `${listing.title} - ${listing.address.city} | Reality Portal`;
-  const description = listing.description.slice(0, 160);
-
-  return {
-    title,
-    description,
-    openGraph: {
-      title,
-      description,
-      type: 'website',
-      images: listing.primaryPhoto ? [listing.primaryPhoto.url] : [],
-    },
-  };
+  return buildListingMetadata(listing);
 }
 
 export default async function ListingDetailPage({ params }: PageProps) {


### PR DESCRIPTION
## Task
Reality-web listing generateMetadata can throw during SSR on a malformed 200 body. In frontend/apps/reality-web, find the listing route's generateMetadata (Next.js) that fetches the listing and accesses fields without guarding a malformed/empty 200 response. Make it defensive: handle missing/malformed body gracefully (fall back to safe default metadata) instead of throwing during SSR. Add a test if the surface supports it.

## Owner
pm-frontend

## Root cause
`src/app/[locale]/listings/[slug]/page.tsx` — `getListing` returns `response.json()` for any 200 response. The old `generateMetadata` only guarded against a falsy `listing`, then read nested fields:

```ts
const title = `${listing.title} - ${listing.address.city} | Reality Portal`;
const description = listing.description.slice(0, 160);
```

A malformed/partial 200 body (e.g. `{}`, or a body missing `address`/`description`) is truthy but not a real `ListingDetail`, so `listing.address.city` and `listing.description.slice(...)` throw during SSR and crash the request.

## Fix
- Extracted a pure, defensive `buildListingMetadata(listing: unknown)` helper into a new standalone module `metadata.ts` (no component / next-intl imports, so it is unit-testable in isolation).
- The helper treats the body as `unknown`, validates `title` and `address.city` are strings, and falls back to safe default metadata (`Listing Not Found - Reality Portal`) otherwise. Optional fields (`description`, `primaryPhoto.url`) are guarded individually.
- `generateMetadata` now simply delegates to `buildListingMetadata(listing)`.

Note: the page-component (`ListingDetailPage`) JSON-LD path is unchanged — it already guards `if (!listing)` and renders `<ListingNotFound />`, and is out of scope for this metadata-SSR bug.

## Tested (Band A — fast check)
- `pnpm -F @ppt/reality-web typecheck` -> exit 0
- `npx @biomejs/biome check <changed files>` -> exit 0 (Checked 3 files, no fixes applied)
- `npx vitest run src/app/[locale]/listings/[slug]/metadata.test.ts` -> exit 0 (8 tests passed) — covers empty `{}` body, missing address, missing title, non-object bodies, missing description, and missing primaryPhoto.

## Built (Band B — full build)
skipped: change <50 LOC substantive, no public API/config touch (added a local helper module + test only)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Notes
Scope-drift check (`scope-check.sh --owner pm-frontend`) exit 0 — all changes within `frontend/apps/reality-web`.

https://claude.ai/code/session_01HoqWfPhxS8ZLYWQM56SiEM

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoqWfPhxS8ZLYWQM56SiEM)_