### PR TITLE
fix(db): route integration repo through RLS-context connection (PAP-80)

### DIFF
--- a/backend/crates/db/src/repositories/integration.rs
+++ b/backend/crates/db/src/repositories/integration.rs
@@ -8,12 +8,28 @@
 //! environment variable to a 64-character hex string (32 bytes).
 //!
 //! Generate a key with: `openssl rand -hex 32`
+//!
+//! # RLS Integration (PAP-67 / PAP-80 / PAP-105)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on `webhook_subscriptions` — the one table used
+//! by this repository that is FORCE-bound today. Under `FORCE` the api-server's
+//! owner connection is no longer exempt, so a query issued on a connection
+//! without `app.current_org_id` set collapses to deny-all (own-org reads return
+//! empty, writes fail the policy `WITH CHECK`).
+//!
+//! Every method therefore takes an **executor whose connection already has RLS
+//! context set** (org + user GUCs) — in handlers this comes from the
+//! `RlsConnection` extractor via `&mut **rls.conn()`. The repository holds **no
+//! pool**, so it cannot issue an un-scoped query even against the tables that
+//! are not FORCE-bound yet. This mirrors the `work_order.rs` / `sentiment.rs`
+//! precedent.
 
 use crate::models::integration::*;
 use crate::DbPool;
 use chrono::{Duration, Utc};
 use integrations::{decrypt_if_available, encrypt_if_available, IntegrationCrypto};
-use sqlx::Error as SqlxError;
+use sqlx::{Error as SqlxError, Executor, PgConnection, Postgres};
 use std::str::FromStr;
 use uuid::Uuid;
 
