### PR TITLE
fix(backend): clear clippy --all-targets lint debt, widen CI gate (PAP-124)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -48,11 +48,15 @@ jobs:
         working-directory: backend
         run: cargo fmt --all -- --check
 
+      # `--all-targets` includes test/bench targets — without it, test-only
+      # lint debt lands silently and the documented local pre-flight
+      # (`cargo clippy --workspace --all-targets -- -D warnings`) diverges
+      # from CI (PAP-124).
       - name: Clippy
         working-directory: backend
         env:
           SQLX_OFFLINE: true
-        run: cargo clippy --workspace -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: RLS Enforcement Check
         working-directory: backend

--- a/backend/servers/api-server/src/routes/admin/mod.rs
+++ b/backend/servers/api-server/src/routes/admin/mod.rs
@@ -72,6 +72,28 @@ pub(super) fn audit_ip_from_headers(headers: &HeaderMap) -> Option<&str> {
     Some(&first[..end])
 }
 
+/// Combined `/api/v1/admin` router. Layered with admin extensions in
+/// `lib.rs::create_router`.
+pub fn router() -> Router<AppState> {
+    Router::new()
+        // Pre-Phase-5 user-lifecycle endpoints (Epic 1, Story 1.6) own
+        // `/users`, `/users/{id}`, `/users/{id}/{suspend,reactivate,delete}`.
+        .merge(users_lifecycle::lifecycle_router())
+        // Phase 2 membership invite/accept/revoke.
+        .merge(memberships::router())
+        // Phase 5 admin tree (capability-gated). The Phase 5 admin/users
+        // module owns global user search + principal_kind transitions —
+        // mounted under /principals to avoid colliding with the legacy
+        // /users routes from users_lifecycle above.
+        .nest("/agencies", agencies::router())
+        .nest("/principals", users::router())
+        .nest("/audit", audit::router())
+        .nest("/capabilities", capabilities::router())
+        .nest("/impersonation", impersonation::router())
+        .nest("/mfa", mfa::router())
+        .nest("/metrics", metrics::router())
+}
+
 #[cfg(test)]
 mod tests {
     use super::audit_ip_from_headers;
@@ -120,26 +142,4 @@ mod tests {
         let h = hdr(v6);
         assert_eq!(audit_ip_from_headers(&h), Some(v6));
     }
-}
-
-/// Combined `/api/v1/admin` router. Layered with admin extensions in
-/// `lib.rs::create_router`.
-pub fn router() -> Router<AppState> {
-    Router::new()
-        // Pre-Phase-5 user-lifecycle endpoints (Epic 1, Story 1.6) own
-        // `/users`, `/users/{id}`, `/users/{id}/{suspend,reactivate,delete}`.
-        .merge(users_lifecycle::lifecycle_router())
-        // Phase 2 membership invite/accept/revoke.
-        .merge(memberships::router())
-        // Phase 5 admin tree (capability-gated). The Phase 5 admin/users
-        // module owns global user search + principal_kind transitions —
-        // mounted under /principals to avoid colliding with the legacy
-        // /users routes from users_lifecycle above.
-        .nest("/agencies", agencies::router())
-        .nest("/principals", users::router())
-        .nest("/audit", audit::router())
-        .nest("/capabilities", capabilities::router())
-        .nest("/impersonation", impersonation::router())
-        .nest("/mfa", mfa::router())
-        .nest("/metrics", metrics::router())
 }

--- a/backend/servers/api-server/tests/aml_dsa_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/aml_dsa_cross_org_idor_tests.rs
@@ -11,7 +11,7 @@
 //! - `get_aml_assessment` → `get_aml_assessment(id)`  (assessment / PEP / sanctions leak)
 //! - `get_edd_record`     → `get_edd(id)`             (EDD record / source-of-funds leak)
 //! - `upload_edd_document`/`verify_edd_document`/`add_edd_note`/`complete_edd`
