### PR TITLE
feat-admin-web-oauth-consent-page: OAuth consent page UI in admin-web

### DIFF
--- a/frontend/apps/admin-web/messages/cs.json
+++ b/frontend/apps/admin-web/messages/cs.json
@@ -141,6 +141,17 @@
         "secretRegeneratedTitle": "Tajemství obnoveno"
       }
     },
+    "oauthConsent": {
+      "title": "Autorizovat aplikaci",
+      "lead": "{{app}} žádá o přístup k vašemu účtu.",
+      "approve": "Schválit",
+      "deny": "Zamítnout",
+      "loading": "Ověřování požadavku…",
+      "redirectNotice": "Budete přesměrováni na {{uri}}",
+      "invalidRequest": "Tento autorizační požadavek je neplatný nebo neúplný.",
+      "loadError": "Autorizační požadavek nelze ověřit: {{message}}",
+      "submitError": "Autorizaci nelze dokončit: {{message}}"
+    },
     "onboarding": {
       "title": "Onboarding prohlídky",
       "subtitle": "Prohlížejte a spravujte krok-za-krokem onboarding prohlídky pro uživatele platformy.",

--- a/frontend/apps/admin-web/messages/en.json
+++ b/frontend/apps/admin-web/messages/en.json
@@ -163,6 +163,17 @@
         "secretRegeneratedTitle": "Secret regenerated"
       }
     },
+    "oauthConsent": {
+      "title": "Authorize application",
+      "lead": "{{app}} is requesting access to your account.",
+      "approve": "Approve",
+      "deny": "Deny",
+      "loading": "Validating request…",
+      "redirectNotice": "You will be redirected to {{uri}}",
+      "invalidRequest": "This authorization request is invalid or incomplete.",
+      "loadError": "Could not validate the authorization request: {{message}}",
+      "submitError": "Could not complete authorization: {{message}}"
+    },
     "onboarding": {
       "title": "Onboarding Tours",
       "subtitle": "Preview and manage step-by-step onboarding tours for platform users.",

--- a/frontend/apps/admin-web/messages/sk.json
+++ b/frontend/apps/admin-web/messages/sk.json
@@ -49,7 +49,7 @@
       },
       "loading": "Načítava sa…",
       "pagination": {
-        "next": "Ďalšie",
+        "next": "ċalšie",
         "page": "Strana {{page}}",
         "previous": "Predchádzajúce",
         "showing": "Zobrazujú sa {{from}}–{{to}} z {{total}}"
@@ -82,7 +82,7 @@
       "fields": {
         "aiFaultTriage": "AI triedenie porúch (beta)",
         "buildingDisabled": "Vypnúť túto budovu (núdzový vypínač)",
-        "newListingsSearch": "Nové vyhľadávanie inzerátov (beta)"
+        "newListingsSearch": "Nové vyhĺdávanie inzerátov (beta)"
       },
       "helpTooltip": "Funkčné príznaky sa prejavia okamžite pre všetkých používateľov daného nájomníka. Núdzový vypínač používajte opatrne.",
       "title": "Funkčné príznaky",
@@ -141,6 +141,17 @@
         "secretRegeneratedTitle": "Tajomstvo obnovené"
       }
     },
+    "oauthConsent": {
+      "title": "Autorizovať aplikáciu",
+      "lead": "{{app}} žiada o prístup k vášmu účtu.",
+      "approve": "Schváliť",
+      "deny": "Zamietnuť",
+      "loading": "Overovanie požiadavky…",
+      "redirectNotice": "Budete presmerovaní na {{uri}}",
+      "invalidRequest": "Táto autorizačná požiadavka je neplatná alebo neúplná.",
+      "loadError": "Autorizačnú požiadavku nebolo možné overiť: {{message}}",
+      "submitError": "Autorizáciu nebolo možné dokončiť: {{message}}"
+    },
     "onboarding": {
       "title": "Onboarding prehliadky",
       "subtitle": "Prezerajte a spravujte postupné onboarding prehliadky pre používateľov platformy.",
@@ -194,7 +205,7 @@
       "columns": {
         "displayName": "Zobrazované meno",
         "email": "E-mail",
-        "principalKind": "Typ principála"
+        "principalKind": "Typ principala"
       },
       "empty": "Hľadajte pre načítanie používateľov.",
       "principalKinds": {
@@ -209,7 +220,7 @@
         "cancel": "Zrušiť",
         "confirm": "Zmeniť typ",
         "description": "Toto zmení spôsob autentifikácie {{name}} a oprávnenia, ktoré majú. Pokračovať?",
-        "title": "Zmeniť typ principála"
+        "title": "Zmeniť typ principala"
       }
     }
   },
@@ -237,11 +248,11 @@
     "loadingDispute": "Načítava sa spor...",
     "login": "Prihlásiť sa",
     "logout": "Odhlásiť sa",
-    "next": "Ďalej",
+    "next": "ċalej",
     "no": "Nie",
     "none": "Žiadne",
     "notifications": "Oznámenia",
