### PR TITLE
triage-issue-950: fix CI false-red image builds from trigger-deploy 403

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -91,6 +91,11 @@ jobs:
   trigger-deploy:
     needs: build
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
+    # continue-on-error: deploy-trigger failures (e.g. OIDC 403 while onyx
+    # auth.yaml is being updated) must not mark a successful image build red.
+    # The images are already pushed when this job runs; a trigger failure is
+    # an infra-side concern, not a build failure. See issue #950.
+    continue-on-error: true
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/docker-frontend.yml
+++ b/.github/workflows/docker-frontend.yml
@@ -93,6 +93,11 @@ jobs:
   trigger-deploy:
     needs: build
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
+    # continue-on-error: deploy-trigger failures (e.g. OIDC 403 while onyx
+    # auth.yaml is being updated) must not mark a successful image build red.
+    # The images are already pushed when this job runs; a trigger failure is
+    # an infra-side concern, not a build failure. See issue #950.
+    continue-on-error: true
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
## Task

Triage GitHub issue #950 (OPEN, no labels): 'CI: trigger-deploy 403 marks all dev image builds red and blocks staging auto-deploy'. Investigate the root cause and implement the smallest correct, self-contained fix.

## Owner

pm-backend

## Root Cause Summary

The `trigger-deploy` job in both `docker-build.yml` and `docker-frontend.yml` calls `POST /api/deploy` on onyx using an OIDC-derived token. The deploy server returns HTTP 403 because the token lacks the `release:deploy` scope — the OIDC→scope mapping in `/etc/ppt-deploy/auth.yaml` on onyx is misconfigured. Since the `trigger-deploy` job has no `continue-on-error`, this 403 marks the entire workflow run as **failed**, even though the Docker image build and push steps already completed successfully.

**The root fix is infra-only**: grant the CI OIDC subject the `release:deploy` scope in `/etc/ppt-deploy/auth.yaml` on onyx. No repo code change can fix the 403.

## Repo-side fix (this PR)

This PR adds `continue-on-error: true` to the `trigger-deploy` job in both workflows — exactly the stop-gap the original triage comment (issue #950, comment by @martin-janci) anticipated but deferred:

> "I've not auto-applied option 2 since it changes CI failure semantics and the real fix is the OIDC grant. If you want the mitigation as a stop-gap while the OIDC mapping is fixed, I can open that PR."

**Effect:**
- Successful image builds will show green (correct) even when the deploy-trigger returns 403.
- The `trigger-deploy` job will still run and its failure will appear as a yellow warning job in the Actions UI, not a red workflow failure — so it remains visible.
- Once the OIDC grant on onyx is fixed, the yellow warning disappears automatically without another PR.

## Changes

- `.github/workflows/docker-build.yml`: added `continue-on-error: true` + explanatory comment to `trigger-deploy` job
- `.github/workflows/docker-frontend.yml`: same

## Tested (Band A — fast check)

`git diff --check` exit 0 — no whitespace/formatting errors in YAML.

This change is CI YAML only (no compilable code). No Band B/C applies.

## Scope drift

None. `.github/workflows/` is infra/CI — within scope for the pm-backend owner role for CI pipeline fixes.

## Code-reuse review

Not applicable — no new code helpers added.

## Notes

- The underlying OIDC 403 is an operational issue on onyx (`/etc/ppt-deploy/auth.yaml`). The reviewer should ensure that infra fix is tracked and applied separately.
- After the infra fix is applied, `continue-on-error: true` remains correct: a deploy-trigger failure should never block the build status signal regardless of cause.

Closes #950

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmzX9snSDSnLKNvWCasN2v)_