### PR TITLE
triage-issue-755: fix Epic 8A notification RLS GUC mismatch (#755 findings #4 & #5)

### DIFF
--- a/backend/crates/db/migrations/00177_fix_epic8a_notification_rls_guc.sql
+++ b/backend/crates/db/migrations/00177_fix_epic8a_notification_rls_guc.sql
@@ -1,0 +1,106 @@
+-- Migration: 00177_fix_epic8a_notification_rls_guc
+-- Security Fix (issue #755, findings #4 & #5): correct the RLS GUC names on the
+-- Epic 8A notification tables and close the owner-bypass gap.
+--
+-- Background
+-- ----------
+-- 00021 (`notification_preferences`) and 00022 (`critical_notifications` /
+-- `critical_notification_acknowledgments`) wrote their RLS policies against the
+-- legacy `request.user_id` / `request.org_id` GUCs. No code path ever sets
+-- those GUCs. The api-server's `RlsConnection` extractor sets
+-- `app.current_user_id` / `app.current_org_id` (see 00159, 00171 for the
+-- convention spelled out verbatim). The mismatch means:
+--
+--   * `notification_preferences` is reached through `RlsConnection` (the repo's
+--     `*_rls` methods). With `request.user_id` unset, the policy collapses to
+--     the all-zeros UUID and matches nothing — the RLS path is silently broken.
+--   * `critical_notifications` is reached through a raw service-role pool, so
+--     `ENABLE` (without `FORCE`) is owner-bypassed and the broken policies are
+--     simply never exercised — defense-in-depth that does nothing.
+--
+-- This migration drops and recreates the policies against the correct
+-- `app.*` GUCs (plus `is_super_admin()` bypass, matching every other RLS table)
+-- and adds `FORCE ROW LEVEL SECURITY`. The critical-notification tables keep a
+-- service-role allowance (GUC unset => permitted) so the existing raw-pool
+-- repository keeps working, mirroring `device_push_tokens_service_policy`
+-- (00159).
+
+-- ============================================================================
+-- notification_preferences (00021): request.user_id -> app.current_user_id
+-- ============================================================================
+
+ALTER TABLE notification_preferences FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS notification_preferences_user_access ON notification_preferences;
+
+CREATE POLICY notification_preferences_user_access ON notification_preferences
+    FOR ALL
+    USING (
+        user_id = NULLIF(current_setting('app.current_user_id', TRUE), '')::UUID
+        OR is_super_admin()
+    )
+    WITH CHECK (
+        user_id = NULLIF(current_setting('app.current_user_id', TRUE), '')::UUID
+        OR is_super_admin()
+    );
+
+-- ============================================================================
+-- critical_notifications (00022): request.* -> app.*
+-- Raw service-role pool sets no GUC, so a service allowance keeps the existing
+-- CriticalNotificationRepository working while FORCE closes owner-bypass.
+-- ============================================================================
+
+ALTER TABLE critical_notifications FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS critical_notifications_org_read ON critical_notifications;
+DROP POLICY IF EXISTS critical_notifications_insert ON critical_notifications;
+
+-- Org members read their org's critical notifications; service role (no user
+-- GUC set) and super-admins may read for delivery fan-out / admin tooling.
+CREATE POLICY critical_notifications_org_read ON critical_notifications
+    FOR SELECT
+    USING (
+        organization_id = NULLIF(current_setting('app.current_org_id', TRUE), '')::UUID
+        OR NULLIF(current_setting('app.current_user_id', TRUE), '') IS NULL
+        OR is_super_admin()
+    );
+
+-- Inserts are creator-attributed; service role / super-admin may insert.
+CREATE POLICY critical_notifications_insert ON critical_notifications
+    FOR INSERT
+    WITH CHECK (
+        created_by = NULLIF(current_setting('app.current_user_id', TRUE), '')::UUID
+        OR NULLIF(current_setting('app.current_user_id', TRUE), '') IS NULL
+        OR is_super_admin()
+    );
+
+-- ============================================================================
+-- critical_notification_acknowledgments (00022): request.* -> app.*
+-- ============================================================================
+
+ALTER TABLE critical_notification_acknowledgments FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS critical_acks_read ON critical_notification_acknowledgments;
+DROP POLICY IF EXISTS critical_acks_insert ON critical_notification_acknowledgments;
+
+CREATE POLICY critical_acks_read ON critical_notification_acknowledgments
+    FOR SELECT
+    USING (
+        user_id = NULLIF(current_setting('app.current_user_id', TRUE), '')::UUID
+        OR NULLIF(current_setting('app.current_user_id', TRUE), '') IS NULL
+        OR is_super_admin()
+        OR EXISTS (
+            SELECT 1 FROM critical_notifications cn
+            WHERE cn.id = notification_id
+              AND cn.organization_id
+                  = NULLIF(current_setting('app.current_org_id', TRUE), '')::UUID
+        )
+    );
+
+CREATE POLICY critical_acks_insert ON critical_notification_acknowledgments
+    FOR INSERT
+    WITH CHECK (
+        user_id = NULLIF(current_setting('app.current_user_id', TRUE), '')::UUID
+        OR NULLIF(current_setting('app.current_user_id', TRUE), '') IS NULL
+        OR is_super_admin()
+    );

--- a/backend/crates/db/tests/notification_rls_guc_tests.rs
+++ b/backend/crates/db/tests/notification_rls_guc_tests.rs
@@ -1,0 +1,143 @@
+//! Migration-effect (catalog metadata) regression test for the Epic 8A
+//! notification RLS GUC-mismatch (issue #755, findings #4 & #5).
+//!
+//! 00021 (`notification_preferences`) and 00022 (`critical_notifications` /
+//! `critical_notification_acknowledgments`) wrote their RLS policies against the
+//! legacy `request.user_id` / `request.org_id` GUCs and only `ENABLE`d RLS.
+//! Nothing sets `request.*`; the project convention (00159, 00171) is
+//! `app.current_user_id` / `app.current_org_id` set by the `RlsConnection`
+//! extractor. The result:
+//!
+//!   * `notification_preferences` is reached via `RlsConnection`, so the
+//!     unset-`request.user_id` policy collapsed to the all-zeros UUID and
+//!     matched nothing — the RLS path was silently broken.
+//!   * the critical-notification tables are reached via a raw service-role pool
+//!     and were `ENABLE`-only, so owner-bypass meant the broken policies were
+//!     never exercised — non-functional defense-in-depth.
+//!
+//! Migration 00177 rewrites the policies against the `app.*` GUCs (plus
+//! `is_super_admin()`) and adds `FORCE ROW LEVEL SECURITY`.
+//!
+//! ## Why this is a metadata test, not a behavioral one
+//!
+//! `#[sqlx::test]` connects as the `DATABASE_URL` superuser, which PostgreSQL
+//! exempts from RLS entirely — a behavioral "must not see" assertion passes
+//! vacuously here. Behavioral cross-tenant isolation is covered by CI's
+//! dedicated non-superuser `rls-smoke-test` / `security-tests` jobs. This suite
+//! instead asserts on the Postgres catalog what 00177 changes, mirroring the
+//! 00171 messaging precedent (`messaging_rls_cross_tenant_tests.rs`):
+//!   1. FORCE RLS (`relforcerowsecurity`) is set on each Epic 8A table.
+//!   2. Each table still carries at least one policy (FORCE is real enforcement,
+//!      not implicit deny-all).
+//!   3. No surviving policy references the legacy `request.` GUC.
+//!
+//! Assertions (1) and (3) FAIL on `origin/dev` (pre-00177:
+//! `relforcerowsecurity = false`, policies still on `request.*`) — the IG3
+//! regression intent — and PASS after 00177 is applied.
+
+use sqlx::PgPool;
+
+/// The three Epic 8A notification tables that 00177 brings under FORCE RLS with
+/// corrected `app.*` GUC policies.
+const NOTIFICATION_TABLES: [&str; 3] = [
+    "notification_preferences",
+    "critical_notifications",
+    "critical_notification_acknowledgments",
+];
+
+/// 00177 must set `relforcerowsecurity = true` (FORCE) on every Epic 8A
+/// notification table, with `relrowsecurity = true` (ENABLE, from 00021/00022)
+/// still in place. Pre-migration these are `(true, false)`, so this fails on
+/// origin/dev.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn notification_tables_have_force_rls_enabled(pool: PgPool) {
+    let rows: Vec<(String, bool, bool)> = sqlx::query_as(
+        r#"
+        SELECT relname, relrowsecurity, relforcerowsecurity
+        FROM pg_class
+        WHERE relname = ANY($1)
+          AND relnamespace = 'public'::regnamespace
+        ORDER BY relname
+        "#,
+    )
+    .bind(&NOTIFICATION_TABLES[..])
+    .fetch_all(&pool)
+    .await
+    .expect("query pg_class RLS flags");
+
+    assert_eq!(
+        rows.len(),
+        NOTIFICATION_TABLES.len(),
+        "expected all Epic 8A notification tables present in pg_class (public schema); got {rows:?}"
+    );
+
+    for (relname, relrowsecurity, relforcerowsecurity) in &rows {
+        assert!(
+            *relrowsecurity,
+            "{relname}: ENABLE ROW LEVEL SECURITY (relrowsecurity) must be set (from 00021/00022)"
+        );
+        assert!(
+            *relforcerowsecurity,
+            "{relname}: FORCE ROW LEVEL SECURITY (relforcerowsecurity) must be set by 00177 — \
+             without FORCE, the table owner bypasses the notification RLS policies (#755)"
+        );
+    }
+}
+
+/// FORCE RLS with no policy is an implicit deny-all; FORCE RLS with policies is
+/// real enforcement. Assert each table still carries at least one RLS policy.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn notification_tables_have_rls_policies(pool: PgPool) {
+    for table in NOTIFICATION_TABLES {
+        let policy_count: i64 = sqlx::query_scalar(
+            r#"
+            SELECT count(*)
+            FROM pg_policies
+            WHERE schemaname = 'public'
+              AND tablename = $1
+            "#,
+        )
+        .bind(table)
+        .fetch_one(&pool)
+        .await
+        .expect("query pg_policies");
+
+        assert!(
+            policy_count > 0,
+            "{table}: expected at least one RLS policy so FORCE ROW LEVEL SECURITY enforces a \
+             real policy rather than implicit deny-all; found {policy_count}"
+        );
+    }
+}
+
+/// No surviving policy on the Epic 8A tables may reference the legacy
+/// `request.` GUC — every policy must use the `app.current_user_id` /
+/// `app.current_org_id` convention. The `qual` (USING) and `with_check`
+/// expressions are inspected as text. Fails on origin/dev (policies still on
+/// `request.user_id` / `request.org_id`).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn notification_policies_use_app_guc_not_request(pool: PgPool) {
+    let offenders: Vec<(String, String)> = sqlx::query_as(
+        r#"
+        SELECT tablename, policyname
+        FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = ANY($1)
+          AND (
+                COALESCE(qual, '')       LIKE '%request.%'
+             OR COALESCE(with_check, '') LIKE '%request.%'
+          )
+        ORDER BY tablename, policyname
+        "#,
+    )
+    .bind(&NOTIFICATION_TABLES[..])
+    .fetch_all(&pool)
+    .await
+    .expect("query pg_policies for legacy request.* GUC");
+
+    assert!(
+        offenders.is_empty(),
+        "Epic 8A notification policies must use the app.* GUC convention (00177); \
+         these still reference the never-set legacy request.* GUC: {offenders:?}"
+    );
+}


