### PR TITLE
fix(vendors): org-key remaining vendor by-id mutations (PAP-129, completes #1260)

### DIFF
--- a/backend/crates/db/src/repositories/vendor.rs
+++ b/backend/crates/db/src/repositories/vendor.rs
@@ -279,11 +279,13 @@ impl VendorRepository {
         Ok(result.rows_affected() > 0)
     }
 
-    /// Set vendor as preferred.
+    /// Set vendor as preferred, scoped to the owning organization (PAP-129
+    /// defense-in-depth — see [`find_by_id`](Self::find_by_id)).
     pub async fn set_preferred<'e, E>(
         &self,
         executor: E,
         id: Uuid,
+        org_id: Uuid,
         is_preferred: bool,
     ) -> Result<Vendor, sqlx::Error>
     where
@@ -292,12 +294,13 @@ impl VendorRepository {
         sqlx::query_as(
             r#"
             UPDATE vendors SET is_preferred = $2, updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $3
             RETURNING *
             "#,
         )
         .bind(id)
         .bind(is_preferred)
+        .bind(org_id)
         .fetch_one(executor)
         .await
     }
@@ -387,39 +390,59 @@ impl VendorRepository {
         .await
     }
 
-    /// Delete a contact.
+    /// Delete a contact, scoped to the owning organization through the owning
+    /// vendor (`vendor_contacts` has no `organization_id` column — PAP-129
+    /// defense-in-depth, see [`find_by_id`](Self::find_by_id)).
     pub async fn delete_contact<'e, E>(
         &self,
         executor: E,
         contact_id: Uuid,
+        org_id: Uuid,
     ) -> Result<bool, sqlx::Error>
     where
         E: Executor<'e, Database = Postgres>,
     {
-        let result = sqlx::query("DELETE FROM vendor_contacts WHERE id = $1")
-            .bind(contact_id)
-            .execute(executor)
-            .await?;
+        let result = sqlx::query(
+            r#"
+            DELETE FROM vendor_contacts vc
+            USING vendors v
+            WHERE vc.id = $1 AND v.id = vc.vendor_id AND v.organization_id = $2
+            "#,
+        )
+        .bind(contact_id)
+        .bind(org_id)
+        .execute(executor)
+        .await?;
         Ok(result.rows_affected() > 0)
     }
 
     /// Resolve the `vendor_id` that owns `contact_id`, if any. Used by the
     /// route layer to derive the owning vendor before deleting a contact.
     ///
-    /// Under RLS the lookup is already org-scoped: a contact belonging to
-    /// another org is invisible and returns `None`.
+    /// Scoped to the owning organization through the vendor row (PAP-129): a
+    /// contact whose vendor belongs to another org resolves to `None`, even on
+    /// a connection whose role bypasses RLS.
     pub async fn find_contact_vendor_id<'e, E>(
         &self,
         executor: E,
         contact_id: Uuid,
+        org_id: Uuid,
     ) -> Result<Option<Uuid>, sqlx::Error>
     where
         E: Executor<'e, Database = Postgres>,
     {
-        sqlx::query_scalar("SELECT vendor_id FROM vendor_contacts WHERE id = $1")
-            .bind(contact_id)
-            .fetch_optional(executor)
-            .await
+        sqlx::query_scalar(
+            r#"
+            SELECT vc.vendor_id
+            FROM vendor_contacts vc
+            JOIN vendors v ON v.id = vc.vendor_id
+            WHERE vc.id = $1 AND v.organization_id = $2
+            "#,
+        )
+        .bind(contact_id)
+        .bind(org_id)
+        .fetch_optional(executor)
+        .await
     }
 
     // ==================== Vendor Contracts ====================
@@ -512,11 +535,13 @@ impl VendorRepository {
         .await
     }
 
-    /// Update a contract.
+    /// Update a contract, scoped to the owning organization (PAP-129
+    /// defense-in-depth — see [`find_by_id`](Self::find_by_id)).
     pub async fn update_contract<'e, E>(
         &self,
         executor: E,
         id: Uuid,
+        org_id: Uuid,
         data: UpdateVendorContract,
     ) -> Result<VendorContract, sqlx::Error>
     where
