### PR TITLE
fix(db): route work_order repo through RLS-context connection (PAP-67)

### DIFF
--- a/backend/crates/db/src/repositories/work_order.rs
+++ b/backend/crates/db/src/repositories/work_order.rs
@@ -1,4 +1,19 @@
 //! Work orders and maintenance scheduling repository (Epic 20).
+//!
+//! # RLS Integration (PAP-67)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on `work_orders`, `work_order_updates`,
+//! `maintenance_schedules`, and `schedule_executions`. Under `FORCE` the
+//! api-server's owner connection is no longer exempt, so a query issued on a
+//! connection without `app.current_org_id` set collapses to deny-all (own-org
+//! reads return empty, writes fail).
+//!
+//! Every method therefore takes an **executor whose connection already has RLS
+//! context set** (org + user GUCs) — in handlers this comes from the
+//! `RlsConnection` extractor via `&mut **rls.conn()`. The repository holds **no
+//! pool**, so there is no way to issue a query that bypasses RLS. This mirrors
+//! the `budget.rs` / `document.rs` precedent.
 
 use crate::models::{
     AddWorkOrderUpdate, CreateMaintenanceSchedule, CreateWorkOrder, MaintenanceCostSummary,
@@ -7,19 +22,25 @@ use crate::models::{
     WorkOrderUpdate, WorkOrderWithDetails,
 };
 use chrono::NaiveDate;
-use sqlx::PgPool;
+use sqlx::{Executor, PgConnection, PgPool, Postgres};
 use uuid::Uuid;
 
 /// Repository for work order and maintenance schedule operations.
+///
+/// Stateless: every method receives an RLS-context-bearing executor. The repo
+/// holds no pool so it cannot issue an un-scoped (deny-all under `FORCE`) query.
 #[derive(Clone)]
-pub struct WorkOrderRepository {
-    pool: PgPool,
-}
+pub struct WorkOrderRepository;
 
 impl WorkOrderRepository {
     /// Create a new repository instance.
-    pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+    ///
+    /// The pool argument is retained for construction-site compatibility with
+    /// the other repositories on `AppState`; this repo deliberately does not
+    /// store it (see module docs — all queries run on a context-set connection
+    /// supplied by the handler's `RlsConnection`).
+    pub fn new(_pool: PgPool) -> Self {
+        Self
     }
 
     // ========================================================================
@@ -27,12 +48,16 @@ impl WorkOrderRepository {
     // ========================================================================
 
     /// Create a new work order.
-    pub async fn create_work_order(
+    pub async fn create_work_order<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         user_id: Uuid,
         data: CreateWorkOrder,
-    ) -> Result<WorkOrder, sqlx::Error> {
+    ) -> Result<WorkOrder, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO work_orders
@@ -59,14 +84,15 @@ impl WorkOrderRepository {
         .bind(data.tags.unwrap_or_default())
         .bind(sqlx::types::Json(data.metadata.unwrap_or_default()))
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Create work order from a fault (Story 20.2 - fault-triggered work orders).
     #[allow(clippy::too_many_arguments)]
-    pub async fn create_from_fault(
+    pub async fn create_from_fault<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         user_id: Uuid,
         fault_id: Uuid,
@@ -74,7 +100,10 @@ impl WorkOrderRepository {
         title: &str,
         description: &str,
         priority: &str,
-    ) -> Result<WorkOrder, sqlx::Error> {
+    ) -> Result<WorkOrder, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO work_orders
@@ -91,16 +120,20 @@ impl WorkOrderRepository {
         .bind(description)
         .bind(priority)
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Create work order from a maintenance schedule.
-    pub async fn create_from_schedule(
+    pub async fn create_from_schedule<'e, E>(
         &self,
+        executor: E,
         schedule: &MaintenanceSchedule,
         due_date: NaiveDate,
-    ) -> Result<WorkOrder, sqlx::Error> {
+    ) -> Result<WorkOrder, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO work_orders
@@ -123,24 +156,38 @@ impl WorkOrderRepository {
         .bind(schedule.estimated_cost)
         .bind(schedule.id)
         .bind(schedule.created_by)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Find work order by ID.
-    pub async fn find_by_id(&self, id: Uuid) -> Result<Option<WorkOrder>, sqlx::Error> {
+    ///
+    /// RLS scopes the result to the connection's org context, so a work order
+    /// owned by another organization is invisible (returns `None`).
+    pub async fn find_by_id<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+    ) -> Result<Option<WorkOrder>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as("SELECT * FROM work_orders WHERE id = $1")
             .bind(id)
-            .fetch_optional(&self.pool)
+            .fetch_optional(executor)
             .await
     }
 
     /// List work orders with filters.
-    pub async fn list(
+    pub async fn list<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: WorkOrderQuery,
-    ) -> Result<Vec<WorkOrder>, sqlx::Error> {
+    ) -> Result<Vec<WorkOrder>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50);
         let offset = query.offset.unwrap_or(0);
 
@@ -185,16 +232,20 @@ impl WorkOrderRepository {
         .bind(query.due_after)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// List work orders with details (building name, equipment name, assignee name).
-    pub async fn list_with_details(
+    pub async fn list_with_details<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: WorkOrderQuery,
-    ) -> Result<Vec<WorkOrderWithDetails>, sqlx::Error> {
+    ) -> Result<Vec<WorkOrderWithDetails>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50);
         let offset = query.offset.unwrap_or(0);
 
@@ -237,19 +288,26 @@ impl WorkOrderRepository {
         .bind(query.priority)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update work order.
+    ///
+    /// Multi-statement (read-modify + status-change log), so it takes a
+    /// connection and reborrows it for each query.
     pub async fn update(
         &self,
+        conn: &mut PgConnection,
         id: Uuid,
         user_id: Uuid,
         data: UpdateWorkOrder,
     ) -> Result<WorkOrder, sqlx::Error> {
         // Get old work order for tracking changes
-        let old = self.find_by_id(id).await?.ok_or(sqlx::Error::RowNotFound)?;
+        let old = self
+            .find_by_id(&mut *conn, id)
+            .await?
+            .ok_or(sqlx::Error::RowNotFound)?;
 
         // Update the work order
         let updated: WorkOrder = sqlx::query_as(
@@ -297,13 +355,14 @@ impl WorkOrderRepository {
         .bind(data.resolution_notes)
         .bind(data.tags)
         .bind(data.metadata.map(sqlx::types::Json))
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         // Track status change
         if let Some(new_status) = &data.status {
             if &old.status != new_status {
                 self.add_update(
+                    &mut *conn,
                     id,
                     user_id,
                     "status_change",
@@ -319,10 +378,13 @@ impl WorkOrderRepository {
     }
 
     /// Delete work order.
-    pub async fn delete(&self, id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete<'e, E>(&self, executor: E, id: Uuid) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM work_orders WHERE id = $1")
             .bind(id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
@@ -330,6 +392,7 @@ impl WorkOrderRepository {
     /// Assign work order to user or vendor.
     pub async fn assign(
         &self,
+        conn: &mut PgConnection,
         id: Uuid,
         user_id: Uuid,
         assigned_to: Option<Uuid>,
@@ -352,7 +415,7 @@ impl WorkOrderRepository {
         .bind(id)
         .bind(assigned_to)
         .bind(vendor_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         // Track assignment
@@ -365,6 +428,7 @@ impl WorkOrderRepository {
         };
 
         self.add_update(
+            &mut *conn,
             id,
             user_id,
             "assignment",
@@ -378,7 +442,12 @@ impl WorkOrderRepository {
     }
 
     /// Start work on a work order.
-    pub async fn start_work(&self, id: Uuid, user_id: Uuid) -> Result<WorkOrder, sqlx::Error> {
+    pub async fn start_work(
+        &self,
+        conn: &mut PgConnection,
+        id: Uuid,
+        user_id: Uuid,
+    ) -> Result<WorkOrder, sqlx::Error> {
         let updated: WorkOrder = sqlx::query_as(
             r#"
             UPDATE work_orders SET
@@ -390,10 +459,11 @@ impl WorkOrderRepository {
             "#,
         )
         .bind(id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         self.add_update(
+            &mut *conn,
             id,
             user_id,
             "status_change",
@@ -409,6 +479,7 @@ impl WorkOrderRepository {
     /// Complete work order.
     pub async fn complete(
         &self,
+        conn: &mut PgConnection,
         id: Uuid,
         user_id: Uuid,
         actual_cost: Option<rust_decimal::Decimal>,
@@ -429,10 +500,11 @@ impl WorkOrderRepository {
         .bind(id)
         .bind(actual_cost)
         .bind(resolution_notes)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         self.add_update(
+            &mut *conn,
             id,
             user_id,
             "status_change",
@@ -448,11 +520,15 @@ impl WorkOrderRepository {
     /// Put work order on hold.
     pub async fn put_on_hold(
         &self,
+        conn: &mut PgConnection,
         id: Uuid,
         user_id: Uuid,
         reason: &str,
     ) -> Result<WorkOrder, sqlx::Error> {
-        let old = self.find_by_id(id).await?.ok_or(sqlx::Error::RowNotFound)?;
+        let old = self
+            .find_by_id(&mut *conn, id)
+            .await?
+            .ok_or(sqlx::Error::RowNotFound)?;
 
         let updated: WorkOrder = sqlx::query_as(
             r#"
@@ -464,10 +540,11 @@ impl WorkOrderRepository {
             "#,
         )
         .bind(id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         self.add_update(
+            &mut *conn,
             id,
             user_id,
             "status_change",
@@ -481,15 +558,19 @@ impl WorkOrderRepository {
     }
 
     /// Add comment/update to work order.
-    pub async fn add_update(
+    pub async fn add_update<'e, E>(
         &self,
+        executor: E,
         work_order_id: Uuid,
         user_id: Uuid,
         update_type: &str,
         content: &str,
         old_value: Option<&str>,
         new_value: Option<&str>,
-    ) -> Result<WorkOrderUpdate, sqlx::Error> {
+    ) -> Result<WorkOrderUpdate, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO work_order_updates
@@ -504,18 +585,23 @@ impl WorkOrderRepository {
         .bind(content)
         .bind(old_value)
         .bind(new_value)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Add user comment to work order.
-    pub async fn add_comment(
+    pub async fn add_comment<'e, E>(
         &self,
+        executor: E,
         work_order_id: Uuid,
         user_id: Uuid,
         data: AddWorkOrderUpdate,
-    ) -> Result<WorkOrderUpdate, sqlx::Error> {
+    ) -> Result<WorkOrderUpdate, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         self.add_update(
+            executor,
             work_order_id,
             user_id,
             data.update_type.as_deref().unwrap_or("comment"),
@@ -527,12 +613,16 @@ impl WorkOrderRepository {
     }
 
     /// List updates/comments for a work order.
-    pub async fn list_updates(
+    pub async fn list_updates<'e, E>(
         &self,
+        executor: E,
         work_order_id: Uuid,
         limit: i32,
         offset: i32,
-    ) -> Result<Vec<WorkOrderUpdate>, sqlx::Error> {
+    ) -> Result<Vec<WorkOrderUpdate>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM work_order_updates
@@ -544,12 +634,19 @@ impl WorkOrderRepository {
         .bind(work_order_id)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Get work order statistics.
-    pub async fn get_statistics(&self, org_id: Uuid) -> Result<WorkOrderStatistics, sqlx::Error> {
+    pub async fn get_statistics<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+    ) -> Result<WorkOrderStatistics, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT
@@ -565,16 +662,20 @@ impl WorkOrderRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get overdue work orders.
-    pub async fn list_overdue(
+    pub async fn list_overdue<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         limit: i32,
-    ) -> Result<Vec<WorkOrder>, sqlx::Error> {
+    ) -> Result<Vec<WorkOrder>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM work_orders
@@ -587,7 +688,7 @@ impl WorkOrderRepository {
         )
         .bind(org_id)
         .bind(limit)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -596,12 +697,16 @@ impl WorkOrderRepository {
     // ========================================================================
 
     /// Create a maintenance schedule.
-    pub async fn create_schedule(
+    pub async fn create_schedule<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         user_id: Uuid,
         data: CreateMaintenanceSchedule,
-    ) -> Result<MaintenanceSchedule, sqlx::Error> {
+    ) -> Result<MaintenanceSchedule, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // Calculate first next_due_date based on start_date
         let next_due = data.start_date;
 
@@ -643,27 +748,35 @@ impl WorkOrderRepository {
         ))
         .bind(sqlx::types::Json(data.metadata.unwrap_or_default()))
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Find schedule by ID.
-    pub async fn find_schedule_by_id(
+    pub async fn find_schedule_by_id<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
-    ) -> Result<Option<MaintenanceSchedule>, sqlx::Error> {
+    ) -> Result<Option<MaintenanceSchedule>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as("SELECT * FROM maintenance_schedules WHERE id = $1")
             .bind(id)
-            .fetch_optional(&self.pool)
+            .fetch_optional(executor)
             .await
     }
 
     /// List schedules with filters.
-    pub async fn list_schedules(
+    pub async fn list_schedules<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: ScheduleQuery,
-    ) -> Result<Vec<MaintenanceSchedule>, sqlx::Error> {
+    ) -> Result<Vec<MaintenanceSchedule>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50);
         let offset = query.offset.unwrap_or(0);
 
@@ -688,16 +801,20 @@ impl WorkOrderRepository {
         .bind(query.due_before)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update schedule.
-    pub async fn update_schedule(
+    pub async fn update_schedule<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         data: UpdateMaintenanceSchedule,
-    ) -> Result<MaintenanceSchedule, sqlx::Error> {
+    ) -> Result<MaintenanceSchedule, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE maintenance_schedules SET
@@ -744,25 +861,32 @@ impl WorkOrderRepository {
                 .map(|c| sqlx::types::Json(serde_json::json!(c))),
         )
         .bind(data.metadata.map(sqlx::types::Json))
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Delete schedule.
-    pub async fn delete_schedule(&self, id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete_schedule<'e, E>(&self, executor: E, id: Uuid) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM maintenance_schedules WHERE id = $1")
             .bind(id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
 
     /// Activate/deactivate schedule.
-    pub async fn set_schedule_active(
+    pub async fn set_schedule_active<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         is_active: bool,
-    ) -> Result<MaintenanceSchedule, sqlx::Error> {
+    ) -> Result<MaintenanceSchedule, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE maintenance_schedules SET
@@ -774,16 +898,20 @@ impl WorkOrderRepository {
         )
         .bind(id)
         .bind(is_active)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get schedules due for execution.
-    pub async fn get_due_schedules(
+    pub async fn get_due_schedules<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         days_ahead: i32,
-    ) -> Result<Vec<MaintenanceSchedule>, sqlx::Error> {
+    ) -> Result<Vec<MaintenanceSchedule>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM maintenance_schedules
@@ -797,13 +925,17 @@ impl WorkOrderRepository {
         )
         .bind(org_id)
         .bind(days_ahead)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update schedule after work order created.
+    ///
+    /// Multi-statement (records an execution row, then advances the schedule),
+    /// so it takes a connection.
     pub async fn mark_schedule_executed(
         &self,
+        conn: &mut PgConnection,
         id: Uuid,
         work_order_id: Uuid,
     ) -> Result<MaintenanceSchedule, sqlx::Error> {
@@ -818,7 +950,7 @@ impl WorkOrderRepository {
         )
         .bind(id)
         .bind(work_order_id)
-        .execute(&self.pool)
+        .execute(&mut *conn)
         .await?;
 
         // Update schedule next_due_date
@@ -835,13 +967,14 @@ impl WorkOrderRepository {
             "#,
         )
         .bind(id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
     }
 
     /// Skip a scheduled maintenance.
     pub async fn skip_schedule_execution(
         &self,
+        conn: &mut PgConnection,
         id: Uuid,
         reason: &str,
     ) -> Result<MaintenanceSchedule, sqlx::Error> {
@@ -856,7 +989,7 @@ impl WorkOrderRepository {
         )
         .bind(id)
         .bind(reason)
-        .execute(&self.pool)
+        .execute(&mut *conn)
         .await?;
 
         // Update next_due_date
@@ -872,17 +1005,21 @@ impl WorkOrderRepository {
             "#,
         )
         .bind(id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
     }
 
     /// Get upcoming schedules.
-    pub async fn get_upcoming_schedules(
+    pub async fn get_upcoming_schedules<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         days_ahead: i32,
         limit: i32,
-    ) -> Result<Vec<UpcomingSchedule>, sqlx::Error> {
+    ) -> Result<Vec<UpcomingSchedule>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT
@@ -906,17 +1043,21 @@ impl WorkOrderRepository {
         .bind(org_id)
         .bind(days_ahead)
         .bind(limit)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Get execution history for a schedule.
-    pub async fn list_executions(
+    pub async fn list_executions<'e, E>(
         &self,
+        executor: E,
         schedule_id: Uuid,
         limit: i32,
         offset: i32,
-    ) -> Result<Vec<ScheduleExecution>, sqlx::Error> {
+    ) -> Result<Vec<ScheduleExecution>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM schedule_executions
@@ -928,7 +1069,7 @@ impl WorkOrderRepository {
         .bind(schedule_id)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -937,12 +1078,19 @@ impl WorkOrderRepository {
     // ========================================================================
 
     /// Get service history for equipment.
-    pub async fn get_service_history(
+    ///
+    /// RLS on `work_orders` scopes this to the connection's org, so the query is
+    /// implicitly tenant-bounded even though it is keyed by `equipment_id`.
+    pub async fn get_service_history<'e, E>(
         &self,
+        executor: E,
         equipment_id: Uuid,
         limit: i32,
         offset: i32,
-    ) -> Result<Vec<ServiceHistoryEntry>, sqlx::Error> {
+    ) -> Result<Vec<ServiceHistoryEntry>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT
@@ -965,17 +1113,21 @@ impl WorkOrderRepository {
         .bind(equipment_id)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Get maintenance cost summary by type.
-    pub async fn get_cost_summary(
+    pub async fn get_cost_summary<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         start_date: NaiveDate,
         end_date: NaiveDate,
-    ) -> Result<Vec<MaintenanceCostSummary>, sqlx::Error> {
+    ) -> Result<Vec<MaintenanceCostSummary>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT
@@ -995,17 +1147,23 @@ impl WorkOrderRepository {
         .bind(org_id)
         .bind(start_date)
         .bind(end_date)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Get service history for building.
-    pub async fn get_building_service_history(
+    ///
+    /// RLS on `work_orders` scopes this to the connection's org.
+    pub async fn get_building_service_history<'e, E>(
         &self,
+        executor: E,
         building_id: Uuid,
         limit: i32,
         offset: i32,
-    ) -> Result<Vec<ServiceHistoryEntry>, sqlx::Error> {
+    ) -> Result<Vec<ServiceHistoryEntry>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT
@@ -1028,7 +1186,7 @@ impl WorkOrderRepository {
         .bind(building_id)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -1037,18 +1195,25 @@ impl WorkOrderRepository {
     // ========================================================================
 
     /// Process due schedules and create work orders.
-    pub async fn process_due_schedules(&self, org_id: Uuid) -> Result<Vec<WorkOrder>, sqlx::Error> {
-        let schedules = self.get_due_schedules(org_id, 0).await?;
+    ///
+    /// Multi-statement loop, so it takes a connection and reborrows it per
+    /// schedule.
+    pub async fn process_due_schedules(
+        &self,
+        conn: &mut PgConnection,
+        org_id: Uuid,
+    ) -> Result<Vec<WorkOrder>, sqlx::Error> {
+        let schedules = self.get_due_schedules(&mut *conn, org_id, 0).await?;
         let mut created_orders = Vec::new();
 
         for schedule in schedules {
             // Create work order from schedule
             let work_order = self
-                .create_from_schedule(&schedule, schedule.next_due_date)
+                .create_from_schedule(&mut *conn, &schedule, schedule.next_due_date)
                 .await?;
 
             // Mark schedule as executed
-            self.mark_schedule_executed(schedule.id, work_order.id)
+            self.mark_schedule_executed(&mut *conn, schedule.id, work_order.id)
                 .await?;
 
             created_orders.push(work_order);

--- a/backend/crates/db/tests/work_order_rls_repo_tests.rs
+++ b/backend/crates/db/tests/work_order_rls_repo_tests.rs
@@ -1,0 +1,307 @@
+//! Repo-level behavioral RLS regression test for PAP-67.
+//!
+//! Background
+//! ----------
+//! Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on `work_orders` (and the rest of the Epic-11+
+//! cluster). The production api-server connects as the table OWNER, which
+//! `FORCE` binds. `WorkOrderRepository` held a raw `PgPool` and ran every query
+//! WITHOUT ever calling `set_request_context`, so on `dev` `get_current_org_id()`
+//! returned NULL and the policy collapsed to `organization_id = NULL` →
+//! **deny-all**: own-org reads returned empty, writes failed. (PAP-67.)
+//!
+//! The fix routes the repo through an RLS-context connection (the `RlsConnection`
+//! extractor in handlers sets the org/user GUCs before any query). This test
+//! exercises the *repository methods themselves* on a `FORCE`-bound role and
+//! proves:
+//!
+//!   1. **Deny-all reproduction** — with the role bound but NO context set
+//!      (exactly what the raw-pool repo did on `dev`), an own-org `find_by_id`
+//!      / `list` returns nothing. This assertion FAILS to reproduce only if the
+//!      regression is absent; it is the "would have failed on dev" evidence.
+//!   2. **Fix** — with `set_request_context(org_a, user_a)` applied first (what
+//!      `RlsConnection` now does), the same repo calls return the own-org row.
+//!   3. **Cross-tenant** — org B's work order stays invisible to an org-A
+//!      caller even with context set.
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — even `FORCE` does not bind a superuser, so a behavioral assertion
+//! would pass vacuously. The test creates a plain `NOSUPERUSER NOBYPASSRLS`
+//! role, grants it access, and `SET ROLE`s to it so `FORCE` actually enforces
+//! the policy the way the production owner role experiences it. Mirrors
+//! `documents_rls_cross_tenant_tests.rs` (the 00172/00163 precedent PAP-67
+//! follows).
+
+use db::models::{CreateWorkOrder, WorkOrderQuery};
+use db::repositories::WorkOrderRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("WO {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@wo.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'WO User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_building(pool: &PgPool, org_id: Uuid, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO buildings (organization_id, street, city, postal_code, country, name)
+        VALUES ($1, $2, 'Bratislava', '81101', 'Slovakia', $3)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(format!("{slug} Street 1"))
+    .bind(format!("{slug} Building"))
+    .fetch_one(pool)
+    .await
+    .expect("seed building")
+}
+
+/// Seed a work order directly (as superuser, RLS-exempt) for an org.
+async fn seed_work_order(pool: &PgPool, org_id: Uuid, building_id: Uuid, user_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO work_orders
+            (organization_id, building_id, title, description, priority, work_type, created_by)
+        VALUES ($1, $2, 'Seeded WO', 'desc', 'medium', 'corrective', $3)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(building_id)
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed work order")
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn work_order_repo_force_rls_deny_all_and_fix(pool: PgPool) {
+    let repo = WorkOrderRepository::new(pool.clone());
+
+    // --- Seed as superuser / super-admin context (satisfies org roles-trigger). ---
+    set_ctx(&pool, None, None, true).await;
+    let org_a = seed_org(&pool, "force-a").await;
+    let org_b = seed_org(&pool, "force-b").await;
+    let user_a = seed_user(&pool, "a@wo.test").await;
+    let user_b = seed_user(&pool, "b@wo.test").await;
+    let bld_a = seed_building(&pool, org_a, "a").await;
+    let bld_b = seed_building(&pool, org_b, "b").await;
+    let wo_a = seed_work_order(&pool, org_a, bld_a, user_a).await;
+    let wo_b = seed_work_order(&pool, org_b, bld_b, user_b).await;
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    let role = format!("ppt_rls_wo_{}", Uuid::new_v4().simple());
+    for stmt in [
+        format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
+        format!(
+            "GRANT SELECT, INSERT, UPDATE, DELETE ON work_orders, work_order_updates TO \"{role}\""
+        ),
+        // RLS policy helpers must be EXECUTE-able by the bound role; the
+        // SECURITY INVOKER soft-delete guard reads `organizations`.
+        format!(
+            "GRANT EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
+             get_current_org_not_deleted() TO \"{role}\""
+        ),
+        format!("GRANT SELECT ON organizations TO \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .expect("grant setup");
+    }
+
+    // ====================================================================
+    // (1) DENY-ALL reproduction: role bound, NO context set (the dev raw-pool
+    //     behavior). Own-org reads return nothing.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        // Explicitly clear any inherited context, then drop to the bound role.
+        sqlx::query("SELECT clear_request_context()")
+            .execute(&mut *conn)
+            .await
+            .expect("clear ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let found = repo
+            .find_by_id(&mut *conn, wo_a)
+            .await
+            .expect("find_by_id (no ctx)");
+        assert!(
+            found.is_none(),
+            "PAP-67 regression: without RLS context, own-org work order must be \
+             invisible (deny-all) — this is what the raw-pool repo did on dev"
+        );
+
+        let listed = repo
+            .list(&mut *conn, org_a, WorkOrderQuery::default())
+            .await
+            .expect("list (no ctx)");
+        assert!(
+            listed.is_empty(),
+            "PAP-67 regression: without RLS context, list returns deny-all empty"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (2) FIX + (3) cross-tenant: set context, drop to bound role, query repo.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        // (2) Own-org row IS now visible through the repo — the fix.
+        let found = repo
+            .find_by_id(&mut *conn, wo_a)
+            .await
+            .expect("find_by_id (ctx)");
+        assert_eq!(
+            found.map(|w| w.id),
+            Some(wo_a),
+            "PAP-67 fix: with RLS context set, the repo must return the own-org work order"
+        );
+
+        let listed = repo
+            .list(&mut *conn, org_a, WorkOrderQuery::default())
+            .await
+            .expect("list (ctx)");
+        assert_eq!(
+            listed.iter().map(|w| w.id).collect::<Vec<_>>(),
+            vec![wo_a],
+            "PAP-67 fix: list returns exactly the own-org work order under context"
+        );
+
+        // (3) Org B's work order stays invisible to an org-A caller.
+        let cross = repo
+            .find_by_id(&mut *conn, wo_b)
+            .await
+            .expect("find_by_id cross");
+        assert!(
+            cross.is_none(),
+            "cross-tenant: org B's work order must NOT be visible to an org-A caller"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (4) WRITE path: a create on a context-set connection succeeds and the
+    //     row is the caller's org. Without context the INSERT would fail the
+    //     policy WITH CHECK (the write-side of deny-all).
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let created = repo
+            .create_work_order(
+                &mut *conn,
+                org_a,
+                user_a,
+                CreateWorkOrder {
+                    building_id: bld_a,
+                    equipment_id: None,
+                    fault_id: None,
+                    title: "Created under RLS".to_string(),
+                    description: "desc".to_string(),
+                    priority: None,
+                    work_type: None,
+                    assigned_to: None,
+                    vendor_id: None,
+                    scheduled_date: None,
+                    due_date: None,
+                    estimated_cost: None,
+                    tags: None,
+                    metadata: None,
+                },
+            )
+            .await
+            .expect("create_work_order under context must succeed");
+        assert_eq!(created.organization_id, org_a);
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup the test role. ---
+    set_ctx(&pool, None, None, true).await;
+    for stmt in [
+        format!("REVOKE ALL ON work_orders, work_order_updates FROM \"{role}\""),
+        format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt)).execute(&pool).await.ok();
+    }
+}

--- a/backend/servers/api-server/src/routes/work_orders.rs
+++ b/backend/servers/api-server/src/routes/work_orders.rs
@@ -1,6 +1,20 @@
 //! Work orders and maintenance scheduling routes (Epic 20).
+//!
+//! # RLS (PAP-67)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` on the work-order /
+//! maintenance-schedule tables, so every query MUST run on a connection that has
+//! `app.current_org_id` set or it collapses to deny-all. Each handler therefore
+//! acquires an [`RlsConnection`] (which validates tenant membership and sets the
+//! org/user GUCs on a dedicated connection) and passes `&mut **rls.conn()` to the
+//! repository. The authoritative organization is `rls.tenant_id()` — the tenant
+//! the caller was validated against — not a client-supplied `organization_id`,
+//! so the SQL org filter and the RLS context can never disagree. Cross-tenant
+//! access is blocked by RLS: a by-id read of another org's row returns no row
+//! (`404`), and a write targeting another org fails the policy's `WITH CHECK`.
+//! `rls.release()` clears the context before the connection returns to the pool.
 
-use api_core::extractors::AuthUser;
+use api_core::extractors::RlsConnection;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -63,122 +77,73 @@ pub fn router() -> Router<AppState> {
         .route("/cost-summary", get(get_cost_summary))
 }
 
-// ==================== Authorization Helpers ====================
+// ==================== Error Helpers ====================
 
-/// Verify the authenticated user is a member of the given organization.
-///
-/// Work-order routes accept the target `organization_id` from the client
-/// (request body / query string) or derive it from the resource being
-/// addressed by id. Either way the caller's membership must be checked
-/// against `organization_members` so org A cannot read or mutate org B's
-/// work orders (cross-tenant IDOR). Mirrors `integrations::sync::verify_org_access`.
-async fn verify_org_access(
-    state: &AppState,
-    user_id: Uuid,
-    org_id: Uuid,
-) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
-    let is_member = state
-        .org_member_repo
-        .is_member(org_id, user_id)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = ?e, "Failed to check org membership");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Database error")),
-            )
-        })?;
-
-    if !is_member {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse::new(
-                "FORBIDDEN",
-                "You are not a member of this organization",
-            )),
-        ));
-    }
-
-    Ok(())
+/// Map a repository error to a `500` with a stable code, logging the cause.
+fn db_error(msg: &'static str, e: sqlx::Error) -> (StatusCode, Json<ErrorResponse>) {
+    tracing::error!("{}: {:?}", msg, e);
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse::new("DB_ERROR", msg)),
+    )
 }
 
-/// Load a work order by id and authorize the caller against its owning org.
+/// Build a `404` response.
+fn not_found(msg: &'static str) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::NOT_FOUND,
+        Json(ErrorResponse::new("NOT_FOUND", msg)),
+    )
+}
+
+/// Load a work order by id under the caller's RLS context.
 ///
-/// Returns `404 NOT_FOUND` if the work order does not exist and `403 FORBIDDEN`
-/// if the caller is not a member of the organization that owns it. By-id
-/// handlers route through this so an org A caller can never read or address an
-/// org B work order. Mirrors the fetch-then-`verify_org_access` idiom in
-/// `integrations::sync`.
+/// RLS scopes `find_by_id` to the connection's org, so a work order owned by
+/// another organization is invisible and surfaces as `404 NOT_FOUND` — the
+/// cross-tenant IDOR guard is now enforced by the database, not an app-level
+/// membership check.
 async fn load_work_order_for_user(
     state: &AppState,
-    user_id: Uuid,
+    rls: &mut RlsConnection,
     work_order_id: Uuid,
 ) -> Result<WorkOrder, (StatusCode, Json<ErrorResponse>)> {
-    let work_order = state
+    state
         .work_order_repo
-        .find_by_id(work_order_id)
+        .find_by_id(&mut **rls.conn(), work_order_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to get work order: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to get work order")),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Work order not found")),
-            )
-        })?;
-
-    verify_org_access(state, user_id, work_order.organization_id).await?;
-
-    Ok(work_order)
+        .map_err(|e| db_error("Failed to get work order", e))?
+        .ok_or_else(|| not_found("Work order not found"))
 }
 
-/// Load a maintenance schedule by id and authorize the caller against its
-/// owning org. Same contract as [`load_work_order_for_user`] for schedules.
+/// Load a maintenance schedule by id under the caller's RLS context.
+/// Same contract as [`load_work_order_for_user`].
 async fn load_schedule_for_user(
     state: &AppState,
-    user_id: Uuid,
+    rls: &mut RlsConnection,
     schedule_id: Uuid,
 ) -> Result<MaintenanceSchedule, (StatusCode, Json<ErrorResponse>)> {
-    let schedule = state
+    state
         .work_order_repo
-        .find_schedule_by_id(schedule_id)
+        .find_schedule_by_id(&mut **rls.conn(), schedule_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to get schedule: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to get schedule")),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Schedule not found")),
-            )
-        })?;
-
-    verify_org_access(state, user_id, schedule.organization_id).await?;
-
-    Ok(schedule)
+        .map_err(|e| db_error("Failed to get schedule", e))?
+        .ok_or_else(|| not_found("Schedule not found"))
 }
 
 // ==================== Request/Response Types ====================
 
 /// Organization query parameter.
+///
+/// Retained for wire compatibility; the authoritative org is `rls.tenant_id()`.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct OrgQuery {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
 }
 
 /// Create work order request.
 #[derive(Debug, Deserialize)]
 pub struct CreateWorkOrderRequest {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     #[serde(flatten)]
     pub data: CreateWorkOrder,
 }
@@ -186,7 +151,7 @@ pub struct CreateWorkOrderRequest {
 /// List work orders query.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct ListWorkOrdersQuery {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     pub building_id: Option<Uuid>,
     pub equipment_id: Option<Uuid>,
     pub fault_id: Option<Uuid>,
@@ -225,7 +190,7 @@ impl From<&ListWorkOrdersQuery> for WorkOrderQuery {
 /// Create schedule request.
 #[derive(Debug, Deserialize)]
 pub struct CreateScheduleRequest {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     #[serde(flatten)]
     pub data: CreateMaintenanceSchedule,
 }
@@ -233,7 +198,7 @@ pub struct CreateScheduleRequest {
 /// List schedules query.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct ListSchedulesQuery {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     pub building_id: Option<Uuid>,
     pub equipment_id: Option<Uuid>,
     pub frequency: Option<String>,
@@ -260,7 +225,7 @@ impl From<&ListSchedulesQuery> for ScheduleQuery {
 /// Upcoming schedules query.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct UpcomingQuery {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     pub days_ahead: Option<i32>,
     pub limit: Option<i32>,
 }
@@ -275,7 +240,7 @@ pub struct PaginationQuery {
 /// Cost summary query.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct CostSummaryQuery {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     pub start_date: NaiveDate,
     pub end_date: NaiveDate,
 }
@@ -306,630 +271,554 @@ pub struct SkipRequest {
     pub reason: String,
 }
 
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct OverdueQuery {
+    pub organization_id: Option<Uuid>,
+    pub limit: Option<i32>,
+}
+
 // ==================== Work Orders (Story 20.2) ====================
 
 async fn create_work_order(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Json(payload): Json<CreateWorkOrderRequest>,
 ) -> Result<(StatusCode, Json<WorkOrder>), (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, payload.organization_id).await?;
-    state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .work_order_repo
-        .create_work_order(payload.organization_id, user.user_id, payload.data)
+        .create_work_order(&mut **rls.conn(), org_id, user_id, payload.data)
         .await
         .map(|wo| (StatusCode::CREATED, Json(wo)))
-        .map_err(|e| {
-            tracing::error!("Failed to create work order: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DB_ERROR",
-                    "Failed to create work order",
-                )),
-            )
-        })
+        .map_err(|e| db_error("Failed to create work order", e));
+    rls.release().await;
+    out
 }
 
 async fn list_work_orders(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<ListWorkOrdersQuery>,
 ) -> Result<Json<Vec<WorkOrder>>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, query.organization_id).await?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .work_order_repo
-        .list(query.organization_id, (&query).into())
+        .list(&mut **rls.conn(), org_id, (&query).into())
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list work orders: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to list work orders")),
-            )
-        })
+        .map_err(|e| db_error("Failed to list work orders", e));
+    rls.release().await;
+    out
 }
 
 async fn list_work_orders_with_details(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<ListWorkOrdersQuery>,
 ) -> Result<Json<Vec<WorkOrderWithDetails>>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, query.organization_id).await?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .work_order_repo
-        .list_with_details(query.organization_id, (&query).into())
+        .list_with_details(&mut **rls.conn(), org_id, (&query).into())
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list work orders: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to list work orders")),
-            )
-        })
+        .map_err(|e| db_error("Failed to list work orders", e));
+    rls.release().await;
+    out
 }
 
 async fn get_statistics(
     State(state): State<AppState>,
-    user: AuthUser,
-    Query(query): Query<OrgQuery>,
+    mut rls: RlsConnection,
+    Query(_query): Query<OrgQuery>,
 ) -> Result<Json<WorkOrderStatistics>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, query.organization_id).await?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .work_order_repo
-        .get_statistics(query.organization_id)
+        .get_statistics(&mut **rls.conn(), org_id)
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to get statistics: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to get statistics")),
-            )
-        })
-}
-
-#[derive(Debug, Deserialize, IntoParams)]
-pub struct OverdueQuery {
-    pub organization_id: Uuid,
-    pub limit: Option<i32>,
+        .map_err(|e| db_error("Failed to get statistics", e));
+    rls.release().await;
+    out
 }
 
 async fn list_overdue(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<OverdueQuery>,
 ) -> Result<Json<Vec<WorkOrder>>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, query.organization_id).await?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .work_order_repo
-        .list_overdue(query.organization_id, query.limit.unwrap_or(20))
+        .list_overdue(&mut **rls.conn(), org_id, query.limit.unwrap_or(20))
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list overdue work orders: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to list overdue")),
-            )
-        })
+        .map_err(|e| db_error("Failed to list overdue", e));
+    rls.release().await;
+    out
 }
 
 async fn get_work_order(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<WorkOrder>, (StatusCode, Json<ErrorResponse>)> {
-    let work_order = load_work_order_for_user(&state, user.user_id, id).await?;
-    Ok(Json(work_order))
+    let out = load_work_order_for_user(&state, &mut rls, id).await.map(Json);
+    rls.release().await;
+    out
 }
 
 async fn update_work_order(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateWorkOrder>,
 ) -> Result<Json<WorkOrder>, (StatusCode, Json<ErrorResponse>)> {
-    load_work_order_for_user(&state, user.user_id, id).await?;
-    state
-        .work_order_repo
-        .update(id, user.user_id, data)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to update work order: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DB_ERROR",
-                    "Failed to update work order",
-                )),
-            )
-        })
+    let user_id = rls.user_id();
+    let out = async {
+        load_work_order_for_user(&state, &mut rls, id).await?;
+        state
+            .work_order_repo
+            .update(&mut **rls.conn(), id, user_id, data)
+            .await
+            .map(Json)
+            .map_err(|e| db_error("Failed to update work order", e))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn delete_work_order(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    load_work_order_for_user(&state, user.user_id, id).await?;
-    let deleted = state.work_order_repo.delete(id).await.map_err(|e| {
-        tracing::error!("Failed to delete work order: {:?}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new(
-                "DB_ERROR",
-                "Failed to delete work order",
-            )),
-        )
-    })?;
-
-    if deleted {
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Work order not found")),
-        ))
+    let out = async {
+        load_work_order_for_user(&state, &mut rls, id).await?;
+        let deleted = state
+            .work_order_repo
+            .delete(&mut **rls.conn(), id)
+            .await
+            .map_err(|e| db_error("Failed to delete work order", e))?;
+        if deleted {
+            Ok(StatusCode::NO_CONTENT)
+        } else {
+            Err(not_found("Work order not found"))
+        }
     }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn assign_work_order(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<AssignRequest>,
 ) -> Result<Json<WorkOrder>, (StatusCode, Json<ErrorResponse>)> {
-    load_work_order_for_user(&state, user.user_id, id).await?;
-    state
-        .work_order_repo
-        .assign(id, user.user_id, data.assigned_to, data.vendor_id)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to assign work order: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DB_ERROR",
-                    "Failed to assign work order",
-                )),
-            )
-        })
+    let user_id = rls.user_id();
+    let out = async {
+        load_work_order_for_user(&state, &mut rls, id).await?;
+        state
+            .work_order_repo
+            .assign(&mut **rls.conn(), id, user_id, data.assigned_to, data.vendor_id)
+            .await
+            .map(Json)
+            .map_err(|e| db_error("Failed to assign work order", e))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn start_work(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<WorkOrder>, (StatusCode, Json<ErrorResponse>)> {
-    load_work_order_for_user(&state, user.user_id, id).await?;
-    state
-        .work_order_repo
-        .start_work(id, user.user_id)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to start work: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to start work")),
-            )
-        })
+    let user_id = rls.user_id();
+    let out = async {
+        load_work_order_for_user(&state, &mut rls, id).await?;
+        state
+            .work_order_repo
+            .start_work(&mut **rls.conn(), id, user_id)
+            .await
+            .map(Json)
+            .map_err(|e| db_error("Failed to start work", e))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn complete_work_order(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<CompleteRequest>,
 ) -> Result<Json<WorkOrder>, (StatusCode, Json<ErrorResponse>)> {
-    load_work_order_for_user(&state, user.user_id, id).await?;
-    state
-        .work_order_repo
-        .complete(
-            id,
-            user.user_id,
-            data.actual_cost,
-            data.resolution_notes.as_deref(),
-        )
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to complete work order: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DB_ERROR",
-                    "Failed to complete work order",
-                )),
+    let user_id = rls.user_id();
+    let out = async {
+        load_work_order_for_user(&state, &mut rls, id).await?;
+        state
+            .work_order_repo
+            .complete(
+                &mut **rls.conn(),
+                id,
+                user_id,
+                data.actual_cost,
+                data.resolution_notes.as_deref(),
             )
-        })
+            .await
+            .map(Json)
+            .map_err(|e| db_error("Failed to complete work order", e))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn put_on_hold(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<HoldRequest>,
 ) -> Result<Json<WorkOrder>, (StatusCode, Json<ErrorResponse>)> {
-    load_work_order_for_user(&state, user.user_id, id).await?;
-    state
-        .work_order_repo
-        .put_on_hold(id, user.user_id, &data.reason)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to put work order on hold: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to put on hold")),
-            )
-        })
+    let user_id = rls.user_id();
+    let out = async {
+        load_work_order_for_user(&state, &mut rls, id).await?;
+        state
+            .work_order_repo
+            .put_on_hold(&mut **rls.conn(), id, user_id, &data.reason)
+            .await
+            .map(Json)
+            .map_err(|e| db_error("Failed to put on hold", e))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn add_comment(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<AddWorkOrderUpdate>,
 ) -> Result<(StatusCode, Json<WorkOrderUpdate>), (StatusCode, Json<ErrorResponse>)> {
-    load_work_order_for_user(&state, user.user_id, id).await?;
-    state
-        .work_order_repo
-        .add_comment(id, user.user_id, data)
-        .await
-        .map(|u| (StatusCode::CREATED, Json(u)))
-        .map_err(|e| {
-            tracing::error!("Failed to add comment: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to add comment")),
-            )
-        })
+    let user_id = rls.user_id();
+    let out = async {
+        load_work_order_for_user(&state, &mut rls, id).await?;
+        state
+            .work_order_repo
+            .add_comment(&mut **rls.conn(), id, user_id, data)
+            .await
+            .map(|u| (StatusCode::CREATED, Json(u)))
+            .map_err(|e| db_error("Failed to add comment", e))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn list_comments(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<Vec<WorkOrderUpdate>>, (StatusCode, Json<ErrorResponse>)> {
-    load_work_order_for_user(&state, user.user_id, id).await?;
-    state
-        .work_order_repo
-        .list_updates(id, query.limit.unwrap_or(50), query.offset.unwrap_or(0))
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list comments: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to list comments")),
+    let out = async {
+        load_work_order_for_user(&state, &mut rls, id).await?;
+        state
+            .work_order_repo
+            .list_updates(
+                &mut **rls.conn(),
+                id,
+                query.limit.unwrap_or(50),
+                query.offset.unwrap_or(0),
             )
-        })
+            .await
+            .map(Json)
+            .map_err(|e| db_error("Failed to list comments", e))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 // ==================== Maintenance Schedules (Story 20.3) ====================
 
 async fn create_schedule(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Json(payload): Json<CreateScheduleRequest>,
 ) -> Result<(StatusCode, Json<MaintenanceSchedule>), (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, payload.organization_id).await?;
-    state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .work_order_repo
-        .create_schedule(payload.organization_id, user.user_id, payload.data)
+        .create_schedule(&mut **rls.conn(), org_id, user_id, payload.data)
         .await
         .map(|s| (StatusCode::CREATED, Json(s)))
-        .map_err(|e| {
-            tracing::error!("Failed to create schedule: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to create schedule")),
-            )
-        })
+        .map_err(|e| db_error("Failed to create schedule", e));
+    rls.release().await;
+    out
 }
 
 async fn list_schedules(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<ListSchedulesQuery>,
 ) -> Result<Json<Vec<MaintenanceSchedule>>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, query.organization_id).await?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .work_order_repo
