### PR TITLE
fix(api-server): route emergency repo through RLS-context connection (PAP-80)

### DIFF
--- a/backend/crates/db/src/repositories/emergency.rs
+++ b/backend/crates/db/src/repositories/emergency.rs
@@ -1,8 +1,32 @@
 //! Emergency repository for Epic 23.
 //!
 //! Handles all database operations for emergency protocols, contacts, incidents, and broadcasts.
+//!
+//! # RLS Integration (PAP-80 / PAP-67)
+//!
+//! Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on every emergency table — `emergency_protocols`,
+//! `emergency_contacts`, `emergency_incidents`, `emergency_incident_attachments`,
+//! `emergency_incident_updates`, `emergency_broadcasts`,
+//! `emergency_broadcast_acknowledgments`, `emergency_drills` (8 tables). Under
+//! `FORCE` the api-server's owner connection is no longer exempt, so a query
+//! issued on a connection WITHOUT `app.current_org_id` set collapses to deny-all
+//! (own-org reads return empty, writes fail the policy `WITH CHECK`).
+//!
+//! Every method therefore takes an **executor whose connection already has RLS
+//! context set** (org + user GUCs) — in handlers this comes from the
+//! `RlsConnection` extractor via `&mut **rls.conn()`. The repository holds **no
+//! pool**, so there is no way to issue a query that bypasses RLS. This mirrors
+//! the `work_order.rs` / `budget.rs` / `sensor.rs` precedent.
+//!
+//! The explicit `organization_id = $N` SQL filters on the parent tables are
+//! retained as defense-in-depth; handlers pass `rls.tenant_id()` (the org the
+//! caller was validated against), so the SQL filter and the RLS context can
+//! never disagree. The child tables (`*_attachments`, `*_updates`,
+//! `*_acknowledgments`) are scoped by RLS through an `EXISTS` join on the
+//! parent's `organization_id`.
 
