### PR TITLE
fix(aml_dsa): close authz & data-integrity gaps (PAP-38)

### DIFF
--- a/backend/crates/db/src/repositories/compliance.rs
+++ b/backend/crates/db/src/repositories/compliance.rs
@@ -363,6 +363,94 @@ impl ComplianceRepository {
         Ok(case)
     }
 
+    /// Resolve the real owner (user id) of a piece of moderated content.
+    ///
+    /// Returns `Ok(None)` when the content row cannot be found or the content
+    /// type has no resolvable owner, so callers can reject the request rather
+    /// than storing a bogus owner (PAP-38). When `organization_id` is provided,
+    /// tenant-scoped tables are filtered by it to prevent cross-tenant
+    /// resolution.
+    pub async fn resolve_content_owner(
+        &self,
+        content_type: ModeratedContentType,
+        content_id: Uuid,
+        organization_id: Option<Uuid>,
+    ) -> Result<Option<Uuid>, SqlxError> {
+        let owner: Option<(Uuid,)> = match content_type {
+            ModeratedContentType::Listing => {
+                sqlx::query_as(
+                    r#"SELECT created_by FROM listings
+                       WHERE id = $1 AND ($2::uuid IS NULL OR organization_id = $2)"#,
+                )
+                .bind(content_id)
+                .bind(organization_id)
+                .fetch_optional(&self.pool)
+                .await?
+            }
+            ModeratedContentType::ListingPhoto => {
+                sqlx::query_as(
+                    r#"SELECT l.created_by FROM listing_photos p
+                       JOIN listings l ON l.id = p.listing_id
+                       WHERE p.id = $1 AND ($2::uuid IS NULL OR l.organization_id = $2)"#,
+                )
+                .bind(content_id)
+                .bind(organization_id)
+                .fetch_optional(&self.pool)
+                .await?
+            }
+            ModeratedContentType::Announcement => {
+                sqlx::query_as(
+                    r#"SELECT author_id FROM announcements
+                       WHERE id = $1 AND ($2::uuid IS NULL OR organization_id = $2)"#,
+                )
+                .bind(content_id)
+                .bind(organization_id)
+                .fetch_optional(&self.pool)
+                .await?
+            }
+            ModeratedContentType::Document => {
+                sqlx::query_as(
+                    r#"SELECT created_by FROM documents
+                       WHERE id = $1 AND ($2::uuid IS NULL OR organization_id = $2)"#,
+                )
+                .bind(content_id)
+                .bind(organization_id)
+                .fetch_optional(&self.pool)
+                .await?
+            }
+            ModeratedContentType::Message => {
+                sqlx::query_as(r#"SELECT sender_id FROM messages WHERE id = $1"#)
+                    .bind(content_id)
+                    .fetch_optional(&self.pool)
+                    .await?
+            }
+            ModeratedContentType::CommunityPost => {
+                sqlx::query_as(r#"SELECT author_id FROM community_posts WHERE id = $1"#)
+                    .bind(content_id)
+                    .fetch_optional(&self.pool)
+                    .await?
+            }
+            ModeratedContentType::Comment => {
+                sqlx::query_as(r#"SELECT author_id FROM community_comments WHERE id = $1"#)
+                    .bind(content_id)
+                    .fetch_optional(&self.pool)
+                    .await?
+            }
+            ModeratedContentType::UserProfile => {
+                // A profile's content_id is the profiled user; that user is the
+                // owner. Confirm the user exists before trusting the id.
+                sqlx::query_as(r#"SELECT id FROM users WHERE id = $1"#)
+                    .bind(content_id)
+                    .fetch_optional(&self.pool)
+                    .await?
+            }
+            // Review has no backing table in the current schema.
+            ModeratedContentType::Review => None,
+        };
+
+        Ok(owner.map(|(id,)| id))
+    }
+
     /// Get moderation case by ID.
     pub async fn get_moderation_case(&self, id: Uuid) -> Result<Option<ModerationCase>, SqlxError> {
         let case =

--- a/backend/crates/db/src/repositories/compliance.rs
+++ b/backend/crates/db/src/repositories/compliance.rs
@@ -419,30 +419,65 @@ impl ComplianceRepository {
                 .await?
             }
             ModeratedContentType::Message => {
-                sqlx::query_as(r#"SELECT sender_id FROM messages WHERE id = $1"#)
-                    .bind(content_id)
-                    .fetch_optional(&self.pool)
-                    .await?
+                // Messages carry no org column; scope via the parent thread so a
+                // reporter cannot resolve a message outside their tenant (PAP-48).
+                sqlx::query_as(
+                    r#"SELECT m.sender_id FROM messages m
+                       JOIN message_threads t ON t.id = m.thread_id
+                       WHERE m.id = $1 AND ($2::uuid IS NULL OR t.organization_id = $2)"#,
+                )
+                .bind(content_id)
+                .bind(organization_id)
+                .fetch_optional(&self.pool)
+                .await?
             }
             ModeratedContentType::CommunityPost => {
-                sqlx::query_as(r#"SELECT author_id FROM community_posts WHERE id = $1"#)
-                    .bind(content_id)
-                    .fetch_optional(&self.pool)
-                    .await?
+                // Posts reach their org via group -> building; scope explicitly
+                // rather than relying on RLS session context (PAP-48).
+                sqlx::query_as(
+                    r#"SELECT p.author_id FROM community_posts p
+                       JOIN community_groups g ON g.id = p.group_id
+                       JOIN buildings b ON b.id = g.building_id
+                       WHERE p.id = $1 AND ($2::uuid IS NULL OR b.organization_id = $2)"#,
+                )
+                .bind(content_id)
+                .bind(organization_id)
+                .fetch_optional(&self.pool)
+                .await?
             }
             ModeratedContentType::Comment => {
-                sqlx::query_as(r#"SELECT author_id FROM community_comments WHERE id = $1"#)
-                    .bind(content_id)
-                    .fetch_optional(&self.pool)
-                    .await?
+                // Comments reach their org via post -> group -> building (PAP-48).
+                sqlx::query_as(
+                    r#"SELECT c.author_id FROM community_comments c
+                       JOIN community_posts p ON p.id = c.post_id
+                       JOIN community_groups g ON g.id = p.group_id
+                       JOIN buildings b ON b.id = g.building_id
+                       WHERE c.id = $1 AND ($2::uuid IS NULL OR b.organization_id = $2)"#,
+                )
+                .bind(content_id)
+                .bind(organization_id)
+                .fetch_optional(&self.pool)
+                .await?
             }
             ModeratedContentType::UserProfile => {
                 // A profile's content_id is the profiled user; that user is the
-                // owner. Confirm the user exists before trusting the id.
-                sqlx::query_as(r#"SELECT id FROM users WHERE id = $1"#)
-                    .bind(content_id)
-                    .fetch_optional(&self.pool)
-                    .await?
+                // owner. Confirm the user exists and — when an org is supplied —
+                // is an active member of that org, so a reporter cannot resolve
+                // a user outside their tenant (PAP-48).
+                sqlx::query_as(
+                    r#"SELECT u.id FROM users u
+                       WHERE u.id = $1
+                         AND ($2::uuid IS NULL OR EXISTS (
+                             SELECT 1 FROM organization_members om
+                             WHERE om.user_id = u.id
+                               AND om.organization_id = $2
+                               AND om.status = 'active'
+                         ))"#,
+                )
+                .bind(content_id)
+                .bind(organization_id)
+                .fetch_optional(&self.pool)
+                .await?
             }
             // Review has no backing table in the current schema.
             ModeratedContentType::Review => None,

--- a/backend/crates/db/tests/moderation_report_owner_resolution_tests.rs
+++ b/backend/crates/db/tests/moderation_report_owner_resolution_tests.rs
@@ -1,0 +1,335 @@
+//! End-to-end DB verification for `ComplianceRepository::resolve_content_owner`
+//! (PAP-38 / PAP-48).
+//!
+//! `report_content` (`api-server/src/routes/aml_dsa.rs`) used to persist a
+//! `Uuid::new_v4()` placeholder as the moderated content's owner. PAP-38
+//! replaced that with a real owner lookup via `resolve_content_owner`, whose
+//! per-type SQL is runtime `query_as` (NOT compile-checked) — so it needs a
+//! live-DB test to prove the columns/joins are valid and the owner is real.
+//!
+//! These tests assert, for every moderatable content type:
+//!   1. a seeded piece of content resolves to its **real** owner id, and
+//!   2. an unknown `content_id` resolves to `None` (the handler maps this to a
+//!      404 *before* any moderation row is written — no bogus-owner rows), and
+//!   3. content owned by org A is **not** resolvable when the caller's tenant
+//!      is org B (the explicit `organization_id = $2` tenant filter — PAP-48).
+//!
+//! Tenant scoping note (PAP-48): the four content types whose tables have no
+//! direct `organization_id` column — Message, CommunityPost, Comment,
+//! UserProfile — are scoped here by joining to their org-bearing parent
+//! (`message_threads`, `community_groups`->`buildings`) or, for UserProfile,
+//! by requiring an active `organization_members` row. Before PAP-48 those four
+//! branches ignored the passed `organization_id` entirely.
+//!
+//! `#[sqlx::test]` connects as the Postgres superuser, which bypasses RLS — so
+//! these tests exercise the *query logic and the explicit tenant filter* in
+//! isolation. RLS-enforcement of the same path under the production owner role
+//! is a separate concern tracked alongside this work.
+
+use db::models::ModeratedContentType;
+use db::repositories::ComplianceRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Mirror `db::tenant_context::set_request_context`. Seeding `organizations`
+/// fires a roles-trigger with an RLS `WITH CHECK`; super-admin context
+/// satisfies it.
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO organizations (name, slug, contact_email, status)
+           VALUES ($1, $2, $3, 'active') RETURNING id"#,
+    )
+    .bind(format!("Mod {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@mod.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+           VALUES ($1, 'test_hash', 'Mod User', 'active', NOW(), 'public') RETURNING id"#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Make `user` an active member of `org` (required for UserProfile scoping).
+async fn seed_membership(pool: &PgPool, org: Uuid, user: Uuid) {
+    sqlx::query(
+        r#"INSERT INTO organization_members (organization_id, user_id, role_type, status)
+           VALUES ($1, $2, 'member', 'active')"#,
+    )
+    .bind(org)
+    .bind(user)
+    .execute(pool)
+    .await
+    .expect("seed membership");
+}
+
+async fn seed_building(pool: &PgPool, org: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO buildings (organization_id, name, street, city, postal_code, country)
+           VALUES ($1, 'Mod Bldg', 'St', 'City', '00000', 'SK') RETURNING id"#,
+    )
+    .bind(org)
+    .fetch_one(pool)
+    .await
+    .expect("seed building")
+}
+
+async fn seed_listing(pool: &PgPool, org: Uuid, owner: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO listings (organization_id, created_by, transaction_type, title,
+               property_type, street, city, postal_code, country, price)
+           VALUES ($1, $2, 'sale', 'L', 'apartment', 'St', 'City', '00000', 'SK', 100000)
+           RETURNING id"#,
+    )
+    .bind(org)
+    .bind(owner)
+    .fetch_one(pool)
+    .await
+    .expect("seed listing")
+}
+
+async fn seed_listing_photo(pool: &PgPool, listing: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO listing_photos (listing_id, url) VALUES ($1, 'https://x/p.jpg')
+           RETURNING id"#,
+    )
+    .bind(listing)
+    .fetch_one(pool)
+    .await
+    .expect("seed listing_photo")
+}
+
+async fn seed_announcement(pool: &PgPool, org: Uuid, author: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO announcements (organization_id, author_id, title, content)
+           VALUES ($1, $2, 'A', 'body') RETURNING id"#,
+    )
+    .bind(org)
+    .bind(author)
+    .fetch_one(pool)
+    .await
+    .expect("seed announcement")
+}
+
+async fn seed_document(pool: &PgPool, org: Uuid, owner: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO documents (organization_id, title, category, file_key, file_name,
+               mime_type, size_bytes, created_by)
+           VALUES ($1, 'D', 'other', 's3/d.pdf', 'd.pdf', 'application/pdf', 1024, $2)
+           RETURNING id"#,
+    )
+    .bind(org)
+    .bind(owner)
+    .fetch_one(pool)
+    .await
+    .expect("seed document")
+}
+
+/// Seed a message in `org` sent by `sender`; returns the message id.
+async fn seed_message(pool: &PgPool, org: Uuid, sender: Uuid, other: Uuid) -> Uuid {
+    let thread = sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO message_threads (organization_id, participant_ids)
+           VALUES ($1, ARRAY[$2, $3]::uuid[]) RETURNING id"#,
+    )
+    .bind(org)
+    .bind(sender)
+    .bind(other)
+    .fetch_one(pool)
+    .await
+    .expect("seed thread");
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO messages (thread_id, sender_id, content) VALUES ($1, $2, 'hi')
+           RETURNING id"#,
+    )
+    .bind(thread)
+    .bind(sender)
+    .fetch_one(pool)
+    .await
+    .expect("seed message")
+}
+
+/// Seed a community group/post/comment chain rooted in `org`'s building.
+/// Returns `(post_id, comment_id)`, both authored by `author`.
+async fn seed_community(pool: &PgPool, building: Uuid, author: Uuid) -> (Uuid, Uuid) {
+    let group = sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO community_groups (building_id, name, slug) VALUES ($1, 'G', $2)
+           RETURNING id"#,
+    )
+    .bind(building)
+    .bind(format!("g-{}", Uuid::new_v4()))
+    .fetch_one(pool)
+    .await
+    .expect("seed group");
+    let post = sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO community_posts (group_id, author_id, content) VALUES ($1, $2, 'p')
+           RETURNING id"#,
+    )
+    .bind(group)
+    .bind(author)
+    .fetch_one(pool)
+    .await
+    .expect("seed post");
+    let comment = sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO community_comments (post_id, author_id, content) VALUES ($1, $2, 'c')
+           RETURNING id"#,
+    )
+    .bind(post)
+    .bind(author)
+    .fetch_one(pool)
+    .await
+    .expect("seed comment");
+    (post, comment)
+}
+
+/// All resolvable types for org A, seeded and owned by a known user, must
+/// resolve to that real owner id — never a placeholder.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn resolve_content_owner_returns_real_owner_for_every_type(pool: PgPool) {
+    set_ctx(&pool, None, None, true).await;
+
+    let org = seed_org(&pool, "owner-a").await;
+    let owner = seed_user(&pool, "owner@mod.test").await;
+    let other = seed_user(&pool, "other@mod.test").await;
+    seed_membership(&pool, org, owner).await;
+    let building = seed_building(&pool, org).await;
+
+    let listing = seed_listing(&pool, org, owner).await;
+    let photo = seed_listing_photo(&pool, listing).await;
+    let announcement = seed_announcement(&pool, org, owner).await;
+    let document = seed_document(&pool, org, owner).await;
+    let message = seed_message(&pool, org, owner, other).await;
+    let (post, comment) = seed_community(&pool, building, owner).await;
+
+    let repo = ComplianceRepository::new(pool.clone());
+    let scope = Some(org);
+
+    let cases = [
+        (ModeratedContentType::Listing, listing),
+        (ModeratedContentType::ListingPhoto, photo),
+        (ModeratedContentType::Announcement, announcement),
+        (ModeratedContentType::Document, document),
+        (ModeratedContentType::Message, message),
+        (ModeratedContentType::CommunityPost, post),
+        (ModeratedContentType::Comment, comment),
+        (ModeratedContentType::UserProfile, owner),
+    ];
+
+    for (content_type, content_id) in cases {
+        let resolved = repo
+            .resolve_content_owner(content_type, content_id, scope)
+            .await
+            .expect("resolve_content_owner should not error");
+        assert_eq!(
+            resolved,
+            Some(owner),
+            "{content_type:?} must resolve to the real owner, got {resolved:?}"
+        );
+    }
+}
+
+/// An unknown `content_id` resolves to `None` for every type. The handler turns
+/// this into a 404 *before* writing a moderation case — so no row is ever
+/// persisted with a bogus owner (test-plan step 3).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn resolve_content_owner_unknown_id_is_none(pool: PgPool) {
+    set_ctx(&pool, None, None, true).await;
+    let org = seed_org(&pool, "unknown-a").await;
+    let repo = ComplianceRepository::new(pool.clone());
+    let bogus = Uuid::new_v4();
+
+    for content_type in [
+        ModeratedContentType::Listing,
+        ModeratedContentType::ListingPhoto,
+        ModeratedContentType::Announcement,
+        ModeratedContentType::Document,
+        ModeratedContentType::Message,
+        ModeratedContentType::CommunityPost,
+        ModeratedContentType::Comment,
+        ModeratedContentType::UserProfile,
+        ModeratedContentType::Review, // no backing table -> always None
+    ] {
+        let resolved = repo
+            .resolve_content_owner(content_type, bogus, Some(org))
+            .await
+            .expect("resolve_content_owner should not error");
+        assert_eq!(resolved, None, "{content_type:?} unknown id must be None");
+    }
+}
+
+/// Content owned by org A must NOT be resolvable when the caller's tenant is
+/// org B — for every type, including the four (Message/CommunityPost/Comment/
+/// UserProfile) that ignored `organization_id` before PAP-48 (test-plan step 4).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn resolve_content_owner_rejects_cross_tenant(pool: PgPool) {
+    set_ctx(&pool, None, None, true).await;
+
+    let org_a = seed_org(&pool, "xt-a").await;
+    let org_b = seed_org(&pool, "xt-b").await;
+    let owner = seed_user(&pool, "xt-owner@mod.test").await;
+    let other = seed_user(&pool, "xt-other@mod.test").await;
+    // `owner` is a member of org A only.
+    seed_membership(&pool, org_a, owner).await;
+    let building_a = seed_building(&pool, org_a).await;
+
+    let listing = seed_listing(&pool, org_a, owner).await;
+    let photo = seed_listing_photo(&pool, listing).await;
+    let announcement = seed_announcement(&pool, org_a, owner).await;
+    let document = seed_document(&pool, org_a, owner).await;
+    let message = seed_message(&pool, org_a, owner, other).await;
+    let (post, comment) = seed_community(&pool, building_a, owner).await;
+
+    let repo = ComplianceRepository::new(pool.clone());
+    let attacker_scope = Some(org_b);
+
+    let cases = [
+        (ModeratedContentType::Listing, listing),
+        (ModeratedContentType::ListingPhoto, photo),
+        (ModeratedContentType::Announcement, announcement),
+        (ModeratedContentType::Document, document),
+        (ModeratedContentType::Message, message),
+        (ModeratedContentType::CommunityPost, post),
+        (ModeratedContentType::Comment, comment),
+        (ModeratedContentType::UserProfile, owner),
+    ];
+
+    for (content_type, content_id) in cases {
+        let resolved = repo
+            .resolve_content_owner(content_type, content_id, attacker_scope)
+            .await
+            .expect("resolve_content_owner should not error");
+        assert_eq!(
+            resolved, None,
+            "{content_type:?} from org A must NOT resolve for an org-B caller (got {resolved:?})"
+        );
+
+        // ...but the same lookup under org A's scope still succeeds, proving the
+        // None above is tenant scoping, not a broken query.
+        let same_tenant = repo
+            .resolve_content_owner(content_type, content_id, Some(org_a))
+            .await
+            .expect("resolve_content_owner should not error");
+        assert_eq!(
+            same_tenant,
+            Some(owner),
+            "{content_type:?} must still resolve for its own tenant"
+        );
+    }
+}

