### PR TITLE
fix(db): route predictive_maintenance repo through RLS-context connection (PAP-80)

### DIFF
--- a/backend/crates/db/src/repositories/predictive_maintenance.rs
+++ b/backend/crates/db/src/repositories/predictive_maintenance.rs
@@ -1,8 +1,30 @@
 //! Repository for Epic 134: Predictive Maintenance & Equipment Intelligence.
+//!
+//! # RLS Integration (PAP-80)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on the predictive-maintenance tables
+//! (`equipment_registry`, `equipment_documents`, `maintenance_logs`,
+//! `maintenance_log_photos`, `equipment_predictions`, `maintenance_alerts`,
+//! `equipment_health_thresholds`). Under `FORCE` the api-server's owner
+//! connection is no longer exempt, so a query issued on a connection without
+//! `app.current_org_id` set collapses to deny-all (own-org reads return empty,
+//! writes fail the policy's `WITH CHECK`).
+//!
+//! Every method therefore takes an **executor whose connection already has RLS
+//! context set** (org + user GUCs) — in handlers this comes from the
+//! `RlsConnection` extractor via `&mut **rls.conn()`. The repository holds **no
+//! pool**, so there is no way to issue a query that bypasses RLS. This mirrors
+//! the `work_order.rs` / `budget.rs` / `document.rs` precedent.
+//!
+//! Single-statement methods take a generic `Executor`; the multi-statement
+//! methods (`run_prediction`, `get_dashboard`) take `&mut PgConnection` and
+//! reborrow it for each query.
 
 use chrono::Utc;
 use common::AppError;
 use rust_decimal::Decimal;
