### PR TITLE
test(api-server): real PKCE assertion with RFC 7636 vector (#1137)

### DIFF
--- a/backend/servers/api-server/src/services/oauth.rs
+++ b/backend/servers/api-server/src/services/oauth.rs
@@ -445,7 +445,7 @@ impl OAuthService {
             .as_ref()
             .ok_or(OAuthServiceError::InvalidCodeVerifier)?;
 
-        if !self.verify_pkce(
+        if !Self::verify_pkce(
             verifier,
             challenge,
             auth_code.code_challenge_method.as_deref(),
@@ -847,7 +847,7 @@ impl OAuthService {
 
     /// Verify PKCE code challenge.
     /// Only S256 method is supported per OAuth 2.1 recommendations.
-    fn verify_pkce(&self, verifier: &str, challenge: &str, method: Option<&str>) -> bool {
+    fn verify_pkce(verifier: &str, challenge: &str, method: Option<&str>) -> bool {
         // Only S256 is supported - plain method is deprecated per OAuth 2.1
         match method.unwrap_or("S256") {
             "S256" => {
@@ -866,13 +866,6 @@ impl OAuthService {
 mod tests {
     use super::*;
 
-    /// Compute a PKCE S256 challenge from a verifier string.
-    fn pkce_challenge(verifier: &str) -> String {
-        let mut hasher = Sha256::new();
-        hasher.update(verifier.as_bytes());
-        URL_SAFE_NO_PAD.encode(hasher.finalize())
-    }
-
     /// Generate `n` random base64url-encoded bytes via the OS CSPRNG.
     fn random_b64(n: usize) -> String {
         let mut bytes = vec![0u8; n];
@@ -882,15 +875,24 @@ mod tests {
 
     #[test]
     fn test_pkce_verification() {
+        // RFC 7636 Appendix B known-answer vector: this pins the S256 challenge
+        // computation so a regression in `verify_pkce` is actually caught.
         let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
-        let expected = pkce_challenge(verifier);
+        let challenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
 
-        assert!(pkce_challenge(verifier) == expected);
-        assert!(pkce_challenge("wrong") != expected);
+        // Correct verifier + challenge under S256 (and default method == S256).
+        assert!(OAuthService::verify_pkce(verifier, challenge, Some("S256")));
+        assert!(OAuthService::verify_pkce(verifier, challenge, None));
 
-        // plain method is not supported — verify_pkce_helper would return false
-        // S256 with mismatched challenge returns false
-        assert!(pkce_challenge("test") != "test");
+        // Wrong verifier must not match the challenge.
+        assert!(!OAuthService::verify_pkce("wrong", challenge, Some("S256")));
+
+        // `plain` is intentionally unsupported, even when verifier == challenge.
+        assert!(!OAuthService::verify_pkce(
+            challenge,
+            challenge,
+            Some("plain")
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Closes #1137. Fixes the PKCE unit test that became a tautology after the #1132 DRY refactor.

The post-#1132 `test_pkce_verification` re-derived the challenge inside the test (`pkce_challenge(verifier) == pkce_challenge(verifier)`), so the positive assertion could never fail, and the `plain`-method rejection path was dropped (only mentioned in a comment).

## Changes
- `verify_pkce` made an associated function (it never used `self`); call site updated to `Self::verify_pkce`. This gives the unit test a callable production seam.
- `test_pkce_verification` now:
  - pins the **RFC 7636 Appendix B** known-answer vector (`verifier` → `E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM`) and asserts the real `verify_pkce`, so a regression in challenge computation is caught;
  - asserts default method (`None`) behaves as `S256`;
  - asserts a wrong verifier fails;
  - re-adds the `plain`-method **rejection** assertion against the real verifier.
- Removed the now-unused `pkce_challenge` test helper.

## Verification
- `cargo check -p api-server --tests` — clean
- `cargo test -p api-server services::oauth::tests::test_pkce_verification` — **ok. 1 passed**

No production behavior change (associated-fn conversion is mechanical; `verify_pkce` body unchanged).