### PR TITLE
feat(aml_dsa): compliance audit logging on AML/EDD/DSA decisions (PAP-42)

### DIFF
--- a/backend/servers/api-server/src/routes/aml_dsa.rs
+++ b/backend/servers/api-server/src/routes/aml_dsa.rs
@@ -20,6 +20,7 @@ use db::models::compliance::{
     CreateModerationCase, DsaReportStatus, EddStatus, ModeratedContentType, ModerationActionType,
     ModerationStatus, TakeModerationAction, ViolationType,
 };
+use db::models::{AuditAction, CreateAuditLog};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -94,6 +95,47 @@ fn require_moderator_role(user: &AuthUser) -> Result<(), (StatusCode, String)> {
             StatusCode::FORBIDDEN,
             "This endpoint requires moderator privileges".to_string(),
         )),
+    }
+}
+
+/// Emit a compliance audit record for an AML/EDD/DSA decision or state change.
+///
+/// Best-effort: a logging failure must never turn a successful compliance
+/// operation into a 500. We log the failure and continue, mirroring the
+/// convention in `routes/listings.rs::global_publish`. The substantive
+/// who/what/when (actor, tenant, resource, decision payload) lands in the
+/// `audit_logs` table so AML record-keeping and EU DSA Art. 17
+/// statement-of-reasons obligations (FR115) have a durable trail.
+async fn write_compliance_audit(
+    state: &AppState,
+    user: &AuthUser,
+    action: AuditAction,
+    resource_type: &str,
+    resource_id: Uuid,
+    details: serde_json::Value,
+) {
+    if let Err(e) = state
+        .audit_log_repo
+        .create(CreateAuditLog {
+            user_id: Some(user.user_id),
+            action,
+            resource_type: Some(resource_type.to_string()),
+            resource_id: Some(resource_id),
+            org_id: user.tenant_id,
+            details: Some(details),
+            old_values: None,
+            new_values: None,
+            ip_address: None,
+            user_agent: None,
+        })
+        .await
+    {
+        tracing::warn!(
+            error = %e,
+            resource_type = resource_type,
+            resource_id = %resource_id,
+            "Failed to write compliance audit log"
+        );
     }
 }
 
@@ -547,6 +589,21 @@ async fn review_aml_assessment(
             )
         })?;
 
+    write_compliance_audit(
+        &state,
+        &user,
+        AuditAction::ResourceUpdated,
+        "aml_assessment",
+        assessment.id,
+        serde_json::json!({
+            "operation": "review_aml_assessment",
+            "decision": req.decision.to_lowercase(),
+            "resulting_status": assessment.status,
+            "notes_provided": req.notes.is_some(),
+        }),
+    )
+    .await;
+
     let risk_factors: Vec<RiskFactor> = assessment
         .risk_factors
         .clone()
@@ -729,6 +786,21 @@ async fn initiate_edd(
             "Failed to initiate EDD".to_string(),
         )
     })?;
+
+    write_compliance_audit(
+        &state,
+        &user,
+        AuditAction::ResourceCreated,
+        "enhanced_due_diligence",
+        edd.id,
+        serde_json::json!({
+            "operation": "initiate_edd",
+            "resulting_status": edd.status,
+            "party_id": edd.party_id,
+            "aml_assessment_id": edd.aml_assessment_id,
+        }),
+    )
+    .await;
 
     let documents_requested: Vec<String> = edd
         .documents_requested
@@ -992,6 +1064,21 @@ async fn verify_edd_document(
             )
         })?;
 
+    write_compliance_audit(
+        &state,
+        &user,
+        AuditAction::ResourceUpdated,
+        "edd_document",
+        doc.id,
+        serde_json::json!({
+            "operation": "verify_edd_document",
+            "edd_id": edd_id,
+            "verification_status": req.status.to_lowercase(),
+            "rejection_provided": req.rejection_reason.is_some(),
+        }),
+    )
+    .await;
+
     Ok(Json(EddDocumentResponse {
         id: doc.id,
         document_type: doc.document_type,
@@ -1125,6 +1212,19 @@ async fn complete_edd(
                 "Failed to complete EDD".to_string(),
             )
         })?;
+
+    write_compliance_audit(
+        &state,
+        &user,
+        AuditAction::ResourceUpdated,
+        "enhanced_due_diligence",
+        edd.id,
+        serde_json::json!({
+            "operation": "complete_edd",
+            "resulting_status": edd.status,
+        }),
+    )
+    .await;
 
     let documents_requested: Vec<String> = edd
         .documents_requested
@@ -1425,6 +1525,20 @@ async fn publish_dsa_report(
                 "Failed to publish report".to_string(),
             )
         })?;
