### PR TITLE
fix(db): route subscription repo through RLS-context connection (PAP-112)

### DIFF
--- a/backend/crates/db/src/repositories/subscription.rs
+++ b/backend/crates/db/src/repositories/subscription.rs
@@ -1,30 +1,34 @@
 //! Subscription and billing repository (Epic 26).
 //!
-//! # RLS Integration
+//! # RLS Integration (PAP-112 / PAP-80 / PAP-67)
 //!
-//! This repository supports two usage patterns:
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on the seven org-scoped billing tables this
+//! repo touches (`organization_subscriptions`, `payment_methods`,
+//! `subscription_invoices`, `invoice_line_items`, `usage_records`,
+//! `subscription_events`, `coupon_redemptions`). Under `FORCE` the
+//! api-server's owner connection is no longer exempt, so a query issued on a
+//! connection without `app.current_org_id` set collapses to deny-all:
+//! own-org reads return empty and writes fail the policy `WITH CHECK`.
 //!
-//! 1. **RLS-aware** (recommended): Use methods with `_rls` suffix that accept an executor
-//!    with RLS context already set (e.g., from `RlsConnection`).
+//! Every method therefore takes an **executor whose connection already has
+//! RLS context set** (org + user GUCs) — in handlers this comes from the
+//! `RlsConnection` extractor via `&mut **rls.conn()`. The repository holds
+//! **no pool**, so there is no way to issue a query that bypasses RLS. This
+//! mirrors the `work_order.rs` / `vendor.rs` / `llm_document.rs` precedent.
 //!
-//! 2. **Legacy**: Use methods without suffix that use the internal pool. These do NOT
-//!    enforce RLS and should be migrated to the RLS-aware pattern.
+//! Single-statement methods take a generic [`Executor`]; multi-statement
+//! methods (`create_subscription`, `create_invoice`, `get_statistics`) and
+//! the transactional ones (`set_default_payment_method`, `redeem_coupon`)
+//! take `&mut PgConnection` and reborrow. The transactions run on the
+//! context-set connection: `set_request_context` sets session-level GUCs, so
+//! the RLS context survives `BEGIN`/`COMMIT`.
 //!
-//! ## Example
-//!
-//! ```rust,ignore
-//! async fn create_subscription(
-//!     mut rls: RlsConnection,
-//!     State(state): State<AppState>,
-//!     Json(data): Json<CreateOrganizationSubscription>,
-//! ) -> Result<Json<OrganizationSubscription>> {
-//!     let subscription = state.subscription_repo.create_subscription_rls(
-//!         rls.conn(), org_id, data
-//!     ).await?;
-//!     rls.release().await;
-//!     Ok(Json(subscription))
-//! }
-//! ```
+//! `subscription_plans` and `subscription_coupons` are **not** FORCE-bound
+//! (they carry public read policies — plans/coupons are platform-global, not
+//! tenant data), so callers without a tenant principal (the public
+//! `/plans/public` endpoint) may run those read methods on a plain pool
+//! executor.
 
 use crate::models::{
     CancelSubscriptionRequest, ChangePlanRequest, CouponRedemption, CreateOrganizationSubscription,
@@ -37,29 +41,32 @@ use crate::models::{
 };
 use chrono::{Days, Months, Utc};
 use rust_decimal::Decimal;
-use sqlx::{Executor, PgPool, Postgres};
+use sqlx::{Connection, Executor, PgConnection, PgPool, Postgres};
 use uuid::Uuid;
 
 /// Repository for subscription and billing operations.
+///
+/// Stateless: every method receives an RLS-context-bearing executor. The repo
+/// holds no pool so it cannot issue an un-scoped (deny-all under `FORCE`)
+/// query.
 #[derive(Clone)]
-pub struct SubscriptionRepository {
-    pool: PgPool,
-}
+pub struct SubscriptionRepository;
 
 impl SubscriptionRepository {
     /// Create a new SubscriptionRepository.
-    pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+    ///
+    /// The pool argument is retained for construction-site compatibility with
+    /// the other repositories on `AppState`; this repo deliberately does not
+    /// store it (see module docs — all queries run on a context-set
+    /// connection supplied by the caller).
+    pub fn new(_pool: PgPool) -> Self {
+        Self
     }
-
-    // ========================================================================
-    // RLS-aware methods (recommended)
-    // ========================================================================
 
     // ==================== Subscription Plans CRUD ====================
 
-    /// Create a new subscription plan with RLS context.
-    pub async fn create_plan_rls<'e, E>(
+    /// Create a new subscription plan.
+    pub async fn create_plan<'e, E>(
         &self,
         executor: E,
         data: CreateSubscriptionPlan,
@@ -95,8 +102,8 @@ impl SubscriptionRepository {
         .await
     }
 
-    /// Find a subscription plan by ID with RLS context.
-    pub async fn find_plan_by_id_rls<'e, E>(
+    /// Find a subscription plan by ID.
+    pub async fn find_plan_by_id<'e, E>(
         &self,
         executor: E,
         id: Uuid,
@@ -110,8 +117,8 @@ impl SubscriptionRepository {
             .await
     }
 
-    /// Find a subscription plan by name with RLS context.
-    pub async fn find_plan_by_name_rls<'e, E>(
+    /// Find a subscription plan by name.
+    pub async fn find_plan_by_name<'e, E>(
         &self,
         executor: E,
         name: &str,
@@ -125,8 +132,8 @@ impl SubscriptionRepository {
             .await
     }
 
-    /// List all subscription plans with RLS context.
-    pub async fn list_plans_rls<'e, E>(
+    /// List all subscription plans.
+    pub async fn list_plans<'e, E>(
         &self,
         executor: E,
         active_only: bool,
@@ -147,8 +154,12 @@ impl SubscriptionRepository {
         }
     }
 
-    /// List public subscription plans with RLS context.
-    pub async fn list_public_plans_rls<'e, E>(
+    /// List public subscription plans (for display to customers).
+    ///
+    /// `subscription_plans` is not FORCE-bound and carries a public read
+    /// policy, so the public (unauthenticated) plans endpoint may pass a
+    /// plain pool executor here.
+    pub async fn list_public_plans<'e, E>(
         &self,
         executor: E,
     ) -> Result<Vec<SubscriptionPlan>, sqlx::Error>
@@ -162,8 +173,8 @@ impl SubscriptionRepository {
         .await
     }
 
-    /// Update a subscription plan with RLS context.
-    pub async fn update_plan_rls<'e, E>(
+    /// Update a subscription plan.
+    pub async fn update_plan<'e, E>(
         &self,
         executor: E,
         id: Uuid,
@@ -215,8 +226,8 @@ impl SubscriptionRepository {
         .await
     }
 
