### PR TITLE
test-gap-hotfix-no-test-pr-939-deploy-server-scopes: cover derive_oidc_scopes edge/boundary cases

### DIFF
--- a/backend/servers/deploy-server/src/infra/audit.rs
+++ b/backend/servers/deploy-server/src/infra/audit.rs
@@ -222,4 +222,58 @@ mod tests {
         assert!(derive_oidc_scopes("refs/heads/bugfix/x").is_empty());
         assert!(derive_oidc_scopes("refs/tags/not-a-version").is_empty());
     }
+
+    #[test]
+    fn empty_and_blank_refs_get_no_scope() {
+        // Edge: an empty or whitespace `git_ref` claim must never grant scopes.
+        assert!(derive_oidc_scopes("").is_empty());
+        assert!(derive_oidc_scopes(" ").is_empty());
+        assert!(derive_oidc_scopes("refs/heads/").is_empty());
+    }
+
+    #[test]
+    fn protected_branches_match_exactly_not_by_prefix() {
+        // `main`/`dev` use `==`, so refs that merely *start with* them
+        // (e.g. a `maintenance` branch or a `develop` branch) must NOT be
+        // granted `release:deploy`.
+        assert!(derive_oidc_scopes("refs/heads/maintenance").is_empty());
+        assert!(derive_oidc_scopes("refs/heads/develop").is_empty());
+        assert!(derive_oidc_scopes("refs/heads/main-backup").is_empty());
+        // A nested ref that ends in `/main` is also not the protected branch.
+        assert!(derive_oidc_scopes("refs/heads/feature/main").is_empty()
+            || derive_oidc_scopes("refs/heads/feature/main")
+                == vec!["worktree:open".to_string(), "worktree:close".to_string()]);
+    }
+
+    #[test]
+    fn version_tag_prefix_boundary() {
+        // `refs/tags/v` is matched by `starts_with`, so the bare prefix and any
+        // `v`-prefixed tag qualify, while a tag without the `v` does not.
+        assert_eq!(
+            derive_oidc_scopes("refs/tags/v"),
+            vec!["release:register".to_string()]
+        );
+        assert_eq!(
+            derive_oidc_scopes("refs/tags/v10.20.30-rc.1"),
+            vec!["release:register".to_string()]
+        );
+        assert!(derive_oidc_scopes("refs/tags/1.2.3").is_empty());
+        assert!(derive_oidc_scopes("refs/tags/release-1").is_empty());
+    }
+
+    #[test]
+    fn nested_feature_branches_get_worktree_scopes() {
+        // The `refs/heads/feature/` prefix match grants worktree scopes for any
+        // depth of nesting, and even an empty suffix.
+        assert_eq!(
+            derive_oidc_scopes("refs/heads/feature/"),
+            vec!["worktree:open".to_string(), "worktree:close".to_string()]
+        );
+        assert_eq!(
+            derive_oidc_scopes("refs/heads/feature/epic-2/sub/task"),
+            vec!["worktree:open".to_string(), "worktree:close".to_string()]
+        );
+        // `featureish` (no slash) is not the feature namespace.
+        assert!(derive_oidc_scopes("refs/heads/featureX").is_empty());
+    }
 }

--- a/backend/servers/deploy-server/src/infra/audit.rs
+++ b/backend/servers/deploy-server/src/infra/audit.rs
@@ -240,9 +240,11 @@ mod tests {
         assert!(derive_oidc_scopes("refs/heads/develop").is_empty());
         assert!(derive_oidc_scopes("refs/heads/main-backup").is_empty());
         // A nested ref that ends in `/main` is also not the protected branch.
-        assert!(derive_oidc_scopes("refs/heads/feature/main").is_empty()
-            || derive_oidc_scopes("refs/heads/feature/main")
-                == vec!["worktree:open".to_string(), "worktree:close".to_string()]);
+        assert!(
+            derive_oidc_scopes("refs/heads/feature/main").is_empty()
+                || derive_oidc_scopes("refs/heads/feature/main")
+                    == vec!["worktree:open".to_string(), "worktree:close".to_string()]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Task
deploy-server OIDC scope mapping (#939) shipped without unit test for `derive_oidc_scopes`. Add focused unit tests for `derive_oidc_scopes` covering the scope-derivation cases (role→scope mappings, empty/edge inputs). TDD: failing test first (IG3), then ensure it passes against current code (the function already exists; this is a test-gap fill).

## Owner
pm-backend (Rust)

## What changed
Pure test addition in `backend/servers/deploy-server/src/infra/audit.rs`. The happy-path role→scope mappings already had unit tests from a prior dispatcher batch (#1055 on dev); this PR fills the **edge/boundary gap** the task calls out:

- `empty_and_blank_refs_get_no_scope` — `""`, `" "`, bare `refs/heads/` grant no scope
- `protected_branches_match_exactly_not_by_prefix` — `==` matching means `maintenance`, `develop`, `main-backup` are NOT granted `release:deploy` (guards against an accidental `starts_with` regression that would over-grant)
- `version_tag_prefix_boundary` — bare `refs/tags/v` and pre-release tags (`v10.20.30-rc.1`) match; non-`v` tags (`1.2.3`, `release-1`) do not
- `nested_feature_branches_get_worktree_scopes` — nested + empty-suffix feature refs grant worktree scopes; `featureX` (no slash) does not

No production code changed — `derive_oidc_scopes` is unchanged.

## Tested (Band A — fast check)
```
cargo test -p deploy-server   # exit 0
```
Result: `test result: ok. 69 passed; 0 failed; 1 ignored`. All 9 `infra::audit::tests` pass, including the 4 new edge-case tests above.

## Built (Band B — full build)
skipped: change is test-only (~50 LOC), no public API / migration / config touched.

## CI parity (Band C — hot-path only)
skipped: test-only change, no security/auth/billing/data-integrity production code modified. (`derive_oidc_scopes` itself is auth-adjacent, but this PR adds no behavior — only locks in the existing contract.)

## Remote-tested
skipped (no ppt-bridge MCP in session)

## Notes
- This is a **test-gap fill** task. IG3's "failing test first" applies to net-new behavior; here the function already exists and is correct, so the tests are green against current code (the goal is to lock in the contract and catch a future `starts_with`/`==` regression). No `fix:` commit accompanies the `test:` commit by design.
- `Cargo.lock` had pre-existing version-bump drift on dev (0.3.44→0.3.57); I deliberately excluded it to keep this PR scoped to the test file.
- scope-check: `scope_drift=false` (only deploy-server, a pm-backend area). reuse-grep: no warnings.

https://claude.ai/code/session_01ThAwfC4GoX1uZYoQG8YxuX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThAwfC4GoX1uZYoQG8YxuX)_