### PR TITLE
dx-integration-marketplace-stubs: wire integration marketplace listing to backend

### DIFF
--- a/frontend/apps/ppt-web/src/features/api-ecosystem/pages/IntegrationMarketplacePage.test.tsx
+++ b/frontend/apps/ppt-web/src/features/api-ecosystem/pages/IntegrationMarketplacePage.test.tsx
@@ -1,0 +1,120 @@
+/// <reference types="vitest/globals" />
+/**
+ * IntegrationMarketplacePage tests (Epic 150, Story 150.1 — dx-integration-marketplace-stubs).
+ *
+ * The page previously rendered a hard-coded `sampleIntegrations` array. These
+ * tests pin the new behaviour: the page now sources its data from the backend
+ * via `useMarketplaceIntegrations`, and covers the loading, error, populated,
+ * empty, and filter paths.
+ */
+
+import type { MarketplaceIntegrationSummary } from '@ppt/api-client';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { IntegrationMarketplacePage } from './IntegrationMarketplacePage';
+
+vi.mock('@ppt/api-client', () => ({
+  useMarketplaceIntegrations: vi.fn(),
+}));
+
+import { useMarketplaceIntegrations } from '@ppt/api-client';
+
+const mockUseMarketplace = vi.mocked(useMarketplaceIntegrations);
+
+function summary(
+  overrides: Partial<MarketplaceIntegrationSummary> = {}
+): MarketplaceIntegrationSummary {
+  return {
+    id: 'id-1',
+    slug: 'quickbooks',
+    name: 'QuickBooks',
+    description: 'Sync invoices and payments.',
+    category: 'accounting',
+    icon_url: null,
+    vendor_name: 'Intuit',
+    status: 'available',
+    rating_average: 4.5,
+    rating_count: 128,
+    install_count: 1542,
+    is_featured: true,
+    is_premium: false,
+    ...overrides,
+  };
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: test stub intentionally partial
+function queryResult(overrides: Record<string, unknown> = {}): any {
+  return {
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+it('shows a loading state while integrations are being fetched', () => {
+  mockUseMarketplace.mockReturnValue(queryResult({ isLoading: true }));
+  render(<IntegrationMarketplacePage />);
+  expect(screen.getByText(/loading integrations/i)).toBeInTheDocument();
+});
+
+it('shows an error state with a retry button when the request fails', () => {
+  const refetch = vi.fn();
+  mockUseMarketplace.mockReturnValue(
+    queryResult({ isError: true, error: new Error('boom'), refetch })
+  );
+  render(<IntegrationMarketplacePage />);
+
+  expect(screen.getByText(/failed to load integrations/i)).toBeInTheDocument();
+  expect(screen.getByText('boom')).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+  expect(refetch).toHaveBeenCalledTimes(1);
+});
+
+it('renders integrations returned by the backend', () => {
+  mockUseMarketplace.mockReturnValue(
+    queryResult({
+      data: [
+        summary({ id: 'a', name: 'QuickBooks', vendor_name: 'Intuit' }),
+        summary({ id: 'b', name: 'Salesforce', vendor_name: 'Salesforce', category: 'crm' }),
+      ],
+    })
+  );
+  render(<IntegrationMarketplacePage />);
+
+  expect(screen.getByText('QuickBooks')).toBeInTheDocument();
+  expect(screen.getByText('Salesforce')).toBeInTheDocument();
+  expect(screen.getByText(/showing 2 integrations/i)).toBeInTheDocument();
+});
+
+it('filters the rendered integrations by the search box', () => {
+  mockUseMarketplace.mockReturnValue(
+    queryResult({
+      data: [
+        summary({ id: 'a', name: 'QuickBooks', vendor_name: 'Intuit' }),
+        summary({ id: 'b', name: 'Salesforce', vendor_name: 'Salesforce' }),
+      ],
+    })
+  );
+  render(<IntegrationMarketplacePage />);
+
+  fireEvent.change(screen.getByPlaceholderText(/search integrations/i), {
+    target: { value: 'salesforce' },
+  });
+
+  expect(screen.queryByText('QuickBooks')).not.toBeInTheDocument();
+  expect(screen.getByText('Salesforce')).toBeInTheDocument();
+  expect(screen.getByText(/showing 1 integration\b/i)).toBeInTheDocument();
+});
+
+it('shows the empty state when the backend returns no integrations', () => {
+  mockUseMarketplace.mockReturnValue(queryResult({ data: [] }));
+  render(<IntegrationMarketplacePage />);
+  expect(screen.getByText(/no integrations found/i)).toBeInTheDocument();
+});

--- a/frontend/apps/ppt-web/src/features/api-ecosystem/pages/IntegrationMarketplacePage.tsx
+++ b/frontend/apps/ppt-web/src/features/api-ecosystem/pages/IntegrationMarketplacePage.tsx
@@ -4,163 +4,31 @@
  * Browse and install integrations from the marketplace.
  */
 
+import { type MarketplaceIntegrationSummary, useMarketplaceIntegrations } from '@ppt/api-client';
 import { useMemo, useState } from 'react';
 import { IntegrationCard, type IntegrationCardProps } from '../components/IntegrationCard';
 
-// Sample data for demonstration
-const sampleIntegrations: IntegrationCardProps[] = [
-  {
-    id: '1',
-    slug: 'quickbooks',
-    name: 'QuickBooks',
-    description:
-      'Sync invoices, payments, and customers with QuickBooks Online for seamless accounting.',
-    category: 'accounting',
-    iconUrl: undefined,
-    vendorName: 'Intuit',
-    status: 'available',
-    ratingAverage: 4.5,
-    ratingCount: 128,
-    installCount: 1542,
-    isFeatured: true,
-    isPremium: false,
-  },
-  {
-    id: '2',
-    slug: 'xero',
-    name: 'Xero',
-    description: 'Powerful accounting integration for invoices, payments, and financial reporting.',
-    category: 'accounting',
-    iconUrl: undefined,
-    vendorName: 'Xero Limited',
-    status: 'available',
-    ratingAverage: 4.3,
-    ratingCount: 89,
-    installCount: 987,
-    isFeatured: false,
-    isPremium: false,
-  },
-  {
-    id: '3',
-    slug: 'salesforce',
-    name: 'Salesforce',
-    description: 'Connect with Salesforce CRM to sync contacts, leads, and opportunities.',
-    category: 'crm',
-    iconUrl: undefined,
-    vendorName: 'Salesforce',
-    status: 'available',
-    ratingAverage: 4.7,
-    ratingCount: 256,
-    installCount: 2341,
-    isFeatured: true,
-    isPremium: true,
-  },
-  {
-    id: '4',
-    slug: 'hubspot',
-    name: 'HubSpot',
-    description: 'Integrate with HubSpot for marketing automation and CRM functionality.',
-    category: 'crm',
-    iconUrl: undefined,
-    vendorName: 'HubSpot',
-    status: 'available',
-    ratingAverage: 4.6,
-    ratingCount: 178,
-    installCount: 1876,
-    isFeatured: false,
-    isPremium: false,
-  },
-  {
-    id: '5',
-    slug: 'slack',
-    name: 'Slack',
-    description: 'Send notifications and updates to Slack channels. Keep your team informed.',
-    category: 'communication',
-    iconUrl: undefined,
-    vendorName: 'Slack Technologies',
-    status: 'available',
-    ratingAverage: 4.8,
-    ratingCount: 312,
-    installCount: 3456,
-    isFeatured: true,
-    isPremium: false,
-  },
-  {
-    id: '6',
-    slug: 'microsoft-teams',
-    name: 'Microsoft Teams',
-    description: 'Post notifications and adaptive cards to Microsoft Teams channels.',
-    category: 'communication',
-    iconUrl: undefined,
-    vendorName: 'Microsoft',
-    status: 'available',
-    ratingAverage: 4.4,
-    ratingCount: 145,
-    installCount: 1234,
-    isFeatured: false,
-    isPremium: false,
-  },
-  {
-    id: '7',
-    slug: 'google-calendar',
-    name: 'Google Calendar',
-    description: 'Sync meetings, inspections, and events with Google Calendar.',
-    category: 'calendar',
-    iconUrl: undefined,
-    vendorName: 'Google',
-    status: 'available',
-    ratingAverage: 4.5,
-    ratingCount: 201,
-    installCount: 2187,
-    isFeatured: false,
-    isPremium: false,
-  },
-  {
-    id: '8',
-    slug: 'outlook-calendar',
-    name: 'Outlook Calendar',
-    description: 'Synchronize events with Microsoft Outlook Calendar.',
-    category: 'calendar',
-    iconUrl: undefined,
-    vendorName: 'Microsoft',
-    status: 'available',
-    ratingAverage: 4.2,
-    ratingCount: 98,
-    installCount: 876,
-    isFeatured: false,
-    isPremium: false,
-  },
-  {
-    id: '9',
-    slug: 'stripe',
-    name: 'Stripe',
-    description: 'Accept payments and manage subscriptions with Stripe.',
-    category: 'payment',
-    iconUrl: undefined,
-    vendorName: 'Stripe',
-    status: 'coming_soon',
-    ratingAverage: undefined,
-    ratingCount: 0,
-    installCount: 0,
-    isFeatured: false,
-    isPremium: false,
-  },
-  {
-    id: '10',
-    slug: 'zapier',
-    name: 'Zapier',
-    description: 'Connect PPT with 5,000+ apps through Zapier automation.',
-    category: 'other',
-    iconUrl: undefined,
-    vendorName: 'Zapier',
-    status: 'available',
-    ratingAverage: 4.6,
-    ratingCount: 187,
-    installCount: 1543,
-    isFeatured: false,
-    isPremium: true,
-  },
-];
+/**
+ * Map a backend `MarketplaceIntegrationSummary` (snake_case wire format) onto
+ * the `IntegrationCardProps` shape the card component expects.
+ */
+function toCardProps(i: MarketplaceIntegrationSummary): IntegrationCardProps {
+  return {
+    id: i.id,
+    slug: i.slug,
+    name: i.name,
+    description: i.description,
+    category: i.category,
+    iconUrl: i.icon_url ?? undefined,
+    vendorName: i.vendor_name,
+    status: i.status,
+    ratingAverage: i.rating_average ?? undefined,
+    ratingCount: i.rating_count,
+    installCount: i.install_count,
+    isFeatured: i.is_featured,
+    isPremium: i.is_premium,
+  };
+}
 
 const categories = [
   { value: '', label: 'All Categories' },
@@ -182,10 +50,13 @@ export function IntegrationMarketplacePage() {
   const [showFeaturedOnly, setShowFeaturedOnly] = useState(false);
   const [showPremiumOnly, setShowPremiumOnly] = useState(false);
   const [sortBy, setSortBy] = useState<'popular' | 'rating' | 'name'>('popular');
-  const [installedIds] = useState<Set<string>>(new Set(['5'])); // Slack is installed
+
+  const { data, isLoading, isError, error, refetch } = useMarketplaceIntegrations();
+
+  const integrations = useMemo<IntegrationCardProps[]>(() => (data ?? []).map(toCardProps), [data]);
 
   const filteredIntegrations = useMemo(() => {
-    let result = [...sampleIntegrations];
+    let result = [...integrations];
 
     // Search filter
     if (searchQuery) {
@@ -228,7 +99,7 @@ export function IntegrationMarketplacePage() {
     });
 
     return result;
-  }, [searchQuery, selectedCategory, showFeaturedOnly, showPremiumOnly, sortBy]);
+  }, [integrations, searchQuery, selectedCategory, showFeaturedOnly, showPremiumOnly, sortBy]);
 
   const handleInstall = (_id: string) => {
     // TODO: Implement installation flow (Epic API-marketplace install)
@@ -330,21 +201,40 @@ export function IntegrationMarketplacePage() {
         </div>
 
         {/* Results count */}
-        <p className="mt-4 text-sm text-gray-500">
-          Showing {filteredIntegrations.length} integration
-          {filteredIntegrations.length !== 1 ? 's' : ''}
-        </p>
+        {!isLoading && !isError && (
+          <p className="mt-4 text-sm text-gray-500">
+            Showing {filteredIntegrations.length} integration
+            {filteredIntegrations.length !== 1 ? 's' : ''}
+          </p>
+        )}
       </div>
 
       {/* Integration grid */}
       <div className="mx-auto max-w-7xl px-4 pb-12 sm:px-6 lg:px-8">
-        {filteredIntegrations.length > 0 ? (
+        {isLoading ? (
+          <div className="rounded-lg border-2 border-dashed border-gray-300 p-12 text-center text-sm text-gray-500">
+            Loading integrations…
+          </div>
+        ) : isError ? (
+          <div className="rounded-lg border-2 border-dashed border-red-300 bg-red-50 p-12 text-center">
+            <h3 className="text-sm font-medium text-red-800">Failed to load integrations</h3>
+            <p className="mt-1 text-sm text-red-600">
+              {error instanceof Error ? error.message : 'An unexpected error occurred.'}
+            </p>
+            <button
+              type="button"
+              onClick={() => refetch()}
+              className="mt-4 rounded-lg border border-red-300 bg-white px-4 py-2 text-sm font-medium text-red-700 hover:bg-red-50"
+            >
+              Retry
+            </button>
+          </div>
+        ) : filteredIntegrations.length > 0 ? (
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
             {filteredIntegrations.map((integration) => (
               <IntegrationCard
                 key={integration.id}
                 {...integration}
-                isInstalled={installedIds.has(integration.id)}
                 onInstall={() => handleInstall(integration.id)}
                 onViewDetails={() => handleViewDetails(integration.id)}
               />

--- a/frontend/packages/api-client/src/ecosystem/api.ts
+++ b/frontend/packages/api-client/src/ecosystem/api.ts
@@ -1,0 +1,32 @@
+/**
+ * API Ecosystem — Integration Marketplace API client (Epic 150, Story 150.1).
+ *
+ * Wraps `GET /api/v1/ecosystem/marketplace`. Uses the shared
+ * `authenticatedFetchJson` helper so the bearer token + MFA-retry behaviour is
+ * inherited (see lib/fetch.ts, #486).
+ */
+
+import { authenticatedFetchJson } from '../lib/fetch';
+import type { MarketplaceIntegrationQuery, MarketplaceIntegrationSummary } from './types';
+
+const API_BASE = '/api/v1/ecosystem';
+
+function buildQueryString(params: MarketplaceIntegrationQuery): string {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null && value !== '') {
+      searchParams.append(key, String(value));
+    }
+  }
+  const qs = searchParams.toString();
+  return qs ? `?${qs}` : '';
+}
+
+/** List marketplace integrations. */
+export async function listMarketplaceIntegrations(
+  query: MarketplaceIntegrationQuery = {}
+): Promise<MarketplaceIntegrationSummary[]> {
+  return authenticatedFetchJson<MarketplaceIntegrationSummary[]>(
+    `${API_BASE}/marketplace${buildQueryString(query)}`
+  );
+}

--- a/frontend/packages/api-client/src/ecosystem/hooks.ts
+++ b/frontend/packages/api-client/src/ecosystem/hooks.ts
@@ -1,0 +1,21 @@
+/**
+ * API Ecosystem — Integration Marketplace React Query hooks (Epic 150, Story 150.1).
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import * as api from './api';
+import type { MarketplaceIntegrationQuery } from './types';
+
+export const ecosystemKeys = {
+  all: ['ecosystem'] as const,
+  marketplace: (query: MarketplaceIntegrationQuery) =>
+    [...ecosystemKeys.all, 'marketplace', query] as const,
+};
+
+/** List marketplace integrations from `GET /api/v1/ecosystem/marketplace`. */
+export function useMarketplaceIntegrations(query: MarketplaceIntegrationQuery = {}) {
+  return useQuery({
+    queryKey: ecosystemKeys.marketplace(query),
+    queryFn: () => api.listMarketplaceIntegrations(query),
+  });
+}

--- a/frontend/packages/api-client/src/ecosystem/index.ts
+++ b/frontend/packages/api-client/src/ecosystem/index.ts
@@ -1,0 +1,7 @@
+/**
+ * API Ecosystem — Integration Marketplace (Epic 150, Story 150.1).
+ */
+
+export * from './api';
+export * from './hooks';
+export * from './types';

--- a/frontend/packages/api-client/src/ecosystem/types.ts
+++ b/frontend/packages/api-client/src/ecosystem/types.ts
@@ -1,0 +1,41 @@
+/**
+ * API Ecosystem — Integration Marketplace types (Epic 150, Story 150.1).
+ *
+ * Mirrors the backend `MarketplaceIntegrationSummary` / `MarketplaceIntegrationQuery`
+ * structs in `backend/crates/db/src/models/api_ecosystem.rs`.
+ *
+ * NOTE: those structs carry no `#[serde(rename_all)]`, so the wire format is
+ * Rust-default snake_case. The field names below match the JSON exactly.
+ */
+
+export type IntegrationStatus = 'available' | 'coming_soon' | 'deprecated' | 'maintenance';
+
+/** Integration summary as returned by `GET /api/v1/ecosystem/marketplace`. */
+export interface MarketplaceIntegrationSummary {
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  category: string;
+  icon_url?: string | null;
+  vendor_name: string;
+  status: IntegrationStatus;
+  rating_average?: number | null;
+  rating_count: number;
+  install_count: number;
+  is_featured: boolean;
+  is_premium: boolean;
+}
+
+/** Query parameters for `GET /api/v1/ecosystem/marketplace` (snake_case on the wire). */
+export interface MarketplaceIntegrationQuery {
+  category?: string;
+  status?: string;
+  search?: string;
+  featured_only?: boolean;
+  premium_only?: boolean;
+  sort_by?: string;
+  sort_order?: string;
+  limit?: number;
+  offset?: number;
+}

--- a/frontend/packages/api-client/src/index.ts
+++ b/frontend/packages/api-client/src/index.ts
@@ -17,6 +17,7 @@ export * from './compliance';
 export * from './critical-notifications';
 export * from './disputes';
 export * from './documents';
+export * from './ecosystem';
 export * from './emergency';
 export * from './esignature';
 export * from './facilities';


### PR DESCRIPTION
## Task
Integration marketplace is stubbed — `frontend/apps/ppt-web/src/features/api-ecosystem/pages/IntegrationMarketplacePage.tsx` and `backend/servers/api-server/src/routes/integrations.rs` have placeholder/stub behavior. Replace the stubs with a working minimal implementation (list available integrations from the backend, render them on the marketplace page) and add tests. Keep scope tight to the marketplace listing path; do NOT touch the Airbnb-specific integration work that is in-flight on another branch.

## Owner
Declared `pm-backend`; actual implementation is **frontend** (`react-web`) — see Scope drift.

## What changed
- **`@ppt/api-client` ecosystem module (new):** `api.ts` + `hooks.ts` + `types.ts` + `index.ts` wrapping `GET /api/v1/ecosystem/marketplace`. The request goes through the shared `authenticatedFetchJson` helper (bearer token + MFA-retry, per #486) rather than a hand-rolled `fetch`. TS types mirror the backend `MarketplaceIntegrationSummary` / `MarketplaceIntegrationQuery` wire format — those structs carry **no** `#[serde(rename_all)]`, so the JSON is Rust-default **snake_case** (`icon_url`, `vendor_name`, `rating_average`, …); the types match exactly and the page maps them to the card's camelCase props.
- **`IntegrationMarketplacePage`:** replaced the hard-coded 10-item `sampleIntegrations` array with `useMarketplaceIntegrations()`. Added loading / error (with Retry) / empty states. The existing client-side search / category / featured / premium / sort UI is preserved and now operates over the fetched list.
- **Registered** the new module in the api-client barrel (`packages/api-client/src/index.ts`).
- **Tests:** `IntegrationMarketplacePage.test.tsx` covers loading, error + retry, populated list, search filtering, and empty states.

## Finding: backend was not actually stubbed
The task pointed at `backend/servers/api-server/src/routes/integrations.rs`, which does not exist. The marketplace listing endpoint lives in `routes/api_ecosystem.rs::list_marketplace_integrations` and is **fully implemented** — it calls `api_ecosystem_repo.list_marketplace_integrations`, which runs a real parameterised SQL query against `marketplace_integrations` (no `todo!`/stub). So the only stub was the frontend page's hard-coded data. No backend changes were needed; this is a pure frontend wiring task.

## Scope (Airbnb / booking-channel)
Intentionally untouched: the Epic 61 `@ppt/api-client/integrations` module and `backend/.../routes/integrations/booking_channel.rs`. This PR adds a brand-new `ecosystem` client module instead of editing the in-flight `integrations` module, so there is no overlap with the in-flight Airbnb/booking work.

## Tested (Band A — fast check)
- `pnpm -F @ppt/web typecheck` → exit 0
- `pnpm -F @ppt/api-client typecheck` → exit 0
- `pnpm biome check <changed files>` → exit 0 (autofixed import order/wrapping)
- `vitest run IntegrationMarketplacePage.test.tsx` → exit 0 (5 passed)

Note: `pnpm -F @ppt/web lint` (eslint) fails repo-wide with "ESLint couldn't find an eslint.config file" (ESLint v10 / missing flat config) — this is a **pre-existing** environment issue on `dev`, not caused by this change. Used Biome (the canonical formatter/linter per CLAUDE.md) on the changed files instead.

## Built (Band B — full build)
Skipped: change is frontend-only, < 50 LOC of substantive logic per file, no public API/config/build-output change. `@ppt/api-client` resolves via `main: ./src/index.ts` (no compiled artifact), so typecheck above covers consumers.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change; auth is inherited unchanged from `authenticatedFetchJson`).

## Remote-tested
Skipped (no ppt-bridge MCP in this session).

## Scope drift
The declared `owner_role` was `pm-backend`, but the implementation is entirely under the `react-web` owner area (`frontend/apps/ppt-web/**`, `frontend/packages/api-client/**`). `scope-check.sh --owner pm-backend` reports exit 2 for that reason; `--owner pm-frontend` reports exit 0 (clean). The drift is the owner-hint being wrong, not the code being out of place — the backend turned out to be already implemented, making this a frontend-only task.

## Code-reuse review
`reuse-grep.sh` emitted one WARN (`useM looks like an existing helper at .../NeighborsScreen.tsx`) — a false positive from truncating the new `useMarketplaceIntegrations` symbol to `useM`. No real duplication: the module reuses the canonical `authenticatedFetchJson` helper and the standard TanStack `useQuery` pattern rather than re-implementing fetch/auth.

## Notes for the reviewer
- Goal-check (`goal-check.sh`) reports IG1/IG2/IG3 fails, but those are artifacts of the dispatcher's plan-driven flow: there is no `.research/plans/<slug>.md` (hand-invoked task), the branch is `auto-impl/*` not `impl/*`, and the regression test ships in the same commit as the fix rather than as a separate `test:` commit. A genuine regression test **is** included (it asserts the data-source/loading/error behaviour that the old hard-coded stub could not satisfy).
- `Install` / `View Details` buttons remain no-ops (`TODO`) — the install/detail flow is explicitly out of scope for this listing-path task.

https://claude.ai/code/session_01ThAwfC4GoX1uZYoQG8YxuX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThAwfC4GoX1uZYoQG8YxuX)_