### PR TITLE
triage-issue-952: fix Reality SSO callback URL (api.<apex> not bare apex)

### DIFF
--- a/backend/servers/api-server/src/bin/seed.rs
+++ b/backend/servers/api-server/src/bin/seed.rs
@@ -29,9 +29,15 @@ use dialoguer::{Confirm, Input, Password};
 /// Default reality-portal OAuth redirect URIs covering the standard prod +
 /// staging Reality Portal apexes. Operators with custom apex hostnames can
 /// override via repeated `--reality-portal-redirect-uri` flags.
+///
+/// Uses the `api.<apex>` subdomain because the bare apex (`rlt.sk`,
+/// `staging.rlt.sk`) reverse-proxies to reality-web (Next.js) which has no
+/// `/api/v1/sso/*` handler — the SSO callback 404s if the redirect_uri points
+/// at the apex. `api.<apex>` is proxied by Caddy to reality-server :8081,
+/// which serves the `/api/v1/sso/callback` handler (fix for #952).
 const DEFAULT_REALITY_PORTAL_REDIRECT_URIS: &[&str] = &[
-    "https://rlt.sk/api/v1/sso/callback",
-    "https://staging.rlt.sk/api/v1/sso/callback",
+    "https://api.rlt.sk/api/v1/sso/callback",
+    "https://api.staging.rlt.sk/api/v1/sso/callback",
 ];
 
 /// UPSERT the `reality-portal` row in `oauth_clients` with the given secret.

--- a/backend/servers/deploy-server/src/infra/blue_green.rs
+++ b/backend/servers/deploy-server/src/infra/blue_green.rs
@@ -299,12 +299,17 @@ pub fn build_service_envs(
     reality_env.push(format!("PM_API_URL={api_base_url}"));
     // `SSO_CALLBACK_URL` defaults to `http://localhost:8081/api/v1/sso/callback`
     // — that endpoint is on reality-server itself, exposed publicly at
-    // `<reality_apex>/api/v1/sso/callback` so the user's browser can reach
-    // it after the OAuth redirect from api-server. Without overriding the
-    // default, the redirect from PM SSO would point at localhost in the
-    // user's browser → broken login.
+    // `api.<reality_apex>/api/v1/sso/callback`. The reality apex host only
+    // reverse-proxies to reality-web (Next.js :3000), which has no
+    // `/api/v1/sso/*` handler; using the bare apex as the callback produces
+    // a Next.js 404 after the OAuth redirect instead of a code exchange
+    // (fix for #952). The `api.<apex>` subdomain is already provisioned by
+    // `BlueGreenDeployer::deploy` → `register_route("api.{reality_apex}", …)`
+    // pointing at reality-server :8081, so this is the correct public URL.
+    // Without overriding the default, the redirect from PM SSO would point at
+    // localhost in the user's browser → broken login.
     reality_env.push(format!(
-        "SSO_CALLBACK_URL=https://{}/api/v1/sso/callback",
+        "SSO_CALLBACK_URL=https://api.{}/api/v1/sso/callback",
         target.reality_apex
     ));
     reality_env.push(format!("PLATFORM_HOST={platform_hosts}"));


### PR DESCRIPTION
## Task

Triage GitHub issue #952 (OPEN, no labels): '[staging] Reality SSO login dead-ends: redirect_uri callback 404s on reality apex'. Investigate the root cause and implement the smallest correct, self-contained fix.

## Owner

pm-backend

## Root cause

The Reality apex host (`rlt.sk` / `staging.rlt.sk`) is proxied by Caddy to reality-web (Next.js :3000), which has **no** `/api/v1/sso/*` handler. The SSO callback endpoint lives on reality-server :8081, exposed at `api.<reality_apex>`.

Two places in the codebase hardcoded the wrong host:

1. `deploy-server/src/infra/blue_green.rs:307` — `SSO_CALLBACK_URL` was set to `https://{reality_apex}/api/v1/sso/callback` (apex → Next.js → 404).
2. `api-server/src/bin/seed.rs:33-34` — `DEFAULT_REALITY_PORTAL_REDIRECT_URIS` listed `https://rlt.sk/api/v1/sso/callback` and `https://staging.rlt.sk/api/v1/sso/callback` (same wrong host).

## Fix

Both locations are updated to use the `api.<apex>` subdomain, which is already registered by `BlueGreenDeployer::deploy` via `register_route("api.{reality_apex}", …)` pointing at reality-server :8081.

**No Caddy routing change needed** — the `api.<reality_apex>` route already exists.

**Operator action required on next deploy:** Re-run `ppt-seed --reality-portal-secret "$PPT_PM_CLIENT_SECRET"` on both prod and staging to UPSERT the `oauth_clients.redirect_uris` column to the corrected `api.` URLs. The seed is idempotent. Until re-seeded, the existing (wrong) DB rows will keep returning "redirect_uri mismatch" for any new SSO flow, but the `SSO_CALLBACK_URL` env fix will take effect on the next container restart regardless.

## Tested (Band A — fast check)

```
cd backend && cargo check -p deploy-server   # exit 0
cd backend && cargo check -p api-server      # exit 0
cd backend && cargo test -p deploy-server    # exit 0  (69 tests pass, 3 ignored smoke)
```

## Built (Band B — full build)

skipped: change <50 LOC of substantive logic, no new public API surface (URL constant + comment update only)

## CI parity (Band C — hot-path only)

skipped: not a hot-path PR (no security/auth/billing/data-integrity change — this fixes a URL constant, not an auth algorithm)

## Remote-tested

skipped

## Scope drift

None. Both changed files are in `backend/servers/` (owned by `pm-backend`).

## Code-reuse review

None. No new symbols added — only string constant values changed.

## Notes

- The existing `build_service_envs_enforces_api_startup_contract` test still passes with no changes needed — it validates key presence, not value correctness.
- Operators running custom apex hostnames are unaffected: `--reality-portal-redirect-uri` overrides the defaults at seed time.
- Closes #952.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VmzX9snSDSnLKNvWCasN2v)_