### PR TITLE
test-direct-messaging-realtime-sync: coverage 6-5 — direct-messaging realtime sync tests

### DIFF
--- a/frontend/apps/ppt-web/src/features/messaging/hooks/useMessaging.realtime.test.tsx
+++ b/frontend/apps/ppt-web/src/features/messaging/hooks/useMessaging.realtime.test.tsx
@@ -1,0 +1,152 @@
+/// <reference types="vitest/globals" />
+/**
+ * Realtime read-state propagation tests for direct messaging
+ * (Coverage 6-5 — Epic 6, Story 6.5).
+ *
+ * The realtime UX for direct messaging hinges on the TanStack cache being
+ * invalidated at exactly the right query keys when the user reads, sends, or
+ * starts a thread — otherwise the thread list, the open thread, and the global
+ * unread badge drift apart and the "live" feel breaks. Those invalidation sets
+ * live in the shared messaging hooks factory but are surfaced through the
+ * ppt-web `useMessaging` wrappers, so we exercise the wrappers here:
+ *
+ *  - `useMarkThreadRead` — the read-state mutation. MUST invalidate the thread
+ *    detail, the thread list, AND the global unread count so every surface that
+ *    shows "unread" updates the moment a thread is opened/read. A refactor that
+ *    drops the unread-count invalidation leaves a stale badge; that regression
+ *    is pinned here.
+ *  - `useSendMessage` — sending a message refreshes the open thread and the
+ *    list preview/order.
+ *  - `useStartThread` — a new thread must appear in the list immediately.
+ *
+ * The presentational behaviour is covered elsewhere; the gap was the
+ * cache-sync contract that makes the realtime sync observable in the UI.
+ */
+
+import { messagingKeys } from '@ppt/api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { useMarkThreadRead, useSendMessage, useStartThread } from './useMessaging';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+function setup() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, invalidateSpy, wrapper };
+}
+
+/** Collect every queryKey passed to invalidateQueries as a JSON string for set comparison. */
+function invalidatedKeys(invalidateSpy: ReturnType<typeof vi.spyOn>): string[] {
+  return invalidateSpy.mock.calls.map((call) =>
+    JSON.stringify((call[0] as { queryKey: unknown })?.queryKey)
+  );
+}
+
+/** A generic 2xx JSON response — the mutations only need `response.ok`. */
+function okJson(body: unknown = {}): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('useMarkThreadRead (read-state propagation)', () => {
+  it('POSTs to /api/v1/messages/threads/:id/read', async () => {
+    mockFetch.mockResolvedValueOnce(okJson({ success: true }));
+    const { wrapper } = setup();
+
+    const { result } = renderHook(() => useMarkThreadRead(), { wrapper });
+    result.current.mutate('thread-1');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/messages/threads/thread-1/read',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('invalidates thread detail, the thread list AND the unread count', async () => {
+    mockFetch.mockResolvedValueOnce(okJson({ success: true }));
+    const { invalidateSpy, wrapper } = setup();
+
+    const { result } = renderHook(() => useMarkThreadRead(), { wrapper });
+    result.current.mutate('thread-1');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const keys = invalidatedKeys(invalidateSpy);
+    // detail of the read thread refreshes (messages flip to read)
+    expect(keys).toContain(JSON.stringify(messagingKeys.threadDetail('thread-1')));
+    // the list refreshes so the per-thread unread badge clears
+    expect(keys).toContain(JSON.stringify(messagingKeys.threads()));
+    // the GLOBAL unread badge must refresh too — dropping this leaves a stale count
+    expect(keys).toContain(JSON.stringify(messagingKeys.unreadCount()));
+  });
+});
+
+describe('useSendMessage (delivery → cache sync)', () => {
+  it('POSTs to the thread messages endpoint', async () => {
+    mockFetch.mockResolvedValueOnce(okJson({ id: 'm-1' }));
+    const { wrapper } = setup();
+
+    const { result } = renderHook(() => useSendMessage(), { wrapper });
+    result.current.mutate({ threadId: 'thread-7', data: { content: 'hello' } });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/messages/threads/thread-7/messages',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('invalidates the open thread and the thread list so the new message shows', async () => {
+    mockFetch.mockResolvedValueOnce(okJson({ id: 'm-1' }));
+    const { invalidateSpy, wrapper } = setup();
+
+    const { result } = renderHook(() => useSendMessage(), { wrapper });
+    result.current.mutate({ threadId: 'thread-7', data: { content: 'hello' } });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const keys = invalidatedKeys(invalidateSpy);
+    expect(keys).toContain(JSON.stringify(messagingKeys.threadDetail('thread-7')));
+    expect(keys).toContain(JSON.stringify(messagingKeys.threads()));
+  });
+});
+
+describe('useStartThread (new thread → cache sync)', () => {
+  it('invalidates the thread list so a freshly started thread appears', async () => {
+    mockFetch.mockResolvedValueOnce(okJson({ thread: { id: 'thread-new' } }));
+    const { invalidateSpy, wrapper } = setup();
+
+    const { result } = renderHook(() => useStartThread(), { wrapper });
+    result.current.mutate({ recipientId: 'user-2', initialMessage: 'hi there' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const keys = invalidatedKeys(invalidateSpy);
+    expect(keys).toContain(JSON.stringify(messagingKeys.threads()));
+  });
+});

--- a/frontend/apps/ppt-web/src/lib/websocket.delivery.test.ts
+++ b/frontend/apps/ppt-web/src/lib/websocket.delivery.test.ts
@@ -1,0 +1,165 @@
+/// <reference types="vitest/globals" />
+/**
+ * Realtime delivery tests for the messaging WebSocket transport
+ * (Coverage 6-5 — Epic 6, Story 6.5).
+ *
+ * `websocket.test.ts` already pins the two pure contract helpers
+ * (`buildWebSocketUrl`, `parseServerMessage`). The untested half is the live
+ * dispatch path inside `WebSocketService`: an inbound `{ event, payload }`
+ * frame off the socket must be parsed and fanned out to the right subscribers.
+ * Direct messaging realtime sync rides this exact path — the api-server pushes
+ * a `message:new` envelope and the messaging UI subscribes to it to invalidate
+ * its caches. If dispatch drops `message:new`, the inbox never updates until a
+ * manual refresh.
+ *
+ * These tests install a controllable fake `WebSocket` so we can drive `onopen`
+ * and `onmessage` deterministically and assert:
+ *  - a `message:new` frame reaches a typed subscriber with the payload intact;
+ *  - wildcard (`*`) subscribers also see it;
+ *  - subscribers for other event types are NOT invoked (no cross-talk);
+ *  - `unsubscribe()` stops further delivery (no leak after a thread unmounts).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { WebSocketService } from './websocket';
+
+/**
+ * Minimal controllable WebSocket stand-in. Captures the handlers the service
+ * attaches and exposes helpers to simulate the connection opening and the
+ * server pushing a frame.
+ */
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  static lastInstance: FakeWebSocket | null = null;
+
+  readyState = FakeWebSocket.CONNECTING;
+  onopen: ((ev: unknown) => void) | null = null;
+  onclose: ((ev: unknown) => void) | null = null;
+  onerror: ((ev: unknown) => void) | null = null;
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  sent: string[] = [];
+
+  constructor(
+    public url: string,
+    public protocols?: string | string[]
+  ) {
+    FakeWebSocket.lastInstance = this;
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+
+  /** Simulate the socket transitioning to OPEN. */
+  simulateOpen(): void {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.({});
+  }
+
+  /** Simulate the server pushing a canonical `{ event, payload }` frame. */
+  simulateServerEvent(event: string, payload: unknown): void {
+    this.onmessage?.({ data: JSON.stringify({ event, payload }) });
+  }
+}
+
+function connectedService(): { service: WebSocketService; socket: FakeWebSocket } {
+  const service = new WebSocketService({
+    url: 'ws://localhost:8080',
+    getToken: () => 'test-jwt',
+  });
+  service.connect();
+  const socket = FakeWebSocket.lastInstance;
+  if (!socket) throw new Error('expected a WebSocket to be constructed');
+  socket.simulateOpen();
+  return { service, socket };
+}
+
+let originalWebSocket: typeof globalThis.WebSocket;
+
+beforeEach(() => {
+  originalWebSocket = globalThis.WebSocket;
+  // biome-ignore lint/suspicious/noExplicitAny: test double for the global WebSocket
+  globalThis.WebSocket = FakeWebSocket as any;
+  FakeWebSocket.lastInstance = null;
+});
+
+afterEach(() => {
+  globalThis.WebSocket = originalWebSocket;
+  vi.restoreAllMocks();
+});
+
+describe('WebSocketService — message:new delivery', () => {
+  it('delivers a message:new frame to a typed subscriber with payload intact', () => {
+    const { service, socket } = connectedService();
+    const handler = vi.fn();
+    service.subscribe('message:new', handler);
+
+    const payload = { threadId: 'thread-1', messageId: 'm-9', senderId: 'user-2' };
+    socket.simulateServerEvent('message:new', payload);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const received = handler.mock.calls[0][0];
+    expect(received.type).toBe('message:new');
+    expect(received.payload).toEqual(payload);
+    expect(typeof received.timestamp).toBe('string');
+  });
+
+  it('also fans the frame out to wildcard (*) subscribers', () => {
+    const { service, socket } = connectedService();
+    const typed = vi.fn();
+    const wildcard = vi.fn();
+    service.subscribe('message:new', typed);
+    service.subscribe('*', wildcard);
+
+    socket.simulateServerEvent('message:new', { threadId: 'thread-1' });
+
+    expect(typed).toHaveBeenCalledTimes(1);
+    expect(wildcard).toHaveBeenCalledTimes(1);
+    expect(wildcard.mock.calls[0][0].type).toBe('message:new');
+  });
+
+  it('does not invoke subscribers for unrelated event types', () => {
+    const { service, socket } = connectedService();
+    const messageHandler = vi.fn();
+    const faultHandler = vi.fn();
+    service.subscribe('message:new', messageHandler);
+    service.subscribe('notification:fault', faultHandler);
+
+    socket.simulateServerEvent('message:new', { threadId: 'thread-1' });
+
+    expect(messageHandler).toHaveBeenCalledTimes(1);
+    expect(faultHandler).not.toHaveBeenCalled();
+  });
+
+  it('stops delivery after unsubscribe (no leak when a thread view unmounts)', () => {
+    const { service, socket } = connectedService();
+    const handler = vi.fn();
+    const unsubscribe = service.subscribe('message:new', handler);
+
+    socket.simulateServerEvent('message:new', { threadId: 'thread-1' });
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    socket.simulateServerEvent('message:new', { threadId: 'thread-1' });
+    // still 1 — the unsubscribed handler must not fire again
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('tracks the last event timestamp for gap detection on delivery', () => {
+    const { service, socket } = connectedService();
+    expect(service.getLastEventTimestamp()).toBeNull();
+
+    service.subscribe('message:new', vi.fn());
+    socket.simulateServerEvent('message:new', { threadId: 'thread-1' });
+
+    expect(service.getLastEventTimestamp()).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Task
Coverage 6-5: add test coverage for direct-messaging realtime sync (websocket message delivery + read-state propagation). Frontend ppt-web / shared hooks; additive tests.

## Owner
pm-frontend

## What changed (additive tests only)
Two new test files in `@ppt/web`, no production code touched:

- **`src/lib/websocket.delivery.test.ts`** — covers the live dispatch path inside `WebSocketService` (the untested half; `websocket.test.ts` already pins the pure `buildWebSocketUrl` / `parseServerMessage` helpers). Installs a controllable fake `WebSocket` and asserts a `message:new` `{event,payload}` frame reaches a typed subscriber with payload intact, also fans out to wildcard (`*`) subscribers, does NOT invoke unrelated-event subscribers (no cross-talk), stops delivery after `unsubscribe()`, and updates the last-event timestamp used for gap detection. This is the transport direct-messaging realtime sync rides on.
- **`src/features/messaging/hooks/useMessaging.realtime.test.tsx`** — covers read-state propagation through the ppt-web messaging hooks. Pins the TanStack cache-invalidation contract that makes realtime sync observable: `useMarkThreadRead` invalidates thread detail + thread list + **global unread count** (dropping the last leaves a stale badge); `useSendMessage` invalidates the open thread + list; `useStartThread` invalidates the list so a new thread appears. Also asserts the request endpoints/methods.

## Tested (Band A — fast check)
- `pnpm -F @ppt/web exec vitest run <2 new files>` → 2 files, 10 tests passed
- `pnpm -F @ppt/web test:run` → 56 files, 638 tests passed (exit 0)
- `pnpm -F @ppt/web typecheck` → exit 0
- `pnpm exec biome check <2 new files>` → No fixes applied, exit 0

## Built (Band B — full build)
Skipped: additive test-only change (no production code, no public API/config touch). Full suite + typecheck already exercise the changed code.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change; tests only).

## Remote-tested
Skipped (no ppt-bridge MCP in session).

## Notes
- Pure additive coverage. The messaging feature has no dedicated `message:new` subscription wired yet (read-state is driven by mark-as-read mutations + query invalidation); these tests pin the realtime infra (`WebSocketService` dispatch) and the cache-sync contract that the inbox/badge rely on, rather than inventing new production wiring.
- Scope-drift check: clean (`scope_drift=false`). Code-reuse pre-flight: clean (no new helpers).
- Goal-check IG1/IG2 report FAIL only because this is a dispatcher-style task with no `.research/plans/*.md` and the mandated `auto-impl/` branch prefix (vs `impl/`); the script's overall exit was 0 and the hard verify gate passed.

https://claude.ai/code/session_01WN8BUMfbDwUyApxvazDRNu

---
_Generated by [Claude Code](https://claude.ai/code/session_01WN8BUMfbDwUyApxvazDRNu)_