### PR TITLE
fix(api-server): clippy explicit_auto_deref on equipment update_maintenance (PAP-71 follow-up)

### DIFF
--- a/backend/servers/api-server/src/routes/ai/equipment.rs
+++ b/backend/servers/api-server/src/routes/ai/equipment.rs
@@ -259,7 +259,7 @@ async fn update_maintenance(
     let tenant_id = rls.tenant_id();
     let out = match state
         .equipment_repo
-        .update_maintenance(&mut **rls.conn(), id, tenant_id, req)
+        .update_maintenance(rls.conn(), id, tenant_id, req)
         .await
     {
         Ok(record) => Ok(Json(serde_json::json!(record))),


### PR DESCRIPTION
One-line clippy fix: `update_maintenance` (a `&mut PgConnection` method) must be called with `rls.conn()`, not `&mut **rls.conn()` — the explicit deref trips `clippy::explicit_auto_deref` under `-D warnings`, which left dev's `check` job red after #1226 merged. Generic-executor calls are unaffected.

Unblocks dev. Follow-up to #1226 (PAP-71).

🤖 Generated with [Claude Code](https://claude.com/claude-code)