### PR TITLE
fix(db): route llm_document repo through RLS-context connection (PAP-80)

### DIFF
--- a/backend/crates/db/src/repositories/llm_document.rs
+++ b/backend/crates/db/src/repositories/llm_document.rs
@@ -1,4 +1,25 @@
 //! LLM Document repository (Epic 64: Advanced AI & LLM Capabilities).
+//!
+//! # RLS Integration (PAP-108 / PAP-80 / PAP-67)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on `document_embeddings` (the RAG store this
+//! repo reads and writes). Under `FORCE` the api-server's owner connection is
+//! no longer exempt, so a query issued on a connection without
+//! `app.current_org_id` set collapses to deny-all (own-org reads return empty,
+//! writes fail the policy `WITH CHECK`) — which silently broke RAG context
+//! retrieval on `dev`.
+//!
+//! Every method therefore takes an **executor whose connection already has RLS
+//! context set** (org + user GUCs) — in handlers this comes from the
+//! `RlsConnection` extractor via `&mut **rls.conn()`. The repository holds **no
+//! pool**, so there is no way to issue a query that bypasses RLS. This mirrors
+//! the `work_order.rs` / `vendor.rs` / `sentiment.rs` precedent.
+//!
+//! The non-RLS tables this repo touches (`llm_generation_requests`,
+//! `voice_assistant_devices`, …) keep their application-level `organization_id`
+//! / `user_id` guards; callers without a tenant principal (the voice-platform
+//! OAuth refresh webhook) may run those methods on a plain pool connection.
 
 use crate::models::llm_document::{
     generation_status, AiEscalationConfig, AiUsageStatistics, DocumentEmbedding,
@@ -6,21 +27,26 @@ use crate::models::llm_document::{
     ProviderStats, RagStatistics, RequestTypeStats, UpdateEscalationConfig, VoiceAssistantDevice,
     VoiceCommandHistory,
 };
-use crate::DbPool;
 use chrono::{DateTime, Utc};
-use sqlx::Error as SqlxError;
+use sqlx::{Error as SqlxError, Executor, PgConnection, PgPool, Postgres};
 use uuid::Uuid;
 
 /// Repository for LLM document generation operations.
+///
+/// Stateless: every method receives an RLS-context-bearing executor. The repo
+/// holds no pool so it cannot issue an un-scoped (deny-all under `FORCE`) query.
 #[derive(Clone)]
-pub struct LlmDocumentRepository {
-    pool: DbPool,
-}
+pub struct LlmDocumentRepository;
 
 impl LlmDocumentRepository {
     /// Create a new LlmDocumentRepository.
-    pub fn new(pool: DbPool) -> Self {
-        Self { pool }
+    ///
+    /// The pool argument is retained for construction-site compatibility with
+    /// the other repositories on `AppState`; this repo deliberately does not
+    /// store it (see module docs — all queries run on a context-set connection
+    /// supplied by the caller).
+    pub fn new(_pool: PgPool) -> Self {
+        Self
     }
 
     // =========================================================================
@@ -29,8 +55,9 @@ impl LlmDocumentRepository {
 
     /// Create a new LLM generation request.
     #[allow(clippy::too_many_arguments)]
-    pub async fn create_generation_request(
+    pub async fn create_generation_request<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         user_id: Uuid,
         request_type: &str,
@@ -38,7 +65,10 @@ impl LlmDocumentRepository {
         model: &str,
         input_data: serde_json::Value,
         prompt_template_id: Option<Uuid>,
-    ) -> Result<LlmGenerationRequest, SqlxError> {
+    ) -> Result<LlmGenerationRequest, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, LlmGenerationRequest>(
             r#"
             INSERT INTO llm_generation_requests (
@@ -57,20 +87,24 @@ impl LlmDocumentRepository {
         .bind(&input_data)
         .bind(prompt_template_id)
         .bind(generation_status::PENDING)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Find a generation request by ID.
-    pub async fn find_generation_request(
+    pub async fn find_generation_request<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
-    ) -> Result<Option<LlmGenerationRequest>, SqlxError> {
+    ) -> Result<Option<LlmGenerationRequest>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, LlmGenerationRequest>(
             "SELECT * FROM llm_generation_requests WHERE id = $1",
         )
         .bind(id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
@@ -80,17 +114,21 @@ impl LlmDocumentRepository {
     /// `None` for both "not found" and "belongs to another tenant" so a caller
     /// in org B cannot read org A's generation request (an IDOR information
     /// leak: prompts, results, cost data).
-    pub async fn find_generation_request_for_org(
+    pub async fn find_generation_request_for_org<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
-    ) -> Result<Option<LlmGenerationRequest>, SqlxError> {
+    ) -> Result<Option<LlmGenerationRequest>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, LlmGenerationRequest>(
             "SELECT * FROM llm_generation_requests WHERE id = $1 AND organization_id = $2",
         )
         .bind(id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
@@ -101,11 +139,15 @@ impl LlmDocumentRepository {
     /// (`units.building_id -> buildings.organization_id`), so this checks the
     /// join rather than a direct column. Returns `true` only when a unit with
     /// that id exists under the caller's org.
-    pub async fn unit_belongs_to_org(
+    pub async fn unit_belongs_to_org<'e, E>(
         &self,
+        executor: E,
         unit_id: Uuid,
         org_id: Uuid,
-    ) -> Result<bool, SqlxError> {
+    ) -> Result<bool, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let exists: Option<bool> = sqlx::query_scalar(
             r#"
             SELECT TRUE
@@ -116,15 +158,16 @@ impl LlmDocumentRepository {
         )
         .bind(unit_id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await?;
         Ok(exists.unwrap_or(false))
     }
 
     /// Update generation request status.
     #[allow(clippy::too_many_arguments)]
-    pub async fn update_generation_status(
+    pub async fn update_generation_status<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         status: &str,
         result: Option<serde_json::Value>,
@@ -132,7 +175,10 @@ impl LlmDocumentRepository {
         tokens_used: Option<i32>,
         cost_cents: Option<i32>,
         latency_ms: Option<i32>,
-    ) -> Result<Option<LlmGenerationRequest>, SqlxError> {
+    ) -> Result<Option<LlmGenerationRequest>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let completed_at =
             if status == generation_status::COMPLETED || status == generation_status::FAILED {
                 Some(Utc::now())
@@ -162,19 +208,23 @@ impl LlmDocumentRepository {
         .bind(cost_cents)
         .bind(latency_ms)
         .bind(completed_at)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// List generation requests for an organization.
-    pub async fn list_generation_requests(
+    pub async fn list_generation_requests<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         request_type: Option<&str>,
         status: Option<&str>,
         limit: i64,
         offset: i64,
-    ) -> Result<Vec<LlmGenerationRequest>, SqlxError> {
+    ) -> Result<Vec<LlmGenerationRequest>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, LlmGenerationRequest>(
             r#"
             SELECT * FROM llm_generation_requests
@@ -190,7 +240,7 @@ impl LlmDocumentRepository {
         .bind(status)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -200,8 +250,9 @@ impl LlmDocumentRepository {
 
     /// Create a prompt template.
     #[allow(clippy::too_many_arguments)]
-    pub async fn create_prompt_template(
+    pub async fn create_prompt_template<'e, E>(
         &self,
+        executor: E,
         organization_id: Option<Uuid>,
         name: &str,
         description: Option<&str>,
@@ -213,7 +264,10 @@ impl LlmDocumentRepository {
         model: &str,
         temperature: Option<f32>,
         max_tokens: Option<i32>,
-    ) -> Result<LlmPromptTemplate, SqlxError> {
+    ) -> Result<LlmPromptTemplate, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, LlmPromptTemplate>(
             r#"
             INSERT INTO llm_prompt_templates (
@@ -237,18 +291,22 @@ impl LlmDocumentRepository {
         .bind(temperature)
         .bind(max_tokens)
         .bind(organization_id.is_none()) // is_system = true if no org
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Find a prompt template by ID.
-    pub async fn find_prompt_template(
+    pub async fn find_prompt_template<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
-    ) -> Result<Option<LlmPromptTemplate>, SqlxError> {
+    ) -> Result<Option<LlmPromptTemplate>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, LlmPromptTemplate>("SELECT * FROM llm_prompt_templates WHERE id = $1")
             .bind(id)
-            .fetch_optional(&self.pool)
+            .fetch_optional(executor)
             .await
     }
 
@@ -259,11 +317,15 @@ impl LlmDocumentRepository {
     /// (`is_system = TRUE`, `organization_id IS NULL`) template shared across
     /// all tenants. Returns `None` for "not found" and for "another tenant's
     /// org-specific template" so org B cannot read org A's prompt templates.
-    pub async fn find_prompt_template_for_org(
+    pub async fn find_prompt_template_for_org<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
-    ) -> Result<Option<LlmPromptTemplate>, SqlxError> {
+    ) -> Result<Option<LlmPromptTemplate>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, LlmPromptTemplate>(
             r#"
             SELECT * FROM llm_prompt_templates
@@ -272,16 +334,20 @@ impl LlmDocumentRepository {
         )
         .bind(id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Find the default template for a request type.
-    pub async fn find_default_template(
+    pub async fn find_default_template<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         request_type: &str,
-    ) -> Result<Option<LlmPromptTemplate>, SqlxError> {
+    ) -> Result<Option<LlmPromptTemplate>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // First try org-specific, then system default
         sqlx::query_as::<_, LlmPromptTemplate>(
             r#"
@@ -297,16 +363,20 @@ impl LlmDocumentRepository {
         )
         .bind(organization_id)
         .bind(request_type)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// List prompt templates.
-    pub async fn list_prompt_templates(
+    pub async fn list_prompt_templates<'e, E>(
         &self,
+        executor: E,
         organization_id: Option<Uuid>,
         request_type: Option<&str>,
-    ) -> Result<Vec<LlmPromptTemplate>, SqlxError> {
+    ) -> Result<Vec<LlmPromptTemplate>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, LlmPromptTemplate>(
             r#"
             SELECT * FROM llm_prompt_templates
@@ -318,14 +388,15 @@ impl LlmDocumentRepository {
         )
         .bind(organization_id)
         .bind(request_type)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update a prompt template.
     #[allow(clippy::too_many_arguments)]
-    pub async fn update_prompt_template(
+    pub async fn update_prompt_template<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         name: Option<&str>,
         description: Option<&str>,
@@ -337,7 +408,10 @@ impl LlmDocumentRepository {
         temperature: Option<f32>,
         max_tokens: Option<i32>,
         is_active: Option<bool>,
-    ) -> Result<Option<LlmPromptTemplate>, SqlxError> {
+    ) -> Result<Option<LlmPromptTemplate>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, LlmPromptTemplate>(
             r#"
             UPDATE llm_prompt_templates SET
@@ -368,7 +442,7 @@ impl LlmDocumentRepository {
         .bind(temperature)
         .bind(max_tokens)
         .bind(is_active)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
@@ -378,8 +452,9 @@ impl LlmDocumentRepository {
 
     /// Create a generated listing description.
     #[allow(clippy::too_many_arguments)]
-    pub async fn create_listing_description(
+    pub async fn create_listing_description<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         listing_id: Option<Uuid>,
         user_id: Uuid,
@@ -388,7 +463,10 @@ impl LlmDocumentRepository {
         property_details: serde_json::Value,
         photo_analysis: Option<serde_json::Value>,
         generation_request_id: Uuid,
-    ) -> Result<GeneratedListingDescription, SqlxError> {
+    ) -> Result<GeneratedListingDescription, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, GeneratedListingDescription>(
             r#"
             INSERT INTO generated_listing_descriptions (
@@ -408,33 +486,41 @@ impl LlmDocumentRepository {
         .bind(&property_details)
         .bind(&photo_analysis)
         .bind(generation_request_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Find a generated description by ID.
-    pub async fn find_listing_description(
+    pub async fn find_listing_description<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
-    ) -> Result<Option<GeneratedListingDescription>, SqlxError> {
+    ) -> Result<Option<GeneratedListingDescription>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, GeneratedListingDescription>(
             "SELECT * FROM generated_listing_descriptions WHERE id = $1",
         )
         .bind(id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// List descriptions for a listing.
-    pub async fn list_listing_descriptions(
+    pub async fn list_listing_descriptions<'e, E>(
         &self,
+        executor: E,
         listing_id: Uuid,
-    ) -> Result<Vec<GeneratedListingDescription>, SqlxError> {
+    ) -> Result<Vec<GeneratedListingDescription>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, GeneratedListingDescription>(
             "SELECT * FROM generated_listing_descriptions WHERE listing_id = $1 ORDER BY generated_at DESC",
         )
         .bind(listing_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -445,11 +531,15 @@ impl LlmDocumentRepository {
     /// generated listing descriptions owned by org A by enumerating a
     /// `listing_id`. Returns an empty vec for both "no descriptions" and
     /// "listing belongs to another tenant", so existence is never leaked.
-    pub async fn list_listing_descriptions_for_org(
+    pub async fn list_listing_descriptions_for_org<'e, E>(
         &self,
+        executor: E,
         listing_id: Uuid,
         org_id: Uuid,
-    ) -> Result<Vec<GeneratedListingDescription>, SqlxError> {
+    ) -> Result<Vec<GeneratedListingDescription>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, GeneratedListingDescription>(
             r#"
             SELECT * FROM generated_listing_descriptions
@@ -459,17 +549,21 @@ impl LlmDocumentRepository {
         )
         .bind(listing_id)
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update edited description.
-    pub async fn update_edited_description(
+    pub async fn update_edited_description<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         edited_description: &str,
         edited_by: Uuid,
-    ) -> Result<Option<GeneratedListingDescription>, SqlxError> {
+    ) -> Result<Option<GeneratedListingDescription>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, GeneratedListingDescription>(
             r#"
             UPDATE generated_listing_descriptions SET
@@ -483,20 +577,24 @@ impl LlmDocumentRepository {
         .bind(id)
         .bind(edited_description)
         .bind(edited_by)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Mark description as published.
-    pub async fn publish_description(
+    pub async fn publish_description<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
-    ) -> Result<Option<GeneratedListingDescription>, SqlxError> {
+    ) -> Result<Option<GeneratedListingDescription>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, GeneratedListingDescription>(
             "UPDATE generated_listing_descriptions SET is_published = TRUE WHERE id = $1 RETURNING *",
         )
         .bind(id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
@@ -506,11 +604,15 @@ impl LlmDocumentRepository {
     /// `organization_id = $2` guard ensures a caller in org B cannot publish
     /// (mutate) a generated listing description owned by org A. Returns `None`
     /// for both "not found" and "belongs to another tenant".
-    pub async fn publish_description_for_org(
+    pub async fn publish_description_for_org<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
-    ) -> Result<Option<GeneratedListingDescription>, SqlxError> {
+    ) -> Result<Option<GeneratedListingDescription>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, GeneratedListingDescription>(
             r#"
             UPDATE generated_listing_descriptions
@@ -521,7 +623,7 @@ impl LlmDocumentRepository {
         )
         .bind(id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
@@ -530,15 +632,24 @@ impl LlmDocumentRepository {
     // =========================================================================
 
     /// Create a document embedding.
-    pub async fn create_embedding(
+    ///
+    /// `document_embeddings` is FORCE-RLS (migration 00179): the executor's
+    /// connection MUST carry the org GUC or the INSERT fails the policy
+    /// `WITH CHECK`.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn create_embedding<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         document_id: Uuid,
         chunk_index: i32,
         chunk_text: &str,
         embedding: Option<Vec<f32>>,
         metadata: serde_json::Value,
-    ) -> Result<DocumentEmbedding, SqlxError> {
+    ) -> Result<DocumentEmbedding, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, DocumentEmbedding>(
             r#"
             INSERT INTO document_embeddings (
@@ -562,28 +673,39 @@ impl LlmDocumentRepository {
                 .and_then(|e| serde_json::to_value(e).ok()),
         )
         .bind(&metadata)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Find embeddings for a document.
-    pub async fn find_document_embeddings(
+    pub async fn find_document_embeddings<'e, E>(
         &self,
+        executor: E,
         document_id: Uuid,
-    ) -> Result<Vec<DocumentEmbedding>, SqlxError> {
+    ) -> Result<Vec<DocumentEmbedding>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, DocumentEmbedding>(
             "SELECT * FROM document_embeddings WHERE document_id = $1 ORDER BY chunk_index",
         )
         .bind(document_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Delete embeddings for a document.
-    pub async fn delete_document_embeddings(&self, document_id: Uuid) -> Result<u64, SqlxError> {
+    pub async fn delete_document_embeddings<'e, E>(
+        &self,
+        executor: E,
+        document_id: Uuid,
+    ) -> Result<u64, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM document_embeddings WHERE document_id = $1")
             .bind(document_id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected())
     }
@@ -592,12 +714,16 @@ impl LlmDocumentRepository {
     ///
     /// This is a fallback method when pgvector is not available.
     /// For production RAG capability, use `search_documents_by_embedding` instead.
-    pub async fn search_documents_by_text(
+    pub async fn search_documents_by_text<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         search_text: &str,
         limit: i32,
-    ) -> Result<Vec<DocumentEmbedding>, SqlxError> {
+    ) -> Result<Vec<DocumentEmbedding>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, DocumentEmbedding>(
             r#"
             SELECT * FROM document_embeddings
@@ -610,7 +736,7 @@ impl LlmDocumentRepository {
         .bind(organization_id)
         .bind(search_text)
         .bind(limit)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -620,11 +746,15 @@ impl LlmDocumentRepository {
 
     /// Update embedding vector for an existing document chunk.
     /// Used after generating embeddings via LLM client.
-    pub async fn update_embedding_vector(
+    pub async fn update_embedding_vector<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         embedding: Vec<f32>,
-    ) -> Result<Option<DocumentEmbedding>, SqlxError> {
+    ) -> Result<Option<DocumentEmbedding>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // Store embedding as JSONB for now (works without pgvector extension)
         // In production with pgvector enabled, this would use vector type directly
         let embedding_json = serde_json::to_value(&embedding).unwrap_or_default();
@@ -640,7 +770,7 @@ impl LlmDocumentRepository {
         )
         .bind(id)
         .bind(&embedding_json)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
@@ -651,8 +781,12 @@ impl LlmDocumentRepository {
     /// Otherwise, falls back to application-level cosine similarity calculation.
     ///
     /// Returns document chunks ordered by relevance (highest similarity first).
+    ///
+    /// Multi-statement: takes `&mut PgConnection` so every query runs on the
+    /// same RLS-context connection.
     pub async fn search_documents_by_embedding(
         &self,
+        conn: &mut PgConnection,
         organization_id: Uuid,
         query_embedding: &[f32],
         limit: i32,
@@ -665,7 +799,7 @@ impl LlmDocumentRepository {
         let pgvector_available: Option<bool> = sqlx::query_scalar(
             "SELECT EXISTS(SELECT 1 FROM pg_extension WHERE extname = 'vector')",
         )
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *conn)
         .await?;
 
         if pgvector_available == Some(true) {
@@ -684,7 +818,7 @@ impl LlmDocumentRepository {
             .bind(organization_id)
             .bind(serde_json::to_value(query_embedding).unwrap_or_default())
             .bind(limit)
-            .fetch_all(&self.pool)
+            .fetch_all(&mut *conn)
             .await?;
 
             // Calculate similarity scores for the results
@@ -721,7 +855,7 @@ impl LlmDocumentRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await?;
 
         // Calculate cosine similarity for each document
@@ -754,8 +888,12 @@ impl LlmDocumentRepository {
 
     /// Bulk create embeddings for a document (for chunked text).
     /// Story 97.2: Efficient batch embedding creation for RAG indexing.
+    ///
+    /// Multi-statement: takes `&mut PgConnection` so every chunk INSERT runs
+    /// on the same RLS-context connection.
     pub async fn create_embeddings_batch(
         &self,
+        conn: &mut PgConnection,
         organization_id: Uuid,
         document_id: Uuid,
         chunks: Vec<(String, serde_json::Value)>, // (chunk_text, metadata)
@@ -765,6 +903,7 @@ impl LlmDocumentRepository {
         for (index, (chunk_text, metadata)) in chunks.into_iter().enumerate() {
             let embedding = self
                 .create_embedding(
+                    &mut *conn,
                     organization_id,
                     document_id,
                     index as i32,
@@ -781,11 +920,15 @@ impl LlmDocumentRepository {
 
     /// Get documents that need embedding generation (embedding is null).
     /// Story 97.2: Used by background job to process pending embeddings.
-    pub async fn get_pending_embeddings(
+    pub async fn get_pending_embeddings<'e, E>(
         &self,
+        executor: E,
         organization_id: Option<Uuid>,
         limit: i32,
-    ) -> Result<Vec<DocumentEmbedding>, SqlxError> {
+    ) -> Result<Vec<DocumentEmbedding>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, DocumentEmbedding>(
             r#"
             SELECT * FROM document_embeddings
@@ -797,17 +940,21 @@ impl LlmDocumentRepository {
         )
         .bind(organization_id)
         .bind(limit)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Count documents with and without embeddings for an organization.
     /// Story 97.2: Used to track RAG indexing progress.
     /// Story 103.5: Now also tracks pgvector migration status.
-    pub async fn count_embedding_status(
+    pub async fn count_embedding_status<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
-    ) -> Result<(i64, i64), SqlxError> {
+    ) -> Result<(i64, i64), SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let counts: (i64, i64) = sqlx::query_as(
             r#"
             SELECT
@@ -818,7 +965,7 @@ impl LlmDocumentRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await?;
 
         Ok(counts)
@@ -832,8 +979,12 @@ impl LlmDocumentRepository {
     ///
     /// This method uses the SQL function created in migration 00079_create_pgvector.sql.
     /// Falls back to application-level search if pgvector is not available.
+    ///
+    /// Multi-statement: takes `&mut PgConnection` so every query runs on the
+    /// same RLS-context connection.
     pub async fn search_documents_pgvector(
         &self,
+        conn: &mut PgConnection,
         organization_id: Uuid,
         query_embedding: &[f32],
         limit: i32,
@@ -845,7 +996,7 @@ impl LlmDocumentRepository {
         let pgvector_available: Option<bool> = sqlx::query_scalar(
             "SELECT EXISTS(SELECT 1 FROM pg_proc WHERE proname = 'search_similar_documents')",
         )
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *conn)
         .await?;
 
         if pgvector_available == Some(true) {
@@ -869,7 +1020,7 @@ impl LlmDocumentRepository {
             .bind(&embedding_str)
             .bind(limit)
             .bind(min_sim)
-            .fetch_all(&self.pool)
+            .fetch_all(&mut *conn)
             .await?;
 
             // Convert to DocumentEmbedding format
@@ -893,21 +1044,31 @@ impl LlmDocumentRepository {
         }
 
         // Fallback to the existing application-level search
-        self.search_documents_by_embedding(organization_id, query_embedding, limit, min_similarity)
-            .await
+        self.search_documents_by_embedding(
+            conn,
+            organization_id,
+            query_embedding,
+            limit,
+            min_similarity,
+        )
+        .await
     }
 
     /// Get RAG statistics for an organization using the v_rag_statistics view (Story 103.5).
+    ///
+    /// Multi-statement: takes `&mut PgConnection` so every query runs on the
+    /// same RLS-context connection.
     #[allow(clippy::type_complexity)]
     pub async fn get_rag_statistics(
         &self,
+        conn: &mut PgConnection,
         organization_id: Uuid,
     ) -> Result<RagStatistics, SqlxError> {
         // Check if the view exists
         let view_exists: Option<bool> = sqlx::query_scalar(
             "SELECT EXISTS(SELECT 1 FROM information_schema.views WHERE table_name = 'v_rag_statistics')",
         )
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *conn)
         .await?;
 
         if view_exists == Some(true) {
@@ -922,7 +1083,7 @@ impl LlmDocumentRepository {
                 "#,
                 )
                 .bind(organization_id)
-                .fetch_optional(&self.pool)
+                .fetch_optional(&mut *conn)
                 .await?;
 
             if let Some((
@@ -959,12 +1120,18 @@ impl LlmDocumentRepository {
     /// Migrate pending JSONB embeddings to pgvector format (Story 103.5).
     ///
     /// Returns the number of embeddings migrated.
-    pub async fn migrate_embeddings_to_pgvector(&self) -> Result<i64, SqlxError> {
+    ///
+    /// Multi-statement: takes `&mut PgConnection` so every query runs on the
+    /// same RLS-context connection.
+    pub async fn migrate_embeddings_to_pgvector(
+        &self,
+        conn: &mut PgConnection,
+    ) -> Result<i64, SqlxError> {
         // Check if the migration function exists
         let function_exists: Option<bool> = sqlx::query_scalar(
             "SELECT EXISTS(SELECT 1 FROM pg_proc WHERE proname = 'migrate_jsonb_to_vector')",
         )
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *conn)
         .await?;
 
         if function_exists == Some(true) {
@@ -972,19 +1139,19 @@ impl LlmDocumentRepository {
             let before_count: i64 = sqlx::query_scalar(
                 "SELECT COUNT(*) FROM document_embeddings WHERE embedding_vector IS NOT NULL",
             )
-            .fetch_one(&self.pool)
+            .fetch_one(&mut *conn)
             .await?;
 
             // Run migration function
             sqlx::query("SELECT migrate_jsonb_to_vector()")
-                .execute(&self.pool)
+                .execute(&mut *conn)
                 .await?;
 
             // Get count after migration
             let after_count: i64 = sqlx::query_scalar(
                 "SELECT COUNT(*) FROM document_embeddings WHERE embedding_vector IS NOT NULL",
             )
-            .fetch_one(&self.pool)
+            .fetch_one(&mut *conn)
             .await?;
 
             return Ok(after_count - before_count);
@@ -998,8 +1165,12 @@ impl LlmDocumentRepository {
     // =========================================================================
 
     /// Get or create escalation config for an organization.
+    ///
+    /// Multi-statement (SELECT then conditional INSERT): takes
+    /// `&mut PgConnection` so both run on the same RLS-context connection.
     pub async fn get_escalation_config(
         &self,
+        conn: &mut PgConnection,
         organization_id: Uuid,
     ) -> Result<AiEscalationConfig, SqlxError> {
         // Try to find existing config
@@ -1007,7 +1178,7 @@ impl LlmDocumentRepository {
             "SELECT * FROM ai_escalation_configs WHERE organization_id = $1",
         )
         .bind(organization_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *conn)
         .await?;
 
         if let Some(config) = existing {
@@ -1025,16 +1196,20 @@ impl LlmDocumentRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
     }
 
     /// Update escalation config.
-    pub async fn update_escalation_config(
+    pub async fn update_escalation_config<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         update: UpdateEscalationConfig,
-    ) -> Result<AiEscalationConfig, SqlxError> {
+    ) -> Result<AiEscalationConfig, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let topics_json = update
             .auto_escalate_topics
             .map(|t| serde_json::to_value(&t).unwrap_or_default());
@@ -1056,7 +1231,7 @@ impl LlmDocumentRepository {
         .bind(&update.escalation_email)
         .bind(&update.escalation_webhook_url)
         .bind(&topics_json)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
@@ -1065,15 +1240,20 @@ impl LlmDocumentRepository {
     // =========================================================================
 
     /// Create a photo enhancement record.
-    pub async fn create_photo_enhancement(
+    #[allow(clippy::too_many_arguments)]
+    pub async fn create_photo_enhancement<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         listing_id: Option<Uuid>,
         user_id: Uuid,
         original_photo_url: &str,
         enhancement_type: &str,
         metadata: serde_json::Value,
-    ) -> Result<PhotoEnhancement, SqlxError> {
+    ) -> Result<PhotoEnhancement, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, PhotoEnhancement>(
             r#"
             INSERT INTO photo_enhancements (
@@ -1090,18 +1270,22 @@ impl LlmDocumentRepository {
         .bind(original_photo_url)
         .bind(enhancement_type)
         .bind(&metadata)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Find photo enhancement by ID.
-    pub async fn find_photo_enhancement(
+    pub async fn find_photo_enhancement<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
-    ) -> Result<Option<PhotoEnhancement>, SqlxError> {
+    ) -> Result<Option<PhotoEnhancement>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, PhotoEnhancement>("SELECT * FROM photo_enhancements WHERE id = $1")
             .bind(id)
-            .fetch_optional(&self.pool)
+            .fetch_optional(executor)
             .await
     }
 
@@ -1110,24 +1294,29 @@ impl LlmDocumentRepository {
     /// `org_id` must originate from the verified request principal. Returns
     /// `None` for both "not found" and "belongs to another tenant" so a caller
     /// in org B cannot read org A's photo enhancement record.
-    pub async fn find_photo_enhancement_for_org(
+    pub async fn find_photo_enhancement_for_org<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
-    ) -> Result<Option<PhotoEnhancement>, SqlxError> {
+    ) -> Result<Option<PhotoEnhancement>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, PhotoEnhancement>(
             "SELECT * FROM photo_enhancements WHERE id = $1 AND organization_id = $2",
         )
         .bind(id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Update photo enhancement status and result.
     #[allow(clippy::too_many_arguments)]
-    pub async fn update_photo_enhancement(
+    pub async fn update_photo_enhancement<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         status: &str,
         enhanced_photo_url: Option<&str>,
@@ -1135,7 +1324,10 @@ impl LlmDocumentRepository {
         error_message: Option<&str>,
         processing_time_ms: Option<i32>,
         cost_cents: Option<i32>,
-    ) -> Result<Option<PhotoEnhancement>, SqlxError> {
+    ) -> Result<Option<PhotoEnhancement>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let completed_at = if status == "completed" || status == "failed" {
             Some(Utc::now())
         } else {
@@ -1164,20 +1356,24 @@ impl LlmDocumentRepository {
         .bind(processing_time_ms)
         .bind(cost_cents)
         .bind(completed_at)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// List photo enhancements for a listing.
-    pub async fn list_photo_enhancements(
+    pub async fn list_photo_enhancements<'e, E>(
         &self,
+        executor: E,
         listing_id: Uuid,
-    ) -> Result<Vec<PhotoEnhancement>, SqlxError> {
+    ) -> Result<Vec<PhotoEnhancement>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, PhotoEnhancement>(
             "SELECT * FROM photo_enhancements WHERE listing_id = $1 ORDER BY created_at DESC",
         )
         .bind(listing_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -1187,8 +1383,9 @@ impl LlmDocumentRepository {
 
     /// Create a voice assistant device link.
     #[allow(clippy::too_many_arguments)]
-    pub async fn create_voice_device(
+    pub async fn create_voice_device<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         user_id: Uuid,
         unit_id: Option<Uuid>,
@@ -1199,7 +1396,10 @@ impl LlmDocumentRepository {
         refresh_token_encrypted: Option<&str>,
         token_expires_at: Option<DateTime<Utc>>,
         capabilities: serde_json::Value,
-    ) -> Result<VoiceAssistantDevice, SqlxError> {
+    ) -> Result<VoiceAssistantDevice, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, VoiceAssistantDevice>(
             r#"
             INSERT INTO voice_assistant_devices (
@@ -1221,56 +1421,75 @@ impl LlmDocumentRepository {
         .bind(refresh_token_encrypted)
         .bind(token_expires_at)
         .bind(&capabilities)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Find voice device by ID.
-    pub async fn find_voice_device(
+    pub async fn find_voice_device<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
-    ) -> Result<Option<VoiceAssistantDevice>, SqlxError> {
+    ) -> Result<Option<VoiceAssistantDevice>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, VoiceAssistantDevice>(
             "SELECT * FROM voice_assistant_devices WHERE id = $1",
         )
         .bind(id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Find voice device by external device ID.
-    pub async fn find_voice_device_by_device_id(
+    pub async fn find_voice_device_by_device_id<'e, E>(
         &self,
+        executor: E,
         platform: &str,
         device_id: &str,
-    ) -> Result<Option<VoiceAssistantDevice>, SqlxError> {
+    ) -> Result<Option<VoiceAssistantDevice>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, VoiceAssistantDevice>(
             "SELECT * FROM voice_assistant_devices WHERE platform = $1 AND device_id = $2 AND is_active = TRUE",
         )
         .bind(platform)
         .bind(device_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// List voice devices for a user.
-    pub async fn list_user_voice_devices(
+    pub async fn list_user_voice_devices<'e, E>(
         &self,
+        executor: E,
         user_id: Uuid,
-    ) -> Result<Vec<VoiceAssistantDevice>, SqlxError> {
+    ) -> Result<Vec<VoiceAssistantDevice>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, VoiceAssistantDevice>(
             "SELECT * FROM voice_assistant_devices WHERE user_id = $1 AND is_active = TRUE ORDER BY linked_at DESC",
         )
         .bind(user_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update voice device last used timestamp.
-    pub async fn update_voice_device_last_used(&self, id: Uuid) -> Result<(), SqlxError> {
+    pub async fn update_voice_device_last_used<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+    ) -> Result<(), SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query("UPDATE voice_assistant_devices SET last_used_at = NOW(), updated_at = NOW() WHERE id = $1")
             .bind(id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(())
     }
@@ -1282,17 +1501,21 @@ impl LlmDocumentRepository {
     /// no row is updated — either the `id` does not exist or the device is not
     /// owned by `user_id`.  The handler maps both cases to `404 Not Found`,
     /// giving an attacker no information about whether the target id exists.
-    pub async fn deactivate_voice_device(
+    pub async fn deactivate_voice_device<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         user_id: Uuid,
-    ) -> Result<bool, SqlxError> {
+    ) -> Result<bool, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query(
             "UPDATE voice_assistant_devices SET is_active = FALSE, updated_at = NOW() WHERE id = $1 AND user_id = $2",
         )
         .bind(id)
         .bind(user_id)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
         Ok(result.rows_affected() > 0)
     }
@@ -1303,8 +1526,9 @@ impl LlmDocumentRepository {
 
     /// Create a voice command history entry.
     #[allow(clippy::too_many_arguments)]
-    pub async fn create_voice_command(
+    pub async fn create_voice_command<'e, E>(
         &self,
+        executor: E,
         device_id: Uuid,
         user_id: Uuid,
         command_text: &str,
@@ -1314,7 +1538,10 @@ impl LlmDocumentRepository {
         success: bool,
         error_message: Option<&str>,
         processing_time_ms: i32,
-    ) -> Result<VoiceCommandHistory, SqlxError> {
+    ) -> Result<VoiceCommandHistory, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, VoiceCommandHistory>(
             r#"
             INSERT INTO voice_command_history (
@@ -1334,7 +1561,7 @@ impl LlmDocumentRepository {
         .bind(success)
         .bind(error_message)
         .bind(processing_time_ms)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
@@ -1343,16 +1570,20 @@ impl LlmDocumentRepository {
     /// Issue #483: used by `list_voice_commands` to return 404 (not 200
     /// with empty list) on a cross-user probe — matches the disclosure
     /// posture of the unlink handler.
-    pub async fn user_owns_voice_device(
+    pub async fn user_owns_voice_device<'e, E>(
         &self,
+        executor: E,
         device_id: Uuid,
         user_id: Uuid,
-    ) -> Result<bool, SqlxError> {
+    ) -> Result<bool, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let row: Option<(Uuid,)> =
             sqlx::query_as("SELECT id FROM voice_assistant_devices WHERE id = $1 AND user_id = $2")
                 .bind(device_id)
                 .bind(user_id)
-                .fetch_optional(&self.pool)
+                .fetch_optional(executor)
                 .await?;
         Ok(row.is_some())
     }
@@ -1363,13 +1594,17 @@ impl LlmDocumentRepository {
     /// preventing cross-tenant IDOR reads.  Returns an empty list (not 404) when
     /// the device does not exist or is not owned by `user_id`, matching the same
     /// conservative disclosure posture used by the deactivate path.
-    pub async fn list_voice_commands(
+    pub async fn list_voice_commands<'e, E>(
         &self,
+        executor: E,
         device_id: Uuid,
         user_id: Uuid,
         limit: i64,
         offset: i64,
-    ) -> Result<Vec<VoiceCommandHistory>, SqlxError> {
+    ) -> Result<Vec<VoiceCommandHistory>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, VoiceCommandHistory>(
             r#"
             SELECT vch.* FROM voice_command_history vch
@@ -1384,7 +1619,7 @@ impl LlmDocumentRepository {
         .bind(user_id)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -1394,13 +1629,17 @@ impl LlmDocumentRepository {
 
     /// Update OAuth tokens for a voice device.
     #[allow(clippy::too_many_arguments)]
-    pub async fn update_voice_device_tokens(
+    pub async fn update_voice_device_tokens<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         access_token_encrypted: &str,
         refresh_token_encrypted: Option<&str>,
         token_expires_at: Option<DateTime<Utc>>,
-    ) -> Result<Option<VoiceAssistantDevice>, SqlxError> {
+    ) -> Result<Option<VoiceAssistantDevice>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, VoiceAssistantDevice>(
             r#"
             UPDATE voice_assistant_devices SET
@@ -1416,16 +1655,20 @@ impl LlmDocumentRepository {
         .bind(access_token_encrypted)
         .bind(refresh_token_encrypted)
         .bind(token_expires_at)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Find voice devices with expiring tokens that need refresh.
-    pub async fn find_devices_needing_token_refresh(
+    pub async fn find_devices_needing_token_refresh<'e, E>(
         &self,
+        executor: E,
         expiry_threshold: DateTime<Utc>,
         limit: i64,
-    ) -> Result<Vec<VoiceAssistantDevice>, SqlxError> {
+    ) -> Result<Vec<VoiceAssistantDevice>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, VoiceAssistantDevice>(
             r#"
             SELECT * FROM voice_assistant_devices
@@ -1440,12 +1683,19 @@ impl LlmDocumentRepository {
         )
         .bind(expiry_threshold)
         .bind(limit)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Clear tokens for a voice device (on revocation or error).
-    pub async fn clear_voice_device_tokens(&self, id: Uuid) -> Result<bool, SqlxError> {
+    pub async fn clear_voice_device_tokens<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+    ) -> Result<bool, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query(
             r#"
             UPDATE voice_assistant_devices SET
@@ -1457,17 +1707,21 @@ impl LlmDocumentRepository {
             "#,
         )
         .bind(id)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
         Ok(result.rows_affected() > 0)
     }
 
     /// Find voice device by user ID and platform.
-    pub async fn find_voice_device_by_user_and_platform(
+    pub async fn find_voice_device_by_user_and_platform<'e, E>(
         &self,
+        executor: E,
         user_id: Uuid,
         platform: &str,
-    ) -> Result<Option<VoiceAssistantDevice>, SqlxError> {
+    ) -> Result<Option<VoiceAssistantDevice>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, VoiceAssistantDevice>(
             r#"
             SELECT * FROM voice_assistant_devices
@@ -1480,7 +1734,7 @@ impl LlmDocumentRepository {
         )
         .bind(user_id)
         .bind(platform)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
@@ -1489,8 +1743,13 @@ impl LlmDocumentRepository {
     // =========================================================================
 
     /// Get AI usage statistics for an organization.
+    ///
+    /// Multi-statement (totals + by-type + by-provider): takes
+    /// `&mut PgConnection` so every query runs on the same RLS-context
+    /// connection.
     pub async fn get_usage_statistics(
         &self,
+        conn: &mut PgConnection,
         organization_id: Uuid,
         start_date: Option<DateTime<Utc>>,
         end_date: Option<DateTime<Utc>>,
@@ -1517,7 +1776,7 @@ impl LlmDocumentRepository {
         .bind(organization_id)
         .bind(start)
         .bind(end)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         // Get by request type
@@ -1538,7 +1797,7 @@ impl LlmDocumentRepository {
         .bind(organization_id)
         .bind(start)
         .bind(end)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await?;
 
         // Get by provider
@@ -1560,7 +1819,7 @@ impl LlmDocumentRepository {
         .bind(organization_id)
         .bind(start)
         .bind(end)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await?;
 
         Ok(AiUsageStatistics {

--- a/backend/crates/db/tests/llm_document_rls_repo_tests.rs
+++ b/backend/crates/db/tests/llm_document_rls_repo_tests.rs
@@ -1,0 +1,295 @@
+//! Repo-level behavioral RLS regression test for PAP-108 (parent PAP-80 / PAP-67).
+//!
+//! Background
+//! ----------
+//! Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on `document_embeddings` — the RAG store that
+//! `LlmDocumentRepository` reads for chat context. The production api-server
+//! connects as the table OWNER, which `FORCE` binds. The repo held a raw
+//! `PgPool` and ran every query WITHOUT ever calling `set_request_context`, so
+//! on `dev` `get_current_org_id()` returned NULL and the policy collapsed to
+//! `organization_id = NULL` → **deny-all**: own-org RAG reads returned empty
+//! (chat silently lost its document context) and embedding writes failed.
+//!
+//! The fix makes the repo stateless: every method takes an RLS-context
+//! executor (the `RlsConnection` extractor — or the short-lived context-set
+//! connection in `send_message` — sets the org/user GUCs before any query).
+//! This test exercises the *repository methods themselves* on a `FORCE`-bound
+//! role and proves:
+//!
+//!   1. **Deny-all reproduction** — with the role bound but NO context set
+//!      (exactly what the raw-pool repo did on `dev`), an own-org
+//!      `find_document_embeddings` / `search_documents_by_text` returns nothing.
+//!   2. **Fix** — with `set_request_context(org_a, user_a)` applied first, the
+//!      same by-id read returns the own-org chunk.
+//!   3. **Cross-tenant by-id** — org B's document embeddings are invisible to
+//!      an org-A caller probing org B's `document_id`.
+//!   4. **Write path** — `create_embedding` succeeds under org-A context and
+//!      the row lands in the caller's org (the write-side of deny-all).
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — even `FORCE` does not bind a superuser, so a behavioral assertion
+//! would pass vacuously. The test creates a plain `NOSUPERUSER NOBYPASSRLS`
+//! role, grants it access, and `SET ROLE`s to it so `FORCE` actually enforces
+//! the policy the way the production owner role experiences it. Mirrors
+//! `sentiment_rls_repo_tests.rs` / `work_order` (the PAP-67 precedent PAP-80
+//! follows).
+
+use db::repositories::LlmDocumentRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("LlmDoc {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@llmdoc.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'LlmDoc User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Seed a parent document (FK target for embeddings) as superuser, RLS-exempt.
+async fn seed_document(pool: &PgPool, org_id: Uuid, created_by: Uuid, title: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO documents (
+            organization_id, title, category, file_key, file_name, mime_type,
+            size_bytes, created_by
+        )
+        VALUES ($1, $2, 'other', $3, $4, 'application/pdf', 1024, $5)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(title)
+    .bind(format!("s3/{title}.pdf"))
+    .bind(format!("{title}.pdf"))
+    .bind(created_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed document")
+}
+
+/// Seed an embedding chunk directly (as superuser, RLS-exempt) for an org.
+async fn seed_embedding(pool: &PgPool, org_id: Uuid, document_id: Uuid, text: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO document_embeddings
+            (organization_id, document_id, chunk_index, chunk_text, metadata)
+        VALUES ($1, $2, 0, $3, '{}'::jsonb)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(document_id)
+    .bind(text)
+    .fetch_one(pool)
+    .await
+    .expect("seed embedding")
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn llm_document_repo_force_rls_deny_all_and_fix(pool: PgPool) {
+    let repo = LlmDocumentRepository::new(pool.clone());
+
+    // --- Seed as superuser / super-admin context (satisfies org roles-trigger). ---
+    set_ctx(&pool, None, None, true).await;
+    let org_a = seed_org(&pool, "llmforce-a").await;
+    let org_b = seed_org(&pool, "llmforce-b").await;
+    let user_a = seed_user(&pool, "a@llmdoc.test").await;
+    let user_b = seed_user(&pool, "b@llmdoc.test").await;
+    let doc_a = seed_document(&pool, org_a, user_a, "llmdoc-rag-a").await;
+    let doc_b = seed_document(&pool, org_b, user_b, "llmdoc-rag-b").await;
+    let chunk_a = seed_embedding(&pool, org_a, doc_a, "boiler maintenance manual chapter").await;
+    let _chunk_b = seed_embedding(&pool, org_b, doc_b, "confidential org-b lease appendix").await;
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    let role = format!("ppt_rls_llmdoc_{}", Uuid::new_v4().simple());
+    for stmt in [
+        format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
+        format!("GRANT SELECT, INSERT, UPDATE, DELETE ON document_embeddings TO \"{role}\""),
+        // The org-not-deleted policy helper reads `organizations` with invoker
+        // rights, so the bound role needs read access to it.
+        format!("GRANT SELECT ON organizations TO \"{role}\""),
+        // RLS policy helpers must be EXECUTE-able by the bound role.
+        format!("GRANT EXECUTE ON FUNCTION get_current_org_id() TO \"{role}\""),
+        format!("GRANT EXECUTE ON FUNCTION get_current_org_not_deleted() TO \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .expect("grant setup");
+    }
+
+    // ====================================================================
+    // (1) DENY-ALL reproduction: role bound, NO context set (the dev raw-pool
+    //     behavior). Own-org RAG reads return nothing.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        // Explicitly clear any inherited context, then drop to the bound role.
+        sqlx::query("SELECT clear_request_context()")
+            .execute(&mut *conn)
+            .await
+            .expect("clear ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let by_doc = repo
+            .find_document_embeddings(&mut *conn, doc_a)
+            .await
+            .expect("find_document_embeddings (no ctx)");
+        assert!(
+            by_doc.is_empty(),
+            "PAP-80 regression: without RLS context, own-org embeddings must be \
+             invisible (deny-all) — this is what the raw-pool repo did on dev"
+        );
+
+        let by_text = repo
+            .search_documents_by_text(&mut *conn, org_a, "boiler", 5)
+            .await
+            .expect("search_documents_by_text (no ctx)");
+        assert!(
+            by_text.is_empty(),
+            "PAP-80 regression: the RAG text search silently returned no context \
+             on the raw pool"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (2) FIX + (3) cross-tenant by-id: set context, drop to bound role, query.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        // (2) Own-org by-id read IS now visible through the repo — the fix.
+        let by_doc = repo
+            .find_document_embeddings(&mut *conn, doc_a)
+            .await
+            .expect("find_document_embeddings (ctx)");
+        assert_eq!(
+            by_doc.iter().map(|e| e.id).collect::<Vec<_>>(),
+            vec![chunk_a],
+            "PAP-80 fix: with RLS context set, the by-id read returns exactly the own-org chunk"
+        );
+
+        // (3) Cross-tenant by-id: probing org B's document id from an org-A
+        //     context must surface nothing.
+        let cross = repo
+            .find_document_embeddings(&mut *conn, doc_b)
+            .await
+            .expect("find_document_embeddings (cross-tenant probe)");
+        assert!(
+            cross.is_empty(),
+            "cross-tenant: org B's embeddings must NOT be readable by an org-A caller"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (4) WRITE path: a create on a context-set connection succeeds and the
+    //     row is the caller's org. Without context the INSERT would fail the
+    //     policy WITH CHECK (the write-side of deny-all).
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let created = repo
+            .create_embedding(
+                &mut *conn,
+                org_a,
+                doc_a,
+                1,
+                "boiler maintenance manual chapter two",
+                None,
+                serde_json::json!({}),
+            )
+            .await
+            .expect("create_embedding under context must succeed");
+        assert_eq!(created.organization_id, org_a);
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup the test role. ---
+    set_ctx(&pool, None, None, true).await;
+    for stmt in [
+        format!("REVOKE ALL ON document_embeddings FROM \"{role}\""),
+        format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .ok();
+    }
+}

--- a/backend/servers/api-server/src/routes/ai/llm.rs
+++ b/backend/servers/api-server/src/routes/ai/llm.rs
@@ -6,12 +6,11 @@
 //! - Story 64.4: AI Photo Enhancement for Listings
 //! - Story 64.5: Voice Assistant Integration (handlers in [`super::voice`])
 
-use crate::routes::ai::require_tenant_id;
 use crate::routes::ai::voice::{
     link_voice_device, list_voice_commands, list_voice_devices, unlink_voice_device,
 };
 use crate::state::AppState;
-use api_core::extractors::principal::RequestPrincipal;
+use api_core::extractors::RlsConnection;
 use axum::{
     extract::{Path, State},
     http::StatusCode,
@@ -79,10 +78,12 @@ pub fn llm_router() -> Router<AppState> {
 )]
 async fn generate_lease(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Json(req): Json<GenerateLeaseRequest>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
+    // RLS context (org GUC) is set on rls.conn(); tenant_id is the authoritative org.
+    let tenant_id = rls.tenant_id();
+    let user_id = rls.user_id();
     let start_time = Instant::now();
 
     // SECURITY (issue #766 / #816): the lease is generated for a specific
@@ -90,21 +91,34 @@ async fn generate_lease(
     // creating the generation request or burning any LLM tokens — otherwise a
     // caller could generate a lease (and have it cost-attributed to their org)
     // against another tenant's unit, leaking the unit's identity/context.
-    let unit_ok = state
-        .llm_document_repo
-        .unit_belongs_to_org(req.unit_id, tenant_id)
-        .await
-        .map_err(|e| {
+    //
+    // Run the pre-LLM DB work on the RLS connection, then release it BEFORE
+    // the (slow) LLM call so we don't pin a pool connection for seconds.
+    let pre_llm = async {
+        let unit_ok = state
+            .llm_document_repo
+            .unit_belongs_to_org(&mut **rls.conn(), req.unit_id, tenant_id)
+            .await?;
+        Ok::<_, sqlx::Error>(unit_ok)
+    }
+    .await;
+
+    let unit_ok = match pre_llm {
+        Ok(ok) => ok,
+        Err(e) => {
+            rls.release().await;
             tracing::error!("Failed to validate unit ownership: {}", e);
-            (
+            return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new(
                     "INTERNAL_ERROR",
                     "Failed to validate unit",
                 )),
-            )
-        })?;
+            ));
+        }
+    };
     if !unit_ok {
+        rls.release().await;
         // 404 (not 403) mirrors the rest of this module: do not confirm the
         // existence of another tenant's unit to a caller who cannot see it.
         return Err((
@@ -132,25 +146,30 @@ async fn generate_lease(
     let request = state
         .llm_document_repo
         .create_generation_request(
+            &mut **rls.conn(),
             tenant_id,
-            principal.user_id,
+            user_id,
             "lease_generation",
             &provider,
             &model,
             input_data.clone(),
             req.template_id,
         )
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to create generation request: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to create request",
-                )),
-            )
-        })?;
+        .await;
+    // Release before the LLM round-trip; the post-LLM status update runs on
+    // the pool (llm_generation_requests is not RLS-bound) scoped by the row id
+    // we created under this tenant.
+    rls.release().await;
+    let request = request.map_err(|e| {
+        tracing::error!("Failed to create generation request: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "INTERNAL_ERROR",
+                "Failed to create request",
+            )),
+        )
+    })?;
 
     if !doc_gen_enabled {
         tracing::info!("LLM document generation disabled via feature flag");
@@ -206,6 +225,7 @@ async fn generate_lease(
             let _ = state
                 .llm_document_repo
                 .update_generation_status(
+                    &state.db,
                     request.id,
                     "completed",
                     Some(result_json.clone()),
@@ -248,6 +268,7 @@ async fn generate_lease(
             let _ = state
                 .llm_document_repo
                 .update_generation_status(
+                    &state.db,
                     request.id,
                     "failed",
                     None,
@@ -315,15 +336,17 @@ Respond with well-structured content that can be converted to a professional doc
 
 async fn list_lease_templates(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
+    let tenant_id = rls.tenant_id();
 
-    match state
+    let result = state
         .llm_document_repo
-        .list_prompt_templates(Some(tenant_id), Some("lease_generation"))
-        .await
-    {
+        .list_prompt_templates(&mut **rls.conn(), Some(tenant_id), Some("lease_generation"))
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(templates) => Ok(Json(serde_json::json!({ "templates": templates }))),
         Err(e) => {
             tracing::error!("Failed to list templates: {}", e);
@@ -340,18 +363,20 @@ async fn list_lease_templates(
 
 async fn get_lease_template(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
     // SECURITY (issue #766 / #816): scope the read to the caller's org so a
     // tenant cannot read another org's prompt template by guessing its id.
     // System templates (org_id NULL) remain readable by everyone.
-    let org_id = require_tenant_id(&principal)?;
-    match state
+    let org_id = rls.tenant_id();
+    let result = state
         .llm_document_repo
-        .find_prompt_template_for_org(id, org_id)
-        .await
-    {
+        .find_prompt_template_for_org(&mut **rls.conn(), id, org_id)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(Some(template)) => Ok(Json(serde_json::json!(template))),
         Ok(None) => Err((
             StatusCode::NOT_FOUND,
@@ -386,10 +411,11 @@ async fn get_lease_template(
 )]
 async fn generate_listing_description(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Json(req): Json<GenerateListingDescriptionRequest>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
+    let tenant_id = rls.tenant_id();
+    let user_id = rls.user_id();
     let start_time = Instant::now();
 
     // Check feature flag for document generation
@@ -411,25 +437,30 @@ async fn generate_listing_description(
     let request = state
         .llm_document_repo
         .create_generation_request(
+            &mut **rls.conn(),
             tenant_id,
-            principal.user_id,
+            user_id,
             "listing_description",
             &provider,
             &model,
             input_data.clone(),
             None,
         )
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to create generation request: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to create request",
-                )),
-            )
-        })?;
+        .await;
+    // Release before the LLM round-trip; the post-LLM writes run on the pool
+    // (generated_listing_descriptions / llm_generation_requests are not
+    // RLS-bound) with the org id taken from the verified principal above.
+    rls.release().await;
+    let request = request.map_err(|e| {
+        tracing::error!("Failed to create generation request: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "INTERNAL_ERROR",
+                "Failed to create request",
+            )),
+        )
+    })?;
 
     // Epic 92.2: Generate listing description using LLM
     let style_str = req.style.as_ref().and_then(|s| s.tone.as_deref());
@@ -494,9 +525,10 @@ async fn generate_listing_description(
     let description = state
         .llm_document_repo
         .create_listing_description(
+            &state.db,
             tenant_id,
             req.listing_id,
-            principal.user_id,
+            user_id,
             &req.language,
             &description_text,
             input_data,
@@ -519,6 +551,7 @@ async fn generate_listing_description(
     let _ = state
         .llm_document_repo
         .update_generation_status(
+            &state.db,
             request.id,
             "completed",
             Some(serde_json::json!({ "description": description_text })),
@@ -591,18 +624,20 @@ Format your response with clear sections for each component."#,
 
 async fn list_listing_descriptions(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(listing_id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
     // SECURITY (issue #766 / #816): scope the read to the caller's org so a
     // tenant cannot read another org's generated listing descriptions by
     // enumerating a listing id.
-    let org_id = require_tenant_id(&principal)?;
-    match state
+    let org_id = rls.tenant_id();
+    let result = state
         .llm_document_repo
-        .list_listing_descriptions_for_org(listing_id, org_id)
-        .await
-    {
+        .list_listing_descriptions_for_org(&mut **rls.conn(), listing_id, org_id)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(descriptions) => Ok(Json(serde_json::json!({ "descriptions": descriptions }))),
         Err(e) => {
             tracing::error!("Failed to list descriptions: {}", e);
@@ -616,17 +651,19 @@ async fn list_listing_descriptions(
 
 async fn publish_description(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
     // SECURITY (issue #766 / #816): scope the mutate to the caller's org so a
     // tenant cannot publish another org's generated listing description.
-    let org_id = require_tenant_id(&principal)?;
-    match state
+    let org_id = rls.tenant_id();
+    let result = state
         .llm_document_repo
-        .publish_description_for_org(id, org_id)
-        .await
-    {
+        .publish_description_for_org(&mut **rls.conn(), id, org_id)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(Some(desc)) => Ok(Json(serde_json::json!(desc))),
         Ok(None) => Err((
             StatusCode::NOT_FOUND,
@@ -658,23 +695,24 @@ async fn publish_description(
 )]
 async fn enhanced_chat(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Json(req): Json<EnhancedChatRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
+    let tenant_id = rls.tenant_id();
 
     // Get escalation config
     let config = state
         .llm_document_repo
-        .get_escalation_config(tenant_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to get escalation config: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get config")),
-            )
-        })?;
+        .get_escalation_config(rls.conn(), tenant_id)
+        .await;
+    rls.release().await;
+    let config = config.map_err(|e| {
+        tracing::error!("Failed to get escalation config: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get config")),
+        )
+    })?;
 
     // Placeholder response - real implementation would:
     // 1. Search document embeddings for relevant context
@@ -699,15 +737,17 @@ async fn enhanced_chat(
 
 async fn get_escalation_config(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
+    let tenant_id = rls.tenant_id();
 
-    match state
+    let result = state
         .llm_document_repo
-        .get_escalation_config(tenant_id)
-        .await
-    {
+        .get_escalation_config(rls.conn(), tenant_id)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(config) => Ok(Json(serde_json::json!(config))),
         Err(e) => {
             tracing::error!("Failed to get config: {}", e);
@@ -721,16 +761,18 @@ async fn get_escalation_config(
 
 async fn update_escalation_config(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Json(req): Json<UpdateEscalationConfig>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
+    let tenant_id = rls.tenant_id();
 
-    match state
+    let result = state
         .llm_document_repo
-        .update_escalation_config(tenant_id, req)
-        .await
-    {
+        .update_escalation_config(&mut **rls.conn(), tenant_id, req)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(config) => Ok(Json(serde_json::json!(config))),
         Err(e) => {
             tracing::error!("Failed to update config: {}", e);
@@ -761,34 +803,37 @@ async fn update_escalation_config(
 )]
 async fn enhance_photo(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Json(req): Json<EnhancePhotoRequest>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
+    let tenant_id = rls.tenant_id();
+    let user_id = rls.user_id();
 
     let metadata = serde_json::to_value(&req.options).unwrap_or_default();
 
     let enhancement = state
         .llm_document_repo
         .create_photo_enhancement(
+            &mut **rls.conn(),
             tenant_id,
             req.listing_id,
-            principal.user_id,
+            user_id,
             &req.photo_url,
             &req.enhancement_type,
             metadata,
         )
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to create enhancement: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to create enhancement",
-                )),
-            )
-        })?;
+        .await;
+    rls.release().await;
+    let enhancement = enhancement.map_err(|e| {
+        tracing::error!("Failed to create enhancement: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "INTERNAL_ERROR",
+                "Failed to create enhancement",
+            )),
+        )
+    })?;
 
     Ok((
         StatusCode::CREATED,
@@ -803,40 +848,51 @@ async fn enhance_photo(
 
 async fn batch_enhance_photos(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Json(req): Json<db::models::BatchEnhancePhotosRequest>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
+    let tenant_id = rls.tenant_id();
+    let user_id = rls.user_id();
 
-    let mut enhancements = Vec::new();
-    for photo_url in &req.photo_urls {
-        let enhancement = state
-            .llm_document_repo
-            .create_photo_enhancement(
-                tenant_id,
-                req.listing_id,
-                principal.user_id,
-                photo_url,
-                &req.enhancement_type,
-                serde_json::json!({}),
-            )
-            .await
-            .map_err(|e| {
-                tracing::error!("Failed to create enhancement: {}", e);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse::new(
-                        "INTERNAL_ERROR",
-                        "Failed to create enhancement",
-                    )),
+    // Run every per-photo INSERT on the same RLS-context connection, then
+    // release once. Errors are captured (not early-returned) so release()
+    // always runs.
+    let result = async {
+        let mut enhancements = Vec::new();
+        for photo_url in &req.photo_urls {
+            let enhancement = state
+                .llm_document_repo
+                .create_photo_enhancement(
+                    &mut **rls.conn(),
+                    tenant_id,
+                    req.listing_id,
+                    user_id,
+                    photo_url,
+                    &req.enhancement_type,
+                    serde_json::json!({}),
                 )
-            })?;
-        enhancements.push(serde_json::json!({
-            "id": enhancement.id,
-            "status": enhancement.status,
-            "original_url": photo_url
-        }));
+                .await?;
+            enhancements.push(serde_json::json!({
+                "id": enhancement.id,
+                "status": enhancement.status,
+                "original_url": photo_url
+            }));
+        }
+        Ok::<_, sqlx::Error>(enhancements)
     }
+    .await;
+    rls.release().await;
+
+    let enhancements = result.map_err(|e| {
+        tracing::error!("Failed to create enhancement: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "INTERNAL_ERROR",
+                "Failed to create enhancement",
+            )),
+        )
+    })?;
 
     Ok((
         StatusCode::CREATED,
@@ -850,17 +906,19 @@ async fn batch_enhance_photos(
 
 async fn get_photo_enhancement(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
     // SECURITY (issue #766 / #816): scope the read to the caller's org so a
     // tenant cannot read another org's photo enhancement by guessing its id.
-    let org_id = require_tenant_id(&principal)?;
-    match state
+    let org_id = rls.tenant_id();
+    let result = state
         .llm_document_repo
-        .find_photo_enhancement_for_org(id, org_id)
-        .await
-    {
+        .find_photo_enhancement_for_org(&mut **rls.conn(), id, org_id)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(Some(enhancement)) => Ok(Json(serde_json::json!(enhancement))),
         Ok(None) => Err((
             StatusCode::NOT_FOUND,
@@ -882,15 +940,17 @@ async fn get_photo_enhancement(
 
 async fn get_ai_statistics(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
+    let tenant_id = rls.tenant_id();
 
-    match state
+    let result = state
         .llm_document_repo
-        .get_usage_statistics(tenant_id, None, None)
-        .await
-    {
+        .get_usage_statistics(rls.conn(), tenant_id, None, None)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(stats) => Ok(Json(serde_json::json!(stats))),
         Err(e) => {
             tracing::error!("Failed to get statistics: {}", e);
@@ -915,22 +975,25 @@ pub struct GenerationRequestsQuery {
 
 async fn list_generation_requests(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     axum::extract::Query(query): axum::extract::Query<GenerationRequestsQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
+    let tenant_id = rls.tenant_id();
 
-    match state
+    let result = state
         .llm_document_repo
         .list_generation_requests(
+            &mut **rls.conn(),
             tenant_id,
             query.request_type.as_deref(),
             query.status.as_deref(),
             query.limit.unwrap_or(50),
             query.offset.unwrap_or(0),
         )
-        .await
-    {
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(requests) => Ok(Json(serde_json::json!({ "requests": requests }))),
         Err(e) => {
             tracing::error!("Failed to list requests: {}", e);
@@ -944,18 +1007,20 @@ async fn list_generation_requests(
 
 async fn get_generation_request(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
     // SECURITY (issue #766 / #816): scope the read to the caller's org so a
     // tenant cannot read another org's generation request (prompts, results,
     // cost data) by guessing its id.
-    let org_id = require_tenant_id(&principal)?;
-    match state
+    let org_id = rls.tenant_id();
+    let result = state
         .llm_document_repo
-        .find_generation_request_for_org(id, org_id)
-        .await
-    {
+        .find_generation_request_for_org(&mut **rls.conn(), id, org_id)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(Some(request)) => Ok(Json(serde_json::json!(request))),
         Ok(None) => Err((
             StatusCode::NOT_FOUND,

--- a/backend/servers/api-server/src/routes/ai/sessions.rs
+++ b/backend/servers/api-server/src/routes/ai/sessions.rs
@@ -463,6 +463,12 @@ async fn send_message(
 
     // Story 97.2: Search for relevant documents using RAG with semantic similarity.
     // Scoped to `tenant_id` derived from the verified principal.
+    //
+    // PAP-108 (PAP-80): `document_embeddings` is FORCE-RLS (migration 00179),
+    // so these reads must run on a connection that carries the org GUC — on the
+    // raw pool the policy collapsed to deny-all and RAG silently returned no
+    // context. Acquire a short-lived RLS-context connection scoped to this
+    // tenant (same pattern as the sentiment block above).
     let mut context_chunks: Vec<ContextChunk> = vec![];
     {
         // Check if semantic search is enabled via feature flag
@@ -472,92 +478,123 @@ async fn send_message(
         let use_semantic_search =
             semantic_search_enabled != "false" && semantic_search_enabled != "0";
 
-        if use_semantic_search {
-            // Try semantic similarity search first (Story 97.2)
-            // Generate embedding for the user's query
-            match state
-                .llm_client
-                .generate_embedding(&req.content, None)
+        let mut rag_conn = match state.db.acquire().await {
+            Ok(mut conn) => {
+                if db::tenant_context::set_request_context(
+                    &mut *conn,
+                    Some(tenant_id),
+                    Some(principal.user_id),
+                    false,
+                )
                 .await
-            {
-                Ok(embedding_result) => {
-                    // Search documents by embedding similarity
-                    match state
-                        .llm_document_repo
-                        .search_documents_by_embedding(
-                            tenant_id,
-                            &embedding_result.embedding,
-                            5,         // Get top 5 relevant chunks
-                            Some(0.6), // Minimum similarity threshold
-                        )
-                        .await
-                    {
-                        Ok(docs_with_scores) => {
-                            for (doc, similarity) in docs_with_scores {
-                                context_chunks.push(ContextChunk {
-                                    source_id: doc.document_id,
-                                    source_title: doc
-                                        .metadata
-                                        .get("title")
-                                        .and_then(|v| v.as_str())
-                                        .unwrap_or("Document")
-                                        .to_string(),
-                                    text: doc.chunk_text.clone(),
-                                    relevance_score: similarity,
-                                });
+                .is_err()
+                {
+                    tracing::warn!("Failed to set RLS context for RAG search");
+                    None
+                } else {
+                    Some(conn)
+                }
+            }
+            Err(e) => {
+                tracing::warn!("Failed to acquire connection for RAG search: {}", e);
+                None
+            }
+        };
+
+        if let Some(conn) = rag_conn.as_mut() {
+            if use_semantic_search {
+                // Try semantic similarity search first (Story 97.2)
+                // Generate embedding for the user's query
+                match state
+                    .llm_client
+                    .generate_embedding(&req.content, None)
+                    .await
+                {
+                    Ok(embedding_result) => {
+                        // Search documents by embedding similarity
+                        match state
+                            .llm_document_repo
+                            .search_documents_by_embedding(
+                                &mut *conn,
+                                tenant_id,
+                                &embedding_result.embedding,
+                                5,         // Get top 5 relevant chunks
+                                Some(0.6), // Minimum similarity threshold
+                            )
+                            .await
+                        {
+                            Ok(docs_with_scores) => {
+                                for (doc, similarity) in docs_with_scores {
+                                    context_chunks.push(ContextChunk {
+                                        source_id: doc.document_id,
+                                        source_title: doc
+                                            .metadata
+                                            .get("title")
+                                            .and_then(|v| v.as_str())
+                                            .unwrap_or("Document")
+                                            .to_string(),
+                                        text: doc.chunk_text.clone(),
+                                        relevance_score: similarity,
+                                    });
+                                }
+                                tracing::debug!(
+                                    "RAG semantic search found {} relevant chunks",
+                                    context_chunks.len()
+                                );
                             }
-                            tracing::debug!(
-                                "RAG semantic search found {} relevant chunks",
-                                context_chunks.len()
-                            );
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                "Semantic search failed, falling back to text search: {}",
-                                e
-                            );
+                            Err(e) => {
+                                tracing::warn!(
+                                    "Semantic search failed, falling back to text search: {}",
+                                    e
+                                );
+                            }
                         }
                     }
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to generate query embedding, falling back to text search: {}",
+                            e
+                        );
+                    }
                 }
-                Err(e) => {
-                    tracing::warn!(
-                        "Failed to generate query embedding, falling back to text search: {}",
-                        e
-                    );
+            }
+
+            // Fallback to text search if semantic search didn't find results or is disabled
+            if context_chunks.is_empty() {
+                match state
+                    .llm_document_repo
+                    .search_documents_by_text(&mut **conn, tenant_id, &req.content, 3)
+                    .await
+                {
+                    Ok(docs) => {
+                        for doc in docs {
+                            context_chunks.push(ContextChunk {
+                                source_id: doc.document_id,
+                                source_title: doc
+                                    .metadata
+                                    .get("title")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("Document")
+                                    .to_string(),
+                                text: doc.chunk_text.clone(),
+                                relevance_score: 0.5, // Lower score for text match fallback
+                            });
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to search documents for RAG context (tenant: {}): {}",
+                            tenant_id,
+                            e
+                        );
+                    }
                 }
             }
         }
 
-        // Fallback to text search if semantic search didn't find results or is disabled
-        if context_chunks.is_empty() {
-            match state
-                .llm_document_repo
-                .search_documents_by_text(tenant_id, &req.content, 3)
-                .await
-            {
-                Ok(docs) => {
-                    for doc in docs {
-                        context_chunks.push(ContextChunk {
-                            source_id: doc.document_id,
-                            source_title: doc
-                                .metadata
-                                .get("title")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("Document")
-                                .to_string(),
-                            text: doc.chunk_text.clone(),
-                            relevance_score: 0.5, // Lower score for text match fallback
-                        });
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "Failed to search documents for RAG context (tenant: {}): {}",
-                        tenant_id,
-                        e
-                    );
-                }
-            }
+        // Clear RLS context before the connection returns to the pool.
+        if let Some(mut conn) = rag_conn {
+            let _ = db::tenant_context::clear_request_context(&mut *conn).await;
         }
     }
 

--- a/backend/servers/api-server/src/routes/ai/voice.rs
+++ b/backend/servers/api-server/src/routes/ai/voice.rs
@@ -5,9 +5,9 @@
 //! other Epic-64 LLM endpoints; they live in their own module purely for size
 //! and are exposed `pub(crate)` so the router constructor can reference them.
 
-use crate::routes::ai::{require_tenant_id, PaginationQuery};
+use crate::routes::ai::PaginationQuery;
 use crate::state::AppState;
-use api_core::extractors::principal::RequestPrincipal;
+use api_core::extractors::RlsConnection;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -23,17 +23,19 @@ use uuid::Uuid;
 
 pub(crate) async fn list_voice_devices(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    // Voice devices are scoped to the user; require_tenant_id still gates
-    // platform-host callers out of a per-tenant API surface.
-    let _ = require_tenant_id(&principal)?;
+    // Voice devices are scoped to the user; the RlsConnection extractor still
+    // gates platform-host callers out of a per-tenant API surface.
+    let user_id = rls.user_id();
 
-    match state
+    let result = state
         .llm_document_repo
-        .list_user_voice_devices(principal.user_id)
-        .await
-    {
+        .list_user_voice_devices(&mut **rls.conn(), user_id)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(devices) => Ok(Json(serde_json::json!({ "devices": devices }))),
         Err(e) => {
             tracing::error!("Failed to list devices: {}", e);
@@ -57,10 +59,11 @@ pub(crate) async fn list_voice_devices(
 )]
 pub(crate) async fn link_voice_device(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Json(req): Json<LinkVoiceDeviceRequest>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
+    let tenant_id = rls.tenant_id();
+    let user_id = rls.user_id();
 
     // Generate a unique device ID: platform prefix + UUID for debugging and uniqueness.
     // Format: "google_assistant_550e8400-e29b-41d4-a716-446655440000"
@@ -69,14 +72,21 @@ pub(crate) async fn link_voice_device(
 
     // Story 98.1: Implement OAuth token exchange using auth_code from request.
     // Exchange the authorization code for access and refresh tokens from the voice platform.
-    let (access_token_encrypted, refresh_token_encrypted, token_expires_at) =
-        exchange_voice_oauth_tokens(&req.platform, &req.auth_code).await?;
+    let oauth_result = exchange_voice_oauth_tokens(&req.platform, &req.auth_code).await;
+    let (access_token_encrypted, refresh_token_encrypted, token_expires_at) = match oauth_result {
+        Ok(tokens) => tokens,
+        Err(e) => {
+            rls.release().await;
+            return Err(e);
+        }
+    };
 
     let device = state
         .llm_document_repo
         .create_voice_device(
+            &mut **rls.conn(),
             tenant_id,
-            principal.user_id,
+            user_id,
             req.unit_id,
             &req.platform,
             &device_id,
@@ -86,17 +96,18 @@ pub(crate) async fn link_voice_device(
             token_expires_at,
             serde_json::json!(["check_balance", "report_fault", "check_announcements"]),
         )
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to link device: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to link device",
-                )),
-            )
-        })?;
+        .await;
+    rls.release().await;
+    let device = device.map_err(|e| {
+        tracing::error!("Failed to link device: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "INTERNAL_ERROR",
+                "Failed to link device",
+            )),
+        )
+    })?;
 
     Ok((
         StatusCode::CREATED,
@@ -225,17 +236,20 @@ async fn exchange_voice_oauth_tokens(
 
 pub(crate) async fn unlink_voice_device(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     // Scope the deactivation to the caller's own devices.  A non-owned or
     // non-existent id both return false from the repository and are mapped to
     // 404, giving an attacker no information about whether the target id exists.
-    match state
+    let user_id = rls.user_id();
+    let result = state
         .llm_document_repo
-        .deactivate_voice_device(id, principal.user_id)
-        .await
-    {
+        .deactivate_voice_device(&mut **rls.conn(), id, user_id)
+        .await;
+    rls.release().await;
+
+    match result {
         Ok(true) => Ok(StatusCode::NO_CONTENT),
         Ok(false) => Err((
             StatusCode::NOT_FOUND,
@@ -253,45 +267,47 @@ pub(crate) async fn unlink_voice_device(
 
 pub(crate) async fn list_voice_commands(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(device_id): Path<Uuid>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+    let user_id = rls.user_id();
+
     // Issue #483: unify disclosure posture with unlink_voice_device — was
     // returning HTTP 200 + empty list for not-owned devices, which leaks
     // device-UUID existence. Return 404 instead.
-    match state
-        .llm_document_repo
-        .user_owns_voice_device(device_id, principal.user_id)
-        .await
-    {
-        Ok(true) => {}
-        Ok(false) => {
-            return Err((
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Device not found")),
-            ));
+    //
+    // Both reads run on the same RLS-context connection; errors are captured
+    // (not early-returned) so release() always runs.
+    let result = async {
+        let owns = state
+            .llm_document_repo
+            .user_owns_voice_device(&mut **rls.conn(), device_id, user_id)
+            .await?;
+        if !owns {
+            return Ok(None);
         }
-        Err(e) => {
-            tracing::error!("Failed to verify voice device ownership: {}", e);
-            return Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to list")),
-            ));
-        }
+        let commands = state
+            .llm_document_repo
+            .list_voice_commands(
+                &mut **rls.conn(),
+                device_id,
+                user_id,
+                query.limit.unwrap_or(50),
+                query.offset.unwrap_or(0),
+            )
+            .await?;
+        Ok::<_, sqlx::Error>(Some(commands))
     }
+    .await;
+    rls.release().await;
 
-    match state
-        .llm_document_repo
-        .list_voice_commands(
-            device_id,
-            principal.user_id,
-            query.limit.unwrap_or(50),
-            query.offset.unwrap_or(0),
-        )
-        .await
-    {
-        Ok(commands) => Ok(Json(serde_json::json!({ "commands": commands }))),
+    match result {
+        Ok(Some(commands)) => Ok(Json(serde_json::json!({ "commands": commands }))),
+        Ok(None) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("NOT_FOUND", "Device not found")),
+        )),
         Err(e) => {
             tracing::error!("Failed to list commands: {}", e);
             Err((

--- a/backend/servers/api-server/src/routes/voice_webhooks.rs
+++ b/backend/servers/api-server/src/routes/voice_webhooks.rs
@@ -142,7 +142,7 @@ async fn alexa_webhook(
             // Welcome message
             let processor = VoiceCommandProcessor::new(state.llm_document_repo.clone());
             let (result, _) = processor
-                .process_command(device.id, "help", &locale)
+                .process_command(rls.conn(), device.id, "help", &locale)
                 .await
                 .map_err(|e| {
                     tracing::error!("Voice command processing failed: {}", e);
@@ -158,7 +158,7 @@ async fn alexa_webhook(
             let command_text = extract_alexa_command_text(intent);
             let processor = VoiceCommandProcessor::new(state.llm_document_repo.clone());
             let (result, _) = processor
-                .process_command(device.id, &command_text, &locale)
+                .process_command(rls.conn(), device.id, &command_text, &locale)
                 .await
                 .map_err(|e| {
                     tracing::error!("Voice command processing failed: {}", e);
@@ -261,7 +261,7 @@ async fn google_actions_webhook(
     // Process the command
     let processor = VoiceCommandProcessor::new(state.llm_document_repo.clone());
     let (result, _) = processor
-        .process_command(device.id, command_text, locale)
+        .process_command(rls.conn(), device.id, command_text, locale)
         .await
         .map_err(|e| {
             tracing::error!("Voice command processing failed: {}", e);
@@ -434,10 +434,15 @@ async fn oauth_token_exchange(
     // (derived above from the verified access token — never random UUIDs).
     let device_id = format!("{}_{}", request.platform, Uuid::new_v4());
 
-    // Create the voice device with tokens
+    // Create the voice device with tokens.
+    // PAP-108 (PAP-80): the repo is stateless; `voice_assistant_devices` is not
+    // RLS-bound, and this handler is authenticated via `AuthUser` (no
+    // RlsConnection extractor), so the pool is the correct executor here. The
+    // org/user scoping comes from the verified PM access token above.
     let device = state
         .llm_document_repo
         .create_voice_device(
+            &state.db,
             org_id,
             user_id,
             None,
@@ -497,10 +502,13 @@ async fn oauth_token_refresh(
 ) -> Result<Json<VoiceTokenRefreshResult>, (StatusCode, Json<ErrorResponse>)> {
     use integrations::{decrypt_if_available, VoiceOAuthManager, VoicePlatform};
 
-    // Find the device
+    // Find the device.
+    // PAP-108 (PAP-80): this endpoint is called by the voice platform (no PM
+    // principal, no RlsConnection); `voice_assistant_devices` is not RLS-bound,
+    // so the pool is the correct executor for the cross-org device lookup.
     let device = state
         .llm_document_repo
-        .find_voice_device(request.device_id)
+        .find_voice_device(&state.db, request.device_id)
         .await
         .map_err(|e| {
             tracing::error!("Database error: {}", e);
@@ -593,6 +601,7 @@ async fn oauth_token_refresh(
     state
         .llm_document_repo
         .update_voice_device_tokens(
+            &state.db,
             device.id,
             &new_access_encrypted,
             new_refresh_encrypted.as_deref(),

--- a/backend/servers/api-server/src/services/voice_commands.rs
+++ b/backend/servers/api-server/src/services/voice_commands.rs
@@ -12,6 +12,7 @@ use db::models::{
 };
 use db::repositories::LlmDocumentRepository;
 use serde_json::json;
+use sqlx::PgConnection;
 use std::time::Instant;
 use thiserror::Error;
 use uuid::Uuid;
@@ -153,8 +154,13 @@ impl VoiceCommandProcessor {
     }
 
     /// Process a complete voice command from device ID to response.
+    ///
+    /// PAP-108 (PAP-80): the repository is stateless, so the caller supplies
+    /// the connection — in webhook handlers this is the `RlsConnection`'s
+    /// context-set connection (`&mut **rls.conn()`).
     pub async fn process_command(
         &self,
+        conn: &mut PgConnection,
         device_id: Uuid,
         command_text: &str,
         locale: &str,
@@ -164,7 +170,7 @@ impl VoiceCommandProcessor {
         // Find the device
         let device = self
             .llm_document_repo
-            .find_voice_device(device_id)
+            .find_voice_device(&mut *conn, device_id)
             .await?
             .ok_or(VoiceCommandError::DeviceNotFound(device_id))?;
 
@@ -189,6 +195,7 @@ impl VoiceCommandProcessor {
         let history = self
             .llm_document_repo
             .create_voice_command(
+                &mut *conn,
                 device_id,
                 device.user_id,
                 command_text,
@@ -204,7 +211,7 @@ impl VoiceCommandProcessor {
         // Update device last used timestamp
         let _ = self
             .llm_document_repo
-            .update_voice_device_last_used(device_id)
+            .update_voice_device_last_used(&mut *conn, device_id)
             .await;
 
         Ok((

--- a/backend/servers/api-server/tests/ai_llm_cross_tenant_idor_tests.rs
+++ b/backend/servers/api-server/tests/ai_llm_cross_tenant_idor_tests.rs
@@ -292,7 +292,7 @@ async fn list_listing_descriptions_for_org_blocks_cross_tenant_read(pool: PgPool
 
     // Same-org read returns the row.
     let same_org = repo
-        .list_listing_descriptions_for_org(listing_in_a, org_a)
+        .list_listing_descriptions_for_org(&pool, listing_in_a, org_a)
         .await
         .expect("query ok");
     assert_eq!(
@@ -303,7 +303,7 @@ async fn list_listing_descriptions_for_org_blocks_cross_tenant_read(pool: PgPool
 
     // Cross-org read returns nothing (the IDOR is blocked).
     let cross_org = repo
-        .list_listing_descriptions_for_org(listing_in_a, org_b)
+        .list_listing_descriptions_for_org(&pool, listing_in_a, org_b)
         .await
         .expect("query ok");
     assert!(
@@ -314,7 +314,7 @@ async fn list_listing_descriptions_for_org_blocks_cross_tenant_read(pool: PgPool
     // Demonstrate the leak the org predicate closes: the unscoped lookup the
     // pre-fix handler performed returns the row regardless of org.
     let unscoped = repo
-        .list_listing_descriptions(listing_in_a)
+        .list_listing_descriptions(&pool, listing_in_a)
         .await
         .expect("query ok");
     assert_eq!(


### PR DESCRIPTION
## Summary

PAP-108 (parent PAP-80 RLS sweep, step 3/3 of this engineer's chain): `LlmDocumentRepository` held a raw `PgPool` while querying **`document_embeddings`**, which migration `00179` put under `FORCE ROW LEVEL SECURITY` + the canonical `get_current_org_id()` policy. Under `FORCE` the api-server's owner connection is no longer exempt, so every RAG read on the raw pool collapsed to **deny-all**: enhanced-chat semantic/text search silently returned no document context on dev, and embedding writes failed the policy `WITH CHECK`. Mounted via `/api/v1/ai/llm` and `/api/v1/webhooks/voice`.

## Changes

- **`crates/db/src/repositories/llm_document.rs`** — stateless repo per the `work_order`/`vendor`/`sentiment` precedent (`47c806799`): no pool stored (`new(_pool)` kept for AppState construction-site compatibility); single-statement methods take a generic `Executor`, the seven multi-statement methods (`search_documents_by_embedding`, `search_documents_pgvector`, `create_embeddings_batch`, `get_rag_statistics`, `migrate_embeddings_to_pgvector`, `get_escalation_config`, `get_usage_statistics`) take `&mut PgConnection` and reborrow.
- **`routes/ai/llm.rs`, `routes/ai/voice.rs`** — handlers switch from `RequestPrincipal` + `require_tenant_id` to the `RlsConnection` extractor; pass `&mut **rls.conn()`, use `rls.tenant_id()`/`rls.user_id()` as the authoritative principal, `release()` before returning. The two LLM-generation handlers release **before** the slow LLM round-trip; post-LLM bookkeeping runs on the pool (those tables are not RLS-bound) keyed by the row created under the tenant context.
- **`routes/ai/sessions.rs`** — the `send_message` RAG block acquires a short-lived context-set connection (same pattern as its sentiment block) so `document_embeddings` reads actually return the tenant's chunks. This fixes the silent RAG no-context bug on dev.
- **`routes/voice_webhooks.rs` / `services/voice_commands.rs`** — `VoiceCommandProcessor::process_command` takes the caller's connection; Alexa/Google webhooks pass their existing `RlsConnection`. The platform-called OAuth refresh endpoint (no PM principal) runs its `voice_assistant_devices` lookups on the pool — correct, since that table carries no RLS.
- **`tests/ai_llm_cross_tenant_idor_tests.rs`** — repo calls updated to the executor signature (`&pool`).
- **NEW `crates/db/tests/llm_document_rls_repo_tests.rs`** — role-switch (`NOSUPERUSER NOBYPASSRLS`) behavioral test: (1) reproduces the raw-pool deny-all, (2) proves the context-set fix on a by-id read, (3) blocks a cross-tenant by-id probe, (4) exercises the write path.

## Verification (remote rbuild/mercury per PAP-80 guardrail)

- `cargo check -p db` ✅ `cargo check -p api-server` ✅
- `cargo clippy -p db --all-targets -- -D warnings` ✅; `cargo clippy -p api-server --lib --test ai_llm_cross_tenant_idor_tests -- -D warnings` ✅ (pre-existing unrelated clippy reds in `portal_webhook_signature_tests.rs` untouched)
- `cargo fmt --all -- --check` ✅
- `cargo test -p db --test llm_document_rls_repo_tests` ✅ (1 passed, against dockerized PG16)

Closes PAP-108. Part of [PAP-80].

🤖 Generated with [Claude Code](https://claude.com/claude-code)