### PR TITLE
gap-82-1: Reality iOS — generate iosApp.xcodeproj via committed XcodeGen manifest (story 82.1)

### DIFF
--- a/mobile-native/CLAUDE.md
+++ b/mobile-native/CLAUDE.md
@@ -54,6 +54,10 @@ Kotlin Multiplatform project for Reality Portal mobile apps.
 # Build iOS framework
 ./gradlew :shared:linkDebugFrameworkIosSimulatorArm64
 
+# Generate + build the iOS app (macOS only; requires `brew install xcodegen`)
+cd iosApp && xcodegen generate          # materialise iosApp.xcodeproj from project.yml
+../../scripts/build-ios.sh development   # KMP framework + xcodebuild (Dev scheme)
+
 # Run tests
 ./gradlew :shared:allTests
 
@@ -92,9 +96,21 @@ mobile-native/
 │   ├── build.gradle.kts
 │   ├── proguard-rules.pro
 │   └── src/main/java/three/two/bit/ppt/reality/
-└── iosApp/                 # iOS application (Xcode)
-    └── iosApp/
+└── iosApp/                 # iOS application (SwiftUI)
+    ├── project.yml         # XcodeGen manifest — single source of truth for iosApp.xcodeproj
+    ├── Configurations/     # Base/Development/Staging/Production xcconfig
+    ├── xcschemes/          # RealityPortal-{Dev,Staging,Prod} schemes
+    └── iosApp/             # Swift sources (App/, Core/{DI,Services,Navigation}, Features/)
 ```
+
+> **iOS project is generated, not committed.** `iosApp.xcodeproj` is produced by
+> `xcodegen generate` from `iosApp/project.yml` and is git-ignored. The manifest
+> declares the three build configs (each wired to its `Configurations/*.xcconfig`),
+> the three schemes, the `iosApp` + `iosAppTests` targets, and a pre-build step
+> that links the `:shared` KMP framework (`link<Build>FrameworkIos<Arch>`) before
+> the Swift compile. The SwiftUI entry point is `iosApp/App/RealityPortalApp.swift`;
+> DI lives in `iosApp/Core/DI/DependencyContainer.swift`; Ktor networking is
+> bootstrapped by the shared module's `HttpClientProvider` (ktor-client-darwin).
 
 ## Version Catalog
 

--- a/mobile-native/iosApp/.gitignore
+++ b/mobile-native/iosApp/.gitignore
@@ -1,0 +1,14 @@
+# The Xcode project is generated from project.yml via `xcodegen generate`
+# (Epic 82 - Story 82.1). It is a build artifact, not a tracked source — see
+# project.yml and scripts/build-ios.sh ("generated, not committed").
+iosApp.xcodeproj/
+
+# Xcode build output + KMP framework staging produced by the pre-build script.
+DerivedData/
+build/
+shared-framework-staging/
+
+# Xcode user state
+*.xcworkspace/xcuserdata/
+xcuserdata/
+*.xcuserstate

--- a/mobile-native/iosApp/project.yml
+++ b/mobile-native/iosApp/project.yml
@@ -1,0 +1,208 @@
+# project.yml — XcodeGen manifest for the Reality Portal iOS app.
+#
+# Epic 82 - Story 82.1: SwiftUI Project Setup
+#
+# Why this file exists
+# --------------------
+# `scripts/build-ios.sh` and `iosApp/xcschemes/INSTALL.md` both assume an
+# `iosApp.xcodeproj` that is *generated, not committed*. Until now nothing in
+# the repo could actually produce it — `build-ios.sh` fails fast when the
+# project is missing, and INSTALL.md asked a human to hand-create the project
+# in Xcode. This manifest closes that gap: `xcodegen generate` (run from this
+# directory) deterministically materialises `iosApp.xcodeproj` from the
+# committed sources, xcconfigs, Info.plists, and schemes — so downstream
+# 82-x screen work has a reproducible, scriptable compiling base.
+#
+# Generate the project (macOS, requires `brew install xcodegen`):
+#   cd mobile-native/iosApp && xcodegen generate
+#
+# The generated `iosApp.xcodeproj` stays git-ignored (see .gitignore); only
+# this manifest + the source/config inputs are tracked.
+
+name: iosApp
+
+options:
+  bundleIdPrefix: three.two.bit.ppt.reality
+  deploymentTarget:
+    iOS: "15.0"
+  createIntermediateGroups: true
+  # Generated schemes would clash with the hand-authored ones under
+  # xcschemes/; we declare the three Reality* schemes explicitly below.
+  generateEmptyDirectories: true
+  groupSortPosition: top
+
+# Build configurations mirror the three committed xcconfigs. The base build
+# type (debug/release) is inferred from each xcconfig's CONFIGURATION key:
+#   Development -> Debug, Staging -> Release, Production -> Release.
+configs:
+  Development: debug
+  Staging: release
+  Production: release
+
+# Project-level xcconfig wiring. Each configuration inherits the matching
+# Configurations/*.xcconfig (which itself #includes Base.xcconfig).
+configFiles:
+  Development: Configurations/Development.xcconfig
+  Staging: Configurations/Staging.xcconfig
+  Production: Configurations/Production.xcconfig
+
+settings:
+  base:
+    # The KMP `:shared` module uses plain `binaries.framework {}` (NOT the
+    # kotlin-cocoapods plugin), so Gradle emits the framework under
+    #   shared/build/bin/<konanTarget>/<debug|release>Framework/shared.framework
+    # The pre-build script picks the right konanTarget by SDK + arch and copies
+    # it to a stable, SDK-agnostic drop dir that the search path below points at.
+    FRAMEWORK_SEARCH_PATHS:
+      - "$(inherited)"
+      - "$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)"
+    ENABLE_USER_SCRIPT_SANDBOXING: NO
+    SWIFT_VERSION: "5.9"
+
+targets:
+  iosApp:
+    type: application
+    platform: iOS
+    # Matches the BlueprintName/BuildableName in xcschemes/*.xcscheme
+    # (BlueprintIdentifier = "iosApp", BuildableName = "iosApp.app").
+    sources:
+      - path: iosApp
+        excludes:
+          - "**/.DS_Store"
+    info:
+      path: iosApp/Resources/Info.plist
+    # Per-config xcconfig also applied at the target level so PRODUCT_BUNDLE_*,
+    # API_BASE_URL, ENVIRONMENT, ENABLE_LOGGING resolve into Info.plist.
+    configFiles:
+      Development: Configurations/Development.xcconfig
+      Staging: Configurations/Staging.xcconfig
+      Production: Configurations/Production.xcconfig
+    settings:
+      base:
+        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+      configs:
+        Development:
+          ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon-Dev
+        Staging:
+          ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon-Staging
+        Production:
+          ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+    dependencies:
+      # The KMP framework is a pre-built static framework dropped in by Gradle;
+      # `embed: false` because it is statically linked into the app binary.
+      - framework: shared.framework
+        embed: false
+        implicit: true
+    preBuildScripts:
+      - name: "Build KMP shared framework"
+        # Builds the `:shared` plain framework with the real (non-cocoapods)
+        # link task, then stages it where FRAMEWORK_SEARCH_PATHS expects it.
+        # Task naming: link<Debug|Release>FrameworkIos<Arch>. Device builds use
+        # IosArm64; simulator builds use IosSimulatorArm64 / IosX64.
+        script: |
+          set -euo pipefail
+          cd "$SRCROOT/.."
+
+          # Map Xcode SDK + arch -> Kotlin/Native konan target.
+          if [ "${PLATFORM_NAME:-iphoneos}" = "iphonesimulator" ]; then
+            case "${ARCHS%% *}" in
+              arm64) KONAN_TARGET="iosSimulatorArm64" ;;
+              *)     KONAN_TARGET="iosX64" ;;
+            esac
+          else
+            KONAN_TARGET="iosArm64"
+          fi
+
+          # Development -> Debug framework, Staging/Production -> Release.
+          if [ "${CONFIGURATION:-Development}" = "Development" ]; then
+            KOTLIN_BUILD="Debug"
+          else
+            KOTLIN_BUILD="Release"
+          fi
+
+          TARGET_CAP="$(printf '%s' "$KONAN_TARGET" | sed 's/^./\U&/')"
+          ./gradlew ":shared:link${KOTLIN_BUILD}Framework${TARGET_CAP}"
+
+          SRC_FW="shared/build/bin/${KONAN_TARGET}/${KOTLIN_BUILD,,}Framework/shared.framework"
+          DEST_DIR="shared/build/xcode-frameworks/${CONFIGURATION}"
+          rm -rf "$DEST_DIR/shared.framework"
+          mkdir -p "$DEST_DIR"
+          cp -R "$SRC_FW" "$DEST_DIR/"
+        basedOnDependencyAnalysis: false
+
+  iosAppTests:
+    type: bundle.unit-test
+    platform: iOS
+    # Matches xcschemes TestAction (BlueprintIdentifier = "iosAppTests",
+    # BuildableName = "iosAppTests.xctest").
+    sources:
+      - path: iosAppTests
+    info:
+      path: iosAppTests/Info.plist
+    dependencies:
+      - target: iosApp
+    settings:
+      base:
+        BUNDLE_LOADER: "$(TEST_HOST)"
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/iosApp.app/iosApp"
+
+# Schemes mirror the three hand-authored xcschemes/*.xcscheme exactly so the
+# existing INSTALL.md naming + build-ios.sh `-scheme` values keep working.
+schemes:
+  RealityPortal-Dev:
+    build:
+      targets:
+        iosApp: all
+        iosAppTests: [test]
+    run:
+      config: Development
+      environmentVariables:
+        - variable: ENVIRONMENT
+          value: development
+          isEnabled: true
+    test:
+      config: Development
+      targets:
+        - iosAppTests
+    profile:
+      config: Development
+    analyze:
+      config: Development
+    archive:
+      config: Development
+
+  RealityPortal-Staging:
+    build:
+      targets:
+        iosApp: all
+        iosAppTests: [test]
+    run:
+      config: Staging
+    test:
+      config: Staging
+      targets:
+        - iosAppTests
+    profile:
+      config: Staging
+    analyze:
+      config: Staging
+    archive:
+      config: Staging
+
+  RealityPortal-Prod:
+    build:
+      targets:
+        iosApp: all
+        iosAppTests: [test]
+    run:
+      config: Production
+    test:
+      config: Production
+      targets:
+        - iosAppTests
+    profile:
+      config: Production
+    analyze:
+      config: Production
+    archive:
+      config: Production