@@ -37,9 +53,12 @@ pub enum IntegrationError {
 ///
 /// Supports optional encryption for sensitive data like OAuth tokens and webhook secrets.
 /// If INTEGRATION_ENCRYPTION_KEY is not set, data will be stored unencrypted (dev mode).
+///
+/// Stateless with respect to the database: every method receives an
+/// RLS-context-bearing executor. The repo holds no pool so it cannot issue an
+/// un-scoped (deny-all under `FORCE`) query.
 #[derive(Clone)]
 pub struct IntegrationRepository {
-    pool: DbPool,
     /// Optional crypto service for encrypting/decrypting sensitive data.
     crypto: Option<IntegrationCrypto>,
 }
@@ -49,11 +68,16 @@ impl IntegrationRepository {
     ///
     /// Automatically attempts to initialize encryption from environment.
     ///
+    /// The pool argument is retained for construction-site compatibility with
+    /// the other repositories on `AppState`; this repo deliberately does not
+    /// store it (see module docs — all queries run on a context-set connection
+    /// supplied by the handler's `RlsConnection`).
+    ///
     /// # Security Warning
     /// If `INTEGRATION_ENCRYPTION_KEY` is not set, OAuth tokens and webhook secrets
     /// will be stored in plaintext. This is acceptable for development but should
     /// be configured in production environments.
-    pub fn new(pool: DbPool) -> Self {
+    pub fn new(_pool: DbPool) -> Self {
         let crypto = IntegrationCrypto::try_from_env();
         if crypto.is_none() {
             // Log at warn level - operators should configure encryption for production
@@ -62,12 +86,15 @@ impl IntegrationRepository {
                  will be stored in plaintext. Configure this for production deployments."
             );
         }
-        Self { pool, crypto }
+        Self { crypto }
     }
 
     /// Create a new IntegrationRepository with explicit crypto configuration.
-    pub fn with_crypto(pool: DbPool, crypto: Option<IntegrationCrypto>) -> Self {
-        Self { pool, crypto }
+    ///
+    /// The pool argument is retained for construction-site compatibility only
+    /// (see [`IntegrationRepository::new`]); it is not stored.
+    pub fn with_crypto(_pool: DbPool, crypto: Option<IntegrationCrypto>) -> Self {
+        Self { crypto }
     }
 
     /// Encrypt a value using the configured crypto, or return plaintext if not configured.
@@ -120,12 +147,16 @@ impl IntegrationRepository {
     /// Create a calendar connection.
     ///
     /// Validates that the provider is a valid calendar provider type.
-    pub async fn create_calendar_connection(
+    pub async fn create_calendar_connection<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         user_id: Uuid,
         data: CreateCalendarConnection,
-    ) -> Result<CalendarConnection, IntegrationError> {
+    ) -> Result<CalendarConnection, IntegrationError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // Validate provider
         CalendarProvider::from_str(&data.provider).map_err(IntegrationError::InvalidProvider)?;
 
@@ -143,7 +174,7 @@ impl IntegrationRepository {
         .bind(&data.provider)
         .bind(&data.calendar_id)
         .bind(&data.sync_direction)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(IntegrationError::Database)
     }
@@ -151,15 +182,19 @@ impl IntegrationRepository {
     /// Get calendar connection by ID.
     ///
     /// Returns the connection with decrypted access_token and refresh_token.
-    pub async fn get_calendar_connection(
+    pub async fn get_calendar_connection<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
-    ) -> Result<Option<CalendarConnection>, SqlxError> {
+    ) -> Result<Option<CalendarConnection>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let conn = sqlx::query_as::<_, CalendarConnection>(
             "SELECT * FROM calendar_connections WHERE id = $1",
         )
         .bind(id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await?;
 
         Ok(conn.map(|c| self.decrypt_calendar_connection(c)))
@@ -168,11 +203,15 @@ impl IntegrationRepository {
     /// List calendar connections for a user.
     ///
     /// Returns connections with decrypted access_token and refresh_token.
-    pub async fn list_calendar_connections(
+    pub async fn list_calendar_connections<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         user_id: Option<Uuid>,
-    ) -> Result<Vec<CalendarConnection>, SqlxError> {
+    ) -> Result<Vec<CalendarConnection>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let connections = if let Some(uid) = user_id {
             sqlx::query_as::<_, CalendarConnection>(
                 r#"
@@ -183,7 +222,7 @@ impl IntegrationRepository {
             )
             .bind(organization_id)
             .bind(uid)
-            .fetch_all(&self.pool)
+            .fetch_all(executor)
             .await?
         } else {
             sqlx::query_as::<_, CalendarConnection>(
@@ -194,7 +233,7 @@ impl IntegrationRepository {
                 "#,
             )
             .bind(organization_id)
-            .fetch_all(&self.pool)
+            .fetch_all(executor)
             .await?
         };
 
@@ -207,11 +246,15 @@ impl IntegrationRepository {
     /// Update calendar connection.
     ///
     /// Returns connection with decrypted tokens.
-    pub async fn update_calendar_connection(
+    pub async fn update_calendar_connection<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         data: UpdateCalendarConnection,
-    ) -> Result<CalendarConnection, SqlxError> {
+    ) -> Result<CalendarConnection, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let conn = sqlx::query_as::<_, CalendarConnection>(
             r#"
             UPDATE calendar_connections SET
@@ -227,17 +270,24 @@ impl IntegrationRepository {
         .bind(&data.calendar_id)
         .bind(&data.sync_direction)
         .bind(&data.sync_status)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await?;
 
         Ok(self.decrypt_calendar_connection(conn))
     }
 
     /// Delete calendar connection.
-    pub async fn delete_calendar_connection(&self, id: Uuid) -> Result<bool, SqlxError> {
+    pub async fn delete_calendar_connection<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+    ) -> Result<bool, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM calendar_connections WHERE id = $1")
             .bind(id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
@@ -245,13 +295,17 @@ impl IntegrationRepository {
     /// Update calendar connection tokens.
     ///
     /// Encrypts access_token and refresh_token before storage.
-    pub async fn update_calendar_tokens(
+    pub async fn update_calendar_tokens<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         access_token: &str,
         refresh_token: Option<&str>,
         expires_at: Option<chrono::DateTime<Utc>>,
-    ) -> Result<(), SqlxError> {
+    ) -> Result<(), SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // Encrypt tokens before storage
         let encrypted_access = self.encrypt(access_token);
         let encrypted_refresh = self.encrypt_optional(refresh_token);
@@ -270,18 +324,22 @@ impl IntegrationRepository {
         .bind(&encrypted_access)
         .bind(&encrypted_refresh)
         .bind(expires_at)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
         Ok(())
     }
 
     /// Update sync status.
-    pub async fn update_sync_status(
+    pub async fn update_sync_status<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         status: &str,
         error: Option<&str>,
-    ) -> Result<(), SqlxError> {
+    ) -> Result<(), SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query(
             r#"
             UPDATE calendar_connections SET
@@ -295,7 +353,7 @@ impl IntegrationRepository {
         .bind(id)
         .bind(status)
         .bind(error)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
         Ok(())
     }
@@ -305,10 +363,14 @@ impl IntegrationRepository {
     // ========================================================================
 
     /// Create a calendar event.
-    pub async fn create_calendar_event(
+    pub async fn create_calendar_event<'e, E>(
         &self,
+        executor: E,
         data: CreateCalendarEvent,
-    ) -> Result<CalendarEvent, SqlxError> {
+    ) -> Result<CalendarEvent, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, CalendarEvent>(
             r#"
             INSERT INTO calendar_events (
@@ -331,7 +393,7 @@ impl IntegrationRepository {
         .bind(data.all_day)
         .bind(&data.recurrence_rule)
         .bind(&data.attendees)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
@@ -339,13 +401,17 @@ impl IntegrationRepository {
     /// Returns true if a new event was created, false if skipped (duplicate).
     ///
     /// Uses atomic INSERT ... ON CONFLICT to avoid race conditions.
-    pub async fn upsert_calendar_event(
+    pub async fn upsert_calendar_event<'e, E>(
         &self,
+        executor: E,
         data: CreateCalendarEvent,
-    ) -> Result<bool, SqlxError> {
+    ) -> Result<bool, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // If no external_event_id provided, just do a regular insert
         if data.external_event_id.is_none() {
-            self.create_calendar_event(data).await?;
+            self.create_calendar_event(executor, data).await?;
             return Ok(true);
         }
 
@@ -372,7 +438,7 @@ impl IntegrationRepository {
         .bind(data.all_day)
         .bind(&data.recurrence_rule)
         .bind(&data.attendees)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
 
         // rows_affected() is 1 if a new event was created, 0 if it already existed
@@ -380,12 +446,16 @@ impl IntegrationRepository {
     }
 
     /// List calendar events for a connection.
-    pub async fn list_calendar_events(
+    pub async fn list_calendar_events<'e, E>(
         &self,
+        executor: E,
         connection_id: Uuid,
         from: Option<chrono::DateTime<Utc>>,
         to: Option<chrono::DateTime<Utc>>,
-    ) -> Result<Vec<CalendarEvent>, SqlxError> {
+    ) -> Result<Vec<CalendarEvent>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let from_date = from.unwrap_or_else(Utc::now);
         let to_date = to.unwrap_or_else(|| Utc::now() + Duration::days(30));
 
@@ -401,7 +471,7 @@ impl IntegrationRepository {
         .bind(connection_id)
         .bind(from_date)
         .bind(to_date)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -412,12 +482,16 @@ impl IntegrationRepository {
     /// Create an accounting export.
     ///
     /// Validates that the system_type is a valid accounting system.
-    pub async fn create_accounting_export(
+    pub async fn create_accounting_export<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         exported_by: Uuid,
         data: CreateAccountingExport,
-    ) -> Result<AccountingExport, IntegrationError> {
+    ) -> Result<AccountingExport, IntegrationError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // Validate accounting system type
         AccountingSystem::from_str(&data.system_type).map_err(IntegrationError::InvalidProvider)?;
 
@@ -437,29 +511,37 @@ impl IntegrationRepository {
         .bind(data.period_start)
         .bind(data.period_end)
         .bind(exported_by)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(IntegrationError::Database)
     }
 
     /// Get accounting export by ID.
-    pub async fn get_accounting_export(
+    pub async fn get_accounting_export<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
-    ) -> Result<Option<AccountingExport>, SqlxError> {
+    ) -> Result<Option<AccountingExport>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, AccountingExport>("SELECT * FROM accounting_exports WHERE id = $1")
             .bind(id)
-            .fetch_optional(&self.pool)
+            .fetch_optional(executor)
             .await
     }
 
     /// List accounting exports for an organization.
-    pub async fn list_accounting_exports(
+    pub async fn list_accounting_exports<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         system_type: Option<&str>,
         limit: i32,
-    ) -> Result<Vec<AccountingExport>, SqlxError> {
+    ) -> Result<Vec<AccountingExport>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         if let Some(st) = system_type {
             sqlx::query_as::<_, AccountingExport>(
                 r#"
@@ -472,7 +554,7 @@ impl IntegrationRepository {
             .bind(organization_id)
             .bind(st)
             .bind(limit)
-            .fetch_all(&self.pool)
+            .fetch_all(executor)
             .await
         } else {
             sqlx::query_as::<_, AccountingExport>(
@@ -485,21 +567,26 @@ impl IntegrationRepository {
             )
             .bind(organization_id)
             .bind(limit)
-            .fetch_all(&self.pool)
+            .fetch_all(executor)
             .await
         }
     }
 
     /// Update accounting export status.
-    pub async fn update_accounting_export_status(
+    #[allow(clippy::too_many_arguments)]
+    pub async fn update_accounting_export_status<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         status: &str,
         file_path: Option<&str>,
         file_size: Option<i64>,
         record_count: Option<i32>,
         error_message: Option<&str>,
-    ) -> Result<AccountingExport, SqlxError> {
+    ) -> Result<AccountingExport, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, AccountingExport>(
             r#"
             UPDATE accounting_exports SET
@@ -519,13 +606,18 @@ impl IntegrationRepository {
         .bind(file_size)
         .bind(record_count)
         .bind(error_message)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get or create accounting export settings.
+    ///
+    /// Multi-statement (SELECT then conditional INSERT), so it takes a
+    /// `&mut PgConnection` and reborrows for each query rather than a generic
+    /// by-value executor.
     pub async fn get_accounting_export_settings(
         &self,
+        conn: &mut PgConnection,
         organization_id: Uuid,
         system_type: &str,
     ) -> Result<AccountingExportSettings, SqlxError> {
@@ -535,7 +627,7 @@ impl IntegrationRepository {
         )
         .bind(organization_id)
         .bind(system_type)
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *conn)
         .await?;
 
         if let Some(settings) = existing {
@@ -551,18 +643,22 @@ impl IntegrationRepository {
             )
             .bind(organization_id)
             .bind(system_type)
-            .fetch_one(&self.pool)
+            .fetch_one(&mut *conn)
             .await
         }
     }
 
     /// Update accounting export settings.
-    pub async fn update_accounting_export_settings(
+    pub async fn update_accounting_export_settings<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         system_type: &str,
         data: UpdateAccountingExportSettings,
-    ) -> Result<AccountingExportSettings, SqlxError> {
+    ) -> Result<AccountingExportSettings, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, AccountingExportSettings>(
             r#"
             UPDATE accounting_export_settings SET
@@ -583,7 +679,7 @@ impl IntegrationRepository {
         .bind(&data.vat_settings)
         .bind(data.auto_export_enabled)
         .bind(&data.auto_export_schedule)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
@@ -594,12 +690,16 @@ impl IntegrationRepository {
     /// Create an e-signature workflow.
     ///
     /// Validates that the provider (if specified) is a valid e-signature provider.
-    pub async fn create_esignature_workflow(
+    pub async fn create_esignature_workflow<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         created_by: Uuid,
         data: CreateESignatureWorkflow,
-    ) -> Result<ESignatureWorkflow, IntegrationError> {
+    ) -> Result<ESignatureWorkflow, IntegrationError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // Validate provider if specified
         if let Some(ref provider) = data.provider {
             ESignatureProvider::from_str(provider).map_err(IntegrationError::InvalidProvider)?;
@@ -628,17 +728,21 @@ impl IntegrationRepository {
         .bind(data.reminder_enabled)
         .bind(data.reminder_days)
         .bind(created_by)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(IntegrationError::Database)
     }
 
     /// Add recipient to e-signature workflow.
-    pub async fn add_esignature_recipient(
+    pub async fn add_esignature_recipient<'e, E>(
         &self,
+        executor: E,
         workflow_id: Uuid,
         data: CreateESignatureRecipient,
-    ) -> Result<ESignatureRecipient, SqlxError> {
+    ) -> Result<ESignatureRecipient, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, ESignatureRecipient>(
             r#"
             INSERT INTO esignature_recipients (
@@ -653,29 +757,38 @@ impl IntegrationRepository {
         .bind(&data.name)
         .bind(&data.role)
         .bind(data.signing_order)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get e-signature workflow by ID.
-    pub async fn get_esignature_workflow(
+    pub async fn get_esignature_workflow<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
-    ) -> Result<Option<ESignatureWorkflow>, SqlxError> {
+    ) -> Result<Option<ESignatureWorkflow>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, ESignatureWorkflow>("SELECT * FROM esignature_workflows WHERE id = $1")
             .bind(id)
-            .fetch_optional(&self.pool)
+            .fetch_optional(executor)
             .await
     }
 
     /// Get e-signature workflow with recipients.
+    ///
+    /// Multi-statement (workflow lookup then recipients), so it takes a
+    /// `&mut PgConnection` and reborrows for each query rather than a generic
+    /// by-value executor.
     pub async fn get_esignature_workflow_with_recipients(
         &self,
+        conn: &mut PgConnection,
         id: Uuid,
     ) -> Result<Option<ESignatureWorkflowWithRecipients>, SqlxError> {
-        let workflow = self.get_esignature_workflow(id).await?;
+        let workflow = self.get_esignature_workflow(&mut *conn, id).await?;
         if let Some(w) = workflow {
-            let recipients = self.list_esignature_recipients(id).await?;
+            let recipients = self.list_esignature_recipients(&mut *conn, id).await?;
             Ok(Some(ESignatureWorkflowWithRecipients {
                 workflow: w,
                 recipients,
@@ -686,25 +799,33 @@ impl IntegrationRepository {
     }
 
     /// List e-signature recipients for a workflow.
-    pub async fn list_esignature_recipients(
+    pub async fn list_esignature_recipients<'e, E>(
         &self,
+        executor: E,
         workflow_id: Uuid,
-    ) -> Result<Vec<ESignatureRecipient>, SqlxError> {
+    ) -> Result<Vec<ESignatureRecipient>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, ESignatureRecipient>(
             "SELECT * FROM esignature_recipients WHERE workflow_id = $1 ORDER BY signing_order",
         )
         .bind(workflow_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// List e-signature workflows for an organization.
-    pub async fn list_esignature_workflows(
+    pub async fn list_esignature_workflows<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         status: Option<&str>,
         limit: i32,
-    ) -> Result<Vec<ESignatureWorkflow>, SqlxError> {
+    ) -> Result<Vec<ESignatureWorkflow>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         if let Some(s) = status {
             sqlx::query_as::<_, ESignatureWorkflow>(
                 r#"
@@ -717,7 +838,7 @@ impl IntegrationRepository {
             .bind(organization_id)
             .bind(s)
             .bind(limit)
-            .fetch_all(&self.pool)
+            .fetch_all(executor)
             .await
         } else {
             sqlx::query_as::<_, ESignatureWorkflow>(
@@ -730,17 +851,21 @@ impl IntegrationRepository {
             )
             .bind(organization_id)
             .bind(limit)
-            .fetch_all(&self.pool)
+            .fetch_all(executor)
             .await
         }
     }
 
     /// Update e-signature workflow status.
-    pub async fn update_esignature_workflow_status(
+    pub async fn update_esignature_workflow_status<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         status: &str,
-    ) -> Result<ESignatureWorkflow, SqlxError> {
+    ) -> Result<ESignatureWorkflow, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, ESignatureWorkflow>(
             r#"
             UPDATE esignature_workflows SET
@@ -753,17 +878,21 @@ impl IntegrationRepository {
         )
         .bind(id)
         .bind(status)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Update e-signature recipient status.
-    pub async fn update_esignature_recipient_status(
+    pub async fn update_esignature_recipient_status<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         status: &str,
         decline_reason: Option<&str>,
-    ) -> Result<ESignatureRecipient, SqlxError> {
+    ) -> Result<ESignatureRecipient, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, ESignatureRecipient>(
             r#"
             UPDATE esignature_recipients SET
@@ -779,7 +908,7 @@ impl IntegrationRepository {
         .bind(id)
         .bind(status)
         .bind(decline_reason)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
@@ -796,11 +925,15 @@ impl IntegrationRepository {
     /// read-modify-write races; the function still returns the current row (if
     /// the envelope exists) so callers can observe the unchanged terminal
     /// state, and returns `None` only when no workflow matches the envelope ID.
-    pub async fn update_esignature_workflow_by_external_id(
+    pub async fn update_esignature_workflow_by_external_id<'e, E>(
         &self,
+        executor: E,
         external_envelope_id: &str,
         status: &str,
-    ) -> Result<Option<ESignatureWorkflow>, SqlxError> {
+    ) -> Result<Option<ESignatureWorkflow>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let terminal: Vec<String> = esignature_status::TERMINAL
             .iter()
             .map(|s| s.to_string())
@@ -827,7 +960,7 @@ impl IntegrationRepository {
         .bind(external_envelope_id)
         .bind(status)
         .bind(terminal)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
@@ -838,12 +971,16 @@ impl IntegrationRepository {
     /// Create a video conference connection.
     ///
     /// Validates that the provider is a valid video conferencing provider.
-    pub async fn create_video_conference_connection(
+    pub async fn create_video_conference_connection<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         user_id: Uuid,
         data: CreateVideoConferenceConnection,
-    ) -> Result<VideoConferenceConnection, IntegrationError> {
+    ) -> Result<VideoConferenceConnection, IntegrationError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // Validate provider
         VideoProvider::from_str(&data.provider).map_err(IntegrationError::InvalidProvider)?;
 
@@ -859,7 +996,7 @@ impl IntegrationRepository {
         .bind(organization_id)
         .bind(user_id)
         .bind(&data.provider)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(IntegrationError::Database)
     }
@@ -867,15 +1004,19 @@ impl IntegrationRepository {
     /// Get video conference connection by ID.
     ///
     /// Returns connection with decrypted access_token and refresh_token.
-    pub async fn get_video_conference_connection(
+    pub async fn get_video_conference_connection<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
-    ) -> Result<Option<VideoConferenceConnection>, SqlxError> {
+    ) -> Result<Option<VideoConferenceConnection>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let conn = sqlx::query_as::<_, VideoConferenceConnection>(
             "SELECT * FROM video_conference_connections WHERE id = $1",
         )
         .bind(id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await?;
 
         Ok(conn.map(|c| self.decrypt_video_connection(c)))
@@ -884,11 +1025,15 @@ impl IntegrationRepository {
     /// List video conference connections for a user.
     ///
     /// Returns connections with decrypted access_token and refresh_token.
-    pub async fn list_video_conference_connections(
+    pub async fn list_video_conference_connections<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         user_id: Option<Uuid>,
-    ) -> Result<Vec<VideoConferenceConnection>, SqlxError> {
+    ) -> Result<Vec<VideoConferenceConnection>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let connections = if let Some(uid) = user_id {
             sqlx::query_as::<_, VideoConferenceConnection>(
                 r#"
@@ -899,7 +1044,7 @@ impl IntegrationRepository {
             )
             .bind(organization_id)
             .bind(uid)
-            .fetch_all(&self.pool)
+            .fetch_all(executor)
             .await?
         } else {
             sqlx::query_as::<_, VideoConferenceConnection>(
@@ -910,7 +1055,7 @@ impl IntegrationRepository {
                 "#,
             )
             .bind(organization_id)
-            .fetch_all(&self.pool)
+            .fetch_all(executor)
             .await?
         };
 
@@ -923,13 +1068,17 @@ impl IntegrationRepository {
     /// Update video conference connection tokens.
     ///
     /// Encrypts access_token and refresh_token before storage.
-    pub async fn update_video_connection_tokens(
+    pub async fn update_video_connection_tokens<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         access_token: &str,
         refresh_token: Option<&str>,
         expires_at: Option<chrono::DateTime<Utc>>,
-    ) -> Result<(), SqlxError> {
+    ) -> Result<(), SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // Encrypt tokens before storage
         let encrypted_access = self.encrypt(access_token);
         let encrypted_refresh = self.encrypt_optional(refresh_token);
@@ -948,18 +1097,25 @@ impl IntegrationRepository {
         .bind(&encrypted_access)
         .bind(&encrypted_refresh)
         .bind(expires_at)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
         Ok(())
     }
 
     /// Delete video conference connection.
-    pub async fn delete_video_conference_connection(&self, id: Uuid) -> Result<bool, SqlxError> {
+    pub async fn delete_video_conference_connection<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+    ) -> Result<bool, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query(
             "UPDATE video_conference_connections SET is_active = false, updated_at = NOW() WHERE id = $1",
         )
         .bind(id)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
         Ok(result.rows_affected() > 0)
     }
@@ -969,12 +1125,16 @@ impl IntegrationRepository {
     // ========================================================================
 
     /// Create a video meeting.
-    pub async fn create_video_meeting(
+    pub async fn create_video_meeting<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         created_by: Uuid,
         data: CreateVideoMeeting,
-    ) -> Result<VideoMeeting, SqlxError> {
+    ) -> Result<VideoMeeting, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, VideoMeeting>(
             r#"
             INSERT INTO video_meetings (
@@ -995,26 +1155,37 @@ impl IntegrationRepository {
         .bind(data.duration_minutes)
         .bind(&data.timezone)
         .bind(created_by)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get video meeting by ID.
-    pub async fn get_video_meeting(&self, id: Uuid) -> Result<Option<VideoMeeting>, SqlxError> {
+    pub async fn get_video_meeting<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+    ) -> Result<Option<VideoMeeting>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, VideoMeeting>("SELECT * FROM video_meetings WHERE id = $1")
             .bind(id)
-            .fetch_optional(&self.pool)
+            .fetch_optional(executor)
             .await
     }
 
     /// List video meetings for an organization.
-    pub async fn list_video_meetings(
+    pub async fn list_video_meetings<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         from: Option<chrono::DateTime<Utc>>,
         status: Option<&str>,
         limit: i32,
-    ) -> Result<Vec<VideoMeeting>, SqlxError> {
+    ) -> Result<Vec<VideoMeeting>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let from_date = from.unwrap_or_else(Utc::now);
 
         if let Some(s) = status {
@@ -1030,7 +1201,7 @@ impl IntegrationRepository {
             .bind(from_date)
             .bind(s)
             .bind(limit)
-            .fetch_all(&self.pool)
+            .fetch_all(executor)
             .await
         } else {
             sqlx::query_as::<_, VideoMeeting>(
@@ -1044,17 +1215,21 @@ impl IntegrationRepository {
             .bind(organization_id)
             .bind(from_date)
             .bind(limit)
-            .fetch_all(&self.pool)
+            .fetch_all(executor)
             .await
         }
     }
 
     /// Update video meeting.
-    pub async fn update_video_meeting(
+    pub async fn update_video_meeting<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         data: UpdateVideoMeeting,
-    ) -> Result<VideoMeeting, SqlxError> {
+    ) -> Result<VideoMeeting, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, VideoMeeting>(
             r#"
             UPDATE video_meetings SET
@@ -1074,19 +1249,23 @@ impl IntegrationRepository {
         .bind(data.start_time)
         .bind(data.duration_minutes)
         .bind(&data.status)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Update video meeting join URLs.
-    pub async fn update_video_meeting_urls(
+    pub async fn update_video_meeting_urls<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         external_meeting_id: &str,
         join_url: &str,
         host_url: Option<&str>,
         password: Option<&str>,
-    ) -> Result<VideoMeeting, SqlxError> {
+    ) -> Result<VideoMeeting, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, VideoMeeting>(
             r#"
             UPDATE video_meetings SET
@@ -1104,15 +1283,22 @@ impl IntegrationRepository {
         .bind(join_url)
         .bind(host_url)
         .bind(password)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Delete video meeting.
-    pub async fn delete_video_meeting(&self, id: Uuid) -> Result<bool, SqlxError> {
+    pub async fn delete_video_meeting<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+    ) -> Result<bool, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM video_meetings WHERE id = $1")
             .bind(id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
@@ -1129,13 +1315,17 @@ impl IntegrationRepository {
     /// - Must not target localhost in production
     ///
     /// Encrypts the webhook secret before storage.
-    pub async fn create_webhook_subscription(
+    pub async fn create_webhook_subscription<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         created_by: Uuid,
         data: CreateWebhookSubscription,
         is_production: bool,
-    ) -> Result<WebhookSubscription, IntegrationError> {
+    ) -> Result<WebhookSubscription, IntegrationError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // Validate webhook URL
         let validation = validate_webhook_url(&data.url, is_production);
         if !validation.is_valid {
@@ -1168,7 +1358,7 @@ impl IntegrationRepository {
         .bind(&data.headers)
         .bind(serde_json::to_value(&data.retry_policy).ok())
         .bind(created_by)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(IntegrationError::Database)?;
 
@@ -1178,15 +1368,19 @@ impl IntegrationRepository {
     /// Get webhook subscription by ID.
     ///
     /// Returns subscription with decrypted secret.
-    pub async fn get_webhook_subscription(
+    pub async fn get_webhook_subscription<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
-    ) -> Result<Option<WebhookSubscription>, SqlxError> {
+    ) -> Result<Option<WebhookSubscription>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let sub = sqlx::query_as::<_, WebhookSubscription>(
             "SELECT * FROM webhook_subscriptions WHERE id = $1",
         )
         .bind(id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await?;
 
         Ok(sub.map(|s| self.decrypt_webhook_subscription(s)))
@@ -1195,10 +1389,14 @@ impl IntegrationRepository {
     /// List webhook subscriptions for an organization.
     ///
     /// Returns subscriptions with decrypted secrets.
-    pub async fn list_webhook_subscriptions(
+    pub async fn list_webhook_subscriptions<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
-    ) -> Result<Vec<WebhookSubscription>, SqlxError> {
+    ) -> Result<Vec<WebhookSubscription>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let subs = sqlx::query_as::<_, WebhookSubscription>(
             r#"
             SELECT * FROM webhook_subscriptions
@@ -1207,7 +1405,7 @@ impl IntegrationRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await?;
 
         Ok(subs
@@ -1220,12 +1418,16 @@ impl IntegrationRepository {
     ///
     /// Validates the webhook URL if it's being updated.
     /// Encrypts the secret if it's being updated.
-    pub async fn update_webhook_subscription(
+    pub async fn update_webhook_subscription<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         data: UpdateWebhookSubscription,
         is_production: bool,
-    ) -> Result<WebhookSubscription, IntegrationError> {
+    ) -> Result<WebhookSubscription, IntegrationError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // Validate new URL if provided
         if let Some(ref url) = data.url {
             let validation = validate_webhook_url(url, is_production);
@@ -1266,7 +1468,7 @@ impl IntegrationRepository {
         .bind(&data.headers)
         .bind(&data.status)
         .bind(serde_json::to_value(&data.retry_policy).ok())
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(IntegrationError::Database)?;
 
@@ -1274,10 +1476,17 @@ impl IntegrationRepository {
     }
 
     /// Delete webhook subscription.
-    pub async fn delete_webhook_subscription(&self, id: Uuid) -> Result<bool, SqlxError> {
+    pub async fn delete_webhook_subscription<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+    ) -> Result<bool, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM webhook_subscriptions WHERE id = $1")
             .bind(id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
@@ -1285,11 +1494,15 @@ impl IntegrationRepository {
     /// Get subscriptions for a specific event.
     ///
     /// Returns subscriptions with decrypted secrets.
-    pub async fn get_subscriptions_for_event(
+    pub async fn get_subscriptions_for_event<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         event_type: &str,
-    ) -> Result<Vec<WebhookSubscription>, SqlxError> {
+    ) -> Result<Vec<WebhookSubscription>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let subs = sqlx::query_as::<_, WebhookSubscription>(
             r#"
             SELECT * FROM webhook_subscriptions
@@ -1300,7 +1513,7 @@ impl IntegrationRepository {
         )
         .bind(organization_id)
         .bind(event_type)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await?;
 
         Ok(subs
@@ -1314,13 +1527,17 @@ impl IntegrationRepository {
     // ========================================================================
 
     /// Create a webhook delivery log.
-    pub async fn create_webhook_delivery_log(
+    pub async fn create_webhook_delivery_log<'e, E>(
         &self,
+        executor: E,
         subscription_id: Uuid,
         event_type: &str,
         event_id: Uuid,
         payload: serde_json::Value,
-    ) -> Result<WebhookDeliveryLog, SqlxError> {
+    ) -> Result<WebhookDeliveryLog, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, WebhookDeliveryLog>(
             r#"
             INSERT INTO webhook_delivery_logs (
@@ -1334,14 +1551,15 @@ impl IntegrationRepository {
         .bind(event_type)
         .bind(event_id)
         .bind(&payload)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Update webhook delivery status.
     #[allow(clippy::too_many_arguments)]
-    pub async fn update_webhook_delivery_status(
+    pub async fn update_webhook_delivery_status<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         status: &str,
         response_status: Option<i32>,
@@ -1349,7 +1567,10 @@ impl IntegrationRepository {
         error_message: Option<&str>,
         duration_ms: Option<i32>,
         next_retry_at: Option<chrono::DateTime<Utc>>,
-    ) -> Result<WebhookDeliveryLog, SqlxError> {
+    ) -> Result<WebhookDeliveryLog, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, WebhookDeliveryLog>(
             r#"
             UPDATE webhook_delivery_logs SET
@@ -1372,15 +1593,19 @@ impl IntegrationRepository {
         .bind(error_message)
         .bind(duration_ms)
         .bind(next_retry_at)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// List webhook delivery logs.
-    pub async fn list_webhook_delivery_logs(
+    pub async fn list_webhook_delivery_logs<'e, E>(
         &self,
+        executor: E,
         query: WebhookDeliveryQuery,
-    ) -> Result<Vec<WebhookDeliveryLog>, SqlxError> {
+    ) -> Result<Vec<WebhookDeliveryLog>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50);
         let offset = query.offset.unwrap_or(0);
 
@@ -1403,15 +1628,19 @@ impl IntegrationRepository {
         .bind(query.to_date)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Get webhook statistics for a subscription.
-    pub async fn get_webhook_statistics(
+    pub async fn get_webhook_statistics<'e, E>(
         &self,
+        executor: E,
         subscription_id: Uuid,
-    ) -> Result<WebhookStatistics, SqlxError> {
+    ) -> Result<WebhookStatistics, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let stats = sqlx::query_as::<_, (i64, i64, i64, i64, Option<f64>)>(
             r#"
             SELECT
@@ -1425,7 +1654,7 @@ impl IntegrationRepository {
             "#,
         )
         .bind(subscription_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await?;
 
         let success_rate = if stats.0 > 0 {
@@ -1445,10 +1674,14 @@ impl IntegrationRepository {
     }
 
     /// Get pending webhook deliveries for retry.
-    pub async fn get_pending_webhook_deliveries(
+    pub async fn get_pending_webhook_deliveries<'e, E>(
         &self,
+        executor: E,
         limit: i32,
-    ) -> Result<Vec<WebhookDeliveryLog>, SqlxError> {
+    ) -> Result<Vec<WebhookDeliveryLog>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, WebhookDeliveryLog>(
             r#"
             SELECT wdl.* FROM webhook_delivery_logs wdl
@@ -1461,7 +1694,7 @@ impl IntegrationRepository {
             "#,
         )
         .bind(limit)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -1473,8 +1706,15 @@ impl IntegrationRepository {
     ///
     /// Logs errors for individual statistics queries but continues collecting other stats.
     /// This ensures partial data is returned even if some queries fail.
+    ///
+    /// Multi-statement (six independent stats queries), so it takes a
+    /// `&mut PgConnection` and reborrows for each query rather than a generic
+    /// by-value executor. The webhook sub-queries hit FORCE-RLS
+    /// `webhook_subscriptions`, so the connection MUST carry the caller's org
+    /// context or they read as zero.
     pub async fn get_integration_statistics(
         &self,
+        conn: &mut PgConnection,
         organization_id: Uuid,
     ) -> Result<IntegrationStatistics, SqlxError> {
         // Calendar stats
@@ -1488,7 +1728,7 @@ impl IntegrationRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
         .unwrap_or_else(|e| {
             tracing::warn!(
@@ -1508,7 +1748,7 @@ impl IntegrationRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
         .unwrap_or_else(|e| {
             tracing::warn!(
@@ -1530,7 +1770,7 @@ impl IntegrationRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
         .unwrap_or_else(|e| {
             tracing::warn!(
@@ -1551,7 +1791,7 @@ impl IntegrationRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
         .unwrap_or_else(|e| {
             tracing::warn!(
@@ -1570,7 +1810,7 @@ impl IntegrationRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
         .unwrap_or_else(|e| {
             tracing::warn!(
@@ -1593,7 +1833,7 @@ impl IntegrationRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
         .unwrap_or_else(|e| {
             tracing::warn!(
@@ -1631,10 +1871,14 @@ impl IntegrationRepository {
     ///
     /// Returns connections where the token expires within the given buffer time
     /// and have a refresh token available.
-    pub async fn get_calendar_connections_needing_refresh(
+    pub async fn get_calendar_connections_needing_refresh<'e, E>(
         &self,
+        executor: E,
         buffer_secs: i64,
-    ) -> Result<Vec<CalendarConnection>, SqlxError> {
+    ) -> Result<Vec<CalendarConnection>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let threshold = Utc::now() + Duration::seconds(buffer_secs);
 
         let connections = sqlx::query_as::<_, CalendarConnection>(
@@ -1649,7 +1893,7 @@ impl IntegrationRepository {
             "#,
         )
         .bind(threshold)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await?;
 
         Ok(connections
@@ -1659,10 +1903,14 @@ impl IntegrationRepository {
     }
 
     /// Get video conference connections that need token refresh.
-    pub async fn get_video_connections_needing_refresh(
+    pub async fn get_video_connections_needing_refresh<'e, E>(
         &self,
+        executor: E,
         buffer_secs: i64,
-    ) -> Result<Vec<VideoConferenceConnection>, SqlxError> {
+    ) -> Result<Vec<VideoConferenceConnection>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let threshold = Utc::now() + Duration::seconds(buffer_secs);
 
         let connections = sqlx::query_as::<_, VideoConferenceConnection>(
@@ -1677,7 +1925,7 @@ impl IntegrationRepository {
             "#,
         )
         .bind(threshold)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await?;
 
         Ok(connections
@@ -1689,7 +1937,14 @@ impl IntegrationRepository {
     /// Mark a calendar connection's tokens as revoked (user-initiated revocation).
     ///
     /// This clears the tokens and sets sync_status to 'disconnected'.
-    pub async fn revoke_calendar_connection_tokens(&self, id: Uuid) -> Result<bool, SqlxError> {
+    pub async fn revoke_calendar_connection_tokens<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+    ) -> Result<bool, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query(
             r#"
             UPDATE calendar_connections SET
@@ -1703,14 +1958,21 @@ impl IntegrationRepository {
             "#,
         )
         .bind(id)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
 
         Ok(result.rows_affected() > 0)
     }
 
     /// Mark a video conference connection's tokens as revoked.
-    pub async fn revoke_video_connection_tokens(&self, id: Uuid) -> Result<bool, SqlxError> {
+    pub async fn revoke_video_connection_tokens<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+    ) -> Result<bool, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query(
             r#"
             UPDATE video_conference_connections SET
@@ -1723,7 +1985,7 @@ impl IntegrationRepository {
             "#,
         )
         .bind(id)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
 
         Ok(result.rows_affected() > 0)
@@ -1732,12 +1994,16 @@ impl IntegrationRepository {
     /// Record a token refresh attempt result.
     ///
     /// Updates the connection with refresh result information for monitoring.
-    pub async fn record_calendar_refresh_result(
+    pub async fn record_calendar_refresh_result<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         success: bool,
         error: Option<&str>,
-    ) -> Result<(), SqlxError> {
+    ) -> Result<(), SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         if success {
             sqlx::query(
                 r#"
@@ -1750,7 +2016,7 @@ impl IntegrationRepository {
                 "#,
             )
             .bind(id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         } else {
             sqlx::query(
@@ -1767,15 +2033,19 @@ impl IntegrationRepository {
             )
             .bind(id)
             .bind(error)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         }
         Ok(())
     }
 
     /// Get count of connections needing refresh (for monitoring).
+    ///
+    /// Multi-statement (two COUNT queries), so it takes a `&mut PgConnection`
+    /// and reborrows for each query rather than a generic by-value executor.
     pub async fn count_connections_needing_refresh(
         &self,
+        conn: &mut PgConnection,
         buffer_secs: i64,
     ) -> Result<(i64, i64), SqlxError> {
         let threshold = Utc::now() + Duration::seconds(buffer_secs);
@@ -1790,7 +2060,7 @@ impl IntegrationRepository {
             "#,
         )
         .bind(threshold)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
         .unwrap_or(0);
 
@@ -1804,7 +2074,7 @@ impl IntegrationRepository {
             "#,
         )
         .bind(threshold)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
         .unwrap_or(0);
 
@@ -1929,7 +2199,11 @@ mod esignature_webhook_idempotency_tests {
         // Provider re-delivers, this time trying to move the workflow to
         // `voided`. The guard must keep it `completed`.
         let returned = repo
-            .update_esignature_workflow_by_external_id(external_id, esignature_status::VOIDED)
+            .update_esignature_workflow_by_external_id(
+                &pool,
+                external_id,
+                esignature_status::VOIDED,
+            )
             .await
             .expect("repo call failed");
 
@@ -1967,7 +2241,11 @@ mod esignature_webhook_idempotency_tests {
         let repo = IntegrationRepository::new(pool.clone());
 
         let returned = repo
-            .update_esignature_workflow_by_external_id(external_id, esignature_status::COMPLETED)
+            .update_esignature_workflow_by_external_id(
+                &pool,
+                external_id,
+                esignature_status::COMPLETED,
+            )
             .await
             .expect("repo call failed");
 

--- a/backend/crates/db/tests/integration_rls_repo_tests.rs
+++ b/backend/crates/db/tests/integration_rls_repo_tests.rs
@@ -1,0 +1,306 @@
+//! Repo-level behavioral RLS regression test for PAP-105 (parent PAP-80 / PAP-67).
+//!
+//! Background
+//! ----------
+//! Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on `webhook_subscriptions` — the one table
+//! used by `IntegrationRepository` that is FORCE-bound today. The production
+//! api-server connects as the table OWNER, which `FORCE` binds.
+//! `IntegrationRepository` held a raw `DbPool` and ran every query WITHOUT
+//! ever calling `set_request_context`, so on `dev` `get_current_org_id()`
+//! returned NULL and the policy collapsed to `organization_id = NULL` →
+//! **deny-all**: own-org reads returned empty, writes failed. (PAP-105.)
+//!
+//! The fix makes the repo hold no pool: every method takes an RLS-context
+//! executor (the `RlsConnection` extractor in handlers sets the org/user GUCs
+//! before any query). This test exercises the *repository methods themselves*
+//! on a `FORCE`-bound role and proves:
+//!
+//!   1. **Deny-all reproduction** — with the role bound but NO context set
+//!      (exactly what the raw-pool repo did on `dev`), an own-org
+//!      `list_webhook_subscriptions` returns nothing.
+//!   2. **Fix** — with `set_request_context(org_a, user_a)` applied first
+//!      (what `RlsConnection` now does), the same call returns the own-org
+//!      subscription, and the own-org by-id `get_webhook_subscription`
+//!      resolves.
+//!   3. **Cross-tenant by-id** — org B's subscription is invisible to an
+//!      org-A caller: `get_webhook_subscription` returns `None` (handlers
+//!      surface 404, indistinguishable from missing).
+//!   4. **Write path** — a `create_webhook_subscription` on a context-set
+//!      connection succeeds and the row is the caller's org (without context
+//!      the INSERT would fail the policy `WITH CHECK` — the write-side of
+//!      deny-all).
+//!
+//! Schema note (Epic-61 scaffold drift)
+//! ------------------------------------
+//! `webhook_subscriptions` was created by migration `00102` for the API
+//! ecosystem; the Epic-61 repository additionally expects `status` and
+//! `retry_policy` columns that no migration ships yet. The test adds those
+//! two nullable/defaulted columns up front (as the RLS-exempt superuser) so
+//! the repository's SQL is runnable — the FORCE policy under test is
+//! `organization_id = get_current_org_id()` and is orthogonal to the added
+//! columns.
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — even `FORCE` does not bind a superuser, so a behavioral
+//! assertion would pass vacuously. The test creates a plain `NOSUPERUSER
+//! NOBYPASSRLS` role, grants it access, and `SET ROLE`s to it so `FORCE`
+//! actually enforces the policy the way the production owner role experiences
+//! it. Mirrors `sentiment_rls_repo_tests.rs` / `emergency_rls_repo_tests.rs`
+//! (the PAP-67 precedent PAP-80 follows).
+
+use db::models::CreateWebhookSubscription;
+use db::repositories::IntegrationRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Integration {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@integration.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'Integration User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Add the Epic-61 columns the repository expects but no migration ships yet
+/// (see module docs — orthogonal to the FORCE policy under test).
+async fn align_webhook_subscriptions_schema(pool: &PgPool) {
+    for stmt in [
+        "ALTER TABLE webhook_subscriptions \
+         ADD COLUMN IF NOT EXISTS status VARCHAR(20) NOT NULL DEFAULT 'active'",
+        "ALTER TABLE webhook_subscriptions ADD COLUMN IF NOT EXISTS retry_policy JSONB",
+    ] {
+        sqlx::query(stmt)
+            .execute(pool)
+            .await
+            .expect("align webhook_subscriptions schema");
+    }
+}
+
+/// Seed a subscription directly (as superuser, RLS-exempt) for an org.
+async fn seed_subscription(pool: &PgPool, org_id: Uuid, created_by: Uuid, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO webhook_subscriptions
+            (organization_id, name, url, secret, events, status, created_by)
+        VALUES ($1, $2, 'https://example.com/hooks/seeded', 'seed-secret',
+                ARRAY['fault.created'], 'active', $3)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(name)
+    .bind(created_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed subscription")
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn integration_repo_force_rls_deny_all_and_fix(pool: PgPool) {
+    // Crypto None for determinism: secrets round-trip as plaintext.
+    let repo = IntegrationRepository::with_crypto(pool.clone(), None);
+
+    // --- Seed as superuser / super-admin context (satisfies org roles-trigger). ---
+    set_ctx(&pool, None, None, true).await;
+    align_webhook_subscriptions_schema(&pool).await;
+    let org_a = seed_org(&pool, "iforce-a").await;
+    let org_b = seed_org(&pool, "iforce-b").await;
+    let user_a = seed_user(&pool, "a@integration.test").await;
+    let user_b = seed_user(&pool, "b@integration.test").await;
+    let sub_a = seed_subscription(&pool, org_a, user_a, "org-a hook").await;
+    let sub_b = seed_subscription(&pool, org_b, user_b, "org-b hook").await;
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    let role = format!("ppt_rls_integration_{}", Uuid::new_v4().simple());
+    for stmt in [
+        format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
+        format!("GRANT SELECT, INSERT, UPDATE, DELETE ON webhook_subscriptions TO \"{role}\""),
+        // RLS policy helpers must be EXECUTE-able by the bound role.
+        format!("GRANT EXECUTE ON FUNCTION get_current_org_id() TO \"{role}\""),
+        format!("GRANT EXECUTE ON FUNCTION get_current_org_not_deleted() TO \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .expect("grant setup");
+    }
+
+    // ====================================================================
+    // (1) DENY-ALL reproduction: role bound, NO context set (the dev raw-pool
+    //     behavior). Own-org reads return nothing.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        // Explicitly clear any inherited context, then drop to the bound role.
+        sqlx::query("SELECT clear_request_context()")
+            .execute(&mut *conn)
+            .await
+            .expect("clear ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let listed = repo
+            .list_webhook_subscriptions(&mut *conn, org_a)
+            .await
+            .expect("list_webhook_subscriptions (no ctx)");
+        assert!(
+            listed.is_empty(),
+            "PAP-105 regression: without RLS context, own-org webhook \
+             subscriptions must be invisible (deny-all) — this is what the \
+             raw-pool repo did on dev"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (2) FIX + (3) cross-tenant by-id: set context, drop to bound role, query.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        // (2) Own-org subscription IS now visible through the repo — the fix.
+        let listed = repo
+            .list_webhook_subscriptions(&mut *conn, org_a)
+            .await
+            .expect("list_webhook_subscriptions (ctx)");
+        assert_eq!(
+            listed.iter().map(|s| s.id).collect::<Vec<_>>(),
+            vec![sub_a],
+            "PAP-105 fix: with RLS context set, list returns exactly the own-org subscription"
+        );
+
+        // Own-org by-id read resolves.
+        let own = repo
+            .get_webhook_subscription(&mut *conn, sub_a)
+            .await
+            .expect("get own-org subscription under context must succeed");
+        assert_eq!(own.map(|s| s.id), Some(sub_a));
+
+        // (3) Cross-tenant by-id read: org B's subscription must be invisible
+        //     to an org-A caller (None → handlers surface 404).
+        let cross = repo
+            .get_webhook_subscription(&mut *conn, sub_b)
+            .await
+            .expect("cross-tenant get must not error, just filter");
+        assert!(
+            cross.is_none(),
+            "cross-tenant: org B's subscription must NOT be visible to an org-A caller"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (4) WRITE path: a create on a context-set connection succeeds and the
+    //     row is the caller's org. Without context the INSERT would fail the
+    //     policy WITH CHECK (the write-side of deny-all).
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let created = repo
+            .create_webhook_subscription(
+                &mut *conn,
+                org_a,
+                user_a,
+                CreateWebhookSubscription {
+                    name: "ctx-created hook".to_string(),
+                    description: None,
+                    url: "https://example.com/hooks/created".to_string(),
+                    events: vec!["fault.created".to_string()],
+                    secret: Some("hook-secret".to_string()),
+                    headers: None,
+                    retry_policy: None,
+                },
+                false,
+            )
+            .await
+            .expect("create_webhook_subscription under context must succeed");
+        assert_eq!(created.organization_id, org_a);
+        // Crypto is None in this test, so the secret round-trips verbatim.
+        assert_eq!(created.secret.as_deref(), Some("hook-secret"));
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup the test role. ---
+    set_ctx(&pool, None, None, true).await;
+    for stmt in [
+        format!("REVOKE ALL ON webhook_subscriptions FROM \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .ok();
+    }
+}

--- a/backend/servers/api-server/src/routes/integrations/sync.rs
+++ b/backend/servers/api-server/src/routes/integrations/sync.rs
@@ -2,8 +2,24 @@
 //!
 //! Covers: integration statistics, calendar connections + sync + events,
 //! accounting exports + settings, e-signature workflows, and video meetings.
+//!
+//! # RLS routing (PAP-105 / PAP-80)
+//!
+//! `IntegrationRepository` holds no pool: every handler acquires an
+//! [`RlsConnection`] (JWT + org-membership validation + org/user GUCs bound to
+//! the pooled connection) and passes `&mut **rls.conn()` to the repository.
+//! Of the tables this surface touches only `webhook_subscriptions` (read by
+//! `get_integration_statistics`) is FORCE-RLS today, but routing everything
+//! through the context-set connection means no query can run un-scoped. The
+//! `{org_id}` path segment is still membership-checked via `verify_org_access`
+//! for the non-FORCE tables; the stats handler additionally requires the path
+//! org to equal `rls.tenant_id()` so the SQL filter and the RLS policy can
+//! never disagree. Every path calls `rls.release().await` before returning,
+//! and slow external I/O (calendar provider fetch, webhook test POST) runs
+//! AFTER release so pool connections are not pinned on network calls.
 
-use api_core::{AuthUser, TenantExtractor};
+use api_core::extractors::RlsConnection;
+use api_core::TenantExtractor;
 use axum::{
     body::Body,
     extract::{Path, Query, State},
@@ -270,26 +286,40 @@ pub fn router() -> Router<AppState> {
 )]
 pub async fn get_integration_stats(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<OrgIdPath>,
 ) -> Result<Json<IntegrationStatistics>, (StatusCode, Json<ErrorResponse>)> {
-    // Verify user belongs to this organization
-    verify_org_access(&state, auth.user_id, path.org_id).await?;
+    // PAP-105 (PAP-80): the webhook sub-queries hit FORCE-RLS
+    // `webhook_subscriptions`, so the stats org must be the org the RLS
+    // context is bound to — a mismatching path org would silently read as
+    // zero. Membership in the tenant is validated by the extractor.
+    if path.org_id != rls.tenant_id() {
+        rls.release().await;
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "FORBIDDEN",
+                "You are not a member of this organization",
+            )),
+        ));
+    }
 
-    let stats = state
+    let result = state
         .integration_repo
-        .get_integration_statistics(path.org_id)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to get integration statistics");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to get integration statistics",
-                )),
-            )
-        })?;
+        .get_integration_statistics(rls.conn(), path.org_id)
+        .await;
+    rls.release().await;
+
+    let stats = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to get integration statistics");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to get integration statistics",
+            )),
+        )
+    })?;
 
     Ok(Json(stats))
 }
@@ -312,27 +342,32 @@ pub async fn get_integration_stats(
 )]
 pub async fn list_calendar_connections(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<OrgIdPath>,
     Query(query): Query<CalendarQuery>,
 ) -> Result<Json<Vec<CalendarConnection>>, (StatusCode, Json<ErrorResponse>)> {
     // Verify user belongs to this organization
-    verify_org_access(&state, auth.user_id, path.org_id).await?;
+    if let Err(e) = verify_org_access(&state, rls.user_id(), path.org_id).await {
+        rls.release().await;
+        return Err(e);
+    }
 
-    let connections = state
+    let result = state
         .integration_repo
-        .list_calendar_connections(path.org_id, query.user_id)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to list calendar connections");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to list calendar connections",
-                )),
-            )
-        })?;
+        .list_calendar_connections(&mut **rls.conn(), path.org_id, query.user_id)
+        .await;
+    rls.release().await;
+
+    let connections = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to list calendar connections");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to list calendar connections",
+            )),
+        )
+    })?;
 
     Ok(Json(connections))
 }
@@ -353,27 +388,33 @@ pub async fn list_calendar_connections(
 )]
 pub async fn create_calendar_connection(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<OrgIdPath>,
     Json(data): Json<CreateCalendarConnection>,
 ) -> Result<(StatusCode, Json<CalendarConnection>), (StatusCode, Json<ErrorResponse>)> {
+    let user_id = rls.user_id();
     // Verify user has access to the organization
-    verify_org_access(&state, auth.user_id, path.org_id).await?;
+    if let Err(e) = verify_org_access(&state, user_id, path.org_id).await {
+        rls.release().await;
+        return Err(e);
+    }
 
-    let connection = state
+    let result = state
         .integration_repo
-        .create_calendar_connection(path.org_id, auth.user_id, data)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to create calendar connection");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to create calendar connection",
-                )),
-            )
-        })?;
+        .create_calendar_connection(&mut **rls.conn(), path.org_id, user_id, data)
+        .await;
+    rls.release().await;
+
+    let connection = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to create calendar connection");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to create calendar connection",
+            )),
+        )
+    })?;
 
     Ok((StatusCode::CREATED, Json(connection)))
 }
@@ -395,29 +436,31 @@ pub async fn create_calendar_connection(
 )]
 pub async fn get_calendar_connection(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<ResourceIdPath>,
 ) -> Result<Json<CalendarConnection>, (StatusCode, Json<ErrorResponse>)> {
     // First get the connection to check organization access
-    let connection = state
+    let result = state
         .integration_repo
-        .get_calendar_connection(path.id)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to get calendar connection");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to get calendar connection",
-                )),
-            )
-        })?;
+        .get_calendar_connection(&mut **rls.conn(), path.id)
+        .await;
+    rls.release().await;
+
+    let connection = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to get calendar connection");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to get calendar connection",
+            )),
+        )
+    })?;
 
     match connection {
         Some(c) => {
             // Verify user has access to the organization that owns this resource
-            verify_org_access(&state, auth.user_id, c.organization_id).await?;
+            verify_org_access(&state, rls.user_id(), c.organization_id).await?;
             Ok(Json(c))
         }
         None => Err((
@@ -448,49 +491,59 @@ pub async fn get_calendar_connection(
 )]
 pub async fn update_calendar_connection(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<ResourceIdPath>,
     Json(data): Json<UpdateCalendarConnection>,
 ) -> Result<Json<CalendarConnection>, (StatusCode, Json<ErrorResponse>)> {
     // First get the connection to check organization access
-    let existing = state
+    let existing = match state
         .integration_repo
-        .get_calendar_connection(path.id)
+        .get_calendar_connection(&mut **rls.conn(), path.id)
         .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to get calendar connection");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DATABASE_ERROR", "Database error")),
-            )
-        })?
-        .ok_or_else(|| {
-            (
+    {
+        Ok(Some(c)) => c,
+        Ok(None) => {
+            rls.release().await;
+            return Err((
                 StatusCode::NOT_FOUND,
                 Json(ErrorResponse::new(
                     "NOT_FOUND",
                     "Calendar connection not found",
                 )),
-            )
-        })?;
+            ));
+        }
+        Err(e) => {
+            rls.release().await;
+            tracing::error!(error = %e, "Failed to get calendar connection");
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DATABASE_ERROR", "Database error")),
+            ));
+        }
+    };
 
     // Verify user has access to the organization that owns this resource
-    verify_org_access(&state, auth.user_id, existing.organization_id).await?;
+    if let Err(e) = verify_org_access(&state, rls.user_id(), existing.organization_id).await {
+        rls.release().await;
+        return Err(e);
+    }
 
-    let connection = state
+    let result = state
         .integration_repo
-        .update_calendar_connection(path.id, data)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to update calendar connection");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to update calendar connection",
-                )),
-            )
-        })?;
+        .update_calendar_connection(&mut **rls.conn(), path.id, data)
+        .await;
+    rls.release().await;
+
+    let connection = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to update calendar connection");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to update calendar connection",
+            )),
+        )
+    })?;
 
     Ok(Json(connection))
 }
@@ -512,48 +565,58 @@ pub async fn update_calendar_connection(
 )]
 pub async fn delete_calendar_connection(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<ResourceIdPath>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     // First get the connection to check organization access
-    let existing = state
+    let existing = match state
         .integration_repo
-        .get_calendar_connection(path.id)
+        .get_calendar_connection(&mut **rls.conn(), path.id)
         .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to get calendar connection");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DATABASE_ERROR", "Database error")),
-            )
-        })?
-        .ok_or_else(|| {
-            (
+    {
+        Ok(Some(c)) => c,
+        Ok(None) => {
+            rls.release().await;
+            return Err((
                 StatusCode::NOT_FOUND,
                 Json(ErrorResponse::new(
                     "NOT_FOUND",
                     "Calendar connection not found",
                 )),
-            )
-        })?;
+            ));
+        }
+        Err(e) => {
+            rls.release().await;
+            tracing::error!(error = %e, "Failed to get calendar connection");
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DATABASE_ERROR", "Database error")),
+            ));
+        }
+    };
 
     // Verify user has access to the organization that owns this resource
-    verify_org_access(&state, auth.user_id, existing.organization_id).await?;
+    if let Err(e) = verify_org_access(&state, rls.user_id(), existing.organization_id).await {
+        rls.release().await;
+        return Err(e);
+    }
 
-    let deleted = state
+    let result = state
         .integration_repo
-        .delete_calendar_connection(path.id)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to delete calendar connection");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to delete calendar connection",
-                )),
-            )
-        })?;
+        .delete_calendar_connection(&mut **rls.conn(), path.id)
+        .await;
+    rls.release().await;
+
+    let deleted = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to delete calendar connection");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to delete calendar connection",
+            )),
+        )
+    })?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)
@@ -586,15 +649,23 @@ pub async fn delete_calendar_connection(
 )]
 pub async fn sync_calendar(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<ResourceIdPath>,
     Json(data): Json<SyncCalendarRequest>,
 ) -> Result<Json<CalendarSyncResult>, (StatusCode, Json<ErrorResponse>)> {
     // Get the calendar connection
-    let connection = state
+    let result = state
         .integration_repo
-        .get_calendar_connection(path.id)
-        .await
+        .get_calendar_connection(&mut **rls.conn(), path.id)
+        .await;
+    // PAP-105 (PAP-80): release before the (slow) external calendar fetch so
+    // we don't pin a pool connection on network I/O. The post-fetch writes
+    // below run on the pool — calendar_events / calendar_connections are not
+    // FORCE-RLS, and org scoping was already enforced by the connection
+    // lookup + membership check here.
+    rls.release().await;
+
+    let connection = result
         .map_err(|e| {
             tracing::error!(error = %e, "Failed to get calendar connection");
             (
@@ -616,7 +687,7 @@ pub async fn sync_calendar(
         })?;
 
     // Verify user has access to the organization that owns this connection
-    verify_org_access(&state, auth.user_id, connection.organization_id).await?;
+    verify_org_access(&state, rls.user_id(), connection.organization_id).await?;
 
     // Check if we have valid tokens
     let access_token = match &connection.access_token {
@@ -708,14 +779,19 @@ pub async fn sync_calendar(
     let sync_result = sync_result.map_err(|e| {
         tracing::error!(error = %e, provider = %connection.provider, "Calendar sync failed");
 
-        // Update sync status to error in the background (fire and forget)
+        // Update sync status to error in the background (fire and forget).
+        // PAP-105 (PAP-80): non-request-context background write to
+        // calendar_connections (not FORCE-RLS); org scoping was already
+        // enforced by the handler's connection lookup above, so the cloned
+        // pool is the executor here.
         let repo = state.integration_repo.clone();
+        let db = state.db.clone();
         let connection_id = path.id;
         let error_msg = e.to_string();
         tokio::spawn(
             async move {
                 let _ = repo
-                    .update_sync_status(connection_id, "error", Some(&error_msg))
+                    .update_sync_status(&db, connection_id, "error", Some(&error_msg))
                     .await;
             }
             .instrument(tracing::info_span!(
@@ -754,10 +830,13 @@ pub async fn sync_calendar(
             attendees: Some(serde_json::to_value(&event.attendees).unwrap_or_default()),
         };
 
-        // Use upsert to handle duplicates - if event with same source_id exists, skip
+        // Use upsert to handle duplicates - if event with same source_id exists, skip.
+        // PAP-105 (PAP-80): post-fetch pool write to calendar_events (not
+        // FORCE-RLS); the RLS connection was released before the provider
+        // round-trip and org scoping was enforced by the lookup above.
         match state
             .integration_repo
-            .upsert_calendar_event(create_data)
+            .upsert_calendar_event(&state.db, create_data)
             .await
         {
             Ok(created) => {
@@ -776,10 +855,10 @@ pub async fn sync_calendar(
     // This is a simplified implementation - in production you'd match by external_event_id
     let events_updated = sync_result.events_updated.len() as i32;
 
-    // Update sync status
+    // Update sync status (pool write to non-FORCE calendar_connections, see above)
     let _ = state
         .integration_repo
-        .update_sync_status(path.id, "active", None)
+        .update_sync_status(&state.db, path.id, "active", None)
         .await;
 
     Ok(Json(CalendarSyncResult {
@@ -805,23 +884,26 @@ pub async fn sync_calendar(
 )]
 pub async fn list_calendar_events(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(path): Path<ResourceIdPath>,
     Query(query): Query<CalendarEventsQuery>,
 ) -> Result<Json<Vec<CalendarEvent>>, (StatusCode, Json<ErrorResponse>)> {
-    let events = state
+    let result = state
         .integration_repo
-        .list_calendar_events(path.id, query.from, query.to)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to list calendar events");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to list calendar events",
-                )),
-            )
-        })?;
+        .list_calendar_events(&mut **rls.conn(), path.id, query.from, query.to)
+        .await;
+    rls.release().await;
+
+    let events = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to list calendar events");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to list calendar events",
+            )),
+        )
+    })?;
 
     Ok(Json(events))
 }
@@ -842,23 +924,26 @@ pub async fn list_calendar_events(
 )]
 pub async fn create_calendar_event(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(_path): Path<ResourceIdPath>,
     Json(data): Json<CreateCalendarEvent>,
 ) -> Result<(StatusCode, Json<CalendarEvent>), (StatusCode, Json<ErrorResponse>)> {
-    let event = state
+    let result = state
         .integration_repo
-        .create_calendar_event(data)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to create calendar event");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to create calendar event",
-                )),
-            )
-        })?;
+        .create_calendar_event(&mut **rls.conn(), data)
+        .await;
+    rls.release().await;
+
+    let event = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to create calendar event");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to create calendar event",
+            )),
+        )
+    })?;
 
     Ok((StatusCode::CREATED, Json(event)))
 }
@@ -881,27 +966,37 @@ pub async fn create_calendar_event(
 )]
 pub async fn list_accounting_exports(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<OrgIdPath>,
     Query(query): Query<AccountingExportQuery>,
 ) -> Result<Json<Vec<AccountingExport>>, (StatusCode, Json<ErrorResponse>)> {
     // Verify user belongs to this organization
-    verify_org_access(&state, auth.user_id, path.org_id).await?;
+    if let Err(e) = verify_org_access(&state, rls.user_id(), path.org_id).await {
+        rls.release().await;
+        return Err(e);
+    }
 
-    let exports = state
+    let result = state
         .integration_repo
-        .list_accounting_exports(path.org_id, query.system_type.as_deref(), query.limit)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to list accounting exports");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to list accounting exports",
-                )),
-            )
-        })?;
+        .list_accounting_exports(
+            &mut **rls.conn(),
+            path.org_id,
+            query.system_type.as_deref(),
+            query.limit,
+        )
+        .await;
+    rls.release().await;
+
+    let exports = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to list accounting exports");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to list accounting exports",
+            )),
+        )
+    })?;
 
     Ok(Json(exports))
 }
@@ -922,27 +1017,33 @@ pub async fn list_accounting_exports(
 )]
 pub async fn create_accounting_export(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<OrgIdPath>,
     Json(data): Json<CreateAccountingExport>,
 ) -> Result<(StatusCode, Json<AccountingExport>), (StatusCode, Json<ErrorResponse>)> {
+    let user_id = rls.user_id();
     // Verify user has access to the organization
-    verify_org_access(&state, auth.user_id, path.org_id).await?;
+    if let Err(e) = verify_org_access(&state, user_id, path.org_id).await {
+        rls.release().await;
+        return Err(e);
+    }
 
-    let export = state
+    let result = state
         .integration_repo
-        .create_accounting_export(path.org_id, auth.user_id, data)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to create accounting export");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to create accounting export",
-                )),
-            )
-        })?;
+        .create_accounting_export(&mut **rls.conn(), path.org_id, user_id, data)
+        .await;
+    rls.release().await;
+
+    let export = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to create accounting export");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to create accounting export",
+            )),
+        )
+    })?;
 
     Ok((StatusCode::CREATED, Json(export)))
 }
@@ -964,28 +1065,30 @@ pub async fn create_accounting_export(
 )]
 pub async fn get_accounting_export(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<ResourceIdPath>,
 ) -> Result<Json<AccountingExport>, (StatusCode, Json<ErrorResponse>)> {
-    let export = state
+    let result = state
         .integration_repo
-        .get_accounting_export(path.id)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to get accounting export");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to get accounting export",
-                )),
-            )
-        })?;
+        .get_accounting_export(&mut **rls.conn(), path.id)
+        .await;
+    rls.release().await;
+
+    let export = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to get accounting export");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to get accounting export",
+            )),
+        )
+    })?;
 
     match export {
         Some(e) => {
             // Verify user has access to the organization that owns this resource
-            verify_org_access(&state, auth.user_id, e.organization_id).await?;
+            verify_org_access(&state, rls.user_id(), e.organization_id).await?;
             Ok(Json(e))
         }
         None => Err((
@@ -1013,24 +1116,26 @@ pub async fn get_accounting_export(
 )]
 pub async fn download_accounting_export(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<ResourceIdPath>,
 ) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
-    // Get the export record
-    let export = state
+    // Get the export record (the only DB read; release before file generation)
+    let result = state
         .integration_repo
-        .get_accounting_export(path.id)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to get accounting export");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to get accounting export",
-                )),
-            )
-        })?;
+        .get_accounting_export(&mut **rls.conn(), path.id)
+        .await;
+    rls.release().await;
+
+    let export = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to get accounting export");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to get accounting export",
+            )),
+        )
+    })?;
 
     let export = match export {
         Some(e) => e,
@@ -1046,7 +1151,7 @@ pub async fn download_accounting_export(
     };
 
     // Verify user has access to the organization that owns this export
-    verify_org_access(&state, auth.user_id, export.organization_id).await?;
+    verify_org_access(&state, rls.user_id(), export.organization_id).await?;
 
     // Check if export is completed
     if export.status != "completed" {
@@ -1177,22 +1282,25 @@ pub async fn download_accounting_export(
 )]
 pub async fn get_accounting_settings(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(path): Path<AccountingSystemPath>,
 ) -> Result<Json<AccountingExportSettings>, (StatusCode, Json<ErrorResponse>)> {
-    let settings = state
+    let result = state
         .integration_repo
-        .get_accounting_export_settings(path.org_id, &path.system)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to get accounting settings");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to get accounting settings",
-                )),
-            )
-        })?;
+        .get_accounting_export_settings(rls.conn(), path.org_id, &path.system)
+        .await;
+    rls.release().await;
+
+    let settings = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to get accounting settings");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to get accounting settings",
+            )),
+        )
+    })?;
 
     Ok(Json(settings))
 }
