### PR TITLE
fix(db): route building_certification repo through RLS-context connection (PAP-80)

### DIFF
--- a/backend/crates/db/src/repositories/building_certification.rs
+++ b/backend/crates/db/src/repositories/building_certification.rs
@@ -1,6 +1,34 @@
 //! Building Certification Repository for Epic 137: Smart Building Certification.
+//!
+//! # RLS Integration (PAP-67 / PAP-80)
+//!
+//! Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on the building-certification cluster:
+//! `building_certifications`, `certification_credits`, `certification_documents`,
+//! `certification_milestones`, `certification_benchmarks`,
+//! `certification_audit_logs`, `certification_costs`, and
+//! `certification_reminders` (8 tables). Under `FORCE` the api-server's
+//! table-owner connection is no longer exempt, so a query issued on a connection
+//! without `app.current_org_id` set collapses to deny-all (own-org reads return
+//! empty, writes fail the policy `WITH CHECK`).
+//!
+//! This repository therefore holds **no pool**. Every method takes an executor
+//! whose connection already has RLS context set — in handlers this comes from
+//! the `RlsConnection` extractor via `&mut **rls.conn()`:
+//!
+//! * single-statement methods take a generic `executor: E`;
+//! * multi-statement methods that compose helpers take `conn: &mut PgConnection`
+//!   and reborrow `&mut *conn` per call.
+//!
+//! Because the repo cannot reach a raw pool, there is no path that bypasses RLS.
+//! This mirrors the `work_order.rs` / `reserve_funds.rs` precedent.
+//!
+//! The explicit `organization_id = $n` predicates are retained as
+//! defense-in-depth: the authoritative org is the caller's `rls.tenant_id()`,
+//! so the SQL filter and the RLS context can never disagree, and cross-tenant
+//! by-id reads return no row (→ 404) under both layers.
 
