### PR TITLE
feat(ppt-web): Voting UI (Epic 5 / FR37-44) — PAP-19

### DIFF
--- a/docs/screens/ppt/vote-create.md
+++ b/docs/screens/ppt/vote-create.md
@@ -4,10 +4,11 @@ name: Vote Create (5-step wizard)
 product: ppt
 implementations:
   ppt-web:
-    component: VoteCreateWizard
-    buildStatus: planned
+    route: /voting/new
+    component: VoteCreatePage
+    buildStatus: shipped
     redesignStatus: in-progress
-    apiStatus: stub
+    apiStatus: complete
   mobile:
     buildStatus: n/a
     redesignStatus: n/a
@@ -111,4 +112,5 @@ UC-04 vote creation. 5-step wizard balances thoroughness (binding decision) with
 
 <!-- newest entries on top -->
 
+- 2026-06-08 — agent (CTO/PAP-19): built ppt-web `VoteCreatePage` (sectioned form: topic, per-type question/option builder for yes-no/single/multiple/ranked, quorum + close schedule) wired to `useCreateVote` + `addQuestion` + `publishVote`; route `/voting/new`; buildStatus planned→shipped, apiStatus stub→complete, component renamed VoteCreateWizard→VoteCreatePage. 5-step stepper chrome + auto-save + legal-preset chips remain a design follow-up.
 - 2026-05-09 — agent: bootstrapped from Batch E (pages/ppt-vote-create.html — 6 artboards: steps 1-5 + confirm); 7 sections + 6 states + 4 notes (with Ranked tally + ZoVB legal flags); declared 8 sharedComponents; parent ppt/voting; sibling ppt/vote-detail

--- a/docs/screens/ppt/vote-detail.md
+++ b/docs/screens/ppt/vote-detail.md
@@ -4,10 +4,11 @@ name: Vote Detail
 product: ppt
 implementations:
   ppt-web:
+    route: /voting/:voteId
     component: VoteDetailPage
-    buildStatus: planned
+    buildStatus: shipped
     redesignStatus: in-progress
-    apiStatus: stub
+    apiStatus: complete
   mobile:
     component: VoteDetailScreen
     buildStatus: planned
@@ -103,4 +104,5 @@ UC-04 deep view + ballot interaction. The act of voting happens here — frictio
 
 <!-- newest entries on top -->
 
+- 2026-06-08 — agent (CTO/PAP-19): built ppt-web `VoteDetailPage` — state-aware manager toolbar (publish/close/cancel), per-unit per-question ballot (4 ballot variants via discriminated switch), live/final results bars, quorum tile, discussion thread — wired to `useVote`/`useVoteEligibility`/`useVoteResults`/`useCastVote`/`usePublishVote`/`useCloseVote`/`useCancelVote`/`useAddVoteComment`; route `/voting/:voteId`; buildStatus planned→shipped, apiStatus stub→complete. Sticky right-rail, audit-log card, and ranked drag-handle (desktop) remain design follow-ups.
 - 2026-05-09 — agent: bootstrapped from Batch E (pages/ppt-vote-detail.html — 4 artboards) + Batch F1 (MobVoteDetailScreen); 4 sections + 4 states + 4 notes; declared 9 sharedComponents; parent ppt/voting; sibling ppt/vote-create

--- a/docs/screens/ppt/voting.md
+++ b/docs/screens/ppt/voting.md
@@ -6,10 +6,11 @@ sitemapRefs:
   mobile: mobile-voting
 implementations:
   ppt-web:
+    route: /voting
     component: VotingPage
-    buildStatus: planned
+    buildStatus: shipped
     redesignStatus: in-progress
-    apiStatus: stub
+    apiStatus: complete
   mobile:
     component: VotingScreen
     buildStatus: shipped
