### PR TITLE
refactor-mediation-duplicated-spinner: dedupe inline spinners in disputes feature

### DIFF
--- a/frontend/apps/ppt-web/src/components/Spinner.tsx
+++ b/frontend/apps/ppt-web/src/components/Spinner.tsx
@@ -12,6 +12,7 @@
 import { useTranslation } from 'react-i18next';
 
 export type SpinnerSize = 'sm' | 'md' | 'lg';
+export type SpinnerColor = 'violet' | 'blue';
 
 const sizeClasses: Record<SpinnerSize, string> = {
   sm: 'h-5 w-5',
@@ -19,23 +20,30 @@ const sizeClasses: Record<SpinnerSize, string> = {
   lg: 'h-10 w-10',
 };
 
+const colorClasses: Record<SpinnerColor, string> = {
+  violet: 'border-violet-600',
+  blue: 'border-blue-600',
+};
+
 export interface SpinnerProps {
   /** Visual size. Defaults to `md` (h-8 w-8). */
   size?: SpinnerSize;
+  /** Border color. Defaults to `violet`. */
+  color?: SpinnerColor;
   /** Accessible label. Defaults to the `common.loading` translation. */
   label?: string;
   /** Extra classes appended after the base spinner classes. */
   className?: string;
 }
 
-export function Spinner({ size = 'md', label, className }: SpinnerProps) {
+export function Spinner({ size = 'md', color = 'violet', label, className }: SpinnerProps) {
   const { t } = useTranslation();
 
   return (
     <div
       role="status"
       aria-label={label ?? t('common.loading')}
-      className={`animate-spin rounded-full ${sizeClasses[size]} border-b-2 border-violet-600${
+      className={`animate-spin rounded-full ${sizeClasses[size]} border-b-2 ${colorClasses[color]}${
         className ? ` ${className}` : ''
       }`}
     />

--- a/frontend/apps/ppt-web/src/components/index.ts
+++ b/frontend/apps/ppt-web/src/components/index.ts
@@ -12,7 +12,7 @@ export { LanguageSwitcher } from './LanguageSwitcher';
 export { OfflineIndicator } from './OfflineIndicator';
 export type { ProtectedRouteProps } from './ProtectedRoute';
 export { ProtectedRoute } from './ProtectedRoute';
-export type { SpinnerProps, SpinnerSize } from './Spinner';
+export type { SpinnerColor, SpinnerProps, SpinnerSize } from './Spinner';
 export { Spinner } from './Spinner';
 export type { Toast, ToastAction, ToastType } from './Toast';
 export { ToastProvider, useToast } from './Toast';

--- a/frontend/apps/ppt-web/src/features/disputes/components/DisputeList.tsx
+++ b/frontend/apps/ppt-web/src/features/disputes/components/DisputeList.tsx
@@ -4,6 +4,7 @@
  */
 
 import { useState } from 'react';
+import { Spinner } from '../../../components/Spinner';
 import {
   categoryLabels,
   DisputeCard,
@@ -157,7 +158,7 @@ export function DisputeList({
       {/* Results */}
       {isLoading ? (
         <div className="flex justify-center py-12">
-          <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-blue-600" />
+          <Spinner size="lg" color="blue" />
         </div>
       ) : disputes.length === 0 ? (
         <div className="bg-white rounded-lg shadow p-8 text-center">

--- a/frontend/apps/ppt-web/src/features/disputes/components/MediationSessionsPanel.tsx
+++ b/frontend/apps/ppt-web/src/features/disputes/components/MediationSessionsPanel.tsx
@@ -6,6 +6,7 @@
 
 import type { MediationSession, SessionStatus, SessionType } from '@ppt/api-client';
 import { useTranslation } from 'react-i18next';
+import { Spinner } from '../../../components/Spinner';
 
 const sessionTypeLabelKeys: Record<SessionType, string> = {
   in_person: 'disputes.mediation.sessions.typeInPerson',
@@ -97,11 +98,7 @@ export function MediationSessionsPanel({
 
       {isLoading ? (
         <div className="flex justify-center py-4">
-          <div
-            role="status"
-            aria-label={t('common.loading')}
-            className="animate-spin rounded-full h-5 w-5 border-b-2 border-violet-600"
-          />
+          <Spinner size="sm" />
         </div>
       ) : ordered.length === 0 ? (
         <p className="text-xs text-gray-400">{t('disputes.mediation.sessions.empty')}</p>

--- a/frontend/apps/ppt-web/src/features/disputes/components/MediationTimelineView.tsx
+++ b/frontend/apps/ppt-web/src/features/disputes/components/MediationTimelineView.tsx
@@ -1,5 +1,6 @@
 import { type TimelineEventType, useDisputeTimeline } from '@ppt/api-client';
 import { useTranslation } from 'react-i18next';
+import { Spinner } from '../../../components/Spinner';
 import { formatTime } from '../utils/formatTime';
 
 interface MediationTimelineViewProps {
@@ -52,11 +53,7 @@ export function MediationTimelineView({ disputeId }: MediationTimelineViewProps)
   if (isLoading) {
     return (
       <div className="flex justify-center py-8">
-        <div
-          role="status"
-          aria-label={t('common.loading')}
-          className="animate-spin rounded-full h-8 w-8 border-b-2 border-violet-600"
-        />
+        <Spinner size="md" />
       </div>
     );
   }

--- a/frontend/apps/ppt-web/src/features/disputes/pages/DisputeDetailPage.tsx
+++ b/frontend/apps/ppt-web/src/features/disputes/pages/DisputeDetailPage.tsx
@@ -4,6 +4,7 @@
  */
 
 import { useState } from 'react';
+import { Spinner } from '../../../components/Spinner';
 import { type ActionItem, ActionItemCard } from '../components/ActionItemCard';
 import type { DisputeCategory, DisputePriority, DisputeStatus } from '../components/DisputeCard';
 import { categoryLabels, priorityLabels, statusLabels } from '../components/DisputeCard';
@@ -194,7 +195,7 @@ export function DisputeDetailPage({
   if (isLoading) {
     return (
       <div className="flex justify-center py-12">
-        <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-blue-600" />
+        <Spinner size="lg" color="blue" />
       </div>
     );
   }

--- a/frontend/apps/ppt-web/src/features/disputes/pages/MediationPage.tsx
+++ b/frontend/apps/ppt-web/src/features/disputes/pages/MediationPage.tsx
@@ -4,6 +4,7 @@
  */
 
 import { useState } from 'react';
+import { Spinner } from '../../../components/Spinner';
 import {
   type MediationSession,
   MediationSessionCard,
@@ -141,7 +142,7 @@ export function MediationPage({
   if (isLoading) {
     return (
       <div className="flex justify-center py-12">
-        <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-blue-600" />
+        <Spinner size="lg" color="blue" />
       </div>
     );
   }


### PR DESCRIPTION
## Task
Duplicated `animate-spin` spinner markup across the disputes/mediation feature (no shared Spinner usage). Files under `frontend/apps/ppt-web/src/features/disputes/`. Replace duplicated inline spinner `<div>`s with the shared `<Spinner>` component (`frontend/apps/ppt-web/src/components/Spinner.tsx`) where it can faithfully reproduce the look.

## Owner
pm-frontend (specialist: react-web)

## Changes
Swapped 5 duplicated inline spinner `<div>`s for the shared `<Spinner>`:

| File | Old markup | New |
|------|-----------|-----|
| `components/MediationSessionsPanel.tsx` | `h-5 w-5 ... border-violet-600` | `<Spinner size="sm" />` |
| `components/MediationTimelineView.tsx` | `h-8 w-8 ... border-violet-600` | `<Spinner size="md" />` |
| `pages/DisputeDetailPage.tsx` | `h-10 w-10 ... border-blue-600` | `<Spinner size="lg" color="blue" />` |
| `pages/MediationPage.tsx` | `h-10 w-10 ... border-blue-600` | `<Spinner size="lg" color="blue" />` |
| `components/DisputeList.tsx` | `h-10 w-10 ... border-blue-600` | `<Spinner size="lg" color="blue" />` |

Minimal extension to `Spinner`: added an optional `color` prop (`'violet' | 'blue'`, default `violet`) so the blue loading spinners render byte-identically without a fragile Tailwind class-order `className` override (two equal-specificity `border-*` color utilities). `SpinnerColor` is re-exported from `components/index.ts`. Default behavior is unchanged for the existing violet call-sites (`MediationWorkspacePage`, `MediationChatThread`).

## Left as-is (with reason)
Two button-/item-style spinners were intentionally **not** migrated — their look cannot be reproduced by the shared `Spinner`, which is built on `border-b-2` (a bottom-only border ring):
- `pages/FileDisputePage.tsx:388` — submit-button spinner `border-2 border-white border-t-transparent` (full ring, white, top-transparent).
- `components/EvidenceUploader.tsx:285` — upload-status spinner `border-2 border-blue-600 border-t-transparent`.

Migrating these would require a second, structurally different variant of `Spinner`; out of scope for this tight dedup. Noted for a possible follow-up.

## Tested (Band A — fast check)
```
pnpm -F @ppt/web typecheck   # exit 0 (tsc --noEmit + tsc -p tsconfig.e2e.json)
pnpm exec biome check <7 changed files>   # exit 0 — Checked 7 files, no fixes applied
```

## Built (Band B — full build)
skipped: change <50 LOC, behavior-preserving refactor, no public API/config touch (Spinner `color` prop is additive/backward-compatible).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (pure frontend CSS/component dedup; no security/auth/billing/data-integrity change).

## Remote-tested
skipped (no ppt-bridge MCP in session).

## Notes
- Scope-drift check: clean (all paths under `frontend/apps/ppt-web/`, owner `pm-frontend`).
- No `Spinner` unit/snapshot test exists, so none needed updating; the `color` default keeps existing renders identical.
- Branch had a stale/polluted tip from a prior attempt (unrelated mobile-native + package.json churn); force-pushed to reset it to a single clean commit on top of `dev`.

https://claude.ai/code/session_01J3xagjXdzAKcZr5MGoDMuk

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3xagjXdzAKcZr5MGoDMuk)_