### PR TITLE
feat-6-4-announce-pin-unpin-web-ui: cover Story 6.4 pin/unpin list UI

### DIFF
--- a/frontend/apps/ppt-web/src/features/announcements/components/AnnouncementList.test.tsx
+++ b/frontend/apps/ppt-web/src/features/announcements/components/AnnouncementList.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * AnnouncementList pin/unpin UI tests (feat-6-4 — Story 6.4 pin/unpin web UI).
+ *
+ * The presentational `PinnedAnnouncementsBand` is covered in isolation by
+ * `PinnedAnnouncementsBand.test.tsx`. The previously-untested layer was the
+ * *integration* in `AnnouncementList` — the glue that:
+ *
+ *  - threads `pinnedAnnouncements` into the sticky band above the list (and
+ *    keeps that band immune to the main list, which carries every status);
+ *  - renders one pin/unpin toggle per card and wires it to `onPin(id, next)`
+ *    where `next` is the negation of the card's current `pinned` flag;
+ *  - shows the "Unpin" affordance on already-pinned rows and "Pin" otherwise.
+ *
+ * These pin the Story 6.4 pin/unpin contract at the list level.
+ */
+
+/// <reference types="vitest/globals" />
+
+import type { AnnouncementSummary } from '@ppt/api-client';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { AnnouncementList } from './AnnouncementList';
+
+function ann(overrides: Partial<AnnouncementSummary> = {}): AnnouncementSummary {
+  return {
+    id: 'ann-1',
+    title: 'Untitled',
+    status: 'published',
+    targetType: 'all',
+    pinned: false,
+    commentsEnabled: false,
+    acknowledgmentRequired: false,
+    publishedAt: '2026-05-26T00:00:00Z',
+    ...overrides,
+  } as AnnouncementSummary;
+}
+
+const baseProps = {
+  total: 0,
+  page: 1,
+  pageSize: 10,
+  onPageChange: vi.fn(),
+  onStatusFilter: vi.fn(),
+  onTargetTypeFilter: vi.fn(),
+  onView: vi.fn(),
+  onEdit: vi.fn(),
+  onDelete: vi.fn(),
+  onPublish: vi.fn(),
+  onArchive: vi.fn(),
+  onPin: vi.fn(),
+  onCreate: vi.fn(),
+};
+
+describe('AnnouncementList — pin/unpin UI (Story 6.4)', () => {
+  it('renders the pinned band from pinnedAnnouncements, separate from the main list', () => {
+    render(
+      <AnnouncementList
+        {...baseProps}
+        announcements={[ann({ id: 'list-1', title: 'In the list' })]}
+        total={1}
+        pinnedAnnouncements={[ann({ id: 'pin-1', title: 'Pinned chip', pinned: true })]}
+      />
+    );
+
+    const band = screen.getByRole('region', { name: 'Pinned announcements' });
+    expect(within(band).getByText('Pinned chip')).toBeInTheDocument();
+    // The list card title lives outside the band.
+    expect(within(band).queryByText('In the list')).not.toBeInTheDocument();
+    expect(screen.getByText('In the list')).toBeInTheDocument();
+  });
+
+  it('does not render the pinned band when there are no pinned announcements', () => {
+    render(
+      <AnnouncementList
+        {...baseProps}
+        announcements={[ann({ id: 'list-1', title: 'Only item' })]}
+        total={1}
+      />
+    );
+
+    expect(screen.queryByRole('region', { name: 'Pinned announcements' })).not.toBeInTheDocument();
+  });
+
+  it('shows "Pin" on an unpinned card and pins it via onPin(id, true)', async () => {
+    const onPin = vi.fn();
+    render(
+      <AnnouncementList
+        {...baseProps}
+        onPin={onPin}
+        announcements={[ann({ id: 'unpinned-1', title: 'Not pinned', pinned: false })]}
+        total={1}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Pin' }));
+    expect(onPin).toHaveBeenCalledTimes(1);
+    expect(onPin).toHaveBeenCalledWith('unpinned-1', true);
+  });
+
+  it('shows "Unpin" on a pinned card and unpins it via onPin(id, false)', async () => {
+    const onPin = vi.fn();
+    render(
+      <AnnouncementList
+        {...baseProps}
+        onPin={onPin}
+        announcements={[ann({ id: 'pinned-1', title: 'Already pinned', pinned: true })]}
+        total={1}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Unpin' }));
+    expect(onPin).toHaveBeenCalledTimes(1);
+    expect(onPin).toHaveBeenCalledWith('pinned-1', false);
+  });
+
+  it('renders an independent pin toggle per card, each carrying its own id and next-state', async () => {
+    const onPin = vi.fn();
+    render(
+      <AnnouncementList
+        {...baseProps}
+        onPin={onPin}
+        announcements={[
+          ann({ id: 'a', title: 'Alpha', pinned: false }),
+          ann({ id: 'b', title: 'Bravo', pinned: true }),
+        ]}
+        total={2}
+      />
+    );
+
+    // One toggle reads "Pin" (for the unpinned row) and one reads "Unpin".
+    await userEvent.click(screen.getByRole('button', { name: 'Pin' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Unpin' }));
+
+    expect(onPin).toHaveBeenNthCalledWith(1, 'a', true);
+    expect(onPin).toHaveBeenNthCalledWith(2, 'b', false);
+  });
+});


### PR DESCRIPTION
## Task
Coverage 6-4: implement pin/unpin announcement web UI (part of Epic 6 cluster) including pin ordering and max-pinned guard display. Frontend ppt-web.

NOTE: pin/unpin may already be shipped on dev under gap-6-4 (PinnedAnnouncementsBand, usePinnedAnnouncements) — first verify current state; if the feature is already shipped, the genuine gap is TEST COVERAGE for it.

## Finding — feature already shipped, gap was test coverage
The pin/unpin web UI is already on `dev` and not re-implemented here:
- `usePinnedAnnouncements` / `usePinAnnouncement` hooks (`frontend/packages/api-client/src/announcements/hooks.ts`)
- `PinnedAnnouncementsBand` sticky band (already unit-tested in `PinnedAnnouncementsBand.test.tsx`)
- pin/unpin toggle per card in `AnnouncementCard` and route wiring in `routes/groups/announcements.tsx` (`handlePin` → `usePinAnnouncement`, `pinnedAnnouncements` → band)

The genuine gap was the **integration layer** in `AnnouncementList` — fed by `pinnedAnnouncements`, rendering one pin/unpin toggle per card — which had **no test**. This PR adds a focused component test there, mirroring the merged coverage-PR pattern (#1190/#1196/#1198). No production code changed.

## Scope of the test (`AnnouncementList.test.tsx`)
- Pinned band renders from `pinnedAnnouncements` and stays separate from the main list (band immune to the list's status mix).
- Band is omitted when there are no pinned items.
- Unpinned card shows "Pin" and calls `onPin(id, true)`; pinned card shows "Unpin" and calls `onPin(id, false)`.
- Per-card toggles are independent — each carries its own id + next-state.

## Owner
pm-frontend

## Tested (Band A — fast check)
- `pnpm -F @ppt/web test:run` → exit 0 — **54 files / 619 tests passed** (5 new + full suite green)
- `pnpm -F @ppt/web typecheck` → exit 0 (tsc --noEmit + e2e tsconfig)
- `pnpm exec biome check <new file>` → exit 0, clean

## Built (Band B — full build)
skipped: test-only change (<50 LOC substantive, no public API / config / build-output touch)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Notes
- Scope-drift check: clean (exit 0) — single frontend test file under pm-frontend area.
- No new helpers introduced (test-only), so no code-reuse concerns.
- No screen-map docs touched.

https://claude.ai/code/session_013TeDtsqspDDsHxHmpUu3pv

---
_Generated by [Claude Code](https://claude.ai/code/session_013TeDtsqspDDsHxHmpUu3pv)_