### PR TITLE
fix(api-server): route vendor repo through RLS-context connection (PAP-70)

### DIFF
--- a/backend/crates/db/src/repositories/vendor.rs
+++ b/backend/crates/db/src/repositories/vendor.rs
@@ -1,4 +1,19 @@
 //! Vendor repository (Epic 21).
+//!
+//! # RLS Integration (PAP-67 / PAP-70)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on `vendors`, `vendor_contacts`,
+//! `vendor_contracts`, `vendor_invoices`, and `vendor_ratings`. Under `FORCE`
+//! the api-server's owner connection is no longer exempt, so a query issued on
+//! a connection without `app.current_org_id` set collapses to deny-all (own-org
+//! reads return empty, writes fail the policy `WITH CHECK`).
+//!
+//! Every method therefore takes an **executor whose connection already has RLS
+//! context set** (org + user GUCs) — in handlers this comes from the
+//! `RlsConnection` extractor via `&mut **rls.conn()`. The repository holds **no
+//! pool**, so there is no way to issue a query that bypasses RLS. This mirrors
+//! the `work_order.rs` / `budget.rs` precedent.
 
 use crate::models::{
     ContractQuery, CreateVendor, CreateVendorContact, CreateVendorContract, CreateVendorInvoice,
@@ -8,25 +23,39 @@ use crate::models::{
 };
 use chrono::NaiveDate;
 use rust_decimal::Decimal;
-use sqlx::PgPool;
+use sqlx::{Executor, PgPool, Postgres};
 use uuid::Uuid;
 
 /// Repository for vendor operations.
+///
+/// Stateless: every method receives an RLS-context-bearing executor. The repo
+/// holds no pool so it cannot issue an un-scoped (deny-all under `FORCE`) query.
 #[derive(Clone)]
-pub struct VendorRepository {
-    pool: PgPool,
-}
+pub struct VendorRepository;
 
 impl VendorRepository {
     /// Create a new VendorRepository.
-    pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+    ///
+    /// The pool argument is retained for construction-site compatibility with
+    /// the other repositories on `AppState`; this repo deliberately does not
+    /// store it (see module docs — all queries run on a context-set connection
+    /// supplied by the handler's `RlsConnection`).
+    pub fn new(_pool: PgPool) -> Self {
+        Self
     }
 
     // ==================== Vendor CRUD ====================
 
     /// Create a new vendor.
-    pub async fn create(&self, org_id: Uuid, data: CreateVendor) -> Result<Vendor, sqlx::Error> {
+    pub async fn create<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+        data: CreateVendor,
+    ) -> Result<Vendor, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO vendors
@@ -53,20 +82,35 @@ impl VendorRepository {
         .bind(data.is_preferred.unwrap_or(false))
         .bind(&data.notes)
         .bind(data.metadata.map(sqlx::types::Json))
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Find vendor by ID.
-    pub async fn find_by_id(&self, id: Uuid) -> Result<Option<Vendor>, sqlx::Error> {
+    pub async fn find_by_id<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+    ) -> Result<Option<Vendor>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as("SELECT * FROM vendors WHERE id = $1")
             .bind(id)
-            .fetch_optional(&self.pool)
+            .fetch_optional(executor)
             .await
     }
 
     /// List vendors for an organization.
-    pub async fn list(&self, org_id: Uuid, query: VendorQuery) -> Result<Vec<Vendor>, sqlx::Error> {
+    pub async fn list<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+        query: VendorQuery,
+    ) -> Result<Vec<Vendor>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let mut sql = String::from(
             r#"
             SELECT * FROM vendors
@@ -104,16 +148,20 @@ impl VendorRepository {
             .bind(&search_pattern)
             .bind(query.limit.unwrap_or(50))
             .bind(query.offset.unwrap_or(0))
-            .fetch_all(&self.pool)
+            .fetch_all(executor)
             .await
     }
 
     /// List vendors with details (active work orders, pending invoices).
-    pub async fn list_with_details(
+    pub async fn list_with_details<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: VendorQuery,
-    ) -> Result<Vec<VendorWithDetails>, sqlx::Error> {
+    ) -> Result<Vec<VendorWithDetails>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let search_pattern = query.search.as_ref().map(|s| format!("%{}%", s));
 
         sqlx::query_as(
@@ -143,12 +191,20 @@ impl VendorRepository {
         .bind(&search_pattern)
         .bind(query.limit.unwrap_or(50))
         .bind(query.offset.unwrap_or(0))
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update a vendor.
-    pub async fn update(&self, id: Uuid, data: UpdateVendor) -> Result<Vendor, sqlx::Error> {
+    pub async fn update<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        data: UpdateVendor,
+    ) -> Result<Vendor, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE vendors SET
@@ -190,21 +246,32 @@ impl VendorRepository {
         .bind(data.is_preferred)
         .bind(&data.notes)
         .bind(data.metadata.map(sqlx::types::Json))
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Delete a vendor.
-    pub async fn delete(&self, id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete<'e, E>(&self, executor: E, id: Uuid) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM vendors WHERE id = $1")
             .bind(id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
 
     /// Set vendor as preferred.
-    pub async fn set_preferred(&self, id: Uuid, is_preferred: bool) -> Result<Vendor, sqlx::Error> {
+    pub async fn set_preferred<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        is_preferred: bool,
+    ) -> Result<Vendor, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE vendors SET is_preferred = $2, updated_at = NOW()
@@ -214,12 +281,19 @@ impl VendorRepository {
         )
         .bind(id)
         .bind(is_preferred)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get vendor statistics.
-    pub async fn get_statistics(&self, org_id: Uuid) -> Result<VendorStatistics, sqlx::Error> {
+    pub async fn get_statistics<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+    ) -> Result<VendorStatistics, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let counts: (i64, i64, i64, i64) = sqlx::query_as(
             r#"
             SELECT
@@ -232,7 +306,7 @@ impl VendorRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await?;
 
         // Get by service counts - simplified for now
@@ -250,11 +324,15 @@ impl VendorRepository {
     // ==================== Vendor Contacts ====================
 
     /// Add a contact to a vendor.
-    pub async fn add_contact(
+    pub async fn add_contact<'e, E>(
         &self,
+        executor: E,
         vendor_id: Uuid,
         data: CreateVendorContact,
-    ) -> Result<VendorContact, sqlx::Error> {
+    ) -> Result<VendorContact, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO vendor_contacts (vendor_id, name, role, phone, email, is_primary)
@@ -268,12 +346,19 @@ impl VendorRepository {
         .bind(&data.phone)
         .bind(&data.email)
         .bind(data.is_primary.unwrap_or(false))
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// List contacts for a vendor.
-    pub async fn list_contacts(&self, vendor_id: Uuid) -> Result<Vec<VendorContact>, sqlx::Error> {
+    pub async fn list_contacts<'e, E>(
+        &self,
+        executor: E,
+        vendor_id: Uuid,
+    ) -> Result<Vec<VendorContact>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM vendor_contacts WHERE vendor_id = $1
@@ -281,40 +366,57 @@ impl VendorRepository {
             "#,
         )
         .bind(vendor_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Delete a contact.
-    pub async fn delete_contact(&self, contact_id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete_contact<'e, E>(
+        &self,
+        executor: E,
+        contact_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM vendor_contacts WHERE id = $1")
             .bind(contact_id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
 
     /// Resolve the `vendor_id` that owns `contact_id`, if any. Used by the
-    /// route layer to derive the owning org for tenant-isolation checks
-    /// (issue #825) before deleting a contact.
-    pub async fn find_contact_vendor_id(
+    /// route layer to derive the owning vendor before deleting a contact.
+    ///
+    /// Under RLS the lookup is already org-scoped: a contact belonging to
+    /// another org is invisible and returns `None`.
+    pub async fn find_contact_vendor_id<'e, E>(
         &self,
+        executor: E,
         contact_id: Uuid,
-    ) -> Result<Option<Uuid>, sqlx::Error> {
+    ) -> Result<Option<Uuid>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_scalar("SELECT vendor_id FROM vendor_contacts WHERE id = $1")
             .bind(contact_id)
-            .fetch_optional(&self.pool)
+            .fetch_optional(executor)
             .await
     }
 
     // ==================== Vendor Contracts ====================
 
     /// Create a contract.
-    pub async fn create_contract(
+    pub async fn create_contract<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         data: CreateVendorContract,
-    ) -> Result<VendorContract, sqlx::Error> {
+    ) -> Result<VendorContract, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO vendor_contracts
@@ -339,27 +441,35 @@ impl VendorRepository {
         .bind(data.auto_renew.unwrap_or(false))
         .bind(data.terms.map(sqlx::types::Json))
         .bind(data.metadata.map(sqlx::types::Json))
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Find contract by ID.
-    pub async fn find_contract_by_id(
+    pub async fn find_contract_by_id<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
-    ) -> Result<Option<VendorContract>, sqlx::Error> {
+    ) -> Result<Option<VendorContract>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as("SELECT * FROM vendor_contracts WHERE id = $1")
             .bind(id)
-            .fetch_optional(&self.pool)
+            .fetch_optional(executor)
             .await
     }
 
     /// List contracts.
-    pub async fn list_contracts(
+    pub async fn list_contracts<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: ContractQuery,
-    ) -> Result<Vec<VendorContract>, sqlx::Error> {
+    ) -> Result<Vec<VendorContract>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM vendor_contracts
@@ -379,16 +489,20 @@ impl VendorRepository {
         .bind(query.expiring_days)
         .bind(query.limit.unwrap_or(50))
         .bind(query.offset.unwrap_or(0))
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update a contract.
-    pub async fn update_contract(
+    pub async fn update_contract<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         data: UpdateVendorContract,
-    ) -> Result<VendorContract, sqlx::Error> {
+    ) -> Result<VendorContract, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE vendor_contracts SET
@@ -424,25 +538,36 @@ impl VendorRepository {
         .bind(data.auto_renew)
         .bind(data.terms.map(sqlx::types::Json))
         .bind(data.metadata.map(sqlx::types::Json))
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Delete a contract.
-    pub async fn delete_contract(&self, id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete_contract<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM vendor_contracts WHERE id = $1")
             .bind(id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
 
     /// Get contracts expiring soon.
-    pub async fn get_expiring_contracts(
+    pub async fn get_expiring_contracts<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         days: i32,
-    ) -> Result<Vec<ExpiringContract>, sqlx::Error> {
+    ) -> Result<Vec<ExpiringContract>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT
@@ -460,19 +585,23 @@ impl VendorRepository {
         )
         .bind(org_id)
         .bind(days)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     // ==================== Vendor Invoices ====================
 
     /// Create an invoice.
-    pub async fn create_invoice(
+    pub async fn create_invoice<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         user_id: Uuid,
         data: CreateVendorInvoice,
-    ) -> Result<VendorInvoice, sqlx::Error> {
+    ) -> Result<VendorInvoice, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO vendor_invoices
@@ -498,24 +627,35 @@ impl VendorRepository {
         .bind(data.line_items.map(sqlx::types::Json))
         .bind(data.metadata.map(sqlx::types::Json))
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Find invoice by ID.
-    pub async fn find_invoice_by_id(&self, id: Uuid) -> Result<Option<VendorInvoice>, sqlx::Error> {
+    pub async fn find_invoice_by_id<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+    ) -> Result<Option<VendorInvoice>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as("SELECT * FROM vendor_invoices WHERE id = $1")
             .bind(id)
-            .fetch_optional(&self.pool)
+            .fetch_optional(executor)
             .await
     }
 
     /// List invoices.
-    pub async fn list_invoices(
+    pub async fn list_invoices<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: InvoiceQuery,
-    ) -> Result<Vec<VendorInvoice>, sqlx::Error> {
+    ) -> Result<Vec<VendorInvoice>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM vendor_invoices
@@ -537,16 +677,20 @@ impl VendorRepository {
         .bind(query.work_order_id)
         .bind(query.limit.unwrap_or(50))
         .bind(query.offset.unwrap_or(0))
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update an invoice.
-    pub async fn update_invoice(
+    pub async fn update_invoice<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         data: UpdateVendorInvoice,
-    ) -> Result<VendorInvoice, sqlx::Error> {
+    ) -> Result<VendorInvoice, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE vendor_invoices SET
@@ -578,16 +722,20 @@ impl VendorRepository {
         .bind(&data.description)
         .bind(data.line_items.map(sqlx::types::Json))
         .bind(data.metadata.map(sqlx::types::Json))
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Approve an invoice.
-    pub async fn approve_invoice(
+    pub async fn approve_invoice<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         user_id: Uuid,
-    ) -> Result<VendorInvoice, sqlx::Error> {
+    ) -> Result<VendorInvoice, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE vendor_invoices SET
@@ -601,17 +749,21 @@ impl VendorRepository {
         )
         .bind(id)
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Reject an invoice.
-    pub async fn reject_invoice(
+    pub async fn reject_invoice<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         user_id: Uuid,
         reason: &str,
-    ) -> Result<VendorInvoice, sqlx::Error> {
+    ) -> Result<VendorInvoice, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE vendor_invoices SET
@@ -626,18 +778,22 @@ impl VendorRepository {
         .bind(id)
         .bind(user_id)
         .bind(reason)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Record payment for an invoice.
-    pub async fn record_payment(
+    pub async fn record_payment<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         amount: Decimal,
         method: Option<&str>,
         reference: Option<&str>,
-    ) -> Result<VendorInvoice, sqlx::Error> {
+    ) -> Result<VendorInvoice, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE vendor_invoices SET
@@ -658,26 +814,37 @@ impl VendorRepository {
         .bind(amount)
         .bind(method)
         .bind(reference)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Delete an invoice.
-    pub async fn delete_invoice(&self, id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete_invoice<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM vendor_invoices WHERE id = $1")
             .bind(id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
 
     /// Get invoice summary by vendor for a period.
-    pub async fn get_invoice_summary(
+    pub async fn get_invoice_summary<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         start_date: NaiveDate,
         end_date: NaiveDate,
-    ) -> Result<Vec<InvoiceSummary>, sqlx::Error> {
+    ) -> Result<Vec<InvoiceSummary>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT
@@ -699,15 +866,19 @@ impl VendorRepository {
         .bind(org_id)
         .bind(start_date)
         .bind(end_date)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Get overdue invoices.
-    pub async fn get_overdue_invoices(
+    pub async fn get_overdue_invoices<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
-    ) -> Result<Vec<VendorInvoice>, sqlx::Error> {
+    ) -> Result<Vec<VendorInvoice>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM vendor_invoices
@@ -718,19 +889,23 @@ impl VendorRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     // ==================== Vendor Ratings ====================
 
     /// Add a rating for a vendor.
-    pub async fn add_rating(
+    pub async fn add_rating<'e, E>(
         &self,
+        executor: E,
         vendor_id: Uuid,
         user_id: Uuid,
         data: CreateVendorRating,
-    ) -> Result<VendorRating, sqlx::Error> {
+    ) -> Result<VendorRating, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO vendor_ratings
@@ -749,17 +924,21 @@ impl VendorRepository {
         .bind(data.communication_rating)
         .bind(data.value_rating)
         .bind(&data.review_text)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// List ratings for a vendor.
-    pub async fn list_ratings(
+    pub async fn list_ratings<'e, E>(
         &self,
+        executor: E,
         vendor_id: Uuid,
         limit: i32,
         offset: i32,
-    ) -> Result<Vec<VendorRating>, sqlx::Error> {
+    ) -> Result<Vec<VendorRating>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM vendor_ratings
@@ -771,7 +950,7 @@ impl VendorRepository {
         .bind(vendor_id)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 }

--- a/backend/crates/db/tests/vendor_rls_repo_tests.rs
+++ b/backend/crates/db/tests/vendor_rls_repo_tests.rs
@@ -1,0 +1,279 @@
+//! Repo-level behavioral RLS regression test for PAP-70 (parent PAP-67).
+//!
+//! Background
+//! ----------
+//! Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on `vendors` (and the rest of the Epic-11+
+//! cluster). The production api-server connects as the table OWNER, which
+//! `FORCE` binds. `VendorRepository` held a raw `PgPool` and ran every query
+//! WITHOUT ever calling `set_request_context`, so on `dev` `get_current_org_id()`
+//! returned NULL and the policy collapsed to `organization_id = NULL` →
+//! **deny-all**: own-org reads returned empty, writes failed. (PAP-70.)
+//!
+//! The fix routes the repo through an RLS-context connection (the `RlsConnection`
+//! extractor in handlers sets the org/user GUCs before any query). This test
+//! exercises the *repository methods themselves* on a `FORCE`-bound role and
+//! proves:
+//!
+//!   1. **Deny-all reproduction** — with the role bound but NO context set
+//!      (exactly what the raw-pool repo did on `dev`), an own-org `find_by_id`
+//!      / `list` returns nothing.
+//!   2. **Fix** — with `set_request_context(org_a, user_a)` applied first (what
+//!      `RlsConnection` now does), the same repo calls return the own-org row.
+//!   3. **Cross-tenant** — org B's vendor stays invisible to an org-A caller
+//!      even with context set.
+//!   4. **Write path** — a `create` on a context-set connection succeeds and the
+//!      row is the caller's org (the write-side of deny-all).
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — even `FORCE` does not bind a superuser, so a behavioral assertion
+//! would pass vacuously. The test creates a plain `NOSUPERUSER NOBYPASSRLS`
+//! role, grants it access, and `SET ROLE`s to it so `FORCE` actually enforces
+//! the policy the way the production owner role experiences it. Mirrors
+//! `work_order_rls_repo_tests.rs` (the PAP-67 precedent PAP-70 follows).
+
+use db::models::{CreateVendor, VendorQuery};
+use db::repositories::VendorRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Vendor {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@vendor.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'Vendor User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Seed a vendor directly (as superuser, RLS-exempt) for an org.
+async fn seed_vendor(pool: &PgPool, org_id: Uuid, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO vendors (organization_id, company_name)
+        VALUES ($1, $2)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .expect("seed vendor")
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn vendor_repo_force_rls_deny_all_and_fix(pool: PgPool) {
+    let repo = VendorRepository::new(pool.clone());
+
+    // --- Seed as superuser / super-admin context (satisfies org roles-trigger). ---
+    set_ctx(&pool, None, None, true).await;
+    let org_a = seed_org(&pool, "vforce-a").await;
+    let org_b = seed_org(&pool, "vforce-b").await;
+    let user_a = seed_user(&pool, "a@vendor.test").await;
+    let _user_b = seed_user(&pool, "b@vendor.test").await;
+    let vendor_a = seed_vendor(&pool, org_a, "Acme A").await;
+    let vendor_b = seed_vendor(&pool, org_b, "Acme B").await;
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    let role = format!("ppt_rls_vendor_{}", Uuid::new_v4().simple());
+    for stmt in [
+        format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
+        format!("GRANT SELECT, INSERT, UPDATE, DELETE ON vendors TO \"{role}\""),
+        // RLS policy helper must be EXECUTE-able by the bound role.
+        format!("GRANT EXECUTE ON FUNCTION get_current_org_id() TO \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .expect("grant setup");
+    }
+
+    // ====================================================================
+    // (1) DENY-ALL reproduction: role bound, NO context set (the dev raw-pool
+    //     behavior). Own-org reads return nothing.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        // Explicitly clear any inherited context, then drop to the bound role.
+        sqlx::query("SELECT clear_request_context()")
+            .execute(&mut *conn)
+            .await
+            .expect("clear ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let found = repo
+            .find_by_id(&mut *conn, vendor_a)
+            .await
+            .expect("find_by_id (no ctx)");
+        assert!(
+            found.is_none(),
+            "PAP-70 regression: without RLS context, own-org vendor must be \
+             invisible (deny-all) — this is what the raw-pool repo did on dev"
+        );
+
+        let listed = repo
+            .list(&mut *conn, org_a, VendorQuery::default())
+            .await
+            .expect("list (no ctx)");
+        assert!(
+            listed.is_empty(),
+            "PAP-70 regression: without RLS context, list returns deny-all empty"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (2) FIX + (3) cross-tenant: set context, drop to bound role, query repo.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        // (2) Own-org row IS now visible through the repo — the fix.
+        let found = repo
+            .find_by_id(&mut *conn, vendor_a)
+            .await
+            .expect("find_by_id (ctx)");
+        assert_eq!(
+            found.map(|v| v.id),
+            Some(vendor_a),
+            "PAP-70 fix: with RLS context set, the repo must return the own-org vendor"
+        );
+
+        let listed = repo
+            .list(&mut *conn, org_a, VendorQuery::default())
+            .await
+            .expect("list (ctx)");
+        assert_eq!(
+            listed.iter().map(|v| v.id).collect::<Vec<_>>(),
+            vec![vendor_a],
+            "PAP-70 fix: list returns exactly the own-org vendor under context"
+        );
+
+        // (3) Org B's vendor stays invisible to an org-A caller.
+        let cross = repo
+            .find_by_id(&mut *conn, vendor_b)
+            .await
+            .expect("find_by_id cross");
+        assert!(
+            cross.is_none(),
+            "cross-tenant: org B's vendor must NOT be visible to an org-A caller"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (4) WRITE path: a create on a context-set connection succeeds and the
+    //     row is the caller's org. Without context the INSERT would fail the
+    //     policy WITH CHECK (the write-side of deny-all).
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let created = repo
+            .create(
+                &mut *conn,
+                org_a,
+                CreateVendor {
+                    company_name: "Created under RLS".to_string(),
+                    contact_name: None,
+                    phone: None,
+                    email: None,
+                    website: None,
+                    address: None,
+                    services: Vec::new(),
+                    license_number: None,
+                    tax_id: None,
+                    contract_start: None,
+                    contract_end: None,
+                    hourly_rate: None,
+                    is_preferred: None,
+                    notes: None,
+                    metadata: None,
+                },
+            )
+            .await
+            .expect("create under context must succeed");
+        assert_eq!(created.organization_id, org_a);
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup the test role. ---
+    set_ctx(&pool, None, None, true).await;
+    for stmt in [
+        format!("REVOKE ALL ON vendors FROM \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt)).execute(&pool).await.ok();
+    }
+}

--- a/backend/servers/api-server/src/routes/vendors.rs
+++ b/backend/servers/api-server/src/routes/vendors.rs
@@ -1,6 +1,21 @@
 //! Vendor management routes (Epic 21).
+//!
+//! # RLS (PAP-67 / PAP-70)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` on the vendor tables
+//! (`vendors`, `vendor_contacts`, `vendor_contracts`, `vendor_invoices`,
+//! `vendor_ratings`), so every query MUST run on a connection that has
+//! `app.current_org_id` set or it collapses to deny-all. Each handler therefore
+//! acquires an [`RlsConnection`] (which validates tenant membership and sets the
+//! org/user GUCs on a dedicated connection) and passes `&mut **rls.conn()` to the
+//! repository. The authoritative organization is `rls.tenant_id()` — the tenant
+//! the caller was validated against — not a client-supplied `organization_id`,
+//! so the SQL org filter and the RLS context can never disagree. Cross-tenant
+//! access is blocked by RLS: a by-id read of another org's row returns no row
+//! (`404`), and a write targeting another org fails the policy's `WITH CHECK`.
+//! `rls.release()` clears the context before the connection returns to the pool.
 
-use api_core::extractors::AuthUser;
+use api_core::extractors::RlsConnection;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -22,158 +37,72 @@ use uuid::Uuid;
 
 use crate::state::AppState;
 
-/// Verify the authenticated user is a member of `org_id`.
-///
-/// This is the tenant-isolation gate for the org-keyed vendor routes
-/// (list / create / statistics — issue #825). The client-supplied
-/// `organization_id` (query param or JSON body) is never trusted on its own;
-/// it is only accepted once confirmed to belong to the authenticated
-/// principal. Cross-tenant callers receive `403 FORBIDDEN`.
-///
-/// Mirrors the `verify_org_access` idiom in `routes/financial.rs` (#802) and
-/// `routes/integrations/sync.rs`.
-async fn verify_org_access(
-    state: &AppState,
-    user_id: Uuid,
-    org_id: Uuid,
-) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
-    if !is_member_or_not_found(state, user_id, org_id).await? {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse::new(
-                "FORBIDDEN",
-                "You are not a member of this organization",
-            )),
-        ));
-    }
-    Ok(())
+// ==================== Error Helpers ====================
+
+/// Map a repository error to a `500` with a stable code, logging the cause.
+fn db_error(msg: &'static str, e: sqlx::Error) -> (StatusCode, Json<ErrorResponse>) {
+    tracing::error!("{}: {:?}", msg, e);
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse::new("DB_ERROR", msg)),
+    )
 }
 
-/// Membership check that maps DB errors to a 500 but returns a plain bool for
-/// the membership outcome, letting the caller choose 403 vs 404 semantics.
-async fn is_member_or_not_found(
-    state: &AppState,
-    user_id: Uuid,
-    org_id: Uuid,
-) -> Result<bool, (StatusCode, Json<ErrorResponse>)> {
-    state
-        .org_member_repo
-        .is_member(org_id, user_id)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = ?e, "Failed to check org membership");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DATABASE_ERROR", "Database error")),
-            )
-        })
+/// Build a `404` response.
+fn not_found(msg: &'static str) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::NOT_FOUND,
+        Json(ErrorResponse::new("NOT_FOUND", msg)),
+    )
 }
 
-/// Resolve the vendor by id and verify the authenticated user belongs to its
-/// owning org. Returns `404` when the vendor does not exist OR the user is not
-/// a member (so cross-tenant probing cannot distinguish "missing" from
-/// "forbidden"). Mirrors `verify_account_access` in `routes/financial.rs`.
-async fn verify_vendor_access(
+/// Load a vendor by id under the caller's RLS context.
+///
+/// RLS scopes `find_by_id` to the connection's org, so a vendor owned by
+/// another organization is invisible and surfaces as `404 NOT_FOUND` — the
+/// cross-tenant IDOR guard is now enforced by the database, not an app-level
+/// membership check.
+async fn load_vendor_for_user(
     state: &AppState,
-    user_id: Uuid,
+    rls: &mut RlsConnection,
     vendor_id: Uuid,
 ) -> Result<Vendor, (StatusCode, Json<ErrorResponse>)> {
-    let vendor = state
+    state
         .vendor_repo
-        .find_by_id(vendor_id)
+        .find_by_id(&mut **rls.conn(), vendor_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to load vendor: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to load vendor")),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Vendor not found")),
-            )
-        })?;
-
-    if !is_member_or_not_found(state, user_id, vendor.organization_id).await? {
-        return Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Vendor not found")),
-        ));
-    }
-
-    Ok(vendor)
+        .map_err(|e| db_error("Failed to load vendor", e))?
+        .ok_or_else(|| not_found("Vendor not found"))
 }
 
-/// Resolve the contract by id and verify org membership. `404` on missing or
-/// cross-tenant.
-async fn verify_contract_access(
+/// Load a contract by id under the caller's RLS context. Same contract as
+/// [`load_vendor_for_user`].
+async fn load_contract_for_user(
     state: &AppState,
-    user_id: Uuid,
+    rls: &mut RlsConnection,
     contract_id: Uuid,
 ) -> Result<VendorContract, (StatusCode, Json<ErrorResponse>)> {
-    let contract = state
+    state
         .vendor_repo
-        .find_contract_by_id(contract_id)
+        .find_contract_by_id(&mut **rls.conn(), contract_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to load contract: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to load contract")),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Contract not found")),
-            )
-        })?;
-
-    if !is_member_or_not_found(state, user_id, contract.organization_id).await? {
-        return Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Contract not found")),
-        ));
-    }
-
-    Ok(contract)
+        .map_err(|e| db_error("Failed to load contract", e))?
+        .ok_or_else(|| not_found("Contract not found"))
 }
 
-/// Resolve the invoice by id and verify org membership. `404` on missing or
-/// cross-tenant.
-async fn verify_invoice_access(
+/// Load an invoice by id under the caller's RLS context. Same contract as
+/// [`load_vendor_for_user`].
+async fn load_invoice_for_user(
     state: &AppState,
-    user_id: Uuid,
+    rls: &mut RlsConnection,
     invoice_id: Uuid,
 ) -> Result<VendorInvoice, (StatusCode, Json<ErrorResponse>)> {
-    let invoice = state
+    state
         .vendor_repo
-        .find_invoice_by_id(invoice_id)
+        .find_invoice_by_id(&mut **rls.conn(), invoice_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to load invoice: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to load invoice")),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Invoice not found")),
-            )
-        })?;
-
-    if !is_member_or_not_found(state, user_id, invoice.organization_id).await? {
-        return Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Invoice not found")),
-        ));
-    }
-
-    Ok(invoice)
+        .map_err(|e| db_error("Failed to load invoice", e))?
+        .ok_or_else(|| not_found("Invoice not found"))
 }
 
 /// Create vendors router.
@@ -218,15 +147,20 @@ pub fn router() -> Router<AppState> {
 // ==================== Request/Response Types ====================
 
 /// Organization query parameter.
+///
+/// Retained for wire compatibility; the authoritative org is `rls.tenant_id()`.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct OrgQuery {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
 }
 
 /// Create vendor request wrapper.
+///
+/// `organization_id` is retained for wire compatibility but ignored — the
+/// authoritative org is `rls.tenant_id()`.
 #[derive(Debug, Deserialize)]
 pub struct CreateVendorRequest {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     #[serde(flatten)]
     pub data: CreateVendor,
 }
@@ -234,7 +168,7 @@ pub struct CreateVendorRequest {
 /// List vendors query.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct ListVendorsQuery {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     pub status: Option<String>,
     pub service: Option<String>,
     pub is_preferred: Option<bool>,
@@ -267,7 +201,7 @@ pub struct PreferredRequest {
 /// Create contract request wrapper.
 #[derive(Debug, Deserialize)]
 pub struct CreateContractRequest {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     #[serde(flatten)]
     pub data: CreateVendorContract,
 }
@@ -275,7 +209,7 @@ pub struct CreateContractRequest {
 /// List contracts query.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct ListContractsQuery {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     pub vendor_id: Option<Uuid>,
     pub status: Option<String>,
     pub contract_type: Option<String>,
@@ -300,14 +234,14 @@ impl From<&ListContractsQuery> for ContractQuery {
 /// Expiring contracts query.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct ExpiringQuery {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     pub days: Option<i32>,
 }
 
 /// Create invoice request wrapper.
 #[derive(Debug, Deserialize)]
 pub struct CreateInvoiceRequest {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     #[serde(flatten)]
     pub data: CreateVendorInvoice,
 }
@@ -315,7 +249,7 @@ pub struct CreateInvoiceRequest {
 /// List invoices query.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct ListInvoicesQuery {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     pub vendor_id: Option<Uuid>,
     pub status: Option<String>,
     pub due_before: Option<NaiveDate>,
@@ -342,7 +276,7 @@ impl From<&ListInvoicesQuery> for InvoiceQuery {
 /// Invoice summary query.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct InvoiceSummaryQuery {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     pub start_date: NaiveDate,
     pub end_date: NaiveDate,
 }
@@ -372,618 +306,549 @@ pub struct PaginationQuery {
 
 async fn create_vendor(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Json(payload): Json<CreateVendorRequest>,
 ) -> Result<(StatusCode, Json<Vendor>), (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, payload.organization_id).await?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .vendor_repo
-        .create(payload.organization_id, payload.data)
+        .create(&mut **rls.conn(), org_id, payload.data)
         .await
         .map(|v| (StatusCode::CREATED, Json(v)))
-        .map_err(|e| {
-            tracing::error!("Failed to create vendor: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to create vendor")),
-            )
-        })
+        .map_err(|e| db_error("Failed to create vendor", e));
+    rls.release().await;
+    out
 }
 
 async fn list_vendors(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<ListVendorsQuery>,
 ) -> Result<Json<Vec<Vendor>>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, query.organization_id).await?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .vendor_repo
-        .list(query.organization_id, (&query).into())
+        .list(&mut **rls.conn(), org_id, (&query).into())
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list vendors: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to list vendors")),
-            )
-        })
+        .map_err(|e| db_error("Failed to list vendors", e));
+    rls.release().await;
+    out
 }
 
 async fn list_vendors_with_details(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<ListVendorsQuery>,
 ) -> Result<Json<Vec<VendorWithDetails>>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, query.organization_id).await?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .vendor_repo
-        .list_with_details(query.organization_id, (&query).into())
+        .list_with_details(&mut **rls.conn(), org_id, (&query).into())
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list vendors: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to list vendors")),
-            )
-        })
+        .map_err(|e| db_error("Failed to list vendors", e));
+    rls.release().await;
+    out
 }
 
 async fn get_statistics(
     State(state): State<AppState>,
-    user: AuthUser,
-    Query(query): Query<OrgQuery>,
+    mut rls: RlsConnection,
+    Query(_query): Query<OrgQuery>,
 ) -> Result<Json<VendorStatistics>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, query.organization_id).await?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .vendor_repo
