### PR TITLE
refactor-mobile-app-tsx-churn-2026-06-03: extract App.tsx route/deep-link wiring

### DIFF
--- a/frontend/apps/mobile/src/App.tsx
+++ b/frontend/apps/mobile/src/App.tsx
@@ -6,10 +6,9 @@ import { useTranslation } from 'react-i18next';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { OfflineBanner, SyncProgressToast, SyncStatusBadge } from './components/sync';
 import { AuthProvider, useAuth } from './contexts';
-import { useOfflineSupport, usePushNotifications } from './hooks';
-import { deepLinkManager } from './qrcode';
+import { useDeepLinkRouting, useOfflineSupport, usePushNotifications } from './hooks';
 import { colors } from './screens/shared/screenStyles';
-import { resolveDeepLinkTarget, type Screen } from './services/deepLinkRouting';
+import type { Screen } from './services/deepLinkRouting';
 import './i18n'; // Initialize i18n
 import {
   AnnouncementDetailScreen,
@@ -92,24 +91,10 @@ function MainApp() {
   }, []);
 
   // gap-85-3: route incoming deep links (custom scheme + universal/App Links).
-  // The manager handles the cold-start initial URL, runtime `url` events, and
-  // queues auth-required links until the user is authenticated.
-  useEffect(() => {
-    const unsubscribe = deepLinkManager.addHandler((link) => {
-      const target = resolveDeepLinkTarget(link);
-      if (target) {
-        handleNavigate(target.screen, target.params);
-      }
-    });
-    void deepLinkManager.initialize();
-    return unsubscribe;
-  }, [handleNavigate]);
-
-  // Keep the manager's auth gate in sync so auth-required links queued while
-  // logged out are dispatched the moment the user authenticates.
-  useEffect(() => {
-    deepLinkManager.setAuthenticated(isAuthenticated);
-  }, [isAuthenticated]);
+  // Wiring lives in `useDeepLinkRouting`: it handles the cold-start initial
+  // URL, runtime `url` events, and the auth gate that queues auth-required
+  // links until the user is authenticated.
+  useDeepLinkRouting(handleNavigate, isAuthenticated);
 
   if (isLoading) {
     return (

--- a/frontend/apps/mobile/src/hooks/index.ts
+++ b/frontend/apps/mobile/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useDeepLinkRouting } from './useDeepLinkRouting';
 export type {
   CacheOptions,
   OfflineState,

--- a/frontend/apps/mobile/src/hooks/useDeepLinkRouting.test.tsx
+++ b/frontend/apps/mobile/src/hooks/useDeepLinkRouting.test.tsx
@@ -1,0 +1,116 @@
+// Wiring contract for `useDeepLinkRouting` — the deep-link glue extracted
+// from `App.tsx` (refactor-mobile-app-tsx-churn). Behaviour-preserving:
+// these assertions pin exactly what the two inlined `App.tsx` effects did so
+// future regressions in the extracted hook are caught.
+//
+//  1. registers a handler with `deepLinkManager` and kicks off `initialize()`
+//  2. a dispatched parsed link is mapped via `resolveDeepLinkTarget` and
+//     forwarded to `onNavigate` (screen + params)
+//  3. the auth gate (`setAuthenticated`) is kept in sync with `isAuthenticated`
+//  4. the registered handler is unsubscribed on cleanup
+//
+// NOTE: we intentionally do NOT import `@testing-library/react-native`. The
+// repo currently has a `react-test-renderer` 19.2.0-vs-19.2.6 peer-dep
+// mismatch that fails every test importing that package (see the comment in
+// `usePushNotifications.test.ts`). Instead we mock React's `useEffect` to run
+// effects synchronously and collect their cleanups — enough to drive this
+// hook's wiring without mounting the RN tree.
+
+import { deepLinkManager, type ParsedDeepLink } from '../qrcode';
+import { useDeepLinkRouting } from './useDeepLinkRouting';
+
+const mockUnsubscribe = jest.fn();
+const mockDeepLink = {
+  registeredHandler: null as ((link: ParsedDeepLink) => void) | null,
+};
+
+jest.mock('../qrcode', () => ({
+  deepLinkManager: {
+    addHandler: jest.fn((handler: (link: ParsedDeepLink) => void) => {
+      mockDeepLink.registeredHandler = handler;
+      return mockUnsubscribe;
+    }),
+    initialize: jest.fn().mockResolvedValue(undefined),
+    setAuthenticated: jest.fn(),
+  },
+}));
+
+// Run every `useEffect` synchronously and collect cleanups so the test can
+// simulate unmount. Effects run in declaration order, matching React.
+type EffectCleanup = () => void;
+const mockCleanups: EffectCleanup[] = [];
+jest.mock('react', () => ({
+  useEffect: (effect: () => undefined | EffectCleanup) => {
+    const cleanup = effect();
+    if (typeof cleanup === 'function') {
+      mockCleanups.push(cleanup);
+    }
+  },
+}));
+
+const manager = deepLinkManager as unknown as {
+  addHandler: jest.Mock;
+  initialize: jest.Mock;
+  setAuthenticated: jest.Mock;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDeepLink.registeredHandler = null;
+  mockCleanups.length = 0;
+});
+
+describe('useDeepLinkRouting', () => {
+  it('registers a handler and initializes the manager', () => {
+    const onNavigate = jest.fn();
+    useDeepLinkRouting(onNavigate, false);
+
+    expect(manager.addHandler).toHaveBeenCalledTimes(1);
+    expect(manager.initialize).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes a dispatched link through resolveDeepLinkTarget to onNavigate', () => {
+    const onNavigate = jest.fn();
+    useDeepLinkRouting(onNavigate, true);
+
+    // A Documents link carrying an id resolves to the DocumentDetail screen.
+    mockDeepLink.registeredHandler?.({
+      success: true,
+      screen: 'Documents',
+      params: { id: 'doc-7' },
+    } as ParsedDeepLink);
+
+    expect(onNavigate).toHaveBeenCalledWith('DocumentDetail', { documentId: 'doc-7' });
+  });
+
+  it('ignores links that resolve to no target', () => {
+    const onNavigate = jest.fn();
+    useDeepLinkRouting(onNavigate, true);
+
+    mockDeepLink.registeredHandler?.({ success: false } as ParsedDeepLink);
+
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it('keeps the auth gate in sync with isAuthenticated', () => {
+    const onNavigate = jest.fn();
+
+    useDeepLinkRouting(onNavigate, false);
+    expect(manager.setAuthenticated).toHaveBeenLastCalledWith(false);
+
+    useDeepLinkRouting(onNavigate, true);
+    expect(manager.setAuthenticated).toHaveBeenLastCalledWith(true);
+  });
+
+  it('unsubscribes the handler on cleanup', () => {
+    const onNavigate = jest.fn();
+    useDeepLinkRouting(onNavigate, false);
+
+    // Simulate unmount: run the effect cleanups React would invoke.
+    for (const cleanup of mockCleanups) {
+      cleanup();
+    }
+
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/apps/mobile/src/hooks/useDeepLinkRouting.ts
+++ b/frontend/apps/mobile/src/hooks/useDeepLinkRouting.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+import { deepLinkManager } from '../qrcode';
+import { resolveDeepLinkTarget } from '../services/deepLinkRouting';
+
+/**
+ * Deep-link wiring (gap-85-3).
+ *
+ * Extracted from `App.tsx` so the glue between the {@link deepLinkManager} and
+ * the app's `handleNavigate` lives in one focused, churn-isolated module.
+ * Future deep-link additions touch this hook (and `resolveDeepLinkTarget`)
+ * instead of the App monolith.
+ *
+ * Behaviour is identical to the two effects it replaces:
+ *  1. Register a handler that maps incoming parsed links → screen+params and
+ *     forwards them to `onNavigate`, then kick off `deepLinkManager.initialize()`
+ *     (cold-start initial URL + runtime `url` events). Cleanup unsubscribes.
+ *  2. Keep the manager's auth gate in sync so auth-required links queued while
+ *     logged out are dispatched the moment the user authenticates.
+ *
+ * @param onNavigate stable navigation callback (App memoises this with `useCallback`)
+ * @param isAuthenticated current auth state, forwarded to the manager's gate
+ */
+export function useDeepLinkRouting(
+  onNavigate: (screen: string, params?: Record<string, unknown>) => void,
+  isAuthenticated: boolean
+): void {
+  useEffect(() => {
+    const unsubscribe = deepLinkManager.addHandler((link) => {
+      const target = resolveDeepLinkTarget(link);
+      if (target) {
+        onNavigate(target.screen, target.params);
+      }
+    });
+    void deepLinkManager.initialize();
+    return unsubscribe;
+  }, [onNavigate]);
+
+  // Keep the manager's auth gate in sync so auth-required links queued while
+  // logged out are dispatched the moment the user authenticates.
+  useEffect(() => {
+    deepLinkManager.setAuthenticated(isAuthenticated);
+  }, [isAuthenticated]);
+}


### PR DESCRIPTION
## Task
frontend/apps/mobile/src/App.tsx churned twice this run (universal links + doc-detail wiring). Reduce churn risk in App.tsx by extracting the repeated/growing logic into small focused modules (e.g. a screen-registry / route-map and deep-link wiring helper), so future feature additions touch a helper instead of the monolith. Behavior-preserving refactor only — no feature changes. Scope: frontend/apps/mobile/ only.

## Owner
pm-frontend

## What changed (behavior-preserving)
The deep-link wiring was the actively-churning part of `App.tsx` (the task names "universal links + doc-detail wiring"). The pure parse→screen mapping was already extracted to `services/deepLinkRouting.ts` (gap-85-3); what remained inline in `App.tsx` were the two `useEffect`s that glue `deepLinkManager` to navigation:

1. register a handler (parse link → `resolveDeepLinkTarget` → `handleNavigate`) + `deepLinkManager.initialize()`, with unsubscribe cleanup
2. keep `deepLinkManager.setAuthenticated(isAuthenticated)` in sync

Both moved verbatim into a new focused hook `src/hooks/useDeepLinkRouting(onNavigate, isAuthenticated)`. `App.tsx` now calls one line instead of carrying the effects, so future deep-link work touches the hook (+ the existing pure mapper) rather than the App monolith. Identical effects, identical deps arrays — no behavior change.

Net: `App.tsx` shrinks ~20 lines; new `useDeepLinkRouting.ts` (43 lines) + test.

### Deliberately out of scope (follow-up)
The `renderScreen` switch is the other large block in `App.tsx`, but it is **not** what churned this run, and turning it into a data-driven screen-registry is a larger, riskier change that would collide head-on with **PR #1011** (also editing `App.tsx`, in review). Kept this PR minimal to reduce conflict surface; the registry extraction can be a separate task once #1011 lands.

## Tested (Band A — fast check)
- `pnpm -F @ppt/mobile typecheck` → exit 0
- `pnpm exec biome check <4 changed files>` → exit 0 (no warnings)
- `pnpm -F @ppt/mobile exec jest src/hooks/useDeepLinkRouting.test.tsx` → 5/5 pass

The new test is intentionally renderer-free: the repo currently has a `react-test-renderer` 19.2.0-vs-19.2.6 peer-dep mismatch that fails every suite importing `@testing-library/react-native` (pre-existing; flagged in `usePushNotifications.test.ts`). The test mocks React's `useEffect` to drive the hook's wiring without mounting the RN tree — same precedent as the push-notifications test.

## Built (Band B — full build)
skipped: change <50 LOC substantive, no public-API/config touch (internal hook extraction).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped

## Notes
- Scope: strictly within `frontend/apps/mobile/`. scope-check.sh → exit 0 (no drift).
- Coordinate with PR #1011 (also touches `App.tsx`); this change is intentionally small and localized to the import block + one effect region to keep the merge conflict trivial.

https://claude.ai/code/session_01NuFprwg6ibzHhu33bYVWPx

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuFprwg6ibzHhu33bYVWPx)_