### PR TITLE
test-gap-screen-map-drift-pr-1033-ppt: sync announcements + faults screen-maps with PR #1033 error/retry wiring

### DIFF
--- a/docs/screens/ppt/announcements.md
+++ b/docs/screens/ppt/announcements.md
@@ -91,9 +91,9 @@ owner: pm-frontend
 
 ## States
 
-- **Empty (list)**: megaphone-icon tile + "Žiadne oznamy" + body + primary "+ Nový oznam" + secondary "Importovať z Faults" link
-- **Loading (list)**: 8 skeleton cards (pin skel + 2 line skels + meta skels + progress-bar skel)
-- **Error 503 (list)**: danger tile + retry; toolbar + sidebar interactive
+- **Empty (list)**: megaphone-icon tile + "Žiadne oznamy" + body + primary "+ Nový oznam" + secondary "Importovať z Faults" link. **Implemented** (PR #1033): `AnnouncementList` shows "No announcements found." when not loading, not error, and the list is empty.
+- **Loading (list)**: 8 skeleton cards (pin skel + 2 line skels + meta skels + progress-bar skel). Code currently renders a single spinner while `isLoading` (skeleton-card treatment still TBD).
+- **Error 503 (list)**: danger tile + retry; toolbar + sidebar interactive. **Implemented** (PR #1033): `AnnouncementList` renders an inline `role="alert"` danger tile (red-50 bg / red-200 border) with `announcements.failedToLoad` ("Failed to load announcements") + a `common.retry` button calling `onRetry` (route wrapper `refetch()`). Threaded `AnnouncementsPageRoute → AnnouncementsPage → AnnouncementList` via `isError`/`onRetry` props; mutually exclusive with loading/empty/loaded.
 - **Loaded (list)**: 8 cards covering 5 states; 2 selected with bulk bar; 1 pinned at top
 - **Detail (existing)**: as designed — published with delivery + ack stats
 
@@ -115,10 +115,13 @@ UC-02 announcements — manager-published, resident-acknowledged messages. The d
 - Audience meta currently free text ("All residents") — must become a tokenized chip set (All residents / Owners only / By unit / By role) tied to the audience-selector when composing.
 - Multi-language announcements (`Slovak · English` in details kv) — implementation must support per-language body editing + per-language read receipts; v1 may ship single-language only.
 - Mobile bottom-nav must drop the legacy 📢 emoji per SKILL.md non-negotiable.
+- **List error/retry wired (PR #1033):** the designed `error-503` artboard now has a code counterpart — `AnnouncementList` owns the loading/error/empty triad and the error tile carries a retry button (`onRetry → refetch()`, i18n `announcements.failedToLoad` + shared `common.retry`). Skeleton-card loading treatment (8 cards per design) is still TBD; code shows a single spinner.
 
 ## Agent Log
 
 <!-- newest entries on top -->
+
+- 2026-06-05 — agent: test-gap-screen-map-drift-pr-1033-ppt — screen-map sync for PR #1033: AnnouncementsPageRoute now threads `isError`/`onRetry` (from `useAnnouncements` error + `refetch`) through AnnouncementsPage → AnnouncementList; AnnouncementList renders the designed error-503 tile as a `role="alert"` inline error + retry button (i18n `announcements.failedToLoad` + `common.retry`), mutually exclusive with loading/empty/loaded; added AnnouncementsPage.test.tsx regression (gap-79-1). Updated States (Empty/Loading/Error → Implemented) + Notes; docs-only, no code change here
 
 - 2026-05-27 — agent: gap-6-2-announcement-read-receipt-retry — Story 6.2 retry: added AnnouncementDetailScreen (mobile) with auto-fire POST /read on mount + acknowledge button; wired AnnouncementDetail case in mobile App.tsx; added auto-mark-read useEffect in ppt-web ViewAnnouncementPageInner (fire-and-forget on announcement load); ppt-web & mobile typecheck + biome clean; mobile component: AnnouncementsScreen + AnnouncementDetailScreen
 

--- a/docs/screens/ppt/faults-list.md
+++ b/docs/screens/ppt/faults-list.md
@@ -84,9 +84,9 @@ owner: pm-frontend
 
 ## States
 
-- **Empty**: not depicted in design; recommended — empty card with check-circle icon + "All caught up" + "No open faults right now." (per project README empty-state voice).
-- **Loading**: not depicted; recommend table skeleton (8 rows × 6 cols) + sidebar group title skeletons; reduced-motion → static.
-- **Error**: not depicted; per voice → blunt single-line "Unable to load faults. Try again". Sidebar + toolbar retained.
+- **Empty**: not depicted in design; recommended — empty card with check-circle icon + "All caught up" + "No open faults right now." (per project README empty-state voice). **Implemented** (PR #1033): `FaultList` renders "No faults found." when `!isLoading && !isError && faults.length === 0`.
+- **Loading**: not depicted; recommend table skeleton (8 rows × 6 cols) + sidebar group title skeletons; reduced-motion → static. **Implemented**: spinner shown while `isLoading`.
+- **Error**: **Implemented** (PR #1033) — `FaultList` renders an inline `role="alert"` danger tile (red-50 bg / red-200 border) with `faults.failedToLoad` ("Failed to load faults") + a `common.retry` button that calls `onRetry` (route wrapper `refetch()`). Mutually exclusive with empty/loaded (`!isLoading && isError`); toolbar + filters retained. Threaded `FaultsPageRoute → FaultsPage → FaultList` via `isError`/`onRetry` props. Design treatment still TBD (per voice → blunt single-line).
 - **Success**: 7-row sample of 38 total, mixed priorities and statuses, demonstrating all 8 status-pill colors via varied row coverage.
 
 ## Notes
@@ -102,13 +102,15 @@ UC-03 faults list — the manager's working surface for the 8-state fault machin
 - Sidebar counts are dynamic (must update on filter change). All-priorities/All-status defaults; multi-select filtering (clicking multiple priorities ANDs them together).
 - "SLA breached" tag in subtitle is a meta count — should expose breach reason on hover (which SLA tier and by how long).
 - Data-table column widths: `72px 1fr 140px 140px 140px 100px` — ID + flexible fault + 3 fixed status columns + age. Below 1024px, collapse status/priority/assignee into a stacked sub-line under the title (mobile-style).
-- The bundle's faults page does not depict empty/loading/error states — these need design at implementation time. Following project voice: blunt, single-line, action-tagged.
+- The bundle's faults page does not depict empty/loading/error states — these need design at implementation time. Following project voice: blunt, single-line, action-tagged. **Update (PR #1033):** loading/error/empty are now wired in code — `FaultList` owns the triad and the error tile carries a retry button (`onRetry → refetch()`). The visual error/empty *design* is still TBD; the code provides a functional baseline (i18n key `faults.failedToLoad` + shared `common.retry`).
 - Mobile nav shouldn't carry the legacy emoji `🔧` — substitute Lucide `wrench` per SKILL.md non-negotiable.
 - Sidebar group headers use uppercase 11/600/.06em — matches the spec for "category eyebrow" type.
 
 ## Agent Log
 
 <!-- newest entries on top -->
+
+- 2026-06-05 — agent: test-gap-screen-map-drift-pr-1033-ppt — screen-map sync for PR #1033: FaultsPageRoute now threads `isError`/`onRetry` (from `useFaults` error + `refetch`) through FaultsPage → FaultList; FaultList renders an inline `role="alert"` error tile + retry button (i18n `faults.failedToLoad` + `common.retry`), mutually exclusive with empty/loaded; added FaultsPage.test.tsx regression (gap-79-1). Updated States (Error/Loading/Empty → Implemented) + Notes; docs-only, no code change here
 
 - 2026-05-24 — agent: gap-79-1 — wired FaultsPage to useFaults+useUpdateFaultStatus+useAssignFault hooks with snake→camelCase mapper; ppt-web.apiStatus stub→partial
 


### PR DESCRIPTION
## Task
Screen-map drift — PR #1033 wired error/retry into AnnouncementsPage+FaultsPage via App.tsx (route wrappers thread `isError`/`onRetry` from `useAnnouncements`/`useFaults` error + `refetch` through the page → list components, which now render an inline `role="alert"` error tile + retry button) without a corresponding `docs/screens/ppt` update. This PR updates the relevant screen-map entries to reflect that wiring and re-runs `/screens validate`. Code (App.tsx) is intentionally untouched — a separate task owns the route-coupling refactor.

## Owner
pm-frontend

## Changes (docs-only)
- `docs/screens/ppt/faults-list.md` — States `Error`/`Loading`/`Empty` flipped from "not depicted" → **Implemented** (PR #1033): inline `role="alert"` danger tile + `common.retry` button, mutually exclusive triad threaded `FaultsPageRoute → FaultsPage → FaultList`. Added Notes > Specific update + Agent Log entry. Noted `FaultsPage.test.tsx` regression.
- `docs/screens/ppt/announcements.md` — States `Empty`/`Loading`/`Error-503` flipped → **Implemented** (PR #1033): the designed `error-503` artboard now has a code counterpart (`AnnouncementList` error tile + retry). Added Notes > Specific update + Agent Log entry. Noted `AnnouncementsPage.test.tsx` regression.

No frontmatter status fields changed (apiStatus stays `partial`; build/redesign untouched) — the drift was purely in the States/Notes prose vs. shipped behavior.

## Tested (Band A — fast check)
`/screens validate` (via `@ppt/screen-map` CLI: `tsx src/cli.ts validate --root <repo>`)
→ `Validated 120 screen-maps: 0 errors, 0 warnings.` (both edited files `ok`), exit 0.

`bash .claude/skills/ppt-implement/scripts/scope-check.sh --owner pm-frontend --base dev --head HEAD` → exit 0 (no scope drift; only `docs/screens/ppt/*.md` touched).

## Built (Band B — full build)
skipped: docs-only change (<50 LOC prose, no public API/config touch).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change; docs only).

## Remote-tested
skipped.

## Notes
- App.tsx NOT restructured — limited to `docs/screens` to avoid conflicting with the route-coupling refactor that owns App.tsx.
- The actual error/retry component + i18n + tests already landed in PR #1033; this PR only closes the screen-map documentation drift.

https://claude.ai/code/session_01YYqXbaK6bvae6X2kJHey3r

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYqXbaK6bvae6X2kJHey3r)_