### PR DESCRIPTION
## Task

Triage GitHub issue #755 — "Current dev review: Epic 8A Notification Preferences". Extract concrete actionable findings, implement the smallest correct fix(es).

#755 is closed, with a maintainer comment claiming the RLS GUC-mismatch finding (#4) was "superseded by `00038_granular_notification_preferences.sql` which uses the correct `app.current_user_id`." **That reasoning is incorrect:** 00038 creates *new* Epic 8B tables (`event_notification_preferences`, `notification_schedule`, …) and never touches the original Epic 8A `notification_preferences` table. Findings #4 and #5 are still live, self-contained, and locatable on current `dev`. This PR fixes them.

## Findings addressed

- **#4 — `notification_preferences` RLS GUC mismatch.** 00021's policy uses `current_setting('request.user_id')`, which no code path sets. The repo's `*_rls` methods run on an `RlsConnection` that sets `app.current_user_id`. With `request.user_id` unset the policy collapses to the all-zeros UUID and matches nothing — the RLS path is silently broken.
- **#5 — `critical_notifications` / `_acknowledgments` RLS GUC mismatch.** 00022's policies use `request.user_id` / `request.org_id` (never set) and only `ENABLE` RLS. The repo uses a raw service-role pool, so owner-bypass means the broken policies are never exercised — non-functional defense-in-depth.

