### PR TITLE
fix(aml_dsa): re-land PAP-38/43 authz+integrity fixes (PAP-60)

### DIFF
--- a/backend/crates/db/src/repositories/compliance.rs
+++ b/backend/crates/db/src/repositories/compliance.rs
@@ -323,6 +323,110 @@ impl ComplianceRepository {
     // CONTENT MODERATION CASES
     // ========================================================================
 
+    /// Resolve the real owner (user id) of a piece of reportable content,
+    /// scoped to the caller's organization where the content table carries one.
+    ///
+    /// Returns `Ok(None)` when the content does not exist (or is not visible to
+    /// the caller's org, or the content type has no resolvable owner table), so
+    /// callers can reject the report instead of persisting a bogus owner.
+    /// Cross-tenant content resolves to `None` to avoid leaking its existence.
+    pub async fn resolve_content_owner(
+        &self,
+        content_type: ModeratedContentType,
+        content_id: Uuid,
+        org_id: Option<Uuid>,
+    ) -> Result<Option<Uuid>, SqlxError> {
+        let owner: Option<Uuid> =
+            match content_type {
+                // A user profile *is* a user; the content id is the owner.
+                ModeratedContentType::UserProfile => {
+                    sqlx::query_scalar(r#"SELECT id FROM users WHERE id = $1"#)
+                        .bind(content_id)
+                        .fetch_optional(&self.pool)
+                        .await?
+                }
+
+                // Org-scoped content: only resolvable from within the owning org.
+                ModeratedContentType::Listing => {
+                    sqlx::query_scalar(
+                        r#"SELECT created_by FROM listings WHERE id = $1 AND organization_id = $2"#,
+                    )
+                    .bind(content_id)
+                    .bind(org_id)
+                    .fetch_optional(&self.pool)
+                    .await?
+                }
+
+                ModeratedContentType::ListingPhoto => {
+                    sqlx::query_scalar(
+                        r#"
+                SELECT l.created_by
+                FROM listing_photos p
+                JOIN listings l ON l.id = p.listing_id
+                WHERE p.id = $1 AND l.organization_id = $2
+                "#,
+                    )
+                    .bind(content_id)
+                    .bind(org_id)
+                    .fetch_optional(&self.pool)
+                    .await?
+                }
+
+                ModeratedContentType::Announcement => sqlx::query_scalar(
+                    r#"SELECT author_id FROM announcements WHERE id = $1 AND organization_id = $2"#,
+                )
+                .bind(content_id)
+                .bind(org_id)
+                .fetch_optional(&self.pool)
+                .await?,
+
+                ModeratedContentType::Document => sqlx::query_scalar(
+                    r#"SELECT created_by FROM documents WHERE id = $1 AND organization_id = $2"#,
+                )
+                .bind(content_id)
+                .bind(org_id)
+                .fetch_optional(&self.pool)
+                .await?,
+
+                ModeratedContentType::Message => {
+                    sqlx::query_scalar(
+                        r#"
+                SELECT m.sender_id
+                FROM messages m
+                JOIN message_threads t ON t.id = m.thread_id
+                WHERE m.id = $1 AND t.organization_id = $2
+                "#,
+                    )
+                    .bind(content_id)
+                    .bind(org_id)
+                    .fetch_optional(&self.pool)
+                    .await?
+                }
+
+                // community_posts scope by organization via the owning group's building.
+                ModeratedContentType::CommunityPost => {
+                    sqlx::query_scalar(
+                        r#"
+                SELECT cp.author_id
+                FROM community_posts cp
+                JOIN community_groups cg ON cg.id = cp.group_id
+                JOIN buildings b ON b.id = cg.building_id
+                WHERE cp.id = $1 AND b.organization_id = $2
+                "#,
+                    )
+                    .bind(content_id)
+                    .bind(org_id)
+                    .fetch_optional(&self.pool)
+                    .await?
+                }
+
+                // No backing owner table in this schema yet — caller rejects (404).
+                ModeratedContentType::Review | ModeratedContentType::Comment => None,
+            };
+
+        Ok(owner)
+    }
+
     /// Create a moderation case (user report).
     pub async fn create_moderation_case(
         &self,
@@ -679,8 +783,18 @@ impl ComplianceRepository {
         Ok(case)
     }
 
-    /// File an appeal.
-    pub async fn file_appeal(&self, id: Uuid, reason: &str) -> Result<ModerationCase, SqlxError> {
+    /// File an appeal, scoped to the case's organization.
+    ///
+    /// The `organization_id` predicate is defense-in-depth against the
+    /// cross-tenant IDOR (PAP-60): even though the handler already verifies
+    /// ownership before calling this, the UPDATE itself refuses to touch a case
+    /// outside `org_id`, mirroring `decide_appeal`.
+    pub async fn file_appeal(
+        &self,
+        id: Uuid,
+        org_id: Uuid,
+        reason: &str,
+    ) -> Result<ModerationCase, SqlxError> {
         let case = sqlx::query_as::<_, ModerationCase>(
             r#"
             UPDATE moderation_cases SET
@@ -689,12 +803,13 @@ impl ComplianceRepository {
                 appeal_filed_at = NOW(),
                 status = 'appealed',
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $3
             RETURNING *
             "#,
         )
         .bind(id)
         .bind(reason)
+        .bind(org_id)
         .fetch_one(&self.pool)
         .await?;
 

--- a/backend/servers/api-server/src/routes/aml_dsa.rs
+++ b/backend/servers/api-server/src/routes/aml_dsa.rs
@@ -376,6 +376,11 @@ async fn create_aml_assessment(
     user: AuthUser,
     Json(req): Json<CreateAmlAssessmentRequest>,
 ) -> Result<Json<AmlAssessmentResponse>, (StatusCode, String)> {
+    // Creating an AML risk assessment is a compliance-officer action, like every
+    // other AML/EDD handler in this module. Without this check any authenticated
+    // tenant user could create assessments (PAP-60/PAP-43).
+    require_compliance_role(&user)?;
+
     let org_id = user.tenant_id.ok_or((
         StatusCode::BAD_REQUEST,
         "Organization context required".to_string(),
@@ -2177,14 +2182,49 @@ async fn file_appeal(
     Path(id): Path<Uuid>,
     Json(req): Json<FileAppealRequest>,
 ) -> Result<Json<ModerationCaseResponse>, (StatusCode, String)> {
-    // Any authenticated user can file appeal for their content
-
     validate_text_field(&req.reason, MAX_APPEAL_REASON_LEN, "reason")
         .map_err(|e| (StatusCode::BAD_REQUEST, e))?;
 
+    // A content owner may appeal a moderation decision on *their own* content.
+    // Load the case scoped to the caller's organization first and enforce
+    // ownership before mutating it; otherwise any authenticated user could
+    // appeal any case in any tenant via a global id (PAP-60/PAP-43 — F5 IDOR).
+    //
+    // A caller with no tenant context, or a case outside the caller's org, is
+    // treated as non-existent (404) so we never leak the case's existence
+    // across tenants.
+    let org_id = user.tenant_id.ok_or((
+        StatusCode::NOT_FOUND,
+        "Moderation case not found".to_string(),
+    ))?;
+
+    let existing = state
+        .compliance_repo
+        .get_moderation_case(id, org_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to load moderation case: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to file appeal".to_string(),
+            )
+        })?
+        .ok_or((
+            StatusCode::NOT_FOUND,
+            "Moderation case not found".to_string(),
+        ))?;
+
+    // Ownership: only the content owner may file the appeal.
+    if existing.content_owner_id != user.user_id {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "You can only appeal moderation decisions on your own content".to_string(),
+        ));
+    }
+
     let case = state
         .compliance_repo
-        .file_appeal(id, &req.reason)
+        .file_appeal(id, org_id, &req.reason)
         .await
         .map_err(|e| {
             tracing::error!("Failed to file appeal: {}", e);
@@ -2319,7 +2359,26 @@ async fn report_content(
     user: AuthUser,
     Json(req): Json<ReportContentRequest>,
 ) -> Result<Json<ModerationCaseResponse>, (StatusCode, String)> {
-    // Any authenticated user can report content
+    // Any authenticated user can report content, but the case must be stored
+    // against the *real* content owner — a random placeholder corrupts
+    // violation-history and owner-notification downstream (PAP-60/PAP-43 — F7).
+    // Resolve the owner (scoped to the caller's org) and reject the report if it
+    // can't be resolved rather than persisting a bogus owner.
+    let content_owner_id = state
+        .compliance_repo
+        .resolve_content_owner(req.content_type, req.content_id, user.tenant_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to resolve content owner: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to report content".to_string(),
+            )
+        })?
+        .ok_or((
+            StatusCode::NOT_FOUND,
+            "Reported content could not be found".to_string(),
+        ))?;
 
     let create_req = CreateModerationCase {
         content_type: req.content_type,
@@ -2327,9 +2386,6 @@ async fn report_content(
         violation_type: req.violation_type,
         report_reason: req.reason,
     };
-
-    // For now, use a placeholder for content_owner_id - in production this would be looked up
-    let content_owner_id = Uuid::new_v4();
 
     let case = state
         .compliance_repo

--- a/backend/servers/api-server/tests/aml_dsa_authz_pap60_tests.rs
+++ b/backend/servers/api-server/tests/aml_dsa_authz_pap60_tests.rs
@@ -1,0 +1,310 @@
+//! Regression tests for the AML/DSA authz & data-integrity gaps (PAP-60,
+//! re-landing the PAP-38/PAP-43 remediation that never reached `dev`; child of
+//! the PAP-35 security review of `routes/aml_dsa.rs`).
+//!
+//! Three gaps are closed here:
+//!
+//! 1. `create_aml_assessment` had NO role check while every other AML/EDD
+//!    handler calls `require_compliance_role` — any authenticated tenant user
+//!    could create AML risk assessments. Now gated: a non-compliance caller
+//!    gets 403.
+//!
+//! 2. `file_appeal` had no authz/ownership check — it called
+//!    `file_appeal(id, reason)` on a global id, so any authenticated user could
+//!    appeal any case in any tenant. Now the handler loads the case and
+//!    enforces tenant isolation (case org == caller org) + ownership (case
+//!    owner == caller); a cross-tenant case is refused with 404.
+//!
+//! 3. `report_content` stored `content_owner_id = Uuid::new_v4()` — a random
+//!    bogus owner on every reported case, corrupting violation-history and
+//!    owner-notification. The owner is now resolved from the real content via
+//!    `ComplianceRepository::resolve_content_owner` (org-scoped), or the report
+//!    is rejected when unresolvable. These repo-layer tests assert the resolver
+//!    returns the *real* owner, refuses cross-org content, and refuses content
+//!    types with no backing owner table.
+//!
+//! HTTP-layer caveat (see `agency_authz_idor_tests.rs`): `TestApp` mounts the
+//! router without `host_tenant_middleware`, and `create_authenticated_user`
+//! mints a token whose claims carry `role = None` / `tenant_id = None` (the
+//! user has no org membership at login time). That is exactly the
+//! "non-privileged / cross-tenant caller" the role and ownership gates must
+//! reject, so the HTTP tests assert the rejection direction.
+
+#[allow(dead_code)]
+mod common;
+
+use axum::http::StatusCode;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{create_authenticated_user, TestApp, TestUser};
+use db::models::compliance::ModeratedContentType;
+use db::repositories::ComplianceRepository;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO organizations (name, slug, contact_email, status)
+           VALUES ($1, $2, $3, 'active') RETURNING id"#,
+    )
+    .bind(format!("PAP43 Org {slug}"))
+    .bind(format!("pap43-org-{slug}-{}", Uuid::new_v4()))
+    .bind(format!("{slug}-{}@pap43.test", Uuid::new_v4()))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, label: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO users (email, password_hash, name, status, email_verified_at)
+           VALUES ($1, 'test_hash', 'PAP43 User', 'active', NOW()) RETURNING id"#,
+    )
+    .bind(format!("{label}-{}@pap43.test", Uuid::new_v4()))
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Seed a listing owned by `owner` in `org`; returns the listing id.
+async fn seed_listing(pool: &PgPool, org: Uuid, owner: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO listings
+               (organization_id, created_by, transaction_type, title,
+                street, city, postal_code, price)
+           VALUES ($1, $2, 'sale', 'PAP43 Listing',
+                   '1 Test St', 'Testville', '00000', 100000.00)
+           RETURNING id"#,
+    )
+    .bind(org)
+    .bind(owner)
+    .fetch_one(pool)
+    .await
+    .expect("seed listing")
+}
+
+/// Seed a moderation case in `org` owned by `owner`; returns the case id.
+async fn seed_moderation_case(pool: &PgPool, org: Uuid, owner: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO moderation_cases
+               (content_type, content_id, content_owner_id, organization_id,
+                report_source, status, priority)
+           VALUES ('listing', $1, $2, $3, 'user', 'pending', 3)
+           RETURNING id"#,
+    )
+    .bind(Uuid::new_v4())
+    .bind(owner)
+    .bind(org)
+    .fetch_one(pool)
+    .await
+    .expect("seed moderation case")
+}
+
+// ===========================================================================
+// (3) report_content: resolve_content_owner returns the REAL owner, org-scoped,
+//     and refuses unresolvable content instead of inventing a random owner.
+// ===========================================================================
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn resolve_content_owner_returns_real_listing_owner(pool: PgPool) {
+    let repo = ComplianceRepository::new(pool.clone());
+    let org = seed_org(&pool, "list").await;
+    let owner = seed_user(&pool, "owner").await;
+    let listing = seed_listing(&pool, org, owner).await;
+
+    let resolved = repo
+        .resolve_content_owner(ModeratedContentType::Listing, listing, Some(org))
+        .await
+        .expect("query ok");
+
+    assert_eq!(
+        resolved,
+        Some(owner),
+        "report_content must persist the listing's real owner, not a placeholder"
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn resolve_content_owner_is_org_scoped(pool: PgPool) {
+    let repo = ComplianceRepository::new(pool.clone());
+    let org_a = seed_org(&pool, "a").await;
+    let org_b = seed_org(&pool, "b").await;
+    let owner = seed_user(&pool, "owner").await;
+    let listing_in_a = seed_listing(&pool, org_a, owner).await;
+
+    // Caller scoped to org B cannot resolve (and therefore cannot report)
+    // content that lives in org A — returns None, so the handler 404s.
+    let cross_org = repo
+        .resolve_content_owner(ModeratedContentType::Listing, listing_in_a, Some(org_b))
+        .await
+        .expect("query ok");
+    assert_eq!(
+        cross_org, None,
+        "content in another org must not be resolvable by a cross-tenant reporter"
+    );
+
+    // No org context at all is likewise unresolvable for org-scoped content.
+    let no_org = repo
+        .resolve_content_owner(ModeratedContentType::Listing, listing_in_a, None)
+        .await
+        .expect("query ok");
+    assert_eq!(
+        no_org, None,
+        "org-scoped content needs an org context to resolve"
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn resolve_content_owner_user_profile_is_self(pool: PgPool) {
+    let repo = ComplianceRepository::new(pool.clone());
+    let org = seed_org(&pool, "prof").await;
+    let user = seed_user(&pool, "profile").await;
+
+    // A user profile *is* the user; the content id is the owner.
+    let resolved = repo
+        .resolve_content_owner(ModeratedContentType::UserProfile, user, Some(org))
+        .await
+        .expect("query ok");
+    assert_eq!(resolved, Some(user));
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn resolve_content_owner_unknown_content_is_none(pool: PgPool) {
+    let repo = ComplianceRepository::new(pool.clone());
+    let org = seed_org(&pool, "none").await;
+
+    // Missing listing → None (handler rejects with 404 rather than a placeholder).
+    let missing = repo
+        .resolve_content_owner(ModeratedContentType::Listing, Uuid::new_v4(), Some(org))
+        .await
+        .expect("query ok");
+    assert_eq!(missing, None);
+
+    // Content types with no backing owner table also resolve to None.
+    for ct in [ModeratedContentType::Review, ModeratedContentType::Comment] {
+        let r = repo
+            .resolve_content_owner(ct, Uuid::new_v4(), Some(org))
+            .await
+            .expect("query ok");
+        assert_eq!(
+            r, None,
+            "{ct:?} has no owner table and must not invent an owner"
+        );
+    }
+}
+
+// ===========================================================================
+// (1) create_aml_assessment is role-gated: a non-compliance caller gets 403.
+// ===========================================================================
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_aml_assessment_requires_compliance_role(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    let (token, _refresh) = create_authenticated_user(&app, &user).await;
+
+    let req = app
+        .post("/api/v1/aml-dsa/aml/assess")
+        .bearer(&token)
+        .json(serde_json::json!({
+            "party_id": Uuid::new_v4(),
+            "party_type": "individual"
+        }))
+        .build();
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "a non-compliance caller must be refused (403) before any assessment is created"
+    );
+}
+
+// ===========================================================================
+// (2) file_appeal enforces tenant isolation: a caller outside the case's org
+//     (here, a caller with no org context) is refused, not allowed to mutate.
+// ===========================================================================
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn file_appeal_rejects_cross_tenant_case(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    // A case that belongs to some org and is owned by some other user.
+    let org = seed_org(&pool, "case").await;
+    let owner = seed_user(&pool, "case-owner").await;
+    let case_id = seed_moderation_case(&pool, org, owner).await;
+
+    // An unrelated authenticated caller (no org context / not the owner).
+    let user = TestUser::new();
+    let (token, _refresh) = create_authenticated_user(&app, &user).await;
+
+    let req = app
+        .post(&format!(
+            "/api/v1/aml-dsa/moderation/cases/{case_id}/appeal"
+        ))
+        .bearer(&token)
+        .json(serde_json::json!({ "reason": "I disagree" }))
+        .build();
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::NOT_FOUND,
+        "a caller outside the case's tenant must not be able to file (or even see) the appeal"
+    );
+
+    // And the case must NOT have been mutated into the appealed state.
+    let appealed: bool =
+        sqlx::query_scalar("SELECT appeal_filed FROM moderation_cases WHERE id = $1")
+            .bind(case_id)
+            .fetch_one(&pool)
+            .await
+            .expect("query ok");
+    assert!(
+        !appealed,
+        "the cross-tenant appeal attempt must not have mutated the case"
+    );
+}
+
+/// Repo-layer proof of the defense-in-depth `organization_id` predicate on
+/// `ComplianceRepository::file_appeal` (PAP-60 acceptance: "Repo UPDATE carries
+/// organization_id"). Even calling the repo directly with a *wrong* org id must
+/// not mutate a case that lives in another org.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn repo_file_appeal_is_org_scoped(pool: PgPool) {
+    let repo = ComplianceRepository::new(pool.clone());
+
+    let org_a = seed_org(&pool, "a").await;
+    let org_b = seed_org(&pool, "b").await;
+    let owner = seed_user(&pool, "owner").await;
+    let case_in_a = seed_moderation_case(&pool, org_a, owner).await;
+
+    // Calling with org B (not the case's org) must affect zero rows: fetch_one
+    // therefore yields RowNotFound rather than mutating the case.
+    let res = repo.file_appeal(case_in_a, org_b, "cross-org appeal").await;
+    assert!(
+        matches!(res, Err(sqlx::Error::RowNotFound)),
+        "file_appeal with the wrong org must not match (and must not mutate) the case"
+    );
+
+    let appealed: bool =
+        sqlx::query_scalar("SELECT appeal_filed FROM moderation_cases WHERE id = $1")
+            .bind(case_in_a)
+            .fetch_one(&pool)
+            .await
+            .expect("query ok");
+    assert!(
+        !appealed,
+        "the org-scoped UPDATE must leave a cross-org case untouched"
+    );
+
+    // Sanity: with the correct org the same call succeeds and flips the flag.
+    let ok = repo
+        .file_appeal(case_in_a, org_a, "rightful appeal")
+        .await
+        .expect("owner-org appeal succeeds");
+    assert!(ok.appeal_filed, "in-org appeal must mutate the case");
+}


### PR DESCRIPTION
## Summary
Re-lands the PAP-38/PAP-43 authz & data-integrity remediation that **never reached `dev`** (PR #1192 closed-unmerged; `856b832bb` is not an ancestor of `origin/dev`). Re-applied on top of current `dev`. Closes three live gaps in `routes/aml_dsa.rs`:

- **F5 [HIGH — cross-tenant IDOR write] `file_appeal`**: load the case scoped to the caller's org and enforce content ownership before mutating. Cross-tenant / no-tenant caller → 404; owner mismatch → 403. Defense-in-depth: `ComplianceRepository::file_appeal` now carries `AND organization_id = $N` (mirrors `decide_appeal`).
- **F6 [MEDIUM — least-privilege] `create_aml_assessment`**: added the missing `require_compliance_role` gate; non-compliance roles → 403.
- **F7 [MEDIUM — data integrity] `report_content`**: dropped the `Uuid::new_v4()` placeholder owner; resolves the real, org-scoped content owner via new `ComplianceRepository::resolve_content_owner`, rejecting unresolvable content with 404.

## Tests
`backend/servers/api-server/tests/aml_dsa_authz_pap60_tests.rs` — role gate, cross-tenant appeal rejection (HTTP + repo-layer org scoping), content-owner resolver (real owner / org-scoped / unresolvable→None).

## Verification
- `cargo check -p api-server` — clean for this diff (lib + new test target compile).
- ⚠️ **`dev` tip does not currently compile** due to an unrelated PAP-36×PAP-46 mismerge in `get_dsa_metrics` (`user.tenant_id` referenced after PAP-46 removed the `AuthUser` extractor). Tracked separately; CI on this PR will be red until that lands. This PR does **not** touch that handler.

Refs PAP-60, PAP-35, PAP-38, PAP-43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)