### PR TITLE
refactor-esignature-webhook-idempotency-tests-churn-2026-06-04: de-duplicate esignature webhook idempotency tests

### DIFF
--- a/backend/servers/api-server/tests/esignature_webhook_idempotency_tests.rs
+++ b/backend/servers/api-server/tests/esignature_webhook_idempotency_tests.rs
@@ -24,13 +24,32 @@
 mod common;
 
 use axum::http::StatusCode;
-use common::TestApp;
-use serde_json::json;
+use common::{seed_org, TestApp, TestResponse};
+use serde_json::{json, Value};
 use sqlx::PgPool;
 use uuid::Uuid;
 
 /// Shared webhook secret pinned for the duration of the test process.
 const TEST_WEBHOOK_SECRET: &str = "esign-webhook-idempotency-test-secret-0123456789";
+
+/// Provider slug used for the seeded requests. The `lightweight` provider is the
+/// in-tree default and needs no external configuration.
+const PROVIDER: &str = "lightweight";
+
+/// Idempotent-ack message the terminal-state guard returns. Pinned here so the
+/// assertion drifts loudly if `routes/signatures.rs` changes the copy.
+const ALREADY_FINALIZED_MSG: &str = "Signature request already finalized; webhook ignored";
+
+/// A seeded terminal signature request plus the identifiers a webhook payload
+/// must carry to address it.
+struct TerminalRequest {
+    /// `signature_requests.id` — used to read back state after the webhook.
+    id: Uuid,
+    /// Provider-side request id the webhook references.
+    provider_request_id: String,
+    /// Email of the single seeded signer.
+    signer_email: String,
+}
 
 /// Ensure `ESIGN_WEBHOOK_SECRET` is set before the handler reads it.
 fn ensure_webhook_secret() {
@@ -40,24 +59,15 @@ fn ensure_webhook_secret() {
     });
 }
 
-/// Seed org + user + document + a signature request in the given status with a
-/// single signer in the given signer status. Returns
-/// (request_id, provider, provider_request_id, signer_email).
+/// Seed user + document + a signature request in the given status with a single
+/// signer in the given signer status. The org is provisioned via the shared
+/// `common::seed_org` helper so this file no longer carries its own org insert.
 async fn seed_terminal_request(
     pool: &PgPool,
     status: &str,
     signer_status: &str,
-) -> (Uuid, String, String, String) {
-    let slug = format!("esign-wh-{}", Uuid::new_v4());
-    let org_id = sqlx::query_scalar::<_, Uuid>(
-        r#"INSERT INTO organizations (name, slug, contact_email, status)
-           VALUES ('ESign WH Org', $1, 'esign-wh@example.com', 'active')
-           RETURNING id"#,
-    )
-    .bind(&slug)
-    .fetch_one(pool)
-    .await
-    .expect("seed org");
+) -> TerminalRequest {
+    let org_id = seed_org(pool, "esign-wh").await;
 
     let user_id = sqlx::query_scalar::<_, Uuid>(
         r#"INSERT INTO users (email, password_hash, name, status, email_verified_at)
@@ -91,7 +101,6 @@ async fn seed_terminal_request(
         "status": signer_status
     }]);
 
