### PR TITLE
dx-push-fanout-blpop-drain: implement PushFanoutWorker BLPOP queue-drain

### DIFF
--- a/backend/crates/integrations/src/redis.rs
+++ b/backend/crates/integrations/src/redis.rs
@@ -321,6 +321,64 @@ impl RedisClient {
         tracing::debug!(pattern = %full_pattern, deleted = deleted, "Cache DEL pattern");
         Ok(deleted)
     }
+
+    // =========================================================================
+    // List / Queue Operations (used by background fan-out workers)
+    // =========================================================================
+
+    /// Append a raw string value to the tail of a Redis list (`RPUSH`).
+    ///
+    /// Used as a simple FIFO job queue: producers `RPUSH` and consumers
+    /// `BLPOP` from the head. Returns the new length of the list.
+    pub async fn queue_push(&self, key: &str, value: &str) -> Result<u64, CacheError> {
+        let full_key = self.build_key(key);
+        let mut conn = self.connection_manager.clone();
+
+        let len: u64 = conn.rpush(&full_key, value).await?;
+        tracing::trace!(key = %full_key, len = len, "Queue RPUSH");
+        Ok(len)
+    }
+
+    /// Block until an element is available at the head of a Redis list, or the
+    /// timeout elapses (`BLPOP`).
+    ///
+    /// `timeout_secs == 0` blocks indefinitely (standard Redis semantics).
+    /// Returns `Ok(Some(value))` when an element was popped, or `Ok(None)` when
+    /// the timeout elapsed with no element available.
+    ///
+    /// NOTE: `BLPOP` holds the underlying connection for up to `timeout_secs`.
+    /// `ConnectionManager` multiplexes a single connection, so callers should
+    /// use a modest timeout (a few seconds) rather than blocking forever, to
+    /// avoid starving other commands that share the manager.
+    pub async fn queue_pop_blocking(
+        &self,
+        key: &str,
+        timeout_secs: f64,
+    ) -> Result<Option<String>, CacheError> {
+        let full_key = self.build_key(key);
+        let mut conn = self.connection_manager.clone();
+
+        // BLPOP returns `[key, value]` on success or nil (→ None) on timeout.
+        let popped: Option<(String, String)> = conn.blpop(&full_key, timeout_secs).await?;
+        match popped {
+            Some((_popped_key, value)) => {
+                tracing::trace!(key = %full_key, "Queue BLPOP hit");
+                Ok(Some(value))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Return the current length of a Redis list (`LLEN`).
+    ///
+    /// Useful for queue-depth metrics / alerting.
+    pub async fn queue_len(&self, key: &str) -> Result<u64, CacheError> {
+        let full_key = self.build_key(key);
+        let mut conn = self.connection_manager.clone();
+
+        let len: u64 = conn.llen(&full_key).await?;
+        Ok(len)
+    }
 }
 
 // ============================================================================
@@ -776,6 +834,16 @@ impl PubSubService {
     /// Get the instance ID.
     pub fn instance_id(&self) -> &str {
         &self.instance_id
+    }
+
+    /// Borrow the underlying [`RedisClient`].
+    ///
+    /// Exposes the raw client so callers that hold a `PubSubService` (the only
+    /// Redis handle threaded into the background workers) can run list/queue
+    /// commands (`RPUSH` / `BLPOP` / `LLEN`) for fan-out job queues without a
+    /// second connection handle.
+    pub fn client(&self) -> &RedisClient {
+        &self.client
     }
 }
 

--- a/backend/servers/api-server/src/services/push_fanout.rs
+++ b/backend/servers/api-server/src/services/push_fanout.rs
@@ -853,14 +853,21 @@ mod tests {
         .with_priority(common::notifications::NotificationPriority::High);
 
         let payload = serde_json::to_string(&original).expect("serialize notification");
-        let decoded: Notification = serde_json::from_str(&payload).expect("deserialize notification");
+        let decoded: Notification =
+            serde_json::from_str(&payload).expect("deserialize notification");
 
         assert_eq!(decoded.id, original.id);
         assert_eq!(decoded.user_id, user_id);
         assert_eq!(decoded.title, "Building update");
         assert_eq!(decoded.body, "The lift will be serviced tomorrow.");
-        assert_eq!(decoded.category, common::notifications::NotificationCategory::Announcements);
-        assert_eq!(decoded.priority, common::notifications::NotificationPriority::High);
+        assert_eq!(
+            decoded.category,
+            common::notifications::NotificationCategory::Announcements
+        );
+        assert_eq!(
+            decoded.priority,
+            common::notifications::NotificationPriority::High
+        );
     }
 
     #[test]

--- a/backend/servers/api-server/src/services/push_fanout.rs
+++ b/backend/servers/api-server/src/services/push_fanout.rs
@@ -556,25 +556,49 @@ impl PushFanoutConfig {
     }
 }
 
+/// Redis list key the notification pipeline enqueues push jobs onto.
+///
+/// Producers `RPUSH` a JSON-serialized [`Notification`] onto this list; the
+/// worker `BLPOP`s from the head and delivers each one via [`FcmHttpAdapter`].
+pub const PUSH_FANOUT_QUEUE_KEY: &str = "push_fanout_queue";
+
+/// BLPOP block timeout (seconds) used when draining the queue.
+///
+/// Kept short so the single multiplexed `ConnectionManager` connection is not
+/// held for long and other Redis commands are not starved. When the queue is
+/// empty, BLPOP returns after this timeout and the drain yields back to the
+/// poll ticker.
+const BLPOP_TIMEOUT_SECS: f64 = 2.0;
+
+/// Safety cap on the number of jobs drained per poll tick, so a flooded queue
+/// can't make a single tick run unbounded.
+const MAX_JOBS_PER_TICK: usize = 256;
+
 /// Background worker that fans out pending push notifications.
 ///
 /// ## Delivery model
 ///
-/// The worker polls a Redis list (`push_fanout_queue`) for pending job payloads
-/// enqueued by the notification pipeline.  Each payload is a JSON object:
+/// The worker drains a Redis list ([`PUSH_FANOUT_QUEUE_KEY`]) for pending job
+/// payloads enqueued by the notification pipeline.  Each payload is a
+/// JSON-serialized [`Notification`]:
 /// ```json
 /// {
+///   "id": "<uuid>",
 ///   "user_id": "<uuid>",
-///   "notification_id": "<uuid>",
+///   "category": "announcements",
 ///   "title": "...",
 ///   "body": "...",
-///   "category": "announcements",
 ///   "priority": "normal"
 /// }
 /// ```
 ///
+/// On each tick the worker `BLPOP`s from the head of the list (short timeout)
+/// and delivers each job via [`FcmHttpAdapter::send`], up to
+/// [`MAX_JOBS_PER_TICK`] jobs per tick.
+///
 /// When Redis is not available (or the worker is disabled) the worker falls
-/// through to a no-op heartbeat loop so the server always starts cleanly.
+/// through to a no-op heartbeat loop so the server always starts cleanly — the
+/// in-process pipeline still delivers push synchronously in that mode.
 pub struct PushFanoutWorker {
     adapter: Arc<FcmHttpAdapter>,
     config: PushFanoutConfig,
@@ -629,12 +653,14 @@ impl PushFanoutWorker {
         )
     }
 
-    /// Process all pending push jobs from the queue.
+    /// Process pending push jobs from the queue.
     ///
-    /// When Redis pubsub is available we pop messages from `push_fanout_queue`.
-    /// When Redis is not available we just log a heartbeat.
+    /// When Redis is available we `BLPOP` jobs off [`PUSH_FANOUT_QUEUE_KEY`] and
+    /// deliver each one via [`FcmHttpAdapter::send`], up to
+    /// [`MAX_JOBS_PER_TICK`] jobs per tick. When Redis is not available we just
+    /// log a heartbeat (the in-process pipeline delivers push synchronously).
     async fn process_pending_jobs(&self) {
-        let Some(ref _pubsub) = self.pubsub else {
+        let Some(ref pubsub) = self.pubsub else {
             // No Redis — nothing to drain; log at trace to avoid spam
             tracing::trace!(
                 "[8A-3] PushFanoutWorker heartbeat (no Redis; in-process pipeline handles push)"
@@ -642,17 +668,85 @@ impl PushFanoutWorker {
             return;
         };
 
-        // TODO: wire BLPOP drain in follow-up PR; real delivery happens synchronously via FcmHttpAdapter::send in the pipeline
-        // When Redis is available: drain the push_fanout_queue.
-        // The `PubSubService` abstraction in `integrations` is pub/sub-oriented;
-        // a proper queue-drain would use `BLPOP` / `LPOP` on the raw Redis client.
-        // We log a debug message here and leave the BLPOP wiring for the follow-up
-        // that adds the dedicated Redis queue — the real delivery happens
-        // synchronously inside `FcmHttpAdapter::send` which is called by
-        // `NotificationPipeline::dispatch` (see notification_pipeline.rs).
-        tracing::debug!(
-            "[8A-3] PushFanoutWorker tick — in-process push delivery active via FcmHttpAdapter"
-        );
+        let redis = pubsub.client();
+        let mut drained = 0usize;
+
+        // Drain up to MAX_JOBS_PER_TICK jobs. BLPOP with a short timeout means
+        // an empty queue ends the drain promptly and yields back to the ticker;
+        // a backed-up queue is bounded by MAX_JOBS_PER_TICK per tick.
+        for _ in 0..MAX_JOBS_PER_TICK {
+            let payload = match redis
+                .queue_pop_blocking(PUSH_FANOUT_QUEUE_KEY, BLPOP_TIMEOUT_SECS)
+                .await
+            {
+                Ok(Some(payload)) => payload,
+                // Timed out with an empty queue — nothing more to do this tick.
+                Ok(None) => break,
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "[8A-3] PushFanoutWorker: BLPOP on push_fanout_queue failed; backing off until next tick"
+                    );
+                    break;
+                }
+            };
+
+            self.deliver_job(&payload).await;
+            drained += 1;
+        }
+
+        if drained > 0 {
+            tracing::info!(
+                drained = drained,
+                "[8A-3] PushFanoutWorker drained push_fanout_queue"
+            );
+        }
+    }
+
+    /// Deliver a single queued job payload.
+    ///
+    /// The payload is a JSON-serialized [`Notification`]. A malformed payload is
+    /// logged and dropped (it has already been popped off the list, so it is not
+    /// retried — re-queuing a poison message would loop forever).
+    async fn deliver_job(&self, payload: &str) {
+        let notification: Notification = match serde_json::from_str(payload) {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "[8A-3] PushFanoutWorker: dropping malformed push_fanout_queue payload"
+                );
+                return;
+            }
+        };
+
+        // `device_tokens` is unused by `FcmHttpAdapter::send` (it re-fetches the
+        // user's tokens from the DB), so an empty slice is fine here.
+        match self
+            .adapter
+            .send(notification.user_id, &[], &notification)
+            .await
+        {
+            Ok(()) => {
+                tracing::debug!(
+                    notification_id = %notification.id,
+                    user_id = %notification.user_id,
+                    "[8A-3] PushFanoutWorker delivered queued push job"
+                );
+            }
+            Err(e) => {
+                // Delivery failed (FCM not configured, DB error, or all sends
+                // failed). The in-app channel remains the mandatory record, so
+                // we log and move on rather than re-queue (avoids hot-looping on
+                // a permanently failing job).
+                tracing::warn!(
+                    notification_id = %notification.id,
+                    user_id = %notification.user_id,
+                    error = %e,
+                    "[8A-3] PushFanoutWorker: push delivery failed for queued job"
+                );
+            }
+        }
     }
 }
 
