### PR TITLE
test-gap-mobile-voting-transforms: unit-test mobile VotingScreen toUiStatus/toUiVote

### DIFF
--- a/frontend/apps/mobile/src/screens/voting/VotingScreen.test.ts
+++ b/frontend/apps/mobile/src/screens/voting/VotingScreen.test.ts
@@ -1,4 +1,5 @@
-import { formatVoteDate, parseVoteSummaries } from './VotingScreen';
+import type { ApiVoteSummary } from './VotingScreen';
+import { formatVoteDate, parseVoteSummaries, toUiStatus, toUiVote } from './VotingScreen';
 
 const validSummary = {
   id: 'vote-1',
@@ -68,5 +69,114 @@ describe('formatVoteDate', () => {
     ['de', /2026/],
   ])('includes the year for locale %s', (locale, yearMatcher) => {
     expect(formatVoteDate(iso, locale as string)).toMatch(yearMatcher as RegExp);
+  });
+});
+
+describe('toUiStatus', () => {
+  // 'active'/'open' collapse to the UI 'active' state…
+  it.each([['active'], ['open']])('maps %s to "active"', (status) => {
+    expect(toUiStatus(status)).toBe('active');
+  });
+
+  // …'closed'/'cancelled' collapse to the UI 'closed' state…
+  it.each([['closed'], ['cancelled']])('maps %s to "closed"', (status) => {
+    expect(toUiStatus(status)).toBe('closed');
+  });
+
+  // …and every other/unknown status falls through to 'pending' (the safe
+  // default) rather than leaking an unmapped backend string into the UI enum.
+  it.each([['draft'], ['scheduled'], ['archived'], ['unknown'], ['']])(
+    'maps unrecognised status %s to "pending"',
+    (status) => {
+      expect(toUiStatus(status)).toBe('pending');
+    }
+  );
+
+  it('returns a value in the VoteStatus union for any input', () => {
+    const allowed = new Set(['active', 'closed', 'pending']);
+    for (const status of ['active', 'open', 'closed', 'cancelled', 'whatever']) {
+      expect(allowed.has(toUiStatus(status))).toBe(true);
+    }
+  });
+});
+
+describe('toUiVote', () => {
+  const base: ApiVoteSummary = {
+    id: 'vote-1',
+    building_id: 'b-1',
+    title: 'Roof repair budget',
+    status: 'open',
+    end_at: '2026-07-01T00:00:00Z',
+    quorum_type: 'simple',
+    participation_count: 12,
+    eligible_count: 40,
+    quorum_met: false,
+  };
+
+  it('maps the summary onto the UI Vote shape', () => {
+    expect(toUiVote(base)).toEqual({
+      id: 'vote-1',
+      title: 'Roof repair budget',
+      description: '',
+      status: 'active',
+      type: 'simple',
+      options: [],
+      startsAt: '',
+      endsAt: '2026-07-01T00:00:00Z',
+      totalVotes: 12,
+      requiredQuorum: 40,
+      currentQuorum: 12,
+      hasVoted: false,
+      createdBy: 'Building Management',
+    });
+  });
+
+  it('routes the status through toUiStatus', () => {
+    expect(toUiVote({ ...base, status: 'cancelled' }).status).toBe('closed');
+    expect(toUiVote({ ...base, status: 'mystery' }).status).toBe('pending');
+  });
+
+  // The list endpoint omits options/results detail, so these are always the
+  // documented "summary" placeholders regardless of input.
+  it('always returns the summary-only placeholders', () => {
+    const ui = toUiVote(base);
+    expect(ui.description).toBe('');
+    expect(ui.type).toBe('simple');
+    expect(ui.options).toEqual([]);
+    expect(ui.startsAt).toBe('');
+    expect(ui.hasVoted).toBe(false);
+    expect(ui.createdBy).toBe('Building Management');
+  });
+
+  // participation_count → totalVotes AND currentQuorum (same source value).
+  it('uses participation_count for both totalVotes and currentQuorum', () => {
+    const ui = toUiVote({ ...base, participation_count: 7 });
+    expect(ui.totalVotes).toBe(7);
+    expect(ui.currentQuorum).toBe(7);
+  });
+
+  // Nullable numeric fields fall back to 0 rather than producing NaN in the
+  // quorum-progress width math on the screen.
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+  ])('defaults missing participation_count (%s) to 0', (_label, value) => {
+    const ui = toUiVote({ ...base, participation_count: value as number | null | undefined });
+    expect(ui.totalVotes).toBe(0);
+    expect(ui.currentQuorum).toBe(0);
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+  ])('defaults missing eligible_count (%s) to 0', (_label, value) => {
+    const ui = toUiVote({ ...base, eligible_count: value as number | null | undefined });
+    expect(ui.requiredQuorum).toBe(0);
+  });
+
+  it('preserves end_at as endsAt verbatim', () => {
+    expect(toUiVote({ ...base, end_at: '2030-01-02T03:04:05Z' }).endsAt).toBe(
+      '2030-01-02T03:04:05Z'
+    );
   });
 });

