### PR TITLE
test(reality-mobile): nav state preservation + deep-link URL schemes (story 82-2, AC-4)

### DIFF
--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/MainActivity.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/MainActivity.kt
@@ -21,8 +21,9 @@ import kotlinx.coroutines.launch
 import three.two.bit.ppt.reality.api.ApiConfig
 import three.two.bit.ppt.reality.auth.SsoService
 import three.two.bit.ppt.reality.listing.ListingRepository
+import three.two.bit.ppt.reality.navigation.DeepLinkRouter
+import three.two.bit.ppt.reality.navigation.DeepLinkTarget as SharedDeepLinkTarget
 import three.two.bit.ppt.reality.navigation.RealityNavHost
-import three.two.bit.ppt.reality.navigation.Screen
 import three.two.bit.ppt.reality.ui.theme.RealityPortalTheme
 
 /**
@@ -169,20 +170,18 @@ fun RealityPortalApp(
     )
 }
 
-/** Navigate to a deep link target (Epic 122) */
+/**
+ * Navigate to a deep link target (Epic 122). Route resolution is delegated to the shared
+ * [DeepLinkRouter] (commonMain) so Android and iOS resolve the same nav-graph routes (story 82-2,
+ * AC-4).
+ */
 private fun navigateToDeepLink(navController: NavHostController, target: DeepLinkTarget) {
-    when (target) {
-        is DeepLinkTarget.Listing -> {
-            navController.navigate(Screen.ListingDetail.createRoute(target.id))
+    val shared =
+        when (target) {
+            is DeepLinkTarget.Listing -> SharedDeepLinkTarget.Listing(target.id)
+            is DeepLinkTarget.Search -> SharedDeepLinkTarget.Search
+            is DeepLinkTarget.Favorites -> SharedDeepLinkTarget.Favorites
+            is DeepLinkTarget.Inquiries -> SharedDeepLinkTarget.Inquiries
         }
-        is DeepLinkTarget.Search -> {
-            navController.navigate(Screen.Search.route)
-        }
-        is DeepLinkTarget.Favorites -> {
-            navController.navigate(Screen.Favorites.route)
-        }
-        is DeepLinkTarget.Inquiries -> {
-            navController.navigate(Screen.Inquiries.route)
-        }
-    }
+    DeepLinkRouter.route(shared)?.let { route -> navController.navigate(route) }
 }

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/navigation/DeepLinkRouter.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/navigation/DeepLinkRouter.kt
@@ -16,7 +16,9 @@ sealed class DeepLinkTarget {
 
     data object Inquiries : DeepLinkTarget()
 
-    /** SSO callback: `reality://sso?token=…`. Handled by validating the token, not by navigation. */
+    /**
+     * SSO callback: `reality://sso?token=…`. Handled by validating the token, not by navigation.
+     */
     data class Sso(val token: String) : DeepLinkTarget()
 }
 
@@ -24,10 +26,9 @@ sealed class DeepLinkTarget {
  * Platform-agnostic deep-link parsing and nav-route resolution for Reality Portal mobile.
  *
  * Story 82-2, AC-4 — owns two things the Compose nav graph and `MainActivity` depend on:
- *
- *  - **Deep-link URL schemes**: turning a `reality://…` URI into a stable [DeepLinkTarget].
- *  - **Navigation state preservation**: the set of top-level tab routes whose back-stack state is
- *    saved/restored when switching tabs (vs. detail/auth routes that are not).
+ * - **Deep-link URL schemes**: turning a `reality://…` URI into a stable [DeepLinkTarget].
+ * - **Navigation state preservation**: the set of top-level tab routes whose back-stack state is
+ *   saved/restored when switching tabs (vs. detail/auth routes that are not).
  *
  * The string parsing here is intentionally framework-free (no `android.net.Uri`) so it is unit
  * testable on the JVM and reusable from iOS.
@@ -46,8 +47,8 @@ object DeepLinkRouter {
     /**
      * The five bottom-bar tab destinations. Switching between these saves and restores back-stack
      * state (`popUpTo(home){ saveState = true }; restoreState = true`), so a user who drills into a
-     * tab and switches away returns to where they left off. Every other route (listing detail, auth,
-     * realtor surfaces) is excluded and does not preserve state.
+     * tab and switches away returns to where they left off. Every other route (listing detail,
+     * auth, realtor surfaces) is excluded and does not preserve state.
      */
     val TOP_LEVEL_ROUTES: Set<String> =
         setOf(ROUTE_HOME, ROUTE_SEARCH, ROUTE_FAVORITES, ROUTE_INQUIRIES, ROUTE_ACCOUNT)

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/navigation/DeepLinkRouter.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/navigation/DeepLinkRouter.kt
@@ -1,0 +1,114 @@
+package three.two.bit.ppt.reality.navigation
+
+/**
+ * A navigable destination reached through a `reality://` deep link (Epic 122) or surfaced by the
+ * SSO callback (Epic 10A-SSO).
+ *
+ * This is the platform-agnostic mirror of the Android `MainActivity.DeepLinkTarget`. Keeping it in
+ * `commonMain` lets the iOS app reuse the exact same parsing + route-resolution contract.
+ */
+sealed class DeepLinkTarget {
+    data class Listing(val id: String) : DeepLinkTarget()
+
+    data object Search : DeepLinkTarget()
+
+    data object Favorites : DeepLinkTarget()
+
+    data object Inquiries : DeepLinkTarget()
+
+    /** SSO callback: `reality://sso?token=…`. Handled by validating the token, not by navigation. */
+    data class Sso(val token: String) : DeepLinkTarget()
+}
+
+/**
+ * Platform-agnostic deep-link parsing and nav-route resolution for Reality Portal mobile.
+ *
+ * Story 82-2, AC-4 — owns two things the Compose nav graph and `MainActivity` depend on:
+ *
+ *  - **Deep-link URL schemes**: turning a `reality://…` URI into a stable [DeepLinkTarget].
+ *  - **Navigation state preservation**: the set of top-level tab routes whose back-stack state is
+ *    saved/restored when switching tabs (vs. detail/auth routes that are not).
+ *
+ * The string parsing here is intentionally framework-free (no `android.net.Uri`) so it is unit
+ * testable on the JVM and reusable from iOS.
+ */
+object DeepLinkRouter {
+
+    const val SCHEME: String = "reality"
+
+    // Route strings — must stay in lockstep with `navigation.Screen` in the Android app.
+    const val ROUTE_HOME: String = "home"
+    const val ROUTE_SEARCH: String = "search"
+    const val ROUTE_FAVORITES: String = "favorites"
+    const val ROUTE_INQUIRIES: String = "inquiries"
+    const val ROUTE_ACCOUNT: String = "account"
+
+    /**
+     * The five bottom-bar tab destinations. Switching between these saves and restores back-stack
+     * state (`popUpTo(home){ saveState = true }; restoreState = true`), so a user who drills into a
+     * tab and switches away returns to where they left off. Every other route (listing detail, auth,
+     * realtor surfaces) is excluded and does not preserve state.
+     */
+    val TOP_LEVEL_ROUTES: Set<String> =
+        setOf(ROUTE_HOME, ROUTE_SEARCH, ROUTE_FAVORITES, ROUTE_INQUIRIES, ROUTE_ACCOUNT)
+
+    /** True when [route] is a state-preserving top-level tab. */
+    fun preservesState(route: String?): Boolean = route in TOP_LEVEL_ROUTES
+
+    /**
+     * Parse a `reality://…` deep-link string into a [DeepLinkTarget], or `null` if the URI is
+     * malformed, uses a foreign scheme, or targets an unknown host.
+     */
+    fun parse(uri: String): DeepLinkTarget? {
+        val schemeSep = uri.indexOf("://")
+        if (schemeSep <= 0) return null
+        if (uri.substring(0, schemeSep) != SCHEME) return null
+
+        val rest = uri.substring(schemeSep + 3)
+        if (rest.isEmpty()) return null
+
+        // Split off the query string (everything after the first '?').
+        val queryStart = rest.indexOf('?')
+        val pathPart = if (queryStart >= 0) rest.substring(0, queryStart) else rest
+        val queryPart = if (queryStart >= 0) rest.substring(queryStart + 1) else ""
+
+        val segments = pathPart.split('/').filter { it.isNotEmpty() }
+        val host = segments.firstOrNull() ?: return null
+        val tail = segments.drop(1)
+
+        return when (host) {
+            "listing" -> tail.firstOrNull()?.let { DeepLinkTarget.Listing(it) }
+            "search" -> DeepLinkTarget.Search
+            "favorites" -> DeepLinkTarget.Favorites
+            "inquiries" -> DeepLinkTarget.Inquiries
+            "sso" -> queryParam(queryPart, "token")?.let { DeepLinkTarget.Sso(it) }
+            else -> null
+        }
+    }
+
+    /**
+     * Resolve a [target] to the nav-graph route string to navigate to, or `null` for targets that
+     * are handled out-of-band (e.g. [DeepLinkTarget.Sso], which validates a token instead).
+     */
+    fun route(target: DeepLinkTarget): String? =
+        when (target) {
+            is DeepLinkTarget.Listing -> "listing/${target.id}"
+            DeepLinkTarget.Search -> ROUTE_SEARCH
+            DeepLinkTarget.Favorites -> ROUTE_FAVORITES
+            DeepLinkTarget.Inquiries -> ROUTE_INQUIRIES
+            is DeepLinkTarget.Sso -> null
+        }
+
+    private fun queryParam(query: String, key: String): String? {
+        if (query.isEmpty()) return null
+        for (pair in query.split('&')) {
+            val eq = pair.indexOf('=')
+            if (eq <= 0) continue
+            if (pair.substring(0, eq) == key) {
+                val value = pair.substring(eq + 1)
+                return value.ifEmpty { null }
+            }
+        }
+        return null
+    }
+}

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/navigation/DeepLinkRouterTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/navigation/DeepLinkRouterTest.kt
@@ -1,0 +1,133 @@
+package three.two.bit.ppt.reality.navigation
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Story 82-2, AC-4 — Reality mobile navigation state preservation and deep-link URL schemes.
+ *
+ * These tests pin the platform-agnostic contract behind the Android `MainActivity` deep-link
+ * handler and the Compose nav graph:
+ *
+ * 1. Deep-link URL schemes (`reality://...`) parse into a stable [DeepLinkTarget].
+ * 2. Each target resolves to the exact nav-graph route string used by the Compose graph.
+ * 3. The set of top-level tab routes (the ones whose back-stack state must be saved/restored
+ *    when switching tabs) is well-defined and matches what the bottom bar drives.
+ */
+class DeepLinkRouterTest {
+
+    // -------- URL scheme parsing (AC-4: deep-link URL schemes) --------
+
+    @Test
+    fun parse_listing_deep_link_extracts_id() {
+        val target = DeepLinkRouter.parse("reality://listing/abc-123")
+        assertEquals(DeepLinkTarget.Listing("abc-123"), target)
+    }
+
+    @Test
+    fun parse_listing_deep_link_with_trailing_segments_uses_first() {
+        // reality://listing/{id}/whatever — the id is the first path segment.
+        val target = DeepLinkRouter.parse("reality://listing/xyz/extra")
+        assertEquals(DeepLinkTarget.Listing("xyz"), target)
+    }
+
+    @Test
+    fun parse_listing_deep_link_without_id_is_null() {
+        assertNull(DeepLinkRouter.parse("reality://listing"))
+        assertNull(DeepLinkRouter.parse("reality://listing/"))
+    }
+
+    @Test
+    fun parse_search_deep_link() {
+        assertEquals(DeepLinkTarget.Search, DeepLinkRouter.parse("reality://search"))
+    }
+
+    @Test
+    fun parse_favorites_deep_link() {
+        assertEquals(DeepLinkTarget.Favorites, DeepLinkRouter.parse("reality://favorites"))
+    }
+
+    @Test
+    fun parse_inquiries_deep_link() {
+        assertEquals(DeepLinkTarget.Inquiries, DeepLinkRouter.parse("reality://inquiries"))
+    }
+
+    @Test
+    fun parse_sso_deep_link_extracts_token() {
+        val target = DeepLinkRouter.parse("reality://sso?token=tok-42")
+        assertEquals(DeepLinkTarget.Sso("tok-42"), target)
+    }
+
+    @Test
+    fun parse_sso_deep_link_without_token_is_null() {
+        assertNull(DeepLinkRouter.parse("reality://sso"))
+    }
+
+    @Test
+    fun parse_rejects_foreign_scheme() {
+        assertNull(DeepLinkRouter.parse("https://listing/abc-123"))
+        assertNull(DeepLinkRouter.parse("ppt://listing/abc-123"))
+    }
+
+    @Test
+    fun parse_rejects_unknown_host() {
+        assertNull(DeepLinkRouter.parse("reality://unknown"))
+    }
+
+    @Test
+    fun parse_rejects_blank_or_garbage() {
+        assertNull(DeepLinkRouter.parse(""))
+        assertNull(DeepLinkRouter.parse("not a uri"))
+    }
+
+    // -------- target -> nav route resolution --------
+
+    @Test
+    fun route_for_listing_matches_compose_graph_route() {
+        assertEquals("listing/abc-123", DeepLinkRouter.route(DeepLinkTarget.Listing("abc-123")))
+    }
+
+    @Test
+    fun route_for_search() {
+        assertEquals("search", DeepLinkRouter.route(DeepLinkTarget.Search))
+    }
+
+    @Test
+    fun route_for_favorites() {
+        assertEquals("favorites", DeepLinkRouter.route(DeepLinkTarget.Favorites))
+    }
+
+    @Test
+    fun route_for_inquiries() {
+        assertEquals("inquiries", DeepLinkRouter.route(DeepLinkTarget.Inquiries))
+    }
+
+    @Test
+    fun route_for_sso_is_null_handled_out_of_band() {
+        // SSO is handled by validating the token, not by navigating the graph.
+        assertNull(DeepLinkRouter.route(DeepLinkTarget.Sso("tok-42")))
+    }
+
+    // -------- top-level tab routes (AC-4: navigation state preservation) --------
+
+    @Test
+    fun top_level_routes_are_the_five_bottom_bar_tabs() {
+        assertEquals(
+            setOf("home", "search", "favorites", "inquiries", "account"),
+            DeepLinkRouter.TOP_LEVEL_ROUTES,
+        )
+    }
+
+    @Test
+    fun tab_routes_preserve_state_but_detail_routes_do_not() {
+        assertTrue(DeepLinkRouter.preservesState("home"))
+        assertTrue(DeepLinkRouter.preservesState("favorites"))
+        // A listing detail route is not a state-preserving tab.
+        assertFalse(DeepLinkRouter.preservesState("listing/abc-123"))
+        assertFalse(DeepLinkRouter.preservesState("auth/login"))
+        assertFalse(DeepLinkRouter.preservesState(null))
+    }
+}

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/navigation/DeepLinkRouterTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/navigation/DeepLinkRouterTest.kt
@@ -11,11 +11,10 @@ import kotlin.test.assertTrue
  *
  * These tests pin the platform-agnostic contract behind the Android `MainActivity` deep-link
  * handler and the Compose nav graph:
- *
  * 1. Deep-link URL schemes (`reality://...`) parse into a stable [DeepLinkTarget].
  * 2. Each target resolves to the exact nav-graph route string used by the Compose graph.
- * 3. The set of top-level tab routes (the ones whose back-stack state must be saved/restored
- *    when switching tabs) is well-defined and matches what the bottom bar drives.
+ * 3. The set of top-level tab routes (the ones whose back-stack state must be saved/restored when
+ *    switching tabs) is well-defined and matches what the bottom bar drives.
  */
 class DeepLinkRouterTest {
 


### PR DESCRIPTION
## What

Adds Kotlin unit tests (TDD, failing-first) for **Reality mobile navigation state preservation and deep-linking URL schemes** — story 82-2, AC-4 — on the Android/KMP target.

To make the behavior unit-testable on the JVM (and reusable from iOS), the `reality://` URL-scheme parsing and nav-route resolution are extracted into a new platform-agnostic `DeepLinkRouter` in `shared/commonMain`. `MainActivity.navigateToDeepLink` now delegates route resolution to it, keeping runtime behavior identical.

### Files
- `mobile-native/shared/src/commonMain/.../navigation/DeepLinkRouter.kt` — pure-Kotlin router: `parse(uri)` → `DeepLinkTarget`, `route(target)` → nav-graph route string, `TOP_LEVEL_ROUTES` / `preservesState(route)` for the state-preserving tab contract.
- `mobile-native/shared/src/commonTest/.../navigation/DeepLinkRouterTest.kt` — 18 tests covering listing/search/favorites/inquiries/sso schemes, malformed/foreign/unknown URIs, route resolution, and the five state-preserving tab routes.
- `mobile-native/androidApp/.../MainActivity.kt` — deep-link route resolution delegates to the shared router (behavior-preserving).

## IG3 — failing-first evidence

Test compiled against `dev` (no `DeepLinkRouter`) fails to resolve, then passes with the implementation:

```
# without implementation (dev state):
error: unresolved reference 'DeepLinkRouter'   -> exit 1  (red)

# with implementation:
JUnit version 4.13.2
..................
OK (18 tests)                                   -> exit 0  (green)
```

Verified by compiling + running the `commonTest` source against the Kotlin 2.3.20 compiler with `kotlin-test-junit` (JUnit4).

## CI / verify note

The mandated `./gradlew test` could **not** be run in this sandbox: the Android Gradle Plugin (`com.android.application:9.2.1`) resolves only from Google's Maven (`dl.google.com` / `maven.google.com`), which is network-blocked here (`host_not_allowed`), and the Gradle module cache is empty. Maven Central + the Gradle Plugin Portal are reachable, so I verified the new sources standalone (compile + JUnit run, 18/18 green) using the embedded Kotlin compiler. The repo's `mobile-native.yml` CI workflow will run the full `./gradlew test` on this PR.

## Scope

Owner role hint was `pm-frontend`, but the task explicitly targets the KMP/mobile-native specialist; all changes are under `mobile-native/` (kotlin-mp area). No frontend (`frontend/`) or backend code touched.

https://claude.ai/code/session_01VZss8M6ckVQKzvoTZkM4At

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZss8M6ckVQKzvoTZkM4At)_