### PR TITLE
refactor-main-rs-churn-2026-06-03: extract router/middleware/CORS setup out of api-server main()

### DIFF
--- a/backend/servers/api-server/src/main.rs
+++ b/backend/servers/api-server/src/main.rs
@@ -101,6 +101,150 @@ fn parse_default_origins() -> Vec<HeaderValue> {
         .collect()
 }
 
+/// Build the production CORS layer.
+///
+/// Origins are configurable via the `CORS_ALLOWED_ORIGINS` env var (falling
+/// back to [`DEFAULT_CORS_ORIGINS`]). `allow_headers` MUST be an explicit list
+/// when paired with `allow_credentials(true)`: per the CORS spec browsers
+/// reject the wildcard with credentials, and tower-http panics at layer
+/// construction if the two are combined.
+///
+/// Extracted from `main()` so CORS-policy edits (a recurring churn point) live
+/// in one cohesive function instead of inline in the `main()` middleware chain.
+fn cors_layer() -> CorsLayer {
+    CorsLayer::new()
+        // Allow requests from configured origins (env var or defaults)
+        .allow_origin(get_cors_allowed_origins())
+        // Allow common HTTP methods
+        .allow_methods([
+            http::Method::GET,
+            http::Method::POST,
+            http::Method::PUT,
+            http::Method::PATCH,
+            http::Method::DELETE,
+            http::Method::OPTIONS,
+        ])
+        // Allow common headers
+        .allow_headers([
+            http::header::AUTHORIZATION,
+            http::header::CONTENT_TYPE,
+            http::header::ACCEPT,
+            http::header::ORIGIN,
+            http::HeaderName::from_static("x-requested-with"),
+        ])
+        // Allow credentials (cookies, authorization headers)
+        .allow_credentials(true)
+        // Cache preflight response for 1 hour
+        .max_age(std::time::Duration::from_secs(3600))
+}
+
+/// Assemble the production router: the shared [`route_table`] plus the
+/// production-only surface layered on top.
+///
+/// The application route table is sourced from the SINGLE source of truth,
+/// `api_server::route_table()` (issue #867). The production binary used to
+/// hand-maintain a parallel chain of `.nest(...)` calls here, which drifted
+/// from `lib.rs::create_router` (used by the integration tests): PR #836 had
+/// to retro-fit five routers that existed only in the test-side router and
+/// were therefore unreachable in production. Building both routers from the
+/// same `route_table()` makes that class of divergence impossible — a route
+/// added to `route_table()` is reachable in production AND exercised by the
+/// tests, and the guard test `route_table_is_single_source_of_truth` fails
+/// the build if `main.rs` ever reverts to hand-listing API routes.
+///
+/// Only production-only surface is added on top here:
+///   - `/metrics`            — needs the production observability registry.
+///   - Swagger UI            — dev/ops doc endpoint.
+///   - Phase-3 host routing  — `/tenant-config`, `/admin/tenants/...`,
+///                             `/internal/caddy-ask`; these depend on the
+///                             live host-tenant middleware and are covered
+///                             by their own focused tests
+///                             (`tenant_config_tests.rs`, `caddy_ask_tests.rs`).
+///
+/// Extracted from `main()` so router-assembly edits stop colliding with the
+/// rest of startup.
+fn build_app_router() -> axum::Router<AppState> {
+    route_table()
+        // Prometheus metrics endpoint (Epic 95.4) — production-only.
+        .route("/metrics", get(metrics_endpoint))
+        // Phase 3: per-host tenant config (read by reality-web at request
+        // time). Mounted at the root because reality-web hits the same host
+        // Caddy serves the app on, and the path must match exactly.
+        .nest("/tenant-config", routes::tenant_config::router())
+        // Phase 3: per-tenant admin endpoints (branding + feature flags).
+        // Stub auth via `require_platform_principal`; Phase 5 swaps to a
+        // real capability registry.
+        .nest(
+            "/admin/tenants/{org_id}/branding",
+            routes::admin_tenants::branding_router(),
+        )
+        .nest(
+            "/admin/tenants/{org_id}/feature-flags",
+            routes::admin_tenants::feature_flags_router(),
+        )
+        // Phase 3: Caddy on-demand TLS ask-endpoint. Mounted at `/internal`,
+        // which is in PUBLIC_ALLOWLIST so host_tenant_middleware skips it
+        // entirely — by definition this endpoint runs BEFORE TLS / a
+        // host -> tenant mapping exists. Auth is enforced inside the handler
+        // (loopback bind in dev, X-Internal-Token shared secret in prod).
+        .nest("/internal/caddy-ask", routes::caddy_ask::router())
+        // Swagger UI
+        .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
+}
+
+/// Layer production middleware onto the assembled router and bind the app
+/// state, yielding the final `Router` ready to serve.
+///
+/// Layer order is significant — Tower layers execute outside-in, so the chain
+/// below is preserved EXACTLY as it was inline in `main()`:
+///   1. admin-core extensions (must be visible to every nested route)
+///   2. global request body cap
+///   3. baseline security headers
+///   4. tracing
+///   5. host-tenant resolution (runs FIRST on the request pipeline)
+///   6. CORS
+///   7. application state
+///
+/// Mirrors the chain in `lib.rs::create_router` via the shared
+/// `attach_admin_extensions` helper so production and tests cannot drift.
+/// Extracted from `main()` so middleware/security-header edits (a recurring
+/// churn point — #954 security headers, #989 gap-sweep) live in one function.
+fn apply_middleware(
+    app: axum::Router<AppState>,
+    admin_ext: &api_server::AdminExtensions,
+    host_tenant_config: api_core::middleware::HostTenantConfig,
+    state: AppState,
+) -> axum::Router {
+    attach_admin_extensions(app, admin_ext)
+        // P0-15: global request body cap. Default Axum limit is 2 MiB which
+        // is fine for JSON but exposes every multipart handler to memory
+        // abuse when the handler itself forgets to limit. Upload routes
+        // that legitimately need more (restore, migration import) raise
+        // this per-route via `DefaultBodyLimit::max(...)` and stream
+        // chunks instead of buffering full payloads. Cap here: 16 MiB.
+        .layer(DefaultBodyLimit::max(16 * 1024 * 1024))
+        // Baseline security headers (HSTS, nosniff, frame-deny, referrer) on
+        // every response — the API edge previously shipped none (#954).
+        .layer(axum::middleware::from_fn(
+            api_core::middleware::security_headers,
+        ))
+        // Middleware
+        .layer(TraceLayer::new_for_http())
+        // Phase 1: Host-resolution (tenant-resolution) middleware. Runs FIRST
+        // on the request pipeline (layers execute outside-in), inspecting the
+        // Host header to inject a `ResolvedTenant` extension before any
+        // handler/extractor runs. Public-allowlist paths (`/health`, etc.)
+        // bypass resolution; unknown hosts fail closed with 404.
+        .layer(axum::middleware::from_fn_with_state(
+            host_tenant_config,
+            api_core::middleware::host_tenant_middleware,
+        ))
+        // CORS configuration - origins configurable via CORS_ALLOWED_ORIGINS env var
+        .layer(cors_layer())
+        // Application state
+        .with_state(state)
+}
+
 #[derive(OpenApi)]
 #[openapi(
     info(
@@ -509,111 +653,12 @@ async fn main() -> anyhow::Result<()> {
     // because `RequireCapability` could not find `AdminDeps` in extensions.
     let admin_ext = build_admin_extensions(db_pool.clone());
 
-    // Build router.
-    //
-    // The application route table is sourced from the SINGLE source of truth,
-    // `api_server::route_table()` (issue #867). The production binary used to
-    // hand-maintain a parallel chain of `.nest(...)` calls here, which drifted
-    // from `lib.rs::create_router` (used by the integration tests): PR #836 had
-    // to retro-fit five routers that existed only in the test-side router and
-    // were therefore unreachable in production. Building both routers from the
-    // same `route_table()` makes that class of divergence impossible — a route
-    // added to `route_table()` is reachable in production AND exercised by the
-    // tests, and the guard test `route_table_is_single_source_of_truth` fails
-    // the build if `main.rs` ever reverts to hand-listing API routes.
-    //
-    // Only production-only surface is added on top here:
-    //   - `/metrics`            — needs the production observability registry.
-    //   - Swagger UI            — dev/ops doc endpoint.
-    //   - Phase-3 host routing  — `/tenant-config`, `/admin/tenants/...`,
-    //                             `/internal/caddy-ask`; these depend on the
-    //                             live host-tenant middleware and are covered
-    //                             by their own focused tests
-    //                             (`tenant_config_tests.rs`, `caddy_ask_tests.rs`).
-    let app = route_table()
-        // Prometheus metrics endpoint (Epic 95.4) — production-only.
-        .route("/metrics", get(metrics_endpoint))
-        // Phase 3: per-host tenant config (read by reality-web at request
-        // time). Mounted at the root because reality-web hits the same host
-        // Caddy serves the app on, and the path must match exactly.
-        .nest("/tenant-config", routes::tenant_config::router())
-        // Phase 3: per-tenant admin endpoints (branding + feature flags).
-        // Stub auth via `require_platform_principal`; Phase 5 swaps to a
-        // real capability registry.
-        .nest(
-            "/admin/tenants/{org_id}/branding",
-            routes::admin_tenants::branding_router(),
-        )
-        .nest(
-            "/admin/tenants/{org_id}/feature-flags",
-            routes::admin_tenants::feature_flags_router(),
-        )
-        // Phase 3: Caddy on-demand TLS ask-endpoint. Mounted at `/internal`,
-        // which is in PUBLIC_ALLOWLIST so host_tenant_middleware skips it
-        // entirely — by definition this endpoint runs BEFORE TLS / a
-        // host -> tenant mapping exists. Auth is enforced inside the handler
-        // (loopback bind in dev, X-Internal-Token shared secret in prod).
-        .nest("/internal/caddy-ask", routes::caddy_ask::router())
-        // Swagger UI
-        .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()));
-
-    // Phase 5 — admin dependency injection (B7). Layered before TraceLayer so
-    // every nested route inherits these extensions. Mirrors the chain in
-    // `lib.rs::create_router` exactly via the shared `attach_admin_extensions`
-    // helper so production and tests cannot drift.
-    let app = attach_admin_extensions(app, &admin_ext)
-        // P0-15: global request body cap. Default Axum limit is 2 MiB which
-        // is fine for JSON but exposes every multipart handler to memory
-        // abuse when the handler itself forgets to limit. Upload routes
-        // that legitimately need more (restore, migration import) raise
-        // this per-route via `DefaultBodyLimit::max(...)` and stream
-        // chunks instead of buffering full payloads. Cap here: 16 MiB.
-        .layer(DefaultBodyLimit::max(16 * 1024 * 1024))
-        // Baseline security headers (HSTS, nosniff, frame-deny, referrer) on
-        // every response — the API edge previously shipped none (#954).
-        .layer(axum::middleware::from_fn(
-            api_core::middleware::security_headers,
-        ))
-        // Middleware
-        .layer(TraceLayer::new_for_http())
-        // Phase 1: Host-resolution (tenant-resolution) middleware. Runs FIRST
-        // on the request pipeline (layers execute outside-in), inspecting the
-        // Host header to inject a `ResolvedTenant` extension before any
-        // handler/extractor runs. Public-allowlist paths (`/health`, etc.)
-        // bypass resolution; unknown hosts fail closed with 404.
-        .layer(axum::middleware::from_fn_with_state(
-            host_tenant_config.clone(),
-            api_core::middleware::host_tenant_middleware,
-        ))
-        // CORS configuration - origins configurable via CORS_ALLOWED_ORIGINS env var
-        .layer(
-            CorsLayer::new()
-                // Allow requests from configured origins (env var or defaults)
-                .allow_origin(get_cors_allowed_origins())
-                // Allow common HTTP methods
-                .allow_methods([
-                    http::Method::GET,
-                    http::Method::POST,
-                    http::Method::PUT,
-                    http::Method::PATCH,
-                    http::Method::DELETE,
-                    http::Method::OPTIONS,
-                ])
-                // Allow common headers
-                .allow_headers([
-                    http::header::AUTHORIZATION,
-                    http::header::CONTENT_TYPE,
-                    http::header::ACCEPT,
-                    http::header::ORIGIN,
-                    http::HeaderName::from_static("x-requested-with"),
-                ])
-                // Allow credentials (cookies, authorization headers)
-                .allow_credentials(true)
-                // Cache preflight response for 1 hour
-                .max_age(std::time::Duration::from_secs(3600)),
-        )
-        // Application state
-        .with_state(state);
+    // Build the production router (shared route table + production-only
+    // surface) then layer production middleware and bind the app state. The
+    // two cohesive blocks live in `build_app_router` / `apply_middleware` so
+    // concurrent PRs editing routing vs. middleware no longer collide here.
+    let app = build_app_router();
+    let app = apply_middleware(app, &admin_ext, host_tenant_config, state);
 
     // Run server
     let addr = SocketAddr::from(([0, 0, 0, 0], 8080));


