### PR TITLE
fix(db): route sensor repo through RLS-context connection (PAP-78)

### DIFF
--- a/backend/crates/db/src/repositories/equipment.rs
+++ b/backend/crates/db/src/repositories/equipment.rs
@@ -1,35 +1,63 @@
 //! Equipment and predictive maintenance repository (Epic 13, Story 13.3).
+//!
+//! # RLS Integration (PAP-67 / PAP-71)
+//!
+//! Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on `equipment`, `equipment_maintenance`, and
+//! `maintenance_predictions`. The api-server connects as the table OWNER, which
+//! `FORCE` binds, so a query issued on a connection without `app.current_org_id`
+//! set collapses to deny-all (own-org reads return empty, writes fail the policy
+//! `WITH CHECK`).
+//!
+//! Every method therefore takes an **executor whose connection already has RLS
+//! context set** (org + user GUCs) — in handlers this comes from the
+//! `RlsConnection` extractor via `&mut **rls.conn()`. The repository holds **no
+//! pool**, so there is no way to issue a query that bypasses RLS. This mirrors
+//! the `work_order.rs` / `budget.rs` / `document.rs` precedent.
+//!
+//! The explicit `organization_id = $N` SQL filters are retained as
+//! defense-in-depth; handlers pass `rls.tenant_id()` (the org the caller was
+//! validated against), so the SQL filter and the RLS context can never disagree.
 
 use crate::models::{
     CreateEquipment, CreateMaintenance, Equipment, EquipmentMaintenance, EquipmentQuery,
     MaintenancePrediction, UpdateEquipment, UpdateMaintenance,
 };
 use chrono::NaiveDate;
-use sqlx::PgPool;
+use sqlx::{Executor, PgConnection, PgPool, Postgres};
 use uuid::Uuid;
 
 /// Repository for equipment and maintenance operations.
+///
+/// Stateless: every method receives an RLS-context-bearing executor. The repo
+/// holds no pool so it cannot issue an un-scoped (deny-all under `FORCE`) query.
 #[derive(Clone)]
-pub struct EquipmentRepository {
-    pool: PgPool,
-}
+pub struct EquipmentRepository;
 
 impl EquipmentRepository {
     /// Create a new repository instance.
-    pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+    ///
+    /// The pool argument is retained for construction-site compatibility with
+    /// the other repositories on `AppState`; this repo deliberately does not
+    /// store it (see module docs — all queries run on a context-set connection
+    /// supplied by the handler's `RlsConnection`).
+    pub fn new(_pool: PgPool) -> Self {
+        Self
     }
 
-    /// Create new equipment.
     /// Create equipment.
     ///
     /// `organization_id` is passed explicitly by the caller and must originate
     /// from the verified request principal, never from client input in `data`.
-    pub async fn create(
+    pub async fn create<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         data: CreateEquipment,
-    ) -> Result<Equipment, sqlx::Error> {
+    ) -> Result<Equipment, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO equipment
@@ -54,33 +82,41 @@ impl EquipmentRepository {
         .bind(data.maintenance_interval_days)
         .bind(data.notes)
         .bind(sqlx::types::Json(data.metadata.unwrap_or_default()))
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
-    /// Get equipment by ID.
     /// Fetch a single equipment row scoped to `org_id`.
     ///
     /// Returns `None` for both "not found" and "belongs to another tenant" so
-    /// callers cannot enumerate foreign-tenant IDs by status code.
-    pub async fn find_by_id(
+    /// callers cannot enumerate foreign-tenant IDs by status code. RLS scopes
+    /// the result to the connection's org context as well.
+    pub async fn find_by_id<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
-    ) -> Result<Option<Equipment>, sqlx::Error> {
+    ) -> Result<Option<Equipment>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as("SELECT * FROM equipment WHERE id = $1 AND organization_id = $2")
             .bind(id)
             .bind(org_id)
-            .fetch_optional(&self.pool)
+            .fetch_optional(executor)
             .await
     }
 
     /// List equipment with query filters.
-    pub async fn list(
+    pub async fn list<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: EquipmentQuery,
-    ) -> Result<Vec<Equipment>, sqlx::Error> {
+    ) -> Result<Vec<Equipment>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50);
         let offset = query.offset.unwrap_or(0);
 
