### PR TITLE
fix(aml_dsa): platform-wide DSA metrics — repair PAP-36×PAP-46 mismerge (PAP-64)

### DIFF
--- a/backend/crates/db/src/repositories/compliance.rs
+++ b/backend/crates/db/src/repositories/compliance.rs
@@ -534,6 +534,79 @@ impl ComplianceRepository {
         })
     }
 
+    /// Get platform-wide moderation queue statistics across ALL organizations.
+    ///
+    /// Unlike [`get_moderation_queue_stats`], this aggregates over every tenant
+    /// and is intended exclusively for the platform-wide DSA transparency
+    /// metrics endpoint, which PAP-47 locked to platform-operator principals
+    /// (`require_platform_compliance_role`). It must never back a tenant-scoped
+    /// route — there is no `organization_id` filter by design.
+    pub async fn get_platform_moderation_queue_stats(
+        &self,
+    ) -> Result<ModerationQueueStats, SqlxError> {
+        let (pending_count,): (i64,) = sqlx::query_as(
+            r#"SELECT COUNT(*) FROM moderation_cases WHERE status = 'pending'"#,
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        let (under_review_count,): (i64,) = sqlx::query_as(
+            r#"SELECT COUNT(*) FROM moderation_cases WHERE status = 'under_review'"#,
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        // Cases by priority
+        let by_priority: Vec<(i32, i64)> = sqlx::query_as(
+            r#"
+            SELECT priority, COUNT(*) as count
+            FROM moderation_cases
+            WHERE status IN ('pending', 'under_review')
+            GROUP BY priority
+            ORDER BY priority
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        // Average resolution time
+        let avg_resolution_time_hours: f64 = sqlx::query_scalar(
+            r#"
+            SELECT COALESCE(AVG(EXTRACT(EPOCH FROM (decided_at - created_at)) / 3600.0)::float, 0.0)
+            FROM moderation_cases
+            WHERE decided_at IS NOT NULL
+            "#,
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        // Overdue count (pending for more than 24 hours)
+        let (overdue_count,): (i64,) = sqlx::query_as(
+            r#"
+            SELECT COUNT(*) FROM moderation_cases
+            WHERE status IN ('pending', 'under_review')
+                AND created_at < NOW() - INTERVAL '24 hours'
+            "#,
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(ModerationQueueStats {
+            pending_count,
+            under_review_count,
+            by_priority: by_priority
+                .into_iter()
+                .map(|(p, c)| PriorityCount {
+                    priority: p,
+                    count: c,
+                })
+                .collect(),
+            by_violation_type: vec![], // Could be expanded
+            avg_resolution_time_hours,
+            overdue_count,
+        })
+    }
+
     /// Assign a moderation case, scoped to caller's organization.
     pub async fn assign_moderation_case(
         &self,

--- a/backend/servers/api-server/src/routes/aml_dsa.rs
+++ b/backend/servers/api-server/src/routes/aml_dsa.rs
@@ -1704,14 +1704,13 @@ async fn get_dsa_metrics(
 ) -> Result<Json<DsaMetricsResponse>, (StatusCode, String)> {
     require_platform_compliance_role(&principal)?;
 
-    let org_id = user.tenant_id.ok_or((
-        StatusCode::BAD_REQUEST,
-        "Organization context required".to_string(),
-    ))?;
-
+    // DSA transparency metrics are a platform-wide VLOP artifact (PAP-47
+    // supersedes the PAP-40 per-tenant model). The handler is gated to
+    // platform-operator principals, which carry no tenant context, so the
+    // stats aggregate across all organizations — no `org_id` scoping.
     let stats = state
         .compliance_repo
-        .get_moderation_queue_stats(org_id)
+        .get_platform_moderation_queue_stats()
         .await
         .map_err(|e| {
             tracing::error!("Failed to get DSA metrics: {}", e);


### PR DESCRIPTION
## PAP-64 — fix `dev` compile break in `get_dsa_metrics`

`dev` (`1644d2f34`) failed `cargo check -p api-server`: `get_dsa_metrics` referenced the removed `user` binding (E0425) — a PAP-36×PAP-46 mismerge. PAP-46 gated the handler on `RequestPrincipal` + `require_platform_compliance_role` and dropped the `AuthUser` extractor, but PAP-36 (landed after) re-introduced `let org_id = user.tenant_id` + an org-scoped `get_moderation_queue_stats(org_id)` call.

### Resolution (option 1 — platform-wide, matches the landed signature)
DSA transparency metrics are a platform-wide VLOP artifact. **PAP-47 (done) supersedes the PAP-40 per-tenant model** and locked these handlers to platform-operator principals, which carry no tenant context. So the body is made consistent with the already-landed platform signature rather than reverting it.

- **`ComplianceRepository::get_platform_moderation_queue_stats()`** — new method, a direct analogue of `get_moderation_queue_stats(org_id)` with the `organization_id` filter removed (aggregates across all orgs). Documented as platform-only; never to back a tenant-scoped route.
- **`get_dsa_metrics`** — drops the `user.tenant_id` path and calls the platform-wide variant. Still gated by `require_platform_compliance_role(&principal)`.

### Verification
- E0425 (`cannot find value user`) is resolved; the changed code compiles with **zero errors**.
- Verified `cargo check -p api-server` against a warm canonical checkout with these two files overlaid: the only residual errors were unrelated `edd_repo` arg-count divergence from a concurrent feature branch (absent on `dev`); the DSA-metrics code is clean.
- CI on this PR (base `dev`) provides the authoritative clean check.

Unblocks [PAP-60](/PAP/issues/PAP-60) (re-land of PAP-38/43 authz fixes) and the [PAP-35](/PAP/issues/PAP-35) production sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Paperclip <noreply@paperclip.ing>
