### PR TITLE
churn-hotspot-mobile-native-search-screen-kt: extract SearchScreen meta line into shared SearchState

### DIFF
--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/search/SearchScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/search/SearchScreen.kt
@@ -938,7 +938,7 @@ fun ListingCard(
                 )
                 Spacer(modifier = Modifier.height(6.dp))
                 Text(
-                    text = listingMeta(listing),
+                    text = SearchState.searchResultMeta(listing.rooms, listing.areaSqm),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -961,12 +961,4 @@ private fun UppercaseBadge(text: String, bg: Color, ink: Color) {
             color = ink,
         )
     }
-}
-
-private fun listingMeta(listing: ListingSummary): String {
-    val parts = buildList {
-        listing.rooms?.let { add("$it izby") }
-        listing.areaSqm?.toInt()?.let { add("$it m²") }
-    }
-    return parts.joinToString(" · ")
 }

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/SearchState.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/SearchState.kt
@@ -15,6 +15,7 @@ package three.two.bit.ppt.reality.listing
  *   to and the generation currently in effect, decide whether the response may be applied. Protects
  *   the search-as-you-type path from out-of-order completions where a slower OLDER request would
  *   otherwise clobber the results of a NEWER one.
+ * - [searchResultMeta] — the "rooms · m²" meta line shown on each result card.
  *
  * Epic 82 - Story 82.3: Reality mobile Home & Search (AC-2 debounced search, AC-4 infinite scroll +
  * FilterSheet).
@@ -121,4 +122,24 @@ object SearchState {
      */
     fun shouldApplyResponse(responseGeneration: Long, currentGeneration: Long): Boolean =
         responseGeneration == currentGeneration
+
+    /**
+     * Meta line for a search-result [ListingCard][three.two.bit.ppt.reality.ui.search.ListingCard]:
+     * room count and floor area joined with " · " (e.g. `3 izby · 84 m²`).
+     *
+     * Pure formatting extracted from the Compose card so it can be unit-tested and reused by the
+     * iOS target. Behaviour is identical to the inline helper it replaced: rooms come first (when
+     * present), then the integer-truncated area in m², and an absent dimension is simply omitted.
+     * With neither dimension present the result is the empty string.
+     *
+     * @param rooms room count, or null when unknown
+     * @param areaSqm floor area in m² (truncated to a whole number for display), or null
+     */
+    fun searchResultMeta(rooms: Int?, areaSqm: Double?): String {
+        val parts = buildList {
+            rooms?.let { add("$it izby") }
+            areaSqm?.toInt()?.let { add("$it m²") }
+        }
+        return parts.joinToString(" · ")
+    }
 }

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/SearchStateTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/SearchStateTest.kt
@@ -165,6 +165,33 @@ class SearchStateTest {
         assertFalse(SearchState.shouldApplyResponse(responseGeneration = 9, currentGeneration = 7))
     }
 