-        .get_statistics(query.organization_id)
+        .get_statistics(&mut **rls.conn(), org_id)
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to get statistics: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to get statistics")),
-            )
-        })
+        .map_err(|e| db_error("Failed to get statistics", e));
+    rls.release().await;
+    out
 }
 
 async fn get_vendor(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Vendor>, (StatusCode, Json<ErrorResponse>)> {
-    let vendor = verify_vendor_access(&state, user.user_id, id).await?;
-    Ok(Json(vendor))
+    let out = load_vendor_for_user(&state, &mut rls, id).await.map(Json);
+    rls.release().await;
+    out
 }
 
 async fn update_vendor(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateVendor>,
 ) -> Result<Json<Vendor>, (StatusCode, Json<ErrorResponse>)> {
-    verify_vendor_access(&state, user.user_id, id).await?;
-    state
-        .vendor_repo
-        .update(id, data)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to update vendor: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to update vendor")),
-            )
-        })
+    let out = async {
+        load_vendor_for_user(&state, &mut rls, id).await?;
+        state
+            .vendor_repo
+            .update(&mut **rls.conn(), id, data)
+            .await
+            .map(Json)
+            .map_err(|e| db_error("Failed to update vendor", e))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn delete_vendor(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    verify_vendor_access(&state, user.user_id, id).await?;
-    let deleted = state.vendor_repo.delete(id).await.map_err(|e| {
-        tracing::error!("Failed to delete vendor: {:?}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new("DB_ERROR", "Failed to delete vendor")),
-        )
-    })?;
-
-    if deleted {
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Vendor not found")),
-        ))
+    let out = async {
+        load_vendor_for_user(&state, &mut rls, id).await?;
+        let deleted = state
+            .vendor_repo
+            .delete(&mut **rls.conn(), id)
+            .await
+            .map_err(|e| db_error("Failed to delete vendor", e))?;
+        if deleted {
+            Ok(StatusCode::NO_CONTENT)
+        } else {
+            Err(not_found("Vendor not found"))
+        }
     }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn set_preferred(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<PreferredRequest>,
 ) -> Result<Json<Vendor>, (StatusCode, Json<ErrorResponse>)> {
-    verify_vendor_access(&state, user.user_id, id).await?;
-    state
-        .vendor_repo
-        .set_preferred(id, data.is_preferred)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to set preferred: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to set preferred")),
-            )
-        })
+    let out = async {
+        load_vendor_for_user(&state, &mut rls, id).await?;
+        state
+            .vendor_repo
+            .set_preferred(&mut **rls.conn(), id, data.is_preferred)
+            .await
+            .map(Json)
+            .map_err(|e| db_error("Failed to set preferred", e))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 // ==================== Vendor Contacts ====================
 
 async fn add_contact(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<CreateVendorContact>,
 ) -> Result<(StatusCode, Json<VendorContact>), (StatusCode, Json<ErrorResponse>)> {
-    verify_vendor_access(&state, user.user_id, id).await?;
-    state
-        .vendor_repo
-        .add_contact(id, data)
-        .await
-        .map(|c| (StatusCode::CREATED, Json(c)))
-        .map_err(|e| {
-            tracing::error!("Failed to add contact: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to add contact")),
-            )
-        })
+    let out = async {
+        load_vendor_for_user(&state, &mut rls, id).await?;
+        state
+            .vendor_repo
+            .add_contact(&mut **rls.conn(), id, data)
+            .await
+            .map(|c| (StatusCode::CREATED, Json(c)))
+            .map_err(|e| db_error("Failed to add contact", e))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn list_contacts(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Vec<VendorContact>>, (StatusCode, Json<ErrorResponse>)> {
-    verify_vendor_access(&state, user.user_id, id).await?;
-    state
-        .vendor_repo
-        .list_contacts(id)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list contacts: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to list contacts")),
-            )
-        })
+    let out = async {
+        load_vendor_for_user(&state, &mut rls, id).await?;
+        state
+            .vendor_repo
+            .list_contacts(&mut **rls.conn(), id)
+            .await
+            .map(Json)
+            .map_err(|e| db_error("Failed to list contacts", e))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn delete_contact(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(contact_id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    // Resolve the owning vendor and verify tenant membership before deleting,
-    // so a foreign caller cannot delete another org's contact by id (#825).
-    let vendor_id = state
-        .vendor_repo
-        .find_contact_vendor_id(contact_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to resolve contact: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to resolve contact")),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Contact not found")),
-            )
-        })?;
-    verify_vendor_access(&state, user.user_id, vendor_id).await?;
+    let out = async {
+        // Resolve the owning vendor under RLS. A contact whose vendor is owned
+        // by another org is invisible (resolves to `None`) → 404. We then load
+        // the vendor to confirm tenant visibility before deleting.
+        let vendor_id = state
+            .vendor_repo
+            .find_contact_vendor_id(&mut **rls.conn(), contact_id)
+            .await
+            .map_err(|e| db_error("Failed to resolve contact", e))?
+            .ok_or_else(|| not_found("Contact not found"))?;
+        load_vendor_for_user(&state, &mut rls, vendor_id).await?;
 
-    let deleted = state
-        .vendor_repo
-        .delete_contact(contact_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to delete contact: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to delete contact")),
-            )
-        })?;
-
-    if deleted {
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Contact not found")),
-        ))
+        let deleted = state
+            .vendor_repo
+            .delete_contact(&mut **rls.conn(), contact_id)
+            .await
+            .map_err(|e| db_error("Failed to delete contact", e))?;
+        if deleted {
+            Ok(StatusCode::NO_CONTENT)
+        } else {
+            Err(not_found("Contact not found"))
+        }
     }
