### PR TITLE
PAP-22: IoT / Smart-Building dashboard UI (Epic 14 / FR71-75)

### DIFF
--- a/docs/screens/ppt/iot-dashboard.md
+++ b/docs/screens/ppt/iot-dashboard.md
@@ -1,0 +1,55 @@
+---
+id: ppt/iot-dashboard
+name: IoT / Smart-Building Dashboard
+product: ppt
+implementations:
+  ppt-web:
+    route: "/iot"
+    component: IotDashboardPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: partial
+endpoints: []
+relatedScreens: []
+sharedComponents: []
+diagrams: []
+useCases: []
+epics:
+  - "14"
+designSources: []
+owner: pm-frontend
+---
+
+# IoT / Smart-Building Dashboard
+
+The manager-web front door for the Epic 14 IoT backend (FR71–75). Backend
+modules + migrations were complete but had **zero UI on any platform**
+([PAP-18](/PAP/issues/PAP-18) gap #3); PAP-22 builds and mounts the web surface.
+
+Presentational `IotDashboardPage` is wired by `routes/groups/iot.tsx` to the
+`@ppt/api-client` IoT module (`useIotDashboard`, `useSensors`,
+`useSensorReadings`, `useAcknowledgeAlert`, `useResolveAlert`):
+
+- **FR71** — device/sensor list (`SensorListPanel`).
+- **FR72** — per-device telemetry readings (`TelemetryPanel`).
+- **FR74** — threshold alerts with acknowledge/resolve (`AlertsPanel`).
+- **FR75** — KPI rollup tiles (`IotStatCard`).
+
+## States
+
+- **Empty**: rendered when an org has no provisioned sensors — panels show empty
+  copy.
+- **Loading**: per-panel loading flags from the api-client query hooks
+  (`dashboardLoading`, `sensorsLoading`, `readingsLoading`).
+- **Error**: query errors surface as empty panels today; `apiStatus: partial`
+  until verified end-to-end against the live IoT backend.
+
+## Notes
+
+### Specific (recent)
+- 2026-06-08 — PAP-22: built the IoT feature dir + `@ppt/api-client` IoT module,
+  mounted `iotRoutes()` in `AppRoutes.tsx` on `/iot`, and created this
+  screen-map entry. `/screens validate` green.
+
+## Agent Log
+- 2026-06-08 — CTO: created on route mount (PAP-22, Epic 14 / FR71–75).

--- a/frontend/apps/ppt-web/src/features/iot/components/AlertsPanel.tsx
+++ b/frontend/apps/ppt-web/src/features/iot/components/AlertsPanel.tsx
@@ -1,0 +1,109 @@
+/**
+ * Alerts panel (Epic 14 — FR74). Recent threshold alerts with acknowledge /
+ * resolve actions.
+ */
+import type { SensorAlert } from '@ppt/api-client';
+import type { JSX } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SensorStatusBadge } from './SensorStatusBadge';
+
+export interface AlertsPanelProps {
+  alerts: SensorAlert[];
+  isLoading: boolean;
+  pendingAlertId: string | null;
+  onAcknowledge: (alertId: string) => void;
+  onResolve: (alertId: string) => void;
+}
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
+}
+
+export function AlertsPanel({
+  alerts,
+  isLoading,
+  pendingAlertId,
+  onAcknowledge,
+  onResolve,
+}: AlertsPanelProps): JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <section className="rounded-lg border border-gray-200 bg-white shadow-sm">
+      <header className="border-b border-gray-100 px-4 py-3">
+        <h2 className="text-sm font-semibold text-gray-700">
+          {t('iot.recentAlerts', { defaultValue: 'Recent alerts' })}
+          <span className="ml-2 text-xs font-normal text-gray-400">{alerts.length}</span>
+        </h2>
+      </header>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-12">
+          <div className="h-6 w-6 animate-spin rounded-full border-b-2 border-blue-600" />
+        </div>
+      ) : alerts.length === 0 ? (
+        <p className="px-4 py-8 text-center text-sm text-gray-400">
+          {t('iot.noAlerts', { defaultValue: 'No active alerts. All clear.' })}
+        </p>
+      ) : (
+        <ul className="divide-y divide-gray-100">
+          {alerts.map((alert) => {
+            const resolved = alert.resolved_at != null;
+            const acknowledged = alert.acknowledged_at != null;
+            const busy = pendingAlertId === alert.id;
+            return (
+              <li key={alert.id} className="px-4 py-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <SensorStatusBadge value={alert.severity} />
+                      {resolved && (
+                        <span className="text-xs text-gray-400">
+                          {t('iot.resolved', { defaultValue: 'resolved' })}
+                        </span>
+                      )}
+                    </div>
+                    <p className="mt-1 truncate text-sm text-gray-800">
+                      {alert.message ??
+                        t('iot.thresholdBreach', {
+                          defaultValue: 'Threshold breach',
+                        })}
+                    </p>
+                    <p className="text-xs text-gray-400">
+                      {t('iot.triggered', { defaultValue: 'Triggered' })}:{' '}
+                      {formatTimestamp(alert.triggered_at)} · {alert.triggered_value} /{' '}
+                      {alert.threshold_value}
+                    </p>
+                  </div>
+                  {!resolved && (
+                    <div className="flex shrink-0 flex-col gap-1">
+                      {!acknowledged && (
+                        <button
+                          type="button"
+                          disabled={busy}
+                          onClick={() => onAcknowledge(alert.id)}
+                          className="rounded border border-gray-300 px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+                        >
+                          {t('iot.acknowledge', { defaultValue: 'Acknowledge' })}
+                        </button>
+                      )}
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() => onResolve(alert.id)}
+                        className="rounded bg-blue-600 px-2 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+                      >
+                        {t('iot.resolve', { defaultValue: 'Resolve' })}
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/iot/components/IotStatCard.tsx
+++ b/frontend/apps/ppt-web/src/features/iot/components/IotStatCard.tsx
@@ -1,0 +1,26 @@
+/**
+ * Single KPI tile for the IoT dashboard rollup (Epic 14 — FR75).
+ */
+import type { JSX } from 'react';
+
+export interface IotStatCardProps {
+  label: string;
+  value: number | string;
+  tone?: 'default' | 'success' | 'warning' | 'danger';
+}
+
+const TONE_STYLES: Record<NonNullable<IotStatCardProps['tone']>, string> = {
+  default: 'text-gray-900',
+  success: 'text-green-600',
+  warning: 'text-amber-600',
+  danger: 'text-red-600',
+};
+
+export function IotStatCard({ label, value, tone = 'default' }: IotStatCardProps): JSX.Element {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+      <div className="text-sm font-medium text-gray-500">{label}</div>
+      <div className={`mt-1 text-2xl font-semibold ${TONE_STYLES[tone]}`}>{value}</div>
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/iot/components/SensorListPanel.tsx
+++ b/frontend/apps/ppt-web/src/features/iot/components/SensorListPanel.tsx
@@ -1,0 +1,72 @@
+/**
+ * Device list panel (Epic 14 — FR71). Selectable list of sensors.
+ */
+import type { Sensor } from '@ppt/api-client';
+import type { JSX } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SensorStatusBadge } from './SensorStatusBadge';
+
+export interface SensorListPanelProps {
+  sensors: Sensor[];
+  isLoading: boolean;
+  selectedSensorId: string | null;
+  onSelectSensor: (id: string) => void;
+}
+
+export function SensorListPanel({
+  sensors,
+  isLoading,
+  selectedSensorId,
+  onSelectSensor,
+}: SensorListPanelProps): JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <section className="rounded-lg border border-gray-200 bg-white shadow-sm">
+      <header className="border-b border-gray-100 px-4 py-3">
+        <h2 className="text-sm font-semibold text-gray-700">
+          {t('iot.devices', { defaultValue: 'Devices' })}
+          <span className="ml-2 text-xs font-normal text-gray-400">{sensors.length}</span>
+        </h2>
+      </header>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-12">
+          <div className="h-6 w-6 animate-spin rounded-full border-b-2 border-blue-600" />
+        </div>
+      ) : sensors.length === 0 ? (
+        <p className="px-4 py-8 text-center text-sm text-gray-400">
+          {t('iot.noDevices', { defaultValue: 'No devices registered yet.' })}
+        </p>
+      ) : (
+        <ul className="divide-y divide-gray-100">
+          {sensors.map((sensor) => {
+            const selected = sensor.id === selectedSensorId;
+            return (
+              <li key={sensor.id}>
+                <button
+                  type="button"
+                  onClick={() => onSelectSensor(sensor.id)}
+                  className={`flex w-full items-center justify-between gap-3 px-4 py-3 text-left hover:bg-gray-50 ${
+                    selected ? 'bg-blue-50' : ''
+                  }`}
+                >
+                  <span className="min-w-0">
+                    <span className="block truncate text-sm font-medium text-gray-900">
+                      {sensor.name}
+                    </span>
+                    <span className="block truncate text-xs text-gray-400">
+                      {sensor.sensor_type}
+                      {sensor.location ? ` · ${sensor.location}` : ''}
+                    </span>
+                  </span>
+                  <SensorStatusBadge value={sensor.status} />
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/iot/components/SensorStatusBadge.tsx
+++ b/frontend/apps/ppt-web/src/features/iot/components/SensorStatusBadge.tsx
@@ -1,0 +1,25 @@
+/**
+ * Sensor status / alert-severity pill (Epic 14 — FR71/FR74).
+ */
+import type { JSX } from 'react';
+
+const STATUS_STYLES: Record<string, string> = {
+  active: 'bg-green-100 text-green-800',
+  online: 'bg-green-100 text-green-800',
+  offline: 'bg-gray-200 text-gray-700',
+  error: 'bg-red-100 text-red-800',
+  warning: 'bg-amber-100 text-amber-800',
+  critical: 'bg-red-100 text-red-800',
+  info: 'bg-blue-100 text-blue-800',
+};
+
+export function SensorStatusBadge({ value }: { value: string }): JSX.Element {
+  const cls = STATUS_STYLES[value?.toLowerCase()] ?? 'bg-gray-100 text-gray-700';
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${cls}`}
+    >
+      {value}
+    </span>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/iot/components/TelemetryPanel.tsx
+++ b/frontend/apps/ppt-web/src/features/iot/components/TelemetryPanel.tsx
@@ -1,0 +1,95 @@
+/**
+ * Telemetry panel (Epic 14 — FR72). Recent readings for the selected sensor.
+ */
+import type { Sensor, SensorReading } from '@ppt/api-client';
+import type { JSX } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export interface TelemetryPanelProps {
+  sensor: Sensor | null;
+  readings: SensorReading[];
+  isLoading: boolean;
+}
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
+}
+
+export function TelemetryPanel({ sensor, readings, isLoading }: TelemetryPanelProps): JSX.Element {
+  const { t } = useTranslation();
+
+  if (!sensor) {
+    return (
+      <section className="rounded-lg border border-gray-200 bg-white p-8 text-center shadow-sm">
+        <p className="text-sm text-gray-400">
+          {t('iot.selectDevicePrompt', {
+            defaultValue: 'Select a device to view its telemetry.',
+          })}
+        </p>
+      </section>
+    );
+  }
+
+  const latest = readings[0];
+
+  return (
+    <section className="rounded-lg border border-gray-200 bg-white shadow-sm">
+      <header className="border-b border-gray-100 px-4 py-3">
+        <h2 className="text-sm font-semibold text-gray-700">
+          {t('iot.telemetry', { defaultValue: 'Telemetry' })}
+          <span className="ml-2 text-xs font-normal text-gray-400">{sensor.name}</span>
+        </h2>
+      </header>
+
+      {latest && (
+        <div className="border-b border-gray-100 px-4 py-3">
+          <span className="text-3xl font-semibold text-gray-900">{latest.value}</span>
+          <span className="ml-1 text-sm text-gray-500">
+            {latest.unit || sensor.unit_of_measurement || ''}
+          </span>
+          <div className="mt-1 text-xs text-gray-400">
+            {t('iot.lastReading', { defaultValue: 'Last reading' })}:{' '}
+            {formatTimestamp(latest.timestamp)}
+          </div>
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-12">
+          <div className="h-6 w-6 animate-spin rounded-full border-b-2 border-blue-600" />
+        </div>
+      ) : readings.length === 0 ? (
+        <p className="px-4 py-8 text-center text-sm text-gray-400">
+          {t('iot.noReadings', { defaultValue: 'No readings in the selected window.' })}
+        </p>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-xs uppercase tracking-wide text-gray-400">
+              <th className="px-4 py-2 font-medium">{t('iot.time', { defaultValue: 'Time' })}</th>
+              <th className="px-4 py-2 text-right font-medium">
+                {t('iot.value', { defaultValue: 'Value' })}
+              </th>
+              <th className="px-4 py-2 font-medium">
+                {t('iot.quality', { defaultValue: 'Quality' })}
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-50">
+            {readings.map((r) => (
+              <tr key={r.id}>
+                <td className="px-4 py-2 text-gray-500">{formatTimestamp(r.timestamp)}</td>
+                <td className="px-4 py-2 text-right font-medium text-gray-900">
+                  {r.value}
+                  <span className="ml-1 text-xs text-gray-400">{r.unit}</span>
+                </td>
+                <td className="px-4 py-2 text-gray-400">{r.quality ?? '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/iot/components/index.ts
+++ b/frontend/apps/ppt-web/src/features/iot/components/index.ts
@@ -1,0 +1,5 @@
+export { AlertsPanel, type AlertsPanelProps } from './AlertsPanel';
+export { IotStatCard, type IotStatCardProps } from './IotStatCard';
+export { SensorListPanel, type SensorListPanelProps } from './SensorListPanel';
+export { SensorStatusBadge } from './SensorStatusBadge';
+export { TelemetryPanel, type TelemetryPanelProps } from './TelemetryPanel';

--- a/frontend/apps/ppt-web/src/features/iot/index.ts
+++ b/frontend/apps/ppt-web/src/features/iot/index.ts
@@ -1,0 +1,7 @@
+/**
+ * IoT / Smart-Building feature (Epic 14 — FR71-75).
+ *
+ * Manager-web front door for the IoT sensor backend.
+ */
+export * from './components';
+export { IotDashboardPage, type IotDashboardPageProps } from './pages';

--- a/frontend/apps/ppt-web/src/features/iot/pages/IotDashboardPage.tsx
+++ b/frontend/apps/ppt-web/src/features/iot/pages/IotDashboardPage.tsx
@@ -1,0 +1,108 @@
+/**
+ * IoT / Smart-Building Dashboard (Epic 14 — FR71-75).
+ *
+ * The manager-web front door for the IoT backend: KPI rollup (FR75), device
+ * list (FR71), per-device telemetry (FR72) and threshold alerts (FR74).
+ *
+ * Presentational only — the route wrapper in `routes/groups/iot.tsx` wires the
+ * `@ppt/api-client` hooks and passes data + handlers in, mirroring the
+ * outages/faults route-group convention.
+ */
+import type { Sensor, SensorAlert, SensorDashboard, SensorReading } from '@ppt/api-client';
+import type { JSX } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AlertsPanel, IotStatCard, SensorListPanel, TelemetryPanel } from '../components';
+
+export interface IotDashboardPageProps {
+  dashboard?: SensorDashboard;
+  dashboardLoading: boolean;
+  sensors: Sensor[];
+  sensorsLoading: boolean;
+  selectedSensorId: string | null;
+  selectedSensor: Sensor | null;
+  readings: SensorReading[];
+  readingsLoading: boolean;
+  alerts: SensorAlert[];
+  pendingAlertId: string | null;
+  onSelectSensor: (id: string) => void;
+  onAcknowledgeAlert: (alertId: string) => void;
+  onResolveAlert: (alertId: string) => void;
+}
+
+export function IotDashboardPage({
+  dashboard,
+  dashboardLoading,
+  sensors,
+  sensorsLoading,
+  selectedSensorId,
+  selectedSensor,
+  readings,
+  readingsLoading,
+  alerts,
+  pendingAlertId,
+  onSelectSensor,
+  onAcknowledgeAlert,
+  onResolveAlert,
+}: IotDashboardPageProps): JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-6">
+      <header className="mb-6">
+        <h1 className="text-2xl font-semibold text-gray-900">
+          {t('iot.dashboardTitle', { defaultValue: 'Smart Building' })}
+        </h1>
+        <p className="mt-1 text-sm text-gray-500">
+          {t('iot.dashboardSubtitle', {
+            defaultValue: 'Sensors, telemetry and alerts across your buildings.',
+          })}
+        </p>
+      </header>
+
+      {/* KPI rollup (FR75) */}
+      <div className="mb-6 grid grid-cols-2 gap-4 md:grid-cols-4">
+        <IotStatCard
+          label={t('iot.totalDevices', { defaultValue: 'Total devices' })}
+          value={dashboardLoading ? '—' : (dashboard?.total_sensors ?? 0)}
+        />
+        <IotStatCard
+          label={t('iot.activeDevices', { defaultValue: 'Active' })}
+          value={dashboardLoading ? '—' : (dashboard?.active_sensors ?? 0)}
+          tone="success"
+        />
+        <IotStatCard
+          label={t('iot.offlineDevices', { defaultValue: 'Offline' })}
+          value={dashboardLoading ? '—' : (dashboard?.offline_sensors ?? 0)}
+          tone={dashboard && dashboard.offline_sensors > 0 ? 'warning' : 'default'}
+        />
+        <IotStatCard
+          label={t('iot.unresolvedAlerts', { defaultValue: 'Open alerts' })}
+          value={dashboardLoading ? '—' : (dashboard?.unresolved_alerts ?? 0)}
+          tone={dashboard && dashboard.unresolved_alerts > 0 ? 'danger' : 'default'}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <div className="lg:col-span-1">
+          <SensorListPanel
+            sensors={sensors}
+            isLoading={sensorsLoading}
+            selectedSensorId={selectedSensorId}
+            onSelectSensor={onSelectSensor}
+          />
+        </div>
+
+        <div className="space-y-6 lg:col-span-2">
+          <TelemetryPanel sensor={selectedSensor} readings={readings} isLoading={readingsLoading} />
+          <AlertsPanel
+            alerts={alerts}
+            isLoading={dashboardLoading}
+            pendingAlertId={pendingAlertId}
+            onAcknowledge={onAcknowledgeAlert}
+            onResolve={onResolveAlert}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/iot/pages/index.ts
+++ b/frontend/apps/ppt-web/src/features/iot/pages/index.ts
@@ -1,0 +1,1 @@
+export { IotDashboardPage, type IotDashboardPageProps } from './IotDashboardPage';

--- a/frontend/apps/ppt-web/src/routes/AppRoutes.tsx
+++ b/frontend/apps/ppt-web/src/routes/AppRoutes.tsx
@@ -20,6 +20,7 @@ import { disputeRoutes } from './groups/disputes';
 import { documentRoutes, newsRoutes } from './groups/documents';
 import { faultRoutes } from './groups/faults';
 import { financialRoutes } from './groups/financial';
+import { iotRoutes } from './groups/iot';
 import { leaseRoutes } from './groups/leases';
 import { messagingRoutes } from './groups/messaging';
 import { meterRoutes } from './groups/meters';
@@ -49,6 +50,7 @@ export function AppRoutes() {
       {meterRoutes()}
       {leaseRoutes()}
       {votingRoutes()}
+      {iotRoutes()}
       {reportRoutes()}
       {buildingRoutes()}
       {settingsRoutes()}

--- a/frontend/apps/ppt-web/src/routes/groups/iot.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/iot.tsx
@@ -1,0 +1,81 @@
+/**
+ * IoT / Smart-Building route group (Epic 14 — FR71-75).
+ *
+ * Owns the IoT route-wrapper component and the `<Route>` table fragment.
+ * Wires `@ppt/api-client` IoT hooks to the presentational dashboard page,
+ * mirroring the outages/faults route-group convention.
+ */
+import {
+  useAcknowledgeSensorAlert,
+  useIotDashboard,
+  useResolveSensorAlert,
+  useSensorReadings,
+  useSensors,
+} from '@ppt/api-client';
+import { useMemo, useState } from 'react';
+import { Route } from 'react-router-dom';
+import { AuthRequiredGate } from '../../components';
+import { useAuth } from '../../contexts';
+import { IotDashboardPage } from '../lazyRoutes';
+
+/**
+ * Route wrapper for the IoT dashboard (Epic 14 / FR71-75).
+ * Manages sensor selection and wires the IoT API hooks.
+ */
+function IotDashboardPageRoute() {
+  const { user } = useAuth();
+  const [selectedSensorId, setSelectedSensorId] = useState<string | null>(null);
+
+  const { data: dashboard, isLoading: dashboardLoading } = useIotDashboard();
+  const { data: sensorsData, isLoading: sensorsLoading } = useSensors();
+  const { data: readingsData, isLoading: readingsLoading } = useSensorReadings(
+    selectedSensorId ?? '',
+    { limit: 50 }
+  );
+
+  const acknowledgeAlert = useAcknowledgeSensorAlert();
+  const resolveAlert = useResolveSensorAlert();
+
+  const sensors = useMemo(() => sensorsData?.sensors ?? [], [sensorsData]);
+  const selectedSensor = useMemo(
+    () => sensors.find((s) => s.id === selectedSensorId) ?? null,
+    [sensors, selectedSensorId]
+  );
+
+  if (!user?.organizationId) {
+    return <AuthRequiredGate />;
+  }
+
+  const pendingAlertId = acknowledgeAlert.isPending
+    ? (acknowledgeAlert.variables ?? null)
+    : resolveAlert.isPending
+      ? (resolveAlert.variables?.alertId ?? null)
+      : null;
+
+  return (
+    <IotDashboardPage
+      dashboard={dashboard}
+      dashboardLoading={dashboardLoading}
+      sensors={sensors}
+      sensorsLoading={sensorsLoading}
+      selectedSensorId={selectedSensorId}
+      selectedSensor={selectedSensor}
+      readings={readingsData?.readings ?? []}
+      readingsLoading={readingsLoading && !!selectedSensorId}
+      alerts={dashboard?.recent_alerts ?? []}
+      pendingAlertId={pendingAlertId}
+      onSelectSensor={setSelectedSensorId}
+      onAcknowledgeAlert={(alertId) => acknowledgeAlert.mutate(alertId)}
+      onResolveAlert={(alertId) => resolveAlert.mutate({ alertId })}
+    />
+  );
+}
+
+/** IoT / Smart-Building routes (Epic 14 / FR71-75). */
+export function iotRoutes() {
+  return (
+    <>
+      <Route path="/iot" element={<IotDashboardPageRoute />} />
+    </>
+  );
+}

--- a/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
+++ b/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
@@ -46,6 +46,11 @@ export const VoteDetailPage = lazy(() =>
   import('../features/voting').then((m) => ({ default: m.VoteDetailPage }))
 );
 
+// IoT / Smart-Building feature (Epic 14)
+export const IotDashboardPage = lazy(() =>
+  import('../features/iot').then((m) => ({ default: m.IotDashboardPage }))
+);
+
 // Disputes feature (Epic 77)
 export const DisputesPage = lazy(() =>
   import('../features/disputes').then((m) => ({ default: m.DisputesPage }))

--- a/frontend/packages/api-client/src/index.ts
+++ b/frontend/packages/api-client/src/index.ts
@@ -29,6 +29,7 @@ export * from './forms';
 export * from './generated';
 export * from './government-portal';
 export * from './integrations';
+export * from './iot';
 export * from './messaging';
 export * from './mfa';
 export * from './migration';

--- a/frontend/packages/api-client/src/iot/api.ts
+++ b/frontend/packages/api-client/src/iot/api.ts
@@ -1,0 +1,122 @@
+/**
+ * IoT / Smart-Building API Client (Epic 14 — FR71-75).
+ *
+ * Direct API functions for sensors, telemetry readings and threshold alerts,
+ * using the shared token provider. Mirrors the `buildings` module conventions.
+ * Base path: `/api/v1/iot/sensors` (see api-server `lib.rs`).
+ */
+
+import { getToken } from '../auth';
+import type {
+  ListAlertsParams,
+  ListAlertsResponse,
+  ListReadingsParams,
+  ListReadingsResponse,
+  ListSensorsParams,
+  ListSensorsResponse,
+  Sensor,
+  SensorAlert,
+  SensorDashboard,
+} from './types';
+
+const _win = typeof window !== 'undefined' ? (window as unknown as Record<string, unknown>) : {};
+const API_BASE = `${_win.__API_BASE_URL__ ? String(_win.__API_BASE_URL__) : ''}/api/v1/iot/sensors`;
+
+function getAuthHeaders(): HeadersInit {
+  const token = getToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+async function apiRequest<T>(url: string, options: RequestInit = {}): Promise<T> {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...getAuthHeaders(),
+      ...options.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.message || `HTTP error ${response.status}`);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return response.json();
+}
+
+function buildQueryString(params: object): string {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null) {
+      searchParams.append(key, String(value));
+    }
+  }
+  const queryString = searchParams.toString();
+  return queryString ? `?${queryString}` : '';
+}
+
+/** Smart-building dashboard rollup, optionally scoped to a building (FR75). */
+export async function getIotDashboard(
+  buildingId?: string,
+  signal?: AbortSignal
+): Promise<SensorDashboard> {
+  const qs = buildQueryString(buildingId ? { building_id: buildingId } : {});
+  return apiRequest<SensorDashboard>(`${API_BASE}/dashboard${qs}`, { signal });
+}
+
+/** List sensors / devices with optional filters (FR71). */
+export async function listSensors(
+  params?: ListSensorsParams,
+  signal?: AbortSignal
+): Promise<ListSensorsResponse> {
+  const qs = buildQueryString(params || {});
+  return apiRequest<ListSensorsResponse>(`${API_BASE}${qs}`, { signal });
+}
+
+/** Get a single sensor by id (FR71). */
+export async function getSensor(id: string, signal?: AbortSignal): Promise<Sensor> {
+  return apiRequest<Sensor>(`${API_BASE}/${id}`, { signal });
+}
+
+/** List telemetry readings for a sensor (FR72). */
+export async function listSensorReadings(
+  sensorId: string,
+  params?: ListReadingsParams,
+  signal?: AbortSignal
+): Promise<ListReadingsResponse> {
+  const qs = buildQueryString(params || {});
+  return apiRequest<ListReadingsResponse>(`${API_BASE}/${sensorId}/readings${qs}`, { signal });
+}
+
+/** List alerts for a sensor (FR74). */
+export async function listSensorAlerts(
+  sensorId: string,
+  params?: ListAlertsParams,
+  signal?: AbortSignal
+): Promise<ListAlertsResponse> {
+  const qs = buildQueryString(params || {});
+  return apiRequest<ListAlertsResponse>(`${API_BASE}/${sensorId}/alerts${qs}`, { signal });
+}
+
+/** Acknowledge an alert (FR74). */
+export async function acknowledgeSensorAlert(alertId: string): Promise<SensorAlert> {
+  return apiRequest<SensorAlert>(`${API_BASE}/alerts/${alertId}/acknowledge`, {
+    method: 'POST',
+  });
+}
+
+/** Resolve an alert, optionally recording the value at resolution (FR74). */
+export async function resolveSensorAlert(
+  alertId: string,
+  resolvedValue?: number | null
+): Promise<SensorAlert> {
+  return apiRequest<SensorAlert>(`${API_BASE}/alerts/${alertId}/resolve`, {
+    method: 'POST',
+    body: JSON.stringify({ resolved_value: resolvedValue ?? null }),
+  });
+}

--- a/frontend/packages/api-client/src/iot/hooks.ts
+++ b/frontend/packages/api-client/src/iot/hooks.ts
@@ -1,0 +1,113 @@
+/**
+ * IoT / Smart-Building TanStack Query Hooks (Epic 14 — FR71-75).
+ *
+ * React hooks for sensors, telemetry and alerts with server-state caching,
+ * following the `buildings` direct-hooks conventions.
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  acknowledgeSensorAlert,
+  getIotDashboard,
+  getSensor,
+  listSensorAlerts,
+  listSensorReadings,
+  listSensors,
+  resolveSensorAlert,
+} from './api';
+import type { ListAlertsParams, ListReadingsParams, ListSensorsParams } from './types';
+
+// ============================================
+// Query Key Factory
+// ============================================
+
+export const iotKeys = {
+  all: ['iot'] as const,
+  dashboard: (buildingId?: string) => [...iotKeys.all, 'dashboard', buildingId ?? null] as const,
+  sensors: () => [...iotKeys.all, 'sensors'] as const,
+  sensorList: (params?: ListSensorsParams) => [...iotKeys.sensors(), 'list', params] as const,
+  sensor: (id: string) => [...iotKeys.sensors(), 'detail', id] as const,
+  readings: (sensorId: string, params?: ListReadingsParams) =>
+    [...iotKeys.sensor(sensorId), 'readings', params] as const,
+  alerts: (sensorId: string, params?: ListAlertsParams) =>
+    [...iotKeys.sensor(sensorId), 'alerts', params] as const,
+};
+
+// ============================================
+// Queries
+// ============================================
+
+/** Smart-building dashboard rollup (FR75). */
+export function useIotDashboard(buildingId?: string) {
+  return useQuery({
+    queryKey: iotKeys.dashboard(buildingId),
+    queryFn: ({ signal }) => getIotDashboard(buildingId, signal),
+    staleTime: 30_000,
+  });
+}
+
+/** List sensors / devices (FR71). */
+export function useSensors(params?: ListSensorsParams) {
+  return useQuery({
+    queryKey: iotKeys.sensorList(params),
+    queryFn: ({ signal }) => listSensors(params, signal),
+    staleTime: 30_000,
+  });
+}
+
+/** Single sensor (FR71). */
+export function useSensor(id: string) {
+  return useQuery({
+    queryKey: iotKeys.sensor(id),
+    queryFn: ({ signal }) => getSensor(id, signal),
+    enabled: !!id,
+    staleTime: 60_000,
+  });
+}
+
+/** Telemetry readings for a sensor (FR72). */
+export function useSensorReadings(sensorId: string, params?: ListReadingsParams) {
+  return useQuery({
+    queryKey: iotKeys.readings(sensorId, params),
+    queryFn: ({ signal }) => listSensorReadings(sensorId, params, signal),
+    enabled: !!sensorId,
+    staleTime: 15_000,
+  });
+}
+
+/** Alerts for a sensor (FR74). */
+export function useSensorAlerts(sensorId: string, params?: ListAlertsParams) {
+  return useQuery({
+    queryKey: iotKeys.alerts(sensorId, params),
+    queryFn: ({ signal }) => listSensorAlerts(sensorId, params, signal),
+    enabled: !!sensorId,
+    staleTime: 15_000,
+  });
+}
+
+// ============================================
+// Mutations
+// ============================================
+
+/** Acknowledge an alert (FR74). Refreshes IoT caches on success. */
+export function useAcknowledgeSensorAlert() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (alertId: string) => acknowledgeSensorAlert(alertId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: iotKeys.all });
+    },
+  });
+}
+
+/** Resolve an alert (FR74). Refreshes IoT caches on success. */
+export function useResolveSensorAlert() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ alertId, resolvedValue }: { alertId: string; resolvedValue?: number | null }) =>
+      resolveSensorAlert(alertId, resolvedValue),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: iotKeys.all });
+    },
+  });
+}

--- a/frontend/packages/api-client/src/iot/index.ts
+++ b/frontend/packages/api-client/src/iot/index.ts
@@ -1,0 +1,40 @@
+/**
+ * IoT / Smart-Building Module (Epic 14 — FR71-75).
+ *
+ * API client, hooks and types for sensors, telemetry readings and alerts.
+ */
+
+export {
+  acknowledgeSensorAlert,
+  getIotDashboard,
+  getSensor,
+  listSensorAlerts,
+  listSensorReadings,
+  listSensors,
+  resolveSensorAlert,
+} from './api';
+export {
+  iotKeys,
+  useAcknowledgeSensorAlert,
+  useIotDashboard,
+  useResolveSensorAlert,
+  useSensor,
+  useSensorAlerts,
+  useSensorReadings,
+  useSensors,
+} from './hooks';
+export type {
+  AggregatedReading,
+  ListAlertsParams,
+  ListAlertsResponse,
+  ListReadingsParams,
+  ListReadingsResponse,
+  ListSensorsParams,
+  ListSensorsResponse,
+  ResolveSensorAlertRequest,
+  Sensor,
+  SensorAlert,
+  SensorDashboard,
+  SensorReading,
+  SensorTypeCount,
+} from './types';

--- a/frontend/packages/api-client/src/iot/types.ts
+++ b/frontend/packages/api-client/src/iot/types.ts
@@ -1,0 +1,133 @@
+/**
+ * IoT / Smart-Building Types (Epic 14 — FR71-75).
+ *
+ * Mirrors the api-server JSON shapes from `routes/iot.rs` /
+ * `crates/db/src/models/sensor.rs`. The backend serializes with the default
+ * serde casing (snake_case), so fields are snake_case to match the wire.
+ */
+
+/** A registered IoT sensor / device (FR71). */
+export interface Sensor {
+  id: string;
+  organization_id: string;
+  building_id: string;
+  unit_id: string | null;
+  name: string;
+  sensor_type: string;
+  location: string | null;
+  location_description: string | null;
+  connection_type: string;
+  connection_config: unknown;
+  unit_of_measurement: string | null;
+  data_interval_seconds: number | null;
+  status: string;
+  last_seen_at: string | null;
+  last_reading_at: string | null;
+  last_error: string | null;
+  error_count: number | null;
+  manufacturer: string | null;
+  model: string | null;
+  firmware_version: string | null;
+  serial_number: string | null;
+  installed_at: string | null;
+  metadata: unknown;
+  created_at: string;
+  updated_at: string;
+  created_by: string;
+}
+
+/** A single telemetry reading from a sensor (FR72). */
+export interface SensorReading {
+  id: string;
+  sensor_id: string;
+  value: number;
+  unit: string;
+  quality: string | null;
+  raw_data: unknown;
+  timestamp: string;
+}
+
+/** An aggregated telemetry bucket (FR72). */
+export interface AggregatedReading {
+  period: string;
+  min_value: number;
+  max_value: number;
+  avg_value: number;
+  count: number;
+}
+
+/** A threshold breach alert (FR74). */
+export interface SensorAlert {
+  id: string;
+  sensor_id: string;
+  threshold_id: string;
+  severity: string;
+  triggered_value: number;
+  threshold_value: number;
+  message: string | null;
+  triggered_at: string;
+  resolved_at: string | null;
+  resolved_value: number | null;
+  acknowledged_by: string | null;
+  acknowledged_at: string | null;
+  notification_sent: boolean;
+}
+
+/** Sensor count grouped by type (dashboard rollup). */
+export interface SensorTypeCount {
+  sensor_type: string;
+  count: number;
+}
+
+/** Smart-building dashboard rollup (FR75). */
+export interface SensorDashboard {
+  total_sensors: number;
+  active_sensors: number;
+  offline_sensors: number;
+  unresolved_alerts: number;
+  sensors_by_type: SensorTypeCount[];
+  recent_alerts: SensorAlert[];
+}
+
+export interface ListSensorsParams {
+  building_id?: string;
+  unit_id?: string;
+  sensor_type?: string;
+  status?: string;
+  search?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ListReadingsParams {
+  from_time?: string;
+  to_time?: string;
+  aggregation?: string;
+  limit?: number;
+}
+
+export interface ListAlertsParams {
+  severity?: string;
+  resolved?: boolean;
+  acknowledged?: boolean;
+  from_time?: string;
+  to_time?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ListSensorsResponse {
+  sensors: Sensor[];
+}
+
+export interface ListReadingsResponse {
+  readings: SensorReading[];
+}
+
+export interface ListAlertsResponse {
+  alerts: SensorAlert[];
+}
+
+export interface ResolveSensorAlertRequest {
+  resolved_value?: number | null;
+}


### PR DESCRIPTION
## PAP-22 — IoT / Smart-Building dashboard UI

Closes the PAP-18 gap #3: Epic 14 backend (modules + migrations) existed but had **zero UI on any platform**. This builds the manager-web front door.

### What's in this PR (IoT-scoped only)
- **`features/iot`** — presentational `IotDashboardPage` + components: KPI rollup (FR75), sensor/device list (FR71), per-device telemetry (FR72), threshold alerts with acknowledge/resolve (FR74).
- **`@ppt/api-client` `iot` module** — `api`/`hooks`/`types` for sensors, readings, alerts; exported from the package barrel.
- **Routing** — `routes/groups/iot.tsx` wires the api-client hooks to the page; `iotRoutes()` mounted on `/iot` in `AppRoutes`; lazy `IotDashboardPage` registered.
- **Collision fix** — namespaced the IoT alert-action exports as `*SensorAlert*` to avoid a barrel ambiguity with admin's `useAcknowledgeAlert` (TS2308).
- **Screen-map** — `docs/screens/ppt/iot-dashboard.md` entry.

### Acceptance criteria
- [x] IoT dashboard surface in ppt-web (device list, telemetry, alerts — FR71–75)
- [x] Route mounted (`/iot`); `@ppt/api-client` IoT module wired
- [x] Screen-map entry added; `/screens validate` green (137 maps, 0 errors)

### Verification
- `screen-map validate` → **137 maps, 0 errors, 0 warnings** (incl. new `iot-dashboard.md`).
- `tsc --noEmit` on `@ppt/api-client` → no IoT errors (the renamed `*SensorAlert*` exports resolve the prior collision).
- `tsc --noEmit` on `ppt-web` → no errors under `features/iot`, `groups/iot`, or the renamed hooks.

### Residual risk
- `apiStatus: partial` — hooks are wired but not yet exercised end-to-end against a live IoT backend; query errors currently surface as empty panels. Follow-up: live-data verification + error states once a seeded IoT dataset is available.

Note: this branch deliberately excludes unrelated in-flight work (meters/leases, voting, reality price-map) present in the shared `dev` working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)