### PR TITLE
verify-swiftui-navigation-deeplink-authguard: verify iOS nav/deep-link/auth-guard (Coverage 82-2)

### DIFF
--- a/docs/screens/reality-mobile/README.md
+++ b/docs/screens/reality-mobile/README.md
@@ -21,6 +21,13 @@ They document iOS-specific implementation status, route bindings, and gaps.
 | [compare-listings.md](compare-listings.md) | CompareListingsView | UC-46.5 | in-progress |
 | [realtors.md](realtors.md) | RealtorsView | UC-49.1 | in-progress |
 | [agencies.md](agencies.md) | AgenciesView | UC-51.1 | in-progress |
+| [navigation.md](navigation.md) | NavigationCoordinator / DeepLinkHandler / NavigationStateRestorationService | 82.2 | shipped |
+
+## Cross-Cutting Infrastructure
+
+| Screen Map | Concern | AC | Status |
+|---|---|---|---|
+| [navigation.md](navigation.md) | Navigation state preservation, URL-scheme deep-linking, auth guard | AC-4, AC-5 | verified (Coverage 82-2); `Info.plist` URL-scheme registration gap flagged for pm-mobile |
 
 ## Stub Destinations (Routes defined, views not implemented)
 

--- a/docs/screens/reality-mobile/navigation.md
+++ b/docs/screens/reality-mobile/navigation.md
@@ -1,0 +1,120 @@
+---
+id: reality-mobile/navigation
+name: Navigation & Deep-Linking Infrastructure (iOS SwiftUI)
+product: reality-mobile
+sitemapRefs: {}
+implementations:
+  ios-swiftui:
+    component: NavigationCoordinator / DeepLinkHandler / NavigationStateRestorationService
+    route: MainTabView (TabView + per-tab NavigationStack), Route enum
+    buildStatus: shipped
+    redesignStatus: n/a
+    apiStatus: n/a
+endpoints: []
+relatedScreens:
+  - id: reality-mobile/auth-login
+    rel: child
+  - id: reality-mobile/home
+    rel: child
+  - id: reality-mobile/account
+    rel: child
+sharedComponents: []
+diagrams: []
+useCases: []
+epics:
+  - "82"
+designSources: []
+owner: reality-frontend
+---
+
+## Functionality Checklist
+
+Cross-cutting navigation/routing infrastructure for the Reality Portal iOS app
+(Epic 82, Story 82.2). This is not a visible "screen" — it documents the
+navigation, deep-link, state-restoration, and auth-guard layer that the visible
+screens sit on top of, and records the AC-4 / AC-5 verification evidence
+(Coverage 82-2).
+
+- [x] [m] **AC-4 — Navigation state preservation across launches/backgrounding.**
+  `NavigationStateRestorationService` snapshots `selectedTab` + per-tab route
+  stacks to `UserDefaults` (`navigation_state`) on `scenePhase == .background`
+  and restores them at launch (`RealityPortalApp.configureApp()`).
+- [x] [m] **AC-4 — Route mirrors keep `NavigationPath` serialisable.**
+  `NavigationCoordinator` maintains `*Routes` mirror arrays shadowing the opaque
+  `NavigationPath`s; `restoreStack(_:for:)` writes both atomically so a
+  save→restore→save cycle does not silently drop stacks (regression test
+  `testRoundTripPersistenceSurvivesDoubleRestoreCycle`).
+- [x] [m] **URL-scheme deep-linking.** `DeepLinkHandler.parse(_:)` maps
+  `realityportal://...` custom-scheme URLs and allow-listed `https://`
+  universal links to typed `Route` values (listing/gallery/map, search +
+  filters, favorites, inquiries + detail + new, account/profile/settings,
+  realtors, agencies, saved-searches, compare). SSO callbacks
+  (`realityportal://sso?token=&state=`) are returned as a distinct
+  `.ssoCallback` result, never as a navigation route.
+- [x] [m] **Universal-link host allow-list.** `allowedUniversalLinkHosts`
+  rejects unknown `https://` hosts as defence-in-depth even before AASA is wired.
+- [x] [m] **AC-5 — Auth guard on deep links.** `RealityPortalApp.handleIncomingURL`
+  intercepts routes whose `Route.requiresAuth == true` when
+  `!authManager.isAuthenticated`, stashes them on
+  `coordinator.pendingDestination`, and bounces to `.login`; the destination is
+  replayed after a successful SSO login.
+- [x] [m] **AC-5 — Auth guard on tab selection.** `MainTabView.handleTabChange`
+  reverts to the previous tab and presents the login sheet when an
+  unauthenticated user selects a protected tab (Favorites / Inquiries / Account).
+- [x] [m] **AC-5 — Auth guard on restore.** `NavigationStateRestorationService.restore`
+  drops protected tab stacks and falls back to `.home` when not authenticated, so
+  protected content never reappears after a re-install / device transfer.
+- [x] [m] **Logout wipes persisted nav state.** `AuthManager.logout()` calls
+  `restorationService?.clear()` so protected stacks do not outlive the session
+  on disk.
+- [x] [m] **SSO CSRF nonce.** `beginSsoFlow()` mints a single-use nonce;
+  `consumeSsoState(_:)` validates it exactly once (rejects nil/empty/mismatch/
+  replay) before the SSO token is accepted.
+- [ ] [m] **GAP — `CFBundleURLTypes` not registered in `Info.plist`.** The
+  parsing + routing + auth-guard logic is complete and unit-tested, but
+  `mobile-native/iosApp/Info.plist` does not declare a `CFBundleURLTypes`
+  entry for the `realityportal` scheme, nor an `applinks:` associated-domains
+  entitlement. Without the URL-type registration iOS will not deliver
+  `realityportal://` URLs to `onOpenURL`, so deep-linking cannot fire at
+  runtime. Fix is owned by `pm-mobile` (touches `mobile-native/**`) — see
+  Agent Log. The scheme name is pinned in `Configuration.urlScheme`
+  (`"realityportal"`) and by `testEnvironmentDeepLinkSchemeIsStable`.
+
+## States
+
+- **Cold launch (authenticated)**: prior tab + per-tab stacks restored verbatim.
+- **Cold launch (unauthenticated)**: protected tab/stacks dropped, lands on `.home`.
+- **Background → foreground**: state saved on background, restored unchanged.
+- **Deep link (allowed route)**: navigates directly to the typed `Route`.
+- **Deep link (protected, signed-out)**: stashed as `pendingDestination`, routed to `.login`, replayed post-login.
+- **Deep link (SSO callback)**: CSRF state validated, token exchanged, pending destination replayed.
+- **Deep link (unknown / foreign host)**: `.unrecognized`, ignored (logged in DEBUG).
+
+## Notes
+
+### Broader context
+
+This layer is implemented across:
+`mobile-native/iosApp/iosApp/Core/Navigation/{NavigationCoordinator,DeepLinkHandler,NavigationStateRestorationService,Route}.swift`,
+wired in `App/RealityPortalApp.swift` + `App/MainTabView.swift`, with auth
+state from `Core/AuthManager.swift`. The Android counterpart uses scheme
+`reality` (see `testEnvironmentDeepLinkSchemeIsStable` note) — the two schemes
+are intentionally different and not yet reconciled.
+
+### Specific (recent)
+
+- AC-4 / AC-5 verified by static audit (Coverage 82-2). All three concerns —
+  navigation state preservation, URL-scheme deep-linking, and the auth guard —
+  are shipped in source and covered by `iosAppTests/RealityPortalTests.swift`
+  (`DeepLinkHandlerTests`, `NavigationStateRestorationServiceTests`,
+  `AuthenticationTests` SSO-nonce suite). No new feature code was required.
+- One runtime gap found: the `realityportal` URL scheme is not declared in
+  `Info.plist` (`CFBundleURLTypes`) and there is no `applinks:` entitlement for
+  universal links. The deep-link handler is dead at runtime until that
+  registration is added under `mobile-native/**` (pm-mobile owner).
+
+## Agent Log
+
+<!-- newest entries on top -->
+
+- 2026-06-10 — agent: Coverage 82-2 — verified AC-4 (nav state preservation), URL-scheme deep-linking, and AC-5 (auth guard) against mobile-native iOS source. All three implemented + unit-tested; no feature code needed. Added this infra screen-map. Flagged GAP: `Info.plist` is missing the `realityportal` `CFBundleURLTypes` registration and `applinks:` entitlement (pm-mobile owner) — handler logic is complete but the OS never delivers the URL until that is added.