@@ -539,7 +564,7 @@ impl VendorRepository {
                 terms = COALESCE($13, terms),
                 metadata = COALESCE($14, metadata),
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $15
             RETURNING *
             "#,
         )
@@ -557,19 +582,28 @@ impl VendorRepository {
         .bind(data.auto_renew)
         .bind(data.terms.map(sqlx::types::Json))
         .bind(data.metadata.map(sqlx::types::Json))
+        .bind(org_id)
         .fetch_one(executor)
         .await
     }
 
-    /// Delete a contract.
-    pub async fn delete_contract<'e, E>(&self, executor: E, id: Uuid) -> Result<bool, sqlx::Error>
+    /// Delete a contract, scoped to the owning organization (PAP-129
+    /// defense-in-depth — see [`find_by_id`](Self::find_by_id)).
+    pub async fn delete_contract<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
     where
         E: Executor<'e, Database = Postgres>,
     {
-        let result = sqlx::query("DELETE FROM vendor_contracts WHERE id = $1")
-            .bind(id)
-            .execute(executor)
-            .await?;
+        let result =
+            sqlx::query("DELETE FROM vendor_contracts WHERE id = $1 AND organization_id = $2")
+                .bind(id)
+                .bind(org_id)
+                .execute(executor)
+                .await?;
         Ok(result.rows_affected() > 0)
     }
 
@@ -698,11 +732,13 @@ impl VendorRepository {
         .await
     }
 
-    /// Update an invoice.
+    /// Update an invoice, scoped to the owning organization (PAP-129
+    /// defense-in-depth — see [`find_by_id`](Self::find_by_id)).
     pub async fn update_invoice<'e, E>(
         &self,
         executor: E,
         id: Uuid,
+        org_id: Uuid,
         data: UpdateVendorInvoice,
     ) -> Result<VendorInvoice, sqlx::Error>
     where
@@ -723,7 +759,7 @@ impl VendorRepository {
                 line_items = COALESCE($11, line_items),
                 metadata = COALESCE($12, metadata),
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $13
             RETURNING *
             "#,
         )
@@ -739,15 +775,18 @@ impl VendorRepository {
         .bind(&data.description)
         .bind(data.line_items.map(sqlx::types::Json))
         .bind(data.metadata.map(sqlx::types::Json))
+        .bind(org_id)
         .fetch_one(executor)
         .await
     }
 
-    /// Approve an invoice.
+    /// Approve an invoice, scoped to the owning organization (PAP-129
+    /// defense-in-depth — see [`find_by_id`](Self::find_by_id)).
     pub async fn approve_invoice<'e, E>(
         &self,
         executor: E,
         id: Uuid,
+        org_id: Uuid,
         user_id: Uuid,
     ) -> Result<VendorInvoice, sqlx::Error>
     where
@@ -760,21 +799,24 @@ impl VendorRepository {
                 approved_by = $2,
                 approved_at = NOW(),
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $3
             RETURNING *
             "#,
         )
         .bind(id)
         .bind(user_id)
+        .bind(org_id)
         .fetch_one(executor)
         .await
     }
 
-    /// Reject an invoice.
+    /// Reject an invoice, scoped to the owning organization (PAP-129
+    /// defense-in-depth — see [`find_by_id`](Self::find_by_id)).
     pub async fn reject_invoice<'e, E>(
         &self,
         executor: E,
         id: Uuid,
+        org_id: Uuid,
         user_id: Uuid,
         reason: &str,
     ) -> Result<VendorInvoice, sqlx::Error>
@@ -788,22 +830,25 @@ impl VendorRepository {
                 rejected_by = $2,
                 rejection_reason = $3,
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $4
             RETURNING *
             "#,
         )
         .bind(id)
         .bind(user_id)
         .bind(reason)
+        .bind(org_id)
         .fetch_one(executor)
         .await
     }
 
-    /// Record payment for an invoice.
+    /// Record payment for an invoice, scoped to the owning organization
+    /// (PAP-129 defense-in-depth — see [`find_by_id`](Self::find_by_id)).
     pub async fn record_payment<'e, E>(
         &self,
         executor: E,
         id: Uuid,
+        org_id: Uuid,
         amount: Decimal,
         method: Option<&str>,
         reference: Option<&str>,
@@ -823,7 +868,7 @@ impl VendorRepository {
                     ELSE 'partially_paid'
                 END,
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $5
             RETURNING *
             "#,
         )