-    /// Delete a subscription plan with RLS context.
-    pub async fn delete_plan_rls<'e, E>(&self, executor: E, id: Uuid) -> Result<bool, sqlx::Error>
+    /// Delete a subscription plan.
+    pub async fn delete_plan<'e, E>(&self, executor: E, id: Uuid) -> Result<bool, sqlx::Error>
     where
         E: Executor<'e, Database = Postgres>,
     {
@@ -229,21 +240,19 @@ impl SubscriptionRepository {
 
     // ==================== Organization Subscriptions CRUD ====================
 
-    /// Create a new organization subscription with RLS context.
-    #[allow(deprecated)]
-    pub async fn create_subscription_rls<'e, E>(
+    /// Create a new organization subscription.
+    ///
+    /// Multi-statement (plan lookup for trial-days, then insert), so it takes
+    /// `&mut PgConnection` and runs both statements on the same context-set
+    /// connection.
+    pub async fn create_subscription(
         &self,
-        executor: E,
+        conn: &mut PgConnection,
         org_id: Uuid,
         data: CreateOrganizationSubscription,
-    ) -> Result<OrganizationSubscription, sqlx::Error>
-    where
-        E: Executor<'e, Database = Postgres>,
-    {
-        // Get plan for trial days calculation - use legacy method since we need a separate query.
-        // TODO: Refactor to accept the plan object as a parameter, or use a JOIN query
-        // within this method to fetch both plan and subscription in one RLS-aware operation.
-        let plan = self.find_plan_by_id(data.plan_id).await?;
+    ) -> Result<OrganizationSubscription, sqlx::Error> {
+        // Get plan for trial days calculation.
+        let plan = self.find_plan_by_id(&mut *conn, data.plan_id).await?;
 
         let billing_cycle = data.billing_cycle.unwrap_or_else(|| "monthly".to_string());
         let now = Utc::now();
@@ -291,12 +300,12 @@ impl SubscriptionRepository {
         .bind(is_trial)
         .bind(data.payment_method_id)
         .bind(&data.metadata)
-        .fetch_one(executor)
+        .fetch_one(&mut *conn)
         .await
     }
 
-    /// Find an organization's subscription with RLS context.
-    pub async fn find_subscription_by_org_rls<'e, E>(
+    /// Find an organization's subscription.
+    pub async fn find_subscription_by_org<'e, E>(
         &self,
         executor: E,
         org_id: Uuid,
@@ -312,8 +321,8 @@ impl SubscriptionRepository {
         .await
     }
 
-    /// Find a subscription by ID with RLS context.
-    pub async fn find_subscription_by_id_rls<'e, E>(
+    /// Find a subscription by ID.
+    pub async fn find_subscription_by_id<'e, E>(
         &self,
         executor: E,
         id: Uuid,
@@ -327,8 +336,8 @@ impl SubscriptionRepository {
             .await
     }
 
-    /// Get subscription with plan details with RLS context.
-    pub async fn get_subscription_with_plan_rls<'e, E>(
+    /// Get subscription with plan details.
+    pub async fn get_subscription_with_plan<'e, E>(
         &self,
         executor: E,
         org_id: Uuid,
@@ -355,8 +364,8 @@ impl SubscriptionRepository {
         .await
     }
 
-    /// Update an organization subscription with RLS context.
-    pub async fn update_subscription_rls<'e, E>(
+    /// Update an organization subscription.
+    pub async fn update_subscription<'e, E>(
         &self,
         executor: E,
         id: Uuid,
@@ -384,8 +393,8 @@ impl SubscriptionRepository {
         .await
     }
 
-    /// Change subscription plan with RLS context.
-    pub async fn change_plan_rls<'e, E>(
+    /// Change subscription plan.
+    pub async fn change_plan<'e, E>(
         &self,
         executor: E,
         id: Uuid,
@@ -411,8 +420,8 @@ impl SubscriptionRepository {
         .await
     }
 
-    /// Cancel a subscription with RLS context.
-    pub async fn cancel_subscription_rls<'e, E>(
+    /// Cancel a subscription.
+    pub async fn cancel_subscription<'e, E>(
         &self,
         executor: E,
         id: Uuid,
@@ -448,8 +457,8 @@ impl SubscriptionRepository {
         .await
     }
 
-    /// Reactivate a cancelled subscription with RLS context.
-    pub async fn reactivate_subscription_rls<'e, E>(
+    /// Reactivate a cancelled subscription.
+    pub async fn reactivate_subscription<'e, E>(
         &self,
         executor: E,
         id: Uuid,
@@ -474,8 +483,12 @@ impl SubscriptionRepository {
         .await
     }
 
-    /// List all subscriptions with RLS context (platform admin).
-    pub async fn list_all_subscriptions_rls<'e, E>(
+    /// List all subscriptions (platform admin).
+    ///
+    /// Note: under FORCE RLS the result is scoped to the caller's RLS
+    /// context — the rows visible are those of the org set on the
+    /// connection.
+    pub async fn list_all_subscriptions<'e, E>(
         &self,
         executor: E,
         status: Option<&str>,
@@ -508,8 +521,8 @@ impl SubscriptionRepository {
 
     // ==================== Payment Methods CRUD ====================
 
-    /// Create a payment method with RLS context.
-    pub async fn create_payment_method_rls<'e, E>(
+    /// Create a payment method.
+    pub async fn create_payment_method<'e, E>(
         &self,
         executor: E,
         org_id: Uuid,
@@ -537,8 +550,8 @@ impl SubscriptionRepository {
         .await
     }
 
-    /// List payment methods for an organization with RLS context.
-    pub async fn list_payment_methods_rls<'e, E>(
+    /// List payment methods for an organization.
+    pub async fn list_payment_methods<'e, E>(
         &self,
         executor: E,
         org_id: Uuid,
@@ -554,8 +567,41 @@ impl SubscriptionRepository {
         .await
     }
 
-    /// Delete a payment method with RLS context.
-    pub async fn delete_payment_method_rls<'e, E>(
+    /// Set default payment method.
+    ///
+    /// Uses a transaction (on the caller's context-set connection) to ensure
+    /// atomicity — prevents race conditions where concurrent requests could
+    /// result in multiple default payment methods. RLS context is set via
+    /// session-level GUCs, so it survives `BEGIN`/`COMMIT`.
+    pub async fn set_default_payment_method(
+        &self,
+        conn: &mut PgConnection,
+        org_id: Uuid,
+        payment_method_id: Uuid,
+    ) -> Result<(), sqlx::Error> {
+        let mut tx = conn.begin().await?;
+
+        // Reset all to non-default
+        sqlx::query("UPDATE payment_methods SET is_default = false WHERE organization_id = $1")
+            .bind(org_id)
+            .execute(&mut *tx)
+            .await?;
+
+        // Set the specified one as default
+        sqlx::query(
+            "UPDATE payment_methods SET is_default = true WHERE id = $1 AND organization_id = $2",
+        )
+        .bind(payment_method_id)
+        .bind(org_id)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Delete a payment method.
+    pub async fn delete_payment_method<'e, E>(
         &self,
         executor: E,
         id: Uuid,
@@ -575,15 +621,17 @@ impl SubscriptionRepository {
 
     // ==================== Invoices ====================
 
-    /// Create an invoice with RLS context.
+    /// Create an invoice.
     ///
-    /// Uses a database sequence for atomic invoice number generation to prevent
-    /// race conditions and duplicate invoice numbers under concurrent requests.
+    /// Uses a database sequence for atomic invoice number generation to
+    /// prevent race conditions and duplicate invoice numbers under concurrent
+    /// requests. Multi-statement (sequence fetch, then insert), so it takes
+    /// `&mut PgConnection`; sequences are not subject to RLS, so running
+    /// `nextval` on the context-set connection is fine.
     #[allow(clippy::too_many_arguments)]
-    #[allow(deprecated)]
-    pub async fn create_invoice_rls<'e, E>(
+    pub async fn create_invoice(
         &self,
-        executor: E,
+        conn: &mut PgConnection,
         org_id: Uuid,
         subscription_id: Option<Uuid>,
         subtotal: Decimal,
@@ -591,18 +639,13 @@ impl SubscriptionRepository {
         total_amount: Decimal,
         currency: &str,
         due_date: chrono::NaiveDate,
-    ) -> Result<SubscriptionInvoice, sqlx::Error>
-    where
-        E: Executor<'e, Database = Postgres>,
-    {
+    ) -> Result<SubscriptionInvoice, sqlx::Error> {
         // Generate invoice number atomically using database sequence
-        // This prevents race conditions where concurrent requests could get the same number
-        // Note: We use the pool for sequence generation as sequences are not affected by RLS
         let seq: (i64,) = sqlx::query_as("SELECT nextval('invoice_number_seq')")
-            .fetch_one(&self.pool)
+            .fetch_one(&mut *conn)
             .await
             .unwrap_or((
-                // Fallback: use count + timestamp if sequence doesn't exist
+                // Fallback: use timestamp if sequence doesn't exist
                 chrono::Utc::now().timestamp_millis() % 100_000_000,
             ));
         let invoice_number = format!("INV-{:08}", seq.0);
@@ -624,12 +667,12 @@ impl SubscriptionRepository {
         .bind(tax_amount)
         .bind(total_amount)
         .bind(currency)
-        .fetch_one(executor)
+        .fetch_one(&mut *conn)
         .await
     }
 
-    /// Find an invoice by ID with RLS context.
-    pub async fn find_invoice_by_id_rls<'e, E>(
+    /// Find an invoice by ID.
+    pub async fn find_invoice_by_id<'e, E>(
         &self,
         executor: E,
         id: Uuid,
@@ -643,8 +686,8 @@ impl SubscriptionRepository {
             .await
     }
 
-    /// List invoices for an organization with RLS context.
-    pub async fn list_invoices_rls<'e, E>(
+    /// List invoices for an organization.
+    pub async fn list_invoices<'e, E>(
         &self,
         executor: E,
         org_id: Uuid,
@@ -674,8 +717,11 @@ impl SubscriptionRepository {
         .await
     }
 
-    /// List invoices with details with RLS context (platform admin).
-    pub async fn list_all_invoices_rls<'e, E>(
+    /// List invoices with details (platform admin).
+    ///
+    /// Note: under FORCE RLS the result is scoped to the caller's RLS
+    /// context.
+    pub async fn list_all_invoices<'e, E>(
         &self,
         executor: E,
         query: InvoiceQueryParams,
@@ -705,8 +751,8 @@ impl SubscriptionRepository {
         .await
     }
 
-    /// Mark invoice as paid with RLS context.
-    pub async fn mark_invoice_paid_rls<'e, E>(
+    /// Mark invoice as paid.
+    pub async fn mark_invoice_paid<'e, E>(
         &self,
         executor: E,
         id: Uuid,
@@ -732,8 +778,8 @@ impl SubscriptionRepository {
         .await
     }
 
-    /// Void an invoice with RLS context.
-    pub async fn void_invoice_rls<'e, E>(
+    /// Void an invoice.
+    pub async fn void_invoice<'e, E>(
         &self,
         executor: E,
         id: Uuid,
@@ -755,9 +801,9 @@ impl SubscriptionRepository {
         .await
     }
 
-    /// Add line items to an invoice with RLS context.
+    /// Add line items to an invoice.
     #[allow(clippy::too_many_arguments)]
-    pub async fn add_invoice_line_item_rls<'e, E>(
+    pub async fn add_invoice_line_item<'e, E>(
         &self,
         executor: E,
         invoice_id: Uuid,
@@ -790,8 +836,8 @@ impl SubscriptionRepository {
         .await
     }
 
-    /// Get line items for an invoice with RLS context.
-    pub async fn get_invoice_line_items_rls<'e, E>(
+    /// Get line items for an invoice.
+    pub async fn get_invoice_line_items<'e, E>(
         &self,
         executor: E,
         invoice_id: Uuid,
@@ -807,8 +853,8 @@ impl SubscriptionRepository {
 
     // ==================== Usage Records ====================
 
-    /// Record a usage metric with RLS context.
-    pub async fn record_usage_rls<'e, E>(
+    /// Record a usage metric.
+    pub async fn record_usage<'e, E>(
         &self,
         executor: E,
         org_id: Uuid,
@@ -836,8 +882,8 @@ impl SubscriptionRepository {
         .await
     }
 
-    /// Get usage summary for an organization with RLS context.
-    pub async fn get_usage_summary_rls<'e, E>(
+    /// Get usage summary for an organization.
+    pub async fn get_usage_summary<'e, E>(
         &self,
         executor: E,
         org_id: Uuid,
@@ -867,8 +913,8 @@ impl SubscriptionRepository {
         .await
     }
 
-    /// Get current usage counts for an organization with RLS context.
-    pub async fn get_current_usage_rls<'e, E>(
+    /// Get current usage counts for an organization.
+    pub async fn get_current_usage<'e, E>(
         &self,
         executor: E,
         org_id: Uuid,
@@ -897,8 +943,8 @@ impl SubscriptionRepository {
 
     // ==================== Subscription Events ====================
 
-    /// Log a subscription event with RLS context.
-    pub async fn log_event_rls<'e, E>(
+    /// Log a subscription event.
+    pub async fn log_event<'e, E>(
         &self,
         executor: E,
         org_id: Uuid,
@@ -930,8 +976,8 @@ impl SubscriptionRepository {
         .await
     }
 
-    /// Get subscription events with RLS context.
-    pub async fn get_events_rls<'e, E>(
+    /// Get subscription events.
+    pub async fn get_events<'e, E>(
         &self,
         executor: E,
         org_id: Uuid,
@@ -951,8 +997,8 @@ impl SubscriptionRepository {
 
     // ==================== Coupons ====================
 
-    /// Create a coupon with RLS context.
-    pub async fn create_coupon_rls<'e, E>(
+    /// Create a coupon.
+    pub async fn create_coupon<'e, E>(
         &self,
         executor: E,
         data: CreateSubscriptionCoupon,
@@ -988,8 +1034,8 @@ impl SubscriptionRepository {
         .await
     }
 
-    /// Find a coupon by code with RLS context.
-    pub async fn find_coupon_by_code_rls<'e, E>(
+    /// Find a coupon by code.
+    pub async fn find_coupon_by_code<'e, E>(
         &self,
         executor: E,
         code: &str,
@@ -1003,8 +1049,8 @@ impl SubscriptionRepository {
             .await
     }
 
-    /// List all coupons with RLS context.
-    pub async fn list_coupons_rls<'e, E>(
+    /// List all coupons.
+    pub async fn list_coupons<'e, E>(
         &self,
         executor: E,
         active_only: bool,
@@ -1025,8 +1071,8 @@ impl SubscriptionRepository {
         }
     }
 
-    /// Update a coupon with RLS context.
-    pub async fn update_coupon_rls<'e, E>(
+    /// Update a coupon.
+    pub async fn update_coupon<'e, E>(
         &self,
         executor: E,
         id: Uuid,
@@ -1066,688 +1112,22 @@ impl SubscriptionRepository {
         .await
     }
 
-    // ==================== Statistics ====================
-
-    /// Get subscription statistics with RLS context.
-    pub async fn get_statistics_rls<'e, E>(
-        &self,
-        executor: E,
-    ) -> Result<SubscriptionStatistics, sqlx::Error>
-    where
-        E: Executor<'e, Database = Postgres>,
-    {
-        // Combined query to get all stats in one round-trip
-        let stats: (i64, i64, i64, i64, Option<Decimal>) = sqlx::query_as(
-            r#"
-            SELECT
-                (SELECT COUNT(*) FROM organization_subscriptions) as total,
-                (SELECT COUNT(*) FROM organization_subscriptions WHERE status = 'active') as active,
-                (SELECT COUNT(*) FROM organization_subscriptions WHERE status = 'trialing') as trial,
-                (SELECT COUNT(*) FROM organization_subscriptions WHERE status = 'cancelled') as cancelled,
-                (SELECT SUM(
-                    CASE WHEN s.billing_cycle = 'annual'
-                        THEN p.annual_price / 12
-                        ELSE p.monthly_price
-                    END
-                )
-                FROM organization_subscriptions s
-                JOIN subscription_plans p ON p.id = s.plan_id
-                WHERE s.status = 'active') as mrr
-            "#,
-        )
-        .fetch_one(executor)
-        .await?;
-
-        let monthly_recurring_revenue = stats.4.unwrap_or(Decimal::ZERO);
-        let annual_recurring_revenue = monthly_recurring_revenue * Decimal::from(12);
-
-        // Get counts by plan - this requires a separate query
-        let by_plan: Vec<PlanSubscriptionCount> = sqlx::query_as(
-            r#"
-            SELECT p.id as plan_id, p.name as plan_name, COUNT(s.id) as count
-            FROM subscription_plans p
-            LEFT JOIN organization_subscriptions s ON s.plan_id = p.id AND s.status = 'active'
-            GROUP BY p.id, p.name
-            ORDER BY count DESC
-            "#,
-        )
-        .fetch_all(&self.pool)
-        .await?;
-
-        Ok(SubscriptionStatistics {
-            total_subscriptions: stats.0,
-            active_subscriptions: stats.1,
-            trial_subscriptions: stats.2,
-            cancelled_subscriptions: stats.3,
-            monthly_recurring_revenue,
-            annual_recurring_revenue,
-            by_plan,
-        })
-    }
-
-    // ========================================================================
-    // Legacy methods (use pool directly - migrate to RLS versions)
-    // ========================================================================
-
-    // ==================== Subscription Plans CRUD ====================
-
-    /// Create a new subscription plan.
-    ///
-    /// **Deprecated**: Use `create_plan_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use create_plan_rls with RlsConnection instead"
-    )]
-    pub async fn create_plan(
-        &self,
-        data: CreateSubscriptionPlan,
-    ) -> Result<SubscriptionPlan, sqlx::Error> {
-        self.create_plan_rls(&self.pool, data).await
-    }
-
-    /// Find a subscription plan by ID.
-    ///
-    /// **Deprecated**: Use `find_plan_by_id_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use find_plan_by_id_rls with RlsConnection instead"
-    )]
-    pub async fn find_plan_by_id(&self, id: Uuid) -> Result<Option<SubscriptionPlan>, sqlx::Error> {
-        self.find_plan_by_id_rls(&self.pool, id).await
-    }
-
-    /// Find a subscription plan by name.
-    ///
-    /// **Deprecated**: Use `find_plan_by_name_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use find_plan_by_name_rls with RlsConnection instead"
-    )]
-    pub async fn find_plan_by_name(
-        &self,
-        name: &str,
-    ) -> Result<Option<SubscriptionPlan>, sqlx::Error> {
-        self.find_plan_by_name_rls(&self.pool, name).await
-    }
-
-    /// List all subscription plans.
-    ///
-    /// **Deprecated**: Use `list_plans_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use list_plans_rls with RlsConnection instead"
-    )]
-    pub async fn list_plans(
-        &self,
-        active_only: bool,
-    ) -> Result<Vec<SubscriptionPlan>, sqlx::Error> {
-        self.list_plans_rls(&self.pool, active_only).await
-    }
-
-    /// List public subscription plans (for display to customers).
-    ///
-    /// **Deprecated**: Use `list_public_plans_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use list_public_plans_rls with RlsConnection instead"
-    )]
-    pub async fn list_public_plans(&self) -> Result<Vec<SubscriptionPlan>, sqlx::Error> {
-        self.list_public_plans_rls(&self.pool).await
-    }
-
-    /// Update a subscription plan.
-    ///
-    /// **Deprecated**: Use `update_plan_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use update_plan_rls with RlsConnection instead"
-    )]
-    pub async fn update_plan(
-        &self,
-        id: Uuid,
-        data: UpdateSubscriptionPlan,
-    ) -> Result<SubscriptionPlan, sqlx::Error> {
-        self.update_plan_rls(&self.pool, id, data).await
-    }
-
-    /// Delete a subscription plan.
-    ///
-    /// **Deprecated**: Use `delete_plan_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use delete_plan_rls with RlsConnection instead"
-    )]
-    pub async fn delete_plan(&self, id: Uuid) -> Result<bool, sqlx::Error> {
-        self.delete_plan_rls(&self.pool, id).await
-    }
-
-    // ==================== Organization Subscriptions CRUD ====================
-
-    /// Create a new organization subscription.
-    ///
-    /// **Deprecated**: Use `create_subscription_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use create_subscription_rls with RlsConnection instead"
-    )]
-    #[allow(deprecated)]
-    pub async fn create_subscription(
-        &self,
-        org_id: Uuid,
-        data: CreateOrganizationSubscription,
-    ) -> Result<OrganizationSubscription, sqlx::Error> {
-        self.create_subscription_rls(&self.pool, org_id, data).await
-    }
-
-    /// Find an organization's subscription.
-    ///
-    /// **Deprecated**: Use `find_subscription_by_org_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use find_subscription_by_org_rls with RlsConnection instead"
-    )]
-    pub async fn find_subscription_by_org(
-        &self,
-        org_id: Uuid,
-    ) -> Result<Option<OrganizationSubscription>, sqlx::Error> {
-        self.find_subscription_by_org_rls(&self.pool, org_id).await
-    }
-
-    /// Find a subscription by ID.
-    ///
-    /// **Deprecated**: Use `find_subscription_by_id_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use find_subscription_by_id_rls with RlsConnection instead"
-    )]
-    pub async fn find_subscription_by_id(
-        &self,
-        id: Uuid,
-    ) -> Result<Option<OrganizationSubscription>, sqlx::Error> {
-        self.find_subscription_by_id_rls(&self.pool, id).await
-    }
-
-    /// Get subscription with plan details.
-    ///
-    /// **Deprecated**: Use `get_subscription_with_plan_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use get_subscription_with_plan_rls with RlsConnection instead"
-    )]
-    pub async fn get_subscription_with_plan(
-        &self,
-        org_id: Uuid,
-    ) -> Result<Option<SubscriptionWithPlan>, sqlx::Error> {
-        self.get_subscription_with_plan_rls(&self.pool, org_id)
-            .await
-    }
-
-    /// Update an organization subscription.
-    ///
-    /// **Deprecated**: Use `update_subscription_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use update_subscription_rls with RlsConnection instead"
-    )]
-    pub async fn update_subscription(
-        &self,
-        id: Uuid,
-        data: UpdateOrganizationSubscription,
-    ) -> Result<OrganizationSubscription, sqlx::Error> {
-        self.update_subscription_rls(&self.pool, id, data).await
-    }
-
-    /// Change subscription plan.
-    ///
-    /// **Deprecated**: Use `change_plan_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use change_plan_rls with RlsConnection instead"
-    )]
-    pub async fn change_plan(
-        &self,
-        id: Uuid,
-        data: ChangePlanRequest,
-    ) -> Result<OrganizationSubscription, sqlx::Error> {
-        self.change_plan_rls(&self.pool, id, data).await
-    }
-
-    /// Cancel a subscription.
-    ///
-    /// **Deprecated**: Use `cancel_subscription_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use cancel_subscription_rls with RlsConnection instead"
-    )]
-    pub async fn cancel_subscription(
-        &self,
-        id: Uuid,
-        data: CancelSubscriptionRequest,
-    ) -> Result<OrganizationSubscription, sqlx::Error> {
-        self.cancel_subscription_rls(&self.pool, id, data).await
-    }
-
-    /// Reactivate a cancelled subscription.
-    ///
-    /// **Deprecated**: Use `reactivate_subscription_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use reactivate_subscription_rls with RlsConnection instead"
-    )]
-    pub async fn reactivate_subscription(
-        &self,
-        id: Uuid,
-    ) -> Result<OrganizationSubscription, sqlx::Error> {
-        self.reactivate_subscription_rls(&self.pool, id).await
-    }
-
-    /// List all subscriptions (platform admin).
-    ///
-    /// **Deprecated**: Use `list_all_subscriptions_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use list_all_subscriptions_rls with RlsConnection instead"
-    )]
-    pub async fn list_all_subscriptions(
-        &self,
-        status: Option<&str>,
-        limit: i32,
-        offset: i32,
-    ) -> Result<Vec<SubscriptionWithPlan>, sqlx::Error> {
-        self.list_all_subscriptions_rls(&self.pool, status, limit, offset)
-            .await
-    }
-
-    // ==================== Payment Methods CRUD ====================
-
-    /// Create a payment method.
-    ///
-    /// **Deprecated**: Use `create_payment_method_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use create_payment_method_rls with RlsConnection instead"
-    )]
-    pub async fn create_payment_method(
-        &self,
-        org_id: Uuid,
-        data: CreateSubscriptionPaymentMethod,
-    ) -> Result<SubscriptionPaymentMethod, sqlx::Error> {
-        self.create_payment_method_rls(&self.pool, org_id, data)
-            .await
-    }
-
-    /// List payment methods for an organization.
-    ///
-    /// **Deprecated**: Use `list_payment_methods_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use list_payment_methods_rls with RlsConnection instead"
-    )]
-    pub async fn list_payment_methods(
-        &self,
-        org_id: Uuid,
-    ) -> Result<Vec<SubscriptionPaymentMethod>, sqlx::Error> {
-        self.list_payment_methods_rls(&self.pool, org_id).await
-    }
-
-    /// Set default payment method.
-    ///
-    /// Uses a transaction to ensure atomicity - prevents race conditions where
-    /// concurrent requests could result in multiple default payment methods.
-    ///
-    /// Note: This method uses transactions internally and cannot be easily
-    /// converted to an RLS-aware pattern. Consider using a stored procedure
-    /// or handling the transaction at a higher level.
-    pub async fn set_default_payment_method(
-        &self,
-        org_id: Uuid,
-        payment_method_id: Uuid,
-    ) -> Result<(), sqlx::Error> {
-        let mut tx = self.pool.begin().await?;
-
-        // Reset all to non-default
-        sqlx::query("UPDATE payment_methods SET is_default = false WHERE organization_id = $1")
-            .bind(org_id)
-            .execute(&mut *tx)
-            .await?;
-
-        // Set the specified one as default
-        sqlx::query(
-            "UPDATE payment_methods SET is_default = true WHERE id = $1 AND organization_id = $2",
-        )
-        .bind(payment_method_id)
-        .bind(org_id)
-        .execute(&mut *tx)
-        .await?;
-
-        tx.commit().await?;
-        Ok(())
-    }
-
-    /// Delete a payment method.
-    ///
-    /// **Deprecated**: Use `delete_payment_method_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use delete_payment_method_rls with RlsConnection instead"
-    )]
-    pub async fn delete_payment_method(&self, id: Uuid, org_id: Uuid) -> Result<bool, sqlx::Error> {
-        self.delete_payment_method_rls(&self.pool, id, org_id).await
-    }
-
-    // ==================== Invoices ====================
-
-    /// Create an invoice.
-    ///
-    /// Uses a database sequence for atomic invoice number generation to prevent
-    /// race conditions and duplicate invoice numbers under concurrent requests.
-    ///
-    /// **Deprecated**: Use `create_invoice_rls` with an RLS-enabled connection instead.
-    #[allow(clippy::too_many_arguments)]
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use create_invoice_rls with RlsConnection instead"
-    )]
-    #[allow(deprecated)]
-    pub async fn create_invoice(
-        &self,
-        org_id: Uuid,
-        subscription_id: Option<Uuid>,
-        subtotal: Decimal,
-        tax_amount: Option<Decimal>,
-        total_amount: Decimal,
-        currency: &str,
-        due_date: chrono::NaiveDate,
-    ) -> Result<SubscriptionInvoice, sqlx::Error> {
-        self.create_invoice_rls(
-            &self.pool,
-            org_id,
-            subscription_id,
-            subtotal,
-            tax_amount,
-            total_amount,
-            currency,
-            due_date,
-        )
-        .await
-    }
-
-    /// Find an invoice by ID.
-    ///
-    /// **Deprecated**: Use `find_invoice_by_id_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use find_invoice_by_id_rls with RlsConnection instead"
-    )]
-    pub async fn find_invoice_by_id(
-        &self,
-        id: Uuid,
-    ) -> Result<Option<SubscriptionInvoice>, sqlx::Error> {
-        self.find_invoice_by_id_rls(&self.pool, id).await
-    }
-
-    /// List invoices for an organization.
-    ///
-    /// **Deprecated**: Use `list_invoices_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use list_invoices_rls with RlsConnection instead"
-    )]
-    pub async fn list_invoices(
-        &self,
-        org_id: Uuid,
-        query: InvoiceQueryParams,
-    ) -> Result<Vec<SubscriptionInvoice>, sqlx::Error> {
-        self.list_invoices_rls(&self.pool, org_id, query).await
-    }
-
-    /// List invoices with details (platform admin).
-    ///
-    /// **Deprecated**: Use `list_all_invoices_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use list_all_invoices_rls with RlsConnection instead"
-    )]
-    pub async fn list_all_invoices(
-        &self,
-        query: InvoiceQueryParams,
-    ) -> Result<Vec<InvoiceWithDetails>, sqlx::Error> {
-        self.list_all_invoices_rls(&self.pool, query).await
-    }
-
-    /// Mark invoice as paid.
-    ///
-    /// **Deprecated**: Use `mark_invoice_paid_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use mark_invoice_paid_rls with RlsConnection instead"
-    )]
-    pub async fn mark_invoice_paid(
-        &self,
-        id: Uuid,
-        payment_method_id: Option<Uuid>,
-    ) -> Result<SubscriptionInvoice, sqlx::Error> {
-        self.mark_invoice_paid_rls(&self.pool, id, payment_method_id)
-            .await
-    }
-
-    /// Void an invoice.
-    ///
-    /// **Deprecated**: Use `void_invoice_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use void_invoice_rls with RlsConnection instead"
-    )]
-    pub async fn void_invoice(&self, id: Uuid) -> Result<SubscriptionInvoice, sqlx::Error> {
-        self.void_invoice_rls(&self.pool, id).await
-    }
-
-    /// Add line items to an invoice.
-    ///
-    /// **Deprecated**: Use `add_invoice_line_item_rls` with an RLS-enabled connection instead.
-    #[allow(clippy::too_many_arguments)]
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use add_invoice_line_item_rls with RlsConnection instead"
-    )]
-    pub async fn add_invoice_line_item(
-        &self,
-        invoice_id: Uuid,
-        description: &str,
-        quantity: Option<Decimal>,
-        unit_price: Decimal,
-        amount: Decimal,
-        item_type: &str,
-        plan_id: Option<Uuid>,
-    ) -> Result<InvoiceLineItem, sqlx::Error> {
-        self.add_invoice_line_item_rls(
-            &self.pool,
-            invoice_id,
-            description,
-            quantity,
-            unit_price,
-            amount,
-            item_type,
-            plan_id,
-        )
-        .await
-    }
-
-    /// Get line items for an invoice.
-    ///
-    /// **Deprecated**: Use `get_invoice_line_items_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use get_invoice_line_items_rls with RlsConnection instead"
-    )]
-    pub async fn get_invoice_line_items(
-        &self,
-        invoice_id: Uuid,
-    ) -> Result<Vec<InvoiceLineItem>, sqlx::Error> {
-        self.get_invoice_line_items_rls(&self.pool, invoice_id)
-            .await
-    }
-
-    // ==================== Usage Records ====================
-
-    /// Record a usage metric.
-    ///
-    /// **Deprecated**: Use `record_usage_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use record_usage_rls with RlsConnection instead"
-    )]
-    pub async fn record_usage(
-        &self,
-        org_id: Uuid,
-        subscription_id: Option<Uuid>,
-        data: CreateUsageRecord,
-    ) -> Result<UsageRecord, sqlx::Error> {
-        self.record_usage_rls(&self.pool, org_id, subscription_id, data)
-            .await
-    }
-
-    /// Get usage summary for an organization.
-    ///
-    /// **Deprecated**: Use `get_usage_summary_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use get_usage_summary_rls with RlsConnection instead"
-    )]
-    pub async fn get_usage_summary(
-        &self,
-        org_id: Uuid,
-        period_start: chrono::DateTime<Utc>,
-        period_end: chrono::DateTime<Utc>,
-    ) -> Result<Vec<UsageSummary>, sqlx::Error> {
-        self.get_usage_summary_rls(&self.pool, org_id, period_start, period_end)
-            .await
-    }
-
-    /// Get current usage counts for an organization.
-    ///
-    /// **Deprecated**: Use `get_current_usage_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use get_current_usage_rls with RlsConnection instead"
-    )]
-    pub async fn get_current_usage(
-        &self,
-        org_id: Uuid,
-    ) -> Result<(i64, i64, i64, i64), sqlx::Error> {
-        self.get_current_usage_rls(&self.pool, org_id).await
-    }
-
-    // ==================== Subscription Events ====================
-
-    /// Log a subscription event.
-    ///
-    /// **Deprecated**: Use `log_event_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use log_event_rls with RlsConnection instead"
-    )]
-    pub async fn log_event(
-        &self,
-        org_id: Uuid,
-        subscription_id: Option<Uuid>,
-        actor_id: Option<Uuid>,
-        data: CreateSubscriptionEvent,
-    ) -> Result<SubscriptionEvent, sqlx::Error> {
-        self.log_event_rls(&self.pool, org_id, subscription_id, actor_id, data)
-            .await
-    }
-
-    /// Get subscription events.
-    ///
-    /// **Deprecated**: Use `get_events_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use get_events_rls with RlsConnection instead"
-    )]
-    pub async fn get_events(
-        &self,
-        org_id: Uuid,
-        limit: i32,
-    ) -> Result<Vec<SubscriptionEvent>, sqlx::Error> {
-        self.get_events_rls(&self.pool, org_id, limit).await
-    }
-
-    // ==================== Coupons ====================
-
-    /// Create a coupon.
-    ///
-    /// **Deprecated**: Use `create_coupon_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use create_coupon_rls with RlsConnection instead"
-    )]
-    pub async fn create_coupon(
-        &self,
-        data: CreateSubscriptionCoupon,
-    ) -> Result<SubscriptionCoupon, sqlx::Error> {
-        self.create_coupon_rls(&self.pool, data).await
-    }
-
-    /// Find a coupon by code.
-    ///
-    /// **Deprecated**: Use `find_coupon_by_code_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use find_coupon_by_code_rls with RlsConnection instead"
-    )]
-    pub async fn find_coupon_by_code(
-        &self,
-        code: &str,
-    ) -> Result<Option<SubscriptionCoupon>, sqlx::Error> {
-        self.find_coupon_by_code_rls(&self.pool, code).await
-    }
-
-    /// List all coupons.
-    ///
-    /// **Deprecated**: Use `list_coupons_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use list_coupons_rls with RlsConnection instead"
-    )]
-    pub async fn list_coupons(
-        &self,
-        active_only: bool,
-    ) -> Result<Vec<SubscriptionCoupon>, sqlx::Error> {
-        self.list_coupons_rls(&self.pool, active_only).await
-    }
-
-    /// Update a coupon.
-    ///
-    /// **Deprecated**: Use `update_coupon_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use update_coupon_rls with RlsConnection instead"
-    )]
-    pub async fn update_coupon(
-        &self,
-        id: Uuid,
-        data: UpdateSubscriptionCoupon,
-    ) -> Result<SubscriptionCoupon, sqlx::Error> {
-        self.update_coupon_rls(&self.pool, id, data).await
-    }
-
     /// Redeem a coupon.
     ///