+    .await;
+    rls.release().await;
+    out
 }
 
 // ==================== Vendor Ratings ====================
 
 async fn add_rating(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<CreateVendorRating>,
 ) -> Result<(StatusCode, Json<VendorRating>), (StatusCode, Json<ErrorResponse>)> {
-    verify_vendor_access(&state, user.user_id, id).await?;
-    state
-        .vendor_repo
-        .add_rating(id, user.user_id, data)
-        .await
-        .map(|r| (StatusCode::CREATED, Json(r)))
-        .map_err(|e| {
-            tracing::error!("Failed to add rating: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to add rating")),
-            )
-        })
+    let user_id = rls.user_id();
+    let out = async {
+        load_vendor_for_user(&state, &mut rls, id).await?;
+        state
+            .vendor_repo
+            .add_rating(&mut **rls.conn(), id, user_id, data)
+            .await
+            .map(|r| (StatusCode::CREATED, Json(r)))
+            .map_err(|e| db_error("Failed to add rating", e))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn list_ratings(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<Vec<VendorRating>>, (StatusCode, Json<ErrorResponse>)> {
-    verify_vendor_access(&state, user.user_id, id).await?;
-    state
-        .vendor_repo
-        .list_ratings(id, query.limit.unwrap_or(50), query.offset.unwrap_or(0))
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list ratings: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to list ratings")),
+    let out = async {
+        load_vendor_for_user(&state, &mut rls, id).await?;
+        state
+            .vendor_repo
+            .list_ratings(
+                &mut **rls.conn(),
+                id,
+                query.limit.unwrap_or(50),
+                query.offset.unwrap_or(0),
             )
-        })
+            .await
+            .map(Json)
+            .map_err(|e| db_error("Failed to list ratings", e))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 // ==================== Contract Endpoints (Story 21.3) ====================
 
 async fn create_contract(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Json(payload): Json<CreateContractRequest>,
 ) -> Result<(StatusCode, Json<VendorContract>), (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, payload.organization_id).await?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .vendor_repo
-        .create_contract(payload.organization_id, payload.data)
+        .create_contract(&mut **rls.conn(), org_id, payload.data)
         .await
         .map(|c| (StatusCode::CREATED, Json(c)))
-        .map_err(|e| {
-            tracing::error!("Failed to create contract: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to create contract")),
-            )
-        })
+        .map_err(|e| db_error("Failed to create contract", e));
+    rls.release().await;
+    out
 }
 
 async fn list_contracts(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<ListContractsQuery>,
 ) -> Result<Json<Vec<VendorContract>>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, query.organization_id).await?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .vendor_repo