+use sqlx::{Executor, PgConnection, Postgres};
 use uuid::Uuid;
 
 use crate::models::predictive_maintenance::{
@@ -12,18 +34,23 @@ use crate::models::predictive_maintenance::{
     MaintenanceDashboard, MaintenanceLog, MaintenanceLogPhoto, PredictionFactor, PredictionResult,
     SetHealthThreshold, UpdateEquipment, UpdateMaintenanceLog,
 };
-use crate::DbPool;
 
 /// Repository for predictive maintenance operations.
+///
+/// Stateless: every method receives an RLS-context-bearing executor. The repo
+/// holds no pool so it cannot issue an un-scoped (deny-all under `FORCE`) query.
 #[derive(Debug, Clone)]
-pub struct PredictiveMaintenanceRepository {
-    pool: DbPool,
-}
+pub struct PredictiveMaintenanceRepository;
 
 impl PredictiveMaintenanceRepository {
     /// Create a new repository.
-    pub fn new(pool: DbPool) -> Self {
-        Self { pool }
+    ///
+    /// The pool argument is retained for construction-site compatibility with
+    /// the other repositories on `AppState`; this repo deliberately does not
+    /// store it (see module docs — all queries run on a context-set connection
+    /// supplied by the handler's `RlsConnection`).
+    pub fn new(_pool: crate::DbPool) -> Self {
+        Self
     }
 
     // ========================================================================
@@ -31,12 +58,16 @@ impl PredictiveMaintenanceRepository {
     // ========================================================================
 
     /// Create new equipment.
-    pub async fn create_equipment(
+    pub async fn create_equipment<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         user_id: Uuid,
         req: CreateEquipment,
-    ) -> Result<Equipment, AppError> {
+    ) -> Result<Equipment, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let equipment = sqlx::query_as::<_, Equipment>(
             r#"
             INSERT INTO equipment_registry (
@@ -68,7 +99,7 @@ impl PredictiveMaintenanceRepository {
         .bind(&req.notes)
         .bind(&req.specifications)
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -76,11 +107,18 @@ impl PredictiveMaintenanceRepository {
     }
 
     /// Get equipment by ID.
-    pub async fn get_equipment(
+    ///
+    /// RLS scopes the result to the connection's org context, so equipment
+    /// owned by another organization is invisible (returns `None`).
+    pub async fn get_equipment<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
-    ) -> Result<Option<Equipment>, AppError> {
+    ) -> Result<Option<Equipment>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let equipment = sqlx::query_as::<_, Equipment>(
             r#"
             SELECT * FROM equipment_registry
@@ -89,7 +127,7 @@ impl PredictiveMaintenanceRepository {
         )
         .bind(id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -97,11 +135,15 @@ impl PredictiveMaintenanceRepository {
     }
 
     /// List equipment with filters.
-    pub async fn list_equipment(
+    pub async fn list_equipment<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: EquipmentQuery,
-    ) -> Result<Vec<Equipment>, AppError> {
+    ) -> Result<Vec<Equipment>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50);
         let offset = query.offset.unwrap_or(0);
         let sort_by = query.sort_by.unwrap_or_else(|| "name".to_string());
@@ -147,7 +189,7 @@ impl PredictiveMaintenanceRepository {
             .bind(query.max_health_score)
             .bind(limit)
             .bind(offset)
-            .fetch_all(&self.pool)
+            .fetch_all(executor)
             .await
             .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -155,13 +197,17 @@ impl PredictiveMaintenanceRepository {
     }
 
     /// Update equipment.
-    pub async fn update_equipment(
+    pub async fn update_equipment<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
         user_id: Uuid,
         req: UpdateEquipment,
-    ) -> Result<Option<Equipment>, AppError> {
+    ) -> Result<Option<Equipment>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let equipment = sqlx::query_as::<_, Equipment>(
             r#"
             UPDATE equipment_registry SET
@@ -206,7 +252,7 @@ impl PredictiveMaintenanceRepository {
         .bind(&req.notes)
         .bind(&req.specifications)
         .bind(user_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -214,7 +260,15 @@ impl PredictiveMaintenanceRepository {
     }
 
     /// Delete equipment.
-    pub async fn delete_equipment(&self, id: Uuid, org_id: Uuid) -> Result<bool, AppError> {
+    pub async fn delete_equipment<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<bool, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query(
             r#"
             DELETE FROM equipment_registry
@@ -223,7 +277,7 @@ impl PredictiveMaintenanceRepository {
         )
         .bind(id)
         .bind(org_id)
-        .execute(&self.pool)
+        .execute(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -231,13 +285,17 @@ impl PredictiveMaintenanceRepository {
     }
 
     /// Add document to equipment.
-    pub async fn add_equipment_document(
+    pub async fn add_equipment_document<'e, E>(
         &self,
+        executor: E,
         equipment_id: Uuid,
         org_id: Uuid,
         user_id: Uuid,
         req: CreateEquipmentDocument,
-    ) -> Result<EquipmentDocument, AppError> {
+    ) -> Result<EquipmentDocument, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let doc = sqlx::query_as::<_, EquipmentDocument>(
             r#"
             INSERT INTO equipment_documents (
@@ -256,7 +314,7 @@ impl PredictiveMaintenanceRepository {
         .bind(req.file_size)
         .bind(&req.mime_type)
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -264,11 +322,15 @@ impl PredictiveMaintenanceRepository {
     }
 
     /// List equipment documents.
-    pub async fn list_equipment_documents(
+    pub async fn list_equipment_documents<'e, E>(
         &self,
+        executor: E,
         equipment_id: Uuid,
         org_id: Uuid,
-    ) -> Result<Vec<EquipmentDocument>, AppError> {
+    ) -> Result<Vec<EquipmentDocument>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let docs = sqlx::query_as::<_, EquipmentDocument>(
             r#"
             SELECT * FROM equipment_documents
@@ -278,7 +340,7 @@ impl PredictiveMaintenanceRepository {
         )
         .bind(equipment_id)
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -290,12 +352,16 @@ impl PredictiveMaintenanceRepository {
     // ========================================================================
 
     /// Create maintenance log.
-    pub async fn create_maintenance_log(
+    pub async fn create_maintenance_log<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         user_id: Uuid,
         req: CreateMaintenanceLog,
-    ) -> Result<MaintenanceLog, AppError> {
+    ) -> Result<MaintenanceLog, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let log = sqlx::query_as::<_, MaintenanceLog>(
             r#"
             INSERT INTO maintenance_logs (
@@ -329,7 +395,7 @@ impl PredictiveMaintenanceRepository {
         .bind(&req.outcome)
         .bind(&req.notes)
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -337,11 +403,18 @@ impl PredictiveMaintenanceRepository {
     }
 
     /// Get maintenance log by ID.
-    pub async fn get_maintenance_log(
+    ///
+    /// RLS scopes the result to the connection's org context, so a log owned by
+    /// another organization is invisible (returns `None`).
+    pub async fn get_maintenance_log<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
-    ) -> Result<Option<MaintenanceLog>, AppError> {
+    ) -> Result<Option<MaintenanceLog>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let log = sqlx::query_as::<_, MaintenanceLog>(
             r#"
             SELECT * FROM maintenance_logs
@@ -350,7 +423,7 @@ impl PredictiveMaintenanceRepository {
         )
         .bind(id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -358,13 +431,17 @@ impl PredictiveMaintenanceRepository {
     }
 
     /// List maintenance logs for equipment.
-    pub async fn list_maintenance_logs(
+    pub async fn list_maintenance_logs<'e, E>(
         &self,
+        executor: E,
         equipment_id: Uuid,
         org_id: Uuid,
         limit: i64,
         offset: i64,
-    ) -> Result<Vec<MaintenanceLog>, AppError> {
+    ) -> Result<Vec<MaintenanceLog>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let logs = sqlx::query_as::<_, MaintenanceLog>(
             r#"
             SELECT * FROM maintenance_logs
@@ -377,7 +454,7 @@ impl PredictiveMaintenanceRepository {
         .bind(org_id)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -385,12 +462,16 @@ impl PredictiveMaintenanceRepository {
     }
 
     /// Update maintenance log.
-    pub async fn update_maintenance_log(
+    pub async fn update_maintenance_log<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
         req: UpdateMaintenanceLog,
-    ) -> Result<Option<MaintenanceLog>, AppError> {
+    ) -> Result<Option<MaintenanceLog>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let log = sqlx::query_as::<_, MaintenanceLog>(
             r#"
             UPDATE maintenance_logs SET
@@ -429,7 +510,7 @@ impl PredictiveMaintenanceRepository {
         .bind(&req.work_performed)
         .bind(&req.outcome)
         .bind(&req.notes)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -438,8 +519,9 @@ impl PredictiveMaintenanceRepository {
 
     /// Add photo to maintenance log.
     #[allow(clippy::too_many_arguments)]
-    pub async fn add_maintenance_photo(
+    pub async fn add_maintenance_photo<'e, E>(
         &self,
+        executor: E,
         log_id: Uuid,
         user_id: Uuid,
         file_path: &str,
@@ -447,7 +529,10 @@ impl PredictiveMaintenanceRepository {
         mime_type: Option<&str>,
         caption: Option<&str>,
         photo_type: Option<&str>,
-    ) -> Result<MaintenanceLogPhoto, AppError> {
+    ) -> Result<MaintenanceLogPhoto, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let photo = sqlx::query_as::<_, MaintenanceLogPhoto>(
             r#"
             INSERT INTO maintenance_log_photos (
@@ -465,7 +550,7 @@ impl PredictiveMaintenanceRepository {
         .bind(caption)
         .bind(photo_type)
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -476,14 +561,18 @@ impl PredictiveMaintenanceRepository {
     ///
     /// `maintenance_log_photos` has no `organization_id` column, so org
     /// ownership is enforced by joining through the parent `maintenance_logs`
-    /// row (which is org-scoped). A `log_id` belonging to another org yields
-    /// zero rows — the handler must surface that as a 404, never a
-    /// cross-tenant read (IDOR #848).
-    pub async fn list_maintenance_photos(
+    /// row (which is org-scoped, and under RLS only the caller's org rows are
+    /// visible). A `log_id` belonging to another org yields zero rows — the
+    /// handler must surface that as a 404, never a cross-tenant read (IDOR #848).
+    pub async fn list_maintenance_photos<'e, E>(
         &self,
+        executor: E,
         log_id: Uuid,
         org_id: Uuid,
-    ) -> Result<Vec<MaintenanceLogPhoto>, AppError> {
+    ) -> Result<Vec<MaintenanceLogPhoto>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let photos = sqlx::query_as::<_, MaintenanceLogPhoto>(
             r#"
             SELECT p.*
@@ -496,7 +585,7 @@ impl PredictiveMaintenanceRepository {
         )
         .bind(log_id)
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -508,14 +597,20 @@ impl PredictiveMaintenanceRepository {
     // ========================================================================
 
     /// Run prediction for equipment (stub implementation).
+    ///
+    /// Multi-statement: reads equipment + maintenance history, then writes a
+    /// prediction row and updates the equipment health score. Takes a
+    /// `&mut PgConnection` and reborrows it for each query so every statement
+    /// runs under the same RLS context.
     pub async fn run_prediction(
         &self,
+        conn: &mut PgConnection,
         equipment_id: Uuid,
         org_id: Uuid,
     ) -> Result<PredictionResult, AppError> {
         // Get equipment info
         let equipment = self
-            .get_equipment(equipment_id, org_id)
+            .get_equipment(&mut *conn, equipment_id, org_id)
             .await?
             .ok_or_else(|| AppError::NotFound("Equipment not found".to_string()))?;
 
@@ -540,7 +635,7 @@ impl PredictiveMaintenanceRepository {
         )
         .bind(equipment_id)
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -627,7 +722,7 @@ impl PredictiveMaintenanceRepository {
         .bind(recommended_action)
         .bind(predicted_failure_date)
         .bind(urgency)
-        .execute(&self.pool)
+        .execute(&mut *conn)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -648,7 +743,7 @@ impl PredictiveMaintenanceRepository {
         .bind(health_score)
         .bind(Decimal::from_f64_retain(failure_probability).unwrap_or_default())
         .bind(predicted_failure_date)
-        .execute(&self.pool)
+        .execute(&mut *conn)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -665,12 +760,16 @@ impl PredictiveMaintenanceRepository {
     }
 
     /// Get prediction history for equipment.
-    pub async fn get_prediction_history(
+    pub async fn get_prediction_history<'e, E>(
         &self,
+        executor: E,
         equipment_id: Uuid,
         org_id: Uuid,
         limit: i64,
-    ) -> Result<Vec<EquipmentPrediction>, AppError> {
+    ) -> Result<Vec<EquipmentPrediction>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let predictions = sqlx::query_as::<_, EquipmentPrediction>(
             r#"
             SELECT * FROM equipment_predictions
@@ -682,7 +781,7 @@ impl PredictiveMaintenanceRepository {
         .bind(equipment_id)
         .bind(org_id)
         .bind(limit)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -695,8 +794,9 @@ impl PredictiveMaintenanceRepository {
 
     /// Create maintenance alert.
     #[allow(clippy::too_many_arguments)]
-    pub async fn create_alert(
+    pub async fn create_alert<'e, E>(
         &self,
+        executor: E,
         equipment_id: Uuid,
         org_id: Uuid,
         prediction_id: Option<Uuid>,
@@ -704,7 +804,10 @@ impl PredictiveMaintenanceRepository {
         severity: &str,
         title: &str,
         message: &str,
-    ) -> Result<MaintenanceAlert, AppError> {
+    ) -> Result<MaintenanceAlert, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let alert = sqlx::query_as::<_, MaintenanceAlert>(
             r#"
             INSERT INTO maintenance_alerts (
@@ -722,7 +825,7 @@ impl PredictiveMaintenanceRepository {
         .bind(severity)
         .bind(title)
         .bind(message)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -730,14 +833,18 @@ impl PredictiveMaintenanceRepository {
     }
 
     /// List active alerts.
-    pub async fn list_alerts(
+    pub async fn list_alerts<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         status: Option<&str>,
         severity: Option<&str>,
         limit: i64,
         offset: i64,
-    ) -> Result<Vec<AlertWithEquipment>, AppError> {
+    ) -> Result<Vec<AlertWithEquipment>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let alerts = sqlx::query_as::<_, AlertWithEquipment>(
             r#"
             SELECT
@@ -768,7 +875,7 @@ impl PredictiveMaintenanceRepository {
         .bind(severity)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -776,12 +883,16 @@ impl PredictiveMaintenanceRepository {
     }
 
     /// Acknowledge alert.
-    pub async fn acknowledge_alert(
+    pub async fn acknowledge_alert<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
         user_id: Uuid,
-    ) -> Result<Option<MaintenanceAlert>, AppError> {
+    ) -> Result<Option<MaintenanceAlert>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let alert = sqlx::query_as::<_, MaintenanceAlert>(
             r#"
             UPDATE maintenance_alerts SET
@@ -795,7 +906,7 @@ impl PredictiveMaintenanceRepository {
         .bind(id)
         .bind(org_id)
         .bind(user_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -803,13 +914,17 @@ impl PredictiveMaintenanceRepository {
     }
 
     /// Resolve alert.
-    pub async fn resolve_alert(
+    pub async fn resolve_alert<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
         user_id: Uuid,
         maintenance_log_id: Option<Uuid>,
-    ) -> Result<Option<MaintenanceAlert>, AppError> {
+    ) -> Result<Option<MaintenanceAlert>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let alert = sqlx::query_as::<_, MaintenanceAlert>(
             r#"
             UPDATE maintenance_alerts SET
@@ -825,7 +940,7 @@ impl PredictiveMaintenanceRepository {
         .bind(org_id)
         .bind(user_id)
         .bind(maintenance_log_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -833,11 +948,15 @@ impl PredictiveMaintenanceRepository {
     }
 
     /// Dismiss alert.
-    pub async fn dismiss_alert(
+    pub async fn dismiss_alert<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
-    ) -> Result<Option<MaintenanceAlert>, AppError> {
+    ) -> Result<Option<MaintenanceAlert>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let alert = sqlx::query_as::<_, MaintenanceAlert>(
             r#"
             UPDATE maintenance_alerts SET
@@ -848,7 +967,7 @@ impl PredictiveMaintenanceRepository {
         )
         .bind(id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -860,11 +979,15 @@ impl PredictiveMaintenanceRepository {
     // ========================================================================
 
     /// Set health threshold.
-    pub async fn set_health_threshold(
+    pub async fn set_health_threshold<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         req: SetHealthThreshold,
-    ) -> Result<HealthThreshold, AppError> {
+    ) -> Result<HealthThreshold, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let threshold = sqlx::query_as::<_, HealthThreshold>(
             r#"
             INSERT INTO equipment_health_thresholds (
@@ -887,7 +1010,7 @@ impl PredictiveMaintenanceRepository {
         .bind(req.warning_threshold)
         .bind(req.alert_on_critical.unwrap_or(true))
         .bind(req.alert_on_warning.unwrap_or(true))
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -895,10 +1018,14 @@ impl PredictiveMaintenanceRepository {
     }
 
     /// List health thresholds.
-    pub async fn list_health_thresholds(
+    pub async fn list_health_thresholds<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
-    ) -> Result<Vec<HealthThreshold>, AppError> {
+    ) -> Result<Vec<HealthThreshold>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let thresholds = sqlx::query_as::<_, HealthThreshold>(
             r#"
             SELECT * FROM equipment_health_thresholds
@@ -907,7 +1034,7 @@ impl PredictiveMaintenanceRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -919,8 +1046,13 @@ impl PredictiveMaintenanceRepository {
     // ========================================================================
 
     /// Get maintenance dashboard data.
+    ///
+    /// Multi-statement read: issues several aggregate queries on one connection,
+    /// reborrowing `&mut *conn` for each so they all run under the same RLS
+    /// context.
     pub async fn get_dashboard(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         building_id: Option<Uuid>,
     ) -> Result<MaintenanceDashboard, AppError> {
@@ -934,7 +1066,7 @@ impl PredictiveMaintenanceRepository {
         )
         .bind(org_id)
         .bind(building_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -950,7 +1082,7 @@ impl PredictiveMaintenanceRepository {
         )
         .bind(org_id)
         .bind(building_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -991,7 +1123,7 @@ impl PredictiveMaintenanceRepository {
         )
         .bind(org_id)
         .bind(building_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1025,7 +1157,7 @@ impl PredictiveMaintenanceRepository {
         )
         .bind(org_id)
         .bind(building_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1043,7 +1175,7 @@ impl PredictiveMaintenanceRepository {
         )
         .bind(org_id)
         .bind(building_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1077,7 +1209,7 @@ impl PredictiveMaintenanceRepository {
         )
         .bind(org_id)
         .bind(building_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1094,7 +1226,7 @@ impl PredictiveMaintenanceRepository {
         )
         .bind(org_id)
         .bind(building_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1118,7 +1250,7 @@ impl PredictiveMaintenanceRepository {
         )
         .bind(org_id)
         .bind(building_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1135,12 +1267,16 @@ impl PredictiveMaintenanceRepository {
     }
 
     /// Get equipment sorted by health score (for dashboard list).
-    pub async fn get_equipment_by_health(
+    pub async fn get_equipment_by_health<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         building_id: Option<Uuid>,
         limit: i64,
-    ) -> Result<Vec<EquipmentSummary>, AppError> {
+    ) -> Result<Vec<EquipmentSummary>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let equipment = sqlx::query_as::<_, EquipmentSummary>(
             r#"
             SELECT
@@ -1160,7 +1296,7 @@ impl PredictiveMaintenanceRepository {
         .bind(org_id)
         .bind(building_id)
         .bind(limit)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 

--- a/backend/crates/db/tests/predictive_maintenance_rls_repo_tests.rs
+++ b/backend/crates/db/tests/predictive_maintenance_rls_repo_tests.rs
@@ -131,8 +131,14 @@ async fn predictive_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     for stmt in [
         format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
         format!("GRANT SELECT, INSERT, UPDATE, DELETE ON equipment_registry TO \"{role}\""),
-        // RLS policy helper must be EXECUTE-able by the bound role.
-        format!("GRANT EXECUTE ON FUNCTION get_current_org_id() TO \"{role}\""),
+        // RLS policy helpers must be EXECUTE-able by the bound role. The
+        // soft-delete leg (get_current_org_not_deleted) reads `organizations`
+        // as SECURITY INVOKER, so the role also needs SELECT on it.
+        format!(
+            "GRANT EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
+             get_current_org_not_deleted() TO \"{role}\""
+        ),
+        format!("GRANT SELECT ON organizations TO \"{role}\""),
     ] {
         sqlx::query(sqlx::AssertSqlSafe(stmt))
             .execute(&pool)
@@ -239,6 +245,11 @@ async fn predictive_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     set_ctx(&pool, None, None, true).await;
     for stmt in [
         format!("REVOKE ALL ON equipment_registry FROM \"{role}\""),
+        format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        format!(
+            "REVOKE EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
+             get_current_org_not_deleted() FROM \"{role}\""
+        ),
         format!("DROP ROLE IF EXISTS \"{role}\""),
     ] {
         sqlx::query(sqlx::AssertSqlSafe(stmt))

--- a/backend/crates/db/tests/predictive_maintenance_rls_repo_tests.rs
+++ b/backend/crates/db/tests/predictive_maintenance_rls_repo_tests.rs
@@ -1,0 +1,249 @@
+//! Repo-level behavioral RLS regression test for PAP-111 (parent PAP-80).
+//!
+//! Background
+//! ----------
+//! Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on `equipment_registry` (and the rest of the
+//! predictive-maintenance + Epic-11+ cluster). The production api-server
+//! connects as the table OWNER, which `FORCE` binds. `PredictiveMaintenanceRepository`
+//! held a raw `PgPool` and ran every query WITHOUT ever calling
+//! `set_request_context`, so on `dev` `get_current_org_id()` returned NULL and
+//! the policy collapsed to `organization_id = NULL` → **deny-all**: own-org
+//! reads returned empty, writes failed. (PAP-80.)
+//!
+//! The fix routes the repo through an RLS-context connection (the `RlsConnection`
+//! extractor in handlers sets the org/user GUCs before any query). This test
+//! exercises the *repository methods themselves* on a `FORCE`-bound role and
+//! proves:
+//!
+//!   1. **Deny-all reproduction** — with the role bound but NO context set
+//!      (exactly what the raw-pool repo did on `dev`), an own-org `get_equipment`
+//!      / `list_equipment` returns nothing.
+//!   2. **Fix** — with `set_request_context(org_a, user_a)` applied first (what
+//!      `RlsConnection` now does), the same repo calls return the own-org row.
+//!   3. **Cross-tenant** — org B's equipment stays invisible to an org-A caller
+//!      even with context set.
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — even `FORCE` does not bind a superuser, so a behavioral assertion
+//! would pass vacuously. The test creates a plain `NOSUPERUSER NOBYPASSRLS`
+//! role, grants it access, and `SET ROLE`s to it so `FORCE` actually enforces
+//! the policy the way the production owner role experiences it. Mirrors
+//! `vendor_rls_repo_tests.rs` / `work_order_rls_repo_tests.rs` (the PAP-67/-70
+//! precedent this follows).
+
+use db::models::predictive_maintenance::EquipmentQuery;
+use db::repositories::PredictiveMaintenanceRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("PM {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@pm.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'PM User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_building(pool: &PgPool, org_id: Uuid, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO buildings (organization_id, street, city, postal_code, country)
+        VALUES ($1, $2, 'Bratislava', '81101', 'Slovakia')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(format!("{slug} Street 1"))
+    .fetch_one(pool)
+    .await
+    .expect("seed building")
+}
+
+/// Seed an equipment row directly (as superuser, RLS-exempt) for an org.
+async fn seed_equipment(pool: &PgPool, org_id: Uuid, building_id: Uuid, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO equipment_registry (organization_id, building_id, name, equipment_type)
+        VALUES ($1, $2, $3, 'hvac')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(building_id)
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .expect("seed equipment")
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn predictive_repo_force_rls_deny_all_and_fix(pool: PgPool) {
+    let repo = PredictiveMaintenanceRepository::new(pool.clone());
+
+    // --- Seed as superuser / super-admin context (satisfies org roles-trigger). ---
+    set_ctx(&pool, None, None, true).await;
+    let org_a = seed_org(&pool, "pmforce-a").await;
+    let org_b = seed_org(&pool, "pmforce-b").await;
+    let user_a = seed_user(&pool, "a@pm.test").await;
+    let _user_b = seed_user(&pool, "b@pm.test").await;
+    let building_a = seed_building(&pool, org_a, "pmforce-a").await;
+    let building_b = seed_building(&pool, org_b, "pmforce-b").await;
+    let equip_a = seed_equipment(&pool, org_a, building_a, "Boiler A").await;
+    let equip_b = seed_equipment(&pool, org_b, building_b, "Boiler B").await;
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    let role = format!("ppt_rls_pm_{}", Uuid::new_v4().simple());
+    for stmt in [
+        format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
+        format!("GRANT SELECT, INSERT, UPDATE, DELETE ON equipment_registry TO \"{role}\""),
+        // RLS policy helper must be EXECUTE-able by the bound role.
+        format!("GRANT EXECUTE ON FUNCTION get_current_org_id() TO \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .expect("grant setup");
+    }
+
+    // ====================================================================
+    // (1) DENY-ALL reproduction: role bound, NO context set (the dev raw-pool
+    //     behavior). Own-org by-id read returns nothing.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        // Explicitly clear any inherited context, then drop to the bound role.
+        sqlx::query("SELECT clear_request_context()")
+            .execute(&mut *conn)
+            .await
+            .expect("clear ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let found = repo
+            .get_equipment(&mut *conn, equip_a, org_a)
+            .await
+            .expect("get_equipment (no ctx)");
+        assert!(
+            found.is_none(),
+            "PAP-80 regression: without RLS context, own-org equipment must be \
+             invisible (deny-all) — this is what the raw-pool repo did on dev"
+        );
+
+        let listed = repo
+            .list_equipment(&mut *conn, org_a, EquipmentQuery::default())
+            .await
+            .expect("list_equipment (no ctx)");
+        assert!(
+            listed.is_empty(),
+            "PAP-80 regression: without RLS context, list returns deny-all empty"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (2) FIX + (3) cross-tenant: set context, drop to bound role, query repo.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        // (2) Own-org row IS now visible through the repo — the fix.
+        let found = repo
+            .get_equipment(&mut *conn, equip_a, org_a)
+            .await
+            .expect("get_equipment (ctx)");
+        assert_eq!(
+            found.map(|e| e.id),
+            Some(equip_a),
+            "PAP-80 fix: with RLS context set, the repo must return the own-org equipment"
+        );
+
+        let listed = repo
+            .list_equipment(&mut *conn, org_a, EquipmentQuery::default())
+            .await
+            .expect("list_equipment (ctx)");
+        assert_eq!(
+            listed.iter().map(|e| e.id).collect::<Vec<_>>(),
+            vec![equip_a],
+            "PAP-80 fix: list returns exactly the own-org equipment under context"
+        );
+
+        // (3) Org B's equipment stays invisible to an org-A caller.
+        let cross = repo
+            .get_equipment(&mut *conn, equip_b, org_a)
+            .await
+            .expect("get_equipment cross");
+        assert!(
+            cross.is_none(),
+            "cross-tenant: org B's equipment must NOT be visible to an org-A caller"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup the test role. ---
+    set_ctx(&pool, None, None, true).await;
+    for stmt in [
+        format!("REVOKE ALL ON equipment_registry FROM \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .ok();
+    }
+}

--- a/backend/crates/db/tests/predictive_maintenance_sort_injection_tests.rs
+++ b/backend/crates/db/tests/predictive_maintenance_sort_injection_tests.rs
@@ -67,6 +67,7 @@ async fn seed_building(pool: &PgPool, org_id: Uuid, slug: &str) -> Uuid {
 
 async fn seed_equipment(
     repo: &PredictiveMaintenanceRepository,
+    pool: &PgPool,
     org_id: Uuid,
     user_id: Uuid,
     building_id: Uuid,
@@ -74,6 +75,7 @@ async fn seed_equipment(
 ) -> Uuid {
     let eq = repo
         .create_equipment(
+            pool,
             org_id,
             user_id,
             CreateEquipment {
@@ -110,8 +112,8 @@ async fn malicious_sort_order_does_not_inject(pool: PgPool) {
     let org = seed_org(&pool, "inj-order").await;
     let user = seed_user(&pool, "inj-order@pm-sort.test").await;
     let building = seed_building(&pool, org, "inj-order").await;
-    seed_equipment(&repo, org, user, building, "Boiler").await;
-    seed_equipment(&repo, org, user, building, "Chiller").await;
+    seed_equipment(&repo, &pool, org, user, building, "Boiler").await;
+    seed_equipment(&repo, &pool, org, user, building, "Chiller").await;
 
     let query = EquipmentQuery {
         sort_by: Some("name".to_string()),
@@ -120,7 +122,7 @@ async fn malicious_sort_order_does_not_inject(pool: PgPool) {
         ..Default::default()
     };
 
-    let result = repo.list_equipment(org, query).await;
+    let result = repo.list_equipment(&pool, org, query).await;
 
     // The injection must be neutralised — the query succeeds and returns the
     // two seeded rows, sorted ascending by name (the allowlisted default).
@@ -146,7 +148,7 @@ async fn malicious_sort_by_does_not_inject(pool: PgPool) {
     let org = seed_org(&pool, "inj-by").await;
     let user = seed_user(&pool, "inj-by@pm-sort.test").await;
     let building = seed_building(&pool, org, "inj-by").await;
-    seed_equipment(&repo, org, user, building, "Alpha").await;
+    seed_equipment(&repo, &pool, org, user, building, "Alpha").await;
 
     let query = EquipmentQuery {
         // Subquery / column injection attempt.
@@ -156,7 +158,7 @@ async fn malicious_sort_by_does_not_inject(pool: PgPool) {
     };
 
     let equipment = repo
-        .list_equipment(org, query)
+        .list_equipment(&pool, org, query)
         .await
         .expect("list_equipment must succeed despite malicious sort_by");
     assert_eq!(equipment.len(), 1);
@@ -171,8 +173,8 @@ async fn legitimate_desc_ordering_still_works(pool: PgPool) {
     let org = seed_org(&pool, "ok-desc").await;
     let user = seed_user(&pool, "ok-desc@pm-sort.test").await;
     let building = seed_building(&pool, org, "ok-desc").await;
-    seed_equipment(&repo, org, user, building, "Aaa").await;
-    seed_equipment(&repo, org, user, building, "Zzz").await;
+    seed_equipment(&repo, &pool, org, user, building, "Aaa").await;
+    seed_equipment(&repo, &pool, org, user, building, "Zzz").await;
 
     let query = EquipmentQuery {
         sort_by: Some("name".to_string()),
@@ -180,7 +182,7 @@ async fn legitimate_desc_ordering_still_works(pool: PgPool) {
         ..Default::default()
     };
 
-    let equipment = repo.list_equipment(org, query).await.expect("list");
+    let equipment = repo.list_equipment(&pool, org, query).await.expect("list");
     assert_eq!(equipment.len(), 2);
     assert_eq!(equipment[0].name, "Zzz", "desc must put Zzz first");
     assert_eq!(equipment[1].name, "Aaa");

--- a/backend/servers/api-server/src/routes/predictive_maintenance.rs
+++ b/backend/servers/api-server/src/routes/predictive_maintenance.rs
@@ -4,11 +4,25 @@
 //! - Story 134.2: Maintenance History Tracking
 //! - Story 134.3: Failure Prediction Engine
 //! - Story 134.4: Predictive Maintenance Dashboard
+//!
+//! # RLS (PAP-80)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` on the
+//! predictive-maintenance tables, so every query MUST run on a connection that
+//! has `app.current_org_id` set or it collapses to deny-all. Each handler
+//! therefore acquires an [`RlsConnection`] (which validates tenant membership
+//! and sets the org/user GUCs on a dedicated connection) and passes
+//! `&mut **rls.conn()` to the repository. The authoritative organization is
+//! `rls.tenant_id()` — the tenant the caller was validated against — so the SQL
+//! org filter and the RLS context can never disagree. Cross-tenant access is
+//! blocked by RLS: a by-id read of another org's row returns no row (`404`), and
+//! a write targeting another org fails the policy's `WITH CHECK`. `rls.release()`
+//! clears the context before the connection returns to the pool.
 
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
-    response::IntoResponse,
+    response::{IntoResponse, Response},
     routing::{delete, get, post, put},
     Json, Router,
 };
@@ -16,7 +30,7 @@ use serde::Deserialize;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-use api_core::extractors::AuthUser;
+use api_core::extractors::RlsConnection;
 
 use crate::state::AppState;
 
@@ -70,12 +84,9 @@ pub fn router() -> Router<AppState> {
         .route("/equipment/by-health", get(get_equipment_by_health))
 }
 
-// Helper to get org_id from AuthUser
-fn get_org_id(auth: &AuthUser) -> Result<Uuid, (StatusCode, String)> {
-    auth.tenant_id.ok_or((
-        StatusCode::BAD_REQUEST,
-        "No organization context".to_string(),
-    ))
+/// Build an internal-error response from a repository error.
+fn db_error(e: impl std::fmt::Display) -> Response {
+    (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
 }
 
 // ============================================================================
@@ -85,153 +96,142 @@ fn get_org_id(auth: &AuthUser) -> Result<Uuid, (StatusCode, String)> {
 /// Create new equipment.
 async fn create_equipment(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(req): Json<CreateEquipment>,
-) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+) -> Response {
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let resp = match s
         .predictive_maintenance_repo
-        .create_equipment(org_id, auth.user_id, req)
+        .create_equipment(&mut **rls.conn(), org_id, user_id, req)
         .await
     {
         Ok(equipment) => (StatusCode::CREATED, Json(equipment)).into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+        Err(e) => db_error(e),
+    };
+    rls.release().await;
+    resp
 }
 
 /// List equipment with filters.
 async fn list_equipment(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<EquipmentQuery>,
-) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+) -> Response {
+    let org_id = rls.tenant_id();
+    let resp = match s
         .predictive_maintenance_repo
-        .list_equipment(org_id, query)
+        .list_equipment(&mut **rls.conn(), org_id, query)
         .await
     {
         Ok(equipment) => Json(equipment).into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+        Err(e) => db_error(e),
+    };
+    rls.release().await;
+    resp
 }
 
 /// Get equipment by ID.
 async fn get_equipment(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+) -> Response {
+    let org_id = rls.tenant_id();
+    let resp = match s
         .predictive_maintenance_repo
-        .get_equipment(id, org_id)
+        .get_equipment(&mut **rls.conn(), id, org_id)
         .await
     {
         Ok(Some(equipment)) => Json(equipment).into_response(),
         Ok(None) => StatusCode::NOT_FOUND.into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+        Err(e) => db_error(e),
+    };
+    rls.release().await;
+    resp
 }
 
 /// Update equipment.
 async fn update_equipment(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateEquipment>,
-) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+) -> Response {
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let resp = match s
         .predictive_maintenance_repo
-        .update_equipment(id, org_id, auth.user_id, req)
+        .update_equipment(&mut **rls.conn(), id, org_id, user_id, req)
         .await
     {
         Ok(Some(equipment)) => Json(equipment).into_response(),
         Ok(None) => StatusCode::NOT_FOUND.into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+        Err(e) => db_error(e),
+    };
+    rls.release().await;
+    resp
 }
 
 /// Delete equipment.
 async fn delete_equipment(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+) -> Response {
+    let org_id = rls.tenant_id();
+    let resp = match s
         .predictive_maintenance_repo
-        .delete_equipment(id, org_id)
+        .delete_equipment(&mut **rls.conn(), id, org_id)
         .await
     {
         Ok(true) => StatusCode::NO_CONTENT.into_response(),
         Ok(false) => StatusCode::NOT_FOUND.into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+        Err(e) => db_error(e),
+    };
+    rls.release().await;
+    resp
 }
 
 /// Add document to equipment.
 async fn add_equipment_document(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<CreateEquipmentDocument>,
-) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+) -> Response {
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let resp = match s
         .predictive_maintenance_repo
-        .add_equipment_document(id, org_id, auth.user_id, req)
+        .add_equipment_document(&mut **rls.conn(), id, org_id, user_id, req)
         .await
     {
         Ok(doc) => (StatusCode::CREATED, Json(doc)).into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+        Err(e) => db_error(e),
+    };
+    rls.release().await;
+    resp
 }
 
 /// List equipment documents.
 async fn list_equipment_documents(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+) -> Response {
+    let org_id = rls.tenant_id();
+    let resp = match s
         .predictive_maintenance_repo
-        .list_equipment_documents(id, org_id)
+        .list_equipment_documents(&mut **rls.conn(), id, org_id)
         .await
     {
         Ok(docs) => Json(docs).into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+        Err(e) => db_error(e),
+    };
+    rls.release().await;
+    resp
 }
 
 // ============================================================================
@@ -241,67 +241,62 @@ async fn list_equipment_documents(
 /// Create maintenance log.
 async fn create_maintenance_log(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(req): Json<CreateMaintenanceLog>,
-) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+) -> Response {
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let resp = match s
         .predictive_maintenance_repo
-        .create_maintenance_log(org_id, auth.user_id, req)
+        .create_maintenance_log(&mut **rls.conn(), org_id, user_id, req)
         .await
     {
         Ok(log) => (StatusCode::CREATED, Json(log)).into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+        Err(e) => db_error(e),
+    };
+    rls.release().await;
+    resp
 }
 
 /// Get maintenance log by ID.
 async fn get_maintenance_log(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+) -> Response {
+    let org_id = rls.tenant_id();
+    let resp = match s
         .predictive_maintenance_repo
-        .get_maintenance_log(id, org_id)
+        .get_maintenance_log(&mut **rls.conn(), id, org_id)
         .await
     {
         Ok(Some(log)) => Json(log).into_response(),
         Ok(None) => StatusCode::NOT_FOUND.into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+        Err(e) => db_error(e),
+    };
+    rls.release().await;
+    resp
 }
 
 /// Update maintenance log.
 async fn update_maintenance_log(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateMaintenanceLog>,
-) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+) -> Response {
+    let org_id = rls.tenant_id();
+    let resp = match s
         .predictive_maintenance_repo
-        .update_maintenance_log(id, org_id, req)
+        .update_maintenance_log(&mut **rls.conn(), id, org_id, req)
         .await
     {
         Ok(Some(log)) => Json(log).into_response(),
         Ok(None) => StatusCode::NOT_FOUND.into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+        Err(e) => db_error(e),
+    };
+    rls.release().await;
+    resp
 }
 
 /// List maintenance logs for equipment.
@@ -313,26 +308,24 @@ struct PaginationQuery {
 
 async fn list_equipment_maintenance_logs(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(equipment_id): Path<Uuid>,
     Query(query): Query<PaginationQuery>,
-) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
+) -> Response {
+    let org_id = rls.tenant_id();
     let limit = query.limit.unwrap_or(50);
     let offset = query.offset.unwrap_or(0);
 
-    match s
+    let resp = match s
         .predictive_maintenance_repo
-        .list_maintenance_logs(equipment_id, org_id, limit, offset)
+        .list_maintenance_logs(&mut **rls.conn(), equipment_id, org_id, limit, offset)
         .await
     {
         Ok(logs) => Json(logs).into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+        Err(e) => db_error(e),
+    };
+    rls.release().await;
+    resp
 }
 
 /// Add photo to maintenance log.
@@ -347,31 +340,37 @@ struct AddPhotoRequest {
 
 async fn add_maintenance_photo(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(log_id): Path<Uuid>,
     Json(req): Json<AddPhotoRequest>,
-) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
+) -> Response {
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
 
     // Only allow attaching photos to a maintenance log the caller's org owns.
+    // Under RLS a foreign-org log_id is invisible and surfaces as 404.
     match s
         .predictive_maintenance_repo
-        .get_maintenance_log(log_id, org_id)
+        .get_maintenance_log(&mut **rls.conn(), log_id, org_id)
         .await
     {
         Ok(Some(_)) => {}
-        Ok(None) => return StatusCode::NOT_FOUND.into_response(),
-        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        Ok(None) => {
+            rls.release().await;
+            return StatusCode::NOT_FOUND.into_response();
+        }
+        Err(e) => {
+            rls.release().await;
+            return db_error(e);
+        }
     }
 
-    match s
+    let resp = match s
         .predictive_maintenance_repo
         .add_maintenance_photo(
+            &mut **rls.conn(),
             log_id,
-            auth.user_id,
+            user_id,
             &req.file_path,
             req.file_size,
             req.mime_type.as_deref(),
@@ -381,42 +380,49 @@ async fn add_maintenance_photo(
         .await
     {
         Ok(photo) => (StatusCode::CREATED, Json(photo)).into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+        Err(e) => db_error(e),
+    };
+    rls.release().await;
+    resp
 }
 
 /// List photos for maintenance log.
 async fn list_maintenance_photos(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(log_id): Path<Uuid>,
-) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
+) -> Response {
+    let org_id = rls.tenant_id();
 
     // Confirm the parent maintenance log belongs to the caller's org before
     // returning any photos. A foreign-org log_id surfaces as 404, never a
     // cross-tenant read (IDOR #848).
     match s
         .predictive_maintenance_repo
-        .get_maintenance_log(log_id, org_id)
+        .get_maintenance_log(&mut **rls.conn(), log_id, org_id)
         .await
     {
         Ok(Some(_)) => {}
-        Ok(None) => return StatusCode::NOT_FOUND.into_response(),
-        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        Ok(None) => {
+            rls.release().await;
+            return StatusCode::NOT_FOUND.into_response();
+        }
+        Err(e) => {
+            rls.release().await;
+            return db_error(e);
+        }
     }
 
-    match s
+    let resp = match s
         .predictive_maintenance_repo
-        .list_maintenance_photos(log_id, org_id)
+        .list_maintenance_photos(&mut **rls.conn(), log_id, org_id)
         .await
     {
         Ok(photos) => Json(photos).into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+        Err(e) => db_error(e),
+    };
+    rls.release().await;
+    resp
 }
 
 // ============================================================================
@@ -426,13 +432,10 @@ async fn list_maintenance_photos(
 /// Run prediction for equipment.
 async fn run_prediction(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(req): Json<RunPredictionRequest>,
-) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
+) -> Response {
+    let org_id = rls.tenant_id();
 
     // Run prediction for specified equipment or all
     let equipment_ids = if let Some(ids) = req.equipment_ids {
@@ -445,12 +448,13 @@ async fn run_prediction(
         };
         match s
             .predictive_maintenance_repo
-            .list_equipment(org_id, query)
+            .list_equipment(&mut **rls.conn(), org_id, query)
             .await
         {
             Ok(equipment) => equipment.into_iter().map(|e| e.id).collect(),
             Err(e) => {
-                return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+                rls.release().await;
+                return db_error(e);
             }
         }
     };
@@ -460,7 +464,7 @@ async fn run_prediction(
     for equipment_id in equipment_ids {
         match s
             .predictive_maintenance_repo
-            .run_prediction(equipment_id, org_id)
+            .run_prediction(rls.conn(), equipment_id, org_id)
             .await
         {
             Ok(result) => results.push(result),
@@ -470,16 +474,17 @@ async fn run_prediction(
         }
     }
 
+    rls.release().await;
     Json(results).into_response()
 }
 
 /// Run batch predictions.
 async fn run_batch_predictions(
     State(s): State<AppState>,
-    auth: AuthUser,
+    rls: RlsConnection,
     Json(req): Json<RunPredictionRequest>,
-) -> impl IntoResponse {
-    run_prediction(State(s), auth, Json(req)).await
+) -> Response {
+    run_prediction(State(s), rls, Json(req)).await
 }
 
 /// Get prediction history for equipment.
@@ -490,25 +495,23 @@ struct PredictionHistoryQuery {
 
 async fn get_equipment_predictions(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(equipment_id): Path<Uuid>,
     Query(query): Query<PredictionHistoryQuery>,
-) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
+) -> Response {
+    let org_id = rls.tenant_id();
     let limit = query.limit.unwrap_or(20);
 
-    match s
+    let resp = match s
         .predictive_maintenance_repo
-        .get_prediction_history(equipment_id, org_id, limit)
+        .get_prediction_history(&mut **rls.conn(), equipment_id, org_id, limit)
         .await
     {
         Ok(predictions) => Json(predictions).into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+        Err(e) => db_error(e),
+    };
+    rls.release().await;
+    resp
 }
 
 // ============================================================================
@@ -526,20 +529,17 @@ struct AlertQuery {
 
 async fn list_alerts(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<AlertQuery>,
-) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
+) -> Response {
+    let org_id = rls.tenant_id();
     let limit = query.limit.unwrap_or(50);
     let offset = query.offset.unwrap_or(0);
 
-    match s
+    let resp = match s
         .predictive_maintenance_repo
         .list_alerts(
+            &mut **rls.conn(),
             org_id,
             query.status.as_deref(),
             query.severity.as_deref(),
@@ -549,76 +549,80 @@ async fn list_alerts(
         .await
     {
         Ok(alerts) => Json(alerts).into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+        Err(e) => db_error(e),
+    };
+    rls.release().await;
+    resp
 }
 
 /// Acknowledge alert.
 async fn acknowledge_alert(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(_req): Json<AcknowledgeAlertRequest>,
-) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+) -> Response {
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let resp = match s
         .predictive_maintenance_repo
-        .acknowledge_alert(id, org_id, auth.user_id)
+        .acknowledge_alert(&mut **rls.conn(), id, org_id, user_id)
         .await
     {
         Ok(Some(alert)) => Json(alert).into_response(),
         Ok(None) => StatusCode::NOT_FOUND.into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+        Err(e) => db_error(e),
+    };
+    rls.release().await;
+    resp
 }
 
 /// Resolve alert.
 async fn resolve_alert(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<ResolveAlertRequest>,
-) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+) -> Response {
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let resp = match s
         .predictive_maintenance_repo
-        .resolve_alert(id, org_id, auth.user_id, req.maintenance_log_id)
+        .resolve_alert(
+            &mut **rls.conn(),
+            id,
+            org_id,
+            user_id,
+            req.maintenance_log_id,
+        )
         .await
     {
         Ok(Some(alert)) => Json(alert).into_response(),
         Ok(None) => StatusCode::NOT_FOUND.into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+        Err(e) => db_error(e),
+    };
+    rls.release().await;
+    resp
 }
 
 /// Dismiss alert.
 async fn dismiss_alert(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+) -> Response {
+    let org_id = rls.tenant_id();
+    let resp = match s
         .predictive_maintenance_repo
-        .dismiss_alert(id, org_id)
+        .dismiss_alert(&mut **rls.conn(), id, org_id)
         .await
     {
         Ok(Some(alert)) => Json(alert).into_response(),
         Ok(None) => StatusCode::NOT_FOUND.into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+        Err(e) => db_error(e),
+    };
+    rls.release().await;
+    resp
 }
 
 // ============================================================================
@@ -626,41 +630,37 @@ async fn dismiss_alert(
 // ============================================================================
 
 /// List health thresholds.
-async fn list_health_thresholds(State(s): State<AppState>, auth: AuthUser) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+async fn list_health_thresholds(State(s): State<AppState>, mut rls: RlsConnection) -> Response {
+    let org_id = rls.tenant_id();
+    let resp = match s
         .predictive_maintenance_repo
-        .list_health_thresholds(org_id)
+        .list_health_thresholds(&mut **rls.conn(), org_id)
         .await
     {
         Ok(thresholds) => Json(thresholds).into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+        Err(e) => db_error(e),
+    };
+    rls.release().await;
+    resp
 }
 
 /// Set health threshold.
 async fn set_health_threshold(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(req): Json<SetHealthThreshold>,
-) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+) -> Response {
+    let org_id = rls.tenant_id();
+    let resp = match s
         .predictive_maintenance_repo
-        .set_health_threshold(org_id, req)
+        .set_health_threshold(&mut **rls.conn(), org_id, req)
         .await
     {
         Ok(threshold) => Json(threshold).into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+        Err(e) => db_error(e),
+    };
+    rls.release().await;
+    resp
 }
 
 // ============================================================================
@@ -676,22 +676,20 @@ struct DashboardQuery {
 /// Get maintenance dashboard.
 async fn get_dashboard(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<DashboardQuery>,
-) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
-    match s
+) -> Response {
+    let org_id = rls.tenant_id();
+    let resp = match s
         .predictive_maintenance_repo
-        .get_dashboard(org_id, query.building_id)
+        .get_dashboard(rls.conn(), org_id, query.building_id)
         .await
     {
         Ok(dashboard) => Json(dashboard).into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+        Err(e) => db_error(e),
+    };
+    rls.release().await;
+    resp
 }
 
 /// Get equipment sorted by health score.
@@ -703,22 +701,20 @@ struct ByHealthQuery {
 
 async fn get_equipment_by_health(
     State(s): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<ByHealthQuery>,
-) -> impl IntoResponse {
-    let org_id = match get_org_id(&auth) {
-        Ok(id) => id,
-        Err(e) => return e.into_response(),
-    };
-
+) -> Response {
+    let org_id = rls.tenant_id();
     let limit = query.limit.unwrap_or(20);
 
-    match s
+    let resp = match s
         .predictive_maintenance_repo
-        .get_equipment_by_health(org_id, query.building_id, limit)
+        .get_equipment_by_health(&mut **rls.conn(), org_id, query.building_id, limit)
         .await
     {
         Ok(equipment) => Json(equipment).into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+        Err(e) => db_error(e),
+    };
+    rls.release().await;
+    resp
 }


### PR DESCRIPTION
## What

Part of the **PAP-80** raw-pool → RLS sweep. `PredictiveMaintenanceRepository` held a raw `PgPool` and queried **8 FORCE-RLS tables** (migration `00179`) without ever setting `app.current_org_id`, so under `FORCE` the api-server's owner connection collapsed to **deny-all** on `dev` (own-org reads empty, writes failed `WITH CHECK`).

Tables: `equipment_registry`, `equipment_documents`, `maintenance_logs`, `maintenance_log_photos`, `equipment_predictions`, `maintenance_alerts`, `equipment_health_thresholds`.

## How

Follows the proven `work_order.rs` / `budget.rs` / `document.rs` precedent:

- Repo holds **no pool** — `new(_pool)` keeps the construction-site signature but stores nothing.
- Single-statement methods take a generic `E: Executor`; the two multi-statement methods (`run_prediction`, `get_dashboard`) take `&mut PgConnection` and reborrow per query.
- Handlers acquire the `RlsConnection` extractor, pass `&mut **rls.conn()` (or `rls.conn()` where deref-coercion applies), use `rls.tenant_id()` as the authoritative org, and call `rls.release()`.
- Photo endpoints keep their parent-log ownership pre-check; under RLS a foreign-org `log_id` now resolves to `404` via the database, not a raw-pool lookup.

No raw-pool query path remains in this repo. One repo = one PR, matching the sweep cadence.

## Tests

- **New** `predictive_maintenance_rls_repo_tests.rs` — by-id read role-switch test mirroring `vendor_rls_repo_tests.rs`: (1) deny-all without context, (2) own-org visibility with `set_request_context`, (3) cross-tenant invisibility — all on a `NOSUPERUSER NOBYPASSRLS` role so `FORCE` actually binds (`#[sqlx::test]` superuser would pass vacuously).
- Updated `predictive_maintenance_sort_injection_tests.rs` to the new executor-passing signatures.

## Verification

`cargo check -p db`, `cargo check -p api-server`, `cargo fmt --check`, and `cargo clippy -p api-server` all **green** on the remote builder (mercury). DB behavioral tests run under the `backend.yml` CI Postgres service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)