### PR TITLE
test-gap-79-1-api-client-integration-coverage: pin announcements/faults client wiring to contract

### DIFF
--- a/frontend/packages/api-client/src/announcements/api.test.ts
+++ b/frontend/packages/api-client/src/announcements/api.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Contract tests for the hand-rolled announcement API client (story 79-1).
+ *
+ * Announcements have no generated `AnnouncementsService` — the hand-rolled
+ * `createAnnouncementsApi` transport in `announcements/api.ts` IS the contract
+ * the ppt-web announcements feature depends on. Without coverage, a typo in a
+ * path segment or a wrong HTTP verb ships silently and 404s at runtime. These
+ * tests pin the request wiring (URL + method) for every endpoint the client
+ * exposes, plus the auth/tenant header construction.
+ *
+ * The companion `hooks.test.ts` already pins the list-query translation and
+ * response normalisation; this file covers the transport surface those hooks
+ * delegate to.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createAnnouncementsApi } from './api';
+
+const BASE = 'https://api.test';
+const ROOT = `${BASE}/api/v1/announcements`;
+const ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+function okJson(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as Response;
+}
+function ok204(): Response {
+  return {
+    ok: true,
+    status: 204,
+    json: async () => {
+      throw new Error('no body');
+    },
+  } as unknown as Response;
+}
+
+function lastCall(): { url: string; method: string; headers: Record<string, string> } {
+  const calls = vi.mocked(fetch).mock.calls;
+  const call = calls[calls.length - 1];
+  if (!call) throw new Error('fetch was not called');
+  const init = call[1] as RequestInit | undefined;
+  return {
+    url: String(call[0]),
+    method: (init?.method ?? 'GET').toUpperCase(),
+    headers: (init?.headers ?? {}) as Record<string, string>,
+  };
+}
+
+const api = () =>
+  createAnnouncementsApi({
+    baseUrl: BASE,
+    accessToken: 'tok-123',
+    tenantId: 'tenant-9',
+  });
+
+describe('announcements api client — request wiring contract', () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(okJson({}));
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('list → GET collection root', async () => {
+    await api().list();
+    const c = lastCall();
+    expect(c.method).toBe('GET');
+    expect(c.url).toBe(ROOT);
+  });
+
+  it('list serializes camelCase filters as query params', async () => {
+    await api().list({ page: 2, pageSize: 20, status: 'published', targetType: 'building' });
+    const c = lastCall();
+    const qs = new URLSearchParams(c.url.split('?')[1] ?? '');
+    expect(c.url.split('?')[0]).toBe(ROOT);
+    expect(qs.get('page')).toBe('2');
+    expect(qs.get('pageSize')).toBe('20');
+    expect(qs.get('status')).toBe('published');
+    expect(qs.get('targetType')).toBe('building');
+  });
+
+  it('listPublished → GET /published', async () => {
+    await api().listPublished();
+    expect(lastCall()).toMatchObject({ url: `${ROOT}/published`, method: 'GET' });
+  });
+
+  it('create → POST collection root', async () => {
+    await api().create({} as Parameters<ReturnType<typeof createAnnouncementsApi>['create']>[0]);
+    expect(lastCall()).toMatchObject({ url: ROOT, method: 'POST' });
+  });
+
+  it('get → GET /{id}', async () => {
+    await api().get(ID);
+    expect(lastCall()).toMatchObject({ url: `${ROOT}/${ID}`, method: 'GET' });
+  });
+
+  it('update → PUT /{id}', async () => {
+    await api().update(
+      ID,
+      {} as Parameters<ReturnType<typeof createAnnouncementsApi>['update']>[1]
+    );
+    expect(lastCall()).toMatchObject({ url: `${ROOT}/${ID}`, method: 'PUT' });
+  });
+
+  it('delete → DELETE /{id} (tolerates empty body)', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(ok204());
+    await expect(api().delete(ID)).resolves.toBeUndefined();
+    expect(lastCall()).toMatchObject({ url: `${ROOT}/${ID}`, method: 'DELETE' });
+  });
+
+  it('publish → POST /{id}/publish', async () => {
+    await api().publish(ID);
+    expect(lastCall()).toMatchObject({ url: `${ROOT}/${ID}/publish`, method: 'POST' });
+  });
+
+  it('schedule → POST /{id}/schedule', async () => {
+    await api().schedule(
+      ID,
+      {} as Parameters<ReturnType<typeof createAnnouncementsApi>['schedule']>[1]
+    );
+    expect(lastCall()).toMatchObject({ url: `${ROOT}/${ID}/schedule`, method: 'POST' });
+  });
+
+  it('archive → POST /{id}/archive', async () => {
+    await api().archive(ID);
+    expect(lastCall()).toMatchObject({ url: `${ROOT}/${ID}/archive`, method: 'POST' });
+  });
+
+  it('pin → POST /{id}/pin', async () => {
+    await api().pin(ID, { pinned: true } as Parameters<
+      ReturnType<typeof createAnnouncementsApi>['pin']
+    >[1]);
+    expect(lastCall()).toMatchObject({ url: `${ROOT}/${ID}/pin`, method: 'POST' });
+  });
+
+  it('markRead → POST /{id}/read', async () => {
+    await api().markRead(ID);
+    expect(lastCall()).toMatchObject({ url: `${ROOT}/${ID}/read`, method: 'POST' });
+  });
+
+  it('acknowledge → POST /{id}/acknowledge', async () => {
+    await api().acknowledge(ID);
+    expect(lastCall()).toMatchObject({ url: `${ROOT}/${ID}/acknowledge`, method: 'POST' });
+  });
+
+  it('getAcknowledgmentStats → GET /{id}/acknowledgments', async () => {
+    await api().getAcknowledgmentStats(ID);
+    expect(lastCall()).toMatchObject({ url: `${ROOT}/${ID}/acknowledgments`, method: 'GET' });
+  });
+
+  it('listComments → GET /{id}/comments', async () => {
+    await api().listComments(ID);
+    expect(lastCall()).toMatchObject({ url: `${ROOT}/${ID}/comments`, method: 'GET' });
+  });
+
+  it('createComment → POST /{id}/comments', async () => {
+    await api().createComment(
+      ID,
+      {} as Parameters<ReturnType<typeof createAnnouncementsApi>['createComment']>[1]
+    );
+    expect(lastCall()).toMatchObject({ url: `${ROOT}/${ID}/comments`, method: 'POST' });
+  });
+
+  it('deleteComment → DELETE /{id}/comments/{commentId}', async () => {
+    await api().deleteComment(ID, 'c-1');
+    expect(lastCall()).toMatchObject({
+      url: `${ROOT}/${ID}/comments/c-1`,
+      method: 'DELETE',
+    });
+  });
+
+  it('getStatistics / getUnreadCount → GET aggregate endpoints', async () => {
+    await api().getStatistics();
+    expect(lastCall()).toMatchObject({ url: `${ROOT}/statistics`, method: 'GET' });
+    await api().getUnreadCount();
+    expect(lastCall()).toMatchObject({ url: `${ROOT}/unread-count`, method: 'GET' });
+  });
+});
+
+describe('announcements api client — auth/tenant headers', () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(okJson({}));
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('attaches Authorization + X-Tenant-ID + JSON content type', async () => {
+    await api().list();
+    const { headers } = lastCall();
+    expect(headers.Authorization).toBe('Bearer tok-123');
+    expect(headers['X-Tenant-ID']).toBe('tenant-9');
+    expect(headers['Content-Type']).toBe('application/json');
+  });
+
+  it('omits Authorization / tenant headers when not configured', async () => {
+    const anon = createAnnouncementsApi({ baseUrl: BASE });
+    await anon.list();
+    const { headers } = lastCall();
+    expect(headers.Authorization).toBeUndefined();
+    expect(headers['X-Tenant-ID']).toBeUndefined();
+    expect(headers['Content-Type']).toBe('application/json');
+  });
+});

