### PR TITLE
test(api-server): send X-Tenant-ID + seed membership in PM photos IDOR tests (PAP-123)

### DIFF
--- a/backend/servers/api-server/tests/predictive_maintenance_photos_idor_tests.rs
+++ b/backend/servers/api-server/tests/predictive_maintenance_photos_idor_tests.rs
@@ -8,17 +8,19 @@
 //! maintenance photos. `add_maintenance_photo` (POST) similarly wrote without
 //! checking the parent log's org.
 //!
-//! The fix derives `org_id` from the JWT `tenant_id` claim (via `AuthUser`),
-//! confirms the parent `maintenance_logs` row belongs to that org (404 if not),
-//! and the repository join `maintenance_log_photos → maintenance_logs` is
-//! org-scoped. A foreign-org `log_id` therefore yields 404, never a
-//! cross-tenant read.
+//! Since the PAP-80 RLS conversion (PAP-111), every predictive-maintenance
+//! handler acquires an `RlsConnection`: the tenant comes from the validated
+//! `X-Tenant-ID` header (membership checked against `organization_members`),
+//! the handler confirms the parent `maintenance_logs` row belongs to that org
+//! (404 if not), and the repository join `maintenance_log_photos →
+//! maintenance_logs` stays org-scoped. A foreign-org `log_id` therefore
+//! yields 404, never a cross-tenant read.
 //!
-//! Tenancy here comes straight from the JWT `tenant_id` claim — the same
-//! mechanism as the reserve-fund suite — so these tests mint a real access
-//! token per org and drive the handlers end-to-end:
-//!   - Org A's token listing photos on Org A's log -> 200 (same-org succeeds).
-//!   - Org B's token listing photos on Org A's log -> 404 (cross-org blocked).
+//! These tests mint a real access token per org, seed the membership rows the
+//! tenant validation requires, send `X-Tenant-ID`, and drive the handlers
+//! end-to-end:
+//!   - Org A's member listing photos on Org A's log -> 200 (same-org succeeds).
+//!   - Org B's member listing photos on Org A's log -> 404 (cross-org blocked).
 
 #[allow(dead_code)]
 mod common;
@@ -101,6 +103,20 @@ async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     .expect("seed user")
 }
 
+async fn seed_membership(pool: &PgPool, org_id: Uuid, user_id: Uuid) {
+    sqlx::query(
+        r#"
+        INSERT INTO organization_members (organization_id, user_id, role_type, status, joined_at)
+        VALUES ($1, $2, 'manager', 'active', NOW())
+        "#,
+    )
+    .bind(org_id)
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .expect("seed membership");
+}
+
 async fn seed_building(pool: &PgPool, org_id: Uuid, slug: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(
         r#"
@@ -181,9 +197,14 @@ async fn list_photos_same_org_succeeds(pool: PgPool) {
     let equipment = seed_equipment(&pool, org_a, building).await;
     let log_id = seed_maintenance_log(&pool, org_a, equipment).await;
     let photo_id = seed_photo(&pool, log_id).await;
+    seed_membership(&pool, org_a, user).await;
 
     let token = access_token(user, org_a);
-    let req = app.get(&photos_uri(log_id)).bearer(&token).build();
+    let req = app
+        .get(&photos_uri(log_id))
+        .bearer(&token)
+        .header("X-Tenant-ID", &org_a.to_string())
+        .build();
     let resp = app.execute(req).await;
 
     resp.assert_status(StatusCode::OK);
@@ -215,11 +236,16 @@ async fn list_photos_cross_org_is_not_found(pool: PgPool) {
     let equipment = seed_equipment(&pool, org_a, building).await;
     let log_id = seed_maintenance_log(&pool, org_a, equipment).await;
     let _ = seed_photo(&pool, log_id).await;
-    let _ = user_a;
+    seed_membership(&pool, org_a, user_a).await;
+    seed_membership(&pool, org_b, user_b).await;
 
-    // Org B token targeting Org A's maintenance log.
+    // Org B member (valid org-B tenant context) targeting Org A's log.
     let token = access_token(user_b, org_b);
-    let req = app.get(&photos_uri(log_id)).bearer(&token).build();
+    let req = app
+        .get(&photos_uri(log_id))
+        .bearer(&token)
+        .header("X-Tenant-ID", &org_b.to_string())
+        .build();
     let resp = app.execute(req).await;
 
     assert_eq!(
@@ -247,12 +273,14 @@ async fn add_photo_cross_org_does_not_insert(pool: PgPool) {
     let building = seed_building(&pool, org_a, "a-a").await;
     let equipment = seed_equipment(&pool, org_a, building).await;
     let log_id = seed_maintenance_log(&pool, org_a, equipment).await;
-    let _ = user_a;
+    seed_membership(&pool, org_a, user_a).await;
+    seed_membership(&pool, org_b, user_b).await;
 
     let token = access_token(user_b, org_b);
     let req = app
         .post(&photos_uri(log_id))
         .bearer(&token)
+        .header("X-Tenant-ID", &org_b.to_string())
         .json(serde_json::json!({ "file_path": "s3://bucket/hijack.jpg" }))
         .build();
     let resp = app.execute(req).await;


### PR DESCRIPTION
## Summary

Dev's `test` gate is red: all 3 tests in `predictive_maintenance_photos_idor_tests.rs` fail with `400 Missing or invalid X-Tenant-ID header` (e.g. run 27252574115).

Cause: the PAP-80 RLS conversion of predictive_maintenance (#1233) moved the photo handlers onto `RlsConnection`, which resolves the tenant from the validated `X-Tenant-ID` header (membership checked against `organization_members`) instead of the JWT `tenant_id` claim. The pre-conversion tests sent neither the header nor membership rows.

Fix mirrors #1241 (the same class of fix for the emergency + vendor IDOR tests after their conversions):
- seed `organization_members` for each principal
- send `X-Tenant-ID` on every request
- the attacker keeps a valid org-B tenant context and targets org A's log id → org-scoped lookup returns `None` → 404 (assertions unchanged)

## Verification

- `cargo check -p api-server --test predictive_maintenance_photos_idor_tests` green (remote builder)
- Test executed for real against Postgres (mercury, `#[sqlx::test]` full-migration replay) — result posted below when the run completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)