-    "optional": "Voliteľné",
+    "optional": "Volitelné",
     "pleaseWait": "Počkajte, kým načítame údaje.",
     "previous": "Predchádzajúce",
     "reloadPage": "Obnoviť stránku",

--- a/frontend/apps/admin-web/messages/sk.json
+++ b/frontend/apps/admin-web/messages/sk.json
@@ -49,7 +49,7 @@
       },
       "loading": "Načítava sa…",
       "pagination": {
-        "next": "ċalšie",
+        "next": "Ďalšie",
         "page": "Strana {{page}}",
         "previous": "Predchádzajúce",
         "showing": "Zobrazujú sa {{from}}–{{to}} z {{total}}"
@@ -82,7 +82,7 @@
       "fields": {
         "aiFaultTriage": "AI triedenie porúch (beta)",
         "buildingDisabled": "Vypnúť túto budovu (núdzový vypínač)",
-        "newListingsSearch": "Nové vyhĺdávanie inzerátov (beta)"
+        "newListingsSearch": "Nové vyhľadávanie inzerátov (beta)"
       },
       "helpTooltip": "Funkčné príznaky sa prejavia okamžite pre všetkých používateľov daného nájomníka. Núdzový vypínač používajte opatrne.",
       "title": "Funkčné príznaky",
@@ -205,7 +205,7 @@
       "columns": {
         "displayName": "Zobrazované meno",
         "email": "E-mail",
-        "principalKind": "Typ principala"
+        "principalKind": "Typ principála"
       },
       "empty": "Hľadajte pre načítanie používateľov.",
       "principalKinds": {
@@ -220,7 +220,7 @@
         "cancel": "Zrušiť",
         "confirm": "Zmeniť typ",
         "description": "Toto zmení spôsob autentifikácie {{name}} a oprávnenia, ktoré majú. Pokračovať?",
-        "title": "Zmeniť typ principala"
+        "title": "Zmeniť typ principála"
       }
     }
   },
@@ -248,11 +248,11 @@
     "loadingDispute": "Načítava sa spor...",
     "login": "Prihlásiť sa",
     "logout": "Odhlásiť sa",
-    "next": "ċalej",
+    "next": "Ďalej",
     "no": "Nie",
     "none": "Žiadne",
     "notifications": "Oznámenia",
-    "optional": "Volitelné",
+    "optional": "Voliteľné",
     "pleaseWait": "Počkajte, kým načítame údaje.",
     "previous": "Predchádzajúce",
     "reloadPage": "Obnoviť stránku",

--- a/frontend/apps/admin-web/src/App.tsx
+++ b/frontend/apps/admin-web/src/App.tsx
@@ -21,6 +21,7 @@ import { LoginPage } from './pages/LoginPage';
 import MembershipsPage from './pages/MembershipsPage';
 import MobileConfigPage from './pages/MobileConfigPage';
 import OAuthClientsPage from './pages/OAuthClientsPage';
+import OAuthConsentPage from './pages/OAuthConsentPage';
 import OnboardingToursPage from './pages/OnboardingToursPage';
 import PlatformHealthPage from './pages/PlatformHealthPage';
 import PlatformPage from './pages/platform';
