### PR TITLE
triage-issue-789: reject mismatched organization_id in list_buildings

### DIFF
--- a/backend/servers/api-server/src/routes/buildings.rs
+++ b/backend/servers/api-server/src/routes/buildings.rs
@@ -563,8 +563,21 @@ pub async fn list_buildings(
     mut rls: RlsConnection,
     Query(query): Query<ListBuildingsQuery>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
-    // RLS policies automatically filter by tenant - user can only see buildings
-    // in organizations they belong to
+    // RLS policies filter by the resolved tenant, so a mismatched
+    // `organization_id` would silently return an empty page. Reject it
+    // explicitly instead — mirrors the guard in `create_building` so the
+    // client-supplied org cannot diverge from the authenticated tenant
+    // (closes the round-10 `list_buildings` finding in #789).
+    if query.organization_id != rls.tenant_id() {
+        rls.release().await;
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "NOT_AUTHORIZED",
+                "You are not a member of this organization",
+            )),
+        ));
+    }
 
     let limit = query
         .limit

--- a/backend/servers/api-server/tests/building_manager_rbac_tests.rs
+++ b/backend/servers/api-server/tests/building_manager_rbac_tests.rs
@@ -69,6 +69,16 @@ async fn resident(pool: &PgPool, app: &TestApp, slug: &str) -> (String, Uuid) {
     (token, org)
 }
 
+/// Authenticate a manager member of a fresh org. Returns (token, org_id).
+async fn manager(pool: &PgPool, app: &TestApp, slug: &str) -> (String, Uuid) {
+    let org = seed_org(pool, slug).await;
+    let user = TestUser::new();
+    let (token, _r) = create_authenticated_user(app, &user).await;
+    let uid = user_id_for(pool, &user.email).await;
+    seed_membership(pool, org, uid, "manager").await;
+    (token, org)
+}
+
 fn authed(
     method: Method,
     uri: &str,
@@ -153,6 +163,60 @@ async fn resident_cannot_bulk_import_buildings(pool: PgPool) {
         resp.status,
         StatusCode::FORBIDDEN,
         "bulk import as resident must be 403, got {}",
+        resp.status
+    );
+}
+
+/// Round-10 finding (#789): `list_buildings` trusted the client-supplied
+/// `organization_id` query param. A member authenticated against org A who
+/// asks for `?organization_id=<orgB>` must be rejected with 403 (matching
+/// `create_building`) rather than receiving a silently-empty 200 page.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_rejects_org_mismatch(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (token, org_a) = manager(&pool, &app, "list-self").await;
+    // A second org the caller is NOT scoped to for this request.
+    let org_b = seed_org(&pool, "list-other").await;
+
+    let resp = app
+        .execute(authed(
+            Method::GET,
+            &format!("/api/v1/buildings?organization_id={org_b}"),
+            org_a,
+            &token,
+            json!({}),
+        ))
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "list with mismatched organization_id must be 403, got {}",
+        resp.status
+    );
+}
+
+/// Positive control: the same manager listing their OWN org succeeds, so the
+/// new guard does not over-reject the happy path.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_allows_own_org(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (token, org) = manager(&pool, &app, "list-ok").await;
+
+    let resp = app
+        .execute(authed(
+            Method::GET,
+            &format!("/api/v1/buildings?organization_id={org}"),
+            org,
+            &token,
+            json!({}),
+        ))
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "list with matching organization_id must be 200, got {}",
         resp.status
     );
 }


### PR DESCRIPTION
## Task

Triage of issue #789 (dev-review rounds 6-10). Most findings in that stale rollup are already fixed on current `dev` (Round 6 stuck-job retry budget is honored in `reset_stuck_jobs` + has a dedicated test; Round 7 `PushFanoutWorker` is now a real Redis-polling worker with a real `FcmHttpAdapter`). The smallest concrete, still-live, self-contained finding implemented here is **Round 10 — `list_buildings` trusts client `organization_id` without tenant match**.

`list_buildings` passed the client-supplied `organization_id` query param straight to the repo and relied solely on RLS to filter. A mismatched org therefore returned a silently-empty `200` page instead of an explicit authorization error — diverging from `create_building` in the same file, which rejects `org != tenant` with `403`. This adds the same explicit guard so the requested org cannot diverge from the authenticated tenant.

(Not a cross-tenant data leak — RLS still scopes the result to the resolved tenant — but a real API-consistency / authorization-signal bug the reviewer flagged as Medium.)

## Owner

pm-backend

## Tested (Band A — fast check)

- `cd backend && cargo check -p api-server` → exit 0
- `cd backend && cargo test -p api-server --test building_manager_rbac_tests --no-run` → exit 0 (test binary compiles)

The two new tests are `#[sqlx::test]` integration tests requiring an ephemeral Postgres, which is not available in the implementer sandbox. They will execute in CI (`backend.yml`):
- `list_rejects_org_mismatch` — member of org A requesting `?organization_id=<orgB>` must get `403` (fails on `dev` today, which returns an empty `200`). IG3 regression test.
- `list_allows_own_org` — positive control: matching org returns `200` (guards against over-rejection).

## Built (Band B — full build)

skipped: change is ~17 LOC handler guard + tests, single crate, no public API/migration/config change.

## CI parity (Band C — hot-path only)

skipped: not a hot-path PR (RLS already enforces tenant isolation; this only upgrades a silent-empty response to an explicit 403). No security/auth/billing/data-integrity behavior change beyond the error signal.

## Scope drift

None. Diff touches only `backend/servers/api-server/src/routes/buildings.rs` and `backend/servers/api-server/tests/building_manager_rbac_tests.rs` (pm-backend area). `scope-check.sh` exit 0.

## Code-reuse review

None. `reuse-grep.sh` exit 0. The guard reuses the existing `RlsConnection::tenant_id()` + `ErrorResponse::new` pattern already used by `create_building`.

## Notes

- Source of the finding was a stale, owner-closed rollup (#789, closed as "stale snapshot"); this PR re-files the one residual that is still cleanly locatable on current `dev`.

https://claude.ai/code/session_01NV9Zjpdpbq5K1FTmpdvYUj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NV9Zjpdpbq5K1FTmpdvYUj)_