### PR TITLE
feat-mobile-push-fcm-apns-integration: iOS APNs entitlement + background-notification mode

### DIFF
--- a/frontend/apps/mobile/app.config.push.test.ts
+++ b/frontend/apps/mobile/app.config.push.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Regression for feat-mobile-push: iOS native push (APNs) configuration.
+ *
+ * The JS push pipeline (`usePushNotifications` + `backgroundNotifications`)
+ * was already complete, but the iOS native config was missing two keys that
+ * iOS *requires* for the pipeline to work end-to-end:
+ *
+ *   1. `ios.entitlements['aps-environment']` — without it iOS never issues an
+ *      APNs device token, so `getDevicePushTokenAsync()` cannot register the
+ *      device with the backend notification pipeline. Must be `development`
+ *      for debug/staging (sandbox APNs) and `production` for release builds.
+ *   2. `ios.infoPlist.UIBackgroundModes` must include `remote-notification` so
+ *      iOS wakes the app for background/silent (data-only) FCM/APNs pushes —
+ *      the path that drives `syncBadgeFromData` for data-only messages.
+ *
+ * These tests pin both keys per environment. `app.config.ts` is a pure
+ * function of `{ config }` + `process.env.APP_ENV`, so we can evaluate it
+ * directly with a fresh module per env (env is read at call time).
+ */
+
+import type { ConfigContext, ExpoConfig } from 'expo/config';
+
+// `app.config.ts` resolves API URLs from the parsed `.env.<env>` file FIRST
+// (`envVars.X ?? process.env.X`), and `.env.production` ships the
+// `__SET_BY_CI__` sentinel that the config refuses to build with. Mock dotenv
+// so the parsed env carries real URLs — this is the same effect CI achieves by
+// overwriting `.env.production` (eas.json env / `eas secret:create`) before a
+// production build. The iOS push keys under test do not otherwise depend on
+// .env values.
+jest.mock('dotenv', () => ({
+  config: () => ({
+    parsed: { API_BASE_URL: 'https://api.ppt.test', WS_BASE_URL: 'wss://api.ppt.test' },
+  }),
+}));
+
+function loadConfig(appEnv: 'development' | 'production'): ExpoConfig {
+  jest.resetModules();
+  process.env.APP_ENV = appEnv;
+  // Re-require so the default export picks up the current APP_ENV.
+  const mod = require('./app.config').default as (ctx: ConfigContext) => ExpoConfig;
+  const ctx: ConfigContext = {
+    projectRoot: '.',
+    staticConfigPath: null,
+    packageJsonPath: null,
+    config: {} as ExpoConfig,
+  };
+  return mod(ctx);
+}
+
+const ORIGINAL_APP_ENV = process.env.APP_ENV;
+
+afterEach(() => {
+  process.env.APP_ENV = ORIGINAL_APP_ENV;
+});
+
+describe('iOS aps-environment entitlement', () => {
+  it('is `development` for development builds (APNs sandbox)', () => {
+    const cfg = loadConfig('development');
+    expect(cfg.ios?.entitlements?.['aps-environment']).toBe('development');
+  });
+
+  it('is `production` for production builds (APNs production gateway)', () => {
+    const cfg = loadConfig('production');
+    expect(cfg.ios?.entitlements?.['aps-environment']).toBe('production');
+  });
+});
+
+describe('iOS UIBackgroundModes', () => {
+  it('includes `remote-notification` so background/silent push wakes the app', () => {
+    const cfg = loadConfig('development');
+    const modes = cfg.ios?.infoPlist?.UIBackgroundModes as string[] | undefined;
+    expect(modes).toContain('remote-notification');
+  });
+
+  it('still includes `remote-notification` in production', () => {
+    const cfg = loadConfig('production');
+    const modes = cfg.ios?.infoPlist?.UIBackgroundModes as string[] | undefined;
+    expect(modes).toContain('remote-notification');
+  });
+});