--- a/frontend/packages/api-client/src/faults/api.test.ts
+++ b/frontend/packages/api-client/src/faults/api.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Contract tests for the hand-rolled fault API client (story 79-1).
+ *
+ * `faults/api.ts` is a hand-written transport layer that the ppt-web faults
+ * feature calls directly. The generated `FaultsService` (from the backend
+ * OpenAPI spec) is the contract source of truth for the endpoints that exist
+ * in both. These tests pin the request wiring (URL template + HTTP method) of
+ * the hand-rolled client against that contract so the two can't silently drift
+ * apart — a drift that would route real fault calls to the wrong path/verb and
+ * 404 at runtime with no compile-time signal.
+ *
+ * Known, intentional divergence: the backend registers `PUT /api/v1/faults/{id}`
+ * (see `backend/servers/api-server/src/routes/faults.rs` `router()`), while the
+ * *generated* `FaultsService.faultsApiUpdate` emits `PATCH`. The hand-rolled
+ * client follows the live backend (`PUT`), which is what the running server
+ * accepts. This test pins `PUT` on the hand-rolled side and documents the
+ * generated-client mismatch so the regression is visible, not invisible.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  addComment,
+  createFault,
+  getFault,
+  listFaultComments,
+  listFaults,
+  resolveFault,
+  updateFault,
+} from './api';
+
+const FAULT_ID = '11111111-1111-1111-1111-111111111111';
+
+/** Minimal ok JSON response stub. */
+function okJson(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as Response;
+}
+
+/** Read the (url, method) pair the client passed to the last fetch call. */
+function lastCall(): { url: string; method: string } {
+  const calls = vi.mocked(fetch).mock.calls;
+  const call = calls[calls.length - 1];
+  if (!call) throw new Error('fetch was not called');
+  const url = String(call[0]);
+  const method = ((call[1] as RequestInit | undefined)?.method ?? 'GET').toUpperCase();
+  return { url, method };
+}
+
+describe('faults api client — request wiring contract', () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(okJson({}));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('listFaults → GET /api/v1/faults', async () => {
+    await listFaults();
+    const { url, method } = lastCall();
+    expect(method).toBe('GET');
+    // No filters → bare collection path (no trailing `?`).
+    expect(url).toBe('/api/v1/faults');
+  });
+
+  it('listFaults serializes filters as snake_case query params', async () => {
+    await listFaults({ building_id: 'b-1', status: 'new', page: 2, limit: 25 });
+    const { url } = lastCall();
+    const qs = new URLSearchParams(url.split('?')[1] ?? '');
+    expect(url.split('?')[0]).toBe('/api/v1/faults');
+    expect(qs.get('building_id')).toBe('b-1');
+    expect(qs.get('status')).toBe('new');
+    expect(qs.get('page')).toBe('2');
+    expect(qs.get('limit')).toBe('25');
+  });
+
+  it('createFault → POST /api/v1/faults', async () => {
+    await createFault({} as Parameters<typeof createFault>[0]);
+    expect(lastCall()).toEqual({ url: '/api/v1/faults', method: 'POST' });
+  });
+
+  it('getFault → GET /api/v1/faults/{id}', async () => {
+    await getFault(FAULT_ID);
+    expect(lastCall()).toEqual({ url: `/api/v1/faults/${FAULT_ID}`, method: 'GET' });
+  });
+
+  it('updateFault → PUT /api/v1/faults/{id} (matches the live backend route)', async () => {
+    await updateFault(FAULT_ID, {} as Parameters<typeof updateFault>[1]);
+    const { url, method } = lastCall();
+    expect(url).toBe(`/api/v1/faults/${FAULT_ID}`);
+    // Backend `router()` registers `.route("/{id}", put(update_fault))`.
+    // The generated FaultsService emits PATCH; the hand-rolled client must
+    // stay on PUT to match the running server. Pinned to catch silent flips.
+    expect(method).toBe('PUT');
+  });
+
+  it('listFaultComments → GET /api/v1/faults/{id}/comments and unwraps `comments`', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(okJson({ comments: [{ id: 'c-1' }] }));
+    const comments = await listFaultComments(FAULT_ID);
+    expect(lastCall()).toEqual({
+      url: `/api/v1/faults/${FAULT_ID}/comments`,
+      method: 'GET',
+    });
+    expect(comments).toEqual([{ id: 'c-1' }]);
+  });
+
+  it('addComment → POST /api/v1/faults/{id}/comments', async () => {
+    await addComment(FAULT_ID, { content: 'hi' } as Parameters<typeof addComment>[1]);
+    expect(lastCall()).toEqual({
+      url: `/api/v1/faults/${FAULT_ID}/comments`,
+      method: 'POST',
+    });
+  });
+
+  it('resolveFault → POST /api/v1/faults/{id}/resolve', async () => {
+    await resolveFault(FAULT_ID, {} as Parameters<typeof resolveFault>[1]);
+    expect(lastCall()).toEqual({
+      url: `/api/v1/faults/${FAULT_ID}/resolve`,
+      method: 'POST',
+    });
+  });
+});
+
+/**
+ * Cross-check the overlap explicitly against the generated `FaultsService`
+ * contract. For every fault operation that exists in *both* the generated
+ * client and the hand-rolled client, the URL template and method must agree
+ * (with the one documented PUT/PATCH update divergence). This array is the
+ * machine-checkable statement of "hand-rolled client ⊆ generated contract".
+ */
+describe('faults api client ↔ generated FaultsService contract', () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(okJson({ comments: [], attachments: [] }));
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  // url template (with `{id}` placeholder) + method, as declared by the
+  // generated FaultsService in src/generated/services.ts.
+  const GENERATED_CONTRACT = {
+    list: { url: '/api/v1/faults', method: 'GET' },
+    create: { url: '/api/v1/faults', method: 'POST' },
+    get: { url: '/api/v1/faults/{id}', method: 'GET' },
+    listComments: { url: '/api/v1/faults/{id}/comments', method: 'GET' },
+    addComment: { url: '/api/v1/faults/{id}/comments', method: 'POST' },
+    resolve: { url: '/api/v1/faults/{id}/resolve', method: 'POST' },
+  } as const;
+
+  function normalize(url: string): string {
+    return url.split('?')[0].replace(FAULT_ID, '{id}');
+  }
+
+  it('list matches generated contract', async () => {
+    await listFaults();
+    const c = lastCall();
+    expect({ url: normalize(c.url), method: c.method }).toEqual(GENERATED_CONTRACT.list);
+  });
+
+  it('create matches generated contract', async () => {
+    await createFault({} as Parameters<typeof createFault>[0]);
+    const c = lastCall();
+    expect({ url: normalize(c.url), method: c.method }).toEqual(GENERATED_CONTRACT.create);
+  });
+
+  it('get matches generated contract', async () => {
+    await getFault(FAULT_ID);
+    const c = lastCall();
+    expect({ url: normalize(c.url), method: c.method }).toEqual(GENERATED_CONTRACT.get);
+  });
+
+  it('listComments matches generated contract', async () => {
+    await listFaultComments(FAULT_ID);
+    const c = lastCall();
+    expect({ url: normalize(c.url), method: c.method }).toEqual(GENERATED_CONTRACT.listComments);
+  });
+
+  it('addComment matches generated contract', async () => {
+    await addComment(FAULT_ID, { content: 'x' } as Parameters<typeof addComment>[1]);
+    const c = lastCall();
+    expect({ url: normalize(c.url), method: c.method }).toEqual(GENERATED_CONTRACT.addComment);
+  });
+
+  it('resolve matches generated contract', async () => {
+    await resolveFault(FAULT_ID, {} as Parameters<typeof resolveFault>[1]);
+    const c = lastCall();
+    expect({ url: normalize(c.url), method: c.method }).toEqual(GENERATED_CONTRACT.resolve);
+  });
+});