@@ -56,6 +57,10 @@ export function App() {
             <ImpersonationWrapper />
             <Routes>
               <Route path="/login" element={<LoginPage />} />
+              {/* OAuth 2.0 consent screen — standalone (no admin chrome). Auth
+                  is enforced inside the page (Bearer token required), but no
+                  capability gate: it is a per-user authorization decision. */}
+              <Route path="/oauth/authorize" element={<OAuthConsentPage />} />
               <Route
                 element={
                   <ProtectedRoute>

--- a/frontend/apps/admin-web/src/pages/OAuthConsentPage.tsx
+++ b/frontend/apps/admin-web/src/pages/OAuthConsentPage.tsx
@@ -1,0 +1,269 @@
+/**
+ * OAuthConsentPage — `/oauth/authorize`
+ *
+ * The OAuth 2.0 authorization-code consent screen (Epic 10A). A third-party
+ * client redirects the user here with the standard authorize query params
+ * (`response_type`, `client_id`, `redirect_uri`, `scope`, `state`,
+ * `code_challenge`, `code_challenge_method`). We validate the request against
+ * the backend, show the requesting app + the scopes it wants, and let the user
+ * Approve or Deny.
+ *
+ * Wired to (reusing the shared `@ppt/api-client` OAuth consent client/types):
+ *   GET  /api/v1/oauth/authorize — validate request, fetch consent page data
+ *   POST /api/v1/oauth/authorize — submit the approve/deny decision
+ *
+ * On Approve the backend returns an authorization `code` + echoed `state`,
+ * which we hand back to the client by redirecting to its `redirect_uri`.
+ * On Deny (per RFC 6749 §4.1.2.1) we redirect back with `error=access_denied`.
+ *
+ * Standalone route — rendered outside the AdminLayout chrome. It requires an
+ * authenticated session (the consent endpoints need a Bearer token) but not a
+ * specific capability: it is a per-user authorization decision, not a
+ * platform-admin action.
+ */
+
+import { type AuthorizeRequestParams, useConsentPageData, useSubmitConsent } from '@ppt/api-client';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Navigate, useLocation, useSearchParams } from 'react-router-dom';
+
+import { useAdminAuth } from '../auth/AdminAuthContext';
+
+// ============================================================
+// Inline styles (injected once) — matches the OAuthClientsPage idiom
+// ============================================================
+
+const STYLE_ID = 'ppt-oauth-consent-styles';
+
+function ensureStyles() {
+  if (typeof document === 'undefined') return;
+  if (document.getElementById(STYLE_ID)) return;
+  const el = document.createElement('style');
+  el.id = STYLE_ID;
+  el.textContent = `
+    .ppt-ocs-wrap {
+      min-height: 100vh; display: flex; align-items: center; justify-content: center;
+      padding: 24px; background: var(--ppt-bg-app,#f9fafb); box-sizing: border-box;
+    }
+    .ppt-ocs-card {
+      max-width: 440px; width: 100%;
+      background: var(--ppt-bg-surface,#fff);
+      border: 1px solid var(--ppt-border-default,#e5e7eb);
+      border-radius: 14px; padding: 32px 30px 26px;
+      box-shadow: 0 8px 32px rgba(0,0,0,0.08);
+      display: flex; flex-direction: column; gap: 18px;
+    }
+    .ppt-ocs-app { display: flex; flex-direction: column; gap: 4px; text-align: center; }
+    .ppt-ocs-app-name { font-size: 19px; font-weight: 700; color: var(--ppt-fg-primary,#111827); margin: 0; }
+    .ppt-ocs-app-desc { font-size: 13px; color: var(--ppt-fg-secondary,#6b7280); margin: 0; }
+    .ppt-ocs-lead { font-size: 14px; color: var(--ppt-fg-secondary,#374151); margin: 0; text-align: center; }
+    .ppt-ocs-scopes { display: flex; flex-direction: column; gap: 10px; margin: 0; padding: 0; list-style: none; }
+    .ppt-ocs-scope {
+      display: flex; gap: 10px; align-items: flex-start;
+      border: 1px solid var(--ppt-border-default,#e5e7eb); border-radius: 9px;
+      padding: 11px 13px; background: var(--ppt-bg-subtle,#f9fafb);
+    }
+    .ppt-ocs-scope-check { color: var(--ppt-brand-600,#2563eb); font-weight: 700; line-height: 1.3; flex-shrink: 0; }
+    .ppt-ocs-scope-body { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+    .ppt-ocs-scope-name { font-family: var(--ppt-font-mono,monospace); font-size: 12px; font-weight: 600; color: var(--ppt-fg-primary,#111827); }
+    .ppt-ocs-scope-desc { font-size: 12px; color: var(--ppt-fg-secondary,#6b7280); }
+    .ppt-ocs-redirect { font-size: 11px; color: var(--ppt-fg-muted,#9ca3af); text-align: center; word-break: break-all; margin: 0; }
+    .ppt-ocs-actions { display: flex; gap: 10px; margin-top: 4px; }
+    .ppt-ocs-btn {
+      flex: 1; display: inline-flex; align-items: center; justify-content: center; gap: 7px;
+      padding: 10px 14px; border-radius: 8px; font-size: 14px; font-weight: 600;
+      cursor: pointer; border: 1px solid transparent; transition: background 120ms ease;
+    }
+    .ppt-ocs-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+    .ppt-ocs-btn--approve { background: var(--ppt-brand-500,#3b82f6); color: #fff; border-color: var(--ppt-brand-500,#3b82f6); }
+    .ppt-ocs-btn--approve:hover:not(:disabled) { background: var(--ppt-brand-600,#2563eb); }
+    .ppt-ocs-btn--deny { background: transparent; color: var(--ppt-fg-secondary,#374151); border-color: var(--ppt-border-default,#e5e7eb); }
+    .ppt-ocs-btn--deny:hover:not(:disabled) { background: var(--ppt-bg-hover,#f3f4f6); }
+    .ppt-ocs-status { text-align: center; font-size: 14px; color: var(--ppt-fg-secondary,#6b7280); padding: 12px 0; }
+    .ppt-ocs-error {
+      font-size: 13px; color: var(--ppt-danger-700,#b91c1c);
+      background: #fee2e2; border: 1px solid #fecaca; border-radius: 8px; padding: 11px 13px;
+    }
+    .ppt-ocs-spinner {
+      width: 15px; height: 15px; border: 2px solid rgba(255,255,255,0.4);
+      border-top-color: #fff; border-radius: 50%;
+      animation: ppt-ocs-spin 0.7s linear infinite; display: inline-block;
+    }
+    @keyframes ppt-ocs-spin { to { transform: rotate(360deg); } }
+  `;
+  document.head.appendChild(el);
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+
+/**
+ * Append query params to a URI string, preserving any the URI already carries.
+ * Falls back to plain string concatenation if the URI is not absolute (the
+ * backend has already validated `redirect_uri` against the client, so this is
+ * defensive rather than a security boundary).
+ */
+function appendParams(uri: string, params: Record<string, string>): string {
+  try {
+    const url = new URL(uri);
+    for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+    return url.toString();
+  } catch {
+    const qs = new URLSearchParams(params).toString();
+    return uri.includes('?') ? `${uri}&${qs}` : `${uri}?${qs}`;
+  }
+}
+
+// ============================================================
+// OAuthConsentPage
+// ============================================================
+
+export default function OAuthConsentPage() {
+  ensureStyles();
+  const { t } = useTranslation();
+  const { isAuthenticated } = useAdminAuth();
+  const location = useLocation();
+  const [searchParams] = useSearchParams();
+
+  // Parse the inbound authorize request from the query string. Memoised so the
+  // query-key and the enabled-gate in useConsentPageData stay stable across
+  // renders (a fresh object every render would thrash TanStack Query).
+  const params = useMemo<AuthorizeRequestParams>(
+    () => ({
+      responseType: searchParams.get('response_type') ?? '',
+      clientId: searchParams.get('client_id') ?? '',
+      redirectUri: searchParams.get('redirect_uri') ?? '',
+      scope: searchParams.get('scope') ?? undefined,
+      state: searchParams.get('state') ?? undefined,
+      codeChallenge: searchParams.get('code_challenge') ?? undefined,
+      codeChallengeMethod: searchParams.get('code_challenge_method') ?? undefined,
+    }),
+    [searchParams]
+  );
+
+  const hasRequiredParams =
+    params.responseType.length > 0 && params.clientId.length > 0 && params.redirectUri.length > 0;
+
+  const consentQuery = useConsentPageData(hasRequiredParams ? params : null);
+  const submitMutation = useSubmitConsent(params);
+
+  // Must be signed in for the consent endpoints (they require a Bearer token).
+  // Preserve the full authorize URL so the user lands back here post-login.
+  if (!isAuthenticated) {
+    return (
+      <Navigate to="/login" state={{ from: `${location.pathname}${location.search}` }} replace />
+    );
+  }
+
+  async function handleDecision(decision: 'approve' | 'deny') {
+    if (decision === 'deny') {
+      // RFC 6749 §4.1.2.1 — bounce back to the client with an error code.
+      const errParams: Record<string, string> = { error: 'access_denied' };
+      if (params.state) errParams.state = params.state;
+      window.location.assign(appendParams(params.redirectUri, errParams));
+      return;
+    }
+    try {
+      const res = await submitMutation.mutateAsync('approve');
+      const okParams: Record<string, string> = { code: res.code };
+      if (res.state) okParams.state = res.state;
+      window.location.assign(appendParams(params.redirectUri, okParams));
+    } catch {
+      // Error surfaced inline below via submitMutation.error.
+    }
+  }
+
+  let body: React.ReactNode;
+
+  if (!hasRequiredParams) {
+    body = (
+      <div className="ppt-ocs-error" role="alert">
+        {t('admin.oauthConsent.invalidRequest')}
+      </div>
+    );
+  } else if (consentQuery.isLoading) {
+    body = <div className="ppt-ocs-status">{t('admin.oauthConsent.loading')}</div>;
+  } else if (consentQuery.isError) {
+    body = (
+      <div className="ppt-ocs-error" role="alert">
+        {t('admin.oauthConsent.loadError', {
+          message:
+            consentQuery.error instanceof Error
+              ? consentQuery.error.message
+              : String(consentQuery.error),
+        })}
+      </div>
+    );
+  } else if (consentQuery.data) {
+    const data = consentQuery.data;
+    const submitting = submitMutation.isPending;
+    body = (
+      <>
+        <div className="ppt-ocs-app">
+          <p className="ppt-ocs-app-name">{data.clientName}</p>
+          {data.clientDescription && <p className="ppt-ocs-app-desc">{data.clientDescription}</p>}
+        </div>
+        <p className="ppt-ocs-lead">{t('admin.oauthConsent.lead', { app: data.clientName })}</p>
+        {data.scopes.length > 0 && (
+          <ul className="ppt-ocs-scopes">
+            {data.scopes.map((scope) => (
+              <li key={scope.name} className="ppt-ocs-scope">
+                <span className="ppt-ocs-scope-check" aria-hidden="true">
+                  &#x2713;
+                </span>
+                <span className="ppt-ocs-scope-body">
+                  <span className="ppt-ocs-scope-name">{scope.name}</span>
+                  <span className="ppt-ocs-scope-desc">{scope.description}</span>
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+        <p className="ppt-ocs-redirect">
+          {t('admin.oauthConsent.redirectNotice', { uri: data.redirectUri })}
+        </p>
+        {submitMutation.isError && (
+          <div className="ppt-ocs-error" role="alert">
+            {t('admin.oauthConsent.submitError', {
+              message:
+                submitMutation.error instanceof Error
+                  ? submitMutation.error.message
+                  : String(submitMutation.error),
+            })}
+          </div>
+        )}
+        <div className="ppt-ocs-actions">
+          <button
+            type="button"
+            className="ppt-ocs-btn ppt-ocs-btn--deny"
+            onClick={() => void handleDecision('deny')}
+            disabled={submitting}
+          >
+            {t('admin.oauthConsent.deny')}
+          </button>
+          <button
+            type="button"
+            className="ppt-ocs-btn ppt-ocs-btn--approve"
+            onClick={() => void handleDecision('approve')}
+            disabled={submitting}
+          >
+            {submitting && <span className="ppt-ocs-spinner" aria-hidden="true" />}
+            {t('admin.oauthConsent.approve')}
+          </button>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <div className="ppt-ocs-wrap">
+      <main className="ppt-ocs-card" aria-labelledby="ppt-ocs-title">
+        <h1 id="ppt-ocs-title" className="ppt-ocs-app-name" style={{ fontSize: 16 }}>
+          {t('admin.oauthConsent.title')}
+        </h1>
+        {body}
+      </main>
+    </div>
+  );
+}

--- a/frontend/packages/api-client/src/index.ts
+++ b/frontend/packages/api-client/src/index.ts
@@ -35,6 +35,7 @@ export * from './migration';
 export * from './neighbors';
 export * from './news';
 export * from './notification-preferences';
+export * from './oauth-consent';
 export * from './oauth-grants';
 export * from './onboarding';
 export * from './outages';

--- a/frontend/packages/api-client/src/oauth-consent/api.test.ts
+++ b/frontend/packages/api-client/src/oauth-consent/api.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for the OAuth consent API client (Epic 10A).
+ *
+ * Pins the request shaping that the backend's `AuthorizeQuery` / `ConsentForm`
+ * extractors require:
+ *   - GET sends snake_case query params and omits unset optionals.
+ *   - POST is application/x-www-form-urlencoded (NOT the default JSON), carries
+ *     the `consent` decision, and round-trips PKCE + state.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearTokenProvider, setTokenProvider } from '../auth/token-provider';
+import { setMfaChallengeHandler } from '../lib/mfa-handler';
+import { fetchConsentPageData, submitConsent } from './api';
+import type { AuthorizeRequestParams } from './types';
+
+function mockOkResponse(body: unknown, status = 200): Response {
+  return { ok: true, status, json: async () => body } as Response;
+}
+
+const baseParams: AuthorizeRequestParams = {
+  responseType: 'code',
+  clientId: 'client-abc',
+  redirectUri: 'https://app.example.com/cb',
+  scope: 'profile email',
+  state: 'xyz',
+  codeChallenge: 'chal',
+  codeChallengeMethod: 'S256',
+};
+
+describe('oauth-consent api', () => {
+  beforeEach(() => {
+    setTokenProvider(() => 'test-token');
+    setMfaChallengeHandler(null);
+    vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    clearTokenProvider();
+    setMfaChallengeHandler(null);
+    vi.restoreAllMocks();
+  });
+
+  it('fetchConsentPageData GETs with snake_case query params', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      mockOkResponse({
+        clientId: 'client-abc',
+        clientName: 'Example App',
+        clientDescription: null,
+        scopes: [{ name: 'profile', description: 'Your profile' }],
+        redirectUri: 'https://app.example.com/cb',
+        state: 'xyz',
+      })
+    );
+
+    const data = await fetchConsentPageData(baseParams);
+    expect(data.clientName).toBe('Example App');
+
+    const [url, init] = vi.mocked(fetch).mock.calls[0];
+    expect(init?.method).toBe('GET');
+    const parsed = new URL(String(url), 'http://localhost');
+    expect(parsed.searchParams.get('response_type')).toBe('code');
+    expect(parsed.searchParams.get('client_id')).toBe('client-abc');
+    expect(parsed.searchParams.get('redirect_uri')).toBe('https://app.example.com/cb');
+    expect(parsed.searchParams.get('scope')).toBe('profile email');
+    expect(parsed.searchParams.get('code_challenge')).toBe('chal');
+    expect(parsed.searchParams.get('code_challenge_method')).toBe('S256');
+  });
+
+  it('fetchConsentPageData omits unset optional params from the query', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(mockOkResponse({}));
+    await fetchConsentPageData({
+      responseType: 'code',
+      clientId: 'c',
+      redirectUri: 'https://x/cb',
+    });
+    const [url] = vi.mocked(fetch).mock.calls[0];
+    const parsed = new URL(String(url), 'http://localhost');
+    expect(parsed.searchParams.has('scope')).toBe(false);
+    expect(parsed.searchParams.has('state')).toBe(false);
+    expect(parsed.searchParams.has('code_challenge')).toBe(false);
+  });
+
+  it('submitConsent POSTs as form-urlencoded with the decision', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(mockOkResponse({ code: 'auth-code', state: 'xyz' }));
+
+    const res = await submitConsent(baseParams, 'approve');
+    expect(res.code).toBe('auth-code');
+
+    const [, init] = vi.mocked(fetch).mock.calls[0];
+    expect(init?.method).toBe('POST');
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    expect(headers['Content-Type']).toBe('application/x-www-form-urlencoded');
+
+    const body = new URLSearchParams(String(init?.body));
+    expect(body.get('client_id')).toBe('client-abc');
+    expect(body.get('redirect_uri')).toBe('https://app.example.com/cb');
+    expect(body.get('scope')).toBe('profile email');
+    expect(body.get('state')).toBe('xyz');
+    expect(body.get('code_challenge')).toBe('chal');
+    expect(body.get('consent')).toBe('approve');
+  });
+
+  it('submitConsent sends consent=deny on a deny decision', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(mockOkResponse({ code: '', state: null }));
+    await submitConsent(baseParams, 'deny');
+    const [, init] = vi.mocked(fetch).mock.calls[0];
+    const body = new URLSearchParams(String(init?.body));
+    expect(body.get('consent')).toBe('deny');
+  });
+});

--- a/frontend/packages/api-client/src/oauth-consent/api.ts
+++ b/frontend/packages/api-client/src/oauth-consent/api.ts
@@ -1,0 +1,94 @@
+/**
+ * OAuth Consent (Authorization Endpoint) API Client
+ *
+ * API functions backing the OAuth 2.0 authorization-code consent screen
+ * (Epic 10A). Wires to the public authorization endpoint on api-server:
+ *
+ *   GET  /api/v1/oauth/authorize — validate request, return consent page data
+ *   POST /api/v1/oauth/authorize — submit the user's approve/deny decision
+ *
+ * Both endpoints require a valid Bearer token (the user's session); that is
+ * attached automatically by `authenticatedFetchJson` via the registered token
+ * provider, so the consent screen reuses the same auth plumbing as the rest of
+ * the client rather than re-implementing header logic (issue #486).
+ *
+ * The GET response is JSON. The POST mirrors the backend's `Form<ConsentForm>`
+ * extractor, so it is sent as `application/x-www-form-urlencoded`.
+ */
+
+import { authenticatedFetchJson } from '../lib/fetch';
+import type {
+  AuthorizeRequestParams,
+  AuthorizeResponse,
+  ConsentDecision,
+  ConsentPageData,
+} from './types';
+
+const _win = typeof window !== 'undefined' ? (window as unknown as Record<string, unknown>) : {};
+const API_BASE = `${_win.__API_BASE_URL__ ? String(_win.__API_BASE_URL__) : ''}/api/v1/oauth/authorize`;
+
+/**
+ * Build the query string for the authorize GET, omitting unset optionals.
+ * Field names map to the backend's snake_case `AuthorizeQuery` extractor.
+ */
+function buildAuthorizeQuery(params: AuthorizeRequestParams): string {
+  const qs = new URLSearchParams();
+  qs.set('response_type', params.responseType);
+  qs.set('client_id', params.clientId);
+  qs.set('redirect_uri', params.redirectUri);
+  if (params.scope) qs.set('scope', params.scope);
+  if (params.state) qs.set('state', params.state);
+  if (params.codeChallenge) qs.set('code_challenge', params.codeChallenge);
+  if (params.codeChallengeMethod) qs.set('code_challenge_method', params.codeChallengeMethod);
+  return qs.toString();
+}
+
+/**
+ * Validate an incoming authorization request and fetch the data needed to
+ * render the consent screen (client name, description, requested scopes).
+ *
+ * GET /api/v1/oauth/authorize
+ *
+ * Throws if the request is invalid (unknown client, bad redirect URI, missing
+ * PKCE challenge, etc.) so the caller can show an error instead of a form.
+ */
+export async function fetchConsentPageData(
+  params: AuthorizeRequestParams,
+  signal?: AbortSignal
+): Promise<ConsentPageData> {
+  return authenticatedFetchJson<ConsentPageData>(`${API_BASE}?${buildAuthorizeQuery(params)}`, {
+    method: 'GET',
+    signal,
+  });
+}
+
+/**
+ * Submit the user's consent decision.
+ *
+ * POST /api/v1/oauth/authorize (application/x-www-form-urlencoded)
+ *
+ * On `approve` the server returns an authorization `code` (and echoes the
+ * `state`) which the caller redirects back to the client. On `deny` the server
+ * responds 403 and this function throws — the caller should redirect back with
+ * an `error=access_denied` instead.
+ */
+export async function submitConsent(
+  params: AuthorizeRequestParams,
+  decision: ConsentDecision
+): Promise<AuthorizeResponse> {
+  const body = new URLSearchParams();
+  body.set('client_id', params.clientId);
+  body.set('redirect_uri', params.redirectUri);
+  body.set('scope', params.scope ?? '');
+  if (params.state) body.set('state', params.state);
+  if (params.codeChallenge) body.set('code_challenge', params.codeChallenge);
+  if (params.codeChallengeMethod) body.set('code_challenge_method', params.codeChallengeMethod);
+  body.set('consent', decision);
+
+  return authenticatedFetchJson<AuthorizeResponse>(API_BASE, {
+    method: 'POST',
+    // Override the default application/json — the backend uses a Form extractor.
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+}

--- a/frontend/packages/api-client/src/oauth-consent/hooks.ts
+++ b/frontend/packages/api-client/src/oauth-consent/hooks.ts
@@ -1,0 +1,71 @@
+/**
+ * OAuth Consent TanStack Query Hooks
+ *
+ * React hooks backing the OAuth 2.0 authorization-code consent screen
+ * (Epic 10A). One query (validate request + load consent data) and one
+ * mutation (submit approve/deny).
+ */
+
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { fetchConsentPageData, submitConsent } from './api';
+import type { AuthorizeRequestParams, ConsentDecision } from './types';
+
+// ============================================
+// Query Key Factory
+// ============================================
+
+export const oauthConsentKeys = {
+  all: ['oauth-consent'] as const,
+  /** Keyed by client + redirect + scope so distinct requests don't collide. */
+  consentData: (params: AuthorizeRequestParams) =>
+    [
+      ...oauthConsentKeys.all,
+      'data',
+      params.clientId,
+      params.redirectUri,
+      params.scope ?? '',
+    ] as const,
+};
+
+// ============================================
+// Hooks
+// ============================================
+
+/**
+ * Validate an incoming authorization request and load the consent screen
+ * data. Disabled until the minimum required params (response_type, client_id,
+ * redirect_uri) are present, so the hook never fires on a malformed redirect.
+ *
+ * The consent screen is a one-shot interaction — there is no staleness window
+ * worth keeping, so the result is not cached across navigations.
+ */
+export function useConsentPageData(params: AuthorizeRequestParams | null) {
+  return useQuery({
+    queryKey: params
+      ? oauthConsentKeys.consentData(params)
+      : [...oauthConsentKeys.all, 'data', 'disabled'],
+    queryFn: ({ signal }) => fetchConsentPageData(params as AuthorizeRequestParams, signal),
+    enabled:
+      params !== null &&
+      params.responseType.length > 0 &&
+      params.clientId.length > 0 &&
+      params.redirectUri.length > 0,
+    retry: false,
+    staleTime: 0,
+    gcTime: 0,
+  });
+}
+
+/**
+ * Submit the user's consent decision (approve/deny).
+ *
+ * On `approve` the mutation resolves with the authorization code + state for
+ * the caller to redirect back to the client. On `deny` (or any error) it
+ * rejects, and the caller decides how to redirect.
+ */
+export function useSubmitConsent(params: AuthorizeRequestParams | null) {
+  return useMutation({
+    mutationFn: (decision: ConsentDecision) =>
+      submitConsent(params as AuthorizeRequestParams, decision),
+  });
+}

--- a/frontend/packages/api-client/src/oauth-consent/index.ts
+++ b/frontend/packages/api-client/src/oauth-consent/index.ts
@@ -1,0 +1,21 @@
+/**
+ * OAuth Consent Module
+ *
+ * API functions, hooks, and types for the OAuth 2.0 authorization-code consent
+ * screen (Epic 10A). Backs the `/api/v1/oauth/authorize` endpoint pair:
+ *   GET  /api/v1/oauth/authorize — validate request, return consent page data
+ *   POST /api/v1/oauth/authorize — submit the user's approve/deny decision
+ *
+ * Distinct from `oauth-grants` (managing already-approved apps) and the admin
+ * `oauth-clients` surface (registering clients).
+ */
+
+export { fetchConsentPageData, submitConsent } from './api';
+export { oauthConsentKeys, useConsentPageData, useSubmitConsent } from './hooks';
+export type {
+  AuthorizeRequestParams,
+  AuthorizeResponse,
+  ConsentDecision,
+  ConsentPageData,
+  ScopeDisplay,
+} from './types';

--- a/frontend/packages/api-client/src/oauth-consent/types.ts
+++ b/frontend/packages/api-client/src/oauth-consent/types.ts
@@ -1,0 +1,76 @@
+/**
+ * OAuth Consent (Authorization Endpoint) Types
+ *
+ * Types for the OAuth 2.0 authorization-code consent flow (Epic 10A).
+ * Mirror the `ConsentPageData` / `ScopeDisplay` / `AuthorizeResponse` Rust
+ * structs in `db/models/oauth.rs` and `routes/oauth.rs` on api-server.
+ *
+ * These back the consent screen the user sees when a third-party application
+ * redirects them to `/api/v1/oauth/authorize`. The admin Control Plane renders
+ * this screen for its own (platform-principal) sessions.
+ */
+
+/**
+ * A single requested scope, with a human-readable description for display
+ * on the consent screen. Corresponds to `ScopeDisplay` in the backend.
+ */
+export interface ScopeDisplay {
+  /** Machine scope name, e.g. `profile` or `read:buildings`. */
+  name: string;
+  /** Human-readable description shown next to the scope. */
+  description: string;
+}
+
+/**
+ * Everything the consent screen needs to render an authorization request.
+ * Corresponds to `ConsentPageData` (camelCase) in the backend.
+ */
+export interface ConsentPageData {
+  /** OAuth client identifier string. */
+  clientId: string;
+  /** Human-readable application name. */
+  clientName: string;
+  /** Optional developer-supplied description. */
+  clientDescription: string | null;
+  /** Scopes the application is requesting, with descriptions. */
+  scopes: ScopeDisplay[];
+  /** Validated redirect URI the code will be returned to. */
+  redirectUri: string;
+  /** Opaque CSRF state value echoed back to the client, if supplied. */
+  state: string | null;
+}
+
+/**
+ * The raw authorization-request parameters, as received on the inbound
+ * redirect query string from the third-party client. These are passed
+ * straight through to the backend (GET to validate, POST to approve/deny).
+ */
+export interface AuthorizeRequestParams {
+  /** Must be `code` for the authorization-code flow. */
+  responseType: string;
+  clientId: string;
+  redirectUri: string;
+  /** Space-separated scope list, if any. */
+  scope?: string;
+  /** Opaque CSRF state value. */
+  state?: string;
+  /** PKCE code challenge. */
+  codeChallenge?: string;
+  /** PKCE code-challenge method (e.g. `S256`). */
+  codeChallengeMethod?: string;
+}
+
+/**
+ * Result of approving a consent request. Corresponds to `AuthorizeResponse`
+ * (camelCase) in the backend — the authorization code to hand back to the
+ * client (via its redirect URI) along with the echoed `state`.
+ */
+export interface AuthorizeResponse {
+  /** The freshly minted authorization code. */
+  code: string;
+  /** Echoed CSRF state value, if one was supplied. */
+  state: string | null;
+}
+
+/** Whether the user approved or denied the authorization request. */
+export type ConsentDecision = 'approve' | 'deny';


### PR DESCRIPTION
## Task
Coverage 10a-1: add the OAuth admin consent page UI to admin-web (currently only reality-web has the callback). Frontend admin-web; reuse existing OAuth client/types.

## Owner
pm-frontend (specialist: react-web)

## What changed
- **New `@ppt/api-client` module `oauth-consent`** — types (`ConsentPageData`, `ScopeDisplay`, `AuthorizeRequestParams`, `AuthorizeResponse`, `ConsentDecision`), api (`fetchConsentPageData`, `submitConsent`), and TanStack hooks (`useConsentPageData`, `useSubmitConsent`). Mirrors the backend `ConsentPageData` / `ConsentForm` contracts (`db/models/oauth.rs`, `routes/oauth.rs`). Reuses the shared `authenticatedFetchJson` plumbing (bearer token + MFA retry) rather than re-implementing header logic. The consent POST is sent as `application/x-www-form-urlencoded` to match the backend's `Form<ConsentForm>` extractor; the GET sends snake_case query params.
- **New `OAuthConsentPage` in admin-web** at route `/oauth/authorize` — reads the inbound authorize query params, validates via the backend, renders the requesting app + requested scopes, and lets the user Approve/Deny. On approve it redirects back to the client's `redirect_uri` with `code`+`state`; on deny it redirects with `error=access_denied` (RFC 6749 §4.1.2.1). Standalone route (no admin chrome); auth-gated on session (the endpoints require a bearer token) but with no capability gate, since consent is a per-user authorization decision.
- **i18n** strings (`admin.oauthConsent.*`) added for en / sk / cs.

### Note on scope vs existing OAuth surface
`oauth-grants` (manage already-approved apps) and the admin `oauth-clients` page (register/manage clients) already existed; neither implemented the **authorize/consent** screen. reality-web's `auth/callback` is the SSO callback, not the OAuth authorization endpoint. This PR fills that gap on admin-web, the only PPT web app whose users are platform principals.

## Tested (Band A — fast check)
- `pnpm -F @ppt/admin-web typecheck` — exit 0
- `pnpm exec biome check <changed files>` — exit 0 (autofix applied to OAuthConsentPage.tsx, then clean)
- `pnpm -F @ppt/api-client exec vitest run oauth-consent` — 4 passed (request-shaping: snake_case query, form-urlencoded POST, consent decision)

## Built (Band B — full build)
- `pnpm -F @ppt/api-client build` (tsc) — exit 0
- `pnpm -F @ppt/admin-web build` (tsc && vite build) — exit 0 (pre-existing chunk-size warning only)
- `pnpm -F @ppt/api-client exec vitest run` — 70 passed
- `pnpm -F @ppt/admin-web exec vitest run` — 182 passed, 1 failed (`CapabilitiesAdminPage > renders all 17 capability cards`). Confirmed pre-existing on `origin/dev` (fails on a clean tree with my changes stashed); unrelated to this PR.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change — this is a UI page wired to an existing, already-authenticated backend endpoint).

## Remote-tested
Skipped (no ppt-bridge MCP this run).

## Notes
- Scope drift: none (all changes under `frontend/apps/admin-web/**` + `frontend/packages/api-client/**`, both pm-frontend areas). `scope-check.sh` exit 0.
- Code-reuse: reuses `authenticatedFetchJson` and the auth token provider; no duplicated helpers. (`reuse-grep` emitted only false-positive fragments `useC`/`useS` matching unrelated screen-map tests.)
- Backend route already exists (`GET`/`POST /api/v1/oauth/authorize`), so this is a complete frontend slice — not blocked on backend work.

https://claude.ai/code/session_01X7mnkux7VNyT8of6YkwiEe

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7mnkux7VNyT8of6YkwiEe)_