### PR TITLE
fix(api-server): route reserve_funds repo through RLS-context connection (PAP-79)

### DIFF
--- a/backend/crates/db/src/repositories/reserve_funds.rs
+++ b/backend/crates/db/src/repositories/reserve_funds.rs
@@ -1,7 +1,34 @@
 //! Reserve Fund Management repository for Epic 141.
+//!
+//! # RLS Integration (PAP-67 / PAP-79)
+//!
+//! Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on the reserve-fund cluster: `reserve_funds`,
+//! `fund_contribution_schedules`, `fund_transactions`, `fund_investment_policies`,
+//! `fund_projections`, `fund_projection_items`, `fund_components`, and
+//! `fund_alerts`. Under `FORCE` the api-server's table-owner connection is no
+//! longer exempt, so a query issued on a connection without `app.current_org_id`
+//! set collapses to deny-all (own-org reads return empty, writes fail the policy
+//! `WITH CHECK`).
+//!
+//! This repository therefore holds **no pool**. Every method takes an executor
+//! whose connection already has RLS context set — in handlers this comes from
+//! the `RlsConnection` extractor via `&mut **rls.conn()`:
+//!
+//! * single-statement methods take a generic `executor: E`;
+//! * multi-statement methods that compose helpers take `conn: &mut PgConnection`
+//!   and reborrow `&mut *conn` per call.
+//!
+//! Because the repo cannot reach a raw pool, there is no path that bypasses RLS.
+//! This mirrors the `work_order.rs` / `budget.rs` precedent.
+//!
+//! The explicit `organization_id = $n` predicates are retained as
+//! defense-in-depth: the authoritative org is the caller's `rls.tenant_id()`,
+//! so the SQL filter and the RLS context can never disagree, and cross-tenant
+//! by-id reads return no row (→ 404) under both layers.
 
 use rust_decimal::Decimal;