-use sqlx::PgPool;
+use sqlx::{Executor, PgConnection, PgPool, Postgres};
 use uuid::Uuid;
 
 use crate::models::building_certification::{
@@ -13,34 +41,38 @@ use crate::models::building_certification::{
     CreateCertificationReminder, UpdateBuildingCertification, UpdateCertificationCredit,
     UpdateCertificationMilestone,
 };
-use crate::DbPool;
 
 /// Repository for building certification operations.
+///
+/// Stateless: every method receives an RLS-context-bearing executor. The repo
+/// holds no pool so it cannot issue an un-scoped (deny-all under `FORCE`) query.
 #[derive(Clone)]
-pub struct BuildingCertificationRepository {
-    pool: DbPool,
-}
+pub struct BuildingCertificationRepository;
 
 impl BuildingCertificationRepository {
     /// Create a new repository instance.
-    pub fn new(pool: DbPool) -> Self {
-        Self { pool }
-    }
-
-    /// Get the pool reference for tests.
-    pub fn pool(&self) -> &PgPool {
-        &self.pool
+    ///
+    /// The pool argument is retained for construction-site compatibility with
+    /// the other repositories on `AppState`; this repo deliberately does not
+    /// store it (see module docs — all queries run on a context-set connection
+    /// supplied by the handler's `RlsConnection`).
+    pub fn new(_pool: PgPool) -> Self {
+        Self
     }
 
     // ==================== Building Certifications ====================
 
     /// Create a new building certification.
-    pub async fn create_certification(
+    pub async fn create_certification<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         input: CreateBuildingCertification,
         user_id: Option<Uuid>,
-    ) -> Result<BuildingCertification, sqlx::Error> {
+    ) -> Result<BuildingCertification, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let percentage = if let (Some(achieved), Some(possible)) =
             (input.total_points_achieved, input.total_points_possible)
         {
@@ -96,16 +128,25 @@ impl BuildingCertificationRepository {
         .bind(input.certification_fee)
         .bind(input.annual_fee)
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
-    /// Get a certification by ID.
-    pub async fn get_certification(
+    /// Get a certification by ID, scoped to the caller's organization.
+    ///
+    /// Returns `None` if the certification does not exist **or** belongs to a
+    /// different organization, so cross-tenant by-id reads (IDOR) surface as a
+    /// 404. Under FORCE-RLS the connection's org context is a second,
+    /// database-enforced guard on top of the explicit predicate.
+    pub async fn get_certification<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         cert_id: Uuid,
-    ) -> Result<Option<BuildingCertification>, sqlx::Error> {
+    ) -> Result<Option<BuildingCertification>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, BuildingCertification>(
             r#"
             SELECT * FROM building_certifications
@@ -114,18 +155,22 @@ impl BuildingCertificationRepository {
         )
         .bind(org_id)
         .bind(cert_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// List certifications with filters.
-    pub async fn list_certifications(
+    pub async fn list_certifications<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         filters: CertificationFilters,
         limit: i64,
         offset: i64,
-    ) -> Result<Vec<BuildingCertification>, sqlx::Error> {
+    ) -> Result<Vec<BuildingCertification>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let mut query =
             String::from("SELECT * FROM building_certifications WHERE organization_id = $1");
         let mut param_count = 1;
@@ -178,16 +223,24 @@ impl BuildingCertificationRepository {
             q = q.bind(days);
         }
 
-        q.bind(limit).bind(offset).fetch_all(&self.pool).await
+        q.bind(limit).bind(offset).fetch_all(executor).await
     }
 
-    /// Update a certification.
-    pub async fn update_certification(
+    /// Update a certification, scoped to the caller's organization.
+    ///
+    /// The `organization_id = $1` predicate means an update targeting another
+    /// org's certification matches zero rows and surfaces as `None` (→ 404),
+    /// not a silent cross-tenant write.
+    pub async fn update_certification<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         cert_id: Uuid,
         input: UpdateBuildingCertification,
-    ) -> Result<Option<BuildingCertification>, sqlx::Error> {
+    ) -> Result<Option<BuildingCertification>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, BuildingCertification>(
             r#"
             UPDATE building_certifications SET
@@ -238,16 +291,20 @@ impl BuildingCertificationRepository {
         .bind(input.certification_fee)
         .bind(input.annual_fee)
         .bind(input.total_investment)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
-    /// Delete a certification.
-    pub async fn delete_certification(
+    /// Delete a certification, scoped to the caller's organization.
+    pub async fn delete_certification<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         cert_id: Uuid,
-    ) -> Result<bool, sqlx::Error> {
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query(
             r#"
             DELETE FROM building_certifications
@@ -256,19 +313,23 @@ impl BuildingCertificationRepository {
         )
         .bind(org_id)
         .bind(cert_id)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
 
         Ok(result.rows_affected() > 0)
     }
 
     /// Get certification with credits summary.
+    ///
+    /// Multi-statement (org-scoped fetch + aggregate), so it takes a connection
+    /// and reborrows it per query.
     pub async fn get_certification_with_credits(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         cert_id: Uuid,
     ) -> Result<Option<CertificationWithCredits>, sqlx::Error> {
-        let cert = self.get_certification(org_id, cert_id).await?;
+        let cert = self.get_certification(&mut *conn, org_id, cert_id).await?;
 
         if let Some(certification) = cert {
             let credits_summary: (i64, i64, i64, i64) = sqlx::query_as(
@@ -284,7 +345,7 @@ impl BuildingCertificationRepository {
             )
             .bind(org_id)
             .bind(cert_id)
-            .fetch_one(&self.pool)
+            .fetch_one(&mut *conn)
             .await?;
 
             Ok(Some(CertificationWithCredits {
@@ -302,11 +363,15 @@ impl BuildingCertificationRepository {
     // ==================== Certification Credits ====================
 
     /// Create a certification credit.
-    pub async fn create_credit(
+    pub async fn create_credit<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         input: CreateCertificationCredit,
-    ) -> Result<CertificationCredit, sqlx::Error> {
+    ) -> Result<CertificationCredit, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, CertificationCredit>(
             r#"
             INSERT INTO certification_credits (
@@ -339,16 +404,20 @@ impl BuildingCertificationRepository {
         .bind(&input.notes)
         .bind(input.responsible_user_id)
         .bind(input.due_date)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
-    /// Get a credit by ID.
-    pub async fn get_credit(
+    /// Get a credit by ID, scoped to the caller's organization.
+    pub async fn get_credit<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         credit_id: Uuid,
-    ) -> Result<Option<CertificationCredit>, sqlx::Error> {
+    ) -> Result<Option<CertificationCredit>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, CertificationCredit>(
             r#"
             SELECT * FROM certification_credits
@@ -357,16 +426,20 @@ impl BuildingCertificationRepository {
         )
         .bind(org_id)
         .bind(credit_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// List credits for a certification.
-    pub async fn list_credits(
+    pub async fn list_credits<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         cert_id: Uuid,
-    ) -> Result<Vec<CertificationCredit>, sqlx::Error> {
+    ) -> Result<Vec<CertificationCredit>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, CertificationCredit>(
             r#"
             SELECT * FROM certification_credits
@@ -376,17 +449,21 @@ impl BuildingCertificationRepository {
         )
         .bind(org_id)
         .bind(cert_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
-    /// Update a credit.
-    pub async fn update_credit(
+    /// Update a credit, scoped to the caller's organization.
+    pub async fn update_credit<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         credit_id: Uuid,
         input: UpdateCertificationCredit,
-    ) -> Result<Option<CertificationCredit>, sqlx::Error> {
+    ) -> Result<Option<CertificationCredit>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, CertificationCredit>(
             r#"
             UPDATE certification_credits SET
@@ -427,12 +504,20 @@ impl BuildingCertificationRepository {
         .bind(&input.notes)
         .bind(input.responsible_user_id)
         .bind(input.due_date)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
-    /// Delete a credit.
-    pub async fn delete_credit(&self, org_id: Uuid, credit_id: Uuid) -> Result<bool, sqlx::Error> {
+    /// Delete a credit, scoped to the caller's organization.
+    pub async fn delete_credit<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+        credit_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query(
             r#"
             DELETE FROM certification_credits
@@ -441,7 +526,7 @@ impl BuildingCertificationRepository {
         )
         .bind(org_id)
         .bind(credit_id)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
 
         Ok(result.rows_affected() > 0)
@@ -450,12 +535,16 @@ impl BuildingCertificationRepository {
     // ==================== Certification Documents ====================
 
     /// Create a certification document.
-    pub async fn create_document(
+    pub async fn create_document<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         input: CreateCertificationDocument,
         user_id: Option<Uuid>,
-    ) -> Result<CertificationDocument, sqlx::Error> {
+    ) -> Result<CertificationDocument, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, CertificationDocument>(
             r#"
             INSERT INTO certification_documents (
@@ -476,16 +565,20 @@ impl BuildingCertificationRepository {
         .bind(input.file_size_bytes)
         .bind(&input.file_type)
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// List documents for a certification.
-    pub async fn list_documents(
+    pub async fn list_documents<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         cert_id: Uuid,
-    ) -> Result<Vec<CertificationDocument>, sqlx::Error> {
+    ) -> Result<Vec<CertificationDocument>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, CertificationDocument>(
             r#"
             SELECT * FROM certification_documents
@@ -495,12 +588,20 @@ impl BuildingCertificationRepository {
         )
         .bind(org_id)
         .bind(cert_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
-    /// Delete a document.
-    pub async fn delete_document(&self, org_id: Uuid, doc_id: Uuid) -> Result<bool, sqlx::Error> {
+    /// Delete a document, scoped to the caller's organization.
+    pub async fn delete_document<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+        doc_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query(
             r#"
             DELETE FROM certification_documents
@@ -509,7 +610,7 @@ impl BuildingCertificationRepository {
         )
         .bind(org_id)
         .bind(doc_id)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
 
         Ok(result.rows_affected() > 0)
@@ -518,11 +619,15 @@ impl BuildingCertificationRepository {
     // ==================== Certification Milestones ====================
 
     /// Create a certification milestone.
-    pub async fn create_milestone(
+    pub async fn create_milestone<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         input: CreateCertificationMilestone,
-    ) -> Result<CertificationMilestone, sqlx::Error> {
+    ) -> Result<CertificationMilestone, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, CertificationMilestone>(
             r#"
             INSERT INTO certification_milestones (
@@ -542,16 +647,20 @@ impl BuildingCertificationRepository {
         .bind(input.depends_on_milestone_id)
         .bind(input.assigned_to)
         .bind(&input.notes)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// List milestones for a certification.
-    pub async fn list_milestones(
+    pub async fn list_milestones<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         cert_id: Uuid,
-    ) -> Result<Vec<CertificationMilestone>, sqlx::Error> {
+    ) -> Result<Vec<CertificationMilestone>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, CertificationMilestone>(
             r#"
             SELECT * FROM certification_milestones
@@ -561,17 +670,21 @@ impl BuildingCertificationRepository {
         )
         .bind(org_id)
         .bind(cert_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
-    /// Update a milestone.
-    pub async fn update_milestone(
+    /// Update a milestone, scoped to the caller's organization.
+    pub async fn update_milestone<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         milestone_id: Uuid,
         input: UpdateCertificationMilestone,
-    ) -> Result<Option<CertificationMilestone>, sqlx::Error> {
+    ) -> Result<Option<CertificationMilestone>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, CertificationMilestone>(
             r#"
             UPDATE certification_milestones SET
@@ -600,16 +713,20 @@ impl BuildingCertificationRepository {
         .bind(input.depends_on_milestone_id)
         .bind(input.assigned_to)
         .bind(&input.notes)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
-    /// Delete a milestone.
-    pub async fn delete_milestone(
+    /// Delete a milestone, scoped to the caller's organization.
+    pub async fn delete_milestone<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         milestone_id: Uuid,
-    ) -> Result<bool, sqlx::Error> {
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query(
             r#"
             DELETE FROM certification_milestones
@@ -618,18 +735,22 @@ impl BuildingCertificationRepository {
         )
         .bind(org_id)
         .bind(milestone_id)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
 
         Ok(result.rows_affected() > 0)
     }
 
     /// Get upcoming milestones across all certifications.
-    pub async fn get_upcoming_milestones(
+    pub async fn get_upcoming_milestones<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         days_ahead: i32,
-    ) -> Result<Vec<CertificationMilestone>, sqlx::Error> {
+    ) -> Result<Vec<CertificationMilestone>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, CertificationMilestone>(
             r#"
             SELECT * FROM certification_milestones
@@ -641,18 +762,22 @@ impl BuildingCertificationRepository {
         )
         .bind(org_id)
         .bind(days_ahead)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     // ==================== Certification Benchmarks ====================
 
     /// Create a certification benchmark.
-    pub async fn create_benchmark(
+    pub async fn create_benchmark<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         input: CreateCertificationBenchmark,
-    ) -> Result<CertificationBenchmark, sqlx::Error> {
+    ) -> Result<CertificationBenchmark, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, CertificationBenchmark>(
             r#"
             INSERT INTO certification_benchmarks (
@@ -676,16 +801,20 @@ impl BuildingCertificationRepository {
         .bind(input.percentile_rank)
         .bind(input.measurement_period_start)
         .bind(input.measurement_period_end)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// List benchmarks for a certification.
-    pub async fn list_benchmarks(
+    pub async fn list_benchmarks<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         cert_id: Uuid,
-    ) -> Result<Vec<CertificationBenchmark>, sqlx::Error> {
+    ) -> Result<Vec<CertificationBenchmark>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, CertificationBenchmark>(
             r#"
             SELECT * FROM certification_benchmarks
@@ -695,19 +824,23 @@ impl BuildingCertificationRepository {
         )
         .bind(org_id)
         .bind(cert_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     // ==================== Certification Costs ====================
 
     /// Create a certification cost.
-    pub async fn create_cost(
+    pub async fn create_cost<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         input: CreateCertificationCost,
         user_id: Option<Uuid>,
-    ) -> Result<CertificationCost, sqlx::Error> {
+    ) -> Result<CertificationCost, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, CertificationCost>(
             r#"
             INSERT INTO certification_costs (
@@ -730,16 +863,20 @@ impl BuildingCertificationRepository {
         .bind(&input.vendor_name)
         .bind(input.vendor_id)
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// List costs for a certification.
-    pub async fn list_costs(
+    pub async fn list_costs<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         cert_id: Uuid,
-    ) -> Result<Vec<CertificationCost>, sqlx::Error> {
+    ) -> Result<Vec<CertificationCost>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, CertificationCost>(
             r#"
             SELECT * FROM certification_costs
@@ -749,16 +886,20 @@ impl BuildingCertificationRepository {
         )
         .bind(org_id)
         .bind(cert_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Get total costs for a certification.
-    pub async fn get_total_costs(
+    pub async fn get_total_costs<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         cert_id: Uuid,
-    ) -> Result<rust_decimal::Decimal, sqlx::Error> {
+    ) -> Result<rust_decimal::Decimal, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result: (rust_decimal::Decimal,) = sqlx::query_as(
             r#"
             SELECT COALESCE(SUM(amount), 0) as total
@@ -768,7 +909,7 @@ impl BuildingCertificationRepository {
         )
         .bind(org_id)
         .bind(cert_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await?;
 
         Ok(result.0)
@@ -777,11 +918,15 @@ impl BuildingCertificationRepository {
     // ==================== Certification Reminders ====================
 
     /// Create a certification reminder.
-    pub async fn create_reminder(
+    pub async fn create_reminder<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         input: CreateCertificationReminder,
-    ) -> Result<CertificationReminder, sqlx::Error> {
+    ) -> Result<CertificationReminder, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, CertificationReminder>(
             r#"
             INSERT INTO certification_reminders (
@@ -804,16 +949,20 @@ impl BuildingCertificationRepository {
             serde_json::to_value(input.notify_roles.unwrap_or_default())
                 .unwrap_or(serde_json::Value::Array(vec![])),
         )
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// List reminders for a certification.
-    pub async fn list_reminders(
+    pub async fn list_reminders<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         cert_id: Uuid,
-    ) -> Result<Vec<CertificationReminder>, sqlx::Error> {
+    ) -> Result<Vec<CertificationReminder>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, CertificationReminder>(
             r#"
             SELECT * FROM certification_reminders
@@ -823,7 +972,7 @@ impl BuildingCertificationRepository {
         )
         .bind(org_id)
         .bind(cert_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -831,8 +980,9 @@ impl BuildingCertificationRepository {
 
     /// Create an audit log entry.
     #[allow(clippy::too_many_arguments)]
-    pub async fn create_audit_log(
+    pub async fn create_audit_log<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         cert_id: Uuid,
         action: &str,
@@ -842,7 +992,10 @@ impl BuildingCertificationRepository {
         new_value: Option<serde_json::Value>,
         user_id: Option<Uuid>,
         notes: Option<&str>,
-    ) -> Result<CertificationAuditLog, sqlx::Error> {
+    ) -> Result<CertificationAuditLog, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, CertificationAuditLog>(
             r#"
             INSERT INTO certification_audit_logs (
@@ -861,17 +1014,21 @@ impl BuildingCertificationRepository {
         .bind(new_value)
         .bind(user_id)
         .bind(notes)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get audit logs for a certification.
-    pub async fn list_audit_logs(
+    pub async fn list_audit_logs<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         cert_id: Uuid,
         limit: i64,
-    ) -> Result<Vec<CertificationAuditLog>, sqlx::Error> {
+    ) -> Result<Vec<CertificationAuditLog>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, CertificationAuditLog>(
             r#"
             SELECT * FROM certification_audit_logs
@@ -883,14 +1040,21 @@ impl BuildingCertificationRepository {
         .bind(org_id)
         .bind(cert_id)
         .bind(limit)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     // ==================== Dashboard ====================
 
     /// Get certification dashboard summary.
-    pub async fn get_dashboard(&self, org_id: Uuid) -> Result<CertificationDashboard, sqlx::Error> {
+    ///
+    /// Multi-statement (several aggregates + upcoming-milestones lookup), so it
+    /// takes a connection and reborrows it per query.
+    pub async fn get_dashboard(
+        &self,
+        conn: &mut PgConnection,
+        org_id: Uuid,
+    ) -> Result<CertificationDashboard, sqlx::Error> {
         // Get counts
         let counts: (i64, i64, i64, i64, rust_decimal::Decimal) = sqlx::query_as(
             r#"
@@ -905,7 +1069,7 @@ impl BuildingCertificationRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         // Get counts by program
@@ -919,7 +1083,7 @@ impl BuildingCertificationRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await?;
 
         // Get counts by level
@@ -936,11 +1100,11 @@ impl BuildingCertificationRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await?;
 
         // Get upcoming milestones
-        let upcoming_milestones = self.get_upcoming_milestones(org_id, 30).await?;
+        let upcoming_milestones = self.get_upcoming_milestones(&mut *conn, org_id, 30).await?;
 
         Ok(CertificationDashboard {
             total_certifications: counts.0,
@@ -961,11 +1125,15 @@ impl BuildingCertificationRepository {
     }
 
     /// Get certifications expiring soon.
-    pub async fn get_expiring_certifications(
+    pub async fn get_expiring_certifications<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         days_ahead: i32,
-    ) -> Result<Vec<BuildingCertification>, sqlx::Error> {
+    ) -> Result<Vec<BuildingCertification>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, BuildingCertification>(
             r#"
             SELECT * FROM building_certifications
@@ -978,7 +1146,7 @@ impl BuildingCertificationRepository {
         )
         .bind(org_id)
         .bind(days_ahead)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 }

--- a/backend/crates/db/tests/building_certification_rls_repo_tests.rs
+++ b/backend/crates/db/tests/building_certification_rls_repo_tests.rs
@@ -1,0 +1,321 @@
+//! Repo-level behavioral RLS regression test for PAP-102 (PAP-80 cluster).
+//!
+//! Background
+//! ----------
+//! Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on the building-certification tables
+//! (`building_certifications` and the rest of the Epic-137 cluster). The
+//! production api-server connects as the table OWNER, which `FORCE` binds.
+//! `BuildingCertificationRepository` held a raw `PgPool` and ran every query
+//! WITHOUT ever calling `set_request_context`, so on `dev`
+//! `get_current_org_id()` returned NULL and the policy collapsed to
+//! `organization_id = NULL` → **deny-all**: own-org reads returned empty, writes
+//! failed. (PAP-102.)
+//!
+//! The fix routes the repo through an RLS-context connection (the `RlsConnection`
+//! extractor in handlers sets the org/user GUCs before any query). This test
+//! exercises the *repository methods themselves* on a `FORCE`-bound role and
+//! proves:
+//!
+//!   1. **Deny-all reproduction** — with the role bound but NO context set
+//!      (exactly what the raw-pool repo did on `dev`), an own-org
+//!      `get_certification` / `list_certifications` returns nothing. This is the
+//!      "would have failed on dev" evidence.
+//!   2. **Fix** — with `set_request_context(org_a, user_a)` applied first (what
+//!      `RlsConnection` now does), the same repo calls return the own-org row.
+//!   3. **Cross-tenant** — org B's certification stays invisible to an org-A
+//!      caller even with context set.
+//!   4. **Write path** — a `create_certification` on a context-set connection
+//!      succeeds and the row is the caller's org. Without context the INSERT
+//!      would fail the policy `WITH CHECK`.
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — even `FORCE` does not bind a superuser, so a behavioral assertion
+//! would pass vacuously. The test creates a plain `NOSUPERUSER NOBYPASSRLS`
+//! role, grants it access, and `SET ROLE`s to it so `FORCE` actually enforces the
+//! policy the way the production owner role experiences it. Mirrors
+//! `reserve_funds_rls_repo_tests.rs` / `work_order_rls_repo_tests.rs` (the
+//! PAP-67 precedent this follows).
+
+use db::models::building_certification::{
+    CertificationLevel, CertificationProgram, CreateBuildingCertification,
+};
+use db::repositories::BuildingCertificationRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("BC {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@bc.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'BC User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_building(pool: &PgPool, org_id: Uuid, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO buildings (organization_id, name, street, city, postal_code, country, status)
+        VALUES ($1, $2, 'Street 1', 'City', '00000', 'Country', 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .expect("seed building")
+}
+
+/// Seed a building certification directly (as superuser, RLS-exempt) for an org.
+async fn seed_cert(pool: &PgPool, org_id: Uuid, building_id: Uuid, user_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO building_certifications
+            (organization_id, building_id, program, level, status, created_by)
+        VALUES ($1, $2, 'leed', 'gold', 'planning', $3)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(building_id)
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed building certification")
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn building_certification_repo_force_rls_deny_all_and_fix(pool: PgPool) {
+    let repo = BuildingCertificationRepository::new(pool.clone());
+
+    // --- Seed as superuser / super-admin context (satisfies org roles-trigger). ---
+    set_ctx(&pool, None, None, true).await;
+    let org_a = seed_org(&pool, "force-bc-a").await;
+    let org_b = seed_org(&pool, "force-bc-b").await;
+    let user_a = seed_user(&pool, "a@bc.test").await;
+    let user_b = seed_user(&pool, "b@bc.test").await;
+    let building_a = seed_building(&pool, org_a, "Building A").await;
+    let building_b = seed_building(&pool, org_b, "Building B").await;
+    let cert_a = seed_cert(&pool, org_a, building_a, user_a).await;
+    let cert_b = seed_cert(&pool, org_b, building_b, user_b).await;
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    let role = format!("ppt_rls_bc_{}", Uuid::new_v4().simple());
+    for stmt in [
+        format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
+        format!("GRANT SELECT, INSERT, UPDATE, DELETE ON building_certifications TO \"{role}\""),
+        // RLS policy helpers must be EXECUTE-able by the bound role; the
+        // soft-delete guard reads `organizations`.
+        format!(
+            "GRANT EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
+             get_current_org_not_deleted() TO \"{role}\""
+        ),
+        format!("GRANT SELECT ON organizations TO \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .expect("grant setup");
+    }
+
+    // ====================================================================
+    // (1) DENY-ALL reproduction: role bound, NO context set (the dev raw-pool
+    //     behavior). Own-org reads return nothing.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        // Explicitly clear any inherited context, then drop to the bound role.
+        sqlx::query("SELECT clear_request_context()")
+            .execute(&mut *conn)
+            .await
+            .expect("clear ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let found = repo
+            .get_certification(&mut *conn, org_a, cert_a)
+            .await
+            .expect("get_certification (no ctx)");
+        assert!(
+            found.is_none(),
+            "PAP-102 regression: without RLS context, own-org building certification must be \
+             invisible (deny-all) — this is what the raw-pool repo did on dev"
+        );
+
+        let listed = repo
+            .list_certifications(&mut *conn, org_a, Default::default(), 50, 0)
+            .await
+            .expect("list_certifications (no ctx)");
+        assert!(
+            listed.is_empty(),
+            "PAP-102 regression: without RLS context, list_certifications returns deny-all empty"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (2) FIX + (3) cross-tenant: set context, drop to bound role, query repo.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        // (2) Own-org row IS now visible through the repo — the fix.
+        let found = repo
+            .get_certification(&mut *conn, org_a, cert_a)
+            .await
+            .expect("get_certification (ctx)");
+        assert_eq!(
+            found.map(|c| c.id),
+            Some(cert_a),
+            "PAP-102 fix: with RLS context set, the repo must return the own-org certification"
+        );
+
+        let listed = repo
+            .list_certifications(&mut *conn, org_a, Default::default(), 50, 0)
+            .await
+            .expect("list_certifications (ctx)");
+        assert_eq!(
+            listed.iter().map(|c| c.id).collect::<Vec<_>>(),
+            vec![cert_a],
+            "PAP-102 fix: list_certifications returns exactly the own-org certification under context"
+        );
+
+        // (3) Org B's certification stays invisible to an org-A caller.
+        let cross = repo
+            .get_certification(&mut *conn, org_a, cert_b)
+            .await
+            .expect("get_certification cross");
+        assert!(
+            cross.is_none(),
+            "cross-tenant: org B's certification must NOT be visible to an org-A caller"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (4) WRITE path: a create on a context-set connection succeeds and the
+    //     row is the caller's org. Without context the INSERT would fail the
+    //     policy WITH CHECK (the write-side of deny-all).
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let created = repo
+            .create_certification(
+                &mut *conn,
+                org_a,
+                CreateBuildingCertification {
+                    building_id: building_a,
+                    program: CertificationProgram::Breeam,
+                    version: None,
+                    level: CertificationLevel::Certified,
+                    status: None,
+                    total_points_possible: None,
+                    total_points_achieved: None,
+                    application_date: None,
+                    certification_date: None,
+                    expiration_date: None,
+                    certificate_number: None,
+                    project_id: None,
+                    assessor_name: None,
+                    assessor_organization: None,
+                    certificate_url: None,
+                    scorecard_url: None,
+                    notes: None,
+                    application_fee: None,
+                    certification_fee: None,
+                    annual_fee: None,
+                },
+                Some(user_a),
+            )
+            .await
+            .expect("create_certification under context must succeed");
+        assert_eq!(created.organization_id, org_a);
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup the test role. ---
+    set_ctx(&pool, None, None, true).await;
+    let _ = user_b; // seeded for symmetry with org_b's certification
+    for stmt in [
+        format!("REVOKE ALL ON building_certifications FROM \"{role}\""),
+        format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .ok();
+    }
+}

--- a/backend/servers/api-server/src/routes/building_certifications.rs
+++ b/backend/servers/api-server/src/routes/building_certifications.rs
@@ -1,4 +1,21 @@
 //! Building Certifications routes for Epic 137: Smart Building Certification.
+//!
+//! # RLS (PAP-67 / PAP-80)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` on the building-certification
+//! cluster (8 tables), so every query MUST run on a connection that has
+//! `app.current_org_id` set or it collapses to deny-all. Each handler therefore
+//! acquires an [`RlsConnection`] (which validates tenant membership and sets the
+//! org/user GUCs on a dedicated connection) and passes that connection to the
+//! repository (`&mut **rls.conn()` to the generic-`Executor` methods, `rls.conn()`
+//! to the `&mut PgConnection` ones, which deref-coerce). The authoritative
+//! organization is `rls.tenant_id()` — the tenant the caller was validated
+//! against — not a client-supplied `organization_id`, so the SQL org filter and
+//! the RLS context can never disagree. Cross-tenant access is blocked by RLS: a
+//! by-id read of another org's row returns no row (`404`), and a write targeting
+//! another org fails the policy's `WITH CHECK`. `rls.release()` clears the
+//! context before the connection returns to the pool (on both the Ok and Err
+//! paths).
 
 use axum::{
     extract::{Path, Query, State},
@@ -9,7 +26,7 @@ use axum::{
 use serde::Deserialize;
 use uuid::Uuid;
 
-use api_core::extractors::AuthUser;
+use api_core::extractors::RlsConnection;
 use db::models::building_certification::{
     BuildingCertification, CertificationBenchmark, CertificationCost, CertificationCredit,
     CertificationDashboard, CertificationDocument, CertificationFilters, CertificationLevel,
@@ -21,14 +38,6 @@ use db::models::building_certification::{
 };
 
 use crate::state::AppState;
-
-/// Helper to get organization ID from auth user.
-fn get_org_id(auth: &AuthUser) -> Result<Uuid, (StatusCode, String)> {
-    auth.tenant_id.ok_or((
-        StatusCode::BAD_REQUEST,
-        "No organization context".to_string(),
-    ))
-}
 
 /// Create the router for building certifications.
 pub fn router() -> Router<AppState> {
@@ -109,21 +118,26 @@ pub struct AuditLogQuery {
     limit: Option<i64>,
 }
 
+fn internal_error(e: sqlx::Error) -> (StatusCode, String) {
+    (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+}
+
 // ==================== Dashboard ====================
 
 /// Get certification dashboard summary.
 async fn get_dashboard(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
 ) -> Result<Json<CertificationDashboard>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .building_certification_repo
-        .get_dashboard(org_id)
+        .get_dashboard(rls.conn(), org_id)
         .await
         .map(Json)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 // ==================== Certifications ====================
@@ -131,10 +145,10 @@ async fn get_dashboard(
 /// List certifications with filters.
 async fn list_certifications(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<ListCertificationsQuery>,
 ) -> Result<Json<Vec<BuildingCertification>>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
+    let org_id = rls.tenant_id();
 
     let filters = CertificationFilters {
         building_id: query.building_id,
@@ -144,9 +158,10 @@ async fn list_certifications(
         expiring_within_days: query.expiring_within_days,
     };
 
-    state
+    let out = state
         .building_certification_repo
         .list_certifications(
+            &mut **rls.conn(),
             org_id,
             filters,
             query.limit.unwrap_or(50),
@@ -154,112 +169,128 @@ async fn list_certifications(
         )
         .await
         .map(Json)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 /// Create a new certification.
 async fn create_certification(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(input): Json<CreateBuildingCertification>,
 ) -> Result<(StatusCode, Json<BuildingCertification>), (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .building_certification_repo
-        .create_certification(org_id, input, Some(auth.user_id))
+        .create_certification(&mut **rls.conn(), org_id, input, Some(user_id))
         .await
         .map(|cert| (StatusCode::CREATED, Json(cert)))
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 /// Get a certification by ID.
 async fn get_certification(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(cert_id): Path<Uuid>,
 ) -> Result<Json<BuildingCertification>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .building_certification_repo
-        .get_certification(org_id, cert_id)
+        .get_certification(&mut **rls.conn(), org_id, cert_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .map(Json)
-        .ok_or((StatusCode::NOT_FOUND, "Certification not found".to_string()))
+        .map_err(internal_error)
+        .and_then(|c| {
+            c.map(Json)
+                .ok_or((StatusCode::NOT_FOUND, "Certification not found".to_string()))
+        });
+    rls.release().await;
+    out
 }
 
 /// Get certification with credits summary.
 async fn get_certification_with_credits(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(cert_id): Path<Uuid>,
 ) -> Result<Json<CertificationWithCredits>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .building_certification_repo
-        .get_certification_with_credits(org_id, cert_id)
+        .get_certification_with_credits(rls.conn(), org_id, cert_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .map(Json)
-        .ok_or((StatusCode::NOT_FOUND, "Certification not found".to_string()))
+        .map_err(internal_error)
+        .and_then(|c| {
+            c.map(Json)
+                .ok_or((StatusCode::NOT_FOUND, "Certification not found".to_string()))
+        });
+    rls.release().await;
+    out
 }
 
 /// Update a certification.
 async fn update_certification(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(cert_id): Path<Uuid>,
     Json(input): Json<UpdateBuildingCertification>,
 ) -> Result<Json<BuildingCertification>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .building_certification_repo
-        .update_certification(org_id, cert_id, input)
+        .update_certification(&mut **rls.conn(), org_id, cert_id, input)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .map(Json)
-        .ok_or((StatusCode::NOT_FOUND, "Certification not found".to_string()))
+        .map_err(internal_error)
+        .and_then(|c| {
+            c.map(Json)
+                .ok_or((StatusCode::NOT_FOUND, "Certification not found".to_string()))
+        });
+    rls.release().await;
+    out
 }
 
 /// Delete a certification.
 async fn delete_certification(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(cert_id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    let deleted = state
+    let org_id = rls.tenant_id();
+    let out = state
         .building_certification_repo
-        .delete_certification(org_id, cert_id)
+        .delete_certification(&mut **rls.conn(), org_id, cert_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-
-    if deleted {
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Err((StatusCode::NOT_FOUND, "Certification not found".to_string()))
-    }
+        .map_err(internal_error)
+        .and_then(|deleted| {
+            if deleted {
+                Ok(StatusCode::NO_CONTENT)
+            } else {
+                Err((StatusCode::NOT_FOUND, "Certification not found".to_string()))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 /// Get certifications expiring soon.
 async fn get_expiring_certifications(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<ExpiringQuery>,
 ) -> Result<Json<Vec<BuildingCertification>>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .building_certification_repo
-        .get_expiring_certifications(org_id, query.days.unwrap_or(90))
+        .get_expiring_certifications(&mut **rls.conn(), org_id, query.days.unwrap_or(90))
         .await
         .map(Json)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 // ==================== Credits ====================
@@ -267,91 +298,102 @@ async fn get_expiring_certifications(
 /// List credits for a certification.
 async fn list_credits(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(cert_id): Path<Uuid>,
 ) -> Result<Json<Vec<CertificationCredit>>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .building_certification_repo
-        .list_credits(org_id, cert_id)
+        .list_credits(&mut **rls.conn(), org_id, cert_id)
         .await
         .map(Json)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 /// Create a certification credit.
 async fn create_credit(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(cert_id): Path<Uuid>,
     Json(mut input): Json<CreateCertificationCredit>,
 ) -> Result<(StatusCode, Json<CertificationCredit>), (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
+    let org_id = rls.tenant_id();
     input.certification_id = cert_id;
 
-    state
+    let out = state
         .building_certification_repo
-        .create_credit(org_id, input)
+        .create_credit(&mut **rls.conn(), org_id, input)
         .await
         .map(|credit| (StatusCode::CREATED, Json(credit)))
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 /// Get a credit by ID.
 async fn get_credit(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path((_cert_id, credit_id)): Path<(Uuid, Uuid)>,
 ) -> Result<Json<CertificationCredit>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .building_certification_repo
-        .get_credit(org_id, credit_id)
+        .get_credit(&mut **rls.conn(), org_id, credit_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .map(Json)
-        .ok_or((StatusCode::NOT_FOUND, "Credit not found".to_string()))
+        .map_err(internal_error)
+        .and_then(|c| {
+            c.map(Json)
+                .ok_or((StatusCode::NOT_FOUND, "Credit not found".to_string()))
+        });
+    rls.release().await;
+    out
 }
 
 /// Update a credit.
 async fn update_credit(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path((_cert_id, credit_id)): Path<(Uuid, Uuid)>,
     Json(input): Json<UpdateCertificationCredit>,
 ) -> Result<Json<CertificationCredit>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .building_certification_repo
-        .update_credit(org_id, credit_id, input)
+        .update_credit(&mut **rls.conn(), org_id, credit_id, input)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .map(Json)
-        .ok_or((StatusCode::NOT_FOUND, "Credit not found".to_string()))
+        .map_err(internal_error)
+        .and_then(|c| {
+            c.map(Json)
+                .ok_or((StatusCode::NOT_FOUND, "Credit not found".to_string()))
+        });
+    rls.release().await;
+    out
 }
 
 /// Delete a credit.
 async fn delete_credit(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path((_cert_id, credit_id)): Path<(Uuid, Uuid)>,
 ) -> Result<StatusCode, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    let deleted = state
+    let org_id = rls.tenant_id();
+    let out = state
         .building_certification_repo
-        .delete_credit(org_id, credit_id)
+        .delete_credit(&mut **rls.conn(), org_id, credit_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-
-    if deleted {
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Err((StatusCode::NOT_FOUND, "Credit not found".to_string()))
-    }
+        .map_err(internal_error)
+        .and_then(|deleted| {
+            if deleted {
+                Ok(StatusCode::NO_CONTENT)
+            } else {
+                Err((StatusCode::NOT_FOUND, "Credit not found".to_string()))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 // ==================== Documents ====================
@@ -359,56 +401,62 @@ async fn delete_credit(
 /// List documents for a certification.
 async fn list_documents(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(cert_id): Path<Uuid>,
 ) -> Result<Json<Vec<CertificationDocument>>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .building_certification_repo
-        .list_documents(org_id, cert_id)
+        .list_documents(&mut **rls.conn(), org_id, cert_id)
         .await
         .map(Json)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 /// Create a certification document.
 async fn create_document(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(cert_id): Path<Uuid>,
     Json(mut input): Json<CreateCertificationDocument>,
 ) -> Result<(StatusCode, Json<CertificationDocument>), (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
     input.certification_id = cert_id;
 
-    state
+    let out = state
         .building_certification_repo
-        .create_document(org_id, input, Some(auth.user_id))
+        .create_document(&mut **rls.conn(), org_id, input, Some(user_id))
         .await
         .map(|doc| (StatusCode::CREATED, Json(doc)))
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 /// Delete a document.
 async fn delete_document(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path((_cert_id, doc_id)): Path<(Uuid, Uuid)>,
 ) -> Result<StatusCode, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    let deleted = state
+    let org_id = rls.tenant_id();
+    let out = state
         .building_certification_repo
-        .delete_document(org_id, doc_id)
+        .delete_document(&mut **rls.conn(), org_id, doc_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-
-    if deleted {
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Err((StatusCode::NOT_FOUND, "Document not found".to_string()))
-    }
+        .map_err(internal_error)
+        .and_then(|deleted| {
+            if deleted {
+                Ok(StatusCode::NO_CONTENT)
+            } else {
+                Err((StatusCode::NOT_FOUND, "Document not found".to_string()))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 // ==================== Milestones ====================
@@ -416,74 +464,82 @@ async fn delete_document(
 /// List milestones for a certification.
 async fn list_milestones(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(cert_id): Path<Uuid>,
 ) -> Result<Json<Vec<CertificationMilestone>>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .building_certification_repo
-        .list_milestones(org_id, cert_id)
+        .list_milestones(&mut **rls.conn(), org_id, cert_id)
         .await
         .map(Json)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 /// Create a certification milestone.
 async fn create_milestone(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(cert_id): Path<Uuid>,
     Json(mut input): Json<CreateCertificationMilestone>,
 ) -> Result<(StatusCode, Json<CertificationMilestone>), (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
+    let org_id = rls.tenant_id();
     input.certification_id = cert_id;
 
-    state
+    let out = state
         .building_certification_repo
-        .create_milestone(org_id, input)
+        .create_milestone(&mut **rls.conn(), org_id, input)
         .await
         .map(|milestone| (StatusCode::CREATED, Json(milestone)))
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 /// Update a milestone.
 async fn update_milestone(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path((_cert_id, milestone_id)): Path<(Uuid, Uuid)>,
     Json(input): Json<UpdateCertificationMilestone>,
 ) -> Result<Json<CertificationMilestone>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .building_certification_repo
-        .update_milestone(org_id, milestone_id, input)
+        .update_milestone(&mut **rls.conn(), org_id, milestone_id, input)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .map(Json)
-        .ok_or((StatusCode::NOT_FOUND, "Milestone not found".to_string()))
+        .map_err(internal_error)
+        .and_then(|m| {
+            m.map(Json)
+                .ok_or((StatusCode::NOT_FOUND, "Milestone not found".to_string()))
+        });
+    rls.release().await;
+    out
 }
 
 /// Delete a milestone.
 async fn delete_milestone(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path((_cert_id, milestone_id)): Path<(Uuid, Uuid)>,
 ) -> Result<StatusCode, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    let deleted = state
+    let org_id = rls.tenant_id();
+    let out = state
         .building_certification_repo
-        .delete_milestone(org_id, milestone_id)
+        .delete_milestone(&mut **rls.conn(), org_id, milestone_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-
-    if deleted {
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Err((StatusCode::NOT_FOUND, "Milestone not found".to_string()))
-    }
+        .map_err(internal_error)
+        .and_then(|deleted| {
+            if deleted {
+                Ok(StatusCode::NO_CONTENT)
+            } else {
+                Err((StatusCode::NOT_FOUND, "Milestone not found".to_string()))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 // ==================== Benchmarks ====================
@@ -491,35 +547,38 @@ async fn delete_milestone(
 /// List benchmarks for a certification.
 async fn list_benchmarks(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(cert_id): Path<Uuid>,
 ) -> Result<Json<Vec<CertificationBenchmark>>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .building_certification_repo
-        .list_benchmarks(org_id, cert_id)
+        .list_benchmarks(&mut **rls.conn(), org_id, cert_id)
         .await
         .map(Json)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 /// Create a certification benchmark.
 async fn create_benchmark(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(cert_id): Path<Uuid>,
     Json(mut input): Json<CreateCertificationBenchmark>,
 ) -> Result<(StatusCode, Json<CertificationBenchmark>), (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
+    let org_id = rls.tenant_id();
     input.certification_id = cert_id;
 
-    state
+    let out = state
         .building_certification_repo
-        .create_benchmark(org_id, input)
+        .create_benchmark(&mut **rls.conn(), org_id, input)
         .await
         .map(|benchmark| (StatusCode::CREATED, Json(benchmark)))
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 // ==================== Costs ====================
@@ -527,51 +586,56 @@ async fn create_benchmark(
 /// List costs for a certification.
 async fn list_costs(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(cert_id): Path<Uuid>,
 ) -> Result<Json<Vec<CertificationCost>>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .building_certification_repo
-        .list_costs(org_id, cert_id)
+        .list_costs(&mut **rls.conn(), org_id, cert_id)
         .await
         .map(Json)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 /// Create a certification cost.
 async fn create_cost(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(cert_id): Path<Uuid>,
     Json(mut input): Json<CreateCertificationCost>,
 ) -> Result<(StatusCode, Json<CertificationCost>), (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
     input.certification_id = cert_id;
 
-    state
+    let out = state
         .building_certification_repo
-        .create_cost(org_id, input, Some(auth.user_id))
+        .create_cost(&mut **rls.conn(), org_id, input, Some(user_id))
         .await
         .map(|cost| (StatusCode::CREATED, Json(cost)))
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 /// Get total costs for a certification.
 async fn get_total_costs(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(cert_id): Path<Uuid>,
 ) -> Result<Json<rust_decimal::Decimal>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .building_certification_repo
-        .get_total_costs(org_id, cert_id)
+        .get_total_costs(&mut **rls.conn(), org_id, cert_id)
         .await
         .map(Json)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 // ==================== Reminders ====================
@@ -579,35 +643,38 @@ async fn get_total_costs(
 /// List reminders for a certification.
 async fn list_reminders(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(cert_id): Path<Uuid>,
 ) -> Result<Json<Vec<CertificationReminder>>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .building_certification_repo
-        .list_reminders(org_id, cert_id)
+        .list_reminders(&mut **rls.conn(), org_id, cert_id)
         .await
         .map(Json)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 /// Create a certification reminder.
 async fn create_reminder(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(cert_id): Path<Uuid>,
     Json(mut input): Json<CreateCertificationReminder>,
 ) -> Result<(StatusCode, Json<CertificationReminder>), (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
+    let org_id = rls.tenant_id();
     input.certification_id = cert_id;
 
-    state
+    let out = state
         .building_certification_repo
-        .create_reminder(org_id, input)
+        .create_reminder(&mut **rls.conn(), org_id, input)
         .await
         .map(|reminder| (StatusCode::CREATED, Json(reminder)))
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 // ==================== Audit Logs ====================
@@ -615,19 +682,25 @@ async fn create_reminder(
 /// List audit logs for a certification.
 async fn list_audit_logs(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(cert_id): Path<Uuid>,
     Query(query): Query<AuditLogQuery>,
 ) -> Result<
     Json<Vec<db::models::building_certification::CertificationAuditLog>>,
     (StatusCode, String),
 > {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .building_certification_repo
-        .list_audit_logs(org_id, cert_id, query.limit.unwrap_or(100))
+        .list_audit_logs(
+            &mut **rls.conn(),
+            org_id,
+            cert_id,
+            query.limit.unwrap_or(100),
+        )
         .await
         .map(Json)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }


### PR DESCRIPTION
## What

PAP-102 / [PAP-80](https://github.com/martin-janci/property-management/issues) RLS sweep: convert `building_certification.rs` from a raw `PgPool` to the RLS-context-executor pattern (the `work_order.rs` / `reserve_funds.rs` precedent).

`BuildingCertificationRepository` held a raw `PgPool` and queried **8 FORCE-RLS tables** (migration `00179`, PAP-62) without ever setting `app.current_org_id`:
`building_certifications`, `certification_credits`, `certification_documents`, `certification_milestones`, `certification_benchmarks`, `certification_audit_logs`, `certification_costs`, `certification_reminders`.

Under `FORCE ROW LEVEL SECURITY` the api-server's table-owner connection is no longer exempt, so on `dev` every read returned empty and every write failed the deny-all policy.

## How

- **Repo holds NO pool.** `pub struct BuildingCertificationRepository;` (unit). `new(_pool)` retained for `AppState` construction-site compatibility but stores nothing.
- Single-statement methods take a generic `executor: E` (`E: Executor<'e, Database = Postgres>`).
- The two multi-statement methods (`get_certification_with_credits`, `get_dashboard`) take `conn: &mut PgConnection` and reborrow `&mut *conn`.
- Handlers acquire the `RlsConnection` extractor, pass `&mut **rls.conn()` (or `rls.conn()` to the `&mut PgConnection` methods), use `rls.tenant_id()` as the authoritative org, and call `rls.release()` on both the Ok and Err paths.
- Authoritative org is `rls.tenant_id()`, so the SQL org filter and the RLS context can never disagree; cross-tenant by-id access now surfaces as **404** via RLS. The explicit `organization_id = $n` predicates are retained as defense-in-depth.

No raw-pool query path remains in this repo.

## Verify

- `cargo check -p db -p api-server --tests` — **green** (run on remote mercury via rbuild; control-plane host is memory-constrained).
- Adds `building_certification_rls_repo_tests.rs`: a `NOSUPERUSER NOBYPASSRLS` role-switch test (mirrors `reserve_funds_rls_repo_tests.rs` / `work_order_rls_repo_tests.rs`) proving:
  1. **deny-all** reproduction — without RLS context, own-org `get_certification`/`list_certifications` return nothing (the dev raw-pool behavior);
  2. **fix** — with context set, the own-org row is visible;
  3. **cross-tenant** — org B's certification stays invisible to an org-A caller;
  4. **write path** — `create_certification` under context succeeds.

  > The DB test compiles green here; it executes against the Postgres service in CI's `backend.yml` (`cargo test`) — no Postgres is reachable from the offload builder.

## Scope

One repo = one PR (matches the work_order / reserve_funds cadence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)