### PR TITLE
dx-nginx-template-churn-2026-06-03: consolidate shared nginx config into included partials

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -55,14 +55,21 @@ docker/
 │   ├── ppt-web.Dockerfile      # Property Management SPA
 │   └── reality-web.Dockerfile  # Reality Portal SSR
 ├── nginx/
-│   ├── ppt-web.nginx.conf.template  # Nginx config template for SPA
-│   │                                # (rendered at container startup —
-│   │                                # /api and /ws proxy upstreams are
-│   │                                # filled from BG_TARGET + BG_COLOR
-│   │                                # so the SPA fetches reach the
-│   │                                # api-server container in the same
-│   │                                # blue/green color)
-│   └── render-template.sh           # envsubst entrypoint hook
+│   ├── ppt-web.nginx.conf.template   # Nginx config template for the ppt-web SPA
+│   │                                 # (rendered at container startup —
+│   │                                 # /api and /ws proxy upstreams are
+│   │                                 # filled from BG_TARGET + BG_COLOR
+│   │                                 # so the SPA fetches reach the
+│   │                                 # api-server container in the same
+│   │                                 # blue/green color)
+│   ├── admin-web.nginx.conf.template # Same, for the admin-web SPA
+│   ├── partials/                     # Shared `include`d snippets, copied to
+│   │   │                             # /etc/nginx/partials/ (NOT conf.d, so the
+│   │   │                             # base image's conf.d/*.conf glob ignores
+│   │   │                             # them); both templates pull them in
+│   │   ├── server-common.conf            # relative redirects + gzip
+│   │   └── security-headers-common.conf  # headers identical across both SPAs
+│   └── render-template.sh            # envsubst entrypoint hook
 └── scripts/
     ├── docker-build.sh         # Multi-arch build script
     └── synology-setup.sh       # Synology setup helper

--- a/docker/frontend/admin-web.Dockerfile
+++ b/docker/frontend/admin-web.Dockerfile
@@ -45,6 +45,11 @@ FROM nginx:alpine AS production
 RUN apk add --no-cache gettext
 
 COPY docker/nginx/admin-web.nginx.conf.template /etc/nginx/conf.d/default.conf.template
+# Shared, `include`d partials (relative redirects, gzip, common security
+# headers). Kept OUTSIDE /etc/nginx/conf.d so the base image's
+# `include /etc/nginx/conf.d/*.conf` does not load them as standalone configs;
+# the template pulls them in by absolute path. No envsubst needed.
+COPY docker/nginx/partials/ /etc/nginx/partials/
 COPY docker/nginx/render-template.sh /docker-entrypoint.d/10-render-template.sh
 RUN chmod +x /docker-entrypoint.d/10-render-template.sh
 

--- a/docker/frontend/ppt-web.Dockerfile
+++ b/docker/frontend/ppt-web.Dockerfile
@@ -69,6 +69,13 @@ RUN apk add --no-cache gettext
 # Ship the template (not the final config) — rendered at startup.
 COPY docker/nginx/ppt-web.nginx.conf.template /etc/nginx/conf.d/default.conf.template
 
+# Shared, `include`d partials (relative redirects, gzip, common security
+# headers). Kept OUTSIDE /etc/nginx/conf.d so the base image's
+# `include /etc/nginx/conf.d/*.conf` does not try to load them as standalone
+# server configs; the template pulls them in by absolute path. No envsubst
+# needed — they carry no `${BG_*}` placeholders.
+COPY docker/nginx/partials/ /etc/nginx/partials/
+
 # nginx:alpine's stock entrypoint runs every script in /docker-entrypoint.d/*.sh
 # before exec'ing nginx, so dropping the renderer here gives us templating
 # without a custom ENTRYPOINT line.

--- a/docker/nginx/admin-web.nginx.conf.template
+++ b/docker/nginx/admin-web.nginx.conf.template
@@ -1,8 +1,11 @@
 # Template — `${BG_TARGET}` and `${BG_COLOR}` are filled in at container
 # startup by /docker-entrypoint.d/10-render-template.sh via `envsubst`.
 #
-# admin-web differs from ppt-web in two ways:
+# Shared, churn-prone boilerplate (relative redirects, gzip, common security
+# headers) lives in /etc/nginx/partials/*.conf and is pulled in via `include`
+# below — identical to ppt-web. admin-web differs from ppt-web only in:
 #   - X-Frame-Options: DENY (admin must never be embedded)
