### PR TITLE
code-review-mobile-native-kmp-deeplink-android-bypasses-shared-router: route Android deep-link dispatch through shared DeepLinkRouter

### DIFF
--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/MainActivity.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/MainActivity.kt
@@ -22,7 +22,7 @@ import three.two.bit.ppt.reality.api.ApiConfig
 import three.two.bit.ppt.reality.auth.SsoService
 import three.two.bit.ppt.reality.listing.ListingRepository
 import three.two.bit.ppt.reality.navigation.DeepLinkRouter
-import three.two.bit.ppt.reality.navigation.DeepLinkTarget as SharedDeepLinkTarget
+import three.two.bit.ppt.reality.navigation.DeepLinkTarget
 import three.two.bit.ppt.reality.navigation.RealityNavHost
 import three.two.bit.ppt.reality.ui.theme.RealityPortalTheme
 
@@ -73,51 +73,27 @@ class MainActivity : ComponentActivity() {
         handleDeepLink(intent)
     }
 
+    /**
+     * Dispatch an incoming `reality://…` intent through the shared [DeepLinkRouter] — the single
+     * source of truth for deep-link scheme/host/path/query parsing (shared across Android + iOS).
+     *
+     * Android contributes only the platform-specific bit: pulling the URI string out of the
+     * [Intent]. All scheme/host matching and percent-decoding lives in [DeepLinkRouter.parse] so a
+     * new shared [DeepLinkTarget] (e.g. [DeepLinkTarget.Sso]) is honoured here automatically rather
+     * than silently no-op-ing on Android.
+     */
     private fun handleDeepLink(intent: Intent?) {
         val uri = intent?.data ?: return
 
-        if (uri.scheme != "reality") return
-
-        when (uri.host) {
-            "sso" -> {
-                // Handle SSO deep-link: reality://sso?token=xxx
-                val token = uri.getQueryParameter("token")
-                if (token != null) {
-                    lifecycleScope.launch { ssoService.validateAndLogin(token) }
-                }
-            }
-            "listing" -> {
-                // Handle listing deep-link: reality://listing/{id}
-                val listingId = uri.pathSegments.firstOrNull()
-                if (listingId != null) {
-                    pendingDeepLink.value = DeepLinkTarget.Listing(listingId)
-                }
-            }
-            "search" -> {
-                // Handle search deep-link: reality://search
-                pendingDeepLink.value = DeepLinkTarget.Search
-            }
-            "favorites" -> {
-                // Handle favorites deep-link: reality://favorites
-                pendingDeepLink.value = DeepLinkTarget.Favorites
-            }
-            "inquiries" -> {
-                // Handle inquiries deep-link: reality://inquiries
-                pendingDeepLink.value = DeepLinkTarget.Inquiries
-            }
+        when (val target = DeepLinkRouter.parse(uri.toString())) {
+            // SSO is handled out-of-band: validate the token instead of navigating.
+            is DeepLinkTarget.Sso ->
+                lifecycleScope.launch { ssoService.validateAndLogin(target.token) }
+            // Navigable targets are deferred until the NavHost is composed.
+            null -> Unit
+            else -> pendingDeepLink.value = target
         }
     }
-}
-
-/** Deep link navigation target (Epic 122) */
-sealed class DeepLinkTarget {
-    data class Listing(val id: String) : DeepLinkTarget()
-
-    data object Search : DeepLinkTarget()
-
-    data object Favorites : DeepLinkTarget()
-
-    data object Inquiries : DeepLinkTarget()
 }
 
 @Composable