@@ -735,5 +829,45 @@ mod tests {
         let config = PushFanoutConfig::default();
         assert!(config.enabled);
         assert_eq!(config.poll_interval_secs, 30);
+    }
+
+    #[test]
+    fn push_fanout_queue_key_is_stable() {
+        // The producer (notification pipeline) and the worker must agree on the
+        // list key. Pin it so a rename can't silently split producer/consumer.
+        assert_eq!(PUSH_FANOUT_QUEUE_KEY, "push_fanout_queue");
+    }
+
+    #[test]
+    fn queued_job_payload_roundtrips_to_notification() {
+        // A push job on the queue is a JSON-serialized `Notification`. The
+        // worker's `deliver_job` deserializes exactly this shape, so a
+        // round-trip here pins the queue contract.
+        let user_id = Uuid::new_v4();
+        let original = Notification::new(
+            user_id,
+            common::notifications::NotificationCategory::Announcements,
+            "Building update",
+            "The lift will be serviced tomorrow.",
+        )
+        .with_priority(common::notifications::NotificationPriority::High);
+
+        let payload = serde_json::to_string(&original).expect("serialize notification");
+        let decoded: Notification = serde_json::from_str(&payload).expect("deserialize notification");
+
+        assert_eq!(decoded.id, original.id);
+        assert_eq!(decoded.user_id, user_id);
+        assert_eq!(decoded.title, "Building update");
+        assert_eq!(decoded.body, "The lift will be serviced tomorrow.");
+        assert_eq!(decoded.category, common::notifications::NotificationCategory::Announcements);
+        assert_eq!(decoded.priority, common::notifications::NotificationPriority::High);
+    }
+
+    #[test]
+    fn malformed_queue_payload_fails_to_deserialize() {
+        // `deliver_job` drops payloads that don't parse as a `Notification`
+        // rather than re-queuing them (a poison message must not hot-loop).
+        let err = serde_json::from_str::<Notification>("{\"not\":\"a notification\"}");
+        assert!(err.is_err());
     }
 }