-    /// Uses a transaction with validation to prevent race conditions and over-redemption.
-    /// Checks max_redemptions before incrementing count and inserting redemption record.
-    ///
-    /// Note: This method uses transactions internally and cannot be easily
-    /// converted to an RLS-aware pattern. Consider using a stored procedure
-    /// or handling the transaction at a higher level.
+    /// Uses a transaction (on the caller's context-set connection) with
+    /// validation to prevent race conditions and over-redemption. Checks
+    /// `max_redemptions` before incrementing the count and inserting the
+    /// redemption record. The `coupon_redemptions` insert is FORCE-RLS-bound,
+    /// so this MUST run on a connection with RLS context set for `org_id`.
     pub async fn redeem_coupon(
         &self,
+        conn: &mut PgConnection,
         coupon_id: Uuid,
         org_id: Uuid,
         subscription_id: Option<Uuid>,
         user_id: Uuid,
     ) -> Result<CouponRedemption, sqlx::Error> {
-        let mut tx = self.pool.begin().await?;
+        let mut tx = conn.begin().await?;
 
         // Check if coupon exists and has remaining redemptions (with row lock)
         let coupon: Option<(i32, Option<i32>)> = sqlx::query_as(
@@ -1801,13 +1181,60 @@ impl SubscriptionRepository {
 
     /// Get subscription statistics.
     ///
-    /// **Deprecated**: Use `get_statistics_rls` with an RLS-enabled connection instead.
-    #[deprecated(
-        since = "0.2.276",
-        note = "Use get_statistics_rls with RlsConnection instead"
-    )]
-    #[allow(deprecated)]
-    pub async fn get_statistics(&self) -> Result<SubscriptionStatistics, sqlx::Error> {
-        self.get_statistics_rls(&self.pool).await
+    /// Multi-statement (aggregate stats, then per-plan counts), so it takes
+    /// `&mut PgConnection` and runs both queries on the same context-set
+    /// connection. Under FORCE RLS the figures are scoped to the caller's
+    /// RLS context.
+    pub async fn get_statistics(
+        &self,
+        conn: &mut PgConnection,
+    ) -> Result<SubscriptionStatistics, sqlx::Error> {
+        // Combined query to get all stats in one round-trip
+        let stats: (i64, i64, i64, i64, Option<Decimal>) = sqlx::query_as(
+            r#"
+            SELECT
+                (SELECT COUNT(*) FROM organization_subscriptions) as total,
+                (SELECT COUNT(*) FROM organization_subscriptions WHERE status = 'active') as active,
+                (SELECT COUNT(*) FROM organization_subscriptions WHERE status = 'trialing') as trial,
+                (SELECT COUNT(*) FROM organization_subscriptions WHERE status = 'cancelled') as cancelled,
+                (SELECT SUM(
+                    CASE WHEN s.billing_cycle = 'annual'
+                        THEN p.annual_price / 12
+                        ELSE p.monthly_price
+                    END
+                )
+                FROM organization_subscriptions s
+                JOIN subscription_plans p ON p.id = s.plan_id
+                WHERE s.status = 'active') as mrr
+            "#,
+        )
+        .fetch_one(&mut *conn)
+        .await?;
+
+        let monthly_recurring_revenue = stats.4.unwrap_or(Decimal::ZERO);
+        let annual_recurring_revenue = monthly_recurring_revenue * Decimal::from(12);
+
+        // Get counts by plan - this requires a separate query
+        let by_plan: Vec<PlanSubscriptionCount> = sqlx::query_as(
+            r#"
+            SELECT p.id as plan_id, p.name as plan_name, COUNT(s.id) as count
+            FROM subscription_plans p
+            LEFT JOIN organization_subscriptions s ON s.plan_id = p.id AND s.status = 'active'
+            GROUP BY p.id, p.name
+            ORDER BY count DESC
+            "#,
+        )
+        .fetch_all(&mut *conn)
+        .await?;
+
+        Ok(SubscriptionStatistics {
+            total_subscriptions: stats.0,
+            active_subscriptions: stats.1,
+            trial_subscriptions: stats.2,
+            cancelled_subscriptions: stats.3,
+            monthly_recurring_revenue,
+            annual_recurring_revenue,
+            by_plan,
+        })
     }
 }

--- a/backend/crates/db/tests/subscription_rls_repo_tests.rs
+++ b/backend/crates/db/tests/subscription_rls_repo_tests.rs
@@ -1,0 +1,303 @@
+//! Repo-level behavioral RLS regression test for PAP-112 (parent PAP-80 / PAP-67).
+//!
+//! Background
+//! ----------
+//! Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on the seven org-scoped billing tables used
+//! by `SubscriptionRepository` (`organization_subscriptions`,
+//! `payment_methods`, `subscription_invoices`, `invoice_line_items`,
+//! `usage_records`, `subscription_events`, `coupon_redemptions`). The
+//! production api-server connects as the table OWNER, which `FORCE` binds.
+//! `SubscriptionRepository` held a raw `PgPool` and its legacy methods ran
+//! every query WITHOUT ever calling `set_request_context`, so on `dev`
+//! `get_current_org_id()` returned NULL and the policies collapsed to
+//! `organization_id = NULL` → **deny-all**: own-org reads returned empty,
+//! writes failed. (PAP-112.)
+//!
+//! The fix makes the repo hold no pool: every method takes an RLS-context
+//! executor (the `RlsConnection` extractor in handlers sets the org/user GUCs
+//! before any query). This test exercises the *repository methods themselves*
+//! on a `FORCE`-bound role and proves:
+//!
+//!   1. **Deny-all reproduction** — with the role bound but NO context set
+//!      (exactly what the raw-pool repo did on `dev`), an own-org
+//!      `find_subscription_by_org` returns nothing.
+//!   2. **Fix** — with `set_request_context(org_a, user_a)` applied first
+//!      (what `RlsConnection` now does), the same call returns the own-org
+//!      subscription, and the own-org by-id `find_subscription_by_id`
+//!      resolves.
+//!   3. **Cross-tenant by-id** — org B's subscription is invisible to an
+//!      org-A caller: `find_subscription_by_id` returns `None` (handlers
+//!      surface 404, indistinguishable from missing).
+//!   4. **Write path** — a `create_subscription` on a context-set connection
+//!      succeeds and the row is the caller's org (without context the INSERT
+//!      would fail the policy `WITH CHECK` — the write-side of deny-all).
+//!      This also covers the multi-statement `&mut PgConnection` shape: the
+//!      method runs the plan lookup (`subscription_plans`, public read
+//!      policy) and the insert on the same context-set connection.
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — even `FORCE` does not bind a superuser, so a behavioral
+//! assertion would pass vacuously. The test creates a plain `NOSUPERUSER
+//! NOBYPASSRLS` role, grants it access, and `SET ROLE`s to it so `FORCE`
+//! actually enforces the policy the way the production owner role experiences
+//! it. Mirrors `integration_rls_repo_tests.rs` / `emergency_rls_repo_tests.rs`
+//! (the PAP-67 precedent PAP-80 follows).
+
+use db::models::CreateOrganizationSubscription;
+use db::repositories::SubscriptionRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Subscription {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@subscription.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'Subscription User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Seed a subscription plan (as superuser). `subscription_plans` is not
+/// FORCE-bound and carries a public read policy, so the bound role can read
+/// it during `create_subscription`'s plan lookup.
+async fn seed_plan(pool: &PgPool, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO subscription_plans (name, display_name, monthly_price, annual_price)
+        VALUES ($1, $2, 29.00, 290.00)
+        RETURNING id
+        "#,
+    )
+    .bind(name)
+    .bind(format!("{name} (display)"))
+    .fetch_one(pool)
+    .await
+    .expect("seed plan")
+}
+
+/// Seed an organization subscription directly (as superuser, RLS-exempt).
+async fn seed_subscription(pool: &PgPool, org_id: Uuid, plan_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organization_subscriptions
+            (organization_id, plan_id, status, billing_cycle,
+             current_period_start, current_period_end)
+        VALUES ($1, $2, 'active', 'monthly', NOW(), NOW() + INTERVAL '1 month')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(plan_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed subscription")
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn subscription_repo_force_rls_deny_all_and_fix(pool: PgPool) {
+    let repo = SubscriptionRepository::new(pool.clone());
+
+    // --- Seed as superuser / super-admin context (satisfies org roles-trigger). ---
+    set_ctx(&pool, None, None, true).await;
+    let org_a = seed_org(&pool, "sforce-a").await;
+    let org_b = seed_org(&pool, "sforce-b").await;
+    let org_c = seed_org(&pool, "sforce-c").await;
+    let user_a = seed_user(&pool, "a@subscription.test").await;
+    let _user_c = seed_user(&pool, "c@subscription.test").await;
+    let plan = seed_plan(&pool, "sforce-basic").await;
+    let sub_a = seed_subscription(&pool, org_a, plan).await;
+    let sub_b = seed_subscription(&pool, org_b, plan).await;
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    let role = format!("ppt_rls_subscription_{}", Uuid::new_v4().simple());
+    for stmt in [
+        format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
+        format!("GRANT SELECT, INSERT, UPDATE, DELETE ON organization_subscriptions TO \"{role}\""),
+        // create_subscription's plan lookup reads subscription_plans (public
+        // read policy, not FORCE-bound).
+        format!("GRANT SELECT ON subscription_plans TO \"{role}\""),
+        // RLS policy helpers must be EXECUTE-able by the bound role.
+        format!("GRANT EXECUTE ON FUNCTION get_current_org_id() TO \"{role}\""),
+        format!("GRANT EXECUTE ON FUNCTION get_current_org_not_deleted() TO \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .expect("grant setup");
+    }
+
+    // ====================================================================
+    // (1) DENY-ALL reproduction: role bound, NO context set (the dev raw-pool
+    //     behavior). Own-org reads return nothing.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        // Explicitly clear any inherited context, then drop to the bound role.
+        sqlx::query("SELECT clear_request_context()")
+            .execute(&mut *conn)
+            .await
+            .expect("clear ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let found = repo
+            .find_subscription_by_org(&mut *conn, org_a)
+            .await
+            .expect("find_subscription_by_org (no ctx)");
+        assert!(
+            found.is_none(),
+            "PAP-112 regression: without RLS context, the own-org subscription \
+             must be invisible (deny-all) — this is what the raw-pool repo did on dev"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (2) FIX + (3) cross-tenant by-id: set context, drop to bound role, query.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        // (2) Own-org subscription IS now visible through the repo — the fix.
+        let found = repo
+            .find_subscription_by_org(&mut *conn, org_a)
+            .await
+            .expect("find_subscription_by_org (ctx)");
+        assert_eq!(
+            found.map(|s| s.id),
+            Some(sub_a),
+            "PAP-112 fix: with RLS context set, the own-org subscription resolves"
+        );
+
+        // Own-org by-id read resolves.
+        let own = repo
+            .find_subscription_by_id(&mut *conn, sub_a)
+            .await
+            .expect("get own-org subscription under context must succeed");
+        assert_eq!(own.map(|s| s.id), Some(sub_a));
+
+        // (3) Cross-tenant by-id read: org B's subscription must be invisible
+        //     to an org-A caller (None → handlers surface 404).
+        let cross = repo
+            .find_subscription_by_id(&mut *conn, sub_b)
+            .await
+            .expect("cross-tenant get must not error, just filter");
+        assert!(
+            cross.is_none(),
+            "cross-tenant: org B's subscription must NOT be visible to an org-A caller"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (4) WRITE path: a create on a context-set connection succeeds and the
+    //     row is the caller's org. Without context the INSERT would fail the
+    //     policy WITH CHECK (the write-side of deny-all). Uses org C because
+    //     organization_subscriptions.organization_id is UNIQUE.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_c)
+            .bind(_user_c)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-C ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let created = repo
+            .create_subscription(
+                &mut conn,
+                org_c,
+                CreateOrganizationSubscription {
+                    plan_id: plan,
+                    billing_cycle: Some("monthly".to_string()),
+                    start_trial: None,
+                    payment_method_id: None,
+                    coupon_code: None,
+                    metadata: None,
+                },
+            )
+            .await
+            .expect("create_subscription under context must succeed");
+        assert_eq!(created.organization_id, org_c);
+        assert_eq!(created.status, "active");
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup the test role. ---
+    set_ctx(&pool, None, None, true).await;
+    for stmt in [
+        format!("REVOKE ALL ON organization_subscriptions FROM \"{role}\""),
+        format!("REVOKE ALL ON subscription_plans FROM \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .ok();
+    }
+}

--- a/backend/crates/db/tests/subscription_rls_repo_tests.rs
+++ b/backend/crates/db/tests/subscription_rls_repo_tests.rs
@@ -150,9 +150,17 @@ async fn subscription_repo_force_rls_deny_all_and_fix(pool: PgPool) {
         // create_subscription's plan lookup reads subscription_plans (public
         // read policy, not FORCE-bound).
         format!("GRANT SELECT ON subscription_plans TO \"{role}\""),
+        // The 00179 policy is `org = get_current_org_id() AND
+        // get_current_org_not_deleted()`; the soft-delete helper is SECURITY
+        // INVOKER and reads `organizations`, so the bound role needs SELECT
+        // there too (else ctx-set reads fail "permission denied for table
+        // organizations" — the no-ctx deny-all leg passes anyway because the
+        // NULL org short-circuits before the soft-delete check).
+        format!("GRANT SELECT ON organizations TO \"{role}\""),
         // RLS policy helpers must be EXECUTE-able by the bound role.
         format!("GRANT EXECUTE ON FUNCTION get_current_org_id() TO \"{role}\""),
         format!("GRANT EXECUTE ON FUNCTION get_current_org_not_deleted() TO \"{role}\""),
+        format!("GRANT EXECUTE ON FUNCTION is_super_admin() TO \"{role}\""),
     ] {
         sqlx::query(sqlx::AssertSqlSafe(stmt))
             .execute(&pool)
@@ -293,6 +301,7 @@ async fn subscription_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     for stmt in [
         format!("REVOKE ALL ON organization_subscriptions FROM \"{role}\""),
         format!("REVOKE ALL ON subscription_plans FROM \"{role}\""),
+        format!("REVOKE ALL ON organizations FROM \"{role}\""),
         format!("DROP ROLE IF EXISTS \"{role}\""),
     ] {
         sqlx::query(sqlx::AssertSqlSafe(stmt))

--- a/backend/servers/api-server/src/routes/subscriptions.rs
+++ b/backend/servers/api-server/src/routes/subscriptions.rs
@@ -1,6 +1,26 @@
 //! Subscription and billing routes (Epic 26).
+//!
+//! # RLS (PAP-112 / PAP-80)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` on the org-scoped billing
+//! tables, so every query MUST run on a connection that has
+//! `app.current_org_id` set or it collapses to deny-all. Each handler
+//! acquires an [`RlsConnection`] (which validates tenant membership and sets
+//! the org/user GUCs on a dedicated connection) and passes
+//! `&mut **rls.conn()` to the repository. The authoritative organization is
+//! `rls.tenant_id()` — the tenant the caller was validated against — so
+//! request bodies/queries that carry an `organization_id` are checked against
+//! it (`403` on mismatch) instead of re-querying membership. Cross-tenant
+//! access is blocked by RLS: a by-id read of another org's row returns no row
+//! (`404`), and a write targeting another org fails the policy `WITH CHECK`.
+//! `rls.release()` clears the context before the connection returns to the
+//! pool.
+//!
+//! The public `/plans/public` endpoint has no tenant principal; it reads
+//! `subscription_plans` (not FORCE-bound, public read policy) on the plain
+//! pool.
 
-use api_core::extractors::{AuthUser, RlsConnection};
+use api_core::extractors::RlsConnection;
 use axum::{
     extract::{Path, Query, State},
     http::{header::AUTHORIZATION, HeaderMap, StatusCode},
@@ -111,101 +131,43 @@ fn require_super_admin(
     Ok(user_id)
 }
 
-/// Verify user has access to the organization using RLS connection.
-async fn verify_org_access_rls(
+/// Require that a request-supplied organization id matches the tenant the
+/// caller was validated against.
+///
+/// `RlsConnection` already validates org membership via
+/// `ValidatedTenantExtractor`, so no DB round-trip is needed — only the
+/// equality check. Releases the connection on mismatch.
+async fn ensure_org_matches(
     rls: &mut RlsConnection,
-    user_id: Uuid,
-    org_id: Uuid,
+    organization_id: Uuid,
 ) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
-    let is_member: Option<(bool,)> = sqlx::query_as(
-        "SELECT EXISTS(SELECT 1 FROM organization_members WHERE user_id = $1 AND organization_id = $2)",
-    )
-    .bind(user_id)
-    .bind(org_id)
-    .fetch_optional(&mut **rls.conn())
-    .await
-    .map_err(|e| {
-        tracing::error!(error = %e, "Failed to check org membership");
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new("DB_ERROR", "Database error")),
-        )
-    })?;
-
-    match is_member {
-        Some((true,)) => Ok(()),
-        _ => Err((
+    if organization_id != rls.tenant_id() {
+        rls.release().await;
+        return Err((
             StatusCode::FORBIDDEN,
             Json(ErrorResponse::new(
                 "FORBIDDEN",
                 "You do not have access to this organization",
             )),
-        )),
+        ));
     }
+    Ok(())
 }
 
-/// Verify user has access to an invoice by its ID using RLS connection.
-async fn verify_invoice_access_rls(
-    state: &AppState,
-    rls: &mut RlsConnection,
-    user_id: Uuid,
-    invoice_id: Uuid,
-) -> Result<Uuid, (StatusCode, Json<ErrorResponse>)> {
-    // Get invoice to find org_id
-    let invoice = state
-        .subscription_repo
-        .find_invoice_by_id_rls(&mut **rls.conn(), invoice_id)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to find invoice");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Database error")),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Invoice not found")),
-            )
-        })?;
-
-    // Verify user has access to this organization
-    verify_org_access_rls(rls, user_id, invoice.organization_id).await?;
-
-    Ok(invoice.organization_id)
-}
-
-/// Verify user has access to a subscription by its ID using RLS connection.
-async fn verify_subscription_access_rls(
-    state: &AppState,
-    rls: &mut RlsConnection,
-    user_id: Uuid,
-    subscription_id: Uuid,
-) -> Result<Uuid, (StatusCode, Json<ErrorResponse>)> {
-    // Get subscription to find org_id
-    let subscription = state
-        .subscription_repo
-        .find_subscription_by_id_rls(&mut **rls.conn(), subscription_id)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "Failed to find subscription");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Database error")),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Subscription not found")),
-            )
-        })?;
-
-    // Verify user has access to this organization
-    verify_org_access_rls(rls, user_id, subscription.organization_id).await?;
-
-    Ok(subscription.organization_id)
+/// Map a repository error: under RLS a cross-tenant (or missing) row surfaces
+/// as `RowNotFound` on mutation paths — translate that to `404` instead of
+/// `500`.
+fn db_error(e: sqlx::Error) -> (StatusCode, Json<ErrorResponse>) {
+    match e {
+        sqlx::Error::RowNotFound => (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("NOT_FOUND", "Resource not found")),
+        ),
+        _ => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new("DB_ERROR", e.to_string())),
+        ),
+    }
 }
 
 /// Create subscription routes router.
