### PR TITLE
refactor-mediation-ref-number-full-uuid: short mediation reference code

### DIFF
--- a/frontend/apps/ppt-web/src/features/disputes/pages/MediationWorkspacePage.tsx
+++ b/frontend/apps/ppt-web/src/features/disputes/pages/MediationWorkspacePage.tsx
@@ -22,6 +22,7 @@ import { MediationResolutionForm } from '../components/MediationResolutionForm';
 import { MediationSessionDialog } from '../components/MediationSessionDialog';
 import { MediationSessionsPanel } from '../components/MediationSessionsPanel';
 import { MediationTimelineView } from '../components/MediationTimelineView';
+import { formatDisputeReference } from '../utils/formatReference';
 
 type Tab = 'timeline' | 'chat' | 'resolve';
 
@@ -242,7 +243,7 @@ export function MediationWorkspacePage({
   }
 
   const disputeStatus = dispute?.status ?? 'unknown';
-  const referenceNumber = dispute ? `DSP-${dispute.id.toUpperCase()}` : disputeId;
+  const referenceNumber = dispute ? formatDisputeReference(dispute.id) : disputeId;
   const disputeTitle = dispute?.subject ?? t('disputes.title');
   const statusLabel = statusLabelKeys[disputeStatus]
     ? t(statusLabelKeys[disputeStatus])

--- a/frontend/apps/ppt-web/src/features/disputes/utils/formatReference.test.ts
+++ b/frontend/apps/ppt-web/src/features/disputes/utils/formatReference.test.ts
@@ -1,0 +1,31 @@
+/// <reference types="vitest/globals" />
+/**
+ * Unit tests for formatDisputeReference — derives a short, human-friendly
+ * reference code from a dispute UUID instead of uppercasing the full UUID.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { formatDisputeReference } from './formatReference';
+
+describe('formatDisputeReference', () => {
+  it('renders a short DSP code from the first 8 hex chars of the UUID', () => {
+    expect(formatDisputeReference('3f2a1b9c-4d5e-6f70-8910-abcdef123456')).toBe('DSP-3F2A1B9C');
+  });
+
+  it('does not return the full uppercased UUID', () => {
+    const id = '3f2a1b9c-4d5e-6f70-8910-abcdef123456';
+    const ref = formatDisputeReference(id);
+    expect(ref).not.toBe(`DSP-${id.toUpperCase()}`);
+    expect(ref.length).toBeLessThanOrEqual(12);
+  });
+
+  it('strips hyphens so the code is always 8 hex digits', () => {
+    // First UUID segment is shorter than 8 chars here; hyphen stripping
+    // ensures we still take 8 contiguous hex characters.
+    expect(formatDisputeReference('abc-de-1234567890')).toBe('DSP-ABCDE123');
+  });
+
+  it('uppercases the code', () => {
+    expect(formatDisputeReference('deadbeefcafe')).toBe('DSP-DEADBEEF');
+  });
+});

--- a/frontend/apps/ppt-web/src/features/disputes/utils/formatReference.ts
+++ b/frontend/apps/ppt-web/src/features/disputes/utils/formatReference.ts
@@ -1,0 +1,13 @@
+/**
+ * Format a dispute's UUID into a short, human-friendly reference code.
+ *
+ * The backend identifies disputes by UUID and does not (yet) expose a
+ * dedicated short code, so we derive a compact `DSP-XXXXXXXX` label from
+ * the first 8 characters of the UUID rather than uppercasing the whole
+ * (unreadable) UUID. Hyphens are stripped first so the 8 characters are
+ * always hex digits regardless of where the first UUID hyphen falls.
+ */
+export function formatDisputeReference(id: string): string {
+  const compact = id.replace(/-/g, '');
+  return `DSP-${compact.slice(0, 8).toUpperCase()}`;
+}


### PR DESCRIPTION
## Task
Mediation reference number uppercases full UUID (DSP-<uuid>) instead of a short code. File: frontend/apps/ppt-web/src/features/disputes/pages/MediationWorkspacePage.tsx. Render a short, human-friendly reference code (e.g. DSP-<first 8 chars of UUID, uppercased> or the backend short code if one exists) rather than the full UUID. [src: PR #555, code-review 2026-05-27]

## Owner
pm-frontend

## What changed
- The mediation workspace header previously rendered `DSP-${dispute.id.toUpperCase()}`, i.e. the entire dispute UUID uppercased — an unreadable reference (e.g. `DSP-3F2A1B9C-4D5E-6F70-8910-ABCDEF123456`).
- The backend `Dispute` type (`frontend/packages/api-client/src/disputes/types.ts`) exposes no dedicated short code, so the reference is derived from the UUID.
- Added `formatDisputeReference(id)` in `frontend/apps/ppt-web/src/features/disputes/utils/formatReference.ts`: strips hyphens and renders `DSP-<first 8 hex chars, uppercased>` (e.g. `DSP-3F2A1B9C`). Hyphen-stripping guarantees 8 contiguous hex digits regardless of the first UUID segment boundary.
- `MediationWorkspacePage.tsx` now calls the helper instead of inlining the uppercase logic.
- Added unit tests (`formatReference.test.ts`) covering the short-code shape, that it is no longer the full uppercased UUID, hyphen stripping, and casing.

Scope note: the same `DSP-${id.toUpperCase()}` pattern also exists in `routes/groups/disputes.tsx` and other dispute list components, but the task is scoped to `MediationWorkspacePage.tsx`, so those are intentionally left untouched. The new helper is available for a follow-up consolidation.

## Tested (Band A — fast check)
- `pnpm -F @ppt/web typecheck` — exit 0
- `pnpm biome check <changed files>` — exit 0 (project standard; the package `lint` script invokes ESLint which is not configured in this repo)
- `pnpm vitest run .../formatReference.test.ts` — 4 passed, exit 0

## Built (Band B — full build)
skipped: change < 50 LOC, pure presentational refactor, no public API/config touch

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Notes
- `referenceNumber` falls back to the raw `disputeId` only when the dispute hasn't loaded yet — unchanged behavior.

https://claude.ai/code/session_01TtigwZgRzp6XxZztt7P8pU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtigwZgRzp6XxZztt7P8pU)_