@@ -1212,23 +1320,26 @@ pub async fn get_accounting_settings(
 )]
 pub async fn update_accounting_settings(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(path): Path<AccountingSystemPath>,
     Json(data): Json<UpdateAccountingExportSettings>,
 ) -> Result<Json<AccountingExportSettings>, (StatusCode, Json<ErrorResponse>)> {
-    let settings = state
+    let result = state
         .integration_repo
-        .update_accounting_export_settings(path.org_id, &path.system, data)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to update accounting settings");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to update accounting settings",
-                )),
-            )
-        })?;
+        .update_accounting_export_settings(&mut **rls.conn(), path.org_id, &path.system, data)
+        .await;
+    rls.release().await;
+
+    let settings = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to update accounting settings");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to update accounting settings",
+            )),
+        )
+    })?;
 
     Ok(Json(settings))
 }
@@ -1251,27 +1362,37 @@ pub async fn update_accounting_settings(
 )]
 pub async fn list_esignature_workflows(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<OrgIdPath>,
     Query(query): Query<ESignatureQuery>,
 ) -> Result<Json<Vec<ESignatureWorkflow>>, (StatusCode, Json<ErrorResponse>)> {
     // Verify user belongs to this organization
-    verify_org_access(&state, auth.user_id, path.org_id).await?;
+    if let Err(e) = verify_org_access(&state, rls.user_id(), path.org_id).await {
+        rls.release().await;
+        return Err(e);
+    }
 
-    let workflows = state
+    let result = state
         .integration_repo
-        .list_esignature_workflows(path.org_id, query.status.as_deref(), query.limit)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to list e-signature workflows");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to list e-signature workflows",
-                )),
-            )
-        })?;
+        .list_esignature_workflows(
+            &mut **rls.conn(),
+            path.org_id,
+            query.status.as_deref(),
+            query.limit,
+        )
+        .await;
+    rls.release().await;
+
+    let workflows = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to list e-signature workflows");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to list e-signature workflows",
+            )),
+        )
+    })?;
 
     Ok(Json(workflows))
 }