--- a/mobile-native/iosApp/xcschemes/INSTALL.md
+++ b/mobile-native/iosApp/xcschemes/INSTALL.md
@@ -1,31 +1,45 @@
-# Installing xcschemes into iosApp.xcodeproj
+# Generating iosApp.xcodeproj (and its schemes)
 
-These scheme files must be placed inside `iosApp.xcodeproj/xcshareddata/xcschemes/`
-to be tracked in source control and shared with the team.
+The Xcode project is **generated, not committed** — its single source of truth is
+`mobile-native/iosApp/project.yml` (an [XcodeGen](https://github.com/yonaskolb/XcodeGen)
+manifest, added in Epic 82 / Story 82.1). The three build configurations
+(Development / Staging / Production, each wired to its `Configurations/*.xcconfig`)
+and the three schemes below are all declared in that manifest, so there is no
+longer any manual Xcode clicking to do.
 
 ## One-time setup (run on a macOS machine with Xcode)
 
 ```bash
+# 1. Install XcodeGen (once)
+brew install xcodegen
+
+# 2. Generate iosApp.xcodeproj from project.yml
 cd mobile-native/iosApp
+xcodegen generate
 
-# 1. Create the xcshareddata/xcschemes directory if it does not exist
+# 3. Open it (schemes + configs are already wired)
+open iosApp.xcodeproj
+```
+
+`scripts/build-ios.sh` runs `xcodegen generate` automatically when the project
+is missing, so CI does not need this step performed by hand.
+
+The generated `iosApp.xcodeproj` is git-ignored (see `iosApp/.gitignore`) — only
+`project.yml` and the `.xcscheme` files in this directory are tracked. The
+schemes are declared in `project.yml`; the raw `.xcscheme` files here are kept
+as a reference / fallback for anyone who still drives the project by hand.
+
+### Manual fallback (no XcodeGen)
+
+If you cannot use XcodeGen, you can still hand-create the project and drop the
+schemes in directly:
+
+```bash
+cd mobile-native/iosApp
 mkdir -p iosApp.xcodeproj/xcshareddata/xcschemes
-
-# 2. Copy all scheme files
 cp xcschemes/*.xcscheme iosApp.xcodeproj/xcshareddata/xcschemes/
-
-# 3. Open Xcode and add the three build configurations
-#    (matching the xcconfig files) to the project:
-#    - Development  (uses Configurations/Development.xcconfig)
-#    - Staging      (uses Configurations/Staging.xcconfig)
-#    - Production   (uses Configurations/Production.xcconfig)
-#
-#    In Xcode: Project > Info > Configurations > "+" button
-#    Then in each configuration's row, set the xcconfig under iosApp target.
-
-# 4. Commit the installed schemes
-git add iosApp.xcodeproj/xcshareddata/xcschemes/
-git commit -m "chore(ios): install dev/staging/prod xcschemes"
+# Then add the Development/Staging/Production configurations in
+# Project > Info > Configurations and point each at its Configurations/*.xcconfig.
 ```
 
 ## App Icon sets

--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -73,23 +73,39 @@ echo ""
 mkdir -p "$OUT_DIR"
 
 # --- Step 1: Build KMP shared framework (required before xcodebuild) ---
+# The :shared module exposes a plain `binaries.framework {}` (NOT the
+# kotlin-cocoapods plugin), so the correct task is `link<Build>Framework<Target>`
+# — `linkPodReleaseFrameworkIosArm64` is a cocoapods-only task and does not
+# exist here (it would fail before xcodebuild ever ran). xcodegen's per-target
+# pre-build script (iosApp/project.yml) also builds the framework on demand;
+# this step keeps the standalone CI path working for device archives.
 echo -e "${BLUE}[1/3] Building KMP shared framework...${NC}"
 (
     cd "$ROOT_DIR/mobile-native"
-    ./gradlew :shared:linkPodReleaseFrameworkIosArm64
+    ./gradlew :shared:linkReleaseFrameworkIosArm64
 )
 echo -e "${GREEN}  KMP framework built.${NC}"
 
 # --- Step 2: xcodebuild ---
 echo -e "${BLUE}[2/3] Running xcodebuild (${CONFIG})...${NC}"
 
-# The Xcode project is generated, not committed. Fail fast with a clear message
-# instead of letting xcodebuild emit a cryptic error (previously masked by
-# `|| true`, which let CI go green on a build that never produced an artifact).
+# The Xcode project is generated, not committed (see iosApp/project.yml). Try to
+# generate it with xcodegen; fail fast with a clear message if that is not
+# possible, instead of letting xcodebuild emit a cryptic error (previously
+# masked by `|| true`, which let CI go green on a build that never produced an
+# artifact).
+if [ ! -d "$IOS_DIR/iosApp.xcodeproj" ]; then
+    if command -v xcodegen >/dev/null 2>&1; then
+        echo -e "${YELLOW}  iosApp.xcodeproj missing — generating from project.yml via xcodegen...${NC}"
+        ( cd "$IOS_DIR" && xcodegen generate )
+    fi
+fi
+
 if [ ! -d "$IOS_DIR/iosApp.xcodeproj" ]; then
     echo -e "${RED}ERROR: Xcode project not found at $IOS_DIR/iosApp.xcodeproj${NC}" >&2
     echo "  The iosApp.xcodeproj is generated and is not committed to the repo." >&2
-    echo "  Generate it (e.g. via the KMP/Xcode project setup) before running this script." >&2
+    echo "  Install xcodegen (brew install xcodegen) and run:" >&2
+    echo "    cd mobile-native/iosApp && xcodegen generate" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Task
Verify/complete SwiftUI project setup for the Reality iOS app under `mobile-native/iosApp` (story 82-1): app entry point, DI wiring, Ktor networking bootstrap, and a smoke build target so downstream 82-x screen work has a compiling base.

## Owner
pm-frontend (specialist: `ios-swiftui`)

## What I found (verification result)
The SwiftUI source layer for story 82.1 was **already present and is internally consistent** — no rework needed there:
- **App entry point** — `iosApp/iosApp/App/RealityPortalApp.swift` (`@main`, `@UIApplicationDelegateAdaptor`, scene-phase + deep-link wiring) plus `AppDelegate.swift`.
- **DI wiring** — `iosApp/iosApp/Core/DI/DependencyContainer.swift` (repositories, `ApiClient`, `SsoService`, factory methods, KMP bridge type aliases).
- **Ktor networking bootstrap** — provided by the shared KMP module: `shared/.../api/HttpClientProvider.kt` (single shared `HttpClient`, ContentNegotiation/JSON) with the iOS `ktor-client-darwin` engine wired in `shared/build.gradle.kts` and iOS config read from Info.plist via `iosMain/.../PlatformConfig.kt`.
- xcconfigs (Base/Development/Staging/Production), three `xcschemes/*.xcscheme`, Info.plists, asset catalogs and localizations were all present.

**The actual gap was the "smoke build target".** There was **no `iosApp.xcodeproj` and no way to produce one** — `scripts/build-ios.sh` literally fails fast with *"the iosApp.xcodeproj is generated and is not committed… generate it before running this script"*, and `xcschemes/INSTALL.md` asked a human to hand-create the project in Xcode. Nothing in the repo could generate it. So downstream 82-x screen work had **no compiling base**.

## What I changed
- **`mobile-native/iosApp/project.yml`** (new) — an XcodeGen manifest that is now the single source of truth for `iosApp.xcodeproj`. It declares:
  - `iosApp` (app) + `iosAppTests` (unit-test) targets matching the existing schemes' `BlueprintName`/`BuildableName`;
  - the three build configs (Development→debug, Staging/Production→release), each wired to its `Configurations/*.xcconfig`;
  - the three `RealityPortal-*` schemes mirroring the hand-authored `.xcscheme` files;
  - per-config app-icon names (AppIcon-Dev / AppIcon-Staging / AppIcon);
  - a pre-build script that builds + stages the `:shared` KMP framework before the Swift compile.
- **`mobile-native/iosApp/.gitignore`** (new) — ignores the generated `iosApp.xcodeproj` + build output (keeps the "generated, not committed" contract honest).
- **`scripts/build-ios.sh`** — two fixes:
  1. **Bug fix:** step 1 called `:shared:linkPodReleaseFrameworkIosArm64`, a **kotlin-cocoapods-only task that does not exist** in this project (the `:shared` module uses a plain `binaries.framework {}`, no cocoapods plugin). Replaced with the real `:shared:linkReleaseFrameworkIosArm64` (same `link<Build>Framework<Target>` convention the CI workflow already uses). As written it would have failed before `xcodebuild` ever ran.
  2. Runs `xcodegen generate` automatically when the project is missing (was: just error out).
- **`xcschemes/INSTALL.md`** + **`mobile-native/CLAUDE.md`** — document the xcodegen generation flow and the iOS app structure.

## Tested (Band A — fast check, Linux)
- `python3 -c "yaml.safe_load(project.yml)"` → exit 0 — valid YAML; targets `[iosApp, iosAppTests]`, configs `{Development: debug, Staging: release, Production: release}`, schemes `[RealityPortal-Dev/Staging/Prod]`.
- `bash -n scripts/build-ios.sh` → exit 0.
- All source/config/Info.plist/xcconfig paths referenced by `project.yml` verified to exist; the per-config `ASSETCATALOG_COMPILER_APPICON_NAME` values match the asset catalogs (`AppIcon{,-Dev,-Staging}.appiconset`).
- Link-task naming cross-checked against `.github/workflows/mobile-native.yml`, which uses `:shared:linkDebugFrameworkIosSimulatorArm64` — same convention as the names I introduced.

## Built (Band B — full build)
**Not possible in this environment — gated on a macOS runner.** `xcodegen generate` + `xcodebuild` require macOS (no runner here). Additionally `./gradlew` cannot resolve plugins offline in this sandbox (AGP 9.2.1 is not fetchable), so I could not empirically enumerate Gradle tasks; the link-task names rely on the documented KMP convention + the existing CI usage above.

## CI parity (Band C)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change). Note the repo's `mobile-native.yml` `build-ios` job only builds the `:shared` framework (`linkDebugFrameworkIosSimulatorArm64`) — it does **not** run `xcodebuild` against `iosApp.xcodeproj`, so the SwiftUI app is still not compiled by CI. Wiring an `xcodebuild`/`xcodegen` step into the macOS CI job is a sensible follow-up now that a manifest exists.

## Notes for the reviewer
- This is a source-level / project-config change. The one thing that genuinely needs a macOS reviewer: run `cd mobile-native/iosApp && xcodegen generate` then `xcodebuild -scheme RealityPortal-Dev build` (or `scripts/build-ios.sh development`) to confirm the generated project compiles. I could not do that on Linux.
- Scope: changes are confined to `mobile-native/iosApp/**`, `mobile-native/CLAUDE.md`, and `scripts/build-ios.sh` (iOS build orchestrator). No app source behavior changed.

https://claude.ai/code/session_01VZss8M6ckVQKzvoTZkM4At

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZss8M6ckVQKzvoTZkM4At)_