### PR TITLE
refactor-auth-refresh-spec-churn-2026-06-04: de-flake & de-duplicate ppt-web auth-refresh e2e spec

### DIFF
--- a/frontend/apps/ppt-web/e2e/auth-helpers.ts
+++ b/frontend/apps/ppt-web/e2e/auth-helpers.ts
@@ -1,0 +1,151 @@
+/**
+ * Shared E2E helpers for the ppt-web auth suites.
+ *
+ * Both `auth-refresh.spec.ts` and `oauth-callback.spec.ts` exercise the same
+ * AuthContext token-storage contract, so the JWT builders, storage keys, mock
+ * user, and localStorage/route helpers live here to avoid drift between the two
+ * specs. Keep the *_KEY constants in sync with `AuthContext.tsx` tokenStorage.
+ */
+
+import { expect, type Page } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Storage keys — must match AuthContext.tsx tokenStorage keys.
+// ---------------------------------------------------------------------------
+
+export const ACCESS_TOKEN_KEY = 'ppt_access_token';
+export const REFRESH_TOKEN_KEY = 'ppt_refresh_token';
+export const USER_KEY = 'ppt_user';
+
+/** sessionStorage key used by @ppt/shared setSsoState / getAndClearSsoState. */
+export const SSO_STATE_KEY = 'sso_state';
+
+export const REFRESH_ENDPOINT = '**/api/v1/auth/refresh';
+export const SSO_CALLBACK_ENDPOINT = '**/api/v1/auth/sso/callback';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+export const MOCK_USER = {
+  id: 'usr-e2e-refresh-01',
+  email: 'manager@test.example',
+  firstName: 'Test',
+  lastName: 'Manager',
+  role: 'manager',
+} as const;
+
+// ---------------------------------------------------------------------------
+// JWT / time builders
+// ---------------------------------------------------------------------------
+
+/** Build a minimal JWT-shaped string using Node.js Buffer base64url encoding. */
+export function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.fakesig`;
+}
+
+/** Seconds from now (unix epoch). */
+export function nowPlus(seconds: number): number {
+  return Math.floor(Date.now() / 1000) + seconds;
+}
+
+/** A signed-shaped manager access token that expires `seconds` from now. */
+export function managerAccessToken(seconds = 900): string {
+  return makeJwt({ sub: MOCK_USER.id, role: 'manager', exp: nowPlus(seconds) });
+}
+
+// ---------------------------------------------------------------------------
+// Storage helpers — all run a single page.evaluate so callers stay terse.
+// ---------------------------------------------------------------------------
+
+/** Navigate to /login and wipe local + session storage for a clean slate. */
+export async function resetStorage(page: Page): Promise<void> {
+  await page.goto('/login');
+  await page.evaluate(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+}
+
+/** Read a single localStorage value from the page. */
+export function readLocalStorage(page: Page, key: string): Promise<string | null> {
+  return page.evaluate((k) => localStorage.getItem(k), key);
+}
+
+/**
+ * Seed localStorage so AuthProvider.initializeAuth() takes the refresh branch:
+ * a stored user + refresh token but NO access token. initializeAuth only sets
+ * the user via the refresh branch when a stored user is present, so we keep the
+ * user but drop the access token to force a silent refresh on mount.
+ */
+export async function seedRefreshableSession(page: Page, refreshToken: string): Promise<void> {
+  await resetStorage(page);
+  await page.evaluate(
+    ({ rtKey, uKey, atKey, rt, user }) => {
+      localStorage.setItem(rtKey, rt);
+      localStorage.setItem(uKey, JSON.stringify(user));
+      // Intentionally NO access token → initializeAuth() refresh branch.
+      localStorage.removeItem(atKey);
+    },
+    {
+      rtKey: REFRESH_TOKEN_KEY,
+      uKey: USER_KEY,
+      atKey: ACCESS_TOKEN_KEY,
+      rt: refreshToken,
+      user: MOCK_USER,
+    }
+  );
+}
+
+/** Seed ONLY a refresh token (no stored user) — used for failure-path tests. */
+export async function seedRefreshTokenOnly(page: Page, refreshToken: string): Promise<void> {
+  await resetStorage(page);
+  await page.evaluate(
+    ({ rtKey, rt }) => {
+      localStorage.setItem(rtKey, rt);
+    },
+    { rtKey: REFRESH_TOKEN_KEY, rt: refreshToken }
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Assertions — poll storage so we never race the AuthContext write.
+// ---------------------------------------------------------------------------
+
+/**
+ * Assert a localStorage key settles to `expected`. Polling (rather than a bare
+ * read after networkidle) removes the race against AuthContext persisting the
+ * rotated tokens.
+ */
+export async function expectLocalStorage(
+  page: Page,
+  key: string,
+  expected: string | null
+): Promise<void> {
+  await expect.poll(() => readLocalStorage(page, key), { timeout: 8000 }).toBe(expected);
+}
+
+// ---------------------------------------------------------------------------
+// Route helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Stub every non-auth API call with an empty 200 so a protected route can
+ * finish rendering. The auth endpoints are left to their dedicated mocks.
+ */
+export async function stubOtherApis(page: Page): Promise<void> {
+  await page.route('**/api/v1/**', async (route) => {
+    const url = route.request().url();
+    if (url.includes('/api/v1/auth/refresh') || url.includes('/api/v1/auth/sso/callback')) {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    });
+  });
+}

--- a/frontend/apps/ppt-web/e2e/auth-refresh.spec.ts
+++ b/frontend/apps/ppt-web/e2e/auth-refresh.spec.ts
@@ -20,100 +20,37 @@
  *   4. No-refresh-token short-circuit — empty storage makes no refresh call
  *      and a protected route lands on /login.
  *
+ * Shared JWT builders, storage keys, and route/storage helpers live in
+ * `auth-helpers.ts` (also consumed by `oauth-callback.spec.ts`).
+ *
  * All API calls are mocked via page.route() — no backend required.
  */
 
-import { expect, test } from '@playwright/test';
+import { expect, type Route, test } from '@playwright/test';
+import {
+  ACCESS_TOKEN_KEY,
+  expectLocalStorage,
+  managerAccessToken,
+  REFRESH_ENDPOINT,
+  REFRESH_TOKEN_KEY,
+  resetStorage,
+  seedRefreshableSession,
+  seedRefreshTokenOnly,
+  stubOtherApis,
+} from './auth-helpers';
 
-// ---------------------------------------------------------------------------
-// Constants — must match AuthContext.tsx tokenStorage keys.
-// ---------------------------------------------------------------------------
+const PROTECTED_ROUTE = '/documents';
 
-const ACCESS_TOKEN_KEY = 'ppt_access_token';
-const REFRESH_TOKEN_KEY = 'ppt_refresh_token';
-const USER_KEY = 'ppt_user';
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** Build a minimal JWT-shaped string using Node.js Buffer base64url encoding. */
-function makeJwt(payload: Record<string, unknown>): string {
-  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
-  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
-  return `${header}.${body}.fakesig`;
+/** Read the `refreshToken` field off a refresh request's JSON body. */
+function sentRefreshToken(route: Route): string | undefined {
+  const body = JSON.parse(route.request().postData() ?? '{}') as { refreshToken?: string };
+  return body.refreshToken;
 }
-
-/** Seconds from now (unix epoch). */
-function nowPlus(seconds: number): number {
-  return Math.floor(Date.now() / 1000) + seconds;
-}
-
-const MOCK_USER = {
-  id: 'usr-e2e-refresh-01',
-  email: 'manager@test.example',
-  firstName: 'Test',
-  lastName: 'Manager',
-  role: 'manager',
-};
-
-/**
- * Seed localStorage so AuthProvider.initializeAuth() takes the refresh branch:
- * a stored user + refresh token but NO access token. initializeAuth only sets
- * the user via the refresh branch when a stored user is present, so we keep the
- * user but drop the access token to force a silent refresh on mount.
- */
-async function seedRefreshableSession(
-  page: import('@playwright/test').Page,
-  refreshToken: string
-): Promise<void> {
-  await page.goto('/login');
-  await page.evaluate(
-    ({ rtKey, uKey, atKey, rt, user }) => {
-      localStorage.clear();
-      sessionStorage.clear();
-      localStorage.setItem(rtKey, rt);
-      localStorage.setItem(uKey, JSON.stringify(user));
-      // Intentionally NO access token → initializeAuth() refresh branch.
-      localStorage.removeItem(atKey);
-    },
-    {
-      rtKey: REFRESH_TOKEN_KEY,
-      uKey: USER_KEY,
-      atKey: ACCESS_TOKEN_KEY,
-      rt: refreshToken,
-      user: MOCK_USER,
-    }
-  );
-}
-
-/** Stub every non-auth API call so a protected route can finish rendering. */
-async function stubOtherApis(page: import('@playwright/test').Page): Promise<void> {
-  await page.route('**/api/v1/**', async (route) => {
-    const url = route.request().url();
-    if (url.includes('/api/v1/auth/refresh')) {
-      await route.continue();
-    } else {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({}),
-      });
-    }
-  });
-}
-
-// ---------------------------------------------------------------------------
-// Suite
-// ---------------------------------------------------------------------------
 
 test.describe('Token Refresh Flow (AuthProvider)', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/login');
-    await page.evaluate(() => {
-      localStorage.clear();
-      sessionStorage.clear();
-    });
+    await resetStorage(page);
+    await stubOtherApis(page);
   });
 
   // -------------------------------------------------------------------------
@@ -125,46 +62,35 @@ test.describe('Token Refresh Flow (AuthProvider)', () => {
     page,
   }) => {
     const oldRefresh = 'refresh-token-old-001';
-    const newAccess = makeJwt({ sub: MOCK_USER.id, role: 'manager', exp: nowPlus(900) });
+    const newAccess = managerAccessToken();
     const newRefresh = 'refresh-token-new-001';
 
     let refreshCallCount = 0;
-    await page.route('**/api/v1/auth/refresh', async (route) => {
+    await page.route(REFRESH_ENDPOINT, async (route) => {
       refreshCallCount += 1;
       // The request must carry the OLD refresh token.
-      const sent = JSON.parse(route.request().postData() ?? '{}') as { refreshToken?: string };
-      expect(sent.refreshToken).toBe(oldRefresh);
+      expect(sentRefreshToken(route)).toBe(oldRefresh);
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({ accessToken: newAccess, refreshToken: newRefresh }),
       });
     });
-    await stubOtherApis(page);
 
     await seedRefreshableSession(page, oldRefresh);
 
-    // Land directly on a protected route. If the silent refresh works the user
-    // stays authenticated and the route renders rather than bouncing to /login.
-    await page.goto('/documents');
-    await page.waitForLoadState('networkidle');
-
-    // The protected route rendered rather than bouncing to /login — the silent
-    // refresh kept the session authenticated. ProtectedRoute redirects to /login
-    // BEFORE rendering children when unauthenticated, so staying on /documents is
-    // a real positive signal (not vacuous): if the refresh-on-mount had failed,
-    // this would be /login instead.
+    // Land directly on a protected route. ProtectedRoute redirects to /login
+    // BEFORE rendering children when unauthenticated, so staying on the
+    // protected route is a real positive signal (not vacuous): a failed
+    // refresh-on-mount would land on /login instead.
+    await page.goto(PROTECTED_ROUTE);
+    await expect(page).toHaveURL(new RegExp(`${PROTECTED_ROUTE}$`), { timeout: 8000 });
     expect(page.url()).not.toContain('/login');
-    expect(page.url()).toContain('/documents');
 
-    // The refresh endpoint was hit exactly once.
+    // The refresh endpoint was hit exactly once with the rotated pair persisted.
     expect(refreshCallCount).toBe(1);
-
-    // Rotated token pair is persisted.
-    const storedAccess = await page.evaluate((k) => localStorage.getItem(k), ACCESS_TOKEN_KEY);
-    const storedRefresh = await page.evaluate((k) => localStorage.getItem(k), REFRESH_TOKEN_KEY);
-    expect(storedAccess).toBe(newAccess);
-    expect(storedRefresh).toBe(newRefresh);
+    await expectLocalStorage(page, ACCESS_TOKEN_KEY, newAccess);
+    await expectLocalStorage(page, REFRESH_TOKEN_KEY, newRefresh);
   });
 
   // -------------------------------------------------------------------------
@@ -174,35 +100,24 @@ test.describe('Token Refresh Flow (AuthProvider)', () => {
   test('clears tokens and redirects to /login when refresh fails on mount', async ({ page }) => {
     const staleRefresh = 'refresh-token-stale-001';
 
-    await page.route('**/api/v1/auth/refresh', async (route) => {
+    await page.route(REFRESH_ENDPOINT, async (route) => {
       await route.fulfill({
         status: 401,
         contentType: 'application/json',
         body: JSON.stringify({ code: 'INVALID_CREDENTIALS', message: 'refresh token expired' }),
       });
     });
-    await stubOtherApis(page);
 
     // Seed ONLY a refresh token (no stored user) so a failed refresh leaves the
     // session unauthenticated and a protected route must redirect to /login.
-    await page.goto('/login');
-    await page.evaluate(
-      ({ rtKey, rt }) => {
-        localStorage.clear();
-        sessionStorage.clear();
-        localStorage.setItem(rtKey, rt);
-      },
-      { rtKey: REFRESH_TOKEN_KEY, rt: staleRefresh }
-    );
+    await seedRefreshTokenOnly(page, staleRefresh);
 
-    await page.goto('/documents');
+    await page.goto(PROTECTED_ROUTE);
     await page.waitForURL('**/login', { timeout: 8000 });
 
     // Stale tokens must have been cleared by initializeAuth()'s catch branch.
-    const storedRefresh = await page.evaluate((k) => localStorage.getItem(k), REFRESH_TOKEN_KEY);
-    const storedAccess = await page.evaluate((k) => localStorage.getItem(k), ACCESS_TOKEN_KEY);
-    expect(storedRefresh).toBeNull();
-    expect(storedAccess).toBeNull();
+    await expectLocalStorage(page, REFRESH_TOKEN_KEY, null);
+    await expectLocalStorage(page, ACCESS_TOKEN_KEY, null);
   });
 
   // -------------------------------------------------------------------------
@@ -213,27 +128,23 @@ test.describe('Token Refresh Flow (AuthProvider)', () => {
     page,
   }) => {
     const oldRefresh = 'refresh-token-rotate-old';
-    const newAccess = makeJwt({ sub: MOCK_USER.id, role: 'manager', exp: nowPlus(900) });
+    const newAccess = managerAccessToken();
     const newRefresh = 'refresh-token-rotate-new';
 
-    await page.route('**/api/v1/auth/refresh', async (route) => {
+    await page.route(REFRESH_ENDPOINT, async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({ accessToken: newAccess, refreshToken: newRefresh }),
       });
     });
-    await stubOtherApis(page);
 
     await seedRefreshableSession(page, oldRefresh);
 
-    await page.goto('/documents');
-    await page.waitForLoadState('networkidle');
+    await page.goto(PROTECTED_ROUTE);
 
-    const storedRefresh = await page.evaluate((k) => localStorage.getItem(k), REFRESH_TOKEN_KEY);
-    // The old refresh token must be gone (rotation, not reuse).
-    expect(storedRefresh).toBe(newRefresh);
-    expect(storedRefresh).not.toBe(oldRefresh);
+    // The old refresh token must be replaced by the rotated one (not reused).
+    await expectLocalStorage(page, REFRESH_TOKEN_KEY, newRefresh);
   });
 
   // -------------------------------------------------------------------------
@@ -242,14 +153,13 @@ test.describe('Token Refresh Flow (AuthProvider)', () => {
 
   test('makes no refresh call and redirects to /login when storage is empty', async ({ page }) => {
     let refreshCallMade = false;
-    await page.route('**/api/v1/auth/refresh', async (route) => {
+    await page.route(REFRESH_ENDPOINT, async (route) => {
       refreshCallMade = true;
-      await route.fulfill({ status: 200, body: '{}' });
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
     });
-    await stubOtherApis(page);
 
     // beforeEach already cleared storage — go straight to a protected route.
-    await page.goto('/documents');
+    await page.goto(PROTECTED_ROUTE);
     await page.waitForURL('**/login', { timeout: 8000 });
 
     expect(refreshCallMade).toBe(false);

--- a/frontend/apps/ppt-web/e2e/oauth-callback.spec.ts
+++ b/frontend/apps/ppt-web/e2e/oauth-callback.spec.ts
@@ -12,58 +12,40 @@
  *   4. Missing code/state — renders an error banner, stays on /auth/callback.
  *   5. API failure — renders an error banner, stays on /auth/callback.
  *
+ * Shared JWT builders, storage keys, and route/storage helpers live in
+ * `auth-helpers.ts` (also consumed by `auth-refresh.spec.ts`).
+ *
  * All API calls are mocked via page.route() — no backend required.
  */
 
-import { expect, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
+import {
+  ACCESS_TOKEN_KEY,
+  MOCK_USER,
+  makeJwt,
+  nowPlus,
+  REFRESH_TOKEN_KEY,
+  readLocalStorage,
+  resetStorage,
+  SSO_CALLBACK_ENDPOINT,
+  SSO_STATE_KEY,
+  stubOtherApis,
+  USER_KEY,
+} from './auth-helpers';
 
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-/** sessionStorage key used by @ppt/shared setSsoState / getAndClearSsoState */
-const SSO_STATE_KEY = 'sso_state';
-
-const ACCESS_TOKEN_KEY = 'ppt_access_token';
-const REFRESH_TOKEN_KEY = 'ppt_refresh_token';
-const USER_KEY = 'ppt_user';
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** Build a minimal JWT-shaped string using Node.js Buffer base64url encoding. */
-function makeJwt(payload: Record<string, unknown>): string {
-  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
-  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
-  return `${header}.${body}.fakesig`;
+/** Seed the SSO state nonce so AuthCallbackPage passes nonce validation. */
+function seedSsoState(page: Page, state: string): Promise<unknown> {
+  return page.evaluate(
+    ({ key, value }) => {
+      sessionStorage.setItem(key, value);
+    },
+    { key: SSO_STATE_KEY, value: state }
+  );
 }
-
-/** Seconds from now (unix epoch) */
-function nowPlus(seconds: number): number {
-  return Math.floor(Date.now() / 1000) + seconds;
-}
-
-const MOCK_USER = {
-  id: 'usr-e2e-01',
-  email: 'manager@test.example',
-  firstName: 'Test',
-  lastName: 'Manager',
-  role: 'manager',
-};
-
-// ---------------------------------------------------------------------------
-// Suite
-// ---------------------------------------------------------------------------
 
 test.describe('OAuth Callback Flow (AuthCallbackPage)', () => {
   test.beforeEach(async ({ page }) => {
-    // Navigate somewhere first so we can touch storage, then clear it.
-    await page.goto('/login');
-    await page.evaluate(() => {
-      localStorage.clear();
-      sessionStorage.clear();
-    });
+    await resetStorage(page);
   });
 
   // -------------------------------------------------------------------------
@@ -78,15 +60,9 @@ test.describe('OAuth Callback Flow (AuthCallbackPage)', () => {
     const validRefreshToken = 'refresh-token-abc123';
     const validState = 'csrf-state-e2e-001';
 
-    // Seed sessionStorage with the state nonce so AuthCallbackPage passes validation.
-    await page.evaluate(
-      ({ key, value }) => {
-        sessionStorage.setItem(key, value);
-      },
-      { key: SSO_STATE_KEY, value: validState }
-    );
+    await seedSsoState(page, validState);
 
-    await page.route('**/api/v1/auth/sso/callback', async (route) => {
+    await page.route(SSO_CALLBACK_ENDPOINT, async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -97,19 +73,8 @@ test.describe('OAuth Callback Flow (AuthCallbackPage)', () => {
         }),
       });
     });
-
     // Absorb any other API calls so the redirect settles without a real backend.
-    await page.route('**/api/v1/**', async (route) => {
-      if (route.request().url().includes('/api/v1/auth/sso/callback')) {
-        await route.continue();
-      } else {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({}),
-        });
-      }
-    });
+    await stubOtherApis(page);
 
     await page.goto(`/auth/callback?code=auth-code-valid-001&state=${validState}`);
 
@@ -117,17 +82,11 @@ test.describe('OAuth Callback Flow (AuthCallbackPage)', () => {
     await page.waitForURL('**/dashboard', { timeout: 8000 });
 
     // Verify tokens are persisted in localStorage by AuthContext.loginWithSsoCode().
-    const storedAccess = await page.evaluate((key) => localStorage.getItem(key), ACCESS_TOKEN_KEY);
-    const storedRefresh = await page.evaluate(
-      (key) => localStorage.getItem(key),
-      REFRESH_TOKEN_KEY
-    );
-    const storedUserRaw = await page.evaluate((key) => localStorage.getItem(key), USER_KEY);
+    expect(await readLocalStorage(page, ACCESS_TOKEN_KEY)).toBe(validAccessToken);
+    expect(await readLocalStorage(page, REFRESH_TOKEN_KEY)).toBe(validRefreshToken);
 
-    expect(storedAccess).toBe(validAccessToken);
-    expect(storedRefresh).toBe(validRefreshToken);
+    const storedUserRaw = await readLocalStorage(page, USER_KEY);
     expect(storedUserRaw).not.toBeNull();
-
     const storedUser = JSON.parse(storedUserRaw as string) as typeof MOCK_USER;
     expect(storedUser.email).toBe(MOCK_USER.email);
     expect(storedUser.id).toBe(MOCK_USER.id);
@@ -142,7 +101,7 @@ test.describe('OAuth Callback Flow (AuthCallbackPage)', () => {
   }) => {
     let apiCallMade = false;
 
-    await page.route('**/api/v1/auth/sso/callback', async (route) => {
+    await page.route(SSO_CALLBACK_ENDPOINT, async (route) => {
       apiCallMade = true;
       await route.fulfill({ status: 400, body: '{}' });
     });
@@ -151,15 +110,11 @@ test.describe('OAuth Callback Flow (AuthCallbackPage)', () => {
     // tab-napping, or a replay attempt (OIDC §3.1.2.7).
     await page.goto('/auth/callback?code=auth-code-x&state=tampered-state');
 
-    // Page stays at /auth/callback (no redirect to /dashboard).
-    await page.waitForLoadState('networkidle');
+    // Error banner must be visible — a web-first assertion that also waits.
+    await expect(page.locator('[role="alert"]')).toBeVisible({ timeout: 5000 });
+
+    // Page stays at /auth/callback (no redirect to /dashboard) and no API call.
     expect(page.url()).toContain('/auth/callback');
-
-    // Error banner must be visible.
-    const errorBanner = page.locator('[role="alert"]');
-    await expect(errorBanner).toBeVisible({ timeout: 5000 });
-
-    // No API call should have been made.
     expect(apiCallMade).toBe(false);
   });
 
@@ -187,17 +142,11 @@ test.describe('OAuth Callback Flow (AuthCallbackPage)', () => {
     );
 
     let apiCallMade = false;
-    await page.route('**/api/v1/auth/sso/callback', async (route) => {
+    await page.route(SSO_CALLBACK_ENDPOINT, async (route) => {
       apiCallMade = true;
       await route.fulfill({ status: 400, body: '{}' });
     });
-    await page.route('**/api/v1/**', async (route) => {
-      if (route.request().url().includes('/api/v1/auth/sso/callback')) {
-        await route.continue();
-      } else {
-        await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
-      }
-    });
+    await stubOtherApis(page);
 
     await page.goto('/auth/callback?code=auth-code-duplicate&state=any-state');
 
@@ -212,19 +161,11 @@ test.describe('OAuth Callback Flow (AuthCallbackPage)', () => {
 
   test('renders error banner when authorization code or state is missing', async ({ page }) => {
     // Seed a valid state so the nonce check passes, but omit the code param.
-    await page.evaluate(
-      ({ key, value }) => {
-        sessionStorage.setItem(key, value);
-      },
-      { key: SSO_STATE_KEY, value: 'state-no-code' }
-    );
+    await seedSsoState(page, 'state-no-code');
 
     await page.goto('/auth/callback?state=state-no-code');
 
-    await page.waitForLoadState('networkidle');
-
-    const errorBanner = page.locator('[role="alert"]');
-    await expect(errorBanner).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('[role="alert"]')).toBeVisible({ timeout: 5000 });
   });
 
   // -------------------------------------------------------------------------
@@ -234,14 +175,9 @@ test.describe('OAuth Callback Flow (AuthCallbackPage)', () => {
   test('renders error banner and stores no tokens when API returns an error', async ({ page }) => {
     const failState = 'csrf-state-fail-001';
 
-    await page.evaluate(
-      ({ key, value }) => {
-        sessionStorage.setItem(key, value);
-      },
-      { key: SSO_STATE_KEY, value: failState }
-    );
+    await seedSsoState(page, failState);
 
-    await page.route('**/api/v1/auth/sso/callback', async (route) => {
+    await page.route(SSO_CALLBACK_ENDPOINT, async (route) => {
       await route.fulfill({
         status: 400,
         contentType: 'application/json',
@@ -251,13 +187,9 @@ test.describe('OAuth Callback Flow (AuthCallbackPage)', () => {
 
     await page.goto(`/auth/callback?code=auth-code-bad-001&state=${failState}`);
 
-    await page.waitForLoadState('networkidle');
-
-    const errorBanner = page.locator('[role="alert"]');
-    await expect(errorBanner).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('[role="alert"]')).toBeVisible({ timeout: 5000 });
 
     // Tokens must NOT have been written.
-    const storedAt = await page.evaluate((key) => localStorage.getItem(key), ACCESS_TOKEN_KEY);
-    expect(storedAt).toBeNull();
+    expect(await readLocalStorage(page, ACCESS_TOKEN_KEY)).toBeNull();
   });
 });


### PR DESCRIPTION
## Task
ppt-web e2e `auth-refresh.spec.ts` (+252 lines, story 79-2 token-refresh coverage) added in PR #1047 is a churn hotspot. Stabilize / de-flake and tidy this e2e spec: `frontend/apps/ppt-web/e2e/auth-refresh.spec.ts`. Reduce duplication, harden selectors/waits, keep coverage equivalent or better. Test-quality refactor, not new behavior.

## Owner
pm-security

## What changed
- **New `e2e/auth-helpers.ts`** — single source of truth for the JWT builders (`makeJwt`, `nowPlus`, `managerAccessToken`), storage keys (`ACCESS_TOKEN_KEY`/`REFRESH_TOKEN_KEY`/`USER_KEY`/`SSO_STATE_KEY`), endpoint glob constants, `MOCK_USER`, and the localStorage seed/read + route-stub helpers. These were previously **duplicated** across `auth-refresh.spec.ts` and `oauth-callback.spec.ts`.
- **`auth-refresh.spec.ts`** refactored onto the shared helpers; per-test boilerplate (inline `makeJwt`, repeated `page.evaluate` storage seeding/reading, inline `stubOtherApis`) removed.
- **`oauth-callback.spec.ts`** also migrated onto the shared helpers (it was the source of the cross-file duplication), behavior identical.

### De-flaking
- Replaced flaky `page.waitForLoadState('networkidle')` + bare post-read `localStorage.getItem` with:
  - web-first `expect(page).toHaveURL(...)` / `page.waitForURL(...)` for redirect assertions, and
  - an `expect.poll`-based `expectLocalStorage` that retries until AuthContext finishes persisting the rotated tokens — removing the race that caused the token-rotation assertions to flake.
- Centralized timeouts; converted the visible-banner checks to web-first `toBeVisible` assertions.

### Coverage
Unchanged: 4 refresh scenarios + 5 callback scenarios, same assertions (rotation persisted, request carries OLD refresh token, exactly-once call, stale-token clear, no-call short-circuit).

## Tested (Band A — fast check)
- `pnpm -F @ppt/web typecheck` (runs `tsc --noEmit` + `tsc -p tsconfig.e2e.json`) → exit 0
- `npx @biomejs/biome check <3 changed e2e files>` → exit 0 (after `--write` import-organize)

Note: the package's `lint` script (`eslint . --ext ts,tsx`) is pre-existing/stale — the repo's actual lint gate is Biome (`pnpm check`, per CLAUDE.md). Ran Biome instead; clean.

## Built (Band B — full build)
skipped: change is test-only (no app/public-API/config/build-output touch).

## CI parity (Band C — hot-path only)
skipped: test-quality refactor, no security/auth/billing/data-integrity behavior change. Playwright e2e run requires a live dev server (localhost:3000) not available in this sandbox; typecheck + Biome cover the static gate.

## Scope drift
`scope-check.sh --owner pm-security` exits 2: the touched files live under `frontend/apps/ppt-web/e2e/**` (frontend owner area), while the task owner is `pm-security`. Expected — this is a frontend test-quality task assigned to the pm-security role. No app/source code touched; diff is confined to the three e2e files.

## Code-reuse review
`reuse-grep.sh` emitted: `WARN: makeJwt looks like an existing helper at oauth-callback.spec.ts`. This is the intended de-duplication, not a re-implementation: `makeJwt`/`nowPlus` now have a SINGLE definition in `auth-helpers.ts`; both specs import it. (`grep "function makeJwt"` → only `auth-helpers.ts`.)

## Notes
Net diff: +246 / −253 across 3 files; duplication eliminated and a reusable, deterministic helper module added.

https://claude.ai/code/session_01YYqXbaK6bvae6X2kJHey3r

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYqXbaK6bvae6X2kJHey3r)_