@@ -392,14 +354,9 @@ async fn create_plan(
 
     let plan = state
         .subscription_repo
-        .create_plan_rls(&mut **rls.conn(), data)
+        .create_plan(&mut **rls.conn(), data)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
     Ok((StatusCode::CREATED, Json(plan)))
@@ -418,20 +375,14 @@ async fn create_plan(
 )]
 async fn list_plans(
     State(state): State<AppState>,
-    _auth: AuthUser,
     mut rls: RlsConnection,
     Query(query): Query<ListPlansQuery>,
 ) -> Result<Json<Vec<SubscriptionPlan>>, (StatusCode, Json<ErrorResponse>)> {
     let plans = state
         .subscription_repo
-        .list_plans_rls(&mut **rls.conn(), query.active_only.unwrap_or(true))
+        .list_plans(&mut **rls.conn(), query.active_only.unwrap_or(true))
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
     Ok(Json(plans))
@@ -455,19 +406,13 @@ async fn list_plans(
 async fn list_public_plans(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<SubscriptionPlan>>, (StatusCode, Json<ErrorResponse>)> {
-    // Public endpoint - no RLS needed as subscription_plans is not tenant-scoped
-    // Using the legacy method is acceptable here since there's no tenant context
-    #[allow(deprecated)]
+    // No tenant principal here: subscription_plans is not FORCE-bound and
+    // carries a public read policy, so the plain pool is the right executor.
     let plans = state
         .subscription_repo
-        .list_public_plans()
+        .list_public_plans(&state.db)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     Ok(Json(plans))
 }
@@ -487,28 +432,24 @@ async fn list_public_plans(
 )]
 async fn get_plan(
     State(state): State<AppState>,
-    _auth: AuthUser,
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<SubscriptionPlan>, (StatusCode, Json<ErrorResponse>)> {
     let plan = state
         .subscription_repo
-        .find_plan_by_id_rls(&mut **rls.conn(), id)
+        .find_plan_by_id(&mut **rls.conn(), id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Plan not found")),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
+
+    let plan = plan.ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("NOT_FOUND", "Plan not found")),
+        )
+    })?;
+
     Ok(Json(plan))
 }
 
