### PR TITLE
feat-6-3-announce-comments-web-ui: cover AnnouncementComments threading/reply web UI + clarify threading depth

### DIFF
--- a/docs/screens/ppt/announcements.md
+++ b/docs/screens/ppt/announcements.md
@@ -9,12 +9,12 @@ implementations:
     component: AnnouncementsPage
     buildStatus: in-progress
     redesignStatus: in-progress
-    apiStatus: complete
+    apiStatus: partial
   mobile:
     component: AnnouncementsScreen + AnnouncementDetailScreen
     buildStatus: in-progress
     redesignStatus: in-progress
-    apiStatus: complete
+    apiStatus: partial
 endpoints:
   - announcements_list
   - announcements_get
@@ -91,9 +91,9 @@ owner: pm-frontend
 
 ## States
 
-- **Empty (list)**: megaphone-icon tile + "Žiadne oznamy" + body + primary "+ Nový oznam" + secondary "Importovať z Faults" link. **Implemented** (PR #1033): `AnnouncementList` shows "No announcements found." when not loading, not error, and the list is empty.
-- **Loading (list)**: 8 skeleton cards (pin skel + 2 line skels + meta skels + progress-bar skel). Code currently renders a single spinner while `isLoading` (skeleton-card treatment still TBD).
-- **Error 503 (list)**: danger tile + retry; toolbar + sidebar interactive. **Implemented** (PR #1033): `AnnouncementList` renders an inline `role="alert"` danger tile (red-50 bg / red-200 border) with `announcements.failedToLoad` ("Failed to load announcements") + a `common.retry` button calling `onRetry` (route wrapper `refetch()`). Threaded `AnnouncementsPageRoute → AnnouncementsPage → AnnouncementList` via `isError`/`onRetry` props; mutually exclusive with loading/empty/loaded.
+- **Empty (list)**: megaphone-icon tile + "Žiadne oznamy" + body + primary "+ Nový oznam" + secondary "Importovať z Faults" link
+- **Loading (list)**: 8 skeleton cards (pin skel + 2 line skels + meta skels + progress-bar skel)
+- **Error 503 (list)**: danger tile + retry; toolbar + sidebar interactive
 - **Loaded (list)**: 8 cards covering 5 states; 2 selected with bulk bar; 1 pinned at top
 - **Detail (existing)**: as designed — published with delivery + ack stats
 
@@ -115,15 +115,13 @@ UC-02 announcements — manager-published, resident-acknowledged messages. The d
 - Audience meta currently free text ("All residents") — must become a tokenized chip set (All residents / Owners only / By unit / By role) tied to the audience-selector when composing.
 - Multi-language announcements (`Slovak · English` in details kv) — implementation must support per-language body editing + per-language read receipts; v1 may ship single-language only.
 - Mobile bottom-nav must drop the legacy 📢 emoji per SKILL.md non-negotiable.
-- **List error/retry wired (PR #1033):** the designed `error-503` artboard now has a code counterpart — `AnnouncementList` owns the loading/error/empty triad and the error tile carries a retry button (`onRetry → refetch()`, i18n `announcements.failedToLoad` + shared `common.retry`). Skeleton-card loading treatment (8 cards per design) is still TBD; code shows a single spinner.
+- **Comment-threading depth (Story 6.3)**: `AnnouncementComments` renders the discussion thread under the detail view (only when `commentsEnabled`). Threads are **capped at depth 3** for the reply affordance — the `Reply` button is suppressed once `depth >= 3`, and indentation (`marginLeft`) is clamped at `min(depth, 3) * 24px`. Deeper replies still render (so a server that returns depth-4+ data won't lose comments) but can't be replied to from the web UI; new replies fold into the depth-3 ancestor. Soft-deleted comments collapse to a `[This comment has been deleted]` tombstone (no content, no actions). Delete affordance shows for the comment owner OR a manager (`technical_manager` / `property_manager`). Any change to the max depth must stay in sync with the backend's comment-nesting limit and the mobile detail screen.
 
 ## Agent Log
 
 <!-- newest entries on top -->
 
-- 2026-06-09 — agent: Coverage 6-2 — announcement web viewing + acknowledgment verified live; apiStatus flipped to reflect wired backend; route-wiring tests added.
-
-- 2026-06-05 — agent: test-gap-screen-map-drift-pr-1033-ppt — screen-map sync for PR #1033: AnnouncementsPageRoute now threads `isError`/`onRetry` (from `useAnnouncements` error + `refetch`) through AnnouncementsPage → AnnouncementList; AnnouncementList renders the designed error-503 tile as a `role="alert"` inline error + retry button (i18n `announcements.failedToLoad` + `common.retry`), mutually exclusive with loading/empty/loaded; added AnnouncementsPage.test.tsx regression (gap-79-1). Updated States (Empty/Loading/Error → Implemented) + Notes; docs-only, no code change here
+- 2026-06-09 — agent: feat-6-3-announce-comments-web-ui — Coverage 6-3: added AnnouncementComments.test.tsx (14 cases) covering threading/replies, depth-3 reply cap, deleted-comment tombstone, add/reply wiring (parentId), owner/manager delete affordance, disabled + empty + loading states, Ctrl+Enter submit. Feature (component + api-client hooks + page wiring) already shipped under gap-6-3; this closes the test-coverage gap (mirrors #1190/#1196 pattern). Clarified comment-threading depth in Notes > Specific. ppt-web test/typecheck/biome clean.
 
 - 2026-05-27 — agent: gap-6-2-announcement-read-receipt-retry — Story 6.2 retry: added AnnouncementDetailScreen (mobile) with auto-fire POST /read on mount + acknowledge button; wired AnnouncementDetail case in mobile App.tsx; added auto-mark-read useEffect in ppt-web ViewAnnouncementPageInner (fire-and-forget on announcement load); ppt-web & mobile typecheck + biome clean; mobile component: AnnouncementsScreen + AnnouncementDetailScreen
 

--- a/docs/screens/ppt/announcements.md
+++ b/docs/screens/ppt/announcements.md
@@ -9,12 +9,12 @@ implementations:
     component: AnnouncementsPage
     buildStatus: in-progress
     redesignStatus: in-progress
-    apiStatus: partial
+    apiStatus: complete
   mobile:
     component: AnnouncementsScreen + AnnouncementDetailScreen
     buildStatus: in-progress
     redesignStatus: in-progress
-    apiStatus: partial
+    apiStatus: complete
 endpoints:
   - announcements_list
   - announcements_get
@@ -91,9 +91,9 @@ owner: pm-frontend
 
 ## States
 
-- **Empty (list)**: megaphone-icon tile + "Žiadne oznamy" + body + primary "+ Nový oznam" + secondary "Importovať z Faults" link
-- **Loading (list)**: 8 skeleton cards (pin skel + 2 line skels + meta skels + progress-bar skel)
-- **Error 503 (list)**: danger tile + retry; toolbar + sidebar interactive
+- **Empty (list)**: megaphone-icon tile + "Žiadne oznamy" + body + primary "+ Nový oznam" + secondary "Importovať z Faults" link. **Implemented** (PR #1033): `AnnouncementList` shows "No announcements found." when not loading, not error, and the list is empty.
+- **Loading (list)**: 8 skeleton cards (pin skel + 2 line skels + meta skels + progress-bar skel). Code currently renders a single spinner while `isLoading` (skeleton-card treatment still TBD).
+- **Error 503 (list)**: danger tile + retry; toolbar + sidebar interactive. **Implemented** (PR #1033): `AnnouncementList` renders an inline `role="alert"` danger tile (red-50 bg / red-200 border) with `announcements.failedToLoad` ("Failed to load announcements") + a `common.retry` button calling `onRetry` (route wrapper `refetch()`). Threaded `AnnouncementsPageRoute → AnnouncementsPage → AnnouncementList` via `isError`/`onRetry` props; mutually exclusive with loading/empty/loaded.
 - **Loaded (list)**: 8 cards covering 5 states; 2 selected with bulk bar; 1 pinned at top
 - **Detail (existing)**: as designed — published with delivery + ack stats
 
@@ -115,6 +115,7 @@ UC-02 announcements — manager-published, resident-acknowledged messages. The d
 - Audience meta currently free text ("All residents") — must become a tokenized chip set (All residents / Owners only / By unit / By role) tied to the audience-selector when composing.
 - Multi-language announcements (`Slovak · English` in details kv) — implementation must support per-language body editing + per-language read receipts; v1 may ship single-language only.
 - Mobile bottom-nav must drop the legacy 📢 emoji per SKILL.md non-negotiable.
+- **List error/retry wired (PR #1033):** the designed `error-503` artboard now has a code counterpart — `AnnouncementList` owns the loading/error/empty triad and the error tile carries a retry button (`onRetry → refetch()`, i18n `announcements.failedToLoad` + shared `common.retry`). Skeleton-card loading treatment (8 cards per design) is still TBD; code shows a single spinner.
 - **Comment-threading depth (Story 6.3)**: `AnnouncementComments` renders the discussion thread under the detail view (only when `commentsEnabled`). Threads are **capped at depth 3** for the reply affordance — the `Reply` button is suppressed once `depth >= 3`, and indentation (`marginLeft`) is clamped at `min(depth, 3) * 24px`. Deeper replies still render (so a server that returns depth-4+ data won't lose comments) but can't be replied to from the web UI; new replies fold into the depth-3 ancestor. Soft-deleted comments collapse to a `[This comment has been deleted]` tombstone (no content, no actions). Delete affordance shows for the comment owner OR a manager (`technical_manager` / `property_manager`). Any change to the max depth must stay in sync with the backend's comment-nesting limit and the mobile detail screen.
 
 ## Agent Log
@@ -122,6 +123,10 @@ UC-02 announcements — manager-published, resident-acknowledged messages. The d
 <!-- newest entries on top -->
 
 - 2026-06-09 — agent: feat-6-3-announce-comments-web-ui — Coverage 6-3: added AnnouncementComments.test.tsx (14 cases) covering threading/replies, depth-3 reply cap, deleted-comment tombstone, add/reply wiring (parentId), owner/manager delete affordance, disabled + empty + loading states, Ctrl+Enter submit. Feature (component + api-client hooks + page wiring) already shipped under gap-6-3; this closes the test-coverage gap (mirrors #1190/#1196 pattern). Clarified comment-threading depth in Notes > Specific. ppt-web test/typecheck/biome clean.
+
+- 2026-06-09 — agent: Coverage 6-2 — announcement web viewing + acknowledgment verified live; apiStatus flipped to reflect wired backend; route-wiring tests added.
+
+- 2026-06-05 — agent: test-gap-screen-map-drift-pr-1033-ppt — screen-map sync for PR #1033: AnnouncementsPageRoute now threads `isError`/`onRetry` (from `useAnnouncements` error + `refetch`) through AnnouncementsPage → AnnouncementList; AnnouncementList renders the designed error-503 tile as a `role="alert"` inline error + retry button (i18n `announcements.failedToLoad` + `common.retry`), mutually exclusive with loading/empty/loaded; added AnnouncementsPage.test.tsx regression (gap-79-1). Updated States (Empty/Loading/Error → Implemented) + Notes; docs-only, no code change here
 
 - 2026-05-27 — agent: gap-6-2-announcement-read-receipt-retry — Story 6.2 retry: added AnnouncementDetailScreen (mobile) with auto-fire POST /read on mount + acknowledge button; wired AnnouncementDetail case in mobile App.tsx; added auto-mark-read useEffect in ppt-web ViewAnnouncementPageInner (fire-and-forget on announcement load); ppt-web & mobile typecheck + biome clean; mobile component: AnnouncementsScreen + AnnouncementDetailScreen
 

--- a/frontend/apps/ppt-web/src/features/announcements/components/AnnouncementComments.test.tsx
+++ b/frontend/apps/ppt-web/src/features/announcements/components/AnnouncementComments.test.tsx
@@ -1,0 +1,321 @@
+/**
+ * AnnouncementComments tests (feat-6-3 — Story 6.3 comments & discussion web UI).
+ *
+ * Mirrors the #1190/#1196 coverage pattern: the component shipped without a
+ * dedicated test. These cover the load-bearing behaviour:
+ *  - top-level comments + nested replies render (threading)
+ *  - the reply affordance is capped at depth 3 (matches the marginLeft cap and
+ *    the backend's max threading depth — see screen-map note)
+ *  - deleted comments collapse to a tombstone (no content / actions)
+ *  - composing a new top-level comment wires to onAddComment with no parentId
+ *  - replying wires to onAddComment with the parent comment id
+ *  - delete affordance: own comment OR manager; hidden otherwise
+ *  - disabled hides all compose/reply/delete affordances
+ *  - empty + loading states
+ */
+/// <reference types="vitest/globals" />
+
+import type { CommentWithAuthor } from '@ppt/api-client';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { AnnouncementComments } from './AnnouncementComments';
+
+function comment(overrides: Partial<CommentWithAuthor> = {}): CommentWithAuthor {
+  return {
+    id: 'c-1',
+    announcementId: 'ann-1',
+    userId: 'user-1',
+    content: 'First!',
+    authorName: 'Alice Tenant',
+    isDeleted: false,
+    createdAt: '2026-06-01T00:00:00Z',
+    updatedAt: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('AnnouncementComments', () => {
+  it('renders top-level comments with their authors and content', () => {
+    render(
+      <AnnouncementComments
+        comments={[comment({ id: 'c-1', content: 'Hello world', authorName: 'Alice Tenant' })]}
+        total={1}
+        onAddComment={vi.fn()}
+        onDeleteComment={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Hello world')).toBeInTheDocument();
+    expect(screen.getByText('Alice Tenant')).toBeInTheDocument();
+    // total count badge
+    expect(screen.getByRole('heading', { name: /discussion/i })).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  it('renders nested replies (threading)', () => {
+    render(
+      <AnnouncementComments
+        comments={[
+          comment({
+            id: 'c-1',
+            content: 'Parent comment',
+            replies: [
+              comment({ id: 'c-2', parentId: 'c-1', content: 'A reply', authorName: 'Bob' }),
+            ],
+          }),
+        ]}
+        total={2}
+        onAddComment={vi.fn()}
+        onDeleteComment={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Parent comment')).toBeInTheDocument();
+    expect(screen.getByText('A reply')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+  });
+
+  it('caps the reply affordance at depth 3 (max threading depth)', () => {
+    // Build a 5-deep chain: depths 0,1,2,3,4. Reply button should appear on
+    // depths 0..2 and disappear at depth 3 and below.
+    const deepChain = comment({
+      id: 'd0',
+      content: 'depth-0',
+      replies: [
+        comment({
+          id: 'd1',
+          content: 'depth-1',
+          replies: [
+            comment({
+              id: 'd2',
+              content: 'depth-2',
+              replies: [
+                comment({
+                  id: 'd3',
+                  content: 'depth-3',
+                  replies: [comment({ id: 'd4', content: 'depth-4' })],
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+
+    render(
+      <AnnouncementComments
+        comments={[deepChain]}
+        total={5}
+        onAddComment={vi.fn()}
+        onDeleteComment={vi.fn()}
+      />
+    );
+
+    // depths 0,1,2 each render a "Reply" button -> 3 buttons total.
+    expect(screen.getAllByRole('button', { name: 'Reply' })).toHaveLength(3);
+    // The deepest comments still render their content.
+    expect(screen.getByText('depth-3')).toBeInTheDocument();
+    expect(screen.getByText('depth-4')).toBeInTheDocument();
+  });
+
+  it('renders a tombstone for deleted comments without content or actions', () => {
+    render(
+      <AnnouncementComments
+        comments={[comment({ id: 'c-1', content: 'secret', isDeleted: true })]}
+        total={1}
+        currentUserId="user-1"
+        onAddComment={vi.fn()}
+        onDeleteComment={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('[This comment has been deleted]')).toBeInTheDocument();
+    expect(screen.queryByText('secret')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Reply' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+  });
+
+  it('submits a new top-level comment with no parentId', async () => {
+    const user = userEvent.setup();
+    const onAddComment = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <AnnouncementComments
+        comments={[]}
+        total={0}
+        onAddComment={onAddComment}
+        onDeleteComment={vi.fn()}
+      />
+    );
+
+    await user.type(screen.getByLabelText('New comment'), 'A fresh take');
+    await user.click(screen.getByRole('button', { name: 'Post comment' }));
+
+    expect(onAddComment).toHaveBeenCalledWith('A fresh take');
+  });
+
+  it('replies wire onAddComment with the parent comment id', async () => {
+    const user = userEvent.setup();
+    const onAddComment = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <AnnouncementComments
+        comments={[comment({ id: 'parent-1', content: 'reply to me' })]}
+        total={1}
+        onAddComment={onAddComment}
+        onDeleteComment={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Reply' }));
+    await user.type(screen.getByLabelText('Reply content'), 'my reply');
+    await user.click(screen.getByRole('button', { name: 'Post reply' }));
+
+    expect(onAddComment).toHaveBeenCalledWith('my reply', 'parent-1');
+  });
+
+  it('shows the delete affordance for the comment owner', () => {
+    render(
+      <AnnouncementComments
+        comments={[comment({ id: 'c-1', userId: 'user-1' })]}
+        total={1}
+        currentUserId="user-1"
+        onAddComment={vi.fn()}
+        onDeleteComment={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('hides the delete affordance for non-owners who are not managers', () => {
+    render(
+      <AnnouncementComments
+        comments={[comment({ id: 'c-1', userId: 'someone-else' })]}
+        total={1}
+        currentUserId="user-1"
+        onAddComment={vi.fn()}
+        onDeleteComment={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+  });
+
+  it('shows the delete affordance to a manager for any comment', async () => {
+    const user = userEvent.setup();
+    const onDeleteComment = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <AnnouncementComments
+        comments={[comment({ id: 'c-1', userId: 'someone-else' })]}
+        total={1}
+        currentUserId="manager-1"
+        isManager
+        onAddComment={vi.fn()}
+        onDeleteComment={onDeleteComment}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(onDeleteComment).toHaveBeenCalledWith('c-1');
+  });
+
+  it('hides all compose/reply/delete affordances when disabled', () => {
+    render(
+      <AnnouncementComments
+        comments={[comment({ id: 'c-1', userId: 'user-1' })]}
+        total={1}
+        currentUserId="user-1"
+        isManager
+        disabled
+        onAddComment={vi.fn()}
+        onDeleteComment={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByLabelText('New comment')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Reply' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+    // existing content still shown
+    expect(screen.getByText('First!')).toBeInTheDocument();
+  });
+
+  it('renders the empty state when there are no comments', () => {
+    render(
+      <AnnouncementComments
+        comments={[]}
+        total={0}
+        onAddComment={vi.fn()}
+        onDeleteComment={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByText('No comments yet. Be the first to start the discussion!')
+    ).toBeInTheDocument();
+  });
+
+  it('renders the loading state instead of empty/list while loading', () => {
+    render(
+      <AnnouncementComments
+        comments={[]}
+        total={0}
+        isLoading
+        onAddComment={vi.fn()}
+        onDeleteComment={vi.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText('Loading comments')).toBeInTheDocument();
+    expect(
+      screen.queryByText('No comments yet. Be the first to start the discussion!')
+    ).not.toBeInTheDocument();
+  });
+
+  it('submits a comment via Ctrl+Enter', async () => {
+    const user = userEvent.setup();
+    const onAddComment = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <AnnouncementComments
+        comments={[]}
+        total={0}
+        onAddComment={onAddComment}
+        onDeleteComment={vi.fn()}
+      />
+    );
+
+    const textarea = screen.getByLabelText('New comment');
+    await user.type(textarea, 'keyboard submit');
+    await user.keyboard('{Control>}{Enter}{/Control}');
+
+    expect(onAddComment).toHaveBeenCalledWith('keyboard submit');
+  });
+
+  it('keeps a reply scoped to its own parent in a multi-comment thread', async () => {
+    const user = userEvent.setup();
+    const onAddComment = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <AnnouncementComments
+        comments={[
+          comment({ id: 'p-1', content: 'first parent' }),
+          comment({ id: 'p-2', content: 'second parent' }),
+        ]}
+        total={2}
+        onAddComment={onAddComment}
+        onDeleteComment={vi.fn()}
+      />
+    );
+
+    // Open the reply form under the second comment.
+    const secondItem = screen.getByText('second parent').closest('.ann-comment') as HTMLElement;
+    await user.click(within(secondItem).getByRole('button', { name: 'Reply' }));
+    await user.type(screen.getByLabelText('Reply content'), 'reply to second');
+    await user.click(screen.getByRole('button', { name: 'Post reply' }));
+
+    expect(onAddComment).toHaveBeenCalledWith('reply to second', 'p-2');
+  });
+});


### PR DESCRIPTION
## Task
Coverage 6-3: implement announcement comments + threading/reply web UI (part of draft PRs #474/#475/#479 Epic 6 cluster) and clarify comment-threading depth in screen-map notes. Frontend ppt-web.

## Owner
pm-frontend (react-web specialist)

## State verification (action references stale draft PRs #474/#475/#479)
The announcement comments + threading/reply web UI is **already shipped on `dev`** under the earlier `gap-6-3` work:
- `frontend/apps/ppt-web/src/features/announcements/components/AnnouncementComments.tsx` — full component with nested replies, depth-3 reply cap, deleted-comment tombstone, owner/manager delete affordance, compose + Ctrl+Enter submit, i18n.
- `frontend/packages/api-client/src/announcements/hooks.ts` — `useAnnouncementComments` / `useCreateAnnouncementComment` / `useDeleteAnnouncementComment` standalone hooks + `useComments` / `useCreateComment` / `useDeleteComment` on the hook factory.
- Wired into `ViewAnnouncementPage` (rendered when `commentsEnabled`).

The genuine gap was **no test for the component**. This PR closes that gap (mirroring the already-merged #1190/#1196 coverage-PR pattern) rather than re-implementing the feature.

## Changes
- **New** `AnnouncementComments.test.tsx` — 14 cases: top-level render, nested replies (threading), depth-3 reply-button cap (deeper replies still render but can't be replied to), deleted tombstone, add-comment (no parentId), reply (parentId), owner delete affordance, non-owner hidden, manager delete-any, disabled hides all affordances, empty state, loading state, Ctrl+Enter submit, reply scoped to its own parent in a multi-comment thread.
- **Doc** `docs/screens/ppt/announcements.md` — added a `Notes > Specific` entry clarifying comment-threading depth (depth-3 reply cap, marginLeft clamp, tombstone, owner/manager delete, sync with backend nesting limit + mobile) and an Agent Log entry.

## Tested (Band A — fast check)
- `pnpm -F @ppt/web test:run src/features/announcements/components/AnnouncementComments.test.tsx` → 14 passed (exit 0)
- `pnpm -F @ppt/web test:run src/features/announcements` (no-regression) → 5 files / 36 passed (exit 0)
- `pnpm -F @ppt/web typecheck` → exit 0
- `pnpm exec biome check apps/ppt-web/.../AnnouncementComments.test.tsx` → clean (exit 0, after autofix)

## Built (Band B — full build)
skipped: test-only + screen-map doc change; no public API / config / build-output change.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped (ppt-bridge MCP not used).

## Scope drift
None. `scope-check.sh --owner pm-frontend` → exit 0. Changes confined to `frontend/apps/ppt-web/` + `docs/screens/**` (both in the frontend owner's area). No api-client change was needed — the comment hooks already exist.

## Code-reuse review
none — no new helpers added (test + doc only).

## Notes
- The component caps the **reply** affordance at depth 3 but still renders deeper replies returned by the server, so over-deep data won't be silently dropped. The test encodes this (5-deep chain → exactly 3 Reply buttons, depth-4 content still visible).
- If the backend's max comment-nesting limit ever changes, the web cap + the mobile detail screen + the screen-map note must be updated together.

https://claude.ai/code/session_01Xt3Ban431zieWsRt4H2pyX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xt3Ban431zieWsRt4H2pyX)_