@@ -105,7 +141,7 @@ impl EquipmentRepository {
         .bind(query.needs_maintenance)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -115,12 +151,16 @@ impl EquipmentRepository {
     /// caller in org B cannot modify equipment belonging to org A.  The WHERE
     /// clause `AND organization_id = $14` makes the update a no-op (returns
     /// `RowNotFound`) when the row exists but belongs to a different tenant.
-    pub async fn update(
+    pub async fn update<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
         data: UpdateEquipment,
-    ) -> Result<Equipment, sqlx::Error> {
+    ) -> Result<Equipment, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE equipment SET
@@ -155,7 +195,7 @@ impl EquipmentRepository {
         .bind(data.notes)
         .bind(data.metadata.map(sqlx::types::Json))
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
@@ -165,27 +205,38 @@ impl EquipmentRepository {
     /// clause `AND organization_id = $2` ensures a caller in org B cannot delete
     /// equipment belonging to org A (returns `false` / not-found rather than
     /// deleting the row).
-    pub async fn delete(&self, id: Uuid, org_id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM equipment WHERE id = $1 AND organization_id = $2")
             .bind(id)
             .bind(org_id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
 
-    /// Create maintenance record.
     /// Create a maintenance record — tenant-scoped.
     ///
     /// `org_id` must originate from the verified request principal.
     /// The INSERT is guarded by a sub-select that ensures `data.equipment_id`
     /// belongs to `org_id`; if the equipment does not exist in that org the
     /// INSERT produces no row and `sqlx` returns `RowNotFound`.
-    pub async fn create_maintenance(
+    pub async fn create_maintenance<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         data: CreateMaintenance,
-    ) -> Result<EquipmentMaintenance, sqlx::Error> {
+    ) -> Result<EquipmentMaintenance, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO equipment_maintenance
@@ -208,7 +259,7 @@ impl EquipmentRepository {
         .bind(data.scheduled_date)
         .bind(data.notes)
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
@@ -218,11 +269,15 @@ impl EquipmentRepository {
     /// The JOIN ensures a caller in org B cannot read a maintenance record
     /// whose parent equipment belongs to org A; returns `None` for both
     /// "not found" and "belongs to another tenant" to prevent ID enumeration.
-    pub async fn find_maintenance_by_id(
+    pub async fn find_maintenance_by_id<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
-    ) -> Result<Option<EquipmentMaintenance>, sqlx::Error> {
+    ) -> Result<Option<EquipmentMaintenance>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT em.* FROM equipment_maintenance em
@@ -232,7 +287,7 @@ impl EquipmentRepository {
         )
         .bind(id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
@@ -241,13 +296,17 @@ impl EquipmentRepository {
     /// `org_id` must originate from the verified request principal.
     /// The JOIN ensures only maintenance records whose parent equipment
     /// belongs to `org_id` are returned.
-    pub async fn list_maintenance(
+    pub async fn list_maintenance<'e, E>(
         &self,
+        executor: E,
         equipment_id: Uuid,
         org_id: Uuid,
         limit: i64,
         offset: i64,
-    ) -> Result<Vec<EquipmentMaintenance>, sqlx::Error> {
+    ) -> Result<Vec<EquipmentMaintenance>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT em.* FROM equipment_maintenance em
@@ -261,7 +320,7 @@ impl EquipmentRepository {
         .bind(org_id)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -272,8 +331,12 @@ impl EquipmentRepository {
     /// tenant boundary is enforced via the parent `equipment` row using an
     /// `EXISTS` sub-select so a caller in org B cannot mutate a maintenance
     /// record whose parent equipment belongs to org A.
+    ///
+    /// Multi-statement (update + optional last-maintenance refresh), so it takes
+    /// a connection and reborrows it for each query.
     pub async fn update_maintenance(
         &self,
+        conn: &mut PgConnection,
         id: Uuid,
         org_id: Uuid,
         data: UpdateMaintenance,
@@ -311,13 +374,13 @@ impl EquipmentRepository {
         .bind(data.status)
         .bind(data.notes)
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         // Update equipment last maintenance date if completed
         if result.status == "completed" {
             if let Some(completed) = result.completed_date {
-                self.update_last_maintenance(result.equipment_id, completed)
+                self.update_last_maintenance(&mut *conn, result.equipment_id, completed)
                     .await?;
             }
         }
@@ -326,11 +389,15 @@ impl EquipmentRepository {
     }
 
     /// Update equipment's last maintenance date.
-    async fn update_last_maintenance(
+    async fn update_last_maintenance<'e, E>(
         &self,
+        executor: E,
         equipment_id: Uuid,
         date: NaiveDate,
-    ) -> Result<(), sqlx::Error> {
+    ) -> Result<(), sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query(
             r#"
             UPDATE equipment
@@ -347,21 +414,25 @@ impl EquipmentRepository {
         )
         .bind(equipment_id)
         .bind(date)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
         Ok(())
     }
 
     /// Create or update a maintenance prediction.
-    pub async fn upsert_prediction(
+    pub async fn upsert_prediction<'e, E>(
         &self,
+        executor: E,
         equipment_id: Uuid,
         risk_score: f64,
         predicted_failure_date: Option<NaiveDate>,
         confidence: f64,
         recommendation: &str,
         factors: serde_json::Value,
-    ) -> Result<MaintenancePrediction, sqlx::Error> {
+    ) -> Result<MaintenancePrediction, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO maintenance_predictions
@@ -386,17 +457,21 @@ impl EquipmentRepository {
         .bind(confidence)
         .bind(recommendation)
         .bind(sqlx::types::Json(factors))
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get high-risk predictions.
-    pub async fn list_high_risk_predictions(
+    pub async fn list_high_risk_predictions<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         min_risk_score: f64,
         limit: i64,
-    ) -> Result<Vec<MaintenancePrediction>, sqlx::Error> {
+    ) -> Result<Vec<MaintenancePrediction>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT p.* FROM maintenance_predictions p
@@ -409,7 +484,7 @@ impl EquipmentRepository {
         .bind(org_id)
         .bind(min_risk_score)
         .bind(limit)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -421,13 +496,17 @@ impl EquipmentRepository {
     /// `RowNotFound` when either the prediction does not exist or the equipment
     /// belongs to a different tenant (callers should surface both as 404 to
     /// prevent ID enumeration).
-    pub async fn acknowledge_prediction(
+    pub async fn acknowledge_prediction<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
         user_id: Uuid,
         action_taken: Option<&str>,
-    ) -> Result<MaintenancePrediction, sqlx::Error> {
+    ) -> Result<MaintenancePrediction, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE maintenance_predictions
@@ -445,17 +524,21 @@ impl EquipmentRepository {
         .bind(org_id)
         .bind(user_id)
         .bind(action_taken)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get equipment needing maintenance soon.
-    pub async fn list_needing_maintenance(
+    pub async fn list_needing_maintenance<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         days_ahead: i32,
         limit: i64,
-    ) -> Result<Vec<Equipment>, sqlx::Error> {
+    ) -> Result<Vec<Equipment>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM equipment
@@ -470,7 +553,7 @@ impl EquipmentRepository {
         .bind(org_id)
         .bind(days_ahead)
         .bind(limit)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 }

--- a/backend/crates/db/src/repositories/sensor.rs
+++ b/backend/crates/db/src/repositories/sensor.rs
@@ -1,4 +1,20 @@
 //! IoT sensor repository (Epic 14).
+//!
+//! # RLS Integration (PAP-67)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on every sensor table (`sensors`,
+//! `sensor_readings`, `sensor_alerts`, `sensor_thresholds`,
+//! `sensor_threshold_templates`, `sensor_fault_correlations`). Under `FORCE`
+//! the api-server's owner connection is no longer exempt, so a query issued on
+//! a connection without `app.current_org_id` set collapses to deny-all (own-org
+//! reads return empty, writes fail).
+//!
+//! Every method therefore takes an **executor whose connection already has RLS
+//! context set** (org + user GUCs) — in handlers this comes from the
+//! `RlsConnection` extractor via `&mut **rls.conn()`. The repository holds **no
+//! pool**, so there is no way to issue a query that bypasses RLS. This mirrors
+//! the `work_order.rs` / `budget.rs` precedent.
 
 use crate::models::{
     AggregatedReading, AlertQuery, CreateSensor, CreateSensorAlert, CreateSensorFaultCorrelation,
@@ -7,19 +23,25 @@ use crate::models::{
     SensorTypeCount, UpdateSensor, UpdateSensorThreshold,
 };
 use chrono::{DateTime, Utc};
-use sqlx::PgPool;
+use sqlx::{Executor, PgConnection, PgPool, Postgres};
 use uuid::Uuid;
 
 /// Repository for IoT sensor operations.
+///
+/// Stateless: every method receives an RLS-context-bearing executor. The repo
+/// holds no pool so it cannot issue an un-scoped (deny-all under `FORCE`) query.
 #[derive(Clone)]
-pub struct SensorRepository {
-    pool: PgPool,
-}
+pub struct SensorRepository;
 
 impl SensorRepository {
     /// Create a new repository instance.
-    pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+    ///
+    /// The pool argument is retained for construction-site compatibility with
+    /// the other repositories on `AppState`; this repo deliberately does not
+    /// store it (see module docs — all queries run on a context-set connection
+    /// supplied by the handler's `RlsConnection`).
+    pub fn new(_pool: PgPool) -> Self {
+        Self
     }
 
     // ========================================================================
@@ -27,7 +49,10 @@ impl SensorRepository {
     // ========================================================================
 
     /// Create a new sensor.
-    pub async fn create(&self, data: CreateSensor) -> Result<Sensor, sqlx::Error> {
+    pub async fn create<'e, E>(&self, executor: E, data: CreateSensor) -> Result<Sensor, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO sensors
@@ -59,20 +84,31 @@ impl SensorRepository {
         .bind(data.installed_at)
         .bind(sqlx::types::Json(data.metadata.unwrap_or_default()))
         .bind(data.created_by)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get sensor by ID.
-    pub async fn find_by_id(&self, id: Uuid) -> Result<Option<Sensor>, sqlx::Error> {
+    pub async fn find_by_id<'e, E>(&self, executor: E, id: Uuid) -> Result<Option<Sensor>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as("SELECT * FROM sensors WHERE id = $1")
             .bind(id)
-            .fetch_optional(&self.pool)
+            .fetch_optional(executor)
             .await
     }
 
     /// List sensors with filters.
-    pub async fn list(&self, org_id: Uuid, query: SensorQuery) -> Result<Vec<Sensor>, sqlx::Error> {
+    pub async fn list<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+        query: SensorQuery,
+    ) -> Result<Vec<Sensor>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50);
         let offset = query.offset.unwrap_or(0);
 
@@ -97,12 +133,20 @@ impl SensorRepository {
         .bind(query.search)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update a sensor.
-    pub async fn update(&self, id: Uuid, data: UpdateSensor) -> Result<Sensor, sqlx::Error> {
+    pub async fn update<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        data: UpdateSensor,
+    ) -> Result<Sensor, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE sensors SET
@@ -136,26 +180,33 @@ impl SensorRepository {
         .bind(data.model)
         .bind(data.firmware_version)
         .bind(data.metadata.map(sqlx::types::Json))
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Delete a sensor.
-    pub async fn delete(&self, id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete<'e, E>(&self, executor: E, id: Uuid) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM sensors WHERE id = $1")
             .bind(id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
 
     /// Update sensor status and timestamps.
-    pub async fn update_status(
+    pub async fn update_status<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         status: &str,
         last_error: Option<&str>,
-    ) -> Result<Sensor, sqlx::Error> {
+    ) -> Result<Sensor, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE sensors SET
@@ -171,12 +222,19 @@ impl SensorRepository {
         .bind(id)
         .bind(status)
         .bind(last_error)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get sensors count by type.
-    pub async fn count_by_type(&self, org_id: Uuid) -> Result<Vec<SensorTypeCount>, sqlx::Error> {
+    pub async fn count_by_type<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+    ) -> Result<Vec<SensorTypeCount>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT sensor_type, COUNT(*) as count
@@ -187,7 +245,7 @@ impl SensorRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -196,8 +254,12 @@ impl SensorRepository {
     // ========================================================================
 
     /// Create a sensor reading.
+    ///
+    /// Multi-statement (INSERT reading + UPDATE parent sensor), so it takes a
+    /// connection and reborrows it for each query.
     pub async fn create_reading(
         &self,
+        conn: &mut PgConnection,
         data: CreateSensorReading,
     ) -> Result<SensorReading, sqlx::Error> {
         // Also update the sensor's last_reading_at
@@ -214,7 +276,7 @@ impl SensorRepository {
         .bind(data.quality.unwrap_or_else(|| "good".to_string()))
         .bind(data.raw_data.map(sqlx::types::Json))
         .bind(data.timestamp)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         // Update sensor status
@@ -223,18 +285,22 @@ impl SensorRepository {
         )
         .bind(data.sensor_id)
         .bind(reading.timestamp)
-        .execute(&self.pool)
+        .execute(&mut *conn)
         .await?;
 
         Ok(reading)
     }
 
     /// Get readings for a sensor.
-    pub async fn list_readings(
+    pub async fn list_readings<'e, E>(
         &self,
+        executor: E,
         sensor_id: Uuid,
         query: ReadingQuery,
-    ) -> Result<Vec<SensorReading>, sqlx::Error> {
+    ) -> Result<Vec<SensorReading>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(100);
         let from = query
             .from_time
@@ -255,18 +321,22 @@ impl SensorRepository {
         .bind(from)
         .bind(to)
         .bind(limit)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Get aggregated readings.
-    pub async fn list_aggregated_readings(
+    pub async fn list_aggregated_readings<'e, E>(
         &self,
+        executor: E,
         sensor_id: Uuid,
         from: DateTime<Utc>,
         to: DateTime<Utc>,
         interval: &str,
-    ) -> Result<Vec<AggregatedReading>, sqlx::Error> {
+    ) -> Result<Vec<AggregatedReading>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let interval_sql = match interval {
             "minute" => "date_trunc('minute', timestamp)",
             "hour" => "date_trunc('hour', timestamp)",
@@ -296,15 +366,19 @@ impl SensorRepository {
             .bind(sensor_id)
             .bind(from)
             .bind(to)
-            .fetch_all(&self.pool)
+            .fetch_all(executor)
             .await
     }
 
     /// Get latest reading for a sensor.
-    pub async fn get_latest_reading(
+    pub async fn get_latest_reading<'e, E>(
         &self,
+        executor: E,
         sensor_id: Uuid,
-    ) -> Result<Option<SensorReading>, sqlx::Error> {
+    ) -> Result<Option<SensorReading>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM sensor_readings
@@ -314,7 +388,7 @@ impl SensorRepository {
             "#,
         )
         .bind(sensor_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
@@ -323,10 +397,14 @@ impl SensorRepository {
     // ========================================================================
 
     /// Create a threshold.
-    pub async fn create_threshold(
+    pub async fn create_threshold<'e, E>(
         &self,
+        executor: E,
         data: CreateSensorThreshold,
-    ) -> Result<SensorThreshold, sqlx::Error> {
+    ) -> Result<SensorThreshold, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO sensor_thresholds
@@ -344,27 +422,35 @@ impl SensorRepository {
         .bind(data.critical_value)
         .bind(data.critical_high)
         .bind(data.alert_cooldown_minutes)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get thresholds for a sensor.
-    pub async fn list_thresholds(
+    pub async fn list_thresholds<'e, E>(
         &self,
+        executor: E,
         sensor_id: Uuid,
-    ) -> Result<Vec<SensorThreshold>, sqlx::Error> {
+    ) -> Result<Vec<SensorThreshold>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as("SELECT * FROM sensor_thresholds WHERE sensor_id = $1 ORDER BY metric")
             .bind(sensor_id)
-            .fetch_all(&self.pool)
+            .fetch_all(executor)
             .await
     }
 
     /// Update a threshold.
-    pub async fn update_threshold(
+    pub async fn update_threshold<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         data: UpdateSensorThreshold,
-    ) -> Result<SensorThreshold, sqlx::Error> {
+    ) -> Result<SensorThreshold, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE sensor_thresholds SET
@@ -388,25 +474,32 @@ impl SensorRepository {
         .bind(data.critical_high)
         .bind(data.enabled)
         .bind(data.alert_cooldown_minutes)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Delete a threshold.
-    pub async fn delete_threshold(&self, id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete_threshold<'e, E>(&self, executor: E, id: Uuid) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM sensor_thresholds WHERE id = $1")
             .bind(id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
 
     /// Get threshold templates.
-    pub async fn list_threshold_templates(
+    pub async fn list_threshold_templates<'e, E>(
         &self,
+        executor: E,
         org_id: Option<Uuid>,
         sensor_type: Option<&str>,
-    ) -> Result<Vec<SensorThresholdTemplate>, sqlx::Error> {
+    ) -> Result<Vec<SensorThresholdTemplate>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM sensor_threshold_templates
@@ -417,7 +510,7 @@ impl SensorRepository {
         )
         .bind(org_id)
         .bind(sensor_type)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -426,7 +519,14 @@ impl SensorRepository {
     // ========================================================================
 
     /// Create an alert.
-    pub async fn create_alert(&self, data: CreateSensorAlert) -> Result<SensorAlert, sqlx::Error> {
+    pub async fn create_alert<'e, E>(
+        &self,
+        executor: E,
+        data: CreateSensorAlert,
+    ) -> Result<SensorAlert, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO sensor_alerts
@@ -441,16 +541,20 @@ impl SensorRepository {
         .bind(data.triggered_value)
         .bind(data.threshold_value)
         .bind(data.message)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// List alerts with filters.
-    pub async fn list_alerts(
+    pub async fn list_alerts<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: AlertQuery,
-    ) -> Result<Vec<SensorAlert>, sqlx::Error> {
+    ) -> Result<Vec<SensorAlert>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50);
         let offset = query.offset.unwrap_or(0);
 
@@ -480,17 +584,21 @@ impl SensorRepository {
         .bind(query.to_time)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Resolve an alert.
     /// resolved_value is optional - if None, only resolved_at is set.
-    pub async fn resolve_alert(
+    pub async fn resolve_alert<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         resolved_value: Option<f64>,
-    ) -> Result<SensorAlert, sqlx::Error> {
+    ) -> Result<SensorAlert, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE sensor_alerts SET
@@ -502,16 +610,20 @@ impl SensorRepository {
         )
         .bind(id)
         .bind(resolved_value)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Acknowledge an alert.
-    pub async fn acknowledge_alert(
+    pub async fn acknowledge_alert<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         user_id: Uuid,
-    ) -> Result<SensorAlert, sqlx::Error> {
+    ) -> Result<SensorAlert, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE sensor_alerts SET
@@ -523,12 +635,19 @@ impl SensorRepository {
         )
         .bind(id)
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Count unresolved alerts.
-    pub async fn count_unresolved_alerts(&self, org_id: Uuid) -> Result<i64, sqlx::Error> {
+    pub async fn count_unresolved_alerts<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+    ) -> Result<i64, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result: (i64,) = sqlx::query_as(
             r#"
             SELECT COUNT(*) FROM sensor_alerts a
@@ -537,7 +656,7 @@ impl SensorRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await?;
         Ok(result.0)
     }
@@ -547,10 +666,14 @@ impl SensorRepository {
     // ========================================================================
 
     /// Create a sensor-fault correlation.
-    pub async fn create_correlation(
+    pub async fn create_correlation<'e, E>(
         &self,
+        executor: E,
         data: CreateSensorFaultCorrelation,
-    ) -> Result<SensorFaultCorrelation, sqlx::Error> {
+    ) -> Result<SensorFaultCorrelation, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO sensor_fault_correlations
@@ -571,46 +694,61 @@ impl SensorRepository {
         .bind(data.sensor_data_end)
         .bind(data.summary)
         .bind(data.created_by)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get correlations for a fault.
-    pub async fn list_correlations_for_fault(
+    pub async fn list_correlations_for_fault<'e, E>(
         &self,
+        executor: E,
         fault_id: Uuid,
-    ) -> Result<Vec<SensorFaultCorrelation>, sqlx::Error> {
+    ) -> Result<Vec<SensorFaultCorrelation>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as("SELECT * FROM sensor_fault_correlations WHERE fault_id = $1")
             .bind(fault_id)
-            .fetch_all(&self.pool)
+            .fetch_all(executor)
             .await
     }
 
     /// Get correlations for a sensor.
-    pub async fn list_correlations_for_sensor(
+    pub async fn list_correlations_for_sensor<'e, E>(
         &self,
+        executor: E,
         sensor_id: Uuid,
-    ) -> Result<Vec<SensorFaultCorrelation>, sqlx::Error> {
+    ) -> Result<Vec<SensorFaultCorrelation>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as("SELECT * FROM sensor_fault_correlations WHERE sensor_id = $1")
             .bind(sensor_id)
-            .fetch_all(&self.pool)
+            .fetch_all(executor)
             .await
     }
 
     /// Delete a correlation.
-    pub async fn delete_correlation(&self, id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete_correlation<'e, E>(&self, executor: E, id: Uuid) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM sensor_fault_correlations WHERE id = $1")
             .bind(id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
 
     /// Get sensors near a location (for auto-correlation).
-    pub async fn get_sensors_for_building(
+    pub async fn get_sensors_for_building<'e, E>(
         &self,
+        executor: E,
         building_id: Uuid,
-    ) -> Result<Vec<Sensor>, sqlx::Error> {
+    ) -> Result<Vec<Sensor>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM sensors
@@ -619,13 +757,17 @@ impl SensorRepository {
             "#,
         )
         .bind(building_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Create batch readings using efficient bulk insert.
+    ///
+    /// Multi-statement (bulk INSERT + UPDATE parent sensor), so it takes a
+    /// connection and reborrows it for each query.
     pub async fn create_batch_readings(
         &self,
+        conn: &mut PgConnection,
         sensor_id: Uuid,
         readings: Vec<crate::models::SingleReading>,
     ) -> Result<i64, sqlx::Error> {
@@ -666,22 +808,26 @@ impl SensorRepository {
                 .bind(reading.timestamp);
         }
 
-        query_builder.execute(&self.pool).await?;
+        query_builder.execute(&mut *conn).await?;
 
         // Update sensor status
         sqlx::query(
             "UPDATE sensors SET last_reading_at = NOW(), last_seen_at = NOW(), status = 'active' WHERE id = $1",
         )
         .bind(sensor_id)
-        .execute(&self.pool)
+        .execute(&mut *conn)
         .await?;
 
         Ok(count)
     }
 
     /// Apply threshold template to a sensor.
+    ///
+    /// Multi-statement (SELECT template + upsert threshold), so it takes a
+    /// connection and reborrows it for each query.
     pub async fn apply_threshold_template(
         &self,
+        conn: &mut PgConnection,
         template_id: Uuid,
         sensor_id: Uuid,
     ) -> Result<SensorThreshold, sqlx::Error> {
@@ -689,7 +835,7 @@ impl SensorRepository {
         let template: SensorThresholdTemplate =
             sqlx::query_as("SELECT * FROM sensor_threshold_templates WHERE id = $1")
                 .bind(template_id)
-                .fetch_one(&self.pool)
+                .fetch_one(&mut *conn)
                 .await?;
 
         // Create threshold from template
@@ -715,13 +861,17 @@ impl SensorRepository {
         .bind(template.warning_high)
         .bind(template.critical_value)
         .bind(template.critical_high)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
     }
 
     /// Get dashboard data for an organization.
+    ///
+    /// Multi-statement (six aggregate reads), so it takes a connection and
+    /// reborrows it for each query.
     pub async fn get_dashboard(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         building_id: Option<Uuid>,
     ) -> Result<crate::models::SensorDashboard, sqlx::Error> {
@@ -731,7 +881,7 @@ impl SensorRepository {
         )
         .bind(org_id)
         .bind(building_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         let (active,): (i64,) = sqlx::query_as(
@@ -739,7 +889,7 @@ impl SensorRepository {
         )
         .bind(org_id)
         .bind(building_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         let (offline,): (i64,) = sqlx::query_as(
@@ -747,7 +897,7 @@ impl SensorRepository {
         )
         .bind(org_id)
         .bind(building_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         // Count unresolved alerts
@@ -761,7 +911,7 @@ impl SensorRepository {
         )
         .bind(org_id)
         .bind(building_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         // Get sensors by type
@@ -776,7 +926,7 @@ impl SensorRepository {
         )
         .bind(org_id)
         .bind(building_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await?;
 
         // Get recent alerts
@@ -791,7 +941,7 @@ impl SensorRepository {
         )
         .bind(org_id)
         .bind(building_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await?;
 
         Ok(crate::models::SensorDashboard {

--- a/backend/crates/db/tests/equipment_rls_repo_tests.rs
+++ b/backend/crates/db/tests/equipment_rls_repo_tests.rs
@@ -1,0 +1,300 @@
+//! Repo-level behavioral RLS regression test for PAP-71 (parent PAP-67).
+//!
+//! Background
+//! ----------
+//! Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on `equipment`, `equipment_maintenance`, and
+//! `maintenance_predictions`. The production api-server connects as the table
+//! OWNER, which `FORCE` binds. `EquipmentRepository` held a raw `PgPool` and ran
+//! every query WITHOUT ever calling `set_request_context`, so on `dev`
+//! `get_current_org_id()` returned NULL and the policy collapsed to
+//! `organization_id = NULL` → **deny-all**: own-org reads returned empty, writes
+//! failed. (PAP-71.)
+//!
+//! The fix routes the repo through an RLS-context connection (the `RlsConnection`
+//! extractor in handlers sets the org/user GUCs before any query). This test
+//! exercises the *repository methods themselves* on a `FORCE`-bound role and
+//! proves:
+//!
+//!   1. **Deny-all reproduction** — with the role bound but NO context set
+//!      (exactly what the raw-pool repo did on `dev`), an own-org `find_by_id`
+//!      / `list` returns nothing.
+//!   2. **Fix** — with `set_request_context(org_a, user_a)` applied first (what
+//!      `RlsConnection` now does), the same repo calls return the own-org row.
+//!   3. **Cross-tenant** — org B's equipment stays invisible to an org-A caller
+//!      even with context set.
+//!   4. **Write path** — a `create` on a context-set connection succeeds and the
+//!      row is the caller's org; without context the INSERT fails the policy.
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — even `FORCE` does not bind a superuser, so a behavioral assertion
+//! would pass vacuously. The test creates a plain `NOSUPERUSER NOBYPASSRLS`
+//! role, grants it access, and `SET ROLE`s to it so `FORCE` actually enforces
+//! the policy the way the production owner role experiences it. Mirrors
+//! `work_order_rls_repo_tests.rs` (the PAP-67 precedent PAP-71 follows).
+
+use db::models::{CreateEquipment, EquipmentQuery};
+use db::repositories::EquipmentRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("EQ {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@eq.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'EQ User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_building(pool: &PgPool, org_id: Uuid, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO buildings (organization_id, street, city, postal_code, country, name)
+        VALUES ($1, $2, 'Bratislava', '81101', 'Slovakia', $3)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(format!("{slug} Street 1"))
+    .bind(format!("{slug} Building"))
+    .fetch_one(pool)
+    .await
+    .expect("seed building")
+}
+
+/// Seed an equipment row directly (as superuser, RLS-exempt) for an org.
+async fn seed_equipment(pool: &PgPool, org_id: Uuid, building_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO equipment (organization_id, building_id, name, category)
+        VALUES ($1, $2, 'Seeded HVAC', 'hvac')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(building_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed equipment")
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn equipment_repo_force_rls_deny_all_and_fix(pool: PgPool) {
+    let repo = EquipmentRepository::new(pool.clone());
+
+    // --- Seed as superuser / super-admin context (satisfies org roles-trigger). ---
+    set_ctx(&pool, None, None, true).await;
+    let org_a = seed_org(&pool, "eq-force-a").await;
+    let org_b = seed_org(&pool, "eq-force-b").await;
+    let user_a = seed_user(&pool, "a@eq.test").await;
+    let bld_a = seed_building(&pool, org_a, "a").await;
+    let bld_b = seed_building(&pool, org_b, "b").await;
+    let eq_a = seed_equipment(&pool, org_a, bld_a).await;
+    let eq_b = seed_equipment(&pool, org_b, bld_b).await;
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    let role = format!("ppt_rls_eq_{}", Uuid::new_v4().simple());
+    for stmt in [
+        format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
+        format!("GRANT SELECT, INSERT, UPDATE, DELETE ON equipment, equipment_maintenance, maintenance_predictions TO \"{role}\""),
+        format!(
+            "GRANT EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
+             get_current_org_not_deleted() TO \"{role}\""
+        ),
+        format!("GRANT SELECT ON organizations TO \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .expect("grant setup");
+    }
+
+    // ====================================================================
+    // (1) DENY-ALL reproduction: role bound, NO context set (the dev raw-pool
+    //     behavior). Own-org reads return nothing.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT clear_request_context()")
+            .execute(&mut *conn)
+            .await
+            .expect("clear ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let found = repo
+            .find_by_id(&mut *conn, eq_a, org_a)
+            .await
+            .expect("find_by_id (no ctx)");
+        assert!(
+            found.is_none(),
+            "PAP-71 regression: without RLS context, own-org equipment must be \
+             invisible (deny-all) — this is what the raw-pool repo did on dev"
+        );
+
+        let listed = repo
+            .list(&mut *conn, org_a, EquipmentQuery::default())
+            .await
+            .expect("list (no ctx)");
+        assert!(
+            listed.is_empty(),
+            "PAP-71 regression: without RLS context, list returns deny-all empty"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (2) FIX + (3) cross-tenant: set context, drop to bound role, query repo.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        // (2) Own-org row IS now visible through the repo — the fix.
+        let found = repo
+            .find_by_id(&mut *conn, eq_a, org_a)
+            .await
+            .expect("find_by_id (ctx)");
+        assert_eq!(
+            found.map(|e| e.id),
+            Some(eq_a),
+            "PAP-71 fix: with RLS context set, the repo must return the own-org equipment"
+        );
+
+        let listed = repo
+            .list(&mut *conn, org_a, EquipmentQuery::default())
+            .await
+            .expect("list (ctx)");
+        assert_eq!(
+            listed.iter().map(|e| e.id).collect::<Vec<_>>(),
+            vec![eq_a],
+            "PAP-71 fix: list returns exactly the own-org equipment under context"
+        );
+
+        // (3) Org B's equipment stays invisible to an org-A caller.
+        let cross = repo
+            .find_by_id(&mut *conn, eq_b, org_a)
+            .await
+            .expect("find_by_id cross");
+        assert!(
+            cross.is_none(),
+            "cross-tenant: org B's equipment must NOT be visible to an org-A caller"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (4) WRITE path: a create on a context-set connection succeeds and the row
+    //     is the caller's org. Without context the INSERT would fail the policy
+    //     WITH CHECK (the write-side of deny-all).
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let created = repo
+            .create(
+                &mut *conn,
+                org_a,
+                CreateEquipment {
+                    building_id: bld_a,
+                    facility_id: None,
+                    name: "Created under RLS".to_string(),
+                    category: "elevator".to_string(),
+                    manufacturer: None,
+                    model: None,
+                    serial_number: None,
+                    installation_date: None,
+                    warranty_expires: None,
+                    expected_lifespan_years: None,
+                    maintenance_interval_days: None,
+                    notes: None,
+                    metadata: None,
+                },
+            )
+            .await
+            .expect("create under context must succeed");
+        assert_eq!(created.organization_id, org_a);
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup the test role. ---
+    set_ctx(&pool, None, None, true).await;
+    for stmt in [
+        format!(
+            "REVOKE ALL ON equipment, equipment_maintenance, maintenance_predictions FROM \"{role}\""
+        ),
+        format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt)).execute(&pool).await.ok();
+    }
+}

--- a/backend/crates/db/tests/sensor_rls_repo_tests.rs
+++ b/backend/crates/db/tests/sensor_rls_repo_tests.rs
@@ -1,0 +1,252 @@
+//! Repo-level behavioral test for the IoT sensor RLS routing (PAP-67 / PAP-78).
+//!
+//! Background
+//! ----------
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on every sensor table. Under `FORCE` the
+//! api-server's owner connection is no longer exempt, so a query issued on a
+//! connection WITHOUT `app.current_org_id` set collapses to deny-all. The
+//! `SensorRepository` was reworked to hold no pool and to take an
+//! RLS-context-bearing executor on every method (supplied by `RlsConnection`
+//! in handlers). This test exercises that contract directly against the repo.
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — even `FORCE` does not bind a superuser. To exercise the policy
+//! the way the production owner role does, the test creates a plain
+//! `NOSUPERUSER NOBYPASSRLS` role, grants it table access, and `SET ROLE`s to
+//! it. `FORCE` binds that role, so the org-scoped policy is enforced. The org
+//! context (`app.current_org_id`) is a session GUC and survives `SET ROLE`.
+
+use db::repositories::SensorRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Set the request context (mirrors `db::tenant_context::set_request_context`).
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Sensors {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@sensors.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'Sensors User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_building(pool: &PgPool, org_id: Uuid, street: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO buildings (organization_id, street, city, postal_code)
+        VALUES ($1, $2, 'Bratislava', '81101')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(street)
+    .fetch_one(pool)
+    .await
+    .expect("seed building")
+}
+
+async fn seed_sensor(pool: &PgPool, org_id: Uuid, building_id: Uuid, created_by: Uuid, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO sensors (organization_id, building_id, name, sensor_type, created_by)
+        VALUES ($1, $2, $3, 'temperature', $4)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(building_id)
+    .bind(name)
+    .bind(created_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed sensor")
+}
+
+/// FORCE RLS on `sensors` must:
+///   1. deny ALL reads on a connection that has NO org context set
+///      (the deny-all regression that 00179's FORCE introduces for any code
+///      path that forgot to route through `RlsConnection`); and
+///   2. expose the caller's OWN org's sensor while hiding another org's sensor
+///      once the org context IS set.
+///
+/// Both assertions go through `SensorRepository::find_by_id` — the exact repo
+/// method the IoT handlers call — so this is a behavioral test of the RLS
+/// routing, not just of the raw SQL policy.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn sensors_force_rls_requires_context_and_blocks_cross_tenant(pool: PgPool) {
+    // --- Seed as superuser (super-admin context satisfies the roles-trigger
+    //     RLS WITH CHECK fired by INSERT INTO organizations). ---
+    set_ctx(&pool, None, None, true).await;
+
+    let org_a = seed_org(&pool, "force-a").await;
+    let org_b = seed_org(&pool, "force-b").await;
+    let user_a = seed_user(&pool, "a@sensors.test").await;
+    let user_b = seed_user(&pool, "b@sensors.test").await;
+    let bldg_a = seed_building(&pool, org_a, "1 Alpha St").await;
+    let bldg_b = seed_building(&pool, org_b, "1 Bravo St").await;
+
+    let sensor_a = seed_sensor(&pool, org_a, bldg_a, user_a, "alpha-temp").await;
+    let sensor_b = seed_sensor(&pool, org_b, bldg_b, user_b, "bravo-temp").await;
+
+    let repo = SensorRepository::new(pool.clone());
+
+    // --- Create a NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    // Random suffix keeps the role name unique across parallel test DBs.
+    let role = format!("ppt_rls_test_{}", Uuid::new_v4().simple());
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"
+    )))
+    .execute(&pool)
+    .await
+    .expect("create role");
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT SELECT ON sensors TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant select on sensors");
+    // The policy calls helper functions (get_current_org_id, is_super_admin,
+    // get_current_org_not_deleted); the role must be able to EXECUTE them.
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
+         get_current_org_not_deleted() TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant execute on rls helpers");
+    // `get_current_org_not_deleted()` is SECURITY INVOKER; its body runs
+    // `SELECT 1 FROM organizations` with the CALLER's privileges, so the bound
+    // role must be able to read `organizations` or the soft-delete guard raises
+    // `permission denied for table organizations`. `organizations` has no RLS
+    // of its own, so a plain table-level SELECT grant is sufficient.
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT SELECT ON organizations TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant select on organizations");
+
+    // --- All role-bound work runs on ONE dedicated connection. `SET ROLE` and
+    //     the org-context GUC are session state, so they must not be spread
+    //     across pool acquisitions. ---
+    {
+        let mut conn = pool.acquire().await.expect("acquire connection");
+
+        // ---- Phase 1: NO org context → deny-all under FORCE. ----
+        // This is the deny-all regression a raw-pool repo would hit: without
+        // `app.current_org_id`, even the OWN-org row is invisible.
+        sqlx::query("SELECT set_request_context(NULL, NULL, false)")
+            .execute(&mut *conn)
+            .await
+            .expect("clear org context");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let no_ctx = repo
+            .find_by_id(&mut *conn, sensor_a)
+            .await
+            .expect("find_by_id (no context)");
+        assert!(
+            no_ctx.is_none(),
+            "without org context a FORCE-RLS sensor read must return None (deny-all)"
+        );
+
+        // ---- Phase 2: org-A context → own visible, cross-tenant hidden. ----
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role before re-setting context");
+        sqlx::query("SELECT set_request_context($1, $2, false)")
+            .bind(org_a)
+            .bind(user_a)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A context");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let own = repo
+            .find_by_id(&mut *conn, sensor_a)
+            .await
+            .expect("find_by_id (org-A own)");
+        assert_eq!(
+            own.map(|s| s.id),
+            Some(sensor_a),
+            "org A's own sensor must be visible under its own context"
+        );
+
+        let cross = repo
+            .find_by_id(&mut *conn, sensor_b)
+            .await
+            .expect("find_by_id (org-B cross-tenant)");
+        assert!(
+            cross.is_none(),
+            "org B's sensor must NOT be visible to an org-A caller (cross-tenant IDOR)"
+        );
+
+        // Drop back to superuser on this connection before it returns to the pool.
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup the test role. ---
+    set_ctx(&pool, None, None, true).await;
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "REVOKE ALL ON sensors FROM \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .ok();
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "REVOKE ALL ON organizations FROM \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .ok();
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "DROP ROLE IF EXISTS \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .ok();
+}

--- a/backend/servers/api-server/src/routes/ai/equipment.rs
+++ b/backend/servers/api-server/src/routes/ai/equipment.rs
@@ -1,8 +1,23 @@
 //! Equipment & predictive maintenance (Story 13.3).
+//!
+//! # RLS (PAP-67 / PAP-71)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` on `equipment`,
+//! `equipment_maintenance`, and `maintenance_predictions`, so every query MUST
+//! run on a connection that has `app.current_org_id` set or it collapses to
+//! deny-all. Each handler therefore acquires an [`RlsConnection`] (which
+//! validates tenant membership and sets the org/user GUCs on a dedicated
+//! connection) and passes `&mut **rls.conn()` to the repository. The
+//! authoritative organization is `rls.tenant_id()` — the tenant the caller was
+//! validated against — not a client-supplied value, so the SQL org filter and
+//! the RLS context can never disagree. Cross-tenant access is blocked by RLS: a
+//! by-id read of another org's row returns no row (`404`), and a write targeting
+//! another org fails the policy's `WITH CHECK`. `rls.release()` clears the
+//! context before the connection returns to the pool.
 
-use crate::routes::ai::{require_tenant_id, PaginationQuery};
+use crate::routes::ai::PaginationQuery;
 use crate::state::AppState;
-use api_core::extractors::principal::RequestPrincipal;
+use api_core::extractors::RlsConnection;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -40,12 +55,16 @@ pub fn equipment_router() -> Router<AppState> {
 
 async fn create_equipment(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Json(req): Json<CreateEquipment>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
-    // SECURITY: owning org is derived from the verified principal, never the body.
-    let organization_id = require_tenant_id(&principal)?;
-    match state.equipment_repo.create(organization_id, req).await {
+    // SECURITY: owning org is the validated RLS tenant, never the body.
+    let organization_id = rls.tenant_id();
+    let out = match state
+        .equipment_repo
+        .create(&mut **rls.conn(), organization_id, req)
+        .await
+    {
         Ok(equipment) => Ok((StatusCode::CREATED, Json(serde_json::json!(equipment)))),
         Err(e) => {
             tracing::error!("Failed to create equipment: {}", e);
@@ -54,17 +73,22 @@ async fn create_equipment(
                 Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to create")),
             ))
         }
-    }
+    };
+    rls.release().await;
+    out
 }
 
 async fn list_equipment(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Query(query): Query<EquipmentQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
-
-    match state.equipment_repo.list(tenant_id, query).await {
+    let tenant_id = rls.tenant_id();
+    let out = match state
+        .equipment_repo
+        .list(&mut **rls.conn(), tenant_id, query)
+        .await
+    {
         Ok(equipment) => Ok(Json(serde_json::json!({ "equipment": equipment }))),
         Err(e) => {
             tracing::error!("Failed to list equipment: {}", e);
@@ -73,17 +97,22 @@ async fn list_equipment(
                 Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to list")),
             ))
         }
-    }
+    };
+    rls.release().await;
+    out
 }
 
 async fn get_equipment(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    // SECURITY: derive the tenant from the verified JWT — never trust client input.
-    let tenant_id = require_tenant_id(&principal)?;
-    match state.equipment_repo.find_by_id(id, tenant_id).await {
+    let tenant_id = rls.tenant_id();
+    let out = match state
+        .equipment_repo
+        .find_by_id(&mut **rls.conn(), id, tenant_id)
+        .await
+    {
         Ok(Some(equipment)) => Ok(Json(serde_json::json!(equipment))),
         Ok(None) => Err((
             StatusCode::NOT_FOUND,
@@ -96,18 +125,23 @@ async fn get_equipment(
                 Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get")),
             ))
         }
-    }
+    };
+    rls.release().await;
+    out
 }
 
 async fn update_equipment(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateEquipment>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    // SECURITY: derive the tenant from the verified JWT — never trust client input.
-    let tenant_id = require_tenant_id(&principal)?;
-    match state.equipment_repo.update(id, tenant_id, req).await {
+    let tenant_id = rls.tenant_id();
+    let out = match state
+        .equipment_repo
+        .update(&mut **rls.conn(), id, tenant_id, req)
+        .await
+    {
         Ok(equipment) => Ok(Json(serde_json::json!(equipment))),
         Err(sqlx::Error::RowNotFound) => Err((
             StatusCode::NOT_FOUND,
@@ -120,17 +154,22 @@ async fn update_equipment(
                 Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to update")),
             ))
         }
-    }
+    };
+    rls.release().await;
+    out
 }
 
 async fn delete_equipment(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    // SECURITY: derive the tenant from the verified JWT — never trust client input.
-    let tenant_id = require_tenant_id(&principal)?;
-    match state.equipment_repo.delete(id, tenant_id).await {
+    let tenant_id = rls.tenant_id();
+    let out = match state
+        .equipment_repo
+        .delete(&mut **rls.conn(), id, tenant_id)
+        .await
+    {
         Ok(true) => Ok(StatusCode::NO_CONTENT),
         Ok(false) => Err((
             StatusCode::NOT_FOUND,
@@ -143,20 +182,22 @@ async fn delete_equipment(
                 Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to delete")),
             ))
         }
-    }
+    };
+    rls.release().await;
+    out
 }
 
 async fn list_maintenance(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    // SECURITY: derive the tenant from the verified JWT — never trust client input.
-    let tenant_id = require_tenant_id(&principal)?;
-    match state
+    let tenant_id = rls.tenant_id();
+    let out = match state
         .equipment_repo
         .list_maintenance(
+            &mut **rls.conn(),
             id,
             tenant_id,
             query.limit.unwrap_or(50),
@@ -172,22 +213,24 @@ async fn list_maintenance(
                 Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to list")),
             ))
         }
-    }
+    };
+    rls.release().await;
+    out
 }
 
 async fn create_maintenance(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(_id): Path<Uuid>,
     Json(req): Json<CreateMaintenance>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
-    // SECURITY: derive the tenant from the verified JWT — never trust client input.
-    // The repository INSERT is guarded by a sub-select that ensures req.equipment_id
-    // belongs to this tenant; a foreign equipment_id yields RowNotFound → 404.
-    let tenant_id = require_tenant_id(&principal)?;
-    match state
+    // SECURITY: org is the validated RLS tenant. The repository INSERT is guarded
+    // by a sub-select that ensures req.equipment_id belongs to this tenant; a
+    // foreign equipment_id yields RowNotFound → 404.
+    let tenant_id = rls.tenant_id();
+    let out = match state
         .equipment_repo
-        .create_maintenance(tenant_id, req)
+        .create_maintenance(&mut **rls.conn(), tenant_id, req)
         .await
     {
         Ok(record) => Ok((StatusCode::CREATED, Json(serde_json::json!(record)))),
@@ -202,20 +245,21 @@ async fn create_maintenance(
                 Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to create")),
             ))
         }
-    }
+    };
+    rls.release().await;
+    out
 }
 
 async fn update_maintenance(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateMaintenance>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    // SECURITY: derive the tenant from the verified JWT — never trust client input.
-    let tenant_id = require_tenant_id(&principal)?;
-    match state
+    let tenant_id = rls.tenant_id();
+    let out = match state
         .equipment_repo
-        .update_maintenance(id, tenant_id, req)
+        .update_maintenance(&mut **rls.conn(), id, tenant_id, req)
         .await
     {
         Ok(record) => Ok(Json(serde_json::json!(record))),
@@ -233,19 +277,20 @@ async fn update_maintenance(
                 Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to update")),
             ))
         }
-    }
+    };
+    rls.release().await;
+    out
 }
 
 async fn list_predictions(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
-
-    match state
+    let tenant_id = rls.tenant_id();
+    let out = match state
         .equipment_repo
-        .list_high_risk_predictions(tenant_id, 50.0, query.limit.unwrap_or(20))
+        .list_high_risk_predictions(&mut **rls.conn(), tenant_id, 50.0, query.limit.unwrap_or(20))
         .await
     {
         Ok(predictions) => Ok(Json(serde_json::json!({ "predictions": predictions }))),
@@ -256,7 +301,9 @@ async fn list_predictions(
                 Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to list")),
             ))
         }
-    }
+    };
+    rls.release().await;
+    out
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -266,22 +313,22 @@ pub struct AcknowledgePredictionRequest {
 
 async fn acknowledge_prediction(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<AcknowledgePredictionRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    // SECURITY: tenant_id is derived from the verified JWT and passed to the
-    // repository so a caller in org B cannot acknowledge predictions belonging
-    // to org A. We return 404 for both "not found" and "wrong tenant" to
-    // prevent cross-tenant ID enumeration.
-    let tenant_id = require_tenant_id(&principal)?;
-
-    match state
+    // SECURITY: org + user come from the validated RLS connection so a caller in
+    // org B cannot acknowledge predictions belonging to org A. We return 404 for
+    // both "not found" and "wrong tenant" to prevent cross-tenant ID enumeration.
+    let tenant_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = match state
         .equipment_repo
         .acknowledge_prediction(
+            &mut **rls.conn(),
             id,
             tenant_id,
-            principal.user_id,
+            user_id,
             req.action_taken.as_deref(),
         )
         .await
@@ -301,7 +348,9 @@ async fn acknowledge_prediction(
                 )),
             ))
         }
-    }
+    };
+    rls.release().await;
+    out
 }
 
 #[derive(Debug, Serialize, Deserialize, Default, utoipa::IntoParams)]
@@ -312,14 +361,14 @@ pub struct MaintenanceDueQuery {
 
 async fn list_needing_maintenance(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Query(query): Query<MaintenanceDueQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
-
-    match state
+    let tenant_id = rls.tenant_id();
+    let out = match state
         .equipment_repo
         .list_needing_maintenance(
+            &mut **rls.conn(),
             tenant_id,
             query.days_ahead.unwrap_or(30),
             query.limit.unwrap_or(20),
@@ -334,5 +383,7 @@ async fn list_needing_maintenance(
                 Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to list")),
             ))
         }
-    }
+    };
+    rls.release().await;
+    out
 }

--- a/backend/servers/api-server/src/routes/iot.rs
+++ b/backend/servers/api-server/src/routes/iot.rs
@@ -1,9 +1,25 @@
 //! IoT routes (Epic 14: IoT & Smart Building).
 //!
 //! Handles sensor registration, data ingestion, dashboards, alerts, and correlations.
+//!
+//! # RLS (PAP-67)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` on every sensor table
+//! (`sensors`, `sensor_readings`, `sensor_alerts`, `sensor_thresholds`,
+//! `sensor_threshold_templates`, `sensor_fault_correlations`), so every query
+//! MUST run on a connection that has `app.current_org_id` set or it collapses to
+//! deny-all. Each handler therefore acquires an [`RlsConnection`] (which
+//! validates tenant membership and sets the org/user GUCs on a dedicated
+//! connection) and passes `&mut **rls.conn()` to the repository. The
+//! authoritative organization is `rls.tenant_id()` — the tenant the caller was
+//! validated against — not a client-supplied `organization_id`, so the SQL org
+//! filter and the RLS context can never disagree. Cross-tenant access is blocked
+//! by RLS: a by-id read of another org's row returns no row (`404`), and a write
+//! targeting another org fails the policy's `WITH CHECK`. `rls.release()` clears
+//! the context before the connection returns to the pool.
 
 use crate::state::AppState;
-use api_core::extractors::principal::RequestPrincipal;
+use api_core::extractors::RlsConnection;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -21,33 +37,38 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 // ============================================================================
-// Helper Functions
+// Error Helpers
 // ============================================================================
-//
-// SECURITY: The previous `extract_tenant_context` helper deserialized the
-// client-supplied `X-Tenant-Context` JSON header directly into a
-// `TenantContext`. No JWT verification — any unauthenticated caller could
-// forge tenancy. That helper has been deleted; every handler now goes
-// through `RequestPrincipal` (verified bearer JWT + host-resolved tenant).
 
-/// Resolve the effective tenant id from a verified [`RequestPrincipal`].
-///
-/// IoT endpoints are per-tenant by definition (sensor inventory, alerts,
-/// dashboards). A platform-kind principal hitting the platform host has no
-/// `effective_org` — for those callers we refuse with 403 rather than fall
-/// back to a wildcard.
-fn require_tenant_id(
-    principal: &RequestPrincipal,
-) -> Result<Uuid, (StatusCode, Json<ErrorResponse>)> {
-    principal.effective_org.ok_or_else(|| {
-        (
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse::new(
-                "TENANT_REQUIRED",
-                "IoT endpoints require a tenant-resolved request",
-            )),
-        )
-    })
+/// Map a repository error to a `500` with a stable code, logging the cause.
+fn db_error(msg: &'static str, e: sqlx::Error) -> (StatusCode, Json<ErrorResponse>) {
+    tracing::error!("{}: {:?}", msg, e);
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse::new("INTERNAL_ERROR", msg)),
+    )
+}
+
+/// Build a `404` response.
+fn not_found(msg: &'static str) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::NOT_FOUND,
+        Json(ErrorResponse::new("NOT_FOUND", msg)),
+    )
+}
+
+/// Map a `fetch_one` error from a by-id write to either `404` (the row is not
+/// visible under the caller's RLS context — cross-tenant or genuinely missing)
+/// or `500` for any other database failure.
+fn write_error(
+    msg: &'static str,
+    not_found_msg: &'static str,
+    e: sqlx::Error,
+) -> (StatusCode, Json<ErrorResponse>) {
+    match e {
+        sqlx::Error::RowNotFound => not_found(not_found_msg),
+        other => db_error(msg, other),
+    }
 }
 
 // ============================================================================
@@ -115,23 +136,20 @@ pub fn sensor_router() -> Router<AppState> {
 )]
 async fn create_sensor(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
-    Json(req): Json<CreateSensor>,
+    mut rls: RlsConnection,
+    Json(mut req): Json<CreateSensor>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-    match state.sensor_repo.create(req).await {
-        Ok(sensor) => Ok((StatusCode::CREATED, Json(serde_json::json!(sensor)))),
-        Err(e) => {
-            tracing::error!("Failed to create sensor: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to create sensor",
-                )),
-            ))
-        }
-    }
+    // Pin the new sensor to the caller's validated org so the INSERT's
+    // organization_id and the RLS WITH CHECK can never disagree.
+    req.organization_id = rls.tenant_id();
+    let out = state
+        .sensor_repo
+        .create(&mut **rls.conn(), req)
+        .await
+        .map(|sensor| (StatusCode::CREATED, Json(serde_json::json!(sensor))))
+        .map_err(|e| db_error("Failed to create sensor", e));
+    rls.release().await;
+    out
 }
 
 #[utoipa::path(
@@ -146,93 +164,73 @@ async fn create_sensor(
 )]
 async fn list_sensors(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Query(query): Query<SensorQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
-
-    match state.sensor_repo.list(tenant_id, query).await {
-        Ok(sensors) => Ok(Json(serde_json::json!({ "sensors": sensors }))),
-        Err(e) => {
-            tracing::error!("Failed to list sensors: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to list sensors",
-                )),
-            ))
-        }
-    }
+    let org_id = rls.tenant_id();
+    let out = state
+        .sensor_repo
+        .list(&mut **rls.conn(), org_id, query)
+        .await
+        .map(|sensors| Json(serde_json::json!({ "sensors": sensors })))
+        .map_err(|e| db_error("Failed to list sensors", e));
+    rls.release().await;
+    out
 }
 
 async fn get_sensor(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-    match state.sensor_repo.find_by_id(id).await {
-        Ok(Some(sensor)) => Ok(Json(serde_json::json!(sensor))),
-        Ok(None) => Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Sensor not found")),
-        )),
-        Err(e) => {
-            tracing::error!("Failed to get sensor: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get sensor")),
-            ))
-        }
-    }
+    let out = state
+        .sensor_repo
+        .find_by_id(&mut **rls.conn(), id)
+        .await
+        .map_err(|e| db_error("Failed to get sensor", e))
+        .and_then(|maybe| match maybe {
+            Some(sensor) => Ok(Json(serde_json::json!(sensor))),
+            None => Err(not_found("Sensor not found")),
+        });
+    rls.release().await;
+    out
 }
 
 async fn update_sensor(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateSensor>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-    match state.sensor_repo.update(id, req).await {
-        Ok(sensor) => Ok(Json(serde_json::json!(sensor))),
-        Err(e) => {
-            tracing::error!("Failed to update sensor: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to update sensor",
-                )),
-            ))
-        }
-    }
+    let out = state
+        .sensor_repo
+        .update(&mut **rls.conn(), id, req)
+        .await
+        .map(|sensor| Json(serde_json::json!(sensor)))
+        .map_err(|e| write_error("Failed to update sensor", "Sensor not found", e));
+    rls.release().await;
+    out
 }
 
 async fn delete_sensor(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-    match state.sensor_repo.delete(id).await {
-        Ok(true) => Ok(StatusCode::NO_CONTENT),
-        Ok(false) => Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Sensor not found")),
-        )),
-        Err(e) => {
-            tracing::error!("Failed to delete sensor: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to delete sensor",
-                )),
-            ))
-        }
-    }
+    let out = state
+        .sensor_repo
+        .delete(&mut **rls.conn(), id)
+        .await
+        .map_err(|e| db_error("Failed to delete sensor", e))
+        .and_then(|deleted| {
+            if deleted {
+                Ok(StatusCode::NO_CONTENT)
+            } else {
+                Err(not_found("Sensor not found"))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -241,86 +239,59 @@ async fn delete_sensor(
 
 async fn list_readings(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Query(query): Query<ReadingQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-    match state.sensor_repo.list_readings(id, query).await {
-        Ok(readings) => Ok(Json(serde_json::json!({ "readings": readings }))),
-        Err(e) => {
-            tracing::error!("Failed to list readings: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to list readings",
-                )),
-            ))
-        }
-    }
+    let out = state
+        .sensor_repo
+        .list_readings(&mut **rls.conn(), id, query)
+        .await
+        .map(|readings| Json(serde_json::json!({ "readings": readings })))
+        .map_err(|e| db_error("Failed to list readings", e));
+    rls.release().await;
+    out
 }
 
 async fn add_reading(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(mut req): Json<CreateSensorReading>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
     req.sensor_id = id;
-
-    match state.sensor_repo.create_reading(req).await {
-        Ok(reading) => Ok((StatusCode::CREATED, Json(serde_json::json!(reading)))),
-        Err(e) => {
-            tracing::error!("Failed to add reading: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to add reading",
-                )),
-            ))
-        }
-    }
+    let out = state
+        .sensor_repo
+        .create_reading(&mut **rls.conn(), req)
+        .await
+        .map(|reading| (StatusCode::CREATED, Json(serde_json::json!(reading))))
+        .map_err(|e| db_error("Failed to add reading", e));
+    rls.release().await;
+    out
 }
 
 async fn add_batch_readings(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<BatchSensorReadings>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-    match state
+    let out = state
         .sensor_repo
-        .create_batch_readings(id, req.readings)
+        .create_batch_readings(&mut **rls.conn(), id, req.readings)
         .await
-    {
-        Ok(count) => Ok((
-            StatusCode::CREATED,
-            Json(serde_json::json!({ "inserted": count })),
-        )),
-        Err(e) => {
-            tracing::error!("Failed to add batch readings: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to add batch readings",
-                )),
-            ))
-        }
-    }
+        .map(|count| (StatusCode::CREATED, Json(serde_json::json!({ "inserted": count }))))
+        .map_err(|e| db_error("Failed to add batch readings", e));
+    rls.release().await;
+    out
 }
 
 async fn get_aggregated_readings(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Query(query): Query<ReadingQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
     let aggregation = query
         .aggregation
         .clone()
@@ -330,23 +301,14 @@ async fn get_aggregated_readings(
         .unwrap_or_else(|| chrono::Utc::now() - chrono::Duration::hours(24));
     let to = query.to_time.unwrap_or_else(chrono::Utc::now);
 
-    match state
+    let out = state
         .sensor_repo
-        .list_aggregated_readings(id, from, to, &aggregation)
+        .list_aggregated_readings(&mut **rls.conn(), id, from, to, &aggregation)
         .await
-    {
-        Ok(readings) => Ok(Json(serde_json::json!({ "aggregated_readings": readings }))),
-        Err(e) => {
-            tracing::error!("Failed to get aggregated readings: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to get aggregated readings",
-                )),
-            ))
-        }
-    }
+        .map(|readings| Json(serde_json::json!({ "aggregated_readings": readings })))
+        .map_err(|e| db_error("Failed to get aggregated readings", e));
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -355,94 +317,71 @@ async fn get_aggregated_readings(
 
 async fn list_thresholds(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-    match state.sensor_repo.list_thresholds(id).await {
-        Ok(thresholds) => Ok(Json(serde_json::json!({ "thresholds": thresholds }))),
-        Err(e) => {
-            tracing::error!("Failed to list thresholds: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to list thresholds",
-                )),
-            ))
-        }
-    }
+    let out = state
+        .sensor_repo
+        .list_thresholds(&mut **rls.conn(), id)
+        .await
+        .map(|thresholds| Json(serde_json::json!({ "thresholds": thresholds })))
+        .map_err(|e| db_error("Failed to list thresholds", e));
+    rls.release().await;
+    out
 }
 
 async fn create_threshold(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(mut req): Json<CreateSensorThreshold>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
     req.sensor_id = id;
-
-    match state.sensor_repo.create_threshold(req).await {
-        Ok(threshold) => Ok((StatusCode::CREATED, Json(serde_json::json!(threshold)))),
-        Err(e) => {
-            tracing::error!("Failed to create threshold: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to create threshold",
-                )),
-            ))
-        }
-    }
+    let out = state
+        .sensor_repo
+        .create_threshold(&mut **rls.conn(), req)
+        .await
+        .map(|threshold| (StatusCode::CREATED, Json(serde_json::json!(threshold))))
+        .map_err(|e| db_error("Failed to create threshold", e));
+    rls.release().await;
+    out
 }
 
 async fn update_threshold(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(threshold_id): Path<Uuid>,
     Json(req): Json<UpdateSensorThreshold>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-    match state.sensor_repo.update_threshold(threshold_id, req).await {
-        Ok(threshold) => Ok(Json(serde_json::json!(threshold))),
-        Err(e) => {
-            tracing::error!("Failed to update threshold: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to update threshold",
-                )),
-            ))
-        }
-    }
+    let out = state
+        .sensor_repo
+        .update_threshold(&mut **rls.conn(), threshold_id, req)
+        .await
+        .map(|threshold| Json(serde_json::json!(threshold)))
+        .map_err(|e| write_error("Failed to update threshold", "Threshold not found", e));
+    rls.release().await;
+    out
 }
 
 async fn delete_threshold(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(threshold_id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-    match state.sensor_repo.delete_threshold(threshold_id).await {
-        Ok(true) => Ok(StatusCode::NO_CONTENT),
-        Ok(false) => Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Threshold not found")),
-        )),
-        Err(e) => {
-            tracing::error!("Failed to delete threshold: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to delete threshold",
-                )),
-            ))
-        }
-    }
+    let out = state
+        .sensor_repo
+        .delete_threshold(&mut **rls.conn(), threshold_id)
+        .await
+        .map_err(|e| db_error("Failed to delete threshold", e))
+        .and_then(|deleted| {
+            if deleted {
+                Ok(StatusCode::NO_CONTENT)
+            } else {
+                Err(not_found("Threshold not found"))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -451,52 +390,36 @@ async fn delete_threshold(
 
 async fn list_sensor_alerts(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Query(mut query): Query<AlertQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
+    let org_id = rls.tenant_id();
     query.sensor_id = Some(id);
-
-    match state.sensor_repo.list_alerts(tenant_id, query).await {
-        Ok(alerts) => Ok(Json(serde_json::json!({ "alerts": alerts }))),
-        Err(e) => {
-            tracing::error!("Failed to list alerts: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to list alerts",
-                )),
-            ))
-        }
-    }
+    let out = state
+        .sensor_repo
+        .list_alerts(&mut **rls.conn(), org_id, query)
+        .await
+        .map(|alerts| Json(serde_json::json!({ "alerts": alerts })))
+        .map_err(|e| db_error("Failed to list alerts", e));
+    rls.release().await;
+    out
 }
 
 async fn acknowledge_alert(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(alert_id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-
-    match state
+    let user_id = rls.user_id();
+    let out = state
         .sensor_repo
-        .acknowledge_alert(alert_id, principal.user_id)
+        .acknowledge_alert(&mut **rls.conn(), alert_id, user_id)
         .await
-    {
-        Ok(alert) => Ok(Json(serde_json::json!(alert))),
-        Err(e) => {
-            tracing::error!("Failed to acknowledge alert: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to acknowledge alert",
-                )),
-            ))
-        }
-    }
+        .map(|alert| Json(serde_json::json!(alert)))
+        .map_err(|e| write_error("Failed to acknowledge alert", "Alert not found", e));
+    rls.release().await;
+    out
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -506,29 +429,19 @@ pub struct ResolveAlertRequest {
 
 async fn resolve_alert(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(alert_id): Path<Uuid>,
     Json(req): Json<ResolveAlertRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
     // Pass resolved_value as Option - NULL is valid when value wasn't captured
-    match state
+    let out = state
         .sensor_repo
-        .resolve_alert(alert_id, req.resolved_value)
+        .resolve_alert(&mut **rls.conn(), alert_id, req.resolved_value)
         .await
-    {
-        Ok(alert) => Ok(Json(serde_json::json!(alert))),
-        Err(e) => {
-            tracing::error!("Failed to resolve alert: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to resolve alert",
-                )),
-            ))
-        }
-    }
+        .map(|alert| Json(serde_json::json!(alert)))
+        .map_err(|e| write_error("Failed to resolve alert", "Alert not found", e));
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -537,73 +450,56 @@ async fn resolve_alert(
 
 async fn list_correlations(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-    match state.sensor_repo.list_correlations_for_sensor(id).await {
-        Ok(correlations) => Ok(Json(serde_json::json!({ "correlations": correlations }))),
-        Err(e) => {
-            tracing::error!("Failed to list correlations: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to list correlations",
-                )),
-            ))
-        }
-    }
+    let out = state
+        .sensor_repo
+        .list_correlations_for_sensor(&mut **rls.conn(), id)
+        .await
+        .map(|correlations| Json(serde_json::json!({ "correlations": correlations })))
+        .map_err(|e| db_error("Failed to list correlations", e));
+    rls.release().await;
+    out
 }
 
 async fn create_correlation(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(mut req): Json<CreateSensorFaultCorrelation>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
     req.sensor_id = id;
-    req.created_by = Some(principal.user_id);
-
-    match state.sensor_repo.create_correlation(req).await {
-        Ok(correlation) => Ok((StatusCode::CREATED, Json(serde_json::json!(correlation)))),
-        Err(e) => {
-            tracing::error!("Failed to create correlation: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to create correlation",
-                )),
-            ))
-        }
-    }
+    req.created_by = Some(rls.user_id());
+    let out = state
+        .sensor_repo
+        .create_correlation(&mut **rls.conn(), req)
+        .await
+        .map(|correlation| (StatusCode::CREATED, Json(serde_json::json!(correlation))))
+        .map_err(|e| db_error("Failed to create correlation", e));
+    rls.release().await;
+    out
 }
 
 async fn delete_correlation(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(correlation_id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-    match state.sensor_repo.delete_correlation(correlation_id).await {
-        Ok(true) => Ok(StatusCode::NO_CONTENT),
-        Ok(false) => Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Correlation not found")),
-        )),
-        Err(e) => {
-            tracing::error!("Failed to delete correlation: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to delete correlation",
-                )),
-            ))
-        }
-    }
+    let out = state
+        .sensor_repo
+        .delete_correlation(&mut **rls.conn(), correlation_id)
+        .await
+        .map_err(|e| db_error("Failed to delete correlation", e))
+        .and_then(|deleted| {
+            if deleted {
+                Ok(StatusCode::NO_CONTENT)
+            } else {
+                Err(not_found("Correlation not found"))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -612,28 +508,18 @@ async fn delete_correlation(
 
 async fn list_threshold_templates(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Query(query): Query<TemplateQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
-
-    match state
+    let org_id = rls.tenant_id();
+    let out = state
         .sensor_repo
-        .list_threshold_templates(Some(tenant_id), query.sensor_type.as_deref())
+        .list_threshold_templates(&mut **rls.conn(), Some(org_id), query.sensor_type.as_deref())
         .await
-    {
-        Ok(templates) => Ok(Json(serde_json::json!({ "templates": templates }))),
-        Err(e) => {
-            tracing::error!("Failed to list templates: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to list templates",
-                )),
-            ))
-        }
-    }
+        .map(|templates| Json(serde_json::json!({ "templates": templates })))
+        .map_err(|e| db_error("Failed to list templates", e));
+    rls.release().await;
+    out
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -643,28 +529,18 @@ pub struct TemplateQuery {
 
 async fn apply_template(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(template_id): Path<Uuid>,
     Json(req): Json<ApplyTemplateRequest>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-    match state
+    let out = state
         .sensor_repo
-        .apply_threshold_template(template_id, req.sensor_id)
+        .apply_threshold_template(&mut **rls.conn(), template_id, req.sensor_id)
         .await
-    {
-        Ok(threshold) => Ok((StatusCode::CREATED, Json(serde_json::json!(threshold)))),
-        Err(e) => {
-            tracing::error!("Failed to apply template: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to apply template",
-                )),
-            ))
-        }
-    }
+        .map(|threshold| (StatusCode::CREATED, Json(serde_json::json!(threshold))))
+        .map_err(|e| write_error("Failed to apply template", "Template not found", e));
+    rls.release().await;
+    out
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -678,28 +554,18 @@ pub struct ApplyTemplateRequest {
 
 async fn get_dashboard(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Query(query): Query<DashboardQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
-
-    match state
+    let org_id = rls.tenant_id();
+    let out = state
         .sensor_repo
-        .get_dashboard(tenant_id, query.building_id)
+        .get_dashboard(&mut **rls.conn(), org_id, query.building_id)
         .await
-    {
-        Ok(dashboard) => Ok(Json(serde_json::json!(dashboard))),
-        Err(e) => {
-            tracing::error!("Failed to get dashboard: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to get dashboard",
-                )),
-            ))
-        }
-    }
+        .map(|dashboard| Json(serde_json::json!(dashboard)))
+        .map_err(|e| db_error("Failed to get dashboard", e));
+    rls.release().await;
+    out
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]


