### PR TITLE
refactor-reality-web-comparison-i18n: move ComparisonUrlHandler strings to next-intl

### DIFF
--- a/frontend/apps/reality-web/messages/cs.json
+++ b/frontend/apps/reality-web/messages/cs.json
@@ -48,6 +48,10 @@
     "search": "Hledat",
     "success": "Úspěch"
   },
+  "comparison": {
+    "loadError": "Nepodařilo se načíst sdílené porovnání. Některé nemovitosti už nemusí být dostupné.",
+    "loading": "Načítá se sdílené porovnání..."
+  },
   "contact": {
     "askQuestion": "Položit otázku",
     "checkAvailability": "Ověřit dostupnost",

--- a/frontend/apps/reality-web/messages/de.json
+++ b/frontend/apps/reality-web/messages/de.json
@@ -48,6 +48,10 @@
     "search": "Suchen",
     "success": "Erfolg"
   },
+  "comparison": {
+    "loadError": "Der geteilte Vergleich konnte nicht geladen werden. Einige Immobilien sind möglicherweise nicht mehr verfügbar.",
+    "loading": "Geteilter Vergleich wird geladen..."
+  },
   "contact": {
     "askQuestion": "Eine Frage stellen",
     "checkAvailability": "Verfügbarkeit prüfen",

--- a/frontend/apps/reality-web/messages/en.json
+++ b/frontend/apps/reality-web/messages/en.json
@@ -48,6 +48,10 @@
     "search": "Search",
     "success": "Success"
   },
+  "comparison": {
+    "loadError": "Failed to load shared comparison. Some properties may no longer be available.",
+    "loading": "Loading shared comparison..."
+  },
   "contact": {
     "askQuestion": "Ask a question",
     "checkAvailability": "Check availability",

--- a/frontend/apps/reality-web/messages/hu.json
+++ b/frontend/apps/reality-web/messages/hu.json
@@ -48,6 +48,10 @@
     "search": "Keresés",
     "success": "Siker"
   },
+  "comparison": {
+    "loadError": "A megosztott összehasonlítás betöltése sikertelen. Egyes ingatlanok már nem érhetők el.",
+    "loading": "Megosztott összehasonlítás betöltése..."
+  },
   "contact": {
     "askQuestion": "Kérdést feltenni",
     "checkAvailability": "Elérhetőséget ellenőrizni",

--- a/frontend/apps/reality-web/messages/pl.json
+++ b/frontend/apps/reality-web/messages/pl.json
@@ -48,6 +48,10 @@
     "search": "Szukaj",
     "success": "Sukces"
   },
+  "comparison": {
+    "loadError": "Nie udało się wczytać udostępnionego porównania. Niektóre nieruchomości mogą być już niedostępne.",
+    "loading": "Wczytywanie udostępnionego porównania..."
+  },
   "contact": {
     "askQuestion": "Zadać pytanie",
     "checkAvailability": "Sprawdzić dostępność",

--- a/frontend/apps/reality-web/messages/sk.json
+++ b/frontend/apps/reality-web/messages/sk.json
@@ -48,6 +48,10 @@
     "search": "Hľadať",
     "success": "Úspech"
   },
+  "comparison": {
+    "loadError": "Nepodarilo sa načítať zdieľané porovnanie. Niektoré nehnuteľnosti už nemusia byť dostupné.",
+    "loading": "Načítava sa zdieľané porovnanie..."
+  },
   "contact": {
     "askQuestion": "Položiť otázku",
     "checkAvailability": "Overiť dostupnosť",

--- a/frontend/apps/reality-web/src/components/comparison/ComparisonUrlHandler.tsx
+++ b/frontend/apps/reality-web/src/components/comparison/ComparisonUrlHandler.tsx
@@ -7,6 +7,7 @@
 'use client';
 
 import type { ListingSummary } from '@ppt/reality-api-client';
+import { useTranslations } from 'next-intl';
 import { useEffect, useState } from 'react';
 
 import { useComparison } from '../../lib/comparison-context';
@@ -16,6 +17,7 @@ interface ComparisonUrlHandlerProps {
 }
 
 export function ComparisonUrlHandler({ sharedIds }: ComparisonUrlHandlerProps) {
+  const t = useTranslations('comparison');
   const { listings, addToComparison } = useComparison();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -49,7 +51,7 @@ export function ComparisonUrlHandler({ sharedIds }: ComparisonUrlHandlerProps) {
           }
         }
       } catch (err) {
-        setError('Failed to load shared comparison. Some properties may no longer be available.');
+        setError(t('loadError'));
         console.error('Error loading shared listings:', err);
       } finally {
         setLoading(false);
@@ -57,13 +59,13 @@ export function ComparisonUrlHandler({ sharedIds }: ComparisonUrlHandlerProps) {
     };
 
     loadSharedListings();
-  }, [sharedIds, listings.length, addToComparison]);
+  }, [sharedIds, listings.length, addToComparison, t]);
 
   if (loading) {
     return (
       <div className="loading-shared">
         <div className="spinner" />
-        <p>Loading shared comparison...</p>
+        <p>{t('loading')}</p>
         <style jsx>{`
           .loading-shared {
             display: flex;


### PR DESCRIPTION
## Task
Reality-web ComparisonUrlHandler hardcodes English loading/error strings — move them to next-intl. File: frontend/apps/reality-web/src/components/comparison/ComparisonUrlHandler.tsx

## Owner
pm-frontend (specialist: nextjs-web)

## Changes
- `ComparisonUrlHandler.tsx`: replaced the two hardcoded English strings (`'Loading shared comparison...'`, `'Failed to load shared comparison. Some properties may no longer be available.'`) with `useTranslations('comparison')` lookups (`t('loading')`, `t('loadError')`). Added `t` to the `useEffect` dependency list to keep Biome's `useExhaustiveDependencies` clean.
- Added a new `comparison` namespace (`loading`, `loadError`) to ALL six locale catalogs the app ships: `en`, `sk`, `cs`, `de`, `hu`, `pl`. (Note: app actually ships 6 locales, not the 4 named in the task — keys added to all of them for parity.) Native translations provided for each, not English stubs.

## Tested (Band A — fast check)
- `pnpm -F @ppt/reality-web typecheck` → exit 0 (`tsc --noEmit`)
- `pnpm exec biome check <changed files>` (7 files) → exit 0, no warnings
- Locale parity check: all 6 catalogs have identical `comparison` keys → ok

## Built (Band B — full build)
skipped: change <50 LOC, no public API/config touch (pure i18n string extraction)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Notes
- Diff is minimal: 7 files, +29/-3. No unrelated files touched. scope-check (pm-frontend) → exit 0, no drift.
- Sibling comparison components (ComparisonTray/View) also have non-translated text but are out of scope for this task.

https://claude.ai/code/session_01J3xagjXdzAKcZr5MGoDMuk

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3xagjXdzAKcZr5MGoDMuk)_