### PR TITLE
fix(db): route api_ecosystem repo through RLS-context executor (PAP-110)

### DIFF
--- a/backend/crates/db/src/repositories/api_ecosystem.rs
+++ b/backend/crates/db/src/repositories/api_ecosystem.rs
@@ -2,22 +2,49 @@
 //!
 //! Provides database operations for Integration Marketplace, Connector Framework,
 //! Webhooks, and Developer Portal.
+//!
+//! # RLS Integration (PAP-110, parent PAP-80)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on six tables this repo queries:
+//! `organization_integrations`, `organization_connectors`,
+//! `connector_execution_logs`, `webhook_subscriptions`, `webhook_deliveries`,
+//! and `integration_ratings` (write side). Under `FORCE` the api-server's
+//! owner connection is no longer exempt, so a query issued on a connection
+//! without `app.current_org_id` set collapses to deny-all (own-org reads
+//! return empty, writes fail).
+//!
+//! The repository therefore holds **no pool**: every method takes an executor
+//! supplied by the caller. Handlers touching the org-scoped tables above pass
+//! the `RlsConnection` extractor's context-set connection (`&mut **rls.conn()`);
+//! handlers for the global, non-`FORCE` catalog tables (marketplace,
+//! connectors, docs, developer portal) pass the app pool directly — the owner
+//! role remains exempt there, matching prior behavior. Single-statement
+//! methods take a generic `Executor`; multi-statement methods take
+//! `&mut PgConnection` and run inside an explicit transaction. This mirrors
+//! the `work_order.rs` / `budget.rs` / `document.rs` precedent.
 
 use crate::models::api_ecosystem::*;
 use crate::DbPool;
 use common::AppError;
+use sqlx::{Connection, Executor, PgConnection, Postgres};
 use uuid::Uuid;
 
 /// Repository for API Ecosystem operations.
+///
+/// Stateless: every method receives an executor from the caller. Org-scoped
+/// (FORCE-RLS) queries must run on an RLS-context-set connection.
 #[derive(Clone)]
