### PR TITLE
refactor-churn-hotspot-mobile-announcements: extract pure helpers from mobile AnnouncementsScreen

### DIFF
--- a/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.test.ts
+++ b/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.test.ts
@@ -1,9 +1,13 @@
 import {
   type Announcement,
   type ApiAnnouncementSummary,
+  applyReadState,
+  buildAnnouncements,
+  countUnread,
   derivePinnedItems,
   extractItems,
   filterMainList,
+  formatRelativeDate,
   toUiAnnouncement,
 } from './AnnouncementsScreen';
 
@@ -124,5 +128,84 @@ describe('filterMainList (PR #943 main feed partitioning)', () => {
     expect(filterMainList(items, 'LIFT').map((a) => a.id)).toEqual(['old']);
     // A term that matched the old `content` body must NOT match now.
     expect(filterMainList(items, 'no-such-title')).toEqual([]);
+  });
+});
+
+// Pure helpers extracted from the component body during the churn-hotspot
+// refactor. These used to live inline (untested); pinning them here prevents
+// silent regression of read-state overlay, unread counting, and the feed's
+// relative-date label.
+
+describe('applyReadState (client-side read overlay)', () => {
+  const base = ui({ id: 'a', isRead: false });
+
+  it('marks an unread row read when its id is in the set', () => {
+    const out = applyReadState(base, new Set(['a']));
+    expect(out.isRead).toBe(true);
+    expect(out).not.toBe(base); // new object — does not mutate input
+  });
+
+  it('returns the same reference when the id is absent', () => {
+    const out = applyReadState(base, new Set(['other']));
+    expect(out).toBe(base);
+  });
+
+  it('returns the same reference when already read', () => {
+    const read = ui({ id: 'a', isRead: true });
+    expect(applyReadState(read, new Set(['a']))).toBe(read);
+  });
+});
+
+describe('buildAnnouncements (response → read-aware UI list)', () => {
+  it('maps the published list and overlays read state', () => {
+    const resp = { announcements: [summary] }; // summary.id === 'a-1'
+    const out = buildAnnouncements(resp, new Set(['a-1']));
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ id: 'a-1', isRead: true, isPinned: true });
+  });
+
+  it('returns [] for an undefined response', () => {
+    expect(buildAnnouncements(undefined, new Set())).toEqual([]);
+  });
+
+  it('leaves rows unread when their id is not in the set', () => {
+    const out = buildAnnouncements({ announcements: [summary] }, new Set());
+    expect(out[0].isRead).toBe(false);
+  });
+});
+
+describe('countUnread', () => {
+  it('counts rows whose isRead is false', () => {
+    const items = [
+      ui({ id: 'a', isRead: false }),
+      ui({ id: 'b', isRead: true }),
+      ui({ id: 'c', isRead: false }),
+    ];
+    expect(countUnread(items)).toBe(2);
+  });
+
+  it('is 0 for an empty list', () => {
+    expect(countUnread([])).toBe(0);
+  });
+});
+
+describe('formatRelativeDate (feed card label)', () => {
+  const now = new Date('2026-05-20T12:00:00Z');
+
+  it('returns "Just now" under one hour', () => {
+    expect(formatRelativeDate('2026-05-20T11:30:00Z', now)).toBe('Just now');
+  });
+
+  it('returns "Nh ago" within the same day', () => {
+    expect(formatRelativeDate('2026-05-20T09:00:00Z', now)).toBe('3h ago');
+  });
+
+  it('returns "Nd ago" within the week', () => {
+    expect(formatRelativeDate('2026-05-18T12:00:00Z', now)).toBe('2d ago');
+  });
+
+  it('returns an absolute month-day label beyond a week', () => {
+    // 2026-05-01 is >7d before now → absolute "May 1" style label.
+    expect(formatRelativeDate('2026-05-01T12:00:00Z', now)).toBe('May 1');
   });
 });

--- a/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.tsx
@@ -102,6 +102,56 @@ export function filterMainList(items: Announcement[], searchQuery: string): Anno
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 }
 
+/**
+ * Overlay the locally-tracked read state onto an announcement.
+ *
+ * Read state is tracked client-side in a `Set<id>` (the published summary
+ * carries no per-user read flag). Once an id is in the set the row is read;
+ * otherwise the row keeps whatever `isRead` the mapper produced.
+ */
+export function applyReadState(announcement: Announcement, readIds: Set<string>): Announcement {
+  if (announcement.isRead || !readIds.has(announcement.id)) return announcement;
+  return { ...announcement, isRead: true };
+}
+
+/** Build the read-state-aware UI list from a published-list response. */
+export function buildAnnouncements(
+  data: ApiAnnouncementListResponse | undefined,
+  readIds: Set<string>
+): Announcement[] {
+  return extractItems(data)
+    .map(toUiAnnouncement)
+    .map((a) => applyReadState(a, readIds));
+}
+
+/** Number of unread rows in a UI list. */
+export function countUnread(items: Announcement[]): number {
+  return items.filter((a) => !a.isRead).length;
+}
+
+/**
+ * Format a timestamp as a short relative label for the feed cards.
+ *
+ * < 1h → "Just now"; < 24h → "Nh ago"; < 7d → "Nd ago"; otherwise an
+ * absolute "Mon D" date. `now` is injectable so the output is deterministic
+ * under test.
+ */
+export function formatRelativeDate(dateString: string, now: Date = new Date()): string {
+  const date = new Date(dateString);
+  const diffMs = now.getTime() - date.getTime();
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffHours < 24) {
+    if (diffHours < 1) return 'Just now';
+    return `${diffHours}h ago`;
+  }
+  if (diffDays < 7) {
+    return `${diffDays}d ago`;
+  }
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
 interface AnnouncementsScreenProps {
   onNavigate?: (screen: string, params?: Record<string, unknown>) => void;
 }
