### PR TITLE
test(db): make RLS test-role teardown leak-proof with DROP OWNED BY (PAP-134)

### DIFF
--- a/backend/crates/db/tests/api_ecosystem_rls_repo_tests.rs
+++ b/backend/crates/db/tests/api_ecosystem_rls_repo_tests.rs
@@ -279,6 +279,11 @@ async fn api_ecosystem_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     for stmt in [
         format!("REVOKE ALL ON webhook_subscriptions FROM \"{role}\""),
         format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        // DROP OWNED severs every remaining privilege this role holds in the
+        // test database — the explicit REVOKEs above keep missing the RLS
+        // helper-function EXECUTE grants, so DROP ROLE failed with "objects
+        // depend on it" and leaked the cluster-global role (PAP-134).
+        format!("DROP OWNED BY \"{role}\""),
         format!("DROP ROLE IF EXISTS \"{role}\""),
     ] {
         sqlx::query(sqlx::AssertSqlSafe(stmt))

--- a/backend/crates/db/tests/document_shares_rls_cross_tenant_tests.rs
+++ b/backend/crates/db/tests/document_shares_rls_cross_tenant_tests.rs
@@ -285,6 +285,14 @@ async fn document_shares_force_rls_blocks_cross_tenant_read(pool: PgPool) {
     .execute(&pool)
     .await
     .ok();
+    // DROP OWNED severs every remaining privilege this role holds in the
+    // test database — the explicit REVOKEs above keep missing the RLS
+    // helper-function EXECUTE grants, so DROP ROLE failed with "objects
+    // depend on it" and leaked the cluster-global role (PAP-134).
+    sqlx::query(sqlx::AssertSqlSafe(format!("DROP OWNED BY \"{role}\"")))
+        .execute(&pool)
+        .await
+        .ok();
     sqlx::query(sqlx::AssertSqlSafe(format!(
         "DROP ROLE IF EXISTS \"{role}\""
     )))

--- a/backend/crates/db/tests/documents_rls_cross_tenant_tests.rs
+++ b/backend/crates/db/tests/documents_rls_cross_tenant_tests.rs
@@ -222,6 +222,14 @@ async fn documents_force_rls_blocks_cross_tenant_read(pool: PgPool) {
     .execute(&pool)
     .await
     .ok();
+    // DROP OWNED severs every remaining privilege this role holds in the
+    // test database — the explicit REVOKEs above keep missing the RLS
+    // helper-function EXECUTE grants, so DROP ROLE failed with "objects
+    // depend on it" and leaked the cluster-global role (PAP-134).
+    sqlx::query(sqlx::AssertSqlSafe(format!("DROP OWNED BY \"{role}\"")))
+        .execute(&pool)
+        .await
+        .ok();
     sqlx::query(sqlx::AssertSqlSafe(format!(
         "DROP ROLE IF EXISTS \"{role}\""
     )))

--- a/backend/crates/db/tests/emergency_rls_repo_tests.rs
+++ b/backend/crates/db/tests/emergency_rls_repo_tests.rs
@@ -286,6 +286,11 @@ async fn emergency_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     set_ctx(&pool, None, None, true).await;
     for stmt in [
         format!("REVOKE ALL ON emergency_protocols FROM \"{role}\""),
+        // DROP OWNED severs every remaining privilege this role holds in the
+        // test database — the explicit REVOKEs above keep missing the RLS
+        // helper-function EXECUTE grants, so DROP ROLE failed with "objects
+        // depend on it" and leaked the cluster-global role (PAP-134).
+        format!("DROP OWNED BY \"{role}\""),
         format!("DROP ROLE IF EXISTS \"{role}\""),
     ] {
         sqlx::query(sqlx::AssertSqlSafe(stmt))

--- a/backend/crates/db/tests/enhanced_tenant_screening_rls_repo_tests.rs
+++ b/backend/crates/db/tests/enhanced_tenant_screening_rls_repo_tests.rs
@@ -274,6 +274,11 @@ async fn screening_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     for stmt in [
         format!("REVOKE ALL ON ai_risk_scoring_models FROM \"{role}\""),
         format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        // DROP OWNED severs every remaining privilege this role holds in the
+        // test database — the explicit REVOKEs above keep missing the RLS
+        // helper-function EXECUTE grants, so DROP ROLE failed with "objects
+        // depend on it" and leaked the cluster-global role (PAP-134).
+        format!("DROP OWNED BY \"{role}\""),
         format!("DROP ROLE IF EXISTS \"{role}\""),
     ] {
         sqlx::query(sqlx::AssertSqlSafe(stmt))

--- a/backend/crates/db/tests/equipment_rls_repo_tests.rs
+++ b/backend/crates/db/tests/equipment_rls_repo_tests.rs
@@ -293,6 +293,11 @@ async fn equipment_repo_force_rls_deny_all_and_fix(pool: PgPool) {
             "REVOKE ALL ON equipment, equipment_maintenance, maintenance_predictions FROM \"{role}\""
         ),
         format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        // DROP OWNED severs every remaining privilege this role holds in the
+        // test database — the explicit REVOKEs above keep missing the RLS
+        // helper-function EXECUTE grants, so DROP ROLE failed with "objects
+        // depend on it" and leaked the cluster-global role (PAP-134).
+        format!("DROP OWNED BY \"{role}\""),
         format!("DROP ROLE IF EXISTS \"{role}\""),
     ] {
         sqlx::query(sqlx::AssertSqlSafe(stmt)).execute(&pool).await.ok();

--- a/backend/crates/db/tests/insurance_rls_repo_tests.rs
+++ b/backend/crates/db/tests/insurance_rls_repo_tests.rs
@@ -288,6 +288,11 @@ async fn insurance_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     for stmt in [
         format!("REVOKE ALL ON insurance_policies FROM \"{role}\""),
         format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        // DROP OWNED severs every remaining privilege this role holds in the
+        // test database — the explicit REVOKEs above keep missing the RLS
+        // helper-function EXECUTE grants, so DROP ROLE failed with "objects
+        // depend on it" and leaked the cluster-global role (PAP-134).
+        format!("DROP OWNED BY \"{role}\""),
         format!("DROP ROLE IF EXISTS \"{role}\""),
     ] {
         sqlx::query(sqlx::AssertSqlSafe(stmt))

--- a/backend/crates/db/tests/integration_rls_repo_tests.rs
+++ b/backend/crates/db/tests/integration_rls_repo_tests.rs
@@ -299,6 +299,11 @@ async fn integration_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     set_ctx(&pool, None, None, true).await;
     for stmt in [
         format!("REVOKE ALL ON webhook_subscriptions FROM \"{role}\""),
+        // DROP OWNED severs every remaining privilege this role holds in the
+        // test database — the explicit REVOKEs above keep missing the RLS
+        // helper-function EXECUTE grants, so DROP ROLE failed with "objects
+        // depend on it" and leaked the cluster-global role (PAP-134).
+        format!("DROP OWNED BY \"{role}\""),
         format!("DROP ROLE IF EXISTS \"{role}\""),
     ] {
         sqlx::query(sqlx::AssertSqlSafe(stmt))

--- a/backend/crates/db/tests/legal_rls_repo_tests.rs
+++ b/backend/crates/db/tests/legal_rls_repo_tests.rs
@@ -278,6 +278,11 @@ async fn legal_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     for stmt in [
         format!("REVOKE ALL ON legal_documents FROM \"{role}\""),
         format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        // DROP OWNED severs every remaining privilege this role holds in the
+        // test database — the explicit REVOKEs above keep missing the RLS
+        // helper-function EXECUTE grants, so DROP ROLE failed with "objects
+        // depend on it" and leaked the cluster-global role (PAP-134).
+        format!("DROP OWNED BY \"{role}\""),
         format!("DROP ROLE IF EXISTS \"{role}\""),
     ] {
         sqlx::query(sqlx::AssertSqlSafe(stmt))

--- a/backend/crates/db/tests/llm_document_rls_repo_tests.rs
+++ b/backend/crates/db/tests/llm_document_rls_repo_tests.rs
@@ -285,6 +285,11 @@ async fn llm_document_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     for stmt in [
         format!("REVOKE ALL ON document_embeddings FROM \"{role}\""),
         format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        // DROP OWNED severs every remaining privilege this role holds in the
+        // test database — the explicit REVOKEs above keep missing the RLS
+        // helper-function EXECUTE grants, so DROP ROLE failed with "objects
+        // depend on it" and leaked the cluster-global role (PAP-134).
+        format!("DROP OWNED BY \"{role}\""),
         format!("DROP ROLE IF EXISTS \"{role}\""),
     ] {
         sqlx::query(sqlx::AssertSqlSafe(stmt))

--- a/backend/crates/db/tests/predictive_maintenance_rls_repo_tests.rs
+++ b/backend/crates/db/tests/predictive_maintenance_rls_repo_tests.rs
@@ -250,6 +250,11 @@ async fn predictive_repo_force_rls_deny_all_and_fix(pool: PgPool) {
             "REVOKE EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
              get_current_org_not_deleted() FROM \"{role}\""
         ),
+        // DROP OWNED severs every remaining privilege this role holds in the
+        // test database — the explicit REVOKEs above keep missing the RLS
+        // helper-function EXECUTE grants, so DROP ROLE failed with "objects
+        // depend on it" and leaked the cluster-global role (PAP-134).
+        format!("DROP OWNED BY \"{role}\""),
         format!("DROP ROLE IF EXISTS \"{role}\""),
     ] {
         sqlx::query(sqlx::AssertSqlSafe(stmt))

--- a/backend/crates/db/tests/sentiment_rls_repo_tests.rs
+++ b/backend/crates/db/tests/sentiment_rls_repo_tests.rs
@@ -260,6 +260,11 @@ async fn sentiment_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     set_ctx(&pool, None, None, true).await;
     for stmt in [
         format!("REVOKE ALL ON sentiment_alerts FROM \"{role}\""),
+        // DROP OWNED severs every remaining privilege this role holds in the
+        // test database — the explicit REVOKEs above keep missing the RLS
+        // helper-function EXECUTE grants, so DROP ROLE failed with "objects
+        // depend on it" and leaked the cluster-global role (PAP-134).
+        format!("DROP OWNED BY \"{role}\""),
         format!("DROP ROLE IF EXISTS \"{role}\""),
     ] {
         sqlx::query(sqlx::AssertSqlSafe(stmt))

--- a/backend/crates/db/tests/subscription_rls_repo_tests.rs
+++ b/backend/crates/db/tests/subscription_rls_repo_tests.rs
@@ -302,6 +302,11 @@ async fn subscription_repo_force_rls_deny_all_and_fix(pool: PgPool) {
         format!("REVOKE ALL ON organization_subscriptions FROM \"{role}\""),
         format!("REVOKE ALL ON subscription_plans FROM \"{role}\""),
         format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        // DROP OWNED severs every remaining privilege this role holds in the
+        // test database — the explicit REVOKEs above keep missing the RLS
+        // helper-function EXECUTE grants, so DROP ROLE failed with "objects
+        // depend on it" and leaked the cluster-global role (PAP-134).
+        format!("DROP OWNED BY \"{role}\""),
         format!("DROP ROLE IF EXISTS \"{role}\""),
     ] {
         sqlx::query(sqlx::AssertSqlSafe(stmt))

--- a/backend/crates/db/tests/vendor_rls_repo_tests.rs
+++ b/backend/crates/db/tests/vendor_rls_repo_tests.rs
@@ -272,6 +272,11 @@ async fn vendor_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     set_ctx(&pool, None, None, true).await;
     for stmt in [
         format!("REVOKE ALL ON vendors FROM \"{role}\""),
+        // DROP OWNED severs every remaining privilege this role holds in the
+        // test database — the explicit REVOKEs above keep missing the RLS
+        // helper-function EXECUTE grants, so DROP ROLE failed with "objects
+        // depend on it" and leaked the cluster-global role (PAP-134).
+        format!("DROP OWNED BY \"{role}\""),
         format!("DROP ROLE IF EXISTS \"{role}\""),
     ] {
         sqlx::query(sqlx::AssertSqlSafe(stmt))


### PR DESCRIPTION
## What

Adds `DROP OWNED BY "<role>"` immediately before `DROP ROLE IF EXISTS "<role>"` in the teardown of all 14 RLS repo / cross-tenant test files that create per-test `NOSUPERUSER NOBYPASSRLS` roles.

## Why

PAP-134: the CI postgres service logs on failed `test` jobs show

```
ERROR: role "ppt_rls_vendor_…" cannot be dropped because some objects depend on it
DETAIL: privileges for function get_current_org_id()
```

Each test's teardown revokes a hand-listed subset of the grants made in setup, and the lists have drifted: none revoke `EXECUTE` on `get_current_org_id()` / `get_current_org_not_deleted()`, and several miss `SELECT ON organizations`. The leftover privileges make `DROP ROLE` fail (silently — teardown uses `.ok()`), leaking cluster-global roles into shared test-cluster state across parallel test binaries.

`DROP OWNED BY` severs every privilege the role holds in the current test database regardless of what setup granted, so the subsequent `DROP ROLE` is reliable and immune to future grant-list drift. Pure insertions; no assertions touched.

## Relation to PAP-133

The four currently-failing dev targets (vendor IDOR, document_template, emergency, sentiment) have deterministic root causes being fixed by the CTO under PAP-133 (`fix/pap-133-dev-test-green`). This PR removes the role-leak/isolation vector flagged in PAP-134 and is complementary — overlap with that branch is limited to different hunks of `emergency`/`sentiment`/`vendor` test files.

## Verification

- `cargo check -p db --tests` — clean
- `cargo fmt -p db --check` — clean
- DB tests require the CI postgres service (no local test database exists); the `test` job on this PR exercises every touched teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)