+
+    write_compliance_audit(
+        &state,
+        &user,
+        AuditAction::ResourceUpdated,
+        "dsa_transparency_report",
+        report.id,
+        serde_json::json!({
+            "operation": "publish_dsa_report",
+            "resulting_status": report.status,
+            "published_at": report.published_at,
+        }),
+    )
+    .await;
 
     Ok(Json(DsaTransparencyReportResponse {
         id: report.id,
@@ -1856,6 +1970,11 @@ async fn take_moderation_action(
     validate_text_field(&req.rationale, MAX_RATIONALE_LEN, "rationale")
         .map_err(|e| (StatusCode::BAD_REQUEST, e))?;
 
+    // Capture the decision payload before it is moved into the repo call so it
+    // can be recorded as the DSA Art. 17 statement of reasons (action + rationale).
+    let moderation_action = req.action;
+    let rationale = req.rationale.clone();
+
     let action = TakeModerationAction {
         action: req.action,
         rationale: req.rationale,
@@ -1873,6 +1992,21 @@ async fn take_moderation_action(
                 "Failed to take action".to_string(),
             )
         })?;
+
+    write_compliance_audit(
+        &state,
+        &user,
+        AuditAction::ResourceUpdated,
+        "moderation_case",
+        case.id,
+        serde_json::json!({
+            "operation": "take_moderation_action",
+            "action": moderation_action,
+            "rationale": rationale,
+            "resulting_status": case.status,
+        }),
+    )
+    .await;
 
     let now = Utc::now();
     let age_hours = (now - case.created_at).num_minutes() as f64 / 60.0;
@@ -1993,6 +2127,21 @@ async fn decide_appeal(
                 "Failed to decide appeal".to_string(),
             )
         })?;
+
+    write_compliance_audit(
+        &state,
+        &user,
+        AuditAction::ResourceUpdated,
+        "moderation_case",
+        case.id,
+        serde_json::json!({
+            "operation": "decide_appeal",
+            "decision": req.decision,
+            "rationale": req.rationale,
+            "resulting_status": case.status,
+        }),
+    )
+    .await;
 
     let now = Utc::now();
     let age_hours = (now - case.created_at).num_minutes() as f64 / 60.0;

--- a/backend/servers/api-server/tests/aml_dsa_audit_logging_tests.rs
+++ b/backend/servers/api-server/tests/aml_dsa_audit_logging_tests.rs
@@ -119,7 +119,7 @@ async fn seed_moderation_case(pool: &PgPool, org_id: Uuid, reported_by: Uuid) ->
            RETURNING id"#,
     )
     .bind(Uuid::new_v4())
-    .bind(Uuid::new_v4())
+    .bind(reported_by)
     .bind(org_id)
     .bind(reported_by)
     .fetch_one(pool)

