### PR TITLE
gap-82-5: Reality mobile inquiries list + account screen — wire stats to reality-server

### DIFF
--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/account/AccountScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/account/AccountScreen.kt
@@ -97,8 +97,7 @@ fun AccountScreen(
             val token = (authState as? AuthState.Authenticated)?.sessionToken
             val baseUrl = ApiConfig.requireBaseUrl()
             ProfileStatsLoader(
-                favoritesRepository =
-                    FavoritesRepository(baseUrl = baseUrl, sessionToken = token),
+                favoritesRepository = FavoritesRepository(baseUrl = baseUrl, sessionToken = token),
                 inquiryRepository = InquiryRepository(baseUrl = baseUrl, sessionToken = token),
             )
         }
@@ -230,7 +229,7 @@ fun AccountScreen(
     }
 }
 
-// ─── Top bar ──────────────────────────────────────────────
+// ─── Top bar ───────────────────────────────────────────────
 
 @Composable
 private fun ProfileTopBar(onEditProfileClick: () -> Unit) {
@@ -551,7 +550,7 @@ private fun SectionDivider() {
     )
 }
 
-// ─── Notification preferences (collapsible) ───────────────────────────
+// ─── Notification preferences (collapsible) ──────────────────────
 
 @Composable
 private fun NotificationPreferencesCard(
@@ -633,7 +632,7 @@ private fun NotificationPreferenceItem(
     }
 }
 
-// ─── App settings + About (preserved, restyled) ─────────────────────────
+// ─── App settings + About (preserved, restyled) ────────────────────────
 
 @Composable
 private fun AppSettingsCard() {
@@ -797,7 +796,7 @@ private fun AboutRow(icon: ImageVector, title: String, onClick: () -> Unit) {
     }
 }
 
-// ─── Sign out card ──────────────────────────────────────────
+// ─── Sign out card ─────────────────────────────────────────
 
 @Composable
 private fun SignOutCard(onClick: () -> Unit) {
@@ -843,7 +842,7 @@ private fun SignOutCard(onClick: () -> Unit) {
     }
 }
 
-// ─── Not signed in ──────────────────────────────────────────
+// ─── Not signed in ─────────────────────────────────────────
 
 @Composable
 private fun NotSignedInContent(onSignInClick: () -> Unit) {

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/account/AccountScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/account/AccountScreen.kt
@@ -33,10 +33,14 @@ import coil.request.ImageRequest
 import kotlinx.coroutines.launch
 import three.two.bit.ppt.reality.BuildConfig
 import three.two.bit.ppt.reality.R
+import three.two.bit.ppt.reality.account.ProfileStats
+import three.two.bit.ppt.reality.account.ProfileStatsLoader
 import three.two.bit.ppt.reality.api.ApiConfig
 import three.two.bit.ppt.reality.auth.AuthState
 import three.two.bit.ppt.reality.auth.SsoService
 import three.two.bit.ppt.reality.auth.SsoUserInfo
+import three.two.bit.ppt.reality.favorites.FavoritesRepository
+import three.two.bit.ppt.reality.inquiry.InquiryRepository
 import three.two.bit.ppt.reality.notifications.NotificationPreferences
 import three.two.bit.ppt.reality.notifications.NotificationRepository
 import three.two.bit.ppt.reality.ui.theme.Brand500
@@ -81,11 +85,22 @@ fun AccountScreen(
     var showLogoutDialog by remember { mutableStateOf(false) }
     var notificationPrefs by remember { mutableStateOf<NotificationPreferences?>(null) }
     var notificationsExpanded by remember { mutableStateOf(false) }
+    var profileStats by remember { mutableStateOf(ProfileStats.UNKNOWN) }
 
     val notificationRepository =
         remember(authState) {
             val token = (authState as? AuthState.Authenticated)?.sessionToken
             NotificationRepository(baseUrl = ApiConfig.requireBaseUrl(), sessionToken = token)
+        }
+    val statsLoader =
+        remember(authState) {
+            val token = (authState as? AuthState.Authenticated)?.sessionToken
+            val baseUrl = ApiConfig.requireBaseUrl()
+            ProfileStatsLoader(
+                favoritesRepository =
+                    FavoritesRepository(baseUrl = baseUrl, sessionToken = token),
+                inquiryRepository = InquiryRepository(baseUrl = baseUrl, sessionToken = token),
+            )
         }
 
     LaunchedEffect(authState) {
@@ -98,6 +113,9 @@ fun AccountScreen(
                         Log.e(TAG, "Failed to load notification preferences", error)
                     },
                 )
+            profileStats = statsLoader.load()
+        } else {
+            profileStats = ProfileStats.UNKNOWN
         }
     }
 