@@ -107,5 +108,6 @@ UC-04 voting list. Quorum tile pattern matches `ui_kits/ppt-web/manager-dashboar
 
 <!-- newest entries on top -->
 
+- 2026-06-08 — agent (CTO/PAP-19): built ppt-web `features/voting/VotingPage` (status-filtered vote list, quorum tile, create CTA) wired to `@ppt/api-client` `useVotes`/`useBuildings`; mounted `votingRoutes()` (`/voting`) in `AppRoutes.tsx` + lazyRoutes; flipped ppt-web buildStatus planned→shipped, apiStatus stub→complete, added route. Functional MVP (English labels); Slovak-localized design-system polish remains a follow-up.
 - 2026-05-09 — agent: integrated Batch E (pages/ppt-voting.html list — 4 artboards: loaded-1-selected/empty/loading/error) + Batch F1 (MobVotingScreen); flipped ppt-web from n/a → planned + redesignStatus → in-progress (drift: route not in sitemap); mobile redesignStatus → in-progress; attached 2 designSources; populated 8 sections + 4 states + 4 notes; declared 7 sharedComponents; added 3 relatedScreens (vote-detail + vote-create children, ppt/home parent)
 - 2026-05-08 — init: created from scan (source: sitemap)

--- a/frontend/apps/ppt-web/src/features/voting/components/BallotQuestion.tsx
+++ b/frontend/apps/ppt-web/src/features/voting/components/BallotQuestion.tsx
@@ -1,0 +1,194 @@
+/**
+ * Ballot input for a single question, rendered via a discriminated switch on
+ * `question.question_type` (Epic 5, vote-detail screen-map). Controlled: parent
+ * owns the `AnswerValue` and receives changes through `onChange`.
+ */
+import type { AnswerValue, VoteQuestion } from '@ppt/api-client';
+
+interface BallotQuestionProps {
+  question: VoteQuestion;
+  value: AnswerValue | undefined;
+  onChange: (value: AnswerValue) => void;
+  disabled?: boolean;
+}
+
+export function BallotQuestion({ question, value, onChange, disabled }: BallotQuestionProps) {
+  return (
+    <fieldset className="rounded-lg border border-gray-200 p-4" disabled={disabled}>
+      <legend className="px-1 text-sm font-semibold text-gray-900">
+        {question.question_text}
+        {question.is_required ? <span className="ml-1 text-red-500">*</span> : null}
+      </legend>
+      {question.description ? (
+        <p className="mb-2 text-sm text-gray-500">{question.description}</p>
+      ) : null}
+      <div className="mt-2 space-y-2">{renderInput(question, value, onChange)}</div>
+    </fieldset>
+  );
+}
+
+function renderInput(
+  question: VoteQuestion,
+  value: AnswerValue | undefined,
+  onChange: (value: AnswerValue) => void
+) {
+  switch (question.question_type) {
+    case 'yes_no':
+      return <YesNo value={value} onChange={onChange} />;
+    case 'single_choice':
+      return <SingleChoice question={question} value={value} onChange={onChange} />;
+    case 'multiple_choice':
+      return <MultipleChoice question={question} value={value} onChange={onChange} />;
+    case 'ranked':
+      return <Ranked question={question} value={value} onChange={onChange} />;
+    default:
+      return null;
+  }
+}
+
+const optionRow =
+  'flex cursor-pointer items-center gap-3 rounded-md border border-gray-200 px-3 py-2 text-sm hover:bg-gray-50';
+
+function YesNo({
+  value,
+  onChange,
+}: {
+  value: AnswerValue | undefined;
+  onChange: (v: AnswerValue) => void;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      {[
+        { label: 'Yes', val: true },
+        { label: 'No', val: false },
+      ].map((opt) => {
+        const selected = value === opt.val;
+        return (
+          <button
+            key={opt.label}
+            type="button"
+            onClick={() => onChange(opt.val)}
+            className={`rounded-md border px-4 py-3 text-sm font-medium ${
+              selected
+                ? opt.val
+                  ? 'border-green-500 bg-green-50 text-green-800'
+                  : 'border-red-500 bg-red-50 text-red-800'
+                : 'border-gray-200 text-gray-700 hover:bg-gray-50'
+            }`}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function SingleChoice({
+  question,
+  value,
+  onChange,
+}: {
+  question: VoteQuestion;
+  value: AnswerValue | undefined;
+  onChange: (v: AnswerValue) => void;
+}) {
+  return (
+    <>
+      {question.options.map((opt) => (
+        <label key={opt.id} className={optionRow}>
+          <input
+            type="radio"
+            name={`q-${question.id}`}
+            checked={value === opt.id}
+            onChange={() => onChange(opt.id)}
+          />
+          <span>{opt.text}</span>
+        </label>
+      ))}
+    </>
+  );
+}
+
+function MultipleChoice({
+  question,
+  value,
+  onChange,
+}: {
+  question: VoteQuestion;
+  value: AnswerValue | undefined;
+  onChange: (v: AnswerValue) => void;
+}) {
+  const selected = Array.isArray(value) ? value : [];
+  const toggle = (id: string) => {
+    onChange(selected.includes(id) ? selected.filter((s) => s !== id) : [...selected, id]);
+  };
+  return (
+    <>
+      {question.options.map((opt) => (
+        <label key={opt.id} className={optionRow}>
+          <input
+            type="checkbox"
+            checked={selected.includes(opt.id)}
+            onChange={() => toggle(opt.id)}
+          />
+          <span>{opt.text}</span>
+        </label>
+      ))}
+    </>
+  );
+}
+
+function Ranked({
+  question,
+  value,
+  onChange,
+}: {
+  question: VoteQuestion;
+  value: AnswerValue | undefined;
+  onChange: (v: AnswerValue) => void;
+}) {
+  // Default ranking = declared option order until the voter reorders.
+  const order = Array.isArray(value) && value.length ? value : question.options.map((o) => o.id);
+  const labelFor = (id: string) => question.options.find((o) => o.id === id)?.text ?? id;
+
+  const move = (index: number, delta: number) => {
+    const next = [...order];
+    const target = index + delta;
+    if (target < 0 || target >= next.length) return;
+    [next[index], next[target]] = [next[target], next[index]];
+    onChange(next);
+  };
+
+  return (
+    <ol className="space-y-2">
+      {order.map((id, index) => (
+        <li
+          key={id}
+          className="flex items-center gap-3 rounded-md border border-gray-200 px-3 py-2"
+        >
+          <span className="w-5 text-sm font-semibold text-gray-500">{index + 1}.</span>
+          <span className="flex-1 text-sm">{labelFor(id)}</span>
+          <button
+            type="button"
+            onClick={() => move(index, -1)}
+            disabled={index === 0}
+            className="rounded px-2 py-0.5 text-gray-500 hover:bg-gray-100 disabled:opacity-30"
+            aria-label="Move up"
+          >
+            ↑
+          </button>
+          <button
+            type="button"
+            onClick={() => move(index, 1)}
+            disabled={index === order.length - 1}
+            className="rounded px-2 py-0.5 text-gray-500 hover:bg-gray-100 disabled:opacity-30"
+            aria-label="Move down"
+          >
+            ↓
+          </button>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/voting/components/QuestionResults.tsx
+++ b/frontend/apps/ppt-web/src/features/voting/components/QuestionResults.tsx
@@ -1,0 +1,37 @@
+/** Per-question results bars for the vote-detail / results view (Epic 5). */
+import type { QuestionResult } from '@ppt/api-client';
+
+export function QuestionResults({ result }: { result: QuestionResult }) {
+  return (
+    <div className="rounded-lg border border-gray-200 p-4">
+      <h4 className="text-sm font-semibold text-gray-900">{result.question_text}</h4>
+      <p className="mb-3 mt-0.5 text-xs text-gray-500">
+        {result.total_responses} response{result.total_responses === 1 ? '' : 's'}
+      </p>
+      <div className="space-y-3">
+        {result.options.map((opt) => {
+          const isWinner = result.winner === opt.option_id;
+          return (
+            <div key={opt.option_id}>
+              <div className="flex justify-between text-sm">
+                <span className={isWinner ? 'font-semibold text-gray-900' : 'text-gray-700'}>
+                  {opt.option_text}
+                  {isWinner ? <span className="ml-1 text-green-600">✓</span> : null}
+                </span>
+                <span className="text-gray-500">
+                  {opt.count} · {Math.round(opt.percentage)}%
+                </span>
+              </div>
+              <div className="mt-1 h-2 w-full overflow-hidden rounded-full bg-gray-200">
+                <div
+                  className={`h-full ${isWinner ? 'bg-green-500' : 'bg-blue-400'}`}
+                  style={{ width: `${Math.min(100, Math.round(opt.percentage))}%` }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/voting/components/QuorumTile.tsx
+++ b/frontend/apps/ppt-web/src/features/voting/components/QuorumTile.tsx
@@ -1,0 +1,33 @@
+/** Quorum + participation tile shared by the list and detail views (Epic 5). */
+import { participationPercent } from '../types';
+
+interface QuorumTileProps {
+  participation: number;
+  eligible: number;
+  quorumMet: boolean;
+  compact?: boolean;
+}
+
+export function QuorumTile({ participation, eligible, quorumMet, compact }: QuorumTileProps) {
+  const pct = participationPercent(participation, eligible);
+  const barColor = quorumMet ? 'bg-green-500' : 'bg-amber-500';
+
+  return (
+    <div className={compact ? 'w-40' : 'w-44'}>
+      <div className="flex items-baseline justify-between">
+        <span className="text-lg font-semibold text-gray-900">
+          {participation}/{eligible}
+        </span>
+        <span className={`text-xs font-medium ${quorumMet ? 'text-green-700' : 'text-amber-700'}`}>
+          {quorumMet ? 'Quorum met' : `${pct}%`}
+        </span>
+      </div>
+      <div className="mt-1 h-2 w-full overflow-hidden rounded-full bg-gray-200">
+        <div className={`h-full ${barColor}`} style={{ width: `${pct}%` }} />
+      </div>
+      <p className="mt-1 text-xs text-gray-500">
+        {participation} of {eligible} eligible voted
+      </p>
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/voting/components/VoteCard.tsx
+++ b/frontend/apps/ppt-web/src/features/voting/components/VoteCard.tsx
@@ -1,0 +1,47 @@
+/** A single vote row/card for the voting list (Epic 5). */
+import type { VoteSummary } from '@ppt/api-client';
+import { QuorumTile } from './QuorumTile';
+import { VoteStatusBadge } from './VoteStatusBadge';
+
+interface VoteCardProps {
+  vote: VoteSummary;
+  onOpen: (voteId: string) => void;
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return '—';
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? '—' : d.toLocaleDateString();
+}
+
+export function VoteCard({ vote, onOpen }: VoteCardProps) {
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen(vote.id)}
+      className="flex w-full items-start justify-between gap-4 rounded-lg bg-white p-4 text-left shadow transition-shadow hover:shadow-md"
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <VoteStatusBadge status={vote.status} />
+          <span className="text-xs text-gray-400">
+            {vote.question_count} question{vote.question_count === 1 ? '' : 's'}
+          </span>
+        </div>
+        <h3 className="mt-1.5 truncate text-base font-semibold text-gray-900">{vote.title}</h3>
+        {vote.description ? (
+          <p className="mt-1 line-clamp-2 text-sm text-gray-500">{vote.description}</p>
+        ) : null}
+        <div className="mt-2 text-xs text-gray-500">Closes {formatDate(vote.end_at)}</div>
+      </div>
+      <div className="shrink-0">
+        <QuorumTile
+          participation={vote.participation_count}
+          eligible={vote.eligible_count}
+          quorumMet={vote.quorum_met}
+          compact
+        />
+      </div>
+    </button>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/voting/components/VoteStatusBadge.tsx
+++ b/frontend/apps/ppt-web/src/features/voting/components/VoteStatusBadge.tsx
@@ -1,0 +1,13 @@
+/** Status pill for a vote (Epic 5). */
+import type { VoteStatus } from '@ppt/api-client';
+import { VOTE_STATUS_COLORS, VOTE_STATUS_LABELS } from '../types';
+
+export function VoteStatusBadge({ status }: { status: VoteStatus }) {
+  return (
+    <span
+      className={`inline-block rounded px-2 py-0.5 text-xs font-medium ${VOTE_STATUS_COLORS[status]}`}
+    >
+      {VOTE_STATUS_LABELS[status]}
+    </span>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/voting/components/index.ts
+++ b/frontend/apps/ppt-web/src/features/voting/components/index.ts
@@ -1,0 +1,6 @@
+/** Voting feature shared components barrel (Epic 5). */
+export { BallotQuestion } from './BallotQuestion';
+export { QuestionResults } from './QuestionResults';
+export { QuorumTile } from './QuorumTile';
+export { VoteCard } from './VoteCard';
+export { VoteStatusBadge } from './VoteStatusBadge';

--- a/frontend/apps/ppt-web/src/features/voting/index.ts
+++ b/frontend/apps/ppt-web/src/features/voting/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Voting feature barrel (Epic 5: Building Voting & Decisions, FR37-44).
+ */
+export * from './components';
+export * from './pages';

--- a/frontend/apps/ppt-web/src/features/voting/pages/VoteCreatePage.tsx
+++ b/frontend/apps/ppt-web/src/features/voting/pages/VoteCreatePage.tsx
@@ -1,0 +1,396 @@
+/**
+ * Vote create page (Epic 5, screen `ppt/vote-create`).
+ *
+ * A sectioned form covering the create wizard's substance: topic, ballot
+ * questions (with per-type option builders), quorum + schedule. On submit it
+ * creates the draft vote, attaches each question, and — if the manager chose to
+ * publish — publishes it, then hands the new vote id back to the route wrapper.
+ */
+import {
+  type AddQuestionRequest,
+  addQuestion,
+  publishVote,
+  type QuestionType,
+  type QuorumType,
+  useBuildings,
+  useCreateVote,
+} from '@ppt/api-client';
+import { useState } from 'react';
+import { useToast } from '../../../components';
+import { QUESTION_TYPE_LABELS, QUORUM_TYPE_LABELS } from '../types';
+
+interface VoteCreatePageProps {
+  onCreated: (voteId: string) => void;
+  onCancel: () => void;
+}
+
+interface DraftQuestion {
+  key: string;
+  question_text: string;
+  question_type: QuestionType;
+  options: Array<{ id: string; text: string }>;
+  is_required: boolean;
+}
+
+const QUESTION_TYPES: QuestionType[] = ['yes_no', 'single_choice', 'multiple_choice', 'ranked'];
+const QUORUM_TYPES: QuorumType[] = ['simple_majority', 'two_thirds', 'weighted'];
+
+function newId(): string {
+  // Browser-native; available in all supported targets.
+  return crypto.randomUUID();
+}
+
+function yesNoOptions() {
+  return [
+    { id: 'yes', text: 'Yes' },
+    { id: 'no', text: 'No' },
+  ];
+}
+
+function blankQuestion(): DraftQuestion {
+  return {
+    key: newId(),
+    question_text: '',
+    question_type: 'yes_no',
+    options: yesNoOptions(),
+    is_required: true,
+  };
+}
+
+export function VoteCreatePage({ onCreated, onCancel }: VoteCreatePageProps) {
+  const { showToast } = useToast();
+  const { data: buildingsData } = useBuildings();
+  const buildingId = buildingsData?.items?.[0]?.id ?? '';
+  const createVote = useCreateVote();
+
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [endAt, setEndAt] = useState('');
+  const [quorumType, setQuorumType] = useState<QuorumType>('simple_majority');
+  const [quorumPercentage, setQuorumPercentage] = useState('');
+  const [questions, setQuestions] = useState<DraftQuestion[]>([blankQuestion()]);
+  const [submitting, setSubmitting] = useState(false);
+
+  const updateQuestion = (key: string, patch: Partial<DraftQuestion>) => {
+    setQuestions((qs) => qs.map((q) => (q.key === key ? { ...q, ...patch } : q)));
+  };
+
+  const setType = (key: string, type: QuestionType) => {
+    setQuestions((qs) =>
+      qs.map((q) => {
+        if (q.key !== key) return q;
+        if (type === 'yes_no') return { ...q, question_type: type, options: yesNoOptions() };
+        // Seed two empty options for choice/ranked types.
+        const seeded =
+          q.options.length >= 2 && q.question_type !== 'yes_no'
+            ? q.options
+            : [
+                { id: newId(), text: '' },
+                { id: newId(), text: '' },
+              ];
+        return { ...q, question_type: type, options: seeded };
+      })
+    );
+  };
+
+  const addOption = (key: string) => {
+    setQuestions((qs) =>
+      qs.map((q) =>
+        q.key === key ? { ...q, options: [...q.options, { id: newId(), text: '' }] } : q
+      )
+    );
+  };
+
+  const setOptionText = (key: string, optId: string, text: string) => {
+    setQuestions((qs) =>
+      qs.map((q) =>
+        q.key === key
+          ? { ...q, options: q.options.map((o) => (o.id === optId ? { ...o, text } : o)) }
+          : q
+      )
+    );
+  };
+
+  const removeOption = (key: string, optId: string) => {
+    setQuestions((qs) =>
+      qs.map((q) =>
+        q.key === key ? { ...q, options: q.options.filter((o) => o.id !== optId) } : q
+      )
+    );
+  };
+
+  const validate = (): string | null => {
+    if (!buildingId) return 'No building is available for this account.';
+    if (!title.trim()) return 'A title is required.';
+    if (!endAt) return 'A closing date is required.';
+    if (questions.length === 0) return 'Add at least one question.';
+    for (const q of questions) {
+      if (!q.question_text.trim()) return 'Every question needs text.';
+      if (q.question_type !== 'yes_no') {
+        const filled = q.options.filter((o) => o.text.trim());
+        if (filled.length < 2)
+          return `"${q.question_text || 'Question'}" needs at least 2 options.`;
+      }
+    }
+    return null;
+  };
+
+  const handleSubmit = async (publish: boolean) => {
+    const err = validate();
+    if (err) {
+      showToast({ type: 'error', title: 'Check the form', message: err });
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const vote = await createVote.mutateAsync({
+        building_id: buildingId,
+        title: title.trim(),
+        description: description.trim() || null,
+        end_at: new Date(endAt).toISOString(),
+        quorum_type: quorumType,
+        quorum_percentage: quorumPercentage ? Number(quorumPercentage) : null,
+      });
+
+      for (let i = 0; i < questions.length; i++) {
+        const q = questions[i];
+        const payload: AddQuestionRequest = {
+          question_text: q.question_text.trim(),
+          question_type: q.question_type,
+          options: q.options
+            .filter((o) => o.text.trim() || q.question_type === 'yes_no')
+            .map((o, idx) => ({ id: o.id, text: o.text.trim(), order: idx })),
+          display_order: i,
+          is_required: q.is_required,
+        };
+        await addQuestion(vote.id, payload);
+      }
+
+      if (publish) {
+        await publishVote(vote.id, {});
+      }
+
+      showToast({
+        type: 'success',
+        title: publish ? 'Vote published' : 'Draft saved',
+        message: publish ? 'Eligible owners can now vote.' : 'You can publish it later.',
+      });
+      onCreated(vote.id);
+    } catch (e) {
+      showToast({
+        type: 'error',
+        title: 'Failed to create vote',
+        message: e instanceof Error ? e.message : 'Unexpected error',
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const inputClass =
+    'mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none';
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <button
+        type="button"
+        onClick={onCancel}
+        className="text-sm text-gray-500 hover:text-gray-700"
+      >
+        ← Back to voting
+      </button>
+      <h1 className="mt-2 text-2xl font-bold text-gray-900">Create vote</h1>
+
+      {/* Topic */}
+      <section className="mt-6 rounded-lg bg-white p-5 shadow">
+        <h2 className="text-sm font-semibold text-gray-900">Topic</h2>
+        <label className="mt-3 block text-sm font-medium text-gray-700">
+          Title
+          <input
+            className={inputClass}
+            value={title}
+            maxLength={120}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="e.g. Approve façade renovation budget"
+          />
+        </label>
+        <label className="mt-3 block text-sm font-medium text-gray-700">
+          Description
+          <textarea
+            className={inputClass}
+            rows={4}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Context owners need to make an informed decision"
+          />
+        </label>
+      </section>
+
+      {/* Questions */}
+      <section className="mt-5 rounded-lg bg-white p-5 shadow">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-gray-900">Questions</h2>
+          <button
+            type="button"
+            onClick={() => setQuestions((qs) => [...qs, blankQuestion()])}
+            className="text-sm font-medium text-blue-600 hover:text-blue-800"
+          >
+            + Add question
+          </button>
+        </div>
+
+        <div className="mt-4 space-y-5">
+          {questions.map((q, idx) => (
+            <div key={q.key} className="rounded-lg border border-gray-200 p-4">
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-semibold uppercase text-gray-400">
+                  Question {idx + 1}
+                </span>
+                {questions.length > 1 ? (
+                  <button
+                    type="button"
+                    onClick={() => setQuestions((qs) => qs.filter((x) => x.key !== q.key))}
+                    className="text-xs text-red-500 hover:text-red-700"
+                  >
+                    Remove
+                  </button>
+                ) : null}
+              </div>
+              <input
+                className={inputClass}
+                value={q.question_text}
+                onChange={(e) => updateQuestion(q.key, { question_text: e.target.value })}
+                placeholder="Question text"
+              />
+              <div className="mt-3 flex flex-wrap gap-2">
+                {QUESTION_TYPES.map((t) => (
+                  <button
+                    key={t}
+                    type="button"
+                    onClick={() => setType(q.key, t)}
+                    className={`rounded-full px-3 py-1 text-xs ${
+                      q.question_type === t
+                        ? 'bg-blue-600 text-white'
+                        : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                    }`}
+                  >
+                    {QUESTION_TYPE_LABELS[t]}
+                  </button>
+                ))}
+              </div>
+
+              {q.question_type !== 'yes_no' ? (
+                <div className="mt-3 space-y-2">
+                  {q.options.map((o) => (
+                    <div key={o.id} className="flex items-center gap-2">
+                      <input
+                        className="w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none"
+                        value={o.text}
+                        onChange={(e) => setOptionText(q.key, o.id, e.target.value)}
+                        placeholder="Option text"
+                      />
+                      {q.options.length > 2 ? (
+                        <button
+                          type="button"
+                          onClick={() => removeOption(q.key, o.id)}
+                          className="text-gray-400 hover:text-red-500"
+                          aria-label="Remove option"
+                        >
+                          ✕
+                        </button>
+                      ) : null}
+                    </div>
+                  ))}
+                  <button
+                    type="button"
+                    onClick={() => addOption(q.key)}
+                    className="text-xs font-medium text-blue-600 hover:text-blue-800"
+                  >
+                    + Add option
+                  </button>
+                </div>
+              ) : (
+                <p className="mt-3 text-xs text-gray-400">Options: Yes / No</p>
+              )}
+
+              <label className="mt-3 flex items-center gap-2 text-xs text-gray-600">
+                <input
+                  type="checkbox"
+                  checked={q.is_required}
+                  onChange={(e) => updateQuestion(q.key, { is_required: e.target.checked })}
+                />
+                Required
+              </label>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Quorum + schedule */}
+      <section className="mt-5 rounded-lg bg-white p-5 shadow">
+        <h2 className="text-sm font-semibold text-gray-900">Quorum &amp; schedule</h2>
+        <label className="mt-3 block text-sm font-medium text-gray-700">
+          Quorum rule
+          <select
+            className={inputClass}
+            value={quorumType}
+            onChange={(e) => setQuorumType(e.target.value as QuorumType)}
+          >
+            {QUORUM_TYPES.map((t) => (
+              <option key={t} value={t}>
+                {QUORUM_TYPE_LABELS[t]}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="mt-3 block text-sm font-medium text-gray-700">
+          Quorum percentage (optional)
+          <input
+            type="number"
+            min={0}
+            max={100}
+            className={inputClass}
+            value={quorumPercentage}
+            onChange={(e) => setQuorumPercentage(e.target.value)}
+            placeholder="e.g. 50"
+          />
+        </label>
+        <label className="mt-3 block text-sm font-medium text-gray-700">
+          Closes at
+          <input
+            type="datetime-local"
+            className={inputClass}
+            value={endAt}
+            onChange={(e) => setEndAt(e.target.value)}
+          />
+        </label>
+      </section>
+
+      <div className="mt-6 flex items-center justify-end gap-3">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md px-4 py-2 text-sm text-gray-600 hover:text-gray-800"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          disabled={submitting}
+          onClick={() => handleSubmit(false)}
+          className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+        >
+          Save draft
+        </button>
+        <button
+          type="button"
+          disabled={submitting}
+          onClick={() => handleSubmit(true)}
+          className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {submitting ? 'Saving…' : 'Publish vote'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/voting/pages/VoteDetailPage.tsx
+++ b/frontend/apps/ppt-web/src/features/voting/pages/VoteDetailPage.tsx
@@ -1,0 +1,331 @@
+/**
+ * Vote detail page (Epic 5, screen `ppt/vote-detail`).
+ *
+ * One screen that covers the deep-view + ballot + administration + results +
+ * discussion stories: it renders the proposal, the state-aware manager action
+ * toolbar (publish / close / cancel), the ballot (per-unit, per-question), live
+ * or final results, and the comment thread — all wired to `@ppt/api-client`.
+ */
+import {
+  type AnswerMap,
+  type AnswerValue,
+  useAddVoteComment,
+  useCancelVote,
+  useCastVote,
+  useCloseVote,
+  usePublishVote,
+  useVote,
+  useVoteComments,
+  useVoteEligibility,
+  useVoteResults,
+} from '@ppt/api-client';
+import { useMemo, useState } from 'react';
+import { Spinner, useToast } from '../../../components';
+import { BallotQuestion, QuestionResults, QuorumTile, VoteStatusBadge } from '../components';
+import { QUORUM_TYPE_LABELS } from '../types';
+
+interface VoteDetailPageProps {
+  voteId: string;
+  onBack: () => void;
+}
+
+function formatDateTime(value: string | null): string {
+  if (!value) return '—';
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? '—' : d.toLocaleString();
+}
+
+export function VoteDetailPage({ voteId, onBack }: VoteDetailPageProps) {
+  const { showToast } = useToast();
+  const { data: vote, isLoading, error } = useVote(voteId);
+  const { data: eligibility } = useVoteEligibility(voteId);
+  const resultsEnabled = vote?.status === 'active' || vote?.status === 'closed';
+  const { data: results } = useVoteResults(voteId, resultsEnabled);
+  const { data: comments } = useVoteComments(voteId);
+
+  const castVote = useCastVote(voteId);
+  const publishVote = usePublishVote(voteId);
+  const closeVote = useCloseVote(voteId);
+  const cancelVote = useCancelVote(voteId);
+  const addComment = useAddVoteComment(voteId);
+
+  const [selectedUnit, setSelectedUnit] = useState('');
+  const [answers, setAnswers] = useState<AnswerMap>({});
+  const [commentText, setCommentText] = useState('');
+
+  const eligibleUnits = eligibility?.eligible_units ?? [];
+  const effectiveUnit = selectedUnit || eligibleUnits[0]?.unit_id || '';
+
+  const canCast = useMemo(
+    () => vote?.status === 'active' && (eligibility?.can_vote ?? false) && !!effectiveUnit,
+    [vote?.status, eligibility?.can_vote, effectiveUnit]
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-24">
+        <Spinner size="lg" color="blue" />
+      </div>
+    );
+  }
+
+  if (error || !vote) {
+    return (
+      <div className="mx-auto max-w-md py-16 text-center">
+        <h1 className="text-lg font-semibold text-gray-900">Vote unavailable</h1>
+        <p className="mt-2 text-sm text-gray-500">
+          {error instanceof Error ? error.message : 'This vote could not be loaded.'}
+        </p>
+        <button
+          type="button"
+          onClick={onBack}
+          className="mt-6 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          Back to voting
+        </button>
+      </div>
+    );
+  }
+
+  const setAnswer = (questionId: string, value: AnswerValue) => {
+    setAnswers((prev) => ({ ...prev, [questionId]: value }));
+  };
+
+  const handleCast = async () => {
+    if (!effectiveUnit) {
+      showToast({ type: 'error', title: 'Select a unit to vote with' });
+      return;
+    }
+    const missing = vote.questions.filter((q) => q.is_required && answers[q.id] === undefined);
+    if (missing.length > 0) {
+      showToast({ type: 'error', title: 'Answer all required questions' });
+      return;
+    }
+    try {
+      await castVote.mutateAsync({ unit_id: effectiveUnit, answers });
+      showToast({ type: 'success', title: 'Ballot submitted', message: 'Your vote was recorded.' });
+      setAnswers({});
+    } catch (e) {
+      showToast({
+        type: 'error',
+        title: 'Failed to submit ballot',
+        message: e instanceof Error ? e.message : 'Unexpected error',
+      });
+    }
+  };
+
+  const runAction = async (label: string, fn: () => Promise<unknown>) => {
+    try {
+      await fn();
+      showToast({ type: 'success', title: `${label} done` });
+    } catch (e) {
+      showToast({
+        type: 'error',
+        title: `${label} failed`,
+        message: e instanceof Error ? e.message : 'Unexpected error',
+      });
+    }
+  };
+
+  const handleCancel = () => {
+    const reason = window.prompt('Reason for cancelling this vote?');
+    if (!reason) return;
+    void runAction('Cancel', () => cancelVote.mutateAsync({ reason }));
+  };
+
+  const handleAddComment = async () => {
+    if (!commentText.trim()) return;
+    try {
+      await addComment.mutateAsync({ content: commentText.trim(), ai_consent: false });
+      setCommentText('');
+    } catch (e) {
+      showToast({
+        type: 'error',
+        title: 'Failed to post comment',
+        message: e instanceof Error ? e.message : 'Unexpected error',
+      });
+    }
+  };
+
+  const busy =
+    publishVote.isPending || closeVote.isPending || cancelVote.isPending || castVote.isPending;
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      <button type="button" onClick={onBack} className="text-sm text-gray-500 hover:text-gray-700">
+        ← Back to voting
+      </button>
+
+      {/* Header */}
+      <div className="mt-2 flex items-start justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2">
+            <VoteStatusBadge status={vote.status} />
+            <span className="text-xs text-gray-500">Closes {formatDateTime(vote.end_at)}</span>
+          </div>
+          <h1 className="mt-1.5 text-2xl font-bold text-gray-900">{vote.title}</h1>
+        </div>
+        <div className="flex shrink-0 flex-wrap justify-end gap-2">
+          {vote.status === 'draft' ? (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => void runAction('Publish', () => publishVote.mutateAsync({}))}
+              className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              Publish now
+            </button>
+          ) : null}
+          {vote.status === 'active' ? (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => void runAction('Close', () => closeVote.mutateAsync())}
+              className="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+            >
+              Close now
+            </button>
+          ) : null}
+          {vote.status === 'draft' || vote.status === 'scheduled' || vote.status === 'active' ? (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={handleCancel}
+              className="rounded-md border border-red-200 px-3 py-1.5 text-sm font-medium text-red-600 hover:bg-red-50 disabled:opacity-50"
+            >
+              Cancel vote
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      {/* Meta + quorum */}
+      <div className="mt-4 flex flex-wrap items-center gap-6 rounded-lg bg-white p-4 shadow">
+        <div className="text-sm">
+          <span className="text-gray-500">Quorum:</span>{' '}
+          <span className="font-medium text-gray-900">{QUORUM_TYPE_LABELS[vote.quorum_type]}</span>
+        </div>
+        <QuorumTile
+          participation={vote.participation_count}
+          eligible={vote.eligible_count}
+          quorumMet={vote.quorum_met}
+        />
+      </div>
+
+      {/* Description */}
+      {vote.description ? (
+        <div className="mt-4 rounded-lg bg-white p-5 shadow">
+          <h2 className="text-sm font-semibold text-gray-900">Description</h2>
+          <p className="mt-2 whitespace-pre-wrap text-sm text-gray-700">{vote.description}</p>
+        </div>
+      ) : null}
+
+      {/* Ballot */}
+      {vote.status === 'active' ? (
+        <div className="mt-4 rounded-lg bg-white p-5 shadow">
+          <h2 className="text-sm font-semibold text-gray-900">Cast your ballot</h2>
+          {eligibleUnits.length === 0 ? (
+            <p className="mt-2 text-sm text-gray-500">
+              {eligibility?.reason ?? 'You have no eligible units for this vote.'}
+            </p>
+          ) : (
+            <>
+              {eligibleUnits.length > 1 ? (
+                <label className="mt-3 block text-sm font-medium text-gray-700">
+                  Voting as unit
+                  <select
+                    className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                    value={effectiveUnit}
+                    onChange={(e) => setSelectedUnit(e.target.value)}
+                  >
+                    {eligibleUnits.map((u) => (
+                      <option key={u.unit_id} value={u.unit_id}>
+                        {u.unit_designation ?? u.unit_id}
+                        {u.already_voted ? ' (already voted)' : ''}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              ) : null}
+              <div className="mt-4 space-y-4">
+                {vote.questions.map((q) => (
+                  <BallotQuestion
+                    key={q.id}
+                    question={q}
+                    value={answers[q.id]}
+                    onChange={(v) => setAnswer(q.id, v)}
+                  />
+                ))}
+              </div>
+              <button
+                type="button"
+                disabled={!canCast || castVote.isPending}
+                onClick={handleCast}
+                className="mt-4 w-full rounded-md bg-blue-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+              >
+                {castVote.isPending ? 'Submitting…' : 'Submit ballot'}
+              </button>
+            </>
+          )}
+        </div>
+      ) : null}
+
+      {/* Results */}
+      {results && results.questions.length > 0 ? (
+        <div className="mt-4 rounded-lg bg-white p-5 shadow">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-semibold text-gray-900">Results</h2>
+            <span className="text-xs text-gray-500">
+              {Math.round(results.participation_rate * 100)}% turnout ·{' '}
+              {results.quorum_met ? 'quorum met' : 'quorum not met'}
+            </span>
+          </div>
+          <div className="mt-3 space-y-4">
+            {results.questions.map((r) => (
+              <QuestionResults key={r.question_id} result={r} />
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {/* Discussion */}
+      <div className="mt-4 rounded-lg bg-white p-5 shadow">
+        <h2 className="text-sm font-semibold text-gray-900">Discussion</h2>
+        <div className="mt-3 space-y-3">
+          {comments && comments.length > 0 ? (
+            comments.map((c) => (
+              <div key={c.id} className="rounded-md border border-gray-100 bg-gray-50 p-3">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium text-gray-900">{c.user_name}</span>
+                  <span className="text-xs text-gray-400">{formatDateTime(c.created_at)}</span>
+                </div>
+                <p className="mt-1 text-sm text-gray-700">{c.content}</p>
+              </div>
+            ))
+          ) : (
+            <p className="text-sm text-gray-500">No comments yet.</p>
+          )}
+        </div>
+        <div className="mt-4 flex gap-2">
+          <input
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            value={commentText}
+            onChange={(e) => setCommentText(e.target.value)}
+            placeholder="Add a comment"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') void handleAddComment();
+            }}
+          />
+          <button
+            type="button"
+            disabled={addComment.isPending || !commentText.trim()}
+            onClick={() => void handleAddComment()}
+            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            Post
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/voting/pages/VotingPage.tsx
+++ b/frontend/apps/ppt-web/src/features/voting/pages/VotingPage.tsx
@@ -1,0 +1,118 @@
+/**
+ * Voting list page (Epic 5, screen `ppt/voting`).
+ *
+ * Lists votes for the manager's current building with a status filter and an
+ * entry point into the create wizard. Data comes from the `@ppt/api-client`
+ * voting hooks; navigation is delegated to the route wrapper via props.
+ */
+import { useBuildings, useVotes, type VoteStatus } from '@ppt/api-client';
+import { useMemo, useState } from 'react';
+import { Spinner } from '../../../components';
+import { VoteCard } from '../components';
+import { VOTE_STATUS_LABELS } from '../types';
+
+interface VotingPageProps {
+  onOpenVote: (voteId: string) => void;
+  onCreateVote: () => void;
+}
+
+const STATUS_FILTERS: Array<VoteStatus | 'all'> = [
+  'all',
+  'draft',
+  'scheduled',
+  'active',
+  'closed',
+  'cancelled',
+];
+
+export function VotingPage({ onOpenVote, onCreateVote }: VotingPageProps) {
+  const { data: buildingsData, isLoading: isLoadingBuildings } = useBuildings();
+  const buildingId = buildingsData?.items?.[0]?.id ?? '';
+
+  const [statusFilter, setStatusFilter] = useState<VoteStatus | 'all'>('all');
+
+  const query = useMemo(
+    () => ({
+      building_id: buildingId || undefined,
+      status: statusFilter === 'all' ? undefined : statusFilter,
+    }),
+    [buildingId, statusFilter]
+  );
+
+  const { data: votes, isLoading, error } = useVotes(query);
+
+  const counts = useMemo(() => {
+    const open = votes?.filter((v) => v.status === 'active').length ?? 0;
+    const closed = votes?.filter((v) => v.status === 'closed').length ?? 0;
+    return { open, closed, total: votes?.length ?? 0 };
+  }, [votes]);
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Voting</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            {counts.total} vote{counts.total === 1 ? '' : 's'} · {counts.open} open ·{' '}
+            {counts.closed} closed
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onCreateVote}
+          className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          + New vote
+        </button>
+      </div>
+
+      <div className="mt-6 flex flex-wrap gap-2">
+        {STATUS_FILTERS.map((s) => (
+          <button
+            key={s}
+            type="button"
+            onClick={() => setStatusFilter(s)}
+            className={`rounded-full px-3 py-1 text-sm ${
+              statusFilter === s
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+            }`}
+          >
+            {s === 'all' ? 'All' : VOTE_STATUS_LABELS[s]}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-6">
+        {isLoading || isLoadingBuildings ? (
+          <div className="flex justify-center py-16">
+            <Spinner size="lg" color="blue" />
+          </div>
+        ) : error ? (
+          <div className="rounded-lg border border-red-200 bg-red-50 p-6 text-center">
+            <p className="text-sm text-red-700">
+              Failed to load votes: {error instanceof Error ? error.message : 'Unknown error'}
+            </p>
+          </div>
+        ) : !votes || votes.length === 0 ? (
+          <div className="rounded-lg bg-white p-12 text-center shadow">
+            <p className="text-gray-500">No votes yet.</p>
+            <button
+              type="button"
+              onClick={onCreateVote}
+              className="mt-4 text-sm font-medium text-blue-600 hover:text-blue-800"
+            >
+              Create the first vote
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {votes.map((vote) => (
+              <VoteCard key={vote.id} vote={vote} onOpen={onOpenVote} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/voting/pages/index.ts
+++ b/frontend/apps/ppt-web/src/features/voting/pages/index.ts
@@ -1,0 +1,4 @@
+/** Voting feature pages barrel (Epic 5, FR37-44). */
+export { VoteCreatePage } from './VoteCreatePage';
+export { VoteDetailPage } from './VoteDetailPage';
+export { VotingPage } from './VotingPage';

--- a/frontend/apps/ppt-web/src/features/voting/types.ts
+++ b/frontend/apps/ppt-web/src/features/voting/types.ts
@@ -1,0 +1,45 @@
+/**
+ * Voting feature — UI helper types and label/colour maps (Epic 5, FR37-44).
+ *
+ * Domain types (Vote, VoteWithDetails, …) come from `@ppt/api-client`; this
+ * module only holds presentation helpers shared across the voting pages.
+ */
+import type { QuestionType, QuorumType, VoteStatus } from '@ppt/api-client';
+
+/** Human-readable status label + Tailwind pill colours per vote status. */
+export const VOTE_STATUS_LABELS: Record<VoteStatus, string> = {
+  draft: 'Draft',
+  scheduled: 'Scheduled',
+  active: 'Open',
+  closed: 'Closed',
+  cancelled: 'Cancelled',
+};
+
+export const VOTE_STATUS_COLORS: Record<VoteStatus, string> = {
+  draft: 'bg-gray-100 text-gray-700',
+  scheduled: 'bg-indigo-100 text-indigo-800',
+  active: 'bg-green-100 text-green-800',
+  closed: 'bg-blue-100 text-blue-800',
+  cancelled: 'bg-red-100 text-red-800',
+};
+
+/** Question-type labels for the create wizard + ballot. */
+export const QUESTION_TYPE_LABELS: Record<QuestionType, string> = {
+  yes_no: 'Yes / No',
+  single_choice: 'Single choice',
+  multiple_choice: 'Multiple choice',
+  ranked: 'Ranked preference',
+};
+
+/** Quorum-rule labels for the create wizard + detail. */
+export const QUORUM_TYPE_LABELS: Record<QuorumType, string> = {
+  simple_majority: 'Simple majority (50% + 1)',
+  two_thirds: 'Two-thirds (2/3)',
+  weighted: 'Weighted by ownership share',
+};
+
+/** Participation as a 0–100 integer percentage, clamped. */
+export function participationPercent(participation: number, eligible: number): number {
+  if (!eligible || eligible <= 0) return 0;
+  return Math.min(100, Math.round((participation / eligible) * 100));
+}

--- a/frontend/apps/ppt-web/src/routes/AppRoutes.tsx
+++ b/frontend/apps/ppt-web/src/routes/AppRoutes.tsx
@@ -25,6 +25,7 @@ import { neighborRoutes } from './groups/neighbors';
 import { outageRoutes } from './groups/outages';
 import { rentalRoutes } from './groups/rentals';
 import { reportRoutes } from './groups/reports';
+import { votingRoutes } from './groups/voting';
 
 export function AppRoutes() {
   return (
@@ -43,6 +44,7 @@ export function AppRoutes() {
       {communityRoutes()}
       {financialRoutes()}
       {rentalRoutes()}
+      {votingRoutes()}
       {reportRoutes()}
       {buildingRoutes()}
       {settingsRoutes()}

--- a/frontend/apps/ppt-web/src/routes/groups/voting.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/voting.tsx
@@ -1,0 +1,72 @@
+/**
+ * Voting route group (Epic 5: Building Voting & Decisions, FR37-44).
+ *
+ * Mounts the `features/voting/` pages into ppt-web. Unlike the meters/leases
+ * groups, the `@ppt/api-client` voting module already ships, so these wrappers
+ * are thin: the pages consume the voting hooks directly and the wrappers only
+ * supply navigation callbacks and the `:voteId` route param.
+ */
+import { Route, useNavigate, useParams } from 'react-router-dom';
+import { ProtectedRoute } from '../../components';
+import { VoteCreatePage, VoteDetailPage, VotingPage } from '../lazyRoutes';
+
+/** Route wrapper: voting list (`/voting`). */
+function VotingPageRoute() {
+  const navigate = useNavigate();
+  return (
+    <VotingPage
+      onOpenVote={(voteId) => navigate(`/voting/${voteId}`)}
+      onCreateVote={() => navigate('/voting/new')}
+    />
+  );
+}
+
+/** Route wrapper: create vote (`/voting/new`). */
+function VoteCreatePageRoute() {
+  const navigate = useNavigate();
+  return (
+    <VoteCreatePage
+      onCreated={(voteId) => navigate(`/voting/${voteId}`)}
+      onCancel={() => navigate('/voting')}
+    />
+  );
+}
+
+/** Route wrapper: vote detail / ballot / administer (`/voting/:voteId`). */
+function VoteDetailPageRoute() {
+  const navigate = useNavigate();
+  const { voteId } = useParams<{ voteId: string }>();
+  return <VoteDetailPage voteId={voteId ?? ''} onBack={() => navigate('/voting')} />;
+}
+
+/** Voting routes (Epic 5, FR37-44). */
+export function votingRoutes() {
+  return (
+    <>
+      <Route
+        path="/voting"
+        element={
+          <ProtectedRoute>
+            <VotingPageRoute />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/voting/new"
+        element={
+          <ProtectedRoute>
+            <VoteCreatePageRoute />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/voting/:voteId"
+        element={
+          <ProtectedRoute>
+            <VoteDetailPageRoute />
+          </ProtectedRoute>
+        }
+      />
+    </>
+  );
+}

--- a/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
+++ b/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
@@ -35,6 +35,17 @@ export const EmergencyContactDirectoryPage = lazy(() =>
   import('../features/emergency').then((m) => ({ default: m.EmergencyContactDirectoryPage }))
 );
 
+// Voting feature (Epic 5: Building Voting & Decisions, FR37-44)
+export const VotingPage = lazy(() =>
+  import('../features/voting').then((m) => ({ default: m.VotingPage }))
+);
+export const VoteCreatePage = lazy(() =>
+  import('../features/voting').then((m) => ({ default: m.VoteCreatePage }))
+);
+export const VoteDetailPage = lazy(() =>
+  import('../features/voting').then((m) => ({ default: m.VoteDetailPage }))
+);
+
 // Disputes feature (Epic 77)
 export const DisputesPage = lazy(() =>
   import('../features/disputes').then((m) => ({ default: m.DisputesPage }))

--- a/frontend/packages/api-client/src/index.ts
+++ b/frontend/packages/api-client/src/index.ts
@@ -42,6 +42,7 @@ export * from './outages';
 export * from './packages';
 export * from './registry';
 export * from './reports';
+export * from './voting';
 export * from './workflow-automation';
 
 // API client configuration

--- a/frontend/packages/api-client/src/voting/api.ts
+++ b/frontend/packages/api-client/src/voting/api.ts
@@ -1,0 +1,254 @@
+/**
+ * Voting API client functions (Epic 5: Building Voting & Decisions, FR37-44).
+ *
+ * Thin fetch wrappers over `/api/v1/voting` (see
+ * `backend/servers/api-server/src/routes/voting.rs`). Mirrors the conventions in
+ * the `faults` module: a shared `fetchApi<T>` helper + `buildQueryString`.
+ */
+
+import type {
+  AddCommentRequest,
+  AddQuestionRequest,
+  CancelVoteRequest,
+  CastVoteRequest,
+  CreateVoteRequest,
+  HideCommentRequest,
+  ListVotesQuery,
+  PublishVoteRequest,
+  UpdateQuestionRequest,
+  UpdateVoteRequest,
+  Vote,
+  VoteAuditLog,
+  VoteComment,
+  VoteCommentWithUser,
+  VoteEligibility,
+  VoteQuestion,
+  VoteReceipt,
+  VoteResponse,
+  VoteResults,
+  VoteSummary,
+  VoteWithDetails,
+} from './types';
+
+const API_BASE = '/api/v1/voting';
+
+/** Helper to build query string from params. */
+function buildQueryString(
+  params: Record<string, string | number | boolean | undefined | null>
+): string {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null && value !== '') {
+      searchParams.append(key, String(value));
+    }
+  }
+  const query = searchParams.toString();
+  return query ? `?${query}` : '';
+}
+
+/** Generic fetch wrapper with error handling. */
+async function fetchApi<T>(url: string, options?: RequestInit): Promise<T> {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...options?.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ message: 'Request failed' }));
+    throw new Error(error.message || `HTTP ${response.status}`);
+  }
+
+  // 204 No Content
+  if (response.status === 204) {
+    return undefined as T;
+  }
+  return response.json();
+}
+
+// ============================================================================
+// Vote CRUD
+// ============================================================================
+
+/** List votes with optional filters. */
+export async function listVotes(query: ListVotesQuery = {}): Promise<VoteSummary[]> {
+  const queryString = buildQueryString({
+    building_id: query.building_id,
+    status: query.status,
+    from_date: query.from_date,
+    to_date: query.to_date,
+    limit: query.limit,
+    offset: query.offset,
+  });
+  return fetchApi<VoteSummary[]>(`${API_BASE}${queryString}`);
+}
+
+/** Get a vote with its questions (and cached results, when closed). */
+export async function getVote(id: string): Promise<VoteWithDetails> {
+  return fetchApi<VoteWithDetails>(`${API_BASE}/${id}`);
+}
+
+/** Create a new vote (starts in `draft`). */
+export async function createVote(data: CreateVoteRequest): Promise<Vote> {
+  return fetchApi<Vote>(API_BASE, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+/** Update a vote — draft only. */
+export async function updateVote(id: string, data: UpdateVoteRequest): Promise<Vote> {
+  return fetchApi<Vote>(`${API_BASE}/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  });
+}
+
+/** Delete a vote — draft only. */
+export async function deleteVote(id: string): Promise<void> {
+  await fetchApi<void>(`${API_BASE}/${id}`, { method: 'DELETE' });
+}
+
+// ============================================================================
+// Workflow transitions
+// ============================================================================
+
+/** Publish a draft vote (→ scheduled or active). */
+export async function publishVote(id: string, data: PublishVoteRequest = {}): Promise<Vote> {
+  return fetchApi<Vote>(`${API_BASE}/${id}/publish`, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+/** Cancel a vote with a required reason. */
+export async function cancelVote(id: string, data: CancelVoteRequest): Promise<Vote> {
+  return fetchApi<Vote>(`${API_BASE}/${id}/cancel`, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+/** Close an active vote and compute final results. */
+export async function closeVote(id: string): Promise<Vote> {
+  return fetchApi<Vote>(`${API_BASE}/${id}/close`, { method: 'POST' });
+}
+
+// ============================================================================
+// Questions
+// ============================================================================
+
+/** Add a question to a draft vote. */
+export async function addQuestion(voteId: string, data: AddQuestionRequest): Promise<VoteQuestion> {
+  return fetchApi<VoteQuestion>(`${API_BASE}/${voteId}/questions`, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+/** List a vote's questions. */
+export async function listQuestions(voteId: string): Promise<VoteQuestion[]> {
+  return fetchApi<VoteQuestion[]>(`${API_BASE}/${voteId}/questions`);
+}
+
+/** Update a question on a draft vote. */
+export async function updateQuestion(
+  voteId: string,
+  questionId: string,
+  data: UpdateQuestionRequest
+): Promise<VoteQuestion> {
+  return fetchApi<VoteQuestion>(`${API_BASE}/${voteId}/questions/${questionId}`, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  });
+}
+
+/** Delete a question from a draft vote. */
+export async function deleteQuestion(voteId: string, questionId: string): Promise<void> {
+  await fetchApi<void>(`${API_BASE}/${voteId}/questions/${questionId}`, { method: 'DELETE' });
+}
+
+// ============================================================================
+// Ballot
+// ============================================================================
+
+/** Check the current user's eligibility to vote. */
+export async function getEligibility(voteId: string): Promise<VoteEligibility> {
+  return fetchApi<VoteEligibility>(`${API_BASE}/${voteId}/eligibility`);
+}
+
+/** Cast a ballot for a unit. */
+export async function castVote(voteId: string, data: CastVoteRequest): Promise<VoteReceipt> {
+  return fetchApi<VoteReceipt>(`${API_BASE}/${voteId}/cast`, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+/** Get the current user's submitted response for a unit (null if none). */
+export async function getMyResponse(voteId: string, unitId: string): Promise<VoteResponse | null> {
+  const queryString = buildQueryString({ unit_id: unitId });
+  return fetchApi<VoteResponse | null>(`${API_BASE}/${voteId}/my-response${queryString}`);
+}
+
+// ============================================================================
+// Results, report & audit
+// ============================================================================
+
+/** Get vote results (cached when closed, live tally when active). */
+export async function getResults(voteId: string): Promise<VoteResults> {
+  return fetchApi<VoteResults>(`${API_BASE}/${voteId}/results`);
+}
+
+/** Get the immutable audit log (admin). */
+export async function getAuditLog(voteId: string): Promise<VoteAuditLog[]> {
+  return fetchApi<VoteAuditLog[]>(`${API_BASE}/${voteId}/audit`);
+}
+
+// ============================================================================
+// Comments
+// ============================================================================
+
+/** List top-level (non-hidden) comments. */
+export async function listComments(voteId: string): Promise<VoteCommentWithUser[]> {
+  return fetchApi<VoteCommentWithUser[]>(`${API_BASE}/${voteId}/comments`);
+}
+
+/** List replies to a comment. */
+export async function listCommentReplies(
+  voteId: string,
+  commentId: string
+): Promise<VoteCommentWithUser[]> {
+  return fetchApi<VoteCommentWithUser[]>(`${API_BASE}/${voteId}/comments/${commentId}/replies`);
+}
+
+/** Add a comment (optionally threaded via `parent_id`). */
+export async function addComment(voteId: string, data: AddCommentRequest): Promise<VoteComment> {
+  return fetchApi<VoteComment>(`${API_BASE}/${voteId}/comments`, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+/** Hide/moderate a comment (moderator). */
+export async function hideComment(
+  voteId: string,
+  commentId: string,
+  data: HideCommentRequest
+): Promise<VoteComment> {
+  return fetchApi<VoteComment>(`${API_BASE}/${voteId}/comments/${commentId}/hide`, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+// ============================================================================
+// Building-scoped
+// ============================================================================
+
+/** List active votes for a building. */
+export async function listActiveVotesForBuilding(buildingId: string): Promise<VoteSummary[]> {
+  return fetchApi<VoteSummary[]>(`${API_BASE}/building/${buildingId}/active`);
+}

--- a/frontend/packages/api-client/src/voting/hooks.ts
+++ b/frontend/packages/api-client/src/voting/hooks.ts
@@ -1,0 +1,261 @@
+/**
+ * TanStack Query hooks for the Voting API (Epic 5, FR37-44).
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import * as api from './api';
+import type {
+  AddCommentRequest,
+  AddQuestionRequest,
+  CancelVoteRequest,
+  CastVoteRequest,
+  CreateVoteRequest,
+  ListVotesQuery,
+  PublishVoteRequest,
+  UpdateQuestionRequest,
+  UpdateVoteRequest,
+} from './types';
+
+// ============================================================================
+// Query keys
+// ============================================================================
+
+export const votingKeys = {
+  all: ['voting'] as const,
+  lists: () => [...votingKeys.all, 'list'] as const,
+  list: (query: ListVotesQuery) => [...votingKeys.lists(), query] as const,
+  buildingActive: (buildingId: string) =>
+    [...votingKeys.all, 'building-active', buildingId] as const,
+  details: () => [...votingKeys.all, 'detail'] as const,
+  detail: (id: string) => [...votingKeys.details(), id] as const,
+  questions: (id: string) => [...votingKeys.all, 'questions', id] as const,
+  eligibility: (id: string) => [...votingKeys.all, 'eligibility', id] as const,
+  myResponse: (id: string, unitId: string) =>
+    [...votingKeys.all, 'my-response', id, unitId] as const,
+  results: (id: string) => [...votingKeys.all, 'results', id] as const,
+  audit: (id: string) => [...votingKeys.all, 'audit', id] as const,
+  comments: (id: string) => [...votingKeys.all, 'comments', id] as const,
+};
+
+// ============================================================================
+// Query hooks
+// ============================================================================
+
+/** List votes with optional filters. */
+export function useVotes(query: ListVotesQuery = {}) {
+  return useQuery({
+    queryKey: votingKeys.list(query),
+    queryFn: () => api.listVotes(query),
+  });
+}
+
+/** List active votes for a building. */
+export function useActiveVotesForBuilding(buildingId: string) {
+  return useQuery({
+    queryKey: votingKeys.buildingActive(buildingId),
+    queryFn: () => api.listActiveVotesForBuilding(buildingId),
+    enabled: !!buildingId,
+  });
+}
+
+/** Get a vote with its questions. */
+export function useVote(id: string) {
+  return useQuery({
+    queryKey: votingKeys.detail(id),
+    queryFn: () => api.getVote(id),
+    enabled: !!id,
+  });
+}
+
+/** List a vote's questions. */
+export function useVoteQuestions(id: string) {
+  return useQuery({
+    queryKey: votingKeys.questions(id),
+    queryFn: () => api.listQuestions(id),
+    enabled: !!id,
+  });
+}
+
+/** Get the current user's eligibility for a vote. */
+export function useVoteEligibility(id: string) {
+  return useQuery({
+    queryKey: votingKeys.eligibility(id),
+    queryFn: () => api.getEligibility(id),
+    enabled: !!id,
+  });
+}
+
+/** Get the current user's response for a unit. */
+export function useMyVoteResponse(id: string, unitId: string) {
+  return useQuery({
+    queryKey: votingKeys.myResponse(id, unitId),
+    queryFn: () => api.getMyResponse(id, unitId),
+    enabled: !!id && !!unitId,
+  });
+}
+
+/** Get vote results (live tally while active, cached once closed). */
+export function useVoteResults(id: string, enabled = true) {
+  return useQuery({
+    queryKey: votingKeys.results(id),
+    queryFn: () => api.getResults(id),
+    enabled: enabled && !!id,
+  });
+}
+
+/** Get the immutable audit log (admin). */
+export function useVoteAuditLog(id: string, enabled = true) {
+  return useQuery({
+    queryKey: votingKeys.audit(id),
+    queryFn: () => api.getAuditLog(id),
+    enabled: enabled && !!id,
+  });
+}
+
+/** List a vote's comments. */
+export function useVoteComments(id: string) {
+  return useQuery({
+    queryKey: votingKeys.comments(id),
+    queryFn: () => api.listComments(id),
+    enabled: !!id,
+  });
+}
+
+// ============================================================================
+// Mutation hooks
+// ============================================================================
+
+/** Create a vote. */
+export function useCreateVote() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateVoteRequest) => api.createVote(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: votingKeys.lists() });
+    },
+  });
+}
+
+/** Update a draft vote. */
+export function useUpdateVote(voteId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: UpdateVoteRequest) => api.updateVote(voteId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: votingKeys.detail(voteId) });
+      queryClient.invalidateQueries({ queryKey: votingKeys.lists() });
+    },
+  });
+}
+
+/** Delete a draft vote. */
+export function useDeleteVote() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (voteId: string) => api.deleteVote(voteId),
+    onSuccess: (_, voteId) => {
+      queryClient.removeQueries({ queryKey: votingKeys.detail(voteId) });
+      queryClient.invalidateQueries({ queryKey: votingKeys.lists() });
+    },
+  });
+}
+
+/** Publish a draft vote. */
+export function usePublishVote(voteId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: PublishVoteRequest = {}) => api.publishVote(voteId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: votingKeys.detail(voteId) });
+      queryClient.invalidateQueries({ queryKey: votingKeys.lists() });
+    },
+  });
+}
+
+/** Cancel a vote. */
+export function useCancelVote(voteId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CancelVoteRequest) => api.cancelVote(voteId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: votingKeys.detail(voteId) });
+      queryClient.invalidateQueries({ queryKey: votingKeys.lists() });
+    },
+  });
+}
+
+/** Close an active vote. */
+export function useCloseVote(voteId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.closeVote(voteId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: votingKeys.detail(voteId) });
+      queryClient.invalidateQueries({ queryKey: votingKeys.results(voteId) });
+      queryClient.invalidateQueries({ queryKey: votingKeys.lists() });
+    },
+  });
+}
+
+/** Add a question to a draft vote. */
+export function useAddQuestion(voteId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: AddQuestionRequest) => api.addQuestion(voteId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: votingKeys.questions(voteId) });
+      queryClient.invalidateQueries({ queryKey: votingKeys.detail(voteId) });
+    },
+  });
+}
+
+/** Update a question on a draft vote. */
+export function useUpdateQuestion(voteId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ questionId, data }: { questionId: string; data: UpdateQuestionRequest }) =>
+      api.updateQuestion(voteId, questionId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: votingKeys.questions(voteId) });
+      queryClient.invalidateQueries({ queryKey: votingKeys.detail(voteId) });
+    },
+  });
+}
+
+/** Delete a question from a draft vote. */
+export function useDeleteQuestion(voteId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (questionId: string) => api.deleteQuestion(voteId, questionId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: votingKeys.questions(voteId) });
+      queryClient.invalidateQueries({ queryKey: votingKeys.detail(voteId) });
+    },
+  });
+}
+
+/** Cast a ballot. */
+export function useCastVote(voteId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CastVoteRequest) => api.castVote(voteId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: votingKeys.detail(voteId) });
+      queryClient.invalidateQueries({ queryKey: votingKeys.results(voteId) });
+      queryClient.invalidateQueries({ queryKey: votingKeys.eligibility(voteId) });
+      // Prefix match invalidates my-response for every unit of this vote.
+      queryClient.invalidateQueries({ queryKey: [...votingKeys.all, 'my-response', voteId] });
+    },
+  });
+}
+
+/** Add a comment to a vote. */
+export function useAddVoteComment(voteId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: AddCommentRequest) => api.addComment(voteId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: votingKeys.comments(voteId) });
+    },
+  });
+}

