### PR TITLE
fix(documents): enforce RLS context on public document-share paths (PAP-21)

### DIFF
--- a/backend/crates/db/migrations/00178_force_document_shares_rls.sql
+++ b/backend/crates/db/migrations/00178_force_document_shares_rls.sql
@@ -1,0 +1,87 @@
+-- Migration: 00178_force_document_shares_rls
+-- Security Fix (PAP-21, follow-up to #754): FORCE row-level security on the
+-- document *share* tables and repair their tenant-isolation policies so the
+-- table owner can no longer bypass them.
+--
+-- Background
+-- ----------
+-- 00172 forced RLS on `documents` / `document_folders` but DELIBERATELY left
+-- `document_shares` and `document_share_access_log` un-forced, with this note:
+--
+--   "Their public share-token endpoints read them via the raw pool with no org
+--    context (the share token is the authorization), so forcing them would
+--    break public sharing. They are tracked as a follow-up (route the public
+--    path through an org-scoped connection first, then force)."
+--
+-- That follow-up is PAP-21. The public share handlers
+-- (`/api/v1/documents/shared/{token}`) now read these tables through a
+-- dedicated connection that sets super-admin RLS context for the single lookup
+-- and clears it afterwards (mirroring `find_by_id_for_share`), so forcing RLS
+-- here no longer breaks public sharing.
+--
+-- Two problems are fixed, exactly as 00172 did for `documents`:
+--
+-- 1. The 00020/00140 policies filter on `current_setting('app.tenant_id')`.
+--    That GUC is NEVER set anywhere -- `set_request_context` sets
+--    `app.current_org_id` / `app.is_super_admin` (00004/00006). So for any
+--    non-owner role the policy evaluated `... = NULL` -> deny-all, and for the
+--    owner role (the production api-server connects as the table owner `ppt`)
+--    RLS was bypassed entirely -> a real cross-tenant IDOR on the share tables.
+--    We rewrite the policies to the standard `is_super_admin()` /
+--    `get_current_org_id()` helpers + the `get_current_org_not_deleted()`
+--    soft-delete guard, matching `documents` (00172) and every other
+--    org-scoped table (00140).
+--
+-- 2. `document_shares` and `document_share_access_log` get
+--    `FORCE ROW LEVEL SECURITY` so the owner role is bound by the policy
+--    instead of bypassing it, closing the IDOR.
+--
+-- Both tables key off the owning document's `organization_id`, so isolation is
+-- expressed by joining through `documents`. The public path supplies
+-- super-admin context (the validated share token is the authorization grant),
+-- which satisfies the `is_super_admin()` OR-leg; authenticated share
+-- management runs under the caller's org context via `RlsConnection`.
+
+-- ============================================================================
+-- Repair tenant-isolation policies (app.tenant_id -> get_current_org_id())
+-- ============================================================================
+
+DROP POLICY IF EXISTS share_tenant_isolation ON document_shares;
+CREATE POLICY share_tenant_isolation ON document_shares
+    FOR ALL
+    USING (
+        (is_super_admin() OR (document_id IN (
+            SELECT id FROM documents WHERE organization_id = get_current_org_id()
+        ))) AND get_current_org_not_deleted()
+    )
+    WITH CHECK (
+        (is_super_admin() OR (document_id IN (
+            SELECT id FROM documents WHERE organization_id = get_current_org_id()
+        ))) AND get_current_org_not_deleted()
+    );
+
+DROP POLICY IF EXISTS access_log_tenant_isolation ON document_share_access_log;
+CREATE POLICY access_log_tenant_isolation ON document_share_access_log
+    FOR ALL
+    USING (
+        (is_super_admin() OR (share_id IN (
+            SELECT ds.id FROM document_shares ds
+            JOIN documents d ON d.id = ds.document_id
+            WHERE d.organization_id = get_current_org_id()
+        ))) AND get_current_org_not_deleted()
+    )
+    WITH CHECK (
+        (is_super_admin() OR (share_id IN (
+            SELECT ds.id FROM document_shares ds
+            JOIN documents d ON d.id = ds.document_id
+            WHERE d.organization_id = get_current_org_id()
+        ))) AND get_current_org_not_deleted()
+    );
+
+-- ============================================================================
+-- FORCE RLS so the table owner (production api-server role) is bound by the
+-- policies above instead of bypassing them.
+-- ============================================================================
+
+ALTER TABLE document_shares FORCE ROW LEVEL SECURITY;
+ALTER TABLE document_share_access_log FORCE ROW LEVEL SECURITY;

--- a/backend/crates/db/src/repositories/document.rs
+++ b/backend/crates/db/src/repositories/document.rs
@@ -1065,6 +1065,99 @@ impl DocumentRepository {
         result
     }
 
+    /// Find a share by token for the public share-token path.
+    ///
+    /// The public share endpoints (`/api/v1/documents/shared/{token}`) are
+    /// unauthenticated: the share token itself is the authorization grant, and
+    /// no `app.current_org_id` is available. `document_shares` is under
+    /// `FORCE ROW LEVEL SECURITY` (#754 / PAP-21), so a raw-pool query carrying
+    /// stale (or no) org context would be filtered to zero rows. This helper
+    /// acquires a dedicated connection, sets super-admin RLS context for the
+    /// single lookup, then clears it before returning the connection to the
+    /// pool. Expiry / revocation are still enforced by the SQL predicate in
+    /// `find_share_by_token_rls`.
+    pub async fn find_share_by_token_for_share(
+        &self,
+        token: &str,
+    ) -> Result<Option<DocumentShare>, SqlxError> {
+        let mut conn = self.pool.acquire().await?;
+
+        // Authorize via the validated share token, not org context.
+        crate::tenant_context::set_request_context(&mut *conn, None, None, true).await?;
+
+        let result = self.find_share_by_token_rls(&mut *conn, token).await;
+
+        // Always clear context before the connection returns to the pool to
+        // prevent super-admin context bleeding into a later request.
+        if let Err(e) = crate::tenant_context::clear_request_context(&mut *conn).await {
+            tracing::error!(
+                error = %e,
+                "SECURITY: failed to clear RLS context after share-token lookup"
+            );
+        }
+
+        result
+    }
+
+    /// Verify a share's password for the public share-token path.
+    ///
+    /// Like `find_share_by_token_for_share`, the share row lives under FORCE
+    /// RLS, so the lookup needed to read `password_hash` runs on a dedicated
+    /// connection with super-admin context that is always cleared afterwards.
+    /// Callers MUST have already validated the share token before calling this.
+    pub async fn verify_share_password_for_share(
+        &self,
+        share_id: Uuid,
+        password: &str,
+    ) -> Result<bool, SqlxError> {
+        let mut conn = self.pool.acquire().await?;
+
+        crate::tenant_context::set_request_context(&mut *conn, None, None, true).await?;
+
+        let share = self.find_share_by_id_rls(&mut *conn, share_id).await;
+
+        if let Err(e) = crate::tenant_context::clear_request_context(&mut *conn).await {
+            tracing::error!(
+                error = %e,
+                "SECURITY: failed to clear RLS context after share-password lookup"
+            );
+        }
+
+        match share? {
+            Some(s) => match s.password_hash {
+                Some(hash) => Ok(verify_password(password, &hash)),
+                None => Ok(true), // No password required
+            },
+            None => Ok(false),
+        }
+    }
+
+    /// Log a public share access for the public share-token path.
+    ///
+    /// `document_share_access_log` is under FORCE RLS (#754 / PAP-21); the
+    /// insert is authorized by the already-validated share token, so it runs on
+    /// a dedicated connection with super-admin context that is always cleared
+    /// afterwards (mirroring `find_by_id_for_share`).
+    pub async fn log_share_access_for_share(
+        &self,
+        data: LogShareAccess,
+    ) -> Result<ShareAccessLog, SqlxError> {
+        let mut conn = self.pool.acquire().await?;
+
+        crate::tenant_context::set_request_context(&mut *conn, None, None, true).await?;
+
+        let result = self.log_share_access_rls(&mut *conn, data).await;
+
+        if let Err(e) = crate::tenant_context::clear_request_context(&mut *conn).await {
+            tracing::error!(
+                error = %e,
+                "SECURITY: failed to clear RLS context after share-access log insert"
+            );
+        }
+
+        result
+    }
+
     /// Find document by ID with details.
     ///
     /// **Deprecated**: Use `find_by_id_with_details_rls` with an RLS-enabled connection instead.

--- a/backend/crates/db/tests/document_shares_rls_cross_tenant_tests.rs
+++ b/backend/crates/db/tests/document_shares_rls_cross_tenant_tests.rs
@@ -1,0 +1,294 @@
+//! Regression test for PAP-21 (follow-up to issue #754) — cross-tenant IDOR on
+//! the document *share* tables caused by missing `FORCE ROW LEVEL SECURITY`.
+//!
+//! Background
+//! ----------
+//! 00020 created `document_shares` / `document_share_access_log` with only
+//! `ENABLE ROW LEVEL SECURITY`, and 00172 deliberately left them un-forced
+//! (the public share-token endpoints read them via the raw pool with no org
+//! context). PostgreSQL exempts the table OWNER from RLS unless the table is
+//! `FORCE`d, and the production api-server connects as the table owner (`ppt`),
+//! so the share policies were silently bypassed — a cross-tenant read of any
+//! org's shares / access logs. To compound it, those policies filtered on
+//! `app.tenant_id`, a GUC that is never set (the codebase sets
+//! `app.current_org_id`), so even a non-owner role saw nothing for its OWN org.
+//!
+//! Migration 00178 (PAP-21) repairs both policies to use `get_current_org_id()`
+//! / `is_super_admin()` and adds `FORCE ROW LEVEL SECURITY`, after the public
+//! handlers were rewired to read these tables through a dedicated super-admin
+//! connection (`find_share_by_token_for_share` et al.).
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — even `FORCE` does not bind a superuser. To exercise the policy
+//! the way the production owner role does, the test creates a plain
+//! `NOSUPERUSER NOBYPASSRLS` role, grants it table access, and `SET ROLE`s to
+//! it. The org context (`app.current_org_id`) is a session GUC and survives
+//! `SET ROLE`.
+//!
+//! Fails on main: before 00178, an org-A caller bound by the (broken,
+//! `app.tenant_id`) policy sees NONE of its own shares — the
+//! `own-share-is-visible` assertion fails. After 00178 the caller sees exactly
+//! its own org's share and never the other org's.
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Shares {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@shares.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'Shares User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_document(pool: &PgPool, org_id: Uuid, created_by: Uuid, title: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO documents (
+            organization_id, title, category, file_key, file_name, mime_type,
+            size_bytes, created_by
+        )
+        VALUES ($1, $2, 'other', $3, $4, 'application/pdf', 1024, $5)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(title)
+    .bind(format!("s3/{title}.pdf"))
+    .bind(format!("{title}.pdf"))
+    .bind(created_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed document")
+}
+
+/// Insert a `link` share and return `(share_id, share_token)`.
+async fn seed_link_share(pool: &PgPool, document_id: Uuid, shared_by: Uuid) -> (Uuid, String) {
+    let token = format!("tok{}", Uuid::new_v4().simple());
+    let id = sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO document_shares (document_id, share_type, shared_by, share_token)
+        VALUES ($1, 'link'::document_share_type, $2, $3)
+        RETURNING id
+        "#,
+    )
+    .bind(document_id)
+    .bind(shared_by)
+    .bind(&token)
+    .fetch_one(pool)
+    .await
+    .expect("seed link share");
+    (id, token)
+}
+
+async fn seed_access_log(pool: &PgPool, share_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO document_share_access_log (share_id, accessed_by, ip_address)
+        VALUES ($1, NULL, '203.0.113.7'::inet)
+        RETURNING id
+        "#,
+    )
+    .bind(share_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed access log")
+}
+
+/// FORCE RLS on `document_shares` / `document_share_access_log` must hide
+/// another org's share + access log from a non-superuser (owner-like) role,
+/// while still exposing the caller's own org's rows, and while a super-admin
+/// context (the public share-token path) sees both. Without 00178's FORCE +
+/// policy fix this isolation is absent (the IDOR PAP-21 closes).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn document_shares_force_rls_blocks_cross_tenant_read(pool: PgPool) {
+    // --- Seed as superuser (super-admin context satisfies the org/role RLS
+    //     WITH CHECK fired by the inserts). ---
+    set_ctx(&pool, None, None, true).await;
+
+    let org_a = seed_org(&pool, "shr-a").await;
+    let org_b = seed_org(&pool, "shr-b").await;
+    let user_a = seed_user(&pool, "a@shares.test").await;
+    let user_b = seed_user(&pool, "b@shares.test").await;
+
+    let doc_a = seed_document(&pool, org_a, user_a, "alpha").await;
+    let doc_b = seed_document(&pool, org_b, user_b, "bravo").await;
+
+    let (share_a, _token_a) = seed_link_share(&pool, doc_a, user_a).await;
+    let (share_b, _token_b) = seed_link_share(&pool, doc_b, user_b).await;
+    let log_a = seed_access_log(&pool, share_a).await;
+    let _log_b = seed_access_log(&pool, share_b).await;
+
+    // --- Create a NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    let role = format!("ppt_shares_rls_test_{}", Uuid::new_v4().simple());
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"
+    )))
+    .execute(&pool)
+    .await
+    .expect("create role");
+    // The share / access-log policies join through `documents`, so the role
+    // needs SELECT on all three tables, plus EXECUTE on the RLS helper
+    // functions and SELECT on `organizations` (read by the SECURITY INVOKER
+    // soft-delete guard `get_current_org_not_deleted()`).
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT SELECT ON documents, document_shares, document_share_access_log, \
+         organizations TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant select");
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
+         get_current_org_not_deleted() TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant execute on rls helpers");
+
+    // --- All role-bound work runs on ONE dedicated connection ('SET ROLE' and
+    //     the org-context GUC are session state). ---
+    {
+        let mut conn = pool.acquire().await.expect("acquire connection");
+
+        // Org-A context, then drop to the FORCE-applicable role.
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A context");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        // Org-A's own share IS visible under its own context. (Fails on main:
+        // the broken `app.tenant_id` policy hides even the caller's own share.)
+        let see_share_a: Option<Uuid> =
+            sqlx::query_scalar("SELECT id FROM document_shares WHERE id = $1")
+                .bind(share_a)
+                .fetch_optional(&mut *conn)
+                .await
+                .expect("select share_a");
+        assert_eq!(
+            see_share_a,
+            Some(share_a),
+            "org A's own share must be visible under its own context"
+        );
+
+        // Org-B's share is NOT visible — the cross-tenant IDOR PAP-21 closes.
+        let see_share_b: Option<Uuid> =
+            sqlx::query_scalar("SELECT id FROM document_shares WHERE id = $1")
+                .bind(share_b)
+                .fetch_optional(&mut *conn)
+                .await
+                .expect("select share_b");
+        assert_eq!(
+            see_share_b, None,
+            "org B's share must NOT be visible to an org-A caller (cross-tenant IDOR)"
+        );
+
+        // A blanket SELECT returns only org-A's share.
+        let visible_shares: Vec<Uuid> =
+            sqlx::query_scalar("SELECT id FROM document_shares ORDER BY created_at")
+                .fetch_all(&mut *conn)
+                .await
+                .expect("select all visible shares");
+        assert_eq!(
+            visible_shares,
+            vec![share_a],
+            "only the caller's own org shares may be visible under FORCE RLS"
+        );
+
+        // The access log inherits the same isolation: org-A's log row visible,
+        // and the blanket read returns only it.
+        let visible_logs: Vec<Uuid> =
+            sqlx::query_scalar("SELECT id FROM document_share_access_log ORDER BY accessed_at")
+                .fetch_all(&mut *conn)
+                .await
+                .expect("select all visible access logs");
+        assert_eq!(
+            visible_logs,
+            vec![log_a],
+            "only the caller's own org share-access logs may be visible under FORCE RLS"
+        );
+
+        // --- Super-admin context (the public share-token path) sees BOTH
+        //     orgs' shares — this is the OR-leg the public handlers rely on.
+        //     Toggle the GUC directly via the built-in `set_config` (always
+        //     executable) rather than `set_request_context`, since the bound
+        //     NOSUPERUSER role may not hold EXECUTE on that custom function. ---
+        sqlx::query("SELECT set_config('app.is_super_admin', 'true', false)")
+            .execute(&mut *conn)
+            .await
+            .expect("set super-admin context");
+        let super_visible: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM document_shares WHERE id = ANY($1)")
+                .bind(vec![share_a, share_b])
+                .fetch_one(&mut *conn)
+                .await
+                .expect("count shares under super-admin");
+        assert_eq!(
+            super_visible, 2,
+            "super-admin context (public share path) must see shares across orgs"
+        );
+
+        // Drop back to superuser on this connection before it returns to the pool.
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup the test role. ---
+    set_ctx(&pool, None, None, true).await;
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "REVOKE ALL ON documents, document_shares, document_share_access_log, \
+         organizations FROM \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .ok();
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "DROP ROLE IF EXISTS \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .ok();
+}