-//!       all gate on `get_edd(id)` → cross-org mutate of another org's EDD subtree
+//!   all gate on `get_edd(id)` → cross-org mutate of another org's EDD subtree
 //!
 //! The `aml_risk_assessments` / `edd_records` tables DO ship FORCE-RLS policies
 //! (migration `00117_rls_edd.sql`) scoped to `get_current_org_id()`, but these

--- a/backend/servers/api-server/tests/enhanced_screening_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/enhanced_screening_cross_org_idor_tests.rs
@@ -291,7 +291,7 @@ async fn repo_ai_result_is_scoped_to_owning_org(pool: PgPool) {
 
     // The complete-data aggregate is likewise closed for the foreign org.
     let cross_complete = repo
-        .get_complete_screening_data(&mut *conn, org_b, screening_a)
+        .get_complete_screening_data(&mut conn, org_b, screening_a)
         .await
         .expect("complete data with wrong org");
     assert!(
@@ -301,7 +301,7 @@ async fn repo_ai_result_is_scoped_to_owning_org(pool: PgPool) {
 
     // ...and open for the owner.
     let own_complete = repo
-        .get_complete_screening_data(&mut *conn, org_a, screening_a)
+        .get_complete_screening_data(&mut conn, org_a, screening_a)
         .await
         .expect("complete data with right org");
     assert!(

--- a/backend/servers/api-server/tests/iot_auth_tests.rs
+++ b/backend/servers/api-server/tests/iot_auth_tests.rs
@@ -45,7 +45,7 @@ async fn iot_endpoints_require_auth(pool: PgPool) {
     let base = "/api/v1/iot/sensors";
 
     let cases: Vec<(Method, String, Option<&str>)> = vec![
-        (Method::POST, format!("{base}"), Some(r#"{"name":"x"}"#)),
+        (Method::POST, base.to_string(), Some(r#"{"name":"x"}"#)),
         (Method::GET, format!("{base}/{sid}"), None),
         (Method::PUT, format!("{base}/{sid}"), Some(r#"{}"#)),
         (Method::DELETE, format!("{base}/{sid}"), None),

--- a/backend/servers/api-server/tests/portal_webhook_signature_tests.rs
+++ b/backend/servers/api-server/tests/portal_webhook_signature_tests.rs
@@ -47,7 +47,10 @@ const VIEWS_URI: &str = "/api/v1/webhooks/portals/reality-portal/views";
 /// `std::env::{set_var, remove_var}` are not safe to interleave with `getenv`
 /// on glibc, and integration tests in this binary may run concurrently. Every
 /// test that mutates the webhook-secret env serializes behind this mutex.
-static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+/// Async-aware (`tokio::sync::Mutex`) because the guard must stay held across
+/// the `.await`s of the whole test body — the env var has to remain stable
+/// while `TestApp` boots and the request executes.
+static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 /// Compute the `sha256=<base64>` header value the verifier expects for `body`.
 fn sign(secret: &str, body: &[u8]) -> String {
@@ -60,7 +63,7 @@ fn sign(secret: &str, body: &[u8]) -> String {
 /// well-formed body) with `401` — never silently accepts an unverified payload.
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn unconfigured_secret_rejects_webhook(pool: PgPool) {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = ENV_LOCK.lock().await;
     std::env::remove_var(PORTAL_SECRET_ENV);
 
     let app = TestApp::new(pool).await;
@@ -85,7 +88,7 @@ async fn unconfigured_secret_rejects_webhook(pool: PgPool) {
 /// rejects with `401` before parsing the body or touching the database.
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn invalid_signature_is_rejected(pool: PgPool) {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = ENV_LOCK.lock().await;
     std::env::set_var(PORTAL_SECRET_ENV, "super-secret-key");
 
     let app = TestApp::new(pool).await;
@@ -112,7 +115,7 @@ async fn invalid_signature_is_rejected(pool: PgPool) {
 /// entirely, the route rejects with `401`.
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn missing_signature_header_is_rejected(pool: PgPool) {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = ENV_LOCK.lock().await;
     std::env::set_var(PORTAL_SECRET_ENV, "super-secret-key");
 
     let app = TestApp::new(pool).await;
@@ -141,7 +144,7 @@ async fn missing_signature_header_is_rejected(pool: PgPool) {
 /// signature was accepted rather than rejected as forged.
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn valid_signature_is_accepted(pool: PgPool) {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = ENV_LOCK.lock().await;
     let secret = "super-secret-key";
     std::env::set_var(PORTAL_SECRET_ENV, secret);
 

--- a/backend/servers/api-server/tests/push_token_tests.rs
+++ b/backend/servers/api-server/tests/push_token_tests.rs
@@ -81,6 +81,7 @@ fn empty_request(method: Method, uri: &str) -> Request<Body> {
 /// - 401 when `AuthUser` can't find/validate a Bearer token.
 /// - 400 when the `X-Tenant-ID` header is missing.
 /// - 403 when a resolved tenant disagrees with the header.
+///
 /// What must NEVER happen is 2xx — that would mean a mutation succeeded.
 fn assert_rejected(status: StatusCode, ctx: &str) {
     let code = status.as_u16();

--- a/backend/servers/api-server/tests/report_schedule_rbac_tests.rs
+++ b/backend/servers/api-server/tests/report_schedule_rbac_tests.rs
@@ -4,9 +4,9 @@
 //!   - #614  RequireCapability / role check on `PUT /api/v1/reports/schedules/{id}`
 //!   - #624  Cross-tenant mutation: caller in Org B could update Org A's schedule
 //!   - #696  Original test suite only proved the outer JWT gate worked — the
-//!          RBAC predicate (`rls.role().is_manager()`) and the cross-tenant
-//!          WHERE clause (`AND organization_id = $caller_org_id`) were never
-//!          exercised because every request was sent without a Bearer JWT.
+//!     RBAC predicate (`rls.role().is_manager()`) and the cross-tenant
+//!     WHERE clause (`AND organization_id = $caller_org_id`) were never
+//!     exercised because every request was sent without a Bearer JWT.
 //!
 //! # What these tests verify
 //!

--- a/backend/servers/api-server/tests/report_schedule_sibling_scope_tests.rs
+++ b/backend/servers/api-server/tests/report_schedule_sibling_scope_tests.rs
@@ -5,16 +5,16 @@
 //!   - #624  Cross-tenant mutation via missing org_id in WHERE (update_schedule)
 //!   - #646  pause_schedule and resume_schedule IDOR (no org scope in WHERE)
 //!   - #647  list_executions / get_execution / get_execution_download_url /
-//!            retry_execution IDOR (no org scope)
+//!     retry_execution IDOR (no org scope)
 //!   - #693  The original cross-tenant tests below sent only `X-Tenant-ID`
-//!          (no Bearer JWT), so `AuthUser`/`RlsConnection` returned 401 at the
-//!          outer gate and the `AND organization_id = $caller_org_id` clause in
-//!          `pause`, `resume`, `get_by_id_scoped`, `get_execution_scoped`, and
-//!          `retry_execution_scoped` was never exercised. The companion
-//!          `*_authenticated` tests below send a real Bearer JWT from a
-//!          manager/resident in `org_b` targeting an `org_a` resource, asserting
-//!          the org-scoped WHERE clause produces a 404 — proving the DB-layer
-//!          isolation fires, not the auth gate.
+//!     (no Bearer JWT), so `AuthUser`/`RlsConnection` returned 401 at the
+//!     outer gate and the `AND organization_id = $caller_org_id` clause in
+//!     `pause`, `resume`, `get_by_id_scoped`, `get_execution_scoped`, and
+//!     `retry_execution_scoped` was never exercised. The companion
+//!     `*_authenticated` tests below send a real Bearer JWT from a
+//!     manager/resident in `org_b` targeting an `org_a` resource, asserting
+//!     the org-scoped WHERE clause produces a 404 — proving the DB-layer
+//!     isolation fires, not the auth gate.
 //!
 //! # Audit-matrix note
 //!

--- a/backend/servers/api-server/tests/ws_integration_tests.rs
+++ b/backend/servers/api-server/tests/ws_integration_tests.rs
@@ -109,25 +109,23 @@ fn refresh_token(user_id: Uuid) -> String {
 /// `sqlx::test` provides an isolated PgPool; we wrap it in `TestApp` to
 /// reuse the same `AppState` construction as the rest of the test suite,
 /// then hand the router to `TestServer`.
-fn build_ws_test_server(pool: PgPool) -> impl std::future::Future<Output = TestServer> {
-    async move {
-        // Ensure JWT_SECRET and RUST_ENV are set before the first TestApp.
-        // TestApp::new does this via its `Once` guards, so we just call it.
-        let test_app = TestApp::new(pool).await;
+async fn build_ws_test_server(pool: PgPool) -> TestServer {
+    // Ensure JWT_SECRET and RUST_ENV are set before the first TestApp.
+    // TestApp::new does this via its `Once` guards, so we just call it.
+    let test_app = TestApp::new(pool).await;
 
-        // Build TestServer with real HTTP transport for WS upgrade support.
-        // `build` returns `TestServer` directly (panics on internal error).
-        TestServerBuilder::new()
-            .http_transport()
-            .build(
-                test_app
-                    .router
-                    .layer(MockConnectInfo(std::net::SocketAddr::from((
-                        [127, 0, 0, 1],
-                        0,
-                    )))),
-            )
-    }
+    // Build TestServer with real HTTP transport for WS upgrade support.
+    // `build` returns `TestServer` directly (panics on internal error).
+    TestServerBuilder::new()
+        .http_transport()
+        .build(
+            test_app
+                .router
+                .layer(MockConnectInfo(std::net::SocketAddr::from((
+                    [127, 0, 0, 1],
+                    0,
+                )))),
+        )
 }
 
 // ============================================================================
@@ -498,10 +496,10 @@ async fn ws_pubsub_fanout_delivers_to_correct_subscriber(pool: PgPool) {
                 .unwrap(),
         );
 
-        let router = api_server::create_router(state).layer(MockConnectInfo(
-            std::net::SocketAddr::from(([127, 0, 0, 1], 0)),
-        ));
-        router
+        api_server::create_router(state).layer(MockConnectInfo(std::net::SocketAddr::from((
+            [127, 0, 0, 1],
+            0,
+        ))))
     };
 
     // `build` returns `TestServer` directly (panics on internal failure).

--- a/backend/servers/deploy-server/src/infra/blue_green.rs
+++ b/backend/servers/deploy-server/src/infra/blue_green.rs
@@ -345,71 +345,6 @@ pub fn build_service_envs(
     Ok(envs)
 }
 
-#[cfg(test)]
-mod build_service_envs_tests {
-    use super::*;
-
-    fn test_target() -> crate::config::Target {
-        crate::config::Target {
-            docker_socket: "/var/run/docker.sock".into(),
-            caddy_url: "http://localhost:2019".into(),
-            reality_apex: "staging.rlt.sk".into(),
-            ppt_apex: "staging.ppt.rlt.sk".into(),
-            idle_timeout: None,
-            promote_strategy: None,
-            rollback_mode: "manual".into(),
-            health_grace: None,
-        }
-    }
-
-    fn set_all_required_secrets() {
-        // Deploy-server-side secrets `build_service_envs` reads, satisfying its
-        // length/hex validation.
-        std::env::set_var("POSTGRES_PASSWORD", "test-postgres-password");
-        std::env::set_var("PPT_JWT_SECRET", "x".repeat(32));
-        std::env::set_var("PPT_TOTP_ENCRYPTION_KEY", "a".repeat(64));
-        std::env::set_var("PPT_INTEGRATION_ENCRYPTION_KEY", "b".repeat(64));
-        std::env::set_var("PPT_PM_CLIENT_SECRET", "c".repeat(32));
-        std::env::set_var("PPT_ESIGN_TOKEN_SECRET", "d".repeat(32));
-        std::env::set_var("PPT_ESIGN_WEBHOOK_SECRET", "webhook-secret");
-    }
-
-    /// Issue #951: every secret the api-server requires at startup
-    /// (`API_REQUIRED_STARTUP_ENV`) must be injected onto the `api` container by
-    /// `build_service_envs`, or the container crash-loops on deploy — and when
-    /// any required deploy-server secret is absent, `build_service_envs` must
-    /// fail fast with a `Config` error rather than start empty-valued containers.
-    ///
-    /// Both halves are in one test because they mutate process-wide env vars and
-    /// would race if run as separate (parallel) tests.
-    #[test]
-    fn build_service_envs_enforces_api_startup_contract() {
-        set_all_required_secrets();
-
-        let envs = build_service_envs("staging", &test_target())
-            .expect("build_service_envs should succeed with all secrets set");
-        let api_env = envs.get("api").expect("`api` service env must exist");
-
-        for key in API_REQUIRED_STARTUP_ENV {
-            assert!(
-                api_env.iter().any(|kv| kv.starts_with(&format!("{key}="))),
-                "the `api` container env is missing `{key}`, which api-server requires at \
-                 startup (issue #951). Add it to `build_service_envs` so the deploy doesn't \
-                 crash-loop the api container."
-            );
-        }
-
-        // Missing required secret -> fail fast with a Config error.
-        std::env::remove_var("PPT_ESIGN_TOKEN_SECRET");
-        let err = build_service_envs("staging", &test_target())
-            .expect_err("must error when a required secret is missing");
-        assert!(
-            matches!(err, crate::DeployError::Config(_)),
-            "expected a Config error, got {err:?}"
-        );
-    }
-}
-
 impl BlueGreenDeployer {
     pub async fn deploy(&self, spec: &BlueGreenSpec) -> Result<()> {
         let docker = self.docker.bollard();
@@ -850,3 +785,68 @@ impl BlueGreenDeployer {
 // Backward-compat aliases (callers from Phase 2 use the staging names).
 pub type StagingDeployer = BlueGreenDeployer;
 pub type StagingDeploySpec = BlueGreenSpec;
+
+#[cfg(test)]
+mod build_service_envs_tests {
+    use super::*;
+
+    fn test_target() -> crate::config::Target {
+        crate::config::Target {
+            docker_socket: "/var/run/docker.sock".into(),
+            caddy_url: "http://localhost:2019".into(),
+            reality_apex: "staging.rlt.sk".into(),
+            ppt_apex: "staging.ppt.rlt.sk".into(),
+            idle_timeout: None,
+            promote_strategy: None,
+            rollback_mode: "manual".into(),
+            health_grace: None,
+        }
+    }
+
+    fn set_all_required_secrets() {
+        // Deploy-server-side secrets `build_service_envs` reads, satisfying its
+        // length/hex validation.
+        std::env::set_var("POSTGRES_PASSWORD", "test-postgres-password");
+        std::env::set_var("PPT_JWT_SECRET", "x".repeat(32));
+        std::env::set_var("PPT_TOTP_ENCRYPTION_KEY", "a".repeat(64));
+        std::env::set_var("PPT_INTEGRATION_ENCRYPTION_KEY", "b".repeat(64));
+        std::env::set_var("PPT_PM_CLIENT_SECRET", "c".repeat(32));
+        std::env::set_var("PPT_ESIGN_TOKEN_SECRET", "d".repeat(32));
+        std::env::set_var("PPT_ESIGN_WEBHOOK_SECRET", "webhook-secret");
+    }
+
+    /// Issue #951: every secret the api-server requires at startup
+    /// (`API_REQUIRED_STARTUP_ENV`) must be injected onto the `api` container by
+    /// `build_service_envs`, or the container crash-loops on deploy — and when
+    /// any required deploy-server secret is absent, `build_service_envs` must
+    /// fail fast with a `Config` error rather than start empty-valued containers.
+    ///
+    /// Both halves are in one test because they mutate process-wide env vars and
+    /// would race if run as separate (parallel) tests.
+    #[test]
+    fn build_service_envs_enforces_api_startup_contract() {
+        set_all_required_secrets();
+
+        let envs = build_service_envs("staging", &test_target())
+            .expect("build_service_envs should succeed with all secrets set");
+        let api_env = envs.get("api").expect("`api` service env must exist");
+
+        for key in API_REQUIRED_STARTUP_ENV {
+            assert!(
+                api_env.iter().any(|kv| kv.starts_with(&format!("{key}="))),
+                "the `api` container env is missing `{key}`, which api-server requires at \
+                 startup (issue #951). Add it to `build_service_envs` so the deploy doesn't \
+                 crash-loop the api container."
+            );
+        }
+
+        // Missing required secret -> fail fast with a Config error.
+        std::env::remove_var("PPT_ESIGN_TOKEN_SECRET");
+        let err = build_service_envs("staging", &test_target())
+            .expect_err("must error when a required secret is missing");
+        assert!(
+            matches!(err, crate::DeployError::Config(_)),
+            "expected a Config error, got {err:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`cargo clippy --workspace --all-targets -- -D warnings` — the documented local pre-flight in `CLAUDE.md` — was red on `dev`, because the CI clippy gate only checked lib/bin targets. Test-target lint debt therefore landed silently (found during PAP-122). This PR sweeps the workspace to `--all-targets` green and widens the CI gate so it can't regress.

## Lint fixes (rust-1.94 lint set — all mechanical, no behavior change)

| File | Lint | Fix |
|------|------|-----|
| `servers/api-server/src/routes/admin/mod.rs` | `items_after_test_module` | moved `router()` above `mod tests` |
| `servers/deploy-server/src/infra/blue_green.rs` | `items_after_test_module` (not in the original report; aborted the first sweep) | moved test module to EOF |
| `tests/iot_auth_tests.rs` | `useless_format` | `format!("{base}")` → `base.to_string()` |
| `tests/aml_dsa_cross_org_idor_tests.rs` | `doc_overindented_list_items` | re-indented doc list continuation |
| `tests/report_schedule_rbac_tests.rs` | `doc_overindented_list_items` ×3 | re-indented doc list continuations |
| `tests/push_token_tests.rs` | `doc_lazy_continuation` | blank doc line before trailing paragraph |
| `tests/ws_integration_tests.rs` | `manual_async_fn`, `let_and_return` | plain `async fn`; return expression directly |
| `tests/enhanced_screening_cross_org_idor_tests.rs` | `explicit_auto_deref` ×2 | `&mut *conn` → `&mut conn` |
| `tests/portal_webhook_signature_tests.rs` | `await_holding_lock` ×4 | `ENV_LOCK` is now `tokio::sync::Mutex` — the guard must legitimately span the test body's awaits (env var has to stay stable while `TestApp` boots and the request executes), so an async-aware mutex is the correct fix, not dropping the guard early |

## CI gate

`backend.yml` Clippy step: `cargo clippy --workspace -- -D warnings` → `cargo clippy --workspace --all-targets -- -D warnings`. No other workflow runs clippy.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` → green (run on the mercury builder, rust 1.94)
- `cargo fmt --all -- --check` → clean

Closes PAP-124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