@@ -1292,28 +1413,34 @@ pub async fn list_esignature_workflows(
 )]
 pub async fn create_esignature_workflow(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<OrgIdPath>,
     Json(data): Json<CreateESignatureWorkflow>,
 ) -> Result<(StatusCode, Json<ESignatureWorkflowWithRecipients>), (StatusCode, Json<ErrorResponse>)>
 {
+    let user_id = rls.user_id();
     // Verify user has access to the organization
-    verify_org_access(&state, auth.user_id, path.org_id).await?;
+    if let Err(e) = verify_org_access(&state, user_id, path.org_id).await {
+        rls.release().await;
+        return Err(e);
+    }
 
-    let workflow = state
+    let result = state
         .integration_repo
-        .create_esignature_workflow(path.org_id, auth.user_id, data)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to create e-signature workflow");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to create e-signature workflow",
-                )),
-            )
-        })?;
+        .create_esignature_workflow(&mut **rls.conn(), path.org_id, user_id, data)
+        .await;
+    rls.release().await;
+
+    let workflow = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to create e-signature workflow");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to create e-signature workflow",
+            )),
+        )
+    })?;
 
     // Wrap workflow with empty recipients list (no recipients added yet)
     let result = ESignatureWorkflowWithRecipients {
@@ -1341,28 +1468,30 @@ pub async fn create_esignature_workflow(
 )]
 pub async fn get_esignature_workflow(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<ResourceIdPath>,
 ) -> Result<Json<ESignatureWorkflowWithRecipients>, (StatusCode, Json<ErrorResponse>)> {
-    let workflow = state
+    let result = state
         .integration_repo
-        .get_esignature_workflow_with_recipients(path.id)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to get e-signature workflow");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to get e-signature workflow",
-                )),
-            )
-        })?;
+        .get_esignature_workflow_with_recipients(rls.conn(), path.id)
+        .await;
+    rls.release().await;
+
+    let workflow = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to get e-signature workflow");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to get e-signature workflow",
+            )),
+        )
+    })?;
 
     match workflow {
         Some(w) => {
             // Verify user has access to the organization that owns this resource
-            verify_org_access(&state, auth.user_id, w.workflow.organization_id).await?;
+            verify_org_access(&state, rls.user_id(), w.workflow.organization_id).await?;
             Ok(Json(w))
         }
         None => Err((
@@ -1390,22 +1519,25 @@ pub async fn get_esignature_workflow(
 )]
 pub async fn send_esignature_workflow(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(path): Path<ResourceIdPath>,
 ) -> Result<Json<ESignatureWorkflow>, (StatusCode, Json<ErrorResponse>)> {
-    let workflow = state
+    let result = state
         .integration_repo
-        .update_esignature_workflow_status(path.id, "sent")
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to send e-signature workflow");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to send e-signature workflow",
-                )),
-            )
-        })?;
+        .update_esignature_workflow_status(&mut **rls.conn(), path.id, "sent")
+        .await;
+    rls.release().await;
+
+    let workflow = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to send e-signature workflow");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to send e-signature workflow",
+            )),
+        )
+    })?;
 
     Ok(Json(workflow))
 }