## Fix

New migration `00177_fix_epic8a_notification_rls_guc.sql` rewrites all five policies onto the project's `app.current_user_id` / `app.current_org_id` convention (+ `is_super_admin()` bypass) and adds `FORCE ROW LEVEL SECURITY`, mirroring the established 00159 (`device_push_tokens`) and 00171 (`messaging`) fixes verbatim.

`notification_preferences` is reached only via `RlsConnection`, so it gets the standard user-scoped policy. The critical-notification tables are reached via a **raw service-role pool** (no GUC set) with tenant scoping enforced in the handler layer — so they keep a service-role allowance (`app.current_user_id` unset ⇒ permitted) exactly like `device_push_tokens_service_policy`, which lets the existing `CriticalNotificationRepository` keep working while FORCE closes owner-bypass for any future RlsConnection use.

## Findings NOT in scope (advisory / stale / cross-stack — left for re-file)

#1, #2 (critical bypass/urgency pipeline), #3 (dual senders), #6, #7 (frontend realtime/modal), #8 (FCM priority) are feature-completion / multi-stack items, not self-contained backend bugs. #9/#10 (device_push_tokens) are covered by 00159/00161 and #750. Only #4/#5 are landed here as the smallest correct backend fix.

## Owner

pm-backend (specialist: db-migration)

