### PR TITLE
refactor-evidenceuploader-test-tsx-churn: de-duplicate and harden EvidenceUploader tests

### DIFF
--- a/frontend/apps/ppt-web/src/features/disputes/components/EvidenceUploader.test.tsx
+++ b/frontend/apps/ppt-web/src/features/disputes/components/EvidenceUploader.test.tsx
@@ -13,190 +13,193 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { EvidenceUploader, type PendingEvidence } from './EvidenceUploader';
 
+const MAX_FILES = 10;
+const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB — mirrors the component cap.
+
 // jsdom has no real object-URL support — stub it so image previews don't throw.
 const mockCreateObjectURL = vi.fn(() => 'blob:mock-url');
 const mockRevokeObjectURL = vi.fn();
 URL.createObjectURL = mockCreateObjectURL;
 URL.revokeObjectURL = mockRevokeObjectURL;
 
+const onChange = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+/** Build a File with an overridable size (jsdom derives size from blob parts). */
 function makeFile(name: string, type: string, sizeBytes = 1024): File {
   const file = new File(['x'], name, { type });
-  // jsdom derives size from the blob parts; override for size-limit tests.
   Object.defineProperty(file, 'size', { value: sizeBytes });
   return file;
 }
 
+/** Build a single pending-evidence entry, overriding any field as needed. */
+function pendingEvidence(overrides: Partial<PendingEvidence> = {}): PendingEvidence {
+  return {
+    id: 'ev-1',
+    file: makeFile('photo.jpg', 'image/jpeg'),
+    description: '',
+    status: 'pending',
+    ...overrides,
+  };
+}
+
+/** Build `count` pending PDF entries — used for the MAX_FILES cap cases. */
+function pdfQueue(count: number): PendingEvidence[] {
+  return Array.from({ length: count }, (_, i) =>
+    pendingEvidence({ id: `ev-${i}`, file: makeFile(`f${i}.pdf`, 'application/pdf') })
+  );
+}
+
+/** Render the uploader with a fresh `onChange` spy and the given queue. */
+function renderUploader(files: PendingEvidence[] = []) {
+  return render(<EvidenceUploader files={files} onChange={onChange} />);
+}
+
+/** Drive the hidden file input with a selection of files. */
 function selectFiles(files: File[]) {
   const input = document.querySelector('input[type="file"]') as HTMLInputElement;
   Object.defineProperty(input, 'files', { value: files, configurable: true });
   fireEvent.change(input);
 }
 