-        .list_contracts(query.organization_id, (&query).into())
+        .list_contracts(&mut **rls.conn(), org_id, (&query).into())
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list contracts: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to list contracts")),
-            )
-        })
+        .map_err(|e| db_error("Failed to list contracts", e));
+    rls.release().await;
+    out
 }
 
 async fn get_expiring_contracts(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<ExpiringQuery>,
 ) -> Result<Json<Vec<ExpiringContract>>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, query.organization_id).await?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .vendor_repo
-        .get_expiring_contracts(query.organization_id, query.days.unwrap_or(30))
+        .get_expiring_contracts(&mut **rls.conn(), org_id, query.days.unwrap_or(30))
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to get expiring contracts: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DB_ERROR",
-                    "Failed to get expiring contracts",
-                )),
-            )
-        })
+        .map_err(|e| db_error("Failed to get expiring contracts", e));
+    rls.release().await;
+    out
 }
 
 async fn get_contract(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<VendorContract>, (StatusCode, Json<ErrorResponse>)> {
-    let contract = verify_contract_access(&state, user.user_id, id).await?;
-    Ok(Json(contract))
+    let out = load_contract_for_user(&state, &mut rls, id).await.map(Json);
+    rls.release().await;
+    out
 }
 
 async fn update_contract(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateVendorContract>,
 ) -> Result<Json<VendorContract>, (StatusCode, Json<ErrorResponse>)> {
-    verify_contract_access(&state, user.user_id, id).await?;
-    state
-        .vendor_repo
-        .update_contract(id, data)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to update contract: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to update contract")),
-            )
-        })
+    let out = async {
+        load_contract_for_user(&state, &mut rls, id).await?;
+        state
+            .vendor_repo
+            .update_contract(&mut **rls.conn(), id, data)
+            .await
+            .map(Json)
+            .map_err(|e| db_error("Failed to update contract", e))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn delete_contract(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    verify_contract_access(&state, user.user_id, id).await?;
-    let deleted = state.vendor_repo.delete_contract(id).await.map_err(|e| {
-        tracing::error!("Failed to delete contract: {:?}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new("DB_ERROR", "Failed to delete contract")),
-        )
-    })?;
-
-    if deleted {
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Contract not found")),
-        ))
+    let out = async {
+        load_contract_for_user(&state, &mut rls, id).await?;
+        let deleted = state
+            .vendor_repo
+            .delete_contract(&mut **rls.conn(), id)
+            .await
+            .map_err(|e| db_error("Failed to delete contract", e))?;
+        if deleted {
+            Ok(StatusCode::NO_CONTENT)
+        } else {
+            Err(not_found("Contract not found"))
+        }
     }
+    .await;
+    rls.release().await;
+    out
 }
 
 // ==================== Invoice Endpoints (Story 21.4) ====================
 
 async fn create_invoice(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Json(payload): Json<CreateInvoiceRequest>,
 ) -> Result<(StatusCode, Json<VendorInvoice>), (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, payload.organization_id).await?;
