### PR TITLE
refactor(ppt-web): extract FileDisputePageRoute + cover partial-fail evidence upload (closes #1095)

### DIFF
--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -13,7 +13,6 @@ import type {
   OutageListQuery,
 } from '@ppt/api-client';
 import {
-  uploadEvidence as apiUploadEvidence,
   getARAgingReport,
   getOverdueInvoices,
   getToken,
@@ -33,7 +32,6 @@ import {
   useCancelOutage,
   useConfirmFault,
   useCreateAnnouncementComment,
-  useCreateDispute,
   useCreateFault,
   useCreateOutage,
   useDeleteAnnouncement,
@@ -117,6 +115,7 @@ import type {
 } from './features/disputes/components/DisputeCard';
 import type { ActivityType } from './features/disputes/components/DisputeTimeline';
 import type { DisputeDetail as UiDisputeDetail } from './features/disputes/pages/DisputeDetailPage';
+import { FileDisputePageRoute } from './features/disputes/pages/FileDisputePageRoute';
 import { useNeighbors, usePrivacySettings } from './features/neighbors';
 import type { ListOutagesParams, OutageDetail } from './features/outages';
 import type {
@@ -166,7 +165,6 @@ import {
   FaultDetailPage,
   FaultsPage,
   FeedPage,
-  FileDisputePage,
   FinancialDashboardPage,
   FolderTreePage,
   ForbiddenPage,
@@ -1121,98 +1119,6 @@ function DisputesPageRoute() {
       onNavigateToView={handleNavigateToView}
       onNavigateToManage={handleNavigateToManage}
       onFilterChange={handleFilterChange}
-    />
-  );
-}
-
-/**
- * Route wrapper for file dispute page (Epic 80, Story 80.2).
- *
- * Step sequence:
- *  1. POST /api/v1/disputes/organizations/:orgId  → creates the dispute (returns id)
- *  2. For each valid PendingEvidence file: POST /api/v1/disputes/:id/evidence
- *  3. Navigate to /disputes/:id (detail page) on success.
- *
- * FileDisputePage is a pure presentational component; all API side-effects live here.
- */
-function FileDisputePageRoute() {
-  const { t } = useTranslation();
-  const navigate = useNavigate();
-  const { user } = useAuth();
-  const { showToast } = useToast();
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  const organizationId = user?.organizationId ?? '';
-
-  const createDispute = useCreateDispute(organizationId);
-
-  if (!user?.organizationId) {
-    return <AuthRequiredGate />;
-  }
-
-  const handleSubmit = async (
-    payload: import('./features/disputes/pages/FileDisputePage').FileDisputeSubmitPayload
-  ) => {
-    setIsSubmitting(true);
-    try {
-      // Step 1 — create the dispute
-      const created = await createDispute.mutateAsync({
-        type: payload.values.type as ApiDisputeType,
-        subject: payload.values.subject,
-        description: payload.values.description,
-        unitId: payload.values.unitId,
-        respondentId: payload.values.respondentId || undefined,
-      });
-
-      // Step 2 — upload evidence files sequentially; skip errored entries.
-      // We call the raw API function (not the hook) because the hook must be
-      // keyed to a disputeId at render time and we only know the id after step 1.
-      const validFiles = payload.evidence.filter((e) => e.status !== 'error');
-      const failedEvidence: typeof validFiles = [];
-      for (const item of validFiles) {
-        try {
-          await apiUploadEvidence(created.id, item.file, item.description || item.file.name);
-        } catch {
-          failedEvidence.push(item);
-        }
-      }
-      const evidenceErrors = failedEvidence.length;
-
-      // Step 3 — toast + navigate to the new dispute detail
-      if (evidenceErrors > 0) {
-        showToast({
-          type: 'warning',
-          title: t('disputes.filedWithEvidenceErrors', 'Dispute filed (some files failed)'),
-          message: t('disputes.evidenceUploadErrorsMsg', { count: evidenceErrors }),
-        });
-      } else {
-        showToast({
-          type: 'success',
-          title: t('disputes.filedSuccessfully', 'Dispute filed successfully'),
-          message: t('disputes.submittedMsg', 'Your dispute has been submitted for review.'),
-        });
-      }
-      // TODO(#627): consume failedEvidence on DisputeDetailPage to surface a retry
-      // prompt once evidence-retry UI lands. For now we just thread it through
-      // router state so the detail page can pick it up when ready.
-      navigate(`/disputes/${created.id}`, {
-        state: evidenceErrors > 0 ? { failedEvidence } : undefined,
-      });
-    } catch (error) {
-      showToast({
-        type: 'error',
-        title: t('disputes.failedToFile', 'Failed to file dispute'),
-        message: error instanceof Error ? error.message : t('auth.unexpectedError'),
-      });
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  return (
-    <FileDisputePage
-      onSubmit={handleSubmit}
-      isSubmitting={isSubmitting || createDispute.isPending}
     />
   );
 }

--- a/frontend/apps/ppt-web/src/features/disputes/pages/FileDisputePageRoute.test.tsx
+++ b/frontend/apps/ppt-web/src/features/disputes/pages/FileDisputePageRoute.test.tsx
@@ -100,9 +100,7 @@ function makeEvidence(
   };
 }
 
-function makePayload(
-  evidence: FileDisputeSubmitPayload['evidence']
-): FileDisputeSubmitPayload {
+function makePayload(evidence: FileDisputeSubmitPayload['evidence']): FileDisputeSubmitPayload {
   return {
     values: {
       type: 'noise',
@@ -180,9 +178,7 @@ describe('FileDisputePageRoute', () => {
     // Only the non-errored file is uploaded.
     expect(mockUploadEvidence).toHaveBeenCalledTimes(1);
     expect(mockUploadEvidence).toHaveBeenCalledWith('dsp-99', good.file, 'good.jpg');
-    expect(mockShowToast).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'success' })
-    );
+    expect(mockShowToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
   });
 
   it('(d) create-dispute failure → error toast and no navigate / upload', async () => {

--- a/frontend/apps/ppt-web/src/features/disputes/pages/FileDisputePageRoute.test.tsx
+++ b/frontend/apps/ppt-web/src/features/disputes/pages/FileDisputePageRoute.test.tsx
@@ -1,0 +1,207 @@
+/// <reference types="vitest/globals" />
+/**
+ * FileDisputePageRoute orchestration tests (#1095).
+ *
+ * The route wrapper threads three steps together — create dispute, sequentially
+ * upload non-errored evidence, then toast + navigate — and previously had zero
+ * coverage. These tests pin the success / partial-fail / filtered / create-fail
+ * branches so the behaviour can't silently regress.
+ *
+ * Covered:
+ *  (a) all-success     → success toast + navigate(detail, undefined)
+ *  (b) partial-fail    → warning toast (correct count) + navigate(detail, {state:{failedEvidence}})
+ *  (c) errored entries → filtered out before upload (status === 'error')
+ *  (d) create failure  → error toast, no navigate
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import { useState } from 'react';
+import type { FileDisputeSubmitPayload } from './FileDisputePage';
+import { FileDisputePageRoute } from './FileDisputePageRoute';
+
+// ── api-client: create-dispute hook + raw evidence upload ──
+const mockMutateAsync = vi.fn();
+const mockUploadEvidence = vi.fn();
+vi.mock('@ppt/api-client', () => ({
+  useCreateDispute: () => ({ mutateAsync: mockMutateAsync, isPending: false }),
+  uploadEvidence: (...args: unknown[]) => mockUploadEvidence(...args),
+}));
+
+// ── auth context: provide an org so the gate passes ──
+vi.mock('../../../contexts', () => ({
+  useAuth: () => ({ user: { organizationId: 'org-1' } }),
+}));
+
+// ── toast + auth gate ──
+const mockShowToast = vi.fn();
+vi.mock('../../../components', () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+  AuthRequiredGate: () => <div>auth required</div>,
+}));
+
+// ── router navigate ──
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+// ── i18n: echo key, but interpolate {count} so the warning message is assertable ──
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: unknown) => {
+      if (key === 'disputes.evidenceUploadErrorsMsg' && opts && typeof opts === 'object') {
+        const count = (opts as { count?: number }).count;
+        return `${count} file(s) failed`;
+      }
+      // String fallbacks come through as the 2nd arg; ignore them, just echo key.
+      return key;
+    },
+  }),
+}));
+
+/**
+ * Stub FileDisputePage with a button that fires onSubmit with the payload
+ * provided per-test via `currentPayload`. Lets us drive the wrapper's
+ * handleSubmit deterministically without exercising the real form.
+ */
+let currentPayload: FileDisputeSubmitPayload;
+vi.mock('./FileDisputePage', () => ({
+  FileDisputePage: ({
+    onSubmit,
+  }: {
+    onSubmit: (p: FileDisputeSubmitPayload) => void | Promise<void>;
+  }) => {
+    const [pending, setPending] = useState(false);
+    return (
+      <button
+        type="button"
+        disabled={pending}
+        onClick={async () => {
+          setPending(true);
+          await onSubmit(currentPayload);
+          setPending(false);
+        }}
+      >
+        submit
+      </button>
+    );
+  },
+}));
+
+function makeEvidence(
+  id: string,
+  status: 'pending' | 'error' = 'pending',
+  description = ''
+): FileDisputeSubmitPayload['evidence'][number] {
+  return {
+    id,
+    file: new File(['x'], `${id}.jpg`, { type: 'image/jpeg' }),
+    description,
+    status,
+  };
+}
+
+function makePayload(
+  evidence: FileDisputeSubmitPayload['evidence']
+): FileDisputeSubmitPayload {
+  return {
+    values: {
+      type: 'noise',
+      subject: 'Loud parties past midnight',
+      description: 'Repeated loud music well past the 22:00 quiet hours threshold.',
+      unitId: 'unit-1',
+      respondentId: '',
+    },
+    evidence,
+  };
+}
+
+async function submit() {
+  screen.getByRole('button', { name: /submit/i }).click();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockMutateAsync.mockResolvedValue({ id: 'dsp-99' });
+  mockUploadEvidence.mockResolvedValue(undefined);
+});
+
+describe('FileDisputePageRoute', () => {
+  it('(a) all-success → success toast + navigate to detail with no router state', async () => {
+    currentPayload = makePayload([makeEvidence('e1'), makeEvidence('e2')]);
+    render(<FileDisputePageRoute />);
+
+    await submit();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/disputes/dsp-99', { state: undefined });
+    });
+    expect(mockMutateAsync).toHaveBeenCalledTimes(1);
+    expect(mockUploadEvidence).toHaveBeenCalledTimes(2);
+    expect(mockShowToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'success', title: 'disputes.filedSuccessfully' })
+    );
+  });
+
+  it('(b) partial-fail → warning toast with count + navigate with failedEvidence state', async () => {
+    const ok = makeEvidence('ok');
+    const bad = makeEvidence('bad');
+    currentPayload = makePayload([ok, bad]);
+    // Second upload throws.
+    mockUploadEvidence.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('boom'));
+    render(<FileDisputePageRoute />);
+
+    await submit();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/disputes/dsp-99', {
+        state: { failedEvidence: [bad] },
+      });
+    });
+    expect(mockShowToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'warning',
+        title: 'disputes.filedWithEvidenceErrors',
+        message: '1 file(s) failed',
+      })
+    );
+  });
+
+  it("(c) evidence with status 'error' is filtered out before upload", async () => {
+    const good = makeEvidence('good', 'pending');
+    const errored = makeEvidence('errored', 'error');
+    currentPayload = makePayload([good, errored]);
+    render(<FileDisputePageRoute />);
+
+    await submit();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/disputes/dsp-99', { state: undefined });
+    });
+    // Only the non-errored file is uploaded.
+    expect(mockUploadEvidence).toHaveBeenCalledTimes(1);
+    expect(mockUploadEvidence).toHaveBeenCalledWith('dsp-99', good.file, 'good.jpg');
+    expect(mockShowToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'success' })
+    );
+  });
+
+  it('(d) create-dispute failure → error toast and no navigate / upload', async () => {
+    currentPayload = makePayload([makeEvidence('e1')]);
+    mockMutateAsync.mockRejectedValueOnce(new Error('create failed'));
+    render(<FileDisputePageRoute />);
+
+    await submit();
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          title: 'disputes.failedToFile',
+          message: 'create failed',
+        })
+      );
+    });
+    expect(mockUploadEvidence).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/apps/ppt-web/src/features/disputes/pages/FileDisputePageRoute.tsx
+++ b/frontend/apps/ppt-web/src/features/disputes/pages/FileDisputePageRoute.tsx
@@ -1,6 +1,6 @@
 import {
-  uploadEvidence as apiUploadEvidence,
   type DisputeType as ApiDisputeType,
+  uploadEvidence as apiUploadEvidence,
   useCreateDispute,
 } from '@ppt/api-client';
 import { useState } from 'react';