### PR DESCRIPTION
## Summary

- Drops the raw `pool: PgPool` field from `SensorRepository`; the struct is now stateless
- Every method takes an RLS-context-bearing executor (`E: Executor` for 25 single-statement methods, `&mut PgConnection` for 4 multi-statement methods)
- IoT handlers (`routes/iot.rs`) now acquire `mut rls: RlsConnection`, pass `&mut **rls.conn()` to the repo, use `rls.tenant_id()` as authoritative org, and call `rls.release().await` on both Ok/Err paths
- Adds `crates/db/tests/sensor_rls_repo_tests.rs`: NOSUPERUSER NOBYPASSRLS role, deny-all without context, own-org visibility with context

Fixes the FORCE-RLS deny-all introduced by migration `00179` (`get_current_org_id()` + `FORCE ROW LEVEL SECURITY` on all sensor tables).

**Tables fixed:** `sensors`, `sensor_readings`, `sensor_alerts`, `sensor_thresholds`, `sensor_threshold_templates`, `sensor_fault_correlations`

Mirrors the proven fix pattern from `budget.rs` (dev) and `work_order.rs` (pap-67-work-order-rls).

Parent: PAP-78 / PAP-67

## Test plan

- [x] `cargo check -p db -p api-server` green on branch
- [x] `cargo check -p db --tests` green (sensor_rls_repo_tests compiles)
- [ ] `#[sqlx::test]` execution via CI rls-smoke / QA environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)