### PR TITLE
feat-mobile-document-download-preview: cover mobile document download + preview helpers

### DIFF
--- a/frontend/apps/mobile/src/screens/documents/DocumentDownload.test.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentDownload.test.tsx
@@ -91,12 +91,9 @@ describe('mimeTypeFromDocType', () => {
     expect(mimeTypeFromDocType(type)).toBe(expected);
   });
 
-  it.each(['folder', 'document'] as const)(
-    'falls back to octet-stream for %s',
-    (type) => {
-      expect(mimeTypeFromDocType(type)).toBe('application/octet-stream');
-    }
-  );
+  it.each(['folder', 'document'] as const)('falls back to octet-stream for %s', (type) => {
+    expect(mimeTypeFromDocType(type)).toBe('application/octet-stream');
+  });
 });
 
 describe('utiFromDocType', () => {
@@ -108,12 +105,13 @@ describe('utiFromDocType', () => {
     expect(utiFromDocType('image')).toBe('public.image');
   });
 
-  it.each(['folder', 'document', 'spreadsheet'] as const)(
-    'falls back to public.data for %s',
-    (type) => {
-      expect(utiFromDocType(type)).toBe('public.data');
-    }
-  );
+  it.each([
+    'folder',
+    'document',
+    'spreadsheet',
+  ] as const)('falls back to public.data for %s', (type) => {
+    expect(utiFromDocType(type)).toBe('public.data');
+  });
 });
 
 describe('formatBytes', () => {

--- a/frontend/apps/mobile/src/screens/documents/DocumentDownload.test.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentDownload.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for the load-bearing helpers in the document download + preview
+ * flow (Story 7A.4, mobile slice).
+ *
+ * DocumentPreviewScreen.test.tsx already pins the preview→download fallback
+ * classifier (`isPreviewUnsupportedError`). This file covers the remaining
+ * load-bearing logic that has direct user-visible / interop consequences:
+ *
+ *  - `downloadToCache` — the cache-reuse decision: a second share of the same
+ *    file MUST NOT re-download the presigned blob (correctness + bandwidth).
+ *  - `mimeTypeFromDocType` / `utiFromDocType` — wrong values silently break
+ *    the share-intent target resolution on Android / iOS respectively.
+ *  - `formatBytes` — the size label shown on the preview card.
+ *
+ * expo-file-system/legacy is mocked so the download path is exercised without
+ * touching a real device filesystem.
+ */
+
+// ─── Mock expo-file-system/legacy BEFORE importing the screen module ─────────────
+
+const mockGetInfoAsync = jest.fn();
+const mockDownloadAsync = jest.fn();
+
+jest.mock('expo-file-system/legacy', () => ({
+  get cacheDirectory() {
+    return 'file:///cache/';
+  },
+  getInfoAsync: (...args: unknown[]) => mockGetInfoAsync(...args),
+  downloadAsync: (...args: unknown[]) => mockDownloadAsync(...args),
+}));
+
+// expo-sharing is imported at module scope by DocumentPreviewScreen; stub it so
+// the import doesn't reach into native code during the test.
+jest.mock('expo-sharing', () => ({
+  isAvailableAsync: jest.fn(),
+  shareAsync: jest.fn(),
+}));
+
+import {
+  downloadToCache,
+  formatBytes,
+  mimeTypeFromDocType,
+  utiFromDocType,
+} from './DocumentPreviewScreen';
+
+beforeEach(() => {
+  mockGetInfoAsync.mockReset();
+  mockDownloadAsync.mockReset();
+});
+
+describe('downloadToCache', () => {
+  it('downloads to the cache directory when no local copy exists', async () => {
+    mockGetInfoAsync.mockResolvedValue({ exists: false });
+    mockDownloadAsync.mockResolvedValue({ uri: 'file:///cache/report.pdf' });
+
+    const uri = await downloadToCache('https://s3.example/presigned', 'report.pdf');
+
+    expect(mockGetInfoAsync).toHaveBeenCalledWith('file:///cache/report.pdf');
+    expect(mockDownloadAsync).toHaveBeenCalledWith(
+      'https://s3.example/presigned',
+      'file:///cache/report.pdf'
+    );
+    expect(uri).toBe('file:///cache/report.pdf');
+  });
+
+  it('reuses the cached copy without re-downloading when it already exists', async () => {
+    mockGetInfoAsync.mockResolvedValue({ exists: true });
+
+    const uri = await downloadToCache('https://s3.example/presigned', 'report.pdf');
+
+    expect(mockDownloadAsync).not.toHaveBeenCalled();
+    expect(uri).toBe('file:///cache/report.pdf');
+  });
+
+  it('returns the URI reported by downloadAsync (may differ from the requested dest)', async () => {
+    mockGetInfoAsync.mockResolvedValue({ exists: false });
+    mockDownloadAsync.mockResolvedValue({ uri: 'file:///cache/redirected.pdf' });
+
+    const uri = await downloadToCache('https://s3.example/presigned', 'report.pdf');
+
+    expect(uri).toBe('file:///cache/redirected.pdf');
+  });
+});
+
+describe('mimeTypeFromDocType', () => {
+  it.each([
+    ['pdf', 'application/pdf'],
+    ['image', 'image/*'],
+    ['spreadsheet', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+  ] as const)('maps %s → %s', (type, expected) => {
+    expect(mimeTypeFromDocType(type)).toBe(expected);
+  });
+
+  it.each(['folder', 'document'] as const)(
+    'falls back to octet-stream for %s',
+    (type) => {
+      expect(mimeTypeFromDocType(type)).toBe('application/octet-stream');
+    }
+  );
+});
+
+describe('utiFromDocType', () => {
+  it('maps pdf to the Adobe PDF UTI', () => {
+    expect(utiFromDocType('pdf')).toBe('com.adobe.pdf');
+  });
+
+  it('maps image to public.image', () => {
+    expect(utiFromDocType('image')).toBe('public.image');
+  });
+
+  it.each(['folder', 'document', 'spreadsheet'] as const)(
+    'falls back to public.data for %s',
+    (type) => {
+      expect(utiFromDocType(type)).toBe('public.data');
+    }
+  );
+});
+
+describe('formatBytes', () => {
+  it.each([
+    [0, '0 B'],
+    [512, '512 B'],
+    [1023, '1023 B'],
+    [1024, '1.0 KB'],
+    [1536, '1.5 KB'],
+    [1024 * 1024, '1.0 MB'],
+    [Math.round(2.5 * 1024 * 1024), '2.5 MB'],
+  ])('formats %d bytes as %s', (bytes, expected) => {
+    expect(formatBytes(bytes)).toBe(expected);
+  });
+});

--- a/frontend/apps/mobile/src/screens/documents/DocumentPreviewScreen.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentPreviewScreen.tsx
@@ -56,7 +56,12 @@ interface DocumentPreviewScreenProps {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function formatBytes(bytes: number): string {
+/**
+ * Human-readable file size. Exported so the size label shown next to a
+ * downloaded/previewed document can be unit-tested at the boundaries
+ * (B / KB / MB) without rendering the RN tree.
+ */
+export function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
@@ -96,8 +101,13 @@ function getFileIcon(type: Document['type']): string {
 /**
  * Download a remote file to the device cache directory and return the local
  * URI. Used before invoking expo-sharing (which requires a local URI).
+ *
+ * Exported so the cache-reuse behaviour (skip the network round-trip when a
+ * session-local copy already exists) can be unit-tested with a mocked
+ * expo-file-system — this is the load-bearing part of the download path that
+ * avoids re-fetching the presigned blob on every share.
  */
-async function downloadToCache(url: string, filename: string): Promise<string> {
+export async function downloadToCache(url: string, filename: string): Promise<string> {
   const dest = `${FileSystem.cacheDirectory ?? ''}${filename}`;
   const info = await FileSystem.getInfoAsync(dest);
   // Re-use cached copy if it's already there (session-local cache).
@@ -310,7 +320,12 @@ export function DocumentPreviewScreen({ document, onBack }: DocumentPreviewScree
 
 // ─── MIME / UTI helpers ───────────────────────────────────────────────────────
 
-function mimeTypeFromDocType(type: Document['type']): string {
+/**
+ * Map the app's coarse document type to a MIME type for expo-sharing.
+ * Exported for unit testing — a wrong MIME type silently breaks the
+ * Android share intent target resolution.
+ */
+export function mimeTypeFromDocType(type: Document['type']): string {
   switch (type) {
     case 'pdf':
       return 'application/pdf';
@@ -323,8 +338,8 @@ function mimeTypeFromDocType(type: Document['type']): string {
   }
 }
 
-/** iOS UTI used by expo-sharing. Ignored on Android. */
-function utiFromDocType(type: Document['type']): string | undefined {
+/** iOS UTI used by expo-sharing. Ignored on Android. Exported for unit testing. */
+export function utiFromDocType(type: Document['type']): string | undefined {
   if (!Platform.OS) return undefined; // safety guard for test env
   switch (type) {
     case 'pdf':


### PR DESCRIPTION
## Task
Coverage 7a-4: implement the mobile (React Native, frontend/apps/mobile) document download + preview slice (presigned download, in-app preview) against the documents API. Include unit tests.

## Owner
pm-frontend (actual area: frontend/apps/mobile → react-native specialist)

## Finding: slice already exists on dev
The 7A.4 mobile download + preview slice is **already implemented and merged on `dev`** (commit `5515fd4`): `DocumentPreviewScreen.tsx` fetches a presigned `/api/v1/documents/{id}/preview` URL, opens it in the native viewer via `Linking.openURL`, falls back to `/download` on `PREVIEW_NOT_SUPPORTED` (400), and shares via `expo-sharing` after `downloadToCache`. The same logic is reused by `DocumentDetailScreen.tsx`. `DocumentPreviewScreen.test.tsx` already pins the `isPreviewUnsupportedError` fallback classifier.

Re-implementing the screen would duplicate shipped code. Instead this PR **closes the test-coverage gap** for the load-bearing pure helpers in that flow, which previously had no tests:

- Exported `downloadToCache`, `formatBytes`, `mimeTypeFromDocType`, `utiFromDocType` from `DocumentPreviewScreen.tsx` (additive — no behaviour change).
- Added `DocumentDownload.test.tsx` (20 cases):
  - `downloadToCache` — cache-reuse decision (no re-download when a session-local copy exists; returns the URI reported by `downloadAsync`), with `expo-file-system/legacy` mocked.
  - `mimeTypeFromDocType` / `utiFromDocType` — correct MIME / iOS-UTI mapping (wrong values silently break the share-intent target resolution).
  - `formatBytes` — B/KB/MB boundaries.

## Tested (Band A — fast check)
- `pnpm -F mobile test -- --testPathPattern="screens/documents"` → exit 0 (3 suites, **40 tests passed**, 20 new). The `expo-sharing` `process.env.EXPO_OS` warning is pre-existing console noise on `dev`, not a failure.
- `pnpm -F mobile typecheck` (`tsc --noEmit`) → exit 0.

## Built (Band B — full build)
skipped: change <50 LOC substantive (test-only + 4 export keywords), no public API / config / build-output change.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Scope drift
`scope-check.sh --owner pm-frontend` returns exit 2: `pm-frontend`'s mapped areas in `owner-areas.json` (`ppt-web`, `reality-web`, `admin-web`, `frontend/packages`, `docs/screens`) do **not** include `frontend/apps/mobile/**`, which belongs to the react-native specialist. The task explicitly targets `frontend/apps/mobile`, so the diff staying entirely under `frontend/apps/mobile/src/screens/documents/` is expected and justified. No files outside the documents screen dir were touched. `reuse-grep` (react-native) returned no warnings.

## Remote-tested
skipped

## Notes
Reviewer call: the underlying feature is already on `dev`; this PR is a coverage top-up rather than a fresh implementation. If a from-scratch re-implementation was expected, that would conflict with the merged code and should be declined in favour of this delta.

https://claude.ai/code/session_01PfMsQwCA66r3YR6yypPGyt

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfMsQwCA66r3YR6yypPGyt)_