### PR TITLE
refactor-mediation-duplicated-spinner: extract shared Spinner component

### DIFF
--- a/frontend/apps/ppt-web/src/components/Spinner.tsx
+++ b/frontend/apps/ppt-web/src/components/Spinner.tsx
@@ -1,0 +1,43 @@
+/**
+ * Spinner
+ *
+ * Shared inline loading spinner used across ppt-web. Replaces the
+ * duplicated `animate-spin rounded-full ... border-b-2` markup that was
+ * inlined in several places (e.g. the mediation workspace + chat thread).
+ *
+ * Renders an accessible spinning indicator: a `role="status"` element with
+ * an `aria-label` (defaults to the shared `common.loading` translation).
+ */
+
+import { useTranslation } from 'react-i18next';
+
+export type SpinnerSize = 'sm' | 'md' | 'lg';
+
+const sizeClasses: Record<SpinnerSize, string> = {
+  sm: 'h-5 w-5',
+  md: 'h-8 w-8',
+  lg: 'h-10 w-10',
+};
+
+export interface SpinnerProps {
+  /** Visual size. Defaults to `md` (h-8 w-8). */
+  size?: SpinnerSize;
+  /** Accessible label. Defaults to the `common.loading` translation. */
+  label?: string;
+  /** Extra classes appended after the base spinner classes. */
+  className?: string;
+}
+
+export function Spinner({ size = 'md', label, className }: SpinnerProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      role="status"
+      aria-label={label ?? t('common.loading')}
+      className={`animate-spin rounded-full ${sizeClasses[size]} border-b-2 border-violet-600${
+        className ? ` ${className}` : ''
+      }`}
+    />
+  );
+}

--- a/frontend/apps/ppt-web/src/components/index.ts
+++ b/frontend/apps/ppt-web/src/components/index.ts
@@ -12,5 +12,7 @@ export { LanguageSwitcher } from './LanguageSwitcher';
 export { OfflineIndicator } from './OfflineIndicator';
 export type { ProtectedRouteProps } from './ProtectedRoute';
 export { ProtectedRoute } from './ProtectedRoute';
+export type { SpinnerProps, SpinnerSize } from './Spinner';
+export { Spinner } from './Spinner';
 export type { Toast, ToastAction, ToastType } from './Toast';
 export { ToastProvider, useToast } from './Toast';

--- a/frontend/apps/ppt-web/src/features/disputes/components/MediationChatThread.tsx
+++ b/frontend/apps/ppt-web/src/features/disputes/components/MediationChatThread.tsx
@@ -1,6 +1,7 @@
 import { useAddMediationNote, useMediationNotes } from '@ppt/api-client';
 import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Spinner } from '../../../components/Spinner';
 import { formatTime } from '../utils/formatTime';
 
 interface MediationChatThreadProps {
@@ -56,11 +57,7 @@ export function MediationChatThread({
   if (isLoading) {
     return (
       <div className="flex justify-center py-8">
-        <div
-          role="status"
-          aria-label={t('common.loading')}
-          className="animate-spin rounded-full h-8 w-8 border-b-2 border-violet-600"
-        />
+        <Spinner size="md" />
       </div>
     );
   }

--- a/frontend/apps/ppt-web/src/features/disputes/pages/MediationWorkspacePage.tsx
+++ b/frontend/apps/ppt-web/src/features/disputes/pages/MediationWorkspacePage.tsx
@@ -14,6 +14,7 @@ import {
 } from '@ppt/api-client';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Spinner } from '../../../components/Spinner';
 import { MediationAssignDialog } from '../components/MediationAssignDialog';
 import { MediationChatThread } from '../components/MediationChatThread';
 import { MediationEscalateDialog } from '../components/MediationEscalateDialog';
@@ -190,11 +191,7 @@ export function MediationWorkspacePage({
   if (disputeLoading && !dispute) {
     return (
       <div className="flex justify-center py-16">
-        <div
-          role="status"
-          aria-label={t('common.loading')}
-          className="animate-spin rounded-full h-10 w-10 border-b-2 border-violet-600"
-        />
+        <Spinner size="lg" />
       </div>
     );
   }


### PR DESCRIPTION
## Task
Duplicated `animate-spin` spinner markup across the mediation page + chat thread (no shared Spinner component). Extract a single shared Spinner component and use it in both places. Primary file: frontend/apps/ppt-web/src/features/disputes/pages/MediationWorkspacePage.tsx (plus the chat-thread spinner duplicate). Behavior/visual output identical. [src: PR #555, code-review 2026-05-27]

## Owner
pm-frontend

## What changed
- New `frontend/apps/ppt-web/src/components/Spinner.tsx` — a shared, accessible inline spinner (`role="status"` + `aria-label` defaulting to `common.loading`), with `sm`/`md`/`lg` sizes mapping to the existing `h-5 w-5` / `h-8 w-8` / `h-10 w-10` markup and the same `animate-spin rounded-full border-b-2 border-violet-600` classes. Exported from the `components` barrel.
- `MediationWorkspacePage.tsx` — replaced the inlined `h-10 w-10` loading spinner with `<Spinner size="lg" />`.
- `MediationChatThread.tsx` — replaced the inlined `h-8 w-8` loading spinner with `<Spinner size="md" />`.

DOM output (class string, `role`, `aria-label`) is byte-identical to the prior inline markup, so visual + accessibility behavior is unchanged.

### Code-reuse pre-flight
Grepped `src/components`, `ui`, `shared`, `common` for an existing Spinner/Loader/LoadingSpinner React component first — none existed (the only `animate-spin` "component" was `PageLoading`, a full-page CSS loader, not a drop-in inline spinner). `animate-spin` is duplicated across ~134 files repo-wide; this PR intentionally narrows scope to the two files named in the task (mediation page + chat thread). `reuse-grep.sh` returned no warnings.

### Spinner imports use the direct module path, not the barrel
Both consumers import `from '../../../components/Spinner'` rather than the `components` barrel. The barrel re-exports `LanguageSwitcher`, which transitively imports `src/i18n/index.ts` (`initReactI18next`). `MediationWorkspacePage.test.tsx` mocks `react-i18next` without `initReactI18next`, so importing through the barrel crashes that suite at load time. The direct import keeps the test graph clean. (Barrel export of `Spinner` is still added for other consumers.)

## Tested (Band A — fast check)
- `pnpm exec tsc --noEmit` (ppt-web typecheck) → exit 0
- `pnpm exec tsc --noEmit -p tsconfig.e2e.json` → exit 0
- `pnpm exec biome check` on the 4 changed files → "Checked 4 files. No fixes applied." exit 0
- `pnpm exec vitest run src/features/disputes` → 7 files / 50 tests passed (incl. `MediationWorkspacePage.test.tsx` loading-state assertion `getByRole('status', { name: 'Loading' })`)

## Built (Band B — full build)
skipped: change <50 LOC, pure component extraction, no public API/config touch.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped

## Notes
- `scope_drift=false` (all 4 files inside pm-frontend area), `code_reuse_warn=none`.
- Other violet spinners in the disputes family (`MediationTimelineView`, `MediationSessionsPanel`) are intentionally left untouched — out of the task's named scope. They are now obvious follow-up candidates for the same `Spinner` (sizes `sm`/`md` already cover them).

https://claude.ai/code/session_012DhWd64XoscUJpe1gM8hXt

---
_Generated by [Claude Code](https://claude.ai/code/session_012DhWd64XoscUJpe1gM8hXt)_