@@ -1425,22 +1557,25 @@ pub async fn send_esignature_workflow(
 )]
 pub async fn void_esignature_workflow(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(path): Path<ResourceIdPath>,
 ) -> Result<Json<ESignatureWorkflow>, (StatusCode, Json<ErrorResponse>)> {
-    let workflow = state
+    let result = state
         .integration_repo
-        .update_esignature_workflow_status(path.id, "voided")
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to void e-signature workflow");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to void e-signature workflow",
-                )),
-            )
-        })?;
+        .update_esignature_workflow_status(&mut **rls.conn(), path.id, "voided")
+        .await;
+    rls.release().await;
+
+    let workflow = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to void e-signature workflow");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to void e-signature workflow",
+            )),
+        )
+    })?;
 
     Ok(Json(workflow))
 }
@@ -1623,27 +1758,32 @@ pub async fn send_esignature_reminder(
 )]
 pub async fn list_video_connections(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<OrgIdPath>,
     Query(query): Query<CalendarQuery>,
 ) -> Result<Json<Vec<VideoConferenceConnection>>, (StatusCode, Json<ErrorResponse>)> {
     // Verify user belongs to this organization
-    verify_org_access(&state, auth.user_id, path.org_id).await?;
+    if let Err(e) = verify_org_access(&state, rls.user_id(), path.org_id).await {
+        rls.release().await;
+        return Err(e);
+    }
 
-    let connections = state
+    let result = state
         .integration_repo
-        .list_video_conference_connections(path.org_id, query.user_id)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to list video connections");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to list video connections",
-                )),
-            )
-        })?;
+        .list_video_conference_connections(&mut **rls.conn(), path.org_id, query.user_id)
+        .await;
+    rls.release().await;
+
+    let connections = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to list video connections");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to list video connections",
+            )),
+        )
+    })?;
 
     Ok(Json(connections))
 }