@@ -122,38 +172,12 @@ export function AnnouncementsScreen({ onNavigate }: AnnouncementsScreenProps) {
   // Story 6.4 — pinned items are derived client-side from the published list
   // (the published endpoint already orders `pinned DESC`). A dedicated query
   // is unnecessary and the endpoint does not accept a `pinned` filter.
-  const pinnedData = data;
-
-  const allRaw: Announcement[] = extractItems(data)
-    .map(toUiAnnouncement)
-    .map((a) => ({ ...a, isRead: readIds.has(a.id) ? true : a.isRead }));
-
-  const pinnedItems: Announcement[] = derivePinnedItems(
-    extractItems(pinnedData)
-      .map(toUiAnnouncement)
-      .map((a) => ({ ...a, isRead: readIds.has(a.id) ? true : a.isRead }))
-  );
+  const allRaw: Announcement[] = buildAnnouncements(data, readIds);
+  const pinnedItems: Announcement[] = derivePinnedItems(allRaw);
 
   const onRefresh = useCallback(async () => {
     await refetch();
   }, [refetch]);
-
-  const formatDate = (dateString: string): string => {
-    const date = new Date(dateString);
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-
-    if (diffHours < 24) {
-      if (diffHours < 1) return 'Just now';
-      return `${diffHours}h ago`;
-    }
-    if (diffDays < 7) {
-      return `${diffDays}d ago`;
-    }
-    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-  };
 
   const markAsRead = (id: string) => {
     setReadIds((prev) => {
@@ -167,7 +191,7 @@ export function AnnouncementsScreen({ onNavigate }: AnnouncementsScreenProps) {
   // Main list excludes pinned items (they appear in the sticky band above)
   const filteredAnnouncements = filterMainList(allRaw, searchQuery);
 
-  const unreadCount = allRaw.filter((a) => !a.isRead).length;
+  const unreadCount = countUnread(allRaw);
 
   const handleCardPress = (announcement: Announcement) => {
     markAsRead(announcement.id);
@@ -251,7 +275,9 @@ export function AnnouncementsScreen({ onNavigate }: AnnouncementsScreenProps) {
               onPress={() => handleCardPress(announcement)}
             >
               <View style={styles.announcementHeader}>
-                <Text style={styles.announcementDate}>{formatDate(announcement.createdAt)}</Text>
+                <Text style={styles.announcementDate}>
+                  {formatRelativeDate(announcement.createdAt)}
+                </Text>
               </View>
 
               <Text style={styles.announcementTitle}>{announcement.title}</Text>


### PR DESCRIPTION
## Task
Churn hotspot: `AnnouncementsScreen.tsx` (frontend mobile React Native app, `frontend/apps/mobile/**`) changed across 4 PRs recently — instability proxy. Reduce risk: refactor `AnnouncementsScreen.tsx` for clarity/cohesion (extract components/hooks, tighten state/data-fetch) WITHOUT changing behavior, and/or add missing test coverage (jest-expo) for any extracted pure logic. Keep scope tight to the announcements screen; no broad rewrite.

## Owner
pm-frontend (specialist: react-native)

## What changed (behavior-preserving)
- Extracted four pure helpers from the component body to module scope:
  - `formatRelativeDate(dateString, now?)` — was an inline `formatDate` re-created every render and untested; `now` is now injectable for deterministic tests. Output identical (`Just now` / `Nh ago` / `Nd ago` / `Mon D`).
  - `applyReadState(announcement, readIds)` — the inline `{ ...a, isRead: readIds.has(a.id) ? true : a.isRead }` overlay, now reference-stable when unchanged.
  - `buildAnnouncements(data, readIds)` — collapses the `extractItems().map(toUiAnnouncement).map(applyReadState)` chain that was **duplicated** (once for the main list, once for pinned).
  - `countUnread(items)` — was an inline `.filter(...).length`.
- Removed the redundant `pinnedData = data` alias; `pinnedItems` now derives via `derivePinnedItems(allRaw)` from the same read-aware list. `derivePinnedItems` only filters `isPinned`, so the result is identical to the old separate map chain — no behavior change.
- Added 12 jest-expo unit tests for the extracted pure logic (`applyReadState`, `buildAnnouncements`, `countUnread`, `formatRelativeDate`).

No JSX structure, styles, query keys, endpoints, or navigation behavior were changed.

## Tested (Band A — fast check)
- `pnpm -F mobile typecheck` → exit 0
- `pnpm -F mobile lint` → no lint script in the mobile package (exit 0); ran `npx @biomejs/biome check` on both changed files instead → exit 0 (CI `frontend.yml` runs Biome at root)
- `npx jest src/screens/announcements/AnnouncementsScreen.test.ts` → exit 0, **22 passed** (10 existing + 12 new)

## Built (Band B — full build)
skipped: change is a small behavior-preserving refactor (~109 net LOC, no public API/config/build-output change). Typecheck + targeted tests cover it.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped

## Scope drift
None — `scope-check.sh --owner pm-frontend` exit 0. Only the two announcements files touched.

## Code-reuse review
none — extracted helpers are local to the screen module; no auth/crypto/http helpers added.

## Notes
The list-shaping pure logic (`toUiAnnouncement`, `extractItems`, `derivePinnedItems`, `filterMainList`) was already extracted and tested; this PR finishes the job for the remaining inline logic in the component body.

https://claude.ai/code/session_01YZjpTKXcb8bFGZR6mmf213

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZjpTKXcb8bFGZR6mmf213)_