### PR TITLE
PAP-133: unbreak dev test job — org grants, vendor org-keying, template enum casts

### DIFF
--- a/backend/crates/db/src/repositories/document_template.rs
+++ b/backend/crates/db/src/repositories/document_template.rs
@@ -20,6 +20,10 @@ impl DocumentTemplateRepository {
     }
 
     /// Create a new template.
+    ///
+    /// `template_type` is a Postgres enum (`document_template_type`) but the
+    /// model decodes it as `String`, so every query that returns it must cast
+    /// it to text — `SELECT *` / `RETURNING *` fail to decode (PAP-133).
     pub async fn create(&self, data: CreateTemplate) -> Result<DocumentTemplate, SqlxError> {
         let placeholders = serde_json::to_value(&data.placeholders).unwrap();
 
@@ -30,7 +34,9 @@ impl DocumentTemplateRepository {
                 content, placeholders, created_by
             )
             VALUES ($1, $2, $3, $4::document_template_type, $5, $6, $7)
-            RETURNING *
+            RETURNING id, organization_id, name, description,
+                template_type::text AS template_type, content, placeholders,
+                usage_count, created_by, created_at, updated_at, deleted_at
             "#,
         )
         .bind(data.organization_id)
@@ -58,7 +64,10 @@ impl DocumentTemplateRepository {
     ) -> Result<Option<DocumentTemplate>, SqlxError> {
         sqlx::query_as::<_, DocumentTemplate>(
             r#"
-            SELECT * FROM document_templates
+            SELECT id, organization_id, name, description,
+                template_type::text AS template_type, content, placeholders,
+                usage_count, created_by, created_at, updated_at, deleted_at
+            FROM document_templates
             WHERE id = $1 AND organization_id = $2 AND deleted_at IS NULL
             "#,
         )
@@ -80,7 +89,10 @@ impl DocumentTemplateRepository {
         let row = sqlx::query(
             r#"
             SELECT
-                t.*,
+                t.id, t.organization_id, t.name, t.description,
+                t.template_type::text AS template_type, t.content,
+                t.placeholders, t.usage_count, t.created_by, t.created_at,
+                t.updated_at, t.deleted_at,
                 u.name as created_by_name
             FROM document_templates t
             JOIN users u ON u.id = t.created_by
@@ -123,7 +135,8 @@ impl DocumentTemplateRepository {
         sqlx::query_as::<_, TemplateSummary>(
             r#"
             SELECT
-                id, name, description, template_type, usage_count,
+                id, name, description,
+                template_type::text AS template_type, usage_count,
                 jsonb_array_length(placeholders) as placeholder_count,
                 created_at
             FROM document_templates
@@ -190,7 +203,9 @@ impl DocumentTemplateRepository {
                 placeholders = COALESCE($7, placeholders),
                 updated_at = NOW()
             WHERE id = $1 AND organization_id = $2 AND deleted_at IS NULL
-            RETURNING *
+            RETURNING id, organization_id, name, description,
+                template_type::text AS template_type, content, placeholders,
+                usage_count, created_by, created_at, updated_at, deleted_at
             "#,
         )
         .bind(id)

--- a/backend/crates/db/src/repositories/vendor.rs
+++ b/backend/crates/db/src/repositories/vendor.rs
@@ -86,17 +86,24 @@ impl VendorRepository {
         .await
     }
 
-    /// Find vendor by ID.
+    /// Find vendor by ID, scoped to the owning organization.
+    ///
+    /// Cross-tenant safety (PAP-133): RLS is the primary boundary, but by-id
+    /// queries stay org-keyed as defense-in-depth — a connection whose role
+    /// bypasses RLS (superuser pools, BYPASSRLS) must still never resolve
+    /// another tenant's row.
     pub async fn find_by_id<'e, E>(
         &self,
         executor: E,
         id: Uuid,
+        org_id: Uuid,
     ) -> Result<Option<Vendor>, sqlx::Error>
     where
         E: Executor<'e, Database = Postgres>,
     {
-        sqlx::query_as("SELECT * FROM vendors WHERE id = $1")
+        sqlx::query_as("SELECT * FROM vendors WHERE id = $1 AND organization_id = $2")
             .bind(id)
+            .bind(org_id)
             .fetch_optional(executor)
             .await
     }
@@ -195,11 +202,13 @@ impl VendorRepository {
         .await
     }
 
-    /// Update a vendor.
+    /// Update a vendor, scoped to the owning organization (PAP-133
+    /// defense-in-depth — see [`find_by_id`](Self::find_by_id)).
     pub async fn update<'e, E>(
         &self,
         executor: E,
         id: Uuid,
+        org_id: Uuid,
         data: UpdateVendor,
     ) -> Result<Vendor, sqlx::Error>
     where
@@ -225,7 +234,7 @@ impl VendorRepository {
                 notes = COALESCE($16, notes),
                 metadata = COALESCE($17, metadata),
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $18
             RETURNING *
             "#,
         )
@@ -246,17 +255,25 @@ impl VendorRepository {
         .bind(data.is_preferred)
         .bind(&data.notes)
         .bind(data.metadata.map(sqlx::types::Json))
+        .bind(org_id)
         .fetch_one(executor)
         .await
     }
 
-    /// Delete a vendor.
-    pub async fn delete<'e, E>(&self, executor: E, id: Uuid) -> Result<bool, sqlx::Error>
+    /// Delete a vendor, scoped to the owning organization (PAP-133
+    /// defense-in-depth — see [`find_by_id`](Self::find_by_id)).
+    pub async fn delete<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
     where
         E: Executor<'e, Database = Postgres>,
     {
-        let result = sqlx::query("DELETE FROM vendors WHERE id = $1")
+        let result = sqlx::query("DELETE FROM vendors WHERE id = $1 AND organization_id = $2")
             .bind(id)
+            .bind(org_id)
             .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
@@ -450,12 +467,14 @@ impl VendorRepository {
         &self,
         executor: E,
         id: Uuid,
+        org_id: Uuid,
     ) -> Result<Option<VendorContract>, sqlx::Error>
     where
         E: Executor<'e, Database = Postgres>,
     {
-        sqlx::query_as("SELECT * FROM vendor_contracts WHERE id = $1")
+        sqlx::query_as("SELECT * FROM vendor_contracts WHERE id = $1 AND organization_id = $2")
             .bind(id)
+            .bind(org_id)
             .fetch_optional(executor)
             .await
     }
@@ -632,12 +651,14 @@ impl VendorRepository {
         &self,
         executor: E,
         id: Uuid,
+        org_id: Uuid,
     ) -> Result<Option<VendorInvoice>, sqlx::Error>
     where
         E: Executor<'e, Database = Postgres>,
     {
-        sqlx::query_as("SELECT * FROM vendor_invoices WHERE id = $1")
+        sqlx::query_as("SELECT * FROM vendor_invoices WHERE id = $1 AND organization_id = $2")
             .bind(id)
+            .bind(org_id)
             .fetch_optional(executor)
             .await
     }

--- a/backend/crates/db/tests/emergency_rls_repo_tests.rs
+++ b/backend/crates/db/tests/emergency_rls_repo_tests.rs
@@ -127,6 +127,9 @@ async fn emergency_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     for stmt in [
         format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
         format!("GRANT SELECT, INSERT, UPDATE, DELETE ON emergency_protocols TO \"{role}\""),
+        // get_current_org_not_deleted() is SECURITY INVOKER and reads
+        // `organizations`, so the bound role needs SELECT on it (PAP-133).
+        format!("GRANT SELECT ON organizations TO \"{role}\""),
         // RLS policy helpers must be EXECUTE-able by the bound role.
         format!("GRANT EXECUTE ON FUNCTION get_current_org_id() TO \"{role}\""),
         format!("GRANT EXECUTE ON FUNCTION get_current_org_not_deleted() TO \"{role}\""),

--- a/backend/crates/db/tests/integration_rls_repo_tests.rs
+++ b/backend/crates/db/tests/integration_rls_repo_tests.rs
@@ -150,6 +150,9 @@ async fn integration_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     for stmt in [
         format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
         format!("GRANT SELECT, INSERT, UPDATE, DELETE ON webhook_subscriptions TO \"{role}\""),
+        // get_current_org_not_deleted() is SECURITY INVOKER and reads
+        // `organizations`, so the bound role needs SELECT on it (PAP-133).
+        format!("GRANT SELECT ON organizations TO \"{role}\""),
         // RLS policy helpers must be EXECUTE-able by the bound role.
         format!("GRANT EXECUTE ON FUNCTION get_current_org_id() TO \"{role}\""),
         format!("GRANT EXECUTE ON FUNCTION get_current_org_not_deleted() TO \"{role}\""),

--- a/backend/crates/db/tests/sentiment_rls_repo_tests.rs
+++ b/backend/crates/db/tests/sentiment_rls_repo_tests.rs
@@ -116,6 +116,9 @@ async fn sentiment_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     for stmt in [
         format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
         format!("GRANT SELECT, INSERT, UPDATE, DELETE ON sentiment_alerts TO \"{role}\""),
+        // get_current_org_not_deleted() is SECURITY INVOKER and reads
+        // `organizations`, so the bound role needs SELECT on it (PAP-133).
+        format!("GRANT SELECT ON organizations TO \"{role}\""),
         // RLS policy helpers must be EXECUTE-able by the bound role.
         format!("GRANT EXECUTE ON FUNCTION get_current_org_id() TO \"{role}\""),
         format!("GRANT EXECUTE ON FUNCTION get_current_org_not_deleted() TO \"{role}\""),

--- a/backend/crates/db/tests/vendor_rls_repo_tests.rs
+++ b/backend/crates/db/tests/vendor_rls_repo_tests.rs
@@ -139,7 +139,7 @@ async fn vendor_repo_force_rls_deny_all_and_fix(pool: PgPool) {
             .expect("set role");
 
         let found = repo
-            .find_by_id(&mut *conn, vendor_a)
+            .find_by_id(&mut *conn, vendor_a, org_a)
             .await
             .expect("find_by_id (no ctx)");
         assert!(
@@ -182,7 +182,7 @@ async fn vendor_repo_force_rls_deny_all_and_fix(pool: PgPool) {
 
         // (2) Own-org row IS now visible through the repo — the fix.
         let found = repo
-            .find_by_id(&mut *conn, vendor_a)
+            .find_by_id(&mut *conn, vendor_a, org_a)
             .await
             .expect("find_by_id (ctx)");
         assert_eq!(
@@ -203,7 +203,7 @@ async fn vendor_repo_force_rls_deny_all_and_fix(pool: PgPool) {
 
         // (3) Org B's vendor stays invisible to an org-A caller.
         let cross = repo
-            .find_by_id(&mut *conn, vendor_b)
+            .find_by_id(&mut *conn, vendor_b, org_a)
             .await
             .expect("find_by_id cross");
         assert!(

--- a/backend/servers/api-server/src/routes/vendors.rs
+++ b/backend/servers/api-server/src/routes/vendors.rs
@@ -58,18 +58,19 @@ fn not_found(msg: &'static str) -> (StatusCode, Json<ErrorResponse>) {
 
 /// Load a vendor by id under the caller's RLS context.
 ///
-/// RLS scopes `find_by_id` to the connection's org, so a vendor owned by
-/// another organization is invisible and surfaces as `404 NOT_FOUND` — the
-/// cross-tenant IDOR guard is now enforced by the database, not an app-level
-/// membership check.
+/// RLS scopes the connection to the caller's org, and the repo query is
+/// additionally org-keyed (PAP-133 defense-in-depth — the org predicate holds
+/// even on a connection whose role bypasses RLS). A vendor owned by another
+/// organization surfaces as `404 NOT_FOUND`.
 async fn load_vendor_for_user(
     state: &AppState,
     rls: &mut RlsConnection,
     vendor_id: Uuid,
 ) -> Result<Vendor, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = rls.tenant_id();
     state
         .vendor_repo
-        .find_by_id(&mut **rls.conn(), vendor_id)
+        .find_by_id(&mut **rls.conn(), vendor_id, org_id)
         .await
         .map_err(|e| db_error("Failed to load vendor", e))?
         .ok_or_else(|| not_found("Vendor not found"))
@@ -82,9 +83,10 @@ async fn load_contract_for_user(
     rls: &mut RlsConnection,
     contract_id: Uuid,
 ) -> Result<VendorContract, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = rls.tenant_id();
     state
         .vendor_repo
-        .find_contract_by_id(&mut **rls.conn(), contract_id)
+        .find_contract_by_id(&mut **rls.conn(), contract_id, org_id)
         .await
         .map_err(|e| db_error("Failed to load contract", e))?
         .ok_or_else(|| not_found("Contract not found"))
@@ -97,9 +99,10 @@ async fn load_invoice_for_user(
     rls: &mut RlsConnection,
     invoice_id: Uuid,
 ) -> Result<VendorInvoice, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = rls.tenant_id();
     state
         .vendor_repo
-        .find_invoice_by_id(&mut **rls.conn(), invoice_id)
+        .find_invoice_by_id(&mut **rls.conn(), invoice_id, org_id)
         .await
         .map_err(|e| db_error("Failed to load invoice", e))?
         .ok_or_else(|| not_found("Invoice not found"))
@@ -386,9 +389,10 @@ async fn update_vendor(
 ) -> Result<Json<Vendor>, (StatusCode, Json<ErrorResponse>)> {
     let out = async {
         load_vendor_for_user(&state, &mut rls, id).await?;
+        let org_id = rls.tenant_id();
         state
             .vendor_repo
-            .update(&mut **rls.conn(), id, data)
+            .update(&mut **rls.conn(), id, org_id, data)
             .await
             .map(Json)
             .map_err(|e| db_error("Failed to update vendor", e))
@@ -405,9 +409,10 @@ async fn delete_vendor(
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     let out = async {
         load_vendor_for_user(&state, &mut rls, id).await?;
+        let org_id = rls.tenant_id();
         let deleted = state
             .vendor_repo
-            .delete(&mut **rls.conn(), id)
+            .delete(&mut **rls.conn(), id, org_id)
             .await
             .map_err(|e| db_error("Failed to delete vendor", e))?;
         if deleted {


### PR DESCRIPTION
## Why

dev's own `cargo test` is red on 4 targets (backend.yml run 27265655200), gating the `test` acceptance job on **every** open backend PR.

## Three root causes, all fixed

1. **Missing `GRANT SELECT ON organizations`** — `emergency_rls_repo_tests` / `sentiment_rls_repo_tests` panic with SQLSTATE 42501: `get_current_org_not_deleted()` is SECURITY INVOKER and reads `organizations`, which their NOSUPERUSER test roles couldn't see. Grant added (and defensively to `integration_rls_repo_tests`, which already grants EXECUTE on that helper).

2. **Vendor cross-tenant IDOR regression (real bug, not a test gap)** — #1225 dropped the app-layer org predicate from by-id vendor queries (`WHERE id = $1`), relying on RLS alone. On an RLS-exempt connection (CI superuser pool) cross-tenant GET returned **200** and DELETE **204**. Re-keyed `find_by_id` / `find_contract_by_id` / `find_invoice_by_id` / `update` / `delete` on `(id, organization_id)` and threaded `rls.tenant_id()` through the handlers — defense-in-depth per the PAP-123 rule that by-id queries stay org-keyed.

3. **document_template enum decode** — `template_type` is a Postgres enum but the model decodes `String`; #1212's `SELECT *` / `RETURNING *` fail with ColumnDecode (these tests were never green; the live template endpoints would 500 the same way). All five queries now use explicit column lists with `template_type::text` casts.

## Verification (real Postgres, all previously-red targets)

- `document_template_cross_tenant_tests`: 3/3 ok
- `emergency_rls_repo_tests`: 1/1 ok
- `sentiment_rls_repo_tests`: 1/1 ok
- `vendor_cross_org_idor_tests` (api-server, HTTP surface): 7/7 ok — incl. the 3 that returned 200/204 on dev
- `vendor_rls_repo_tests` + `integration_rls_repo_tests` (signature/grant changes): ok
- `cargo fmt --check` clean, `cargo clippy --workspace -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)