### PR TITLE
fix(db): route ai_chat repo through RLS-context connection (PAP-103)

### DIFF
--- a/backend/crates/db/src/repositories/ai_chat.rs
+++ b/backend/crates/db/src/repositories/ai_chat.rs
@@ -1,22 +1,53 @@
 //! AI Chat repository (Epic 13, Story 13.1).
+//!
+//! # RLS Integration (PAP-80 / PAP-67)
+//!
+//! Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on the three AI-chat tables this repo touches —
+//! `ai_chat_sessions`, `ai_chat_messages`, and `ai_training_feedback`. Under
+//! `FORCE` the api-server's owner connection is no longer exempt, so a query
+//! issued on a connection WITHOUT `app.current_org_id` set collapses to deny-all
+//! (own-org reads return empty, writes fail the policy `WITH CHECK`).
+//!
+//! Every method therefore takes an **executor whose connection already has RLS
+//! context set** (org + user GUCs) — in handlers this comes from the
+//! `RlsConnection` extractor via `&mut **rls.conn()`. The repository holds **no
+//! pool**, so there is no way to issue a query that bypasses RLS. This mirrors
+//! the `work_order.rs` / `vendor.rs` / `sensor.rs` precedent.
+//!
+//! Single-statement methods take a generic `E: Executor`. `add_message` writes
+//! two statements (the message INSERT and the parent-session `last_message_at`
+//! UPDATE) that must run on the SAME RLS-scoped connection, so it takes a
+//! `&mut PgConnection` and reborrows.
+//!
+//! The explicit `organization_id = $N` SQL filters are retained as
+//! defense-in-depth; handlers pass `rls.tenant_id()` (the org the caller was
+//! validated against), so the SQL filter and the RLS context can never disagree.
 
 use crate::models::{
     AiChatMessage, AiChatSession, AiTrainingFeedback, ChatSessionSummary, CreateChatSession,
     ProvideFeedback,
 };
-use sqlx::PgPool;
+use sqlx::{Executor, PgPool, Postgres};
 use uuid::Uuid;
 
 /// Repository for AI chat operations.
+///
+/// Deliberately a zero-sized type: it holds no pool so it cannot issue an
+/// un-scoped (deny-all under `FORCE`) query. All queries run on a context-set
+/// connection supplied by the handler's `RlsConnection`.
 #[derive(Clone)]