@@ -1664,27 +1804,33 @@ pub async fn list_video_connections(
 )]
 pub async fn create_video_connection(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<OrgIdPath>,
     Json(data): Json<CreateVideoConferenceConnection>,
 ) -> Result<(StatusCode, Json<VideoConferenceConnection>), (StatusCode, Json<ErrorResponse>)> {
+    let user_id = rls.user_id();
     // Verify user has access to the organization
-    verify_org_access(&state, auth.user_id, path.org_id).await?;
+    if let Err(e) = verify_org_access(&state, user_id, path.org_id).await {
+        rls.release().await;
+        return Err(e);
+    }
 
-    let connection = state
+    let result = state
         .integration_repo
-        .create_video_conference_connection(path.org_id, auth.user_id, data)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to create video connection");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to create video connection",
-                )),
-            )
-        })?;
+        .create_video_conference_connection(&mut **rls.conn(), path.org_id, user_id, data)
+        .await;
+    rls.release().await;
+
+    let connection = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to create video connection");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to create video connection",
+            )),
+        )
+    })?;
 
     Ok((StatusCode::CREATED, Json(connection)))
 }
@@ -1704,22 +1850,25 @@ pub async fn create_video_connection(
 )]
 pub async fn delete_video_connection(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(path): Path<ResourceIdPath>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let deleted = state
+    let result = state
         .integration_repo
-        .delete_video_conference_connection(path.id)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to delete video connection");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to delete video connection",
-                )),
-            )
-        })?;
+        .delete_video_conference_connection(&mut **rls.conn(), path.id)
+        .await;
+    rls.release().await;
+
+    let deleted = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to delete video connection");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to delete video connection",
+            )),
+        )
+    })?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)
@@ -1750,32 +1899,38 @@ pub async fn delete_video_connection(
 )]
 pub async fn list_video_meetings(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<OrgIdPath>,
     Query(query): Query<VideoMeetingQuery>,
 ) -> Result<Json<Vec<VideoMeeting>>, (StatusCode, Json<ErrorResponse>)> {
     // Verify user belongs to this organization
-    verify_org_access(&state, auth.user_id, path.org_id).await?;
+    if let Err(e) = verify_org_access(&state, rls.user_id(), path.org_id).await {
+        rls.release().await;
+        return Err(e);
+    }
 
-    let meetings = state
+    let result = state
         .integration_repo
         .list_video_meetings(
+            &mut **rls.conn(),
             path.org_id,
             query.from,
             query.status.as_deref(),
             query.limit,
         )
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to list video meetings");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to list video meetings",
-                )),
-            )
-        })?;
+        .await;
+    rls.release().await;
+
+    let meetings = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to list video meetings");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to list video meetings",
+            )),
+        )
+    })?;
 
     Ok(Json(meetings))
 }