--- a/backend/servers/api-server/tests/aml_dsa_audit_logging_tests.rs
+++ b/backend/servers/api-server/tests/aml_dsa_audit_logging_tests.rs
@@ -1,0 +1,252 @@
+//! Compliance audit-logging regression for `routes/aml_dsa.rs` (PAP-42, parent
+//! PAP-35 security review; FR115 production-readiness).
+//!
+//! The AML/EDD/DSA module previously emitted only `tracing::*` logs and **zero**
+//! durable audit records, failing the PAP-35 audit-logging requirement and the
+//! substantive obligations FR115 rests on (AML record-keeping; EU DSA Art. 17
+//! statement-of-reasons / decision records). Each decision/state-change handler
+//! now writes a `CreateAuditLog` row (actor + tenant + action + decision
+//! payload) best-effort.
+//!
+//! These tests drive the real handlers through the mounted router with a minted
+//! JWT carrying the required role (same approach as
+//! `listings_global_publish_authz_tests.rs`), then assert a matching row landed
+//! in `audit_logs`. They cover the two handlers named in the PAP-42 acceptance
+//! criteria: `review_aml_assessment` and `take_moderation_action`.
+
+#[allow(dead_code)]
+mod common;
+
+use axum::{
+    body::Body,
+    http::{header, Method, Request, StatusCode},
+};
+use chrono::Utc;
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::Serialize;
+use serde_json::{json, Value};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::TestApp;
+
+/// Same secret `TestConfig::default()` stamps into `JWT_SECRET`, so tokens we
+/// mint here validate against the `AuthUser` extractor's cached verifier.
+const JWT_SECRET: &str = "test-secret-key-that-is-at-least-64-characters-long-for-testing-purposes";
+
+/// Minimal mirror of `api_core::extractors::auth::Claims` (the access-token
+/// wire shape the extractor decodes). `role` is snake_case to match
+/// `TenantRole`'s serde representation.
+#[derive(Serialize)]
+struct TestClaims {
+    sub: Uuid,
+    exp: i64,
+    iat: i64,
+    token_type: String,
+    tenant_id: Option<Uuid>,
+    role: Option<String>,
+    email: String,
+    name: String,
+}
+
+/// Mint a real access JWT for `user_id` in `org_id` with `role`
+/// (snake_case, e.g. "platform_admin" / "manager").
+fn mint_token(user_id: Uuid, org_id: Uuid, role: &str) -> String {
+    let now = Utc::now().timestamp();
+    let claims = TestClaims {
+        sub: user_id,
+        iat: now,
+        exp: now + 3600,
+        token_type: "access".to_string(),
+        tenant_id: Some(org_id),
+        role: Some(role.to_string()),
+        email: format!("{user_id}@aml-audit.test"),
+        name: "AML Audit Test".to_string(),
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(JWT_SECRET.as_bytes()),
+    )
+    .expect("mint jwt")
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO organizations (name, slug, contact_email, status)
+           VALUES ($1, $2, $3, 'active') RETURNING id"#,
+    )
+    .bind(format!("AmlAudit {slug}"))
+    .bind(format!("aml-audit-{slug}-{}", Uuid::new_v4()))
+    .bind(format!("{slug}-{}@aml-audit.test", Uuid::new_v4()))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO users (email, password_hash, name, status, email_verified_at)
+           VALUES ($1, 'x', 'AML Audit User', 'active', NOW()) RETURNING id"#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_assessment(pool: &PgPool, org_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO aml_risk_assessments (organization_id, party_id, party_type)
+           VALUES ($1, $2, 'individual') RETURNING id"#,
+    )
+    .bind(org_id)
+    .bind(Uuid::new_v4())
+    .fetch_one(pool)
+    .await
+    .expect("seed assessment")
+}
+
+/// Seed a pending moderation case. Mirrors `compliance_repo.create_moderation_case`'s
+/// required columns; remaining columns fall back to their schema defaults.
+async fn seed_moderation_case(pool: &PgPool, org_id: Uuid, reported_by: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO moderation_cases (
+               content_type, content_id, content_owner_id, organization_id,
+               report_source, reported_by, violation_type, report_reason, priority
+           )
+           VALUES ('listing', $1, $2, $3, 'user', $4, 'spam', 'test report', 3)
+           RETURNING id"#,
+    )
+    .bind(Uuid::new_v4())
+    .bind(Uuid::new_v4())
+    .bind(org_id)
+    .bind(reported_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed moderation case")
+}
+
+fn authed_json(method: Method, uri: &str, org: Uuid, token: &str, body: Value) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .header("X-Tenant-ID", org.to_string())
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap()
+}
+
+/// Count audit rows matching the given resource for the actor + tenant.
+async fn audit_row(pool: &PgPool, resource_type: &str, resource_id: Uuid) -> Option<Value> {
+    sqlx::query_scalar::<_, Value>(
+        r#"SELECT details FROM audit_logs
+           WHERE resource_type = $1 AND resource_id = $2
+           ORDER BY created_at DESC LIMIT 1"#,
+    )
+    .bind(resource_type)
+    .bind(resource_id)
+    .fetch_optional(pool)
+    .await
+    .expect("query audit_logs")
+}
+
+// ---------------------------------------------------------------------------
+// review_aml_assessment — AML approve/reject decision must be audited.
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn review_aml_assessment_writes_audit_row(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org = seed_org(&pool, "review").await;
+    let user = seed_user(&pool, &format!("rev-{}@aml-audit.test", Uuid::new_v4())).await;
+    let assessment = seed_assessment(&pool, org).await;
+
+    // Compliance gate requires SuperAdmin/PlatformAdmin.
+    let token = mint_token(user, org, "platform_admin");
+    let resp = app
+        .execute(authed_json(
+            Method::POST,
+            &format!("/api/v1/aml-dsa/aml/assessments/{assessment}/review"),
+            org,
+            &token,
+            json!({ "decision": "approved", "notes": "verified ok" }),
+        ))
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "review must succeed, got {} (body: {})",
+        resp.status,
+        String::from_utf8_lossy(&resp.body)
+    );
+
+    let details = audit_row(&pool, "aml_assessment", assessment)
+        .await
+        .expect("an audit row must exist for the AML review decision");
+    assert_eq!(
+        details["operation"], "review_aml_assessment",
+        "audit details must capture the operation, got {details}"
+    );
+    assert_eq!(
+        details["decision"], "approved",
+        "audit details must record the approve/reject decision, got {details}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// take_moderation_action — DSA statement-of-reasons must be audited
+// (action + rationale).
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn take_moderation_action_writes_audit_row(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org = seed_org(&pool, "moderate").await;
+    let user = seed_user(&pool, &format!("mod-{}@aml-audit.test", Uuid::new_v4())).await;
+    let case = seed_moderation_case(&pool, org, user).await;
+
+    // Moderation gate requires Manager or higher.
+    let token = mint_token(user, org, "manager");
+    let resp = app
+        .execute(authed_json(
+            Method::POST,
+            &format!("/api/v1/aml-dsa/moderation/cases/{case}/action"),
+            org,
+            &token,
+            // `ModerationActionType` derives serde with no `rename_all`, so its
+            // wire form is the variant name verbatim ("Remove"), not snake_case.
+            json!({ "action": "Remove", "rationale": "violates content policy" }),
+        ))
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "moderation action must succeed, got {} (body: {})",
+        resp.status,
+        String::from_utf8_lossy(&resp.body)
+    );
+
+    let details = audit_row(&pool, "moderation_case", case)
+        .await
+        .expect("an audit row must exist for the moderation decision");
+    assert_eq!(
+        details["operation"], "take_moderation_action",
+        "audit details must capture the operation, got {details}"
+    );
+    // EU DSA Art. 17 statement of reasons: the action + rationale are the
+    // load-bearing fields and must be persisted.
+    assert_eq!(
+        details["action"], "Remove",
+        "audit details must record the moderation action, got {details}"
+    );
+    assert_eq!(
+        details["rationale"], "violates content policy",
+        "audit details must record the rationale (statement of reasons), got {details}"
+    );
+}