--- a/frontend/apps/mobile/app.config.ts
+++ b/frontend/apps/mobile/app.config.ts
@@ -175,10 +175,36 @@ export default ({ config }: ConfigContext): ExpoConfig => {
        * this into the generated `<app>.entitlements` at prebuild time.
        */
       associatedDomains: [...(config.ios?.associatedDomains ?? []), `applinks:${appLinkHost}`],
+      /**
+       * feat-mobile-push: APNs entitlement (required for iOS push).
+       * Without `aps-environment`, iOS never issues an APNs device token, so
+       * `Notifications.getDevicePushTokenAsync()` in `usePushNotifications`
+       * cannot register the device with the backend notification pipeline.
+       * `development` for debug/staging (APNs sandbox gateway), `production`
+       * for release builds (APNs production gateway). Expo writes this into the
+       * generated `<app>.entitlements` at prebuild time, alongside the
+       * universal-links entitlement above.
+       */
+      entitlements: {
+        ...(config.ios?.entitlements ?? {}),
+        'aps-environment': debugMode ? 'development' : 'production',
+      },
       infoPlist: {
         ...(config.ios?.infoPlist ?? {}),
         API_BASE_URL: apiBaseUrl,
         ENVIRONMENT: environment,
+        /**
+         * feat-mobile-push: enable background/silent push delivery.
+         * `remote-notification` lets iOS wake the app for background (data-only)
+         * FCM/APNs pushes so the notification-preference pipeline's background
+         * path runs — e.g. `syncBadgeFromData` mirroring the badge count onto
+         * the app icon for data-only messages. Without it, iOS drops the wake
+         * event and only foreground/tapped notifications are handled.
+         */
+        UIBackgroundModes: [
+          ...((config.ios?.infoPlist?.UIBackgroundModes as string[] | undefined) ?? []),
+          'remote-notification',
+        ],
         NSPhotoLibraryUsageDescription:
           'The app needs access to your photos to upload property images.',
         NSCameraUsageDescription:


### PR DESCRIPTION
## Task
Coverage 8a-3: implement React Native mobile OS push integration (FCM for Android / APNs for iOS) — register device token, persist to backend, handle foreground/background notification delivery for the notification-preference pipeline. Mobile (frontend/apps/mobile). VERIFY current state first; close the genuine gap (impl or test coverage) rather than re-implementing existing code.

## Owner
pm-frontend (specialist: react-native)

## What was already done (NOT re-implemented)
Verification first: the JS push pipeline is already complete and tested.
- `src/hooks/usePushNotifications.ts` — requests permission, obtains native FCM/APNs token via `getDevicePushTokenAsync()` + Expo token, POSTs to `/api/v1/users/me/push-tokens` (FCM/APNs platform split), DELETE on unregister, Android notification channels, foreground + tap + cold-start handlers, badge sync. (Epic 85.3 / PR #918, with regression tests.)
- `src/services/backgroundNotifications.ts` — cold-start launch handling, `deepLinkForNotification`, `syncBadgeFromData`. (tested)
- `app.config.ts` — `expo-notifications` plugin + `google-services.json` (FCM Android) already wired.

## The genuine gap (closed here)
iOS native config was missing two keys the pipeline needs end-to-end:
1. `ios.entitlements['aps-environment']` — without it iOS never issues an APNs device token, so the existing `getDevicePushTokenAsync()` registration cannot run on iOS. Set to `development` (debug/staging → APNs sandbox) / `production` (release → APNs production gateway).
2. `ios.infoPlist.UIBackgroundModes` now includes `remote-notification` — required for iOS to wake the app for **background/silent (data-only) FCM/APNs pushes**, which is the "background notification delivery" path that feeds `syncBadgeFromData` for data-only messages. Without it iOS drops the wake event and only foreground/tapped notifications are handled.

Both are written into the Expo-generated `<app>.entitlements` / `Info.plist` at prebuild, alongside the existing universal-links entitlement.

## Tested (Band A — fast check)
- `pnpm -F @ppt/mobile test -- app.config.push usePushNotifications backgroundNotifications` → `Test Suites: 3 passed`, `Tests: 23 passed` (exit 0)
- `pnpm -F @ppt/mobile typecheck` → exit 0
- `pnpm exec biome check apps/mobile/app.config.ts apps/mobile/app.config.push.test.ts` → exit 0
- IG3: the new `app.config.push.test.ts` was confirmed to FAIL on the unmodified config (4 failures via stash) and pass with the fix.

## Built (Band B — full build)
skipped: change <50 LOC substantive, config + test only, no app build-output change beyond prebuild plist keys (covered by the config unit test).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity logic — iOS native push capability config).

## Remote-tested
skipped (no ppt-bridge MCP / no iOS device prebuild in this environment).

## Scope drift
`scope-check.sh --owner pm-frontend` exited 2 on:
- `frontend/apps/mobile/app.config.ts`
- `frontend/apps/mobile/app.config.push.test.ts`

This is a mapping artifact, not real drift: `scripts/owner-areas.json` lists ppt-web / reality-web / admin-web / packages / docs/screens under `pm-frontend` but **omits `frontend/apps/mobile/**`**. The task explicitly targets `frontend/apps/mobile` and was assigned owner_role=pm-frontend, so both changed paths are exactly the intended target. Reviewer to confirm (and optionally add `frontend/apps/mobile/**` to the pm-frontend owner area).

## Code-reuse review
`reuse-grep.sh --specialist react-native` → no warnings. No new auth/crypto/http helpers added; reuses the existing config + expo plumbing.

## Notes
- The Android FCM side was already complete (google-services.json + POST_NOTIFICATIONS perm + channels); no change needed there.
- `app.config.push.test.ts` mocks `dotenv` so the production branch doesn't trip the `__SET_BY_CI__` placeholder-URL guard (mirrors how CI overrides `.env.production`).

https://claude.ai/code/session_01WN8BUMfbDwUyApxvazDRNu

---
_Generated by [Claude Code](https://claude.ai/code/session_01WN8BUMfbDwUyApxvazDRNu)_