--- a/backend/servers/api-server/src/routes/documents/shares.rs
+++ b/backend/servers/api-server/src/routes/documents/shares.rs
@@ -411,10 +411,16 @@ async fn access_shared_document(
     Path(token): Path<String>,
 ) -> Result<Json<SharedDocumentResponse>, (StatusCode, Json<ErrorResponse>)> {
     let ip_address = addr.ip().to_string();
-    // Find share by token
-    // TODO: This endpoint is public, no RLS context available
-    #[allow(deprecated)]
-    let share = match state.document_repo.find_share_by_token(&token).await {
+    // Find share by token. This public endpoint has no caller org context, so
+    // the validated token is the authorization grant: the lookup runs with
+    // super-admin RLS context on a dedicated connection (see
+    // `find_share_by_token_for_share`) so it stays correct under FORCE RLS on
+    // `document_shares` (#754 / PAP-21).
+    let share = match state
+        .document_repo
+        .find_share_by_token_for_share(&token)
+        .await
+    {
         Ok(Some(s)) => s,
         Ok(None) => {
             return Err((
@@ -476,12 +482,13 @@ async fn access_shared_document(
         }
     };
 
-    // Log access - important for audit trail but shouldn't fail the request
-    // Public endpoint, no RLS context
-    #[allow(deprecated)]
+    // Log access - important for audit trail but shouldn't fail the request.
+    // Public endpoint: the validated token authorizes the write, which runs
+    // with super-admin RLS context on a dedicated connection (FORCE RLS on
+    // `document_share_access_log`, #754 / PAP-21).
     if let Err(e) = state
         .document_repo
-        .log_share_access(LogShareAccess {
+        .log_share_access_for_share(LogShareAccess {
             share_id: share.id,
             accessed_by: None,
             ip_address: Some(ip_address.clone()),
@@ -542,10 +549,16 @@ async fn access_protected_share(
     Json(req): Json<AccessShareRequest>,
 ) -> Result<Json<SharedDocumentResponse>, (StatusCode, Json<ErrorResponse>)> {
     let ip_address = addr.ip().to_string();
-    // Find share by token
-    // TODO: This endpoint is public, no RLS context available
-    #[allow(deprecated)]
-    let share = match state.document_repo.find_share_by_token(&token).await {
+    // Find share by token. This public endpoint has no caller org context, so
+    // the validated token is the authorization grant: the lookup runs with
+    // super-admin RLS context on a dedicated connection (see
+    // `find_share_by_token_for_share`) so it stays correct under FORCE RLS on
+    // `document_shares` (#754 / PAP-21).
+    let share = match state
+        .document_repo
+        .find_share_by_token_for_share(&token)
+        .await
+    {
         Ok(Some(s)) => s,
         Ok(None) => {
             return Err((
@@ -568,10 +581,12 @@ async fn access_protected_share(
         }
     };
 
-    // Verify password
+    // Verify password. The share row is under FORCE RLS, so the lookup needed
+    // to read its password hash runs with super-admin RLS context on a
+    // dedicated connection (#754 / PAP-21).
     if !state
         .document_repo
-        .verify_share_password(share.id, &req.password)
+        .verify_share_password_for_share(share.id, &req.password)
         .await
         .unwrap_or(false)
     {
@@ -609,12 +624,13 @@ async fn access_protected_share(
         }
     };
 
-    // Log access - important for audit trail but shouldn't fail the request
-    // Public endpoint, no RLS context
-    #[allow(deprecated)]
+    // Log access - important for audit trail but shouldn't fail the request.
+    // Public endpoint: the validated token authorizes the write, which runs
+    // with super-admin RLS context on a dedicated connection (FORCE RLS on
+    // `document_share_access_log`, #754 / PAP-21).
     if let Err(e) = state
         .document_repo
-        .log_share_access(LogShareAccess {
+        .log_share_access_for_share(LogShareAccess {
             share_id: share.id,
             accessed_by: None,
             ip_address: Some(ip_address.clone()),


### PR DESCRIPTION
## PAP-21 — Close document public-share RLS-context TODOs (security)

Closes the two RLS-context TODOs in the public share-token endpoints
(`backend/servers/api-server/src/routes/documents/shares.rs:415,:546`). This is
the follow-up that migration `00172_force_documents_rls.sql` explicitly deferred:

> `document_shares` and `document_share_access_log` are deliberately NOT forced
> here … tracked as a follow-up (route the public path through an org-scoped
> connection first, then force).

### The gap
`document_shares` / `document_share_access_log` had only `ENABLE` RLS (never
`FORCE`), and their policies filtered on `current_setting('app.tenant_id')` — a
GUC **never set anywhere** (the codebase sets `app.current_org_id`). Production
api-server connects as the table **owner** (`ppt`), which bypasses un-`FORCE`d
RLS, so isolation on these tables was effectively off (a cross-tenant IDOR on
share rows + access logs). The public handlers read them via the raw pool with
no deterministic RLS context.

### The fix
1. **Routes** (`shares.rs`): the two public handlers now read shares / verify
   passwords / write the access log through dedicated **super-admin-context**
   connections (`find_share_by_token_for_share`, `verify_share_password_for_share`,
   `log_share_access_for_share`) that always clear context afterwards — mirroring
   the existing `find_by_id_for_share` (#754). TODOs and `#[allow(deprecated)]`
   removed.
2. **Repo** (`document.rs`): the three `*_for_share` helpers above.
3. **Migration `00178`**: repair `share_tenant_isolation` /
   `access_log_tenant_isolation` to the standard
   `is_super_admin() OR organization_id = get_current_org_id()` form (+ soft-delete
   guard), then `FORCE ROW LEVEL SECURITY` on both tables so the owner role is
   bound by the policy.

Authenticated share management (list/create/revoke) already runs under the
caller's org context via `RlsConnection` and keeps working; the public path
supplies super-admin context (the validated token is the authorization grant).

### Test (IG3-style, fails on main)
`backend/crates/db/tests/document_shares_rls_cross_tenant_tests.rs` — mirrors the
`documents_rls_cross_tenant_tests.rs` (#754) pattern: creates a
`NOSUPERUSER NOBYPASSRLS` role so `FORCE` binds, then asserts an org-A caller
sees only its own share + access log (never org B's), while super-admin context
(the public path) sees across orgs. On `main` the broken `app.tenant_id` policy
hides even the caller's own share → the test fails; after this PR it passes.

### Verification
- `cargo clippy -p db --all-targets` and `cargo clippy -p api-server --lib`
  (the changed targets) are clean with `-D warnings`.
- `cargo test` for the new test is **not runnable in my environment** (the
  offloaded builder has no `DATABASE_URL`/Postgres); it compiles and runs in
  CI's postgres-backed job (incl. the dedicated non-superuser RLS job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>