### PR TITLE
bug-risky-churn-pr-992-mobile-app-tsx: regression test for deep-link → document-detail nav payload

### DIFF
--- a/frontend/apps/mobile/src/services/deepLinkRouting.pipeline.test.ts
+++ b/frontend/apps/mobile/src/services/deepLinkRouting.pipeline.test.ts
@@ -1,0 +1,76 @@
+/**
+ * End-to-end pipeline regression test for the deep-link -> document-detail
+ * navigation payload path wired in `App.tsx` (the path that churned across
+ * PR #992 and its predecessors).
+ *
+ * `deepLinkRouting.test.ts` exercises `resolveDeepLinkTarget` in isolation with
+ * a *hand-built* `ParsedDeepLink`. That leaves a gap: `App.tsx` never builds a
+ * `ParsedDeepLink` by hand — at runtime the `deepLinkManager` feeds it the
+ * output of `parseDeepLink(url)`. A drift in EITHER stage would silently break
+ * document deep links while keeping the isolated unit test green, e.g.:
+ *   - the `documents/:id` route table entry changing its param name away from
+ *     `id` (parse stage), or
+ *   - `resolveDeepLinkTarget` renaming the `documentId` payload key (resolve
+ *     stage) — the key `App.tsx`'s `DocumentDetail` case reads as `documentId`.
+ *
+ * This test pins the WHOLE chain a tapped link travels:
+ *   raw URL  ->  parseDeepLink  ->  resolveDeepLinkTarget  ->  { screen, params }
+ * for both the cold-start custom-scheme link and the HTTPS universal link, so
+ * the payload that `handleNavigate` ultimately hands to `DocumentDetailScreen`
+ * is locked down on both sides of the boundary.
+ *
+ * Pure-logic test (no `@testing-library/react-native` render), matching the
+ * `deepLinkRouting.test.ts` / `backgroundNotifications.test.ts` style.
+ */
+
+import { parseDeepLink } from '../qrcode';
+import { resolveDeepLinkTarget } from './deepLinkRouting';
+
+/** Run the exact runtime chain: parse the URL, then resolve to a nav target. */
+function navigateTargetFor(url: string) {
+  return resolveDeepLinkTarget(parseDeepLink(url));
+}
+
+describe('deep-link -> DocumentDetail payload pipeline (PR #992 churn guard)', () => {
+  it('routes a custom-scheme documents/:id link to DocumentDetail + documentId', () => {
+    expect(navigateTargetFor('ppt://documents/doc-123')).toEqual({
+      screen: 'DocumentDetail',
+      params: { documentId: 'doc-123' },
+    });
+  });
+
+  it('routes the alternate custom scheme (ppt-management) the same way', () => {
+    expect(navigateTargetFor('ppt-management://documents/doc-123')).toEqual({
+      screen: 'DocumentDetail',
+      params: { documentId: 'doc-123' },
+    });
+  });
+
+  it('routes an HTTPS universal-link documents/:id to DocumentDetail + documentId', () => {
+    // app.ppt.example.com is the DEFAULT_APP_LINK_HOST used in tests.
+    expect(navigateTargetFor('https://app.ppt.example.com/documents/doc-123')).toEqual({
+      screen: 'DocumentDetail',
+      params: { documentId: 'doc-123' },
+    });
+  });
+
+  it('hands DocumentDetailScreen exactly `documentId` (not `id`) so its query is enabled', () => {
+    const target = navigateTargetFor('ppt://documents/doc-123');
+
+    // Guards against the payload key drifting back to `id`, which would leave
+    // DocumentDetailScreen with `documentId === undefined` and its detail query
+    // disabled — a silent dead deep link.
+    expect(target?.params).toHaveProperty('documentId', 'doc-123');
+    expect(target?.params).not.toHaveProperty('id');
+  });
+
+  it('routes a documents link without an id to the Documents list (no detail nav)', () => {
+    expect(navigateTargetFor('ppt://documents')).toEqual({ screen: 'Documents' });
+  });
+
+  it('yields no navigation target for a URL this app does not own', () => {
+    // parseDeepLink fails -> resolveDeepLinkTarget returns null -> App does not navigate.
+    expect(navigateTargetFor('https://evil.example.com/documents/doc-123')).toBeNull();
+    expect(navigateTargetFor('not-a-url')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Task
Risky churn — mobile `App.tsx` deep-link / document-detail wiring has been changing across back-to-back PRs without test coverage. Add a regression test for the deep-link → document-detail navigation payload path in the mobile app so future churn is guarded. TDD: failing test first (IG3), then green. Keep the change scoped to test coverage (+ minimal fix only if a real bug is found).

## Owner
`pm-frontend` (React Native — `frontend/apps/mobile`). Specialist: `react-native`.

## What changed
Test-only. One new file: `frontend/apps/mobile/src/services/deepLinkRouting.pipeline.test.ts`.

The deep-link → document-detail path in `App.tsx` runs, at runtime:

```
raw URL → deepLinkManager → parseDeepLink(url) → resolveDeepLinkTarget(parsed) → handleNavigate(screen, params) → renderScreen() mounts <DocumentDetailScreen documentId=… />
```

The existing `deepLinkRouting.test.ts` only exercises `resolveDeepLinkTarget` with a **hand-built** `ParsedDeepLink` — it never chains the real `parseDeepLink` the manager actually feeds it. So a drift in **either** stage (the `documents/:id` route param name, or the resolver's `documentId` payload key that `App.tsx`'s `DocumentDetail` case reads) would silently break document deep links while keeping the unit test green.

The new test pins the **whole chain** (`parseDeepLink` → `resolveDeepLinkTarget`) for:
- custom scheme `ppt://documents/doc-123`
- alternate scheme `ppt-management://documents/doc-123`
- HTTPS universal link `https://app.ppt.example.com/documents/doc-123`
- the no-id case (lands on `Documents` list, no detail nav)
- the not-owned-URL guard (no navigation)

and asserts the payload is exactly `{ screen: 'DocumentDetail', params: { documentId } }` (and **not** `{ id }`).

Pure-logic test (no `@testing-library/react-native` render), matching the existing `deepLinkRouting.test.ts` / `backgroundNotifications.test.ts` style. A render-based `App` mount test was prototyped but abandoned: the mobile workspace has a pre-existing peer-dep mismatch (`react-test-renderer@19.2.6` vs RTL's expected exact `19.2.0`) that makes **all** RTL-render tests fail to run on `dev` (e.g. `LanguageSwitcher.test.tsx`) — unrelated to this task and out of scope to fix here.

## TDD / IG3 evidence
Verified the test genuinely fails on the regression it guards: temporarily flipping the resolver payload key from `documentId` back to `id` made the suite go red (4/6 failing, incl. the `documentId`-not-`id` assertion); restoring it returned 6/6 green. No production bug was found — the current wiring is correct — so the change is test-only with no paired `fix:` commit.

## Tested (Band A — fast check)
```
pnpm -F mobile typecheck            # tsc --noEmit → exit 0
pnpm exec biome check apps/mobile/src/services/deepLinkRouting.pipeline.test.ts   # exit 0
pnpm exec jest src/services/deepLinkRouting.pipeline.test.ts   # 6 passed → exit 0
```
(`pnpm -F mobile lint` — mobile package has no `lint` script; ran repo Biome instead.)

## Built (Band B — full build)
skipped: change is test-only (<50 LOC, no public API / migration / config touch).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped (no ppt-bridge MCP in session).

## Scope drift
The `scope-check.sh` advisory flagged drift (exit 2) **only** because the dispatcher passed `owner_role=pm-frontend`, while `owner-areas.json` maps `frontend/apps/mobile/**` to `pm-mobile`. Re-running with `--owner pm-mobile` is clean (exit 0). The single changed file is entirely within `frontend/apps/mobile/` — this is an owner-label classification artifact, not real cross-area churn. Reviewer to confirm.

## Code-reuse review
`reuse-grep.sh --specialist react-native` → no warnings.

## Notes
- Direct dispatcher task (not a `.research/plans/<slug>.md` flow), so `goal-check` IG1 (plan file) and IG2 (`impl/` branch prefix) are N/A — branch name `auto-impl/…` is per the dispatcher mandate.

https://claude.ai/code/session_01ThAwfC4GoX1uZYoQG8YxuX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThAwfC4GoX1uZYoQG8YxuX)_