--- a/backend/servers/api-server/src/routes/aml_dsa.rs
+++ b/backend/servers/api-server/src/routes/aml_dsa.rs
@@ -1779,7 +1779,10 @@ async fn file_appeal(
                 "Failed to file appeal".to_string(),
             )
         })?
-        .ok_or((StatusCode::NOT_FOUND, "Moderation case not found".to_string()))?;
+        .ok_or((
+            StatusCode::NOT_FOUND,
+            "Moderation case not found".to_string(),
+        ))?;
 
     authorize_appeal(&user, &existing)?;
 

--- a/backend/servers/api-server/src/routes/aml_dsa.rs
+++ b/backend/servers/api-server/src/routes/aml_dsa.rs
@@ -18,7 +18,7 @@ use common::TenantRole;
 use db::models::compliance::{
     AmlAssessmentStatus, AmlRiskLevel, CreateAmlRiskAssessment, CreateEnhancedDueDiligence,
     CreateModerationCase, DsaReportStatus, EddStatus, ModeratedContentType, ModerationActionType,
-    ModerationStatus, TakeModerationAction, ViolationType,
+    ModerationCase, ModerationStatus, TakeModerationAction, ViolationType,
 };
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -81,6 +81,24 @@ fn require_compliance_role(user: &AuthUser) -> Result<(), (StatusCode, String)> 
             StatusCode::FORBIDDEN,
             "This endpoint requires compliance officer privileges".to_string(),
         )),