### PR DESCRIPTION
## PAP-42 — Add compliance audit logging to `aml_dsa.rs`

Parent: **PAP-35** security review. Severity: **HIGH (compliance)** — blocks FR115 production-readiness.

### What
Every decision/state-change handler in `routes/aml_dsa.rs` now writes a best-effort `CreateAuditLog` row (actor=`user_id`, org=`tenant_id`, resource_type/id, action, decision payload in `details`) via a shared `write_compliance_audit` helper. A logging failure is logged via `tracing::warn!` and **never** turns a successful operation into a 500 — mirrors `routes/listings.rs::global_publish`.

Handlers covered:
- `review_aml_assessment` — AML approve/reject
- `initiate_edd`, `verify_edd_document`, `complete_edd` — EDD lifecycle + document verification
- `take_moderation_action` — DSA Art. 17 statement of reasons (records action + rationale)
- `decide_appeal` — appeal outcome
- `publish_dsa_report` — public-facing publish action

### Tests
`tests/aml_dsa_audit_logging_tests.rs` drives the real handlers through the mounted router with a minted role JWT and asserts the matching `audit_logs` row + payload shape for the two acceptance handlers (`review_aml_assessment`, `take_moderation_action`).

### Verification
- `cargo check -p api-server --tests` → Finished, no errors/warnings.
- Focused test runs against Postgres (CI `cargo test --workspace`).

### QA spot-check (per acceptance)
Audit row shape: `action` ∈ {`resource_updated`,`resource_created`}, `resource_type` ∈ {`aml_assessment`,`enhanced_due_diligence`,`edd_document`,`dsa_transparency_report`,`moderation_case`}, `user_id`=actor, `org_id`=tenant, `details.operation` = handler name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)