### PR TITLE
fix(db): route sentiment repo through RLS-context connection (PAP-80)

### DIFF
--- a/backend/crates/db/src/repositories/sentiment.rs
+++ b/backend/crates/db/src/repositories/sentiment.rs
@@ -1,30 +1,55 @@
 //! Sentiment analysis repository (Epic 13, Story 13.2).
+//!
+//! # RLS Integration (PAP-67 / PAP-80)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on `sentiment_trends`, `sentiment_alerts`, and
+//! `sentiment_thresholds`. Under `FORCE` the api-server's owner connection is no
+//! longer exempt, so a query issued on a connection without `app.current_org_id`
+//! set collapses to deny-all (own-org reads return empty, writes fail the policy
+//! `WITH CHECK`).
+//!
+//! Every method therefore takes an **executor whose connection already has RLS
+//! context set** (org + user GUCs) — in handlers this comes from the
+//! `RlsConnection` extractor via `&mut **rls.conn()`. The repository holds **no
+//! pool**, so there is no way to issue a query that bypasses RLS. This mirrors
+//! the `work_order.rs` / `vendor.rs` precedent.
 
 use crate::models::{
     CreateSentimentAlert, SentimentAlert, SentimentThresholds, SentimentTrend, SentimentTrendQuery,
     UpdateSentimentThresholds, UpsertSentimentTrend,
 };
 use chrono::NaiveDate;
-use sqlx::PgPool;
+use sqlx::{Executor, PgConnection, PgPool, Postgres};
 use uuid::Uuid;
 
 /// Repository for sentiment analysis operations.
+///
+/// Stateless: every method receives an RLS-context-bearing executor. The repo
+/// holds no pool so it cannot issue an un-scoped (deny-all under `FORCE`) query.
 #[derive(Clone)]