-pub struct ApiEcosystemRepository {
-    pool: DbPool,
-}
+pub struct ApiEcosystemRepository;
 
 impl ApiEcosystemRepository {
     /// Create a new repository instance.
-    pub fn new(pool: DbPool) -> Self {
-        Self { pool }
+    ///
+    /// The pool argument is retained for construction-site compatibility with
+    /// the other repositories on `AppState`; this repo deliberately does not
+    /// store it (see module docs).
+    pub fn new(_pool: DbPool) -> Self {
+        Self
     }
 
     // ============================================
@@ -25,10 +52,14 @@ impl ApiEcosystemRepository {
     // ============================================
 
     /// List marketplace integrations with optional filtering.
-    pub async fn list_marketplace_integrations(
+    pub async fn list_marketplace_integrations<'e, E>(
         &self,
+        executor: E,
         query: &MarketplaceIntegrationQuery,
-    ) -> Result<Vec<MarketplaceIntegrationSummary>, AppError> {
+    ) -> Result<Vec<MarketplaceIntegrationSummary>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50).min(100) as i64;
         let offset = query.offset.unwrap_or(0) as i64;
 
@@ -58,7 +89,7 @@ impl ApiEcosystemRepository {
         .bind(query.sort_by.as_ref())
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -66,17 +97,21 @@ impl ApiEcosystemRepository {
     }
 
     /// Get a marketplace integration by ID.
-    pub async fn get_marketplace_integration(
+    pub async fn get_marketplace_integration<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
-    ) -> Result<Option<MarketplaceIntegration>, AppError> {
+    ) -> Result<Option<MarketplaceIntegration>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let integration = sqlx::query_as::<_, MarketplaceIntegration>(
             r#"
             SELECT * FROM marketplace_integrations WHERE id = $1
             "#,
         )
         .bind(id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -84,17 +119,21 @@ impl ApiEcosystemRepository {
     }
 
     /// Get a marketplace integration by slug.
-    pub async fn get_marketplace_integration_by_slug(
+    pub async fn get_marketplace_integration_by_slug<'e, E>(
         &self,
+        executor: E,
         slug: &str,
-    ) -> Result<Option<MarketplaceIntegration>, AppError> {
+    ) -> Result<Option<MarketplaceIntegration>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let integration = sqlx::query_as::<_, MarketplaceIntegration>(
             r#"
             SELECT * FROM marketplace_integrations WHERE slug = $1
             "#,
         )
         .bind(slug)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -102,10 +141,14 @@ impl ApiEcosystemRepository {
     }
 
     /// Create a new marketplace integration (admin only).
-    pub async fn create_marketplace_integration(
+    pub async fn create_marketplace_integration<'e, E>(
         &self,
+        executor: E,
         req: &CreateMarketplaceIntegration,
-    ) -> Result<MarketplaceIntegration, AppError> {
+    ) -> Result<MarketplaceIntegration, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let integration = sqlx::query_as::<_, MarketplaceIntegration>(
             r#"
             INSERT INTO marketplace_integrations (
@@ -133,7 +176,7 @@ impl ApiEcosystemRepository {
         .bind(&req.pricing_info)
         .bind(req.is_premium.unwrap_or(false))
         .bind(&req.required_scopes)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -141,11 +184,15 @@ impl ApiEcosystemRepository {
     }
 
     /// Update a marketplace integration.
-    pub async fn update_marketplace_integration(
+    pub async fn update_marketplace_integration<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         req: &UpdateMarketplaceIntegration,
-    ) -> Result<Option<MarketplaceIntegration>, AppError> {
+    ) -> Result<Option<MarketplaceIntegration>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let integration = sqlx::query_as::<_, MarketplaceIntegration>(
             r#"
             UPDATE marketplace_integrations SET
@@ -188,7 +235,7 @@ impl ApiEcosystemRepository {
         .bind(req.is_featured)
         .bind(req.is_premium)
         .bind(&req.required_scopes)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -196,10 +243,17 @@ impl ApiEcosystemRepository {
     }
 
     /// Delete a marketplace integration.
-    pub async fn delete_marketplace_integration(&self, id: Uuid) -> Result<bool, AppError> {
+    pub async fn delete_marketplace_integration<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+    ) -> Result<bool, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM marketplace_integrations WHERE id = $1")
             .bind(id)
-            .execute(&self.pool)
+            .execute(executor)
             .await
             .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -207,9 +261,13 @@ impl ApiEcosystemRepository {
     }
 
     /// Get integration category counts.
-    pub async fn get_integration_category_counts(
+    pub async fn get_integration_category_counts<'e, E>(
         &self,
-    ) -> Result<Vec<IntegrationCategoryCount>, AppError> {
+        executor: E,
+    ) -> Result<Vec<IntegrationCategoryCount>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let counts = sqlx::query_as::<_, IntegrationCategoryCount>(
             r#"
             SELECT category, COUNT(*) as count
@@ -219,7 +277,7 @@ impl ApiEcosystemRepository {
             ORDER BY count DESC
             "#,
         )
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -233,8 +291,13 @@ impl ApiEcosystemRepository {
     /// Install an integration for an organization.
     /// Uses a transaction to ensure atomicity between installation and install count increment.
     /// Only increments install_count for new installations, not reinstalls.
+    ///
+    /// Multi-statement: takes `&mut PgConnection` (an RLS-context-set
+    /// connection — `organization_integrations` is FORCE-RLS) and opens the
+    /// transaction on it.
     pub async fn install_integration(
         &self,
+        conn: &mut PgConnection,
         organization_id: Uuid,
         user_id: Uuid,
         req: &InstallIntegration,
@@ -246,8 +309,7 @@ impl ApiEcosystemRepository {
             .map(|c| serde_json::to_string(c).unwrap_or_default());
 
         // Use a transaction to ensure atomicity
-        let mut tx = self
-            .pool
+        let mut tx = conn
             .begin()
             .await
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -312,10 +374,14 @@ impl ApiEcosystemRepository {
     }
 
     /// List organization integrations.
-    pub async fn list_organization_integrations(
+    pub async fn list_organization_integrations<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
-    ) -> Result<Vec<OrganizationIntegration>, AppError> {
+    ) -> Result<Vec<OrganizationIntegration>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let integrations = sqlx::query_as::<_, OrganizationIntegration>(
             r#"
             SELECT * FROM organization_integrations
@@ -324,7 +390,7 @@ impl ApiEcosystemRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -334,11 +400,15 @@ impl ApiEcosystemRepository {
     /// Uninstall an integration.
     /// Note: `org_integration_id` is the primary key (id) of the organization_integrations record,
     /// not the marketplace integration_id.
-    pub async fn uninstall_integration(
+    pub async fn uninstall_integration<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         org_integration_id: Uuid,
-    ) -> Result<bool, AppError> {
+    ) -> Result<bool, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query(
             r#"
             UPDATE organization_integrations
@@ -348,7 +418,7 @@ impl ApiEcosystemRepository {
         )
         .bind(organization_id)
         .bind(org_integration_id)
-        .execute(&self.pool)
+        .execute(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -360,7 +430,14 @@ impl ApiEcosystemRepository {
     // ============================================
 
     /// List connectors for an integration.
-    pub async fn list_connectors(&self, integration_id: Uuid) -> Result<Vec<Connector>, AppError> {
+    pub async fn list_connectors<'e, E>(
+        &self,
+        executor: E,
+        integration_id: Uuid,
+    ) -> Result<Vec<Connector>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let connectors = sqlx::query_as::<_, Connector>(
             r#"
             SELECT * FROM connectors
@@ -369,7 +446,7 @@ impl ApiEcosystemRepository {
             "#,
         )
         .bind(integration_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -377,14 +454,21 @@ impl ApiEcosystemRepository {
     }
 
     /// Get a connector by ID.
-    pub async fn get_connector(&self, id: Uuid) -> Result<Option<Connector>, AppError> {
+    pub async fn get_connector<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+    ) -> Result<Option<Connector>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let connector = sqlx::query_as::<_, Connector>(
             r#"
             SELECT * FROM connectors WHERE id = $1
             "#,
         )
         .bind(id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -392,7 +476,14 @@ impl ApiEcosystemRepository {
     }
 
     /// Create a new connector.
-    pub async fn create_connector(&self, req: &CreateConnector) -> Result<Connector, AppError> {
+    pub async fn create_connector<'e, E>(
+        &self,
+        executor: E,
+        req: &CreateConnector,
+    ) -> Result<Connector, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let connector = sqlx::query_as::<_, Connector>(
             r#"
             INSERT INTO connectors (
@@ -420,7 +511,7 @@ impl ApiEcosystemRepository {
         .bind(&req.supported_actions)
         .bind(&req.error_mapping)
         .bind(&req.data_transformations)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -428,11 +519,15 @@ impl ApiEcosystemRepository {
     }
 
     /// Update a connector.
-    pub async fn update_connector(
+    pub async fn update_connector<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         req: &UpdateConnector,
-    ) -> Result<Option<Connector>, AppError> {
+    ) -> Result<Option<Connector>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let connector = sqlx::query_as::<_, Connector>(
             r#"
             UPDATE connectors SET
@@ -469,7 +564,7 @@ impl ApiEcosystemRepository {
         .bind(&req.supported_actions)
         .bind(&req.error_mapping)
         .bind(&req.data_transformations)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -477,10 +572,13 @@ impl ApiEcosystemRepository {
     }
 
     /// Delete a connector.
-    pub async fn delete_connector(&self, id: Uuid) -> Result<bool, AppError> {
+    pub async fn delete_connector<'e, E>(&self, executor: E, id: Uuid) -> Result<bool, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM connectors WHERE id = $1")
             .bind(id)
-            .execute(&self.pool)
+            .execute(executor)
             .await
             .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -489,10 +587,14 @@ impl ApiEcosystemRepository {
 
     /// List connector actions.
     /// Maps DB columns to model fields for schema compatibility.
-    pub async fn list_connector_actions(
+    pub async fn list_connector_actions<'e, E>(
         &self,
+        executor: E,
         connector_id: Uuid,
-    ) -> Result<Vec<ConnectorAction>, AppError> {
+    ) -> Result<Vec<ConnectorAction>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let actions = sqlx::query_as::<_, ConnectorAction>(
             r#"
             SELECT
@@ -507,7 +609,7 @@ impl ApiEcosystemRepository {
             "#,
         )
         .bind(connector_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -519,10 +621,14 @@ impl ApiEcosystemRepository {
     // ============================================
 
     /// List enhanced webhook subscriptions for an organization.
-    pub async fn list_enhanced_webhooks(
+    pub async fn list_enhanced_webhooks<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
-    ) -> Result<Vec<EnhancedWebhookSubscription>, AppError> {
+    ) -> Result<Vec<EnhancedWebhookSubscription>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let subscriptions = sqlx::query_as::<_, EnhancedWebhookSubscription>(
             r#"
             SELECT * FROM webhook_subscriptions
@@ -531,7 +637,7 @@ impl ApiEcosystemRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -539,17 +645,24 @@ impl ApiEcosystemRepository {
     }
 
     /// Get a webhook subscription by ID.
-    pub async fn get_enhanced_webhook(
+    ///
+    /// RLS scopes this by-id read to the connection's org: another org's
+    /// subscription is invisible and surfaces as `None` (`404`).
+    pub async fn get_enhanced_webhook<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
-    ) -> Result<Option<EnhancedWebhookSubscription>, AppError> {
+    ) -> Result<Option<EnhancedWebhookSubscription>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let subscription = sqlx::query_as::<_, EnhancedWebhookSubscription>(
             r#"
             SELECT * FROM webhook_subscriptions WHERE id = $1
             "#,
         )
         .bind(id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -557,10 +670,17 @@ impl ApiEcosystemRepository {
     }
 
     /// Delete a webhook subscription.
-    pub async fn delete_enhanced_webhook(&self, id: Uuid) -> Result<bool, AppError> {
+    pub async fn delete_enhanced_webhook<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+    ) -> Result<bool, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM webhook_subscriptions WHERE id = $1")
             .bind(id)
-            .execute(&self.pool)
+            .execute(executor)
             .await
             .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -572,17 +692,21 @@ impl ApiEcosystemRepository {
     // ============================================
 
     /// Get a developer registration by ID.
-    pub async fn get_developer_registration(
+    pub async fn get_developer_registration<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
-    ) -> Result<Option<DeveloperRegistration>, AppError> {
+    ) -> Result<Option<DeveloperRegistration>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let registration = sqlx::query_as::<_, DeveloperRegistration>(
             r#"
             SELECT * FROM developer_accounts WHERE id = $1
             "#,
         )
         .bind(id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -590,10 +714,14 @@ impl ApiEcosystemRepository {
     }
 
     /// List API keys for a developer.
-    pub async fn list_developer_api_keys(
+    pub async fn list_developer_api_keys<'e, E>(
         &self,
+        executor: E,
         developer_id: Uuid,
-    ) -> Result<Vec<DeveloperApiKey>, AppError> {
+    ) -> Result<Vec<DeveloperApiKey>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let keys = sqlx::query_as::<_, DeveloperApiKey>(
             r#"
             SELECT * FROM developer_api_keys
@@ -602,7 +730,7 @@ impl ApiEcosystemRepository {
             "#,
         )
         .bind(developer_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -610,7 +738,15 @@ impl ApiEcosystemRepository {
     }
 
     /// Revoke an API key.
-    pub async fn revoke_api_key(&self, key_id: Uuid, revoked_by: Uuid) -> Result<bool, AppError> {
+    pub async fn revoke_api_key<'e, E>(
+        &self,
+        executor: E,
+        key_id: Uuid,
+        revoked_by: Uuid,
+    ) -> Result<bool, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query(
             r#"
             UPDATE developer_api_keys SET
@@ -622,7 +758,7 @@ impl ApiEcosystemRepository {
         )
         .bind(key_id)
         .bind(revoked_by)
-        .execute(&self.pool)
+        .execute(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -634,12 +770,16 @@ impl ApiEcosystemRepository {
     // ============================================
 
     /// List ratings for an integration.
-    pub async fn list_integration_ratings(
+    pub async fn list_integration_ratings<'e, E>(
         &self,
+        executor: E,
         integration_id: Uuid,
         limit: i32,
         offset: i32,
-    ) -> Result<Vec<IntegrationRatingWithUser>, AppError> {
+    ) -> Result<Vec<IntegrationRatingWithUser>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let ratings = sqlx::query_as::<_, IntegrationRatingWithUser>(
             r#"
             SELECT
@@ -656,7 +796,7 @@ impl ApiEcosystemRepository {
         .bind(integration_id)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -664,13 +804,17 @@ impl ApiEcosystemRepository {
     }
 
     /// Create an integration rating.
-    pub async fn create_integration_rating(
+    pub async fn create_integration_rating<'e, E>(
         &self,
+        executor: E,
         integration_id: Uuid,
         organization_id: Uuid,
         user_id: Uuid,
         req: &CreateIntegrationRating,
-    ) -> Result<IntegrationRating, AppError> {
+    ) -> Result<IntegrationRating, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let rating = sqlx::query_as::<_, IntegrationRating>(
             r#"
             INSERT INTO integration_ratings (
@@ -686,7 +830,7 @@ impl ApiEcosystemRepository {
         .bind(user_id)
         .bind(req.rating)
         .bind(&req.review)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -694,11 +838,15 @@ impl ApiEcosystemRepository {
     }
 
     /// Get an organization integration by ID.
-    pub async fn get_organization_integration(
+    pub async fn get_organization_integration<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         integration_id: Uuid,
-    ) -> Result<Option<OrganizationIntegration>, AppError> {
+    ) -> Result<Option<OrganizationIntegration>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let integration = sqlx::query_as::<_, OrganizationIntegration>(
             r#"
             SELECT * FROM organization_integrations
@@ -707,7 +855,7 @@ impl ApiEcosystemRepository {
         )
         .bind(organization_id)
         .bind(integration_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -715,12 +863,16 @@ impl ApiEcosystemRepository {
     }
 
     /// Update an organization integration.
-    pub async fn update_organization_integration(
+    pub async fn update_organization_integration<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         integration_id: Uuid,
         req: &UpdateOrganizationIntegration,
-    ) -> Result<Option<OrganizationIntegration>, AppError> {
+    ) -> Result<Option<OrganizationIntegration>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let integration = sqlx::query_as::<_, OrganizationIntegration>(
             r#"
             UPDATE organization_integrations SET
@@ -735,7 +887,7 @@ impl ApiEcosystemRepository {
         .bind(integration_id)
         .bind(&req.configuration)
         .bind(req.enabled)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -752,10 +904,14 @@ impl ApiEcosystemRepository {
     /// - endpoint_path -> path
     /// - request_schema -> input_schema
     /// - response_schema -> output_schema
-    pub async fn create_connector_action(
+    pub async fn create_connector_action<'e, E>(
         &self,
+        executor: E,
         req: &CreateConnectorAction,
-    ) -> Result<ConnectorAction, AppError> {
+    ) -> Result<ConnectorAction, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let action = sqlx::query_as::<_, ConnectorAction>(
             r#"
             INSERT INTO connector_actions (
@@ -779,7 +935,7 @@ impl ApiEcosystemRepository {
         .bind(&req.request_schema)
         .bind(&req.response_schema)
         .bind(&req.pagination_config)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -789,11 +945,15 @@ impl ApiEcosystemRepository {
     /// List connector execution logs.
     /// Note: DB schema uses org_connector_id (FK to organization_connectors), not organization_id.
     /// We join through organization_connectors to filter by organization.
-    pub async fn list_connector_execution_logs(
+    pub async fn list_connector_execution_logs<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         query: &ConnectorExecutionQuery,
-    ) -> Result<Vec<ConnectorExecutionLog>, AppError> {
+    ) -> Result<Vec<ConnectorExecutionLog>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50).min(100) as i64;
         let offset = query.offset.unwrap_or(0).max(0) as i64;
 
@@ -836,7 +996,7 @@ impl ApiEcosystemRepository {
         .bind(query.status.as_ref())
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -850,12 +1010,16 @@ impl ApiEcosystemRepository {
     /// Create an enhanced webhook subscription.
     /// Note: DB schema has simpler columns than the enhanced model. We map enhanced
     /// fields to what the DB supports and return a compatible struct.
-    pub async fn create_enhanced_webhook(
+    pub async fn create_enhanced_webhook<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         user_id: Uuid,
         req: &CreateEnhancedWebhookSubscription,
-    ) -> Result<EnhancedWebhookSubscription, AppError> {
+    ) -> Result<EnhancedWebhookSubscription, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // Serialize retry_policy as JSON for retry_config column
         let retry_config_json = req
             .retry_policy
@@ -892,7 +1056,7 @@ impl ApiEcosystemRepository {
         .bind(&req.headers)
         .bind(&retry_config_json)
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -900,11 +1064,15 @@ impl ApiEcosystemRepository {
     }
 
     /// Update an enhanced webhook subscription.
-    pub async fn update_enhanced_webhook(
+    pub async fn update_enhanced_webhook<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         req: &UpdateEnhancedWebhookSubscription,
-    ) -> Result<Option<EnhancedWebhookSubscription>, AppError> {
+    ) -> Result<Option<EnhancedWebhookSubscription>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // Serialize retry_policy as JSON
         let retry_policy_json = req
             .retry_policy
@@ -945,7 +1113,7 @@ impl ApiEcosystemRepository {
         .bind(&req.headers)
         .bind(&retry_policy_json)
         .bind(is_active)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -953,12 +1121,16 @@ impl ApiEcosystemRepository {
     }
 
     /// List webhook delivery logs.
-    pub async fn list_webhook_delivery_logs(
+    pub async fn list_webhook_delivery_logs<'e, E>(
         &self,
+        executor: E,
         webhook_id: Uuid,
         limit: i32,
         offset: i32,
-    ) -> Result<Vec<EnhancedWebhookDeliveryLog>, AppError> {
+    ) -> Result<Vec<EnhancedWebhookDeliveryLog>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let logs = sqlx::query_as::<_, EnhancedWebhookDeliveryLog>(
             r#"
             SELECT * FROM webhook_deliveries
@@ -970,7 +1142,7 @@ impl ApiEcosystemRepository {
         .bind(webhook_id)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -978,10 +1150,14 @@ impl ApiEcosystemRepository {
     }
 
     /// Get webhook statistics.
-    pub async fn get_webhook_statistics(
+    pub async fn get_webhook_statistics<'e, E>(
         &self,
+        executor: E,
         webhook_id: Uuid,
-    ) -> Result<EnhancedWebhookStatistics, AppError> {
+    ) -> Result<EnhancedWebhookStatistics, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // Query basic stats
         let row = sqlx::query(
             r#"
@@ -999,7 +1175,7 @@ impl ApiEcosystemRepository {
             "#,
         )
         .bind(webhook_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1039,11 +1215,15 @@ impl ApiEcosystemRepository {
     // ============================================
 
     /// Register a developer.
-    pub async fn register_developer(
+    pub async fn register_developer<'e, E>(
         &self,
+        executor: E,
         user_id: Uuid,
         req: &CreateDeveloperRegistration,
-    ) -> Result<DeveloperRegistration, AppError> {
+    ) -> Result<DeveloperRegistration, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let registration = sqlx::query_as::<_, DeveloperRegistration>(
             r#"
             INSERT INTO developer_accounts (
@@ -1057,7 +1237,7 @@ impl ApiEcosystemRepository {
         .bind(&req.company_name)
         .bind(&req.website)
         .bind(&req.use_case)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1065,17 +1245,21 @@ impl ApiEcosystemRepository {
     }
 
     /// Get developer registration by user ID.
-    pub async fn get_developer_registration_by_user(
+    pub async fn get_developer_registration_by_user<'e, E>(
         &self,
+        executor: E,
         user_id: Uuid,
-    ) -> Result<Option<DeveloperRegistration>, AppError> {
+    ) -> Result<Option<DeveloperRegistration>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let registration = sqlx::query_as::<_, DeveloperRegistration>(
             r#"
             SELECT * FROM developer_accounts WHERE user_id = $1
             "#,
         )
         .bind(user_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1083,12 +1267,16 @@ impl ApiEcosystemRepository {
     }
 
     /// Review a developer registration (approve/reject).
-    pub async fn review_developer_registration(
+    pub async fn review_developer_registration<'e, E>(
         &self,
+        executor: E,
         developer_id: Uuid,
         reviewer_id: Uuid,
         req: &ReviewDeveloperRegistration,
-    ) -> Result<Option<DeveloperRegistration>, AppError> {
+    ) -> Result<Option<DeveloperRegistration>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let registration = sqlx::query_as::<_, DeveloperRegistration>(
             r#"
             UPDATE developer_accounts SET
@@ -1102,7 +1290,7 @@ impl ApiEcosystemRepository {
         .bind(developer_id)
         .bind(&req.status)
         .bind(reviewer_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1110,13 +1298,17 @@ impl ApiEcosystemRepository {
     }
 
     /// Create a developer API key.
-    pub async fn create_developer_api_key(
+    pub async fn create_developer_api_key<'e, E>(
         &self,
+        executor: E,
         developer_id: Uuid,
         req: &CreateDeveloperApiKey,
         key_prefix: &str,
         key_hash: &str,
-    ) -> Result<DeveloperApiKey, AppError> {
+    ) -> Result<DeveloperApiKey, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // Calculate expiration from expires_in_days
         let expires_at = req
             .expires_in_days
@@ -1138,7 +1330,7 @@ impl ApiEcosystemRepository {
         .bind(&req.scopes)
         .bind(req.is_sandbox.unwrap_or(false))
         .bind(expires_at)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1147,19 +1339,29 @@ impl ApiEcosystemRepository {
 
     /// Rotate (replace) a developer API key.
     /// Preserves all settings from the old key including is_sandbox.
+    ///
+    /// Multi-statement: takes `&mut PgConnection` and runs the
+    /// revoke-old/insert-new pair inside a transaction so a failure cannot
+    /// leave the developer with the old key revoked and no replacement.
     pub async fn rotate_developer_api_key(
         &self,
+        conn: &mut PgConnection,
         key_id: Uuid,
         revoked_by: Uuid,
         new_key_prefix: &str,
         new_key_hash: &str,
     ) -> Result<Option<DeveloperApiKey>, AppError> {
+        let mut tx = conn
+            .begin()
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
         // First, get the existing key info
         let existing = sqlx::query_as::<_, DeveloperApiKey>(
             r#"SELECT * FROM developer_api_keys WHERE id = $1 AND revoked_at IS NULL"#,
         )
         .bind(key_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *tx)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1180,7 +1382,7 @@ impl ApiEcosystemRepository {
         )
         .bind(key_id)
         .bind(revoked_by)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1202,9 +1404,13 @@ impl ApiEcosystemRepository {
         .bind(&old_key.rate_limit_tier)
         .bind(old_key.is_sandbox) // Preserve sandbox setting
         .bind(old_key.expires_at)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *tx)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
+
+        tx.commit()
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
 
         Ok(Some(new_key))
     }
@@ -1214,10 +1420,14 @@ impl ApiEcosystemRepository {
     // ============================================
 
     /// List pre-built integration connections for an organization.
-    pub async fn list_prebuilt_connections(
+    pub async fn list_prebuilt_connections<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
-    ) -> Result<Vec<PreBuiltIntegrationConnection>, AppError> {
+    ) -> Result<Vec<PreBuiltIntegrationConnection>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let connections = sqlx::query_as::<_, PreBuiltIntegrationConnection>(
             r#"
             SELECT * FROM prebuilt_integration_connections
@@ -1226,7 +1436,7 @@ impl ApiEcosystemRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1234,11 +1444,15 @@ impl ApiEcosystemRepository {
     }
 
     /// Get a pre-built integration connection by type.
-    pub async fn get_prebuilt_connection(
+    pub async fn get_prebuilt_connection<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         integration_type: &str,
-    ) -> Result<Option<PreBuiltIntegrationConnection>, AppError> {
+    ) -> Result<Option<PreBuiltIntegrationConnection>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let connection = sqlx::query_as::<_, PreBuiltIntegrationConnection>(
             r#"
             SELECT * FROM prebuilt_integration_connections
@@ -1247,7 +1461,7 @@ impl ApiEcosystemRepository {
         )
         .bind(organization_id)
         .bind(integration_type)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1255,12 +1469,16 @@ impl ApiEcosystemRepository {
     }
 
     /// Create a pre-built integration connection.
-    pub async fn create_prebuilt_connection(
+    pub async fn create_prebuilt_connection<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         user_id: Uuid,
         req: &CreatePreBuiltIntegrationConnection,
-    ) -> Result<PreBuiltIntegrationConnection, AppError> {
+    ) -> Result<PreBuiltIntegrationConnection, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let connection = sqlx::query_as::<_, PreBuiltIntegrationConnection>(
             r#"
             INSERT INTO prebuilt_integration_connections (
@@ -1278,7 +1496,7 @@ impl ApiEcosystemRepository {
         .bind(&req.integration_type)
         .bind(&req.configuration)
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1286,12 +1504,16 @@ impl ApiEcosystemRepository {
     }
 
     /// Update a pre-built integration connection.
-    pub async fn update_prebuilt_connection(
+    pub async fn update_prebuilt_connection<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         integration_type: &str,
         req: &UpdatePreBuiltIntegrationConnection,
-    ) -> Result<Option<PreBuiltIntegrationConnection>, AppError> {
+    ) -> Result<Option<PreBuiltIntegrationConnection>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let connection = sqlx::query_as::<_, PreBuiltIntegrationConnection>(
             r#"
             UPDATE prebuilt_integration_connections SET
@@ -1306,7 +1528,7 @@ impl ApiEcosystemRepository {
         .bind(integration_type)
         .bind(&req.configuration)
         .bind(req.sync_enabled)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1314,17 +1536,21 @@ impl ApiEcosystemRepository {
     }
 
     /// Delete a pre-built integration connection.
-    pub async fn delete_prebuilt_connection(
+    pub async fn delete_prebuilt_connection<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         integration_type: &str,
-    ) -> Result<bool, AppError> {
+    ) -> Result<bool, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query(
             r#"DELETE FROM prebuilt_integration_connections WHERE organization_id = $1 AND integration_type = $2"#,
         )
         .bind(organization_id)
         .bind(integration_type)
-        .execute(&self.pool)
+        .execute(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1332,14 +1558,18 @@ impl ApiEcosystemRepository {
     }
 
     /// Update pre-built integration connection with OAuth tokens.
-    pub async fn update_prebuilt_connection_tokens(
+    pub async fn update_prebuilt_connection_tokens<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         integration_type: &str,
         access_token: &str,
         refresh_token: Option<&str>,
         expires_at: Option<chrono::DateTime<chrono::Utc>>,
-    ) -> Result<Option<PreBuiltIntegrationConnection>, AppError> {
+    ) -> Result<Option<PreBuiltIntegrationConnection>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let connection = sqlx::query_as::<_, PreBuiltIntegrationConnection>(
             r#"
             UPDATE prebuilt_integration_connections SET
@@ -1357,7 +1587,7 @@ impl ApiEcosystemRepository {
         .bind(access_token)
         .bind(refresh_token)
         .bind(expires_at)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1365,13 +1595,17 @@ impl ApiEcosystemRepository {
     }
 
     /// Record sync result for pre-built integration.
-    pub async fn record_prebuilt_sync(
+    pub async fn record_prebuilt_sync<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         integration_type: &str,
         success: bool,
         error: Option<&str>,
-    ) -> Result<(), AppError> {
+    ) -> Result<(), AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query(
             r#"
             UPDATE prebuilt_integration_connections SET
@@ -1386,7 +1620,7 @@ impl ApiEcosystemRepository {
         .bind(integration_type)
         .bind(success)
         .bind(error)
-        .execute(&self.pool)
+        .execute(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1398,10 +1632,14 @@ impl ApiEcosystemRepository {
     // ============================================
 
     /// List all published API documentation.
-    pub async fn list_api_documentation(
+    pub async fn list_api_documentation<'e, E>(
         &self,
+        executor: E,
         published_only: bool,
-    ) -> Result<Vec<ApiDocumentation>, AppError> {
+    ) -> Result<Vec<ApiDocumentation>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let docs = if published_only {
             sqlx::query_as::<_, ApiDocumentation>(
                 r#"
@@ -1410,7 +1648,7 @@ impl ApiEcosystemRepository {
                 ORDER BY category, order_index, title
                 "#,
             )
-            .fetch_all(&self.pool)
+            .fetch_all(executor)
             .await
         } else {
             sqlx::query_as::<_, ApiDocumentation>(
@@ -1419,7 +1657,7 @@ impl ApiEcosystemRepository {
                 ORDER BY category, order_index, title
                 "#,
             )
-            .fetch_all(&self.pool)
+            .fetch_all(executor)
             .await
         }
         .map_err(|e| AppError::Database(e.to_string()))?;
@@ -1428,17 +1666,21 @@ impl ApiEcosystemRepository {
     }
 
     /// Get API documentation by slug.
-    pub async fn get_api_documentation(
+    pub async fn get_api_documentation<'e, E>(
         &self,
+        executor: E,
         slug: &str,
-    ) -> Result<Option<ApiDocumentation>, AppError> {
+    ) -> Result<Option<ApiDocumentation>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let doc = sqlx::query_as::<_, ApiDocumentation>(
             r#"
             SELECT * FROM api_documentation WHERE slug = $1
             "#,
         )
         .bind(slug)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1446,10 +1688,14 @@ impl ApiEcosystemRepository {
     }
 
     /// Create API documentation.
-    pub async fn create_api_documentation(
+    pub async fn create_api_documentation<'e, E>(
         &self,
+        executor: E,
         req: &CreateApiDocumentation,
-    ) -> Result<ApiDocumentation, AppError> {
+    ) -> Result<ApiDocumentation, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let doc = sqlx::query_as::<_, ApiDocumentation>(
             r#"
             INSERT INTO api_documentation (slug, title, content, category, order_index, is_published)
@@ -1463,7 +1709,7 @@ impl ApiEcosystemRepository {
         .bind(&req.category)
         .bind(req.order_index.unwrap_or(0))
         .bind(req.is_published.unwrap_or(false))
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1471,11 +1717,15 @@ impl ApiEcosystemRepository {
     }
 
     /// Update API documentation.
-    pub async fn update_api_documentation(
+    pub async fn update_api_documentation<'e, E>(
         &self,
+        executor: E,
         slug: &str,
         req: &UpdateApiDocumentation,
-    ) -> Result<Option<ApiDocumentation>, AppError> {
+    ) -> Result<Option<ApiDocumentation>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let doc = sqlx::query_as::<_, ApiDocumentation>(
             r#"
             UPDATE api_documentation SET
@@ -1495,7 +1745,7 @@ impl ApiEcosystemRepository {
         .bind(&req.category)
         .bind(req.order_index)
         .bind(req.is_published)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1503,10 +1753,17 @@ impl ApiEcosystemRepository {
     }
 
     /// Delete API documentation.
-    pub async fn delete_api_documentation(&self, slug: &str) -> Result<bool, AppError> {
+    pub async fn delete_api_documentation<'e, E>(
+        &self,
+        executor: E,
+        slug: &str,
+    ) -> Result<bool, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM api_documentation WHERE slug = $1")
             .bind(slug)
-            .execute(&self.pool)
+            .execute(executor)
             .await
             .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1514,10 +1771,14 @@ impl ApiEcosystemRepository {
     }
 
     /// List code samples for an endpoint.
-    pub async fn list_code_samples(
+    pub async fn list_code_samples<'e, E>(
         &self,
+        executor: E,
         endpoint_path: &str,
-    ) -> Result<Vec<ApiCodeSample>, AppError> {
+    ) -> Result<Vec<ApiCodeSample>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let samples = sqlx::query_as::<_, ApiCodeSample>(
             r#"
             SELECT * FROM api_code_samples
@@ -1526,7 +1787,7 @@ impl ApiEcosystemRepository {
             "#,
         )
         .bind(endpoint_path)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1534,10 +1795,14 @@ impl ApiEcosystemRepository {
     }
 
     /// Create a code sample.
-    pub async fn create_code_sample(
+    pub async fn create_code_sample<'e, E>(
         &self,
+        executor: E,
         req: &CreateApiCodeSample,
-    ) -> Result<ApiCodeSample, AppError> {
+    ) -> Result<ApiCodeSample, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let sample = sqlx::query_as::<_, ApiCodeSample>(
             r#"
             INSERT INTO api_code_samples (endpoint_path, http_method, language, code, description)
@@ -1550,7 +1815,7 @@ impl ApiEcosystemRepository {
         .bind(&req.language)
         .bind(&req.code)
         .bind(&req.description)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1562,10 +1827,14 @@ impl ApiEcosystemRepository {
     // ============================================
 
     /// Get sandbox environment for a developer.
-    pub async fn get_sandbox_environment(
+    pub async fn get_sandbox_environment<'e, E>(
         &self,
+        executor: E,
         developer_id: Uuid,
-    ) -> Result<Option<SandboxConfig>, AppError> {
+    ) -> Result<Option<SandboxConfig>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let sandbox = sqlx::query_as::<_, SandboxConfig>(
             r#"
             SELECT * FROM developer_sandboxes
@@ -1576,7 +1845,7 @@ impl ApiEcosystemRepository {
             "#,
         )
         .bind(developer_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1584,12 +1853,16 @@ impl ApiEcosystemRepository {
     }
 
     /// Create sandbox environment for a developer.
-    pub async fn create_sandbox_environment(
+    pub async fn create_sandbox_environment<'e, E>(
         &self,
+        executor: E,
         developer_id: Uuid,
         req: &CreateSandboxConfig,
         expires_at: Option<chrono::DateTime<chrono::Utc>>,
-    ) -> Result<SandboxConfig, AppError> {
+    ) -> Result<SandboxConfig, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let configuration = serde_json::json!({
             "test_mode": true,
             "seed_data": req.seed_test_data.unwrap_or(true)
@@ -1607,7 +1880,7 @@ impl ApiEcosystemRepository {
         .bind(&configuration)
         .bind(req.seed_test_data.unwrap_or(true))
         .bind(expires_at)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1619,10 +1892,14 @@ impl ApiEcosystemRepository {
     // ============================================
 
     /// Get developer usage statistics.
-    pub async fn get_developer_usage_stats(
+    pub async fn get_developer_usage_stats<'e, E>(
         &self,
+        executor: E,
         developer_id: Uuid,
-    ) -> Result<DeveloperUsageStats, AppError> {
+    ) -> Result<DeveloperUsageStats, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // Query API usage statistics for the developer
         let row = sqlx::query(
             r#"
@@ -1638,7 +1915,7 @@ impl ApiEcosystemRepository {
             "#,
         )
         .bind(developer_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1655,7 +1932,13 @@ impl ApiEcosystemRepository {
     }
 
     /// Get developer portal statistics (admin).
-    pub async fn get_developer_portal_stats(&self) -> Result<DeveloperPortalStatistics, AppError> {
+    pub async fn get_developer_portal_stats<'e, E>(
+        &self,
+        executor: E,
+    ) -> Result<DeveloperPortalStatistics, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let row = sqlx::query(
             r#"
             SELECT
@@ -1669,7 +1952,7 @@ impl ApiEcosystemRepository {
                 COALESCE((SELECT SUM(request_count) FROM developer_api_usage WHERE date >= date_trunc('month', CURRENT_DATE)), 0) as api_calls_this_month
             "#,
         )
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1688,10 +1971,14 @@ impl ApiEcosystemRepository {
     }
 
     /// Get ecosystem dashboard for an organization.
-    pub async fn get_ecosystem_dashboard(
+    pub async fn get_ecosystem_dashboard<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
-    ) -> Result<ApiEcosystemDashboard, AppError> {
+    ) -> Result<ApiEcosystemDashboard, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let row = sqlx::query(
             r#"
             SELECT
@@ -1709,7 +1996,7 @@ impl ApiEcosystemRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1735,10 +2022,14 @@ impl ApiEcosystemRepository {
     }
 
     /// Get ecosystem statistics for an organization.
-    pub async fn get_ecosystem_statistics(
+    pub async fn get_ecosystem_statistics<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
-    ) -> Result<ApiEcosystemStatistics, AppError> {
+    ) -> Result<ApiEcosystemStatistics, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let row = sqlx::query(
             r#"
             SELECT
@@ -1756,7 +2047,7 @@ impl ApiEcosystemRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -1774,14 +2065,17 @@ impl ApiEcosystemRepository {
     }
 
     /// List all connectors (no integration filter).
-    pub async fn list_all_connectors(&self) -> Result<Vec<Connector>, AppError> {
+    pub async fn list_all_connectors<'e, E>(&self, executor: E) -> Result<Vec<Connector>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let connectors = sqlx::query_as::<_, Connector>(
             r#"
             SELECT * FROM connectors
             ORDER BY name
             "#,
         )
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 

--- a/backend/crates/db/src/repositories/api_ecosystem.rs
+++ b/backend/crates/db/src/repositories/api_ecosystem.rs
@@ -621,6 +621,12 @@ impl ApiEcosystemRepository {
     // ============================================
 
     /// List enhanced webhook subscriptions for an organization.
+    ///
+    /// Selects with the same column aliasing as the create/update RETURNING:
+    /// the DB schema (00102) has no `auth_type`/`status`/`retry_policy`/...
+    /// columns, so a `SELECT *` cannot decode into the enhanced model. This
+    /// was masked pre-fix because the raw-pool read returned zero rows under
+    /// FORCE RLS (deny-all) and never reached the decoder.
     pub async fn list_enhanced_webhooks<'e, E>(
         &self,
         executor: E,
@@ -631,7 +637,16 @@ impl ApiEcosystemRepository {
     {
         let subscriptions = sqlx::query_as::<_, EnhancedWebhookSubscription>(
             r#"
-            SELECT * FROM webhook_subscriptions
+            SELECT
+                id, organization_id, name, description, url,
+                'hmac_sha256' as auth_type, NULL::jsonb as auth_config,
+                events, NULL::jsonb as filters, NULL::jsonb as payload_template,
+                CASE WHEN is_active THEN 'active' ELSE 'inactive' END as status,
+                headers, retry_config as retry_policy,
+                NULL::int4 as rate_limit_requests, NULL::int4 as rate_limit_window_seconds,
+                30000 as timeout_ms, TRUE as verify_ssl,
+                created_by, created_at, updated_at
+            FROM webhook_subscriptions
             WHERE organization_id = $1
             ORDER BY created_at DESC
             "#,
@@ -647,7 +662,8 @@ impl ApiEcosystemRepository {
     /// Get a webhook subscription by ID.
     ///
     /// RLS scopes this by-id read to the connection's org: another org's
-    /// subscription is invisible and surfaces as `None` (`404`).
+    /// subscription is invisible and surfaces as `None` (`404`). Uses the
+    /// same column aliasing as [`Self::list_enhanced_webhooks`] — see there.
     pub async fn get_enhanced_webhook<'e, E>(
         &self,
         executor: E,
@@ -658,7 +674,16 @@ impl ApiEcosystemRepository {
     {
         let subscription = sqlx::query_as::<_, EnhancedWebhookSubscription>(
             r#"
-            SELECT * FROM webhook_subscriptions WHERE id = $1
+            SELECT
+                id, organization_id, name, description, url,
+                'hmac_sha256' as auth_type, NULL::jsonb as auth_config,
+                events, NULL::jsonb as filters, NULL::jsonb as payload_template,
+                CASE WHEN is_active THEN 'active' ELSE 'inactive' END as status,
+                headers, retry_config as retry_policy,
+                NULL::int4 as rate_limit_requests, NULL::int4 as rate_limit_window_seconds,
+                30000 as timeout_ms, TRUE as verify_ssl,
+                created_by, created_at, updated_at
+            FROM webhook_subscriptions WHERE id = $1
             "#,
         )
         .bind(id)
@@ -1131,9 +1156,26 @@ impl ApiEcosystemRepository {
     where
         E: Executor<'e, Database = Postgres>,
     {
+        // Aliased projection: the 00102 `webhook_deliveries` schema has no
+        // `event_id`/`attempts`/`created_at`/... columns the enhanced model
+        // expects, so a `SELECT *` cannot decode (masked pre-fix by the
+        // FORCE-RLS deny-all returning zero rows).
         let logs = sqlx::query_as::<_, EnhancedWebhookDeliveryLog>(
             r#"
-            SELECT * FROM webhook_deliveries
+            SELECT
+                id, subscription_id, event_type,
+                id as event_id,
+                payload, NULL::jsonb as transformed_payload,
+                status,
+                attempt_number as attempts,
+                delivered_at as last_attempt_at,
+                next_retry_at,
+                NULL::jsonb as request_headers,
+                response_status, response_headers, response_body,
+                error_message, NULL::text as error_code,
+                duration_ms, NULL::text as ip_address,
+                delivered_at as created_at
+            FROM webhook_deliveries
             WHERE subscription_id = $1
             ORDER BY delivered_at DESC
             LIMIT $2 OFFSET $3

--- a/backend/crates/db/tests/api_ecosystem_rls_repo_tests.rs
+++ b/backend/crates/db/tests/api_ecosystem_rls_repo_tests.rs
@@ -1,0 +1,289 @@
+//! Repo-level behavioral RLS regression test for PAP-110 (parent PAP-80 / PAP-67).
+//!
+//! Background
+//! ----------
+//! Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on six tables `ApiEcosystemRepository`
+//! queries: `organization_integrations`, `organization_connectors`,
+//! `connector_execution_logs`, `webhook_subscriptions`, `webhook_deliveries`,
+//! and `integration_ratings`. The production api-server connects as the table
+//! OWNER, which `FORCE` binds. The repo held a raw `PgPool` and ran every
+//! query WITHOUT ever calling `set_request_context`, so on `dev`
+//! `get_current_org_id()` returned NULL and the policies collapsed to
+//! deny-all: own-org webhook/integration reads returned empty and writes
+//! failed. Worse, the by-id webhook reads (`/webhooks/{id}`) had no app-level
+//! org check either, so before `FORCE` they were a cross-tenant IDOR.
+//!
+//! The fix makes the repo stateless: every method takes an executor whose
+//! connection already has RLS context set (handlers use the `RlsConnection`
+//! extractor). This test exercises the *repository methods themselves* on a
+//! `FORCE`-bound role and proves, against `webhook_subscriptions`:
+//!
+//!   1. **Deny-all reproduction** — with the role bound but NO context set
+//!      (exactly what the raw-pool repo did on `dev`), an own-org
+//!      `get_enhanced_webhook` / `list_enhanced_webhooks` returns nothing.
+//!   2. **Fix** — with `set_request_context(org_a, user_a)` applied first,
+//!      the same by-id read returns the own-org subscription.
+//!   3. **Cross-tenant by-id** — org B's webhook is invisible to an org-A
+//!      caller probing org B's subscription id (the IDOR guard, now enforced
+//!      by the database).
+//!   4. **Write path** — `create_enhanced_webhook` succeeds under org-A
+//!      context and the row lands in the caller's org.
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — even `FORCE` does not bind a superuser, so a behavioral
+//! assertion would pass vacuously. The test creates a plain `NOSUPERUSER
+//! NOBYPASSRLS` role, grants it access, and `SET ROLE`s to it so `FORCE`
+//! actually enforces the policy the way the production owner role
+//! experiences it. Mirrors `llm_document_rls_repo_tests.rs` /
+//! `sentiment_rls_repo_tests.rs` (the PAP-67 precedent PAP-80 follows).
+
+use db::models::CreateEnhancedWebhookSubscription;
+use db::repositories::ApiEcosystemRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Ecosystem {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@ecosystem.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'Ecosystem User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Seed a webhook subscription directly (as superuser, RLS-exempt) for an org.
+async fn seed_webhook(pool: &PgPool, org_id: Uuid, created_by: Uuid, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO webhook_subscriptions
+            (organization_id, name, url, secret, events, created_by)
+        VALUES ($1, $2, 'https://example.test/hook', 'whsec_test', ARRAY['integration.installed'], $3)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(name)
+    .bind(created_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed webhook subscription")
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn api_ecosystem_repo_force_rls_deny_all_and_fix(pool: PgPool) {
+    let repo = ApiEcosystemRepository::new(pool.clone());
+
+    // --- Seed as superuser / super-admin context (satisfies org roles-trigger). ---
+    set_ctx(&pool, None, None, true).await;
+    let org_a = seed_org(&pool, "ecoforce-a").await;
+    let org_b = seed_org(&pool, "ecoforce-b").await;
+    let user_a = seed_user(&pool, "a@ecosystem.test").await;
+    let user_b = seed_user(&pool, "b@ecosystem.test").await;
+    let hook_a = seed_webhook(&pool, org_a, user_a, "org-a billing hook").await;
+    let hook_b = seed_webhook(&pool, org_b, user_b, "org-b confidential hook").await;
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    let role = format!("ppt_rls_ecosystem_{}", Uuid::new_v4().simple());
+    for stmt in [
+        format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
+        format!("GRANT SELECT, INSERT, UPDATE, DELETE ON webhook_subscriptions TO \"{role}\""),
+        // The org-not-deleted policy helper reads `organizations` with invoker
+        // rights, so the bound role needs read access to it.
+        format!("GRANT SELECT ON organizations TO \"{role}\""),
+        // RLS policy helpers must be EXECUTE-able by the bound role.
+        format!("GRANT EXECUTE ON FUNCTION get_current_org_id() TO \"{role}\""),
+        format!("GRANT EXECUTE ON FUNCTION get_current_org_not_deleted() TO \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .expect("grant setup");
+    }
+
+    // ====================================================================
+    // (1) DENY-ALL reproduction: role bound, NO context set (the dev raw-pool
+    //     behavior). Own-org webhook reads return nothing.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        // Explicitly clear any inherited context, then drop to the bound role.
+        sqlx::query("SELECT clear_request_context()")
+            .execute(&mut *conn)
+            .await
+            .expect("clear ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let by_id = repo
+            .get_enhanced_webhook(&mut *conn, hook_a)
+            .await
+            .expect("get_enhanced_webhook (no ctx)");
+        assert!(
+            by_id.is_none(),
+            "PAP-80 regression: without RLS context, the own-org webhook must be \
+             invisible (deny-all) — this is what the raw-pool repo did on dev"
+        );
+
+        let listed = repo
+            .list_enhanced_webhooks(&mut *conn, org_a)
+            .await
+            .expect("list_enhanced_webhooks (no ctx)");
+        assert!(
+            listed.is_empty(),
+            "PAP-80 regression: the org-scoped webhook list silently returned \
+             nothing on the raw pool"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (2) FIX + (3) cross-tenant by-id: set context, drop to bound role, query.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        // (2) Own-org by-id read IS now visible through the repo — the fix.
+        let by_id = repo
+            .get_enhanced_webhook(&mut *conn, hook_a)
+            .await
+            .expect("get_enhanced_webhook (ctx)")
+            .expect("own-org webhook must be visible with RLS context set");
+        assert_eq!(
+            by_id.id, hook_a,
+            "PAP-80 fix: with RLS context set, the by-id read returns exactly the own-org webhook"
+        );
+        assert_eq!(by_id.organization_id, org_a);
+
+        // (3) Cross-tenant by-id: probing org B's webhook id from an org-A
+        //     context must surface nothing (handler maps None to 404). This
+        //     was an unguarded IDOR before — the handler had no org check.
+        let cross = repo
+            .get_enhanced_webhook(&mut *conn, hook_b)
+            .await
+            .expect("get_enhanced_webhook (cross-tenant probe)");
+        assert!(
+            cross.is_none(),
+            "cross-tenant: org B's webhook must NOT be readable by an org-A caller"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (4) WRITE path: a create on a context-set connection succeeds and the
+    //     row is the caller's org. Without context the INSERT would fail the
+    //     policy WITH CHECK (the write-side of deny-all).
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let created = repo
+            .create_enhanced_webhook(
+                &mut *conn,
+                org_a,
+                user_a,
+                &CreateEnhancedWebhookSubscription {
+                    name: "org-a created under ctx".to_string(),
+                    description: None,
+                    url: "https://example.test/created".to_string(),
+                    auth_type: "hmac_sha256".to_string(),
+                    auth_config: None,
+                    events: vec!["integration.installed".to_string()],
+                    filters: None,
+                    payload_template: None,
+                    headers: None,
+                    retry_policy: None,
+                    rate_limit_requests: None,
+                    rate_limit_window_seconds: None,
+                    timeout_ms: None,
+                    verify_ssl: None,
+                },
+            )
+            .await
+            .expect("create_enhanced_webhook under context must succeed");
+        assert_eq!(created.organization_id, org_a);
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup the test role. ---
+    set_ctx(&pool, None, None, true).await;
+    for stmt in [
+        format!("REVOKE ALL ON webhook_subscriptions FROM \"{role}\""),
+        format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .ok();
+    }
+}

--- a/backend/servers/api-server/src/routes/api_ecosystem.rs
+++ b/backend/servers/api-server/src/routes/api_ecosystem.rs
@@ -1,7 +1,28 @@
 //! API Ecosystem Expansion routes (Epic 150).
 //!
 //! Routes for integration marketplace, connector framework, webhooks, and developer portal.
+//!
+//! # RLS (PAP-110, parent PAP-80)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` on the org-scoped tables
+//! behind this router (`organization_integrations`, `organization_connectors`,
+//! `connector_execution_logs`, `webhook_subscriptions`, `webhook_deliveries`,
+//! `integration_ratings`), so queries against them MUST run on a connection
+//! with `app.current_org_id` set or they collapse to deny-all. Handlers that
+//! touch those tables acquire an [`RlsConnection`] (which validates tenant
+//! membership and sets the org/user GUCs on a dedicated connection) and pass
+//! `&mut **rls.conn()` to the repository. The authoritative organization is
+//! `rls.tenant_id()` — the tenant the caller was validated against — not the
+//! client-supplied `{org_id}` path segment (retained for wire compatibility),
+//! so the SQL org filter and the RLS context can never disagree. Cross-tenant
+//! by-id access surfaces as `404` via RLS. `rls.release()` clears the context
+//! before the connection returns to the pool.
+//!
+//! Handlers for the global catalog tables (marketplace, connectors, docs,
+//! developer portal — not FORCE-RLS; the owner role remains exempt) pass the
+//! app pool directly, preserving public/platform-admin access semantics.
 
+use api_core::extractors::RlsConnection;
 use api_core::{AuthUser, TenantExtractor};
 use axum::{
     extract::{Path, Query, State},
@@ -177,6 +198,9 @@ pub fn router() -> Router<AppState> {
 // ==================== Types ====================
 
 /// Organization ID path parameter.
+///
+/// Retained for wire compatibility; the authoritative org for RLS-scoped
+/// handlers is `rls.tenant_id()`.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct OrgIdPath {
     pub org_id: Uuid,
@@ -273,7 +297,7 @@ async fn list_marketplace_integrations(
 ) -> Result<Json<Vec<MarketplaceIntegrationSummary>>, (StatusCode, Json<ErrorResponse>)> {
     let integrations = state
         .api_ecosystem_repo
-        .list_marketplace_integrations(&query)
+        .list_marketplace_integrations(&state.db, &query)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -309,7 +333,7 @@ async fn create_marketplace_integration(
 
     let integration = state
         .api_ecosystem_repo
-        .create_marketplace_integration(&request)
+        .create_marketplace_integration(&state.db, &request)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -333,7 +357,7 @@ async fn get_marketplace_integration(
 ) -> Result<Json<MarketplaceIntegration>, (StatusCode, Json<ErrorResponse>)> {
     let integration = state
         .api_ecosystem_repo
-        .get_marketplace_integration(path.id)
+        .get_marketplace_integration(&state.db, path.id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| not_found("Integration", path.id))?;
@@ -370,7 +394,7 @@ async fn update_marketplace_integration(
     }
     let integration = state
         .api_ecosystem_repo
-        .update_marketplace_integration(path.id, &request)
+        .update_marketplace_integration(&state.db, path.id, &request)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| not_found("Integration", path.id))?;
@@ -405,7 +429,7 @@ async fn delete_marketplace_integration(
     }
     let deleted = state
         .api_ecosystem_repo
-        .delete_marketplace_integration(path.id)
+        .delete_marketplace_integration(&state.db, path.id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -430,7 +454,7 @@ async fn list_integration_categories(
 ) -> Result<Json<Vec<IntegrationCategoryCount>>, (StatusCode, Json<ErrorResponse>)> {
     let categories = state
         .api_ecosystem_repo
-        .get_integration_category_counts()
+        .get_integration_category_counts(&state.db)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -451,6 +475,9 @@ fn default_limit() -> i32 {
 }
 
 /// List integration ratings.
+///
+/// Public read: the `integration_ratings_read` policy is `USING (TRUE)`, so
+/// this works on the plain pool even under `FORCE` RLS.
 #[utoipa::path(
     get,
     path = "/api/v1/ecosystem/marketplace/{id}/ratings",
@@ -469,7 +496,7 @@ async fn list_integration_ratings(
     let offset = query.offset.max(0);
     let ratings = state
         .api_ecosystem_repo
-        .list_integration_ratings(path.id, limit, offset)
+        .list_integration_ratings(&state.db, path.id, limit, offset)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -477,6 +504,9 @@ async fn list_integration_ratings(
 }
 
 /// Create integration rating.
+///
+/// `integration_ratings` writes are FORCE-RLS org-scoped — runs on the
+/// caller's RLS connection; the org is `rls.tenant_id()`.
 #[utoipa::path(
     post,
     path = "/api/v1/ecosystem/marketplace/{id}/ratings",
@@ -489,21 +519,20 @@ async fn list_integration_ratings(
 )]
 async fn create_integration_rating(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(path): Path<IntegrationIdPath>,
     Json(request): Json<CreateIntegrationRating>,
 ) -> Result<Json<IntegrationRating>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = auth
-        .tenant_id
-        .ok_or_else(|| error_response("MISSING_ORG", "Organization context required"))?;
-
-    let rating = state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .api_ecosystem_repo
-        .create_integration_rating(path.id, org_id, auth.user_id, &request)
+        .create_integration_rating(&mut **rls.conn(), path.id, org_id, user_id, &request)
         .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
-
-    Ok(Json(rating))
+        .map(Json)
+        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()));
+    rls.release().await;
+    out
 }
 
 /// List organization integrations.
@@ -518,16 +547,18 @@ async fn create_integration_rating(
 )]
 async fn list_organization_integrations(
     State(state): State<AppState>,
-    _tenant: TenantExtractor,
-    Path(path): Path<OrgIdPath>,
+    mut rls: RlsConnection,
+    Path(_path): Path<OrgIdPath>,
 ) -> Result<Json<Vec<OrganizationIntegration>>, (StatusCode, Json<ErrorResponse>)> {
-    let integrations = state
+    let org_id = rls.tenant_id();
+    let out = state
         .api_ecosystem_repo
-        .list_organization_integrations(path.org_id)
+        .list_organization_integrations(&mut **rls.conn(), org_id)
         .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
-
-    Ok(Json(integrations))
+        .map(Json)
+        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()));
+    rls.release().await;
+    out
 }
 
 /// Install integration.
@@ -543,104 +574,125 @@ async fn list_organization_integrations(
 )]
 async fn install_integration(
     State(state): State<AppState>,
-    _tenant: TenantExtractor,
-    auth: AuthUser,
-    Path(path): Path<OrgIdPath>,
+    mut rls: RlsConnection,
+    Path(_path): Path<OrgIdPath>,
     Json(request): Json<InstallIntegration>,
 ) -> Result<Json<OrganizationIntegration>, (StatusCode, Json<ErrorResponse>)> {
-    let installation = state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .api_ecosystem_repo
-        .install_integration(path.org_id, auth.user_id, &request)
+        .install_integration(rls.conn(), org_id, user_id, &request)
         .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
-
-    Ok(Json(installation))
+        .map(Json)
+        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()));
+    rls.release().await;
+    out
 }
 
 /// Get organization integration.
 async fn get_organization_integration(
     State(state): State<AppState>,
-    _tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Path(path): Path<OrgIntegrationPath>,
 ) -> Result<Json<OrganizationIntegration>, (StatusCode, Json<ErrorResponse>)> {
-    let integration = state
+    let org_id = rls.tenant_id();
+    let out = state
         .api_ecosystem_repo
-        .get_organization_integration(path.org_id, path.id)
+        .get_organization_integration(&mut **rls.conn(), org_id, path.id)
         .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
-        .ok_or_else(|| not_found("Integration", path.id))?;
-
-    Ok(Json(integration))
+        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))
+        .and_then(|opt| {
+            opt.map(Json)
+                .ok_or_else(|| not_found("Integration", path.id))
+        });
+    rls.release().await;
+    out
 }
 
 /// Update organization integration.
 async fn update_organization_integration(
     State(state): State<AppState>,
-    _tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Path(path): Path<OrgIntegrationPath>,
     Json(request): Json<UpdateOrganizationIntegration>,
 ) -> Result<Json<OrganizationIntegration>, (StatusCode, Json<ErrorResponse>)> {
-    let integration = state
+    let org_id = rls.tenant_id();
+    let out = state
         .api_ecosystem_repo
-        .update_organization_integration(path.org_id, path.id, &request)
+        .update_organization_integration(&mut **rls.conn(), org_id, path.id, &request)
         .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
-        .ok_or_else(|| not_found("Integration", path.id))?;
-
-    Ok(Json(integration))
+        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))
+        .and_then(|opt| {
+            opt.map(Json)
+                .ok_or_else(|| not_found("Integration", path.id))
+        });
+    rls.release().await;
+    out
 }
 
 /// Uninstall integration.
 async fn uninstall_integration(
     State(state): State<AppState>,
-    _tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Path(path): Path<OrgIntegrationPath>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let uninstalled = state
+    let org_id = rls.tenant_id();
+    let out = state
         .api_ecosystem_repo
-        .uninstall_integration(path.org_id, path.id)
+        .uninstall_integration(&mut **rls.conn(), org_id, path.id)
         .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
-
-    if uninstalled {
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Err(not_found("Integration", path.id))
-    }
+        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))
+        .and_then(|uninstalled| {
+            if uninstalled {
+                Ok(StatusCode::NO_CONTENT)
+            } else {
+                Err(not_found("Integration", path.id))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 /// Sync integration.
 async fn sync_integration(
     State(state): State<AppState>,
-    _tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Path(path): Path<OrgIntegrationPath>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    // Verify the integration exists
-    let integration = state
-        .api_ecosystem_repo
-        .get_organization_integration(path.org_id, path.id)
-        .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
-        .ok_or_else(|| not_found("Integration", path.id))?;
+    let org_id = rls.tenant_id();
+    let out = async {
+        // Verify the integration exists (RLS scopes the read to the caller's org)
+        let integration = state
+            .api_ecosystem_repo
+            .get_organization_integration(&mut **rls.conn(), org_id, path.id)
+            .await
+            .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
+            .ok_or_else(|| not_found("Integration", path.id))?;
 
-    // In a real implementation, this would trigger an async sync job
-    // For now, we update the last_sync_at timestamp and return success
-    let _ = state
-        .api_ecosystem_repo
-        .update_organization_integration(
-            path.org_id,
-            integration.integration_id,
-            &db::models::UpdateOrganizationIntegration::default(),
-        )
-        .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
+        // In a real implementation, this would trigger an async sync job
+        // For now, we update the last_sync_at timestamp and return success
+        let _ = state
+            .api_ecosystem_repo
+            .update_organization_integration(
+                &mut **rls.conn(),
+                org_id,
+                integration.integration_id,
+                &db::models::UpdateOrganizationIntegration::default(),
+            )
+            .await
+            .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
-    Ok(Json(serde_json::json!({
-        "status": "completed",
-        "integration_id": path.id,
-        "records_synced": 0,
-        "synced_at": Utc::now()
-    })))
+        Ok(Json(serde_json::json!({
+            "status": "completed",
+            "integration_id": path.id,
+            "records_synced": 0,
+            "synced_at": Utc::now()
+        })))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 // ==================== Story 150.2: Connector Framework ====================
@@ -651,7 +703,7 @@ async fn list_connectors(
 ) -> Result<Json<Vec<Connector>>, (StatusCode, Json<ErrorResponse>)> {
     let connectors = state
         .api_ecosystem_repo
-        .list_all_connectors()
+        .list_all_connectors(&state.db)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -677,7 +729,7 @@ async fn create_connector(
 
     let connector = state
         .api_ecosystem_repo
-        .create_connector(&request)
+        .create_connector(&state.db, &request)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -691,7 +743,7 @@ async fn get_connector(
 ) -> Result<Json<Connector>, (StatusCode, Json<ErrorResponse>)> {
     let connector = state
         .api_ecosystem_repo
-        .get_connector(path.id)
+        .get_connector(&state.db, path.id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| not_found("Connector", path.id))?;
@@ -718,7 +770,7 @@ async fn update_connector(
 
     let connector = state
         .api_ecosystem_repo
-        .update_connector(path.id, &request)
+        .update_connector(&state.db, path.id, &request)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| not_found("Connector", path.id))?;
@@ -744,7 +796,7 @@ async fn delete_connector(
 
     let deleted = state
         .api_ecosystem_repo
-        .delete_connector(path.id)
+        .delete_connector(&state.db, path.id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -762,7 +814,7 @@ async fn list_connector_actions(
 ) -> Result<Json<Vec<ConnectorAction>>, (StatusCode, Json<ErrorResponse>)> {
     let actions = state
         .api_ecosystem_repo
-        .list_connector_actions(path.id)
+        .list_connector_actions(&state.db, path.id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -778,7 +830,7 @@ async fn create_connector_action(
 ) -> Result<Json<ConnectorAction>, (StatusCode, Json<ErrorResponse>)> {
     let action = state
         .api_ecosystem_repo
-        .create_connector_action(&request)
+        .create_connector_action(&state.db, &request)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -788,17 +840,19 @@ async fn create_connector_action(
 /// List connector execution logs.
 async fn list_connector_logs(
     State(state): State<AppState>,
-    _tenant: TenantExtractor,
-    Path(path): Path<OrgIdPath>,
+    mut rls: RlsConnection,
+    Path(_path): Path<OrgIdPath>,
     Query(query): Query<ConnectorExecutionQuery>,
 ) -> Result<Json<Vec<ConnectorExecutionLog>>, (StatusCode, Json<ErrorResponse>)> {
-    let logs = state
+    let org_id = rls.tenant_id();
+    let out = state
         .api_ecosystem_repo
-        .list_connector_execution_logs(path.org_id, &query)
+        .list_connector_execution_logs(&mut **rls.conn(), org_id, &query)
         .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
-
-    Ok(Json(logs))
+        .map(Json)
+        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()));
+    rls.release().await;
+    out
 }
 
 // ==================== Story 150.3: Webhook Management ====================
@@ -806,146 +860,169 @@ async fn list_connector_logs(
 /// List enhanced webhooks.
 async fn list_enhanced_webhooks(
     State(state): State<AppState>,
-    _tenant: TenantExtractor,
-    Path(path): Path<OrgIdPath>,
+    mut rls: RlsConnection,
+    Path(_path): Path<OrgIdPath>,
 ) -> Result<Json<Vec<EnhancedWebhookSubscription>>, (StatusCode, Json<ErrorResponse>)> {
-    let webhooks = state
+    let org_id = rls.tenant_id();
+    let out = state
         .api_ecosystem_repo
-        .list_enhanced_webhooks(path.org_id)
+        .list_enhanced_webhooks(&mut **rls.conn(), org_id)
         .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
-
-    Ok(Json(webhooks))
+        .map(Json)
+        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()));
+    rls.release().await;
+    out
 }
 
 /// Create enhanced webhook.
 async fn create_enhanced_webhook(
     State(state): State<AppState>,
-    _tenant: TenantExtractor,
-    auth: AuthUser,
-    Path(path): Path<OrgIdPath>,
+    mut rls: RlsConnection,
+    Path(_path): Path<OrgIdPath>,
     Json(request): Json<CreateEnhancedWebhookSubscription>,
 ) -> Result<Json<EnhancedWebhookSubscription>, (StatusCode, Json<ErrorResponse>)> {
-    let webhook = state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .api_ecosystem_repo
-        .create_enhanced_webhook(path.org_id, auth.user_id, &request)
+        .create_enhanced_webhook(&mut **rls.conn(), org_id, user_id, &request)
         .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
-
-    Ok(Json(webhook))
+        .map(Json)
+        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()));
+    rls.release().await;
+    out
 }
 
 /// Get enhanced webhook.
+///
+/// RLS scopes the by-id read to the caller's org — another org's webhook
+/// surfaces as `404` (previously this read was unscoped: cross-tenant IDOR).
 async fn get_enhanced_webhook(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(path): Path<IntegrationIdPath>,
 ) -> Result<Json<EnhancedWebhookSubscription>, (StatusCode, Json<ErrorResponse>)> {
-    let webhook = state
+    let out = state
         .api_ecosystem_repo
-        .get_enhanced_webhook(path.id)
+        .get_enhanced_webhook(&mut **rls.conn(), path.id)
         .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
-        .ok_or_else(|| not_found("Webhook", path.id))?;
-
-    Ok(Json(webhook))
+        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))
+        .and_then(|opt| opt.map(Json).ok_or_else(|| not_found("Webhook", path.id)));
+    rls.release().await;
+    out
 }
 
 /// Update enhanced webhook.
 async fn update_enhanced_webhook(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(path): Path<IntegrationIdPath>,
     Json(request): Json<UpdateEnhancedWebhookSubscription>,
 ) -> Result<Json<EnhancedWebhookSubscription>, (StatusCode, Json<ErrorResponse>)> {
-    let webhook = state
+    let out = state
         .api_ecosystem_repo
-        .update_enhanced_webhook(path.id, &request)
+        .update_enhanced_webhook(&mut **rls.conn(), path.id, &request)
         .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
-        .ok_or_else(|| not_found("Webhook", path.id))?;
-
-    Ok(Json(webhook))
+        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))
+        .and_then(|opt| opt.map(Json).ok_or_else(|| not_found("Webhook", path.id)));
+    rls.release().await;
+    out
 }
 
 /// Delete enhanced webhook.
 async fn delete_enhanced_webhook(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(path): Path<IntegrationIdPath>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let deleted = state
+    let out = state
         .api_ecosystem_repo
-        .delete_enhanced_webhook(path.id)
+        .delete_enhanced_webhook(&mut **rls.conn(), path.id)
         .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
-
-    if deleted {
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Err(not_found("Webhook", path.id))
-    }
+        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))
+        .and_then(|deleted| {
+            if deleted {
+                Ok(StatusCode::NO_CONTENT)
+            } else {
+                Err(not_found("Webhook", path.id))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 /// Test enhanced webhook.
 async fn test_enhanced_webhook(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(path): Path<IntegrationIdPath>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    // Get the webhook to verify it exists and get the URL
-    let webhook = state
-        .api_ecosystem_repo
-        .get_enhanced_webhook(path.id)
-        .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
-        .ok_or_else(|| not_found("Webhook", path.id))?;
+    let out = async {
+        // Get the webhook to verify it exists and get the URL
+        let webhook = state
+            .api_ecosystem_repo
+            .get_enhanced_webhook(&mut **rls.conn(), path.id)
+            .await
+            .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
+            .ok_or_else(|| not_found("Webhook", path.id))?;
 
-    // In a real implementation, we would send a test payload to the webhook URL
-    // For now, we return a simulated response
-    let test_payload = serde_json::json!({
-        "event": "webhook.test",
-        "timestamp": Utc::now(),
-        "subscription_id": webhook.id,
-        "test": true
-    });
+        // In a real implementation, we would send a test payload to the webhook URL
+        // For now, we return a simulated response
+        let test_payload = serde_json::json!({
+            "event": "webhook.test",
+            "timestamp": Utc::now(),
+            "subscription_id": webhook.id,
+            "test": true
+        });
 
-    Ok(Json(serde_json::json!({
-        "success": true,
-        "webhook_id": webhook.id,
-        "url": webhook.url,
-        "test_payload": test_payload,
-        "status_code": 200,
-        "response_time_ms": 150,
-        "message": "Test webhook delivery simulated successfully"
-    })))
+        Ok(Json(serde_json::json!({
+            "success": true,
+            "webhook_id": webhook.id,
+            "url": webhook.url,
+            "test_payload": test_payload,
+            "status_code": 200,
+            "response_time_ms": 150,
+            "message": "Test webhook delivery simulated successfully"
+        })))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 /// List webhook delivery logs.
 async fn list_webhook_delivery_logs(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(path): Path<IntegrationIdPath>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<Vec<EnhancedWebhookDeliveryLog>>, (StatusCode, Json<ErrorResponse>)> {
     let limit = query.limit.clamp(1, 100);
     let offset = query.offset.max(0);
-    let logs = state
+    let out = state
         .api_ecosystem_repo
-        .list_webhook_delivery_logs(path.id, limit, offset)
+        .list_webhook_delivery_logs(&mut **rls.conn(), path.id, limit, offset)
         .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
-
-    Ok(Json(logs))
+        .map(Json)
+        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()));
+    rls.release().await;
+    out
 }
 
 /// Get enhanced webhook statistics.
 async fn get_enhanced_webhook_stats(
     State(state): State<AppState>,
+    mut rls: RlsConnection,
     Path(path): Path<IntegrationIdPath>,
 ) -> Result<Json<EnhancedWebhookStatistics>, (StatusCode, Json<ErrorResponse>)> {
-    let stats = state
+    let out = state
         .api_ecosystem_repo
-        .get_webhook_statistics(path.id)
+        .get_webhook_statistics(&mut **rls.conn(), path.id)
         .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
-
-    Ok(Json(stats))
+        .map(Json)
+        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()));
+    rls.release().await;
+    out
 }
 
 /// List available webhook event types.
@@ -987,139 +1064,167 @@ async fn list_webhook_event_types(
 /// List pre-built integration connections.
 async fn list_prebuilt_connections(
     State(state): State<AppState>,
-    _tenant: TenantExtractor,
-    Path(path): Path<OrgIdPath>,
+    mut rls: RlsConnection,
+    Path(_path): Path<OrgIdPath>,
 ) -> Result<Json<Vec<PreBuiltIntegrationConnection>>, (StatusCode, Json<ErrorResponse>)> {
-    let connections = state
+    let org_id = rls.tenant_id();
+    let out = state
         .api_ecosystem_repo
-        .list_prebuilt_connections(path.org_id)
+        .list_prebuilt_connections(&mut **rls.conn(), org_id)
         .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
-
-    Ok(Json(connections))
+        .map(Json)
+        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()));
+    rls.release().await;
+    out
 }
 
 /// Create pre-built integration connection.
 async fn create_prebuilt_connection(
     State(state): State<AppState>,
-    _tenant: TenantExtractor,
-    auth: AuthUser,
-    Path(path): Path<OrgIdPath>,
+    mut rls: RlsConnection,
+    Path(_path): Path<OrgIdPath>,
     Json(request): Json<CreatePreBuiltIntegrationConnection>,
 ) -> Result<Json<PreBuiltIntegrationConnection>, (StatusCode, Json<ErrorResponse>)> {
-    let connection = state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .api_ecosystem_repo
-        .create_prebuilt_connection(path.org_id, auth.user_id, &request)
+        .create_prebuilt_connection(&mut **rls.conn(), org_id, user_id, &request)
         .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
-
-    Ok(Json(connection))
+        .map(Json)
+        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()));
+    rls.release().await;
+    out
 }
 
 /// Get pre-built integration connection.
 async fn get_prebuilt_connection(
     State(state): State<AppState>,
-    _tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Path(path): Path<PrebuiltTypePath>,
 ) -> Result<Json<PreBuiltIntegrationConnection>, (StatusCode, Json<ErrorResponse>)> {
-    let connection = state
+    let org_id = rls.tenant_id();
+    let out = state
         .api_ecosystem_repo
-        .get_prebuilt_connection(path.org_id, &path.integration_type)
+        .get_prebuilt_connection(&mut **rls.conn(), org_id, &path.integration_type)
         .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
-        .ok_or_else(|| not_found("Pre-built connection", &path.integration_type))?;
-
-    Ok(Json(connection))
+        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))
+        .and_then(|opt| {
+            opt.map(Json)
+                .ok_or_else(|| not_found("Pre-built connection", &path.integration_type))
+        });
+    rls.release().await;
+    out
 }
 
 /// Update pre-built integration connection.
 async fn update_prebuilt_connection(
     State(state): State<AppState>,
-    _tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Path(path): Path<PrebuiltTypePath>,
     Json(request): Json<UpdatePreBuiltIntegrationConnection>,
 ) -> Result<Json<PreBuiltIntegrationConnection>, (StatusCode, Json<ErrorResponse>)> {
-    let connection = state
+    let org_id = rls.tenant_id();
+    let out = state
         .api_ecosystem_repo
-        .update_prebuilt_connection(path.org_id, &path.integration_type, &request)
+        .update_prebuilt_connection(&mut **rls.conn(), org_id, &path.integration_type, &request)
         .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
-        .ok_or_else(|| not_found("Pre-built connection", &path.integration_type))?;
-
-    Ok(Json(connection))
+        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))
+        .and_then(|opt| {
+            opt.map(Json)
+                .ok_or_else(|| not_found("Pre-built connection", &path.integration_type))
+        });
+    rls.release().await;
+    out
 }
 
 /// Delete pre-built integration connection.
 async fn delete_prebuilt_connection(
     State(state): State<AppState>,
-    _tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Path(path): Path<PrebuiltTypePath>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let deleted = state
+    let org_id = rls.tenant_id();
+    let out = state
         .api_ecosystem_repo
-        .delete_prebuilt_connection(path.org_id, &path.integration_type)
+        .delete_prebuilt_connection(&mut **rls.conn(), org_id, &path.integration_type)
         .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
-
-    if deleted {
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Err(not_found("Pre-built connection", &path.integration_type))
-    }
+        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))
+        .and_then(|deleted| {
+            if deleted {
+                Ok(StatusCode::NO_CONTENT)
+            } else {
+                Err(not_found("Pre-built connection", &path.integration_type))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 /// Sync pre-built integration.
 async fn sync_prebuilt_connection(
     State(state): State<AppState>,
-    _tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Path(path): Path<PrebuiltTypePath>,
     Json(request): Json<SyncPreBuiltIntegrationRequest>,
 ) -> Result<Json<PreBuiltIntegrationSyncResult>, (StatusCode, Json<ErrorResponse>)> {
-    // Verify the connection exists
-    let connection = state
-        .api_ecosystem_repo
-        .get_prebuilt_connection(path.org_id, &path.integration_type)
-        .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
-        .ok_or_else(|| not_found("Pre-built connection", &path.integration_type))?;
+    let org_id = rls.tenant_id();
+    let out = async {
+        // Verify the connection exists
+        let connection = state
+            .api_ecosystem_repo
+            .get_prebuilt_connection(&mut **rls.conn(), org_id, &path.integration_type)
+            .await
+            .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
+            .ok_or_else(|| not_found("Pre-built connection", &path.integration_type))?;
 
-    // Check if connection is in a valid state for sync
-    if connection.status != "connected" {
-        return Err(error_response(
-            "INVALID_STATE",
-            "Connection must be in 'connected' status to sync",
-        ));
+        // Check if connection is in a valid state for sync
+        if connection.status != "connected" {
+            return Err(error_response(
+                "INVALID_STATE",
+                "Connection must be in 'connected' status to sync",
+            ));
+        }
+
+        let start_time = Utc::now();
+
+        // In a real implementation, this would:
+        // 1. Use the stored OAuth tokens to authenticate with the external service
+        // 2. Fetch data based on request.entity_types and date range
+        // 3. Transform and store the data locally
+        // 4. Handle errors and retries
+        // For now, we simulate the sync operation
+
+        let _full_sync = request.full_sync.unwrap_or(false);
+        let duration_ms = (Utc::now() - start_time).num_milliseconds() as i32;
+
+        // Record the sync attempt
+        let _ = state
+            .api_ecosystem_repo
+            .record_prebuilt_sync(
+                &mut **rls.conn(),
+                org_id,
+                &path.integration_type,
+                true,
+                None,
+            )
+            .await;
+
+        let result = PreBuiltIntegrationSyncResult {
+            integration_type: path.integration_type.clone(),
+            records_created: 0,
+            records_updated: 0,
+            records_deleted: 0,
+            errors: vec![],
+            synced_at: Utc::now(),
+            duration_ms,
+        };
+
+        Ok(Json(result))
     }
-
-    let start_time = Utc::now();
-
-    // In a real implementation, this would:
-    // 1. Use the stored OAuth tokens to authenticate with the external service
-    // 2. Fetch data based on request.entity_types and date range
-    // 3. Transform and store the data locally
-    // 4. Handle errors and retries
-    // For now, we simulate the sync operation
-
-    let _full_sync = request.full_sync.unwrap_or(false);
-    let duration_ms = (Utc::now() - start_time).num_milliseconds() as i32;
-
-    // Record the sync attempt
-    let _ = state
-        .api_ecosystem_repo
-        .record_prebuilt_sync(path.org_id, &path.integration_type, true, None)
-        .await;
-
-    let result = PreBuiltIntegrationSyncResult {
-        integration_type: path.integration_type,
-        records_created: 0,
-        records_updated: 0,
-        records_deleted: 0,
-        errors: vec![],
-        synced_at: Utc::now(),
-        duration_ms,
-    };
-
-    Ok(Json(result))
+    .await;
+    rls.release().await;
+    out
 }
 
 /// Get OAuth URL for pre-built integration.
@@ -1208,49 +1313,56 @@ fn oauth_env(integration: &str, key: &str) -> Result<String, (StatusCode, Json<E
 /// Handle OAuth callback for pre-built integration.
 async fn handle_prebuilt_oauth_callback(
     State(state): State<AppState>,
-    _tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Path(path): Path<PrebuiltTypePath>,
     Json(request): Json<OAuthCallbackRequest>,
 ) -> Result<Json<PreBuiltIntegrationConnection>, (StatusCode, Json<ErrorResponse>)> {
-    // Verify the connection exists (should have been created when OAuth flow started)
-    let _existing = state
-        .api_ecosystem_repo
-        .get_prebuilt_connection(path.org_id, &path.integration_type)
-        .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
-        .ok_or_else(|| not_found("Pre-built connection", &path.integration_type))?;
+    let org_id = rls.tenant_id();
+    let out = async {
+        // Verify the connection exists (should have been created when OAuth flow started)
+        let _existing = state
+            .api_ecosystem_repo
+            .get_prebuilt_connection(&mut **rls.conn(), org_id, &path.integration_type)
+            .await
+            .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
+            .ok_or_else(|| not_found("Pre-built connection", &path.integration_type))?;
 
-    // In a real implementation, we would:
-    // 1. Exchange the authorization code for access/refresh tokens using the integration's token endpoint
-    // 2. Encrypt the tokens before storage
-    // 3. Calculate token expiration time
-    // 4. Update the connection with the tokens
+        // In a real implementation, we would:
+        // 1. Exchange the authorization code for access/refresh tokens using the integration's token endpoint
+        // 2. Encrypt the tokens before storage
+        // 3. Calculate token expiration time
+        // 4. Update the connection with the tokens
 
-    // For now, we simulate the token exchange
-    let simulated_access_token = format!("encrypted_access_token_{}", Uuid::new_v4());
-    let simulated_refresh_token = format!("encrypted_refresh_token_{}", Uuid::new_v4());
-    let token_expires_at = Utc::now() + Duration::hours(1);
+        // For now, we simulate the token exchange
+        let simulated_access_token = format!("encrypted_access_token_{}", Uuid::new_v4());
+        let simulated_refresh_token = format!("encrypted_refresh_token_{}", Uuid::new_v4());
+        let token_expires_at = Utc::now() + Duration::hours(1);
 
-    // Validate state parameter if provided (for CSRF protection)
-    if request.state.is_some() {
-        // In production, verify the state matches what was generated in get_prebuilt_oauth_url
+        // Validate state parameter if provided (for CSRF protection)
+        if request.state.is_some() {
+            // In production, verify the state matches what was generated in get_prebuilt_oauth_url
+        }
+
+        // Update the connection with tokens
+        let connection = state
+            .api_ecosystem_repo
+            .update_prebuilt_connection_tokens(
+                &mut **rls.conn(),
+                org_id,
+                &path.integration_type,
+                &simulated_access_token,
+                Some(&simulated_refresh_token),
+                Some(token_expires_at),
+            )
+            .await
+            .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
+            .ok_or_else(|| not_found("Pre-built connection", &path.integration_type))?;
+
+        Ok(Json(connection))
     }
-
-    // Update the connection with tokens
-    let connection = state
-        .api_ecosystem_repo
-        .update_prebuilt_connection_tokens(
-            path.org_id,
-            &path.integration_type,
-            &simulated_access_token,
-            Some(&simulated_refresh_token),
-            Some(token_expires_at),
-        )
-        .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
-        .ok_or_else(|| not_found("Pre-built connection", &path.integration_type))?;
-
-    Ok(Json(connection))
+    .await;
+    rls.release().await;
+    out
 }
 
 // ==================== Story 150.5: Developer Portal ====================
@@ -1263,7 +1375,7 @@ async fn register_developer(
 ) -> Result<Json<DeveloperRegistration>, (StatusCode, Json<ErrorResponse>)> {
     let registration = state
         .api_ecosystem_repo
-        .register_developer(auth.user_id, &request)
+        .register_developer(&state.db, auth.user_id, &request)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -1278,7 +1390,7 @@ async fn get_developer_registration(
 ) -> Result<Json<DeveloperRegistration>, (StatusCode, Json<ErrorResponse>)> {
     let registration = state
         .api_ecosystem_repo
-        .get_developer_registration(path.id)
+        .get_developer_registration(&state.db, path.id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| not_found("Developer", path.id))?;
@@ -1304,7 +1416,7 @@ async fn review_developer_registration(
     }
     let registration = state
         .api_ecosystem_repo
-        .review_developer_registration(path.id, auth.user_id, &request)
+        .review_developer_registration(&state.db, path.id, auth.user_id, &request)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| not_found("Developer", path.id))?;
@@ -1322,7 +1434,7 @@ async fn list_developer_api_keys(
     if !auth.is_platform_admin() {
         let dev_account = state
             .api_ecosystem_repo
-            .get_developer_registration(path.id)
+            .get_developer_registration(&state.db, path.id)
             .await
             .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
             .ok_or_else(|| not_found("Developer", path.id))?;
@@ -1339,7 +1451,7 @@ async fn list_developer_api_keys(
 
     let keys = state
         .api_ecosystem_repo
-        .list_developer_api_keys(path.id)
+        .list_developer_api_keys(&state.db, path.id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -1374,7 +1486,7 @@ async fn create_developer_api_key(
     if !auth.is_platform_admin() {
         let dev_account = state
             .api_ecosystem_repo
-            .get_developer_registration(path.id)
+            .get_developer_registration(&state.db, path.id)
             .await
             .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
             .ok_or_else(|| not_found("Developer", path.id))?;
@@ -1405,7 +1517,7 @@ async fn create_developer_api_key(
 
     let api_key = state
         .api_ecosystem_repo
-        .create_developer_api_key(path.id, &request, &key_prefix, &key_hash)
+        .create_developer_api_key(&state.db, path.id, &request, &key_prefix, &key_hash)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -1440,7 +1552,7 @@ async fn revoke_developer_api_key(
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     let revoked = state
         .api_ecosystem_repo
-        .revoke_api_key(path.key_id, auth.user_id)
+        .revoke_api_key(&state.db, path.key_id, auth.user_id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -1460,7 +1572,7 @@ async fn rotate_developer_api_key(
     // Fetch existing key to determine sandbox status for the new key prefix
     let existing_keys = state
         .api_ecosystem_repo
-        .list_developer_api_keys(path.id)
+        .list_developer_api_keys(&state.db, path.id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
     let old_key = existing_keys
@@ -1477,9 +1589,17 @@ async fn rotate_developer_api_key(
     let key_prefix = key.chars().take(8).collect::<String>();
     let key_hash = format!("sha256:{}", sha256_simple(&key));
 
+    // The rotate is multi-statement (revoke old + insert new in one
+    // transaction), so it needs a dedicated connection from the pool.
+    let mut conn = state
+        .db
+        .acquire()
+        .await
+        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
+
     let api_key = state
         .api_ecosystem_repo
-        .rotate_developer_api_key(path.key_id, auth.user_id, &key_prefix, &key_hash)
+        .rotate_developer_api_key(&mut conn, path.key_id, auth.user_id, &key_prefix, &key_hash)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| not_found("API key", path.key_id))?;
@@ -1507,7 +1627,7 @@ async fn get_developer_usage_stats(
     if !auth.is_platform_admin() {
         let dev_account = state
             .api_ecosystem_repo
-            .get_developer_registration(path.id)
+            .get_developer_registration(&state.db, path.id)
             .await
             .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
             .ok_or_else(|| not_found("Developer", path.id))?;
@@ -1524,7 +1644,7 @@ async fn get_developer_usage_stats(
 
     let stats = state
         .api_ecosystem_repo
-        .get_developer_usage_stats(path.id)
+        .get_developer_usage_stats(&state.db, path.id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -1542,7 +1662,7 @@ async fn create_sandbox_environment(
     if !auth.is_platform_admin() {
         let dev_account = state
             .api_ecosystem_repo
-            .get_developer_registration(path.id)
+            .get_developer_registration(&state.db, path.id)
             .await
             .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
             .ok_or_else(|| not_found("Developer", path.id))?;
@@ -1563,7 +1683,7 @@ async fn create_sandbox_environment(
 
     let sandbox = state
         .api_ecosystem_repo
-        .create_sandbox_environment(path.id, &request, expires_at)
+        .create_sandbox_environment(&state.db, path.id, &request, expires_at)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -1580,7 +1700,7 @@ async fn get_sandbox_environment(
     if !auth.is_platform_admin() {
         let dev_account = state
             .api_ecosystem_repo
-            .get_developer_registration(path.id)
+            .get_developer_registration(&state.db, path.id)
             .await
             .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
             .ok_or_else(|| not_found("Developer", path.id))?;
@@ -1597,7 +1717,7 @@ async fn get_sandbox_environment(
 
     let sandbox = state
         .api_ecosystem_repo
-        .get_sandbox_environment(path.id)
+        .get_sandbox_environment(&state.db, path.id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| error_response("NOT_FOUND", "Sandbox environment not found"))?;
@@ -1616,7 +1736,7 @@ async fn test_sandbox_request(
     if !auth.is_platform_admin() {
         let dev_account = state
             .api_ecosystem_repo
-            .get_developer_registration(path.id)
+            .get_developer_registration(&state.db, path.id)
             .await
             .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
             .ok_or_else(|| not_found("Developer", path.id))?;
@@ -1634,7 +1754,7 @@ async fn test_sandbox_request(
     // Verify sandbox exists
     let _sandbox = state
         .api_ecosystem_repo
-        .get_sandbox_environment(path.id)
+        .get_sandbox_environment(&state.db, path.id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| error_response("NOT_FOUND", "Sandbox environment not found"))?;
@@ -1712,7 +1832,7 @@ async fn list_api_documentation(
     // Public endpoint - list only published docs
     let docs = state
         .api_ecosystem_repo
-        .list_api_documentation(true)
+        .list_api_documentation(&state.db, true)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -1737,7 +1857,7 @@ async fn create_api_documentation(
 
     let doc = state
         .api_ecosystem_repo
-        .create_api_documentation(&request)
+        .create_api_documentation(&state.db, &request)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -1751,7 +1871,7 @@ async fn get_api_documentation(
 ) -> Result<Json<ApiDocumentation>, (StatusCode, Json<ErrorResponse>)> {
     let doc = state
         .api_ecosystem_repo
-        .get_api_documentation(&path.slug)
+        .get_api_documentation(&state.db, &path.slug)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| not_found("Documentation", &path.slug))?;
@@ -1778,7 +1898,7 @@ async fn update_api_documentation(
 
     let doc = state
         .api_ecosystem_repo
-        .update_api_documentation(&path.slug, &request)
+        .update_api_documentation(&state.db, &path.slug, &request)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| not_found("Documentation", &path.slug))?;
@@ -1804,7 +1924,7 @@ async fn delete_api_documentation(
 
     let deleted = state
         .api_ecosystem_repo
-        .delete_api_documentation(&path.slug)
+        .delete_api_documentation(&state.db, &path.slug)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -1823,7 +1943,7 @@ async fn list_code_samples(
     let endpoint_path = format!("/api/v1/{}", path.slug);
     let samples = state
         .api_ecosystem_repo
-        .list_code_samples(&endpoint_path)
+        .list_code_samples(&state.db, &endpoint_path)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -1849,7 +1969,7 @@ async fn create_code_sample(
 
     let sample = state
         .api_ecosystem_repo
-        .create_code_sample(&request)
+        .create_code_sample(&state.db, &request)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -1873,7 +1993,7 @@ async fn get_developer_portal_stats(
 
     let stats = state
         .api_ecosystem_repo
-        .get_developer_portal_stats()
+        .get_developer_portal_stats(&state.db)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -1885,29 +2005,33 @@ async fn get_developer_portal_stats(
 /// Get API ecosystem dashboard.
 async fn get_ecosystem_dashboard(
     State(state): State<AppState>,
-    _tenant: TenantExtractor,
-    Path(path): Path<OrgIdPath>,
+    mut rls: RlsConnection,
+    Path(_path): Path<OrgIdPath>,
 ) -> Result<Json<ApiEcosystemDashboard>, (StatusCode, Json<ErrorResponse>)> {
-    let dashboard = state
+    let org_id = rls.tenant_id();
+    let out = state
         .api_ecosystem_repo
-        .get_ecosystem_dashboard(path.org_id)
+        .get_ecosystem_dashboard(&mut **rls.conn(), org_id)
         .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
-
-    Ok(Json(dashboard))
+        .map(Json)
+        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()));
+    rls.release().await;
+    out
 }
 
 /// Get API ecosystem statistics.
 async fn get_ecosystem_statistics(
     State(state): State<AppState>,
-    _tenant: TenantExtractor,
-    Path(path): Path<OrgIdPath>,
+    mut rls: RlsConnection,
+    Path(_path): Path<OrgIdPath>,
 ) -> Result<Json<ApiEcosystemStatistics>, (StatusCode, Json<ErrorResponse>)> {
-    let stats = state
+    let org_id = rls.tenant_id();
+    let out = state
         .api_ecosystem_repo
-        .get_ecosystem_statistics(path.org_id)
+        .get_ecosystem_statistics(&mut **rls.conn(), org_id)
         .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
-
-    Ok(Json(stats))
+        .map(Json)
+        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()));
+    rls.release().await;
+    out
 }


### PR DESCRIPTION
## Summary

PAP-80 RLS sweep, child PAP-110 (chain step 2/2 after PAP-109/legal). `ApiEcosystemRepository` held a raw `PgPool` and queried **6 FORCE-RLS tables** (migration 00179: `organization_integrations`, `organization_connectors`, `connector_execution_logs`, `webhook_subscriptions`, `webhook_deliveries`, `integration_ratings`) without ever setting `app.current_org_id` — under `FORCE` the owner connection is bound, so every org-scoped read returned empty and every write failed (deny-all) on dev. Mounted live at `/api/v1/ecosystem`.

### Conversion (work_order / budget.rs / document.rs precedent)

- Repo is **stateless** — holds no pool; `new(_pool)` retained for `AppState` construction-site compatibility.
- 56 single-statement methods take a generic `E: Executor<'e, Database = Postgres>`.
- 2 multi-statement methods take `&mut PgConnection` with explicit transactions: `install_integration` (unchanged semantics) and `rotate_developer_api_key` (**fix**: revoke-old/insert-new was previously non-atomic on the pool — a failure could leave the developer with the old key revoked and no replacement).
- Handlers for the 6 FORCE-RLS tables acquire `RlsConnection`, pass `&mut **rls.conn()`, use `rls.tenant_id()` as the authoritative org (the `{org_id}` path segment is retained for wire compat but no longer trusted), and `release()` before returning.
- Handlers for global non-FORCE catalog tables (marketplace, connectors, docs, developer portal) pass `&state.db` — public endpoints (marketplace browse, published docs, ratings read via the `USING (TRUE)` policy) and platform-admin endpoints keep their existing access semantics.

### Security hardening included

- **Cross-tenant IDOR closed:** `/webhooks/{id}` get/put/delete/test/logs/stats had **no app-level org check at all**; they now require tenant context and RLS scopes by-id access to 404. Prebuilt-connection handlers similarly stop trusting the client-supplied org.
- `create_integration_rating`, `create_enhanced_webhook`, `install_integration` now derive org/user from the validated RLS context instead of `auth.tenant_id`/path.

### Latent decode bug fixed (was masked by deny-all)

`list_enhanced_webhooks` / `get_enhanced_webhook` / `list_webhook_delivery_logs` used `SELECT *`, but the 00102 schema has none of the enhanced model's `auth_type`/`status`/`retry_policy`/`event_id`/`attempts` columns — the decode fails the moment a row is visible. The raw-pool deny-all returned zero rows, so this never surfaced; fixing the RLS routing exposes it. The reads now use the same aliased projection the create/update `RETURNING` already used.

## Verification (all remote on mercury via rbuild)

- `cargo check -p db -p api-server` ✅
- `cargo clippy -p db -p api-server -- -D warnings` ✅
- `cargo +1.94.1 fmt --all -- --check` (CI-pinned rustfmt) ✅
- **New role-switch RLS test ran for real** against Postgres (`ppt-pap103-pg`, full `db::MIGRATOR` replay): `cargo test -p db --test api_ecosystem_rls_repo_tests` → `test result: ok. 1 passed; 0 failed` (1105s). Covers: deny-all reproduction without context, own-org by-id visibility with context, cross-tenant by-id invisibility, and the write path landing in the caller's org (NOSUPERUSER NOBYPASSRLS role so FORCE actually binds — mirrors `llm_document_rls_repo_tests.rs`).

## API contract notes

- The webhook by-id endpoints and prebuilt/org-integration endpoints now require tenant context (`RlsConnection` = validated membership). Previously some accepted any authenticated/unauthenticated caller — that was the vulnerability.
- One repo = one PR to `dev`, matching the PAP-67/PAP-80 cadence (#1230, #1234, #1237, #1239, #1246).

🤖 Generated with [Claude Code](https://claude.com/claude-code)