### PR DESCRIPTION
## Task
Test coverage for the core-features API client integration (story 79-1): assert announcements/faults api-client wiring against the generated client contract.

## Owner
pm-frontend

## What changed
Two new vitest suites in `@ppt/api-client`, pinning the request wiring (URL template + HTTP method) of the hand-rolled core-features API clients so they can't silently drift from the backend / generated-client contract.

- `frontend/packages/api-client/src/faults/api.test.ts` (190 LOC, 14 tests)
  - Pins `listFaults` (+ snake_case query params), `createFault`, `getFault`, `updateFault`, `listFaultComments` (+ `comments` unwrap), `addComment`, `resolveFault` paths and methods.
  - A dedicated `faults api client ↔ generated FaultsService contract` block cross-checks every overlapping op against the URL/method declared by the generated `FaultsService` (`src/generated/services.ts`).
  - **Documents a real contract divergence:** the live backend registers `PUT /api/v1/faults/{id}` (`backend/servers/api-server/src/routes/faults.rs` `router()`), but the generated `FaultsService.faultsApiUpdate` emits `PATCH`. The hand-rolled client correctly follows the backend (`PUT`); the test pins `PUT` so a silent flip is caught, and the divergence is now visible rather than hidden.
- `frontend/packages/api-client/src/announcements/api.test.ts` (199 LOC, 20 tests)
  - Announcements have **no** generated service — the hand-rolled `createAnnouncementsApi` IS the contract. Pins the full transport surface (list/listPublished/create/get/update/delete/publish/schedule/archive/pin/markRead/acknowledge/getAcknowledgmentStats/listComments/createComment/deleteComment/statistics/unread-count) plus Authorization + X-Tenant-ID + Content-Type header construction (present when configured, absent for anon).