--- a/frontend/apps/ppt-web/src/features/disputes/pages/FileDisputePageRoute.tsx
+++ b/frontend/apps/ppt-web/src/features/disputes/pages/FileDisputePageRoute.tsx
@@ -1,0 +1,101 @@
+import {
+  uploadEvidence as apiUploadEvidence,
+  type DisputeType as ApiDisputeType,
+  useCreateDispute,
+} from '@ppt/api-client';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { AuthRequiredGate, useToast } from '../../../components';
+import { useAuth } from '../../../contexts';
+import { FileDisputePage, type FileDisputeSubmitPayload } from './FileDisputePage';
+
+/**
+ * Route wrapper for file dispute page (Epic 80, Story 80.2).
+ *
+ * Step sequence:
+ *  1. POST /api/v1/disputes/organizations/:orgId  → creates the dispute (returns id)
+ *  2. For each valid PendingEvidence file: POST /api/v1/disputes/:id/evidence
+ *  3. Navigate to /disputes/:id (detail page) on success.
+ *
+ * FileDisputePage is a pure presentational component; all API side-effects live here.
+ */
+export function FileDisputePageRoute() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const { showToast } = useToast();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const organizationId = user?.organizationId ?? '';
+
+  const createDispute = useCreateDispute(organizationId);
+
+  if (!user?.organizationId) {
+    return <AuthRequiredGate />;
+  }
+
+  const handleSubmit = async (payload: FileDisputeSubmitPayload) => {
+    setIsSubmitting(true);
+    try {
+      // Step 1 — create the dispute
+      const created = await createDispute.mutateAsync({
+        type: payload.values.type as ApiDisputeType,
+        subject: payload.values.subject,
+        description: payload.values.description,
+        unitId: payload.values.unitId,
+        respondentId: payload.values.respondentId || undefined,
+      });
+
+      // Step 2 — upload evidence files sequentially; skip errored entries.
+      // We call the raw API function (not the hook) because the hook must be
+      // keyed to a disputeId at render time and we only know the id after step 1.
+      const validFiles = payload.evidence.filter((e) => e.status !== 'error');
+      const failedEvidence: typeof validFiles = [];
+      for (const item of validFiles) {
+        try {
+          await apiUploadEvidence(created.id, item.file, item.description || item.file.name);
+        } catch {
+          failedEvidence.push(item);
+        }
+      }
+      const evidenceErrors = failedEvidence.length;
+
+      // Step 3 — toast + navigate to the new dispute detail
+      if (evidenceErrors > 0) {
+        showToast({
+          type: 'warning',
+          title: t('disputes.filedWithEvidenceErrors', 'Dispute filed (some files failed)'),
+          message: t('disputes.evidenceUploadErrorsMsg', { count: evidenceErrors }),
+        });
+      } else {
+        showToast({
+          type: 'success',
+          title: t('disputes.filedSuccessfully', 'Dispute filed successfully'),
+          message: t('disputes.submittedMsg', 'Your dispute has been submitted for review.'),
+        });
+      }
+      // TODO(#627): consume failedEvidence on DisputeDetailPage to surface a retry
+      // prompt once evidence-retry UI lands. For now we just thread it through
+      // router state so the detail page can pick it up when ready.
+      navigate(`/disputes/${created.id}`, {
+        state: evidenceErrors > 0 ? { failedEvidence } : undefined,
+      });
+    } catch (error) {
+      showToast({
+        type: 'error',
+        title: t('disputes.failedToFile', 'Failed to file dispute'),
+        message: error instanceof Error ? error.message : t('auth.unexpectedError'),
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <FileDisputePage
+      onSubmit={handleSubmit}
+      isSubmitting={isSubmitting || createDispute.isPending}
+    />
+  );
+}


### PR DESCRIPTION
Closes #1095

## What

The dispute-filing orchestration lived as an un-exported inline `FileDisputePageRoute` wrapper in `frontend/apps/ppt-web/src/App.tsx` (~90 lines) with **zero test coverage**. This extracts it into an exported, testable module and adds route-level tests.

## Changes

- **New:** `features/disputes/pages/FileDisputePageRoute.tsx` — the wrapper moved verbatim and exported. Same hooks (`useCreateDispute`, raw `uploadEvidence`, `useAuth`, `useToast`, `useNavigate`, `useTranslation`), same toast keys, same `navigate(\`/disputes/\${id}\`, { state })` shape, same top-level error catch. **No behaviour change.**
- **App.tsx:** import `FileDisputePageRoute` from the new module; removed the inline definition and its now-unused imports (`uploadEvidence`, `useCreateDispute`, `FileDisputePage`). Surgical edit only.
- **New:** `FileDisputePageRoute.test.tsx` — mocks `useCreateDispute`, `uploadEvidence`, `useAuth`, `useToast`, `useNavigate`, `useTranslation`, and the presentational `FileDisputePage`.

## Test cases

1. **all-success** → success toast + `navigate(detail, { state: undefined })`; both evidence files uploaded.
2. **partial-fail** (one upload throws) → warning toast with correct `{count}` + `navigate(detail, { state: { failedEvidence } })`.
3. **errored evidence** (`status === 'error'`) filtered out before upload — only the valid file is uploaded.
4. **create-dispute failure** → error toast, no upload, no navigate.

## Verification

No local toolchain — relying on CI (biome + typecheck + vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)