### PR TITLE
fix(api-server): route enhanced_tenant_screening through RLS-context connection (PAP-74)

### DIFF
--- a/backend/crates/db/src/repositories/enhanced_tenant_screening.rs
+++ b/backend/crates/db/src/repositories/enhanced_tenant_screening.rs
@@ -1,22 +1,43 @@
 // Epic 135: Enhanced Tenant Screening with AI Risk Scoring
 // Repository for AI-powered tenant screening operations
+//
+// # RLS Integration (PAP-67 / PAP-74)
+//
+// Migration `00179` put `FORCE ROW LEVEL SECURITY` + the canonical
+// `get_current_org_id()` policy on the screening tables (`screening_*`,
+// `ai_risk_scoring_models`). Under `FORCE` the api-server's owner connection is
+// no longer exempt, so a query issued on a connection without
+// `app.current_org_id` set collapses to deny-all (own-org reads return empty,
+// writes fail).
+//
+// Every method therefore takes an **executor whose connection already has RLS
+// context set** (org + user GUCs) — in handlers this comes from the
+// `RlsConnection` extractor via `&mut **rls.conn()`. The repository holds **no
+// pool**, so there is no way to issue a query that bypasses RLS. This mirrors
+// the `work_order.rs` / `budget.rs` precedent.
 
 use rust_decimal::Decimal;
-use sqlx::PgPool;
+use sqlx::{Acquire, Executor, PgConnection, PgPool, Postgres};
 use uuid::Uuid;
 
 use crate::models::enhanced_tenant_screening::*;
 
 /// Repository for enhanced tenant screening operations.
+///
+/// Stateless: every method receives an RLS-context-bearing executor. The repo
+/// holds no pool so it cannot issue an un-scoped (deny-all under `FORCE`) query.
 #[derive(Debug, Clone)]