@@ -539,14 +480,9 @@ async fn update_plan(
 
     let plan = state
         .subscription_repo
-        .update_plan_rls(&mut **rls.conn(), id, data)
+        .update_plan(&mut **rls.conn(), id, data)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
     Ok(Json(plan))
@@ -577,14 +513,9 @@ async fn delete_plan(
 
     let deleted = state
         .subscription_repo
-        .delete_plan_rls(&mut **rls.conn(), id)
+        .delete_plan(&mut **rls.conn(), id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
 
@@ -608,29 +539,24 @@ async fn delete_plan(
     responses(
         (status = 201, description = "Subscription created", body = OrganizationSubscription),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden - organization mismatch"),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "Subscriptions"
 )]
 async fn create_subscription(
     State(state): State<AppState>,
-    auth: AuthUser,
     mut rls: RlsConnection,
     Json(request): Json<CreateSubscriptionRequest>,
 ) -> Result<(StatusCode, Json<OrganizationSubscription>), (StatusCode, Json<ErrorResponse>)> {
-    // Verify user has access to this organization
-    verify_org_access_rls(&mut rls, auth.user_id, request.organization_id).await?;
+    ensure_org_matches(&mut rls, request.organization_id).await?;
+    let org_id = rls.tenant_id();
 
     let subscription = state
         .subscription_repo
-        .create_subscription_rls(&mut **rls.conn(), request.organization_id, request.data)
+        .create_subscription(&mut **rls.conn(), org_id, request.data)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
     Ok((StatusCode::CREATED, Json(subscription)))
@@ -650,31 +576,27 @@ async fn create_subscription(
 )]
 async fn get_subscription(
     State(state): State<AppState>,
-    auth: AuthUser,
     mut rls: RlsConnection,
     Query(query): Query<OrgQuery>,
 ) -> Result<Json<OrganizationSubscription>, (StatusCode, Json<ErrorResponse>)> {
-    // Verify user has access to this organization
-    verify_org_access_rls(&mut rls, auth.user_id, query.organization_id).await?;
+    ensure_org_matches(&mut rls, query.organization_id).await?;
+    let org_id = rls.tenant_id();
 
     let subscription = state
         .subscription_repo
-        .find_subscription_by_org_rls(&mut **rls.conn(), query.organization_id)
+        .find_subscription_by_org(&mut **rls.conn(), org_id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "No active subscription")),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
+
+    let subscription = subscription.ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("NOT_FOUND", "No active subscription")),
+        )
+    })?;
+
     Ok(Json(subscription))
 }
 