@@ -1796,27 +1951,33 @@ pub async fn list_video_meetings(
 )]
 pub async fn create_video_meeting(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<OrgIdPath>,
     Json(data): Json<CreateVideoMeeting>,
 ) -> Result<(StatusCode, Json<VideoMeeting>), (StatusCode, Json<ErrorResponse>)> {
+    let user_id = rls.user_id();
     // Verify user has access to the organization
-    verify_org_access(&state, auth.user_id, path.org_id).await?;
+    if let Err(e) = verify_org_access(&state, user_id, path.org_id).await {
+        rls.release().await;
+        return Err(e);
+    }
 
-    let meeting = state
+    let result = state
         .integration_repo
-        .create_video_meeting(path.org_id, auth.user_id, data)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to create video meeting");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to create video meeting",
-                )),
-            )
-        })?;
+        .create_video_meeting(&mut **rls.conn(), path.org_id, user_id, data)
+        .await;
+    rls.release().await;
+
+    let meeting = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to create video meeting");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to create video meeting",
+            )),
+        )
+    })?;
 
     Ok((StatusCode::CREATED, Json(meeting)))
 }
@@ -1838,28 +1999,30 @@ pub async fn create_video_meeting(
 )]
 pub async fn get_video_meeting(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<ResourceIdPath>,
 ) -> Result<Json<VideoMeeting>, (StatusCode, Json<ErrorResponse>)> {
-    let meeting = state
+    let result = state
         .integration_repo
-        .get_video_meeting(path.id)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to get video meeting");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to get video meeting",
-                )),
-            )
-        })?;
+        .get_video_meeting(&mut **rls.conn(), path.id)
+        .await;
+    rls.release().await;
+
+    let meeting = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to get video meeting");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to get video meeting",
+            )),
+        )
+    })?;
 
     match meeting {
         Some(m) => {
             // Verify user has access to the organization that owns this resource
-            verify_org_access(&state, auth.user_id, m.organization_id).await?;
+            verify_org_access(&state, rls.user_id(), m.organization_id).await?;
             Ok(Json(m))
         }
         None => Err((
@@ -1887,46 +2050,56 @@ pub async fn get_video_meeting(
 )]
 pub async fn update_video_meeting(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<ResourceIdPath>,
     Json(data): Json<UpdateVideoMeeting>,
 ) -> Result<Json<VideoMeeting>, (StatusCode, Json<ErrorResponse>)> {
     // First get the meeting to check organization access
-    let existing = state
+    let existing = match state
         .integration_repo
-        .get_video_meeting(path.id)
+        .get_video_meeting(&mut **rls.conn(), path.id)
         .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to get video meeting");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DATABASE_ERROR", "Database error")),
-            )
-        })?
-        .ok_or_else(|| {
-            (
+    {
+        Ok(Some(m)) => m,
+        Ok(None) => {
+            rls.release().await;
+            return Err((
                 StatusCode::NOT_FOUND,
                 Json(ErrorResponse::new("NOT_FOUND", "Video meeting not found")),
-            )
-        })?;
+            ));
+        }
+        Err(e) => {
+            rls.release().await;
+            tracing::error!(error = %e, "Failed to get video meeting");
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DATABASE_ERROR", "Database error")),
+            ));
+        }
+    };
 
     // Verify user has access to the organization that owns this resource
-    verify_org_access(&state, auth.user_id, existing.organization_id).await?;
+    if let Err(e) = verify_org_access(&state, rls.user_id(), existing.organization_id).await {
+        rls.release().await;
+        return Err(e);
+    }
 
-    let meeting = state
+    let result = state
         .integration_repo
-        .update_video_meeting(path.id, data)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to update video meeting");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to update video meeting",
-                )),
-            )
-        })?;
+        .update_video_meeting(&mut **rls.conn(), path.id, data)
+        .await;
+    rls.release().await;
+
+    let meeting = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to update video meeting");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to update video meeting",
+            )),
+        )
+    })?;
 
     Ok(Json(meeting))
 }
@@ -1948,45 +2121,55 @@ pub async fn update_video_meeting(
 )]
 pub async fn delete_video_meeting(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<ResourceIdPath>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     // First get the meeting to check organization access
-    let existing = state
+    let existing = match state
         .integration_repo
-        .get_video_meeting(path.id)
+        .get_video_meeting(&mut **rls.conn(), path.id)
         .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to get video meeting");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DATABASE_ERROR", "Database error")),
-            )
-        })?
-        .ok_or_else(|| {
-            (
+    {
+        Ok(Some(m)) => m,
+        Ok(None) => {
+            rls.release().await;
+            return Err((
                 StatusCode::NOT_FOUND,
                 Json(ErrorResponse::new("NOT_FOUND", "Video meeting not found")),
-            )
-        })?;
+            ));
+        }
+        Err(e) => {
+            rls.release().await;
+            tracing::error!(error = %e, "Failed to get video meeting");
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DATABASE_ERROR", "Database error")),
+            ));
+        }
+    };
 
     // Verify user has access to the organization that owns this resource
-    verify_org_access(&state, auth.user_id, existing.organization_id).await?;
+    if let Err(e) = verify_org_access(&state, rls.user_id(), existing.organization_id).await {
+        rls.release().await;
+        return Err(e);
+    }
 
-    let deleted = state
+    let result = state
         .integration_repo
-        .delete_video_meeting(path.id)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to delete video meeting");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to delete video meeting",
-                )),
-            )
-        })?;
+        .delete_video_meeting(&mut **rls.conn(), path.id)
+        .await;
+    rls.release().await;
+
+    let deleted = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to delete video meeting");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to delete video meeting",
+            )),
+        )
+    })?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)
@@ -2013,28 +2196,32 @@ pub async fn delete_video_meeting(
 )]
 pub async fn start_video_meeting(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(path): Path<ResourceIdPath>,
 ) -> Result<Json<VideoMeeting>, (StatusCode, Json<ErrorResponse>)> {
-    let meeting = state
+    let result = state
         .integration_repo
         .update_video_meeting(
+            &mut **rls.conn(),
             path.id,
             UpdateVideoMeeting {
                 status: Some("started".to_string()),
                 ..Default::default()
             },
         )
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to start video meeting");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to start video meeting",
-                )),
-            )
-        })?;
+        .await;
+    rls.release().await;
+
+    let meeting = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to start video meeting");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to start video meeting",
+            )),
+        )
+    })?;
 
     Ok(Json(meeting))
 }

--- a/backend/servers/api-server/src/routes/integrations/webhook.rs
+++ b/backend/servers/api-server/src/routes/integrations/webhook.rs
@@ -7,7 +7,21 @@
 //!    - E-signature providers (DocuSign, Adobe Sign, HelloSign)
 //!    - Booking.com OTA push notifications
 //!    - Portal/listing-site webhooks (public, no auth)
+//!
+//! # RLS routing (PAP-105 / PAP-80)
+//!
+//! `webhook_subscriptions` runs under `FORCE ROW LEVEL SECURITY` (migration
+//! `00179`), so every outbound-subscription handler acquires an
+//! [`RlsConnection`] and runs its queries on that context-set connection; the
+//! `{org_id}` path segment must equal `rls.tenant_id()` so the SQL org filter
+//! and the policy can never disagree, and by-id reads of another tenant's
+//! subscription resolve to `None` → `404` via RLS. The inbound receivers have
+//! no request principal: the e-signature receiver writes the non-FORCE
+//! `esignature_workflows` table on the pool (scoped by the provider-signed
+//! envelope id), and must NEVER touch `webhook_subscriptions` that way.
+//! Every authenticated path calls `rls.release().await` before returning.
 
+use api_core::extractors::RlsConnection;
 use axum::{
     body::{Body, Bytes},
     extract::{Path, State},
@@ -109,25 +123,40 @@ pub fn router() -> Router<AppState> {
 )]
 pub async fn list_webhook_subscriptions(
     State(state): State<AppState>,
-    auth: api_core::AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<OrgIdPath>,
 ) -> Result<Json<Vec<WebhookSubscription>>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, auth.user_id, path.org_id).await?;
+    // PAP-105 (PAP-80): webhook_subscriptions is FORCE-RLS, so the path org
+    // must be the org the RLS context is bound to — a mismatching path org
+    // would silently read as empty. Membership in the tenant is validated by
+    // the extractor.
+    if path.org_id != rls.tenant_id() {
+        rls.release().await;
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "FORBIDDEN",
+                "You are not a member of this organization",
+            )),
+        ));
+    }
 
-    let subscriptions = state
+    let result = state
         .integration_repo
-        .list_webhook_subscriptions(path.org_id)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to list webhook subscriptions");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to list webhook subscriptions",
-                )),
-            )
-        })?;
+        .list_webhook_subscriptions(&mut **rls.conn(), path.org_id)
+        .await;
+    rls.release().await;
+
+    let subscriptions = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to list webhook subscriptions");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to list webhook subscriptions",
+            )),
+        )
+    })?;
 
     Ok(Json(subscriptions))
 }
@@ -148,30 +177,46 @@ pub async fn list_webhook_subscriptions(
 )]
 pub async fn create_webhook_subscription(
     State(state): State<AppState>,
-    auth: api_core::AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<OrgIdPath>,
     Json(data): Json<CreateWebhookSubscription>,
 ) -> Result<(StatusCode, Json<WebhookSubscription>), (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, auth.user_id, path.org_id).await?;
