### PR TITLE
triage-issue-769: validate worktree path params on get/close/logs (deploy-server)

### DIFF
--- a/backend/servers/deploy-server/src/api/logs.rs
+++ b/backend/servers/deploy-server/src/api/logs.rs
@@ -27,6 +27,10 @@ pub async fn handler(
 ) -> Result<Sse<impl Stream<Item = std::result::Result<Event, Infallible>>>> {
     caller.require_scope("worktree:read")?;
 
+    // Validate the path param at the boundary (#769 finding 6) — the name is
+    // interpolated into the expected container name (`wt-{name}-{service}`) below.
+    crate::infra::git::validate_alias_strict(&name)?;
+
     let wt = svc
         .store
         .get_worktree(&name)

--- a/backend/servers/deploy-server/src/api/worktree.rs
+++ b/backend/servers/deploy-server/src/api/worktree.rs
@@ -560,6 +560,11 @@ pub async fn get_handler(
     Path(name): Path<String>,
 ) -> Result<Json<Worktree>> {
     caller.require_scope("worktree:read")?;
+    // Validate the path param with the same strict rules `open_handler` applies
+    // to a freshly-created alias (#769 finding 6). The name flows into Caddy host
+    // strings and Postgres DB-name reconstruction downstream; reject anything that
+    // isn't `[A-Za-z0-9_-]` (no path separators, no leading dash) at the boundary.
+    crate::infra::git::validate_alias_strict(&name)?;
     let wt = svc
         .store
         .get_worktree(&name)
@@ -582,6 +587,10 @@ pub async fn close_handler(
     Path(name): Path<String>,
 ) -> Result<Json<Worktree>> {
     caller.require_scope("worktree:close")?;
+    // Validate the path param before it reaches the lock registry, the store, or
+    // the Caddy/Postgres cleanup paths (#769 finding 6). Same strict rules as
+    // `open_handler`.
+    crate::infra::git::validate_alias_strict(&name)?;
     // Serialize against concurrent open/close/GC for the same worktree (#11, #12).
     let _lock = svc.worktree_locks.acquire(&name).await;
 

--- a/backend/servers/deploy-server/tests/common/mod.rs
+++ b/backend/servers/deploy-server/tests/common/mod.rs
@@ -64,6 +64,11 @@ pub async fn setup_app(target_names: &[&str]) -> TestApp {
     run_git_assert(&["init", work_str]);
     run_git_assert(&["-C", work_str, "config", "user.email", "t@t"]);
     run_git_assert(&["-C", work_str, "config", "user.name", "t"]);
+    // Disable commit signing for the fixture repo. A developer (or CI) machine
+    // with `commit.gpgsign=true` in global config would otherwise make the
+    // fixture `git commit` invoke a signing backend and fail with a non-zero
+    // exit. Mirrors the per-test fixture in `infra/git.rs`.
+    run_git_assert(&["-C", work_str, "config", "commit.gpgsign", "false"]);
     std::fs::write(work.join("README.md"), "hi").unwrap();
     run_git_assert(&["-C", work_str, "add", "."]);
     run_git_assert(&["-C", work_str, "commit", "-m", "init"]);

--- a/backend/servers/deploy-server/tests/worktree_path_validation.rs
+++ b/backend/servers/deploy-server/tests/worktree_path_validation.rs
@@ -1,0 +1,113 @@
+// backend/servers/deploy-server/tests/worktree_path_validation.rs
+//! Regression for issue #769 (Low, finding 6): worktree path params on the
+//! `get` / `close` / `logs` endpoints must be run through `validate_alias_strict`
+//! at the API boundary — the same strict rules `open_handler` already applies to
+//! a freshly-created alias.
+//!
+//! Before the fix the `{name}` segment flowed straight into the store lookup,
+//! the Caddy host strings, and (on the dedicated close path) Postgres DB-name
+//! reconstruction without any character allowlist. An out-of-charset name like
+//! `a/b` or `a";DROP` fell through to a 404 (NotFound) instead of being rejected
+//! with a 400 (BadRequest) up front.
+//!
+//! These cases reach validation BEFORE any Docker / Postgres call, so they do
+//! not require a live docker daemon (unlike the happy-path smoke test).
+
+mod common;
+
+use common::{setup_app, TestApp};
+
+/// Names that must be rejected at the boundary with HTTP 400.
+const MALICIOUS_NAMES: &[&str] = &[
+    "a%22%3BDROP%20DATABASE%20%22x%22%3B--", // a";DROP DATABASE "x";-- (url-encoded)
+    "-foo",                                  // leading dash (option-injection shape)
+    "ab%20cd",                               // contains a space
+    "a..b",                                  // path-traversal-ish dots
+];
+
+#[tokio::test]
+async fn get_handler_rejects_malicious_path_param() {
+    let TestApp { app, token, .. } = setup_app(&["staging"]).await;
+    let server = axum_test::TestServer::new(app);
+    let auth = format!("Bearer {token}");
+
+    for name in MALICIOUS_NAMES {
+        let resp = server
+            .get(&format!("/api/worktree/{name}"))
+            .add_header("Authorization", &auth)
+            .await;
+        assert_eq!(
+            resp.status_code(),
+            400,
+            "GET /api/worktree/{name} should be rejected with 400 (got {}); \
+             body: {}",
+            resp.status_code(),
+            resp.text()
+        );
+    }
+}
+
+#[tokio::test]
+async fn close_handler_rejects_malicious_path_param() {
+    let TestApp { app, token, .. } = setup_app(&["staging"]).await;
+    let server = axum_test::TestServer::new(app);
+    let auth = format!("Bearer {token}");
+
+    for name in MALICIOUS_NAMES {
+        let resp = server
+            .post(&format!("/api/worktree/{name}/close"))
+            .add_header("Authorization", &auth)
+            .await;
+        assert_eq!(
+            resp.status_code(),
+            400,
+            "POST /api/worktree/{name}/close should be rejected with 400 (got {}); \
+             body: {}",
+            resp.status_code(),
+            resp.text()
+        );
+    }
+}
+
+#[tokio::test]
+async fn logs_handler_rejects_malicious_path_param() {
+    let TestApp { app, token, .. } = setup_app(&["staging"]).await;
+    let server = axum_test::TestServer::new(app);
+    let auth = format!("Bearer {token}");
+
+    for name in MALICIOUS_NAMES {
+        let resp = server
+            .get(&format!("/api/logs/{name}"))
+            .add_header("Authorization", &auth)
+            .await;
+        assert_eq!(
+            resp.status_code(),
+            400,
+            "GET /api/logs/{name} should be rejected with 400 (got {}); \
+             body: {}",
+            resp.status_code(),
+            resp.text()
+        );
+    }
+}
+
+/// A well-formed name must NOT be rejected by the validator — it passes the
+/// allowlist and proceeds to the normal lookup path (which then resolves to
+/// not-found / etc., never a 400). This guards against the validator
+/// over-rejecting legitimate aliases.
+#[tokio::test]
+async fn get_handler_valid_name_is_not_rejected_by_validator() {
+    let TestApp { app, token, .. } = setup_app(&["staging"]).await;
+    let server = axum_test::TestServer::new(app);
+    let auth = format!("Bearer {token}");
+
+    let resp = server
+        .get("/api/worktree/does-not-exist")
+        .add_header("Authorization", &auth)
+        .await;
+    assert_ne!(
+        resp.status_code(),
+        400,
+        "a valid alias must not be rejected as a bad request by the path validator"
+    );
+}


### PR DESCRIPTION
## Task

Triage of issue #769 ("Current dev review: Deploy server"). The issue is a broad multi-finding review; this PR lands the smallest concrete, self-contained, still-live backend finding:

**Finding 6 (Low):** "Worktree path params (`get`/`close`/`logs`) skip `validate_alias_strict`."

`open_handler` runs `validate_alias_strict` on the alias before any side effect, but `get_handler`, `close_handler`, and the logs `handler` took the `{name}` path segment and passed it straight to:
- `store.get_worktree(&name)`,
- Caddy host strings (`format!("api.wt-{}.{}", wt.name, ...)`), and
- Postgres DB-name reconstruction (`format!("{}{}", user_db_prefix, name)`) on the dedicated close path (the reconstructed name is later interpolated into `DROP DATABASE "{db_name}"`).

Fix: call `crate::infra::git::validate_alias_strict(&name)?` at the top of all three handlers (after the scope check, before any state is touched), mirroring `open_handler`. Malformed input now returns 400 (BadRequest) at the boundary instead of falling through to a 404/500.

Reused the existing `validate_alias_strict` helper — no new validator added.

### Findings intentionally NOT addressed here
The other findings (High: prod-direct deploy / promote-after-failed-health-grace; Medium: image-ref allowlist, shared-worktree prod-adjacent URLs, scope/`*` wildcard model; Low: default pg admin password, outbound fetch redirect hardening) are larger design changes, not minimal self-contained fixes, and are left for dedicated follow-ups.

## Owner
pm-backend (specialist: rust-backend)

## Tested (Band A — fast check)
- `cargo check -p deploy-server` → exit 0
- `cargo test -p deploy-server --test worktree_path_validation` → 4 passed; 0 failed
- `cargo test -p deploy-server` (full suite) → 69 lib + 4 new tests passed; smoke tests remain `#[ignore]` (need docker)

**IG3 (fail-on-main):** with the handler edits stashed, the 3 malicious-name tests FAIL (names fall through to 404/500); with the fix they pass. Confirmed via `git stash` of the two src files.

## Built (Band B — full build)
Skipped: change is ~18 LOC of substantive src + tests, no public API / migration / config change.

Note: `cargo clippy -p deploy-server` surfaces one pre-existing `items-after-test-module` error in `src/infra/blue_green.rs:344` — a file this PR does NOT touch (clippy version drift on dev). All files changed here are clippy-clean.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR. (Defense-in-depth input validation; the store already uses parameterized queries so this is hardening, not a live SQLi.)

## Remote-tested
skipped

## Notes
- Also added `commit.gpgsign=false` to the shared test fixture (`tests/common/mod.rs`) — without it the fixture `git commit` fails on signing-enabled hosts (mirrors the existing per-test fixture in `infra/git.rs`). This unblocks the new HTTP-level tests and the existing (ignored) smoke tests on such hosts.
- `scope_drift=false` (all changes under `backend/servers/deploy-server/`). `code_reuse_warn=none`.

https://claude.ai/code/session_01NV9Zjpdpbq5K1FTmpdvYUj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NV9Zjpdpbq5K1FTmpdvYUj)_