### PR DESCRIPTION
## Task
api-server main.rs (backend/servers/api-server/src/main.rs) was touched twice recently (gap-sweep + security headers) — a churn marker. Reduce churn/coupling in main.rs by extracting cohesive setup blocks (e.g. router assembly, middleware/security-header layering, server bootstrap) into helper functions/modules so concurrent PRs stop colliding in main.rs. Keep startup behavior identical. [src: PR #989, PR #963]

## Owner
pm-backend

## What changed
Behavior-preserving extraction only. Three cohesive blocks moved out of the
monolithic `main()` into dedicated free functions in the same file:

- `build_app_router() -> Router<AppState>` — the production router assembly
  (shared `route_table()` + production-only surface: `/metrics`, Swagger UI,
  Phase-3 host routing).
- `apply_middleware(app, admin_ext, host_tenant_config, state) -> Router` — the
  middleware/security-header layering chain (admin extensions → body cap →
  security headers → tracing → host-tenant resolution → CORS → state).
- `cors_layer() -> CorsLayer` — the CORS policy construction.

`main()` now calls these three helpers instead of inlining ~100 lines of
router/middleware builder chains. **No behavioral change**: layer order, the
16 MiB body cap, security headers, host-tenant middleware, CORS policy
(env-driven origins, methods, headers, credentials, max-age), the route
surface, and the bind/serve path are all preserved exactly. The recently
colliding inline middleware chain (#954 security headers, #989 gap-sweep) is
now an isolated function body, so concurrent PRs editing routing vs.
middleware vs. CORS no longer collide in one `main()`.

No new helper symbols in auth/crypto/http paths — the change reuses the
existing `route_table()`, `attach_admin_extensions()`, and
`get_cors_allowed_origins()` from the library crate.

## Tested (Band A — fast check)
```
cd backend && SQLX_OFFLINE=true cargo check -p api-server      → exit 0
cd backend && cargo fmt -p api-server -- --check               → exit 0
cd backend && SQLX_OFFLINE=true cargo clippy -p api-server --bin api-server -- -D warnings → exit 0
```

Note: `cargo clippy -p api-server --all-targets -- -D warnings` reports a
PRE-EXISTING lint (`clippy::items_after_test_module` in
`src/routes/admin/mod.rs`) that is unchanged by this PR (that file is not
touched — `git diff` is empty for it) and present on `dev`. The binary
target — the only thing this refactor touches — is clean under `-D warnings`.

## Built (Band B — full build)
skipped: pure behavior-preserving refactor, no public API/config/migration
change; cargo check + bin clippy cover the compile surface.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR — no security/auth/billing/data-integrity behavior
change (security-header and CORS layering are byte-identical, only relocated).

## Remote-tested
skipped

## Notes
- Conservative scope: this is the same file as a prior failed attempt
  (failed on sandbox infra, no PR). Limited strictly to a mechanical,
  behavior-preserving extraction.
- Scope drift: false (only `backend/servers/api-server/src/main.rs` changed;
  Cargo.lock drift reverted to keep scope tight).
- Code-reuse: none — no duplicated helpers introduced.

https://claude.ai/code/session_012DhWd64XoscUJpe1gM8hXt

---
_Generated by [Claude Code](https://claude.ai/code/session_012DhWd64XoscUJpe1gM8hXt)_