-pub struct AiChatRepository {
-    pool: PgPool,
-}
+pub struct AiChatRepository;
 
 impl AiChatRepository {
     /// Create a new repository instance.
-    pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+    ///
+    /// The pool argument is retained for construction-site compatibility with
+    /// the other repositories on `AppState`; this repo deliberately does not
+    /// store it (see module docs — all queries run on a context-set connection
+    /// supplied by the handler's `RlsConnection`).
+    pub fn new(_pool: PgPool) -> Self {
+        Self
     }
 
     /// Create a new chat session.
@@ -24,12 +55,16 @@ impl AiChatRepository {
     /// `organization_id` and `user_id` are passed explicitly by the caller and
     /// must originate from the verified request principal, never from client
     /// input in `data`.
-    pub async fn create_session(
+    pub async fn create_session<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         user_id: Uuid,
         data: CreateChatSession,
-    ) -> Result<AiChatSession, sqlx::Error> {
+    ) -> Result<AiChatSession, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO ai_chat_sessions (organization_id, user_id, title, context)
@@ -41,7 +76,7 @@ impl AiChatRepository {
         .bind(user_id)
         .bind(data.title)
         .bind(sqlx::types::Json(data.context.unwrap_or_default()))
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
@@ -50,25 +85,33 @@ impl AiChatRepository {
     /// `org_id` must originate from the verified request principal.
     /// Returns `None` for both "not found" and "belongs to another tenant"
     /// to prevent cross-tenant ID enumeration.
-    pub async fn find_session_by_id(
+    pub async fn find_session_by_id<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
-    ) -> Result<Option<AiChatSession>, sqlx::Error> {
+    ) -> Result<Option<AiChatSession>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as("SELECT * FROM ai_chat_sessions WHERE id = $1 AND organization_id = $2")
             .bind(id)
             .bind(org_id)
-            .fetch_optional(&self.pool)
+            .fetch_optional(executor)
             .await
     }
 
     /// List user's chat sessions.
-    pub async fn list_user_sessions(
+    pub async fn list_user_sessions<'e, E>(
         &self,
+        executor: E,
         user_id: Uuid,
         limit: i64,
         offset: i64,
-    ) -> Result<Vec<ChatSessionSummary>, sqlx::Error> {
+    ) -> Result<Vec<ChatSessionSummary>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT
@@ -88,14 +131,20 @@ impl AiChatRepository {
         .bind(user_id)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Add a message to a session.
+    ///
+    /// Takes a `&mut PgConnection` (rather than a generic by-value executor) so
+    /// the message INSERT and the parent-session `last_message_at` UPDATE both
+    /// run on the SAME RLS-scoped connection, keeping `app.current_org_id` in
+    /// scope for the second statement's policy check.
     #[allow(clippy::too_many_arguments)]
     pub async fn add_message(
         &self,
+        executor: &mut sqlx::PgConnection,
         session_id: Uuid,
         role: &str,
         content: &str,
@@ -123,7 +172,7 @@ impl AiChatRepository {
         .bind(escalation_reason)
         .bind(tokens_used)
         .bind(latency_ms)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *executor)
         .await?;
 
         // Update session last_message_at
@@ -131,7 +180,7 @@ impl AiChatRepository {
             "UPDATE ai_chat_sessions SET last_message_at = NOW(), updated_at = NOW() WHERE id = $1",
         )
         .bind(session_id)
-        .execute(&self.pool)
+        .execute(&mut *executor)
         .await?;
 
         Ok(message)
@@ -142,13 +191,17 @@ impl AiChatRepository {
     /// `org_id` must originate from the verified request principal.
     /// The JOIN ensures a caller in org B cannot enumerate messages from a
     /// session owned by org A.
-    pub async fn list_session_messages(
+    pub async fn list_session_messages<'e, E>(
         &self,
+        executor: E,
         session_id: Uuid,
         org_id: Uuid,
         limit: i64,
         offset: i64,
-    ) -> Result<Vec<AiChatMessage>, sqlx::Error> {
+    ) -> Result<Vec<AiChatMessage>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT m.* FROM ai_chat_messages m
@@ -162,7 +215,7 @@ impl AiChatRepository {
         .bind(org_id)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -171,28 +224,40 @@ impl AiChatRepository {
     /// `org_id` must originate from the verified request principal.
     /// Returns `false` for both "not found" and "belongs to another tenant"
     /// to prevent cross-tenant ID enumeration.
-    pub async fn delete_session(&self, id: Uuid, org_id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete_session<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result =
             sqlx::query("DELETE FROM ai_chat_sessions WHERE id = $1 AND organization_id = $2")
                 .bind(id)
                 .bind(org_id)
-                .execute(&self.pool)
+                .execute(executor)
                 .await?;
         Ok(result.rows_affected() > 0)
     }
 
     /// Update session title.
-    pub async fn update_session_title(
+    pub async fn update_session_title<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         title: &str,
-    ) -> Result<AiChatSession, sqlx::Error> {
+    ) -> Result<AiChatSession, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             "UPDATE ai_chat_sessions SET title = $2, updated_at = NOW() WHERE id = $1 RETURNING *",
         )
         .bind(id)
         .bind(title)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
@@ -201,11 +266,15 @@ impl AiChatRepository {
     ///
     /// `user_id` is passed explicitly by the caller and must originate from the
     /// verified request principal, never from client input in `data`.
-    pub async fn add_feedback(
+    pub async fn add_feedback<'e, E>(
         &self,
+        executor: E,
         user_id: Uuid,
         data: ProvideFeedback,
-    ) -> Result<AiTrainingFeedback, sqlx::Error> {
+    ) -> Result<AiTrainingFeedback, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO ai_training_feedback (message_id, user_id, rating, helpful, feedback_text)
@@ -222,7 +291,7 @@ impl AiChatRepository {
         .bind(data.rating)
         .bind(data.helpful)
         .bind(data.feedback_text)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
@@ -235,12 +304,16 @@ impl AiChatRepository {
     /// caller in org B cannot attach feedback to a message in org A's chat
     /// session (an IDOR write + training-data-poisoning vector). Returns
     /// `Ok(None)` when the message does not exist or belongs to another org.
-    pub async fn add_feedback_for_org(
+    pub async fn add_feedback_for_org<'e, E>(
         &self,
+        executor: E,
         user_id: Uuid,
         org_id: Uuid,
         data: ProvideFeedback,
-    ) -> Result<Option<AiTrainingFeedback>, sqlx::Error> {
+    ) -> Result<Option<AiTrainingFeedback>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO ai_training_feedback (message_id, user_id, rating, helpful, feedback_text)
@@ -263,17 +336,21 @@ impl AiChatRepository {
         .bind(data.helpful)
         .bind(data.feedback_text)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Get escalated messages for review.
-    pub async fn list_escalated_messages(
+    pub async fn list_escalated_messages<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         limit: i64,
         offset: i64,
-    ) -> Result<Vec<AiChatMessage>, sqlx::Error> {
+    ) -> Result<Vec<AiChatMessage>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT m.* FROM ai_chat_messages m
@@ -286,7 +363,7 @@ impl AiChatRepository {
         .bind(org_id)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 }

--- a/backend/crates/db/tests/ai_chat_rls_repo_tests.rs
+++ b/backend/crates/db/tests/ai_chat_rls_repo_tests.rs
@@ -1,0 +1,262 @@
+//! Repo-level behavioral RLS regression test for PAP-103 (parent PAP-80 / PAP-67).
+//!
+//! Background
+//! ----------
+//! Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on the three AI-chat tables (`ai_chat_sessions`,
+//! `ai_chat_messages`, `ai_training_feedback`). The production api-server connects
+//! as the table OWNER, which `FORCE` binds. `AiChatRepository` held a raw `PgPool`
+//! and ran every query WITHOUT ever calling `set_request_context`, so on `dev`
+//! `get_current_org_id()` returned NULL and the policy collapsed to
+//! `organization_id = NULL` → **deny-all**: own-org reads returned empty, writes
+//! failed. (PAP-103.)
+//!
+//! The fix routes the repo through an RLS-context connection (the `RlsConnection`
+//! extractor in handlers sets the org/user GUCs before any query). This test
+//! exercises the *repository methods themselves* on a `FORCE`-bound role and
+//! proves, against `ai_chat_sessions`:
+//!
+//!   1. **Deny-all reproduction** — with the role bound but NO context set
+//!      (exactly what the raw-pool repo did on `dev`), an own-org
+//!      `find_session_by_id` returns nothing.
+//!   2. **Fix** — with `set_request_context(org_a, user_a)` applied first (what
+//!      `RlsConnection` now does), the same repo call returns the own-org row.
+//!   3. **Cross-tenant** — org B's session stays invisible to an org-A caller.
+//!   4. **Write path** — `create_session` on a context-set connection succeeds
+//!      and the row is the caller's org.
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — even `FORCE` does not bind a superuser, so a behavioral assertion
+//! would pass vacuously. The test creates a plain `NOSUPERUSER NOBYPASSRLS`
+//! role, grants it access, and `SET ROLE`s to it so `FORCE` actually enforces the
+//! policy the way the production owner role experiences it. Mirrors
+//! `enhanced_tenant_screening_rls_repo_tests.rs` (the PAP-74 precedent PAP-103
+//! follows — the ai_chat policies also carry the `get_current_org_not_deleted()`
+//! soft-delete guard, so the bound role needs `organizations` SELECT + the
+//! helper-function EXECUTE grants).
+
+use db::models::CreateChatSession;
+use db::repositories::AiChatRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("AiChat {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@aichat.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'AiChat User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Seed a chat session directly (as superuser, RLS-exempt) for an org/user.
+async fn seed_session(pool: &PgPool, org_id: Uuid, user_id: Uuid, title: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO ai_chat_sessions (organization_id, user_id, title)
+        VALUES ($1, $2, $3)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(user_id)
+    .bind(title)
+    .fetch_one(pool)
+    .await
+    .expect("seed session")
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn ai_chat_repo_force_rls_deny_all_and_fix(pool: PgPool) {
+    let repo = AiChatRepository::new(pool.clone());
+
+    // --- Seed as superuser / super-admin context (satisfies org roles-trigger). ---
+    set_ctx(&pool, None, None, true).await;
+    let org_a = seed_org(&pool, "aichat-a").await;
+    let org_b = seed_org(&pool, "aichat-b").await;
+    let user_a = seed_user(&pool, "a@aichat.test").await;
+    let user_b = seed_user(&pool, "b@aichat.test").await;
+    let session_a = seed_session(&pool, org_a, user_a, "Session A").await;
+    let session_b = seed_session(&pool, org_b, user_b, "Session B").await;
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    let role = format!("ppt_rls_aichat_{}", Uuid::new_v4().simple());
+    for stmt in [
+        format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
+        format!("GRANT SELECT, INSERT, UPDATE, DELETE ON ai_chat_sessions TO \"{role}\""),
+        // RLS policy helpers must be EXECUTE-able by the bound role; the
+        // not-deleted guard reads `organizations`.
+        format!(
+            "GRANT EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
+             get_current_org_not_deleted() TO \"{role}\""
+        ),
+        format!("GRANT SELECT ON organizations TO \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .expect("grant setup");
+    }
+
+    // ====================================================================
+    // (1) DENY-ALL reproduction: role bound, NO context set (the dev raw-pool
+    //     behavior). Own-org reads return nothing.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        // Explicitly clear any inherited context, then drop to the bound role.
+        sqlx::query("SELECT clear_request_context()")
+            .execute(&mut *conn)
+            .await
+            .expect("clear ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let found = repo
+            .find_session_by_id(&mut *conn, session_a, org_a)
+            .await
+            .expect("find_session_by_id (no ctx)");
+        assert!(
+            found.is_none(),
+            "PAP-103 regression: without RLS context, own-org chat session must be \
+             invisible (deny-all) — this is what the raw-pool repo did on dev"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (2) FIX + (3) cross-tenant: set context, drop to bound role, query repo.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        // (2) Own-org row IS now visible through the repo — the fix.
+        let found = repo
+            .find_session_by_id(&mut *conn, session_a, org_a)
+            .await
+            .expect("find_session_by_id (ctx)");
+        assert_eq!(
+            found.map(|s| s.id),
+            Some(session_a),
+            "PAP-103 fix: with RLS context set, the repo must return the own-org session"
+        );
+
+        // (3) Org B's session stays invisible to an org-A caller — even though
+        //     the SQL filter is passed org_a, RLS independently denies the row.
+        let cross = repo
+            .find_session_by_id(&mut *conn, session_b, org_a)
+            .await
+            .expect("find_session_by_id cross");
+        assert!(
+            cross.is_none(),
+            "cross-tenant: org B's session must NOT be visible to an org-A caller"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (4) WRITE path: a create on a context-set connection succeeds and the
+    //     row is the caller's org. Without context the INSERT would fail the
+    //     policy WITH CHECK (the write-side of deny-all).
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let created = repo
+            .create_session(
+                &mut *conn,
+                org_a,
+                user_a,
+                CreateChatSession {
+                    title: Some("Created under RLS".to_string()),
+                    context: None,
+                },
+            )
+            .await
+            .expect("create_session under context must succeed");
+        assert_eq!(created.organization_id, org_a);
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup the test role. ---
+    set_ctx(&pool, None, None, true).await;
+    for stmt in [
+        format!("REVOKE ALL ON ai_chat_sessions FROM \"{role}\""),
+        format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .ok();
+    }
+}

--- a/backend/servers/api-server/src/routes/ai/sessions.rs
+++ b/backend/servers/api-server/src/routes/ai/sessions.rs
@@ -1,8 +1,7 @@
 //! AI chat sessions (Story 13.1) and sentiment analysis (Story 13.2).
 
-use crate::routes::ai::{require_tenant_id, AlertsQuery, PaginationQuery};
+use crate::routes::ai::{AlertsQuery, PaginationQuery};
 use crate::state::AppState;
-use api_core::extractors::principal::RequestPrincipal;
 use api_core::extractors::RlsConnection;
 use axum::{
     extract::{Path, Query, State},
@@ -48,17 +47,21 @@ pub fn ai_chat_router() -> Router<AppState> {
 )]
 async fn create_session(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Json(req): Json<CreateChatSession>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
-    // SECURITY: the owning org/user are derived from the verified principal,
-    // never trusted from the request body (prevents IDOR / cross-tenant writes).
-    let organization_id = require_tenant_id(&principal)?;
-    match state
+    // SECURITY: the owning org/user are derived from the RLS-validated request
+    // context, never trusted from the request body (prevents IDOR / cross-tenant
+    // writes). The connection carries RLS context so the INSERT also satisfies
+    // the FORCE-RLS `WITH CHECK` policy.
+    let organization_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let result = state
         .ai_chat_repo
-        .create_session(organization_id, principal.user_id, req)
-        .await
-    {
+        .create_session(&mut **rls.conn(), organization_id, user_id, req)
+        .await;
+    rls.release().await;
+    match result {
         Ok(session) => Ok((StatusCode::CREATED, Json(serde_json::json!(session)))),
         Err(e) => {
             tracing::error!("Failed to create session: {}", e);
@@ -85,18 +88,21 @@ async fn create_session(
 )]
 async fn list_sessions(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    match state
+    let user_id = rls.user_id();
+    let result = state
         .ai_chat_repo
         .list_user_sessions(
-            principal.user_id,
+            &mut **rls.conn(),
+            user_id,
             query.limit.unwrap_or(50),
             query.offset.unwrap_or(0),
         )
-        .await
-    {
+        .await;
+    rls.release().await;
+    match result {
         Ok(sessions) => Ok(Json(serde_json::json!({ "sessions": sessions }))),
         Err(e) => {
             tracing::error!("Failed to list sessions: {}", e);
@@ -113,15 +119,16 @@ async fn list_sessions(
 
 async fn get_session(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(session_id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_tenant_id(&principal)?;
-    match state
+    let org_id = rls.tenant_id();
+    let result = state
         .ai_chat_repo
-        .find_session_by_id(session_id, org_id)
-        .await
-    {
+        .find_session_by_id(&mut **rls.conn(), session_id, org_id)
+        .await;
+    rls.release().await;
+    match result {
         Ok(Some(session)) => Ok(Json(serde_json::json!(session))),
         Ok(None) => Err((
             StatusCode::NOT_FOUND,
@@ -142,11 +149,16 @@ async fn get_session(
 
 async fn delete_session(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(session_id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_tenant_id(&principal)?;
-    match state.ai_chat_repo.delete_session(session_id, org_id).await {
+    let org_id = rls.tenant_id();
+    let result = state
+        .ai_chat_repo
+        .delete_session(&mut **rls.conn(), session_id, org_id)
+        .await;
+    rls.release().await;
+    match result {
         Ok(true) => Ok(StatusCode::NO_CONTENT),
         Ok(false) => Err((
             StatusCode::NOT_FOUND,
@@ -167,21 +179,23 @@ async fn delete_session(
 
 async fn list_messages(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(session_id): Path<Uuid>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_tenant_id(&principal)?;
-    match state
+    let org_id = rls.tenant_id();
+    let result = state
         .ai_chat_repo
         .list_session_messages(
+            &mut **rls.conn(),
             session_id,
             org_id,
             query.limit.unwrap_or(100),
             query.offset.unwrap_or(0),
         )
-        .await
-    {
+        .await;
+    rls.release().await;
+    match result {
         Ok(messages) => Ok(Json(serde_json::json!({ "messages": messages }))),
         Err(e) => {
             tracing::error!("Failed to list messages: {}", e);
@@ -216,22 +230,29 @@ const MAX_RESPONSE_TOKENS: u32 = 2048;
 
 async fn send_message(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(session_id): Path<Uuid>,
     Json(req): Json<SendChatMessage>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
     let start_time = Instant::now();
 
-    // SECURITY: tenant is now derived from the verified principal, never from
-    // a client-supplied header. Per-tenant features (RAG, sentiment trend
-    // bookkeeping, custom system prompt) require a resolved org; a platform
-    // principal on the platform host has no `effective_org` and is rejected.
-    let tenant_id = require_tenant_id(&principal)?;
+    // SECURITY: tenant is now derived from the RLS-validated request context,
+    // never from a client-supplied header. Per-tenant features (RAG, sentiment
+    // trend bookkeeping, custom system prompt) require a resolved org; a platform
+    // principal on the platform host has no `effective_org` and is rejected by
+    // the `RlsConnection` extractor itself.
+    //
+    // The RLS connection is held for the whole handler (including the LLM call)
+    // because the AI-chat reads/writes must run on a context-set connection.
+    // Early `?` returns leave cleanup to `RlsConnection::drop` (spawns a
+    // context-clear task); the happy path calls `rls.release().await` explicitly.
+    let tenant_id = rls.tenant_id();
+    let user_id = rls.user_id();
 
     // Verify session exists and belongs to this tenant.
     let _session = state
         .ai_chat_repo
-        .find_session_by_id(session_id, tenant_id)
+        .find_session_by_id(&mut **rls.conn(), session_id, tenant_id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to find session: {}", e);
@@ -254,7 +275,13 @@ async fn send_message(
     // Story 97.1: Load more messages for context, will be truncated to fit token limits
     let history = state
         .ai_chat_repo
-        .list_session_messages(session_id, tenant_id, DEFAULT_HISTORY_LIMIT, 0)
+        .list_session_messages(
+            &mut **rls.conn(),
+            session_id,
+            tenant_id,
+            DEFAULT_HISTORY_LIMIT,
+            0,
+        )
         .await
         .unwrap_or_default();
 
@@ -262,6 +289,7 @@ async fn send_message(
     let user_msg = state
         .ai_chat_repo
         .add_message(
+            rls.conn(),
             session_id,
             "user",
             &req.content,
@@ -304,7 +332,7 @@ async fn send_message(
                             if db::tenant_context::set_request_context(
                                 &mut *sconn,
                                 Some(tenant_id),
-                                Some(principal.user_id),
+                                Some(user_id),
                                 false,
                             )
                             .await
@@ -483,7 +511,7 @@ async fn send_message(
                 if db::tenant_context::set_request_context(
                     &mut *conn,
                     Some(tenant_id),
-                    Some(principal.user_id),
+                    Some(user_id),
                     false,
                 )
                 .await
@@ -754,6 +782,7 @@ async fn send_message(
     let assistant_msg = state
         .ai_chat_repo
         .add_message(
+            rls.conn(),
             session_id,
             "assistant",
             &response_content,
@@ -801,12 +830,15 @@ async fn send_message(
         })
     };
 
+    // Clear RLS context before returning the connection to the pool (happy path).
+    rls.release().await;
+
     Ok((StatusCode::CREATED, Json(response_json)))
 }
 
 async fn provide_feedback(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(message_id): Path<Uuid>,
     Json(req): Json<ProvideFeedback>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
@@ -814,16 +846,18 @@ async fn provide_feedback(
     feedback.message_id = message_id;
 
     // SECURITY (issue #766 / #816): feedback author AND the owning tenant are
-    // both derived from the verified principal, never from the request body or
+    // both derived from the RLS-validated request context, never from the body or
     // the path. The repo only writes when the target message's session belongs
     // to the caller's org — otherwise a caller in org B could attach feedback
     // to (and poison the training signal for) org A's chat messages.
-    let org_id = require_tenant_id(&principal)?;
-    match state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let result = state
         .ai_chat_repo
-        .add_feedback_for_org(principal.user_id, org_id, feedback)
-        .await
-    {
+        .add_feedback_for_org(&mut **rls.conn(), user_id, org_id, feedback)
+        .await;
+    rls.release().await;
+    match result {
         Ok(Some(fb)) => Ok((StatusCode::CREATED, Json(serde_json::json!(fb)))),
         Ok(None) => Err((
             StatusCode::NOT_FOUND,
@@ -844,20 +878,22 @@ async fn provide_feedback(
 
 async fn list_escalated(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
+    let tenant_id = rls.tenant_id();
 
-    match state
+    let result = state
         .ai_chat_repo
         .list_escalated_messages(
+            &mut **rls.conn(),
             tenant_id,
             query.limit.unwrap_or(50),
             query.offset.unwrap_or(0),
         )
-        .await
-    {
+        .await;
+    rls.release().await;
+    match result {
         Ok(messages) => Ok(Json(serde_json::json!({ "messages": messages }))),
         Err(e) => {
             tracing::error!("Failed to list escalated: {}", e);

--- a/backend/servers/api-server/tests/ai_llm_cross_tenant_idor_tests.rs
+++ b/backend/servers/api-server/tests/ai_llm_cross_tenant_idor_tests.rs
@@ -112,7 +112,7 @@ async fn find_session_by_id_blocks_cross_tenant_read(pool: PgPool) {
 
     // Same-org read succeeds.
     let same_org = repo
-        .find_session_by_id(session_in_a, org_a)
+        .find_session_by_id(&pool, session_in_a, org_a)
         .await
         .expect("query ok");
     assert!(
@@ -122,7 +122,7 @@ async fn find_session_by_id_blocks_cross_tenant_read(pool: PgPool) {
 
     // Cross-org read returns None (the IDOR is blocked).
     let cross_org = repo
-        .find_session_by_id(session_in_a, org_b)
+        .find_session_by_id(&pool, session_in_a, org_b)
         .await
         .expect("query ok");
     assert!(
@@ -165,6 +165,7 @@ async fn add_feedback_for_org_blocks_cross_tenant_write(pool: PgPool) {
     // the repo returns None and writes nothing.
     let cross = repo
         .add_feedback_for_org(
+            &pool,
             user_b,
             org_b,
             ProvideFeedback {
@@ -195,6 +196,7 @@ async fn add_feedback_for_org_blocks_cross_tenant_write(pool: PgPool) {
     // Same-org feedback (user A in org A) succeeds.
     let same = repo
         .add_feedback_for_org(
+            &pool,
             user_a,
             org_a,
             ProvideFeedback {


### PR DESCRIPTION
## What

Converts `AiChatRepository` from a raw `PgPool` to the RLS-context-executor pattern (PAP-80 / PAP-67 sweep, step 2/4). Mounted via `/api/v1/ai/chat`.

`ai_chat` queried **3 FORCE-RLS tables** (migration `00179`: `ai_chat_sessions`, `ai_chat_messages`, `ai_training_feedback`) through a raw pool that never set `app.current_org_id`. Under `FORCE` the api-server owner connection is no longer exempt, so on `dev` every read returned empty and every write failed the policy `WITH CHECK` (deny-all).

## How (follows the merged `work_order.rs` / `vendor.rs` / `sensor.rs` precedent)

- **Repo holds no pool.** `AiChatRepository` is now a zero-sized type; `new(_pool)` is retained only for `AppState` construction-site compatibility.
- **Single-statement methods** take a generic `E: Executor`. `add_message` writes two statements (message INSERT + parent-session `last_message_at` UPDATE) on the **same** RLS-scoped connection, so it takes `&mut PgConnection` and reborrows.
- **Handlers** (`routes/ai/sessions.rs`) acquire the `RlsConnection` extractor, pass `&mut **rls.conn()` (or `rls.conn()` where the param is already `&mut PgConnection`), use `rls.tenant_id()` as the authoritative org, and `release()` to clear context.
- Explicit `organization_id` SQL filters are kept as **defense-in-depth**; the org passed is `rls.tenant_id()`, so the SQL filter and the RLS context can never disagree. Cross-tenant by-id reads now surface as `None`/404 via RLS.
- `send_message` holds the connection for the whole handler (including the LLM call) because its AI-chat reads/writes must run on the context-set connection. Noted inline as a possible future pool-holding optimization.

## Tests

- **New** `crates/db/tests/ai_chat_rls_repo_tests.rs` — `find_session_by_id` (by-id read) + `create_session` (write) exercised on a `NOSUPERUSER NOBYPASSRLS` role via the `enhanced_tenant_screening_rls_repo_tests.rs` role-switch pattern. Proves: deny-all reproduction (no ctx), the fix (ctx set), cross-tenant invisibility, and the write path. **Passes.**
- Updated `ai_llm_cross_tenant_idor_tests.rs` for the new executor-first signatures.

## Verify (on remote — mercury/rbuild, per the OOM guardrail)

- `cargo check -p db -p api-server` ✅ green
- `cargo check -p db -p api-server --tests` ✅ green
- `cargo clippy -p db -p api-server -- -D warnings` ✅ green
- `cargo fmt --check` ✅ clean
- `cargo test -p db --test ai_chat_rls_repo_tests` ✅ `1 passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)