-    let provider = "lightweight".to_string();
     let provider_request_id = format!("prov-req-{}", Uuid::new_v4());
 
     let request_id = sqlx::query_scalar::<_, Uuid>(
@@ -106,14 +115,29 @@ async fn seed_terminal_request(
     .bind(org_id)
     .bind(status)
     .bind(&signers)
-    .bind(&provider)
+    .bind(PROVIDER)
     .bind(&provider_request_id)
     .bind(user_id)
     .fetch_one(pool)
     .await
     .expect("seed signature_request");
 
-    (request_id, provider, provider_request_id, signer_email)
+    TerminalRequest {
+        id: request_id,
+        provider_request_id,
+        signer_email,
+    }
+}
+
+/// POST a webhook delivery for `PROVIDER` with the pinned secret header.
+async fn post_webhook(app: &TestApp, payload: Value) -> TestResponse {
+    app.execute(
+        app.post(&format!("/api/v1/signature-requests/webhook/{PROVIDER}"))
+            .header("x-webhook-secret", TEST_WEBHOOK_SECRET)
+            .json(payload)
+            .build(),
+    )
+    .await
 }
 
 /// Read the current signer status for the single seeded signer.
@@ -127,6 +151,16 @@ async fn signer_status(pool: &PgPool, request_id: Uuid) -> String {
     .expect("read signer status")
 }
 
+/// Read the `signed_document_id` linked to a request (None when no signed
+/// document has been stored).
+async fn signed_document_id(pool: &PgPool, request_id: Uuid) -> Option<Uuid> {
+    sqlx::query_scalar(r#"SELECT signed_document_id FROM signature_requests WHERE id = $1"#)
+        .bind(request_id)
+        .fetch_one(pool)
+        .await
+        .expect("read signed_document_id")
+}
+
 // ===========================================================================
 // W1 — duplicate `completed` webhook on a completed request is a no-op
 // ===========================================================================
@@ -137,26 +171,24 @@ async fn duplicate_completed_webhook_on_terminal_request_is_noop(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
     // Request already finalized as `completed`, signer already `signed`.
-    let (request_id, provider, provider_request_id, signer_email) =
-        seed_terminal_request(&pool, "completed", "signed").await;
+    let req = seed_terminal_request(&pool, "completed", "signed").await;
+    assert_eq!(
+        signer_status(&pool, req.id).await,
+        "signed",
+        "precondition: signer is already signed"
+    );
 
-    let before = signer_status(&pool, request_id).await;
-    assert_eq!(before, "signed", "precondition: signer is already signed");
-
-    let resp = app
-        .execute(
-            app.post(&format!("/api/v1/signature-requests/webhook/{}", provider))
-                .header("x-webhook-secret", TEST_WEBHOOK_SECRET)
-                .json(json!({
-                    "event_type": "completed",
-                    "provider_request_id": provider_request_id,
-                    "signer_email": signer_email,
-                    "signer_status": "signed",
-                    "signed_document_url": "https://provider.example/signed.pdf"
-                }))
-                .build(),
-        )
-        .await;
+    let resp = post_webhook(
+        &app,
+        json!({
+            "event_type": "completed",
+            "provider_request_id": req.provider_request_id,
+            "signer_email": req.signer_email,
+            "signer_status": "signed",
+            "signed_document_url": "https://provider.example/signed.pdf"
+        }),
+    )
+    .await;
 
     // Idempotent acknowledgement: 200, success, and the guard message so the
     // provider stops retrying.
@@ -165,26 +197,18 @@ async fn duplicate_completed_webhook_on_terminal_request_is_noop(pool: PgPool) {
     assert_eq!(body.get("success"), Some(&json!(true)));
     assert_eq!(
         body.get("message"),
-        Some(&json!(
-            "Signature request already finalized; webhook ignored"
-        )),
+        Some(&json!(ALREADY_FINALIZED_MSG)),
         "expected the terminal-state guard message, got: {body}"
     );
 
     // No side effects: signer status unchanged, no signed document linked.
     assert_eq!(
-        signer_status(&pool, request_id).await,
+        signer_status(&pool, req.id).await,
         "signed",
         "duplicate webhook must not mutate signer status"
     );
-    let signed_doc: Option<Uuid> =
-        sqlx::query_scalar(r#"SELECT signed_document_id FROM signature_requests WHERE id = $1"#)
-            .bind(request_id)
-            .fetch_one(&pool)
-            .await
-            .expect("read signed_document_id");
     assert!(
-        signed_doc.is_none(),
+        signed_document_id(&pool, req.id).await.is_none(),
         "duplicate webhook must not store a signed document on a terminal request"
     );
 }
@@ -200,28 +224,24 @@ async fn signer_event_on_terminal_request_does_not_retransition(pool: PgPool) {
 
     // Request finalized as `completed`; signer recorded as `signed`. A late /
     // duplicate `declined` event must not flip the signer back.
-    let (request_id, provider, provider_request_id, signer_email) =
-        seed_terminal_request(&pool, "completed", "signed").await;
+    let req = seed_terminal_request(&pool, "completed", "signed").await;
 
-    let resp = app
-        .execute(
-            app.post(&format!("/api/v1/signature-requests/webhook/{}", provider))
-                .header("x-webhook-secret", TEST_WEBHOOK_SECRET)
-                .json(json!({
-                    "event_type": "signer_declined",
-                    "provider_request_id": provider_request_id,
-                    "signer_email": signer_email,
-                    "signer_status": "declined",
-                    "decline_reason": "changed my mind"
-                }))
-                .build(),
-        )
-        .await;
+    let resp = post_webhook(
+        &app,
+        json!({
+            "event_type": "signer_declined",
+            "provider_request_id": req.provider_request_id,
+            "signer_email": req.signer_email,
+            "signer_status": "declined",
+            "decline_reason": "changed my mind"
+        }),
+    )
+    .await;
 
     resp.assert_status(StatusCode::OK);
 
     assert_eq!(
-        signer_status(&pool, request_id).await,
+        signer_status(&pool, req.id).await,
         "signed",
         "terminal request must not re-transition signer status on a late event"
     );


### PR DESCRIPTION
## Task
api-server esignature_webhook_idempotency_tests.rs is a churn hotspot (+228 lines, terminal-state regression). Refactor/de-duplicate and stabilize this test file: backend/servers/api-server/tests/esignature_webhook_idempotency_tests.rs. Reduce duplication, keep coverage equivalent or better. Test-quality refactor, not new behavior. [src: PR #1034]

## Owner
pm-backend (specialist: rust-backend)

## What changed (test-quality refactor, no behavior change)
- **Reuse shared helper**: `seed_terminal_request` now provisions its org via `common::seed_org` instead of carrying its own `organizations` INSERT.
- **Extract `post_webhook(app, payload)`**: collapses the repeated `POST /api/v1/signature-requests/webhook/{provider}` + `x-webhook-secret` header + `.json().build()` pattern shared by W1 and W2.
- **Named `TerminalRequest` struct** replaces the positional 4-tuple return (`id` / `provider_request_id` / `signer_email`), so call sites read by field instead of by index. The unused provider element of the old tuple is gone.
- **Pinned constants**: `PROVIDER` (`"lightweight"`) and `ALREADY_FINALIZED_MSG` (the terminal-state guard ack copy from `routes/signatures.rs:716`). The W1 message assertion now references the const so it drifts loudly if the handler copy changes.
- **New `signed_document_id` read helper** alongside `signer_status`, replacing the inline `sqlx::query_scalar` in W1.

Coverage is equivalent: W1 still asserts 200 + `success:true` + guard message + signer unchanged + no signed document stored; W2 still asserts 200 + signer not re-transitioned on a late `declined` event. Net `-68 / +88` lines but lower duplication (single webhook-POST path, single org-seed path).

## Tested (Band A — fast check)
- `cargo fmt --check -p api-server` → exit 0
- `SQLX_OFFLINE=true cargo check -p api-server --tests` → exit 0
- `SQLX_OFFLINE=true cargo clippy -p api-server --test esignature_webhook_idempotency_tests -- -D warnings` → exit 0

The `#[sqlx::test]` cases require a live Postgres, which is not available in the implementer environment, so `cargo test` was not executed locally — CI's Postgres-backed `backend.yml` job runs them. Whole-crate `cargo clippy -p api-server --tests` surfaces one **pre-existing** `clippy::items_after_test_module` error in `src/routes/admin/mod.rs:76` (untouched by this PR, present on `dev`); the refactored test target itself is clippy-clean.

## Built (Band B — full build)
skipped: test-only refactor, no public API / migration / config change.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (test-quality refactor, no security/auth/billing/data-integrity behavior change).

## Remote-tested
skipped.

## Scope drift
None — `scope-check.sh --owner pm-backend` exit 0 (only the target test file changed). Cargo.lock toolchain drift was reverted to keep the PR scoped.

## Code-reuse review
None — `reuse-grep.sh --specialist rust-backend` exit 0. The refactor adds no auth/crypto/http helpers; it consumes the existing `common::seed_org`.

## Notes
- `common::seed_org` names the org `Test Org esign-wh` (vs. the old `ESign WH Org`). The org name is never asserted — only the returned id is used — so behavior is unchanged.

https://claude.ai/code/session_012DhWd64XoscUJpe1gM8hXt

---
_Generated by [Claude Code](https://claude.ai/code/session_012DhWd64XoscUJpe1gM8hXt)_