### PR TITLE
fix(announcements): make targeting predicate GIN-indexable via @> containment (#1070)

### DIFF
--- a/backend/crates/db/src/repositories/announcement.rs
+++ b/backend/crates/db/src/repositories/announcement.rs
@@ -50,6 +50,15 @@ use uuid::Uuid;
 /// It references `$1` for the organization id (the `roles` arm), so callers must
 /// bind the org id as the first parameter. Expanded via `concat!` at compile
 /// time, so the resulting query string stays a `'static str`.
+///
+/// Membership is tested as JSONB array containment —
+/// `announcements.target_ids @> to_jsonb(<value>::text)` — rather than
+/// `<value> IN (SELECT jsonb_array_elements_text(target_ids))`. Both express
+/// "is `<value>` an element of the `target_ids` array" (Postgres treats
+/// `'["a","b"]'::jsonb @> '"a"'::jsonb` as true), but only the `@>` form is a
+/// sargable operator the GIN index `idx_announcements_target_ids_gin`
+/// (migration 00176) can serve, so the planner can probe it instead of
+/// unnesting every candidate row's array (issue #999 / #1070).
 macro_rules! announcement_targeting_predicate {
     () => {
         r#"
@@ -59,13 +68,13 @@ macro_rules! announcement_targeting_predicate {
                     JOIN units u ON u.id = ur.unit_id
                     WHERE ur.user_id = NULLIF(current_setting('app.current_user_id', true), '')::uuid
                       AND ur.end_date IS NULL
-                      AND u.building_id::text IN (SELECT jsonb_array_elements_text(announcements.target_ids))
+                      AND announcements.target_ids @> to_jsonb(u.building_id::text)
                 ))
                 OR (target_type = 'units' AND EXISTS (
                     SELECT 1 FROM unit_residents ur
                     WHERE ur.user_id = NULLIF(current_setting('app.current_user_id', true), '')::uuid
                       AND ur.end_date IS NULL
-                      AND ur.unit_id::text IN (SELECT jsonb_array_elements_text(announcements.target_ids))
+                      AND announcements.target_ids @> to_jsonb(ur.unit_id::text)
                 ))
                 OR (target_type = 'roles' AND EXISTS (
                     SELECT 1 FROM user_memberships m
@@ -73,7 +82,7 @@ macro_rules! announcement_targeting_predicate {
                       AND m.organization_id = $1
                       AND m.revoked_at IS NULL
                       AND (m.expires_at IS NULL OR m.expires_at > NOW())
-                      AND m.role IN (SELECT jsonb_array_elements_text(announcements.target_ids))
+                      AND announcements.target_ids @> to_jsonb(m.role::text)
                 ))
 "#
     };


### PR DESCRIPTION
## Summary
Closes #1069 and #1070 (duplicate findings from post-merge review of PR #1037).

PR #1037 added `idx_announcements_target_ids_gin` (GIN on `announcements.target_ids`, migration 00176) to speed up the published-feed targeting predicate for issue #999. But the predicate matched membership with:

```sql
<value> IN (SELECT jsonb_array_elements_text(announcements.target_ids))
```

This unnests each candidate row's own JSONB array via a set-returning function — there is **no indexable operator**, so the planner can never use a GIN index for it. The index was pure write-amplification + disk with no read benefit.

## Fix
Rewrite all three arms of `announcement_targeting_predicate!` to JSONB array containment:

```sql
announcements.target_ids @> to_jsonb(u.building_id::text)   -- building
announcements.target_ids @> to_jsonb(ur.unit_id::text)      -- units
announcements.target_ids @> to_jsonb(m.role::text)          -- roles
```

- **Semantically identical**: Postgres documents the special case `'["a","b"]'::jsonb @> '"a"'::jsonb` → `true` (array contains scalar element), which is exactly the element-membership the old form expressed.
- **`@>` is sargable** on the default `jsonb_ops` GIN opclass, so the planner can now probe `idx_announcements_target_ids_gin` instead of unnesting every candidate row.
- `m.role::text` preserves the original text-comparison semantics (`jsonb_array_elements_text` returned text).
- Predicate stays shared verbatim between `list_published_rls` + `count_published_rls` (the macro), so they can't diverge.

## What is intentionally NOT changed
Migration `00176`'s SQL is left untouched. It's already merged/applied, and SQLx validates migration checksums at runtime — editing even a comment would break server startup on any DB where 00176 already ran. The rationale now lives in the `announcement_targeting_predicate!` doc comment instead.

## Verification
- `cargo check -p db` — clean.
- Equivalence is covered on CI by the existing `published_feed_is_filtered_by_targeting` `#[sqlx::test]`, which asserts exact visible-set + count across the building, unit, role, and `all` arms. (No local DB in this worktree, so the sqlx::test runs on CI.)
- Confirming the index is actually chosen still wants an `EXPLAIN (ANALYZE)` on a seeded org as the published set grows — the rewrite makes the index *usable*; planner choice is cost-based.