--- a/frontend/packages/api-client/src/voting/index.ts
+++ b/frontend/packages/api-client/src/voting/index.ts
@@ -1,0 +1,96 @@
+/**
+ * Voting API module exports (Epic 5: Building Voting & Decisions, FR37-44).
+ */
+
+// API functions.
+//
+// The comment-domain helpers are re-exported under vote-scoped aliases
+// (`addComment` → `addVoteComment`, `listComments` → `listVoteComments`, …)
+// because the bare names collide with the `faults` and `news` modules in the
+// top-level `@ppt/api-client` barrel (TS2308). UIs consume the React Query
+// hooks anyway; the raw aliases stay available for non-React callers.
+export {
+  addComment as addVoteComment,
+  addQuestion,
+  cancelVote,
+  castVote,
+  closeVote,
+  createVote,
+  deleteQuestion,
+  deleteVote,
+  getAuditLog,
+  getEligibility,
+  getMyResponse,
+  getResults,
+  getVote,
+  hideComment as hideVoteComment,
+  listActiveVotesForBuilding,
+  listCommentReplies as listVoteCommentReplies,
+  listComments as listVoteComments,
+  listQuestions,
+  listVotes,
+  publishVote,
+  updateQuestion,
+  updateVote,
+} from './api';
+
+// React Query hooks
+export {
+  useActiveVotesForBuilding,
+  useAddQuestion,
+  useAddVoteComment,
+  useCancelVote,
+  useCastVote,
+  useCloseVote,
+  useCreateVote,
+  useDeleteQuestion,
+  useDeleteVote,
+  useMyVoteResponse,
+  usePublishVote,
+  useUpdateQuestion,
+  useUpdateVote,
+  useVote,
+  useVoteAuditLog,
+  useVoteComments,
+  useVoteEligibility,
+  useVoteQuestions,
+  useVoteResults,
+  useVotes,
+  votingKeys,
+} from './hooks';
+
+// Types. `AddCommentRequest`/`HideCommentRequest` are vote-scoped aliases to
+// avoid the same `faults`-module collision as the functions above.
+export type {
+  AddCommentRequest as AddVoteCommentRequest,
+  AddQuestionRequest,
+  AnswerMap,
+  AnswerValue,
+  CancelVoteRequest,
+  CastVoteRequest,
+  CreateVoteRequest,
+  EligibleUnit,
+  HideCommentRequest as HideVoteCommentRequest,
+  ListVotesQuery,
+  OptionResult,
+  PublishVoteRequest,
+  QuestionOption,
+  QuestionResult,
+  QuestionType,
+  QuorumType,
+  UpdateQuestionRequest,
+  UpdateVoteRequest,
+  Vote,
+  VoteAuditAction,
+  VoteAuditLog,
+  VoteComment,
+  VoteCommentWithUser,
+  VoteEligibility,
+  VoteQuestion,
+  VoteReceipt,
+  VoteResponse,
+  VoteResults,
+  VoteStatus,
+  VoteSummary,
+  VoteWithDetails,
+} from './types';