-pub struct SentimentRepository {
-    pool: PgPool,
-}
+pub struct SentimentRepository;
 
 impl SentimentRepository {
     /// Create a new repository instance.
-    pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+    ///
+    /// The pool argument is retained for construction-site compatibility with
+    /// the other repositories on `AppState`; this repo deliberately does not
+    /// store it (see module docs — all queries run on a context-set connection
+    /// supplied by the handler's `RlsConnection`).
+    pub fn new(_pool: PgPool) -> Self {
+        Self
     }
 
     /// Upsert a sentiment trend record.
-    pub async fn upsert_trend(
+    pub async fn upsert_trend<'e, E>(
         &self,
+        executor: E,
         data: UpsertSentimentTrend,
-    ) -> Result<SentimentTrend, sqlx::Error> {
+    ) -> Result<SentimentTrend, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO sentiment_trends
@@ -48,16 +73,20 @@ impl SentimentRepository {
         .bind(data.negative_count)
         .bind(data.neutral_count)
         .bind(data.positive_count)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get sentiment trends.
-    pub async fn list_trends(
+    pub async fn list_trends<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: SentimentTrendQuery,
-    ) -> Result<Vec<SentimentTrend>, sqlx::Error> {
+    ) -> Result<Vec<SentimentTrend>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(30);
         let from_date = query
             .from_date
@@ -81,7 +110,7 @@ impl SentimentRepository {
             .bind(from_date)
             .bind(to_date)
             .bind(limit)
-            .fetch_all(&self.pool)
+            .fetch_all(executor)
             .await
         } else {
             sqlx::query_as(
@@ -97,16 +126,20 @@ impl SentimentRepository {
             .bind(from_date)
             .bind(to_date)
             .bind(limit)
-            .fetch_all(&self.pool)
+            .fetch_all(executor)
             .await
         }
     }
 
     /// Create a sentiment alert.
-    pub async fn create_alert(
+    pub async fn create_alert<'e, E>(
         &self,
+        executor: E,
         data: CreateSentimentAlert,
-    ) -> Result<SentimentAlert, sqlx::Error> {
+    ) -> Result<SentimentAlert, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO sentiment_alerts
@@ -122,18 +155,22 @@ impl SentimentRepository {
         .bind(data.current_sentiment)
         .bind(data.previous_sentiment)
         .bind(&data.sample_message_ids)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// List alerts for organization.
-    pub async fn list_alerts(
+    pub async fn list_alerts<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         acknowledged: Option<bool>,
         limit: i64,
         offset: i64,
-    ) -> Result<Vec<SentimentAlert>, sqlx::Error> {
+    ) -> Result<Vec<SentimentAlert>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         match acknowledged {
             Some(ack) => {
                 sqlx::query_as(
@@ -148,7 +185,7 @@ impl SentimentRepository {
                 .bind(ack)
                 .bind(limit)
                 .bind(offset)
-                .fetch_all(&self.pool)
+                .fetch_all(executor)
                 .await
             }
             None => {
@@ -163,7 +200,7 @@ impl SentimentRepository {
                 .bind(org_id)
                 .bind(limit)
                 .bind(offset)
-                .fetch_all(&self.pool)
+                .fetch_all(executor)
                 .await
             }
         }
@@ -171,17 +208,22 @@ impl SentimentRepository {
 
     /// Acknowledge an alert — tenant-scoped.
     ///
-    /// `org_id` must originate from the verified request principal.
-    /// `WHERE id = $1 AND organization_id = $2` ensures a caller in org B
-    /// cannot acknowledge an alert that belongs to org A; `fetch_one` returns
-    /// `RowNotFound` when either the alert does not exist or belongs to a
-    /// different tenant (callers should surface both as 404).
-    pub async fn acknowledge_alert(
+    /// `org_id` is the authoritative tenant from `RlsConnection::tenant_id()`.
+    /// The `WHERE id = $1 AND organization_id = $2` clause plus the active
+    /// `FORCE` RLS policy both scope the write to the caller's org, so a caller
+    /// in org B cannot acknowledge an alert that belongs to org A; `fetch_one`
+    /// returns `RowNotFound` when either the alert does not exist or belongs to
+    /// a different tenant (callers should surface both as 404).
+    pub async fn acknowledge_alert<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
         user_id: Uuid,
-    ) -> Result<SentimentAlert, sqlx::Error> {
+    ) -> Result<SentimentAlert, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE sentiment_alerts
@@ -193,17 +235,25 @@ impl SentimentRepository {
         .bind(id)
         .bind(org_id)
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get or create sentiment thresholds for organization.
-    pub async fn get_thresholds(&self, org_id: Uuid) -> Result<SentimentThresholds, sqlx::Error> {
+    ///
+    /// Multi-statement (SELECT then conditional INSERT), so it takes a
+    /// `&mut PgConnection` and reborrows for each query rather than a generic
+    /// by-value executor.
+    pub async fn get_thresholds(
+        &self,
+        conn: &mut PgConnection,
+        org_id: Uuid,
+    ) -> Result<SentimentThresholds, sqlx::Error> {
         // Try to get existing
         let existing: Option<SentimentThresholds> =
             sqlx::query_as("SELECT * FROM sentiment_thresholds WHERE organization_id = $1")
                 .bind(org_id)
-                .fetch_optional(&self.pool)
+                .fetch_optional(&mut *conn)
                 .await?;
 
         match existing {
@@ -218,18 +268,22 @@ impl SentimentRepository {
                     "#,
                 )
                 .bind(org_id)
-                .fetch_one(&self.pool)
+                .fetch_one(&mut *conn)
                 .await
             }
         }
     }
 
     /// Update sentiment thresholds.
-    pub async fn update_thresholds(
+    pub async fn update_thresholds<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         data: UpdateSentimentThresholds,
-    ) -> Result<SentimentThresholds, sqlx::Error> {
+    ) -> Result<SentimentThresholds, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE sentiment_thresholds SET
@@ -249,17 +303,21 @@ impl SentimentRepository {
         .bind(data.spike_threshold_change)
         .bind(data.min_messages_for_alert)
         .bind(data.enabled)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get organization average sentiment for a date range.
-    pub async fn get_org_average_sentiment(
+    pub async fn get_org_average_sentiment<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         from_date: NaiveDate,
         to_date: NaiveDate,
-    ) -> Result<f64, sqlx::Error> {
+    ) -> Result<f64, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result: (Option<f64>,) = sqlx::query_as(
             r#"
             SELECT AVG(avg_sentiment) as avg
@@ -271,7 +329,7 @@ impl SentimentRepository {
         .bind(org_id)
         .bind(from_date)
         .bind(to_date)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await?;
 
         Ok(result.0.unwrap_or(0.0))

--- a/backend/crates/db/tests/sentiment_rls_repo_tests.rs
+++ b/backend/crates/db/tests/sentiment_rls_repo_tests.rs
@@ -1,0 +1,267 @@
+//! Repo-level behavioral RLS regression test for PAP-80 (parent PAP-67).
+//!
+//! Background
+//! ----------
+//! Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on `sentiment_alerts`, `sentiment_thresholds`,
+//! and `sentiment_trends`. The production api-server connects as the table
+//! OWNER, which `FORCE` binds. `SentimentRepository` held a raw `PgPool` and ran
+//! every query WITHOUT ever calling `set_request_context`, so on `dev`
+//! `get_current_org_id()` returned NULL and the policy collapsed to
+//! `organization_id = NULL` → **deny-all**: own-org reads returned empty, writes
+//! failed. (PAP-80.)
+//!
+//! The fix makes the repo stateless: every method takes an RLS-context
+//! connection (the `RlsConnection` extractor in handlers sets the org/user GUCs
+//! before any query). This test exercises the *repository methods themselves* on
+//! a `FORCE`-bound role and proves:
+//!
+//!   1. **Deny-all reproduction** — with the role bound but NO context set
+//!      (exactly what the raw-pool repo did on `dev`), an own-org `list_alerts`
+//!      returns nothing.
+//!   2. **Fix** — with `set_request_context(org_a, user_a)` applied first (what
+//!      `RlsConnection` now does), the same call returns the own-org row.
+//!   3. **Cross-tenant by-id** — org B's alert cannot be acknowledged by an
+//!      org-A caller: the by-id `acknowledge_alert` surfaces `RowNotFound`,
+//!      while the own-org alert acknowledges fine.
+//!   4. **Write path** — a `create_alert` on a context-set connection succeeds
+//!      and the row is the caller's org (the write-side of deny-all).
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — even `FORCE` does not bind a superuser, so a behavioral assertion
+//! would pass vacuously. The test creates a plain `NOSUPERUSER NOBYPASSRLS`
+//! role, grants it access, and `SET ROLE`s to it so `FORCE` actually enforces
+//! the policy the way the production owner role experiences it. Mirrors
+//! `emergency_rls_repo_tests.rs` / `vendor_rls_repo_tests.rs` (the PAP-67
+//! precedent PAP-80 follows).
+
+use db::models::CreateSentimentAlert;
+use db::repositories::SentimentRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Sentiment {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@sentiment.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'Sentiment User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Seed an alert directly (as superuser, RLS-exempt) for an org.
+async fn seed_alert(pool: &PgPool, org_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO sentiment_alerts
+            (organization_id, alert_type, threshold_breached, current_sentiment)
+        VALUES ($1, 'spike_negative', -0.5, -0.7)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed alert")
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn sentiment_repo_force_rls_deny_all_and_fix(pool: PgPool) {
+    let repo = SentimentRepository::new(pool.clone());
+
+    // --- Seed as superuser / super-admin context (satisfies org roles-trigger). ---
+    set_ctx(&pool, None, None, true).await;
+    let org_a = seed_org(&pool, "sforce-a").await;
+    let org_b = seed_org(&pool, "sforce-b").await;
+    let user_a = seed_user(&pool, "a@sentiment.test").await;
+    let _user_b = seed_user(&pool, "b@sentiment.test").await;
+    let alert_a = seed_alert(&pool, org_a).await;
+    let alert_b = seed_alert(&pool, org_b).await;
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    let role = format!("ppt_rls_sentiment_{}", Uuid::new_v4().simple());
+    for stmt in [
+        format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
+        format!("GRANT SELECT, INSERT, UPDATE, DELETE ON sentiment_alerts TO \"{role}\""),
+        // RLS policy helpers must be EXECUTE-able by the bound role.
+        format!("GRANT EXECUTE ON FUNCTION get_current_org_id() TO \"{role}\""),
+        format!("GRANT EXECUTE ON FUNCTION get_current_org_not_deleted() TO \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .expect("grant setup");
+    }
+
+    // ====================================================================
+    // (1) DENY-ALL reproduction: role bound, NO context set (the dev raw-pool
+    //     behavior). Own-org reads return nothing.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        // Explicitly clear any inherited context, then drop to the bound role.
+        sqlx::query("SELECT clear_request_context()")
+            .execute(&mut *conn)
+            .await
+            .expect("clear ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let listed = repo
+            .list_alerts(&mut *conn, org_a, None, 50, 0)
+            .await
+            .expect("list_alerts (no ctx)");
+        assert!(
+            listed.is_empty(),
+            "PAP-80 regression: without RLS context, own-org alerts must be \
+             invisible (deny-all) — this is what the raw-pool repo did on dev"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (2) FIX + (3) cross-tenant by-id: set context, drop to bound role, query.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        // (2) Own-org alert IS now visible through the repo — the fix.
+        let listed = repo
+            .list_alerts(&mut *conn, org_a, None, 50, 0)
+            .await
+            .expect("list_alerts (ctx)");
+        assert_eq!(
+            listed.iter().map(|a| a.id).collect::<Vec<_>>(),
+            vec![alert_a],
+            "PAP-80 fix: with RLS context set, list returns exactly the own-org alert"
+        );
+
+        // (3) Cross-tenant by-id write: org B's alert cannot be acknowledged by
+        //     an org-A caller — the by-id UPDATE matches no visible row.
+        let cross = repo
+            .acknowledge_alert(&mut *conn, alert_b, org_a, user_a)
+            .await;
+        assert!(
+            matches!(cross, Err(sqlx::Error::RowNotFound)),
+            "cross-tenant: org B's alert must NOT be acknowledgeable by an org-A caller \
+             (expected RowNotFound, got {cross:?})"
+        );
+
+        // Own-org by-id acknowledge succeeds.
+        let acked = repo
+            .acknowledge_alert(&mut *conn, alert_a, org_a, user_a)
+            .await
+            .expect("acknowledge own-org alert under context must succeed");
+        assert_eq!(acked.id, alert_a);
+        assert!(acked.acknowledged, "own-org alert is now acknowledged");
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (4) WRITE path: a create on a context-set connection succeeds and the
+    //     row is the caller's org. Without context the INSERT would fail the
+    //     policy WITH CHECK (the write-side of deny-all).
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let created = repo
+            .create_alert(
+                &mut *conn,
+                CreateSentimentAlert {
+                    organization_id: org_a,
+                    building_id: None,
+                    alert_type: "anomaly".to_string(),
+                    threshold_breached: -0.4,
+                    current_sentiment: -0.6,
+                    previous_sentiment: None,
+                    sample_message_ids: vec![],
+                },
+            )
+            .await
+            .expect("create_alert under context must succeed");
+        assert_eq!(created.organization_id, org_a);
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup the test role. ---
+    set_ctx(&pool, None, None, true).await;
+    for stmt in [
+        format!("REVOKE ALL ON sentiment_alerts FROM \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .ok();
+    }
+}

--- a/backend/servers/api-server/src/routes/ai/sessions.rs
+++ b/backend/servers/api-server/src/routes/ai/sessions.rs
@@ -3,6 +3,7 @@
 use crate::routes::ai::{require_tenant_id, AlertsQuery, PaginationQuery};
 use crate::state::AppState;
 use api_core::extractors::principal::RequestPrincipal;
+use api_core::extractors::RlsConnection;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -294,59 +295,107 @@ async fn send_message(
         if analyze_sentiment {
             match state.llm_client.analyze_sentiment(&req.content, None).await {
                 Ok(result) => {
-                    // Check if alert should be triggered based on organization thresholds
-                    if let Ok(thresholds) = state.sentiment_repo.get_thresholds(tenant_id).await {
-                        if thresholds.enabled {
-                            // Story 97.4: Check if sentiment requires attention and create alert
-                            let should_alert = result.requires_attention
-                                || (result.score < 0.0
-                                    && result.score.abs() >= thresholds.negative_threshold);
+                    // PAP-80: the sentiment tables are FORCE-RLS, so these
+                    // best-effort writes must run on a connection that carries
+                    // the org GUC (the raw pool collapses to deny-all). Acquire a
+                    // short-lived RLS-context connection scoped to this tenant.
+                    match state.db.acquire().await {
+                        Ok(mut sconn) => {
+                            if db::tenant_context::set_request_context(
+                                &mut *sconn,
+                                Some(tenant_id),
+                                Some(principal.user_id),
+                                false,
+                            )
+                            .await
+                            .is_err()
+                            {
+                                tracing::warn!("Failed to set RLS context for sentiment write");
+                            } else {
+                                // Check if alert should be triggered based on organization thresholds
+                                if let Ok(thresholds) = state
+                                    .sentiment_repo
+                                    .get_thresholds(&mut sconn, tenant_id)
+                                    .await
+                                {
+                                    if thresholds.enabled {
+                                        // Story 97.4: Check if sentiment requires attention and create alert
+                                        let should_alert = result.requires_attention
+                                            || (result.score < 0.0
+                                                && result.score.abs()
+                                                    >= thresholds.negative_threshold);
 
-                            if should_alert {
-                                let alert = CreateSentimentAlert {
-                                    organization_id: tenant_id,
-                                    building_id: None, // Could be extracted from session context
-                                    alert_type: alert_type::SPIKE_NEGATIVE.to_string(),
-                                    threshold_breached: thresholds.negative_threshold,
-                                    current_sentiment: result.score,
-                                    previous_sentiment: None,
-                                    sample_message_ids: vec![user_msg.id],
-                                };
+                                        if should_alert {
+                                            let alert = CreateSentimentAlert {
+                                                organization_id: tenant_id,
+                                                building_id: None, // Could be extracted from session context
+                                                alert_type: alert_type::SPIKE_NEGATIVE.to_string(),
+                                                threshold_breached: thresholds.negative_threshold,
+                                                current_sentiment: result.score,
+                                                previous_sentiment: None,
+                                                sample_message_ids: vec![user_msg.id],
+                                            };
 
-                                if let Err(e) = state.sentiment_repo.create_alert(alert).await {
-                                    tracing::warn!("Failed to create sentiment alert: {}", e);
-                                } else {
-                                    tracing::info!(
-                                        "Created sentiment alert for message {} (score: {:.2})",
-                                        user_msg.id,
-                                        result.score
-                                    );
+                                            if let Err(e) = state
+                                                .sentiment_repo
+                                                .create_alert(&mut *sconn, alert)
+                                                .await
+                                            {
+                                                tracing::warn!(
+                                                    "Failed to create sentiment alert: {}",
+                                                    e
+                                                );
+                                            } else {
+                                                tracing::info!(
+                                                    "Created sentiment alert for message {} (score: {:.2})",
+                                                    user_msg.id,
+                                                    result.score
+                                                );
+                                            }
+                                        }
+
+                                        // Update daily sentiment trend
+                                        let today = chrono::Utc::now().date_naive();
+                                        let (neg, neut, pos) = match result.label.as_str() {
+                                            "negative" => (1, 0, 0),
+                                            "neutral" => (0, 1, 0),
+                                            "positive" => (0, 0, 1),
+                                            _ => (0, 0, 0),
+                                        };
+
+                                        let trend_data = UpsertSentimentTrend {
+                                            organization_id: tenant_id,
+                                            building_id: None,
+                                            date: today,
+                                            avg_sentiment: result.score,
+                                            message_count: 1,
+                                            negative_count: neg,
+                                            neutral_count: neut,
+                                            positive_count: pos,
+                                        };
+
+                                        if let Err(e) = state
+                                            .sentiment_repo
+                                            .upsert_trend(&mut *sconn, trend_data)
+                                            .await
+                                        {
+                                            tracing::warn!(
+                                                "Failed to update sentiment trend: {}",
+                                                e
+                                            );
+                                        }
+                                    }
                                 }
                             }
 
-                            // Update daily sentiment trend
-                            let today = chrono::Utc::now().date_naive();
-                            let (neg, neut, pos) = match result.label.as_str() {
-                                "negative" => (1, 0, 0),
-                                "neutral" => (0, 1, 0),
-                                "positive" => (0, 0, 1),
-                                _ => (0, 0, 0),
-                            };
-
-                            let trend_data = UpsertSentimentTrend {
-                                organization_id: tenant_id,
-                                building_id: None,
-                                date: today,
-                                avg_sentiment: result.score,
-                                message_count: 1,
-                                negative_count: neg,
-                                neutral_count: neut,
-                                positive_count: pos,
-                            };
-
-                            if let Err(e) = state.sentiment_repo.upsert_trend(trend_data).await {
-                                tracing::warn!("Failed to update sentiment trend: {}", e);
-                            }
+                            // Clear context before the connection returns to the pool.
+                            let _ = db::tenant_context::clear_request_context(&mut *sconn).await;
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "Failed to acquire connection for sentiment write: {}",
+                                e
+                            );
                         }
                     }
 
@@ -802,12 +851,19 @@ pub fn sentiment_router() -> Router<AppState> {
 
 async fn get_trends(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Query(query): Query<SentimentTrendQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
+    // RLS context (org GUC) is set on rls.conn(); tenant_id is the authoritative org.
+    let tenant_id = rls.tenant_id();
 
-    match state.sentiment_repo.list_trends(tenant_id, query).await {
+    let result = state
+        .sentiment_repo
+        .list_trends(&mut **rls.conn(), tenant_id, query)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(trends) => Ok(Json(serde_json::json!({ "trends": trends }))),
         Err(e) => {
             tracing::error!("Failed to get trends: {}", e);
@@ -821,21 +877,24 @@ async fn get_trends(
 
 async fn list_alerts(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Query(query): Query<AlertsQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
+    let tenant_id = rls.tenant_id();
 
-    match state
+    let result = state
         .sentiment_repo
         .list_alerts(
+            &mut **rls.conn(),
             tenant_id,
             query.acknowledged,
             query.limit.unwrap_or(50),
             query.offset.unwrap_or(0),
         )
-        .await
-    {
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(alerts) => Ok(Json(serde_json::json!({ "alerts": alerts }))),
         Err(e) => {
             tracing::error!("Failed to list alerts: {}", e);
@@ -852,16 +911,19 @@ async fn list_alerts(
 
 async fn acknowledge_alert(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(alert_id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_tenant_id(&principal)?;
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
 
-    match state
+    let result = state
         .sentiment_repo
-        .acknowledge_alert(alert_id, org_id, principal.user_id)
-        .await
-    {
+        .acknowledge_alert(&mut **rls.conn(), alert_id, org_id, user_id)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(alert) => Ok(Json(serde_json::json!(alert))),
         Err(sqlx::Error::RowNotFound) => Err((
             StatusCode::NOT_FOUND,
@@ -882,11 +944,17 @@ async fn acknowledge_alert(
 
 async fn get_thresholds(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
+    let tenant_id = rls.tenant_id();
 
-    match state.sentiment_repo.get_thresholds(tenant_id).await {
+    let result = state
+        .sentiment_repo
+        .get_thresholds(rls.conn(), tenant_id)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(thresholds) => Ok(Json(serde_json::json!(thresholds))),
         Err(e) => {
             tracing::error!("Failed to get thresholds: {}", e);
@@ -903,12 +971,18 @@ async fn get_thresholds(
 
 async fn update_thresholds(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Json(req): Json<UpdateSentimentThresholds>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
+    let tenant_id = rls.tenant_id();
 
-    match state.sentiment_repo.update_thresholds(tenant_id, req).await {
+    let result = state
+        .sentiment_repo
+        .update_thresholds(&mut **rls.conn(), tenant_id, req)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(thresholds) => Ok(Json(serde_json::json!(thresholds))),
         Err(e) => {
             tracing::error!("Failed to update thresholds: {}", e);
@@ -922,56 +996,42 @@ async fn update_thresholds(
 
 async fn get_dashboard(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_tenant_id(&principal)?;
+    let org_id = rls.tenant_id();
     let today = chrono::Utc::now().date_naive();
     let thirty_days_ago = today - chrono::Duration::days(30);
 
-    let org_avg = state
-        .sentiment_repo
-        .get_org_average_sentiment(org_id, thirty_days_ago, today)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to get org average sentiment: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to get dashboard",
-                )),
-            )
-        })?;
+    // Run all three reads on the same RLS-context connection, then release once.
+    // Errors are captured (not early-returned) so release() always runs.
+    let dashboard = async {
+        let org_avg = state
+            .sentiment_repo
+            .get_org_average_sentiment(&mut **rls.conn(), org_id, thirty_days_ago, today)
+            .await?;
+        let trends = state
+            .sentiment_repo
+            .list_trends(&mut **rls.conn(), org_id, SentimentTrendQuery::default())
+            .await?;
+        let alerts = state
+            .sentiment_repo
+            .list_alerts(&mut **rls.conn(), org_id, Some(false), 5, 0)
+            .await?;
+        Ok::<_, sqlx::Error>((org_avg, trends, alerts))
+    }
+    .await;
+    rls.release().await;
 
-    let trends = state
-        .sentiment_repo
-        .list_trends(org_id, SentimentTrendQuery::default())
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to get trends: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to get dashboard",
-                )),
-            )
-        })?;
-
-    let alerts = state
-        .sentiment_repo
-        .list_alerts(org_id, Some(false), 5, 0)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to get alerts: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to get dashboard",
-                )),
-            )
-        })?;
+    let (org_avg, trends, alerts) = dashboard.map_err(|e| {
+        tracing::error!("Failed to get dashboard: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "INTERNAL_ERROR",
+                "Failed to get dashboard",
+            )),
+        )
+    })?;
 
     Ok(Json(serde_json::json!({
         "organization_avg": org_avg,


### PR DESCRIPTION
## What & why (PAP-107, child of PAP-80 / PAP-67 RLS sweep)

`SentimentRepository` held a raw `PgPool` and queried **3 FORCE-RLS tables** —
`sentiment_trends`, `sentiment_alerts`, `sentiment_thresholds` (migration `00179`,
PAP-62) — without ever setting `app.current_org_id`. Under `FORCE ROW LEVEL
SECURITY` the api-server's owner connection is no longer exempt, so on `dev`
`get_current_org_id()` returned NULL and every policy collapsed to deny-all:
own-org reads returned empty, writes failed `WITH CHECK`. Mounted via
`/api/v1/ai/sentiment`.

## Change

- **`SentimentRepository` is now stateless** — `new(_pool)` kept only for
  `AppState` construction-site compatibility; the repo holds **no pool**, so it
  cannot issue an un-scoped (deny-all) query. Mirrors the merged `vendor.rs` /
  `work_order.rs` precedent.
- Single-statement methods take a generic `E: Executor<'e, Database = Postgres>`.
  The one multi-statement method (`get_thresholds`: SELECT then conditional
  INSERT) takes `&mut PgConnection` and reborrows.
- **Handlers** (`routes/ai/sessions.rs`) acquire the `RlsConnection` extractor,
  pass `&mut **rls.conn()`, use `rls.tenant_id()` as the authoritative org, and
  `release()` to clear context. Org filter and RLS context can no longer
  disagree; cross-tenant by-id `acknowledge_alert` now surfaces as 404
  (`RowNotFound`) via RLS.
- The best-effort sentiment writes inside the **ai-chat `send_message`** handler
  (`get_thresholds`/`create_alert`/`upsert_trend`) acquire a short-lived
  RLS-context connection so they engage the FORCE policy instead of silently
  failing. Kept self-contained (separate acquire) to minimise overlap with the
  concurrent PAP-103 `ai_chat.rs` conversion, which also touches this file.

## Tests

`backend/crates/db/tests/sentiment_rls_repo_tests.rs` — `NOSUPERUSER
NOBYPASSRLS` role-switch pattern (mirrors `emergency_rls_repo_tests.rs` /
`vendor_rls_repo_tests.rs`):
1. **deny-all** reproduction (role bound, no context) — own-org `list_alerts` empty;
2. **fix** — with context set, `list_alerts` returns the own-org row;
3. **cross-tenant by-id** — `acknowledge_alert` on org B's alert by an org-A
   caller → `RowNotFound`; own-org acknowledge succeeds;
4. **write path** — `create_alert` under context succeeds, row is the caller's org.

## Verification

- `cargo check -p db` ✅ and `cargo check -p api-server` ✅ — green on remote
  builder (mercury/rbuild), per the control-plane OOM guardrail.
- `cargo clippy -p db -p api-server -- -D warnings` ✅ and `cargo fmt --check` ✅.
- Test target compiles; it executes in CI `backend.yml` (`cargo test --workspace`
  against a `postgres:16` service with migrations applied).

> Note: both this PR and PAP-103 (`ai_chat.rs`) edit `routes/ai/sessions.rs`; a
> mechanical merge may be needed for whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)