### PR TITLE
test(api-server): fix dev test gate — X-Tenant-ID in emergency + vendor IDOR tests (PAP-123)

### DIFF
--- a/backend/servers/api-server/tests/emergency_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/emergency_cross_org_idor_tests.rs
@@ -9,16 +9,18 @@
 //! `create_incident` (mass-notification + incident lifecycle) were not gated to
 //! managers.
 //!
-//! The fix threads the authenticated `user_id` through a `verify_org_access`
-//! membership check on every org-keyed path (403 for non-members) and gates the
-//! broadcast/incident-create + lifecycle actions behind `verify_org_manager`
-//! (403 for ordinary members). The repository's by-id queries are already keyed
-//! on `(id, organization_id)`, so once the org is verified a foreign UUID
-//! resolves to `None` → `404`.
+//! Since the PAP-80 RLS conversion, every emergency handler acquires an
+//! `RlsConnection`: the tenant comes from the validated `X-Tenant-ID` header
+//! (membership checked against `organization_members`, 403 for non-members),
+//! the client-supplied `organization_id` query/body value is ignored for
+//! scoping, and broadcast/incident lifecycle actions are gated on a manager
+//! role (403 for ordinary members). Repository queries stay keyed on
+//! `(id, organization_id)`, so a foreign UUID resolves to `None` → `404`.
 //!
 //! These tests exercise the HTTP surface end-to-end with real HS256 JWTs:
 //!   1. Seed two orgs (A, B), a member user in each, and a protocol in Org A.
-//!   2. Org B's member probes Org A's resources → rejected (403); no leak/write.
+//!   2. Org B's member targets Org A via `X-Tenant-ID` → rejected (403);
+//!      no leak/write.
 //!   3. Org A's member reads/writes its own org → allowed (2xx) — proving the
 //!      test establishes real org/tenant context (the membership row), so the
 //!      cross-org rejection is NOT a trivial "no context" pass.
