### PR TITLE
gap-6-2-announcement-web-viewing-ack: web announcement viewing & ack tests

### DIFF
--- a/frontend/apps/ppt-web/src/features/announcements/components/AcknowledgmentStats.test.tsx
+++ b/frontend/apps/ppt-web/src/features/announcements/components/AcknowledgmentStats.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * AcknowledgmentStats tests (gap-6-2 — Story 6.2 web viewing & acknowledgment).
+ *
+ * Verifies: read/acknowledged percentage math, pending-count pluralization,
+ * and the divide-by-zero guard when no users are targeted.
+ */
+/// <reference types="vitest/globals" />
+
+import type { AcknowledgmentStats as AcknowledgmentStatsType } from '@ppt/api-client';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { AcknowledgmentStats } from './AcknowledgmentStats';
+
+function stats(overrides: Partial<AcknowledgmentStatsType> = {}): AcknowledgmentStatsType {
+  return {
+    announcementId: 'ann-1',
+    totalTargeted: 10,
+    readCount: 6,
+    acknowledgedCount: 2,
+    pendingCount: 4,
+    ...overrides,
+  };
+}
+
+describe('AcknowledgmentStats', () => {
+  it('renders read and acknowledged counts against the targeted total', () => {
+    render(<AcknowledgmentStats stats={stats()} />);
+
+    expect(screen.getByText('6')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    // Both columns reference the same /10 denominator.
+    expect(screen.getAllByText('/ 10')).toHaveLength(2);
+  });
+
+  it('computes whole-number percentages', () => {
+    render(<AcknowledgmentStats stats={stats({ readCount: 6, acknowledgedCount: 2 })} />);
+
+    expect(screen.getByText('Read (60%)')).toBeInTheDocument();
+    expect(screen.getByText('Acknowledged (20%)')).toBeInTheDocument();
+  });
+
+  it('guards against divide-by-zero when no users are targeted', () => {
+    render(
+      <AcknowledgmentStats
+        stats={stats({ totalTargeted: 0, readCount: 0, acknowledgedCount: 0, pendingCount: 0 })}
+      />
+    );
+
+    expect(screen.getByText('Read (0%)')).toBeInTheDocument();
+    expect(screen.getByText('Acknowledged (0%)')).toBeInTheDocument();
+  });
+
+  it('shows the pending banner with singular wording for one pending user', () => {
+    render(<AcknowledgmentStats stats={stats({ pendingCount: 1 })} />);
+
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText(/user haven't read yet/)).toBeInTheDocument();
+  });
+
+  it('shows the pending banner with plural wording for multiple pending users', () => {
+    render(<AcknowledgmentStats stats={stats({ pendingCount: 3 })} />);
+
+    expect(screen.getByText(/users haven't read yet/)).toBeInTheDocument();
+  });
+
+  it('hides the pending banner when nobody is pending', () => {
+    render(<AcknowledgmentStats stats={stats({ pendingCount: 0 })} />);
+
+    expect(screen.queryByText(/haven't read yet/)).not.toBeInTheDocument();
+  });
+
+  it('forwards a custom className to the root element', () => {
+    const { container } = render(<AcknowledgmentStats stats={stats()} className="custom-x" />);
+
+    expect(container.firstChild).toHaveClass('custom-x');
+  });
+});

--- a/frontend/apps/ppt-web/src/features/announcements/pages/ViewAnnouncementPage.test.tsx
+++ b/frontend/apps/ppt-web/src/features/announcements/pages/ViewAnnouncementPage.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * ViewAnnouncementPage tests (gap-6-2 — Story 6.2 web viewing & acknowledgment).
+ *
+ * Mirrors the shipped mobile AnnouncementDetailScreen behaviour on web:
+ *  - "Mark as Read" wires to onMarkRead.
+ *  - "Acknowledge" appears only when acknowledgmentRequired AND a handler is
+ *    supplied, and wires to onAcknowledge.
+ *  - The manager AcknowledgmentStats panel renders only when acknowledgment is
+ *    required and stats are provided.
+ */
+/// <reference types="vitest/globals" />
+
+import type { AcknowledgmentStats, AnnouncementWithDetails } from '@ppt/api-client';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { ViewAnnouncementPage } from './ViewAnnouncementPage';
+
+function announcement(overrides: Partial<AnnouncementWithDetails> = {}): AnnouncementWithDetails {
+  return {
+    id: 'ann-1',
+    organizationId: 'org-1',
+    authorId: 'author-1',
+    authorName: 'Jane Manager',
+    title: 'Roof repair scheduled',
+    content: 'The roof repair starts Monday.',
+    targetType: 'all',
+    targetIds: [],
+    status: 'published',
+    pinned: false,
+    commentsEnabled: false,
+    acknowledgmentRequired: false,
+    readCount: 4,
+    acknowledgedCount: 0,
+    commentCount: 0,
+    attachmentCount: 0,
+    createdAt: '2026-06-01T00:00:00Z',
+    updatedAt: '2026-06-01T00:00:00Z',
+    publishedAt: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+const ackStats: AcknowledgmentStats = {
+  announcementId: 'ann-1',
+  totalTargeted: 10,
+  readCount: 4,
+  acknowledgedCount: 2,
+  pendingCount: 6,
+};
+
+function noopHandlers() {
+  return {
+    onEdit: vi.fn(),
+    onPublish: vi.fn(),
+    onArchive: vi.fn(),
+    onPin: vi.fn(),
+    onDelete: vi.fn(),
+    onBack: vi.fn(),
+  };
+}
+
+describe('ViewAnnouncementPage', () => {
+  it('renders the announcement title, author and read count', () => {
+    render(
+      <ViewAnnouncementPage announcement={announcement()} attachments={[]} {...noopHandlers()} />
+    );
+
+    expect(screen.getByText('Roof repair scheduled')).toBeInTheDocument();
+    expect(screen.getByText(/Jane Manager/)).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+  });
+
+  it('fires onMarkRead when the "Mark as Read" button is clicked', async () => {
+    const onMarkRead = vi.fn();
+    render(
+      <ViewAnnouncementPage
+        announcement={announcement()}
+        attachments={[]}
+        onMarkRead={onMarkRead}
+        {...noopHandlers()}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Mark as Read' }));
+    expect(onMarkRead).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the "Mark as Read" button when no handler is supplied', () => {
+    render(
+      <ViewAnnouncementPage announcement={announcement()} attachments={[]} {...noopHandlers()} />
+    );
+
+    expect(screen.queryByRole('button', { name: 'Mark as Read' })).not.toBeInTheDocument();
+  });
+
+  it('shows and wires the Acknowledge button when acknowledgment is required', async () => {
+    const onAcknowledge = vi.fn();
+    render(
+      <ViewAnnouncementPage
+        announcement={announcement({ acknowledgmentRequired: true })}
+        attachments={[]}
+        onAcknowledge={onAcknowledge}
+        {...noopHandlers()}
+      />
+    );
+
+    const btn = screen.getByRole('button', { name: 'Acknowledge' });
+    await userEvent.click(btn);
+    expect(onAcknowledge).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the Acknowledge button when acknowledgment is not required', () => {
+    render(
+      <ViewAnnouncementPage
+        announcement={announcement({ acknowledgmentRequired: false })}
+        attachments={[]}
+        onAcknowledge={vi.fn()}
+        {...noopHandlers()}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'Acknowledge' })).not.toBeInTheDocument();
+  });
+
+  it('renders the manager AcknowledgmentStats panel only when required and stats are present', () => {
+    const { rerender } = render(
+      <ViewAnnouncementPage
+        announcement={announcement({ acknowledgmentRequired: true })}
+        attachments={[]}
+        acknowledgmentStats={ackStats}
+        {...noopHandlers()}
+      />
+    );
+
+    expect(screen.getByText('Acknowledgment Status')).toBeInTheDocument();
+
+    // No stats provided -> panel hidden even when ack is required.
+    rerender(
+      <ViewAnnouncementPage
+        announcement={announcement({ acknowledgmentRequired: true })}
+        attachments={[]}
+        {...noopHandlers()}
+      />
+    );
+    expect(screen.queryByText('Acknowledgment Status')).not.toBeInTheDocument();
+  });
+
+  it('shows a loading spinner instead of content while loading', () => {
+    render(
+      <ViewAnnouncementPage
+        announcement={announcement()}
+        attachments={[]}
+        isLoading
+        {...noopHandlers()}
+      />
+    );
+
+    expect(screen.getByLabelText('Loading')).toBeInTheDocument();
+    expect(screen.queryByText('Roof repair scheduled')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Task
Web announcement viewing & acknowledgment UI in ppt-web (story 6-2). Wire `mark_read` / `acknowledge` to the existing backend routes; render `AcknowledgmentStats` / `UserAcknowledgmentStatus`. This supersedes stale draft PRs #474/#475/#479 which never merged. The mobile screen already shipped — mirror its behavior on web. Add tests.

## Owner
pm-frontend (ppt-web — React SPA)

## What this PR delivers
On inspection, the Story 6.2 web implementation was **already wired and shipped** on `dev`:

- `ViewAnnouncementPageInner` (App.tsx) wires `useMarkReadAnnouncement`, `useAcknowledgeAnnouncement`, and `useAnnouncementAcknowledgmentStats` to the existing backend routes `POST /api/v1/announcements/{id}/read`, `POST /{id}/acknowledge`, and `GET /{id}/acknowledgments`.
- Mark-read auto-fires once on view (StrictMode-guarded), plus an explicit "Mark as Read" button; "Acknowledge" is gated on `acknowledgmentRequired`.
- The manager `AcknowledgmentStats` panel renders when stats are present. This already matches the shipped mobile `AnnouncementDetailScreen` (which itself renders stat counts + an acknowledge button, not a per-user list).

The genuine gap the stale draft PRs never closed was **test coverage**. This PR lands it:

- `AcknowledgmentStats.test.tsx` — percentage math, divide-by-zero guard (`totalTargeted=0`), singular/plural pending banner, custom `className` passthrough.
- `ViewAnnouncementPage.test.tsx` — Mark-as-Read wiring, Acknowledge button gated on `acknowledgmentRequired` + handler, manager stats panel gated on stats presence, loading-state short-circuit.

## Tested (Band A — fast check)
- `pnpm exec vitest run AcknowledgmentStats.test.tsx ViewAnnouncementPage.test.tsx` → exit 0 (2 files, 14 tests passed)
- `pnpm -F @ppt/web typecheck` (`tsc --noEmit` + e2e tsconfig) → exit 0
- `biome check` on both new files → exit 0 (after autofix)

Note: `pnpm -F @ppt/web lint` fails with `ESLint couldn't find an eslint.config.*` — a **pre-existing** repo misconfiguration (the project lints via Biome per CLAUDE.md), unrelated to this change. The Biome gate that CI actually runs is green.

## Built (Band B — full build)
skipped: change <50 LOC of substantive product code (test-only), no public API/config touch.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change — test-only).

## Remote-tested
skipped

## Notes
- `UserAcknowledgmentStatus` (per-user read/ack list) is defined in both the backend models and `@ppt/api-client` types, and the backend has a `get_acknowledgment_list_rls` repo method + an `AcknowledgmentListResponse` struct — but the `GET /{id}/acknowledgments` handler currently returns **only** `AcknowledgmentStatsResponse` (the `AcknowledgmentListQuery` is accepted but ignored as `_query`). There is no web data source for the per-user list today, and mobile does not render one either, so web/mobile parity is achieved without it. Surfacing the per-user list would require a backend handler change (out of pm-frontend scope) and is left as a follow-up.
- Goal-check IG1/IG5/IG6 fail because this is a dispatcher gap-task with no `.research/plans/` slug; IG2 fails because the branch is `auto-impl/*` (per task input) not `impl/*`; IG3 is a WARN because this is a legitimate test-backfill against already-merged implementation. None are code-quality failures.

https://claude.ai/code/session_01ThAwfC4GoX1uZYoQG8YxuX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThAwfC4GoX1uZYoQG8YxuX)_