### PR TITLE
fix(mobile): remove dead announcement category filter + MoveDocumentSheet type cleanup

### DIFF
--- a/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.test.ts
+++ b/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.test.ts
@@ -31,7 +31,6 @@ describe('toUiAnnouncement (PR #918 published-summary mapping)', () => {
     expect(ui).toMatchObject({
       id: 'a-1',
       title: 'Lift maintenance Friday',
-      category: 'general',
       createdAt: '2026-05-20T08:00:00Z', // from published_at
       isPinned: true,
     });
@@ -72,7 +71,6 @@ describe('extractItems (PR #918 reads `announcements`, not `items`)', () => {
 
 const ui = (over: Partial<Announcement> & Pick<Announcement, 'id'>): Announcement => ({
   title: over.title ?? over.id,
-  category: 'general',
   createdAt: '2026-05-01T00:00:00Z',
   author: 'Building Management',
   isRead: false,
@@ -103,34 +101,28 @@ describe('filterMainList (PR #943 main feed partitioning)', () => {
     ui({
       id: 'old',
       title: 'Lift maintenance',
-      category: 'maintenance',
       createdAt: '2026-05-01T00:00:00Z',
     }),
     ui({
       id: 'new',
       title: 'Garden event',
-      category: 'event',
       createdAt: '2026-05-03T00:00:00Z',
     }),
   ];
 
   it('excludes pinned items from the main feed', () => {
-    expect(filterMainList(items, 'all', '').map((a) => a.id)).not.toContain('pin');
+    expect(filterMainList(items, '').map((a) => a.id)).not.toContain('pin');
   });
 
   it('sorts the remaining items newest-first', () => {
-    expect(filterMainList(items, 'all', '').map((a) => a.id)).toEqual(['new', 'old']);
-  });
-
-  it('applies the active category filter', () => {
-    expect(filterMainList(items, 'maintenance', '').map((a) => a.id)).toEqual(['old']);
+    expect(filterMainList(items, '').map((a) => a.id)).toEqual(['new', 'old']);
   });
 
   it('matches the search query against the TITLE only (no content body since #943)', () => {
-    expect(filterMainList(items, 'all', 'garden').map((a) => a.id)).toEqual(['new']);
+    expect(filterMainList(items, 'garden').map((a) => a.id)).toEqual(['new']);
     // Case-insensitive.
-    expect(filterMainList(items, 'all', 'LIFT').map((a) => a.id)).toEqual(['old']);
+    expect(filterMainList(items, 'LIFT').map((a) => a.id)).toEqual(['old']);
     // A term that matched the old `content` body must NOT match now.
-    expect(filterMainList(items, 'all', 'no-such-title')).toEqual([]);
+    expect(filterMainList(items, 'no-such-title')).toEqual([]);
   });
 });

--- a/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.tsx
@@ -11,8 +11,6 @@ import {
 import { useApiQuery } from '../../hooks/useApi';
 import { colors } from '../shared/screenStyles';
 
-export type AnnouncementCategory = 'general' | 'urgent' | 'maintenance' | 'event' | 'financial';
-
 export interface AnnouncementAttachment {
   id: string;
   name: string;
@@ -23,7 +21,6 @@ export interface AnnouncementAttachment {
 export interface Announcement {
   id: string;
   title: string;
-  category: AnnouncementCategory;
   createdAt: string;
   author: string;
   isRead: boolean;
@@ -62,7 +59,6 @@ export function toUiAnnouncement(a: ApiAnnouncementSummary): Announcement {
   return {
     id: a.id,
     title: a.title,
-    category: 'general',
     createdAt: a.published_at ?? new Date().toISOString(),
     author: 'Building Management',
     isRead: false,
@@ -94,20 +90,14 @@ export function derivePinnedItems(items: Announcement[]): Announcement[] {
 /**
  * Build the main (non-pinned) feed from the published list (PR #943).
  *
- * Excludes pinned items (they live in the sticky band), applies the active
- * category filter, matches the search query against the TITLE only (the
- * published summary has no `content` body since PR #943), and sorts
- * newest-first by `createdAt`.
+ * Excludes pinned items (they live in the sticky band), matches the search
+ * query against the TITLE only (the published summary has no `content` body
+ * since PR #943), and sorts newest-first by `createdAt`.
  */
-export function filterMainList(
-  items: Announcement[],
-  filter: 'all' | AnnouncementCategory,
-  searchQuery: string
-): Announcement[] {
+export function filterMainList(items: Announcement[], searchQuery: string): Announcement[] {
   const q = searchQuery.toLowerCase();
   return items
     .filter((a) => !a.isPinned)
-    .filter((a) => (filter === 'all' ? true : a.category === filter))
     .filter((a) => q === '' || a.title.toLowerCase().includes(q))
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 }
@@ -117,7 +107,6 @@ interface AnnouncementsScreenProps {
 }
 
 export function AnnouncementsScreen({ onNavigate }: AnnouncementsScreenProps) {
-  const [filter, setFilter] = useState<'all' | AnnouncementCategory>('all');
   const [searchQuery, setSearchQuery] = useState('');
   const [readIds, setReadIds] = useState<Set<string>>(new Set());
 
@@ -149,36 +138,6 @@ export function AnnouncementsScreen({ onNavigate }: AnnouncementsScreenProps) {
     await refetch();
   }, [refetch]);
 
-  const getCategoryColor = (category: AnnouncementCategory): string => {
-    switch (category) {
-      case 'urgent':
-        return colors.danger;
-      case 'maintenance':
-        return colors.warning;
-      case 'event':
-        return colors.eventCategoryInk;
-      case 'financial':
-        return colors.success;
-      default:
-        return colors.textMuted;
-    }
-  };
-
-  const getCategoryIcon = (category: AnnouncementCategory): string => {
-    switch (category) {
-      case 'urgent':
-        return '🚨';
-      case 'maintenance':
-        return '🔧';
-      case 'event':
-        return '📅';
-      case 'financial':
-        return '💰';
-      default:
-        return '📢';
-    }
-  };
-
   const formatDate = (dateString: string): string => {
     const date = new Date(dateString);
     const now = new Date();
@@ -206,7 +165,7 @@ export function AnnouncementsScreen({ onNavigate }: AnnouncementsScreenProps) {
   };
 
   // Main list excludes pinned items (they appear in the sticky band above)
-  const filteredAnnouncements = filterMainList(allRaw, filter, searchQuery);
+  const filteredAnnouncements = filterMainList(allRaw, searchQuery);
 
   const unreadCount = allRaw.filter((a) => !a.isRead).length;
 
@@ -261,26 +220,6 @@ export function AnnouncementsScreen({ onNavigate }: AnnouncementsScreenProps) {
         />
       </View>
 
-      {/* Filters */}
-      <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.filtersContainer}>
-        <View style={styles.filters}>
-          {(['all', 'urgent', 'maintenance', 'event', 'financial', 'general'] as const).map(
-            (cat) => (
-              <Pressable
-                key={cat}
-                style={[styles.filterButton, filter === cat && styles.filterButtonActive]}
-                onPress={() => setFilter(cat)}
-              >
-                {cat !== 'all' && <Text style={styles.filterIcon}>{getCategoryIcon(cat)}</Text>}
-                <Text style={[styles.filterText, filter === cat && styles.filterTextActive]}>
-                  {cat.charAt(0).toUpperCase() + cat.slice(1)}
-                </Text>
-              </Pressable>
-            )
-          )}
-        </View>
-      </ScrollView>
-
       {/* Announcements List */}
       <ScrollView
         style={styles.scrollView}
@@ -312,15 +251,6 @@ export function AnnouncementsScreen({ onNavigate }: AnnouncementsScreenProps) {
               onPress={() => handleCardPress(announcement)}
             >
               <View style={styles.announcementHeader}>
-                <View
-                  style={[
-                    styles.categoryBadge,
-                    { backgroundColor: getCategoryColor(announcement.category) },
-                  ]}
-                >
-                  <Text style={styles.categoryIcon}>{getCategoryIcon(announcement.category)}</Text>
-                  <Text style={styles.categoryText}>{announcement.category}</Text>
-                </View>
                 <Text style={styles.announcementDate}>{formatDate(announcement.createdAt)}</Text>
               </View>
 
@@ -425,40 +355,6 @@ const styles = StyleSheet.create({
     padding: 12,
     fontSize: 16,
   },
-  filtersContainer: {
-    backgroundColor: colors.surface,
-    paddingBottom: 16,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.border,
-  },
-  filters: {
-    flexDirection: 'row',
-    paddingHorizontal: 16,
-    gap: 8,
-  },
-  filterButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 14,
-    paddingVertical: 8,
-    borderRadius: 20,
-    backgroundColor: colors.surfaceMuted,
-    gap: 4,
-  },
-  filterButtonActive: {
-    backgroundColor: colors.accent,
-  },
-  filterIcon: {
-    fontSize: 14,
-  },
-  filterText: {
-    fontSize: 14,
-    color: colors.textMuted,
-    fontWeight: '500',
-  },
-  filterTextActive: {
-    color: colors.surface,
-  },
   scrollView: {
     flex: 1,
     padding: 16,
@@ -503,23 +399,6 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     alignItems: 'center',
     marginBottom: 8,
-  },
-  categoryBadge: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 8,
-    paddingVertical: 4,
-    borderRadius: 4,
-    gap: 4,
-  },
-  categoryIcon: {
-    fontSize: 12,
-  },
-  categoryText: {
-    fontSize: 11,
-    fontWeight: '600',
-    color: colors.surface,
-    textTransform: 'uppercase',
   },
   announcementDate: {
     fontSize: 12,

--- a/frontend/apps/mobile/src/screens/announcements/index.ts
+++ b/frontend/apps/mobile/src/screens/announcements/index.ts
@@ -1,7 +1,3 @@
 export { AnnouncementDetailScreen } from './AnnouncementDetailScreen';
-export type {
-  Announcement,
-  AnnouncementAttachment,
-  AnnouncementCategory,
-} from './AnnouncementsScreen';
+export type { Announcement, AnnouncementAttachment } from './AnnouncementsScreen';
 export { AnnouncementsScreen } from './AnnouncementsScreen';

--- a/frontend/apps/mobile/src/screens/documents/DocumentsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentsScreen.tsx
@@ -86,7 +86,7 @@ interface ApiDocumentListResponse {
  * id of the containing folder (null for root-level folders) and
  * `document_count` is the number of documents directly in the folder.
  */
-interface ApiFolderTreeNode {
+export interface ApiFolderTreeNode {
   id: string;
   name: string;
   parent_id?: string | null;

--- a/frontend/apps/mobile/src/screens/documents/MoveDocumentSheet.tsx
+++ b/frontend/apps/mobile/src/screens/documents/MoveDocumentSheet.tsx
@@ -35,29 +35,15 @@ import {
 } from 'react-native';
 import { useApiMutation } from '../../hooks/useApi';
 import { colors } from '../shared/screenStyles';
+// `ApiFolderTreeNode` is the canonical folder-tree node shape owned by
+// DocumentsScreen. This is a type-only import — erased at compile time, so it
+// does not introduce a runtime circular dependency.
+import type { ApiFolderTreeNode } from './DocumentsScreen';
 
 // ─── API types ────────────────────────────────────────────────────────────────
 
 interface MoveDocumentRequest {
   folder_id: string | null;
-}
-
-interface MoveDocumentResponse {
-  message: string;
-  document: {
-    id: string;
-    folder_id: string | null;
-  };
-}
-
-// ─── Folder tree node (re-declared locally to avoid circular imports) ─────────────────
-
-interface ApiFolderTreeNode {
-  id: string;
-  name: string;
-  parent_id?: string | null;
-  document_count: number;
-  children?: ApiFolderTreeNode[] | null;
 }
 
 // ─── Flatten tree to a depth-first list for the scrollable folder picker ─────────
@@ -110,7 +96,10 @@ export function MoveDocumentSheet({
 
   const [selectedId, setSelectedId] = useState<string | null>(currentFolderId);
 
-  const moveMutation = useApiMutation<MoveDocumentResponse, MoveDocumentRequest>(
+  // The move endpoint returns the full updated Document, but the result is
+  // never read here (we just invalidate the affected queries on success), so
+  // the response is typed as `void` rather than a hand-rolled shape.
+  const moveMutation = useApiMutation<void, MoveDocumentRequest>(
     `/api/v1/documents/${documentId}/move`,
     'POST'
   );

--- a/frontend/apps/mobile/src/screens/index.ts
+++ b/frontend/apps/mobile/src/screens/index.ts
@@ -1,6 +1,6 @@
 // Auth screens (UC-14)
 
-export type { Announcement, AnnouncementAttachment, AnnouncementCategory } from './announcements';
+export type { Announcement, AnnouncementAttachment } from './announcements';
 export { AnnouncementDetailScreen, AnnouncementsScreen } from './announcements';
 export {
   AuthFlow,


### PR DESCRIPTION
Closes #1092
Closes #1097

Two post-merge mobile cleanups, no behavioural change to live features.

## Fix A — remove dead announcement category filter (#1092)
The announcement category was always hardcoded to `'general'` in `toUiAnnouncement` (the `/api/v1/announcements/published` summary carries no category), so the category UI was inert/misleading. Removed:
- the category filter bar/chips and the `filter`/`setFilter` state;
- the per-row category badge and the `getCategoryColor`/`getCategoryIcon` helpers (they only served the dead feature);
- the frontend-only `AnnouncementCategory` enum (unused after the strip) and its two re-exports;
- the `Announcement.category` field and the hardcoded `category: 'general'` mapping;
- the dead category branch in `filterMainList` (now `(items, searchQuery)`) and its `it('applies the active category filter')` test case, plus orphaned styles.

Preserved: pinned sticky band, title-only search, main-list partitioning, and all their tests. `DashboardScreen` keeps its own independent local `Announcement`/category type — untouched.

This is the **full UI removal** (issue "option 2"), not the minimal-fallback path — `AnnouncementCategory` had no real consumers anywhere in `frontend/apps/mobile`.

## Fix B — MoveDocumentSheet type cleanup (#1097)
- Dropped the inaccurate hand-rolled `MoveDocumentResponse` (`{message, document:{id, folder_id}}`); the backend returns a full `Document` and the mutation result is never read, so the mutation is now typed as `void`.
- Removed the duplicated local `ApiFolderTreeNode`; exported the canonical one from `DocumentsScreen.tsx` (shapes were verified identical) and pulled it in via a type-only import (erased at compile time, no runtime circular dependency).

## Verification
No local JS toolchain in this environment — relying on CI (biome + typecheck + jest). Confirmed via grep that no remaining references to `AnnouncementCategory`, `getCategoryColor`, `getCategoryIcon`, `setFilter`, or `MoveDocumentResponse` exist in the mobile app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)