@@ -137,7 +139,14 @@ async fn list_protocols_from_other_org_is_rejected(pool: PgPool) {
 
     let token_b = mint_token(user_b, "lst-b@emergency-idor.test");
     let uri = format!("/api/v1/emergency/protocols?organization_id={org_a}");
-    let resp = app.execute(app.get(&uri).bearer(&token_b).build()).await;
+    let resp = app
+        .execute(
+            app.get(&uri)
+                .bearer(&token_b)
+                .header("X-Tenant-ID", &org_a.to_string())
+                .build(),
+        )
+        .await;
 
     assert_eq!(
         resp.status,
@@ -163,7 +172,14 @@ async fn get_protocol_from_other_org_is_rejected(pool: PgPool) {
     let token_b = mint_token(user_b, "get-b@emergency-idor.test");
     // Attacker supplies the VICTIM org id together with the victim protocol id.
     let uri = format!("/api/v1/emergency/protocols/{protocol_a}?organization_id={org_a}");
-    let resp = app.execute(app.get(&uri).bearer(&token_b).build()).await;
+    let resp = app
+        .execute(
+            app.get(&uri)
+                .bearer(&token_b)
+                .header("X-Tenant-ID", &org_a.to_string())
+                .build(),
+        )
+        .await;
 
     assert_eq!(
         resp.status,
@@ -201,6 +217,7 @@ async fn create_protocol_for_other_org_is_rejected(pool: PgPool) {
         .execute(
             app.post("/api/v1/emergency/protocols")
                 .bearer(&token_b)
+                .header("X-Tenant-ID", &org_a.to_string())
                 .json(body)
                 .build(),
         )
@@ -237,7 +254,14 @@ async fn delete_protocol_from_other_org_is_rejected(pool: PgPool) {
 
     let token_b = mint_token(user_b, "del-b@emergency-idor.test");
     let uri = format!("/api/v1/emergency/protocols/{protocol_a}?organization_id={org_a}");
-    let resp = app.execute(app.delete(&uri).bearer(&token_b).build()).await;
+    let resp = app
+        .execute(
+            app.delete(&uri)
+                .bearer(&token_b)
+                .header("X-Tenant-ID", &org_a.to_string())
+                .build(),
+        )
+        .await;
 
     assert_eq!(
         resp.status,
@@ -280,6 +304,7 @@ async fn create_broadcast_as_plain_member_is_rejected(pool: PgPool) {
         .execute(
             app.post("/api/v1/emergency/broadcasts")
                 .bearer(&token)
+                .header("X-Tenant-ID", &org_a.to_string())
                 .json(body)
                 .build(),
         )
@@ -320,7 +345,14 @@ async fn get_protocol_for_own_org_succeeds(pool: PgPool) {
 
     let token_a = mint_token(user_a, "own-a@emergency-idor.test");
     let uri = format!("/api/v1/emergency/protocols/{protocol_a}?organization_id={org_a}");
-    let resp = app.execute(app.get(&uri).bearer(&token_a).build()).await;
+    let resp = app
+        .execute(
+            app.get(&uri)
+                .bearer(&token_a)
+                .header("X-Tenant-ID", &org_a.to_string())
+                .build(),
+        )
+        .await;
 
     assert_eq!(
         resp.status,
@@ -365,6 +397,7 @@ async fn create_broadcast_as_manager_succeeds(pool: PgPool) {
         .execute(
             app.post("/api/v1/emergency/broadcasts")
                 .bearer(&token)
+                .header("X-Tenant-ID", &org_a.to_string())
                 .json(body)
                 .build(),
         )

--- a/backend/servers/api-server/tests/vendor_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/vendor_cross_org_idor_tests.rs
@@ -9,12 +9,13 @@
 //! caller belongs to it. A foreign caller could read/mutate any other org's
 //! vendor, contract or invoice by UUID, or list/write into an arbitrary org.
 //!
-//! The fix threads the authenticated `user_id` through a `verify_org_access`
-//! membership check on the org-keyed paths, and re-derives the org from the
-//! fetched row (`verify_vendor_access` / `verify_contract_access` /
-//! `verify_invoice_access`) for by-id resources — returning `404` on
-//! cross-tenant probes so "missing" and "forbidden" are indistinguishable, and
-//! `403` on org-keyed reads/writes.
+//! Since the PAP-80 RLS conversion, every vendor handler acquires an
+//! `RlsConnection`: the tenant comes from the validated `X-Tenant-ID` header
+//! (membership checked against `organization_members`, 403 for non-members)
+//! and the client-supplied `organization_id` is ignored for scoping. By-id
+//! queries stay keyed on `(id, organization_id)`, so a cross-tenant probe made
+//! with the attacker's own valid tenant context resolves to `None` → `404` —
+//! "missing" and "forbidden" remain indistinguishable.
 //!
 //! These tests exercise the HTTP surface end-to-end with real HS256 JWTs:
 //!   1. Seed two orgs (A, B), a member user in each, and a vendor in Org A.
@@ -144,7 +145,14 @@ async fn list_vendors_from_other_org_is_rejected(pool: PgPool) {
     // User B (member of Org B only) asks for Org A's vendors.
     let token_b = mint_token(user_b, "lst-b@vendor-idor.test");
     let uri = format!("/api/v1/vendors?organization_id={org_a}");
-    let resp = app.execute(app.get(&uri).bearer(&token_b).build()).await;
+    let resp = app
+        .execute(
+            app.get(&uri)
+                .bearer(&token_b)
+                .header("X-Tenant-ID", &org_a.to_string())
+                .build(),
+        )
+        .await;
 
     assert_eq!(
         resp.status,
@@ -169,7 +177,16 @@ async fn get_vendor_from_other_org_is_rejected(pool: PgPool) {
 
     let token_b = mint_token(user_b, "get-b@vendor-idor.test");
     let uri = format!("/api/v1/vendors/{vendor_a}");
-    let resp = app.execute(app.get(&uri).bearer(&token_b).build()).await;
+    // Valid context for the attacker's OWN org — the by-id probe must fail on
+    // row scoping (404), not on a missing tenant header.
+    let resp = app
+        .execute(
+            app.get(&uri)
+                .bearer(&token_b)
+                .header("X-Tenant-ID", &org_b.to_string())
+                .build(),
+        )
+        .await;
 
     assert_rejected(resp.status, "get_vendor cross-tenant");
     // Specifically: must not 200 with Org A's vendor.
@@ -195,7 +212,14 @@ async fn delete_vendor_from_other_org_is_rejected(pool: PgPool) {
 
     let token_b = mint_token(user_b, "del-b@vendor-idor.test");
     let uri = format!("/api/v1/vendors/{vendor_a}");
-    let resp = app.execute(app.delete(&uri).bearer(&token_b).build()).await;
+    let resp = app
+        .execute(
+            app.delete(&uri)
+                .bearer(&token_b)
+                .header("X-Tenant-ID", &org_b.to_string())
+                .build(),
+        )
+        .await;
 
     assert_rejected(resp.status, "delete_vendor cross-tenant");
     assert_ne!(
@@ -233,6 +257,7 @@ async fn update_vendor_from_other_org_is_rejected(pool: PgPool) {
         .execute(
             RequestBuilder::new(Method::PATCH, &uri)
                 .bearer(&token_b)
+                .header("X-Tenant-ID", &org_b.to_string())
                 .json(body)
                 .build(),
         )
@@ -274,6 +299,7 @@ async fn create_vendor_for_other_org_is_rejected(pool: PgPool) {
         .execute(
             app.post("/api/v1/vendors")
                 .bearer(&token_b)
+                .header("X-Tenant-ID", &org_a.to_string())
                 .json(body)
                 .build(),
         )
@@ -309,7 +335,14 @@ async fn get_vendor_for_own_org_succeeds(pool: PgPool) {
 
     let token_a = mint_token(user_a, "own-a@vendor-idor.test");
     let uri = format!("/api/v1/vendors/{vendor_a}");
-    let resp = app.execute(app.get(&uri).bearer(&token_a).build()).await;
+    let resp = app
+        .execute(
+            app.get(&uri)
+                .bearer(&token_a)
+                .header("X-Tenant-ID", &org_a.to_string())
+                .build(),
+        )
+        .await;
 
     assert_eq!(
         resp.status,


### PR DESCRIPTION
## Summary

Dev's `backend.yml` `test` job has been red since the PAP-80 RLS conversions landed for the emergency and vendor routes. Bisect of dev's run history:

- First red on the 7 emergency failures: run 27245671530 at `b7fc9101a` (emergency → RlsConnection).
- 3 vendor failures (`list_vendors_from_other_org_is_rejected`, `create_vendor_for_other_org_is_rejected`, `get_vendor_for_own_org_succeeds`) visible at run 27242437744 (`e972947ff`), introduced by `125c9caac` (vendor → RlsConnection) — currently **masked** by `cargo test`'s fail-fast because the emergency test binary fails first.

Root cause: `RlsConnection` resolves the tenant from the validated `X-Tenant-ID` header (membership-checked, 403 for non-members) and ignores the client-supplied `organization_id`. The pre-conversion IDOR tests never sent the header, so org-scoped requests failed 400 instead of the asserted 403/200/201. **Test-only change; no production code touched.**

## Changes

- `emergency_cross_org_idor_tests.rs`: all 7 tests send `X-Tenant-ID` — cross-org probes use the victim org id (membership check → 403), same-org positives use their own org id.
- `vendor_cross_org_idor_tests.rs`: same for the 3 hard failures; the 3 by-id probe tests (`get`/`delete`/`update` cross-tenant) now send the attacker's *own* valid tenant context so they exercise DB-level row scoping (404) instead of passing vacuously on a missing-header 400.
- Doc headers updated to describe the post-PAP-80 contract.

## Verification

The failing gate itself is the verification: this PR's `test` job runs the full suite including both fixed binaries. Remote spot-run was attempted but the builder hit disk limits; CI is authoritative here.

Fixes PAP-123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)