### PR TITLE
test-gap-6-2-announcement-ack-coverage: cover Story 6.2 announcement acknowledgment hooks

### DIFF
--- a/frontend/apps/ppt-web/src/features/announcements/hooks/acknowledgment.test.tsx
+++ b/frontend/apps/ppt-web/src/features/announcements/hooks/acknowledgment.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * Acknowledgment hook-layer tests (gap-6-2 — Story 6.2 web viewing & acknowledgment).
+ *
+ * Covers the three data-layer hooks the ViewAnnouncementPage wires the
+ * "Mark as Read" button, the "Acknowledge" button, and the manager stats panel
+ * to. The presentational behaviour is already covered by
+ * `ViewAnnouncementPage.test.tsx` / `AcknowledgmentStats.test.tsx`; the gap was
+ * the hooks themselves — specifically:
+ *
+ *  - the request contract (endpoint + HTTP method) for read / acknowledge /
+ *    acknowledgment-stats, and
+ *  - the TanStack cache-invalidation contract on success. The Story 6.2 fix made
+ *    `useMarkReadAnnouncement` invalidate the *list* cache (not just detail +
+ *    unread-count) so unread badges update immediately; `useAcknowledgeAnnouncement`
+ *    must refresh both the detail and the per-announcement acknowledgments cache.
+ *    Those invalidation sets are exactly the kind of thing a refactor can silently
+ *    drop, so they are pinned here.
+ */
+
+/// <reference types="vitest/globals" />
+import {
+  announcementKeys,
+  useAcknowledgeAnnouncement,
+  useAnnouncementAcknowledgmentStats,
+  useMarkReadAnnouncement,
+} from '@ppt/api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+function setup() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, invalidateSpy, wrapper };
+}
+
+/** Collect every queryKey passed to invalidateQueries as a JSON string for set comparison. */
+function invalidatedKeys(invalidateSpy: ReturnType<typeof vi.spyOn>): string[] {
+  return invalidateSpy.mock.calls.map((call) =>
+    JSON.stringify((call[0] as { queryKey: unknown })?.queryKey)
+  );
+}
+
+function ok204(): Response {
+  return {
+    ok: true,
+    status: 204,
+    json: async () => {
+      throw new Error('no body');
+    },
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('useMarkReadAnnouncement', () => {
+  it('POSTs to /api/v1/announcements/:id/read', async () => {
+    mockFetch.mockResolvedValueOnce(ok204());
+    const { wrapper } = setup();
+
+    const { result } = renderHook(() => useMarkReadAnnouncement(), { wrapper });
+    result.current.mutate('ann-1');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/announcements/ann-1/read',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('invalidates detail, unread-count AND the list cache so unread badges refresh', async () => {
+    mockFetch.mockResolvedValueOnce(ok204());
+    const { invalidateSpy, wrapper } = setup();
+
+    const { result } = renderHook(() => useMarkReadAnnouncement(), { wrapper });
+    result.current.mutate('ann-1');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const keys = invalidatedKeys(invalidateSpy);
+    expect(keys).toContain(JSON.stringify(announcementKeys.detail('ann-1')));
+    expect(keys).toContain(JSON.stringify(announcementKeys.unreadCount()));
+    // Story 6.2 fix: list cache must be invalidated so unread badges update.
+    expect(keys).toContain(JSON.stringify(announcementKeys.lists()));
+  });
+
+  it('surfaces a server error message', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: async () => ({ message: 'Not in audience' }),
+    } as Response);
+    const { wrapper } = setup();
+
+    const { result } = renderHook(() => useMarkReadAnnouncement(), { wrapper });
+    result.current.mutate('ann-1');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Not in audience');
+  });
+});
+
+describe('useAcknowledgeAnnouncement', () => {
+  it('POSTs to /api/v1/announcements/:id/acknowledge', async () => {
+    mockFetch.mockResolvedValueOnce(ok204());
+    const { wrapper } = setup();
+
+    const { result } = renderHook(() => useAcknowledgeAnnouncement(), { wrapper });
+    result.current.mutate('ann-9');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/announcements/ann-9/acknowledge',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('invalidates the detail and the per-announcement acknowledgments cache', async () => {
+    mockFetch.mockResolvedValueOnce(ok204());
+    const { invalidateSpy, wrapper } = setup();
+
+    const { result } = renderHook(() => useAcknowledgeAnnouncement(), { wrapper });
+    result.current.mutate('ann-9');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const keys = invalidatedKeys(invalidateSpy);
+    expect(keys).toContain(JSON.stringify(announcementKeys.detail('ann-9')));
+    expect(keys).toContain(JSON.stringify(announcementKeys.acknowledgments('ann-9')));
+  });
+});
+
+describe('useAnnouncementAcknowledgmentStats', () => {
+  it('GETs /api/v1/announcements/:id/acknowledgments and returns the stats payload', async () => {
+    const payload = {
+      stats: {
+        announcementId: 'ann-2',
+        totalTargeted: 10,
+        readCount: 6,
+        acknowledgedCount: 2,
+        pendingCount: 4,
+      },
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => payload,
+    } as Response);
+    const { wrapper } = setup();
+
+    const { result } = renderHook(() => useAnnouncementAcknowledgmentStats('ann-2'), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(payload);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('/api/v1/announcements/ann-2/acknowledgments');
+    // No method override -> defaults to GET.
+    expect((init as RequestInit | undefined)?.method).toBeUndefined();
+  });
+
+  it('stays disabled (no request) until an id is supplied', () => {
+    const { wrapper } = setup();
+
+    const { result } = renderHook(() => useAnnouncementAcknowledgmentStats(''), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('respects an explicit enabled=false flag', () => {
+    const { wrapper } = setup();
+
+    const { result } = renderHook(() => useAnnouncementAcknowledgmentStats('ann-2', false), {
+      wrapper,
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Task
AC test coverage for the announcement acknowledgment flow (story 6-2): `mark_read`, `acknowledge`, and acknowledgment-stats rendering paths in ppt-web (`frontend/apps/ppt-web`). TDD: add failing-first test (IG3), confirm green. Vitest is the runner.

## Owner
pm-frontend (specialist: react-web)

## What changed
Adds `frontend/apps/ppt-web/src/features/announcements/hooks/acknowledgment.test.tsx` — hook-layer coverage for the three Story 6.2 data hooks the `ViewAnnouncementPage` wires the "Mark as Read" button, "Acknowledge" button, and the manager stats panel to:

- `useMarkReadAnnouncement` — `POST /api/v1/announcements/:id/read`; invalidates `detail`, `unreadCount` **and** `lists()` (the Story 6.2 fix so unread badges refresh); surfaces server error message.
- `useAcknowledgeAnnouncement` — `POST /api/v1/announcements/:id/acknowledge`; invalidates `detail` + per-announcement `acknowledgments`.
- `useAnnouncementAcknowledgmentStats` — `GET /api/v1/announcements/:id/acknowledgments`; returns the stats payload; stays disabled (no fetch) on empty id or `enabled=false`.

### Gap closed
`packages/api-client/src/announcements/hooks.test.ts` only covered the pure list helpers (`buildAnnouncementQuery` / `toPaginatedResponse`). The read/acknowledge/stats hooks — the load-bearing Story 6.2 data layer, including the cache-invalidation contract a refactor can silently drop — had no coverage. The presentational layer (`AcknowledgmentStats.test.tsx`, `ViewAnnouncementPage.test.tsx`) was already covered; this adds the missing data layer. Test placed in `@ppt/web` because it needs jsdom + RTL `renderHook` + react-query (not available in the node-env `@ppt/api-client` package), following the existing `useOcrMeterReading.test.tsx` precedent.

## Tested (Band A — fast check)
- `pnpm -F @ppt/web typecheck` → exit 0 (tsc --noEmit + e2e tsconfig)
- `npx @biomejs/biome check <changed file>` → exit 0 ("No fixes applied")
- `vitest run src/features/announcements/hooks/acknowledgment.test.tsx` → 8/8 passed
- `vitest run src/features/announcements` (regression) → 30/30 passed

### IG3 — failing-first evidence
Temporarily broke source to confirm the tests fail on regression, then restored (source diff empty):
- Dropped the Story 6.2 `lists()` invalidation in `useMarkReadAnnouncement` → invalidation test failed.
- Changed acknowledge endpoint `/acknowledge` → `/ack` → endpoint test failed.
Result: 2 failed / 6 passed while broken; 8/8 green after restore.

## Built (Band B — full build)
skipped: test-only change (~200 LOC of tests, no public API/config/source touch).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (test-only, no security/auth/billing/data-integrity change).

## Remote-tested
skipped

## Notes
- Scope-drift check (`scope-check.sh --owner pm-frontend`) → exit 0; only the new test file is added, no source modified.
- No new helpers added → no code-reuse warnings.

https://claude.ai/code/session_01VZss8M6ckVQKzvoTZkM4At

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZss8M6ckVQKzvoTZkM4At)_