### PR TITLE
gap-82-4-reality-mobile-listing-detail-favorites: optimistic favorite toggle on reality mobile listing detail

### DIFF
--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingDetailScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingDetailScreen.kt
@@ -168,15 +168,20 @@ fun ListingDetailScreen(
                         onShareClick = { showShareSheet = true },
                         onFavoriteClick = {
                             if (authState is AuthState.Authenticated && !isFavoriteLoading) {
+                                val previousFav = isFavorite
                                 val newFav = !isFavorite
+                                // Optimistic UI: flip the heart immediately, then reconcile with
+                                // the server response. On failure we roll the state back to
+                                // `previousFav` so the icon never lies about persisted state.
+                                isFavorite = newFav
                                 isFavoriteLoading = true
                                 scope.launch {
                                     val result =
                                         if (newFav) favoritesRepository.addFavorite(listingId)
                                         else favoritesRepository.removeFavorite(listingId)
                                     result.fold(
-                                        onSuccess = { isFavorite = newFav },
-                                        onFailure = { /* revert silently */ },
+                                        onSuccess = { /* optimistic value already applied */ },
+                                        onFailure = { isFavorite = previousFav },
                                     )
                                     isFavoriteLoading = false
                                 }


### PR DESCRIPTION
## Task

Reality mobile listing-detail screen + favorites toggle (story 82-4): render full listing detail from the reality API and wire a favorite/unfavorite action to the favorites endpoint with optimistic UI. Android target (KMP / Jetpack Compose); build with Gradle.

## Owner

pm-frontend (specialist: kotlin-mp — `mobile-native/`, Android Compose)

## What changed

The Android Compose `ListingDetailScreen` already renders the full listing detail from the reality API (`ListingRepository.getListingDetail`) and already wired add/remove favorite to `FavoritesRepository` (`POST`/`DELETE /api/v1/favorites/{id}`, with `GET .../check` for initial state). The one piece of the story that was missing was **optimistic UI** on the favorite toggle: the old handler set `isFavorite` only after the server responded, so the heart did not react on tap.

This PR makes the toggle optimistic:
- Capture `previousFav`, flip `isFavorite` to the new value immediately on tap (heart updates instantly).
- Fire the add/remove call; on success keep the optimistic value, on failure roll back to `previousFav` so the icon never misrepresents persisted state.
- `isFavoriteLoading` still guards against concurrent toggles.

Net diff: 7 insertions / 2 deletions in one file.

## Tested (Band A — fast check)

`cd mobile-native && ./gradlew :shared:compileKotlinJvm` — **could not run**: the sandbox has no network egress (`dl.google.com` → HTTP 403 `host_not_allowed`) and the Android Gradle Plugin 9.2.1 is not in the local Gradle cache, so plugin resolution fails at settings evaluation (`Plugin [id: 'com.android.application', version: '9.2.1'] was not found`). No Android SDK is present either (`ANDROID_HOME` unset). This is an environment limitation, not a code issue — the change does not add imports, symbols, or signatures.

Static verification performed instead:
- Diff reviewed: all referenced symbols (`isFavorite`, `isFavoriteLoading`, `favoritesRepository`, `scope`) already in scope; no new imports needed.
- Pushed file confirmed byte-identical to the local commit (`git diff HEAD FETCH_HEAD` → empty).
- `scope-check.sh --owner pm-frontend` → exit 0 (no scope drift).

**Relying on CI `mobile-native.yml` (Gradle build + unit tests) to perform the real compile.** Kept as draft until CI is green.

## Built (Band B — full build)

Skipped: change is <10 LOC, no public API / config / signature change. (Also blocked by the same sandbox network/SDK limitation as Band A.)

## CI parity (Band C — hot-path only)

Skipped: not a hot-path PR (no security / auth / billing / data-integrity change).

## Remote-tested

Skipped: ppt-bridge MCP not connected in this session.

## Notes

- Existing repository semantics are unchanged. One pre-existing edge case worth a reviewer's eye: `FavoritesRepository.addFavorite` surfaces HTTP 409 (already-favorited) as a `Result.failure`, so a rapid double-toggle could roll an already-persisted favorite back optically. The `isFavoriteLoading` guard makes this unreachable in the normal single-tap flow; left as-is to stay in scope.
- Screen-map `docs/screens/reality-mobile/listing-detail.md` documents the **iOS SwiftUI** counterpart (story 82.4 iOS), not this Compose screen; no screen-map edit applies to the Android target here.

https://claude.ai/code/session_01VZss8M6ckVQKzvoTZkM4At

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZss8M6ckVQKzvoTZkM4At)_