-        .list_schedules(query.organization_id, (&query).into())
+        .list_schedules(&mut **rls.conn(), org_id, (&query).into())
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list schedules: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to list schedules")),
-            )
-        })
+        .map_err(|e| db_error("Failed to list schedules", e));
+    rls.release().await;
+    out
 }
 
 async fn get_upcoming_schedules(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<UpcomingQuery>,
 ) -> Result<Json<Vec<UpcomingSchedule>>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, query.organization_id).await?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .work_order_repo
         .get_upcoming_schedules(
-            query.organization_id,
+            &mut **rls.conn(),
+            org_id,
             query.days_ahead.unwrap_or(30),
             query.limit.unwrap_or(20),
         )
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to get upcoming schedules: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to get upcoming")),
-            )
-        })
+        .map_err(|e| db_error("Failed to get upcoming", e));
+    rls.release().await;
+    out
 }
 
 async fn process_due_schedules(
     State(state): State<AppState>,
-    user: AuthUser,
-    Query(query): Query<OrgQuery>,
+    mut rls: RlsConnection,
+    Query(_query): Query<OrgQuery>,
 ) -> Result<Json<Vec<WorkOrder>>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, query.organization_id).await?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .work_order_repo
-        .process_due_schedules(query.organization_id)
+        .process_due_schedules(&mut **rls.conn(), org_id)
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to process due schedules: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DB_ERROR",
-                    "Failed to process schedules",
-                )),
-            )
-        })
+        .map_err(|e| db_error("Failed to process schedules", e));
+    rls.release().await;
+    out
 }
 
 async fn get_schedule(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<MaintenanceSchedule>, (StatusCode, Json<ErrorResponse>)> {
-    let schedule = load_schedule_for_user(&state, user.user_id, id).await?;
-    Ok(Json(schedule))
+    let out = load_schedule_for_user(&state, &mut rls, id).await.map(Json);
+    rls.release().await;
+    out
 }
 
 async fn update_schedule(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateMaintenanceSchedule>,
 ) -> Result<Json<MaintenanceSchedule>, (StatusCode, Json<ErrorResponse>)> {
-    load_schedule_for_user(&state, user.user_id, id).await?;
-    state
-        .work_order_repo
-        .update_schedule(id, data)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to update schedule: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to update schedule")),
-            )
-        })
+    let out = async {
+        load_schedule_for_user(&state, &mut rls, id).await?;
+        state
+            .work_order_repo
+            .update_schedule(&mut **rls.conn(), id, data)
+            .await
+            .map(Json)
+            .map_err(|e| db_error("Failed to update schedule", e))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn delete_schedule(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    load_schedule_for_user(&state, user.user_id, id).await?;
-    let deleted = state
-        .work_order_repo
-        .delete_schedule(id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to delete schedule: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to delete schedule")),
-            )
-        })?;
-
-    if deleted {
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Schedule not found")),
-        ))
+    let out = async {
+        load_schedule_for_user(&state, &mut rls, id).await?;
+        let deleted = state
+            .work_order_repo
+            .delete_schedule(&mut **rls.conn(), id)
+            .await
+            .map_err(|e| db_error("Failed to delete schedule", e))?;
+        if deleted {
+            Ok(StatusCode::NO_CONTENT)
+        } else {
+            Err(not_found("Schedule not found"))
+        }
     }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn activate_schedule(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<MaintenanceSchedule>, (StatusCode, Json<ErrorResponse>)> {
-    load_schedule_for_user(&state, user.user_id, id).await?;
-    state
-        .work_order_repo
-        .set_schedule_active(id, true)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to activate schedule: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DB_ERROR",
-                    "Failed to activate schedule",
-                )),
-            )
-        })
+    let out = async {
+        load_schedule_for_user(&state, &mut rls, id).await?;
+        state
+            .work_order_repo
+            .set_schedule_active(&mut **rls.conn(), id, true)
+            .await
+            .map(Json)
+            .map_err(|e| db_error("Failed to activate schedule", e))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn deactivate_schedule(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<MaintenanceSchedule>, (StatusCode, Json<ErrorResponse>)> {
-    load_schedule_for_user(&state, user.user_id, id).await?;
-    state
-        .work_order_repo
-        .set_schedule_active(id, false)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to deactivate schedule: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DB_ERROR",
-                    "Failed to deactivate schedule",
-                )),
-            )
-        })
+    let out = async {
+        load_schedule_for_user(&state, &mut rls, id).await?;
+        state
+            .work_order_repo
+            .set_schedule_active(&mut **rls.conn(), id, false)
+            .await
+            .map(Json)
+            .map_err(|e| db_error("Failed to deactivate schedule", e))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn skip_schedule(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<SkipRequest>,
 ) -> Result<Json<MaintenanceSchedule>, (StatusCode, Json<ErrorResponse>)> {
-    load_schedule_for_user(&state, user.user_id, id).await?;
-    state
-        .work_order_repo
-        .skip_schedule_execution(id, &data.reason)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to skip schedule: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to skip schedule")),
-            )
-        })
+    let out = async {
+        load_schedule_for_user(&state, &mut rls, id).await?;
+        state
+            .work_order_repo
+            .skip_schedule_execution(&mut **rls.conn(), id, &data.reason)
+            .await
+            .map(Json)
+            .map_err(|e| db_error("Failed to skip schedule", e))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn list_executions(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<Vec<ScheduleExecution>>, (StatusCode, Json<ErrorResponse>)> {
-    load_schedule_for_user(&state, user.user_id, id).await?;
-    state
-        .work_order_repo
-        .list_executions(id, query.limit.unwrap_or(50), query.offset.unwrap_or(0))
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list executions: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to list executions")),
+    let out = async {
+        load_schedule_for_user(&state, &mut rls, id).await?;
+        state
+            .work_order_repo
+            .list_executions(
+                &mut **rls.conn(),
+                id,
+                query.limit.unwrap_or(50),
+                query.offset.unwrap_or(0),
             )
-        })
+            .await
+            .map(Json)
+            .map_err(|e| db_error("Failed to list executions", e))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 // ==================== Service History (Story 20.4) ====================
 //
-// NOTE (#821 P2 — deferred): the two service-history endpoints below are keyed
-// by `equipment_id` / `building_id`, neither of which carries an
-// `organization_id` the handler can authorize against without a cross-resource
-// lookup (equipment/building → owning org). The work_order_repo exposes no
-// org-scoped variant for these queries, so closing the cross-tenant gap here
-// requires an org-scoped repo method (or threading the equipment/building repo
-// RLS lookup) — a separate slice tracked as the #821 P2 follow-up. The P1
-// IDOR on the work-order and schedule handlers (read/mutate by id, plus the
-// org-supplied create/list endpoints) is fixed above.
+// These endpoints are keyed by `equipment_id` / `building_id`, which carry no
+// `organization_id` of their own. Under PAP-67 they now run on an
+// `RlsConnection`, so RLS on `work_orders` scopes the result to the caller's
+// org automatically — closing the cross-tenant gap the previous #821 P2 note
+// described, without a separate equipment/building → org lookup.
 
 async fn get_equipment_service_history(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(equipment_id): Path<Uuid>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<Vec<ServiceHistoryEntry>>, (StatusCode, Json<ErrorResponse>)> {
-    state
+    let out = state
         .work_order_repo
         .get_service_history(
+            &mut **rls.conn(),
             equipment_id,
             query.limit.unwrap_or(50),
             query.offset.unwrap_or(0),
         )
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to get service history: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DB_ERROR",
-                    "Failed to get service history",
-                )),
-            )
-        })
+        .map_err(|e| db_error("Failed to get service history", e));
+    rls.release().await;
+    out
 }
 
 async fn get_building_service_history(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(building_id): Path<Uuid>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<Vec<ServiceHistoryEntry>>, (StatusCode, Json<ErrorResponse>)> {
-    state
+    let out = state
         .work_order_repo
         .get_building_service_history(
+            &mut **rls.conn(),
             building_id,
             query.limit.unwrap_or(50),
             query.offset.unwrap_or(0),
         )
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to get service history: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DB_ERROR",
-                    "Failed to get service history",
-                )),
-            )
-        })
+        .map_err(|e| db_error("Failed to get service history", e));
+    rls.release().await;
+    out
 }
 
 async fn get_cost_summary(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<CostSummaryQuery>,
 ) -> Result<Json<Vec<MaintenanceCostSummary>>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, query.organization_id).await?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .work_order_repo
-        .get_cost_summary(query.organization_id, query.start_date, query.end_date)
+        .get_cost_summary(&mut **rls.conn(), org_id, query.start_date, query.end_date)
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to get cost summary: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to get cost summary")),
-            )
-        })
+        .map_err(|e| db_error("Failed to get cost summary", e));
+    rls.release().await;
+    out
 }


### PR DESCRIPTION
Reference fix for PAP-67: work_order repo + route converted off the raw pool to RLS-context connections (document.rs/budget.rs precedent). Drops the raw `pool` field; repo methods take an RLS-context executor; handlers use `RlsConnection` + `rls.tenant_id()` + `release()`. Adds repo-level FORCE-RLS deny-all/fix regression test. `cargo check -p db && -p api-server` green; test compiles (DB exec via CI rls-smoke).

First of 23 offender repos found by the full 135-table sweep; remaining tracked as PAP-70..80 children of PAP-67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)