-use sqlx::PgPool;
+use sqlx::{Executor, Postgres};
 use uuid::Uuid;
 
 use crate::models::{
@@ -18,20 +42,23 @@ use crate::models::{
 use crate::DbPool;
 
 /// Repository for emergency management operations.
+///
+/// Stateless: every method receives an RLS-context-bearing executor (the
+/// per-request connection from the `RlsConnection` extractor). The repo holds
+/// **no pool**, so it cannot issue an un-scoped query that would collapse to
+/// deny-all under the `FORCE ROW LEVEL SECURITY` policies (migration `00179`).
 #[derive(Clone)]
-pub struct EmergencyRepository {
-    pool: DbPool,
-}
+pub struct EmergencyRepository;
 
 impl EmergencyRepository {
     /// Create a new EmergencyRepository.
-    pub fn new(pool: DbPool) -> Self {
-        Self { pool }
-    }
-
-    /// Get the database pool reference.
-    pub fn pool(&self) -> &PgPool {
-        &self.pool
+    ///
+    /// The pool argument is retained for construction-site compatibility with
+    /// the other repositories on `AppState`; this repo deliberately does not
+    /// store it — every query runs on a context-set connection supplied by the
+    /// handler's `RlsConnection`.
+    pub fn new(_pool: DbPool) -> Self {
+        Self
     }
 
     // ============================================
@@ -39,12 +66,16 @@ impl EmergencyRepository {
     // ============================================
 
     /// Create a new emergency protocol.
-    pub async fn create_protocol(
+    pub async fn create_protocol<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         created_by: Uuid,
         data: CreateEmergencyProtocol,
-    ) -> Result<EmergencyProtocol, sqlx::Error> {
+    ) -> Result<EmergencyProtocol, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyProtocol>(
             r#"
             INSERT INTO emergency_protocols (
@@ -66,31 +97,39 @@ impl EmergencyRepository {
         .bind(data.is_active)
         .bind(data.priority)
         .bind(created_by)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Find emergency protocol by ID.
-    pub async fn find_protocol_by_id(
+    pub async fn find_protocol_by_id<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         protocol_id: Uuid,
-    ) -> Result<Option<EmergencyProtocol>, sqlx::Error> {
+    ) -> Result<Option<EmergencyProtocol>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyProtocol>(
             "SELECT * FROM emergency_protocols WHERE id = $1 AND organization_id = $2",
         )
         .bind(protocol_id)
         .bind(organization_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// List emergency protocols with filters.
-    pub async fn list_protocols(
+    pub async fn list_protocols<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         query: EmergencyProtocolQuery,
-    ) -> Result<Vec<EmergencyProtocol>, sqlx::Error> {
+    ) -> Result<Vec<EmergencyProtocol>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50);
         let offset = query.offset.unwrap_or(0);
 
@@ -111,17 +150,21 @@ impl EmergencyRepository {
         .bind(query.is_active)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update an emergency protocol.
-    pub async fn update_protocol(
+    pub async fn update_protocol<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         protocol_id: Uuid,
         data: UpdateEmergencyProtocol,
-    ) -> Result<Option<EmergencyProtocol>, sqlx::Error> {
+    ) -> Result<Option<EmergencyProtocol>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyProtocol>(
             r#"
             UPDATE emergency_protocols SET
@@ -152,21 +195,25 @@ impl EmergencyRepository {
         .bind(&data.attachments)
         .bind(data.is_active)
         .bind(data.priority)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Delete an emergency protocol.
-    pub async fn delete_protocol(
+    pub async fn delete_protocol<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         protocol_id: Uuid,
-    ) -> Result<bool, sqlx::Error> {
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result =
             sqlx::query("DELETE FROM emergency_protocols WHERE id = $1 AND organization_id = $2")
                 .bind(protocol_id)
                 .bind(organization_id)
-                .execute(&self.pool)
+                .execute(executor)
                 .await?;
 
         Ok(result.rows_affected() > 0)
@@ -177,11 +224,15 @@ impl EmergencyRepository {
     // ============================================
 
     /// Create a new emergency contact.
-    pub async fn create_contact(
+    pub async fn create_contact<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         data: CreateEmergencyContact,
-    ) -> Result<EmergencyContact, sqlx::Error> {
+    ) -> Result<EmergencyContact, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyContact>(
             r#"
             INSERT INTO emergency_contacts (
@@ -203,31 +254,39 @@ impl EmergencyRepository {
         .bind(data.priority_order)
         .bind(&data.contact_type)
         .bind(&data.available_hours)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Find emergency contact by ID.
-    pub async fn find_contact_by_id(
+    pub async fn find_contact_by_id<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         contact_id: Uuid,
-    ) -> Result<Option<EmergencyContact>, sqlx::Error> {
+    ) -> Result<Option<EmergencyContact>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyContact>(
             "SELECT * FROM emergency_contacts WHERE id = $1 AND organization_id = $2",
         )
         .bind(contact_id)
         .bind(organization_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// List emergency contacts with filters.
-    pub async fn list_contacts(
+    pub async fn list_contacts<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         query: EmergencyContactQuery,
-    ) -> Result<Vec<EmergencyContact>, sqlx::Error> {
+    ) -> Result<Vec<EmergencyContact>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50);
         let offset = query.offset.unwrap_or(0);
 
@@ -248,17 +307,21 @@ impl EmergencyRepository {
         .bind(query.is_active)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update an emergency contact.
-    pub async fn update_contact(
+    pub async fn update_contact<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         contact_id: Uuid,
         data: UpdateEmergencyContact,
-    ) -> Result<Option<EmergencyContact>, sqlx::Error> {
+    ) -> Result<Option<EmergencyContact>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyContact>(
             r#"
             UPDATE emergency_contacts SET
@@ -293,21 +356,25 @@ impl EmergencyRepository {
         .bind(&data.contact_type)
         .bind(data.is_active)
         .bind(&data.available_hours)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Delete an emergency contact.
-    pub async fn delete_contact(
+    pub async fn delete_contact<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         contact_id: Uuid,
-    ) -> Result<bool, sqlx::Error> {
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result =
             sqlx::query("DELETE FROM emergency_contacts WHERE id = $1 AND organization_id = $2")
                 .bind(contact_id)
                 .bind(organization_id)
-                .execute(&self.pool)
+                .execute(executor)
                 .await?;
 
         Ok(result.rows_affected() > 0)
@@ -318,12 +385,16 @@ impl EmergencyRepository {
     // ============================================
 
     /// Create a new emergency incident.
-    pub async fn create_incident(
+    pub async fn create_incident<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         reported_by: Uuid,
         data: CreateEmergencyIncident,
-    ) -> Result<EmergencyIncident, sqlx::Error> {
+    ) -> Result<EmergencyIncident, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyIncident>(
             r#"
             INSERT INTO emergency_incidents (
@@ -347,31 +418,39 @@ impl EmergencyRepository {
         .bind(data.longitude)
         .bind(data.protocol_id)
         .bind(&data.metadata)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Find emergency incident by ID.
-    pub async fn find_incident_by_id(
+    pub async fn find_incident_by_id<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         incident_id: Uuid,
-    ) -> Result<Option<EmergencyIncident>, sqlx::Error> {
+    ) -> Result<Option<EmergencyIncident>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyIncident>(
             "SELECT * FROM emergency_incidents WHERE id = $1 AND organization_id = $2",
         )
         .bind(incident_id)
         .bind(organization_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// List emergency incidents with filters.
-    pub async fn list_incidents(
+    pub async fn list_incidents<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         query: EmergencyIncidentQuery,
-    ) -> Result<Vec<EmergencyIncident>, sqlx::Error> {
+    ) -> Result<Vec<EmergencyIncident>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50);
         let offset = query.offset.unwrap_or(0);
 
@@ -396,17 +475,21 @@ impl EmergencyRepository {
         .bind(query.active_only)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update an emergency incident.
-    pub async fn update_incident(
+    pub async fn update_incident<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         incident_id: Uuid,
         data: UpdateEmergencyIncident,
-    ) -> Result<Option<EmergencyIncident>, sqlx::Error> {
+    ) -> Result<Option<EmergencyIncident>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyIncident>(
             r#"
             UPDATE emergency_incidents SET
@@ -437,16 +520,20 @@ impl EmergencyRepository {
         .bind(data.protocol_id)
         .bind(data.fault_id)
         .bind(&data.metadata)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Acknowledge an incident.
-    pub async fn acknowledge_incident(
+    pub async fn acknowledge_incident<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         incident_id: Uuid,
-    ) -> Result<Option<EmergencyIncident>, sqlx::Error> {
+    ) -> Result<Option<EmergencyIncident>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyIncident>(
             r#"
             UPDATE emergency_incidents SET
@@ -458,19 +545,23 @@ impl EmergencyRepository {
         )
         .bind(incident_id)
         .bind(organization_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Resolve an incident.
     /// Only incidents that are not already resolved or closed can be resolved.
-    pub async fn resolve_incident(
+    pub async fn resolve_incident<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         incident_id: Uuid,
         resolved_by: Uuid,
         resolution: &str,
-    ) -> Result<Option<EmergencyIncident>, sqlx::Error> {
+    ) -> Result<Option<EmergencyIncident>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyIncident>(
             r#"
             UPDATE emergency_incidents SET
@@ -488,16 +579,20 @@ impl EmergencyRepository {
         .bind(organization_id)
         .bind(resolution)
         .bind(resolved_by)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Close an incident.
-    pub async fn close_incident(
+    pub async fn close_incident<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         incident_id: Uuid,
-    ) -> Result<Option<EmergencyIncident>, sqlx::Error> {
+    ) -> Result<Option<EmergencyIncident>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyIncident>(
             r#"
             UPDATE emergency_incidents SET
@@ -509,17 +604,21 @@ impl EmergencyRepository {
         )
         .bind(incident_id)
         .bind(organization_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Add attachment to incident.
-    pub async fn add_incident_attachment(
+    pub async fn add_incident_attachment<'e, E>(
         &self,
+        executor: E,
         incident_id: Uuid,
         uploaded_by: Uuid,
         data: AddIncidentAttachment,
-    ) -> Result<EmergencyIncidentAttachment, sqlx::Error> {
+    ) -> Result<EmergencyIncidentAttachment, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyIncidentAttachment>(
             r#"
             INSERT INTO emergency_incident_attachments (incident_id, document_id, attachment_type, description, uploaded_by)
@@ -532,30 +631,38 @@ impl EmergencyRepository {
         .bind(&data.attachment_type)
         .bind(&data.description)
         .bind(uploaded_by)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// List incident attachments.
-    pub async fn list_incident_attachments(
+    pub async fn list_incident_attachments<'e, E>(
         &self,
+        executor: E,
         incident_id: Uuid,
-    ) -> Result<Vec<EmergencyIncidentAttachment>, sqlx::Error> {
+    ) -> Result<Vec<EmergencyIncidentAttachment>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyIncidentAttachment>(
             "SELECT * FROM emergency_incident_attachments WHERE incident_id = $1 ORDER BY created_at DESC",
         )
         .bind(incident_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Add update to incident timeline.
-    pub async fn add_incident_update(
+    pub async fn add_incident_update<'e, E>(
         &self,
+        executor: E,
         incident_id: Uuid,
         updated_by: Uuid,
         data: CreateIncidentUpdate,
-    ) -> Result<EmergencyIncidentUpdate, sqlx::Error> {
+    ) -> Result<EmergencyIncidentUpdate, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyIncidentUpdate>(
             r#"
             INSERT INTO emergency_incident_updates (incident_id, update_type, previous_status, new_status, message, updated_by)
@@ -569,20 +676,24 @@ impl EmergencyRepository {
         .bind(&data.new_status)
         .bind(&data.message)
         .bind(updated_by)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// List incident updates.
-    pub async fn list_incident_updates(
+    pub async fn list_incident_updates<'e, E>(
         &self,
+        executor: E,
         incident_id: Uuid,
-    ) -> Result<Vec<EmergencyIncidentUpdate>, sqlx::Error> {
+    ) -> Result<Vec<EmergencyIncidentUpdate>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyIncidentUpdate>(
             "SELECT * FROM emergency_incident_updates WHERE incident_id = $1 ORDER BY created_at DESC",
         )
         .bind(incident_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -591,12 +702,16 @@ impl EmergencyRepository {
     // ============================================
 
     /// Create a new emergency broadcast.
-    pub async fn create_broadcast(
+    pub async fn create_broadcast<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         sent_by: Uuid,
         data: CreateEmergencyBroadcast,
-    ) -> Result<EmergencyBroadcast, sqlx::Error> {
+    ) -> Result<EmergencyBroadcast, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyBroadcast>(
             r#"
             INSERT INTO emergency_broadcasts (
@@ -616,31 +731,39 @@ impl EmergencyRepository {
         .bind(sent_by)
         .bind(data.expires_at)
         .bind(&data.metadata)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Find emergency broadcast by ID.
-    pub async fn find_broadcast_by_id(
+    pub async fn find_broadcast_by_id<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         broadcast_id: Uuid,
-    ) -> Result<Option<EmergencyBroadcast>, sqlx::Error> {
+    ) -> Result<Option<EmergencyBroadcast>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyBroadcast>(
             "SELECT * FROM emergency_broadcasts WHERE id = $1 AND organization_id = $2",
         )
         .bind(broadcast_id)
         .bind(organization_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// List emergency broadcasts with filters.
-    pub async fn list_broadcasts(
+    pub async fn list_broadcasts<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         query: EmergencyBroadcastQuery,
-    ) -> Result<Vec<EmergencyBroadcast>, sqlx::Error> {
+    ) -> Result<Vec<EmergencyBroadcast>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50);
         let offset = query.offset.unwrap_or(0);
 
@@ -661,17 +784,21 @@ impl EmergencyRepository {
         .bind(query.is_active)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update broadcast delivery counts.
-    pub async fn update_broadcast_counts(
+    pub async fn update_broadcast_counts<'e, E>(
         &self,
+        executor: E,
         broadcast_id: Uuid,
         recipient_count: i32,
         delivered_count: i32,
-    ) -> Result<bool, sqlx::Error> {
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query(
             r#"
             UPDATE emergency_broadcasts SET
@@ -683,36 +810,44 @@ impl EmergencyRepository {
         .bind(broadcast_id)
         .bind(recipient_count)
         .bind(delivered_count)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
 
         Ok(result.rows_affected() > 0)
     }
 
     /// Deactivate a broadcast.
-    pub async fn deactivate_broadcast(
+    pub async fn deactivate_broadcast<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         broadcast_id: Uuid,
-    ) -> Result<bool, sqlx::Error> {
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query(
             "UPDATE emergency_broadcasts SET is_active = FALSE WHERE id = $1 AND organization_id = $2",
         )
         .bind(broadcast_id)
         .bind(organization_id)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
 
         Ok(result.rows_affected() > 0)
     }
 
     /// Acknowledge a broadcast.
-    pub async fn acknowledge_broadcast(
+    pub async fn acknowledge_broadcast<'e, E>(
         &self,
+        executor: E,
         broadcast_id: Uuid,
         user_id: Uuid,
         data: AcknowledgeBroadcast,
-    ) -> Result<EmergencyBroadcastAcknowledgment, sqlx::Error> {
+    ) -> Result<EmergencyBroadcastAcknowledgment, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyBroadcastAcknowledgment>(
             r#"
             INSERT INTO emergency_broadcast_acknowledgments (broadcast_id, user_id, status, message)
@@ -726,28 +861,36 @@ impl EmergencyRepository {
         .bind(user_id)
         .bind(&data.status)
         .bind(&data.message)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// List broadcast acknowledgments.
-    pub async fn list_broadcast_acknowledgments(
+    pub async fn list_broadcast_acknowledgments<'e, E>(
         &self,
+        executor: E,
         broadcast_id: Uuid,
-    ) -> Result<Vec<EmergencyBroadcastAcknowledgment>, sqlx::Error> {
+    ) -> Result<Vec<EmergencyBroadcastAcknowledgment>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyBroadcastAcknowledgment>(
             "SELECT * FROM emergency_broadcast_acknowledgments WHERE broadcast_id = $1 ORDER BY acknowledged_at DESC",
         )
         .bind(broadcast_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Get acknowledgment count by status.
-    pub async fn get_acknowledgment_counts(
+    pub async fn get_acknowledgment_counts<'e, E>(
         &self,
+        executor: E,
         broadcast_id: Uuid,
-    ) -> Result<(i64, i64, i64, i64), sqlx::Error> {
+    ) -> Result<(i64, i64, i64, i64), sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query_as::<_, (i64, i64, i64, i64)>(
             r#"
             SELECT
@@ -760,7 +903,7 @@ impl EmergencyRepository {
             "#,
         )
         .bind(broadcast_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await?;
 
         Ok(result)
@@ -771,12 +914,16 @@ impl EmergencyRepository {
     // ============================================
 
     /// Create a new emergency drill.
-    pub async fn create_drill(
+    pub async fn create_drill<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         created_by: Uuid,
         data: CreateEmergencyDrill,
-    ) -> Result<EmergencyDrill, sqlx::Error> {
+    ) -> Result<EmergencyDrill, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyDrill>(
             r#"
             INSERT INTO emergency_drills (
@@ -795,31 +942,39 @@ impl EmergencyRepository {
         .bind(data.scheduled_at)
         .bind(data.participants_expected)
         .bind(created_by)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Find emergency drill by ID.
-    pub async fn find_drill_by_id(
+    pub async fn find_drill_by_id<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         drill_id: Uuid,
-    ) -> Result<Option<EmergencyDrill>, sqlx::Error> {
+    ) -> Result<Option<EmergencyDrill>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyDrill>(
             "SELECT * FROM emergency_drills WHERE id = $1 AND organization_id = $2",
         )
         .bind(drill_id)
         .bind(organization_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// List emergency drills with filters.
-    pub async fn list_drills(
+    pub async fn list_drills<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         query: EmergencyDrillQuery,
-    ) -> Result<Vec<EmergencyDrill>, sqlx::Error> {
+    ) -> Result<Vec<EmergencyDrill>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50);
         let offset = query.offset.unwrap_or(0);
 
@@ -840,17 +995,21 @@ impl EmergencyRepository {
         .bind(&query.status)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update an emergency drill.
-    pub async fn update_drill(
+    pub async fn update_drill<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         drill_id: Uuid,
         data: UpdateEmergencyDrill,
-    ) -> Result<Option<EmergencyDrill>, sqlx::Error> {
+    ) -> Result<Option<EmergencyDrill>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyDrill>(
             r#"
             UPDATE emergency_drills SET
@@ -883,16 +1042,20 @@ impl EmergencyRepository {
         .bind(data.duration_minutes)
         .bind(&data.notes)
         .bind(&data.issues_found)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Start a drill (change status to in_progress).
-    pub async fn start_drill(
+    pub async fn start_drill<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         drill_id: Uuid,
-    ) -> Result<Option<EmergencyDrill>, sqlx::Error> {
+    ) -> Result<Option<EmergencyDrill>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyDrill>(
             r#"
             UPDATE emergency_drills SET
@@ -904,17 +1067,21 @@ impl EmergencyRepository {
         )
         .bind(drill_id)
         .bind(organization_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Complete a drill.
-    pub async fn complete_drill(
+    pub async fn complete_drill<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         drill_id: Uuid,
         data: CompleteDrill,
-    ) -> Result<Option<EmergencyDrill>, sqlx::Error> {
+    ) -> Result<Option<EmergencyDrill>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyDrill>(
             r#"
             UPDATE emergency_drills SET
@@ -935,16 +1102,20 @@ impl EmergencyRepository {
         .bind(data.duration_minutes)
         .bind(&data.notes)
         .bind(&data.issues_found)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Cancel a drill.
-    pub async fn cancel_drill(
+    pub async fn cancel_drill<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         drill_id: Uuid,
-    ) -> Result<Option<EmergencyDrill>, sqlx::Error> {
+    ) -> Result<Option<EmergencyDrill>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyDrill>(
             r#"
             UPDATE emergency_drills SET
@@ -956,22 +1127,26 @@ impl EmergencyRepository {
         )
         .bind(drill_id)
         .bind(organization_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Delete an emergency drill.
-    pub async fn delete_drill(
+    pub async fn delete_drill<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         drill_id: Uuid,
-    ) -> Result<bool, sqlx::Error> {
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query(
             "DELETE FROM emergency_drills WHERE id = $1 AND organization_id = $2 AND status = 'scheduled'",
         )
         .bind(drill_id)
         .bind(organization_id)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
 
         Ok(result.rows_affected() > 0)
@@ -982,10 +1157,14 @@ impl EmergencyRepository {
     // ============================================
 
     /// Get emergency statistics for organization.
-    pub async fn get_statistics(
+    pub async fn get_statistics<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
-    ) -> Result<EmergencyStatistics, sqlx::Error> {
+    ) -> Result<EmergencyStatistics, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyStatistics>(
             r#"
             SELECT
@@ -1002,15 +1181,19 @@ impl EmergencyRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get incident summary by type.
-    pub async fn get_incident_summary_by_type(
+    pub async fn get_incident_summary_by_type<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
-    ) -> Result<Vec<IncidentTypeSummary>, sqlx::Error> {
+    ) -> Result<Vec<IncidentTypeSummary>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, IncidentTypeSummary>(
             r#"
             SELECT
@@ -1024,15 +1207,19 @@ impl EmergencyRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Get incident summary by severity.
-    pub async fn get_incident_summary_by_severity(
+    pub async fn get_incident_summary_by_severity<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
-    ) -> Result<Vec<IncidentSeveritySummary>, sqlx::Error> {
+    ) -> Result<Vec<IncidentSeveritySummary>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, IncidentSeveritySummary>(
             r#"
             SELECT
@@ -1052,15 +1239,19 @@ impl EmergencyRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Get active incidents (for dashboard).
-    pub async fn get_active_incidents(
+    pub async fn get_active_incidents<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
-    ) -> Result<Vec<EmergencyIncident>, sqlx::Error> {
+    ) -> Result<Vec<EmergencyIncident>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyIncident>(
             r#"
             SELECT * FROM emergency_incidents
@@ -1078,16 +1269,20 @@ impl EmergencyRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Get upcoming drills.
-    pub async fn get_upcoming_drills(
+    pub async fn get_upcoming_drills<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         days_ahead: i32,
-    ) -> Result<Vec<EmergencyDrill>, sqlx::Error> {
+    ) -> Result<Vec<EmergencyDrill>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EmergencyDrill>(
             r#"
             SELECT * FROM emergency_drills
@@ -1100,7 +1295,7 @@ impl EmergencyRepository {
         )
         .bind(organization_id)
         .bind(days_ahead)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 }

--- a/backend/crates/db/tests/emergency_rls_repo_tests.rs
+++ b/backend/crates/db/tests/emergency_rls_repo_tests.rs
@@ -1,0 +1,293 @@
+//! Repo-level behavioral RLS regression test for PAP-80 (parent PAP-67).
+//!
+//! Background
+//! ----------
+//! Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on every emergency table (`emergency_protocols`
+//! and the other seven). The production api-server connects as the table OWNER,
+//! which `FORCE` binds. `EmergencyRepository` held a raw `PgPool` and ran every
+//! query WITHOUT ever calling `set_request_context`, so on `dev`
+//! `get_current_org_id()` returned NULL and the policy collapsed to
+//! `organization_id = NULL` → **deny-all**: own-org reads returned empty, writes
+//! failed. (PAP-80.)
+//!
+//! The fix routes the repo through an RLS-context connection (the `RlsConnection`
+//! extractor in handlers sets the org/user GUCs before any query). This test
+//! exercises the *repository methods themselves* on a `FORCE`-bound role and
+//! proves:
+//!
+//!   1. **Deny-all reproduction** — with the role bound but NO context set
+//!      (exactly what the raw-pool repo did on `dev`), an own-org
+//!      `find_protocol_by_id` / `list_protocols` returns nothing.
+//!   2. **Fix** — with `set_request_context(org_a, user_a)` applied first (what
+//!      `RlsConnection` now does), the same repo calls return the own-org row.
+//!   3. **Cross-tenant** — org B's protocol stays invisible to an org-A caller
+//!      even with context set.
+//!   4. **Write path** — a `create_protocol` on a context-set connection succeeds
+//!      and the row is the caller's org (the write-side of deny-all).
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — even `FORCE` does not bind a superuser, so a behavioral assertion
+//! would pass vacuously. The test creates a plain `NOSUPERUSER NOBYPASSRLS`
+//! role, grants it access, and `SET ROLE`s to it so `FORCE` actually enforces
+//! the policy the way the production owner role experiences it. Mirrors
+//! `vendor_rls_repo_tests.rs` / `work_order_rls_repo_tests.rs` (the PAP-67
+//! precedent PAP-80 follows).
+
+use db::models::{CreateEmergencyProtocol, EmergencyProtocolQuery};
+use db::repositories::EmergencyRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// `EmergencyProtocolQuery` does not derive `Default`; build an all-`None`
+/// (unfiltered) query for the list assertions.
+fn any_protocols() -> EmergencyProtocolQuery {
+    EmergencyProtocolQuery {
+        building_id: None,
+        protocol_type: None,
+        is_active: None,
+        limit: None,
+        offset: None,
+    }
+}
+
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Emergency {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@emergency.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'Emergency User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Seed a protocol directly (as superuser, RLS-exempt) for an org.
+async fn seed_protocol(pool: &PgPool, org_id: Uuid, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO emergency_protocols (organization_id, name, protocol_type)
+        VALUES ($1, $2, 'fire')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .expect("seed protocol")
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn emergency_repo_force_rls_deny_all_and_fix(pool: PgPool) {
+    let repo = EmergencyRepository::new(pool.clone());
+
+    // --- Seed as superuser / super-admin context (satisfies org roles-trigger). ---
+    set_ctx(&pool, None, None, true).await;
+    let org_a = seed_org(&pool, "eforce-a").await;
+    let org_b = seed_org(&pool, "eforce-b").await;
+    let user_a = seed_user(&pool, "a@emergency.test").await;
+    let _user_b = seed_user(&pool, "b@emergency.test").await;
+    let protocol_a = seed_protocol(&pool, org_a, "Fire A").await;
+    let protocol_b = seed_protocol(&pool, org_b, "Fire B").await;
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    let role = format!("ppt_rls_emergency_{}", Uuid::new_v4().simple());
+    for stmt in [
+        format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
+        format!("GRANT SELECT, INSERT, UPDATE, DELETE ON emergency_protocols TO \"{role}\""),
+        // RLS policy helpers must be EXECUTE-able by the bound role.
+        format!("GRANT EXECUTE ON FUNCTION get_current_org_id() TO \"{role}\""),
+        format!("GRANT EXECUTE ON FUNCTION get_current_org_not_deleted() TO \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .expect("grant setup");
+    }
+
+    // ====================================================================
+    // (1) DENY-ALL reproduction: role bound, NO context set (the dev raw-pool
+    //     behavior). Own-org reads return nothing.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        // Explicitly clear any inherited context, then drop to the bound role.
+        sqlx::query("SELECT clear_request_context()")
+            .execute(&mut *conn)
+            .await
+            .expect("clear ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let found = repo
+            .find_protocol_by_id(&mut *conn, org_a, protocol_a)
+            .await
+            .expect("find_protocol_by_id (no ctx)");
+        assert!(
+            found.is_none(),
+            "PAP-80 regression: without RLS context, own-org protocol must be \
+             invisible (deny-all) — this is what the raw-pool repo did on dev"
+        );
+
+        let listed = repo
+            .list_protocols(&mut *conn, org_a, any_protocols())
+            .await
+            .expect("list_protocols (no ctx)");
+        assert!(
+            listed.is_empty(),
+            "PAP-80 regression: without RLS context, list returns deny-all empty"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (2) FIX + (3) cross-tenant: set context, drop to bound role, query repo.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        // (2) Own-org row IS now visible through the repo — the fix.
+        let found = repo
+            .find_protocol_by_id(&mut *conn, org_a, protocol_a)
+            .await
+            .expect("find_protocol_by_id (ctx)");
+        assert_eq!(
+            found.map(|p| p.id),
+            Some(protocol_a),
+            "PAP-80 fix: with RLS context set, the repo must return the own-org protocol"
+        );
+
+        let listed = repo
+            .list_protocols(&mut *conn, org_a, any_protocols())
+            .await
+            .expect("list_protocols (ctx)");
+        assert_eq!(
+            listed.iter().map(|p| p.id).collect::<Vec<_>>(),
+            vec![protocol_a],
+            "PAP-80 fix: list returns exactly the own-org protocol under context"
+        );
+
+        // (3) Org B's protocol stays invisible to an org-A caller.
+        let cross = repo
+            .find_protocol_by_id(&mut *conn, org_a, protocol_b)
+            .await
+            .expect("find_protocol_by_id cross");
+        assert!(
+            cross.is_none(),
+            "cross-tenant: org B's protocol must NOT be visible to an org-A caller"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (4) WRITE path: a create on a context-set connection succeeds and the
+    //     row is the caller's org. Without context the INSERT would fail the
+    //     policy WITH CHECK (the write-side of deny-all).
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let created = repo
+            .create_protocol(
+                &mut *conn,
+                org_a,
+                user_a,
+                CreateEmergencyProtocol {
+                    building_id: None,
+                    name: "Created under RLS".to_string(),
+                    protocol_type: "fire".to_string(),
+                    description: None,
+                    steps: serde_json::json!([]),
+                    contacts: None,
+                    evacuation_info: None,
+                    attachments: None,
+                    is_active: None,
+                    priority: None,
+                },
+            )
+            .await
+            .expect("create_protocol under context must succeed");
+        assert_eq!(created.organization_id, org_a);
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup the test role. ---
+    set_ctx(&pool, None, None, true).await;
+    for stmt in [
+        format!("REVOKE ALL ON emergency_protocols FROM \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .ok();
+    }
+}

--- a/backend/servers/api-server/src/routes/emergency.rs
+++ b/backend/servers/api-server/src/routes/emergency.rs
@@ -1,16 +1,36 @@
 //! Emergency management routes for Epic 23.
 //!
 //! Handles emergency protocols, contacts, incidents, broadcasts, and drills.
+//!
+//! # RLS routing (PAP-80)
+//!
+//! Every handler acquires an [`RlsConnection`], which validates the caller's
+//! JWT + org membership and opens a pooled connection with the RLS context
+//! (`app.current_org_id` / user GUCs) bound to it. All `emergency_*` tables run
+//! under `FORCE ROW LEVEL SECURITY` (migration `00179`), so the connection is
+//! the only thing that scopes a query to the caller's tenant — the repository
+//! holds no pool of its own.
+//!
+//! The authoritative organization is therefore `rls.tenant_id()` (the
+//! membership-validated org from the session), **not** any client-supplied
+//! `organization_id`. The org-keyed repo queries combine that value with the
+//! RLS context, so the explicit `organization_id = $N` SQL filter and the
+//! policy can never disagree; a foreign-tenant id resolves to `None` → `404`.
+//! Membership is enforced by the extractor, so the previous `verify_org_access`
+//! helper is no longer needed; manager-gated actions still check `rls.role()`.
+//!
+//! **IMPORTANT**: every path calls `rls.release().await` before returning so the
+//! RLS context is cleared and the connection returns clean to the pool.
 
-use api_core::extractors::AuthUser;
+use api_core::extractors::RlsConnection;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
-    response::{IntoResponse, Response},
+    response::IntoResponse,
     routing::{delete, get, post, put},
     Json, Router,
 };
-use common::ErrorResponse;
+use common::{ErrorResponse, TenantRole};
 use db::models::{
     AcknowledgeBroadcast, AddIncidentAttachment, CompleteDrill, CreateEmergencyBroadcast,
     CreateEmergencyContact, CreateEmergencyDrill, CreateEmergencyIncident, CreateEmergencyProtocol,
@@ -25,165 +45,27 @@ use uuid::Uuid;
 use crate::state::AppState;
 
 // ============================================
-// Tenant-isolation helpers (issue #827)
+// Authorization helper (issue #827 / PAP-80)
 // ============================================
 //
-// Every emergency handler used to trust a client-supplied `organization_id`
-// (query param or JSON body) and pass it straight to the repository, so any
-// authenticated user could read or mutate another org's protocols, incidents,
-// broadcasts, contacts and drills simply by supplying the victim org's UUID.
-//
-// The fix mirrors the `verify_org_access` idiom in `routes/vendors.rs` (#825)
-// and `routes/financial.rs` (#802): the client-supplied org is never trusted on
-// its own; it is only accepted once the authenticated principal is confirmed to
-// be an active member of it. Cross-tenant callers get `403 FORBIDDEN` on the
-// org-keyed paths. The repository's by-id queries are already keyed on
-// `(id, organization_id)`, so once the org is verified a foreign UUID resolves
-// to `None` → `404`, leaving "missing" and "forbidden" indistinguishable.
+// Org membership is enforced up-front by the `RlsConnection` extractor (it
+// rejects non-members before the handler body runs), and RLS scopes every
+// query to `rls.tenant_id()`. The only remaining handler-level check is the
+// manager gate on mass-notification / incident-lifecycle actions, which mirrors
+// the original `verify_org_manager` role set: org_admin / manager plus the
+// platform-level admin roles. `TechnicalManager` is intentionally excluded to
+// preserve the pre-conversion authorization surface.
 
-/// Membership check that maps DB errors to a `500` response but returns a plain
-/// bool for the membership outcome, letting the caller pick 403 vs 404.
-async fn is_org_member(state: &AppState, user_id: Uuid, org_id: Uuid) -> Result<bool, Response> {
-    state
-        .org_member_repo
-        .is_member(org_id, user_id)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = ?e, "Failed to check org membership");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DATABASE_ERROR", "Database error")),
-            )
-                .into_response()
-        })
-}
-
-/// Verify the authenticated user is an active member of `org_id`. Returns a
-/// ready-to-send `403` response on mismatch, so callers can simply
-/// `if let Err(resp) = verify_org_access(..).await { return resp; }`.
-async fn verify_org_access(state: &AppState, user_id: Uuid, org_id: Uuid) -> Result<(), Response> {
-    if !is_org_member(state, user_id, org_id).await? {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse::new(
-                "FORBIDDEN",
-                "You are not a member of this organization",
-            )),
-        )
-            .into_response());
-    }
-    Ok(())
-}
-
-/// Verify the authenticated user has at least manager-level authority in
-/// `org_id`. Used to gate mass-notification / incident-creation actions
-/// (broadcast + incident create — issue #827). Membership is checked first
-/// (403 for non-members), then role: org_admin / manager and the
-/// platform-level admin roles pass; ordinary residents/owners get `403`.
-async fn verify_org_manager(state: &AppState, user_id: Uuid, org_id: Uuid) -> Result<(), Response> {
-    verify_org_access(state, user_id, org_id).await?;
-
-    let role_type = state
-        .org_member_repo
-        .get_user_role_type(org_id, user_id)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = ?e, "Failed to load org role");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DATABASE_ERROR", "Database error")),
-            )
-                .into_response()
-        })?;
-
-    let is_manager = matches!(
-        role_type.as_deref().map(str::to_lowercase).as_deref(),
-        Some("super_admin" | "superadmin" | "platform_admin" | "platformadmin")
-            | Some("org_admin" | "orgadmin")
-            | Some("manager")
-    );
-
-    if !is_manager {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse::new(
-                "FORBIDDEN",
-                "Manager role required for this action",
-            )),
-        )
-            .into_response());
-    }
-    Ok(())
-}
-
-/// Verify the caller is a member of `org_id` AND that `incident_id` belongs to
-/// it. Used for the incident sub-resources (attachments / updates) whose repo
-/// methods key only on `incident_id` and therefore cannot self-scope. Returns
-/// `404` when the incident does not exist in the caller's org so a foreign
-/// incident UUID is indistinguishable from a missing one.
-async fn verify_incident_in_org(
-    state: &AppState,
-    user_id: Uuid,
-    org_id: Uuid,
-    incident_id: Uuid,
-) -> Result<(), Response> {
-    verify_org_access(state, user_id, org_id).await?;
-
-    let found = state
-        .emergency_repo
-        .find_incident_by_id(org_id, incident_id)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = ?e, "Failed to load incident");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Database error")),
-            )
-                .into_response()
-        })?;
-
-    if found.is_none() {
-        return Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Incident not found")),
-        )
-            .into_response());
-    }
-    Ok(())
-}
-
-/// Verify the caller is a member of `org_id` AND that `broadcast_id` belongs to
-/// it. Used for the broadcast sub-resources (acknowledge / acknowledgments)
-/// whose repo methods key only on `broadcast_id`. `404` on cross-tenant.
-async fn verify_broadcast_in_org(
-    state: &AppState,
-    user_id: Uuid,
-    org_id: Uuid,
-    broadcast_id: Uuid,
-) -> Result<(), Response> {
-    verify_org_access(state, user_id, org_id).await?;
-
-    let found = state
-        .emergency_repo
-        .find_broadcast_by_id(org_id, broadcast_id)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = ?e, "Failed to load broadcast");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Database error")),
-            )
-                .into_response()
-        })?;
-
-    if found.is_none() {
-        return Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Broadcast not found")),
-        )
-            .into_response());
-    }
-    Ok(())
+/// True if `role` may perform manager-gated emergency actions (broadcast +
+/// incident create/acknowledge — issue #827).
+fn is_emergency_manager(role: TenantRole) -> bool {
+    matches!(
+        role,
+        TenantRole::SuperAdmin
+            | TenantRole::PlatformAdmin
+            | TenantRole::OrgAdmin
+            | TenantRole::Manager
+    )
 }
 
 // ============================================
@@ -421,17 +303,17 @@ pub fn router() -> Router<AppState> {
 
 async fn create_protocol(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(req): Json<CreateProtocolRequest>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, req.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let user = rls.user_id();
+    let result = state
         .emergency_repo
-        .create_protocol(req.organization_id, auth.user_id, req.data)
-        .await
-    {
+        .create_protocol(&mut **rls.conn(), org, user, req.data)
+        .await;
+    rls.release().await;
+    match result {
         Ok(protocol) => (StatusCode::CREATED, Json(protocol)).into_response(),
         Err(e) => {
             tracing::error!("Failed to create protocol: {:?}", e);
@@ -446,17 +328,16 @@ async fn create_protocol(
 
 async fn list_protocols(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<ProtocolListQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .list_protocols(query.organization_id, EmergencyProtocolQuery::from(&query))
-        .await
-    {
+        .list_protocols(&mut **rls.conn(), org, EmergencyProtocolQuery::from(&query))
+        .await;
+    rls.release().await;
+    match result {
         Ok(protocols) => Json(protocols).into_response(),
         Err(e) => {
             tracing::error!("Failed to list protocols: {:?}", e);
@@ -471,18 +352,17 @@ async fn list_protocols(
 
 async fn get_protocol(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-    Query(query): Query<OrgQuery>,
+    Query(_): Query<OrgQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .find_protocol_by_id(query.organization_id, id)
-        .await
-    {
+        .find_protocol_by_id(&mut **rls.conn(), org, id)
+        .await;
+    rls.release().await;
+    match result {
         Ok(Some(protocol)) => Json(protocol).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -510,18 +390,17 @@ pub struct UpdateProtocolRequest {
 
 async fn update_protocol(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateProtocolRequest>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, req.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .update_protocol(req.organization_id, id, req.data)
-        .await
-    {
+        .update_protocol(&mut **rls.conn(), org, id, req.data)
+        .await;
+    rls.release().await;
+    match result {
         Ok(Some(protocol)) => Json(protocol).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -541,18 +420,17 @@ async fn update_protocol(
 
 async fn delete_protocol(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-    Query(query): Query<OrgQuery>,
+    Query(_): Query<OrgQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .delete_protocol(query.organization_id, id)
-        .await
-    {
+        .delete_protocol(&mut **rls.conn(), org, id)
+        .await;
+    rls.release().await;
+    match result {
         Ok(true) => StatusCode::NO_CONTENT.into_response(),
         Ok(false) => (
             StatusCode::NOT_FOUND,
@@ -576,17 +454,16 @@ async fn delete_protocol(
 
 async fn create_contact(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(req): Json<CreateContactRequest>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, req.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .create_contact(req.organization_id, req.data)
-        .await
-    {
+        .create_contact(&mut **rls.conn(), org, req.data)
+        .await;
+    rls.release().await;
+    match result {
         Ok(contact) => (StatusCode::CREATED, Json(contact)).into_response(),
         Err(e) => {
             tracing::error!("Failed to create contact: {:?}", e);
@@ -601,17 +478,16 @@ async fn create_contact(
 
 async fn list_contacts(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<ContactListQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .list_contacts(query.organization_id, EmergencyContactQuery::from(&query))
-        .await
-    {
+        .list_contacts(&mut **rls.conn(), org, EmergencyContactQuery::from(&query))
+        .await;
+    rls.release().await;
+    match result {
         Ok(contacts) => Json(contacts).into_response(),
         Err(e) => {
             tracing::error!("Failed to list contacts: {:?}", e);
@@ -626,18 +502,17 @@ async fn list_contacts(
 
 async fn get_contact(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-    Query(query): Query<OrgQuery>,
+    Query(_): Query<OrgQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .find_contact_by_id(query.organization_id, id)
-        .await
-    {
+        .find_contact_by_id(&mut **rls.conn(), org, id)
+        .await;
+    rls.release().await;
+    match result {
         Ok(Some(contact)) => Json(contact).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -665,18 +540,17 @@ pub struct UpdateContactRequest {
 
 async fn update_contact(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateContactRequest>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, req.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .update_contact(req.organization_id, id, req.data)
-        .await
-    {
+        .update_contact(&mut **rls.conn(), org, id, req.data)
+        .await;
+    rls.release().await;
+    match result {
         Ok(Some(contact)) => Json(contact).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -696,18 +570,17 @@ async fn update_contact(
 
 async fn delete_contact(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-    Query(query): Query<OrgQuery>,
+    Query(_): Query<OrgQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .delete_contact(query.organization_id, id)
-        .await
-    {
+        .delete_contact(&mut **rls.conn(), org, id)
+        .await;
+    rls.release().await;
+    match result {
         Ok(true) => StatusCode::NO_CONTENT.into_response(),
         Ok(false) => (
             StatusCode::NOT_FOUND,
@@ -731,17 +604,28 @@ async fn delete_contact(
 
 async fn create_incident(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(req): Json<CreateIncidentRequest>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_manager(&state, auth.user_id, req.organization_id).await {
-        return resp;
+    let org = rls.tenant_id();
+    let user = rls.user_id();
+    if !is_emergency_manager(rls.role()) {
+        rls.release().await;
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "FORBIDDEN",
+                "Manager role required for this action",
+            )),
+        )
+            .into_response();
     }
-    match state
+    let result = state
         .emergency_repo
-        .create_incident(req.organization_id, auth.user_id, req.data)
-        .await
-    {
+        .create_incident(&mut **rls.conn(), org, user, req.data)
+        .await;
+    rls.release().await;
+    match result {
         Ok(incident) => (StatusCode::CREATED, Json(incident)).into_response(),
         Err(e) => {
             tracing::error!("Failed to create incident: {:?}", e);
@@ -756,17 +640,16 @@ async fn create_incident(
 
 async fn list_incidents(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<IncidentListQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .list_incidents(query.organization_id, EmergencyIncidentQuery::from(&query))
-        .await
-    {
+        .list_incidents(&mut **rls.conn(), org, EmergencyIncidentQuery::from(&query))
+        .await;
+    rls.release().await;
+    match result {
         Ok(incidents) => Json(incidents).into_response(),
         Err(e) => {
             tracing::error!("Failed to list incidents: {:?}", e);
@@ -781,17 +664,16 @@ async fn list_incidents(
 
 async fn get_active_incidents(
     State(state): State<AppState>,
-    auth: AuthUser,
-    Query(query): Query<OrgQuery>,
+    mut rls: RlsConnection,
+    Query(_): Query<OrgQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .get_active_incidents(query.organization_id)
-        .await
-    {
+        .get_active_incidents(&mut **rls.conn(), org)
+        .await;
+    rls.release().await;
+    match result {
         Ok(incidents) => Json(incidents).into_response(),
         Err(e) => {
             tracing::error!("Failed to get active incidents: {:?}", e);
@@ -806,18 +688,17 @@ async fn get_active_incidents(
 
 async fn get_incident(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-    Query(query): Query<OrgQuery>,
+    Query(_): Query<OrgQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .find_incident_by_id(query.organization_id, id)
-        .await
-    {
+        .find_incident_by_id(&mut **rls.conn(), org, id)
+        .await;
+    rls.release().await;
+    match result {
         Ok(Some(incident)) => Json(incident).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -845,18 +726,17 @@ pub struct UpdateIncidentRequest {
 
 async fn update_incident(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateIncidentRequest>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, req.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .update_incident(req.organization_id, id, req.data)
-        .await
-    {
+        .update_incident(&mut **rls.conn(), org, id, req.data)
+        .await;
+    rls.release().await;
+    match result {
         Ok(Some(incident)) => Json(incident).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -876,18 +756,28 @@ async fn update_incident(
 
 async fn acknowledge_incident(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-    Query(query): Query<OrgQuery>,
+    Query(_): Query<OrgQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_manager(&state, auth.user_id, query.organization_id).await {
-        return resp;
+    let org = rls.tenant_id();
+    if !is_emergency_manager(rls.role()) {
+        rls.release().await;
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "FORBIDDEN",
+                "Manager role required for this action",
+            )),
+        )
+            .into_response();
     }
-    match state
+    let result = state
         .emergency_repo
-        .acknowledge_incident(query.organization_id, id)
-        .await
-    {
+        .acknowledge_incident(&mut **rls.conn(), org, id)
+        .await;
+    rls.release().await;
+    match result {
         Ok(Some(incident)) => Json(incident).into_response(),
         Ok(None) => (
             StatusCode::BAD_REQUEST,
@@ -910,24 +800,23 @@ async fn acknowledge_incident(
 
 #[derive(Debug, Deserialize)]
 struct ResolveIncidentRequest {
-    organization_id: Uuid,
     resolution: String,
 }
 
 async fn resolve_incident(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<ResolveIncidentRequest>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, req.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let user = rls.user_id();
+    let result = state
         .emergency_repo
-        .resolve_incident(req.organization_id, id, auth.user_id, &req.resolution)
-        .await
-    {
+        .resolve_incident(&mut **rls.conn(), org, id, user, &req.resolution)
+        .await;
+    rls.release().await;
+    match result {
         Ok(Some(incident)) => Json(incident).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -947,18 +836,17 @@ async fn resolve_incident(
 
 async fn close_incident(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-    Query(query): Query<OrgQuery>,
+    Query(_): Query<OrgQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .close_incident(query.organization_id, id)
-        .await
-    {
+        .close_incident(&mut **rls.conn(), org, id)
+        .await;
+    rls.release().await;
+    match result {
         Ok(Some(incident)) => Json(incident).into_response(),
         Ok(None) => (
             StatusCode::BAD_REQUEST,
@@ -981,20 +869,47 @@ async fn close_incident(
 
 async fn add_incident_attachment(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-    Query(query): Query<OrgQuery>,
+    Query(_): Query<OrgQuery>,
     Json(data): Json<AddIncidentAttachment>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_incident_in_org(&state, auth.user_id, query.organization_id, id).await
-    {
-        return resp;
-    }
+    let org = rls.tenant_id();
+    let user = rls.user_id();
+    // The attachments table is RLS-scoped via the parent incident, but it keys
+    // only on `incident_id`; confirm the incident is in the caller's org first
+    // so an unknown / cross-tenant id yields a 404 instead of a policy-violation
+    // 500 on the INSERT.
     match state
         .emergency_repo
-        .add_incident_attachment(id, auth.user_id, data)
+        .find_incident_by_id(&mut **rls.conn(), org, id)
         .await
     {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            rls.release().await;
+            return (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Incident not found")),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!("Failed to load incident: {:?}", e);
+            rls.release().await;
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
+            )
+                .into_response();
+        }
+    }
+    let result = state
+        .emergency_repo
+        .add_incident_attachment(&mut **rls.conn(), id, user, data)
+        .await;
+    rls.release().await;
+    match result {
         Ok(attachment) => (StatusCode::CREATED, Json(attachment)).into_response(),
         Err(e) => {
             tracing::error!("Failed to add incident attachment: {:?}", e);
@@ -1009,15 +924,41 @@ async fn add_incident_attachment(
 
 async fn list_incident_attachments(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-    Query(query): Query<OrgQuery>,
+    Query(_): Query<OrgQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_incident_in_org(&state, auth.user_id, query.organization_id, id).await
+    let org = rls.tenant_id();
+    match state
+        .emergency_repo
+        .find_incident_by_id(&mut **rls.conn(), org, id)
+        .await
     {
-        return resp;
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            rls.release().await;
+            return (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Incident not found")),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!("Failed to load incident: {:?}", e);
+            rls.release().await;
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
+            )
+                .into_response();
+        }
     }
-    match state.emergency_repo.list_incident_attachments(id).await {
+    let result = state
+        .emergency_repo
+        .list_incident_attachments(&mut **rls.conn(), id)
+        .await;
+    rls.release().await;
+    match result {
         Ok(attachments) => Json(attachments).into_response(),
         Err(e) => {
             tracing::error!("Failed to list incident attachments: {:?}", e);
@@ -1032,20 +973,43 @@ async fn list_incident_attachments(
 
 async fn add_incident_update(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-    Query(query): Query<OrgQuery>,
+    Query(_): Query<OrgQuery>,
     Json(data): Json<CreateIncidentUpdate>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_incident_in_org(&state, auth.user_id, query.organization_id, id).await
-    {
-        return resp;
-    }
+    let org = rls.tenant_id();
+    let user = rls.user_id();
     match state
         .emergency_repo
-        .add_incident_update(id, auth.user_id, data)
+        .find_incident_by_id(&mut **rls.conn(), org, id)
         .await
     {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            rls.release().await;
+            return (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Incident not found")),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!("Failed to load incident: {:?}", e);
+            rls.release().await;
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
+            )
+                .into_response();
+        }
+    }
+    let result = state
+        .emergency_repo
+        .add_incident_update(&mut **rls.conn(), id, user, data)
+        .await;
+    rls.release().await;
+    match result {
         Ok(update) => (StatusCode::CREATED, Json(update)).into_response(),
         Err(e) => {
             tracing::error!("Failed to add incident update: {:?}", e);
@@ -1060,15 +1024,41 @@ async fn add_incident_update(
 
 async fn list_incident_updates(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-    Query(query): Query<OrgQuery>,
+    Query(_): Query<OrgQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_incident_in_org(&state, auth.user_id, query.organization_id, id).await
+    let org = rls.tenant_id();
+    match state
+        .emergency_repo
+        .find_incident_by_id(&mut **rls.conn(), org, id)
+        .await
     {
-        return resp;
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            rls.release().await;
+            return (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Incident not found")),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!("Failed to load incident: {:?}", e);
+            rls.release().await;
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
+            )
+                .into_response();
+        }
     }
-    match state.emergency_repo.list_incident_updates(id).await {
+    let result = state
+        .emergency_repo
+        .list_incident_updates(&mut **rls.conn(), id)
+        .await;
+    rls.release().await;
+    match result {
         Ok(updates) => Json(updates).into_response(),
         Err(e) => {
             tracing::error!("Failed to list incident updates: {:?}", e);
@@ -1087,17 +1077,28 @@ async fn list_incident_updates(
 
 async fn create_broadcast(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(req): Json<CreateBroadcastRequest>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_manager(&state, auth.user_id, req.organization_id).await {
-        return resp;
+    let org = rls.tenant_id();
+    let user = rls.user_id();
+    if !is_emergency_manager(rls.role()) {
+        rls.release().await;
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "FORBIDDEN",
+                "Manager role required for this action",
+            )),
+        )
+            .into_response();
     }
-    match state
+    let result = state
         .emergency_repo
-        .create_broadcast(req.organization_id, auth.user_id, req.data)
-        .await
-    {
+        .create_broadcast(&mut **rls.conn(), org, user, req.data)
+        .await;
+    rls.release().await;
+    match result {
         Ok(broadcast) => (StatusCode::CREATED, Json(broadcast)).into_response(),
         Err(e) => {
             tracing::error!("Failed to create broadcast: {:?}", e);
@@ -1112,17 +1113,20 @@ async fn create_broadcast(
 
 async fn list_broadcasts(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<BroadcastListQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .list_broadcasts(query.organization_id, EmergencyBroadcastQuery::from(&query))
-        .await
-    {
+        .list_broadcasts(
+            &mut **rls.conn(),
+            org,
+            EmergencyBroadcastQuery::from(&query),
+        )
+        .await;
+    rls.release().await;
+    match result {
         Ok(broadcasts) => Json(broadcasts).into_response(),
         Err(e) => {
             tracing::error!("Failed to list broadcasts: {:?}", e);
@@ -1137,18 +1141,17 @@ async fn list_broadcasts(
 
 async fn get_broadcast(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-    Query(query): Query<OrgQuery>,
+    Query(_): Query<OrgQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .find_broadcast_by_id(query.organization_id, id)
-        .await
-    {
+        .find_broadcast_by_id(&mut **rls.conn(), org, id)
+        .await;
+    rls.release().await;
+    match result {
         Ok(Some(broadcast)) => Json(broadcast).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -1168,18 +1171,28 @@ async fn get_broadcast(
 
 async fn deactivate_broadcast(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-    Query(query): Query<OrgQuery>,
+    Query(_): Query<OrgQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_manager(&state, auth.user_id, query.organization_id).await {
-        return resp;
+    let org = rls.tenant_id();
+    if !is_emergency_manager(rls.role()) {
+        rls.release().await;
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "FORBIDDEN",
+                "Manager role required for this action",
+            )),
+        )
+            .into_response();
     }
-    match state
+    let result = state
         .emergency_repo
-        .deactivate_broadcast(query.organization_id, id)
-        .await
-    {
+        .deactivate_broadcast(&mut **rls.conn(), org, id)
+        .await;
+    rls.release().await;
+    match result {
         Ok(true) => StatusCode::OK.into_response(),
         Ok(false) => (
             StatusCode::NOT_FOUND,
@@ -1199,21 +1212,46 @@ async fn deactivate_broadcast(
 
 async fn acknowledge_broadcast(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-    Query(query): Query<OrgQuery>,
+    Query(_): Query<OrgQuery>,
     Json(data): Json<AcknowledgeBroadcast>,
 ) -> impl IntoResponse {
-    if let Err(resp) =
-        verify_broadcast_in_org(&state, auth.user_id, query.organization_id, id).await
-    {
-        return resp;
-    }
+    let org = rls.tenant_id();
+    let user = rls.user_id();
+    // The acknowledgments table is RLS-scoped via the parent broadcast but keys
+    // only on `broadcast_id`; confirm the broadcast is in the caller's org so a
+    // cross-tenant / unknown id yields 404 rather than a policy-violation 500.
     match state
         .emergency_repo
-        .acknowledge_broadcast(id, auth.user_id, data)
+        .find_broadcast_by_id(&mut **rls.conn(), org, id)
         .await
     {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            rls.release().await;
+            return (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Broadcast not found")),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!("Failed to load broadcast: {:?}", e);
+            rls.release().await;
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
+            )
+                .into_response();
+        }
+    }
+    let result = state
+        .emergency_repo
+        .acknowledge_broadcast(&mut **rls.conn(), id, user, data)
+        .await;
+    rls.release().await;
+    match result {
         Ok(ack) => (StatusCode::CREATED, Json(ack)).into_response(),
         Err(e) => {
             tracing::error!("Failed to acknowledge broadcast: {:?}", e);
@@ -1228,20 +1266,41 @@ async fn acknowledge_broadcast(
 
 async fn list_broadcast_acknowledgments(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-    Query(query): Query<OrgQuery>,
+    Query(_): Query<OrgQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) =
-        verify_broadcast_in_org(&state, auth.user_id, query.organization_id, id).await
-    {
-        return resp;
-    }
+    let org = rls.tenant_id();
     match state
         .emergency_repo
-        .list_broadcast_acknowledgments(id)
+        .find_broadcast_by_id(&mut **rls.conn(), org, id)
         .await
     {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            rls.release().await;
+            return (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Broadcast not found")),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!("Failed to load broadcast: {:?}", e);
+            rls.release().await;
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
+            )
+                .into_response();
+        }
+    }
+    let result = state
+        .emergency_repo
+        .list_broadcast_acknowledgments(&mut **rls.conn(), id)
+        .await;
+    rls.release().await;
+    match result {
         Ok(acks) => Json(acks).into_response(),
         Err(e) => {
             tracing::error!("Failed to list broadcast acknowledgments: {:?}", e);
@@ -1260,17 +1319,17 @@ async fn list_broadcast_acknowledgments(
 
 async fn create_drill(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(req): Json<CreateDrillRequest>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, req.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let user = rls.user_id();
+    let result = state
         .emergency_repo
-        .create_drill(req.organization_id, auth.user_id, req.data)
-        .await
-    {
+        .create_drill(&mut **rls.conn(), org, user, req.data)
+        .await;
+    rls.release().await;
+    match result {
         Ok(drill) => (StatusCode::CREATED, Json(drill)).into_response(),
         Err(e) => {
             tracing::error!("Failed to create drill: {:?}", e);
@@ -1285,17 +1344,16 @@ async fn create_drill(
 
 async fn list_drills(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<DrillListQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .list_drills(query.organization_id, EmergencyDrillQuery::from(&query))
-        .await
-    {
+        .list_drills(&mut **rls.conn(), org, EmergencyDrillQuery::from(&query))
+        .await;
+    rls.release().await;
+    match result {
         Ok(drills) => Json(drills).into_response(),
         Err(e) => {
             tracing::error!("Failed to list drills: {:?}", e);
@@ -1310,24 +1368,22 @@ async fn list_drills(
 
 #[derive(Debug, Deserialize, IntoParams)]
 struct UpcomingDrillsQuery {
-    organization_id: Uuid,
     days: Option<i32>,
 }
 
 async fn get_upcoming_drills(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<UpcomingDrillsQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
-        return resp;
-    }
+    let org = rls.tenant_id();
     let days = query.days.unwrap_or(30);
-    match state
+    let result = state
         .emergency_repo
-        .get_upcoming_drills(query.organization_id, days)
-        .await
-    {
+        .get_upcoming_drills(&mut **rls.conn(), org, days)
+        .await;
+    rls.release().await;
+    match result {
         Ok(drills) => Json(drills).into_response(),
         Err(e) => {
             tracing::error!("Failed to get upcoming drills: {:?}", e);
@@ -1342,18 +1398,17 @@ async fn get_upcoming_drills(
 
 async fn get_drill(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-    Query(query): Query<OrgQuery>,
+    Query(_): Query<OrgQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .find_drill_by_id(query.organization_id, id)
-        .await
-    {
+        .find_drill_by_id(&mut **rls.conn(), org, id)
+        .await;
+    rls.release().await;
+    match result {
         Ok(Some(drill)) => Json(drill).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -1381,18 +1436,17 @@ pub struct UpdateDrillRequest {
 
 async fn update_drill(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateDrillRequest>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, req.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .update_drill(req.organization_id, id, req.data)
-        .await
-    {
+        .update_drill(&mut **rls.conn(), org, id, req.data)
+        .await;
+    rls.release().await;
+    match result {
         Ok(Some(drill)) => Json(drill).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -1412,18 +1466,17 @@ async fn update_drill(
 
 async fn start_drill(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-    Query(query): Query<OrgQuery>,
+    Query(_): Query<OrgQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .start_drill(query.organization_id, id)
-        .await
-    {
+        .start_drill(&mut **rls.conn(), org, id)
+        .await;
+    rls.release().await;
+    match result {
         Ok(Some(drill)) => Json(drill).into_response(),
         Ok(None) => (
             StatusCode::BAD_REQUEST,
@@ -1454,18 +1507,17 @@ pub struct CompleteDrillRequest {
 
 async fn complete_drill(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<CompleteDrillRequest>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, req.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .complete_drill(req.organization_id, id, req.data)
-        .await
-    {
+        .complete_drill(&mut **rls.conn(), org, id, req.data)
+        .await;
+    rls.release().await;
+    match result {
         Ok(Some(drill)) => Json(drill).into_response(),
         Ok(None) => (
             StatusCode::BAD_REQUEST,
@@ -1488,18 +1540,17 @@ async fn complete_drill(
 
 async fn cancel_drill(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-    Query(query): Query<OrgQuery>,
+    Query(_): Query<OrgQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .cancel_drill(query.organization_id, id)
-        .await
-    {
+        .cancel_drill(&mut **rls.conn(), org, id)
+        .await;
+    rls.release().await;
+    match result {
         Ok(Some(drill)) => Json(drill).into_response(),
         Ok(None) => (
             StatusCode::BAD_REQUEST,
@@ -1522,18 +1573,17 @@ async fn cancel_drill(
 
 async fn delete_drill(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-    Query(query): Query<OrgQuery>,
+    Query(_): Query<OrgQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .delete_drill(query.organization_id, id)
-        .await
-    {
+        .delete_drill(&mut **rls.conn(), org, id)
+        .await;
+    rls.release().await;
+    match result {
         Ok(true) => StatusCode::NO_CONTENT.into_response(),
         Ok(false) => (
             StatusCode::BAD_REQUEST,
@@ -1560,17 +1610,16 @@ async fn delete_drill(
 
 async fn get_statistics(
     State(state): State<AppState>,
-    auth: AuthUser,
-    Query(query): Query<OrgQuery>,
+    mut rls: RlsConnection,
+    Query(_): Query<OrgQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .get_statistics(query.organization_id)
-        .await
-    {
+        .get_statistics(&mut **rls.conn(), org)
+        .await;
+    rls.release().await;
+    match result {
         Ok(stats) => Json(stats).into_response(),
         Err(e) => {
             tracing::error!("Failed to get statistics: {:?}", e);
@@ -1585,17 +1634,16 @@ async fn get_statistics(
 
 async fn get_incidents_by_type(
     State(state): State<AppState>,
-    auth: AuthUser,
-    Query(query): Query<OrgQuery>,
+    mut rls: RlsConnection,
+    Query(_): Query<OrgQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .get_incident_summary_by_type(query.organization_id)
-        .await
-    {
+        .get_incident_summary_by_type(&mut **rls.conn(), org)
+        .await;
+    rls.release().await;
+    match result {
         Ok(summary) => Json(summary).into_response(),
         Err(e) => {
             tracing::error!("Failed to get incidents by type: {:?}", e);
@@ -1610,17 +1658,16 @@ async fn get_incidents_by_type(
 
 async fn get_incidents_by_severity(
     State(state): State<AppState>,
-    auth: AuthUser,
-    Query(query): Query<OrgQuery>,
+    mut rls: RlsConnection,
+    Query(_): Query<OrgQuery>,
 ) -> impl IntoResponse {
-    if let Err(resp) = verify_org_access(&state, auth.user_id, query.organization_id).await {
-        return resp;
-    }
-    match state
+    let org = rls.tenant_id();
+    let result = state
         .emergency_repo
-        .get_incident_summary_by_severity(query.organization_id)
-        .await
-    {
+        .get_incident_summary_by_severity(&mut **rls.conn(), org)
+        .await;
+    rls.release().await;
+    match result {
         Ok(summary) => Json(summary).into_response(),
         Err(e) => {
             tracing::error!("Failed to get incidents by severity: {:?}", e);


### PR DESCRIPTION
## Summary

Part of the **PAP-80** RLS sweep (parent PAP-67). `emergency.rs` read **8 FORCE-RLS tables** through a raw `PgPool`, so under migration `00179`'s `FORCE ROW LEVEL SECURITY` the owner connection's deny-all policies never engaged correctly (own-org reads collapse to empty, writes fail `WITH CHECK`). Mounted at `/api/v1/emergency`.

This converts the repo + handlers to the proven RLS-context-executor pattern (`work_order.rs` / `budget.rs` / `sensor.rs` precedent).

### Repository (`crates/db/.../emergency.rs`)
- Drop `pool: DbPool`; `EmergencyRepository` is now stateless (`new(_pool)` kept for `AppState` construction-site compatibility).
- All 42 methods are single-statement → each takes a generic `E: Executor<'e, Database = Postgres>` and runs on the caller-supplied, context-bearing connection.

### Handlers (`servers/api-server/.../routes/emergency.rs`)
- Every handler acquires the `RlsConnection` extractor, passes `&mut **rls.conn()`, uses `rls.tenant_id()` as the **authoritative** org (client-supplied `organization_id` is no longer trusted), and `release()`s on every path.
- Membership is now enforced by the extractor, so `verify_org_access` / `verify_org_manager` / `verify_*_in_org` are removed. The manager gate on incident-create / acknowledge / broadcast-create / deactivate is preserved via `rls.role()` (same role set as before; `TechnicalManager` still excluded).
- Incident/broadcast sub-resources (attachments / updates / acknowledgments) keep a by-id existence pre-check so a cross-tenant / unknown id still yields `404`, not a policy-violation `500`.

### Test
- `emergency_rls_repo_tests.rs`: a `NOSUPERUSER NOBYPASSRLS` role-switch test proving deny-all without context, own-org visibility + cross-tenant isolation with context, and a context-set create path (mirrors `vendor_rls_repo_tests.rs`).

## Verification
- `cargo check -p db --tests` — **green** (remote/mercury)
- `cargo check -p api-server` — **green** (remote/mercury)
- `cargo fmt --check` — emergency files clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)