### PR TITLE
fix(messaging): trim participant display name to drop trailing space (#1071)

### DIFF
--- a/frontend/apps/ppt-web/src/features/messaging/hooks/useMessaging.test.ts
+++ b/frontend/apps/ppt-web/src/features/messaging/hooks/useMessaging.test.ts
@@ -1,0 +1,91 @@
+/// <reference types="vitest/globals" />
+/**
+ * Unit tests for the messaging API → UI name-join mappers (#1071).
+ *
+ * The `users` table has a single `name` column, so the API maps it onto
+ * `firstName` and leaves `lastName` empty. The mappers must not leave a
+ * trailing space when joining first/last into a display name (e.g. `"Jane "`),
+ * while still joining a real first+last pair with a single space.
+ */
+
+import type {
+  MessageWithSender,
+  ParticipantInfo,
+  ThreadDetailResponse,
+  ThreadWithPreview,
+} from '@ppt/api-client';
+import { describe, expect, it } from 'vitest';
+import { mapApiMessageToUi, mapApiThreadDetailToUi, mapApiThreadToUi } from './useMessaging';
+
+function participant(firstName: string, lastName: string): ParticipantInfo {
+  return { id: 'p1', firstName, lastName, email: 'p1@example.com' };
+}
+
+function message(sender: ParticipantInfo): MessageWithSender {
+  return {
+    id: 'm1',
+    threadId: 't1',
+    sender,
+    content: 'hi',
+    readAt: null,
+    isDeleted: false,
+    createdAt: '2026-06-06T00:00:00Z',
+  };
+}
+
+function thread(other: ParticipantInfo): ThreadWithPreview {
+  return {
+    id: 't1',
+    organizationId: 'o1',
+    participantIds: ['p1', 'me'],
+    otherParticipant: other,
+    lastMessage: {
+      id: 'm1',
+      content: 'hi',
+      senderId: 'p1',
+      isFromMe: false,
+      createdAt: '2026-06-06T00:00:00Z',
+    },
+    unreadCount: 0,
+    createdAt: '2026-06-06T00:00:00Z',
+    updatedAt: '2026-06-06T00:00:00Z',
+  };
+}
+
+function threadDetail(other: ParticipantInfo): ThreadDetailResponse {
+  return {
+    thread: {
+      id: 't1',
+      organizationId: 'o1',
+      participantIds: ['p1', 'me'],
+      lastMessageAt: '2026-06-06T00:00:00Z',
+      createdAt: '2026-06-06T00:00:00Z',
+      updatedAt: '2026-06-06T00:00:00Z',
+    },
+    otherParticipant: other,
+    messages: [message(other)],
+    messageCount: 1,
+  };
+}
+
+describe('messaging name-join mappers (#1071)', () => {
+  it('drops the trailing space when lastName is empty', () => {
+    expect(mapApiMessageToUi(message(participant('Jane', ''))).senderName).toBe('Jane');
+
+    const ui = mapApiThreadToUi(thread(participant('Jane', '')));
+    expect(ui.lastMessageSenderName).toBe('Jane');
+    expect(ui.participants[0].userName).toBe('Jane');
+
+    expect(
+      mapApiThreadDetailToUi(threadDetail(participant('Jane', ''))).participants[0].userName
+    ).toBe('Jane');
+  });
+
+  it('joins a real first and last name with a single space', () => {
+    expect(mapApiMessageToUi(message(participant('Jane', 'Doe'))).senderName).toBe('Jane Doe');
+
+    const ui = mapApiThreadToUi(thread(participant('Jane', 'Doe')));
+    expect(ui.lastMessageSenderName).toBe('Jane Doe');
+    expect(ui.participants[0].userName).toBe('Jane Doe');
+  });
+});

--- a/frontend/apps/ppt-web/src/features/messaging/hooks/useMessaging.ts
+++ b/frontend/apps/ppt-web/src/features/messaging/hooks/useMessaging.ts
@@ -60,6 +60,17 @@ function getNeighborsApi(accessToken: string | undefined) {
 // ---------------------------------------------------------------------------
 
 /**
+ * Join a participant's first/last name into a display name.
+ *
+ * The `users` table has a single `name` column, so the API maps it onto
+ * `firstName` and leaves `lastName` empty. Trim the join so a missing last
+ * name doesn't leave a trailing space (e.g. `"Jane "`).
+ */
+function fullName(firstName: string, lastName: string): string {
+  return `${firstName} ${lastName}`.trim();
+}
+
+/**
  * Map an API ThreadWithPreview to the feature-layer MessageThread type.
  */
 export function mapApiThreadToUi(apiThread: ThreadWithPreview): MessageThread {
@@ -76,7 +87,7 @@ export function mapApiThreadToUi(apiThread: ThreadWithPreview): MessageThread {
     lastMessageSenderId: lastMsg?.senderId ?? undefined,
     lastMessageSenderName: lastMsg?.isFromMe
       ? undefined
-      : `${participant.firstName} ${participant.lastName}`,
+      : fullName(participant.firstName, participant.lastName),
     unreadCount: apiThread.unreadCount,
     createdAt: apiThread.createdAt,
     updatedAt: apiThread.updatedAt,
@@ -84,7 +95,7 @@ export function mapApiThreadToUi(apiThread: ThreadWithPreview): MessageThread {
       {
         id: participant.id,
         userId: participant.id,
-        userName: `${participant.firstName} ${participant.lastName}`,
+        userName: fullName(participant.firstName, participant.lastName),
         userAvatar: undefined,
         joinedAt: apiThread.createdAt,
         lastReadAt: undefined,
@@ -102,7 +113,7 @@ export function mapApiMessageToUi(apiMsg: MessageWithSender): Message {
     id: apiMsg.id,
     threadId: apiMsg.threadId,
     senderId: apiMsg.sender.id,
-    senderName: `${apiMsg.sender.firstName} ${apiMsg.sender.lastName}`,
+    senderName: fullName(apiMsg.sender.firstName, apiMsg.sender.lastName),
     content: apiMsg.content,
     createdAt: apiMsg.createdAt,
     readBy: apiMsg.readAt ? [apiMsg.sender.id] : [],
@@ -130,7 +141,7 @@ export function mapApiThreadDetailToUi(detail: ThreadDetailResponse): ThreadWith
       {
         id: other.id,
         userId: other.id,
-        userName: `${other.firstName} ${other.lastName}`,
+        userName: fullName(other.firstName, other.lastName),
         userAvatar: undefined,
         joinedAt: thread.createdAt,
         lastReadAt: undefined,


### PR DESCRIPTION
## Summary
Closes #1071 (follow-up from post-merge review of PR #1040).

After the `users.first_name`/`last_name` → `name` schema-drift fix (#1008/#1040), the API maps the single `name` column onto `firstName` and sends an empty `lastName`. ppt-web's messaging mappers joined the name as `` `${firstName} ${lastName}` `` **without trimming**, so display names rendered with a dangling trailing space (`"Jane "`).

## Fix
- Add a small `fullName(firstName, lastName)` helper in `useMessaging.ts` that trims the join.
- Use it at all four join sites: thread-preview `lastMessageSenderName`, thread `participants[].userName`, message `senderName`, and thread-detail `participants[].userName`.
- The mobile app (`MessagesScreen.tsx`) already trims its join; this brings ppt-web in line.

## Tests
- New `useMessaging.test.ts` asserts the join drops the trailing space when `lastName` is empty and still joins a real first+last with a single space, across `mapApiMessageToUi`, `mapApiThreadToUi`, and `mapApiThreadDetailToUi`.

## Verification
- `vitest run useMessaging.test.ts` — **2 passed**
- `tsc --noEmit` (ppt-web) — clean
- `biome check` — clean

## Note on the broader option
The issue also suggested migrating `ParticipantInfo` to a single `name`/`display_name` field (since `users` no longer has a first/last split). That's a cross-cutting API + generated-client + mobile/web change; this PR takes the contained presentation fix. The DTO migration can be tracked separately if desired.