### PR TITLE
fix(api-server): unmount Epic-61 scaffold integration routes (PAP-122)

### DIFF
--- a/backend/servers/api-server/src/routes/integrations/mod.rs
+++ b/backend/servers/api-server/src/routes/integrations/mod.rs
@@ -4,8 +4,8 @@
 //! |---------|--------|--------|
 //! | install | `install` | connect/disconnect for Airbnb, Booking.com, portals |
 //! | oauth   | `oauth`   | OAuth callback flows (Airbnb OAuth callback) |
-//! | sync    | `sync`    | calendar, accounting, e-signature, video CRUD + sync |
-//! | webhook | `webhook` | webhook subscriptions CRUD + incoming webhook receivers |
+//! | sync    | `sync`    | calendar, accounting, e-signature, video CRUD + sync — UNMOUNTED (PAP-122) |
+//! | webhook | `webhook` | inbound webhook receivers (subscription CRUD unmounted, PAP-122) |
 //! | booking_channel | `booking_channel` | Booking.com listing push + conflict detection (Gap 83-2) |
 //! | token_rotation | `token_rotation` | Airbnb OAuth token refresh, rotation, revocation (Gap 83-1) |
 
@@ -24,7 +24,11 @@ use crate::state::AppState;
 /// Assemble the integrations router from all surface sub-modules.
 pub fn router() -> Router<AppState> {
     Router::new()
-        .merge(sync::router())
+        // ROADMAP(PAP-122): sync::router() (Epic-61 calendar / accounting /
+        // e-signature / video CRUD) unmounted — the backing tables exist in no
+        // migration, so every handler fails at runtime with undefined-table
+        // errors. Remount after authoring the Epic-61 migrations (incl.
+        // FORCE-RLS policies per migration 00179 conventions).
         .merge(install::router())
         .merge(oauth::router())
         .merge(webhook::router())

--- a/backend/servers/api-server/src/routes/integrations/sync.rs
+++ b/backend/servers/api-server/src/routes/integrations/sync.rs
@@ -3,6 +3,14 @@
 //! Covers: integration statistics, calendar connections + sync + events,
 //! accounting exports + settings, e-signature workflows, and video meetings.
 //!
+//! UNMOUNTED (PAP-122): `router()` is not merged into the integrations
+//! router — `calendar_connections`, `calendar_events`, `accounting_exports`,
+//! `accounting_export_settings`, `esignature_workflows`,
+//! `esignature_recipients`, `video_conference_connections`, and
+//! `video_meetings` exist in no migration, so every handler fails at runtime
+//! with undefined-table errors. Remount after the Epic-61 migrations land
+//! (incl. FORCE-RLS policies per migration 00179 conventions).
+//!
 //! # RLS routing (PAP-105 / PAP-80)
 //!
 //! `IntegrationRepository` holds no pool: every handler acquires an

--- a/backend/servers/api-server/src/routes/integrations/webhook.rs
+++ b/backend/servers/api-server/src/routes/integrations/webhook.rs
@@ -2,9 +2,13 @@
 //!
 //! Covers two concerns:
 //! 1. **Outbound webhook management** — CRUD for webhook subscriptions,
-//!    test delivery, and delivery logs (Story 61.5).
+//!    test delivery, and delivery logs (Story 61.5). UNMOUNTED (PAP-122):
+//!    the backing schema exists in no migration; see `router()` for the
+//!    remount conditions. The live subscription surface is the
+//!    enhanced-webhook CRUD in `routes/api_ecosystem.rs`.
 //! 2. **Inbound webhook receivers** — endpoints that external systems POST to:
-//!    - E-signature providers (DocuSign, Adobe Sign, HelloSign)
+//!    - E-signature providers (DocuSign, Adobe Sign, HelloSign) — UNMOUNTED
+//!      (PAP-122), writes the migration-less `esignature_workflows` table
 //!    - Booking.com OTA push notifications
 //!    - Portal/listing-site webhooks (public, no auth)
 //!
@@ -27,7 +31,7 @@ use axum::{
     extract::{Path, State},
     http::{header, HeaderMap, StatusCode},
     response::Response,
-    routing::{get, post},
+    routing::post,
     Json, Router,
 };
 use db::models::{
@@ -73,29 +77,20 @@ struct ESignatureWebhookPayload {
 /// Create webhook-surface router.
 pub fn router() -> Router<AppState> {
     Router::new()
-        // Outbound webhook subscriptions (Story 61.5)
-        .route(
-            "/organizations/{org_id}/webhooks",
-            get(list_webhook_subscriptions),
-        )
-        .route(
-            "/organizations/{org_id}/webhooks",
-            post(create_webhook_subscription),
-        )
-        .route("/webhooks/{id}", get(get_webhook_subscription))
-        .route(
-            "/webhooks/{id}",
-            axum::routing::put(update_webhook_subscription),
-        )
-        .route(
-            "/webhooks/{id}",
-            axum::routing::delete(delete_webhook_subscription),
-        )
-        .route("/webhooks/{id}/test", post(test_webhook))
-        .route("/webhooks/{id}/logs", get(list_webhook_logs))
-        .route("/webhooks/{id}/stats", get(get_webhook_stats))
-        // Inbound webhook receivers
-        .route("/esignatures/webhook", post(esignature_webhook))
+        // ROADMAP(PAP-122): outbound webhook-subscription CRUD (Story 61.5)
+        // unmounted — the `IntegrationRepository` SQL behind it expects
+        // `status` / `retry_policy` columns and a `webhook_delivery_logs`
+        // table that exist in no migration, and it duplicates the live,
+        // schema-aligned enhanced-webhook surface in `routes/api_ecosystem.rs`
+        // (which is what `/organizations/{org_id}/webhooks` should keep
+        // serving). Remount only after the Epic-61 migrations land AND the
+        // two surfaces are reconciled onto one column convention.
+        //
+        // ROADMAP(PAP-122): the e-signature inbound receiver is unmounted with
+        // the rest of the e-signature surface — its handler writes
+        // `esignature_workflows`, which exists in no migration.
+        //
+        // Inbound webhook receivers (live)
         .route("/booking/push", post(booking_push_notification))
         .route(
             "/webhooks/portal/{connection_id}",


### PR DESCRIPTION
## Summary

Epic-61 integrations schema drift (PAP-122, found during PAP-105): the repo SQL behind `/api/v1/integrations` targets tables that exist in **no migration**, so every mounted handler 500'd at runtime (runtime `sqlx::query` → compile never caught it).

**CTO decision: gate (retire-for-now), don't ship migrations.** Lenses: YAGNI (features never worked, zero usage signal), blast radius (unmount-only, code retained), reversibility (two-way door — remount when product pulls Epic-61).

## Changes

- **`integrations/mod.rs`** — unmount `sync::router()` (calendar / accounting / e-signature / video CRUD). All 8 backing tables exist in no migration.
- **`integrations/webhook.rs`** — unmount the Story-61.5 outbound webhook-subscription CRUD (8 routes) and the e-signature inbound receiver. The CRUD duplicates the live, schema-aligned enhanced-webhook surface in `routes/api_ecosystem.rs` (which maps `is_active`/`retry_config` correctly), while this copy expects `status`/`retry_policy` columns and a `webhook_delivery_logs` table that don't exist. Remount requires migrations **and** reconciling the two surfaces onto one column convention. Live inbound receivers (Booking.com push, portal, Airbnb) stay mounted.
- ROADMAP(PAP-122) comments per the PAP-33/PAP-24 scaffold-gating pattern.

## Verification

- `cargo clippy -p api-server -- -D warnings` green (matches CI gate; `--all-targets` has a pre-existing unrelated `items_after_test_module` failure in `routes/admin/mod.rs` on dev).
- `cargo fmt --all --check` clean.
- No test exercises the unmounted routes (only `/integrations/airbnb/webhook`, which stays); no OpenAPI `paths()` registration references them; no ppt-web consumer.

Refs PAP-122, PAP-105 (PR #1239), PAP-33 precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)