### PR TITLE
fix(insurance): route repo through RLS-context connection (PAP-73 / PAP-67)

### DIFF
--- a/backend/crates/db/src/repositories/insurance.rs
+++ b/backend/crates/db/src/repositories/insurance.rs
@@ -1,8 +1,25 @@
 //! Insurance repository for Epic 22.
 //!
 //! Handles all database operations for insurance policies, claims, and reminders.
+//!
+//! # RLS Integration (PAP-67)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on every insurance table (`insurance_policies`,
+//! `insurance_claims`, `insurance_claim_documents`, `insurance_claim_history`,
+//! `insurance_policy_documents`, `insurance_renewal_reminders`). Under `FORCE`
+//! the api-server's owner connection is no longer exempt, so a query issued on a
+//! connection without `app.current_org_id` set collapses to deny-all (own-org
+//! reads return empty, writes fail).
+//!
+//! Every method therefore takes an **executor whose connection already has RLS
+//! context set** (org + user GUCs) — in handlers this comes from the
+//! `RlsConnection` extractor via `&mut **rls.conn()`. The repository holds **no
+//! pool**, so there is no way to issue a query that bypasses RLS. This mirrors
+//! the `work_order.rs` / `budget.rs` precedent. The explicit `organization_id`
+//! filters are retained as defence-in-depth alongside the RLS policy.
 