+    }
+}
+
+/// Authorize a caller to file an appeal on a moderation case.
+///
+/// A caller may appeal only if they own the content under moderation, or the
+/// case belongs to their organization. Without this check any authenticated
+/// user could appeal any case in any tenant (PAP-38).
+fn authorize_appeal(user: &AuthUser, case: &ModerationCase) -> Result<(), (StatusCode, String)> {
+    let is_owner = case.content_owner_id == user.user_id;
+    let same_org = user.tenant_id.is_some() && case.organization_id == user.tenant_id;
+    if is_owner || same_org {
+        Ok(())
+    } else {
+        Err((
+            StatusCode::FORBIDDEN,
+            "You are not authorized to file an appeal on this case".to_string(),
+        ))
     }
 }
 
@@ -161,6 +179,8 @@ async fn create_aml_assessment(
     user: AuthUser,
     Json(req): Json<CreateAmlAssessmentRequest>,
 ) -> Result<Json<AmlAssessmentResponse>, (StatusCode, String)> {
+    require_compliance_role(&user)?;
+
     let org_id = user.tenant_id.ok_or((
         StatusCode::BAD_REQUEST,
         "Organization context required".to_string(),
@@ -1746,7 +1766,22 @@ async fn file_appeal(
     Path(id): Path<Uuid>,
     Json(req): Json<FileAppealRequest>,
 ) -> Result<Json<ModerationCaseResponse>, (StatusCode, String)> {
-    // Any authenticated user can file appeal for their content
+    // Any authenticated user can file an appeal, but only for content they own
+    // or for a case within their own organization.
+    let existing = state
+        .compliance_repo
+        .get_moderation_case(id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to load moderation case: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to file appeal".to_string(),
+            )
+        })?
+        .ok_or((StatusCode::NOT_FOUND, "Moderation case not found".to_string()))?;
+
+    authorize_appeal(&user, &existing)?;
 
     let case = state
         .compliance_repo
@@ -1867,15 +1902,31 @@ async fn report_content(
 ) -> Result<Json<ModerationCaseResponse>, (StatusCode, String)> {
     // Any authenticated user can report content
 
+    // Resolve the real owner of the reported content. Storing a placeholder
+    // here corrupts violation-history and owner-notification logic downstream,
+    // so reject the report when the owner cannot be determined (PAP-38).
+    let content_owner_id = state
+        .compliance_repo
+        .resolve_content_owner(req.content_type, req.content_id, user.tenant_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to resolve content owner: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to report content".to_string(),
+            )
+        })?
+        .ok_or((
+            StatusCode::NOT_FOUND,
+            "Reported content could not be found".to_string(),
+        ))?;
+
     let create_req = CreateModerationCase {
         content_type: req.content_type,
         content_id: req.content_id,
         violation_type: req.violation_type,
         report_reason: req.reason,
     };
-
-    // For now, use a placeholder for content_owner_id - in production this would be looked up
-    let content_owner_id = Uuid::new_v4();
 
     let case = state
         .compliance_repo
@@ -1960,4 +2011,110 @@ async fn get_action_templates(
         .collect();
 
     Ok(Json(responses))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use db::models::compliance::{ModerationStatus, ReportSource};
+
+    fn user_with(role: Option<TenantRole>, tenant_id: Option<Uuid>) -> AuthUser {
+        AuthUser {
+            user_id: Uuid::new_v4(),
+            email: "u@example.com".to_string(),
+            name: "U".to_string(),
+            tenant_id,
+            role,
+        }
+    }
+
+    fn case_for(content_owner_id: Uuid, organization_id: Option<Uuid>) -> ModerationCase {
+        let now = Utc::now();
+        ModerationCase {
+            id: Uuid::new_v4(),
+            content_type: ModeratedContentType::Listing,
+            content_id: Uuid::new_v4(),
+            content_preview: None,
+            content_owner_id,
+            organization_id,
+            report_source: ReportSource::User,
+            reported_by: None,
+            automated_confidence: None,
+            violation_type: None,
+            report_reason: None,
+            status: ModerationStatus::Pending,
+            priority: 3,
+            assigned_to: None,
+            assigned_at: None,
+            decision: None,
+            decision_rationale: None,
+            action_template_id: None,
+            decided_by: None,
+            decided_at: None,
+            appeal_filed: false,
+            appeal_reason: None,
+            appeal_filed_at: None,
+            appeal_decision: None,
+            appeal_decided_by: None,
+            appeal_decided_at: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[test]
+    fn create_assessment_requires_compliance_role() {
+        // Non-compliance roles are rejected with 403.
+        for role in [
+            None,
+            Some(TenantRole::Manager),
+            Some(TenantRole::Owner),
+            Some(TenantRole::OrgAdmin),
+        ] {
+            let err = require_compliance_role(&user_with(role, Some(Uuid::new_v4())))
+                .expect_err("non-compliance role must be rejected");
+            assert_eq!(err.0, StatusCode::FORBIDDEN);
+        }
+
+        // Compliance roles are allowed.
+        for role in [TenantRole::SuperAdmin, TenantRole::PlatformAdmin] {
+            assert!(require_compliance_role(&user_with(Some(role), Some(Uuid::new_v4()))).is_ok());
+        }
+    }
+
+    #[test]
+    fn appeal_rejected_for_other_owner_and_other_org() {
+        let user = user_with(Some(TenantRole::Resident), Some(Uuid::new_v4()));
+        // Case owned by someone else, in a different org.
+        let case = case_for(Uuid::new_v4(), Some(Uuid::new_v4()));
+        let err = authorize_appeal(&user, &case).expect_err("cross-tenant appeal must be rejected");
+        assert_eq!(err.0, StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn appeal_allowed_for_content_owner() {
+        let user = user_with(Some(TenantRole::Resident), Some(Uuid::new_v4()));
+        // Different org, but the caller owns the content.
+        let case = case_for(user.user_id, Some(Uuid::new_v4()));
+        assert!(authorize_appeal(&user, &case).is_ok());
+    }
+
+    #[test]
+    fn appeal_allowed_within_same_org() {
+        let org = Uuid::new_v4();
+        let user = user_with(Some(TenantRole::Resident), Some(org));
+        // Different owner, but the case belongs to the caller's org.
+        let case = case_for(Uuid::new_v4(), Some(org));
+        assert!(authorize_appeal(&user, &case).is_ok());
+    }
+
+    #[test]
+    fn appeal_no_tenant_matches_orgless_case_only_by_ownership() {
+        // A user without a tenant must not pass the org check against an
+        // org-less case purely because both are None.
+        let user = user_with(Some(TenantRole::Resident), None);
+        let case = case_for(Uuid::new_v4(), None);
+        let err = authorize_appeal(&user, &case).expect_err("None==None must not grant access");
+        assert_eq!(err.0, StatusCode::FORBIDDEN);
+    }
 }


### PR DESCRIPTION
## Summary
Security-review remediation for `backend/servers/api-server/src/routes/aml_dsa.rs` (PAP-38, parent PAP-35). Closes three HIGH gaps that block FR115 production-readiness.

1. **`create_aml_assessment`** — added `require_compliance_role(&user)?`. Only `SuperAdmin`/`PlatformAdmin` may create AML risk assessments; non-compliance roles now get **403** (previously any authenticated tenant user could).
2. **`file_appeal`** — loads the moderation case and authorizes via new `authorize_appeal()`: caller must own the content **or** the case must be in their org; otherwise **403** (case missing → 404). Previously any user could appeal any case in any tenant.
3. **`report_content`** — resolves the real owner via new `ComplianceRepository::resolve_content_owner()` (per `content_type`, tenant-scoped) instead of the `Uuid::new_v4()` placeholder; returns **404** when unresolved, keeping violation-history and owner-notification correct.

## Tests
Added unit tests in `aml_dsa::tests` (5 tests, all passing):
- `create_assessment_requires_compliance_role`
- `appeal_rejected_for_other_owner_and_other_org`
- `appeal_allowed_for_content_owner`
- `appeal_allowed_within_same_org`
- `appeal_no_tenant_matches_orgless_case_only_by_ownership` (guards against `None == None` granting access)

`cargo test -p api-server --lib aml_dsa` → `5 passed; 0 failed`. Full `api-server` crate compiles clean.

## QA note
Per acceptance, QA should verify `report_content` persists the real `content_owner_id` end-to-end against a real DB (the owner-resolution SQL uses runtime `query_as`, not compile-checked).

Co-Authored-By: Paperclip <noreply@paperclip.ing>