-    state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .vendor_repo
-        .create_invoice(payload.organization_id, user.user_id, payload.data)
+        .create_invoice(&mut **rls.conn(), org_id, user_id, payload.data)
         .await
         .map(|i| (StatusCode::CREATED, Json(i)))
-        .map_err(|e| {
-            tracing::error!("Failed to create invoice: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to create invoice")),
-            )
-        })
+        .map_err(|e| db_error("Failed to create invoice", e));
+    rls.release().await;
+    out
 }
 
 async fn list_invoices(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<ListInvoicesQuery>,
 ) -> Result<Json<Vec<VendorInvoice>>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, query.organization_id).await?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .vendor_repo
-        .list_invoices(query.organization_id, (&query).into())
+        .list_invoices(&mut **rls.conn(), org_id, (&query).into())
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list invoices: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to list invoices")),
-            )
-        })
+        .map_err(|e| db_error("Failed to list invoices", e));
+    rls.release().await;
+    out
 }
 
 async fn get_overdue_invoices(
     State(state): State<AppState>,
-    user: AuthUser,
-    Query(query): Query<OrgQuery>,
+    mut rls: RlsConnection,
+    Query(_query): Query<OrgQuery>,
 ) -> Result<Json<Vec<VendorInvoice>>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, query.organization_id).await?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .vendor_repo
