### PR TITLE
code-review-mobile-native-kmp-deeplink-token-not-url-decoded: URL-decode deep-link query params in shared DeepLinkRouter

### DIFF
--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/navigation/DeepLinkRouter.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/navigation/DeepLinkRouter.kt
@@ -120,9 +120,10 @@ object DeepLinkRouter {
      * byte sequence interpreted as UTF-8.
      *
      * This mirrors Android's `android.net.Uri.getQueryParameter`, which decodes its result. The
-     * shared router previously returned the raw, still-encoded substring, so the same `reality://sso`
-     * deep link produced a decoded token on Android but an encoded token on the shared/iOS path —
-     * breaking SSO validation on iOS. Decoding here makes every platform agree on the token string.
+     * shared router previously returned the raw, still-encoded substring, so the same
+     * `reality://sso` deep link produced a decoded token on Android but an encoded token on the
+     * shared/iOS path — breaking SSO validation on iOS. Decoding here makes every platform agree on
+     * the token string.
      *
      * Malformed escapes (a `%` not followed by two hex digits) are passed through literally rather
      * than throwing, matching the lenient behaviour of platform URI decoders.

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/navigation/DeepLinkRouter.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/navigation/DeepLinkRouter.kt
@@ -105,11 +105,68 @@ object DeepLinkRouter {
         for (pair in query.split('&')) {
             val eq = pair.indexOf('=')
             if (eq <= 0) continue
-            if (pair.substring(0, eq) == key) {
-                val value = pair.substring(eq + 1)
+            // The key itself may be percent-encoded; decode before comparing.
+            if (urlDecode(pair.substring(0, eq)) == key) {
+                val value = urlDecode(pair.substring(eq + 1))
                 return value.ifEmpty { null }
             }
         }
         return null
     }
+
+    /**
+     * Percent-decode a query-component string using `application/x-www-form-urlencoded` semantics:
+     * `+` decodes to a space and each `%XX` triplet decodes to the byte `0xXX`, with the resulting
+     * byte sequence interpreted as UTF-8.
+     *
+     * This mirrors Android's `android.net.Uri.getQueryParameter`, which decodes its result. The
+     * shared router previously returned the raw, still-encoded substring, so the same `reality://sso`
+     * deep link produced a decoded token on Android but an encoded token on the shared/iOS path —
+     * breaking SSO validation on iOS. Decoding here makes every platform agree on the token string.
+     *
+     * Malformed escapes (a `%` not followed by two hex digits) are passed through literally rather
+     * than throwing, matching the lenient behaviour of platform URI decoders.
+     */
+    private fun urlDecode(value: String): String {
+        // Fast path: nothing to decode.
+        if (value.indexOf('%') < 0 && value.indexOf('+') < 0) return value
+
+        val bytes = ArrayList<Byte>(value.length)
+        var i = 0
+        while (i < value.length) {
+            when (val c = value[i]) {
+                '+' -> {
+                    bytes.add(' '.code.toByte())
+                    i += 1
+                }
+                '%' -> {
+                    val hi = if (i + 1 < value.length) hexDigit(value[i + 1]) else -1
+                    val lo = if (i + 2 < value.length) hexDigit(value[i + 2]) else -1
+                    if (hi >= 0 && lo >= 0) {
+                        bytes.add(((hi shl 4) or lo).toByte())
+                        i += 3
+                    } else {
+                        // Not a valid escape — keep the literal '%'.
+                        bytes.add(c.code.toByte())
+                        i += 1
+                    }
+                }
+                else -> {
+                    // Append the raw UTF-8 bytes of this character.
+                    for (b in c.toString().encodeToByteArray()) bytes.add(b)
+                    i += 1
+                }
+            }
+        }
+        return bytes.toByteArray().decodeToString()
+    }
+
+    /** Return the value 0..15 for a hex digit char, or -1 if [c] is not a hex digit. */
+    private fun hexDigit(c: Char): Int =
+        when (c) {
+            in '0'..'9' -> c - '0'
+            in 'a'..'f' -> c - 'a' + 10
+            in 'A'..'F' -> c - 'A' + 10
+            else -> -1
+        }
 }

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/navigation/DeepLinkRouterTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/navigation/DeepLinkRouterTest.kt
@@ -77,7 +77,8 @@ class DeepLinkRouterTest {
 
     @Test
     fun parse_sso_deep_link_decodes_plus_as_space() {
-        // Query semantics: '+' decodes to a space (form-urlencoded), matching platform URI decoders.
+        // Query semantics: '+' decodes to a space (form-urlencoded), matching platform URI
+        // decoders.
         val target = DeepLinkRouter.parse("reality://sso?token=a+b")
         assertEquals(DeepLinkTarget.Sso("a b"), target)
     }
@@ -98,7 +99,8 @@ class DeepLinkRouterTest {
 
     @Test
     fun parse_sso_deep_link_tolerates_malformed_escape() {
-        // A stray '%' not followed by two hex digits is passed through literally rather than throwing.
+        // A stray '%' not followed by two hex digits is passed through literally rather than
+        // throwing.
         val target = DeepLinkRouter.parse("reality://sso?token=50%off")
         assertEquals(DeepLinkTarget.Sso("50%off"), target)
     }

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/navigation/DeepLinkRouterTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/navigation/DeepLinkRouterTest.kt
@@ -66,6 +66,44 @@ class DeepLinkRouterTest {
     }
 
     @Test
+    fun parse_sso_deep_link_percent_decodes_token() {
+        // A real JWT/opaque token may contain reserved chars that get percent-encoded in the URL.
+        // The shared router must decode them so the token matches what Android's
+        // `Uri.getQueryParameter` (which decodes) hands to the same SSO validation path.
+        // %2B -> '+', %2F -> '/', %3D -> '='  (a base64url/base64 token with padding)
+        val target = DeepLinkRouter.parse("reality://sso?token=ab%2Bcd%2Fef%3D%3D")
+        assertEquals(DeepLinkTarget.Sso("ab+cd/ef=="), target)
+    }
+
+    @Test
+    fun parse_sso_deep_link_decodes_plus_as_space() {
+        // Query semantics: '+' decodes to a space (form-urlencoded), matching platform URI decoders.
+        val target = DeepLinkRouter.parse("reality://sso?token=a+b")
+        assertEquals(DeepLinkTarget.Sso("a b"), target)
+    }
+
+    @Test
+    fun parse_sso_deep_link_decodes_utf8_multibyte() {
+        // %C3%A1 is the UTF-8 encoding of 'á' — two bytes must combine into one char.
+        val target = DeepLinkRouter.parse("reality://sso?token=caf%C3%A9")
+        assertEquals(DeepLinkTarget.Sso("café"), target)
+    }
+
+    @Test
+    fun parse_sso_deep_link_leaves_unencoded_token_untouched() {
+        // No escapes -> fast path returns the token verbatim.
+        val target = DeepLinkRouter.parse("reality://sso?token=plain-token-123")
+        assertEquals(DeepLinkTarget.Sso("plain-token-123"), target)
+    }
+
+    @Test
+    fun parse_sso_deep_link_tolerates_malformed_escape() {
+        // A stray '%' not followed by two hex digits is passed through literally rather than throwing.
+        val target = DeepLinkRouter.parse("reality://sso?token=50%off")
+        assertEquals(DeepLinkTarget.Sso("50%off"), target)
+    }
+
+    @Test
     fun parse_rejects_foreign_scheme() {
         assertNull(DeepLinkRouter.parse("https://listing/abc-123"))
         assertNull(DeepLinkRouter.parse("ppt://listing/abc-123"))


### PR DESCRIPTION
## Task
DeepLinkRouter skips URL-decoding while Android `Uri.getQueryParameter` decodes — SSO tokens diverge per platform. Make the shared `DeepLinkRouter` URL-decode query-parameter values (percent-decoding, including `+`→space per query semantics) so all platforms produce identical token strings, and add a unit test asserting a percent-encoded SSO token decodes correctly. Scope kept to the deep-link routing path.

## Owner
pm-frontend (hint). Actual work is **mobile-native KMP** → specialist `kotlin-mp`. Per `owner-areas.json`, `mobile-native/**` maps to `pm-mobile`, not `pm-frontend`.

## Root cause (verified against current code)
- `shared/.../navigation/DeepLinkRouter.kt` `queryParam()` returned the raw substring after `=` with **no** percent-decoding.
- `androidApp/.../MainActivity.kt:84` uses `android.net.Uri.getQueryParameter`, which **does** URL-decode.
- Result: the same `reality://sso?token=…` deep link produced a decoded token on Android but a still-encoded token on the shared/iOS path, so iOS SSO validation ran against the wrong string.

## Fix
- `queryParam()` now percent-decodes **both** key and value via a new private `urlDecode()` helper.
- `urlDecode()` uses `application/x-www-form-urlencoded` semantics: `+` → space, `%XX` → byte, UTF-8 reassembly of multibyte sequences. Malformed escapes (`%` not followed by two hex digits) are passed through literally, matching lenient platform URI decoders. Fast-path returns the input verbatim when there is nothing to decode.
- All platforms (Android `Uri`, shared/iOS) now agree on the token string.

## Tested (Band A — fast check)
Full Gradle build is infeasible in this sandbox — the proxy cannot resolve the Android Gradle Plugin (`com.android.application:9.2.1`), so `./gradlew :shared:compileKotlinJvm` fails at plugin resolution before reaching our code. Ran the smallest meaningful band instead, using the bundled `kotlin-compiler-embeddable-2.3.20`:

- Standalone Kotlin compile of `DeepLinkRouter.kt` against `kotlin-stdlib` → **exit 0** (production file compiles clean).
- Compiled + ran a driver replicating every new/changed test assertion against the compiled class → **ALL_PASS / exit 0**:
  - `token=ab%2Bcd%2Fef%3D%3D` → `ab+cd/ef==` (base64 padding)
  - `token=a+b` → `a b` (plus → space)
  - `token=caf%C3%A9` → `café` (UTF-8 multibyte)
  - `token=plain-token-123` → unchanged (fast path)
  - `token=50%off` → `50%off` (malformed escape tolerated)
  - plus listing / no-token-null / foreign-scheme-null regressions.

The shared commonTest cases (`DeepLinkRouterTest.kt`) mirror these assertions and will run under `:shared:jvmTest` in CI where the AGP can be resolved.

## Built (Band B — full build)
Skipped: change <50 LOC of substantive logic, no public API/config surface change. (Full Gradle build also blocked by AGP resolution in this sandbox — see above.)

## CI parity (Band C — hot-path only)
Touches the SSO token path, but the change is a pure local string-decode with no network/crypto/data-integrity surface. Local CI replication infeasible (same AGP block). CI's `mobile-native.yml` (Gradle build + unit tests) will exercise `:shared:jvmTest` on push.

## Scope drift
`scope-check.sh --owner pm-frontend` exits 2 because the diff lives entirely under `mobile-native/shared/**`, which `owner-areas.json` maps to `pm-mobile`, not the supplied `pm-frontend` hint. This is an owner-label mismatch, not real drift — both changed files are squarely within the intended deep-link routing path:
- `mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/navigation/DeepLinkRouter.kt`
- `mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/navigation/DeepLinkRouterTest.kt`

## Code-reuse review
`reuse-grep.sh --specialist kotlin-mp` → no warnings. `urlDecode`/`hexDigit` are new private helpers local to `DeepLinkRouter`; the module is deliberately framework-free (no `android.net.Uri`) so it stays JVM-testable and iOS-reusable.

## Notes
- Android `MainActivity` is unchanged — it already decodes via `Uri.getQueryParameter`; the fix only brings the shared/iOS path into agreement.
- No new dependencies.


---
_Generated by [Claude Code](https://claude.ai/code/session_019j23oYVyhhAgRDpEMGnTAT)_