@@ -831,19 +876,28 @@ impl VendorRepository {
         .bind(amount)
         .bind(method)
         .bind(reference)
+        .bind(org_id)
         .fetch_one(executor)
         .await
     }
 
-    /// Delete an invoice.
-    pub async fn delete_invoice<'e, E>(&self, executor: E, id: Uuid) -> Result<bool, sqlx::Error>
+    /// Delete an invoice, scoped to the owning organization (PAP-129
+    /// defense-in-depth — see [`find_by_id`](Self::find_by_id)).
+    pub async fn delete_invoice<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
     where
         E: Executor<'e, Database = Postgres>,
     {
-        let result = sqlx::query("DELETE FROM vendor_invoices WHERE id = $1")
-            .bind(id)
-            .execute(executor)
-            .await?;
+        let result =
+            sqlx::query("DELETE FROM vendor_invoices WHERE id = $1 AND organization_id = $2")
+                .bind(id)
+                .bind(org_id)
+                .execute(executor)
+                .await?;
         Ok(result.rows_affected() > 0)
     }
 

--- a/backend/servers/api-server/src/routes/vendors.rs
+++ b/backend/servers/api-server/src/routes/vendors.rs
@@ -432,11 +432,12 @@ async fn set_preferred(
     Path(id): Path<Uuid>,
     Json(data): Json<PreferredRequest>,
 ) -> Result<Json<Vendor>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = rls.tenant_id();
     let out = async {
         load_vendor_for_user(&state, &mut rls, id).await?;
         state
             .vendor_repo
-            .set_preferred(&mut **rls.conn(), id, data.is_preferred)
+            .set_preferred(&mut **rls.conn(), id, org_id, data.is_preferred)
             .await
             .map(Json)
             .map_err(|e| db_error("Failed to set preferred", e))
@@ -492,13 +493,15 @@ async fn delete_contact(
     mut rls: RlsConnection,
     Path(contact_id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = rls.tenant_id();
     let out = async {
-        // Resolve the owning vendor under RLS. A contact whose vendor is owned
-        // by another org is invisible (resolves to `None`) → 404. We then load
-        // the vendor to confirm tenant visibility before deleting.
+        // Resolve the owning vendor, keyed to the caller's org (PAP-129: the
+        // org join holds even where RLS does not bind). A contact whose vendor
+        // is owned by another org resolves to `None` → 404. We then load the
+        // vendor to confirm tenant visibility before deleting.
         let vendor_id = state
             .vendor_repo
-            .find_contact_vendor_id(&mut **rls.conn(), contact_id)
+            .find_contact_vendor_id(&mut **rls.conn(), contact_id, org_id)
             .await
             .map_err(|e| db_error("Failed to resolve contact", e))?
             .ok_or_else(|| not_found("Contact not found"))?;
@@ -506,7 +509,7 @@ async fn delete_contact(
 
         let deleted = state
             .vendor_repo
-            .delete_contact(&mut **rls.conn(), contact_id)
+            .delete_contact(&mut **rls.conn(), contact_id, org_id)
             .await
             .map_err(|e| db_error("Failed to delete contact", e))?;
         if deleted {
@@ -634,11 +637,12 @@ async fn update_contract(
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateVendorContract>,
 ) -> Result<Json<VendorContract>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = rls.tenant_id();
     let out = async {
         load_contract_for_user(&state, &mut rls, id).await?;
         state
             .vendor_repo
-            .update_contract(&mut **rls.conn(), id, data)
+            .update_contract(&mut **rls.conn(), id, org_id, data)
             .await
             .map(Json)
             .map_err(|e| db_error("Failed to update contract", e))
@@ -653,11 +657,12 @@ async fn delete_contract(
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = rls.tenant_id();
     let out = async {
         load_contract_for_user(&state, &mut rls, id).await?;
         let deleted = state
             .vendor_repo
-            .delete_contract(&mut **rls.conn(), id)
+            .delete_contract(&mut **rls.conn(), id, org_id)
             .await
             .map_err(|e| db_error("Failed to delete contract", e))?;
         if deleted {
@@ -754,11 +759,12 @@ async fn update_invoice(
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateVendorInvoice>,
 ) -> Result<Json<VendorInvoice>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = rls.tenant_id();
     let out = async {
         load_invoice_for_user(&state, &mut rls, id).await?;
         state
             .vendor_repo
-            .update_invoice(&mut **rls.conn(), id, data)
+            .update_invoice(&mut **rls.conn(), id, org_id, data)
             .await
             .map(Json)
             .map_err(|e| db_error("Failed to update invoice", e))
@@ -773,11 +779,12 @@ async fn delete_invoice(
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = rls.tenant_id();
     let out = async {
         load_invoice_for_user(&state, &mut rls, id).await?;
         let deleted = state
             .vendor_repo
-            .delete_invoice(&mut **rls.conn(), id)
+            .delete_invoice(&mut **rls.conn(), id, org_id)
             .await
             .map_err(|e| db_error("Failed to delete invoice", e))?;
         if deleted {
@@ -796,12 +803,13 @@ async fn approve_invoice(
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<VendorInvoice>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = rls.tenant_id();
     let user_id = rls.user_id();
     let out = async {
         load_invoice_for_user(&state, &mut rls, id).await?;
         state
             .vendor_repo
-            .approve_invoice(&mut **rls.conn(), id, user_id)
+            .approve_invoice(&mut **rls.conn(), id, org_id, user_id)
             .await
             .map(Json)
             .map_err(|e| db_error("Failed to approve invoice", e))
@@ -817,12 +825,13 @@ async fn reject_invoice(
     Path(id): Path<Uuid>,
     Json(data): Json<RejectRequest>,
 ) -> Result<Json<VendorInvoice>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = rls.tenant_id();
     let user_id = rls.user_id();
     let out = async {
         load_invoice_for_user(&state, &mut rls, id).await?;
         state
             .vendor_repo
-            .reject_invoice(&mut **rls.conn(), id, user_id, &data.reason)
+            .reject_invoice(&mut **rls.conn(), id, org_id, user_id, &data.reason)
             .await
             .map(Json)
             .map_err(|e| db_error("Failed to reject invoice", e))
@@ -838,6 +847,7 @@ async fn record_payment(
     Path(id): Path<Uuid>,
     Json(data): Json<RecordPaymentRequest>,
 ) -> Result<Json<VendorInvoice>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = rls.tenant_id();
     let out = async {
         load_invoice_for_user(&state, &mut rls, id).await?;
         state
@@ -845,6 +855,7 @@ async fn record_payment(
             .record_payment(
                 &mut **rls.conn(),
                 id,
+                org_id,
                 data.amount,
                 data.method.as_deref(),
                 data.reference.as_deref(),


### PR DESCRIPTION
## Summary

**Scope reduced after #1260:** while this PR was in CI, [PAP-133] (#1260, `c278efece`) landed the same three test-gate fixes (vendor `find_by_id`/`update`/`delete` + contract/invoice finds, template enum casts, test role grants) — dev's `test` job is unblocked by that PR. This PR was rebuilt on top of it and now carries only the **remaining vendor defense-in-depth** that #1260 did not cover.

### What this adds (PAP-129, completes the PAP-133 org-keying)

The remaining vendor by-id mutations still relied on RLS alone, which an RLS-exempt connection (superuser pool / BYPASSRLS — exactly what CI's `#[sqlx::test]` pool is) bypasses:

- `set_preferred`
- `update_contract` / `delete_contract`
- `update_invoice` / `delete_invoice` / `approve_invoice` / `reject_invoice` / `record_payment`
- `find_contact_vendor_id` / `delete_contact` — scoped through the owning-vendor join (`vendor_contacts` has no `organization_id` column)

All now keyed on `(id, organization_id = rls.tenant_id())`, matching the #1260 parameter order and doc style. Handlers thread `rls.tenant_id()`.

## Verification (remote — mercury + PAP-103 Postgres)

- `cargo check -p db -p api-server`, `cargo clippy --workspace -- -D warnings` (CI-exact), `cargo fmt --check`
- `vendor_cross_org_idor_tests` (7/7) and `vendor_rls_repo_tests` re-run on the rebuilt branch — results posted in the PAP-129 thread
- The full equivalent change set (superset of this diff) already passed this repo's complete CI earlier today on this PR's previous head (`609a1edaf`)

Paperclip: PAP-129 (parent PAP-123)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