--- a/frontend/packages/api-client/src/voting/types.ts
+++ b/frontend/packages/api-client/src/voting/types.ts
@@ -1,0 +1,323 @@
+/**
+ * Voting API types (Epic 5: Building Voting & Decisions, FR37-44).
+ *
+ * Mirrors the backend models in `backend/crates/db/src/models/vote.rs` and the
+ * routes in `backend/servers/api-server/src/routes/voting.rs`. JSON field names
+ * are the serde defaults (snake_case == Rust field names; no renames). Nullable
+ * columns are typed `T | null` to match the wire shape; route wrappers strip
+ * `null` → `undefined` for the camelCase UI types.
+ */
+
+// ============================================================================
+// Enums
+// ============================================================================
+
+/** Lifecycle status of a vote (`vote.rs:10-18`). */
+export type VoteStatus = 'draft' | 'scheduled' | 'active' | 'closed' | 'cancelled';
+
+/** Question answer mode (`vote.rs:21-28`). */
+export type QuestionType = 'yes_no' | 'single_choice' | 'multiple_choice' | 'ranked';
+
+/** Quorum rule (`vote.rs:31-37`). */
+export type QuorumType = 'simple_majority' | 'two_thirds' | 'weighted';
+
+/** Immutable audit-trail actions (`vote.rs:40-52`). */
+export type VoteAuditAction =
+  | 'vote_created'
+  | 'vote_published'
+  | 'vote_cancelled'
+  | 'question_added'
+  | 'question_removed'
+  | 'ballot_cast'
+  | 'ballot_updated'
+  | 'comment_added'
+  | 'comment_hidden'
+  | 'vote_closed'
+  | 'results_calculated';
+
+/**
+ * Answer payload by question type:
+ * - `yes_no`: boolean
+ * - `single_choice`: option id (string)
+ * - `multiple_choice`: option ids (string[])
+ * - `ranked`: option ids in rank order (string[])
+ */
+export type AnswerValue = boolean | string | string[];
+
+/** Map of `question_id` → answer (the `answers` JSONB payload). */
+export type AnswerMap = Record<string, AnswerValue>;
+
+// ============================================================================
+// Core entities
+// ============================================================================
+
+/** A selectable option on a question (`vote.rs:197-201`). */
+export interface QuestionOption {
+  id: string;
+  text: string;
+  order?: number | null;
+}
+
+/** Full vote record (`votes` table / `vote.rs:59-86`). */
+export interface Vote {
+  id: string;
+  organization_id: string;
+  building_id: string;
+  title: string;
+  description: string | null;
+  start_at: string | null;
+  end_at: string;
+  status: VoteStatus;
+  quorum_type: QuorumType;
+  quorum_percentage: number | null;
+  allow_delegation: boolean;
+  anonymous_voting: boolean;
+  participation_count: number;
+  eligible_count: number;
+  quorum_met: boolean;
+  results: VoteResults | null;
+  results_calculated_at: string | null;
+  created_by: string;
+  published_by: string | null;
+  published_at: string | null;
+  cancelled_by: string | null;
+  cancelled_at: string | null;
+  cancellation_reason: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Compact vote row for list views (`vote.rs:125-136`). */
+export interface VoteSummary {
+  id: string;
+  building_id: string;
+  title: string;
+  description: string | null;
+  status: VoteStatus;
+  quorum_type: QuorumType;
+  start_at: string | null;
+  end_at: string;
+  participation_count: number;
+  eligible_count: number;
+  quorum_met: boolean;
+  question_count: number;
+  created_at: string;
+}
+
+/** A question attached to a vote (`vote.rs:204-216`). */
+export interface VoteQuestion {
+  id: string;
+  vote_id: string;
+  question_text: string;
+  description: string | null;
+  question_type: QuestionType;
+  options: QuestionOption[];
+  display_order: number;
+  is_required: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Vote detail with its questions and (optional) cached results (`vote.rs:139-148`). */
+export interface VoteWithDetails extends Vote {
+  questions: VoteQuestion[];
+}
+
+/** A unit the current user may vote on (`vote.rs:420-429`). */
+export interface EligibleUnit {
+  unit_id: string;
+  unit_designation: string | null;
+  ownership_share: string | null;
+  is_delegated: boolean;
+  delegation_id: string | null;
+  already_voted: boolean;
+}
+
+/** Result of an eligibility check for the current user (`vote.rs:410-417`). */
+export interface VoteEligibility {
+  vote_id: string;
+  user_id: string;
+  eligible_units: EligibleUnit[];
+  can_vote: boolean;
+  reason: string | null;
+}
+
+/** A cast ballot (`vote.rs:245-257`). */
+export interface VoteResponse {
+  id: string;
+  vote_id: string;
+  user_id: string;
+  unit_id: string;
+  delegation_id: string | null;
+  is_delegated: boolean;
+  answers: AnswerMap;
+  vote_weight: string;
+  response_hash: string;
+  submitted_at: string;
+}
+
+/** Confirmation returned after casting a ballot (`vote.rs:270-278`). */
+export interface VoteReceipt {
+  response_id: string;
+  vote_id: string;
+  unit_id: string;
+  submitted_at: string;
+  response_hash: string;
+  confirmation_number: string;
+}
+
+/** Per-option tally inside a question result. */
+export interface OptionResult {
+  option_id: string;
+  option_text: string;
+  count: number;
+  weighted_count: number;
+  percentage: number;
+}
+
+/** Tally for a single question (`vote.rs:372-381`). */
+export interface QuestionResult {
+  question_id: string;
+  question_text: string;
+  question_type: QuestionType;
+  options: OptionResult[];
+  total_responses: number;
+  winner: string | null;
+}
+
+/** Computed / cached results for a vote (`vote.rs:360-369`). */
+export interface VoteResults {
+  vote_id: string;
+  participation_count: number;
+  eligible_count: number;
+  participation_rate: number;
+  quorum_met: boolean;
+  questions: QuestionResult[];
+  calculated_at: string;
+}
+
+/** Immutable audit-log entry (`vote.rs:331-342`). */
+export interface VoteAuditLog {
+  id: string;
+  vote_id: string;
+  user_id: string | null;
+  action: VoteAuditAction;
+  data_hash: string;
+  data_snapshot: unknown | null;
+  ip_address: string | null;
+  user_agent: string | null;
+  created_at: string;
+}
+
+/** A discussion comment (`vote.rs:285-299`). */
+export interface VoteComment {
+  id: string;
+  vote_id: string;
+  user_id: string;
+  parent_id: string | null;
+  content: string;
+  hidden: boolean;
+  hidden_by: string | null;
+  hidden_at: string | null;
+  hidden_reason: string | null;
+  ai_consent: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Comment flattened with author + reply count (`vote.rs:302-308`). */
+export interface VoteCommentWithUser extends VoteComment {
+  user_name: string;
+  reply_count: number;
+}
+
+// ============================================================================
+// Request payloads
+// ============================================================================
+
+/** `POST /api/v1/voting` (`voting.rs:70-81`). */
+export interface CreateVoteRequest {
+  building_id: string;
+  title: string;
+  description?: string | null;
+  start_at?: string | null;
+  end_at: string;
+  quorum_type: QuorumType;
+  quorum_percentage?: number | null;
+  allow_delegation?: boolean | null;
+  anonymous_voting?: boolean | null;
+}
+
+/** `PUT /api/v1/voting/{id}` — draft only (`voting.rs:84-94`). */
+export interface UpdateVoteRequest {
+  title?: string | null;
+  description?: string | null;
+  start_at?: string | null;
+  end_at?: string | null;
+  quorum_type?: QuorumType | null;
+  quorum_percentage?: number | null;
+  allow_delegation?: boolean | null;
+  anonymous_voting?: boolean | null;
+}
+
+/** `POST /api/v1/voting/{id}/publish` (`voting.rs:97-100`). */
+export interface PublishVoteRequest {
+  start_at?: string | null;
+}
+
+/** `POST /api/v1/voting/{id}/cancel` (`voting.rs:103-106`). */
+export interface CancelVoteRequest {
+  reason: string;
+}
+
+/** `POST /api/v1/voting/{id}/questions` (`voting.rs:109-117`). */
+export interface AddQuestionRequest {
+  question_text: string;
+  description?: string | null;
+  question_type: QuestionType;
+  options: QuestionOption[];
+  display_order?: number | null;
+  is_required?: boolean | null;
+}
+
+/** `PUT /api/v1/voting/{id}/questions/{question_id}` (`voting.rs:120-127`). */
+export interface UpdateQuestionRequest {
+  question_text?: string | null;
+  description?: string | null;
+  options?: QuestionOption[] | null;
+  display_order?: number | null;
+  is_required?: boolean | null;
+}
+
+/** `POST /api/v1/voting/{id}/cast` (`voting.rs:130-135`). */
+export interface CastVoteRequest {
+  unit_id: string;
+  delegation_id?: string | null;
+  answers: AnswerMap;
+}
+
+/** `POST /api/v1/voting/{id}/comments` (`voting.rs:138-143`). */
+export interface AddCommentRequest {
+  parent_id?: string | null;
+  content: string;
+  ai_consent: boolean;
+}
+
+/** `POST /api/v1/voting/{id}/comments/{comment_id}/hide` (`voting.rs:146-149`). */
+export interface HideCommentRequest {
+  reason: string;
+}
+
+// ============================================================================
+// Query params
+// ============================================================================
+
+/** `GET /api/v1/voting` filters (`voting.rs:152-160`). */
+export interface ListVotesQuery {
+  building_id?: string;
+  status?: VoteStatus;
+  from_date?: string;
+  to_date?: string;
+  limit?: number;
+  offset?: number;
+}


### PR DESCRIPTION
## Summary
Builds the **manager-web (ppt-web) Voting UI** — the #1 MVP gap from PAP-18 (voting backend + mobile shipped, ppt-web had no voting route).

## What's included
- **`features/voting/`**
  - `VotingPage` — status-filtered vote list with quorum/participation tiles, building-scoped via `useBuildings()`+`useVotes()`.
  - `VoteCreatePage` — topic, per-type question builder (yes-no / single / multiple / ranked) with option editor, quorum rule + close schedule; create → attach questions → optional publish.
  - `VoteDetailPage` — state-aware manager toolbar (publish / close / cancel), per-unit per-question ballot (4 ballot variants via discriminated switch on `question_type`), live/final results bars, discussion thread.
- **Routing** — `votingRoutes()` mounted in `AppRoutes.tsx` (`/voting`, `/voting/new`, `/voting/:voteId`) + lazy code-split entries in `lazyRoutes.tsx`.
- **`@ppt/api-client`** — exports the voting module from the barrel; comment-domain symbols aliased (`addComment`→`addVoteComment`, `listComments`→`listVoteComments`, `AddCommentRequest`→`AddVoteCommentRequest`, …) to resolve TS2308 collisions with the `faults`/`news` modules.
- **Screen-maps** — `voting` / `vote-create` / `vote-detail` flipped ppt-web `buildStatus` planned→shipped, `apiStatus` stub→complete, routes recorded, agent-log entries added.

## Verification
- `tsc --noEmit` — ppt-web ✅ (0), api-client ✅ (0)
- `biome check` on new files — ✅ clean
- screen-map validate — ✅ 120 maps, 0 errors

## Follow-ups (design polish, not MVP-blocking)
Slovak localization, 5-step wizard chrome + auto-save, sticky right-rail, audit-log card, ranked drag-handle (desktop) — tracked against the screen-maps.

Closes PAP-19.