### PR DESCRIPTION
## Task
PushFanoutWorker BLPOP queue-drain is deferred — the Redis path is currently a logging no-op. Implement the actual BLPOP-based queue drain. File: `backend/servers/api-server/src/services/push_fanout.rs` (around line 621).

## Owner
pm-backend (specialist: rust-backend)

## What changed
The deferred no-op in `PushFanoutWorker::process_pending_jobs` is replaced with a real BLPOP-based drain of the `push_fanout_queue` Redis list:

- **`integrations/src/redis.rs`** — added list/queue ops to `RedisClient`:
  - `queue_push` (`RPUSH`) — producer-side enqueue (returns new list length)
  - `queue_pop_blocking` (`BLPOP`) — `Ok(Some(value))` on hit, `Ok(None)` on timeout
  - `queue_len` (`LLEN`) — queue-depth metric
  - `PubSubService::client()` accessor so the worker (which only holds a `PubSubService`) can reach the raw client without a second handle.
- **`api-server/.../push_fanout.rs`** — `process_pending_jobs` now BLPOPs jobs (short 2s timeout, bounded to `MAX_JOBS_PER_TICK = 256` per tick) and delivers each via `FcmHttpAdapter::send`. Job payload is a JSON-serialized `Notification` (`Notification` is already `Serialize`/`Deserialize`). Malformed payloads are logged and dropped (no re-queue → no poison-message hot-loop). Delivery failures are logged, not re-queued (in-app remains the mandatory record channel). The no-Redis heartbeat path is unchanged, so the server still starts cleanly without Redis.