-use sqlx::PgPool;
+use sqlx::{Executor, PgConnection, PgPool, Postgres};
 use uuid::Uuid;
 
 use crate::models::reserve_funds::{
@@ -14,15 +41,21 @@ use crate::models::reserve_funds::{
 };
 
 /// Repository for reserve fund operations.
+///
+/// Stateless: every method receives an RLS-context-bearing executor. The repo
+/// holds no pool so it cannot issue an un-scoped (deny-all under `FORCE`) query.
 #[derive(Clone)]
-pub struct ReserveFundRepository {
-    pool: PgPool,
-}
+pub struct ReserveFundRepository;
 
 impl ReserveFundRepository {
     /// Create a new repository instance.
-    pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+    ///
+    /// The pool argument is retained for construction-site compatibility with
+    /// the other repositories on `AppState`; this repo deliberately does not
+    /// store it (see module docs — all queries run on a context-set connection
+    /// supplied by the handler's `RlsConnection`).
+    pub fn new(_pool: PgPool) -> Self {
+        Self
     }
 
     // ========================================================================
@@ -30,12 +63,16 @@ impl ReserveFundRepository {
     // ========================================================================
 
     /// Create a new reserve fund.
-    pub async fn create_fund(
+    pub async fn create_fund<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         req: CreateReserveFund,
         created_by: Uuid,
-    ) -> Result<ReserveFund, sqlx::Error> {
+    ) -> Result<ReserveFund, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, ReserveFund>(
             r#"
             INSERT INTO reserve_funds (
@@ -55,7 +92,7 @@ impl ReserveFundRepository {
         .bind(req.minimum_balance)
         .bind(req.currency.unwrap_or_else(|| "EUR".to_string()))
         .bind(created_by)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
@@ -64,30 +101,43 @@ impl ReserveFundRepository {
     /// Returns `None` if the fund does not exist **or** belongs to a different
     /// organization, so callers cannot distinguish "not found" from "not yours"
     /// — the handler maps both to a 404 and cross-tenant reads (IDOR) are
-    /// impossible (see #810).
-    pub async fn get_fund(
+    /// impossible (see #810). Under FORCE-RLS the connection's org context is a
+    /// second, database-enforced guard on top of the explicit predicate.
+    pub async fn get_fund<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         fund_id: Uuid,
-    ) -> Result<Option<ReserveFund>, sqlx::Error> {
+    ) -> Result<Option<ReserveFund>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, ReserveFund>(
             "SELECT * FROM reserve_funds WHERE id = $1 AND organization_id = $2",
         )
         .bind(fund_id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Verify a fund belongs to `org_id`, returning [`sqlx::Error::RowNotFound`]
     /// otherwise so child-resource operations on the fund stay tenant-scoped.
-    async fn ensure_fund_in_org(&self, org_id: Uuid, fund_id: Uuid) -> Result<(), sqlx::Error> {
+    async fn ensure_fund_in_org<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+        fund_id: Uuid,
+    ) -> Result<(), sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let exists: Option<Uuid> = sqlx::query_scalar(
             "SELECT id FROM reserve_funds WHERE id = $1 AND organization_id = $2",
         )
         .bind(fund_id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await?;
 
         if exists.is_some() {
@@ -98,13 +148,17 @@ impl ReserveFundRepository {
     }
 
     /// List all funds for an organization.
-    pub async fn list_funds(
+    pub async fn list_funds<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         fund_type: Option<FundType>,
         building_id: Option<Uuid>,
         active_only: bool,
-    ) -> Result<Vec<ReserveFund>, sqlx::Error> {
+    ) -> Result<Vec<ReserveFund>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let mut query = String::from("SELECT * FROM reserve_funds WHERE organization_id = $1");
         let mut param_count = 1;
 
@@ -134,7 +188,7 @@ impl ReserveFundRepository {
             q = q.bind(bid);
         }
 
-        q.fetch_all(&self.pool).await
+        q.fetch_all(executor).await
     }
 
     /// Update a reserve fund, scoped to the caller's organization.
@@ -142,12 +196,16 @@ impl ReserveFundRepository {
     /// The `organization_id = $8` predicate means an update targeting another
     /// org's fund matches zero rows and surfaces as
     /// [`sqlx::Error::RowNotFound`] (→ 404), not a silent cross-tenant write.
-    pub async fn update_fund(
+    pub async fn update_fund<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         fund_id: Uuid,
         req: UpdateReserveFund,
-    ) -> Result<ReserveFund, sqlx::Error> {
+    ) -> Result<ReserveFund, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, ReserveFund>(
             r#"
             UPDATE reserve_funds SET
@@ -170,15 +228,18 @@ impl ReserveFundRepository {
         .bind(req.minimum_balance)
         .bind(req.is_active)
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Delete a reserve fund.
-    pub async fn delete_fund(&self, fund_id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete_fund<'e, E>(&self, executor: E, fund_id: Uuid) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM reserve_funds WHERE id = $1")
             .bind(fund_id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
@@ -188,13 +249,17 @@ impl ReserveFundRepository {
     // ========================================================================
 
     /// Create a contribution schedule for a fund the caller owns.
+    ///
+    /// Multi-statement (ownership check + insert), so it takes a connection and
+    /// reborrows it for each query.
     pub async fn create_contribution_schedule(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         fund_id: Uuid,
         req: CreateContributionSchedule,
     ) -> Result<FundContributionSchedule, sqlx::Error> {
-        self.ensure_fund_in_org(org_id, fund_id).await?;
+        self.ensure_fund_in_org(&mut *conn, org_id, fund_id).await?;
         sqlx::query_as::<_, FundContributionSchedule>(
             r#"
             INSERT INTO fund_contribution_schedules (
@@ -213,18 +278,19 @@ impl ReserveFundRepository {
         .bind(req.start_date)
         .bind(req.end_date)
         .bind(req.auto_collect.unwrap_or(false))
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
     }
 
     /// List contribution schedules for a fund the caller owns.
     pub async fn list_contribution_schedules(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         fund_id: Uuid,
         active_only: bool,
     ) -> Result<Vec<FundContributionSchedule>, sqlx::Error> {
-        self.ensure_fund_in_org(org_id, fund_id).await?;
+        self.ensure_fund_in_org(&mut *conn, org_id, fund_id).await?;
         let query = if active_only {
             "SELECT * FROM fund_contribution_schedules WHERE fund_id = $1 AND is_active = true ORDER BY next_due_date"
         } else {
@@ -233,7 +299,7 @@ impl ReserveFundRepository {
 
         sqlx::query_as::<_, FundContributionSchedule>(query)
             .bind(fund_id)
-            .fetch_all(&self.pool)
+            .fetch_all(&mut *conn)
             .await
     }
 
@@ -242,12 +308,16 @@ impl ReserveFundRepository {
     /// The `fund_id IN (… organization_id = $9)` subquery ensures a schedule
     /// owned by another org matches zero rows (→ 404), closing the #810 IDOR
     /// for the child resource.
-    pub async fn update_contribution_schedule(
+    pub async fn update_contribution_schedule<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         schedule_id: Uuid,
         req: UpdateContributionSchedule,
-    ) -> Result<FundContributionSchedule, sqlx::Error> {
+    ) -> Result<FundContributionSchedule, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, FundContributionSchedule>(
             r#"
             UPDATE fund_contribution_schedules SET
@@ -275,18 +345,22 @@ impl ReserveFundRepository {
         .bind(req.is_active)
         .bind(req.auto_collect)
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Delete a contribution schedule.
-    pub async fn delete_contribution_schedule(
+    pub async fn delete_contribution_schedule<'e, E>(
         &self,
+        executor: E,
         schedule_id: Uuid,
-    ) -> Result<bool, sqlx::Error> {
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM fund_contribution_schedules WHERE id = $1")
             .bind(schedule_id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
@@ -296,8 +370,12 @@ impl ReserveFundRepository {
     // ========================================================================
 
     /// Record a fund transaction against a fund the caller owns.
+    ///
+    /// Multi-statement (balance read + insert + balance update), so it takes a
+    /// connection and reborrows it for each query.
     pub async fn record_transaction(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         fund_id: Uuid,
         req: RecordFundTransaction,
@@ -305,9 +383,9 @@ impl ReserveFundRepository {
     ) -> Result<FundTransaction, sqlx::Error> {
         // Get current balance — org-scoped so a foreign fund yields RowNotFound.
         let fund = self
-            .get_fund(org_id, fund_id)
+            .get_fund(&mut *conn, org_id, fund_id)
             .await?
-            .ok_or_else(|| sqlx::Error::RowNotFound)?;
+            .ok_or(sqlx::Error::RowNotFound)?;
 
         // Calculate new balance
         let amount = req.amount;
@@ -351,7 +429,7 @@ impl ReserveFundRepository {
         .bind(req.transfer_to_fund_id)
         .bind(req.requires_approval.unwrap_or(false))
         .bind(created_by)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         // Update fund balance
@@ -360,7 +438,7 @@ impl ReserveFundRepository {
         )
         .bind(fund_id)
         .bind(new_balance)
-        .execute(&self.pool)
+        .execute(&mut *conn)
         .await?;
 
         Ok(transaction)
@@ -371,11 +449,15 @@ impl ReserveFundRepository {
     /// The `fund_id IN (… organization_id = $7)` predicate confines results to
     /// funds owned by the caller, so passing another org's `fund_id` returns an
     /// empty list rather than leaking transactions (#810).
-    pub async fn list_transactions(
+    pub async fn list_transactions<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: TransactionQuery,
-    ) -> Result<Vec<FundTransaction>, sqlx::Error> {
+    ) -> Result<Vec<FundTransaction>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(100);
         let offset = query.offset.unwrap_or(0);
 
@@ -400,7 +482,7 @@ impl ReserveFundRepository {
         .bind(limit)
         .bind(offset)
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -411,6 +493,7 @@ impl ReserveFundRepository {
     /// [`sqlx::Error::RowNotFound`] before any balance is mutated (#810).
     pub async fn transfer_funds(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         req: FundTransferRequest,
         created_by: Uuid,
@@ -418,6 +501,7 @@ impl ReserveFundRepository {
         // Record withdrawal from source
         let withdrawal = self
             .record_transaction(
+                &mut *conn,
                 org_id,
                 req.from_fund_id,
                 RecordFundTransaction {
@@ -436,6 +520,7 @@ impl ReserveFundRepository {
         // Record deposit to destination
         let deposit = self
             .record_transaction(
+                &mut *conn,
                 org_id,
                 req.to_fund_id,
                 RecordFundTransaction {
@@ -461,11 +546,12 @@ impl ReserveFundRepository {
     /// Create an investment policy for a fund the caller owns.
     pub async fn create_investment_policy(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         fund_id: Uuid,
         req: CreateInvestmentPolicy,
     ) -> Result<FundInvestmentPolicy, sqlx::Error> {
-        self.ensure_fund_in_org(org_id, fund_id).await?;
+        self.ensure_fund_in_org(&mut *conn, org_id, fund_id).await?;
         sqlx::query_as::<_, FundInvestmentPolicy>(
             r#"
             INSERT INTO fund_investment_policies (
@@ -489,17 +575,18 @@ impl ReserveFundRepository {
         .bind(req.max_single_investment)
         .bind(req.min_liquidity_pct)
         .bind(req.effective_date)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
     }
 
     /// Get active investment policy for a fund the caller owns.
     pub async fn get_active_investment_policy(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         fund_id: Uuid,
     ) -> Result<Option<FundInvestmentPolicy>, sqlx::Error> {
-        self.ensure_fund_in_org(org_id, fund_id).await?;
+        self.ensure_fund_in_org(&mut *conn, org_id, fund_id).await?;
         sqlx::query_as::<_, FundInvestmentPolicy>(
             r#"
             SELECT * FROM fund_investment_policies
@@ -511,22 +598,23 @@ impl ReserveFundRepository {
             "#,
         )
         .bind(fund_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *conn)
         .await
     }
 
     /// List investment policies for a fund the caller owns.
     pub async fn list_investment_policies(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         fund_id: Uuid,
     ) -> Result<Vec<FundInvestmentPolicy>, sqlx::Error> {
-        self.ensure_fund_in_org(org_id, fund_id).await?;
+        self.ensure_fund_in_org(&mut *conn, org_id, fund_id).await?;
         sqlx::query_as::<_, FundInvestmentPolicy>(
             "SELECT * FROM fund_investment_policies WHERE fund_id = $1 ORDER BY effective_date DESC",
         )
         .bind(fund_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await
     }
 
@@ -537,20 +625,21 @@ impl ReserveFundRepository {
     /// Create a fund projection for a fund the caller owns.
     pub async fn create_projection(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         fund_id: Uuid,
         req: CreateFundProjection,
     ) -> Result<FundProjection, sqlx::Error> {
         // Get current balance for starting balance — org-scoped (#810).
         let fund = self
-            .get_fund(org_id, fund_id)
+            .get_fund(&mut *conn, org_id, fund_id)
             .await?
-            .ok_or_else(|| sqlx::Error::RowNotFound)?;
+            .ok_or(sqlx::Error::RowNotFound)?;
 
         // Mark existing projections as not current
         sqlx::query("UPDATE fund_projections SET is_current = false WHERE fund_id = $1")
             .bind(fund_id)
-            .execute(&self.pool)
+            .execute(&mut *conn)
             .await?;
 
         sqlx::query_as::<_, FundProjection>(
@@ -573,33 +662,36 @@ impl ReserveFundRepository {
         .bind(fund.current_balance)
         .bind(req.recommended_annual_contribution)
         .bind(&req.prepared_by)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
     }
 
     /// Get current projection for a fund the caller owns.
     pub async fn get_current_projection(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         fund_id: Uuid,
     ) -> Result<Option<FundProjection>, sqlx::Error> {
-        self.ensure_fund_in_org(org_id, fund_id).await?;
+        self.ensure_fund_in_org(&mut *conn, org_id, fund_id).await?;
         sqlx::query_as::<_, FundProjection>(
             "SELECT * FROM fund_projections WHERE fund_id = $1 AND is_current = true LIMIT 1",
         )
         .bind(fund_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *conn)
         .await
     }
 
     /// Add projection line items to a projection the caller owns.
     pub async fn add_projection_items(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         projection_id: Uuid,
         items: Vec<CreateProjectionItem>,
     ) -> Result<Vec<FundProjectionItem>, sqlx::Error> {
-        self.ensure_projection_in_org(org_id, projection_id).await?;
+        self.ensure_projection_in_org(&mut *conn, org_id, projection_id)
+            .await?;
         let mut results = Vec::new();
 
         for item in items {
@@ -623,7 +715,7 @@ impl ReserveFundRepository {
             .bind(item.beginning_balance)
             .bind(item.ending_balance)
             .bind(&item.expenditure_details)
-            .fetch_one(&self.pool)
+            .fetch_one(&mut *conn)
             .await?;
 
             results.push(result);
@@ -635,25 +727,31 @@ impl ReserveFundRepository {
     /// Get projection items for a projection the caller owns.
     pub async fn get_projection_items(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         projection_id: Uuid,
     ) -> Result<Vec<FundProjectionItem>, sqlx::Error> {
-        self.ensure_projection_in_org(org_id, projection_id).await?;
+        self.ensure_projection_in_org(&mut *conn, org_id, projection_id)
+            .await?;
         sqlx::query_as::<_, FundProjectionItem>(
             "SELECT * FROM fund_projection_items WHERE projection_id = $1 ORDER BY projection_year",
         )
         .bind(projection_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await
     }
 
     /// Verify a projection's parent fund belongs to `org_id`, returning
     /// [`sqlx::Error::RowNotFound`] otherwise (#810).
-    async fn ensure_projection_in_org(
+    async fn ensure_projection_in_org<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         projection_id: Uuid,
-    ) -> Result<(), sqlx::Error> {
+    ) -> Result<(), sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let exists: Option<Uuid> = sqlx::query_scalar(
             r#"
             SELECT fp.id
@@ -664,7 +762,7 @@ impl ReserveFundRepository {
         )
         .bind(projection_id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await?;
 
         if exists.is_some() {
@@ -681,11 +779,12 @@ impl ReserveFundRepository {
     /// Create a fund component for a fund the caller owns.
     pub async fn create_component(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         fund_id: Uuid,
         req: CreateFundComponent,
     ) -> Result<FundComponent, sqlx::Error> {
-        self.ensure_fund_in_org(org_id, fund_id).await?;
+        self.ensure_fund_in_org(&mut *conn, org_id, fund_id).await?;
         sqlx::query_as::<_, FundComponent>(
             r#"
             INSERT INTO fund_components (
@@ -708,31 +807,36 @@ impl ReserveFundRepository {
         .bind(req.condition_rating)
         .bind(req.last_inspection_date)
         .bind(req.next_replacement_date)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
     }
 
     /// List components for a fund the caller owns.
     pub async fn list_components(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         fund_id: Uuid,
     ) -> Result<Vec<FundComponent>, sqlx::Error> {
-        self.ensure_fund_in_org(org_id, fund_id).await?;
-        self.list_components_unscoped(fund_id).await
+        self.ensure_fund_in_org(&mut *conn, org_id, fund_id).await?;
+        self.list_components_unscoped(&mut *conn, fund_id).await
     }
 
     /// List components without an organization check. Internal helper for
     /// methods that have already verified fund ownership.
-    async fn list_components_unscoped(
+    async fn list_components_unscoped<'e, E>(
         &self,
+        executor: E,
         fund_id: Uuid,
-    ) -> Result<Vec<FundComponent>, sqlx::Error> {
+    ) -> Result<Vec<FundComponent>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, FundComponent>(
             "SELECT * FROM fund_components WHERE fund_id = $1 ORDER BY next_replacement_date NULLS LAST",
         )
         .bind(fund_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -740,12 +844,16 @@ impl ReserveFundRepository {
     ///
     /// The `fund_id IN (… organization_id = $11)` subquery makes an update
     /// against another org's component match zero rows (→ 404) (#810).
-    pub async fn update_component(
+    pub async fn update_component<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         component_id: Uuid,
         req: UpdateFundComponent,
-    ) -> Result<FundComponent, sqlx::Error> {
+    ) -> Result<FundComponent, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, FundComponent>(
             r#"
             UPDATE fund_components SET
@@ -777,15 +885,22 @@ impl ReserveFundRepository {
         .bind(req.last_inspection_date)
         .bind(req.next_replacement_date)
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Delete a component.
-    pub async fn delete_component(&self, component_id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete_component<'e, E>(
+        &self,
+        executor: E,
+        component_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM fund_components WHERE id = $1")
             .bind(component_id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
@@ -796,8 +911,9 @@ impl ReserveFundRepository {
 
     /// Create a fund alert.
     #[allow(clippy::too_many_arguments)]
-    pub async fn create_alert(
+    pub async fn create_alert<'e, E>(
         &self,
+        executor: E,
         fund_id: Uuid,
         alert_type: &str,
         severity: &str,
@@ -805,7 +921,10 @@ impl ReserveFundRepository {
         message: &str,
         threshold_value: Option<Decimal>,
         current_value: Option<Decimal>,
-    ) -> Result<FundAlert, sqlx::Error> {
+    ) -> Result<FundAlert, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, FundAlert>(
             r#"
             INSERT INTO fund_alerts (
@@ -823,12 +942,19 @@ impl ReserveFundRepository {
         .bind(message)
         .bind(threshold_value)
         .bind(current_value)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// List active alerts for an organization.
-    pub async fn list_active_alerts(&self, org_id: Uuid) -> Result<Vec<FundAlert>, sqlx::Error> {
+    pub async fn list_active_alerts<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+    ) -> Result<Vec<FundAlert>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, FundAlert>(
             r#"
             SELECT fa.* FROM fund_alerts fa
@@ -838,7 +964,7 @@ impl ReserveFundRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -846,12 +972,16 @@ impl ReserveFundRepository {
     ///
     /// The `fund_id IN (… organization_id = $3)` subquery confines the update
     /// to alerts on funds the caller owns (#810).
-    pub async fn acknowledge_alert(
+    pub async fn acknowledge_alert<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         alert_id: Uuid,
         user_id: Uuid,
-    ) -> Result<FundAlert, sqlx::Error> {
+    ) -> Result<FundAlert, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, FundAlert>(
             r#"
             UPDATE fund_alerts SET
@@ -867,17 +997,21 @@ impl ReserveFundRepository {
         .bind(alert_id)
         .bind(user_id)
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Resolve an alert, scoped to the caller's organization (#810).
-    pub async fn resolve_alert(
+    pub async fn resolve_alert<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         alert_id: Uuid,
         user_id: Uuid,
-    ) -> Result<FundAlert, sqlx::Error> {
+    ) -> Result<FundAlert, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, FundAlert>(
             r#"
             UPDATE fund_alerts SET
@@ -894,7 +1028,7 @@ impl ReserveFundRepository {
         .bind(alert_id)
         .bind(user_id)
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
@@ -903,9 +1037,15 @@ impl ReserveFundRepository {
     // ========================================================================
 
     /// Get fund dashboard for an organization.
-    pub async fn get_fund_dashboard(&self, org_id: Uuid) -> Result<FundDashboard, sqlx::Error> {
+    pub async fn get_fund_dashboard(
+        &self,
+        conn: &mut PgConnection,
+        org_id: Uuid,
+    ) -> Result<FundDashboard, sqlx::Error> {
         // Get all funds
-        let funds = self.list_funds(org_id, None, None, true).await?;
+        let funds = self
+            .list_funds(&mut *conn, org_id, None, None, true)
+            .await?;
 
         let mut total_balance = Decimal::ZERO;
         let mut total_target = Decimal::ZERO;
@@ -938,7 +1078,7 @@ impl ReserveFundRepository {
 
             // Get upcoming contributions
             let schedules = self
-                .list_contribution_schedules(org_id, fund.id, true)
+                .list_contribution_schedules(&mut *conn, org_id, fund.id, true)
                 .await?;
             let upcoming = schedules.iter().map(|s| s.amount).sum();
 
@@ -947,7 +1087,7 @@ impl ReserveFundRepository {
                 "SELECT COUNT(*) FROM fund_alerts WHERE fund_id = $1 AND is_active = true",
             )
             .bind(fund.id)
-            .fetch_one(&self.pool)
+            .fetch_one(&mut *conn)
             .await?;
 
             fund_summaries.push(FundSummary {
@@ -978,7 +1118,7 @@ impl ReserveFundRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         Ok(FundDashboard {
@@ -994,13 +1134,14 @@ impl ReserveFundRepository {
     /// Get fund health report for a fund the caller owns.
     pub async fn get_fund_health_report(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         fund_id: Uuid,
     ) -> Result<FundHealthReport, sqlx::Error> {
         let fund = self
-            .get_fund(org_id, fund_id)
+            .get_fund(&mut *conn, org_id, fund_id)
             .await?
-            .ok_or_else(|| sqlx::Error::RowNotFound)?;
+            .ok_or(sqlx::Error::RowNotFound)?;
 
         let mut issues = Vec::new();
         let mut recommendations = Vec::new();
@@ -1044,7 +1185,7 @@ impl ReserveFundRepository {
             "SELECT * FROM fund_projections WHERE fund_id = $1 AND is_current = true LIMIT 1",
         )
         .bind(fund_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *conn)
         .await?;
         if projection.is_none() {
             issues.push("No current reserve study".to_string());
@@ -1053,7 +1194,7 @@ impl ReserveFundRepository {
         }
 
         // Check upcoming component replacements (fund ownership verified).
-        let components = self.list_components_unscoped(fund_id).await?;
+        let components = self.list_components_unscoped(&mut *conn, fund_id).await?;
         let urgent_components: Vec<_> = components
             .iter()
             .filter(|c| c.remaining_life_years.map(|y| y <= 2).unwrap_or(false))

--- a/backend/crates/db/tests/reserve_funds_rls_repo_tests.rs
+++ b/backend/crates/db/tests/reserve_funds_rls_repo_tests.rs
@@ -1,0 +1,287 @@
+//! Repo-level behavioral RLS regression test for PAP-79 (PAP-67 cluster).
+//!
+//! Background
+//! ----------
+//! Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on the reserve-fund tables (`reserve_funds` and
+//! the rest of the Epic-141 cluster). The production api-server connects as the
+//! table OWNER, which `FORCE` binds. `ReserveFundRepository` held a raw `PgPool`
+//! and ran every query WITHOUT ever calling `set_request_context`, so on `dev`
+//! `get_current_org_id()` returned NULL and the policy collapsed to
+//! `organization_id = NULL` → **deny-all**: own-org reads returned empty, writes
+//! failed. (PAP-79.)
+//!
+//! The fix routes the repo through an RLS-context connection (the `RlsConnection`
+//! extractor in handlers sets the org/user GUCs before any query). This test
+//! exercises the *repository methods themselves* on a `FORCE`-bound role and
+//! proves:
+//!
+//!   1. **Deny-all reproduction** — with the role bound but NO context set
+//!      (exactly what the raw-pool repo did on `dev`), an own-org `get_fund` /
+//!      `list_funds` returns nothing. This is the "would have failed on dev"
+//!      evidence.
+//!   2. **Fix** — with `set_request_context(org_a, user_a)` applied first (what
+//!      `RlsConnection` now does), the same repo calls return the own-org row.
+//!   3. **Cross-tenant** — org B's fund stays invisible to an org-A caller even
+//!      with context set.
+//!   4. **Write path** — a `create_fund` on a context-set connection succeeds and
+//!      the row is the caller's org. Without context the INSERT would fail the
+//!      policy `WITH CHECK`.
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — even `FORCE` does not bind a superuser, so a behavioral assertion
+//! would pass vacuously. The test creates a plain `NOSUPERUSER NOBYPASSRLS`
+//! role, grants it access, and `SET ROLE`s to it so `FORCE` actually enforces the
+//! policy the way the production owner role experiences it. Mirrors
+//! `work_order_rls_repo_tests.rs` (the PAP-67 precedent this follows).
+
+use db::models::reserve_funds::{CreateReserveFund, FundType};
+use db::repositories::ReserveFundRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("RF {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@rf.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'RF User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Seed a reserve fund directly (as superuser, RLS-exempt) for an org.
+async fn seed_fund(pool: &PgPool, org_id: Uuid, name: &str, user_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO reserve_funds
+            (organization_id, name, fund_type, current_balance, currency, created_by)
+        VALUES ($1, $2, 'reserve', 0, 'EUR', $3)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(name)
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed reserve fund")
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn reserve_fund_repo_force_rls_deny_all_and_fix(pool: PgPool) {
+    let repo = ReserveFundRepository::new(pool.clone());
+
+    // --- Seed as superuser / super-admin context (satisfies org roles-trigger). ---
+    set_ctx(&pool, None, None, true).await;
+    let org_a = seed_org(&pool, "force-rf-a").await;
+    let org_b = seed_org(&pool, "force-rf-b").await;
+    let user_a = seed_user(&pool, "a@rf.test").await;
+    let user_b = seed_user(&pool, "b@rf.test").await;
+    let fund_a = seed_fund(&pool, org_a, "Fund A", user_a).await;
+    let fund_b = seed_fund(&pool, org_b, "Fund B", user_b).await;
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    let role = format!("ppt_rls_rf_{}", Uuid::new_v4().simple());
+    for stmt in [
+        format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
+        format!("GRANT SELECT, INSERT, UPDATE, DELETE ON reserve_funds TO \"{role}\""),
+        // RLS policy helpers must be EXECUTE-able by the bound role; the
+        // soft-delete guard reads `organizations`.
+        format!(
+            "GRANT EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
+             get_current_org_not_deleted() TO \"{role}\""
+        ),
+        format!("GRANT SELECT ON organizations TO \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .expect("grant setup");
+    }
+
+    // ====================================================================
+    // (1) DENY-ALL reproduction: role bound, NO context set (the dev raw-pool
+    //     behavior). Own-org reads return nothing.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        // Explicitly clear any inherited context, then drop to the bound role.
+        sqlx::query("SELECT clear_request_context()")
+            .execute(&mut *conn)
+            .await
+            .expect("clear ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let found = repo
+            .get_fund(&mut *conn, org_a, fund_a)
+            .await
+            .expect("get_fund (no ctx)");
+        assert!(
+            found.is_none(),
+            "PAP-79 regression: without RLS context, own-org reserve fund must be \
+             invisible (deny-all) — this is what the raw-pool repo did on dev"
+        );
+
+        let listed = repo
+            .list_funds(&mut *conn, org_a, None, None, false)
+            .await
+            .expect("list_funds (no ctx)");
+        assert!(
+            listed.is_empty(),
+            "PAP-79 regression: without RLS context, list_funds returns deny-all empty"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (2) FIX + (3) cross-tenant: set context, drop to bound role, query repo.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        // (2) Own-org row IS now visible through the repo — the fix.
+        let found = repo
+            .get_fund(&mut *conn, org_a, fund_a)
+            .await
+            .expect("get_fund (ctx)");
+        assert_eq!(
+            found.map(|f| f.id),
+            Some(fund_a),
+            "PAP-79 fix: with RLS context set, the repo must return the own-org reserve fund"
+        );
+
+        let listed = repo
+            .list_funds(&mut *conn, org_a, None, None, false)
+            .await
+            .expect("list_funds (ctx)");
+        assert_eq!(
+            listed.iter().map(|f| f.id).collect::<Vec<_>>(),
+            vec![fund_a],
+            "PAP-79 fix: list_funds returns exactly the own-org fund under context"
+        );
+
+        // (3) Org B's fund stays invisible to an org-A caller.
+        let cross = repo
+            .get_fund(&mut *conn, org_a, fund_b)
+            .await
+            .expect("get_fund cross");
+        assert!(
+            cross.is_none(),
+            "cross-tenant: org B's reserve fund must NOT be visible to an org-A caller"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (4) WRITE path: a create on a context-set connection succeeds and the
+    //     row is the caller's org. Without context the INSERT would fail the
+    //     policy WITH CHECK (the write-side of deny-all).
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let created = repo
+            .create_fund(
+                &mut *conn,
+                org_a,
+                CreateReserveFund {
+                    building_id: None,
+                    name: "Created under RLS".to_string(),
+                    description: None,
+                    fund_type: FundType::Reserve,
+                    target_balance: None,
+                    minimum_balance: None,
+                    currency: None,
+                },
+                user_a,
+            )
+            .await
+            .expect("create_fund under context must succeed");
+        assert_eq!(created.organization_id, org_a);
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup the test role. ---
+    set_ctx(&pool, None, None, true).await;
+    let _ = user_b; // seeded for symmetry with org_b's fund
+    for stmt in [
+        format!("REVOKE ALL ON reserve_funds FROM \"{role}\""),
+        format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .ok();
+    }
+}

--- a/backend/servers/api-server/src/routes/reserve_funds.rs
+++ b/backend/servers/api-server/src/routes/reserve_funds.rs
@@ -8,7 +8,9 @@
 //! so every query MUST run on a connection that has `app.current_org_id` set or
 //! it collapses to deny-all. Each handler therefore acquires an [`RlsConnection`]
 //! (which validates tenant membership and sets the org/user GUCs on a dedicated
-//! connection) and passes `&mut **rls.conn()` to the repository. The
+//! connection) and passes that connection to the repository (`&mut **rls.conn()`
+//! to the generic-`Executor` methods, `rls.conn()` to the `&mut PgConnection`
+//! ones, which deref-coerce). The
 //! authoritative organization is `rls.tenant_id()` — the tenant the caller was
 //! validated against — not a client-supplied `organization_id`, so the SQL org
 //! filter and the RLS context can never disagree. Cross-tenant access is blocked
@@ -226,7 +228,7 @@ async fn get_dashboard(
     let org_id = rls.tenant_id();
     let out = state
         .reserve_fund_repo
-        .get_fund_dashboard(&mut **rls.conn(), org_id)
+        .get_fund_dashboard(rls.conn(), org_id)
         .await
         .map(Json)
         .map_err(|e| internal_error(&format!("Failed to get dashboard: {}", e)));
@@ -243,7 +245,7 @@ async fn get_fund_health(
     let org_id = rls.tenant_id();
     let out = state
         .reserve_fund_repo
-        .get_fund_health_report(&mut **rls.conn(), org_id, fund_id)
+        .get_fund_health_report(rls.conn(), org_id, fund_id)
         .await
         .map(Json)
         .map_err(|e| repo_error("get health report", "Fund not found", e));
@@ -266,7 +268,7 @@ async fn list_schedules(
     let out = state
         .reserve_fund_repo
         .list_contribution_schedules(
-            &mut **rls.conn(),
+            rls.conn(),
             org_id,
             fund_id,
             query.active_only.unwrap_or(false),
@@ -288,7 +290,7 @@ async fn create_schedule(
     let org_id = rls.tenant_id();
     let out = state
         .reserve_fund_repo
-        .create_contribution_schedule(&mut **rls.conn(), org_id, fund_id, req)
+        .create_contribution_schedule(rls.conn(), org_id, fund_id, req)
         .await
         .map(Json)
         .map_err(|e| repo_error("create schedule", "Fund not found", e));
@@ -349,7 +351,7 @@ async fn record_transaction(
     let user_id = rls.user_id();
     let out = state
         .reserve_fund_repo
-        .record_transaction(&mut **rls.conn(), org_id, fund_id, req, user_id)
+        .record_transaction(rls.conn(), org_id, fund_id, req, user_id)
         .await
         .map(Json)
         .map_err(|e| repo_error("record transaction", "Fund not found", e));
@@ -367,7 +369,7 @@ async fn transfer_funds(
     let user_id = rls.user_id();
     let out = state
         .reserve_fund_repo
-        .transfer_funds(&mut **rls.conn(), org_id, req, user_id)
+        .transfer_funds(rls.conn(), org_id, req, user_id)
         .await
         .map(Json)
         .map_err(|e| repo_error("transfer funds", "Fund not found", e));
@@ -388,7 +390,7 @@ async fn list_policies(
     let org_id = rls.tenant_id();
     let out = state
         .reserve_fund_repo
-        .list_investment_policies(&mut **rls.conn(), org_id, fund_id)
+        .list_investment_policies(rls.conn(), org_id, fund_id)
         .await
         .map(Json)
         .map_err(|e| repo_error("list policies", "Fund not found", e));
@@ -406,7 +408,7 @@ async fn create_policy(
     let org_id = rls.tenant_id();
     let out = state
         .reserve_fund_repo
-        .create_investment_policy(&mut **rls.conn(), org_id, fund_id, req)
+        .create_investment_policy(rls.conn(), org_id, fund_id, req)
         .await
         .map(Json)
         .map_err(|e| repo_error("create policy", "Fund not found", e));
@@ -423,7 +425,7 @@ async fn get_active_policy(
     let org_id = rls.tenant_id();
     let out = state
         .reserve_fund_repo
-        .get_active_investment_policy(&mut **rls.conn(), org_id, fund_id)
+        .get_active_investment_policy(rls.conn(), org_id, fund_id)
         .await
         .map(Json)
         .map_err(|e| repo_error("get active policy", "Fund not found", e));
@@ -445,7 +447,7 @@ async fn create_projection(
     let org_id = rls.tenant_id();
     let out = state
         .reserve_fund_repo
-        .create_projection(&mut **rls.conn(), org_id, fund_id, req)
+        .create_projection(rls.conn(), org_id, fund_id, req)
         .await
         .map(Json)
         .map_err(|e| repo_error("create projection", "Fund not found", e));
@@ -462,7 +464,7 @@ async fn get_current_projection(
     let org_id = rls.tenant_id();
     let out = state
         .reserve_fund_repo
-        .get_current_projection(&mut **rls.conn(), org_id, fund_id)
+        .get_current_projection(rls.conn(), org_id, fund_id)
         .await
         .map(Json)
         .map_err(|e| repo_error("get projection", "Fund not found", e));
@@ -479,7 +481,7 @@ async fn get_projection_items(
     let org_id = rls.tenant_id();
     let out = state
         .reserve_fund_repo
-        .get_projection_items(&mut **rls.conn(), org_id, projection_id)
+        .get_projection_items(rls.conn(), org_id, projection_id)
         .await
         .map(Json)
         .map_err(|e| repo_error("get projection items", "Projection not found", e));
@@ -497,7 +499,7 @@ async fn add_projection_items(
     let org_id = rls.tenant_id();
     let out = state
         .reserve_fund_repo
-        .add_projection_items(&mut **rls.conn(), org_id, projection_id, items)
+        .add_projection_items(rls.conn(), org_id, projection_id, items)
         .await
         .map(Json)
         .map_err(|e| repo_error("add projection items", "Projection not found", e));
@@ -518,7 +520,7 @@ async fn list_components(
     let org_id = rls.tenant_id();
     let out = state
         .reserve_fund_repo
-        .list_components(&mut **rls.conn(), org_id, fund_id)
+        .list_components(rls.conn(), org_id, fund_id)
         .await
         .map(Json)
         .map_err(|e| repo_error("list components", "Fund not found", e));
@@ -536,7 +538,7 @@ async fn create_component(
     let org_id = rls.tenant_id();
     let out = state
         .reserve_fund_repo
-        .create_component(&mut **rls.conn(), org_id, fund_id, req)
+        .create_component(rls.conn(), org_id, fund_id, req)
         .await
         .map(Json)
         .map_err(|e| repo_error("create component", "Fund not found", e));

--- a/backend/servers/api-server/src/routes/reserve_funds.rs
+++ b/backend/servers/api-server/src/routes/reserve_funds.rs
@@ -1,9 +1,24 @@
 //! Reserve Fund Management routes for Epic 141.
 //!
 //! REST API endpoints for HOA/Condo reserve fund management.
+//!
+//! # RLS (PAP-67 / PAP-79)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` on the reserve-fund cluster,
+//! so every query MUST run on a connection that has `app.current_org_id` set or
+//! it collapses to deny-all. Each handler therefore acquires an [`RlsConnection`]
+//! (which validates tenant membership and sets the org/user GUCs on a dedicated
+//! connection) and passes `&mut **rls.conn()` to the repository. The
+//! authoritative organization is `rls.tenant_id()` — the tenant the caller was
+//! validated against — not a client-supplied `organization_id`, so the SQL org
+//! filter and the RLS context can never disagree. Cross-tenant access is blocked
+//! by RLS: a by-id read of another org's row returns no row (`404`), and a write
+//! targeting another org fails the policy's `WITH CHECK`. `rls.release()` clears
+//! the context before the connection returns to the pool (both on the Ok and Err
+//! paths).
 
 use crate::state::AppState;
-use api_core::extractors::AuthUser;
+use api_core::extractors::RlsConnection;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -101,10 +116,6 @@ fn internal_error(msg: &str) -> (StatusCode, Json<ErrorResponse>) {
     )
 }
 
-fn forbidden_error(msg: &str) -> (StatusCode, Json<ErrorResponse>) {
-    (StatusCode::FORBIDDEN, Json(ErrorResponse::forbidden(msg)))
-}
-
 fn not_found_error(msg: &str) -> (StatusCode, Json<ErrorResponse>) {
     (StatusCode::NOT_FOUND, Json(ErrorResponse::not_found(msg)))
 }
@@ -134,121 +145,110 @@ fn repo_error(
 /// List reserve funds.
 async fn list_funds(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<FundListQuery>,
 ) -> ApiResult<Json<Vec<ReserveFund>>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let funds = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
         .list_funds(
+            &mut **rls.conn(),
             org_id,
             query.fund_type,
             query.building_id,
             query.active_only.unwrap_or(false),
         )
         .await
-        .map_err(|e| internal_error(&format!("Failed to list funds: {}", e)))?;
-
-    Ok(Json(funds))
+        .map(Json)
+        .map_err(|e| internal_error(&format!("Failed to list funds: {}", e)));
+    rls.release().await;
+    out
 }
 
 /// Create a reserve fund.
 async fn create_fund(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Json(req): Json<CreateReserveFund>,
 ) -> ApiResult<Json<ReserveFund>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let fund = state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .reserve_fund_repo
-        .create_fund(org_id, req, user.user_id)
+        .create_fund(&mut **rls.conn(), org_id, req, user_id)
         .await
-        .map_err(|e| internal_error(&format!("Failed to create fund: {}", e)))?;
-
-    Ok(Json(fund))
+        .map(Json)
+        .map_err(|e| internal_error(&format!("Failed to create fund: {}", e)));
+    rls.release().await;
+    out
 }
 
 /// Get a reserve fund by ID.
 async fn get_fund(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
 ) -> ApiResult<Json<ReserveFund>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let fund = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .get_fund(org_id, fund_id)
+        .get_fund(&mut **rls.conn(), org_id, fund_id)
         .await
-        .map_err(|e| internal_error(&format!("Failed to get fund: {}", e)))?
-        .ok_or_else(|| not_found_error("Fund not found"))?;
-
-    Ok(Json(fund))
+        .map_err(|e| internal_error(&format!("Failed to get fund: {}", e)))
+        .and_then(|f| f.map(Json).ok_or_else(|| not_found_error("Fund not found")));
+    rls.release().await;
+    out
 }
 
 /// Update a reserve fund.
 async fn update_fund(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
     Json(req): Json<UpdateReserveFund>,
 ) -> ApiResult<Json<ReserveFund>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let fund = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .update_fund(org_id, fund_id, req)
+        .update_fund(&mut **rls.conn(), org_id, fund_id, req)
         .await
-        .map_err(|e| repo_error("update fund", "Fund not found", e))?;
-
-    Ok(Json(fund))
+        .map(Json)
+        .map_err(|e| repo_error("update fund", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 /// Get fund dashboard.
 async fn get_dashboard(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
 ) -> ApiResult<Json<FundDashboard>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let dashboard = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .get_fund_dashboard(org_id)
+        .get_fund_dashboard(&mut **rls.conn(), org_id)
         .await
-        .map_err(|e| internal_error(&format!("Failed to get dashboard: {}", e)))?;
-
-    Ok(Json(dashboard))
+        .map(Json)
+        .map_err(|e| internal_error(&format!("Failed to get dashboard: {}", e)));
+    rls.release().await;
+    out
 }
 
 /// Get fund health report.
 async fn get_fund_health(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
 ) -> ApiResult<Json<FundHealthReport>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let report = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .get_fund_health_report(org_id, fund_id)
+        .get_fund_health_report(&mut **rls.conn(), org_id, fund_id)
         .await
-        .map_err(|e| repo_error("get health report", "Fund not found", e))?;
-
-    Ok(Json(report))
+        .map(Json)
+        .map_err(|e| repo_error("get health report", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -258,61 +258,60 @@ async fn get_fund_health(
 /// List contribution schedules.
 async fn list_schedules(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
     Query(query): Query<ActiveOnlyQuery>,
 ) -> ApiResult<Json<Vec<FundContributionSchedule>>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let schedules = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .list_contribution_schedules(org_id, fund_id, query.active_only.unwrap_or(false))
+        .list_contribution_schedules(
+            &mut **rls.conn(),
+            org_id,
+            fund_id,
+            query.active_only.unwrap_or(false),
+        )
         .await
-        .map_err(|e| repo_error("list schedules", "Fund not found", e))?;
-
-    Ok(Json(schedules))
+        .map(Json)
+        .map_err(|e| repo_error("list schedules", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 /// Create a contribution schedule.
 async fn create_schedule(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
     Json(req): Json<CreateContributionSchedule>,
 ) -> ApiResult<Json<FundContributionSchedule>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let schedule = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .create_contribution_schedule(org_id, fund_id, req)
+        .create_contribution_schedule(&mut **rls.conn(), org_id, fund_id, req)
         .await
-        .map_err(|e| repo_error("create schedule", "Fund not found", e))?;
-
-    Ok(Json(schedule))
+        .map(Json)
+        .map_err(|e| repo_error("create schedule", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 /// Update a contribution schedule.
 async fn update_schedule(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path((_fund_id, schedule_id)): Path<(Uuid, Uuid)>,
     Json(req): Json<UpdateContributionSchedule>,
 ) -> ApiResult<Json<FundContributionSchedule>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let schedule = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .update_contribution_schedule(org_id, schedule_id, req)
+        .update_contribution_schedule(&mut **rls.conn(), org_id, schedule_id, req)
         .await
-        .map_err(|e| repo_error("update schedule", "Schedule not found", e))?;
-
-    Ok(Json(schedule))
+        .map(Json)
+        .map_err(|e| repo_error("update schedule", "Schedule not found", e));
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -322,62 +321,58 @@ async fn update_schedule(
 /// List transactions.
 async fn list_transactions(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
     Query(mut query): Query<TransactionQuery>,
 ) -> ApiResult<Json<Vec<FundTransaction>>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
+    let org_id = rls.tenant_id();
     query.fund_id = Some(fund_id);
 
-    let transactions = state
+    let out = state
         .reserve_fund_repo
-        .list_transactions(org_id, query)
+        .list_transactions(&mut **rls.conn(), org_id, query)
         .await
-        .map_err(|e| internal_error(&format!("Failed to list transactions: {}", e)))?;
-
-    Ok(Json(transactions))
+        .map(Json)
+        .map_err(|e| internal_error(&format!("Failed to list transactions: {}", e)));
+    rls.release().await;
+    out
 }
 
 /// Record a transaction.
 async fn record_transaction(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
     Json(req): Json<RecordFundTransaction>,
 ) -> ApiResult<Json<FundTransaction>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let transaction = state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .reserve_fund_repo
-        .record_transaction(org_id, fund_id, req, user.user_id)
+        .record_transaction(&mut **rls.conn(), org_id, fund_id, req, user_id)
         .await
-        .map_err(|e| repo_error("record transaction", "Fund not found", e))?;
-
-    Ok(Json(transaction))
+        .map(Json)
+        .map_err(|e| repo_error("record transaction", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 /// Transfer funds between accounts.
 async fn transfer_funds(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Json(req): Json<FundTransferRequest>,
 ) -> ApiResult<Json<(FundTransaction, FundTransaction)>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let transactions = state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .reserve_fund_repo
-        .transfer_funds(org_id, req, user.user_id)
+        .transfer_funds(&mut **rls.conn(), org_id, req, user_id)
         .await
-        .map_err(|e| repo_error("transfer funds", "Fund not found", e))?;
-
-    Ok(Json(transactions))
+        .map(Json)
+        .map_err(|e| repo_error("transfer funds", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -387,59 +382,53 @@ async fn transfer_funds(
 /// List investment policies.
 async fn list_policies(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
 ) -> ApiResult<Json<Vec<FundInvestmentPolicy>>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let policies = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .list_investment_policies(org_id, fund_id)
+        .list_investment_policies(&mut **rls.conn(), org_id, fund_id)
         .await
-        .map_err(|e| repo_error("list policies", "Fund not found", e))?;
-
-    Ok(Json(policies))
+        .map(Json)
+        .map_err(|e| repo_error("list policies", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 /// Create an investment policy.
 async fn create_policy(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
     Json(req): Json<CreateInvestmentPolicy>,
 ) -> ApiResult<Json<FundInvestmentPolicy>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let policy = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .create_investment_policy(org_id, fund_id, req)
+        .create_investment_policy(&mut **rls.conn(), org_id, fund_id, req)
         .await
-        .map_err(|e| repo_error("create policy", "Fund not found", e))?;
-
-    Ok(Json(policy))
+        .map(Json)
+        .map_err(|e| repo_error("create policy", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 /// Get active investment policy.
 async fn get_active_policy(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
 ) -> ApiResult<Json<Option<FundInvestmentPolicy>>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let policy = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .get_active_investment_policy(org_id, fund_id)
+        .get_active_investment_policy(&mut **rls.conn(), org_id, fund_id)
         .await
-        .map_err(|e| repo_error("get active policy", "Fund not found", e))?;
-
-    Ok(Json(policy))
+        .map(Json)
+        .map_err(|e| repo_error("get active policy", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -449,79 +438,71 @@ async fn get_active_policy(
 /// Create a projection.
 async fn create_projection(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
     Json(req): Json<CreateFundProjection>,
 ) -> ApiResult<Json<FundProjection>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let projection = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .create_projection(org_id, fund_id, req)
+        .create_projection(&mut **rls.conn(), org_id, fund_id, req)
         .await
-        .map_err(|e| repo_error("create projection", "Fund not found", e))?;
-
-    Ok(Json(projection))
+        .map(Json)
+        .map_err(|e| repo_error("create projection", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 /// Get current projection.
 async fn get_current_projection(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
 ) -> ApiResult<Json<Option<FundProjection>>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let projection = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .get_current_projection(org_id, fund_id)
+        .get_current_projection(&mut **rls.conn(), org_id, fund_id)
         .await
-        .map_err(|e| repo_error("get projection", "Fund not found", e))?;
-
-    Ok(Json(projection))
+        .map(Json)
+        .map_err(|e| repo_error("get projection", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 /// Get projection items.
 async fn get_projection_items(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path((_fund_id, projection_id)): Path<(Uuid, Uuid)>,
 ) -> ApiResult<Json<Vec<FundProjectionItem>>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let items = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .get_projection_items(org_id, projection_id)
+        .get_projection_items(&mut **rls.conn(), org_id, projection_id)
         .await
-        .map_err(|e| repo_error("get projection items", "Projection not found", e))?;
-
-    Ok(Json(items))
+        .map(Json)
+        .map_err(|e| repo_error("get projection items", "Projection not found", e));
+    rls.release().await;
+    out
 }
 
 /// Add projection items.
 async fn add_projection_items(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path((_fund_id, projection_id)): Path<(Uuid, Uuid)>,
     Json(items): Json<Vec<CreateProjectionItem>>,
 ) -> ApiResult<Json<Vec<FundProjectionItem>>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let created = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .add_projection_items(org_id, projection_id, items)
+        .add_projection_items(&mut **rls.conn(), org_id, projection_id, items)
         .await
-        .map_err(|e| repo_error("add projection items", "Projection not found", e))?;
-
-    Ok(Json(created))
+        .map(Json)
+        .map_err(|e| repo_error("add projection items", "Projection not found", e));
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -531,60 +512,54 @@ async fn add_projection_items(
 /// List components.
 async fn list_components(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
 ) -> ApiResult<Json<Vec<FundComponent>>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let components = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .list_components(org_id, fund_id)
+        .list_components(&mut **rls.conn(), org_id, fund_id)
         .await
-        .map_err(|e| repo_error("list components", "Fund not found", e))?;
-
-    Ok(Json(components))
+        .map(Json)
+        .map_err(|e| repo_error("list components", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 /// Create a component.
 async fn create_component(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
     Json(req): Json<CreateFundComponent>,
 ) -> ApiResult<Json<FundComponent>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let component = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .create_component(org_id, fund_id, req)
+        .create_component(&mut **rls.conn(), org_id, fund_id, req)
         .await
-        .map_err(|e| repo_error("create component", "Fund not found", e))?;
-
-    Ok(Json(component))
+        .map(Json)
+        .map_err(|e| repo_error("create component", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 /// Update a component.
 async fn update_component(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path((_fund_id, component_id)): Path<(Uuid, Uuid)>,
     Json(req): Json<UpdateFundComponent>,
 ) -> ApiResult<Json<FundComponent>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let component = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .update_component(org_id, component_id, req)
+        .update_component(&mut **rls.conn(), org_id, component_id, req)
         .await
-        .map_err(|e| repo_error("update component", "Component not found", e))?;
-
-    Ok(Json(component))
+        .map(Json)
+        .map_err(|e| repo_error("update component", "Component not found", e));
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -594,55 +569,51 @@ async fn update_component(
 /// List active alerts.
 async fn list_alerts(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
 ) -> ApiResult<Json<Vec<FundAlert>>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let alerts = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .list_active_alerts(org_id)
+        .list_active_alerts(&mut **rls.conn(), org_id)
         .await
-        .map_err(|e| internal_error(&format!("Failed to list alerts: {}", e)))?;
-
-    Ok(Json(alerts))
+        .map(Json)
+        .map_err(|e| internal_error(&format!("Failed to list alerts: {}", e)));
+    rls.release().await;
+    out
 }
 
 /// Acknowledge an alert.
 async fn acknowledge_alert(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(alert_id): Path<Uuid>,
 ) -> ApiResult<Json<FundAlert>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let alert = state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .reserve_fund_repo
-        .acknowledge_alert(org_id, alert_id, user.user_id)
+        .acknowledge_alert(&mut **rls.conn(), org_id, alert_id, user_id)
         .await
-        .map_err(|e| repo_error("acknowledge alert", "Alert not found", e))?;
-
-    Ok(Json(alert))
+        .map(Json)
+        .map_err(|e| repo_error("acknowledge alert", "Alert not found", e));
+    rls.release().await;
+    out
 }
 
 /// Resolve an alert.
 async fn resolve_alert(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(alert_id): Path<Uuid>,
 ) -> ApiResult<Json<FundAlert>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let alert = state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .reserve_fund_repo
-        .resolve_alert(org_id, alert_id, user.user_id)
+        .resolve_alert(&mut **rls.conn(), org_id, alert_id, user_id)
         .await
-        .map_err(|e| repo_error("resolve alert", "Alert not found", e))?;
-
-    Ok(Json(alert))
+        .map(Json)
+        .map_err(|e| repo_error("resolve alert", "Alert not found", e));
+    rls.release().await;
+    out
 }


### PR DESCRIPTION
## PAP-79 / PAP-67: \`reserve_funds\` deny-all under FORCE-RLS

### Problem
Migration \`00179\` (PAP-62, #1216) put \`FORCE ROW LEVEL SECURITY\` on the reserve-fund cluster. \`reserve_funds.rs\` held a raw \`PgPool\`, ran every query via \`&self.pool\`, and never called \`set_request_context\` — so under FORCE the api-server's table-owner connection is no longer RLS-exempt and queries collapse to **deny-all** on \`dev\`: own-org reads return empty, writes fail the policy \`WITH CHECK\`. Router: \`/api/v1/reserve-funds\`.

FORCE-RLS tables touched: \`reserve_funds\`, \`fund_contribution_schedules\`, \`fund_transactions\`, \`fund_investment_policies\`, \`fund_projections\`, \`fund_projection_items\`, \`fund_components\`, \`fund_alerts\`.

### Fix (follows the proven \`work_order\` / \`budget\` pattern)
- **Repo** (\`crates/db/src/repositories/reserve_funds.rs\`): dropped the raw \`pool\` field entirely. Single-statement methods take a generic \`executor: E\`; multi-statement methods that compose helpers take \`conn: &mut PgConnection\` and reborrow \`&mut *conn\` per call. \`new(_pool)\` keeps the \`AppState\` construction site working. No second raw-pool path exists, so no query can bypass RLS.
- **Routes** (\`servers/api-server/src/routes/reserve_funds.rs\`): each handler takes \`mut rls: RlsConnection\`, passes \`&mut **rls.conn()\` to the repo, uses \`rls.tenant_id()\`/\`rls.user_id()\` as the authoritative org/user (so the SQL filter and RLS context can never disagree), and calls \`rls.release().await\` before returning on both Ok and Err paths. The explicit \`organization_id\` predicates are retained as defense-in-depth.
- **Test** (\`crates/db/tests/reserve_funds_rls_repo_tests.rs\`): repo-level behavioral test mirroring \`work_order_rls_repo_tests.rs\` — a \`NOSUPERUSER NOBYPASSRLS\` role so FORCE binds. Asserts deny-all without context, own-org visibility with context, cross-tenant invisibility on a by-id read, and a successful write under context.

### Verification
- \`cargo check -p db -p api-server\` — green.
- \`cargo test -p db --no-run --test reserve_funds_rls_repo_tests\` — compiles to an executable.
- DB execution of the \`#[sqlx::test]\` runs in CI (\`rls-smoke\`) / QA.

Parent: PAP-67. See PAP-68 for the matching \`check-rls-enforcement.sh\` detection guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)