@@ -120,10 +138,17 @@ fun AccountScreen(
                     item { ProfileTopBar(onEditProfileClick = onProfileEditClick) }
                     item { ProfileHero(user = state.user) }
                     item { Spacer(modifier = Modifier.height(8.dp)) }
-                    // Stats counts will come from /me/stats once the endpoint exists.
-                    // Until then we pass nulls — StatCard renders an em-dash to
-                    // signal "unknown" rather than a fake number.
-                    item { StatsRow(favorites = null, searches = null, inquiries = null) }
+                    // Stats are derived from the `total` field of the favorites,
+                    // saved-searches, and inquiries list endpoints (reality-server has
+                    // no single /me/stats endpoint). A failed call leaves that field
+                    // null so StatCard renders an em-dash instead of a fake 0.
+                    item {
+                        StatsRow(
+                            favorites = profileStats.favorites,
+                            searches = profileStats.searches,
+                            inquiries = profileStats.inquiries,
+                        )
+                    }
                     item { Spacer(modifier = Modifier.height(24.dp)) }
                     item {
                         SectionList(
@@ -205,7 +230,7 @@ fun AccountScreen(
     }
 }
 
-// ─── Top bar ────────────────────────────────────────────────────────────────
+// ─── Top bar ──────────────────────────────────────────────
 
 @Composable
 private fun ProfileTopBar(onEditProfileClick: () -> Unit) {
@@ -231,7 +256,7 @@ private fun ProfileTopBar(onEditProfileClick: () -> Unit) {
     }
 }
 
-// ─── Hero ────────────────────────────────────────────────────────────────────
+// ─── Hero ────────────────────────────────────────────────
 
 @Composable
 private fun ProfileHero(user: SsoUserInfo) {
@@ -333,7 +358,7 @@ private fun VerifiedPill() {
     }
 }
 
-// ─── Stats row ──────────────────────────────────────────────────────────────
+// ─── Stats row ─────────────────────────────────────────────
 
 @Composable
 private fun StatsRow(favorites: Int?, searches: Int?, inquiries: Int?) {
@@ -391,7 +416,7 @@ private fun StatCard(value: String, label: String, modifier: Modifier = Modifier
     }
 }
 
-// ─── Section list ───────────────────────────────────────────────────────────
+// ─── Section list ──────────────────────────────────────────
 
 @Composable
 private fun SectionList(
@@ -526,7 +551,7 @@ private fun SectionDivider() {
     )
 }
 
-// ─── Notification preferences (collapsible) ─────────────────────────────────
+// ─── Notification preferences (collapsible) ───────────────────────────
 
 @Composable
 private fun NotificationPreferencesCard(
@@ -608,7 +633,7 @@ private fun NotificationPreferenceItem(
     }
 }
 
-// ─── App settings + About (preserved, restyled) ──────────────────────────────
+// ─── App settings + About (preserved, restyled) ─────────────────────────
 
 @Composable
 private fun AppSettingsCard() {
@@ -772,7 +797,7 @@ private fun AboutRow(icon: ImageVector, title: String, onClick: () -> Unit) {
     }
 }
 
-// ─── Sign out card ───────────────────────────────────────────────────────────
+// ─── Sign out card ──────────────────────────────────────────
 
 @Composable
 private fun SignOutCard(onClick: () -> Unit) {
@@ -818,7 +843,7 @@ private fun SignOutCard(onClick: () -> Unit) {
     }
 }
 
-// ─── Not signed in ──────────────────────────────────────────────────────────
+// ─── Not signed in ──────────────────────────────────────────
 
 @Composable
 private fun NotSignedInContent(onSignInClick: () -> Unit) {

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/account/ProfileStats.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/account/ProfileStats.kt
@@ -10,9 +10,8 @@ import three.two.bit.ppt.reality.inquiry.InquiryRepository
  * renders a dash rather than a misleading `0`. The reality-server has no single `/me/stats`
  * endpoint, so the counts are derived from the `total` field returned by the three list endpoints
  * the app already calls:
- *
  * - favorites - `GET /api/v1/favorites` -> `FavoritesResponse.total`
- * - searches  - `GET /api/v1/saved-searches` -> `SavedSearchesResponse.total`
+ * - searches - `GET /api/v1/saved-searches` -> `SavedSearchesResponse.total`
  * - inquiries - `GET /api/v1/inquiries` -> `InquiriesResponse.total`
  *
  * Epic 48 - Story 48.5: Portal Mobile Account.

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/account/ProfileStats.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/account/ProfileStats.kt
@@ -40,15 +40,10 @@ class ProfileStatsLoader(
     private val inquiryRepository: InquiryRepository,
 ) {
     suspend fun load(): ProfileStats {
-        val favorites =
-            favoritesRepository.getFavorites().getOrNull()?.total?.toIntClampedOrNull()
+        val favorites = favoritesRepository.getFavorites().getOrNull()?.total?.toIntClampedOrNull()
         val searches = favoritesRepository.getSavedSearches().getOrNull()?.total
         val inquiries = inquiryRepository.getInquiries().getOrNull()?.total
-        return ProfileStats(
-            favorites = favorites,
-            searches = searches,
-            inquiries = inquiries,
-        )
+        return ProfileStats(favorites = favorites, searches = searches, inquiries = inquiries)
     }
 }
 

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/account/ProfileStats.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/account/ProfileStats.kt
@@ -7,19 +7,19 @@ import three.two.bit.ppt.reality.inquiry.InquiryRepository
  * Aggregated counts shown in the Account / Profile screen stat strip.
  *
  * Each field is nullable: a `null` means "count unknown" (the underlying request failed) and the UI
- * renders an em-dash rather than a misleading `0`. The reality-server has no single `/me/stats`
+ * renders a dash rather than a misleading `0`. The reality-server has no single `/me/stats`
  * endpoint, so the counts are derived from the `total` field returned by the three list endpoints
  * the app already calls:
  *
- * - favorites — `GET /api/v1/favorites` → `FavoritesResponse.total`
- * - searches  — `GET /api/v1/saved-searches` → `SavedSearchesResponse.total`
- * - inquiries — `GET /api/v1/inquiries` → `InquiriesResponse.total`
+ * - favorites - `GET /api/v1/favorites` -> `FavoritesResponse.total`
+ * - searches  - `GET /api/v1/saved-searches` -> `SavedSearchesResponse.total`
+ * - inquiries - `GET /api/v1/inquiries` -> `InquiriesResponse.total`
  *
  * Epic 48 - Story 48.5: Portal Mobile Account.
  */
 data class ProfileStats(val favorites: Int?, val searches: Int?, val inquiries: Int?) {
     companion object {
-        /** All-unknown stats — the initial state before the network calls resolve. */
+        /** All-unknown stats - the initial state before the network calls resolve. */
         val UNKNOWN = ProfileStats(favorites = null, searches = null, inquiries = null)
     }
 }
@@ -27,13 +27,13 @@ data class ProfileStats(val favorites: Int?, val searches: Int?, val inquiries: 
 /**
  * Loads the profile stat counts for the signed-in user.
  *
- * Lives in `commonMain` (and is unit-tested in `commonTest`) so the count-derivation logic is shared
- * with iOS and verifiable without an Android build. The three calls are independent: a failure in
- * one leaves the others intact and only that field falls back to `null`.
+ * Lives in `commonMain` (and is unit-tested in `commonTest`) so the count-derivation logic is
+ * shared with iOS and verifiable without an Android build. The three calls are independent: a
+ * failure in one leaves the others intact and only that field falls back to `null`.
  *
  * The class takes an [InquiryRepository] and a [FavoritesRepository] (which also owns saved
- * searches) rather than constructing its own, so callers can inject the session-scoped instances and
- * tests can supply mock-engine-backed repositories.
+ * searches) rather than constructing its own, so callers can inject the session-scoped instances
+ * and tests can supply mock-engine-backed repositories.
  */
 class ProfileStatsLoader(
     private val favoritesRepository: FavoritesRepository,

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/account/ProfileStats.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/account/ProfileStats.kt
@@ -1,0 +1,59 @@
+package three.two.bit.ppt.reality.account
+
+import three.two.bit.ppt.reality.favorites.FavoritesRepository
+import three.two.bit.ppt.reality.inquiry.InquiryRepository
+
+/**
+ * Aggregated counts shown in the Account / Profile screen stat strip.
+ *
+ * Each field is nullable: a `null` means "count unknown" (the underlying request failed) and the UI
+ * renders an em-dash rather than a misleading `0`. The reality-server has no single `/me/stats`
+ * endpoint, so the counts are derived from the `total` field returned by the three list endpoints
+ * the app already calls:
+ *
+ * - favorites — `GET /api/v1/favorites` → `FavoritesResponse.total`
+ * - searches  — `GET /api/v1/saved-searches` → `SavedSearchesResponse.total`
+ * - inquiries — `GET /api/v1/inquiries` → `InquiriesResponse.total`
+ *
+ * Epic 48 - Story 48.5: Portal Mobile Account.
+ */
+data class ProfileStats(val favorites: Int?, val searches: Int?, val inquiries: Int?) {
+    companion object {
+        /** All-unknown stats — the initial state before the network calls resolve. */
+        val UNKNOWN = ProfileStats(favorites = null, searches = null, inquiries = null)
+    }
+}
+
+/**
+ * Loads the profile stat counts for the signed-in user.
+ *
+ * Lives in `commonMain` (and is unit-tested in `commonTest`) so the count-derivation logic is shared
+ * with iOS and verifiable without an Android build. The three calls are independent: a failure in
+ * one leaves the others intact and only that field falls back to `null`.
+ *
+ * The class takes an [InquiryRepository] and a [FavoritesRepository] (which also owns saved
+ * searches) rather than constructing its own, so callers can inject the session-scoped instances and
+ * tests can supply mock-engine-backed repositories.
+ */
+class ProfileStatsLoader(
+    private val favoritesRepository: FavoritesRepository,
+    private val inquiryRepository: InquiryRepository,
+) {
+    suspend fun load(): ProfileStats {
+        val favorites =
+            favoritesRepository.getFavorites().getOrNull()?.total?.toIntClampedOrNull()
+        val searches = favoritesRepository.getSavedSearches().getOrNull()?.total
+        val inquiries = inquiryRepository.getInquiries().getOrNull()?.total
+        return ProfileStats(
+            favorites = favorites,
+            searches = searches,
+            inquiries = inquiries,
+        )
+    }
+}
+
+/**
+ * `FavoritesResponse.total` is a `Long`; the stat strip renders an `Int`. Clamp to [Int.MAX_VALUE]
+ * defensively rather than overflowing on an implausibly large count.
+ */
+private fun Long.toIntClampedOrNull(): Int = if (this > Int.MAX_VALUE) Int.MAX_VALUE else toInt()

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/account/ProfileStatsLoaderTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/account/ProfileStatsLoaderTest.kt
@@ -19,10 +19,11 @@ import three.two.bit.ppt.reality.favorites.FavoritesRepository
 import three.two.bit.ppt.reality.inquiry.InquiryRepository
 
 /**
- * Unit tests for [ProfileStatsLoader] — the Account-screen stat-strip aggregator.
+ * Unit tests for [ProfileStatsLoader] - the Account-screen stat-strip aggregator.
  *
- * Lives in `commonMain` / `commonTest` so the derivation logic (read `total` off each list endpoint,
- * fall back to `null` on failure) is verifiable on the JVM without an Android/Gradle device build.
+ * Lives in `commonMain` / `commonTest` so the derivation logic (read `total` off each list
+ * endpoint, fall back to `null` on failure) is verifiable on the JVM without an Android/Gradle
+ * device build.
  *
  * Epic 48 - Story 48.5 (gap-82-5): wire Account stats to reality-server list endpoints.
  */

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/account/ProfileStatsLoaderTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/account/ProfileStatsLoaderTest.kt
@@ -1,0 +1,131 @@
+package three.two.bit.ppt.reality.account
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import three.two.bit.ppt.reality.favorites.FavoritesRepository
+import three.two.bit.ppt.reality.inquiry.InquiryRepository
+
+/**
+ * Unit tests for [ProfileStatsLoader] — the Account-screen stat-strip aggregator.
+ *
+ * Lives in `commonMain` / `commonTest` so the derivation logic (read `total` off each list endpoint,
+ * fall back to `null` on failure) is verifiable on the JVM without an Android/Gradle device build.
+ *
+ * Epic 48 - Story 48.5 (gap-82-5): wire Account stats to reality-server list endpoints.
+ */
+class ProfileStatsLoaderTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+    }
+
+    /**
+     * Routes each request to a canned response keyed by the path's last meaningful segment, so a
+     * single MockEngine can back both repositories the loader fans out to.
+     */
+    private fun loaderWith(
+        favoritesStatus: HttpStatusCode = HttpStatusCode.OK,
+        favoritesBody: String = """{"favorites":[],"total":0}""",
+        savedSearchesStatus: HttpStatusCode = HttpStatusCode.OK,
+        savedSearchesBody: String = """{"searches":[],"total":0}""",
+        inquiriesStatus: HttpStatusCode = HttpStatusCode.OK,
+        inquiriesBody: String = """{"inquiries":[],"total":0,"page":1,"page_size":20}""",
+    ): ProfileStatsLoader {
+        val engine = MockEngine { request ->
+            val path = request.url.encodedPath
+            when {
+                path.contains("/saved-searches") ->
+                    if (savedSearchesStatus.isSuccess()) {
+                        respond(
+                            content = ByteReadChannel(savedSearchesBody),
+                            status = savedSearchesStatus,
+                            headers =
+                                headersOf(HttpHeaders.ContentType, "application/json"),
+                        )
+                    } else {
+                        respondError(savedSearchesStatus)
+                    }
+                path.contains("/favorites") ->
+                    if (favoritesStatus.isSuccess()) {
+                        respond(
+                            content = ByteReadChannel(favoritesBody),
+                            status = favoritesStatus,
+                            headers =
+                                headersOf(HttpHeaders.ContentType, "application/json"),
+                        )
+                    } else {
+                        respondError(favoritesStatus)
+                    }
+                path.contains("/inquiries") ->
+                    if (inquiriesStatus.isSuccess()) {
+                        respond(
+                            content = ByteReadChannel(inquiriesBody),
+                            status = inquiriesStatus,
+                            headers =
+                                headersOf(HttpHeaders.ContentType, "application/json"),
+                        )
+                    } else {
+                        respondError(inquiriesStatus)
+                    }
+                else -> respondError(HttpStatusCode.NotFound)
+            }
+        }
+        val client = HttpClient(engine) { install(ContentNegotiation) { json(json) } }
+        return ProfileStatsLoader(
+            favoritesRepository =
+                FavoritesRepository("https://example.test", "tok", client),
+            inquiryRepository = InquiryRepository("https://example.test", "tok", client),
+        )
+    }
+
+    @Test
+    fun load_reads_total_from_each_endpoint() = runTest {
+        val loader =
+            loaderWith(
+                favoritesBody = """{"favorites":[],"total":7}""",
+                savedSearchesBody = """{"searches":[],"total":3}""",
+                inquiriesBody = """{"inquiries":[],"total":5,"page":1,"page_size":20}""",
+            )
+        val stats = loader.load()
+        assertEquals(7, stats.favorites)
+        assertEquals(3, stats.searches)
+        assertEquals(5, stats.inquiries)
+    }
+
+    @Test
+    fun load_falls_back_to_null_per_failing_endpoint() = runTest {
+        val loader =
+            loaderWith(
+                favoritesStatus = HttpStatusCode.InternalServerError,
+                savedSearchesBody = """{"searches":[],"total":2}""",
+                inquiriesStatus = HttpStatusCode.Unauthorized,
+            )
+        val stats = loader.load()
+        assertNull(stats.favorites, "favorites should be null when its call fails")
+        assertEquals(2, stats.searches, "searches should still resolve independently")
+        assertNull(stats.inquiries, "inquiries should be null when its call fails")
+    }
+
+    @Test
+    fun load_clamps_oversized_favorites_total_to_int_max() = runTest {
+        val loader =
+            loaderWith(favoritesBody = """{"favorites":[],"total":3000000000}""")
+        val stats = loader.load()
+        assertEquals(Int.MAX_VALUE, stats.favorites)
+    }
+}

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/account/ProfileStatsLoaderTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/account/ProfileStatsLoaderTest.kt
@@ -54,8 +54,7 @@ class ProfileStatsLoaderTest {
                         respond(
                             content = ByteReadChannel(savedSearchesBody),
                             status = savedSearchesStatus,
-                            headers =
-                                headersOf(HttpHeaders.ContentType, "application/json"),
+                            headers = headersOf(HttpHeaders.ContentType, "application/json"),
                         )
                     } else {
                         respondError(savedSearchesStatus)
@@ -65,8 +64,7 @@ class ProfileStatsLoaderTest {
                         respond(
                             content = ByteReadChannel(favoritesBody),
                             status = favoritesStatus,
-                            headers =
-                                headersOf(HttpHeaders.ContentType, "application/json"),
+                            headers = headersOf(HttpHeaders.ContentType, "application/json"),
                         )
                     } else {
                         respondError(favoritesStatus)
@@ -76,8 +74,7 @@ class ProfileStatsLoaderTest {
                         respond(
                             content = ByteReadChannel(inquiriesBody),
                             status = inquiriesStatus,
-                            headers =
-                                headersOf(HttpHeaders.ContentType, "application/json"),
+                            headers = headersOf(HttpHeaders.ContentType, "application/json"),
                         )
                     } else {
                         respondError(inquiriesStatus)
@@ -87,8 +84,7 @@ class ProfileStatsLoaderTest {
         }
         val client = HttpClient(engine) { install(ContentNegotiation) { json(json) } }
         return ProfileStatsLoader(
-            favoritesRepository =
-                FavoritesRepository("https://example.test", "tok", client),
+            favoritesRepository = FavoritesRepository("https://example.test", "tok", client),
             inquiryRepository = InquiryRepository("https://example.test", "tok", client),
         )
     }
@@ -123,8 +119,7 @@ class ProfileStatsLoaderTest {
 
     @Test
     fun load_clamps_oversized_favorites_total_to_int_max() = runTest {
-        val loader =
-            loaderWith(favoritesBody = """{"favorites":[],"total":3000000000}""")
+        val loader = loaderWith(favoritesBody = """{"favorites":[],"total":3000000000}""")
         val stats = loader.load()
         assertEquals(Int.MAX_VALUE, stats.favorites)
     }

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/account/ProfileStatsLoaderTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/account/ProfileStatsLoaderTest.kt
@@ -8,6 +8,7 @@ import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
+import io.ktor.http.isSuccess
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.ByteReadChannel
 import kotlin.test.Test


### PR DESCRIPTION
## Task
Reality mobile inquiries list + account screen (story 82-5): wire the inquiries feed and the account/profile screen to their reality-server endpoints, including auth state.

## Owner
pm-frontend (specialist: kotlin-mp)

## What was already in place
The Reality mobile (KMP / Compose Android) **inquiries list** and **account/profile** screens were already implemented and wired in prior epic-48 work:

- `InquiriesScreen.kt` — wired to `InquiryRepository` (`GET /api/v1/inquiries`, `/api/v1/viewings`, `DELETE /api/v1/viewings/{id}`), session-token-aware, with full auth-state handling (`Authenticated` / `Loading` / `Unauthenticated`/`Error` → not-signed-in CTA), status filter, messages/viewings tabs, retry, and cancel-viewing.
- `AccountScreen.kt` — wired to `SsoService.authState` + `NotificationRepository` (load/update prefs), with sign-in/sign-out and the same auth-state branching.

## Gap closed in this PR
The Account stat strip (Favorites / Searches / Inquiries) was passing hardcoded `null` placeholders with a `// once /me/stats exists` TODO. There is **no** `/me/stats` endpoint on reality-server, but the three counts are already exposed as the `total` field of the list endpoints the app calls. This PR derives them:

- favorites — `GET /api/v1/favorites` → `FavoritesResponse.total`
- searches — `GET /api/v1/saved-searches` → `SavedSearchesResponse.total`
- inquiries — `GET /api/v1/inquiries` → `InquiriesResponse.total`

New `commonMain` `ProfileStatsLoader` (+ `ProfileStats` value type) fans out the three calls; each is independent so one failure leaves the other two intact and only that field falls back to `null` (UI shows an em-dash, never a fake `0`). Stats reset to `UNKNOWN` on sign-out. The `Long` favorites total is clamped to `Int.MAX_VALUE` defensively. Logic lives in `commonMain` so iOS can reuse it and it is unit-testable on the JVM.

### Files
- `mobile-native/shared/src/commonMain/.../account/ProfileStats.kt` (new) — `ProfileStats` + `ProfileStatsLoader`.
- `mobile-native/shared/src/commonTest/.../account/ProfileStatsLoaderTest.kt` (new) — MockEngine tests: reads totals; per-endpoint null fallback; Int clamp.
- `mobile-native/androidApp/.../ui/account/AccountScreen.kt` — load stats in `LaunchedEffect(authState)`, pass live values to `StatsRow`, reset on sign-out. Public composable signature unchanged (Navigation.kt untouched).

## Scope
Kept strictly to the inquiries + account surfaces. Did **not** touch `SearchScreen.kt`, `DeepLinkRouter.kt`, `MainActivity`/`Navigation.kt`, or `iosApp/**` (owned by sibling PRs #1125 / #1124 / #1123). `scope-check.sh --owner pm-frontend` → exit 0 (no drift). `reuse-grep.sh` → exit 0 (no duplicated helper).

## Tested (Band A — fast check)
`cd mobile-native && ./gradlew :shared:compileKotlinJvm :shared:jvmTest --offline`

**Could not run to completion in this environment.** Gradle fails at plugin resolution — `com.android.application` (AGP) cannot be fetched because Google's Maven (`dl.google.com`) is network-blocked in the sandbox. This is an environment limit, not a code defect, and it fails *before* any Kotlin compilation of the diff.

Static verification performed instead:
- New logic is pure `commonMain` Kotlin with no Android-only types (KMP-safe).
- All referenced symbols verified against source: `FavoritesResponse.total: Long`, `SavedSearchesResponse.total: Int`, `InquiriesResponse.total: Int`; both repos expose a 3-arg `(baseUrl, sessionToken, client)` ctor used by the test.
- Test deps confirmed present in `shared/build.gradle.kts` commonTest (`ktor-client-mock`, `kotlinx-coroutines-test`, content-negotiation, json) — same pattern as the existing `FavoritesRepositoryTest`.

CI `mobile-native.yml` is the authoritative verification surface for the Gradle build + `:shared:jvmTest` run.

## Built (Band B — full build)
Skipped: blocked by the same AGP network limit (see above). Change is < 60 LOC of substantive logic, no public API/signature change.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change — read-only stat counts behind existing auth).

## Remote-tested
Skipped (no ppt-bridge MCP in session).

## Notes
- Opened as **draft** pending green `mobile-native.yml` CI (the local Gradle build is environment-blocked).
- The auth-state wiring for both screens predates this PR; this PR only closes the account-stats gap. If the reviewer considers the inquiries/account screens already complete from prior epic-48 stories, this can be treated as the finishing slice of story 82-5.

https://claude.ai/code/session_014qz5u91hjwh2gVYDD8ESji

---
_Generated by [Claude Code](https://claude.ai/code/session_014qz5u91hjwh2gVYDD8ESji)_