No production code changed — test-only.

## Tested (Band A — fast check)
- `pnpm -F @ppt/api-client typecheck` → exit 0
- `pnpm exec biome check <both test files>` → exit 0 (after autofix)
- `pnpm -F @ppt/api-client test:run` → exit 0 — **6 files, 66 tests passing** (34 new)

IG3 verification: temporarily flipped `updateFault` `PUT`→`PATCH` in `faults/api.ts` → the `updateFault → PUT` test failed as expected (`expected 'PATCH' to be 'PUT'`); reverted. The suite genuinely guards the wiring.

## Built (Band B — full build)
Skipped: test-only change, no public API / config / build-output touch.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
Skipped (no ppt-bridge MCP in session).

## Notes
- Specialist: `react-web`. Scope-drift: false (only `frontend/packages/api-client/src/**` touched). Code-reuse warnings: none.
- Follow-up worth filing separately (out of scope here): the generated `FaultsService.faultsApiUpdate` PATCH vs backend PUT mismatch is a real client/spec drift — the TypeSpec/OpenAPI for the fault-update endpoint or the backend route should be reconciled. This PR only documents and guards against it on the hand-rolled side.

https://claude.ai/code/session_01CJ35u1zjr2AUmpGr6tNewD

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJ35u1zjr2AUmpGr6tNewD)_