### PR TITLE
fix(api): correct document version/download contract drift in TypeSpec (#974.4)

### DIFF
--- a/docs/api/typespec/domains/documents.tsp
+++ b/docs/api/typespec/domains/documents.tsp
@@ -60,6 +60,46 @@ model Folder {
   ...AuditableEntity;
 }
 
+@doc("Presigned-URL response for document download/preview (Story 7A.4)")
+model DocumentUrlResponse {
+  url: string;
+  expiresAt: dateTime;
+}
+
+@doc("A single document version (Story 7B.1)")
+model DocumentVersion {
+  id: uuid;
+  versionNumber: int32;
+  isCurrentVersion: boolean;
+  fileKey: string;
+  fileName: string;
+  mimeType: string;
+  sizeBytes: int64;
+  createdBy: uuid;
+  createdByName: string;
+  createdAt: dateTime;
+}
+
+@doc("Full version history for a document (Story 7B.1)")
+model DocumentVersionHistory {
+  documentId: uuid;
+  title: string;
+  totalVersions: int32;
+  versions: DocumentVersion[];
+}
+
+@doc("Envelope returned by the version-history endpoint")
+model VersionHistoryResponse {
+  history: DocumentVersionHistory;
+}
+
+@doc("Result of creating a document version (Story 7B.1)")
+model CreateVersionResponse {
+  id: uuid;
+  versionNumber: int32;
+  message: string;
+}
+
 @route("/api/v1/documents")
 @tag("Documents")
 interface DocumentsApi {
@@ -110,24 +150,28 @@ interface DocumentsApi {
     @path id: uuid
   ): { @statusCode statusCode: 204; };
 
+  // Returns a presigned S3 URL (with Content-Disposition: attachment), not the
+  // file bytes — matches the api-server `UrlResponse` handler (Story 7A.4).
   @get @route("/{id}/download") download(
     @header("Authorization") token: string,
     @header("X-Tenant-ID") tenantId: uuid,
     @path id: uuid
-  ): { @header("Content-Type") contentType: string; @body body: bytes; };
+  ): DocumentUrlResponse;
 
-  @post @route("/{id}/new-version") uploadNewVersion(
+  // Create a new version. The api-server route is POST /{id}/versions taking a
+  // storage-key payload (file already uploaded to S3), not POST /{id}/new-version.
+  @post @route("/{id}/versions") uploadVersion(
     @header("Authorization") token: string,
     @header("X-Tenant-ID") tenantId: uuid,
     @path id: uuid,
-    @body body: { fileContent: string; fileName: string; mimeType: string; }
-  ): Document;
+    @body body: { fileKey: string; fileName: string; mimeType: string; sizeBytes: int64; }
+  ): { @statusCode statusCode: 201; @body body: CreateVersionResponse; };
 
   @get @route("/{id}/versions") listVersions(
     @header("Authorization") token: string,
     @header("X-Tenant-ID") tenantId: uuid,
     @path id: uuid
-  ): Document[];
+  ): VersionHistoryResponse;
 
   @get @route("/folders") listFolders(
     @header("Authorization") token: string,


### PR DESCRIPTION
## Summary
Addresses gap **974.4** of #974. The documents TypeSpec had drifted from the actual api-server routes, so the published OpenAPI contract (and any client generated from it) described endpoints/shapes that don't exist.

## Drifts fixed (TypeSpec ↔ api-server)
| Spec (before) | Backend reality | Fix |
|---|---|---|
| `POST /{id}/new-version` `uploadNewVersion` → `Document` | route is `POST /{id}/versions` (`create_version`), body = storage key, → `CreateVersionResponse` | replaced with `uploadVersion` at `/{id}/versions` |
| `GET /{id}/download` → `bytes` | handler returns presigned-S3-URL JSON (`UrlResponse { url, expiresAt }`) | `download` → `DocumentUrlResponse` |
| `GET /{id}/versions` → `Document[]` | returns `VersionHistoryResponse { history: { documentId, title, totalVersions, versions[] } }` | `listVersions` → `VersionHistoryResponse` |

Added models: `DocumentUrlResponse`, `DocumentVersion`, `DocumentVersionHistory`, `VersionHistoryResponse`, `CreateVersionResponse` (mirroring the Rust `UrlResponse` / `DocumentVersion` / `DocumentVersionHistory` / `CreateVersionResponse`).

## Verification
- `tsp compile .` — clean (only pre-existing warnings in other domains).
- `spectral lint` (CI's rules) — **0 errors** (430 pre-existing warnings, none new).
- The phantom `/new-version` path no longer appears in the compiled spec; the new ops/models do.

## Scope decision (please read)
**TypeSpec source only — the committed `docs/api/generated/openapi.yaml` is intentionally not regenerated here.** In a fresh checkout a no-op `tsp compile` already produces a **~960-line diff** vs the committed spec (it restores the entire `/api/v1/announcements` interface and stamps `version 0.0.0` instead of `0.1.28`, since the version is injected by `update-version.sh` at build time). Regenerating would bury this fix under that unrelated drift and a wrong version stamp.

`api-validation.yml` compiles the TypeSpec **fresh** and Spectral-lints that (it does not gate the committed `openapi.yaml`/SDK for staleness), so this source fix is validated end-to-end by CI. **Refreshing the committed generated artifacts is a separate repo-hygiene task** worth tracking — the generated OpenAPI is broadly stale vs source.

## Notes
- The documents domain also has a deeper, systemic camelCase(spec)-vs-snake_case(backend) field-casing mismatch; the frontend already works around it with hand-written `@ppt/api-client/documents` types. That's out of scope here (it's not a structural/path drift) but is the reason this gap is one of several in #974.
- `GET /{id}/versions/{versionId}` and the restore endpoint also exist in the backend and remain unmodeled — left for a follow-up to keep this change scoped to the cited drifts.