+    // PAP-105 (PAP-80): webhook_subscriptions is FORCE-RLS — the INSERT's
+    // org must be the org the RLS context is bound to or the policy
+    // WITH CHECK rejects the write. Membership in the tenant is validated by
+    // the extractor.
+    if path.org_id != rls.tenant_id() {
+        rls.release().await;
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "FORBIDDEN",
+                "You are not a member of this organization",
+            )),
+        ));
+    }
+    let user_id = rls.user_id();
 
     let is_production = std::env::var("RUST_ENV")
         .map(|v| v == "production")
         .unwrap_or(false);
 
-    let subscription = state
+    let result = state
         .integration_repo
-        .create_webhook_subscription(path.org_id, auth.user_id, data, is_production)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to create webhook subscription");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to create webhook subscription",
-                )),
-            )
-        })?;
+        .create_webhook_subscription(&mut **rls.conn(), path.org_id, user_id, data, is_production)
+        .await;
+    rls.release().await;
+
+    let subscription = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to create webhook subscription");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to create webhook subscription",
+            )),
+        )
+    })?;
 
     Ok((StatusCode::CREATED, Json(subscription)))
 }
@@ -193,27 +238,33 @@ pub async fn create_webhook_subscription(
 )]
 pub async fn get_webhook_subscription(
     State(state): State<AppState>,
-    auth: api_core::AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<ResourceIdPath>,
 ) -> Result<Json<WebhookSubscription>, (StatusCode, Json<ErrorResponse>)> {
-    let subscription = state
+    // FORCE-RLS scopes the by-id read: another tenant's subscription resolves
+    // to None → 404, indistinguishable from a missing one.
+    let result = state
         .integration_repo
-        .get_webhook_subscription(path.id)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to get webhook subscription");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to get webhook subscription",
-                )),
-            )
-        })?;
+        .get_webhook_subscription(&mut **rls.conn(), path.id)
+        .await;
+    rls.release().await;
+
+    let subscription = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to get webhook subscription");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to get webhook subscription",
+            )),
+        )
+    })?;
 
     match subscription {
         Some(s) => {
-            verify_org_access(&state, auth.user_id, s.organization_id).await?;
+            // Defense-in-depth: RLS already guarantees the row is the
+            // caller's org, but keep the explicit membership check.
+            verify_org_access(&state, rls.user_id(), s.organization_id).await?;
             Ok(Json(s))
         }
         None => Err((
@@ -244,51 +295,63 @@ pub async fn get_webhook_subscription(
 )]
 pub async fn update_webhook_subscription(
     State(state): State<AppState>,
-    auth: api_core::AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<ResourceIdPath>,
     Json(data): Json<UpdateWebhookSubscription>,
 ) -> Result<Json<WebhookSubscription>, (StatusCode, Json<ErrorResponse>)> {
-    let existing = state
+    // FORCE-RLS scopes the by-id read: another tenant's subscription resolves
+    // to None → 404 before any write is attempted.
+    let existing = match state
         .integration_repo
-        .get_webhook_subscription(path.id)
+        .get_webhook_subscription(&mut **rls.conn(), path.id)
         .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to get webhook subscription");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DATABASE_ERROR", "Database error")),
-            )
-        })?
-        .ok_or_else(|| {
-            (
+    {
+        Ok(Some(s)) => s,
+        Ok(None) => {
+            rls.release().await;
+            return Err((
                 StatusCode::NOT_FOUND,
                 Json(ErrorResponse::new(
                     "NOT_FOUND",
                     "Webhook subscription not found",
                 )),
-            )
-        })?;
+            ));
+        }
+        Err(e) => {
+            rls.release().await;
+            tracing::error!(error = %e, "Failed to get webhook subscription");
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DATABASE_ERROR", "Database error")),
+            ));
+        }
+    };
 
-    verify_org_access(&state, auth.user_id, existing.organization_id).await?;
+    if let Err(e) = verify_org_access(&state, rls.user_id(), existing.organization_id).await {
+        rls.release().await;
+        return Err(e);
+    }
 
     let is_production = std::env::var("RUST_ENV")
         .map(|v| v == "production")
         .unwrap_or(false);
 
-    let subscription = state
+    let result = state
         .integration_repo
-        .update_webhook_subscription(path.id, data, is_production)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to update webhook subscription");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to update webhook subscription",
-                )),
-            )
-        })?;
+        .update_webhook_subscription(&mut **rls.conn(), path.id, data, is_production)
+        .await;
+    rls.release().await;
+
+    let subscription = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to update webhook subscription");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to update webhook subscription",
+            )),
+        )
+    })?;
 
     Ok(Json(subscription))
 }
@@ -310,46 +373,58 @@ pub async fn update_webhook_subscription(
 )]
 pub async fn delete_webhook_subscription(
     State(state): State<AppState>,
-    auth: api_core::AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<ResourceIdPath>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let existing = state
+    // FORCE-RLS scopes the by-id read: another tenant's subscription resolves
+    // to None → 404 before any delete is attempted.
+    let existing = match state
         .integration_repo
-        .get_webhook_subscription(path.id)
+        .get_webhook_subscription(&mut **rls.conn(), path.id)
         .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to get webhook subscription");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DATABASE_ERROR", "Database error")),
-            )
-        })?
-        .ok_or_else(|| {
-            (
+    {
+        Ok(Some(s)) => s,
+        Ok(None) => {
+            rls.release().await;
+            return Err((
                 StatusCode::NOT_FOUND,
                 Json(ErrorResponse::new(
                     "NOT_FOUND",
                     "Webhook subscription not found",
                 )),
-            )
-        })?;
-
-    verify_org_access(&state, auth.user_id, existing.organization_id).await?;
-
-    let deleted = state
-        .integration_repo
-        .delete_webhook_subscription(path.id)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to delete webhook subscription");
-            (
+            ));
+        }
+        Err(e) => {
+            rls.release().await;
+            tracing::error!(error = %e, "Failed to get webhook subscription");
+            return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to delete webhook subscription",
-                )),
-            )
-        })?;
+                Json(ErrorResponse::new("DATABASE_ERROR", "Database error")),
+            ));
+        }
+    };
+
+    if let Err(e) = verify_org_access(&state, rls.user_id(), existing.organization_id).await {
+        rls.release().await;
+        return Err(e);
+    }
+
+    let result = state
+        .integration_repo
+        .delete_webhook_subscription(&mut **rls.conn(), path.id)
+        .await;
+    rls.release().await;
+
+    let deleted = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to delete webhook subscription");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to delete webhook subscription",
+            )),
+        )
+    })?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)
@@ -380,24 +455,30 @@ pub async fn delete_webhook_subscription(
 )]
 pub async fn test_webhook(
     State(state): State<AppState>,
-    auth: api_core::AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<ResourceIdPath>,
     Json(data): Json<TestWebhookRequest>,
 ) -> Result<Json<TestWebhookResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let subscription = state
+    // FORCE-RLS scopes the by-id read: another tenant's subscription resolves
+    // to None → 404. PAP-105 (PAP-80): release the RLS connection right after
+    // the lookup so the (up to 30s) outbound test POST below does not pin a
+    // pool connection.
+    let result = state
         .integration_repo
-        .get_webhook_subscription(path.id)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to get webhook subscription");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to get webhook subscription",
-                )),
-            )
-        })?;
+        .get_webhook_subscription(&mut **rls.conn(), path.id)
+        .await;
+    rls.release().await;
+
+    let subscription = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to get webhook subscription");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to get webhook subscription",
+            )),
+        )
+    })?;
 
     let subscription = match subscription {
         Some(s) => s,
@@ -412,7 +493,7 @@ pub async fn test_webhook(
         }
     };
 
-    verify_org_access(&state, auth.user_id, subscription.organization_id).await?;
+    verify_org_access(&state, rls.user_id(), subscription.organization_id).await?;
 
     let test_payload = data.payload.unwrap_or_else(|| {
         serde_json::json!({
@@ -573,30 +654,36 @@ pub async fn test_webhook(
 )]
 pub async fn list_webhook_logs(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(path): Path<ResourceIdPath>,
 ) -> Result<Json<Vec<WebhookDeliveryLog>>, (StatusCode, Json<ErrorResponse>)> {
-    let logs = state
+    let result = state
         .integration_repo
-        .list_webhook_delivery_logs(WebhookDeliveryQuery {
-            subscription_id: Some(path.id),
-            event_type: None,
-            status: None,
-            from_date: None,
-            to_date: None,
-            limit: Some(100),
-            offset: None,
-        })
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to list webhook logs");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to list webhook logs",
-                )),
-            )
-        })?;
+        .list_webhook_delivery_logs(
+            &mut **rls.conn(),
+            WebhookDeliveryQuery {
+                subscription_id: Some(path.id),
+                event_type: None,
+                status: None,
+                from_date: None,
+                to_date: None,
+                limit: Some(100),
+                offset: None,
+            },
+        )
+        .await;
+    rls.release().await;
+
+    let logs = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to list webhook logs");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to list webhook logs",
+            )),
+        )
+    })?;
 
     Ok(Json(logs))
 }
@@ -615,22 +702,25 @@ pub async fn list_webhook_logs(
 )]
 pub async fn get_webhook_stats(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(path): Path<ResourceIdPath>,
 ) -> Result<Json<WebhookStatistics>, (StatusCode, Json<ErrorResponse>)> {
-    let stats = state
+    let result = state
         .integration_repo
-        .get_webhook_statistics(path.id)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to get webhook statistics");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DATABASE_ERROR",
-                    "Failed to get webhook statistics",
-                )),
-            )
-        })?;
+        .get_webhook_statistics(&mut **rls.conn(), path.id)
+        .await;
+    rls.release().await;
+
+    let stats = result.map_err(|e| {
+        tracing::error!(error = %e, "Failed to get webhook statistics");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to get webhook statistics",
+            )),
+        )
+    })?;
 
     Ok(Json(stats))
 }
@@ -807,9 +897,13 @@ pub async fn esignature_webhook(
         };
 
         if let Some(status) = new_status {
+            // PAP-105 (PAP-80): inbound provider webhook — no request
+            // principal, so no RLS context to bind. esignature_workflows is
+            // not FORCE-RLS and the write is scoped by the provider-signed
+            // envelope id, so the pool is the executor here.
             if let Err(e) = state
                 .integration_repo
-                .update_esignature_workflow_by_external_id(envelope_id, status)
+                .update_esignature_workflow_by_external_id(&state.db, envelope_id, status)
                 .await
             {
                 tracing::warn!(


### PR DESCRIPTION
## Summary

PAP-105 (child of the PAP-80 RLS sweep, parent PAP-67). `IntegrationRepository` (Epic 61: calendar sync, accounting exports, e-signatures, video conferencing, webhooks) held a raw `DbPool` and read `webhook_subscriptions` — FORCE-RLS since migration `00179` — without ever setting `app.current_org_id`. Under `FORCE` the owner connection is bound too, so every webhook-subscription read returned empty and every write failed (deny-all) on dev.

## Changes

- **`repositories/integration.rs`** — repo holds **no pool** (the `crypto` field stays; `new(_pool)`/`with_crypto(_pool, ..)` keep signatures for AppState compat). 50 single-statement methods take a generic `Executor`; 4 multi-statement methods (`get_accounting_export_settings`, `get_esignature_workflow_with_recipients`, `get_integration_statistics`, `count_connections_needing_refresh`) take `&mut PgConnection`.
- **`routes/integrations/sync.rs`** (22 handlers) + **`webhook.rs`** (8 handlers) — acquire `RlsConnection`, pass `&mut **rls.conn()`, `rls.release()` on every path (released *before* slow outbound provider calls). FORCE-RLS org-in-path handlers replace `verify_org_access` with a `path.org_id == rls.tenant_id()` guard; by-id webhook-subscription reads now 404 cross-tenant via RLS.
- **Non-request-context sites** — the fire-and-forget sync-status update (`tokio::spawn`) and the inbound e-signature receiver run on the pool, which is safe only because they touch non-FORCE tables; each site carries a comment stating that constraint.
- **`tests/integration_rls_repo_tests.rs`** — NOSUPERUSER role-switch test (mirrors `sentiment_rls_repo_tests.rs`): deny-all without context, own-org list + by-id get with context, cross-tenant by-id get → `None`, context-set create succeeds.

## Notes for review

- Eight previously **unauthenticated** integration handlers (e.g. `list/create_calendar_event`, accounting settings, webhook logs/stats) now require auth + tenant via `RlsConnection` — pre-existing missing-auth holes closed as a side effect; this is an API-contract change.
- Schema drift: most Epic-61 tables exist in no migration; only `webhook_subscriptions` (00102) is real, and it lacks the `status`/`retry_policy` columns the repo SQL uses. The test adds those columns up front as superuser (documented in the test header). Follow-up tracked on the PAP board.

## Verification (remote builder)

- `cargo check -p db` ✅  `cargo check -p api-server` ✅
- `cargo fmt --all -- --check` ✅  CI-scope `cargo clippy -p db -p api-server -- -D warnings` ✅
- `cargo test -p db --test integration_rls_repo_tests` ✅ (1 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)