### PR TITLE
fix(db): route legal repo through RLS-context connection (PAP-80 / PAP-109)

### DIFF
--- a/backend/crates/db/src/repositories/legal.rs
+++ b/backend/crates/db/src/repositories/legal.rs
@@ -1,4 +1,29 @@
 //! Legal document and compliance repository (Epic 25).
+//!
+//! # RLS Integration (PAP-80 / PAP-67)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on all eight legal/compliance tables
+//! (`legal_documents`, `legal_document_versions`, `compliance_requirements`,
+//! `compliance_verifications`, `legal_notices`, `legal_notice_recipients`,
+//! `compliance_templates`, `compliance_audit_trail`). Under `FORCE` the
+//! api-server's owner connection is no longer exempt, so a query issued on a
+//! connection without `app.current_org_id` set collapses to deny-all (own-org
+//! reads return empty, writes fail the policy `WITH CHECK`).
+//!
+//! Every method therefore takes an **executor whose connection already has RLS
+//! context set** (org + user GUCs) — in handlers this comes from the
+//! `RlsConnection` extractor via `&mut **rls.conn()`. The repository holds **no
+//! pool**, so there is no way to issue a query that bypasses RLS. Single-
+//! statement methods take a generic `Executor`; methods that run more than one
+//! statement (or call an `*_in_org` guard before their query) take
+//! `&mut PgConnection` and reborrow it per query. This mirrors the
+//! `work_order.rs` / `budget.rs` / `document.rs` precedent.
+//!
+//! The explicit `organization_id = $n` filters are retained as defence in
+//! depth: the handler passes `rls.tenant_id()` as the authoritative org, which
+//! is the same tenant the connection's RLS context was set to, so the SQL
+//! filter and the policy can never disagree.
 
 use crate::models::{
     AcknowledgeNotice, ApplyTemplate, ComplianceAuditTrail, ComplianceCategoryCount,
@@ -12,30 +37,40 @@ use crate::models::{
     UpdateComplianceTemplate, UpdateLegalDocument, UpdateLegalNotice,
 };
 use chrono::{Months, NaiveDate};
-use sqlx::PgPool;
+use sqlx::{Executor, PgConnection, PgPool, Postgres};
 use uuid::Uuid;
 
 /// Repository for legal document and compliance operations.
+///
+/// Stateless: every method receives an RLS-context-bearing executor. The repo
+/// holds no pool so it cannot issue an un-scoped (deny-all under `FORCE`) query.
 #[derive(Clone)]
-pub struct LegalRepository {
-    pool: PgPool,
-}
+pub struct LegalRepository;
 
 impl LegalRepository {
     /// Create a new LegalRepository.
-    pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+    ///
+    /// The pool argument is retained for construction-site compatibility with
+    /// the other repositories on `AppState`; this repo deliberately does not
+    /// store it (see module docs — all queries run on a context-set connection
+    /// supplied by the handler's `RlsConnection`).
+    pub fn new(_pool: PgPool) -> Self {
+        Self
     }
 
     // ==================== Legal Documents CRUD ====================
 
     /// Create a new legal document.
-    pub async fn create_document(
+    pub async fn create_document<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         user_id: Uuid,
         data: CreateLegalDocument,
-    ) -> Result<LegalDocument, sqlx::Error> {
+    ) -> Result<LegalDocument, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // Calculate retention expiry date if retention period is provided
         // Using proper month arithmetic for accuracy
         let retention_expires_at = data.retention_period_months.map(|months| {
@@ -74,32 +109,40 @@ impl LegalRepository {
         .bind(&data.tags)
         .bind(data.metadata.map(sqlx::types::Json))
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Find a legal document by ID, scoped to an organization.
     ///
     /// A foreign-org `id` returns `None` (→ HTTP 404), preventing cross-tenant
-    /// reads (IDOR, #829).
-    pub async fn find_document_by_id(
+    /// reads (IDOR, #829) — now enforced by RLS as well as the explicit filter.
+    pub async fn find_document_by_id<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
-    ) -> Result<Option<LegalDocument>, sqlx::Error> {
+    ) -> Result<Option<LegalDocument>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as("SELECT * FROM legal_documents WHERE id = $1 AND organization_id = $2")
             .bind(id)
             .bind(org_id)
-            .fetch_optional(&self.pool)
+            .fetch_optional(executor)
             .await
     }
 
     /// List legal documents for an organization.
-    pub async fn list_documents(
+    pub async fn list_documents<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: LegalDocumentQuery,
-    ) -> Result<Vec<LegalDocument>, sqlx::Error> {
+    ) -> Result<Vec<LegalDocument>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let search_pattern = query.search.as_ref().map(|s| format!("%{}%", s));
 
         sqlx::query_as(
@@ -125,16 +168,20 @@ impl LegalRepository {
         .bind(&search_pattern)
         .bind(query.limit.unwrap_or(50))
         .bind(query.offset.unwrap_or(0))
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// List legal documents with version counts.
-    pub async fn list_documents_with_summary(
+    pub async fn list_documents_with_summary<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: LegalDocumentQuery,
-    ) -> Result<Vec<LegalDocumentSummary>, sqlx::Error> {
+    ) -> Result<Vec<LegalDocumentSummary>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let search_pattern = query.search.as_ref().map(|s| format!("%{}%", s));
 
         sqlx::query_as(
@@ -166,7 +213,7 @@ impl LegalRepository {
         .bind(&search_pattern)
         .bind(query.limit.unwrap_or(50))
         .bind(query.offset.unwrap_or(0))
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -174,12 +221,16 @@ impl LegalRepository {
     ///
     /// Returns `None` when no row in `org_id` matches `id` (→ HTTP 404),
     /// so a cross-tenant `id` cannot be mutated (IDOR, #829).
-    pub async fn update_document(
+    pub async fn update_document<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
         data: UpdateLegalDocument,
-    ) -> Result<Option<LegalDocument>, sqlx::Error> {
+    ) -> Result<Option<LegalDocument>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE legal_documents SET
@@ -222,17 +273,25 @@ impl LegalRepository {
         .bind(data.retention_expires_at)
         .bind(&data.tags)
         .bind(data.metadata.map(sqlx::types::Json))
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Delete a legal document, scoped to an organization.
-    pub async fn delete_document(&self, id: Uuid, org_id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete_document<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result =
             sqlx::query("DELETE FROM legal_documents WHERE id = $1 AND organization_id = $2")
                 .bind(id)
                 .bind(org_id)
-                .execute(&self.pool)
+                .execute(executor)
                 .await?;
         Ok(result.rows_affected() > 0)
     }
@@ -243,13 +302,21 @@ impl LegalRepository {
     ///
     /// Used to org-scope child-resource (version) operations so a foreign-org
     /// `document_id` cannot be read or written through (IDOR, #829).
-    async fn document_in_org(&self, document_id: Uuid, org_id: Uuid) -> Result<bool, sqlx::Error> {
+    async fn document_in_org<'e, E>(
+        &self,
+        executor: E,
+        document_id: Uuid,
+        org_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let exists: Option<Uuid> = sqlx::query_scalar(
             "SELECT id FROM legal_documents WHERE id = $1 AND organization_id = $2",
         )
         .bind(document_id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await?;
         Ok(exists.is_some())
     }
@@ -259,12 +326,13 @@ impl LegalRepository {
     /// Returns `None` when the parent document is not in `org_id` (→ HTTP 404).
     pub async fn add_document_version(
         &self,
+        conn: &mut PgConnection,
         document_id: Uuid,
         org_id: Uuid,
         user_id: Uuid,
         data: CreateLegalDocumentVersion,
     ) -> Result<Option<LegalDocumentVersion>, sqlx::Error> {
-        if !self.document_in_org(document_id, org_id).await? {
+        if !self.document_in_org(&mut *conn, document_id, org_id).await? {
             return Ok(None);
         }
         let version: LegalDocumentVersion = sqlx::query_as(
@@ -287,7 +355,7 @@ impl LegalRepository {
         .bind(&data.mime_type)
         .bind(&data.change_notes)
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
         Ok(Some(version))
     }
@@ -297,10 +365,11 @@ impl LegalRepository {
     /// Returns `None` when the parent document is not in `org_id` (→ HTTP 404).
     pub async fn list_document_versions(
         &self,
+        conn: &mut PgConnection,
         document_id: Uuid,
         org_id: Uuid,
     ) -> Result<Option<Vec<LegalDocumentVersion>>, sqlx::Error> {
-        if !self.document_in_org(document_id, org_id).await? {
+        if !self.document_in_org(&mut *conn, document_id, org_id).await? {
             return Ok(None);
         }
         let versions = sqlx::query_as(
@@ -311,7 +380,7 @@ impl LegalRepository {
             "#,
         )
         .bind(document_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await?;
         Ok(Some(versions))
     }
@@ -319,11 +388,12 @@ impl LegalRepository {
     /// Get a specific version, scoped to an organization.
     pub async fn get_document_version(
         &self,
+        conn: &mut PgConnection,
         document_id: Uuid,
         org_id: Uuid,
         version_number: i32,
     ) -> Result<Option<LegalDocumentVersion>, sqlx::Error> {
-        if !self.document_in_org(document_id, org_id).await? {
+        if !self.document_in_org(&mut *conn, document_id, org_id).await? {
             return Ok(None);
         }
         sqlx::query_as(
@@ -334,18 +404,22 @@ impl LegalRepository {
         )
         .bind(document_id)
         .bind(version_number)
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *conn)
         .await
     }
 
     // ==================== Compliance Requirements CRUD ====================
 
     /// Create a compliance requirement.
-    pub async fn create_requirement(
+    pub async fn create_requirement<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         data: CreateComplianceRequirement,
-    ) -> Result<ComplianceRequirement, sqlx::Error> {
+    ) -> Result<ComplianceRequirement, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO compliance_requirements
@@ -366,33 +440,41 @@ impl LegalRepository {
         .bind(data.is_mandatory.unwrap_or(true))
         .bind(&data.responsible_party)
         .bind(&data.notes)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Find a compliance requirement by ID, scoped to an organization.
     ///
     /// A foreign-org `id` returns `None` (→ HTTP 404) (IDOR, #829).
-    pub async fn find_requirement_by_id(
+    pub async fn find_requirement_by_id<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
-    ) -> Result<Option<ComplianceRequirement>, sqlx::Error> {
+    ) -> Result<Option<ComplianceRequirement>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             "SELECT * FROM compliance_requirements WHERE id = $1 AND organization_id = $2",
         )
         .bind(id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// List compliance requirements.
-    pub async fn list_requirements(
+    pub async fn list_requirements<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: ComplianceQuery,
-    ) -> Result<Vec<ComplianceRequirement>, sqlx::Error> {
+    ) -> Result<Vec<ComplianceRequirement>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM compliance_requirements
@@ -416,16 +498,20 @@ impl LegalRepository {
         .bind(query.overdue_only)
         .bind(query.limit.unwrap_or(50))
         .bind(query.offset.unwrap_or(0))
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// List requirements with verification details.
-    pub async fn list_requirements_with_details(
+    pub async fn list_requirements_with_details<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: ComplianceQuery,
-    ) -> Result<Vec<ComplianceRequirementWithDetails>, sqlx::Error> {
+    ) -> Result<Vec<ComplianceRequirementWithDetails>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT
@@ -455,19 +541,23 @@ impl LegalRepository {
         .bind(query.overdue_only)
         .bind(query.limit.unwrap_or(50))
         .bind(query.offset.unwrap_or(0))
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update a compliance requirement, scoped to an organization.
     ///
     /// Returns `None` when no row in `org_id` matches `id` (→ HTTP 404) (IDOR, #829).
-    pub async fn update_requirement(
+    pub async fn update_requirement<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
         data: UpdateComplianceRequirement,
-    ) -> Result<Option<ComplianceRequirement>, sqlx::Error> {
+    ) -> Result<Option<ComplianceRequirement>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE compliance_requirements SET
@@ -500,18 +590,26 @@ impl LegalRepository {
         .bind(data.is_mandatory)
         .bind(&data.responsible_party)
         .bind(&data.notes)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Delete a compliance requirement, scoped to an organization.
-    pub async fn delete_requirement(&self, id: Uuid, org_id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete_requirement<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query(
             "DELETE FROM compliance_requirements WHERE id = $1 AND organization_id = $2",
         )
         .bind(id)
         .bind(org_id)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
         Ok(result.rows_affected() > 0)
     }
@@ -519,17 +617,21 @@ impl LegalRepository {
     // ==================== Compliance Verifications ====================
 
     /// Check that a compliance requirement belongs to an organization.
-    async fn requirement_in_org(
+    async fn requirement_in_org<'e, E>(
         &self,
+        executor: E,
         requirement_id: Uuid,
         org_id: Uuid,
-    ) -> Result<bool, sqlx::Error> {
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let exists: Option<Uuid> = sqlx::query_scalar(
             "SELECT id FROM compliance_requirements WHERE id = $1 AND organization_id = $2",
         )
         .bind(requirement_id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await?;
         Ok(exists.is_some())
     }
@@ -539,12 +641,16 @@ impl LegalRepository {
     /// Returns `None` when the requirement is not in `org_id` (→ HTTP 404).
     pub async fn create_verification(
         &self,
+        conn: &mut PgConnection,
         requirement_id: Uuid,
         org_id: Uuid,
         user_id: Uuid,
         data: CreateComplianceVerification,
     ) -> Result<Option<ComplianceVerification>, sqlx::Error> {
-        if !self.requirement_in_org(requirement_id, org_id).await? {
+        if !self
+            .requirement_in_org(&mut *conn, requirement_id, org_id)
+            .await?
+        {
             return Ok(None);
         }
         // Record the verification
@@ -567,7 +673,7 @@ impl LegalRepository {
         .bind(data.valid_until)
         .bind(&data.issues_found)
         .bind(&data.corrective_actions)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         // Update the requirement status and verification dates
@@ -584,7 +690,7 @@ impl LegalRepository {
         .bind(requirement_id)
         .bind(&data.status)
         .bind(user_id)
-        .execute(&self.pool)
+        .execute(&mut *conn)
         .await?;
 
         Ok(Some(verification))
@@ -595,10 +701,14 @@ impl LegalRepository {
     /// Returns `None` when the requirement is not in `org_id` (→ HTTP 404).
     pub async fn list_verifications(
         &self,
+        conn: &mut PgConnection,
         requirement_id: Uuid,
         org_id: Uuid,
     ) -> Result<Option<Vec<ComplianceVerification>>, sqlx::Error> {
-        if !self.requirement_in_org(requirement_id, org_id).await? {
+        if !self
+            .requirement_in_org(&mut *conn, requirement_id, org_id)
+            .await?
+        {
             return Ok(None);
         }
         let verifications = sqlx::query_as(
@@ -609,7 +719,7 @@ impl LegalRepository {
             "#,
         )
         .bind(requirement_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await?;
         Ok(Some(verifications))
     }
@@ -617,6 +727,7 @@ impl LegalRepository {
     /// Get compliance statistics.
     pub async fn get_compliance_statistics(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
     ) -> Result<ComplianceStatistics, sqlx::Error> {
         let counts: (i64, i64, i64, i64, i64) = sqlx::query_as(
@@ -632,7 +743,7 @@ impl LegalRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         let by_category: Vec<ComplianceCategoryCount> = sqlx::query_as(
@@ -645,7 +756,7 @@ impl LegalRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await?;
 
         let upcoming_verifications: Vec<UpcomingVerification> = sqlx::query_as(
@@ -662,7 +773,7 @@ impl LegalRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await?;
 
         Ok(ComplianceStatistics {
@@ -681,6 +792,7 @@ impl LegalRepository {
     /// Create a legal notice.
     pub async fn create_notice(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         user_id: Uuid,
         data: CreateLegalNotice,
@@ -704,7 +816,7 @@ impl LegalRepository {
         .bind(data.requires_acknowledgment.unwrap_or(false))
         .bind(data.acknowledgment_deadline)
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         // Add recipients
@@ -721,7 +833,7 @@ impl LegalRepository {
             .bind(recipient.recipient_id)
             .bind(&recipient.recipient_name)
             .bind(&recipient.recipient_email)
-            .execute(&self.pool)
+            .execute(&mut *conn)
             .await?;
         }
 
@@ -731,36 +843,52 @@ impl LegalRepository {
     /// Find a legal notice by ID, scoped to an organization.
     ///
     /// A foreign-org `id` returns `None` (→ HTTP 404) (IDOR, #829).
-    pub async fn find_notice_by_id(
+    pub async fn find_notice_by_id<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
-    ) -> Result<Option<LegalNotice>, sqlx::Error> {
+    ) -> Result<Option<LegalNotice>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as("SELECT * FROM legal_notices WHERE id = $1 AND organization_id = $2")
             .bind(id)
             .bind(org_id)
-            .fetch_optional(&self.pool)
+            .fetch_optional(executor)
             .await
     }
 
     /// Check that a legal notice belongs to an organization.
-    async fn notice_in_org(&self, notice_id: Uuid, org_id: Uuid) -> Result<bool, sqlx::Error> {
+    async fn notice_in_org<'e, E>(
+        &self,
+        executor: E,
+        notice_id: Uuid,
+        org_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let exists: Option<Uuid> = sqlx::query_scalar(
             "SELECT id FROM legal_notices WHERE id = $1 AND organization_id = $2",
         )
         .bind(notice_id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await?;
         Ok(exists.is_some())
     }
 
     /// List legal notices.
-    pub async fn list_notices(
+    pub async fn list_notices<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: LegalNoticeQuery,
-    ) -> Result<Vec<LegalNotice>, sqlx::Error> {
+    ) -> Result<Vec<LegalNotice>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM legal_notices
@@ -782,16 +910,20 @@ impl LegalRepository {
         .bind(query.requires_acknowledgment)
         .bind(query.limit.unwrap_or(50))
         .bind(query.offset.unwrap_or(0))
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// List notices with recipient summary.
-    pub async fn list_notices_with_recipients(
+    pub async fn list_notices_with_recipients<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: LegalNoticeQuery,
-    ) -> Result<Vec<NoticeWithRecipients>, sqlx::Error> {
+    ) -> Result<Vec<NoticeWithRecipients>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT
@@ -821,19 +953,23 @@ impl LegalRepository {
         .bind(query.requires_acknowledgment)
         .bind(query.limit.unwrap_or(50))
         .bind(query.offset.unwrap_or(0))
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update a legal notice, scoped to an organization.
     ///
     /// Returns `None` when no row in `org_id` matches `id` (→ HTTP 404) (IDOR, #829).
-    pub async fn update_notice(
+    pub async fn update_notice<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
         data: UpdateLegalNotice,
-    ) -> Result<Option<LegalNotice>, sqlx::Error> {
+    ) -> Result<Option<LegalNotice>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE legal_notices SET
@@ -856,17 +992,25 @@ impl LegalRepository {
         .bind(&data.delivery_method)
         .bind(data.requires_acknowledgment)
         .bind(data.acknowledgment_deadline)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Delete a legal notice, scoped to an organization.
-    pub async fn delete_notice(&self, id: Uuid, org_id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete_notice<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result =
             sqlx::query("DELETE FROM legal_notices WHERE id = $1 AND organization_id = $2")
                 .bind(id)
                 .bind(org_id)
-                .execute(&self.pool)
+                .execute(executor)
                 .await?;
         Ok(result.rows_affected() > 0)
     }
@@ -878,6 +1022,7 @@ impl LegalRepository {
     /// that can retry failures and update individual recipient statuses accordingly.
     pub async fn send_notice(
         &self,
+        conn: &mut PgConnection,
         id: Uuid,
         org_id: Uuid,
     ) -> Result<Option<LegalNotice>, sqlx::Error> {
@@ -891,7 +1036,7 @@ impl LegalRepository {
         )
         .bind(id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *conn)
         .await?;
 
         let Some(notice) = notice else {
@@ -909,7 +1054,7 @@ impl LegalRepository {
             "#,
         )
         .bind(id)
-        .execute(&self.pool)
+        .execute(&mut *conn)
         .await?;
 
         Ok(Some(notice))
@@ -922,10 +1067,11 @@ impl LegalRepository {
     /// Returns `None` when the parent notice is not in `org_id` (→ HTTP 404).
     pub async fn list_notice_recipients(
         &self,
+        conn: &mut PgConnection,
         notice_id: Uuid,
         org_id: Uuid,
     ) -> Result<Option<Vec<LegalNoticeRecipient>>, sqlx::Error> {
-        if !self.notice_in_org(notice_id, org_id).await? {
+        if !self.notice_in_org(&mut *conn, notice_id, org_id).await? {
             return Ok(None);
         }
         let recipients = sqlx::query_as(
@@ -936,7 +1082,7 @@ impl LegalRepository {
             "#,
         )
         .bind(notice_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await?;
         Ok(Some(recipients))
     }
@@ -947,12 +1093,13 @@ impl LegalRepository {
     /// Returns `None` when the parent notice is not in `org_id` (→ HTTP 404).
     pub async fn acknowledge_notice(
         &self,
+        conn: &mut PgConnection,
         notice_id: Uuid,
         recipient_id: Uuid,
         org_id: Uuid,
         data: AcknowledgeNotice,
     ) -> Result<Option<LegalNoticeRecipient>, sqlx::Error> {
-        if !self.notice_in_org(notice_id, org_id).await? {
+        if !self.notice_in_org(&mut *conn, notice_id, org_id).await? {
             return Ok(None);
         }
         // The unique constraint on (notice_id, recipient_id) ensures this update
@@ -972,13 +1119,14 @@ impl LegalRepository {
             data.acknowledgment_method
                 .unwrap_or_else(|| "manual".to_string()),
         )
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *conn)
         .await
     }
 
     /// Get notice statistics.
     pub async fn get_notice_statistics(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
     ) -> Result<NoticeStatistics, sqlx::Error> {
         let counts: (i64, i64, i64) = sqlx::query_as(
@@ -992,7 +1140,7 @@ impl LegalRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         let by_type: Vec<NoticeTypeCount> = sqlx::query_as(
@@ -1005,7 +1153,7 @@ impl LegalRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await?;
 
         // Count at recipient level for consistency (all counts are recipient-based)
@@ -1022,7 +1170,7 @@ impl LegalRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         Ok(NoticeStatistics {
@@ -1042,11 +1190,15 @@ impl LegalRepository {
     // ==================== Compliance Templates ====================
 
     /// Create a compliance template.
-    pub async fn create_template(
+    pub async fn create_template<'e, E>(
         &self,
+        executor: E,
         org_id: Option<Uuid>,
         data: CreateComplianceTemplate,
-    ) -> Result<ComplianceTemplate, sqlx::Error> {
+    ) -> Result<ComplianceTemplate, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO compliance_templates
@@ -1061,7 +1213,7 @@ impl LegalRepository {
         .bind(&data.description)
         .bind(data.checklist_items.map(sqlx::types::Json))
         .bind(data.frequency.unwrap_or_else(|| "annually".to_string()))
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
@@ -1069,12 +1221,18 @@ impl LegalRepository {
     ///
     /// Resolves the caller's own org templates and shared system templates
     /// (`organization_id IS NULL`); a *different* org's private template
-    /// returns `None` (→ HTTP 404) (IDOR, #829).
-    pub async fn find_template_by_id(
+    /// returns `None` (→ HTTP 404) (IDOR, #829). The RLS policy on
+    /// `compliance_templates` mirrors this `org = current OR org IS NULL` rule,
+    /// so shared templates remain visible under context.
+    pub async fn find_template_by_id<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
-    ) -> Result<Option<ComplianceTemplate>, sqlx::Error> {
+    ) -> Result<Option<ComplianceTemplate>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM compliance_templates
@@ -1083,16 +1241,20 @@ impl LegalRepository {
         )
         .bind(id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// List templates (organization-specific + system templates).
-    pub async fn list_templates(
+    pub async fn list_templates<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         category: Option<String>,
-    ) -> Result<Vec<ComplianceTemplate>, sqlx::Error> {
+    ) -> Result<Vec<ComplianceTemplate>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM compliance_templates
@@ -1103,7 +1265,7 @@ impl LegalRepository {
         )
         .bind(org_id)
         .bind(&category)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -1111,12 +1273,16 @@ impl LegalRepository {
     ///
     /// Only the owning org's own (non-system) templates can be updated; a
     /// foreign-org or system template returns `None` (→ HTTP 404) (IDOR, #829).
-    pub async fn update_template(
+    pub async fn update_template<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
         data: UpdateComplianceTemplate,
-    ) -> Result<Option<ComplianceTemplate>, sqlx::Error> {
+    ) -> Result<Option<ComplianceTemplate>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE compliance_templates SET
@@ -1137,20 +1303,28 @@ impl LegalRepository {
         .bind(&data.description)
         .bind(data.checklist_items.map(sqlx::types::Json))
         .bind(&data.frequency)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Delete a template, scoped to an organization.
     ///
     /// Only the owning org's own (non-system) templates can be deleted.
-    pub async fn delete_template(&self, id: Uuid, org_id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete_template<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query(
             "DELETE FROM compliance_templates WHERE id = $1 AND organization_id = $2 AND is_system = FALSE",
         )
         .bind(id)
         .bind(org_id)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
         Ok(result.rows_affected() > 0)
     }
@@ -1158,13 +1332,14 @@ impl LegalRepository {
     /// Apply a template to create requirements.
     pub async fn apply_template(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         data: ApplyTemplate,
     ) -> Result<Vec<ComplianceRequirement>, sqlx::Error> {
         let template = self
-            .find_template_by_id(data.template_id, org_id)
+            .find_template_by_id(&mut *conn, data.template_id, org_id)
             .await?
-            .ok_or_else(|| sqlx::Error::RowNotFound)?;
+            .ok_or(sqlx::Error::RowNotFound)?;
 
         // Calculate next due date based on frequency
         let next_due_date = calculate_next_due_date(&template.frequency);
@@ -1185,7 +1360,7 @@ impl LegalRepository {
         .bind(&template.category)
         .bind(&template.frequency)
         .bind(next_due_date)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         Ok(vec![requirement])
@@ -1194,12 +1369,16 @@ impl LegalRepository {
     // ==================== Compliance Audit Trail ====================
 
     /// Create an audit trail entry.
-    pub async fn create_audit_entry(
+    pub async fn create_audit_entry<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         user_id: Uuid,
         data: CreateAuditTrailEntry,
-    ) -> Result<ComplianceAuditTrail, sqlx::Error> {
+    ) -> Result<ComplianceAuditTrail, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO compliance_audit_trail
@@ -1218,20 +1397,24 @@ impl LegalRepository {
         .bind(data.old_values.map(sqlx::types::Json))
         .bind(data.new_values.map(sqlx::types::Json))
         .bind(&data.notes)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// List audit trail entries.
-    pub async fn list_audit_trail(
+    pub async fn list_audit_trail<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         requirement_id: Option<Uuid>,
         document_id: Option<Uuid>,
         notice_id: Option<Uuid>,
         limit: i32,
         offset: i32,
-    ) -> Result<Vec<ComplianceAuditTrail>, sqlx::Error> {
+    ) -> Result<Vec<ComplianceAuditTrail>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM compliance_audit_trail
@@ -1249,7 +1432,7 @@ impl LegalRepository {
         .bind(notice_id)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 }

--- a/backend/crates/db/tests/legal_rls_repo_tests.rs
+++ b/backend/crates/db/tests/legal_rls_repo_tests.rs
@@ -1,0 +1,285 @@
+//! Repo-level behavioral RLS regression test for PAP-109 (parent PAP-80 / PAP-67).
+//!
+//! Background
+//! ----------
+//! Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on the eight legal/compliance tables, including
+//! `legal_documents`. The production api-server connects as the table OWNER,
+//! which `FORCE` binds. `LegalRepository` held a raw `PgPool` and ran every
+//! query WITHOUT ever calling `set_request_context`, so on `dev`
+//! `get_current_org_id()` returned NULL and the policy collapsed to
+//! `organization_id = NULL` → **deny-all**: own-org reads returned empty, writes
+//! failed. (PAP-80.)
+//!
+//! The fix routes the repo through an RLS-context connection (the `RlsConnection`
+//! extractor in handlers sets the org/user GUCs before any query). This test
+//! exercises the *repository methods themselves* on a `FORCE`-bound role and
+//! proves:
+//!
+//!   1. **Deny-all reproduction** — with the role bound but NO context set
+//!      (exactly what the raw-pool repo did on `dev`), an own-org
+//!      `find_document_by_id` / `list_documents` returns nothing.
+//!   2. **Fix** — with `set_request_context(org_a, user_a)` applied first (what
+//!      `RlsConnection` now does), the same repo calls return the own-org row.
+//!   3. **Cross-tenant** — org B's document stays invisible to an org-A caller
+//!      even with context set.
+//!   4. **Write path** — a `create_document` on a context-set connection succeeds
+//!      and the row is the caller's org; without context the INSERT fails the
+//!      policy.
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — even `FORCE` does not bind a superuser, so a behavioral assertion
+//! would pass vacuously. The test creates a plain `NOSUPERUSER NOBYPASSRLS`
+//! role, grants it access, and `SET ROLE`s to it so `FORCE` actually enforces
+//! the policy the way the production owner role experiences it. Mirrors
+//! `equipment_rls_repo_tests.rs` / `work_order_rls_repo_tests.rs` (the PAP-67
+//! precedent PAP-109 follows).
+
+use db::models::{CreateLegalDocument, LegalDocumentQuery};
+use db::repositories::LegalRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("LEGAL {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@legal.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'Legal User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Seed a legal document directly (as superuser, RLS-exempt) for an org.
+async fn seed_document(pool: &PgPool, org_id: Uuid, user_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO legal_documents (organization_id, document_type, title, created_by)
+        VALUES ($1, 'contract', 'Seeded Document', $2)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed document")
+}
+
+fn sample_create() -> CreateLegalDocument {
+    CreateLegalDocument {
+        building_id: None,
+        document_type: "policy".to_string(),
+        title: "Created under RLS".to_string(),
+        description: None,
+        parties: None,
+        effective_date: None,
+        expiry_date: None,
+        file_path: None,
+        file_name: None,
+        file_size: None,
+        mime_type: None,
+        is_confidential: None,
+        retention_period_months: None,
+        tags: None,
+        metadata: None,
+    }
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn legal_repo_force_rls_deny_all_and_fix(pool: PgPool) {
+    let repo = LegalRepository::new(pool.clone());
+
+    // --- Seed as superuser / super-admin context (satisfies org roles-trigger). ---
+    set_ctx(&pool, None, None, true).await;
+    let org_a = seed_org(&pool, "legal-force-a").await;
+    let org_b = seed_org(&pool, "legal-force-b").await;
+    let user_a = seed_user(&pool, "a@legal.test").await;
+    let user_b = seed_user(&pool, "b@legal.test").await;
+    let doc_a = seed_document(&pool, org_a, user_a).await;
+    let doc_b = seed_document(&pool, org_b, user_b).await;
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    let role = format!("ppt_rls_legal_{}", Uuid::new_v4().simple());
+    for stmt in [
+        format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
+        format!("GRANT SELECT, INSERT, UPDATE, DELETE ON legal_documents TO \"{role}\""),
+        format!(
+            "GRANT EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
+             get_current_org_not_deleted() TO \"{role}\""
+        ),
+        format!("GRANT SELECT ON organizations TO \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .expect("grant setup");
+    }
+
+    // ====================================================================
+    // (1) DENY-ALL reproduction: role bound, NO context set (the dev raw-pool
+    //     behavior). Own-org reads return nothing.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT clear_request_context()")
+            .execute(&mut *conn)
+            .await
+            .expect("clear ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let found = repo
+            .find_document_by_id(&mut *conn, doc_a, org_a)
+            .await
+            .expect("find_document_by_id (no ctx)");
+        assert!(
+            found.is_none(),
+            "PAP-80 regression: without RLS context, own-org document must be \
+             invisible (deny-all) — this is what the raw-pool repo did on dev"
+        );
+
+        let listed = repo
+            .list_documents(&mut *conn, org_a, LegalDocumentQuery::default())
+            .await
+            .expect("list_documents (no ctx)");
+        assert!(
+            listed.is_empty(),
+            "PAP-80 regression: without RLS context, list returns deny-all empty"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (2) FIX + (3) cross-tenant: set context, drop to bound role, query repo.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        // (2) Own-org row IS now visible through the repo — the fix.
+        let found = repo
+            .find_document_by_id(&mut *conn, doc_a, org_a)
+            .await
+            .expect("find_document_by_id (ctx)");
+        assert_eq!(
+            found.map(|d| d.id),
+            Some(doc_a),
+            "PAP-80 fix: with RLS context set, the repo must return the own-org document"
+        );
+
+        let listed = repo
+            .list_documents(&mut *conn, org_a, LegalDocumentQuery::default())
+            .await
+            .expect("list_documents (ctx)");
+        assert_eq!(
+            listed.iter().map(|d| d.id).collect::<Vec<_>>(),
+            vec![doc_a],
+            "PAP-80 fix: list returns exactly the own-org document under context"
+        );
+
+        // (3) Org B's document stays invisible to an org-A caller.
+        let cross = repo
+            .find_document_by_id(&mut *conn, doc_b, org_a)
+            .await
+            .expect("find_document_by_id cross");
+        assert!(
+            cross.is_none(),
+            "cross-tenant: org B's document must NOT be visible to an org-A caller"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (4) WRITE path: a create on a context-set connection succeeds and the row
+    //     is the caller's org. Without context the INSERT would fail the policy
+    //     WITH CHECK (the write-side of deny-all).
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let created = repo
+            .create_document(&mut *conn, org_a, user_a, sample_create())
+            .await
+            .expect("create_document under context must succeed");
+        assert_eq!(created.organization_id, org_a);
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup the test role. ---
+    set_ctx(&pool, None, None, true).await;
+    for stmt in [
+        format!("REVOKE ALL ON legal_documents FROM \"{role}\""),
+        format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt)).execute(&pool).await.ok();
+    }
+}

--- a/backend/servers/api-server/src/routes/legal.rs
+++ b/backend/servers/api-server/src/routes/legal.rs
@@ -1,6 +1,21 @@
 //! Legal document and compliance routes (Epic 25).
+//!
+//! # RLS (PAP-80 / PAP-67)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` on all eight
+//! legal/compliance tables, so every query MUST run on a connection that has
+//! `app.current_org_id` set or it collapses to deny-all. Each handler therefore
+//! acquires an [`RlsConnection`] (which authenticates the caller, validates
+//! tenant membership, and sets the org/user GUCs on a dedicated connection) and
+//! passes `&mut **rls.conn()` to the repository. The authoritative organization
+//! is `rls.tenant_id()` — the tenant the caller was validated against — not a
+//! client-supplied `organization_id`, so the SQL org filter and the RLS context
+//! can never disagree. Cross-tenant access is blocked by RLS: a by-id read of
+//! another org's row returns no row (`404`), and a write targeting another org
+//! fails the policy's `WITH CHECK`. `rls.release()` clears the context before
+//! the connection returns to the pool.
 
-use api_core::extractors::AuthUser;
+use api_core::extractors::RlsConnection;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -83,18 +98,34 @@ pub fn router() -> Router<AppState> {
         .route("/audit-trail", post(create_audit_entry))
 }
 
-// ==================== Request/Response Types ====================
+// ==================== Error Helpers ====================
 
-/// Organization query parameter.
-#[derive(Debug, Deserialize, IntoParams)]
-pub struct OrgQuery {
-    pub organization_id: Uuid,
+/// Map a repository error to a `500`, logging the cause under `msg`.
+fn db_error(msg: &str, e: sqlx::Error) -> (StatusCode, Json<ErrorResponse>) {
+    tracing::error!("{}: {:?}", msg, e);
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse::new("DB_ERROR", e.to_string())),
+    )
 }
 
+/// Build a `404` response.
+fn not_found(msg: &'static str) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::NOT_FOUND,
+        Json(ErrorResponse::new("NOT_FOUND", msg)),
+    )
+}
+
+// ==================== Request/Response Types ====================
+
 /// Create legal document request wrapper.
+///
+/// `organization_id` is accepted for backwards compatibility but ignored — the
+/// authoritative org is the caller's validated tenant (`rls.tenant_id()`).
 #[derive(Debug, Deserialize)]
 pub struct CreateDocumentRequest {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     #[serde(flatten)]
     pub data: CreateLegalDocument,
 }
@@ -102,7 +133,7 @@ pub struct CreateDocumentRequest {
 /// List legal documents query.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct ListDocumentsQuery {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     pub building_id: Option<Uuid>,
     pub document_type: Option<String>,
     pub is_confidential: Option<bool>,
@@ -131,7 +162,7 @@ impl From<&ListDocumentsQuery> for LegalDocumentQuery {
 /// Create compliance requirement request wrapper.
 #[derive(Debug, Deserialize)]
 pub struct CreateRequirementRequest {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     #[serde(flatten)]
     pub data: CreateComplianceRequirement,
 }
@@ -139,7 +170,7 @@ pub struct CreateRequirementRequest {
 /// List compliance requirements query.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct ListRequirementsQuery {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     pub building_id: Option<Uuid>,
     pub category: Option<String>,
     pub status: Option<String>,
@@ -168,7 +199,7 @@ impl From<&ListRequirementsQuery> for ComplianceQuery {
 /// Create legal notice request wrapper.
 #[derive(Debug, Deserialize)]
 pub struct CreateNoticeRequest {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     #[serde(flatten)]
     pub data: CreateLegalNotice,
 }
@@ -176,7 +207,7 @@ pub struct CreateNoticeRequest {
 /// List legal notices query.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct ListNoticesQuery {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     pub building_id: Option<Uuid>,
     pub notice_type: Option<String>,
     pub priority: Option<String>,
@@ -211,14 +242,14 @@ pub struct CreateTemplateRequest {
 /// List templates query.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct ListTemplatesQuery {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     pub category: Option<String>,
 }
 
 /// Apply template request.
 #[derive(Debug, Deserialize)]
 pub struct ApplyTemplateRequest {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     #[serde(flatten)]
     pub data: ApplyTemplate,
 }
@@ -226,7 +257,7 @@ pub struct ApplyTemplateRequest {
 /// Create audit entry request wrapper.
 #[derive(Debug, Deserialize)]
 pub struct CreateAuditRequest {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     #[serde(flatten)]
     pub data: CreateAuditTrailEntry,
 }
@@ -234,7 +265,7 @@ pub struct CreateAuditRequest {
 /// Audit trail query.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct AuditTrailQuery {
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     pub requirement_id: Option<Uuid>,
     pub document_id: Option<Uuid>,
     pub notice_id: Option<Uuid>,
@@ -242,861 +273,633 @@ pub struct AuditTrailQuery {
     pub offset: Option<i32>,
 }
 
-/// Pagination query.
-#[derive(Debug, Deserialize, IntoParams)]
-pub struct PaginationQuery {
-    pub limit: Option<i32>,
-    pub offset: Option<i32>,
-}
-
-/// Resolve the caller's organization from the authenticated JWT `tenant_id`
-/// claim. Used to org-scope by-id reads/mutations so a foreign-org resource
-/// id surfaces as 404 rather than a cross-tenant leak (IDOR, #829).
-fn org_context(user: &AuthUser) -> Result<Uuid, (StatusCode, Json<ErrorResponse>)> {
-    user.tenant_id.ok_or_else(|| {
-        (
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse::forbidden("No organization context")),
-        )
-    })
-}
-
 // ==================== Legal Document Endpoints ====================
 
 async fn create_document(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Json(payload): Json<CreateDocumentRequest>,
 ) -> Result<(StatusCode, Json<LegalDocument>), (StatusCode, Json<ErrorResponse>)> {
-    state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .legal_repo
-        .create_document(payload.organization_id, user.user_id, payload.data)
+        .create_document(&mut **rls.conn(), org_id, user_id, payload.data)
         .await
         .map(|d| (StatusCode::CREATED, Json(d)))
-        .map_err(|e| {
-            tracing::error!("Failed to create legal document: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })
+        .map_err(|e| db_error("Failed to create legal document", e));
+    rls.release().await;
+    out
 }
 
 async fn list_documents(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<ListDocumentsQuery>,
 ) -> Result<Json<Vec<LegalDocument>>, (StatusCode, Json<ErrorResponse>)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .list_documents(query.organization_id, (&query).into())
+        .list_documents(&mut **rls.conn(), org_id, (&query).into())
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list legal documents: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })
+        .map_err(|e| db_error("Failed to list legal documents", e));
+    rls.release().await;
+    out
 }
 
 async fn list_documents_summary(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<ListDocumentsQuery>,
 ) -> Result<Json<Vec<LegalDocumentSummary>>, (StatusCode, Json<ErrorResponse>)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .list_documents_with_summary(query.organization_id, (&query).into())
+        .list_documents_with_summary(&mut **rls.conn(), org_id, (&query).into())
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list legal documents: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })
+        .map_err(|e| db_error("Failed to list legal documents", e));
+    rls.release().await;
+    out
 }
 
 async fn get_document(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<LegalDocument>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = org_context(&user)?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .find_document_by_id(id, org_id)
+        .find_document_by_id(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to get legal document: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .map(Json)
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Document not found")),
-            )
-        })
+        .map_err(|e| db_error("Failed to get legal document", e))
+        .and_then(|opt| opt.map(Json).ok_or_else(|| not_found("Document not found")));
+    rls.release().await;
+    out
 }
 
 async fn update_document(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateLegalDocument>,
 ) -> Result<Json<LegalDocument>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = org_context(&user)?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .update_document(id, org_id, data)
+        .update_document(&mut **rls.conn(), id, org_id, data)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to update legal document: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .map(Json)
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Document not found")),
-            )
-        })
+        .map_err(|e| db_error("Failed to update legal document", e))
+        .and_then(|opt| opt.map(Json).ok_or_else(|| not_found("Document not found")));
+    rls.release().await;
+    out
 }
 
 async fn delete_document(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = org_context(&user)?;
-    let deleted = state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .delete_document(id, org_id)
+        .delete_document(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to delete legal document: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
-
-    if deleted {
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Document not found")),
-        ))
-    }
+        .map_err(|e| db_error("Failed to delete legal document", e))
+        .and_then(|deleted| {
+            if deleted {
+                Ok(StatusCode::NO_CONTENT)
+            } else {
+                Err(not_found("Document not found"))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 // ==================== Document Versions ====================
 
 async fn add_version(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<CreateLegalDocumentVersion>,
 ) -> Result<(StatusCode, Json<LegalDocumentVersion>), (StatusCode, Json<ErrorResponse>)> {
-    let org_id = org_context(&user)?;
-    state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .legal_repo
-        .add_document_version(id, org_id, user.user_id, data)
+        .add_document_version(&mut **rls.conn(), id, org_id, user_id, data)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to add document version: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .map(|v| (StatusCode::CREATED, Json(v)))
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Document not found")),
-            )
-        })
+        .map_err(|e| db_error("Failed to add document version", e))
+        .and_then(|opt| {
+            opt.map(|v| (StatusCode::CREATED, Json(v)))
+                .ok_or_else(|| not_found("Document not found"))
+        });
+    rls.release().await;
+    out
 }
 
 async fn list_versions(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Vec<LegalDocumentVersion>>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = org_context(&user)?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .list_document_versions(id, org_id)
+        .list_document_versions(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to list document versions: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .map(Json)
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Document not found")),
-            )
-        })
+        .map_err(|e| db_error("Failed to list document versions", e))
+        .and_then(|opt| opt.map(Json).ok_or_else(|| not_found("Document not found")));
+    rls.release().await;
+    out
 }
 
 async fn get_version(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path((id, version)): Path<(Uuid, i32)>,
 ) -> Result<Json<LegalDocumentVersion>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = org_context(&user)?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .get_document_version(id, org_id, version)
+        .get_document_version(&mut **rls.conn(), id, org_id, version)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to get document version: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .map(Json)
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Version not found")),
-            )
-        })
+        .map_err(|e| db_error("Failed to get document version", e))
+        .and_then(|opt| opt.map(Json).ok_or_else(|| not_found("Version not found")));
+    rls.release().await;
+    out
 }
 
 // ==================== Compliance Requirements ====================
 
 async fn create_requirement(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Json(payload): Json<CreateRequirementRequest>,
 ) -> Result<(StatusCode, Json<ComplianceRequirement>), (StatusCode, Json<ErrorResponse>)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .create_requirement(payload.organization_id, payload.data)
+        .create_requirement(&mut **rls.conn(), org_id, payload.data)
         .await
         .map(|r| (StatusCode::CREATED, Json(r)))
-        .map_err(|e| {
-            tracing::error!("Failed to create compliance requirement: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })
+        .map_err(|e| db_error("Failed to create compliance requirement", e));
+    rls.release().await;
+    out
 }
 
 async fn list_requirements(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<ListRequirementsQuery>,
 ) -> Result<Json<Vec<ComplianceRequirement>>, (StatusCode, Json<ErrorResponse>)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .list_requirements(query.organization_id, (&query).into())
+        .list_requirements(&mut **rls.conn(), org_id, (&query).into())
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list compliance requirements: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })
+        .map_err(|e| db_error("Failed to list compliance requirements", e));
+    rls.release().await;
+    out
 }
 
 async fn list_requirements_with_details(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<ListRequirementsQuery>,
 ) -> Result<Json<Vec<ComplianceRequirementWithDetails>>, (StatusCode, Json<ErrorResponse>)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .list_requirements_with_details(query.organization_id, (&query).into())
+        .list_requirements_with_details(&mut **rls.conn(), org_id, (&query).into())
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list compliance requirements: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })
+        .map_err(|e| db_error("Failed to list compliance requirements", e));
+    rls.release().await;
+    out
 }
 
 async fn get_compliance_statistics(
     State(state): State<AppState>,
-    _user: AuthUser,
-    Query(query): Query<OrgQuery>,
+    mut rls: RlsConnection,
 ) -> Result<Json<ComplianceStatistics>, (StatusCode, Json<ErrorResponse>)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .get_compliance_statistics(query.organization_id)
+        .get_compliance_statistics(&mut **rls.conn(), org_id)
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to get compliance statistics: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })
+        .map_err(|e| db_error("Failed to get compliance statistics", e));
+    rls.release().await;
+    out
 }
 
 async fn get_requirement(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ComplianceRequirement>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = org_context(&user)?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .find_requirement_by_id(id, org_id)
+        .find_requirement_by_id(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to get compliance requirement: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .map(Json)
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Requirement not found")),
-            )
-        })
+        .map_err(|e| db_error("Failed to get compliance requirement", e))
+        .and_then(|opt| {
+            opt.map(Json)
+                .ok_or_else(|| not_found("Requirement not found"))
+        });
+    rls.release().await;
+    out
 }
 
 async fn update_requirement(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateComplianceRequirement>,
 ) -> Result<Json<ComplianceRequirement>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = org_context(&user)?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .update_requirement(id, org_id, data)
+        .update_requirement(&mut **rls.conn(), id, org_id, data)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to update compliance requirement: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .map(Json)
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Requirement not found")),
-            )
-        })
+        .map_err(|e| db_error("Failed to update compliance requirement", e))
+        .and_then(|opt| {
+            opt.map(Json)
+                .ok_or_else(|| not_found("Requirement not found"))
+        });
+    rls.release().await;
+    out
 }
 
 async fn delete_requirement(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = org_context(&user)?;
-    let deleted = state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .delete_requirement(id, org_id)
+        .delete_requirement(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to delete compliance requirement: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
-
-    if deleted {
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Requirement not found")),
-        ))
-    }
+        .map_err(|e| db_error("Failed to delete compliance requirement", e))
+        .and_then(|deleted| {
+            if deleted {
+                Ok(StatusCode::NO_CONTENT)
+            } else {
+                Err(not_found("Requirement not found"))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 // ==================== Compliance Verifications ====================
 
 async fn create_verification(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<CreateComplianceVerification>,
 ) -> Result<(StatusCode, Json<ComplianceVerification>), (StatusCode, Json<ErrorResponse>)> {
-    let org_id = org_context(&user)?;
-    state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .legal_repo
-        .create_verification(id, org_id, user.user_id, data)
+        .create_verification(&mut **rls.conn(), id, org_id, user_id, data)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to create compliance verification: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .map(|v| (StatusCode::CREATED, Json(v)))
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Requirement not found")),
-            )
-        })
+        .map_err(|e| db_error("Failed to create compliance verification", e))
+        .and_then(|opt| {
+            opt.map(|v| (StatusCode::CREATED, Json(v)))
+                .ok_or_else(|| not_found("Requirement not found"))
+        });
+    rls.release().await;
+    out
 }
 
 async fn list_verifications(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Vec<ComplianceVerification>>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = org_context(&user)?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .list_verifications(id, org_id)
+        .list_verifications(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to list compliance verifications: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .map(Json)
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Requirement not found")),
-            )
-        })
+        .map_err(|e| db_error("Failed to list compliance verifications", e))
+        .and_then(|opt| {
+            opt.map(Json)
+                .ok_or_else(|| not_found("Requirement not found"))
+        });
+    rls.release().await;
+    out
 }
 
 // ==================== Legal Notices ====================
 
 async fn create_notice(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Json(payload): Json<CreateNoticeRequest>,
 ) -> Result<(StatusCode, Json<LegalNotice>), (StatusCode, Json<ErrorResponse>)> {
-    state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .legal_repo
-        .create_notice(payload.organization_id, user.user_id, payload.data)
+        .create_notice(&mut **rls.conn(), org_id, user_id, payload.data)
         .await
         .map(|n| (StatusCode::CREATED, Json(n)))
-        .map_err(|e| {
-            tracing::error!("Failed to create legal notice: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })
+        .map_err(|e| db_error("Failed to create legal notice", e));
+    rls.release().await;
+    out
 }
 
 async fn list_notices(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<ListNoticesQuery>,
 ) -> Result<Json<Vec<LegalNotice>>, (StatusCode, Json<ErrorResponse>)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .list_notices(query.organization_id, (&query).into())
+        .list_notices(&mut **rls.conn(), org_id, (&query).into())
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list legal notices: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })
+        .map_err(|e| db_error("Failed to list legal notices", e));
+    rls.release().await;
+    out
 }
 
 async fn list_notices_with_recipients(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<ListNoticesQuery>,
 ) -> Result<Json<Vec<NoticeWithRecipients>>, (StatusCode, Json<ErrorResponse>)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .list_notices_with_recipients(query.organization_id, (&query).into())
+        .list_notices_with_recipients(&mut **rls.conn(), org_id, (&query).into())
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list legal notices: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })
+        .map_err(|e| db_error("Failed to list legal notices", e));
+    rls.release().await;
+    out
 }
 
 async fn get_notice_statistics(
     State(state): State<AppState>,
-    _user: AuthUser,
-    Query(query): Query<OrgQuery>,
+    mut rls: RlsConnection,
 ) -> Result<Json<NoticeStatistics>, (StatusCode, Json<ErrorResponse>)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .get_notice_statistics(query.organization_id)
+        .get_notice_statistics(&mut **rls.conn(), org_id)
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to get notice statistics: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })
+        .map_err(|e| db_error("Failed to get notice statistics", e));
+    rls.release().await;
+    out
 }
 
 async fn get_notice(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<LegalNotice>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = org_context(&user)?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .find_notice_by_id(id, org_id)
+        .find_notice_by_id(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to get legal notice: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .map(Json)
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Notice not found")),
-            )
-        })
+        .map_err(|e| db_error("Failed to get legal notice", e))
+        .and_then(|opt| opt.map(Json).ok_or_else(|| not_found("Notice not found")));
+    rls.release().await;
+    out
 }
 
 async fn update_notice(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateLegalNotice>,
 ) -> Result<Json<LegalNotice>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = org_context(&user)?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .update_notice(id, org_id, data)
+        .update_notice(&mut **rls.conn(), id, org_id, data)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to update legal notice: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .map(Json)
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Notice not found")),
-            )
-        })
+        .map_err(|e| db_error("Failed to update legal notice", e))
+        .and_then(|opt| opt.map(Json).ok_or_else(|| not_found("Notice not found")));
+    rls.release().await;
+    out
 }
 
 async fn delete_notice(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = org_context(&user)?;
-    let deleted = state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .delete_notice(id, org_id)
+        .delete_notice(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to delete legal notice: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
-
-    if deleted {
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Notice not found")),
-        ))
-    }
+        .map_err(|e| db_error("Failed to delete legal notice", e))
+        .and_then(|deleted| {
+            if deleted {
+                Ok(StatusCode::NO_CONTENT)
+            } else {
+                Err(not_found("Notice not found"))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 async fn send_notice(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<LegalNotice>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = org_context(&user)?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .send_notice(id, org_id)
+        .send_notice(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to send legal notice: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .map(Json)
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Notice not found")),
-            )
-        })
+        .map_err(|e| db_error("Failed to send legal notice", e))
+        .and_then(|opt| opt.map(Json).ok_or_else(|| not_found("Notice not found")));
+    rls.release().await;
+    out
 }
 
 // ==================== Notice Recipients ====================
 
 async fn list_recipients(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Vec<LegalNoticeRecipient>>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = org_context(&user)?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .list_notice_recipients(id, org_id)
+        .list_notice_recipients(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to list notice recipients: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .map(Json)
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Notice not found")),
-            )
-        })
+        .map_err(|e| db_error("Failed to list notice recipients", e))
+        .and_then(|opt| opt.map(Json).ok_or_else(|| not_found("Notice not found")));
+    rls.release().await;
+    out
 }
 
 async fn acknowledge_notice(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path((notice_id, recipient_id)): Path<(Uuid, Uuid)>,
     Json(data): Json<AcknowledgeNotice>,
 ) -> Result<Json<LegalNoticeRecipient>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = org_context(&user)?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .acknowledge_notice(notice_id, recipient_id, org_id, data)
+        .acknowledge_notice(&mut **rls.conn(), notice_id, recipient_id, org_id, data)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to acknowledge notice: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .map(Json)
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new(
-                    "NOT_FOUND",
-                    "Notice or recipient not found",
-                )),
-            )
-        })
+        .map_err(|e| db_error("Failed to acknowledge notice", e))
+        .and_then(|opt| {
+            opt.map(Json)
+                .ok_or_else(|| not_found("Notice or recipient not found"))
+        });
+    rls.release().await;
+    out
 }
 
 // ==================== Compliance Templates ====================
 
 async fn create_template(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Json(payload): Json<CreateTemplateRequest>,
 ) -> Result<(StatusCode, Json<ComplianceTemplate>), (StatusCode, Json<ErrorResponse>)> {
-    state
+    // Authoritative org is the caller's tenant; a tenant cannot create a global
+    // (NULL-org) system template through this endpoint.
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .create_template(payload.organization_id, payload.data)
+        .create_template(&mut **rls.conn(), Some(org_id), payload.data)
         .await
         .map(|t| (StatusCode::CREATED, Json(t)))
-        .map_err(|e| {
-            tracing::error!("Failed to create compliance template: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })
+        .map_err(|e| db_error("Failed to create compliance template", e));
+    rls.release().await;
+    out
 }
 
 async fn list_templates(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<ListTemplatesQuery>,
 ) -> Result<Json<Vec<ComplianceTemplate>>, (StatusCode, Json<ErrorResponse>)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .list_templates(query.organization_id, query.category)
+        .list_templates(&mut **rls.conn(), org_id, query.category)
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list compliance templates: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })
+        .map_err(|e| db_error("Failed to list compliance templates", e));
+    rls.release().await;
+    out
 }
 
 async fn get_template(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ComplianceTemplate>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = org_context(&user)?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .find_template_by_id(id, org_id)
+        .find_template_by_id(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to get compliance template: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .map(Json)
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Template not found")),
-            )
-        })
+        .map_err(|e| db_error("Failed to get compliance template", e))
+        .and_then(|opt| opt.map(Json).ok_or_else(|| not_found("Template not found")));
+    rls.release().await;
+    out
 }
 
 async fn update_template(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateComplianceTemplate>,
 ) -> Result<Json<ComplianceTemplate>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = org_context(&user)?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .update_template(id, org_id, data)
+        .update_template(&mut **rls.conn(), id, org_id, data)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to update compliance template: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .map(Json)
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new(
-                    "NOT_FOUND",
-                    "Template not found (or is system template)",
-                )),
-            )
-        })
+        .map_err(|e| db_error("Failed to update compliance template", e))
+        .and_then(|opt| {
+            opt.map(Json)
+                .ok_or_else(|| not_found("Template not found (or is system template)"))
+        });
+    rls.release().await;
+    out
 }
 
 async fn delete_template(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = org_context(&user)?;
-    let deleted = state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .delete_template(id, org_id)
+        .delete_template(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to delete compliance template: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
-
-    if deleted {
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new(
-                "NOT_FOUND",
-                "Template not found (or is system template)",
-            )),
-        ))
-    }
+        .map_err(|e| db_error("Failed to delete compliance template", e))
+        .and_then(|deleted| {
+            if deleted {
+                Ok(StatusCode::NO_CONTENT)
+            } else {
+                Err(not_found("Template not found (or is system template)"))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 async fn apply_template(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Json(payload): Json<ApplyTemplateRequest>,
 ) -> Result<(StatusCode, Json<Vec<ComplianceRequirement>>), (StatusCode, Json<ErrorResponse>)> {
-    let org_id = org_context(&user)?;
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
-        .apply_template(org_id, payload.data)
+        .apply_template(&mut **rls.conn(), org_id, payload.data)
         .await
         .map(|r| (StatusCode::CREATED, Json(r)))
-        .map_err(|e| {
-            tracing::error!("Failed to apply compliance template: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })
+        .map_err(|e| db_error("Failed to apply compliance template", e));
+    rls.release().await;
+    out
 }
 
 // ==================== Audit Trail ====================
 
 async fn list_audit_trail(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<AuditTrailQuery>,
 ) -> Result<Json<Vec<ComplianceAuditTrail>>, (StatusCode, Json<ErrorResponse>)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .legal_repo
         .list_audit_trail(
-            query.organization_id,
+            &mut **rls.conn(),
+            org_id,
             query.requirement_id,
             query.document_id,
             query.notice_id,
@@ -1105,30 +908,24 @@ async fn list_audit_trail(
         )
         .await
         .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list audit trail: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })
+        .map_err(|e| db_error("Failed to list audit trail", e));
+    rls.release().await;
+    out
 }
 
 async fn create_audit_entry(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Json(payload): Json<CreateAuditRequest>,
 ) -> Result<(StatusCode, Json<ComplianceAuditTrail>), (StatusCode, Json<ErrorResponse>)> {
-    state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .legal_repo
-        .create_audit_entry(payload.organization_id, user.user_id, payload.data)
+        .create_audit_entry(&mut **rls.conn(), org_id, user_id, payload.data)
         .await
         .map(|a| (StatusCode::CREATED, Json(a)))
-        .map_err(|e| {
-            tracing::error!("Failed to create audit entry: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })
+        .map_err(|e| db_error("Failed to create audit entry", e));
+    rls.release().await;
+    out
 }


### PR DESCRIPTION
## What

Converts `LegalRepository` (`/api/v1/legal`, Epic 25) from a raw `PgPool` to the RLS-context-executor pattern — the PAP-80 child for `legal.rs`.

Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical `get_current_org_id()` policy on the **8** legal/compliance tables this repo touches:
`legal_documents`, `legal_document_versions`, `compliance_requirements`, `compliance_verifications`, `legal_notices`, `legal_notice_recipients`, `compliance_templates`, `compliance_audit_trail`.

Under `FORCE` the api-server's owner connection is no longer exempt, so the raw-pool repo (which never set `app.current_org_id`) collapsed to **deny-all** on `dev`: own-org reads returned empty, writes failed the policy.

## How (follows the `work_order.rs` / `budget.rs` / `document.rs` precedent)

- `LegalRepository` holds **no pool** — now a unit struct; `new(_pool)` retained for `AppState` construction compatibility.
- Single-statement methods take a generic `E: Executor<'e, Database = Postgres>`.
- Multi-statement methods (and the `*_in_org` child-scope guards' callers: `add_document_version`, `list_/get_document_version`, `create_verification`, `list_verifications`, `get_compliance_statistics`, `create_notice`, `send_notice`, `get_notice_statistics`, `list_notice_recipients`, `acknowledge_notice`, `apply_template`) take `&mut PgConnection` and reborrow per query.
- Handlers acquire the `RlsConnection` extractor, pass `&mut **rls.conn()`, use `rls.tenant_id()` as the **authoritative** org (client-supplied `organization_id` is now ignored), and call `rls.release()`.
- Cross-tenant by-id access surfaces as `404` via RLS; the explicit `organization_id = $n` filters are kept as defence-in-depth and can never disagree with the context (`org == rls.tenant_id()`).

### Notes
- `compliance_templates`' policy is `organization_id IS NULL OR organization_id = get_current_org_id()`, so **shared system templates stay visible** under context — template reads are preserved.
- `create_template` now forces the caller's org (`Some(rls.tenant_id())`), so a tenant cannot inject a global (NULL-org) system template through this endpoint.

## Verify (on remote / mercury — control-plane host is memory-constrained)
- `cargo check -p db -p api-server` — **green**.
- `cargo test -p db --test legal_rls_repo_tests` — **1 passed**. New `legal_rls_repo_tests.rs` uses the `NOSUPERUSER NOBYPASSRLS` role-switch pattern (mirrors `equipment`/`work_order`): deny-all reproduction → fix → cross-tenant invisibility → write path.

Part of the [PAP-80] RLS raw-pool sweep. One repo = one PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)