Added queue-key constant `PUSH_FANOUT_QUEUE_KEY` shared by producer/consumer.

## Notes for reviewer
- No producer currently enqueues to `push_fanout_queue` (verified by grep) — real delivery still also happens synchronously inside `FcmHttpAdapter::send` via `NotificationPipeline::dispatch`. This PR makes the queue path functional so any future async producer is actually drained instead of silently dropped (the original gap from PR #515).
- BLPOP uses a short timeout because `ConnectionManager` multiplexes a single connection; a long block would starve other Redis commands. Documented inline.
- `Cargo.lock` had pre-existing workspace-version drift (0.3.44 → 0.3.61) that the build refreshed; reverted to keep the diff to the two relevant source files.

## Tested (Band A — fast check)
- `SQLX_OFFLINE=true cargo check -p integrations` — exit 0
- `SQLX_OFFLINE=true cargo check -p api-server` — exit 0
- `SQLX_OFFLINE=true cargo test -p api-server --lib push_fanout` — exit 0 (10 passed; 3 new: `push_fanout_queue_key_is_stable`, `queued_job_payload_roundtrips_to_notification`, `malformed_queue_payload_fails_to_deserialize`)
- `SQLX_OFFLINE=true cargo test -p integrations --lib redis` — exit 0 (5 passed)

## Built (Band B — full build)
- `SQLX_OFFLINE=true cargo clippy -p integrations -p api-server -- -D warnings` — exit 0 (non-trivial change + public API surface added to integrations crate)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Scope drift
none — `scope-check.sh --owner pm-backend` exit 0

## Code-reuse review
none — `reuse-grep.sh --specialist rust-backend` exit 0

https://claude.ai/code/session_01YYqXbaK6bvae6X2kJHey3r

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYqXbaK6bvae6X2kJHey3r)_