-        .get_overdue_invoices(query.organization_id)
+        .get_overdue_invoices(&mut **rls.conn(), org_id)
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to get overdue invoices: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DB_ERROR",
-                    "Failed to get overdue invoices",
-                )),
-            )
-        })
+        .map_err(|e| db_error("Failed to get overdue invoices", e));
+    rls.release().await;
+    out
 }
 
 async fn get_invoice_summary(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<InvoiceSummaryQuery>,
 ) -> Result<Json<Vec<InvoiceSummary>>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, query.organization_id).await?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .vendor_repo
-        .get_invoice_summary(query.organization_id, query.start_date, query.end_date)
+        .get_invoice_summary(&mut **rls.conn(), org_id, query.start_date, query.end_date)
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to get invoice summary: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DB_ERROR",
-                    "Failed to get invoice summary",
-                )),
-            )
-        })
+        .map_err(|e| db_error("Failed to get invoice summary", e));
+    rls.release().await;
+    out
 }
 
 async fn get_invoice(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<VendorInvoice>, (StatusCode, Json<ErrorResponse>)> {
-    let invoice = verify_invoice_access(&state, user.user_id, id).await?;
-    Ok(Json(invoice))
+    let out = load_invoice_for_user(&state, &mut rls, id).await.map(Json);
+    rls.release().await;
+    out
 }
 
 async fn update_invoice(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateVendorInvoice>,
 ) -> Result<Json<VendorInvoice>, (StatusCode, Json<ErrorResponse>)> {
-    verify_invoice_access(&state, user.user_id, id).await?;
-    state
-        .vendor_repo
-        .update_invoice(id, data)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to update invoice: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to update invoice")),
-            )
-        })
+    let out = async {
+        load_invoice_for_user(&state, &mut rls, id).await?;
+        state
+            .vendor_repo
+            .update_invoice(&mut **rls.conn(), id, data)
+            .await
+            .map(Json)
+            .map_err(|e| db_error("Failed to update invoice", e))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn delete_invoice(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    verify_invoice_access(&state, user.user_id, id).await?;
-    let deleted = state.vendor_repo.delete_invoice(id).await.map_err(|e| {
-        tracing::error!("Failed to delete invoice: {:?}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new("DB_ERROR", "Failed to delete invoice")),
-        )
-    })?;
-
-    if deleted {
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Invoice not found")),
-        ))
+    let out = async {
+        load_invoice_for_user(&state, &mut rls, id).await?;
+        let deleted = state
+            .vendor_repo
+            .delete_invoice(&mut **rls.conn(), id)
+            .await
+            .map_err(|e| db_error("Failed to delete invoice", e))?;
+        if deleted {
+            Ok(StatusCode::NO_CONTENT)
+        } else {
+            Err(not_found("Invoice not found"))
+        }
     }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn approve_invoice(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<VendorInvoice>, (StatusCode, Json<ErrorResponse>)> {
-    verify_invoice_access(&state, user.user_id, id).await?;
-    state
-        .vendor_repo
-        .approve_invoice(id, user.user_id)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to approve invoice: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to approve invoice")),
-            )
-        })
+    let user_id = rls.user_id();
+    let out = async {
+        load_invoice_for_user(&state, &mut rls, id).await?;
+        state
+            .vendor_repo
+            .approve_invoice(&mut **rls.conn(), id, user_id)
+            .await
+            .map(Json)
+            .map_err(|e| db_error("Failed to approve invoice", e))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn reject_invoice(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<RejectRequest>,
 ) -> Result<Json<VendorInvoice>, (StatusCode, Json<ErrorResponse>)> {
-    verify_invoice_access(&state, user.user_id, id).await?;
-    state
-        .vendor_repo
-        .reject_invoice(id, user.user_id, &data.reason)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to reject invoice: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to reject invoice")),
-            )
-        })
+    let user_id = rls.user_id();
+    let out = async {
+        load_invoice_for_user(&state, &mut rls, id).await?;
+        state
+            .vendor_repo
+            .reject_invoice(&mut **rls.conn(), id, user_id, &data.reason)
+            .await
+            .map(Json)
+            .map_err(|e| db_error("Failed to reject invoice", e))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn record_payment(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<RecordPaymentRequest>,
 ) -> Result<Json<VendorInvoice>, (StatusCode, Json<ErrorResponse>)> {
-    verify_invoice_access(&state, user.user_id, id).await?;
-    state
-        .vendor_repo
-        .record_payment(
-            id,
-            data.amount,
-            data.method.as_deref(),
-            data.reference.as_deref(),
-        )
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to record payment: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to record payment")),
+    let out = async {
+        load_invoice_for_user(&state, &mut rls, id).await?;
+        state
+            .vendor_repo
+            .record_payment(
+                &mut **rls.conn(),
+                id,
+                data.amount,
+                data.method.as_deref(),
+                data.reference.as_deref(),
             )
-        })
+            .await
+            .map(Json)
+            .map_err(|e| db_error("Failed to record payment", e))
+    }
+    .await;
+    rls.release().await;
+    out
 }