### PR DESCRIPTION
## Task

Coverage 82-2 — verify/evidence SwiftUI navigation state preservation (AC-4), URL-scheme deep-linking, and auth guard (AC-5) in the mobile-native iOS app; add a screen-map for ppt-reality-mobile where missing. mobile-native KMP/SwiftUI.

## Owner

pm-frontend (verify-first; docs-only landing under `docs/screens/**`)

## Verification result — all three ACs already shipped

Static audit of `mobile-native/iosApp/` confirms the ACs are implemented and unit-tested. **No feature code was written** (verify-first task).

| Concern | Evidence (source) | Tests |
|---|---|---|
| **AC-4** nav state preservation | `NavigationStateRestorationService.save/restore` (UserDefaults `navigation_state`, on `scenePhase==.background` / launch); `NavigationCoordinator` route-mirror arrays + `restoreStack` | `NavigationStateRestorationServiceTests` (round-trip, double-restore-cycle regression, tab preserve) |
| **URL-scheme deep-linking** | `DeepLinkHandler.parse` maps `realityportal://...` + allow-listed universal links to typed `Route`; SSO callbacks split out as `.ssoCallback` | `DeepLinkTests` + `DeepLinkHandlerTests` (every URL pattern in the type's table) |
| **AC-5** auth guard | `RealityPortalApp.handleIncomingURL` gates `requiresAuth` deep links → `pendingDestination` + `.login`; `MainTabView.handleTabChange` reverts protected-tab selection; `restore` drops protected stacks when signed-out; `AuthManager.logout()` wipes persisted state | `AuthenticationTests` (SSO CSRF nonce single-use/replay/mismatch), restoration auth-gating tests |

## Gap found (flagged, not fixed here)

`mobile-native/iosApp/Info.plist` does **not** register `CFBundleURLTypes` for the `realityportal` scheme, and there is no `applinks:` associated-domains entitlement. The handler/routing/guard logic is complete and tested, but **iOS will not deliver `realityportal://` URLs to `onOpenURL` until the URL-type is registered** — so deep-linking is inert at runtime. That fix lives under `mobile-native/**` (owner `pm-mobile`), out of this `pm-frontend` task's scope; it is documented in the new screen-map's checklist + Agent Log so the follow-up is actionable.

## Changes

- `docs/screens/reality-mobile/navigation.md` (new) — cross-cutting navigation/deep-link/auth-guard infra screen-map with AC-4/AC-5 evidence and the Info.plist gap.
- `docs/screens/reality-mobile/README.md` — registers the new map + a Cross-Cutting Infrastructure section.

## Tested (Band A — fast check)

- `scope-check.sh --owner pm-frontend` → exit 0 (both files under `docs/screens/**`).
- Frontmatter validated manually against `@ppt/screen-map` Zod schema (`product: reality-mobile`, `platform: ios-swiftui`, `buildStatus: shipped`, `redesignStatus/apiStatus: n/a`, `rel: child` all valid enum values); all `relatedScreens` IDs resolve to existing maps (`auth-login`, `home`, `account`). `pnpm`/`tsx` not installed in the sandbox worktree (no network) so the `/screens validate` CLI could not be executed — schema conformance checked by hand.

## Built (Band B — full build)

skipped: docs-only change (<50 LOC, no public API/config/build-output touch).

## CI parity (Band C — hot-path only)

skipped: docs-only, no security/auth/billing/data-integrity code change. `screen-map.yml` CI will run `/screens validate` on this PR.

## Remote-tested

skipped.

## Notes

- Verify-first no-op success on the feature side: the shipped iOS code already satisfies AC-4 and AC-5; this PR records the evidence and the one actionable runtime gap.
- A macOS reviewer is **not** required — no Swift was changed.

https://claude.ai/code/session_01Kk2msvgV6Moeg1anudbrs1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kk2msvgV6Moeg1anudbrs1)_