+    // ── searchResultMeta ─────────────────────────────────────────────────
+
+    @Test
+    fun searchResultMeta_roomsAndArea_joinedWithSeparator() {
+        assertEquals("3 izby · 84 m²", SearchState.searchResultMeta(rooms = 3, areaSqm = 84.0))
+    }
+
+    @Test
+    fun searchResultMeta_areaTruncatedToWholeNumber() {
+        assertEquals("2 izby · 64 m²", SearchState.searchResultMeta(rooms = 2, areaSqm = 64.9))
+    }
+
+    @Test
+    fun searchResultMeta_onlyRooms() {
+        assertEquals("1 izby", SearchState.searchResultMeta(rooms = 1, areaSqm = null))
+    }
+
+    @Test
+    fun searchResultMeta_onlyArea() {
+        assertEquals("50 m²", SearchState.searchResultMeta(rooms = null, areaSqm = 50.0))
+    }
+
+    @Test
+    fun searchResultMeta_neither_isEmpty() {
+        assertEquals("", SearchState.searchResultMeta(rooms = null, areaSqm = null))
+    }
+
     private fun summary(id: String) =
         ListingSummary(
             id = id,


### PR DESCRIPTION
## Task
Churn hotspot: mobile-native SearchScreen.kt (+1293 LOC across PR #1125 gap-82-3 reality mobile search/filters) — instability proxy. Refactor SearchScreen.kt for clarity/cohesion (extract pure helpers into the shared module where reusable, tighten state/data-fetch) WITHOUT behavior change, and/or add missing commonTest coverage for any extracted pure logic. Keep scope tight to the search screen; no broad rewrite.

## Owner
pm-mobile (specialist: kotlin-mp)

## What changed (tight scope)
The only inline pure logic left in `SearchScreen.kt` was the private `listingMeta(listing)` helper that builds the result-card meta line (`rooms · m²`). Everything else search-related already lives in the unit-tested `SearchState` (commonMain).

- Extracted that formatting into a new pure helper `SearchState.searchResultMeta(rooms: Int?, areaSqm: Double?)` in `commonMain`, so it can be unit-tested without a Compose runtime and reused by the iOS target (consistent with the existing `buildSearchRequest` / `mergePage` / `shouldApplyResponse` pattern in the same file).
- `SearchScreen.kt` now calls `SearchState.searchResultMeta(listing.rooms, listing.areaSqm)` instead of the local function; the private `listingMeta` is removed. No other change to the screen.
- Added 5 `commonTest` cases covering rooms+area, area truncation, rooms-only, area-only, and the empty case.

**Behaviour is byte-identical** to the previous inline helper (same `"$rooms izby"` / `"$area m²"` parts, same `" · "` join, same omit-when-null semantics). Verified by the assertion driver below producing `3 izby · 84 m²` etc.

### Deliberately NOT touched
`HomeScreen.kt` and `FavoritesScreen.kt` each have their own *intentionally different* `listingMeta` (Home uses pluralized string resources + a leading separator; Favorites orders area-then-rooms as `N+1` and falls back to city). Unifying those would be a behaviour change and out of scope ("keep scope tight to the search screen; no broad rewrite"), so they were left as-is.

## Tested (Band A — fast check)
Gradle/AGP full build is blocked by the sandbox proxy (documented in PRs #1155/#1156), so the smallest meaningful band was used: a standalone `kotlinc` compile of the changed shared source plus a driver replicating the test assertions.

```
# Compile the real (changed) SearchState.kt against minimal model stubs
java -cp <gradle-lib>/*.jar org.jetbrains.kotlin.cli.jvm.K2JVMCompiler \
  -no-stdlib -classpath kotlin-stdlib-2.0.21.jar -d out.jar SearchState.kt Stubs.kt Driver.kt
# compile_exit=0

# Run driver replicating SearchStateTest assertions
java -cp out.jar:kotlin-stdlib-2.0.21.jar ...DriverKt
ok   rooms+area            (3 izby · 84 m²)
ok   area truncated        (2 izby · 64 m²)
ok   only rooms            (1 izby)
ok   only area             (50 m²)
ok   neither empty         ("")
ok   blank query -> null   (regression)
ok   filter count          (regression)
ok   apply latest gen      (regression)
ok   discard stale         (regression)
ALL_PASS
# run_exit=0
```

## Built (Band B — full build)
Skipped: change is < 50 LOC, no public-API/migration/config change. Gradle `:shared:compileKotlinJvm :androidApp:assembleDebug` is unavailable in this sandbox (proxy-blocked, per #1155/#1156); the Band-A standalone compile of the changed shared source is the substitute. The unmodified `SearchState.kt` compiled cleanly with the new helper.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change — pure UI-formatting refactor). The `mobile-native.yml` Gradle job will run the real `commonTest` (incl. the 5 new cases) on PR.

## Remote-tested
Skipped (no ppt-bridge MCP).

## Scope drift
None — `scope-check.sh --owner pm-mobile` exited 0. All three touched files are under `mobile-native/`.

## Code-reuse review
None — `reuse-grep.sh --specialist kotlin-mp` produced no warnings. The new helper sits beside the existing `SearchState` helpers and removes a duplicated inline function rather than adding one.

## Notes
- MCP `push_files` truncation guard (#1014): each pushed file was read back via `get_file_contents` and verified byte-exact. `SearchScreen.kt` (42 KB) round-tripped with blob SHA `7887d596…` matching local `git hash-object` exactly — no truncation.
- Net diff: +49 / −9 across 3 files.

https://claude.ai/code/session_01R9pSLuxXXVYG2g18vyCszM

---
_Generated by [Claude Code](https://claude.ai/code/session_01R9pSLuxXXVYG2g18vyCszM)_