### PR DESCRIPTION
## PAP-70 — route \`vendor\` repo through RLS-context connection (FORCE-RLS deny-all)

Parent: PAP-67. Detection guard: PAP-68.

### Problem
\`vendor.rs\` held a raw \`PgPool\` and ran every query via \`&self.pool\` without ever calling \`set_request_context\`. Under migration \`00179\`'s \`FORCE ROW LEVEL SECURITY\` the api-server's owner connection is no longer exempt, so own-org reads returned empty and writes failed the policy \`WITH CHECK\` — deny-all on \`dev\`. Router: \`/api/v1/vendors\`.

**FORCE-RLS tables:** vendors, vendor_contacts, vendor_contracts, vendor_invoices, vendor_ratings.

### Fix (follows the proven \`work_order\` / \`budget.rs\` pattern)
- **Repo** (\`crates/db/src/repositories/vendor.rs\`): dropped the raw \`pool\` field; every method now takes an executor whose connection already has RLS context set (generic \`Executor<Postgres>\`). \`new(_pool)\` retained for \`AppState\` construction so there is no second raw-pool path.
- **Route** (\`servers/api-server/src/routes/vendors.rs\`): each handler acquires \`RlsConnection\`, passes \`&mut **rls.conn()\` to the repo, uses \`rls.tenant_id()\` as the authoritative org (SQL filter and RLS context can never disagree), and calls \`rls.release()\` on both Ok/Err. Cross-tenant by-id reads now surface as \`404\` via RLS instead of an app-level \`verify_org_access\` check.
- **Test** (\`crates/db/tests/vendor_rls_repo_tests.rs\`): mirrors \`work_order_rls_repo_tests.rs\` — a \`NOSUPERUSER NOBYPASSRLS\` role so \`FORCE\` actually binds; asserts (1) deny-all without context, (2) own-org visibility + (3) cross-tenant invisibility with context, (4) the write path under context.

### Verification
- \`cargo check -p db -p api-server\` — green
- \`cargo check -p db --tests\` — green (new test compiles)
- DB execution of the \`#[sqlx::test]\` runs in CI (\`rls-smoke\`) / QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)