--- a/frontend/apps/mobile/src/screens/voting/VotingScreen.test.ts
+++ b/frontend/apps/mobile/src/screens/voting/VotingScreen.test.ts
@@ -85,12 +85,15 @@ describe('toUiStatus', () => {
 
   // …and every other/unknown status falls through to 'pending' (the safe
   // default) rather than leaking an unmapped backend string into the UI enum.
-  it.each([['draft'], ['scheduled'], ['archived'], ['unknown'], ['']])(
-    'maps unrecognised status %s to "pending"',
-    (status) => {
-      expect(toUiStatus(status)).toBe('pending');
-    }
-  );
+  it.each([
+    ['draft'],
+    ['scheduled'],
+    ['archived'],
+    ['unknown'],
+    [''],
+  ])('maps unrecognised status %s to "pending"', (status) => {
+    expect(toUiStatus(status)).toBe('pending');
+  });
 
   it('returns a value in the VoteStatus union for any input', () => {
     const allowed = new Set(['active', 'closed', 'pending']);

--- a/frontend/apps/mobile/src/screens/voting/VotingScreen.tsx
+++ b/frontend/apps/mobile/src/screens/voting/VotingScreen.tsx
@@ -32,7 +32,7 @@ export interface Vote {
 }
 
 /** Subset of `VoteSummary` from `GET /api/v1/voting`. */
-interface ApiVoteSummary {
+export interface ApiVoteSummary {
   id: string;
   building_id: string;
   title: string;
@@ -94,8 +94,11 @@ export function formatVoteDate(dateString: string, locale: string): string {
   });
 }
 
-/** Map the api-server's status string onto the UI's narrowed enum. */
-function toUiStatus(status: string): VoteStatus {
+/** Map the api-server's status string onto the UI's narrowed enum.
+ *
+ *  Exported so the pure status mapping can be unit-tested without rendering
+ *  the screen. */
+export function toUiStatus(status: string): VoteStatus {
   switch (status) {
     case 'active':
     case 'open':
@@ -110,8 +113,12 @@ function toUiStatus(status: string): VoteStatus {
 
 /** The list endpoint only returns summaries — no questions/options/results
  *  detail. The screen still renders, but inline voting is disabled until
- *  the user navigates into the (future) detail screen. */
-function toUiVote(s: ApiVoteSummary): Vote {
+ *  the user navigates into the (future) detail screen.
+ *
+ *  Exported so the summary→UI mapping (including the numeric `?? 0` fallbacks
+ *  and the `currentQuorum === participation_count` invariant) can be
+ *  unit-tested without rendering the screen. */
+export function toUiVote(s: ApiVoteSummary): Vote {
   const total = s.participation_count ?? 0;
   return {
     id: s.id,


### PR DESCRIPTION
## Task
Mobile VotingScreen pure transforms toUiStatus/toUiVote have no tests — add focused unit tests for these pure transform functions in frontend/apps/mobile. TDD: add the failing-first test (IG3) then confirm green against current code.

## Owner
pm-frontend (note: code lives under `frontend/apps/mobile/**`, which `owner-areas.json` maps to `pm-mobile` — see Scope drift)

## What changed
- `VotingScreen.tsx`: export the two previously module-private pure transforms `toUiStatus` and `toUiVote`, plus the `ApiVoteSummary` type, so they can be unit-tested without rendering the screen (no behaviour change — only visibility). Doc comments updated to note testability.
- `VotingScreen.test.ts`: add two `describe` blocks (16 new test cases):
  - `toUiStatus`: `active`/`open` → `active`; `closed`/`cancelled` → `closed`; unknown/empty → `pending`; output always within the `VoteStatus` union.
  - `toUiVote`: full summary→`Vote` mapping; status routed through `toUiStatus`; summary-only placeholders (`description`/`type`/`options`/`startsAt`/`hasVoted`/`createdBy`); `participation_count` drives both `totalVotes` and `currentQuorum`; `participation_count`/`eligible_count` `?? 0` fallbacks for null/undefined; `end_at` preserved as `endsAt`.

## IG3 — failing-first evidence
With the source transforms still module-private (export change stashed), the new tests fail as expected:
```
TypeError: (0 , _VotingScreen.toUiVote) is not a function
Tests: 19 failed, 14 passed, 33 total
```
After restoring the exports, all green (see Tested).

## Tested (Band A — fast check)
```
pnpm -F @ppt/mobile test -- VotingScreen   -> Test Suites: 1 passed; Tests: 33 passed, 33 total (exit 0)
pnpm -F @ppt/mobile typecheck              -> tsc --noEmit, no errors (exit 0)
biome check VotingScreen.tsx VotingScreen.test.ts -> Checked 2 files, no fixes applied (exit 0)
```

## Built (Band B — full build)
skipped: test-only change (~123 LOC of tests + 3 `export` keyword additions), no public API/runtime behaviour/config touch.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped

## Scope drift
`scope-check.sh --owner pm-frontend` returns exit 2 because both changed files live under `frontend/apps/mobile/**`, which `owner-areas.json` maps to `pm-mobile`, not `pm-frontend`. This is a benign owner-tag mismatch: the task explicitly targets `frontend/apps/mobile`. No files outside the mobile VotingScreen were touched.
- `frontend/apps/mobile/src/screens/voting/VotingScreen.tsx`
- `frontend/apps/mobile/src/screens/voting/VotingScreen.test.ts`

## Code-reuse review
`reuse-grep.sh --specialist react-native` returned no warnings. No new helpers — only made existing functions exportable and added tests.

## Notes
The 3 `export` additions are the minimal change needed to make the pure transforms unit-testable; runtime behaviour of the screen is unchanged (the functions are still consumed internally via the same call sites).

https://claude.ai/code/session_012DhWd64XoscUJpe1gM8hXt

---
_Generated by [Claude Code](https://claude.ai/code/session_012DhWd64XoscUJpe1gM8hXt)_