### PR TITLE
fix(api-server): close cross-tenant IDOR in list_listing_descriptions (security-llm-doc-idor)

### DIFF
--- a/backend/crates/db/src/repositories/llm_document.rs
+++ b/backend/crates/db/src/repositories/llm_document.rs
@@ -438,6 +438,31 @@ impl LlmDocumentRepository {
         .await
     }
 
+    /// List descriptions for a listing — tenant-scoped (issue #766 / #816).
+    ///
+    /// `org_id` must originate from the verified request principal. The
+    /// `organization_id = $2` guard ensures a caller in org B cannot read the
+    /// generated listing descriptions owned by org A by enumerating a
+    /// `listing_id`. Returns an empty vec for both "no descriptions" and
+    /// "listing belongs to another tenant", so existence is never leaked.
+    pub async fn list_listing_descriptions_for_org(
+        &self,
+        listing_id: Uuid,
+        org_id: Uuid,
+    ) -> Result<Vec<GeneratedListingDescription>, SqlxError> {
+        sqlx::query_as::<_, GeneratedListingDescription>(
+            r#"
+            SELECT * FROM generated_listing_descriptions
+            WHERE listing_id = $1 AND organization_id = $2
+            ORDER BY generated_at DESC
+            "#,
+        )
+        .bind(listing_id)
+        .bind(org_id)
+        .fetch_all(&self.pool)
+        .await
+    }
+
     /// Update edited description.
     pub async fn update_edited_description(
         &self,

--- a/backend/servers/api-server/src/routes/ai.rs
+++ b/backend/servers/api-server/src/routes/ai.rs
@@ -2665,12 +2665,16 @@ Format your response with clear sections for each component."#,
 
 async fn list_listing_descriptions(
     State(state): State<AppState>,
-    _principal: RequestPrincipal,
+    principal: RequestPrincipal,
     Path(listing_id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+    // SECURITY (issue #766 / #816): scope the read to the caller's org so a
+    // tenant cannot read another org's generated listing descriptions by
+    // enumerating a listing id.
+    let org_id = require_tenant_id(&principal)?;
     match state
         .llm_document_repo
-        .list_listing_descriptions(listing_id)
+        .list_listing_descriptions_for_org(listing_id, org_id)
         .await
     {
         Ok(descriptions) => Ok(Json(serde_json::json!({ "descriptions": descriptions }))),

--- a/backend/servers/api-server/tests/ai_llm_cross_tenant_idor_tests.rs
+++ b/backend/servers/api-server/tests/ai_llm_cross_tenant_idor_tests.rs
@@ -6,12 +6,13 @@
 //! row id and applied NO `organization_id` predicate, so a caller in org B
 //! could read/mutate org A's rows by guessing (or enumerating) the UUID:
 //!
-//! - `get_lease_template`     → `find_prompt_template(id)`     (template leak)
-//! - `get_generation_request` → `find_generation_request(id)`  (prompt/result/cost leak)
-//! - `get_photo_enhancement`  → `find_photo_enhancement(id)`   (photo record leak)
-//! - `publish_description`    → `publish_description(id)`       (cross-tenant mutate)
-//! - `provide_feedback`       → `add_feedback(user_id, …)`     (cross-tenant write / training poison)
-//! - `generate_lease`         → no `unit_id` ↔ tenant validation
+//! - `get_lease_template`       → `find_prompt_template(id)`     (template leak)
+//! - `get_generation_request`   → `find_generation_request(id)`  (prompt/result/cost leak)
+//! - `get_photo_enhancement`    → `find_photo_enhancement(id)`   (photo record leak)
+//! - `publish_description`      → `publish_description(id)`       (cross-tenant mutate)
+//! - `list_listing_descriptions`→ `list_listing_descriptions(listing_id)` (cross-tenant read)
+//! - `provide_feedback`         → `add_feedback(user_id, …)`     (cross-tenant write / training poison)
+//! - `generate_lease`           → no `unit_id` ↔ tenant validation
 //!
 //! The fix adds `_for_org` repository variants (and a `unit_belongs_to_org`
 //! check) that thread the principal's `effective_org` into the SQL WHERE
@@ -32,7 +33,7 @@
 //! so they run against `db::MIGRATOR` deterministically.
 
 use db::models::ProvideFeedback;
-use db::repositories::AiChatRepository;
+use db::repositories::{AiChatRepository, LlmDocumentRepository};
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -219,5 +220,106 @@ async fn add_feedback_for_org_blocks_cross_tenant_write(pool: PgPool) {
     assert_eq!(
         count_after_same, 1,
         "exactly one feedback row exists after the same-org write"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (3) Listing-description list read is tenant-scoped — org B cannot read org
+//     A's generated listing descriptions by enumerating a listing id.
+//
+// `generated_listing_descriptions` does not ship a migration in `db::MIGRATOR`
+// (the LLM-document tables are provisioned out-of-band), so we create the
+// minimal shape the repository's `SELECT *` maps onto. This pins the IDOR
+// contract on `list_listing_descriptions_for_org` directly at the repo layer,
+// matching the rationale documented at the top of this file.
+// ---------------------------------------------------------------------------
+
+async fn create_generated_listing_descriptions_table(pool: &PgPool) {
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS generated_listing_descriptions (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            organization_id UUID NOT NULL,
+            listing_id UUID,
+            user_id UUID NOT NULL,
+            language TEXT NOT NULL,
+            original_description TEXT NOT NULL,
+            property_details JSONB NOT NULL DEFAULT '{}'::jsonb,
+            photo_analysis JSONB,
+            generated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            edited_description TEXT,
+            edited_at TIMESTAMPTZ,
+            edited_by UUID,
+            is_published BOOLEAN NOT NULL DEFAULT FALSE,
+            generation_request_id UUID NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+        "#,
+    )
+    .execute(pool)
+    .await
+    .expect("create generated_listing_descriptions");
+}
+
+async fn seed_listing_description(pool: &PgPool, org_id: Uuid, listing_id: Uuid, user_id: Uuid) {
+    sqlx::query(
+        r#"
+        INSERT INTO generated_listing_descriptions (
+            organization_id, listing_id, user_id, language,
+            original_description, property_details, generation_request_id
+        )
+        VALUES ($1, $2, $3, 'sk', 'secret copy', '{}'::jsonb, gen_random_uuid())
+        "#,
+    )
+    .bind(org_id)
+    .bind(listing_id)
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .expect("seed listing description");
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_listing_descriptions_for_org_blocks_cross_tenant_read(pool: PgPool) {
+    create_generated_listing_descriptions_table(&pool).await;
+    let repo = LlmDocumentRepository::new(pool.clone());
+
+    let org_a = seed_org(&pool, "desc-a").await;
+    let org_b = seed_org(&pool, "desc-b").await;
+    let user_a = seed_user(&pool, "desc-a@ai-idor.test").await;
+    let listing_in_a = Uuid::new_v4();
+    seed_listing_description(&pool, org_a, listing_in_a, user_a).await;
+
+    // Same-org read returns the row.
+    let same_org = repo
+        .list_listing_descriptions_for_org(listing_in_a, org_a)
+        .await
+        .expect("query ok");
+    assert_eq!(
+        same_org.len(),
+        1,
+        "org A must be able to read its own listing descriptions"
+    );
+
+    // Cross-org read returns nothing (the IDOR is blocked).
+    let cross_org = repo
+        .list_listing_descriptions_for_org(listing_in_a, org_b)
+        .await
+        .expect("query ok");
+    assert!(
+        cross_org.is_empty(),
+        "org B must NOT be able to read org A's listing descriptions"
+    );
+
+    // Demonstrate the leak the org predicate closes: the unscoped lookup the
+    // pre-fix handler performed returns the row regardless of org.
+    let unscoped = repo
+        .list_listing_descriptions(listing_in_a)
+        .await
+        .expect("query ok");
+    assert_eq!(
+        unscoped.len(),
+        1,
+        "sanity: the unscoped query (the vulnerable pre-fix path) does leak the row"
     );
 }


### PR DESCRIPTION
## Summary

Closes the remaining cross-tenant IDOR in the Epic-64 LLM-document cluster (`routes/ai.rs`). Plan: `.research/plans/security-llm-doc-idor.md` (issue #766 / #816 family).

The `list_listing_descriptions` handler bound `_principal` and discarded it, then called a tenant-blind repo query (`SELECT * FROM generated_listing_descriptions WHERE listing_id = $1`), letting a caller in org B read org A's generated listing descriptions by enumerating a `listing_id`.

### Finding while implementing
Two of the plan's three targets were **already fixed on `dev`** (issue #766/#816):
- `publish_description` → already uses `publish_description_for_org` (org-scoped UPDATE)
- `get_photo_enhancement` → already uses `find_photo_enhancement_for_org` (org-scoped SELECT)

Only `list_listing_descriptions` remained tenant-blind. This PR finishes the cluster.

## Changes
- `backend/crates/db/src/repositories/llm_document.rs`: add `list_listing_descriptions_for_org(listing_id, org_id)` with `AND organization_id = $2`, mirroring the existing `_for_org` idiom. The old unscoped `list_listing_descriptions` is retained (used by the regression test to demonstrate the leak the predicate closes).
- `backend/servers/api-server/src/routes/ai.rs`: bind `principal`, resolve the org via `require_tenant_id(&principal)`, and call the scoped repo method. Empty list (not 404) on a cross-tenant `listing_id`, matching the conservative disclosure posture documented in the test file.
- `backend/servers/api-server/tests/ai_llm_cross_tenant_idor_tests.rs`: add `list_listing_descriptions_for_org_blocks_cross_tenant_read` — org A creates a description; org A reads it (1 row), org B reads it (0 rows), and the unscoped query is asserted to still leak (1 row) to prove the predicate is what closes the gap. The test creates the `generated_listing_descriptions` table inline because the LLM-document tables ship no migration in `db::MIGRATOR`.

## Verification
- `cargo check -p db -p api-server` — passes.
- Test target `ai_llm_cross_tenant_idor_tests` compiles (`cargo test --no-run`). DB-backed `#[sqlx::test]` execution is not available in the cloud container (no Postgres); CI will run it.
- `backend/scripts/lints/check-discarded-principal.sh` — none of the three plan handlers are flagged (the remaining 9 informational hits are pre-existing in unrelated files).
- The pre-existing clippy `items-after-test-module` error is in `admin/mod.rs` (not in this diff) and is a newer-clippy-version artifact of the container toolchain.

## Out of scope
- `ai.rs` module split (tracked separately).
- Maintenance/chat-session/sentiment IDOR cluster (PR #725).

https://claude.ai/code/session_01HoqWfPhxS8ZLYWQM56SiEM

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoqWfPhxS8ZLYWQM56SiEM)_