@@ -173,15 +149,9 @@ fun RealityPortalApp(
 /**
  * Navigate to a deep link target (Epic 122). Route resolution is delegated to the shared
  * [DeepLinkRouter] (commonMain) so Android and iOS resolve the same nav-graph routes (story 82-2,
- * AC-4).
+ * AC-4). Out-of-band targets (e.g. [DeepLinkTarget.Sso]) resolve to a `null` route and are no-ops
+ * here — they are handled before navigation in [MainActivity.handleDeepLink].
  */
 private fun navigateToDeepLink(navController: NavHostController, target: DeepLinkTarget) {
-    val shared =
-        when (target) {
-            is DeepLinkTarget.Listing -> SharedDeepLinkTarget.Listing(target.id)
-            is DeepLinkTarget.Search -> SharedDeepLinkTarget.Search
-            is DeepLinkTarget.Favorites -> SharedDeepLinkTarget.Favorites
-            is DeepLinkTarget.Inquiries -> SharedDeepLinkTarget.Inquiries
-        }
-    DeepLinkRouter.route(shared)?.let { route -> navController.navigate(route) }
+    DeepLinkRouter.route(target)?.let { route -> navController.navigate(route) }
 }

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/navigation/AndroidDeepLinkDispatchTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/navigation/AndroidDeepLinkDispatchTest.kt
@@ -4,16 +4,14 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 /**
  * Regression guard for the Android `MainActivity` deep-link handler (`androidApp`).
  *
  * `MainActivity.handleDeepLink` used to reimplement `reality://` scheme/host dispatch with
- * `android.net.Uri` and a *second*, Android-only `DeepLinkTarget` sealed class that lacked `Sso`
- * — so a new shared target would silently no-op on Android. It now does nothing platform-specific
+ * `android.net.Uri` and a *second*, Android-only `DeepLinkTarget` sealed class that lacked `Sso` —
+ * so a new shared target would silently no-op on Android. It now does nothing platform-specific
  * beyond pulling the URI string off the `Intent` and delegating to [DeepLinkRouter]:
- *
  * ```kotlin
  * when (val target = DeepLinkRouter.parse(uri.toString())) {
  *     is DeepLinkTarget.Sso -> ssoService.validateAndLogin(target.token)   // out-of-band

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/navigation/AndroidDeepLinkDispatchTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/navigation/AndroidDeepLinkDispatchTest.kt
@@ -1,0 +1,85 @@
+package three.two.bit.ppt.reality.navigation
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Regression guard for the Android `MainActivity` deep-link handler (`androidApp`).
+ *
+ * `MainActivity.handleDeepLink` used to reimplement `reality://` scheme/host dispatch with
+ * `android.net.Uri` and a *second*, Android-only `DeepLinkTarget` sealed class that lacked `Sso`
+ * — so a new shared target would silently no-op on Android. It now does nothing platform-specific
+ * beyond pulling the URI string off the `Intent` and delegating to [DeepLinkRouter]:
+ *
+ * ```kotlin
+ * when (val target = DeepLinkRouter.parse(uri.toString())) {
+ *     is DeepLinkTarget.Sso -> ssoService.validateAndLogin(target.token)   // out-of-band
+ *     null -> Unit                                                          // not a deep link
+ *     else -> pendingDeepLink.value = target                               // navigate later
+ * }
+ * ```
+ *
+ * These tests assert that the Android dispatch the handler relies on matches the shared router:
+ * 1. Every host the old Android handler special-cased (`listing`, `search`, `favorites`,
+ *    `inquiries`, `sso`) still parses to the expected shared [DeepLinkTarget].
+ * 2. The Sso-vs-navigable partition the handler branches on is well-defined: `Sso` is the *only*
+ *    target whose [DeepLinkRouter.route] is `null` (handled out-of-band), and every other target
+ *    resolves to a navigable route. This is what makes `else -> pendingDeepLink.value = target`
+ *    safe — no navigable target is ever dropped, and no out-of-band target is ever navigated.
+ */
+class AndroidDeepLinkDispatchTest {
+
+    /** The five hosts the legacy Android `when (uri.host)` block handled, plus expected target. */
+    private val androidHandledLinks: List<Pair<String, DeepLinkTarget>> =
+        listOf(
+            "reality://listing/abc-123" to DeepLinkTarget.Listing("abc-123"),
+            "reality://search" to DeepLinkTarget.Search,
+            "reality://favorites" to DeepLinkTarget.Favorites,
+            "reality://inquiries" to DeepLinkTarget.Inquiries,
+            "reality://sso?token=tok-42" to DeepLinkTarget.Sso("tok-42"),
+        )
+
+    @Test
+    fun android_handled_links_parse_via_shared_router() {
+        for ((uri, expected) in androidHandledLinks) {
+            assertEquals(expected, DeepLinkRouter.parse(uri), "mismatch for $uri")
+        }
+    }
+
+    @Test
+    fun sso_is_the_only_out_of_band_target_rest_are_navigable() {
+        for ((uri, target) in androidHandledLinks) {
+            val route = DeepLinkRouter.route(target)
+            if (target is DeepLinkTarget.Sso) {
+                // Handler validates the token; navigateToDeepLink must NOT navigate it.
+                assertNull(route, "Sso must be out-of-band for $uri")
+            } else {
+                // Handler stashes it in pendingDeepLink; navigateToDeepLink must navigate it.
+                assertNotNull(route, "navigable target must resolve to a route for $uri")
+            }
+        }
+    }
+
+    @Test
+    fun handler_drops_links_the_router_does_not_recognise() {
+        // The `null` branch of the handler: foreign scheme / unknown host / garbage are ignored.
+        assertNull(DeepLinkRouter.parse("https://listing/abc-123"))
+        assertNull(DeepLinkRouter.parse("reality://unknown"))
+        assertNull(DeepLinkRouter.parse(""))
+    }
+
+    @Test
+    fun sso_token_is_percent_decoded_consistently_with_android_uri() {
+        // Android's Uri.getQueryParameter decodes; MainActivity now feeds the raw URI string to the
+        // shared router, which decodes itself. Both paths must yield the same token (PR #1155).
+        val target = DeepLinkRouter.parse("reality://sso?token=ab%2Bcd%2Fef%3D%3D")
+        assertEquals(DeepLinkTarget.Sso("ab+cd/ef=="), target)
+        // And the navigable side stays out-of-band regardless of token contents.
+        val sso = target as? DeepLinkTarget.Sso
+        assertNotNull(sso)
+        assertNull(DeepLinkRouter.route(sso))
+    }
+}


### PR DESCRIPTION
## Task
MainActivity.kt reimplements deep-link scheme/host dispatch with android.net.Uri (lines ~76-109) instead of delegating to the shared DeepLinkRouter (documented single source of truth, DeepLinkRouter.kt:36); a second Android-only DeepLinkTarget sealed class (~113-121) lacks Sso, so adding a new shared target silently no-ops on Android. Route Android deep-link handling through the shared DeepLinkRouter so there is one source of truth; remove/align the duplicate Android-only target enum; add a test asserting Android dispatch matches the shared router. Scope: deep-link path only (mobile-native/androidApp MainActivity + shared DeepLinkRouter).

## Owner
pm-mobile (specialist: kotlin-mp)

## What changed
- **`androidApp/.../MainActivity.kt`** — `handleDeepLink` no longer does its own `android.net.Uri` scheme/host/path/query dispatch. It now extracts the URI string from the `Intent` and delegates to `DeepLinkRouter.parse(uri.toString())`, branching only on `Sso` (out-of-band token validation via `SsoService`) vs navigable targets (stashed in `pendingDeepLink`) vs `null` (ignored). The `reality` scheme check, `uri.host` `when`, `pathSegments`, and `getQueryParameter` are all gone — the shared router owns them.
- **Removed** the duplicate Android-only `sealed class DeepLinkTarget` (which lacked `Sso`) and the `SharedDeepLinkTarget` alias + enum-mapping in `navigateToDeepLink`. MainActivity now uses the shared `three.two.bit.ppt.reality.navigation.DeepLinkTarget` everywhere. `navigateToDeepLink` is reduced to `DeepLinkRouter.route(target)?.let { navController.navigate(it) }` (Sso resolves to a `null` route → safe no-op).
- **Added** `shared/src/commonTest/.../AndroidDeepLinkDispatchTest.kt` — pins the contract MainActivity now relies on: every host the legacy Android handler special-cased parses via the shared router; `Sso` is the sole out-of-band target (route == null) and every other target is navigable; unknown/foreign/garbage links are dropped; the percent-decoded SSO token (PR #1155) round-trips.

Complements the merged sibling PR #1155 (shared router URL-decodes query params): with Android delegating, the `reality://sso?token=…` token is now decoded once, in the shared router, identically on Android and iOS.

## Tested (Band A — fast check)
Gradle/AGP full build is blocked by the sandbox proxy (cannot resolve `com.android.application` plugin). Used the smallest meaningful band instead: standalone compile + run with the embedded Kotlin compiler (`/opt/gradle-8.14.3/lib/kotlin-compiler-embeddable-2.0.21.jar`).

- `K2JVMCompiler DeepLinkRouter.kt` (production source) → **exit 0**.
- `K2JVMCompiler DeepLinkRouter.kt + AndroidDeepLinkDispatchTest.kt + DeepLinkRouterTest.kt + driver` (test files type-checked against the real router types; `kotlin.test` provided by a contract-aware shim) → **exit 0**.
- Run driver invoking all 4 `AndroidDeepLinkDispatchTest` methods → `ALL_ANDROID_DISPATCH_TESTS_PASSED`, **exit 0**.

`MainActivity.kt` could not be compiled offline (depends on Android framework + Compose, unavailable in the sandbox). Statically verified instead: exhaustive `when` (Sso / null / else), shared `DeepLinkTarget` import resolves, and no residual references to the removed Android-only type or `android.net.Uri` dispatch helpers anywhere in `mobile-native`.

## Built (Band B — full build)
skipped: change < 50 LOC of substantive logic; no public-API/migration/config change. Real Gradle Band-B (`:androidApp:assembleRelease`) is proxy-blocked regardless — CI's `mobile-native.yml` will run it on the PR.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity logic change — SSO token handling is unchanged, merely re-routed through the existing shared parser).

## Scope drift
None. `scope-check.sh --owner pm-mobile` → exit 0. Both touched files are under `mobile-native/` (androidApp + shared commonTest).

## Code-reuse review
None. `reuse-grep.sh --specialist kotlin-mp` → exit 0. This PR *removes* a duplicated abstraction rather than adding one.

## Notes
- Verification is honest: the Kotlin logic (shared router contract + new test) is compiled and executed offline and passes; the Android-framework compile of MainActivity itself relies on CI (`mobile-native.yml`) because AGP can't resolve through the sandbox proxy.
- iOS deep-link handling does not exist yet (`iosApp` has no `DeepLinkRouter`/`DeepLinkTarget` references), so nothing iOS-side is affected.

https://claude.ai/code/session_01R9pSLuxXXVYG2g18vyCszM

---
_Generated by [Claude Code](https://claude.ai/code/session_01R9pSLuxXXVYG2g18vyCszM)_