### PR TITLE
triage-dispatcher-mcp-push-large-file-issue-1014: bound action-list.json size to prevent MCP-push corruption (#1014)

### DIFF
--- a/.research/action-list-reconcile.sh
+++ b/.research/action-list-reconcile.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# action-list archive-move reconciler — sibling of archive-reconcile.sh.
+#
+# Sweeps active action-list.json for items whose status is terminal
+# (done/dropped) and moves them to action-list-archive.json idempotently.
+#
+# Why this script exists (issue #1014):
+#
+#   dispatcher-prompt.md (Phase 1, step 4) mandates that action-list.json
+#   hold NON-TERMINAL items only (status ∈ {open, in-progress}); done/dropped
+#   items are supposed to live in action-list-archive.json. But unlike the
+#   assignments split — which has archive-reconcile.sh enforcing the move
+#   every Phase 6 — there was no equivalent reconciler for action-list, so
+#   terminal rows accumulated in the live file (snapshot 2026-06-06: 25
+#   terminal rows out of 82; the issue reports ~66 accreting over time).
+#
+#   The bloat is the ROOT CAUSE of issue #1014: when `git push` is HTTP-403'd
+#   by the sandbox proxy, Phase 6 falls back to the GitHub MCP push_files
+#   tool, which requires the full file content INLINE in the tool call. A
+#   ~75-92 KB literal truncates on emission, so the file lands on dev as a
+#   1-2 item stub — silent corruption. Keeping action-list.json small (only
+#   live, non-terminal work) keeps it well inside the inline-push limit and
+#   removes the corruption vector at the source.
+#
+# Idempotent + re-runnable: after --apply the moved items are gone from the
+# active file so they no longer match the sweep set. Re-running on a clean
+# state is a no-op. Concurrent runs that each re-archive the same id produce
+# ONE row per id (group_by + map(last) keeps the freshest by file position).
+#
+# Combined-count guard (mirrors archive-reconcile.sh T17): the script refuses
+# to write if the combined active+archive item count would change — items
+# MOVE, they never disappear. This makes a buggy sweep fail closed instead of
+# destroying backlog.
+#
+# Usage:
+#   ./.research/action-list-reconcile.sh             # dry-run: print move set, write nothing
+#   ./.research/action-list-reconcile.sh --apply     # actually move terminal items
+#   ACTION_LIST=… ACTION_ARCHIVE=… ./.research/action-list-reconcile.sh [--apply]
+
+set -euo pipefail
+
+ACTION_LIST="${ACTION_LIST:-.research/management/action-list.json}"
+ACTION_ARCHIVE="${ACTION_ARCHIVE:-.research/management/action-list-archive.json}"
+APPLY=0
+[ "${1:-}" = "--apply" ] && APPLY=1
+
+if [ ! -f "$ACTION_LIST" ]; then
+  echo "action-list-reconcile: active file missing — nothing to do: $ACTION_LIST" >&2
+  exit 0
+fi
+
+# Build the move set from CURRENT active file state (sweep semantics — same as
+# archive-reconcile.sh). Terminal = status in {done, dropped}. (open/in-progress
+# stay; merged/failed are not action-list statuses but are tolerated as terminal
+# for forward-compat.)
+MOVE_IDS_JSON=$(jq '[.items[]
+  | select(.status=="done" or .status=="dropped" or .status=="merged" or .status=="failed")
+  | .id]' "$ACTION_LIST")
+
+MOVE_COUNT=$(echo "$MOVE_IDS_JSON" | jq 'length')
+ACTIVE_BEFORE=$(jq '.items | length' "$ACTION_LIST")
+ARCHIVE_BEFORE=0
+[ -f "$ACTION_ARCHIVE" ] && ARCHIVE_BEFORE=$(jq '.items | length' "$ACTION_ARCHIVE")
+COMBINED_BEFORE=$((ACTIVE_BEFORE + ARCHIVE_BEFORE))
+
+if [ "$MOVE_COUNT" = "0" ]; then
+  echo "action-list-reconcile: no terminal items in active (clean)"
+  echo "  active=$ACTIVE_BEFORE archive=$ARCHIVE_BEFORE combined=$COMBINED_BEFORE"
+  exit 0
+fi
+
+echo "action-list-reconcile: $MOVE_COUNT terminal item(s) in active action-list.json"
+jq -r --argjson ids "$MOVE_IDS_JSON" '
+  .items[]
+  | select(.id as $i | $ids | index($i))
+  | "  \(.id) :: status=\(.status) owner=\(.owner_role // "-")"' "$ACTION_LIST"
+
+if [ "$APPLY" = "0" ]; then
+  echo "  (dry-run — pass --apply to move them)"
+  exit 0
+fi
+
+# Ensure the archive file exists with a valid skeleton before we extend it.
+if [ ! -f "$ACTION_ARCHIVE" ]; then
+  echo '{"generated":"","items":[]}' > "$ACTION_ARCHIVE"
+fi
+
+TMP_ARCHIVE=$(mktemp)
+TMP_ACTIVE=$(mktemp)
+trap 'rm -f "$TMP_ARCHIVE" "$TMP_ACTIVE"' EXIT
+
+# Append matching active items to archive, then dedup by id keeping the freshest
+# item (group_by + map(last)). Stamp archived_at as archive-reconcile.sh does.
+jq --argjson ids "$MOVE_IDS_JSON" --slurpfile active "$ACTION_LIST" '
+  .items = (
+    (.items + [ $active[0].items[] | select(.id as $i | $ids | index($i)) ])
+    | group_by(.id)
+    | map(last)
+  )
+  | .archived_at = (now | todate)
+' "$ACTION_ARCHIVE" > "$TMP_ARCHIVE"
+
+# Drop matching items from active.
+jq --argjson ids "$MOVE_IDS_JSON" '
+  .items |= map(select(.id as $i | $ids | index($i) | not))
+' "$ACTION_LIST" > "$TMP_ACTIVE"
+
+# Combined-count guard — refuse to write a destructive result. Items MOVE, so
+# the combined count must stay exactly equal (a decrease means an item was lost;
+# an increase means the dedup-on-append failed).
+NEW_ACTIVE=$(jq '.items | length' "$TMP_ACTIVE")
+NEW_ARCHIVE=$(jq '.items | length' "$TMP_ARCHIVE")
+NEW_COMBINED=$((NEW_ACTIVE + NEW_ARCHIVE))
+
+if [ "$NEW_COMBINED" -ne "$COMBINED_BEFORE" ]; then
+  echo "action-list-reconcile: ABORT — combined count changed $COMBINED_BEFORE → $NEW_COMBINED" >&2
+  echo "  refusing to write; leaving $ACTION_LIST and $ACTION_ARCHIVE untouched." >&2
+  exit 2
+fi
+
+mv "$TMP_ARCHIVE" "$ACTION_ARCHIVE"
+mv "$TMP_ACTIVE"  "$ACTION_LIST"
+trap - EXIT
+
+echo "action-list-reconcile: moved $MOVE_COUNT item(s)"
+echo "  active=$ACTIVE_BEFORE → $NEW_ACTIVE  archive=$ARCHIVE_BEFORE → $NEW_ARCHIVE  combined=$COMBINED_BEFORE (unchanged)"

--- a/.research/dispatcher-self-test.sh
+++ b/.research/dispatcher-self-test.sh
@@ -41,6 +41,11 @@ combined_rows_jq() {
 FAIL=0
 note() { printf '  ok    %s\n' "$1"; }
 fail() { printf '  FAIL  %s\n' "$1" >&2; FAIL=1; }
+# warn() — advisory only: prints but does NOT set FAIL. Used for invariants
+# that are self-healing on the next run (e.g. action-list archive bloat, which
+# action-list-reconcile.sh sweeps) so introducing the check doesn't retroactively
+# hard-fail an already-bloated dev snapshot.
+warn() { printf '  WARN  %s\n' "$1" >&2; }
 
 echo "==> dispatcher-self-test"
 echo "    assignments: $ASSIGN"
@@ -596,6 +601,24 @@ if [ -f "$ACTION_LIST" ]; then
   fi
   echo
 fi
+
+# --- T26: action-list.json holds non-terminal items only (issue #1014) ------
+# Spec (dispatcher-prompt.md Phase 1 step 4): action-list.json carries only
+# open/in-progress items; done/dropped live in action-list-archive.json. Bloat
+# from un-archived terminal rows is what pushed the file past the MCP inline
+# push limit and corrupted it on dev. Advisory (warn, not fail) because
+# action-list-reconcile.sh --apply is self-healing on the next Phase 6.
+echo "T26 action-list.json holds non-terminal items only (issue #1014; advisory)"
+if [ -f "$ACTION_LIST" ]; then
+  TERM=$(jq -r '[.items[] | select(.status=="done" or .status=="dropped" or .status=="merged" or .status=="failed")] | length' "$ACTION_LIST")
+  if [ "$TERM" = "0" ]; then note "no terminal items in action-list.json (archive split clean)"
+  else
+    warn "$TERM terminal item(s) in action-list.json — run: bash .research/action-list-reconcile.sh --apply"
+  fi
+else
+  printf '  skip  %s not found\n' "$ACTION_LIST"
+fi
+echo
 
 # --- Summary ---------------------------------------------------------------
 if [ "$FAIL" = "0" ]; then

--- a/.research/mcp-push-size-guard.sh
+++ b/.research/mcp-push-size-guard.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# MCP-push size guard (issue #1014) — defence-in-depth for the Phase 6 push.
+#
+# When `git push` is HTTP-403'd by the sandbox proxy, dispatcher Phase 6 falls
+# back to the GitHub MCP push_files tool. That tool requires the FULL file
+# content inline in the tool call; a large literal (~tens of KB and up)
+# truncates on emission, so the file lands on dev silently corrupted (issue
+# #1014: action-list.json was stubbed to 1-2 items).
+#
+# The structural fix is action-list-reconcile.sh, which keeps action-list.json
+# small by archiving terminal items every run. THIS guard is the belt-and-
+# suspenders backstop: before the MCP push path runs, it checks every file the
+# dispatcher is about to push and FAILS CLOSED if any exceeds a safe inline
+# size. A blocked push is recoverable (next run retries on a fixed base); a
+# silently-truncated push is not.
+#
+# It is a no-op when PUSH_METHOD != mcp (direct `git push` has no inline limit).
+#
+# Usage:
+#   PUSH_METHOD=mcp ./.research/mcp-push-size-guard.sh <file> [<file>...]
+#   # or read the staged set from git:
+#   PUSH_METHOD=mcp ./.research/mcp-push-size-guard.sh --staged
+#
+# Tunables (env):
+#   PUSH_METHOD            mcp (default) | git. Guard only enforces under mcp.
+#   MCP_INLINE_MAX_BYTES   per-file hard ceiling, default 65536 (64 KiB).
+#                          Files above this are NOT safe to inline-push.
+#
+# Exit codes:
+#   0  all files safe to inline-push (or PUSH_METHOD != mcp → skipped).
+#   3  at least one file exceeds the inline ceiling — DO NOT MCP-push.
+#      Remediation printed on stderr (run the reconcilers / use git push).
+#  64  usage error.
+
+set -euo pipefail
+
+PUSH_METHOD="${PUSH_METHOD:-mcp}"
+MCP_INLINE_MAX_BYTES="${MCP_INLINE_MAX_BYTES:-65536}"
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: $0 <file> [<file>...] | --staged" >&2
+  exit 64
+fi
+
+# Direct git push has no inline-content limit — nothing to guard.
+if [ "$PUSH_METHOD" != "mcp" ]; then
+  echo "mcp-push-size-guard: PUSH_METHOD=$PUSH_METHOD (not mcp) — skipped"
+  exit 0
+fi
+
+FILES=()
+if [ "${1:-}" = "--staged" ]; then
+  while IFS= read -r f; do
+    [ -n "$f" ] && FILES+=("$f")
+  done < <(git diff --cached --name-only --diff-filter=ACM)
+else
+  FILES=("$@")
+fi
+
+if [ "${#FILES[@]}" -eq 0 ]; then
+  echo "mcp-push-size-guard: no files to check — OK"
+  exit 0
+fi
+
+file_size() { wc -c < "$1" | tr -d '[:space:]'; }
+
+OVERSIZE=0
+for f in "${FILES[@]}"; do
+  [ -f "$f" ] || continue
+  sz=$(file_size "$f")
+  if [ "$sz" -gt "$MCP_INLINE_MAX_BYTES" ]; then
+    echo "mcp-push-size-guard: OVERSIZE $f = ${sz}B > ${MCP_INLINE_MAX_BYTES}B ceiling" >&2
+    OVERSIZE=$((OVERSIZE + 1))
+  else
+    echo "mcp-push-size-guard: ok       $f = ${sz}B"
+  fi
+done
+
+if [ "$OVERSIZE" -gt 0 ]; then
+  cat >&2 <<EOF
+
+mcp-push-size-guard: ABORT — $OVERSIZE file(s) exceed the MCP inline-push ceiling.
+  Inline MCP push_files would TRUNCATE these and corrupt them on dev (issue #1014).
+  Remediation (in order):
+    1. Run the archive reconcilers to shrink active state, then re-stage:
+         bash .research/action-list-reconcile.sh --apply
+         bash .research/archive-reconcile.sh --apply
+    2. If a file is still oversize after archiving, do NOT MCP-push it. Land
+       this run via direct 'git push' (PUSH_METHOD=git) where the proxy allows,
+       or defer — the next run retries on a corrected base. A blocked push is
+       recoverable; a truncated one is not.
+EOF
+  exit 3
+fi
+
+echo "mcp-push-size-guard: all ${#FILES[@]} file(s) within ${MCP_INLINE_MAX_BYTES}B inline ceiling — safe to MCP-push"
+exit 0


### PR DESCRIPTION
## Task
Triage GitHub issue #1014 — "Dispatcher action-list.json corruption when MCP push falls back from blocked git push". Investigate root cause and implement a robust fix. The named file (`.research/management/action-list.json`) is dispatcher-owned and was NOT edited.

## Owner
pm-backend

## Root cause (confirmed)
When `git push` is HTTP-403'd by the sandbox proxy, dispatcher Phase 6 falls back to the GitHub MCP `push_files` tool, which requires the **full file content inline** in the tool call. `action-list.json` had grown to 82 items — **25 of them terminal (`done`/`dropped`)** — because the spec mandate (`dispatcher-prompt.md` Phase 1 step 4: "action-list.json holds non-terminal items only; done/dropped live in `action-list-archive.json`") was **never automated**. Unlike `assignments.json` (which has `archive-reconcile.sh` sweeping every Phase 6), `action-list.json` had no equivalent reconciler, so terminal rows accreted and pushed the file past the inline-push limit. The fallback truncated it to a 2-item stub on `dev`.

## Fix (two robust, self-contained parts + a guard)
1. **`.research/action-list-reconcile.sh`** (NEW) — sibling of `archive-reconcile.sh`. Sweeps `done`/`dropped` items from `action-list.json` into `action-list-archive.json`, idempotently, with a combined-count guard (items MOVE, never disappear). On the current snapshot it moves all 25 terminal rows, shrinking the live file **42 KB → 26 KB** (57 items, all `open`/`in-progress`). This removes the corruption vector at the source by keeping the file inside the inline-push limit.
2. **`.research/mcp-push-size-guard.sh`** (NEW) — defence-in-depth. Before the MCP push path, fails **closed** (exit 3) if any staged file exceeds a 64 KiB inline ceiling, with a remediation hint. A blocked push is recoverable next run; a truncated one is not.
3. **`dispatcher-self-test.sh` T26** — advisory (`warn`, non-blocking) check that `action-list.json` holds non-terminal items only, mirroring the T18/T19 split invariants for assignments. Self-test still PASSES (exit 0) and surfaces the bloat with the reconcile command.

## Tested (Band A)
- `bash -n` on all three scripts — clean.
- `action-list-reconcile.sh` on temp copies of the dispatcher-owned files (originals untouched): dry-run lists 25 terminal items; `--apply` moves them (active 82→57, archive 44→69, combined 126 unchanged); re-run is a no-op; archive remains valid JSON.
- `mcp-push-size-guard.sh`: small file → exit 0; 70 KB file → exit 3 with remediation; `PUSH_METHOD=git` → skipped exit 0.
- `dispatcher-self-test.sh` → exit 0 (PASS) with `T26 WARN 25 terminal item(s)` advisory.

## Built / CI parity
Skipped — shell-only research tooling, no compiled artifact and no app CI surface. The dispatcher self-test is the relevant gate and passes.

## Scope drift
`true` (advisory). `scope-check.sh --owner pm-backend` returns rc=2 because `.research/` dispatcher infra isn't mapped to `pm-backend`'s owner areas. This is legitimate, explicitly-authorized dispatcher-tooling work (the task permits fixes under `.research/*.sh` and `.claude/skills/**`). Touched paths: `.research/action-list-reconcile.sh`, `.research/mcp-push-size-guard.sh`, `.research/dispatcher-self-test.sh`, `.research/dispatcher-prompt.md`. No `.research/management/**` file was modified.

## Notes — REMAINING MANUAL STEP (important)
The functional fix (the two helper scripts + the T26 self-test invariant) is landed on this branch, byte-exact and verified via `get_file_contents`.

The Phase 6 **wiring edits to `.research/dispatcher-prompt.md`** (which make the dispatcher actually invoke `action-list-reconcile.sh --apply` and `mcp-push-size-guard.sh --staged`) are committed locally but were **deliberately NOT pushed via MCP**: that file is 136 KB / 2443 lines — itself over the 64 KiB inline ceiling — so an inline MCP push would risk the exact truncation corruption this PR repairs (and would corrupt the dispatcher's own prompt on `dev`). Apply those prompt edits from a machine with normal `git push`, or cherry-pick local commit `8e180a4`. The prompt diff is small and additive:
- Phase 6 "Archive move" section: adds an `action-list-reconcile.sh --apply` step + `action-list-archive.json` to `git add`.
- Phase 6 MCP-push block: adds a `mcp-push-size-guard.sh --staged` pre-check that aborts on oversize.

Until the prompt is wired, operators can run `bash .research/action-list-reconcile.sh --apply` manually to shrink the file. The scripts are fully functional standalone.

Closes #1014 once the prompt wiring is applied.

https://claude.ai/code/session_01CJ35u1zjr2AUmpGr6tNewD

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJ35u1zjr2AUmpGr6tNewD)_