@@ -692,31 +614,27 @@ async fn get_subscription(
 )]
 async fn get_subscription_with_plan(
     State(state): State<AppState>,
-    auth: AuthUser,
     mut rls: RlsConnection,
     Query(query): Query<OrgQuery>,
 ) -> Result<Json<SubscriptionWithPlan>, (StatusCode, Json<ErrorResponse>)> {
-    // Verify user has access to this organization
-    verify_org_access_rls(&mut rls, auth.user_id, query.organization_id).await?;
+    ensure_org_matches(&mut rls, query.organization_id).await?;
+    let org_id = rls.tenant_id();
 
     let subscription = state
         .subscription_repo
-        .get_subscription_with_plan_rls(&mut **rls.conn(), query.organization_id)
+        .get_subscription_with_plan(&mut **rls.conn(), org_id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "No active subscription")),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
+
+    let subscription = subscription.ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("NOT_FOUND", "No active subscription")),
+        )
+    })?;
+
     Ok(Json(subscription))
 }
 
@@ -729,30 +647,24 @@ async fn get_subscription_with_plan(
     responses(
         (status = 200, description = "Subscription updated", body = OrganizationSubscription),
         (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Subscription not found"),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "Subscriptions"
 )]
 async fn update_subscription(
     State(state): State<AppState>,
-    auth: AuthUser,
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateOrganizationSubscription>,
 ) -> Result<Json<OrganizationSubscription>, (StatusCode, Json<ErrorResponse>)> {
-    // Verify user has access to this subscription's organization
-    let _org_id = verify_subscription_access_rls(&state, &mut rls, auth.user_id, id).await?;
-
+    // RLS scopes the by-id update to the caller's org: a cross-tenant id
+    // matches no row and surfaces as 404.
     let subscription = state
         .subscription_repo
-        .update_subscription_rls(&mut **rls.conn(), id, data)
+        .update_subscription(&mut **rls.conn(), id, data)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
     Ok(Json(subscription))
@@ -767,30 +679,22 @@ async fn update_subscription(
     responses(
         (status = 200, description = "Plan changed", body = OrganizationSubscription),
         (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Subscription not found"),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "Subscriptions"
 )]
 async fn change_plan(
     State(state): State<AppState>,
-    auth: AuthUser,
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<ChangePlanRequest>,
 ) -> Result<Json<OrganizationSubscription>, (StatusCode, Json<ErrorResponse>)> {
-    // Verify user has access to this subscription's organization
-    let _org_id = verify_subscription_access_rls(&state, &mut rls, auth.user_id, id).await?;
-
     let subscription = state
         .subscription_repo
-        .change_plan_rls(&mut **rls.conn(), id, data)
+        .change_plan(&mut **rls.conn(), id, data)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
     Ok(Json(subscription))
@@ -805,30 +709,22 @@ async fn change_plan(
     responses(
         (status = 200, description = "Subscription cancelled", body = OrganizationSubscription),
         (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Subscription not found"),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "Subscriptions"
 )]
 async fn cancel_subscription(
     State(state): State<AppState>,
-    auth: AuthUser,
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<CancelSubscriptionRequest>,
 ) -> Result<Json<OrganizationSubscription>, (StatusCode, Json<ErrorResponse>)> {
-    // Verify user has access to this subscription's organization
-    let _org_id = verify_subscription_access_rls(&state, &mut rls, auth.user_id, id).await?;
-
     let subscription = state
         .subscription_repo
-        .cancel_subscription_rls(&mut **rls.conn(), id, data)
+        .cancel_subscription(&mut **rls.conn(), id, data)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
     Ok(Json(subscription))
@@ -842,29 +738,21 @@ async fn cancel_subscription(
     responses(
         (status = 200, description = "Subscription reactivated", body = OrganizationSubscription),
         (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Subscription not found"),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "Subscriptions"
 )]
 async fn reactivate_subscription(
     State(state): State<AppState>,
-    auth: AuthUser,
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<OrganizationSubscription>, (StatusCode, Json<ErrorResponse>)> {
-    // Verify user has access to this subscription's organization
-    let _org_id = verify_subscription_access_rls(&state, &mut rls, auth.user_id, id).await?;
-
     let subscription = state
         .subscription_repo
-        .reactivate_subscription_rls(&mut **rls.conn(), id)
+        .reactivate_subscription(&mut **rls.conn(), id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
     Ok(Json(subscription))
@@ -894,19 +782,14 @@ async fn list_all_subscriptions(
 
     let subscriptions = state
         .subscription_repo
-        .list_all_subscriptions_rls(
+        .list_all_subscriptions(
             &mut **rls.conn(),
             query.status.as_deref(),
             query.limit.unwrap_or(50),
             query.offset.unwrap_or(0),
         )
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
     Ok(Json(subscriptions))
@@ -922,30 +805,25 @@ async fn list_all_subscriptions(
     responses(
         (status = 201, description = "Payment method created", body = SubscriptionPaymentMethod),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden - organization mismatch"),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "Subscriptions"
 )]
 async fn create_payment_method(
     State(state): State<AppState>,
-    auth: AuthUser,
     mut rls: RlsConnection,
     Query(query): Query<OrgQuery>,
     Json(data): Json<CreateSubscriptionPaymentMethod>,
 ) -> Result<(StatusCode, Json<SubscriptionPaymentMethod>), (StatusCode, Json<ErrorResponse>)> {
-    // Verify user has access to this organization
-    verify_org_access_rls(&mut rls, auth.user_id, query.organization_id).await?;
+    ensure_org_matches(&mut rls, query.organization_id).await?;
+    let org_id = rls.tenant_id();
 
     let method = state
         .subscription_repo
-        .create_payment_method_rls(&mut **rls.conn(), query.organization_id, data)
+        .create_payment_method(&mut **rls.conn(), org_id, data)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
     Ok((StatusCode::CREATED, Json(method)))
@@ -965,23 +843,17 @@ async fn create_payment_method(
 )]
 async fn list_payment_methods(
     State(state): State<AppState>,
-    auth: AuthUser,
     mut rls: RlsConnection,
     Query(query): Query<OrgQuery>,
 ) -> Result<Json<Vec<SubscriptionPaymentMethod>>, (StatusCode, Json<ErrorResponse>)> {
-    // Verify user has access to this organization
-    verify_org_access_rls(&mut rls, auth.user_id, query.organization_id).await?;
+    ensure_org_matches(&mut rls, query.organization_id).await?;
+    let org_id = rls.tenant_id();
 
     let methods = state
         .subscription_repo
-        .list_payment_methods_rls(&mut **rls.conn(), query.organization_id)
+        .list_payment_methods(&mut **rls.conn(), org_id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
     Ok(Json(methods))
@@ -1004,30 +876,22 @@ async fn list_payment_methods(
 )]
 async fn set_default_payment_method(
     State(state): State<AppState>,
-    auth: AuthUser,
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Query(query): Query<OrgQuery>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    // Verify user has access to this organization
-    verify_org_access_rls(&mut rls, auth.user_id, query.organization_id).await?;
+    ensure_org_matches(&mut rls, query.organization_id).await?;
+    let org_id = rls.tenant_id();
 
-    // Release RLS connection before calling transaction-based method
-    rls.release().await;
-
-    // Note: set_default_payment_method uses internal transaction, not RLS-aware
-    // This is intentional as documented in the repository
+    // Transactional, but runs on the RLS-context connection: payment_methods
+    // is FORCE-RLS-bound, so the raw pool would be deny-all here.
     state
         .subscription_repo
-        .set_default_payment_method(query.organization_id, id)
+        .set_default_payment_method(&mut **rls.conn(), org_id, id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
+    rls.release().await;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -1049,24 +913,18 @@ async fn set_default_payment_method(
 )]
 async fn delete_payment_method(
     State(state): State<AppState>,
-    auth: AuthUser,
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Query(query): Query<OrgQuery>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    // Verify user has access to this organization
-    verify_org_access_rls(&mut rls, auth.user_id, query.organization_id).await?;
+    ensure_org_matches(&mut rls, query.organization_id).await?;
+    let org_id = rls.tenant_id();
 
     let deleted = state
         .subscription_repo
-        .delete_payment_method_rls(&mut **rls.conn(), id, query.organization_id)
+        .delete_payment_method(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
 
@@ -1096,27 +954,17 @@ async fn delete_payment_method(
 )]
 async fn list_invoices(
     State(state): State<AppState>,
-    auth: AuthUser,
     mut rls: RlsConnection,
     Query(query): Query<ListInvoicesQuery>,
 ) -> Result<Json<Vec<SubscriptionInvoice>>, (StatusCode, Json<ErrorResponse>)> {
-    // Verify user has access to this organization
-    verify_org_access_rls(&mut rls, auth.user_id, query.organization_id).await?;
+    ensure_org_matches(&mut rls, query.organization_id).await?;
+    let org_id = rls.tenant_id();
 
     let invoices = state
         .subscription_repo
-        .list_invoices_rls(
-            &mut **rls.conn(),
-            query.organization_id,
-            InvoiceQueryParams::from(&query),
-        )
+        .list_invoices(&mut **rls.conn(), org_id, InvoiceQueryParams::from(&query))
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
     Ok(Json(invoices))
@@ -1136,31 +984,26 @@ async fn list_invoices(
 )]
 async fn get_invoice(
     State(state): State<AppState>,
-    auth: AuthUser,
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<SubscriptionInvoice>, (StatusCode, Json<ErrorResponse>)> {
-    // Verify access and get the invoice
-    let _org_id = verify_invoice_access_rls(&state, &mut rls, auth.user_id, id).await?;
-
+    // RLS scopes the by-id read to the caller's org: a cross-tenant invoice
+    // is indistinguishable from a missing one (404).
     let invoice = state
         .subscription_repo
-        .find_invoice_by_id_rls(&mut **rls.conn(), id)
+        .find_invoice_by_id(&mut **rls.conn(), id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Invoice not found")),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
+
+    let invoice = invoice.ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("NOT_FOUND", "Invoice not found")),
+        )
+    })?;
+
     Ok(Json(invoice))
 }
 
@@ -1171,29 +1014,37 @@ async fn get_invoice(
     params(("id" = Uuid, Path, description = "Invoice ID")),
     responses(
         (status = 200, description = "Line items retrieved", body = Vec<InvoiceLineItem>),
+        (status = 404, description = "Invoice not found"),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "Subscriptions"
 )]
 async fn get_invoice_line_items(
     State(state): State<AppState>,
-    auth: AuthUser,
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Vec<InvoiceLineItem>>, (StatusCode, Json<ErrorResponse>)> {
-    // Verify user has access to this invoice's organization
-    let _org_id = verify_invoice_access_rls(&state, &mut rls, auth.user_id, id).await?;
+    // Resolve the invoice first so a cross-tenant (RLS-invisible) id keeps
+    // returning 404 rather than an empty list.
+    let invoice = state
+        .subscription_repo
+        .find_invoice_by_id(&mut **rls.conn(), id)
+        .await
+        .map_err(db_error)?;
+
+    if invoice.is_none() {
+        rls.release().await;
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("NOT_FOUND", "Invoice not found")),
+        ));
+    }
 
     let items = state
         .subscription_repo
-        .get_invoice_line_items_rls(&mut **rls.conn(), id)
+        .get_invoice_line_items(&mut **rls.conn(), id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
     Ok(Json(items))
@@ -1207,29 +1058,21 @@ async fn get_invoice_line_items(
     responses(
         (status = 200, description = "Invoice marked as paid", body = SubscriptionInvoice),
         (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Invoice not found"),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "Subscriptions"
 )]
 async fn mark_invoice_paid(
     State(state): State<AppState>,
-    auth: AuthUser,
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<SubscriptionInvoice>, (StatusCode, Json<ErrorResponse>)> {
-    // Verify user has access to this invoice's organization
-    let _org_id = verify_invoice_access_rls(&state, &mut rls, auth.user_id, id).await?;
-
     let invoice = state
         .subscription_repo
-        .mark_invoice_paid_rls(&mut **rls.conn(), id, None)
+        .mark_invoice_paid(&mut **rls.conn(), id, None)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
     Ok(Json(invoice))
@@ -1243,29 +1086,21 @@ async fn mark_invoice_paid(
     responses(
         (status = 200, description = "Invoice voided", body = SubscriptionInvoice),
         (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Invoice not found"),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "Subscriptions"
 )]
 async fn void_invoice(
     State(state): State<AppState>,
-    auth: AuthUser,
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<SubscriptionInvoice>, (StatusCode, Json<ErrorResponse>)> {
-    // Verify user has access to this invoice's organization
-    let _org_id = verify_invoice_access_rls(&state, &mut rls, auth.user_id, id).await?;
-
     let invoice = state
         .subscription_repo
-        .void_invoice_rls(&mut **rls.conn(), id)
+        .void_invoice(&mut **rls.conn(), id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
     Ok(Json(invoice))
@@ -1295,14 +1130,9 @@ async fn list_all_invoices(
 
     let invoices = state
         .subscription_repo
-        .list_all_invoices_rls(&mut **rls.conn(), InvoiceQueryParams::from(&query))
+        .list_all_invoices(&mut **rls.conn(), InvoiceQueryParams::from(&query))
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
     Ok(Json(invoices))
@@ -1318,46 +1148,36 @@ async fn list_all_invoices(
     responses(
         (status = 201, description = "Usage recorded", body = db::models::UsageRecord),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden - organization mismatch"),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "Subscriptions"
 )]
 async fn record_usage(
     State(state): State<AppState>,
-    auth: AuthUser,
     mut rls: RlsConnection,
     Json(request): Json<RecordUsageRequest>,
 ) -> Result<(StatusCode, Json<db::models::UsageRecord>), (StatusCode, Json<ErrorResponse>)> {
-    // Verify user has access to this organization
-    verify_org_access_rls(&mut rls, auth.user_id, request.organization_id).await?;
+    ensure_org_matches(&mut rls, request.organization_id).await?;
+    let org_id = rls.tenant_id();
 
     // Get subscription for org
     let subscription = state
         .subscription_repo
-        .find_subscription_by_org_rls(&mut **rls.conn(), request.organization_id)
+        .find_subscription_by_org(&mut **rls.conn(), org_id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     let record = state
         .subscription_repo
-        .record_usage_rls(
+        .record_usage(
             &mut **rls.conn(),
-            request.organization_id,
+            org_id,
             subscription.map(|s| s.id),
             request.data,
         )
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
     Ok((StatusCode::CREATED, Json(record)))
@@ -1377,12 +1197,11 @@ async fn record_usage(
 )]
 async fn get_usage_summary(
     State(state): State<AppState>,
-    auth: AuthUser,
     mut rls: RlsConnection,
     Query(query): Query<UsageSummaryQuery>,
 ) -> Result<Json<Vec<UsageSummary>>, (StatusCode, Json<ErrorResponse>)> {
-    // Verify user has access to this organization
-    verify_org_access_rls(&mut rls, auth.user_id, query.organization_id).await?;
+    ensure_org_matches(&mut rls, query.organization_id).await?;
+    let org_id = rls.tenant_id();
 
     let now = Utc::now();
     let period_start = query.period_start.unwrap_or(
@@ -1393,19 +1212,9 @@ async fn get_usage_summary(
 
     let summary = state
         .subscription_repo
-        .get_usage_summary_rls(
-            &mut **rls.conn(),
-            query.organization_id,
-            period_start,
-            period_end,
-        )
+        .get_usage_summary(&mut **rls.conn(), org_id, period_start, period_end)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
     Ok(Json(summary))
@@ -1425,23 +1234,17 @@ async fn get_usage_summary(
 )]
 async fn get_current_usage(
     State(state): State<AppState>,
-    auth: AuthUser,
     mut rls: RlsConnection,
     Query(query): Query<OrgQuery>,
 ) -> Result<Json<CurrentUsageResponse>, (StatusCode, Json<ErrorResponse>)> {
-    // Verify user has access to this organization
-    verify_org_access_rls(&mut rls, auth.user_id, query.organization_id).await?;
+    ensure_org_matches(&mut rls, query.organization_id).await?;
+    let org_id = rls.tenant_id();
 
     let (buildings, units, users, storage) = state
         .subscription_repo
-        .get_current_usage_rls(&mut **rls.conn(), query.organization_id)
+        .get_current_usage(&mut **rls.conn(), org_id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
     Ok(Json(CurrentUsageResponse {
@@ -1478,14 +1281,9 @@ async fn create_coupon(
 
     let coupon = state
         .subscription_repo
-        .create_coupon_rls(&mut **rls.conn(), data)
+        .create_coupon(&mut **rls.conn(), data)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
     Ok((StatusCode::CREATED, Json(coupon)))
@@ -1505,20 +1303,14 @@ async fn create_coupon(
 )]
 async fn list_coupons(
     State(state): State<AppState>,
-    _auth: AuthUser,
     mut rls: RlsConnection,
     Query(query): Query<ListCouponsQuery>,
 ) -> Result<Json<Vec<SubscriptionCoupon>>, (StatusCode, Json<ErrorResponse>)> {
     let coupons = state
         .subscription_repo
-        .list_coupons_rls(&mut **rls.conn(), query.active_only.unwrap_or(true))
+        .list_coupons(&mut **rls.conn(), query.active_only.unwrap_or(true))
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
     Ok(Json(coupons))
@@ -1534,6 +1326,7 @@ async fn list_coupons(
         (status = 200, description = "Coupon updated", body = SubscriptionCoupon),
         (status = 401, description = "Unauthorized"),
         (status = 403, description = "Forbidden - platform admin only"),
+        (status = 404, description = "Coupon not found"),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "Subscriptions"
@@ -1550,14 +1343,9 @@ async fn update_coupon(
 
     let coupon = state
         .subscription_repo
-        .update_coupon_rls(&mut **rls.conn(), id, data)
+        .update_coupon(&mut **rls.conn(), id, data)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
     Ok(Json(coupon))
@@ -1578,25 +1366,20 @@ async fn update_coupon(
 )]
 async fn redeem_coupon(
     State(state): State<AppState>,
-    auth: AuthUser,
     mut rls: RlsConnection,
     Query(query): Query<OrgQuery>,
     Json(data): Json<RedeemCouponRequest>,
 ) -> Result<Json<CouponRedemption>, (StatusCode, Json<ErrorResponse>)> {
-    // Verify user has access to this organization
-    verify_org_access_rls(&mut rls, auth.user_id, query.organization_id).await?;
+    ensure_org_matches(&mut rls, query.organization_id).await?;
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
 
     // Find the coupon
     let coupon = state
         .subscription_repo
-        .find_coupon_by_code_rls(&mut **rls.conn(), &data.coupon_code)
+        .find_coupon_by_code(&mut **rls.conn(), &data.coupon_code)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?
+        .map_err(db_error)?
         .ok_or_else(|| {
             (
                 StatusCode::NOT_FOUND,
@@ -1610,36 +1393,26 @@ async fn redeem_coupon(
     // Get subscription for org
     let subscription = state
         .subscription_repo
-        .find_subscription_by_org_rls(&mut **rls.conn(), query.organization_id)
+        .find_subscription_by_org(&mut **rls.conn(), org_id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
-    // Release RLS connection before calling transaction-based method
-    rls.release().await;
-
-    // Note: redeem_coupon uses internal transaction, not RLS-aware
-    // This is intentional as documented in the repository
+    // Transactional, but runs on the RLS-context connection: the
+    // coupon_redemptions insert is FORCE-RLS-bound, so the raw pool would
+    // fail the policy WITH CHECK.
     let redemption = state
         .subscription_repo
         .redeem_coupon(
+            &mut **rls.conn(),
             coupon.id,
-            query.organization_id,
+            org_id,
             subscription.map(|s| s.id),
-            auth.user_id,
+            user_id,
         )
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
+    rls.release().await;
     Ok(Json(redemption))
 }
 
@@ -1667,14 +1440,9 @@ async fn get_statistics(
 
     let stats = state
         .subscription_repo
-        .get_statistics_rls(&mut **rls.conn())
+        .get_statistics(&mut **rls.conn())
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
+        .map_err(db_error)?;
 
     rls.release().await;
     Ok(Json(stats))

--- a/backend/servers/api-server/src/routes/subscriptions.rs
+++ b/backend/servers/api-server/src/routes/subscriptions.rs
@@ -554,7 +554,7 @@ async fn create_subscription(
 
     let subscription = state
         .subscription_repo
-        .create_subscription(&mut **rls.conn(), org_id, request.data)
+        .create_subscription(rls.conn(), org_id, request.data)
         .await
         .map_err(db_error)?;
 
@@ -887,7 +887,7 @@ async fn set_default_payment_method(
     // is FORCE-RLS-bound, so the raw pool would be deny-all here.
     state
         .subscription_repo
-        .set_default_payment_method(&mut **rls.conn(), org_id, id)
+        .set_default_payment_method(rls.conn(), org_id, id)
         .await
         .map_err(db_error)?;
 
@@ -1403,7 +1403,7 @@ async fn redeem_coupon(
     let redemption = state
         .subscription_repo
         .redeem_coupon(
-            &mut **rls.conn(),
+            rls.conn(),
             coupon.id,
             org_id,
             subscription.map(|s| s.id),
@@ -1440,7 +1440,7 @@ async fn get_statistics(
 
     let stats = state
         .subscription_repo
-        .get_statistics(&mut **rls.conn())
+        .get_statistics(rls.conn())
         .await
         .map_err(db_error)?;
 


### PR DESCRIPTION
## Summary

Part of the PAP-80 raw-pool→RLS sweep (work_order/vendor/llm_document precedent). `SubscriptionRepository` held a raw `PgPool` and its legacy methods queried the 7 FORCE-RLS billing tables from migration 00179 (`organization_subscriptions`, `payment_methods`, `subscription_invoices`, `invoice_line_items`, `usage_records`, `subscription_events`, `coupon_redemptions`) without ever setting `app.current_org_id` — deny-all on dev. Mounted at `/api/v1/subscriptions` + `/api/v1/admin/subscriptions`.

## Changes

- **Repo is stateless** — no pool field (`new(_pool)` kept for the AppState construction site); all 35 deprecated legacy wrappers deleted; `_rls` suffixes dropped.
- Single-statement methods take a generic `Executor`; multi-statement ones (`create_subscription` plan-lookup+insert, `create_invoice` nextval+insert, `get_statistics`) take `&mut PgConnection` and reborrow.
- **The two formerly raw-pool transactions (`set_default_payment_method`, `redeem_coupon`) now run `conn.begin()` on the RLS-context connection** — both write FORCE-RLS tables and were broken on the pool. Session-level GUCs survive BEGIN/COMMIT.
- Handlers: `rls.tenant_id()` is the authoritative org — request-supplied `organization_id` is checked against it (403 on mismatch) instead of the old per-request DB membership query; RLS-invisible by-id rows map to 404 (`RowNotFound`).
- Public `/plans/public` keeps the plain pool: `subscription_plans` is not FORCE-bound (public read policy, untouched by 00179) and the endpoint has no tenant principal.
- Admin list/statistics endpoints keep their existing super-admin gate; under FORCE RLS their figures are scoped to the caller's tenant context (pre-existing behavior since the handlers moved to `RlsConnection`, noted in doc comments).

## Verification (all remote/mercury per the control-plane capacity guardrail)

- `cargo check -p db` ✅ / `cargo check -p api-server` ✅
- `cargo clippy -p db -p api-server -- -D warnings` ✅
- `cargo fmt --all --check` ✅
- New `backend/crates/db/tests/subscription_rls_repo_tests.rs` — NOSUPERUSER NOBYPASSRLS role-switch test (deny-all repro without context, own-org reads + cross-tenant by-id `None` with context, `create_subscription` write path) — executed for real against Postgres; result posted below when the run completes.

Depends on #1245 for a green dev `test` gate (pre-existing PM-photos test failures from #1233).

🤖 Generated with [Claude Code](https://claude.com/claude-code)