### PR TITLE
fix(ppt-web): localize status-component dates + add version-history loading test

### DIFF
--- a/frontend/apps/ppt-web/src/features/documents/components/OcrStatusBadge.tsx
+++ b/frontend/apps/ppt-web/src/features/documents/components/OcrStatusBadge.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { OcrStatus } from '@ppt/api-client';
+import { formatDateTime } from '@ppt/shared';
 import { useTranslation } from 'react-i18next';
 
 interface OcrStatusBadgeProps {
@@ -187,17 +188,9 @@ export function OcrProcessingStatus({
   onReprocess,
   isReprocessing,
 }: OcrProcessingStatusProps) {
-  const { t } = useTranslation();
-  const formatDate = (dateString: string): string => {
-    const date = new Date(dateString);
-    return date.toLocaleString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  };
+  const { t, i18n } = useTranslation();
+  const formatDate = (dateString: string): string =>
+    formatDateTime(dateString, { locale: i18n.language });
 
   return (
     <div className="ocr-processing-status">

--- a/frontend/apps/ppt-web/src/features/documents/pages/DocumentDetail.versions.test.tsx
+++ b/frontend/apps/ppt-web/src/features/documents/pages/DocumentDetail.versions.test.tsx
@@ -167,6 +167,17 @@ describe('DocumentDetail version history (PR #990)', () => {
     expect(screen.getByText('1.5 KB')).toBeInTheDocument();
   });
 
+  it('shows the loading state while versions are fetching', () => {
+    setVersions({ data: undefined, isLoading: true });
+
+    render(<DocumentDetail documentId="doc-1" />);
+
+    expect(screen.getByText('Loading versions…')).toBeInTheDocument();
+    expect(
+      screen.queryByText('No versions are available for this document.')
+    ).not.toBeInTheDocument();
+  });
+
   it('shows the empty state when there are no versions', () => {
     setVersions({ data: [] });
 

--- a/frontend/apps/ppt-web/src/features/government-portal/pages/SubmissionStatusPage.tsx
+++ b/frontend/apps/ppt-web/src/features/government-portal/pages/SubmissionStatusPage.tsx
@@ -12,6 +12,7 @@ import type {
   RegulatorySubmissionAudit,
   SubmissionStatus,
 } from '@ppt/api-client';
+import { formatDate as formatDateShared, formatDateTime } from '@ppt/shared';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SubmissionStatusBadge } from '../components/SubmissionStatusBadge';
@@ -51,7 +52,7 @@ export function SubmissionStatusPage({
   onCancel,
   onBack,
 }: SubmissionStatusPageProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [showErrorDetails, setShowErrorDetails] = useState(false);
   const [showAuditTrail, setShowAuditTrail] = useState(false);
   const [cancelError, setCancelError] = useState<string | null>(null);
@@ -59,22 +60,11 @@ export function SubmissionStatusPage({
 
   const formatDate = (dateString?: string) => {
     if (!dateString) return '—';
-    return new Date(dateString).toLocaleDateString('en-GB', {
-      day: '2-digit',
-      month: 'short',
-      year: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
+    return formatDateTime(dateString, { locale: i18n.language });
   };
 
-  const formatShortDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-GB', {
-      day: '2-digit',
-      month: 'short',
-      year: 'numeric',
-    });
-  };
+  const formatShortDate = (dateString: string) =>
+    formatDateShared(dateString, { locale: i18n.language });
 
   const canRetry = submission.status === 'rejected' || submission.status === 'requires_correction';
   const canValidate = submission.status === 'draft' || submission.status === 'requires_correction';


### PR DESCRIPTION
Closes #1094
Closes #1096

Two small post-merge ppt-web follow-ups:

- **#1096 — localize dates:** `OcrProcessingStatus` (`OcrStatusBadge.tsx`) and `SubmissionStatusPage` no longer hardcode `en-US`/`en-GB` date locales. They now use the `@ppt/shared` `formatDate`/`formatDateTime` helpers driven by the active UI language (`i18n.language`), preserving each spot's date vs date+time granularity.
- **#1094 — version-history loading test:** Added the missing `it(...)` covering the loading state in `DocumentDetail.versions.test.tsx` (the docblock claimed loading coverage but none existed).

No local toolchain — relying on CI (biome + typecheck + vitest) for verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)