### PR TITLE
test(ppt-web): make e2e specs runnable + typecheck-gated; fix setReturnUrl comments (closes #1088)

### DIFF
--- a/frontend/apps/ppt-web/e2e/README.md
+++ b/frontend/apps/ppt-web/e2e/README.md
@@ -1,0 +1,46 @@
+# ppt-web E2E specs (Playwright) — MANUAL-ONLY
+
+These Playwright specs (`*.spec.ts` + `fixtures.ts`, driven by
+`../playwright.config.ts`) are **not executed in CI**. Their non-execution is
+intentional and documented here — not a silent gap.
+
+## Why they are not run in CI
+
+Running headed browsers on every `frontend/**` PR is slow and prone to
+flakiness; wiring a Playwright job into `frontend.yml` is an ops decision that
+is deliberately out of scope. So CI does **not** run these specs.
+
+## What CI *does* do
+
+CI type-checks these specs so that compile/import breakage fails fast. The root
+`pnpm typecheck` (run in `.github/workflows/frontend.yml`) invokes ppt-web's
+`typecheck`, which now also runs `typecheck:e2e`:
+
+```jsonc
+"typecheck":     "tsc --noEmit && pnpm typecheck:e2e",
+"typecheck:e2e": "tsc --noEmit -p tsconfig.e2e.json"
+```
+
+`tsconfig.e2e.json` type-checks `e2e/**` and `playwright.config.ts` against the
+`@playwright/test` types. A spec that no longer compiles (e.g. a renamed import
+or a removed selector helper) will turn the typecheck job red, even though the
+spec itself is never executed.
+
+> Context: `auth-refresh.spec.ts` once shipped logically broken on `dev` (its
+> redirect assertions targeted a route that was not behind `<ProtectedRoute>`).
+> Typecheck-gating cannot catch that class of *semantic* rot, but it does stop
+> *compile-level* rot from accumulating unnoticed.
+
+## Running them locally
+
+The specs target a running dev server (`baseURL: http://localhost:3000`); the
+Playwright config starts `pnpm dev` for you via its `webServer` block.
+
+```bash
+# from the repo root (frontend/ workspace)
+pnpm --filter @ppt/web exec playwright install   # one-time: download browsers
+pnpm --filter @ppt/web test:e2e                  # runs `playwright test`
+```
+
+Some specs (real login/logout in `auth.spec.ts`) additionally need the backend
+API running with seeded test users; they fail gracefully when it is absent.

--- a/frontend/apps/ppt-web/package.json
+++ b/frontend/apps/ppt-web/package.json
@@ -8,12 +8,14 @@
     "build": "tsc && vite build",
     "build:analyze": "tsc && vite build && echo 'Bundle analysis available at dist/stats.html'",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && pnpm typecheck:e2e",
+    "typecheck:e2e": "tsc --noEmit -p tsconfig.e2e.json",
     "lint": "eslint . --ext ts,tsx",
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "test:a11y": "vitest run src/**/*.a11y.test.tsx"
+    "test:a11y": "vitest run src/**/*.a11y.test.tsx",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@ppt/admin-ui": "workspace:*",
@@ -38,6 +40,7 @@
   },
   "devDependencies": {
     "@axe-core/react": "^4.10.0",
+    "@playwright/test": "^1.51.1",
     "@ppt/dev-panel": "workspace:*",
     "@ppt/vite-plugin-worktree": "workspace:*",
     "@tailwindcss/postcss": "^4.3.0",

--- a/frontend/apps/ppt-web/src/pages/AuthCallbackPage.test.tsx
+++ b/frontend/apps/ppt-web/src/pages/AuthCallbackPage.test.tsx
@@ -19,7 +19,9 @@
  * Covered guarantees:
  *   1. Happy path: code+state → exchangeSsoCode → access/refresh/user/tenants
  *      written to localStorage → redirect to /dashboard.
- *   2. Return URL: a stored return URL wins over the /dashboard default.
+ *   2. Return URL: a return URL stored under the `auth_return_url`
+ *      sessionStorage key (the key getAndClearReturnUrl reads) wins over the
+ *      /dashboard default.
  *   3. Refresh flow: after callback stores a refresh token, a subsequent
  *      AuthProvider mount rehydrates the session and a refreshToken() call
  *      rotates the access token (token-storage + refresh integration).
@@ -223,7 +225,10 @@ describe('AuthCallbackPage — SSO /auth/callback flow (Story 79.2)', () => {
 
   it('redirects to the stored return URL when present', async () => {
     setSsoState(STATE_NONCE);
-    // setReturnUrl sanitizes; write directly to the sanitized key it reads.
+    // Write the value directly under the 'auth_return_url' key that
+    // getAndClearReturnUrl reads (no key transformation). '/settings' is a
+    // same-origin relative path, so the read-side re-validation passes it
+    // through unchanged.
     sessionStorage.setItem('auth_return_url', '/settings');
     exchangeSsoCodeSpy.mockResolvedValue(makeLoginResponse());
 

--- a/frontend/apps/ppt-web/tsconfig.e2e.json
+++ b/frontend/apps/ppt-web/tsconfig.e2e.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "types": ["node", "@playwright/test"]
+  },
+  "include": ["e2e/**/*.ts", "playwright.config.ts"]
+}

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -274,6 +274,9 @@ importers:
       '@axe-core/react':
         specifier: ^4.10.0
         version: 4.11.3
+      '@playwright/test':
+        specifier: ^1.51.1
+        version: 1.60.0
       '@ppt/dev-panel':
         specifier: workspace:*
         version: link:../../packages/dev-panel
@@ -3658,6 +3661,14 @@ packages:
       '@parcel/watcher-win32-x64': 2.5.6
     dev: false
 
+  /@playwright/test@1.60.0:
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dependencies:
+      playwright: 1.60.0
+    dev: true
+
   /@react-native-async-storage/async-storage@3.1.0(react-native@0.85.3)(react@19.2.0):
     resolution: {integrity: sha512-ENwbn3kj/dOapdR3GVgfX5x9f9/rxHnsqol1bUkt26lrv0aAq6UoXnTlv7y2dT7RH0AShh9B1+KAPDVjJXnk0w==}
     peerDependencies:
@@ -6427,6 +6438,14 @@ packages:
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  /fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -8702,6 +8721,22 @@ packages:
       confbox: 0.2.4
       exsolve: 1.0.8
       pathe: 2.0.3
+    dev: true
+
+  /playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dev: true
+
+  /playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: true
 
   /plist@3.1.1:


### PR DESCRIPTION
Closes #1088

## Part 1 — fix misleading setReturnUrl comments (minor)
`AuthCallbackPage.test.tsx` had two comments claiming `setReturnUrl` "sanitizes" the value into a special key. Reworded both (the inline comment + the frontmatter docblock entry) to state the truth: the test writes the value directly under the `auth_return_url` sessionStorage key that `getAndClearReturnUrl` reads — no key transformation. `/settings` is a same-origin relative path, so the read-side re-validation passes it through unchanged. **No test logic changed** (all 7 tests still pass).

## Part 2 — stop the e2e specs rotting silently (primary)
The `frontend/apps/ppt-web/e2e/` Playwright specs were never executed or typechecked by CI, so compile/import breakage went undetected.

- **Runnable locally:** added `"test:e2e": "playwright test"` to `package.json` and `@playwright/test@^1.51.1` to devDependencies (resolves to 1.60.0; lockfile regenerated, frozen install verified clean).
- **Typecheck-gated in CI:** added `tsconfig.e2e.json` covering `e2e/**` + `playwright.config.ts` against the `@playwright/test` types, and wired a `typecheck:e2e` step into ppt-web's `typecheck` (`tsc --noEmit && pnpm typecheck:e2e`). `frontend.yml` runs `pnpm typecheck`, so the specs are now type-checked and a compile/import break fails fast. The main `tsconfig.json` (used by `build`) still excludes specs, so `pnpm build` is unaffected.
- **Documented:** added `e2e/README.md` stating the specs are MANUAL-ONLY (run via `pnpm --filter @ppt/web test:e2e` against a local dev server), are NOT executed in CI, and are typecheck-gated only — so their non-execution is intentional, not silent.

### Deliberately NOT done
No headed-browser Playwright CI job was added — running real browsers on every ppt-web PR is slow and flaky, and that's an ops decision out of scope for this follow-up.

### Verification (via remote builder)
- frozen `pnpm install` — clean (deterministic lockfile)
- `pnpm typecheck` (full workspace, incl. new `typecheck:e2e`) — exit 0
- `pnpm check` (Biome) — exit 0 (pre-existing warnings only)
- `pnpm -F @ppt/web build` — exit 0
- `pnpm -F @ppt/web test:run AuthCallbackPage.test.tsx` — 7/7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)