+#   - Content-Security-Policy: frame-ancestors 'none'
 #   - Cache-Control: no-store on HTML (no admin caching at intermediaries)
 
 server {
@@ -13,48 +16,25 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Emit relative redirects (#957) — see ppt-web template. Avoids leaking the
-    # internal :8080 port / https->http downgrade in implicit slash redirects.
-    absolute_redirect off;
-
-    gzip on;
-    gzip_vary on;
-    gzip_min_length 1024;
-    gzip_proxied expired no-cache no-store private auth;
-    gzip_types
-        text/plain
-        text/css
-        text/xml
-        text/javascript
-        application/javascript
-        application/x-javascript
-        application/json
-        application/xml
-        application/rss+xml
-        application/atom+xml
-        image/svg+xml;
+    # Relative redirects + gzip (shared with ppt-web).
+    include /etc/nginx/partials/server-common.conf;
 
     # Stronger security headers than ppt-web — admin is sensitive.
+    include /etc/nginx/partials/security-headers-common.conf;
     add_header X-Frame-Options "DENY" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-XSS-Protection "1; mode=block" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Cache-Control "no-store" always;
-    # HSTS — was missing (#954). The super-admin console is served TLS-only.
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
     # CSP — was missing (#954). frame-ancestors 'none' mirrors X-Frame-Options
     # DENY (admin must never be framed); connect-src kept permissive (https:/wss:)
     # for same-origin /api proxying and external telemetry.
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
 
+    # Cache static assets. `add_header` in a location does NOT inherit the
+    # parent's headers, so re-include the common set + re-declare X-Frame-Options.
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
         add_header Cache-Control "public, immutable" always;
+        include /etc/nginx/partials/security-headers-common.conf;
         add_header X-Frame-Options "DENY" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header X-XSS-Protection "1; mode=block" always;
-        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
     }
 
     location /health {

--- a/docker/nginx/partials/security-headers-common.conf
+++ b/docker/nginx/partials/security-headers-common.conf
@@ -1,0 +1,17 @@
+# Security headers shared, byte-for-byte, by ppt-web and admin-web.
+#
+# `include`d both at server level AND inside the static-asset `location` block:
+# nginx's `add_header` does NOT inherit into a `location` that defines its own
+# `add_header`, so any block that re-declares headers must re-include this file
+# to keep the full set. That re-declaration was the copy-paste churn (#954
+# HSTS/CSP roll-out) this partial removes.
+#
+# NOT included here (they differ between the two apps, so they stay inline in
+# each template): X-Frame-Options (SAMEORIGIN vs DENY), Content-Security-Policy
+# (frame-ancestors 'self' vs 'none'), and admin-web's Cache-Control no-store.
+
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-XSS-Protection "1; mode=block" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+# HSTS (#954) — both hosts are served TLS-only behind Caddy.
+add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;

--- a/docker/nginx/partials/server-common.conf
+++ b/docker/nginx/partials/server-common.conf
@@ -1,0 +1,37 @@
+# Shared nginx server-block prelude for the ppt-web / admin-web SPA images.
+#
+# `include`d (by absolute path) from both *.nginx.conf.template files so the
+# bits that are byte-identical between the two SPAs live in exactly one place.
+# These directives carry NO `${BG_*}` placeholders, so they are NOT run through
+# envsubst — they are copied into the image verbatim and pulled in by nginx at
+# config-load time (after the template itself is rendered).
+#
+# Kept here because they were copy-pasted across both templates and churned
+# together (see #957 relative-redirects). What stays per-template: anything
+# that legitimately differs between ppt-web and admin-web (X-Frame-Options,
+# Content-Security-Policy, admin's no-store Cache-Control, the proxy upstreams).
+
+# Emit relative redirects (#957). Without this, nginx's implicit trailing-slash
+# redirect for `/api` -> `/api/` builds an ABSOLUTE Location from the listen
+# socket (`http://host:8080/api/`), leaking the internal port and downgrading
+# https->http. A relative `Location: /api/` is resolved by the browser against
+# the original scheme+host.
+absolute_redirect off;
+
+# Gzip compression
+gzip on;
+gzip_vary on;
+gzip_min_length 1024;
+gzip_proxied expired no-cache no-store private auth;
+gzip_types
+    text/plain
+    text/css
+    text/xml
+    text/javascript
+    application/javascript
+    application/x-javascript
+    application/json
+    application/xml
+    application/rss+xml
+    application/atom+xml
+    image/svg+xml;

--- a/docker/nginx/ppt-web.nginx.conf.template
+++ b/docker/nginx/ppt-web.nginx.conf.template
@@ -2,6 +2,10 @@
 # startup by /docker-entrypoint.d/10-render-template.sh via `envsubst` so the
 # `proxy_pass` upstream resolves to the same blue/green color of api-server
 # in the same Docker network as this ppt-web container.
+#
+# Shared, churn-prone boilerplate (relative redirects, gzip, common security
+# headers) lives in /etc/nginx/partials/*.conf and is pulled in via `include`
+# below. Only the bits that genuinely differ from admin-web stay inline here.
 
 server {
     listen 8080;
@@ -11,52 +15,24 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Emit relative redirects (#957). Without this, nginx's implicit
-    # trailing-slash redirect for `/api` -> `/api/` builds an ABSOLUTE Location
-    # from the listen socket (`http://host:8080/api/`), leaking the internal
-    # port and downgrading https->http. A relative `Location: /api/` is resolved
-    # by the browser against the original scheme+host.
-    absolute_redirect off;
-
-    # Gzip compression
-    gzip on;
-    gzip_vary on;
-    gzip_min_length 1024;
-    gzip_proxied expired no-cache no-store private auth;
-    gzip_types
-        text/plain
-        text/css
-        text/xml
-        text/javascript
-        application/javascript
-        application/x-javascript
-        application/json
-        application/xml
-        application/rss+xml
-        application/atom+xml
-        image/svg+xml;
+    # Relative redirects + gzip (shared with admin-web).
+    include /etc/nginx/partials/server-common.conf;
 
     # Security headers
+    include /etc/nginx/partials/security-headers-common.conf;
     add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-XSS-Protection "1; mode=block" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    # HSTS — was missing (#954). This host is served TLS-only behind Caddy.
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
     # CSP — was missing (#954). frame-ancestors 'self' mirrors the SAMEORIGIN
     # policy above; connect-src is kept permissive (https:/wss:) so same-origin
     # /api + /ws proxying and any external uploads/telemetry keep working.
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
 
-    # Cache static assets (include security headers since add_header in location overrides parent)
+    # Cache static assets. `add_header` in a location does NOT inherit the
+    # parent's headers, so re-include the common set + re-declare X-Frame-Options.
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
         add_header Cache-Control "public, immutable" always;
+        include /etc/nginx/partials/security-headers-common.conf;
         add_header X-Frame-Options "SAMEORIGIN" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header X-XSS-Protection "1; mode=block" always;
-        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
     }
 
     # Health check endpoint


### PR DESCRIPTION
## Task
docker/nginx admin-web + ppt-web templates churned twice this run (security headers + redirects). Consolidate the shared/duplicated nginx config so security headers + redirect blocks live in one included partial instead of being copy-pasted across `docker/nginx/admin-web.nginx.conf.template` and the ppt-web template. Reduce churn/duplication; keep served behavior identical.

## Owner
pm-devops

## What changed
- New `docker/nginx/partials/server-common.conf` — `absolute_redirect off;` (the #957 relative-redirect block) + the full `gzip` block. Byte-identical between both SPAs.
- New `docker/nginx/partials/security-headers-common.conf` — the four `add_header` lines that were identical in both templates (`X-Content-Type-Options`, `X-XSS-Protection`, `Referrer-Policy`, HSTS from #954). `include`d **both** at server level **and** inside the static-asset `location` block, because nginx `add_header` does not inherit into a location that re-declares headers — that re-declaration was the copy-paste churn source.
- Both templates now `include` the partials; only genuinely-divergent directives stay inline:
  - `X-Frame-Options` — `SAMEORIGIN` (ppt-web) vs `DENY` (admin-web)
  - `Content-Security-Policy` — `frame-ancestors 'self'` vs `'none'`
  - admin-web's `Cache-Control "no-store"` at server level
- Partials live in `/etc/nginx/partials/` (NOT `conf.d/`) so the base image's `include /etc/nginx/conf.d/*.conf` glob does not try to load them as standalone server configs. Templates pull them in by absolute path. No envsubst needed — partials carry no `${BG_*}` placeholders.
- Both Dockerfiles add `COPY docker/nginx/partials/ /etc/nginx/partials/`.
- `docker/README.md` directory tree updated (admin-web template + partials/ were undocumented).

## Behavior equivalence (the key claim)
The local Docker daemon is unavailable in this sandbox, so `nginx -t` could not be run. Instead, behavior-preservation was proven structurally: each template was re-expanded by inlining the `include`d partials, then compared to the previous `origin/dev` template. Result — **per-block `add_header` directive multisets are identical** for both apps. The only difference is intra-block ordering of distinct `add_header` directives (e.g. `X-Frame-Options` now follows the common-headers block), which is HTTP-irrelevant: each directive emits its own distinct response header and response-header ordering does not affect behavior.

## Tested (Band A — fast check)
- `git diff --check` → exit 0 (clean, no whitespace/merge-marker issues)
- Structural behavior-equivalence diff (inline-includes vs old template): per-block directive multisets IDENTICAL for ppt-web and admin-web → exit 0

## Built (Band B — full build)
Skipped: docker build / `nginx -t` require the Docker daemon, which is unavailable in this sandbox. Change is config-only (no application code, no public API/migration). Reviewer/CI `docker-frontend.yml` will exercise the real image build + nginx config load.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity logic change — security *headers* are unchanged in value/set, only de-duplicated).

## Remote-tested
Skipped (no ppt-bridge MCP in session).

## Scope drift
None — all changes confined to `docker/nginx/**`, `docker/frontend/*.Dockerfile`, and `docker/README.md` (DevOps/infra). `.research/**` untouched.

## Code-reuse review
None — no auth/crypto/http-client helpers added; this is nginx config consolidation (the change itself is a de-duplication).

## Notes
- Reviewer: please run `docker build` (or rely on `docker-frontend.yml`) to confirm `nginx -t` passes on the rendered config — that is the one check the sandbox could not run.
- `docker/nginx/render-template.sh` log line still says "rendered ppt-web nginx config" but is shared by both images; left as-is (cosmetic, pre-existing, out of scope).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Msydm7t6H2AADzGU8VpJtJ)_