-use sqlx::PgPool;
+use sqlx::{Executor, PgConnection, Postgres};
 use uuid::Uuid;
 
 use crate::models::{
@@ -16,20 +33,21 @@ use crate::models::{
 use crate::DbPool;
 
 /// Repository for insurance management operations.
+///
+/// Stateless: every method receives an RLS-context-bearing executor. The repo
+/// holds no pool so it cannot issue an un-scoped (deny-all under `FORCE`) query.
 #[derive(Clone)]
-pub struct InsuranceRepository {
-    pool: DbPool,
-}
+pub struct InsuranceRepository;
 
 impl InsuranceRepository {
     /// Create a new InsuranceRepository.
-    pub fn new(pool: DbPool) -> Self {
-        Self { pool }
-    }
-
-    /// Get the database pool reference.
-    pub fn pool(&self) -> &PgPool {
-        &self.pool
+    ///
+    /// The pool argument is retained for construction-site compatibility with
+    /// the other repositories on `AppState`; this repo deliberately does not
+    /// store it (see module docs — all queries run on a context-set connection
+    /// supplied by the handler's `RlsConnection`).
+    pub fn new(_pool: DbPool) -> Self {
+        Self
     }
 
     // ============================================
@@ -37,11 +55,15 @@ impl InsuranceRepository {
     // ============================================
 
     /// Create a new insurance policy.
-    pub async fn create_policy(
+    pub async fn create_policy<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         data: CreateInsurancePolicy,
-    ) -> Result<InsurancePolicy, sqlx::Error> {
+    ) -> Result<InsurancePolicy, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, InsurancePolicy>(
             r#"
             INSERT INTO insurance_policies (
@@ -75,31 +97,39 @@ impl InsuranceRepository {
         .bind(data.auto_renew)
         .bind(&data.terms)
         .bind(&data.metadata)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Find insurance policy by ID.
-    pub async fn find_policy_by_id(
+    pub async fn find_policy_by_id<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         policy_id: Uuid,
-    ) -> Result<Option<InsurancePolicy>, sqlx::Error> {
+    ) -> Result<Option<InsurancePolicy>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, InsurancePolicy>(
             "SELECT * FROM insurance_policies WHERE id = $1 AND organization_id = $2",
         )
         .bind(policy_id)
         .bind(organization_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// List insurance policies with filters.
-    pub async fn list_policies(
+    pub async fn list_policies<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         query: InsurancePolicyQuery,
-    ) -> Result<Vec<InsurancePolicy>, sqlx::Error> {
+    ) -> Result<Vec<InsurancePolicy>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50);
         let offset = query.offset.unwrap_or(0);
 
@@ -126,17 +156,21 @@ impl InsuranceRepository {
         .bind(query.expiring_within_days)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update an insurance policy.
-    pub async fn update_policy(
+    pub async fn update_policy<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         policy_id: Uuid,
         data: UpdateInsurancePolicy,
-    ) -> Result<Option<InsurancePolicy>, sqlx::Error> {
+    ) -> Result<Option<InsurancePolicy>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, InsurancePolicy>(
             r#"
             UPDATE insurance_policies SET
@@ -189,32 +223,40 @@ impl InsuranceRepository {
         .bind(data.auto_renew)
         .bind(&data.terms)
         .bind(&data.metadata)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Delete an insurance policy.
-    pub async fn delete_policy(
+    pub async fn delete_policy<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         policy_id: Uuid,
-    ) -> Result<bool, sqlx::Error> {
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result =
             sqlx::query("DELETE FROM insurance_policies WHERE id = $1 AND organization_id = $2")
                 .bind(policy_id)
                 .bind(organization_id)
-                .execute(&self.pool)
+                .execute(executor)
                 .await?;
 
         Ok(result.rows_affected() > 0)
     }
 
     /// Get expiring policies.
-    pub async fn get_expiring_policies(
+    pub async fn get_expiring_policies<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         days_ahead: i32,
-    ) -> Result<Vec<ExpiringPolicy>, sqlx::Error> {
+    ) -> Result<Vec<ExpiringPolicy>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, ExpiringPolicy>(
             r#"
             SELECT
@@ -236,7 +278,7 @@ impl InsuranceRepository {
         )
         .bind(organization_id)
         .bind(days_ahead)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -245,11 +287,15 @@ impl InsuranceRepository {
     // ============================================
 
     /// Add document to policy.
-    pub async fn add_policy_document(
+    pub async fn add_policy_document<'e, E>(
         &self,
+        executor: E,
         policy_id: Uuid,
         data: AddPolicyDocument,
-    ) -> Result<InsurancePolicyDocument, sqlx::Error> {
+    ) -> Result<InsurancePolicyDocument, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, InsurancePolicyDocument>(
             r#"
             INSERT INTO insurance_policy_documents (policy_id, document_id, document_type)
@@ -260,35 +306,43 @@ impl InsuranceRepository {
         .bind(policy_id)
         .bind(data.document_id)
         .bind(&data.document_type)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// List policy documents.
-    pub async fn list_policy_documents(
+    pub async fn list_policy_documents<'e, E>(
         &self,
+        executor: E,
         policy_id: Uuid,
-    ) -> Result<Vec<InsurancePolicyDocument>, sqlx::Error> {
+    ) -> Result<Vec<InsurancePolicyDocument>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, InsurancePolicyDocument>(
             "SELECT * FROM insurance_policy_documents WHERE policy_id = $1 ORDER BY created_at DESC",
         )
         .bind(policy_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Remove document from policy.
-    pub async fn remove_policy_document(
+    pub async fn remove_policy_document<'e, E>(
         &self,
+        executor: E,
         policy_id: Uuid,
         document_id: Uuid,
-    ) -> Result<bool, sqlx::Error> {
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query(
             "DELETE FROM insurance_policy_documents WHERE policy_id = $1 AND document_id = $2",
         )
         .bind(policy_id)
         .bind(document_id)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
 
         Ok(result.rows_affected() > 0)
@@ -299,12 +353,16 @@ impl InsuranceRepository {
     // ============================================
 
     /// Create a new insurance claim.
-    pub async fn create_claim(
+    pub async fn create_claim<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         submitted_by: Uuid,
         data: CreateInsuranceClaim,
-    ) -> Result<InsuranceClaim, sqlx::Error> {
+    ) -> Result<InsuranceClaim, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, InsuranceClaim>(
             r#"
             INSERT INTO insurance_claims (
@@ -328,31 +386,39 @@ impl InsuranceRepository {
         .bind(&data.currency)
         .bind(submitted_by)
         .bind(&data.metadata)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Find insurance claim by ID.
-    pub async fn find_claim_by_id(
+    pub async fn find_claim_by_id<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         claim_id: Uuid,
-    ) -> Result<Option<InsuranceClaim>, sqlx::Error> {
+    ) -> Result<Option<InsuranceClaim>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, InsuranceClaim>(
             "SELECT * FROM insurance_claims WHERE id = $1 AND organization_id = $2",
         )
         .bind(claim_id)
         .bind(organization_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Find insurance claim with policy details.
-    pub async fn find_claim_with_policy(
+    pub async fn find_claim_with_policy<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         claim_id: Uuid,
-    ) -> Result<Option<InsuranceClaimWithPolicy>, sqlx::Error> {
+    ) -> Result<Option<InsuranceClaimWithPolicy>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, InsuranceClaimWithPolicy>(
             r#"
             SELECT
@@ -368,16 +434,20 @@ impl InsuranceRepository {
         )
         .bind(claim_id)
         .bind(organization_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// List insurance claims with filters.
-    pub async fn list_claims(
+    pub async fn list_claims<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         query: InsuranceClaimQuery,
-    ) -> Result<Vec<InsuranceClaimWithPolicy>, sqlx::Error> {
+    ) -> Result<Vec<InsuranceClaimWithPolicy>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50);
         let offset = query.offset.unwrap_or(0);
 
@@ -411,17 +481,21 @@ impl InsuranceRepository {
         .bind(query.incident_date_to)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update an insurance claim.
-    pub async fn update_claim(
+    pub async fn update_claim<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         claim_id: Uuid,
         data: UpdateInsuranceClaim,
-    ) -> Result<Option<InsuranceClaim>, sqlx::Error> {
+    ) -> Result<Option<InsuranceClaim>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, InsuranceClaim>(
             r#"
             UPDATE insurance_claims SET
@@ -468,17 +542,21 @@ impl InsuranceRepository {
         .bind(&data.resolution_notes)
         .bind(&data.denial_reason)
         .bind(&data.metadata)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Submit a claim.
-    pub async fn submit_claim(
+    pub async fn submit_claim<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         claim_id: Uuid,
         submitted_by: Uuid,
-    ) -> Result<Option<InsuranceClaim>, sqlx::Error> {
+    ) -> Result<Option<InsuranceClaim>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, InsuranceClaim>(
             r#"
             UPDATE insurance_claims SET
@@ -493,15 +571,16 @@ impl InsuranceRepository {
         .bind(claim_id)
         .bind(organization_id)
         .bind(submitted_by)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Review a claim (approve, deny, etc.).
     /// Only claims with status: submitted, under_review, or information_requested can be reviewed.
     #[allow(clippy::too_many_arguments)]
-    pub async fn review_claim(
+    pub async fn review_claim<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         claim_id: Uuid,
         reviewed_by: Uuid,
@@ -509,7 +588,10 @@ impl InsuranceRepository {
         approved_amount: Option<rust_decimal::Decimal>,
         denial_reason: Option<&str>,
         resolution_notes: Option<&str>,
-    ) -> Result<Option<InsuranceClaim>, sqlx::Error> {
+    ) -> Result<Option<InsuranceClaim>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, InsuranceClaim>(
             r#"
             UPDATE insurance_claims SET
@@ -532,18 +614,22 @@ impl InsuranceRepository {
         .bind(approved_amount)
         .bind(denial_reason)
         .bind(resolution_notes)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Record payment for a claim.
     /// Only claims with status: approved or partially_approved can receive payments.
-    pub async fn record_claim_payment(
+    pub async fn record_claim_payment<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         claim_id: Uuid,
         payment_amount: rust_decimal::Decimal,
-    ) -> Result<Option<InsuranceClaim>, sqlx::Error> {
+    ) -> Result<Option<InsuranceClaim>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, InsuranceClaim>(
             r#"
             UPDATE insurance_claims SET
@@ -561,37 +647,45 @@ impl InsuranceRepository {
         .bind(claim_id)
         .bind(organization_id)
         .bind(payment_amount)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Delete an insurance claim.
-    pub async fn delete_claim(
+    pub async fn delete_claim<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         claim_id: Uuid,
-    ) -> Result<bool, sqlx::Error> {
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query(
             "DELETE FROM insurance_claims WHERE id = $1 AND organization_id = $2 AND status = 'draft'",
         )
         .bind(claim_id)
         .bind(organization_id)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
 
         Ok(result.rows_affected() > 0)
     }
 
     /// Get claim history.
-    pub async fn get_claim_history(
+    pub async fn get_claim_history<'e, E>(
         &self,
+        executor: E,
         claim_id: Uuid,
-    ) -> Result<Vec<InsuranceClaimHistory>, sqlx::Error> {
+    ) -> Result<Vec<InsuranceClaimHistory>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, InsuranceClaimHistory>(
             "SELECT * FROM insurance_claim_history WHERE claim_id = $1 ORDER BY created_at DESC",
         )
         .bind(claim_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -600,11 +694,15 @@ impl InsuranceRepository {
     // ============================================
 
     /// Add document to claim.
-    pub async fn add_claim_document(
+    pub async fn add_claim_document<'e, E>(
         &self,
+        executor: E,
         claim_id: Uuid,
         data: AddClaimDocument,
-    ) -> Result<InsuranceClaimDocument, sqlx::Error> {
+    ) -> Result<InsuranceClaimDocument, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, InsuranceClaimDocument>(
             r#"
             INSERT INTO insurance_claim_documents (claim_id, document_id, document_type)
@@ -615,35 +713,43 @@ impl InsuranceRepository {
         .bind(claim_id)
         .bind(data.document_id)
         .bind(&data.document_type)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// List claim documents.
-    pub async fn list_claim_documents(
+    pub async fn list_claim_documents<'e, E>(
         &self,
+        executor: E,
         claim_id: Uuid,
-    ) -> Result<Vec<InsuranceClaimDocument>, sqlx::Error> {
+    ) -> Result<Vec<InsuranceClaimDocument>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, InsuranceClaimDocument>(
             "SELECT * FROM insurance_claim_documents WHERE claim_id = $1 ORDER BY created_at DESC",
         )
         .bind(claim_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Remove document from claim.
-    pub async fn remove_claim_document(
+    pub async fn remove_claim_document<'e, E>(
         &self,
+        executor: E,
         claim_id: Uuid,
         document_id: Uuid,
-    ) -> Result<bool, sqlx::Error> {
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query(
             "DELETE FROM insurance_claim_documents WHERE claim_id = $1 AND document_id = $2",
         )
         .bind(claim_id)
         .bind(document_id)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
 
         Ok(result.rows_affected() > 0)
@@ -654,11 +760,15 @@ impl InsuranceRepository {
     // ============================================
 
     /// Create renewal reminder.
-    pub async fn create_reminder(
+    pub async fn create_reminder<'e, E>(
         &self,
+        executor: E,
         policy_id: Uuid,
         data: CreateRenewalReminder,
-    ) -> Result<InsuranceRenewalReminder, sqlx::Error> {
+    ) -> Result<InsuranceRenewalReminder, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, InsuranceRenewalReminder>(
             r#"
             INSERT INTO insurance_renewal_reminders (policy_id, days_before_expiry, reminder_type)
@@ -669,29 +779,37 @@ impl InsuranceRepository {
         .bind(policy_id)
         .bind(data.days_before_expiry)
         .bind(&data.reminder_type)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// List policy reminders.
-    pub async fn list_policy_reminders(
+    pub async fn list_policy_reminders<'e, E>(
         &self,
+        executor: E,
         policy_id: Uuid,
-    ) -> Result<Vec<InsuranceRenewalReminder>, sqlx::Error> {
+    ) -> Result<Vec<InsuranceRenewalReminder>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, InsuranceRenewalReminder>(
             "SELECT * FROM insurance_renewal_reminders WHERE policy_id = $1 ORDER BY days_before_expiry DESC",
         )
         .bind(policy_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update renewal reminder.
-    pub async fn update_reminder(
+    pub async fn update_reminder<'e, E>(
         &self,
+        executor: E,
         reminder_id: Uuid,
         data: UpdateRenewalReminder,
-    ) -> Result<Option<InsuranceRenewalReminder>, sqlx::Error> {
+    ) -> Result<Option<InsuranceRenewalReminder>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, InsuranceRenewalReminder>(
             r#"
             UPDATE insurance_renewal_reminders SET
@@ -707,34 +825,52 @@ impl InsuranceRepository {
         .bind(data.days_before_expiry)
         .bind(&data.reminder_type)
         .bind(data.is_active)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Delete renewal reminder.
-    pub async fn delete_reminder(&self, reminder_id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete_reminder<'e, E>(
+        &self,
+        executor: E,
+        reminder_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM insurance_renewal_reminders WHERE id = $1")
             .bind(reminder_id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
 
         Ok(result.rows_affected() > 0)
     }
 
     /// Mark reminder as sent.
-    pub async fn mark_reminder_sent(&self, reminder_id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn mark_reminder_sent<'e, E>(
+        &self,
+        executor: E,
+        reminder_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result =
             sqlx::query("UPDATE insurance_renewal_reminders SET sent_at = NOW() WHERE id = $1")
                 .bind(reminder_id)
-                .execute(&self.pool)
+                .execute(executor)
                 .await?;
 
         Ok(result.rows_affected() > 0)
     }
 
     /// Get pending reminders to send.
+    ///
+    /// Multi-statement (a join read, then a per-policy lookup), so it takes a
+    /// connection and reborrows it for each query.
     pub async fn get_pending_reminders(
         &self,
+        conn: &mut PgConnection,
         organization_id: Uuid,
     ) -> Result<Vec<(InsuranceRenewalReminder, InsurancePolicy)>, sqlx::Error> {
         // Get reminders that are due and haven't been sent
@@ -752,13 +888,13 @@ impl InsuranceRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await?;
 
         let mut results = Vec::new();
         for reminder in reminders {
             if let Some(policy) = self
-                .find_policy_by_id(organization_id, reminder.policy_id)
+                .find_policy_by_id(&mut *conn, organization_id, reminder.policy_id)
                 .await?
             {
                 results.push((reminder, policy));
@@ -773,8 +909,12 @@ impl InsuranceRepository {
     // ============================================
 
     /// Get insurance statistics for organization.
+    ///
+    /// Multi-statement (policy + claim aggregates), so it takes a connection and
+    /// reborrows it for each query.
     pub async fn get_statistics(
         &self,
+        conn: &mut PgConnection,
         organization_id: Uuid,
     ) -> Result<InsuranceStatistics, sqlx::Error> {
         let policy_stats = sqlx::query_as::<_, (i64, i64, i64, Option<rust_decimal::Decimal>, Option<rust_decimal::Decimal>)>(
@@ -790,7 +930,7 @@ impl InsuranceRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         let claim_stats = sqlx::query_as::<_, (i64, i64, Option<rust_decimal::Decimal>, Option<rust_decimal::Decimal>)>(
@@ -805,7 +945,7 @@ impl InsuranceRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         Ok(InsuranceStatistics {
@@ -822,10 +962,14 @@ impl InsuranceRepository {
     }
 
     /// Get claim summary by status.
-    pub async fn get_claim_summary_by_status(
+    pub async fn get_claim_summary_by_status<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
-    ) -> Result<Vec<ClaimStatusSummary>, sqlx::Error> {
+    ) -> Result<Vec<ClaimStatusSummary>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, ClaimStatusSummary>(
             r#"
             SELECT
@@ -841,15 +985,19 @@ impl InsuranceRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Get policy summary by type.
-    pub async fn get_policy_summary_by_type(
+    pub async fn get_policy_summary_by_type<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
-    ) -> Result<Vec<PolicyTypeSummary>, sqlx::Error> {
+    ) -> Result<Vec<PolicyTypeSummary>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, PolicyTypeSummary>(
             r#"
             SELECT
@@ -864,7 +1012,7 @@ impl InsuranceRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 }

--- a/backend/crates/db/tests/insurance_rls_repo_tests.rs
+++ b/backend/crates/db/tests/insurance_rls_repo_tests.rs
@@ -1,0 +1,298 @@
+//! Repo-level behavioral RLS regression test for PAP-73 (parent PAP-67).
+//!
+//! Background
+//! ----------
+//! Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on `insurance_policies` (and the rest of the
+//! insurance cluster: `insurance_claims`, `insurance_claim_documents`,
+//! `insurance_claim_history`, `insurance_policy_documents`,
+//! `insurance_renewal_reminders`). The production api-server connects as the
+//! table OWNER, which `FORCE` binds. `InsuranceRepository` held a raw `PgPool`
+//! and ran every query WITHOUT ever calling `set_request_context`, so on `dev`
+//! `get_current_org_id()` returned NULL and the policy collapsed to
+//! `organization_id = NULL` → **deny-all**: own-org reads returned empty, writes
+//! failed. (PAP-73.)
+//!
+//! The fix routes the repo through an RLS-context connection (the `RlsConnection`
+//! extractor in handlers sets the org/user GUCs before any query). This test
+//! exercises the *repository methods themselves* on a `FORCE`-bound role and
+//! proves:
+//!
+//!   1. **Deny-all reproduction** — with the role bound but NO context set
+//!      (exactly what the raw-pool repo did on `dev`), an own-org
+//!      `find_policy_by_id` / `list_policies` returns nothing.
+//!   2. **Fix** — with `set_request_context(org_a, user_a)` applied first (what
+//!      `RlsConnection` now does), the same repo calls return the own-org row.
+//!   3. **Cross-tenant** — org B's policy stays invisible to an org-A caller
+//!      even with context set.
+//!   4. **Write path** — a `create_policy` on a context-set connection succeeds.
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — even `FORCE` does not bind a superuser, so a behavioral assertion
+//! would pass vacuously. The test creates a plain `NOSUPERUSER NOBYPASSRLS`
+//! role, grants it access, and `SET ROLE`s to it so `FORCE` actually enforces
+//! the policy the way the production owner role experiences it. Mirrors
+//! `work_order_rls_repo_tests.rs` (the PAP-67 precedent PAP-73 follows).
+
+use chrono::NaiveDate;
+use db::models::{CreateInsurancePolicy, InsurancePolicyQuery};
+use db::repositories::InsuranceRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Ins {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@ins.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'Ins User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Seed an insurance policy directly (as superuser, RLS-exempt) for an org.
+async fn seed_policy(pool: &PgPool, org_id: Uuid, suffix: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO insurance_policies
+            (organization_id, policy_number, policy_name, provider_name, policy_type,
+             effective_date, expiration_date)
+        VALUES ($1, $2, $3, 'Acme Insure', 'property', '2025-01-01', '2026-01-01')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(format!("POL-{suffix}"))
+    .bind(format!("Policy {suffix}"))
+    .fetch_one(pool)
+    .await
+    .expect("seed policy")
+}
+
+fn sample_policy(suffix: &str) -> CreateInsurancePolicy {
+    CreateInsurancePolicy {
+        policy_number: format!("POL-{suffix}"),
+        policy_name: format!("Policy {suffix}"),
+        provider_name: "Acme Insure".to_string(),
+        provider_contact: None,
+        provider_phone: None,
+        provider_email: None,
+        policy_type: "property".to_string(),
+        coverage_amount: None,
+        deductible: None,
+        premium_amount: None,
+        premium_frequency: None,
+        building_id: None,
+        unit_id: None,
+        coverage_description: None,
+        effective_date: NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+        expiration_date: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+        renewal_date: None,
+        auto_renew: None,
+        terms: None,
+        metadata: None,
+    }
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn insurance_repo_force_rls_deny_all_and_fix(pool: PgPool) {
+    let repo = InsuranceRepository::new(pool.clone());
+
+    // --- Seed as superuser / super-admin context (satisfies org roles-trigger). ---
+    set_ctx(&pool, None, None, true).await;
+    let org_a = seed_org(&pool, "force-a").await;
+    let org_b = seed_org(&pool, "force-b").await;
+    let user_a = seed_user(&pool, "a@ins.test").await;
+    let pol_a = seed_policy(&pool, org_a, "a").await;
+    let _pol_b = seed_policy(&pool, org_b, "b").await;
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    let role = format!("ppt_rls_ins_{}", Uuid::new_v4().simple());
+    for stmt in [
+        format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
+        format!("GRANT SELECT, INSERT, UPDATE, DELETE ON insurance_policies TO \"{role}\""),
+        // RLS policy helpers must be EXECUTE-able by the bound role; the
+        // SECURITY INVOKER soft-delete guard reads `organizations`.
+        format!(
+            "GRANT EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
+             get_current_org_not_deleted() TO \"{role}\""
+        ),
+        format!("GRANT SELECT ON organizations TO \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .expect("grant setup");
+    }
+
+    // ====================================================================
+    // (1) DENY-ALL reproduction: role bound, NO context set (the dev raw-pool
+    //     behavior). Own-org reads return nothing.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        // Explicitly clear any inherited context, then drop to the bound role.
+        sqlx::query("SELECT clear_request_context()")
+            .execute(&mut *conn)
+            .await
+            .expect("clear ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let found = repo
+            .find_policy_by_id(&mut *conn, org_a, pol_a)
+            .await
+            .expect("find_policy_by_id (no ctx)");
+        assert!(
+            found.is_none(),
+            "PAP-73 regression: without RLS context, own-org policy must be \
+             invisible (deny-all) — this is what the raw-pool repo did on dev"
+        );
+
+        let listed = repo
+            .list_policies(&mut *conn, org_a, InsurancePolicyQuery::default())
+            .await
+            .expect("list_policies (no ctx)");
+        assert!(
+            listed.is_empty(),
+            "PAP-73 regression: without RLS context, list returns deny-all empty"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (2) FIX + (3) cross-tenant: set context, drop to bound role, query repo.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        // (2) Own-org row IS now visible through the repo — the fix.
+        let found = repo
+            .find_policy_by_id(&mut *conn, org_a, pol_a)
+            .await
+            .expect("find_policy_by_id (ctx)");
+        assert_eq!(
+            found.map(|p| p.id),
+            Some(pol_a),
+            "PAP-73 fix: with RLS context set, the repo must return the own-org policy"
+        );
+
+        let listed = repo
+            .list_policies(&mut *conn, org_a, InsurancePolicyQuery::default())
+            .await
+            .expect("list_policies (ctx)");
+        assert_eq!(
+            listed.iter().map(|p| p.id).collect::<Vec<_>>(),
+            vec![pol_a],
+            "PAP-73 fix: list returns exactly the own-org policy under context"
+        );
+
+        // (3) Org B's policy stays invisible to an org-A caller.
+        let cross = repo
+            .find_policy_by_id(&mut *conn, org_a, _pol_b)
+            .await
+            .expect("find_policy_by_id cross");
+        assert!(
+            cross.is_none(),
+            "cross-tenant: org B's policy must NOT be visible to an org-A caller"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (4) WRITE path: a create on a context-set connection succeeds and the
+    //     row is the caller's org. Without context the INSERT would fail the
+    //     policy WITH CHECK (the write-side of deny-all).
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let created = repo
+            .create_policy(&mut *conn, org_a, sample_policy("created-under-rls"))
+            .await
+            .expect("create_policy under context must succeed");
+        assert_eq!(created.organization_id, org_a);
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup the test role. ---
+    set_ctx(&pool, None, None, true).await;
+    for stmt in [
+        format!("REVOKE ALL ON insurance_policies FROM \"{role}\""),
+        format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .ok();
+    }
+}

--- a/backend/servers/api-server/src/routes/insurance.rs
+++ b/backend/servers/api-server/src/routes/insurance.rs
@@ -4,18 +4,26 @@
 //!
 //! # Authentication & tenancy (SECURITY-CRITICAL)
 //!
-//! Every handler derives the owning organization from the verified
-//! [`RequestPrincipal`] (built from the bearer JWT + host-resolved tenant),
-//! never from a client-supplied `organization_id` query param / request-body
-//! field. The previous implementation read tenancy from
-//! `query.building_id.unwrap_or_default()` (a placeholder that resolved to
-//! `Uuid::nil()` when absent) on the list endpoints, and accepted an
-//! `?organization_id=` query param / body `organization_id` on the
-//! get/mutate endpoints. Both let any caller read or mutate another org's
-//! policies/claims (a cross-tenant IDOR) and produced empty/garbage results
-//! for legitimate callers. See issue #826.
+//! # RLS (PAP-67)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` on every insurance table, so
+//! each query MUST run on a connection that has `app.current_org_id` set or it
+//! collapses to deny-all. Each handler therefore acquires an [`RlsConnection`]
+//! (which validates tenant membership and sets the org/user GUCs on a dedicated
+//! connection) and passes `&mut **rls.conn()` to the repository. The
+//! authoritative organization is `rls.tenant_id()` — the tenant the caller was
+//! validated against — not a client-supplied `organization_id`, so the SQL org
+//! filter and the RLS context can never disagree. Cross-tenant access is blocked
+//! by RLS: a by-id read of another org's row returns no row (`404`), and a write
+//! targeting another org fails the policy's `WITH CHECK`. `rls.release()` clears
+//! the context before the connection returns to the pool.
+//!
+//! This replaces the previous `RequestPrincipal` + `require_org_id` scheme that
+//! derived the org from the principal but ran every query on a raw pool (issue
+//! #826 closed the client-supplied-org IDOR; PAP-67 closes the deny-all under
+//! `FORCE` and pushes cross-tenant enforcement into the database).
 
-use api_core::extractors::principal::RequestPrincipal;
+use api_core::extractors::RlsConnection;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -37,27 +45,24 @@ use uuid::Uuid;
 use crate::state::AppState;
 
 // ============================================
-// Helper Functions
+// Error Helpers
 // ============================================
 
-/// Resolve the effective tenant (organization) id from a verified
-/// [`RequestPrincipal`].
-///
-/// Insurance data is per-tenant by definition. A platform-kind principal
-/// hitting the platform host has no `effective_org` — for those callers we
-/// refuse with 403 rather than fall back to a wildcard / nil org. Non-platform
-/// principals without a host-resolved tenant never reach this point because
-/// `RequestPrincipal` rejects them earlier.
-fn require_org_id(principal: &RequestPrincipal) -> Result<Uuid, (StatusCode, Json<ErrorResponse>)> {
-    principal.effective_org.ok_or_else(|| {
-        (
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse::new(
-                "TENANT_REQUIRED",
-                "Insurance endpoints require a tenant-resolved request",
-            )),
-        )
-    })
+/// Map a repository error to a `500` with a stable code, logging the cause.
+fn db_error(msg: &'static str, e: sqlx::Error) -> (StatusCode, Json<ErrorResponse>) {
+    tracing::error!("{}: {:?}", msg, e);
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse::new("DB_ERROR", msg)),
+    )
+}
+
+/// Build a `404` response.
+fn not_found(msg: &'static str) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::NOT_FOUND,
+        Json(ErrorResponse::new("NOT_FOUND", msg)),
+    )
 }
 
 // ============================================
@@ -122,8 +127,8 @@ impl From<ListClaimsQuery> for db::models::InsuranceClaimQuery {
 
 /// Request to create a policy.
 ///
-/// The owning organization is derived from the authenticated principal, never
-/// from the request body (issue #826).
+/// The owning organization is derived from the RLS-validated tenant
+/// (`rls.tenant_id()`), never from the request body (issue #826).
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct CreatePolicyRequest {
     #[serde(flatten)]
@@ -284,145 +289,105 @@ pub fn router() -> Router<AppState> {
 /// List insurance policies.
 async fn list_policies(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Query(query): Query<ListPoliciesQuery>,
-    principal: RequestPrincipal,
 ) -> Result<Json<ListPoliciesResponse>, (StatusCode, Json<ErrorResponse>)> {
-    // SECURITY: the org is derived from the verified principal, never from a
-    // client-supplied query param (issue #826 — was `building_id.unwrap_or_default()`).
-    let org_id = require_org_id(&principal)?;
-
-    let policies = state
+    let org_id = rls.tenant_id();
+    let out = state
         .insurance_repo
-        .list_policies(org_id, query.into())
+        .list_policies(&mut **rls.conn(), org_id, query.into())
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
-
-    Ok(Json(ListPoliciesResponse { policies }))
+        .map(|policies| Json(ListPoliciesResponse { policies }))
+        .map_err(|e| db_error("Failed to list policies", e));
+    rls.release().await;
+    out
 }
 
 /// Create a new insurance policy.
 async fn create_policy(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Json(payload): Json<CreatePolicyRequest>,
 ) -> Result<Json<InsurancePolicy>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_org_id(&principal)?;
-    let policy = state
+    let org_id = rls.tenant_id();
+    let out = state
         .insurance_repo
-        .create_policy(org_id, payload.data)
+        .create_policy(&mut **rls.conn(), org_id, payload.data)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
-
-    Ok(Json(policy))
+        .map(Json)
+        .map_err(|e| db_error("Failed to create policy", e));
+    rls.release().await;
+    out
 }
 
 /// Get a policy by ID.
 async fn get_policy(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(policy_id): Path<Uuid>,
-    principal: RequestPrincipal,
 ) -> Result<Json<InsurancePolicy>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_org_id(&principal)?;
-    let policy = state
+    let org_id = rls.tenant_id();
+    let out = state
         .insurance_repo
-        .find_policy_by_id(org_id, policy_id)
+        .find_policy_by_id(&mut **rls.conn(), org_id, policy_id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Policy not found")),
-            )
-        })?;
-
-    Ok(Json(policy))
+        .map_err(|e| db_error("Failed to get policy", e))
+        .and_then(|p| p.map(Json).ok_or_else(|| not_found("Policy not found")));
+    rls.release().await;
+    out
 }
 
 /// Update a policy.
 async fn update_policy(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(policy_id): Path<Uuid>,
-    principal: RequestPrincipal,
     Json(payload): Json<UpdatePolicyRequest>,
 ) -> Result<Json<InsurancePolicy>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_org_id(&principal)?;
-    let policy = state
+    let org_id = rls.tenant_id();
+    let out = state
         .insurance_repo
-        .update_policy(org_id, policy_id, payload.data)
+        .update_policy(&mut **rls.conn(), org_id, policy_id, payload.data)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Policy not found")),
-            )
-        })?;
-
-    Ok(Json(policy))
+        .map_err(|e| db_error("Failed to update policy", e))
+        .and_then(|p| p.map(Json).ok_or_else(|| not_found("Policy not found")));
+    rls.release().await;
+    out
 }
 
 /// Delete a policy.
 async fn delete_policy(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(policy_id): Path<Uuid>,
-    principal: RequestPrincipal,
 ) -> Result<Json<DeleteResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_org_id(&principal)?;
-    let success = state
+    let org_id = rls.tenant_id();
+    let out = state
         .insurance_repo
-        .delete_policy(org_id, policy_id)
+        .delete_policy(&mut **rls.conn(), org_id, policy_id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
-
-    Ok(Json(DeleteResponse { success }))
+        .map(|success| Json(DeleteResponse { success }))
+        .map_err(|e| db_error("Failed to delete policy", e));
+    rls.release().await;
+    out
 }
 
 /// Get expiring policies.
 async fn get_expiring_policies(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Query(params): Query<ExpiringQuery>,
-    principal: RequestPrincipal,
 ) -> Result<Json<ExpiringPoliciesResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_org_id(&principal)?;
+    let org_id = rls.tenant_id();
     let days_ahead = params.days_ahead.unwrap_or(30);
-
-    let policies = state
+    let out = state
         .insurance_repo
-        .get_expiring_policies(org_id, days_ahead)
+        .get_expiring_policies(&mut **rls.conn(), org_id, days_ahead)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
-
-    Ok(Json(ExpiringPoliciesResponse { policies }))
+        .map(|policies| Json(ExpiringPoliciesResponse { policies }))
+        .map_err(|e| db_error("Failed to get expiring policies", e));
+    rls.release().await;
+    out
 }
 
 // ============================================
@@ -432,62 +397,50 @@ async fn get_expiring_policies(
 /// List policy documents.
 async fn list_policy_documents(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(policy_id): Path<Uuid>,
-    _principal: RequestPrincipal,
 ) -> Result<Json<PolicyDocumentsResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let documents = state
+    let out = state
         .insurance_repo
-        .list_policy_documents(policy_id)
+        .list_policy_documents(&mut **rls.conn(), policy_id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
-
-    Ok(Json(PolicyDocumentsResponse { documents }))
+        .map(|documents| Json(PolicyDocumentsResponse { documents }))
+        .map_err(|e| db_error("Failed to list policy documents", e));
+    rls.release().await;
+    out
 }
 
 /// Add document to policy.
 async fn add_policy_document(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(policy_id): Path<Uuid>,
-    _principal: RequestPrincipal,
     Json(payload): Json<AddPolicyDocument>,
 ) -> Result<Json<InsurancePolicyDocument>, (StatusCode, Json<ErrorResponse>)> {
-    let document = state
+    let out = state
         .insurance_repo
-        .add_policy_document(policy_id, payload)
+        .add_policy_document(&mut **rls.conn(), policy_id, payload)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
-
-    Ok(Json(document))
+        .map(Json)
+        .map_err(|e| db_error("Failed to add policy document", e));
+    rls.release().await;
+    out
 }
 
 /// Remove document from policy.
 async fn remove_policy_document(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path((policy_id, document_id)): Path<(Uuid, Uuid)>,
-    _principal: RequestPrincipal,
 ) -> Result<Json<DeleteResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let success = state
+    let out = state
         .insurance_repo
-        .remove_policy_document(policy_id, document_id)
+        .remove_policy_document(&mut **rls.conn(), policy_id, document_id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
-
-    Ok(Json(DeleteResponse { success }))
+        .map(|success| Json(DeleteResponse { success }))
+        .map_err(|e| db_error("Failed to remove policy document", e));
+    rls.release().await;
+    out
 }
 
 // ============================================
@@ -497,89 +450,67 @@ async fn remove_policy_document(
 /// List policy reminders.
 async fn list_reminders(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(policy_id): Path<Uuid>,
-    _principal: RequestPrincipal,
 ) -> Result<Json<RemindersResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let reminders = state
+    let out = state
         .insurance_repo
-        .list_policy_reminders(policy_id)
+        .list_policy_reminders(&mut **rls.conn(), policy_id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
-
-    Ok(Json(RemindersResponse { reminders }))
+        .map(|reminders| Json(RemindersResponse { reminders }))
+        .map_err(|e| db_error("Failed to list reminders", e));
+    rls.release().await;
+    out
 }
 
 /// Create reminder for policy.
 async fn create_reminder(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(policy_id): Path<Uuid>,
-    _principal: RequestPrincipal,
     Json(payload): Json<CreateRenewalReminder>,
 ) -> Result<Json<InsuranceRenewalReminder>, (StatusCode, Json<ErrorResponse>)> {
-    let reminder = state
+    let out = state
         .insurance_repo
-        .create_reminder(policy_id, payload)
+        .create_reminder(&mut **rls.conn(), policy_id, payload)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
-
-    Ok(Json(reminder))
+        .map(Json)
+        .map_err(|e| db_error("Failed to create reminder", e));
+    rls.release().await;
+    out
 }
 
 /// Update a reminder.
 async fn update_reminder(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(reminder_id): Path<Uuid>,
-    _principal: RequestPrincipal,
     Json(payload): Json<UpdateRenewalReminder>,
 ) -> Result<Json<InsuranceRenewalReminder>, (StatusCode, Json<ErrorResponse>)> {
-    let reminder = state
+    let out = state
         .insurance_repo
-        .update_reminder(reminder_id, payload)
+        .update_reminder(&mut **rls.conn(), reminder_id, payload)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Reminder not found")),
-            )
-        })?;
-
-    Ok(Json(reminder))
+        .map_err(|e| db_error("Failed to update reminder", e))
+        .and_then(|r| r.map(Json).ok_or_else(|| not_found("Reminder not found")));
+    rls.release().await;
+    out
 }
 
 /// Delete a reminder.
 async fn delete_reminder(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(reminder_id): Path<Uuid>,
-    _principal: RequestPrincipal,
 ) -> Result<Json<DeleteResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let success = state
+    let out = state
         .insurance_repo
-        .delete_reminder(reminder_id)
+        .delete_reminder(&mut **rls.conn(), reminder_id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
-
-    Ok(Json(DeleteResponse { success }))
+        .map(|success| Json(DeleteResponse { success }))
+        .map_err(|e| db_error("Failed to delete reminder", e));
+    rls.release().await;
+    out
 }
 
 // ============================================
@@ -589,236 +520,171 @@ async fn delete_reminder(
 /// List insurance claims.
 async fn list_claims(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Query(query): Query<ListClaimsQuery>,
-    principal: RequestPrincipal,
 ) -> Result<Json<ListClaimsResponse>, (StatusCode, Json<ErrorResponse>)> {
-    // SECURITY: the org is derived from the verified principal, never from a
-    // client-supplied query param (issue #826 — was `building_id.unwrap_or_default()`).
-    let org_id = require_org_id(&principal)?;
-
-    let claims = state
+    let org_id = rls.tenant_id();
+    let out = state
         .insurance_repo
-        .list_claims(org_id, query.into())
+        .list_claims(&mut **rls.conn(), org_id, query.into())
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
-
-    Ok(Json(ListClaimsResponse { claims }))
+        .map(|claims| Json(ListClaimsResponse { claims }))
+        .map_err(|e| db_error("Failed to list claims", e));
+    rls.release().await;
+    out
 }
 
 /// Create a new insurance claim.
 async fn create_claim(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Json(payload): Json<CreateClaimRequest>,
 ) -> Result<Json<InsuranceClaim>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_org_id(&principal)?;
-    let claim = state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .insurance_repo
-        .create_claim(org_id, principal.user_id, payload.data)
+        .create_claim(&mut **rls.conn(), org_id, user_id, payload.data)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
-
-    Ok(Json(claim))
+        .map(Json)
+        .map_err(|e| db_error("Failed to create claim", e));
+    rls.release().await;
+    out
 }
 
 /// Get a claim by ID.
 async fn get_claim(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(claim_id): Path<Uuid>,
-    principal: RequestPrincipal,
 ) -> Result<Json<InsuranceClaimWithPolicy>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_org_id(&principal)?;
-    let claim = state
+    let org_id = rls.tenant_id();
+    let out = state
         .insurance_repo
-        .find_claim_with_policy(org_id, claim_id)
+        .find_claim_with_policy(&mut **rls.conn(), org_id, claim_id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Claim not found")),
-            )
-        })?;
-
-    Ok(Json(claim))
+        .map_err(|e| db_error("Failed to get claim", e))
+        .and_then(|c| c.map(Json).ok_or_else(|| not_found("Claim not found")));
+    rls.release().await;
+    out
 }
 
 /// Update a claim.
 async fn update_claim(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(claim_id): Path<Uuid>,
-    principal: RequestPrincipal,
     Json(payload): Json<UpdateClaimRequest>,
 ) -> Result<Json<InsuranceClaim>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_org_id(&principal)?;
-    let claim = state
+    let org_id = rls.tenant_id();
+    let out = state
         .insurance_repo
-        .update_claim(org_id, claim_id, payload.data)
+        .update_claim(&mut **rls.conn(), org_id, claim_id, payload.data)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Claim not found")),
-            )
-        })?;
-
-    Ok(Json(claim))
+        .map_err(|e| db_error("Failed to update claim", e))
+        .and_then(|c| c.map(Json).ok_or_else(|| not_found("Claim not found")));
+    rls.release().await;
+    out
 }
 
 /// Submit a claim for review.
 async fn submit_claim(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(claim_id): Path<Uuid>,
-    principal: RequestPrincipal,
 ) -> Result<Json<InsuranceClaim>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_org_id(&principal)?;
-    let claim = state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .insurance_repo
-        .submit_claim(org_id, claim_id, principal.user_id)
+        .submit_claim(&mut **rls.conn(), org_id, claim_id, user_id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new(
-                    "NOT_FOUND",
-                    "Claim not found or already submitted",
-                )),
-            )
-        })?;
-
-    Ok(Json(claim))
+        .map_err(|e| db_error("Failed to submit claim", e))
+        .and_then(|c| {
+            c.map(Json)
+                .ok_or_else(|| not_found("Claim not found or already submitted"))
+        });
+    rls.release().await;
+    out
 }
 
 /// Review a claim (approve/deny).
 async fn review_claim(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(claim_id): Path<Uuid>,
-    principal: RequestPrincipal,
     Json(payload): Json<ReviewClaimRequest>,
 ) -> Result<Json<InsuranceClaim>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_org_id(&principal)?;
-    let claim = state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .insurance_repo
         .review_claim(
+            &mut **rls.conn(),
             org_id,
             claim_id,
-            principal.user_id,
+            user_id,
             &payload.status,
             payload.approved_amount,
             payload.denial_reason.as_deref(),
             payload.resolution_notes.as_deref(),
         )
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Claim not found")),
-            )
-        })?;
-
-    Ok(Json(claim))
+        .map_err(|e| db_error("Failed to review claim", e))
+        .and_then(|c| c.map(Json).ok_or_else(|| not_found("Claim not found")));
+    rls.release().await;
+    out
 }
 
 /// Record payment for a claim.
 async fn record_claim_payment(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(claim_id): Path<Uuid>,
-    principal: RequestPrincipal,
     Json(payload): Json<RecordClaimPaymentRequest>,
 ) -> Result<Json<InsuranceClaim>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_org_id(&principal)?;
-    let claim = state
+    let org_id = rls.tenant_id();
+    let out = state
         .insurance_repo
-        .record_claim_payment(org_id, claim_id, payload.payment_amount)
+        .record_claim_payment(&mut **rls.conn(), org_id, claim_id, payload.payment_amount)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Claim not found")),
-            )
-        })?;
-
-    Ok(Json(claim))
+        .map_err(|e| db_error("Failed to record claim payment", e))
+        .and_then(|c| c.map(Json).ok_or_else(|| not_found("Claim not found")));
+    rls.release().await;
+    out
 }
 
 /// Delete a claim (only drafts).
 async fn delete_claim(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(claim_id): Path<Uuid>,
-    principal: RequestPrincipal,
 ) -> Result<Json<DeleteResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_org_id(&principal)?;
-    let success = state
+    let org_id = rls.tenant_id();
+    let out = state
         .insurance_repo
-        .delete_claim(org_id, claim_id)
+        .delete_claim(&mut **rls.conn(), org_id, claim_id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
-
-    Ok(Json(DeleteResponse { success }))
+        .map(|success| Json(DeleteResponse { success }))
+        .map_err(|e| db_error("Failed to delete claim", e));
+    rls.release().await;
+    out
 }
 
 /// Get claim history.
 async fn get_claim_history(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(claim_id): Path<Uuid>,
-    _principal: RequestPrincipal,
 ) -> Result<Json<ClaimHistoryResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let history = state
+    let out = state
         .insurance_repo
-        .get_claim_history(claim_id)
+        .get_claim_history(&mut **rls.conn(), claim_id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
-
-    Ok(Json(ClaimHistoryResponse { history }))
+        .map(|history| Json(ClaimHistoryResponse { history }))
+        .map_err(|e| db_error("Failed to get claim history", e));
+    rls.release().await;
+    out
 }
 
 // ============================================
@@ -828,62 +694,50 @@ async fn get_claim_history(
 /// List claim documents.
 async fn list_claim_documents(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(claim_id): Path<Uuid>,
-    _principal: RequestPrincipal,
 ) -> Result<Json<ClaimDocumentsResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let documents = state
+    let out = state
         .insurance_repo
-        .list_claim_documents(claim_id)
+        .list_claim_documents(&mut **rls.conn(), claim_id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
-
-    Ok(Json(ClaimDocumentsResponse { documents }))
+        .map(|documents| Json(ClaimDocumentsResponse { documents }))
+        .map_err(|e| db_error("Failed to list claim documents", e));
+    rls.release().await;
+    out
 }
 
 /// Add document to claim.
 async fn add_claim_document(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(claim_id): Path<Uuid>,
-    _principal: RequestPrincipal,
     Json(payload): Json<AddClaimDocument>,
 ) -> Result<Json<InsuranceClaimDocument>, (StatusCode, Json<ErrorResponse>)> {
-    let document = state
+    let out = state
         .insurance_repo
-        .add_claim_document(claim_id, payload)
+        .add_claim_document(&mut **rls.conn(), claim_id, payload)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
-
-    Ok(Json(document))
+        .map(Json)
+        .map_err(|e| db_error("Failed to add claim document", e));
+    rls.release().await;
+    out
 }
 
 /// Remove document from claim.
 async fn remove_claim_document(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path((claim_id, document_id)): Path<(Uuid, Uuid)>,
-    _principal: RequestPrincipal,
 ) -> Result<Json<DeleteResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let success = state
+    let out = state
         .insurance_repo
-        .remove_claim_document(claim_id, document_id)
+        .remove_claim_document(&mut **rls.conn(), claim_id, document_id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
-
-    Ok(Json(DeleteResponse { success }))
+        .map(|success| Json(DeleteResponse { success }))
+        .map_err(|e| db_error("Failed to remove claim document", e));
+    rls.release().await;
+    out
 }
 
 // ============================================
@@ -893,47 +747,37 @@ async fn remove_claim_document(
 /// Get insurance statistics.
 async fn get_statistics(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
 ) -> Result<Json<StatisticsResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_org_id(&principal)?;
-    let statistics = state
-        .insurance_repo
-        .get_statistics(org_id)
-        .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+    let org_id = rls.tenant_id();
+    let out = async {
+        let statistics = state
+            .insurance_repo
+            .get_statistics(&mut **rls.conn(), org_id)
+            .await
+            .map_err(|e| db_error("Failed to get statistics", e))?;
 
-    let claims_by_status = state
-        .insurance_repo
-        .get_claim_summary_by_status(org_id)
-        .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        let claims_by_status = state
+            .insurance_repo
+            .get_claim_summary_by_status(&mut **rls.conn(), org_id)
+            .await
+            .map_err(|e| db_error("Failed to get claim summary", e))?;
 
-    let policies_by_type = state
-        .insurance_repo
-        .get_policy_summary_by_type(org_id)
-        .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        let policies_by_type = state
+            .insurance_repo
+            .get_policy_summary_by_type(&mut **rls.conn(), org_id)
+            .await
+            .map_err(|e| db_error("Failed to get policy summary", e))?;
 
-    Ok(Json(StatisticsResponse {
-        statistics,
-        claims_by_status,
-        policies_by_type,
-    }))
+        Ok(Json(StatisticsResponse {
+            statistics,
+            claims_by_status,
+            policies_by_type,
+        }))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 // ============================================

--- a/backend/servers/api-server/src/routes/insurance.rs
+++ b/backend/servers/api-server/src/routes/insurance.rs
@@ -753,7 +753,7 @@ async fn get_statistics(
     let out = async {
         let statistics = state
             .insurance_repo
-            .get_statistics(&mut **rls.conn(), org_id)
+            .get_statistics(rls.conn(), org_id)
             .await
             .map_err(|e| db_error("Failed to get statistics", e))?;
 

--- a/backend/servers/api-server/tests/insurance_cross_tenant_idor_tests.rs
+++ b/backend/servers/api-server/tests/insurance_cross_tenant_idor_tests.rs
@@ -209,7 +209,7 @@ async fn list_policies_from_other_org_is_rejected(pool: PgPool) {
     let user_b = seed_user(&pool, "lst-pol-b@ins-idor.test").await;
 
     let repo = InsuranceRepository::new(pool.clone());
-    repo.create_policy(org_a, sample_policy("a1"))
+    repo.create_policy(&pool, org_a, sample_policy("a1"))
         .await
         .expect("seed policy in org A");
 
@@ -237,7 +237,7 @@ async fn get_policy_from_other_org_is_rejected(pool: PgPool) {
 
     let repo = InsuranceRepository::new(pool.clone());
     let policy_in_a = repo
-        .create_policy(org_a, sample_policy("a2"))
+        .create_policy(&pool, org_a, sample_policy("a2"))
         .await
         .expect("seed policy in org A");
 
@@ -264,7 +264,7 @@ async fn delete_policy_from_other_org_is_rejected(pool: PgPool) {
 
     let repo = InsuranceRepository::new(pool.clone());
     let policy_in_a = repo
-        .create_policy(org_a, sample_policy("a3"))
+        .create_policy(&pool, org_a, sample_policy("a3"))
         .await
         .expect("seed policy in org A");
 
@@ -298,10 +298,10 @@ async fn list_claims_from_other_org_is_rejected(pool: PgPool) {
 
     let repo = InsuranceRepository::new(pool.clone());
     let policy_in_a = repo
-        .create_policy(org_a, sample_policy("a4"))
+        .create_policy(&pool, org_a, sample_policy("a4"))
         .await
         .expect("seed policy in org A");
-    repo.create_claim(org_a, user_a, sample_claim(policy_in_a.id, "a4"))
+    repo.create_claim(&pool, org_a, user_a, sample_claim(policy_in_a.id, "a4"))
         .await
         .expect("seed claim in org A");
 
@@ -327,17 +327,17 @@ async fn repo_policies_are_scoped_to_owning_org(pool: PgPool) {
 
     let repo = InsuranceRepository::new(pool.clone());
     let policy_a = repo
-        .create_policy(org_a, sample_policy("repo-a"))
+        .create_policy(&pool, org_a, sample_policy("repo-a"))
         .await
         .expect("policy A");
     let _policy_b = repo
-        .create_policy(org_b, sample_policy("repo-b"))
+        .create_policy(&pool, org_b, sample_policy("repo-b"))
         .await
         .expect("policy B");
 
     // Org A's list contains only org A's policy.
     let listed_a = repo
-        .list_policies(org_a, InsurancePolicyQuery::default())
+        .list_policies(&pool, org_a, InsurancePolicyQuery::default())
         .await
         .expect("list A");
     assert_eq!(listed_a.len(), 1, "org A must see exactly its own policy");
@@ -351,7 +351,7 @@ async fn repo_policies_are_scoped_to_owning_org(pool: PgPool) {
 
     // Looking up org A's policy with org B's id returns nothing (closed IDOR).
     let cross = repo
-        .find_policy_by_id(org_b, policy_a.id)
+        .find_policy_by_id(&pool, org_b, policy_a.id)
         .await
         .expect("find with wrong org");
     assert!(
@@ -361,7 +361,7 @@ async fn repo_policies_are_scoped_to_owning_org(pool: PgPool) {
 
     // The legitimate owner can read it.
     let own = repo
-        .find_policy_by_id(org_a, policy_a.id)
+        .find_policy_by_id(&pool, org_a, policy_a.id)
         .await
         .expect("find with right org");
     assert!(own.is_some(), "org A must read its own policy by id");
@@ -380,25 +380,25 @@ async fn repo_claims_are_scoped_to_owning_org(pool: PgPool) {
 
     let repo = InsuranceRepository::new(pool.clone());
     let policy_a = repo
-        .create_policy(org_a, sample_policy("repo-clm-a"))
+        .create_policy(&pool, org_a, sample_policy("repo-clm-a"))
         .await
         .expect("policy A");
     let policy_b = repo
-        .create_policy(org_b, sample_policy("repo-clm-b"))
+        .create_policy(&pool, org_b, sample_policy("repo-clm-b"))
         .await
         .expect("policy B");
     let claim_a = repo
-        .create_claim(org_a, user_a, sample_claim(policy_a.id, "repo-a"))
+        .create_claim(&pool, org_a, user_a, sample_claim(policy_a.id, "repo-a"))
         .await
         .expect("claim A");
     let _claim_b = repo
-        .create_claim(org_b, user_b, sample_claim(policy_b.id, "repo-b"))
+        .create_claim(&pool, org_b, user_b, sample_claim(policy_b.id, "repo-b"))
         .await
         .expect("claim B");
 
     // Org A's claim list contains only org A's claim.
     let listed_a = repo
-        .list_claims(org_a, InsuranceClaimQuery::default())
+        .list_claims(&pool, org_a, InsuranceClaimQuery::default())
         .await
         .expect("list A");
     assert_eq!(listed_a.len(), 1, "org A must see exactly its own claim");
@@ -409,7 +409,7 @@ async fn repo_claims_are_scoped_to_owning_org(pool: PgPool) {
 
     // Org B cannot read org A's claim by id.
     let cross = repo
-        .find_claim_with_policy(org_b, claim_a.id)
+        .find_claim_with_policy(&pool, org_b, claim_a.id)
         .await
         .expect("find with wrong org");
     assert!(
@@ -419,7 +419,7 @@ async fn repo_claims_are_scoped_to_owning_org(pool: PgPool) {
 
     // The legitimate owner can.
     let own = repo
-        .find_claim_with_policy(org_a, claim_a.id)
+        .find_claim_with_policy(&pool, org_a, claim_a.id)
         .await
         .expect("find with right org");
     assert!(own.is_some(), "org A must read its own claim by id");
@@ -478,7 +478,7 @@ async fn list_policies_returns_only_callers_own_org(pool: PgPool) {
     // Seed a policy owned by org A.
     let repo = InsuranceRepository::new(pool.clone());
     let policy_a = repo
-        .create_policy(org_a, sample_policy("positive-a"))
+        .create_policy(&pool, org_a, sample_policy("positive-a"))
         .await
         .expect("seed policy in org A");
 

--- a/backend/servers/api-server/tests/insurance_cross_tenant_idor_tests.rs
+++ b/backend/servers/api-server/tests/insurance_cross_tenant_idor_tests.rs
@@ -42,11 +42,9 @@
 #[allow(dead_code)]
 mod common;
 
-use api_core::middleware::host_tenant::{ResolvedTenant, TenantSource};
 use axum::{
     body::Body,
     http::{header, Method, Request, StatusCode},
-    middleware::Next,
 };
 use chrono::NaiveDate;
 use db::models::{
@@ -58,7 +56,7 @@ use sqlx::PgPool;
 use tower::ServiceExt;
 use uuid::Uuid;
 
-use common::{create_authenticated_user, TestApp, TestUser};
+use common::{create_authenticated_user_with_org, TestApp, TestUser};
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -91,32 +89,6 @@ async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     .fetch_one(pool)
     .await
     .expect("seed user")
-}
-
-/// Look up the user id created by `create_authenticated_user`.
-async fn user_id_for(pool: &PgPool, email: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
-        .bind(email)
-        .fetch_one(pool)
-        .await
-        .expect("user id lookup")
-}
-
-/// Grant an active `user_memberships` row so `MembershipRepository::is_active`
-/// (used by `RequestPrincipal`) returns true for `(user, org)`.
-async fn seed_user_membership(pool: &PgPool, org_id: Uuid, user_id: Uuid) {
-    sqlx::query(
-        r#"
-        INSERT INTO user_memberships (user_id, organization_id, role)
-        VALUES ($1, $2, 'manager')
-        ON CONFLICT DO NOTHING
-        "#,
-    )
-    .bind(user_id)
-    .bind(org_id)
-    .execute(pool)
-    .await
-    .expect("seed user_membership");
 }
 
 fn sample_policy(suffix: &str) -> CreateInsurancePolicy {
@@ -431,49 +403,29 @@ async fn repo_claims_are_scoped_to_owning_org(pool: PgPool) {
 // ---------------------------------------------------------------------------
 //
 // This is the end-to-end proof that the handler now derives the org from the
-// authenticated principal. We wrap `create_router` with a middleware that
-// injects `ResolvedTenant { Subdomain, org_a }` (standing in for
-// `host_tenant_middleware`, which `TestApp` does not mount), mint a real JWT
-// for a user who has an active membership in org A, and seed one policy in
-// org A.
+// authenticated principal via `RlsConnection`. We mint a real JWT for a user
+// who is an active `organization_members` member of org A (the membership table
+// `ValidatedTenantExtractor` checks), pass `X-Tenant-ID: org_a` (the canonical
+// tenant-resolution path under `TestApp`, which mounts no `host_tenant_middleware`),
+// and seed one policy in org A.
 //
-// On the FIXED code, `list_policies` resolves `org_id = principal.effective_org
-// = org_a` and returns that policy → `policies.len() == 1`.
+// On the FIXED code, `list_policies` resolves `org_id = rls.tenant_id() = org_a`
+// and returns that policy → `policies.len() == 1`.
 //
-// On `main`, `list_policies` ignores the principal and uses
+// On `main`, `list_policies` ignored the principal and used
 // `query.building_id.unwrap_or_default()` = `Uuid::nil()`, so the org-scoped
-// repository query matches nothing → `policies.len() == 0`. This assertion is
+// repository query matched nothing → `policies.len() == 0`. This assertion is
 // what fails on main and passes on the fix.
-
-/// Build a router (the production `create_router`) wrapped so that every
-/// request carries a `ResolvedTenant` for `org_id`, mimicking a real
-/// tenant-resolved host.
-async fn tenant_resolved_app(pool: PgPool, org_id: Uuid) -> (TestApp, axum::Router) {
-    let app = TestApp::new(pool).await;
-    let router = app.router.clone().layer(axum::middleware::from_fn(
-        move |mut req: Request<Body>, next: Next| async move {
-            req.extensions_mut().insert(ResolvedTenant {
-                organization_id: org_id,
-                source: TenantSource::Subdomain,
-            });
-            next.run(req).await
-        },
-    ));
-    (app, router)
-}
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn list_policies_returns_only_callers_own_org(pool: PgPool) {
-    let org_a = seed_org(&pool, "pos-pol-a").await;
-
-    // Register + verify + login a user → real access-token JWT.
-    let bootstrap = TestApp::new(pool.clone()).await;
+    // Register + verify + login a user and make them an active `org_admin`
+    // member of a fresh org A. `create_authenticated_user_with_org` seeds the
+    // membership into `organization_members` — the table `RlsConnection`'s
+    // `ValidatedTenantExtractor` validates against — and returns org A's id.
+    let app = TestApp::new(pool.clone()).await;
     let user = TestUser::with_email(&format!("pos-pol-{}@ins-idor.test", Uuid::new_v4()));
-    let (access_token, _refresh) = create_authenticated_user(&bootstrap, &user).await;
-    let uid = user_id_for(&pool, &user.email).await;
-
-    // Active membership in org A so `RequestPrincipal` resolves `effective_org`.
-    seed_user_membership(&pool, org_a, uid).await;
+    let (access_token, org_a) = create_authenticated_user_with_org(&app, &user, "pos-pol-a").await;
 
     // Seed a policy owned by org A.
     let repo = InsuranceRepository::new(pool.clone());
@@ -482,17 +434,15 @@ async fn list_policies_returns_only_callers_own_org(pool: PgPool) {
         .await
         .expect("seed policy in org A");
 
-    // Router with org_a as the resolved tenant.
-    let (_app, router) = tenant_resolved_app(pool.clone(), org_a).await;
-
     let request = Request::builder()
         .method(Method::GET)
         .uri("/api/v1/insurance/policies")
         .header(header::AUTHORIZATION, format!("Bearer {access_token}"))
+        .header("X-Tenant-ID", org_a.to_string())
         .body(Body::empty())
         .unwrap();
 
-    let response = router.oneshot(request).await.expect("request");
+    let response = app.router.clone().oneshot(request).await.expect("request");
     assert_eq!(
         response.status(),
         StatusCode::OK,


### PR DESCRIPTION
## What

Routes `InsuranceRepository` through an RLS-context connection so the `/api/v1/insurance` endpoints work under migration `00179`'s `FORCE ROW LEVEL SECURITY`.

Under `FORCE`, the api-server owner connection is no longer RLS-exempt. The repo held a raw `pool: PgPool` and never called `set_request_context`, so on `dev` every query collapsed to deny-all: own-org reads returned empty and writes failed.

FORCE-RLS tables covered (per 00179): `insurance_policies`, `insurance_claims`, `insurance_claim_documents`, `insurance_claim_history`, `insurance_policy_documents`, `insurance_renewal_reminders`.

## How (follows the proven `work_order` / `budget` pattern)

- **Repo** (`crates/db/src/repositories/insurance.rs`): dropped the raw `pool` field — no second raw-pool path. Single-statement methods take a generic `executor: E where E: Executor<'e, Database = Postgres>`; the two multi-statement methods (`get_statistics`, `get_pending_reminders`) take `conn: &mut PgConnection` and reborrow per call. `new(_pool)` retained for the `AppState` construction site. Explicit `organization_id` filters kept as defence-in-depth alongside RLS.
- **Route** (`servers/api-server/src/routes/insurance.rs`): every handler takes `mut rls: RlsConnection`, derives the org from `rls.tenant_id()` (authoritative — SQL filter and RLS context can never disagree), passes `&mut **rls.conn()` to the repo, and calls `rls.release().await` before returning. Drops the `RequestPrincipal` + `require_org_id` scheme.
- **Tests**: new `crates/db/tests/insurance_rls_repo_tests.rs` mirrors `work_order_rls_repo_tests.rs` — a `NOSUPERUSER NOBYPASSRLS` role so `FORCE` binds; asserts deny-all without context, own-org visibility + cross-tenant invisibility with context for a by-id read + list, and a write under context. The existing `insurance_cross_tenant_idor_tests.rs` direct repo calls updated to pass an executor.

## Verify

- `cargo check -p db -p api-server --tests` — green.
- Changed files `rustfmt`-clean.
- DB execution of the `#[sqlx::test]` runs in CI (`rls-smoke`) / QA.

Parent: PAP-67. See PAP-68 for the matching `check-rls-enforcement.sh` detection guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)