+/** The queue handed to the most recent `onChange` call (asserts one happened). */
+function lastChange(): PendingEvidence[] {
+  expect(onChange).toHaveBeenCalled();
+  return onChange.mock.lastCall?.[0] as PendingEvidence[];
+}
+
 describe('EvidenceUploader', () => {
-  const onChange = vi.fn();
+  describe('empty state', () => {
+    it('renders the drop zone with the accepted-format hint', () => {
+      renderUploader();
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('renders the drop zone with the accepted-format hint when empty', () => {
-    render(<EvidenceUploader files={[]} onChange={onChange} />);
-
-    expect(
-      screen.getByRole('button', { name: /drop evidence files here or click to browse/i })
-    ).toBeInTheDocument();
-    expect(screen.getByText(/JPG, PNG, PDF, MP3, MP4/i)).toBeInTheDocument();
-  });
-
-  it('exposes the accepted extensions and multiple attribute on the file input', () => {
-    render(<EvidenceUploader files={[]} onChange={onChange} />);
-
-    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
-    expect(input).toHaveAttribute('accept', '.jpg,.jpeg,.png,.webp,.mp3,.mp4,.pdf');
-    expect(input).toHaveAttribute('multiple');
-  });
-
-  it('accepts a valid file with pending status and creates an image preview', () => {
-    render(<EvidenceUploader files={[]} onChange={onChange} />);
-
-    selectFiles([makeFile('photo.jpg', 'image/jpeg')]);
-
-    expect(onChange).toHaveBeenCalledTimes(1);
-    const next: PendingEvidence[] = onChange.mock.calls[0][0];
-    expect(next).toHaveLength(1);
-    expect(next[0].status).toBe('pending');
-    expect(next[0].error).toBeUndefined();
-    expect(next[0].preview).toBe('blob:mock-url');
-    expect(mockCreateObjectURL).toHaveBeenCalledTimes(1);
-  });
-
-  it('marks an unsupported file type as error and skips the preview', () => {
-    render(<EvidenceUploader files={[]} onChange={onChange} />);
-
-    selectFiles([makeFile('virus.exe', 'application/x-msdownload')]);
-
-    const next: PendingEvidence[] = onChange.mock.calls[0][0];
-    expect(next[0].status).toBe('error');
-    expect(next[0].error).toMatch(/unsupported file type/i);
-    expect(next[0].preview).toBeUndefined();
-    expect(mockCreateObjectURL).not.toHaveBeenCalled();
-  });
-
-  it('marks a file exceeding the 50 MB limit as error', () => {
-    render(<EvidenceUploader files={[]} onChange={onChange} />);
-
-    selectFiles([makeFile('huge.pdf', 'application/pdf', 51 * 1024 * 1024)]);
-
-    const next: PendingEvidence[] = onChange.mock.calls[0][0];
-    expect(next[0].status).toBe('error');
-    expect(next[0].error).toMatch(/max 50 MB/i);
-  });
-
-  it('caps the queue at 10 files and hides the drop zone when full', () => {
-    const full: PendingEvidence[] = Array.from({ length: 10 }, (_, i) => ({
-      id: `ev-${i}`,
-      file: makeFile(`f${i}.pdf`, 'application/pdf'),
-      description: '',
-      status: 'pending',
-    }));
-
-    render(<EvidenceUploader files={full} onChange={onChange} />);
-
-    // Drop zone is gone once the cap is reached (the hidden file input itself
-    // stays mounted; only the clickable drop zone is conditional).
-    expect(
-      screen.queryByRole('button', { name: /drop evidence files here/i })
-    ).not.toBeInTheDocument();
-    // All 10 queued files are still listed.
-    expect(screen.getByRole('list', { name: /evidence files/i })).toBeInTheDocument();
-  });
-
-  it('drops files beyond the remaining slots', () => {
-    const existing: PendingEvidence[] = Array.from({ length: 9 }, (_, i) => ({
-      id: `ev-${i}`,
-      file: makeFile(`f${i}.pdf`, 'application/pdf'),
-      description: '',
-      status: 'pending',
-    }));
-
-    render(<EvidenceUploader files={existing} onChange={onChange} />);
-
-    // Two incoming files, but only one slot remains.
-    selectFiles([makeFile('a.pdf', 'application/pdf'), makeFile('b.pdf', 'application/pdf')]);
-
-    const next: PendingEvidence[] = onChange.mock.calls[0][0];
-    expect(next).toHaveLength(10);
-  });
-
-  it('removes a queued file and revokes its object URL', () => {
-    const files: PendingEvidence[] = [
-      {
-        id: 'ev-1',
-        file: makeFile('photo.jpg', 'image/jpeg'),
-        description: '',
-        preview: 'blob:mock-url',
-        status: 'pending',
-      },
-    ];
-
-    render(<EvidenceUploader files={files} onChange={onChange} />);
-
-    fireEvent.click(screen.getByRole('button', { name: /remove photo\.jpg/i }));
-
-    expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
-    expect(onChange).toHaveBeenCalledWith([]);
-  });
-
-  it('edits a per-file description through onChange', () => {
-    const files: PendingEvidence[] = [
-      {
-        id: 'ev-1',
-        file: makeFile('clip.mp4', 'video/mp4'),
-        description: '',
-        status: 'pending',
-      },
-    ];
-
-    render(<EvidenceUploader files={files} onChange={onChange} />);
-
-    fireEvent.change(screen.getByLabelText(/description for clip\.mp4/i), {
-      target: { value: 'noise recording' },
+      expect(
+        screen.getByRole('button', { name: /drop evidence files here or click to browse/i })
+      ).toBeInTheDocument();
+      expect(screen.getByText(/JPG, PNG, PDF, MP3, MP4/i)).toBeInTheDocument();
     });
 
-    const next: PendingEvidence[] = onChange.mock.calls[0][0];
-    expect(next[0].description).toBe('noise recording');
+    it('exposes the accepted extensions and multiple attribute on the file input', () => {
+      renderUploader();
+
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+      expect(input).toHaveAttribute('accept', '.jpg,.jpeg,.png,.webp,.mp3,.mp4,.pdf');
+      expect(input).toHaveAttribute('multiple');
+    });
   });
 
-  it('shows the error message for an errored file and omits its description input', () => {
-    const files: PendingEvidence[] = [
-      {
-        id: 'ev-1',
-        file: makeFile('bad.exe', 'application/x-msdownload'),
-        description: '',
-        status: 'error',
-        error: 'Unsupported file type: application/x-msdownload',
-      },
-    ];
+  describe('file selection + validation', () => {
+    it('accepts a valid file with pending status and creates an image preview', () => {
+      renderUploader();
 
-    render(<EvidenceUploader files={files} onChange={onChange} />);
+      selectFiles([makeFile('photo.jpg', 'image/jpeg')]);
 
-    expect(screen.getByText(/unsupported file type/i)).toBeInTheDocument();
-    expect(screen.queryByLabelText(/description for bad\.exe/i)).not.toBeInTheDocument();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const next = lastChange();
+      expect(next).toHaveLength(1);
+      expect(next[0].status).toBe('pending');
+      expect(next[0].error).toBeUndefined();
+      expect(next[0].preview).toBe('blob:mock-url');
+      expect(mockCreateObjectURL).toHaveBeenCalledTimes(1);
+    });
+
+    it('marks an unsupported file type as error and skips the preview', () => {
+      renderUploader();
+
+      selectFiles([makeFile('virus.exe', 'application/x-msdownload')]);
+
+      const next = lastChange();
+      expect(next[0].status).toBe('error');
+      expect(next[0].error).toMatch(/unsupported file type/i);
+      expect(next[0].preview).toBeUndefined();
+      expect(mockCreateObjectURL).not.toHaveBeenCalled();
+    });
+
+    it('marks a file exceeding the 50 MB limit as error', () => {
+      renderUploader();
+
+      selectFiles([makeFile('huge.pdf', 'application/pdf', MAX_FILE_SIZE + 1)]);
+
+      const next = lastChange();
+      expect(next[0].status).toBe('error');
+      expect(next[0].error).toMatch(/max 50 MB/i);
+    });
   });
 
-  it('renders an uploading spinner and a disabled remove button mid-upload', () => {
-    const files: PendingEvidence[] = [
-      {
-        id: 'ev-1',
-        file: makeFile('doc.pdf', 'application/pdf'),
-        description: '',
-        status: 'uploading',
-      },
-    ];
+  describe('MAX_FILES cap', () => {
+    it('hides the drop zone but keeps listing files when full', () => {
+      renderUploader(pdfQueue(MAX_FILES));
 
-    render(<EvidenceUploader files={files} onChange={onChange} />);
+      // The clickable drop zone is conditional; the hidden input stays mounted.
+      expect(
+        screen.queryByRole('button', { name: /drop evidence files here/i })
+      ).not.toBeInTheDocument();
+      expect(screen.getByRole('list', { name: /evidence files/i })).toBeInTheDocument();
+    });
 
-    expect(screen.getByLabelText(/uploading/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /remove doc\.pdf/i })).toBeDisabled();
+    it('drops files beyond the remaining slots', () => {
+      renderUploader(pdfQueue(MAX_FILES - 1));
+
+      // Two incoming files, but only one slot remains.
+      selectFiles([makeFile('a.pdf', 'application/pdf'), makeFile('b.pdf', 'application/pdf')]);
+
+      expect(lastChange()).toHaveLength(MAX_FILES);
+    });
+  });
+
+  describe('per-file actions', () => {
+    it('removes a queued file and revokes its object URL', () => {
+      renderUploader([pendingEvidence({ preview: 'blob:mock-url' })]);
+
+      fireEvent.click(screen.getByRole('button', { name: /remove photo\.jpg/i }));
+
+      expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+      expect(onChange).toHaveBeenCalledWith([]);
+    });
+
+    it('edits a per-file description through onChange', () => {
+      renderUploader([pendingEvidence({ file: makeFile('clip.mp4', 'video/mp4') })]);
+
+      fireEvent.change(screen.getByLabelText(/description for clip\.mp4/i), {
+        target: { value: 'noise recording' },
+      });
+
+      expect(lastChange()[0].description).toBe('noise recording');
+    });
+  });
+
+  describe('status indicators', () => {
+    it('shows the error message for an errored file and omits its description input', () => {
+      renderUploader([
+        pendingEvidence({
+          file: makeFile('bad.exe', 'application/x-msdownload'),
+          status: 'error',
+          error: 'Unsupported file type: application/x-msdownload',
+        }),
+      ]);
+
+      expect(screen.getByText(/unsupported file type/i)).toBeInTheDocument();
+      expect(screen.queryByLabelText(/description for bad\.exe/i)).not.toBeInTheDocument();
+    });
+
+    it('renders an uploading spinner and a disabled remove button mid-upload', () => {
+      renderUploader([
+        pendingEvidence({ file: makeFile('doc.pdf', 'application/pdf'), status: 'uploading' }),
+      ]);
+
+      expect(screen.getByLabelText(/uploading/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /remove doc\.pdf/i })).toBeDisabled();
+    });
+
+    it('renders an uploaded checkmark when a file finished uploading', () => {
+      renderUploader([
+        pendingEvidence({ file: makeFile('doc.pdf', 'application/pdf'), status: 'uploaded' }),
+      ]);
+
+      expect(screen.getByLabelText(/uploaded/i)).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Task
ppt-web EvidenceUploader.test.tsx is a churn hotspot (+202 lines, dispute-filing AC-2 regression). Refactor/de-duplicate and stabilize this test file: `frontend/apps/ppt-web/src/features/disputes/components/EvidenceUploader.test.tsx`. Reduce duplication, harden, keep coverage equivalent or better. Test-quality refactor, not new behavior. [src: PR #1048]

## Owner
pm-frontend

## What changed
Test-quality refactor only — no component (`EvidenceUploader.tsx`) changes.

- Extracted helpers to remove duplication: `renderUploader`, `pendingEvidence` (factory with overrides), `pdfQueue(count)`, and `lastChange()` (asserts an `onChange` happened then returns its last payload). This collapses the repeated `render(<EvidenceUploader .../>)`, hand-built `PendingEvidence[]` literals, `Array.from(...)` queues, and `onChange.mock.calls[0][0]` access scattered across the file.
- Replaced magic numbers with named `MAX_FILES` / `MAX_FILE_SIZE` constants mirroring the component cap (size test now uses `MAX_FILE_SIZE + 1` instead of a literal `51 * 1024 * 1024`).
- Grouped cases into `describe` blocks (empty state, file selection + validation, MAX_FILES cap, per-file actions, status indicators) for readability.
- Hardened: `lastChange()` now uses `mock.lastCall` and asserts a call occurred (no silent `undefined` on a missing callback); added one new case covering the previously-untested `uploaded` status checkmark.

Coverage: equivalent-or-better — all 11 original behaviors preserved, +1 new (`uploaded` indicator). 12 tests pass.

## Tested (Band A — fast check)
- `pnpm -F @ppt/web typecheck` → exit 0
- `vitest run src/features/disputes/components/EvidenceUploader.test.tsx` → exit 0 — Test Files 1 passed, Tests 12 passed
- `biome check src/features/disputes/components/EvidenceUploader.test.tsx` → exit 0 — no fixes applied

## Built (Band B — full build)
skipped: test-only change, no public API / config / build-output touch.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change; tests only).

## Remote-tested
skipped

## Scope drift
None — only `frontend/apps/ppt-web/src/features/disputes/components/EvidenceUploader.test.tsx` changed; `scope-check.sh --owner pm-frontend` exit 0.

## Code-reuse review
none

## Notes
Pure test-quality refactor; component behavior unchanged. The "+202 lines" churn was the file's initial creation (single commit on `dev`); this PR reduces per-test boilerplate so future edits touch shared helpers rather than every case.

https://claude.ai/code/session_012DhWd64XoscUJpe1gM8hXt

---
_Generated by [Claude Code](https://claude.ai/code/session_012DhWd64XoscUJpe1gM8hXt)_