### PR TITLE
fix(aml-dsa): lock DSA reports to platform roles + fix file-path disclosure (PAP-47)

### DIFF
--- a/backend/servers/api-server/src/routes/aml_dsa.rs
+++ b/backend/servers/api-server/src/routes/aml_dsa.rs
@@ -1356,6 +1356,38 @@ pub struct GenerateDsaReportRequest {
     pub period_end: DateTime<Utc>,
 }
 
+/// Short-lived presigned download URL for a DSA report file.
+#[derive(Debug, Serialize)]
+pub struct DsaReportDownloadResponse {
+    pub url: String,
+    pub expires_at: DateTime<Utc>,
+}
+
+/// Build a non-disclosing download reference for a DSA report.
+///
+/// PAP-47 / PAP-35: the stored `report_file_path` is an internal storage key
+/// and must never be returned to clients. When a report file exists we expose
+/// only the public API path to the download endpoint (which itself issues a
+/// short-lived presigned URL); otherwise `None`. Never the raw key/filesystem
+/// path.
+fn dsa_report_download_ref(id: Uuid, report_file_path: &Option<String>) -> Option<String> {
+    report_file_path
+        .as_ref()
+        .map(|_| format!("/api/v1/aml-dsa/dsa/reports/{id}/download"))
+}
+
+// ----------------------------------------------------------------------------
+// DSA transparency reports (Epic 67 / Story 67.3) — platform-VLOP model.
+//
+// Per the PAP-40 -> PAP-47 decision, DSA transparency reporting is a
+// PLATFORM-LEVEL regulatory artifact (32bit is the regulated VLOP/intermediary
+// under the EU DSA), not a per-tenant one. These reports are platform-wide by
+// design: every handler below is gated to platform roles via
+// `require_compliance_role` (SuperAdmin/PlatformAdmin) and accepts NO
+// client-supplied org/tenant filter, so scope cannot be narrowed or injected
+// from request input.
+// ----------------------------------------------------------------------------
+
 /// List DSA transparency reports.
 async fn list_dsa_reports(
     State(state): State<AppState>,
@@ -1568,11 +1600,15 @@ async fn publish_dsa_report(
 }
 
 /// Download DSA report as PDF.
+///
+/// PAP-47 / PAP-35: returns a short-lived presigned URL generated from the
+/// stored storage key — the raw `report_file_path` is NEVER returned to the
+/// client (that was the file-path disclosure flagged in the PAP-35 review).
 async fn download_dsa_report(
     State(state): State<AppState>,
     user: AuthUser,
     Path(id): Path<Uuid>,
-) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+) -> Result<Json<DsaReportDownloadResponse>, (StatusCode, String)> {
     require_compliance_role(&user)?;
 
     let report = state
@@ -1588,18 +1624,41 @@ async fn download_dsa_report(
         })?
         .ok_or((StatusCode::NOT_FOUND, format!("Report {} not found", id)))?;
 
-    // Return a scoped, opaque download reference keyed by report id rather than
-    // disclosing the internal filesystem path (`report_file_path`).
-    match dsa_report_download_ref(report.id, &report.report_file_path) {
-        Some(download_url) => Ok(Json(serde_json::json!({
-            "report_id": report.id,
-            "download_url": download_url
-        }))),
-        None => Err((
-            StatusCode::NOT_FOUND,
-            "Report file not yet generated".to_string(),
-        )),
-    }
+    let file_key = report.report_file_path.ok_or((
+        StatusCode::NOT_FOUND,
+        "Report file not yet generated".to_string(),
+    ))?;
+
+    let storage = state.storage_service.as_ref().ok_or_else(|| {
+        tracing::error!("Storage service not configured — DSA report downloads unavailable");
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Report storage is not configured.".to_string(),
+        )
+    })?;
+
+    let filename = format!("dsa-transparency-report-{id}.pdf");
+    let presigned = storage
+        .generate_download_url(
+            &file_key,
+            &filename,
+            "application/pdf",
+            Some(storage.download_ttl_secs()),
+        )
+        .await
+        .map_err(|e| {
+            // Log the internal key for diagnostics; never surface it to the client.
+            tracing::error!(error = %e, report_id = %id, "Failed to presign DSA report download");
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Unable to generate download URL. Please try again later.".to_string(),
+            )
+        })?;
+
+    Ok(Json(DsaReportDownloadResponse {
+        url: presigned.url,
+        expires_at: presigned.expires_at,
+    }))
 }
 
 /// DSA metrics for current period.


### PR DESCRIPTION
## Summary

Implements [PAP-47](/PAP/issues/PAP-47) — the DSA transparency report security remediation under the platform-VLOP model decided by the PAP-40→PAP-47 escalation.

**Decision context:** PAP-35 flagged that `dsa_transparency_reports` had no `organization_id`/RLS. PAP-40 initially said per-tenant; the one-way-door guard in PAP-47 fired when the spec (Epic 67/Story 67.3) and handler logic both read platform-sole-VLOP. Atlas (CEO) reversed the per-tenant call — no migration needed.

### Changes

**Item 2 — Platform-role lockdown (documentation + verification):**
- All 6 DSA handlers (`list / get / publish / download / generate_dsa_report / get_dsa_metrics`) were already gated to SuperAdmin/PlatformAdmin via `require_compliance_role`. Verified no client-supplied org/tenant filter exists. Added an audit-trail comment block documenting the platform-VLOP model and the no-injection guarantee.

**Item 3 — File-path disclosure fix (PAP-35):**
- Added `dsa_report_download_ref()` helper: the four list/get/generate/publish handlers now return an opaque API path (`/api/v1/aml-dsa/dsa/reports/{id}/download`) in `download_url` instead of the raw `report_file_path` storage key.
- Rewrote `download_dsa_report` to issue a **short-lived presigned URL** via `StorageService::generate_download_url` (matching the document-download pattern in `documents/core.rs`). The internal storage key is only logged for diagnostics, never returned in the response.

**No migration** — `dsa_transparency_reports` stays without `organization_id`/RLS. The table is a platform-level regulatory artifact aggregated over org-scoped `moderation_cases`.

## Test plan

- [ ] `cargo check -p api-server` → clean (verified: EXIT=0)
- [ ] GET `/api/v1/aml-dsa/dsa/reports` as SuperAdmin → `download_url` is null or an API path, never a filesystem path
- [ ] GET `/api/v1/aml-dsa/dsa/reports/{id}/download` as SuperAdmin with storage configured → returns `{ url, expires_at }`
- [ ] GET `/api/v1/aml-dsa/dsa/reports/{id}/download` as Manager → 403
- [ ] Any DSA endpoint with no `organization_id` param → still works (platform-wide by design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)