### PR TITLE
code-review-mobile-native-kmp-search-stale-response-race: guard SearchScreen against stale-response race

### DIFF
--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/search/SearchScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/search/SearchScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
@@ -106,27 +107,55 @@ fun SearchScreen(
     val networkErrorMsg = stringResource(R.string.error_network)
     val searchFailedMsg = stringResource(R.string.error_generic)
 
+    // Stale-response race guard. Each new (page-1) search bumps a monotonic generation and
+    // cancels the in-flight job; the apply step is gated on SearchState.shouldApplyResponse so a
+    // slower OLDER request that completes after a NEWER one can't clobber the newer results.
+    // Page > 1 (infinite-scroll append) reuses the current generation so legitimate appends still
+    // land. searchGeneration/searchJob are plain holders (no recomposition needed).
+    val searchGeneration = remember { intArrayOf(0) }
+    val searchJob = remember { arrayOfNulls<Job>(1) }
+
     // Shared search logic lives in SearchState (commonMain) so it's unit-tested and
     // reusable by the iOS target; this composable is a thin shell around it.
     fun performSearch(page: Int = 1) {
-        scope.launch {
-            isLoading = true
-            errorMessage = null
+        // A fresh search (page 1) supersedes anything in flight: cancel it and bump the
+        // generation so its late response is discarded by the guard below.
+        if (page <= 1) {
+            searchJob[0]?.cancel()
+            searchGeneration[0] += 1
+        }
+        val generation = searchGeneration[0].toLong()
 
-            val request =
-                SearchState.buildSearchRequest(
-                    query = searchQuery,
-                    type = selectedType,
-                    category = selectedCategory,
-                    minPrice = minPrice,
-                    maxPrice = maxPrice,
-                    minRooms = minRooms,
-                    sort = selectedSort,
-                    page = page,
-                )
-            repository
-                .searchListings(request)
-                .fold(
+        searchJob[0] =
+            scope.launch {
+                isLoading = true
+                errorMessage = null
+
+                val request =
+                    SearchState.buildSearchRequest(
+                        query = searchQuery,
+                        type = selectedType,
+                        category = selectedCategory,
+                        minPrice = minPrice,
+                        maxPrice = maxPrice,
+                        minRooms = minRooms,
+                        sort = selectedSort,
+                        page = page,
+                    )
+                val result = repository.searchListings(request)
+
+                // Discard responses that no longer belong to the latest search generation —
+                // this is what prevents an out-of-order older response from winning.
+                if (
+                    !SearchState.shouldApplyResponse(
+                        responseGeneration = generation,
+                        currentGeneration = searchGeneration[0].toLong(),
+                    )
+                ) {
+                    return@launch
+                }
+
+                result.fold(
                     onSuccess = { response ->
                         searchResults =
                             SearchState.mergePage(searchResults, response.listings, page)
@@ -137,8 +166,8 @@ fun SearchScreen(
                         errorMessage = if (it.isNetworkError()) networkErrorMsg else searchFailedMsg
                     },
                 )
-            isLoading = false
-        }
+                isLoading = false
+            }
     }
 
     LaunchedEffect(Unit) { performSearch() }
@@ -324,7 +353,7 @@ private enum class ViewMode {
     MAP,
 }
 
-// ─── Top bar ─────────────────────────────────────────────────────────────────
+// ─── Top bar ───────────────────────────────────────────────────────────
 
 @Composable
 private fun ListingsTopBar(
@@ -423,7 +452,7 @@ private fun SegmentChip(icon: ImageVector, label: String, selected: Boolean, onC
     }
 }
 
-// ─── Search input ───────────────────────────────────────────────────────────
+// ─── Search input ──────────────────────────────────────────────────────
 
 @Composable
 private fun SearchInputRow(
@@ -457,7 +486,7 @@ private fun SearchInputRow(
     )
 }
 
-// ─── Rooms chip strip ──────────────────────────────────────────────────────
+// ─── Rooms chip strip ──────────────────────────────────────────────
 
 @Composable
 private fun RoomsChipStrip(selected: Int?, onSelect: (Int?) -> Unit, totalResults: Int) {
@@ -507,7 +536,7 @@ private fun RoomsChipStrip(selected: Int?, onSelect: (Int?) -> Unit, totalResult
     }
 }
 
-// ─── Filter sheet (modal bottom sheet) ─────────────────────────────────
+// ─── Filter sheet (modal bottom sheet) ───────────────────────────────
 //
 // AC-4: advanced filters are presented as a Material 3 ModalBottomSheet, named
 // `FilterSheet` to match the iOS shared component (docs/screens/reality-mobile/search.md
@@ -677,7 +706,7 @@ private fun FilterSheet(
     }
 }
 
-// ─── Empty / error / map placeholder ───────────────────────────────────
+// ─── Empty / error / map placeholder ─────────────────────────────────
 
 @Composable
 private fun ErrorBanner(error: String) {

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/SearchState.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/SearchState.kt
@@ -11,6 +11,10 @@ package three.two.bit.ppt.reality.listing
  *   the reported total, and whether a load is in flight, decide whether to fetch the next page.
  * - [mergePage] — append-or-replace semantics for paginated results (page 1 replaces, later pages
  *   append).
+ * - [shouldApplyResponse] — stale-response guard: given the request generation a response belongs to
+ *   and the generation currently in effect, decide whether the response may be applied. Protects the
+ *   search-as-you-type path from out-of-order completions where a slower OLDER request would
+ *   otherwise clobber the results of a NEWER one.
  *
  * Epic 82 - Story 82.3: Reality mobile Home & Search (AC-2 debounced search, AC-4 infinite scroll +
  * FilterSheet).
@@ -96,4 +100,25 @@ object SearchState {
         incoming: List<ListingSummary>,
         page: Int,
     ): List<ListingSummary> = if (page <= 1) incoming else existing + incoming
+
+    /**
+     * Stale-response guard for search-as-you-type.
+     *
+     * Each search dispatched from the screen is tagged with a monotonically increasing generation
+     * token (captured at launch time). When the network request completes, the caller passes the
+     * generation the response belongs to ([responseGeneration]) together with the generation that is
+     * currently in effect ([currentGeneration]) — i.e. the token of the most-recently-launched
+     * search. The response may only be applied when it belongs to the latest generation.
+     *
+     * This makes the apply step order-independent: if a slower OLDER request finishes after a NEWER
+     * one was launched, its [responseGeneration] is behind [currentGeneration] and the response is
+     * discarded instead of clobbering the newer (correct) results. A response from a generation
+     * ahead of the current one is impossible by construction and is treated as stale too.
+     *
+     * @param responseGeneration the generation the just-completed response was dispatched under
+     * @param currentGeneration the generation of the most-recently-launched search
+     * @return true when the response is the latest in flight and may be applied
+     */
+    fun shouldApplyResponse(responseGeneration: Long, currentGeneration: Long): Boolean =
+        responseGeneration == currentGeneration
 }

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/SearchState.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/SearchState.kt
@@ -11,9 +11,9 @@ package three.two.bit.ppt.reality.listing
  *   the reported total, and whether a load is in flight, decide whether to fetch the next page.
  * - [mergePage] — append-or-replace semantics for paginated results (page 1 replaces, later pages
  *   append).
- * - [shouldApplyResponse] — stale-response guard: given the request generation a response belongs to
- *   and the generation currently in effect, decide whether the response may be applied. Protects the
- *   search-as-you-type path from out-of-order completions where a slower OLDER request would
+ * - [shouldApplyResponse] — stale-response guard: given the request generation a response belongs
+ *   to and the generation currently in effect, decide whether the response may be applied. Protects
+ *   the search-as-you-type path from out-of-order completions where a slower OLDER request would
  *   otherwise clobber the results of a NEWER one.
  *
  * Epic 82 - Story 82.3: Reality mobile Home & Search (AC-2 debounced search, AC-4 infinite scroll +
@@ -106,8 +106,8 @@ object SearchState {
      *
      * Each search dispatched from the screen is tagged with a monotonically increasing generation
      * token (captured at launch time). When the network request completes, the caller passes the
-     * generation the response belongs to ([responseGeneration]) together with the generation that is
-     * currently in effect ([currentGeneration]) — i.e. the token of the most-recently-launched
+     * generation the response belongs to ([responseGeneration]) together with the generation that
+     * is currently in effect ([currentGeneration]) — i.e. the token of the most-recently-launched
      * search. The response may only be applied when it belongs to the latest generation.
      *
      * This makes the apply step order-independent: if a slower OLDER request finishes after a NEWER

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/SearchStateTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/SearchStateTest.kt
@@ -124,6 +124,47 @@ class SearchStateTest {
         assertEquals(listOf("a", "b"), merged.map { it.id })
     }
 
+    // ── shouldApplyResponse (stale-response race guard) ──────────────────
+
+    @Test
+    fun shouldApplyResponse_appliesLatestGeneration() {
+        // Response belongs to the generation currently in effect → apply it.
+        assertTrue(SearchState.shouldApplyResponse(responseGeneration = 3, currentGeneration = 3))
+    }
+
+    @Test
+    fun shouldApplyResponse_discardsStaleOlderResponse() {
+        // A slower OLDER request (gen 1) completes after a NEWER one (gen 2) was launched.
+        // Its response must NOT be applied — this is the bug being fixed.
+        assertFalse(SearchState.shouldApplyResponse(responseGeneration = 1, currentGeneration = 2))
+    }
+
+    @Test
+    fun shouldApplyResponse_staleResponseDoesNotOverwriteNewerResult() {
+        // End-to-end shape of the race: a NEWER query's result is already applied; the OLDER
+        // query's response then arrives out of order and must be dropped, leaving the newer
+        // result intact.
+        val currentGeneration = 5L
+        val newerResult = listOf(summary("new-1"), summary("new-2"))
+
+        var applied = newerResult
+
+        // The stale (older) response tries to clobber the state.
+        val staleResponse = listOf(summary("old-1"))
+        if (SearchState.shouldApplyResponse(responseGeneration = 4L, currentGeneration)) {
+            applied = SearchState.mergePage(applied, staleResponse, page = 1)
+        }
+
+        assertEquals(newerResult, applied)
+        assertEquals(listOf("new-1", "new-2"), applied.map { it.id })
+    }
+
+    @Test
+    fun shouldApplyResponse_futureGenerationIsTreatedAsStale() {
+        // A generation ahead of current is impossible by construction; guard rejects it too.
+        assertFalse(SearchState.shouldApplyResponse(responseGeneration = 9, currentGeneration = 7))
+    }
+
     private fun summary(id: String) =
         ListingSummary(
             id = id,


### PR DESCRIPTION
## Task
SearchScreen stale-response race — overlapping searches can clobber newer results. In the mobile-native KMP shared module, the Search screen issues network searches as the user types. Overlapping/concurrent searches can complete out of order, so a SLOWER older request can clobber the results of a NEWER request (a stale-response race). Fix the race so only the most-recent query's response is applied, and add a unit test (commonTest) asserting that a stale/older response does NOT overwrite the newer result.

## Root cause
`SearchScreen.performSearch()` launched each search in a fresh `scope.launch { … }` coroutine and applied the response unconditionally on completion. With debounced search-as-you-type, several searches can be in flight at once; coroutine completion order is not request order. A slower OLDER request finishing after a NEWER one had already updated `searchResults` would overwrite the newer (correct) results with stale data.

## Fix
- **commonMain** — added a pure, unit-testable guard `SearchState.shouldApplyResponse(responseGeneration, currentGeneration): Boolean` (returns true only when the response belongs to the generation currently in effect). Kept in the shared module so the iOS target reuses the same logic.
- **androidApp `SearchScreen.kt`** — each fresh search (page 1, the search-as-you-type path) now:
  1. cancels the in-flight `Job` (coroutine cancellation), and
  2. bumps a monotonically increasing generation token.
  The captured generation is compared against the current one after the network call returns; if it is behind (an out-of-order older response), the result is discarded via early `return@launch` before any state is written. Infinite-scroll appends (`page > 1`) reuse the current generation so legitimate page appends still land.
- Generation/job are held in `remember { intArrayOf(0) }` / `remember { arrayOfNulls<Job>(1) }` (plain holders — no recomposition needed).

Scope kept tight to the search path; no unrelated refactors.

## Tested (Band A — fast check)
Gradle full build is infeasible in this sandbox (the proxy cannot resolve the Android Gradle Plugin — same block PR #1155 documented). Instead I ran the smallest meaningful verify band:

1. **Standalone Kotlin compile of the real changed shared source.** Compiled the actual `SearchState.kt` (commonMain) together with a small JVM driver, using the Gradle-bundled Kotlin compiler (`/opt/gradle-8.14.3/lib/kotlin-compiler-embeddable-2.0.21.jar`) against `kotlin-stdlib`:
   ```
   java -cp <gradle-lib>/* org.jetbrains.kotlin.cli.jvm.K2JVMCompiler \
     -cp kotlin-stdlib-2.0.21.jar -no-stdlib -no-reflect \
     SearchState.kt Driver.kt -d out.jar
   → compile-exit=0
   ```
2. **Ran the driver replicating the new commonTest assertions** (the four `shouldApplyResponse_*` cases + a `mergePage` page-2 append sanity check):
   ```
   java -cp out.jar:kotlin-stdlib-2.0.21.jar ...DriverKt
   ok   - appliesLatestGeneration
   ok   - discardsStaleOlderResponse
   ok   - staleResponseDoesNotOverwriteNewerResult-equals
   ok   - staleResponseDoesNotOverwriteNewerResult-ids
   ok   - futureGenerationIsTreatedAsStale
   ok   - mergePage-append-page2
   ALL PASS  → run-exit=0
   ```

The new commonTest cases in `SearchStateTest.kt` mirror these assertions and will run under the real `:shared:jvmTest` / `:shared:test` task in CI. `SearchScreen.kt` (androidApp, Compose) was reviewed for coherence but not compiled locally (requires AGP, blocked by the sandbox proxy).

## Built (Band B — full build)
skipped: Gradle/AGP resolution blocked by sandbox proxy (documented above and in PR #1155). Substantive change is ~25 LOC of new shared logic + the screen wiring.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change). The mobile-native CI job (`mobile-native.yml`: Gradle build + unit tests) will exercise the new commonTest.

## Remote-tested
skipped (no ppt-bridge MCP for mobile-native builds).

## Scope drift
False (true scope drift). All three changed files live under `mobile-native/**` (the search path only):
- `mobile-native/shared/src/commonMain/.../listing/SearchState.kt`
- `mobile-native/shared/src/commonTest/.../listing/SearchStateTest.kt`
- `mobile-native/androidApp/.../ui/search/SearchScreen.kt`

Note on owner mapping: the dispatcher's `owner_role` hint was `pm-frontend`, but `owner-areas.json` maps `mobile-native/**` to `pm-mobile` (specialist `kotlin-mp`), which is the correct owner for this code. The advisory `scope-check.sh` against the local `dev` ref returned exit 2, but that is an artifact of the worktree's local `dev` ref lagging far behind `origin/dev` (it diffed the entire branch divergence, not this PR's commits). This PR's actual commits touch only the three search files above. Documented loosely as instructed (cf. PR #1155).

## Code-reuse review
none — `reuse-grep.sh` returned no warnings. The new `shouldApplyResponse` is a small pure helper added alongside the existing `SearchState` helpers (`mergePage`, `shouldLoadNextPage`); no duplicate of an existing symbol.

## Notes
- The guard is generation-equality based; cancellation of the in-flight job is belt-and-suspenders (a cancelled job won't apply, and even if a response races past cancellation the generation check discards it).
- iOS SwiftUI SearchView already debounces but should adopt the same `shouldApplyResponse` guard in a follow-up if it shares the same multi-in-flight exposure — out of scope here.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01QnTU6brXbRr8Vj34wNhUdj)_