-pub struct EnhancedTenantScreeningRepository {
-    pool: PgPool,
-}
+pub struct EnhancedTenantScreeningRepository;
 
 impl EnhancedTenantScreeningRepository {
     /// Create a new repository instance.
-    pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+    ///
+    /// The pool argument is retained for construction-site compatibility with
+    /// the other repositories on `AppState`; this repo deliberately does not
+    /// store it (see module docs — all queries run on a context-set connection
+    /// supplied by the handler's `RlsConnection`).
+    pub fn new(_pool: PgPool) -> Self {
+        Self
     }
 
     // =========================================================================
@@ -24,12 +45,16 @@ impl EnhancedTenantScreeningRepository {
     // =========================================================================
 
     /// Create a new AI risk scoring model.
-    pub async fn create_risk_model(
+    pub async fn create_risk_model<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         user_id: Uuid,
         req: CreateAiRiskScoringModel,
-    ) -> Result<AiRiskScoringModel, sqlx::Error> {
+    ) -> Result<AiRiskScoringModel, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO ai_risk_scoring_models (
@@ -86,58 +111,79 @@ impl EnhancedTenantScreeningRepository {
         .bind(req.poor_threshold.unwrap_or(20))
         .bind(req.auto_approve_threshold)
         .bind(req.auto_reject_threshold)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get AI risk scoring model by ID, scoped to the owning organization.
     ///
     /// Issue #834 (cross-tenant PII): models carry provider weighting / scoring
-    /// configuration. The `organization_id = $2` predicate stops a caller from
-    /// another org reading a foreign model by guessing its UUID.
-    pub async fn get_risk_model(
+    /// configuration. The `organization_id = $2` predicate is defense-in-depth
+    /// alongside RLS — under FORCE-RLS a foreign model is already invisible.
+    pub async fn get_risk_model<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         id: Uuid,
-    ) -> Result<Option<AiRiskScoringModel>, sqlx::Error> {
+    ) -> Result<Option<AiRiskScoringModel>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             "SELECT * FROM ai_risk_scoring_models WHERE id = $1 AND organization_id = $2",
         )
         .bind(id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Get active AI risk scoring model for organization.
-    pub async fn get_active_risk_model(
+    pub async fn get_active_risk_model<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
-    ) -> Result<Option<AiRiskScoringModel>, sqlx::Error> {
+    ) -> Result<Option<AiRiskScoringModel>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             "SELECT * FROM ai_risk_scoring_models WHERE organization_id = $1 AND is_active = true",
         )
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// List all risk models for organization.
-    pub async fn list_risk_models(
+    pub async fn list_risk_models<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
-    ) -> Result<Vec<AiRiskScoringModel>, sqlx::Error> {
+    ) -> Result<Vec<AiRiskScoringModel>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             "SELECT * FROM ai_risk_scoring_models WHERE organization_id = $1 ORDER BY created_at DESC",
         )
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Activate a risk model (deactivates others).
-    pub async fn activate_risk_model(&self, org_id: Uuid, id: Uuid) -> Result<(), sqlx::Error> {
-        let mut tx = self.pool.begin().await?;
+    ///
+    /// Multi-statement (deactivate-all then activate-one), so it takes a
+    /// connection and runs both writes inside a transaction on that
+    /// RLS-context-bearing connection.
+    pub async fn activate_risk_model(
+        &self,
+        conn: &mut PgConnection,
+        org_id: Uuid,
+        id: Uuid,
+    ) -> Result<(), sqlx::Error> {
+        let mut tx = conn.begin().await?;
 
         // Deactivate all models for org
         sqlx::query(
@@ -160,10 +206,15 @@ impl EnhancedTenantScreeningRepository {
     }
 
     /// Delete a risk model.
-    pub async fn delete_risk_model(&self, id: Uuid) -> Result<bool, sqlx::Error> {
+    ///
+    /// RLS scopes the delete to the caller's org; a foreign id matches no row.
+    pub async fn delete_risk_model<'e, E>(&self, executor: E, id: Uuid) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM ai_risk_scoring_models WHERE id = $1")
             .bind(id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
@@ -173,11 +224,15 @@ impl EnhancedTenantScreeningRepository {
     // =========================================================================
 
     /// Create screening provider config.
-    pub async fn create_provider_config(
+    pub async fn create_provider_config<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         req: CreateScreeningProviderConfig,
-    ) -> Result<ScreeningProviderConfig, sqlx::Error> {
+    ) -> Result<ScreeningProviderConfig, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // Note: In production, encrypt api_key and api_secret before storing
         sqlx::query_as(
             r#"
@@ -196,7 +251,7 @@ impl EnhancedTenantScreeningRepository {
         .bind(req.rate_limit_per_hour.unwrap_or(100))
         .bind(req.priority.unwrap_or(1))
         .bind(req.cost_per_check)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
@@ -205,39 +260,51 @@ impl EnhancedTenantScreeningRepository {
     /// Issue #834: provider configs hold third-party integration settings
     /// (endpoints, rate limits, cost). Scope by org so a foreign caller cannot
     /// read another tenant's provider wiring by UUID.
-    pub async fn get_provider_config(
+    pub async fn get_provider_config<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         id: Uuid,
-    ) -> Result<Option<ScreeningProviderConfig>, sqlx::Error> {
+    ) -> Result<Option<ScreeningProviderConfig>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             "SELECT * FROM screening_provider_configs WHERE id = $1 AND organization_id = $2",
         )
         .bind(id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// List provider configs for organization.
-    pub async fn list_provider_configs(
+    pub async fn list_provider_configs<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
-    ) -> Result<Vec<ScreeningProviderConfig>, sqlx::Error> {
+    ) -> Result<Vec<ScreeningProviderConfig>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             "SELECT * FROM screening_provider_configs WHERE organization_id = $1 ORDER BY priority",
         )
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// List active provider configs by type.
-    pub async fn list_active_providers_by_type(
+    pub async fn list_active_providers_by_type<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         provider_type: ScreeningProviderType,
-    ) -> Result<Vec<ScreeningProviderConfig>, sqlx::Error> {
+    ) -> Result<Vec<ScreeningProviderConfig>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM screening_provider_configs
@@ -247,17 +314,23 @@ impl EnhancedTenantScreeningRepository {
         )
         .bind(org_id)
         .bind(provider_type)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update provider status.
-    pub async fn update_provider_status(
+    ///
+    /// RLS scopes the update to the caller's org; a foreign id matches no row.
+    pub async fn update_provider_status<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         status: ProviderIntegrationStatus,
         error_message: Option<&str>,
-    ) -> Result<(), sqlx::Error> {
+    ) -> Result<(), sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query(
             r#"
             UPDATE screening_provider_configs
@@ -268,16 +341,25 @@ impl EnhancedTenantScreeningRepository {
         .bind(id)
         .bind(status)
         .bind(error_message)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
         Ok(())
     }
 
     /// Delete provider config.
-    pub async fn delete_provider_config(&self, id: Uuid) -> Result<bool, sqlx::Error> {
+    ///
+    /// RLS scopes the delete to the caller's org; a foreign id matches no row.
+    pub async fn delete_provider_config<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM screening_provider_configs WHERE id = $1")
             .bind(id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
@@ -287,13 +369,17 @@ impl EnhancedTenantScreeningRepository {
     // =========================================================================
 
     /// Create AI screening result.
-    pub async fn create_ai_result(
+    pub async fn create_ai_result<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         screening_id: Uuid,
         model: &AiRiskScoringModel,
         component_scores: ComponentScores,
-    ) -> Result<ScreeningAiResult, sqlx::Error> {
+    ) -> Result<ScreeningAiResult, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // Calculate weighted score
         let ai_risk_score = calculate_weighted_score(model, &component_scores);
         let risk_category = AiRiskCategory::from_score(ai_risk_score, model);
@@ -327,45 +413,59 @@ impl EnhancedTenantScreeningRepository {
         .bind(component_scores.reference_quality)
         .bind(&recommendation)
         .bind(get_recommendation_reason(ai_risk_score, &risk_category))
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
-    /// Get AI result by screening ID.
     /// Get the AI result for a screening, scoped to the owning organization.
     ///
     /// Issue #834 (cross-tenant PII): AI results carry risk scores and
     /// recommendations. Scoping by `organization_id` closes the IDOR where any
     /// org could read another org's result by guessing the screening UUID.
-    pub async fn get_ai_result_by_screening(
+    pub async fn get_ai_result_by_screening<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         screening_id: Uuid,
-    ) -> Result<Option<ScreeningAiResult>, sqlx::Error> {
+    ) -> Result<Option<ScreeningAiResult>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             "SELECT * FROM screening_ai_results WHERE screening_id = $1 AND organization_id = $2",
         )
         .bind(screening_id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Get AI result by ID.
-    pub async fn get_ai_result(&self, id: Uuid) -> Result<Option<ScreeningAiResult>, sqlx::Error> {
+    pub async fn get_ai_result<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+    ) -> Result<Option<ScreeningAiResult>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as("SELECT * FROM screening_ai_results WHERE id = $1")
             .bind(id)
-            .fetch_optional(&self.pool)
+            .fetch_optional(executor)
             .await
     }
 
     /// List AI results for organization.
-    pub async fn list_ai_results(
+    pub async fn list_ai_results<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         limit: i32,
         offset: i32,
-    ) -> Result<Vec<ScreeningAiResult>, sqlx::Error> {
+    ) -> Result<Vec<ScreeningAiResult>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM screening_ai_results
@@ -377,7 +477,7 @@ impl EnhancedTenantScreeningRepository {
         .bind(org_id)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -386,11 +486,15 @@ impl EnhancedTenantScreeningRepository {
     // =========================================================================
 
     /// Create risk factor.
-    pub async fn create_risk_factor(
+    pub async fn create_risk_factor<'e, E>(
         &self,
+        executor: E,
         ai_result_id: Uuid,
         req: CreateScreeningRiskFactor,
-    ) -> Result<ScreeningRiskFactor, sqlx::Error> {
+    ) -> Result<ScreeningRiskFactor, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO screening_risk_factors (
@@ -412,28 +516,36 @@ impl EnhancedTenantScreeningRepository {
         .bind(&req.source_data)
         .bind(req.is_compliant)
         .bind(&req.compliance_notes)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get risk factors for AI result.
-    pub async fn get_risk_factors(
+    pub async fn get_risk_factors<'e, E>(
         &self,
+        executor: E,
         ai_result_id: Uuid,
-    ) -> Result<Vec<ScreeningRiskFactor>, sqlx::Error> {
+    ) -> Result<Vec<ScreeningRiskFactor>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             "SELECT * FROM screening_risk_factors WHERE ai_result_id = $1 ORDER BY score_impact DESC",
         )
         .bind(ai_result_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Get negative/critical risk factors.
-    pub async fn get_negative_risk_factors(
+    pub async fn get_negative_risk_factors<'e, E>(
         &self,
+        executor: E,
         ai_result_id: Uuid,
-    ) -> Result<Vec<ScreeningRiskFactor>, sqlx::Error> {
+    ) -> Result<Vec<ScreeningRiskFactor>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM screening_risk_factors
@@ -442,7 +554,7 @@ impl EnhancedTenantScreeningRepository {
             "#,
         )
         .bind(ai_result_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -451,11 +563,15 @@ impl EnhancedTenantScreeningRepository {
     // =========================================================================
 
     /// Create credit result.
-    pub async fn create_credit_result(
+    pub async fn create_credit_result<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         req: CreateScreeningCreditResult,
-    ) -> Result<ScreeningCreditResult, sqlx::Error> {
+    ) -> Result<ScreeningCreditResult, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO screening_credit_results (
@@ -491,25 +607,28 @@ impl EnhancedTenantScreeningRepository {
         .bind(req.bankruptcies_count)
         .bind(req.most_recent_bankruptcy_date)
         .bind(req.public_records_count)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
-    /// Get credit result by screening ID.
     /// Get the credit result for a screening, scoped to the owning organization.
     ///
     /// Issue #834: credit results are sensitive PII (FICO scores, accounts).
-    pub async fn get_credit_result_by_screening(
+    pub async fn get_credit_result_by_screening<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         screening_id: Uuid,
-    ) -> Result<Option<ScreeningCreditResult>, sqlx::Error> {
+    ) -> Result<Option<ScreeningCreditResult>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             "SELECT * FROM screening_credit_results WHERE screening_id = $1 AND organization_id = $2",
         )
         .bind(screening_id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
@@ -518,11 +637,15 @@ impl EnhancedTenantScreeningRepository {
     // =========================================================================
 
     /// Create background result.
-    pub async fn create_background_result(
+    pub async fn create_background_result<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         req: CreateScreeningBackgroundResult,
-    ) -> Result<ScreeningBackgroundResult, sqlx::Error> {
+    ) -> Result<ScreeningBackgroundResult, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO screening_background_results (
@@ -550,7 +673,7 @@ impl EnhancedTenantScreeningRepository {
         .bind(req.identity_match_score)
         .bind(req.ssn_verified)
         .bind(req.address_history_verified)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
@@ -558,17 +681,21 @@ impl EnhancedTenantScreeningRepository {
     ///
     /// Issue #834: background results are sensitive PII (criminal records,
     /// identity verification).
-    pub async fn get_background_result_by_screening(
+    pub async fn get_background_result_by_screening<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         screening_id: Uuid,
-    ) -> Result<Option<ScreeningBackgroundResult>, sqlx::Error> {
+    ) -> Result<Option<ScreeningBackgroundResult>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             "SELECT * FROM screening_background_results WHERE screening_id = $1 AND organization_id = $2",
         )
         .bind(screening_id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
@@ -577,11 +704,15 @@ impl EnhancedTenantScreeningRepository {
     // =========================================================================
 
     /// Create eviction result.
-    pub async fn create_eviction_result(
+    pub async fn create_eviction_result<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         req: CreateScreeningEvictionResult,
-    ) -> Result<ScreeningEvictionResult, sqlx::Error> {
+    ) -> Result<ScreeningEvictionResult, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO screening_eviction_results (
@@ -602,24 +733,28 @@ impl EnhancedTenantScreeningRepository {
         .bind(req.most_recent_eviction_date)
         .bind(&req.eviction_records)
         .bind(req.unlawful_detainer_count)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get eviction result by screening ID, scoped to the owning organization.
     ///
     /// Issue #834: eviction history is sensitive PII.
-    pub async fn get_eviction_result_by_screening(
+    pub async fn get_eviction_result_by_screening<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         screening_id: Uuid,
-    ) -> Result<Option<ScreeningEvictionResult>, sqlx::Error> {
+    ) -> Result<Option<ScreeningEvictionResult>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             "SELECT * FROM screening_eviction_results WHERE screening_id = $1 AND organization_id = $2",
         )
         .bind(screening_id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
@@ -628,11 +763,15 @@ impl EnhancedTenantScreeningRepository {
     // =========================================================================
 
     /// Create queue item.
-    pub async fn create_queue_item(
+    pub async fn create_queue_item<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         req: CreateScreeningQueueItem,
-    ) -> Result<ScreeningRequestQueueItem, sqlx::Error> {
+    ) -> Result<ScreeningRequestQueueItem, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO screening_request_queue (
@@ -647,15 +786,21 @@ impl EnhancedTenantScreeningRepository {
         .bind(req.check_type)
         .bind(req.provider_config_id)
         .bind(req.priority.unwrap_or(5))
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get pending queue items.
-    pub async fn get_pending_queue_items(
+    ///
+    /// RLS scopes the rows to the caller's org under FORCE-RLS.
+    pub async fn get_pending_queue_items<'e, E>(
         &self,
+        executor: E,
         limit: i32,
-    ) -> Result<Vec<ScreeningRequestQueueItem>, sqlx::Error> {
+    ) -> Result<Vec<ScreeningRequestQueueItem>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM screening_request_queue
@@ -665,17 +810,24 @@ impl EnhancedTenantScreeningRepository {
             "#,
         )
         .bind(limit)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update queue item status.
-    pub async fn update_queue_item_status(
+    ///
+    /// Exactly one branch runs (one statement), so a generic executor suffices.
+    /// RLS scopes the update to the caller's org; a foreign id matches no row.
+    pub async fn update_queue_item_status<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         status: &str,
         error: Option<&str>,
-    ) -> Result<(), sqlx::Error> {
+    ) -> Result<(), sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         match status {
             "processing" => {
                 sqlx::query(
@@ -683,7 +835,7 @@ impl EnhancedTenantScreeningRepository {
                 )
                 .bind(id)
                 .bind(status)
-                .execute(&self.pool)
+                .execute(executor)
                 .await?;
             }
             "completed" => {
@@ -692,7 +844,7 @@ impl EnhancedTenantScreeningRepository {
                 )
                 .bind(id)
                 .bind(status)
-                .execute(&self.pool)
+                .execute(executor)
                 .await?;
             }
             "failed" | "retry" => {
@@ -707,7 +859,7 @@ impl EnhancedTenantScreeningRepository {
                 .bind(id)
                 .bind(status)
                 .bind(error)
-                .execute(&self.pool)
+                .execute(executor)
                 .await?;
             }
             _ => {
@@ -716,7 +868,7 @@ impl EnhancedTenantScreeningRepository {
                 )
                 .bind(id)
                 .bind(status)
-                .execute(&self.pool)
+                .execute(executor)
                 .await?;
             }
         }
@@ -728,12 +880,16 @@ impl EnhancedTenantScreeningRepository {
     // =========================================================================
 
     /// Create screening report.
-    pub async fn create_report(
+    pub async fn create_report<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         user_id: Uuid,
         req: CreateScreeningReport,
-    ) -> Result<ScreeningReport, sqlx::Error> {
+    ) -> Result<ScreeningReport, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO screening_reports (
@@ -751,25 +907,28 @@ impl EnhancedTenantScreeningRepository {
         .bind(&req.file_url)
         .bind(req.file_size_bytes)
         .bind(&req.content_hash)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
-    /// Get reports for screening.
     /// Get reports for a screening, scoped to the owning organization.
     ///
     /// Issue #834: screening reports aggregate the sensitive PII above.
-    pub async fn get_reports_by_screening(
+    pub async fn get_reports_by_screening<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         screening_id: Uuid,
-    ) -> Result<Vec<ScreeningReport>, sqlx::Error> {
+    ) -> Result<Vec<ScreeningReport>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             "SELECT * FROM screening_reports WHERE screening_id = $1 AND organization_id = $2 AND deleted_at IS NULL ORDER BY generated_at DESC",
         )
         .bind(screening_id)
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -778,7 +937,14 @@ impl EnhancedTenantScreeningRepository {
     // =========================================================================
 
     /// Get screening statistics for organization.
-    pub async fn get_statistics(&self, org_id: Uuid) -> Result<ScreeningStatistics, sqlx::Error> {
+    pub async fn get_statistics<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+    ) -> Result<ScreeningStatistics, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT
@@ -794,15 +960,19 @@ impl EnhancedTenantScreeningRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get risk category distribution.
-    pub async fn get_risk_distribution(
+    pub async fn get_risk_distribution<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
-    ) -> Result<Vec<RiskCategoryDistribution>, sqlx::Error> {
+    ) -> Result<Vec<RiskCategoryDistribution>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             WITH totals AS (
@@ -819,7 +989,7 @@ impl EnhancedTenantScreeningRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -829,27 +999,31 @@ impl EnhancedTenantScreeningRepository {
     /// component lookup is org-scoped. `get_risk_factors` keys off the
     /// AI-result id, which is itself org-scoped above, so it needs no separate
     /// org predicate.
+    ///
+    /// Multi-call: composes the per-artefact helpers above, so it takes a
+    /// connection and reborrows `&mut *conn` for each query.
     pub async fn get_complete_screening_data(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         screening_id: Uuid,
     ) -> Result<CompleteScreeningData, sqlx::Error> {
         let ai_result = self
-            .get_ai_result_by_screening(org_id, screening_id)
+            .get_ai_result_by_screening(&mut *conn, org_id, screening_id)
             .await?;
         let risk_factors = if let Some(ref ai) = ai_result {
-            self.get_risk_factors(ai.id).await?
+            self.get_risk_factors(&mut *conn, ai.id).await?
         } else {
             vec![]
         };
         let credit_result = self
-            .get_credit_result_by_screening(org_id, screening_id)
+            .get_credit_result_by_screening(&mut *conn, org_id, screening_id)
             .await?;
         let background_result = self
-            .get_background_result_by_screening(org_id, screening_id)
+            .get_background_result_by_screening(&mut *conn, org_id, screening_id)
             .await?;
         let eviction_result = self
-            .get_eviction_result_by_screening(org_id, screening_id)
+            .get_eviction_result_by_screening(&mut *conn, org_id, screening_id)
             .await?;
 
         Ok(CompleteScreeningData {

--- a/backend/crates/db/tests/enhanced_tenant_screening_rls_repo_tests.rs
+++ b/backend/crates/db/tests/enhanced_tenant_screening_rls_repo_tests.rs
@@ -1,0 +1,284 @@
+//! Repo-level behavioral RLS regression test for PAP-74 (parent PAP-67).
+//!
+//! Background
+//! ----------
+//! Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on the screening cluster
+//! (`ai_risk_scoring_models`, `screening_*`). The production api-server connects
+//! as the table OWNER, which `FORCE` binds. `EnhancedTenantScreeningRepository`
+//! held a raw `PgPool` and ran every query WITHOUT ever calling
+//! `set_request_context`, so on `dev` `get_current_org_id()` returned NULL and the
+//! policy collapsed to `organization_id = NULL` → **deny-all**: own-org reads
+//! returned empty, writes failed. (PAP-74.)
+//!
+//! The fix routes the repo through an RLS-context connection (the `RlsConnection`
+//! extractor in handlers sets the org/user GUCs before any query). This test
+//! exercises the *repository methods themselves* on a `FORCE`-bound role and
+//! proves, against `ai_risk_scoring_models`:
+//!
+//!   1. **Deny-all reproduction** — with the role bound but NO context set
+//!      (exactly what the raw-pool repo did on `dev`), an own-org `get_risk_model`
+//!      / `list_risk_models` returns nothing.
+//!   2. **Fix** — with `set_request_context(org_a, user_a)` applied first (what
+//!      `RlsConnection` now does), the same repo calls return the own-org row.
+//!   3. **Cross-tenant** — org B's model stays invisible to an org-A caller.
+//!   4. **Write path** — `create_risk_model` on a context-set connection succeeds
+//!      and the row is the caller's org.
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — even `FORCE` does not bind a superuser, so a behavioral assertion
+//! would pass vacuously. The test creates a plain `NOSUPERUSER NOBYPASSRLS`
+//! role, grants it access, and `SET ROLE`s to it so `FORCE` actually enforces the
+//! policy the way the production owner role experiences it. Mirrors
+//! `work_order_rls_repo_tests.rs` (the PAP-67 precedent PAP-74 follows).
+
+use db::models::enhanced_tenant_screening::CreateAiRiskScoringModel;
+use db::repositories::enhanced_tenant_screening::EnhancedTenantScreeningRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Screen {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@screen.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'Screen User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// A minimal model request — all weights/thresholds default in the repo.
+fn model_req(name: &str) -> CreateAiRiskScoringModel {
+    CreateAiRiskScoringModel {
+        name: name.to_string(),
+        description: None,
+        credit_history_weight: None,
+        rental_history_weight: None,
+        income_stability_weight: None,
+        employment_stability_weight: None,
+        eviction_history_weight: None,
+        criminal_background_weight: None,
+        identity_verification_weight: None,
+        reference_quality_weight: None,
+        excellent_threshold: None,
+        good_threshold: None,
+        fair_threshold: None,
+        poor_threshold: None,
+        auto_approve_threshold: None,
+        auto_reject_threshold: None,
+    }
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn screening_repo_force_rls_deny_all_and_fix(pool: PgPool) {
+    let repo = EnhancedTenantScreeningRepository::new(pool.clone());
+
+    // --- Seed as superuser / super-admin context (satisfies org roles-trigger). ---
+    set_ctx(&pool, None, None, true).await;
+    let org_a = seed_org(&pool, "force-a").await;
+    let org_b = seed_org(&pool, "force-b").await;
+    let user_a = seed_user(&pool, "a@screen.test").await;
+    let user_b = seed_user(&pool, "b@screen.test").await;
+
+    // Seed one risk model per org (superuser bypasses RLS for this setup).
+    let model_a = repo
+        .create_risk_model(&pool, org_a, user_a, model_req("Model A"))
+        .await
+        .expect("seed model A")
+        .id;
+    let model_b = repo
+        .create_risk_model(&pool, org_b, user_b, model_req("Model B"))
+        .await
+        .expect("seed model B")
+        .id;
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    let role = format!("ppt_rls_screen_{}", Uuid::new_v4().simple());
+    for stmt in [
+        format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
+        format!("GRANT SELECT, INSERT, UPDATE, DELETE ON ai_risk_scoring_models TO \"{role}\""),
+        // RLS policy helpers must be EXECUTE-able by the bound role; the
+        // not-deleted guard reads `organizations`.
+        format!(
+            "GRANT EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
+             get_current_org_not_deleted() TO \"{role}\""
+        ),
+        format!("GRANT SELECT ON organizations TO \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .expect("grant setup");
+    }
+
+    // ====================================================================
+    // (1) DENY-ALL reproduction: role bound, NO context set (the dev raw-pool
+    //     behavior). Own-org reads return nothing.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        // Explicitly clear any inherited context, then drop to the bound role.
+        sqlx::query("SELECT clear_request_context()")
+            .execute(&mut *conn)
+            .await
+            .expect("clear ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let found = repo
+            .get_risk_model(&mut *conn, org_a, model_a)
+            .await
+            .expect("get_risk_model (no ctx)");
+        assert!(
+            found.is_none(),
+            "PAP-74 regression: without RLS context, own-org risk model must be \
+             invisible (deny-all) — this is what the raw-pool repo did on dev"
+        );
+
+        let listed = repo
+            .list_risk_models(&mut *conn, org_a)
+            .await
+            .expect("list_risk_models (no ctx)");
+        assert!(
+            listed.is_empty(),
+            "PAP-74 regression: without RLS context, list returns deny-all empty"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (2) FIX + (3) cross-tenant: set context, drop to bound role, query repo.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        // (2) Own-org row IS now visible through the repo — the fix.
+        let found = repo
+            .get_risk_model(&mut *conn, org_a, model_a)
+            .await
+            .expect("get_risk_model (ctx)");
+        assert_eq!(
+            found.map(|m| m.id),
+            Some(model_a),
+            "PAP-74 fix: with RLS context set, the repo must return the own-org risk model"
+        );
+
+        let listed = repo
+            .list_risk_models(&mut *conn, org_a)
+            .await
+            .expect("list_risk_models (ctx)");
+        assert_eq!(
+            listed.iter().map(|m| m.id).collect::<Vec<_>>(),
+            vec![model_a],
+            "PAP-74 fix: list returns exactly the own-org model under context"
+        );
+
+        // (3) Org B's model stays invisible to an org-A caller.
+        let cross = repo
+            .get_risk_model(&mut *conn, org_a, model_b)
+            .await
+            .expect("get_risk_model cross");
+        assert!(
+            cross.is_none(),
+            "cross-tenant: org B's model must NOT be visible to an org-A caller"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (4) WRITE path: a create on a context-set connection succeeds and the
+    //     row is the caller's org. Without context the INSERT would fail the
+    //     policy WITH CHECK (the write-side of deny-all).
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let created = repo
+            .create_risk_model(&mut *conn, org_a, user_a, model_req("Created under RLS"))
+            .await
+            .expect("create_risk_model under context must succeed");
+        assert_eq!(created.organization_id, org_a);
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup the test role. ---
+    set_ctx(&pool, None, None, true).await;
+    for stmt in [
+        format!("REVOKE ALL ON ai_risk_scoring_models FROM \"{role}\""),
+        format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .ok();
+    }
+}

--- a/backend/servers/api-server/src/routes/enhanced_tenant_screening.rs
+++ b/backend/servers/api-server/src/routes/enhanced_tenant_screening.rs
@@ -1,5 +1,19 @@
 // Epic 135: Enhanced Tenant Screening with AI Risk Scoring
 // REST API routes for AI-powered tenant screening
+//
+// # RLS (PAP-67 / PAP-74)
+//
+// Migration `00179` put `FORCE ROW LEVEL SECURITY` on the screening tables, so
+// every query MUST run on a connection that has `app.current_org_id` set or it
+// collapses to deny-all. Each handler therefore acquires an [`RlsConnection`]
+// (which validates tenant membership and sets the org/user GUCs on a dedicated
+// connection) and passes `&mut **rls.conn()` to the repository. The authoritative
+// organization is `rls.tenant_id()` — the tenant the caller was validated
+// against — not a client-supplied `organization_id`, so the SQL org filter and
+// the RLS context can never disagree. Cross-tenant access is blocked by RLS: a
+// by-id read of another org's row returns no row (`404`), and a write targeting
+// another org fails the policy's `WITH CHECK`. `rls.release()` clears the context
+// before the connection returns to the pool (called on every Ok/Err path).
 
 use axum::{
     extract::{Path, Query, State},
@@ -11,7 +25,7 @@ use axum::{
 use serde::Deserialize;
 use uuid::Uuid;
 
-use api_core::extractors::AuthUser;
+use api_core::extractors::RlsConnection;
 use db::models::enhanced_tenant_screening::*;
 use db::repositories::enhanced_tenant_screening::ComponentScores;
 
@@ -68,32 +82,19 @@ pub fn router() -> Router<AppState> {
 }
 
 // =============================================================================
-// Helper Functions
-// =============================================================================
-
-fn get_org_id(auth: &AuthUser) -> Result<Uuid, (StatusCode, String)> {
-    auth.tenant_id.ok_or((
-        StatusCode::BAD_REQUEST,
-        "No organization context".to_string(),
-    ))
-}
-
-// =============================================================================
 // AI Risk Scoring Models
 // =============================================================================
 
 /// List all risk models for organization.
-async fn list_risk_models(State(s): State<AppState>, auth: AuthUser) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+async fn list_risk_models(State(s): State<AppState>, mut rls: RlsConnection) -> impl IntoResponse {
+    let org_id = rls.tenant_id();
+    let result = s
         .enhanced_tenant_screening_repo
-        .list_risk_models(org_id)
-        .await
-    {
+        .list_risk_models(&mut **rls.conn(), org_id)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(models) => Json(models).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
@@ -102,19 +103,18 @@ async fn list_risk_models(State(s): State<AppState>, auth: AuthUser) -> impl Int
 /// Create a new AI risk scoring model.
 async fn create_risk_model(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(req): Json<CreateAiRiskScoringModel>,
 ) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let result = s
         .enhanced_tenant_screening_repo
-        .create_risk_model(org_id, auth.user_id, req)
-        .await
-    {
+        .create_risk_model(&mut **rls.conn(), org_id, user_id, req)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(model) => (StatusCode::CREATED, Json(model)).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
@@ -123,19 +123,17 @@ async fn create_risk_model(
 /// Get a risk model by ID.
 async fn get_risk_model(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+    let org_id = rls.tenant_id();
+    let result = s
         .enhanced_tenant_screening_repo
-        .get_risk_model(org_id, id)
-        .await
-    {
+        .get_risk_model(&mut **rls.conn(), org_id, id)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(Some(model)) => Json(model).into_response(),
         Ok(None) => (StatusCode::NOT_FOUND, "Risk model not found").into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
@@ -145,15 +143,16 @@ async fn get_risk_model(
 /// Delete a risk model.
 async fn delete_risk_model(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> impl IntoResponse {
-    let _ = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
+    let result = s
+        .enhanced_tenant_screening_repo
+        .delete_risk_model(&mut **rls.conn(), id)
+        .await;
+    rls.release().await;
 
-    match s.enhanced_tenant_screening_repo.delete_risk_model(id).await {
+    match result {
         Ok(true) => StatusCode::NO_CONTENT.into_response(),
         Ok(false) => (StatusCode::NOT_FOUND, "Risk model not found").into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
@@ -163,19 +162,17 @@ async fn delete_risk_model(
 /// Activate a risk model.
 async fn activate_risk_model(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+    let org_id = rls.tenant_id();
+    let result = s
         .enhanced_tenant_screening_repo
-        .activate_risk_model(org_id, id)
-        .await
-    {
+        .activate_risk_model(rls.conn(), org_id, id)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(()) => StatusCode::OK.into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
@@ -186,17 +183,18 @@ async fn activate_risk_model(
 // =============================================================================
 
 /// List provider configs.
-async fn list_provider_configs(State(s): State<AppState>, auth: AuthUser) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+async fn list_provider_configs(
+    State(s): State<AppState>,
+    mut rls: RlsConnection,
+) -> impl IntoResponse {
+    let org_id = rls.tenant_id();
+    let result = s
         .enhanced_tenant_screening_repo
-        .list_provider_configs(org_id)
-        .await
-    {
+        .list_provider_configs(&mut **rls.conn(), org_id)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(configs) => Json(configs).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
@@ -205,19 +203,17 @@ async fn list_provider_configs(State(s): State<AppState>, auth: AuthUser) -> imp
 /// Create provider config.
 async fn create_provider_config(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(req): Json<CreateScreeningProviderConfig>,
 ) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+    let org_id = rls.tenant_id();
+    let result = s
         .enhanced_tenant_screening_repo
-        .create_provider_config(org_id, req)
-        .await
-    {
+        .create_provider_config(&mut **rls.conn(), org_id, req)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(config) => (StatusCode::CREATED, Json(config)).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
@@ -226,19 +222,17 @@ async fn create_provider_config(
 /// Get provider config.
 async fn get_provider_config(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+    let org_id = rls.tenant_id();
+    let result = s
         .enhanced_tenant_screening_repo
-        .get_provider_config(org_id, id)
-        .await
-    {
+        .get_provider_config(&mut **rls.conn(), org_id, id)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(Some(config)) => Json(config).into_response(),
         Ok(None) => (StatusCode::NOT_FOUND, "Provider config not found").into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
@@ -248,19 +242,16 @@ async fn get_provider_config(
 /// Delete provider config.
 async fn delete_provider_config(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> impl IntoResponse {
-    let _ = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+    let result = s
         .enhanced_tenant_screening_repo
-        .delete_provider_config(id)
-        .await
-    {
+        .delete_provider_config(&mut **rls.conn(), id)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(true) => StatusCode::NO_CONTENT.into_response(),
         Ok(false) => (StatusCode::NOT_FOUND, "Provider config not found").into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
@@ -276,20 +267,22 @@ struct UpdateProviderStatusRequest {
 /// Update provider status.
 async fn update_provider_status(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateProviderStatusRequest>,
 ) -> impl IntoResponse {
-    let _ = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+    let result = s
         .enhanced_tenant_screening_repo
-        .update_provider_status(id, req.status, req.error_message.as_deref())
-        .await
-    {
+        .update_provider_status(
+            &mut **rls.conn(),
+            id,
+            req.status,
+            req.error_message.as_deref(),
+        )
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(()) => StatusCode::OK.into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
@@ -308,19 +301,22 @@ struct ListResultsQuery {
 /// List AI results.
 async fn list_ai_results(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Query(q): Query<ListResultsQuery>,
 ) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+    let org_id = rls.tenant_id();
+    let result = s
         .enhanced_tenant_screening_repo
-        .list_ai_results(org_id, q.limit.unwrap_or(50), q.offset.unwrap_or(0))
-        .await
-    {
+        .list_ai_results(
+            &mut **rls.conn(),
+            org_id,
+            q.limit.unwrap_or(50),
+            q.offset.unwrap_or(0),
+        )
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(results) => Json(results).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
@@ -329,19 +325,17 @@ async fn list_ai_results(
 /// Get AI result for screening.
 async fn get_ai_result(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(screening_id): Path<Uuid>,
 ) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+    let org_id = rls.tenant_id();
+    let result = s
         .enhanced_tenant_screening_repo
-        .get_ai_result_by_screening(org_id, screening_id)
-        .await
-    {
+        .get_ai_result_by_screening(&mut **rls.conn(), org_id, screening_id)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(Some(result)) => Json(result).into_response(),
         Ok(None) => (StatusCode::NOT_FOUND, "AI result not found").into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
@@ -351,24 +345,22 @@ async fn get_ai_result(
 /// Get risk factors for screening.
 async fn get_risk_factors(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(screening_id): Path<Uuid>,
 ) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
+    let org_id = rls.tenant_id();
 
-    // First get the (org-scoped) AI result to get its ID
-    match s
+    // First get the (org-scoped) AI result to get its ID, then its factors.
+    let ai_result = s
         .enhanced_tenant_screening_repo
-        .get_ai_result_by_screening(org_id, screening_id)
-        .await
-    {
+        .get_ai_result_by_screening(&mut **rls.conn(), org_id, screening_id)
+        .await;
+
+    let response = match ai_result {
         Ok(Some(ai_result)) => {
             match s
                 .enhanced_tenant_screening_repo
-                .get_risk_factors(ai_result.id)
+                .get_risk_factors(&mut **rls.conn(), ai_result.id)
                 .await
             {
                 Ok(factors) => Json(factors).into_response(),
@@ -377,25 +369,25 @@ async fn get_risk_factors(
         }
         Ok(None) => (StatusCode::NOT_FOUND, "AI result not found").into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+    };
+    rls.release().await;
+    response
 }
 
 /// Get complete screening data.
 async fn get_complete_screening_data(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(screening_id): Path<Uuid>,
 ) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+    let org_id = rls.tenant_id();
+    let result = s
         .enhanced_tenant_screening_repo
-        .get_complete_screening_data(org_id, screening_id)
-        .await
-    {
+        .get_complete_screening_data(rls.conn(), org_id, screening_id)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(data) => Json(data).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
@@ -404,109 +396,110 @@ async fn get_complete_screening_data(
 /// Run AI scoring on a screening.
 async fn run_ai_scoring(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(req): Json<RunAiScoringRequest>,
 ) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
+    let org_id = rls.tenant_id();
+
+    // Get the active model or specified model.
+    let model_res = if let Some(model_id) = req.model_id {
+        s.enhanced_tenant_screening_repo
+            .get_risk_model(&mut **rls.conn(), org_id, model_id)
+            .await
+    } else {
+        s.enhanced_tenant_screening_repo
+            .get_active_risk_model(&mut **rls.conn(), org_id)
+            .await
     };
 
-    // Get the active model or specified model
-    let model = if let Some(model_id) = req.model_id {
-        match s
-            .enhanced_tenant_screening_repo
-            .get_risk_model(org_id, model_id)
-            .await
-        {
-            Ok(Some(m)) => m,
-            Ok(None) => {
-                return (StatusCode::NOT_FOUND, "Specified model not found").into_response()
+    let response = match model_res {
+        Ok(Some(model)) => {
+            // Get credit, background, and eviction results to compute component scores.
+            let credit = s
+                .enhanced_tenant_screening_repo
+                .get_credit_result_by_screening(&mut **rls.conn(), org_id, req.screening_id)
+                .await
+                .ok()
+                .flatten();
+            let background = s
+                .enhanced_tenant_screening_repo
+                .get_background_result_by_screening(&mut **rls.conn(), org_id, req.screening_id)
+                .await
+                .ok()
+                .flatten();
+            let eviction = s
+                .enhanced_tenant_screening_repo
+                .get_eviction_result_by_screening(&mut **rls.conn(), org_id, req.screening_id)
+                .await
+                .ok()
+                .flatten();
+
+            // Calculate component scores.
+            let component_scores = ComponentScores {
+                credit_history: credit.as_ref().and_then(|c| {
+                    c.credit_score.map(|score| {
+                        // Convert FICO score (300-850) to 0-100 scale
+                        ((score - 300) * 100 / 550).clamp(0, 100)
+                    })
+                }),
+                rental_history: None,   // Would need rental history integration
+                income_stability: None, // Would need income verification integration
+                employment_stability: None, // Would need employment verification integration
+                eviction_history: eviction.as_ref().map(|e| {
+                    if e.eviction_count.unwrap_or(0) == 0 {
+                        100
+                    } else {
+                        (100 - e.eviction_count.unwrap_or(0) * 25).clamp(0, 100)
+                    }
+                }),
+                criminal_background: background.as_ref().map(|b| {
+                    let felony_penalty = b.felony_count.unwrap_or(0) * 30;
+                    let misdemeanor_penalty = b.misdemeanor_count.unwrap_or(0) * 10;
+                    (100 - felony_penalty - misdemeanor_penalty).clamp(0, 100)
+                }),
+                identity_verification: background.as_ref().map(|b| {
+                    if b.identity_verified.unwrap_or(false) && b.ssn_verified.unwrap_or(false) {
+                        100
+                    } else if b.identity_verified.unwrap_or(false) {
+                        75
+                    } else {
+                        25
+                    }
+                }),
+                reference_quality: None, // Would need reference check integration
+            };
+
+            // Create AI result.
+            match s
+                .enhanced_tenant_screening_repo
+                .create_ai_result(
+                    &mut **rls.conn(),
+                    org_id,
+                    req.screening_id,
+                    &model,
+                    component_scores,
+                )
+                .await
+            {
+                Ok(result) => (StatusCode::CREATED, Json(result)).into_response(),
+                Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
             }
-            Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
         }
-    } else {
-        match s
-            .enhanced_tenant_screening_repo
-            .get_active_risk_model(org_id)
-            .await
-        {
-            Ok(Some(m)) => m,
-            Ok(None) => {
-                return (
+        Ok(None) => {
+            if req.model_id.is_some() {
+                (StatusCode::NOT_FOUND, "Specified model not found").into_response()
+            } else {
+                (
                     StatusCode::BAD_REQUEST,
                     "No active risk model configured for organization",
                 )
                     .into_response()
             }
-            Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
         }
-    };
-
-    // Get credit, background, and eviction results to compute component scores
-    let credit = s
-        .enhanced_tenant_screening_repo
-        .get_credit_result_by_screening(org_id, req.screening_id)
-        .await
-        .ok()
-        .flatten();
-    let background = s
-        .enhanced_tenant_screening_repo
-        .get_background_result_by_screening(org_id, req.screening_id)
-        .await
-        .ok()
-        .flatten();
-    let eviction = s
-        .enhanced_tenant_screening_repo
-        .get_eviction_result_by_screening(org_id, req.screening_id)
-        .await
-        .ok()
-        .flatten();
-
-    // Calculate component scores
-    let component_scores = ComponentScores {
-        credit_history: credit.as_ref().and_then(|c| {
-            c.credit_score.map(|score| {
-                // Convert FICO score (300-850) to 0-100 scale
-                ((score - 300) * 100 / 550).clamp(0, 100)
-            })
-        }),
-        rental_history: None,       // Would need rental history integration
-        income_stability: None,     // Would need income verification integration
-        employment_stability: None, // Would need employment verification integration
-        eviction_history: eviction.as_ref().map(|e| {
-            if e.eviction_count.unwrap_or(0) == 0 {
-                100
-            } else {
-                (100 - e.eviction_count.unwrap_or(0) * 25).clamp(0, 100)
-            }
-        }),
-        criminal_background: background.as_ref().map(|b| {
-            let felony_penalty = b.felony_count.unwrap_or(0) * 30;
-            let misdemeanor_penalty = b.misdemeanor_count.unwrap_or(0) * 10;
-            (100 - felony_penalty - misdemeanor_penalty).clamp(0, 100)
-        }),
-        identity_verification: background.as_ref().map(|b| {
-            if b.identity_verified.unwrap_or(false) && b.ssn_verified.unwrap_or(false) {
-                100
-            } else if b.identity_verified.unwrap_or(false) {
-                75
-            } else {
-                25
-            }
-        }),
-        reference_quality: None, // Would need reference check integration
-    };
-
-    // Create AI result
-    match s
-        .enhanced_tenant_screening_repo
-        .create_ai_result(org_id, req.screening_id, &model, component_scores)
-        .await
-    {
-        Ok(result) => (StatusCode::CREATED, Json(result)).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+    };
+    rls.release().await;
+    response
 }
 
 // =============================================================================
@@ -516,19 +509,17 @@ async fn run_ai_scoring(
 /// Get credit result.
 async fn get_credit_result(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(screening_id): Path<Uuid>,
 ) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+    let org_id = rls.tenant_id();
+    let result = s
         .enhanced_tenant_screening_repo
-        .get_credit_result_by_screening(org_id, screening_id)
-        .await
-    {
+        .get_credit_result_by_screening(&mut **rls.conn(), org_id, screening_id)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(Some(result)) => Json(result).into_response(),
         Ok(None) => (StatusCode::NOT_FOUND, "Credit result not found").into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
@@ -538,19 +529,17 @@ async fn get_credit_result(
 /// Create credit result.
 async fn create_credit_result(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(req): Json<CreateScreeningCreditResult>,
 ) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+    let org_id = rls.tenant_id();
+    let result = s
         .enhanced_tenant_screening_repo
-        .create_credit_result(org_id, req)
-        .await
-    {
+        .create_credit_result(&mut **rls.conn(), org_id, req)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(result) => (StatusCode::CREATED, Json(result)).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
@@ -563,19 +552,17 @@ async fn create_credit_result(
 /// Get background result.
 async fn get_background_result(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(screening_id): Path<Uuid>,
 ) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+    let org_id = rls.tenant_id();
+    let result = s
         .enhanced_tenant_screening_repo
-        .get_background_result_by_screening(org_id, screening_id)
-        .await
-    {
+        .get_background_result_by_screening(&mut **rls.conn(), org_id, screening_id)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(Some(result)) => Json(result).into_response(),
         Ok(None) => (StatusCode::NOT_FOUND, "Background result not found").into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
@@ -585,19 +572,17 @@ async fn get_background_result(
 /// Create background result.
 async fn create_background_result(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(req): Json<CreateScreeningBackgroundResult>,
 ) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+    let org_id = rls.tenant_id();
+    let result = s
         .enhanced_tenant_screening_repo
-        .create_background_result(org_id, req)
-        .await
-    {
+        .create_background_result(&mut **rls.conn(), org_id, req)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(result) => (StatusCode::CREATED, Json(result)).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
@@ -610,19 +595,17 @@ async fn create_background_result(
 /// Get eviction result.
 async fn get_eviction_result(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(screening_id): Path<Uuid>,
 ) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+    let org_id = rls.tenant_id();
+    let result = s
         .enhanced_tenant_screening_repo
-        .get_eviction_result_by_screening(org_id, screening_id)
-        .await
-    {
+        .get_eviction_result_by_screening(&mut **rls.conn(), org_id, screening_id)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(Some(result)) => Json(result).into_response(),
         Ok(None) => (StatusCode::NOT_FOUND, "Eviction result not found").into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
@@ -632,19 +615,17 @@ async fn get_eviction_result(
 /// Create eviction result.
 async fn create_eviction_result(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(req): Json<CreateScreeningEvictionResult>,
 ) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+    let org_id = rls.tenant_id();
+    let result = s
         .enhanced_tenant_screening_repo
-        .create_eviction_result(org_id, req)
-        .await
-    {
+        .create_eviction_result(&mut **rls.conn(), org_id, req)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(result) => (StatusCode::CREATED, Json(result)).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
@@ -655,17 +636,14 @@ async fn create_eviction_result(
 // =============================================================================
 
 /// Get pending queue items.
-async fn get_pending_queue(State(s): State<AppState>, auth: AuthUser) -> impl IntoResponse {
-    let _ = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+async fn get_pending_queue(State(s): State<AppState>, mut rls: RlsConnection) -> impl IntoResponse {
+    let result = s
         .enhanced_tenant_screening_repo
-        .get_pending_queue_items(50)
-        .await
-    {
+        .get_pending_queue_items(&mut **rls.conn(), 50)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(items) => Json(items).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
@@ -674,19 +652,17 @@ async fn get_pending_queue(State(s): State<AppState>, auth: AuthUser) -> impl In
 /// Create queue item.
 async fn create_queue_item(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(req): Json<CreateScreeningQueueItem>,
 ) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+    let org_id = rls.tenant_id();
+    let result = s
         .enhanced_tenant_screening_repo
-        .create_queue_item(org_id, req)
-        .await
-    {
+        .create_queue_item(&mut **rls.conn(), org_id, req)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(item) => (StatusCode::CREATED, Json(item)).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
@@ -701,20 +677,17 @@ struct UpdateQueueStatusRequest {
 /// Update queue item status.
 async fn update_queue_status(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateQueueStatusRequest>,
 ) -> impl IntoResponse {
-    let _ = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+    let result = s
         .enhanced_tenant_screening_repo
-        .update_queue_item_status(id, &req.status, req.error.as_deref())
-        .await
-    {
+        .update_queue_item_status(&mut **rls.conn(), id, &req.status, req.error.as_deref())
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(()) => StatusCode::OK.into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
@@ -727,19 +700,17 @@ async fn update_queue_status(
 /// Get reports for screening.
 async fn get_reports(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(screening_id): Path<Uuid>,
 ) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+    let org_id = rls.tenant_id();
+    let result = s
         .enhanced_tenant_screening_repo
-        .get_reports_by_screening(org_id, screening_id)
-        .await
-    {
+        .get_reports_by_screening(&mut **rls.conn(), org_id, screening_id)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(reports) => Json(reports).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
@@ -748,19 +719,18 @@ async fn get_reports(
 /// Create report.
 async fn create_report(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(req): Json<CreateScreeningReport>,
 ) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let result = s
         .enhanced_tenant_screening_repo
-        .create_report(org_id, auth.user_id, req)
-        .await
-    {
+        .create_report(&mut **rls.conn(), org_id, user_id, req)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(report) => (StatusCode::CREATED, Json(report)).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
@@ -771,34 +741,33 @@ async fn create_report(
 // =============================================================================
 
 /// Get screening statistics.
-async fn get_statistics(State(s): State<AppState>, auth: AuthUser) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+async fn get_statistics(State(s): State<AppState>, mut rls: RlsConnection) -> impl IntoResponse {
+    let org_id = rls.tenant_id();
+    let result = s
         .enhanced_tenant_screening_repo
-        .get_statistics(org_id)
-        .await
-    {
+        .get_statistics(&mut **rls.conn(), org_id)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(stats) => Json(stats).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }
 
 /// Get risk distribution.
-async fn get_risk_distribution(State(s): State<AppState>, auth: AuthUser) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+async fn get_risk_distribution(
+    State(s): State<AppState>,
+    mut rls: RlsConnection,
+) -> impl IntoResponse {
+    let org_id = rls.tenant_id();
+    let result = s
         .enhanced_tenant_screening_repo
-        .get_risk_distribution(org_id)
-        .await
-    {
+        .get_risk_distribution(&mut **rls.conn(), org_id)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(dist) => Json(dist).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }

--- a/backend/servers/api-server/tests/enhanced_screening_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/enhanced_screening_cross_org_idor_tests.rs
@@ -195,13 +195,13 @@ async fn repo_risk_model_is_scoped_to_owning_org(pool: PgPool) {
 
     let repo = EnhancedTenantScreeningRepository::new(pool.clone());
     let model_a = repo
-        .create_risk_model(org_a, user_a, sample_model("Model A"))
+        .create_risk_model(&pool, org_a, user_a, sample_model("Model A"))
         .await
         .expect("create model A");
 
     // The owning org reads its model.
     let own = repo
-        .get_risk_model(org_a, model_a.id)
+        .get_risk_model(&pool, org_a, model_a.id)
         .await
         .expect("get model with right org");
     assert!(own.is_some(), "org A must read its own risk model by id");
@@ -209,7 +209,7 @@ async fn repo_risk_model_is_scoped_to_owning_org(pool: PgPool) {
 
     // A foreign org gets nothing (closed IDOR).
     let cross = repo
-        .get_risk_model(org_b, model_a.id)
+        .get_risk_model(&pool, org_b, model_a.id)
         .await
         .expect("get model with wrong org");
     assert!(
@@ -229,19 +229,19 @@ async fn repo_provider_config_is_scoped_to_owning_org(pool: PgPool) {
 
     let repo = EnhancedTenantScreeningRepository::new(pool.clone());
     let config_a = repo
-        .create_provider_config(org_a, sample_provider("Provider A"))
+        .create_provider_config(&pool, org_a, sample_provider("Provider A"))
         .await
         .expect("create provider A");
 
     let own = repo
-        .get_provider_config(org_a, config_a.id)
+        .get_provider_config(&pool, org_a, config_a.id)
         .await
         .expect("get config with right org");
     assert!(own.is_some(), "org A must read its own provider config");
     assert_eq!(own.unwrap().id, config_a.id);
 
     let cross = repo
-        .get_provider_config(org_b, config_a.id)
+        .get_provider_config(&pool, org_b, config_a.id)
         .await
         .expect("get config with wrong org");
     assert!(
@@ -262,7 +262,7 @@ async fn repo_ai_result_is_scoped_to_owning_org(pool: PgPool) {
     let user_a = seed_user(&pool, "ai-a@screening-idor.test").await;
     let repo = EnhancedTenantScreeningRepository::new(pool.clone());
     let model_a = repo
-        .create_risk_model(org_a, user_a, sample_model("AI Model A"))
+        .create_risk_model(&pool, org_a, user_a, sample_model("AI Model A"))
         .await
         .expect("create model A");
     let screening_a = seed_screening(&pool, org_a, "ai-a").await;
@@ -270,7 +270,7 @@ async fn repo_ai_result_is_scoped_to_owning_org(pool: PgPool) {
 
     // The owning org reads the AI result for its screening.
     let own = repo
-        .get_ai_result_by_screening(org_a, screening_a)
+        .get_ai_result_by_screening(&pool, org_a, screening_a)
         .await
         .expect("get ai result with right org");
     assert!(own.is_some(), "org A must read its own screening AI result");
@@ -278,7 +278,7 @@ async fn repo_ai_result_is_scoped_to_owning_org(pool: PgPool) {
 
     // A foreign org gets nothing — the risk score / recommendation never leaks.
     let cross = repo
-        .get_ai_result_by_screening(org_b, screening_a)
+        .get_ai_result_by_screening(&pool, org_b, screening_a)
         .await
         .expect("get ai result with wrong org");
     assert!(
@@ -286,9 +286,12 @@ async fn repo_ai_result_is_scoped_to_owning_org(pool: PgPool) {
         "org B must not read org A's screening AI result"
     );
 
+    // The complete-data aggregate (multi-statement) takes a connection.
+    let mut conn = pool.acquire().await.expect("acquire conn");
+
     // The complete-data aggregate is likewise closed for the foreign org.
     let cross_complete = repo
-        .get_complete_screening_data(org_b, screening_a)
+        .get_complete_screening_data(&mut *conn, org_b, screening_a)
         .await
         .expect("complete data with wrong org");
     assert!(
@@ -298,7 +301,7 @@ async fn repo_ai_result_is_scoped_to_owning_org(pool: PgPool) {
 
     // ...and open for the owner.
     let own_complete = repo
-        .get_complete_screening_data(org_a, screening_a)
+        .get_complete_screening_data(&mut *conn, org_a, screening_a)
         .await
         .expect("complete data with right org");
     assert!(


### PR DESCRIPTION
## What

`EnhancedTenantScreeningRepository` held a raw `PgPool` and ran every query via `&self.pool` without ever calling `set_request_context`. Under migration **00179**'s `FORCE ROW LEVEL SECURITY`, the api-server's owner connection is no longer exempt, so `get_current_org_id()` returns NULL and the screening policies collapse to **deny-all**: own-org reads return empty, writes fail on `dev`.

This is the `enhanced_tenant_screening` slice of the PAP-67 raw-pool RLS sweep. Tables: `ai_risk_scoring_models`, `screening_*` (ai/background/credit/eviction/provider_configs/reports/...).

## Fix (mirrors the proven PAP-67 `work_order` / merged `budget.rs` pattern)

- **Repo** (`crates/db/.../enhanced_tenant_screening.rs`): drop the `pool` field — the struct is now stateless. Single-statement methods take a generic `executor: E: Executor<Postgres>`; the two multi-statement methods (`activate_risk_model`, `get_complete_screening_data`) take `conn: &mut PgConnection` and reborrow per call. `new(_pool)` keeps the `AppState` construction site working but stores nothing, so the repo **cannot** issue an un-scoped (deny-all under FORCE) query.
- **Routes**: each handler takes `mut rls: RlsConnection`, passes the context-set connection to the repo, and calls `rls.release().await` on every Ok/Err path. The authoritative org is `rls.tenant_id()` (the validated tenant), so the SQL org filter and the RLS context can never disagree. Cross-tenant by-id reads now 404 via RLS; the old `get_org_id` early-returns are gone.
- **Tests**: new repo-level behavioral RLS regression test (`crates/db/tests/enhanced_tenant_screening_rls_repo_tests.rs`) on a `NOSUPERUSER NOBYPASSRLS` role (so FORCE binds) proving deny-all without context, own-org visibility with context, cross-tenant invisibility, and the write path. The existing `enhanced_screening_cross_org_idor_tests.rs` is updated to the new executor signatures.

## Verification

| Gate | Result |
|------|--------|
| `cargo check -p db -p api-server --tests` | ✅ green |
| `cargo fmt --all -- --check` | ✅ clean |
| `cargo clippy --workspace -- -D warnings` (exact CI cmd) | ✅ clean |
| new `#[sqlx::test]` DB execution | runs in CI `rls-smoke` (compiles locally) |

Parent: **PAP-67**. Detection guard: **PAP-68**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)