### PR TITLE
fix(aml_dsa): make get_dsa_metrics platform-wide, unblock dev compile (PAP-64)

### DIFF
--- a/backend/crates/db/src/repositories/compliance.rs
+++ b/backend/crates/db/src/repositories/compliance.rs
@@ -542,11 +542,10 @@ impl ComplianceRepository {
     pub async fn get_platform_moderation_queue_stats(
         &self,
     ) -> Result<ModerationQueueStats, SqlxError> {
-        let (pending_count,): (i64,) = sqlx::query_as(
-            r#"SELECT COUNT(*) FROM moderation_cases WHERE status = 'pending'"#,
-        )
-        .fetch_one(&self.pool)
-        .await?;
+        let (pending_count,): (i64,) =
+            sqlx::query_as(r#"SELECT COUNT(*) FROM moderation_cases WHERE status = 'pending'"#)
+                .fetch_one(&self.pool)
+                .await?;
 
         let (under_review_count,): (i64,) = sqlx::query_as(
             r#"SELECT COUNT(*) FROM moderation_cases WHERE status = 'under_review'"#,

--- a/backend/crates/db/src/repositories/compliance.rs
+++ b/backend/crates/db/src/repositories/compliance.rs
@@ -534,6 +534,77 @@ impl ComplianceRepository {
         })
     }
 
+    /// Get moderation queue statistics across the entire platform (all
+    /// organizations). DSA transparency metrics are platform-wide per the
+    /// PAP-40 tenancy decision and are exposed only to platform-operator
+    /// compliance roles (see `require_platform_compliance_role`). Mirrors
+    /// `get_moderation_queue_stats` with the `organization_id` filter removed.
+    pub async fn get_platform_moderation_queue_stats(
+        &self,
+    ) -> Result<ModerationQueueStats, SqlxError> {
+        let (pending_count,): (i64,) = sqlx::query_as(
+            r#"SELECT COUNT(*) FROM moderation_cases WHERE status = 'pending'"#,
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        let (under_review_count,): (i64,) = sqlx::query_as(
+            r#"SELECT COUNT(*) FROM moderation_cases WHERE status = 'under_review'"#,
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        // Cases by priority
+        let by_priority: Vec<(i32, i64)> = sqlx::query_as(
+            r#"
+            SELECT priority, COUNT(*) as count
+            FROM moderation_cases
+            WHERE status IN ('pending', 'under_review')
+            GROUP BY priority
+            ORDER BY priority
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        // Average resolution time
+        let avg_resolution_time_hours: f64 = sqlx::query_scalar(
+            r#"
+            SELECT COALESCE(AVG(EXTRACT(EPOCH FROM (decided_at - created_at)) / 3600.0)::float, 0.0)
+            FROM moderation_cases
+            WHERE decided_at IS NOT NULL
+            "#,
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        // Overdue count (pending for more than 24 hours)
+        let (overdue_count,): (i64,) = sqlx::query_as(
+            r#"
+            SELECT COUNT(*) FROM moderation_cases
+            WHERE status IN ('pending', 'under_review')
+                AND created_at < NOW() - INTERVAL '24 hours'
+            "#,
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(ModerationQueueStats {
+            pending_count,
+            under_review_count,
+            by_priority: by_priority
+                .into_iter()
+                .map(|(p, c)| PriorityCount {
+                    priority: p,
+                    count: c,
+                })
+                .collect(),
+            by_violation_type: vec![], // Could be expanded
+            avg_resolution_time_hours,
+            overdue_count,
+        })
+    }
+
     /// Assign a moderation case, scoped to caller's organization.
     pub async fn assign_moderation_case(
         &self,

--- a/backend/servers/api-server/src/routes/aml_dsa.rs
+++ b/backend/servers/api-server/src/routes/aml_dsa.rs
@@ -1704,14 +1704,12 @@ async fn get_dsa_metrics(
 ) -> Result<Json<DsaMetricsResponse>, (StatusCode, String)> {
     require_platform_compliance_role(&principal)?;
 
-    let org_id = user.tenant_id.ok_or((
-        StatusCode::BAD_REQUEST,
-        "Organization context required".to_string(),
-    ))?;
-
+    // DSA transparency metrics are platform-wide (all organizations), per the
+    // PAP-40 tenancy decision and the platform-only gate above (PAP-46). There
+    // is no org context here — a platform operator has `tenant_id = None`.
     let stats = state
         .compliance_repo
-        .get_moderation_queue_stats(org_id)
+        .get_platform_moderation_queue_stats()
         .await
         .map_err(|e| {
             tracing::error!("Failed to get DSA metrics: {}", e);


### PR DESCRIPTION
## PAP-64 — `dev` does not compile (PAP-36 × PAP-46 mismerge)

**Severity:** `dev` tip (`1644d2f34`) failed `cargo check -p api-server` (E0425: `cannot find value user`), blocking ALL WS-A verification — every PR to `dev` and every CI run. Also blocks PAP-60.

### Root cause
- **PAP-46** (`25b48b40a`) moved `get_dsa_metrics` to `principal: RequestPrincipal` and removed the `user: AuthUser` extractor — DSA metrics are platform-only per the PAP-40 tenancy decision.
- **PAP-36** (`87041cc1e`, landed after) re-introduced `let org_id = user.tenant_id` + an org-scoped `get_moderation_queue_stats(org_id)` call. The merged tip references `user`, which no longer exists.

### Resolution — Option 1 (platform-wide, per PAP-40/46)
The contradiction was semantic, not a typo. The endpoint is gated behind `require_platform_compliance_role` (`principal.is_platform()`), and a platform operator has `tenant_id = None`. Re-adding `AuthUser` (Option 2) would make the endpoint **400 on every call** — incoherent for a platform-only endpoint.

This PR completes PAP-46's intent:
- Adds `ComplianceRepo::get_platform_moderation_queue_stats()` — the existing org-scoped query with the `organization_id` filter dropped. Mirrors the established platform-wide repo pattern (e.g. `create_dsa_report`).
- Switches `get_dsa_metrics` to it and removes the dead `org_id` path.

No new auth surface: the platform-only gate (PAP-46/PAP-47) is unchanged; this only aligns the **data returned** with the **auth already shipped**.

### Verification
`cargo check -p api-server` finishes clean (552 crates, no errors) — was E0425.

### Blast radius / reversibility
Two-way door. Touches one read endpoint's data scope (org → platform-wide aggregate), gated unchanged behind platform-operator role. No migration, no schema change.

Unblocks PAP-60 and the WS-A verification path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)