## Tested (Band A — fast check)

```
cargo +stable test -p db --test notification_rls_guc_tests --no-run
Finished `test` profile [unoptimized] target(s) in 4m 45s   # exit 0
```

Compiles clean (no errors/warnings). The migration is embedded + validated by `sqlx::migrate!` at macro-expansion time. **Tests themselves require a live Postgres** (`#[sqlx::test]`) and will run in CI's db-backed jobs — same as the 00171 precedent they mirror. No local DB in this sandbox.

## Built (Band B — full build)

Skipped: change is a single migration + catalog-metadata test (≤250 LOC, no public Rust API surface). The `cargo test --no-run` above already compiled the full `db` crate dependency graph.

## CI parity (Band C — hot-path only)

Not run locally (no DB in sandbox). This IS a security/RLS change, so the db-backed `backend.yml` test job + the dedicated non-superuser `rls-smoke-test` / `security-tests` jobs will exercise the new regression tests. The metadata assertions fail on `origin/dev` (pre-FORCE, `request.*` policies) and pass after 00177 — the IG3 regression intent.

## Notes

- IG3 regression test: `backend/crates/db/tests/notification_rls_guc_tests.rs` — fails on `origin/dev`, passes with 00177.
- No code-reuse concerns (no new auth/crypto/http helpers).
- Cargo.lock workspace-version churn from the local build was deliberately reverted to keep the diff minimal.

https://claude.ai/code/session_01CJ35u1zjr2AUmpGr6tNewD

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJ35u1zjr2AUmpGr6tNewD)_