### PR TITLE
fix(api-server): board_meetings cross-tenant IDOR — RLS executor pattern + org keying (PAP-137)

### DIFF
--- a/backend/crates/db/src/repositories/board_meetings.rs
+++ b/backend/crates/db/src/repositories/board_meetings.rs
@@ -1,8 +1,33 @@
 //! Epic 143: Board Meeting Management Repository
 //!
 //! This module provides database operations for board meeting management.
+//!
+//! # RLS Integration (PAP-137 / PAP-67 / PAP-80)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on the board-meeting tables (`board_members`,
+//! `board_meetings`, `meeting_agenda_items`, `meeting_motions`, `motion_votes`,
+//! `meeting_attendance`, `meeting_minutes`, `meeting_action_items`,
+//! `meeting_documents`). Under `FORCE` the api-server's owner connection is no
+//! longer exempt, so a query issued on a connection without
+//! `app.current_org_id` set collapses to deny-all.
+//!
+//! Every method therefore takes an **executor whose connection already has RLS
+//! context set** (org + user GUCs) — in handlers this comes from the
+//! `RlsConnection` extractor via `&mut **rls.conn()`. The repository holds
+//! **no pool**, so there is no way to issue a query that bypasses RLS. This
+//! mirrors the `vendor.rs` / `work_order.rs` / `budget.rs` precedent.
+//!
+//! Cross-tenant safety (PAP-133 defense-in-depth): RLS is the primary
+//! boundary, but by-id queries stay org-keyed — a connection whose role
+//! bypasses RLS (superuser pools, BYPASSRLS) must still never resolve another
+//! tenant's row. `board_members` and `board_meetings` carry their own
+//! `organization_id`; child tables (`meeting_agenda_items`, `meeting_motions`,
+//! `motion_votes`, `meeting_attendance`, `meeting_minutes`,
+//! `meeting_action_items`, `meeting_documents`) are keyed through the root
+//! `board_meetings.organization_id` via `EXISTS`.
 
-use sqlx::PgPool;
+use sqlx::{Executor, PgConnection, PgPool, Postgres};
 use uuid::Uuid;
 
 use crate::models::board_meetings::{
@@ -17,15 +42,21 @@ use crate::models::board_meetings::{
 };
 
 /// Repository for board meeting operations.
+///
+/// Stateless: every method receives an RLS-context-bearing executor. The repo
+/// holds no pool so it cannot issue an un-scoped (deny-all under `FORCE`) query.
 #[derive(Debug, Clone)]
-pub struct BoardMeetingRepository {
-    pool: PgPool,
-}
+pub struct BoardMeetingRepository;
 
 impl BoardMeetingRepository {
     /// Create a new repository instance.
-    pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+    ///
+    /// The pool argument is retained for construction-site compatibility with
+    /// the other repositories on `AppState`; this repo deliberately does not
+    /// store it (see module docs — all queries run on a context-set connection
+    /// supplied by the handler's `RlsConnection`).
+    pub fn new(_pool: PgPool) -> Self {
+        Self
     }
 
     // ========================================================================
@@ -33,12 +64,16 @@ impl BoardMeetingRepository {
     // ========================================================================
 
     /// Create a new board member.
-    pub async fn create_board_member(
+    pub async fn create_board_member<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         appointed_by: Uuid,
         input: CreateBoardMember,
-    ) -> Result<BoardMember, sqlx::Error> {
+    ) -> Result<BoardMember, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, BoardMember>(
             r#"
             INSERT INTO board_members (
@@ -59,24 +94,39 @@ impl BoardMeetingRepository {
         .bind(input.sms_notifications.unwrap_or(false))
         .bind(appointed_by)
         .bind(input.notes)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
-    /// Get a board member by ID.
-    pub async fn get_board_member(&self, id: Uuid) -> Result<Option<BoardMember>, sqlx::Error> {
-        sqlx::query_as::<_, BoardMember>("SELECT * FROM board_members WHERE id = $1")
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await
+    /// Get a board member by ID, scoped to the owning organization.
+    pub async fn get_board_member<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<Option<BoardMember>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        sqlx::query_as::<_, BoardMember>(
+            "SELECT * FROM board_members WHERE id = $1 AND organization_id = $2",
+        )
+        .bind(id)
+        .bind(org_id)
+        .fetch_optional(executor)
+        .await
     }
 
     /// List board members with optional filters.
-    pub async fn list_board_members(
+    pub async fn list_board_members<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: BoardMemberQuery,
-    ) -> Result<Vec<BoardMemberSummary>, sqlx::Error> {
+    ) -> Result<Vec<BoardMemberSummary>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let page = query.page.unwrap_or(1).max(1);
         let per_page = query.per_page.unwrap_or(50).min(100);
         let offset = (page - 1) * per_page;
@@ -101,16 +151,24 @@ impl BoardMeetingRepository {
         .bind(query.is_active)
         .bind(per_page)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
-    /// Update a board member.
-    pub async fn update_board_member(
+    /// Update a board member, scoped to the owning organization.
+    ///
+    /// Returns `None` when no row matches `(id, org_id)` — including the
+    /// cross-tenant case, which is indistinguishable from "not found".
+    pub async fn update_board_member<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
+        org_id: Uuid,
         input: UpdateBoardMember,
-    ) -> Result<BoardMember, sqlx::Error> {
+    ) -> Result<Option<BoardMember>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, BoardMember>(
             r#"
             UPDATE board_members SET
@@ -122,7 +180,7 @@ impl BoardMeetingRepository {
                 sms_notifications = COALESCE($7, sms_notifications),
                 notes = COALESCE($8, notes),
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $9
             RETURNING *
             "#,
         )
@@ -134,16 +192,27 @@ impl BoardMeetingRepository {
         .bind(input.email_notifications)
         .bind(input.sms_notifications)
         .bind(input.notes)
-        .fetch_one(&self.pool)
+        .bind(org_id)
+        .fetch_optional(executor)
         .await
     }
 
-    /// Delete a board member.
-    pub async fn delete_board_member(&self, id: Uuid) -> Result<bool, sqlx::Error> {
-        let result = sqlx::query("DELETE FROM board_members WHERE id = $1")
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
+    /// Delete a board member, scoped to the owning organization.
+    pub async fn delete_board_member<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let result =
+            sqlx::query("DELETE FROM board_members WHERE id = $1 AND organization_id = $2")
+                .bind(id)
+                .bind(org_id)
+                .execute(executor)
+                .await?;
         Ok(result.rows_affected() > 0)
     }
 
@@ -152,12 +221,16 @@ impl BoardMeetingRepository {
     // ========================================================================
 
     /// Create a new board meeting.
-    pub async fn create_meeting(
+    pub async fn create_meeting<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         created_by: Uuid,
         input: CreateBoardMeeting,
-    ) -> Result<BoardMeeting, sqlx::Error> {
+    ) -> Result<BoardMeeting, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, BoardMeeting>(
             r#"
             INSERT INTO board_meetings (
@@ -188,31 +261,53 @@ impl BoardMeetingRepository {
         .bind(input.secretary_id)
         .bind(input.description)
         .bind(created_by)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
-    /// Get a meeting by ID.
-    pub async fn get_meeting(&self, id: Uuid) -> Result<Option<BoardMeeting>, sqlx::Error> {
-        sqlx::query_as::<_, BoardMeeting>("SELECT * FROM board_meetings WHERE id = $1")
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await
+    /// Get a meeting by ID, scoped to the owning organization.
+    pub async fn get_meeting<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<Option<BoardMeeting>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        sqlx::query_as::<_, BoardMeeting>(
+            "SELECT * FROM board_meetings WHERE id = $1 AND organization_id = $2",
+        )
+        .bind(id)
+        .bind(org_id)
+        .fetch_optional(executor)
+        .await
     }
 
     /// Get meeting detail with all related data.
-    pub async fn get_meeting_detail(&self, id: Uuid) -> Result<Option<MeetingDetail>, sqlx::Error> {
-        let meeting = match self.get_meeting(id).await? {
+    ///
+    /// Org validation happens on the root meeting fetch: when the meeting does
+    /// not belong to `org_id` this returns `Ok(None)` and no child data is
+    /// read. The child queries stay org-keyed regardless (defense-in-depth).
+    pub async fn get_meeting_detail(
+        &self,
+        conn: &mut PgConnection,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<Option<MeetingDetail>, sqlx::Error> {
+        let meeting = match self.get_meeting(&mut *conn, id, org_id).await? {
             Some(m) => m,
             None => return Ok(None),
         };
 
-        let agenda_items = self.list_agenda_items(id).await?;
-        let motions = self.list_meeting_motions(id).await?;
-        let attendance = self.list_meeting_attendance(id).await?;
-        let action_items = self.list_meeting_action_items(id).await?;
-        let documents = self.list_meeting_documents(id).await?;
-        let minutes = self.get_meeting_minutes(id).await?;
+        let agenda_items = self.list_agenda_items(&mut *conn, id, org_id).await?;
+        let motions = self.list_meeting_motions(&mut *conn, id, org_id).await?;
+        let attendance = self.list_meeting_attendance(&mut *conn, id, org_id).await?;
+        let action_items = self
+            .list_meeting_action_items(&mut *conn, id, org_id)
+            .await?;
+        let documents = self.list_meeting_documents(&mut *conn, id, org_id).await?;
+        let minutes = self.get_meeting_minutes(&mut *conn, id, org_id).await?;
 
         Ok(Some(MeetingDetail {
             meeting,
@@ -226,11 +321,15 @@ impl BoardMeetingRepository {
     }
 
     /// List meetings with optional filters.
-    pub async fn list_meetings(
+    pub async fn list_meetings<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: MeetingQuery,
-    ) -> Result<Vec<MeetingSummary>, sqlx::Error> {
+    ) -> Result<Vec<MeetingSummary>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let page = query.page.unwrap_or(1).max(1);
         let per_page = query.per_page.unwrap_or(20).min(100);
         let offset = (page - 1) * per_page;
@@ -261,16 +360,21 @@ impl BoardMeetingRepository {
         .bind(query.to_date)
         .bind(per_page)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
-    /// Update a meeting.
-    pub async fn update_meeting(
+    /// Update a meeting, scoped to the owning organization.
+    pub async fn update_meeting<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
+        org_id: Uuid,
         input: UpdateBoardMeeting,
-    ) -> Result<BoardMeeting, sqlx::Error> {
+    ) -> Result<Option<BoardMeeting>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, BoardMeeting>(
             r#"
             UPDATE board_meetings SET
@@ -297,7 +401,7 @@ impl BoardMeetingRepository {
                 description = COALESCE($22, description),
                 notes = COALESCE($23, notes),
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $24
             RETURNING *
             "#,
         )
@@ -324,66 +428,104 @@ impl BoardMeetingRepository {
         .bind(input.secretary_id)
         .bind(input.description)
         .bind(input.notes)
-        .fetch_one(&self.pool)
+        .bind(org_id)
+        .fetch_optional(executor)
         .await
     }
 
-    /// Start a meeting.
-    pub async fn start_meeting(&self, id: Uuid) -> Result<BoardMeeting, sqlx::Error> {
+    /// Start a meeting, scoped to the owning organization.
+    pub async fn start_meeting<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<Option<BoardMeeting>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, BoardMeeting>(
             r#"
             UPDATE board_meetings SET
                 status = 'in_progress',
                 actual_start = NOW(),
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             RETURNING *
             "#,
         )
         .bind(id)
-        .fetch_one(&self.pool)
+        .bind(org_id)
+        .fetch_optional(executor)
         .await
     }
 
-    /// End a meeting.
-    pub async fn end_meeting(&self, id: Uuid) -> Result<BoardMeeting, sqlx::Error> {
+    /// End a meeting, scoped to the owning organization.
+    pub async fn end_meeting<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<Option<BoardMeeting>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, BoardMeeting>(
             r#"
             UPDATE board_meetings SET
                 status = 'completed',
                 actual_end = NOW(),
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             RETURNING *
             "#,
         )
         .bind(id)
-        .fetch_one(&self.pool)
+        .bind(org_id)
+        .fetch_optional(executor)
         .await
     }
 
-    /// Cancel a meeting.
-    pub async fn cancel_meeting(&self, id: Uuid) -> Result<BoardMeeting, sqlx::Error> {
+    /// Cancel a meeting, scoped to the owning organization.
+    pub async fn cancel_meeting<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<Option<BoardMeeting>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, BoardMeeting>(
             r#"
             UPDATE board_meetings SET
                 status = 'cancelled',
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             RETURNING *
             "#,
         )
         .bind(id)
-        .fetch_one(&self.pool)
+        .bind(org_id)
+        .fetch_optional(executor)
         .await
     }
 
-    /// Delete a meeting.
-    pub async fn delete_meeting(&self, id: Uuid) -> Result<bool, sqlx::Error> {
-        let result = sqlx::query("DELETE FROM board_meetings WHERE id = $1")
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
+    /// Delete a meeting, scoped to the owning organization.
+    pub async fn delete_meeting<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let result =
+            sqlx::query("DELETE FROM board_meetings WHERE id = $1 AND organization_id = $2")
+                .bind(id)
+                .bind(org_id)
+                .execute(executor)
+                .await?;
         Ok(result.rows_affected() > 0)
     }
 
@@ -392,11 +534,18 @@ impl BoardMeetingRepository {
     // ========================================================================
 
     /// Add an agenda item.
-    pub async fn add_agenda_item(
+    ///
+    /// Callers must validate that `input.meeting_id` belongs to the caller's
+    /// organization first (root-meeting fetch via [`Self::get_meeting`]).
+    pub async fn add_agenda_item<'e, E>(
         &self,
+        executor: E,
         added_by: Uuid,
         input: CreateAgendaItem,
-    ) -> Result<MeetingAgendaItem, sqlx::Error> {
+    ) -> Result<MeetingAgendaItem, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MeetingAgendaItem>(
             r#"
             INSERT INTO meeting_agenda_items (
@@ -419,40 +568,75 @@ impl BoardMeetingRepository {
         .bind(input.presenter_name)
         .bind(input.document_ids.as_deref())
         .bind(added_by)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
-    /// Get an agenda item.
-    pub async fn get_agenda_item(
+    /// Get an agenda item, keyed through the root meeting's organization.
+    pub async fn get_agenda_item<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
-    ) -> Result<Option<MeetingAgendaItem>, sqlx::Error> {
-        sqlx::query_as::<_, MeetingAgendaItem>("SELECT * FROM meeting_agenda_items WHERE id = $1")
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await
+        org_id: Uuid,
+    ) -> Result<Option<MeetingAgendaItem>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        sqlx::query_as::<_, MeetingAgendaItem>(
+            r#"
+            SELECT i.* FROM meeting_agenda_items i
+            WHERE i.id = $1
+                AND EXISTS (
+                    SELECT 1 FROM board_meetings bm
+                    WHERE bm.id = i.meeting_id AND bm.organization_id = $2
+                )
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .fetch_optional(executor)
+        .await
     }
 
-    /// List agenda items for a meeting.
-    pub async fn list_agenda_items(
+    /// List agenda items for a meeting, keyed through the root meeting's
+    /// organization.
+    pub async fn list_agenda_items<'e, E>(
         &self,
+        executor: E,
         meeting_id: Uuid,
-    ) -> Result<Vec<MeetingAgendaItem>, sqlx::Error> {
+        org_id: Uuid,
+    ) -> Result<Vec<MeetingAgendaItem>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MeetingAgendaItem>(
-            "SELECT * FROM meeting_agenda_items WHERE meeting_id = $1 ORDER BY display_order",
+            r#"
+            SELECT i.* FROM meeting_agenda_items i
+            WHERE i.meeting_id = $1
+                AND EXISTS (
+                    SELECT 1 FROM board_meetings bm
+                    WHERE bm.id = i.meeting_id AND bm.organization_id = $2
+                )
+            ORDER BY i.display_order
+            "#,
         )
         .bind(meeting_id)
-        .fetch_all(&self.pool)
+        .bind(org_id)
+        .fetch_all(executor)
         .await
     }
 
-    /// Update an agenda item.
-    pub async fn update_agenda_item(
+    /// Update an agenda item, keyed through the root meeting's organization.
+    pub async fn update_agenda_item<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
+        org_id: Uuid,
         input: UpdateAgendaItem,
-    ) -> Result<MeetingAgendaItem, sqlx::Error> {
+    ) -> Result<Option<MeetingAgendaItem>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MeetingAgendaItem>(
             r#"
             UPDATE meeting_agenda_items SET
@@ -474,6 +658,11 @@ impl BoardMeetingRepository {
                 follow_up_due_date = COALESCE($17, follow_up_due_date),
                 updated_at = NOW()
             WHERE id = $1
+                AND EXISTS (
+                    SELECT 1 FROM board_meetings bm
+                    WHERE bm.id = meeting_agenda_items.meeting_id
+                        AND bm.organization_id = $18
+                )
             RETURNING *
             "#,
         )
@@ -494,16 +683,22 @@ impl BoardMeetingRepository {
         .bind(input.follow_up_required)
         .bind(input.follow_up_assignee)
         .bind(input.follow_up_due_date)
-        .fetch_one(&self.pool)
+        .bind(org_id)
+        .fetch_optional(executor)
         .await
     }
 
-    /// Complete an agenda item.
-    pub async fn complete_agenda_item(
+    /// Complete an agenda item, keyed through the root meeting's organization.
+    pub async fn complete_agenda_item<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
+        org_id: Uuid,
         outcome: Option<String>,
-    ) -> Result<MeetingAgendaItem, sqlx::Error> {
+    ) -> Result<Option<MeetingAgendaItem>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MeetingAgendaItem>(
             r#"
             UPDATE meeting_agenda_items SET
@@ -511,21 +706,46 @@ impl BoardMeetingRepository {
                 outcome = COALESCE($2, outcome),
                 updated_at = NOW()
             WHERE id = $1
+                AND EXISTS (
+                    SELECT 1 FROM board_meetings bm
+                    WHERE bm.id = meeting_agenda_items.meeting_id
+                        AND bm.organization_id = $3
+                )
             RETURNING *
             "#,
         )
         .bind(id)
         .bind(outcome)
-        .fetch_one(&self.pool)
+        .bind(org_id)
+        .fetch_optional(executor)
         .await
     }
 
-    /// Delete an agenda item.
-    pub async fn delete_agenda_item(&self, id: Uuid) -> Result<bool, sqlx::Error> {
-        let result = sqlx::query("DELETE FROM meeting_agenda_items WHERE id = $1")
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
+    /// Delete an agenda item, keyed through the root meeting's organization.
+    pub async fn delete_agenda_item<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let result = sqlx::query(
+            r#"
+            DELETE FROM meeting_agenda_items
+            WHERE id = $1
+                AND EXISTS (
+                    SELECT 1 FROM board_meetings bm
+                    WHERE bm.id = meeting_agenda_items.meeting_id
+                        AND bm.organization_id = $2
+                )
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .execute(executor)
+        .await?;
         Ok(result.rows_affected() > 0)
     }
 
@@ -534,11 +754,18 @@ impl BoardMeetingRepository {
     // ========================================================================
 
     /// Create a motion.
-    pub async fn create_motion(
+    ///
+    /// Callers must validate that `input.meeting_id` belongs to the caller's
+    /// organization first (root-meeting fetch via [`Self::get_meeting`]).
+    pub async fn create_motion<'e, E>(
         &self,
+        executor: E,
         proposed_by: Uuid,
         input: CreateMotion,
-    ) -> Result<MeetingMotion, sqlx::Error> {
+    ) -> Result<MeetingMotion, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MeetingMotion>(
             r#"
             INSERT INTO meeting_motions (
@@ -557,26 +784,50 @@ impl BoardMeetingRepository {
         .bind(proposed_by)
         .bind(input.effective_date)
         .bind(input.notes)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
-    /// Get a motion.
-    pub async fn get_motion(&self, id: Uuid) -> Result<Option<MeetingMotion>, sqlx::Error> {
-        sqlx::query_as::<_, MeetingMotion>("SELECT * FROM meeting_motions WHERE id = $1")
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await
+    /// Get a motion, keyed through the root meeting's organization.
+    pub async fn get_motion<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<Option<MeetingMotion>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        sqlx::query_as::<_, MeetingMotion>(
+            r#"
+            SELECT mm.* FROM meeting_motions mm
+            WHERE mm.id = $1
+                AND EXISTS (
+                    SELECT 1 FROM board_meetings bm
+                    WHERE bm.id = mm.meeting_id AND bm.organization_id = $2
+                )
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .fetch_optional(executor)
+        .await
     }
 
-    /// Get motion detail with votes.
-    pub async fn get_motion_detail(&self, id: Uuid) -> Result<Option<MotionDetail>, sqlx::Error> {
-        let motion = match self.get_motion(id).await? {
+    /// Get motion detail with votes, keyed through the root meeting's
+    /// organization. Org validation happens on the root motion fetch.
+    pub async fn get_motion_detail(
+        &self,
+        conn: &mut PgConnection,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<Option<MotionDetail>, sqlx::Error> {
+        let motion = match self.get_motion(&mut *conn, id, org_id).await? {
             Some(m) => m,
             None => return Ok(None),
         };
 
-        let votes = self.list_motion_votes(id).await?;
+        let votes = self.list_motion_votes(&mut *conn, id, org_id).await?;
 
         let vote_summary = VoteSummary {
             total_votes: votes.len() as i32,
@@ -595,25 +846,44 @@ impl BoardMeetingRepository {
         }))
     }
 
-    /// List motions for a meeting.
-    pub async fn list_meeting_motions(
+    /// List motions for a meeting, keyed through the root meeting's
+    /// organization.
+    pub async fn list_meeting_motions<'e, E>(
         &self,
+        executor: E,
         meeting_id: Uuid,
-    ) -> Result<Vec<MeetingMotion>, sqlx::Error> {
+        org_id: Uuid,
+    ) -> Result<Vec<MeetingMotion>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MeetingMotion>(
-            "SELECT * FROM meeting_motions WHERE meeting_id = $1 ORDER BY created_at",
+            r#"
+            SELECT mm.* FROM meeting_motions mm
+            WHERE mm.meeting_id = $1
+                AND EXISTS (
+                    SELECT 1 FROM board_meetings bm
+                    WHERE bm.id = mm.meeting_id AND bm.organization_id = $2
+                )
+            ORDER BY mm.created_at
+            "#,
         )
         .bind(meeting_id)
-        .fetch_all(&self.pool)
+        .bind(org_id)
+        .fetch_all(executor)
         .await
     }
 
     /// List motions with filters.
-    pub async fn list_motions(
+    pub async fn list_motions<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: MotionQuery,
-    ) -> Result<Vec<MotionSummary>, sqlx::Error> {
+    ) -> Result<Vec<MotionSummary>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let page = query.page.unwrap_or(1).max(1);
         let per_page = query.per_page.unwrap_or(20).min(100);
         let offset = (page - 1) * per_page;
@@ -642,16 +912,21 @@ impl BoardMeetingRepository {
         .bind(query.proposed_by)
         .bind(per_page)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
-    /// Second a motion.
-    pub async fn second_motion(
+    /// Second a motion, keyed through the root meeting's organization.
+    pub async fn second_motion<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
+        org_id: Uuid,
         seconded_by: Uuid,
-    ) -> Result<MeetingMotion, sqlx::Error> {
+    ) -> Result<Option<MeetingMotion>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MeetingMotion>(
             r#"
             UPDATE meeting_motions SET
@@ -659,17 +934,31 @@ impl BoardMeetingRepository {
                 status = 'seconded',
                 updated_at = NOW()
             WHERE id = $1
+                AND EXISTS (
+                    SELECT 1 FROM board_meetings bm
+                    WHERE bm.id = meeting_motions.meeting_id
+                        AND bm.organization_id = $3
+                )
             RETURNING *
             "#,
         )
         .bind(id)
         .bind(seconded_by)
-        .fetch_one(&self.pool)
+        .bind(org_id)
+        .fetch_optional(executor)
         .await
     }
 
-    /// Start voting on a motion.
-    pub async fn start_motion_voting(&self, id: Uuid) -> Result<MeetingMotion, sqlx::Error> {
+    /// Start voting on a motion, keyed through the root meeting's organization.
+    pub async fn start_motion_voting<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<Option<MeetingMotion>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MeetingMotion>(
             r#"
             UPDATE meeting_motions SET
@@ -677,17 +966,35 @@ impl BoardMeetingRepository {
                 voting_started_at = NOW(),
                 updated_at = NOW()
             WHERE id = $1
+                AND EXISTS (
+                    SELECT 1 FROM board_meetings bm
+                    WHERE bm.id = meeting_motions.meeting_id
+                        AND bm.organization_id = $2
+                )
             RETURNING *
             "#,
         )
         .bind(id)
-        .fetch_one(&self.pool)
+        .bind(org_id)
+        .fetch_optional(executor)
         .await
     }
 
-    /// End voting on a motion and calculate result.
-    pub async fn end_motion_voting(&self, id: Uuid) -> Result<MeetingMotion, sqlx::Error> {
-        // First count votes
+    /// End voting on a motion and calculate result, keyed through the root
+    /// meeting's organization. Returns `None` when the motion does not belong
+    /// to `org_id`.
+    pub async fn end_motion_voting(
+        &self,
+        conn: &mut PgConnection,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<Option<MeetingMotion>, sqlx::Error> {
+        // Org validation on the root motion fetch before counting votes.
+        if self.get_motion(&mut *conn, id, org_id).await?.is_none() {
+            return Ok(None);
+        }
+
+        // Count votes
         let vote_counts: (i64, i64, i64, i64) = sqlx::query_as(
             r#"
             SELECT
@@ -700,7 +1007,7 @@ impl BoardMeetingRepository {
             "#,
         )
         .bind(id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         let (in_favor, opposed, abstain, recused) = vote_counts;
@@ -721,6 +1028,11 @@ impl BoardMeetingRepository {
                 voting_ended_at = NOW(),
                 updated_at = NOW()
             WHERE id = $1
+                AND EXISTS (
+                    SELECT 1 FROM board_meetings bm
+                    WHERE bm.id = meeting_motions.meeting_id
+                        AND bm.organization_id = $7
+                )
             RETURNING *
             "#,
         )
@@ -730,16 +1042,22 @@ impl BoardMeetingRepository {
         .bind(opposed as i32)
         .bind(abstain as i32)
         .bind(recused as i32)
-        .fetch_one(&self.pool)
+        .bind(org_id)
+        .fetch_optional(&mut *conn)
         .await
     }
 
-    /// Update a motion.
-    pub async fn update_motion(
+    /// Update a motion, keyed through the root meeting's organization.
+    pub async fn update_motion<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
+        org_id: Uuid,
         input: UpdateMotion,
-    ) -> Result<MeetingMotion, sqlx::Error> {
+    ) -> Result<Option<MeetingMotion>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MeetingMotion>(
             r#"
             UPDATE meeting_motions SET
@@ -751,6 +1069,11 @@ impl BoardMeetingRepository {
                 notes = COALESCE($7, notes),
                 updated_at = NOW()
             WHERE id = $1
+                AND EXISTS (
+                    SELECT 1 FROM board_meetings bm
+                    WHERE bm.id = meeting_motions.meeting_id
+                        AND bm.organization_id = $8
+                )
             RETURNING *
             "#,
         )
@@ -761,16 +1084,36 @@ impl BoardMeetingRepository {
         .bind(input.resolution_text)
         .bind(input.effective_date)
         .bind(input.notes)
-        .fetch_one(&self.pool)
+        .bind(org_id)
+        .fetch_optional(executor)
         .await
     }
 
-    /// Delete a motion.
-    pub async fn delete_motion(&self, id: Uuid) -> Result<bool, sqlx::Error> {
-        let result = sqlx::query("DELETE FROM meeting_motions WHERE id = $1")
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
+    /// Delete a motion, keyed through the root meeting's organization.
+    pub async fn delete_motion<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let result = sqlx::query(
+            r#"
+            DELETE FROM meeting_motions
+            WHERE id = $1
+                AND EXISTS (
+                    SELECT 1 FROM board_meetings bm
+                    WHERE bm.id = meeting_motions.meeting_id
+                        AND bm.organization_id = $2
+                )
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .execute(executor)
+        .await?;
         Ok(result.rows_affected() > 0)
     }
 
@@ -779,11 +1122,18 @@ impl BoardMeetingRepository {
     // ========================================================================
 
     /// Cast a vote on a motion.
-    pub async fn cast_vote(
+    ///
+    /// Callers must validate that `input.motion_id` belongs to the caller's
+    /// organization first (root-motion fetch via [`Self::get_motion`]).
+    pub async fn cast_vote<'e, E>(
         &self,
+        executor: E,
         board_member_id: Uuid,
         input: CastVote,
-    ) -> Result<MotionVote, sqlx::Error> {
+    ) -> Result<MotionVote, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MotionVote>(
             r#"
             INSERT INTO motion_votes (motion_id, board_member_id, vote, recusal_reason)
@@ -799,16 +1149,36 @@ impl BoardMeetingRepository {
         .bind(board_member_id)
         .bind(input.vote)
         .bind(input.recusal_reason)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
-    /// List votes for a motion.
-    pub async fn list_motion_votes(&self, motion_id: Uuid) -> Result<Vec<MotionVote>, sqlx::Error> {
-        sqlx::query_as::<_, MotionVote>("SELECT * FROM motion_votes WHERE motion_id = $1")
-            .bind(motion_id)
-            .fetch_all(&self.pool)
-            .await
+    /// List votes for a motion, keyed through the root meeting's organization.
+    pub async fn list_motion_votes<'e, E>(
+        &self,
+        executor: E,
+        motion_id: Uuid,
+        org_id: Uuid,
+    ) -> Result<Vec<MotionVote>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        sqlx::query_as::<_, MotionVote>(
+            r#"
+            SELECT mv.* FROM motion_votes mv
+            WHERE mv.motion_id = $1
+                AND EXISTS (
+                    SELECT 1
+                    FROM meeting_motions mm
+                    JOIN board_meetings bm ON bm.id = mm.meeting_id
+                    WHERE mm.id = mv.motion_id AND bm.organization_id = $2
+                )
+            "#,
+        )
+        .bind(motion_id)
+        .bind(org_id)
+        .fetch_all(executor)
+        .await
     }
 
     // ========================================================================
@@ -816,11 +1186,18 @@ impl BoardMeetingRepository {
     // ========================================================================
 
     /// Record attendance.
-    pub async fn record_attendance(
+    ///
+    /// Callers must validate that `input.meeting_id` belongs to the caller's
+    /// organization first (root-meeting fetch via [`Self::get_meeting`]).
+    pub async fn record_attendance<'e, E>(
         &self,
+        executor: E,
         marked_by: Uuid,
         input: RecordAttendance,
-    ) -> Result<MeetingAttendance, sqlx::Error> {
+    ) -> Result<MeetingAttendance, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MeetingAttendance>(
             r#"
             INSERT INTO meeting_attendance (
@@ -844,25 +1221,45 @@ impl BoardMeetingRepository {
         .bind(input.guest_affiliation)
         .bind(input.notes)
         .bind(marked_by)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
-    /// List attendance for a meeting.
-    pub async fn list_meeting_attendance(
+    /// List attendance for a meeting, keyed through the root meeting's
+    /// organization.
+    pub async fn list_meeting_attendance<'e, E>(
         &self,
+        executor: E,
         meeting_id: Uuid,
-    ) -> Result<Vec<MeetingAttendance>, sqlx::Error> {
+        org_id: Uuid,
+    ) -> Result<Vec<MeetingAttendance>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MeetingAttendance>(
-            "SELECT * FROM meeting_attendance WHERE meeting_id = $1 ORDER BY arrived_at",
+            r#"
+            SELECT ma.* FROM meeting_attendance ma
+            WHERE ma.meeting_id = $1
+                AND EXISTS (
+                    SELECT 1 FROM board_meetings bm
+                    WHERE bm.id = ma.meeting_id AND bm.organization_id = $2
+                )
+            ORDER BY ma.arrived_at
+            "#,
         )
         .bind(meeting_id)
-        .fetch_all(&self.pool)
+        .bind(org_id)
+        .fetch_all(executor)
         .await
     }
 
-    /// Update quorum status for a meeting.
-    pub async fn update_meeting_quorum(&self, meeting_id: Uuid) -> Result<bool, sqlx::Error> {
+    /// Update quorum status for a meeting, scoped to the owning organization.
+    pub async fn update_meeting_quorum(
+        &self,
+        conn: &mut PgConnection,
+        meeting_id: Uuid,
+        org_id: Uuid,
+    ) -> Result<bool, sqlx::Error> {
         // Count present attendees
         let present: (i64,) = sqlx::query_as(
             r#"
@@ -872,15 +1269,17 @@ impl BoardMeetingRepository {
             "#,
         )
         .bind(meeting_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
-        // Get required quorum
-        let quorum: (Option<i32>,) =
-            sqlx::query_as("SELECT quorum_required FROM board_meetings WHERE id = $1")
-                .bind(meeting_id)
-                .fetch_one(&self.pool)
-                .await?;
+        // Get required quorum (org-keyed root fetch)
+        let quorum: (Option<i32>,) = sqlx::query_as(
+            "SELECT quorum_required FROM board_meetings WHERE id = $1 AND organization_id = $2",
+        )
+        .bind(meeting_id)
+        .bind(org_id)
+        .fetch_one(&mut *conn)
+        .await?;
 
         let quorum_met = present.0 >= quorum.0.unwrap_or(1) as i64;
 
@@ -890,13 +1289,14 @@ impl BoardMeetingRepository {
                 quorum_present = $2,
                 quorum_met = $3,
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $4
             "#,
         )
         .bind(meeting_id)
         .bind(present.0 as i32)
         .bind(quorum_met)
-        .execute(&self.pool)
+        .bind(org_id)
+        .execute(&mut *conn)
         .await?;
 
         Ok(quorum_met)
@@ -907,11 +1307,18 @@ impl BoardMeetingRepository {
     // ========================================================================
 
     /// Create meeting minutes.
-    pub async fn create_minutes(
+    ///
+    /// Callers must validate that `input.meeting_id` belongs to the caller's
+    /// organization first (root-meeting fetch via [`Self::get_meeting`]).
+    pub async fn create_minutes<'e, E>(
         &self,
+        executor: E,
         prepared_by: Uuid,
         input: CreateMinutes,
-    ) -> Result<MeetingMinutes, sqlx::Error> {
+    ) -> Result<MeetingMinutes, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MeetingMinutes>(
             r#"
             INSERT INTO meeting_minutes (
@@ -934,29 +1341,49 @@ impl BoardMeetingRepository {
         .bind(input.adjournment)
         .bind(input.full_content)
         .bind(prepared_by)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
-    /// Get minutes for a meeting.
-    pub async fn get_meeting_minutes(
+    /// Get minutes for a meeting, keyed through the root meeting's
+    /// organization.
+    pub async fn get_meeting_minutes<'e, E>(
         &self,
+        executor: E,
         meeting_id: Uuid,
-    ) -> Result<Option<MeetingMinutes>, sqlx::Error> {
+        org_id: Uuid,
+    ) -> Result<Option<MeetingMinutes>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MeetingMinutes>(
-            "SELECT * FROM meeting_minutes WHERE meeting_id = $1 ORDER BY version DESC LIMIT 1",
+            r#"
+            SELECT m.* FROM meeting_minutes m
+            WHERE m.meeting_id = $1
+                AND EXISTS (
+                    SELECT 1 FROM board_meetings bm
+                    WHERE bm.id = m.meeting_id AND bm.organization_id = $2
+                )
+            ORDER BY m.version DESC LIMIT 1
+            "#,
         )
         .bind(meeting_id)
-        .fetch_optional(&self.pool)
+        .bind(org_id)
+        .fetch_optional(executor)
         .await
     }
 
-    /// Update minutes.
-    pub async fn update_minutes(
+    /// Update minutes, keyed through the root meeting's organization.
+    pub async fn update_minutes<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
+        org_id: Uuid,
         input: UpdateMinutes,
-    ) -> Result<MeetingMinutes, sqlx::Error> {
+    ) -> Result<Option<MeetingMinutes>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MeetingMinutes>(
             r#"
             UPDATE meeting_minutes SET
@@ -972,6 +1399,11 @@ impl BoardMeetingRepository {
                 full_content = COALESCE($11, full_content),
                 updated_at = NOW()
             WHERE id = $1
+                AND EXISTS (
+                    SELECT 1 FROM board_meetings bm
+                    WHERE bm.id = meeting_minutes.meeting_id
+                        AND bm.organization_id = $12
+                )
             RETURNING *
             "#,
         )
@@ -986,17 +1418,23 @@ impl BoardMeetingRepository {
         .bind(input.announcements)
         .bind(input.adjournment)
         .bind(input.full_content)
-        .fetch_one(&self.pool)
+        .bind(org_id)
+        .fetch_optional(executor)
         .await
     }
 
-    /// Approve minutes.
-    pub async fn approve_minutes(
+    /// Approve minutes, keyed through the root meeting's organization.
+    pub async fn approve_minutes<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
+        org_id: Uuid,
         approved_by: Uuid,
         approval_motion_id: Option<Uuid>,
-    ) -> Result<MeetingMinutes, sqlx::Error> {
+    ) -> Result<Option<MeetingMinutes>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MeetingMinutes>(
             r#"
             UPDATE meeting_minutes SET
@@ -1006,13 +1444,19 @@ impl BoardMeetingRepository {
                 approval_motion_id = $3,
                 updated_at = NOW()
             WHERE id = $1
+                AND EXISTS (
+                    SELECT 1 FROM board_meetings bm
+                    WHERE bm.id = meeting_minutes.meeting_id
+                        AND bm.organization_id = $4
+                )
             RETURNING *
             "#,
         )
         .bind(id)
         .bind(approved_by)
         .bind(approval_motion_id)
-        .fetch_one(&self.pool)
+        .bind(org_id)
+        .fetch_optional(executor)
         .await
     }
 
@@ -1021,11 +1465,18 @@ impl BoardMeetingRepository {
     // ========================================================================
 
     /// Create an action item.
-    pub async fn create_action_item(
+    ///
+    /// Callers must validate that `input.meeting_id` belongs to the caller's
+    /// organization first (root-meeting fetch via [`Self::get_meeting`]).
+    pub async fn create_action_item<'e, E>(
         &self,
+        executor: E,
         created_by: Uuid,
         input: CreateActionItem,
-    ) -> Result<MeetingActionItem, sqlx::Error> {
+    ) -> Result<MeetingActionItem, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MeetingActionItem>(
             r#"
             INSERT INTO meeting_action_items (
@@ -1047,40 +1498,74 @@ impl BoardMeetingRepository {
         .bind(input.priority)
         .bind(input.notes)
         .bind(created_by)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
-    /// Get an action item.
-    pub async fn get_action_item(
+    /// Get an action item, keyed through the root meeting's organization.
+    pub async fn get_action_item<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
-    ) -> Result<Option<MeetingActionItem>, sqlx::Error> {
-        sqlx::query_as::<_, MeetingActionItem>("SELECT * FROM meeting_action_items WHERE id = $1")
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await
+        org_id: Uuid,
+    ) -> Result<Option<MeetingActionItem>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        sqlx::query_as::<_, MeetingActionItem>(
+            r#"
+            SELECT ai.* FROM meeting_action_items ai
+            WHERE ai.id = $1
+                AND EXISTS (
+                    SELECT 1 FROM board_meetings bm
+                    WHERE bm.id = ai.meeting_id AND bm.organization_id = $2
+                )
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .fetch_optional(executor)
+        .await
     }
 
-    /// List action items for a meeting.
-    pub async fn list_meeting_action_items(
+    /// List action items for a meeting, keyed through the root meeting's
+    /// organization.
+    pub async fn list_meeting_action_items<'e, E>(
         &self,
+        executor: E,
         meeting_id: Uuid,
-    ) -> Result<Vec<MeetingActionItem>, sqlx::Error> {
+        org_id: Uuid,
+    ) -> Result<Vec<MeetingActionItem>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MeetingActionItem>(
-            "SELECT * FROM meeting_action_items WHERE meeting_id = $1 ORDER BY created_at",
+            r#"
+            SELECT ai.* FROM meeting_action_items ai
+            WHERE ai.meeting_id = $1
+                AND EXISTS (
+                    SELECT 1 FROM board_meetings bm
+                    WHERE bm.id = ai.meeting_id AND bm.organization_id = $2
+                )
+            ORDER BY ai.created_at
+            "#,
         )
         .bind(meeting_id)
-        .fetch_all(&self.pool)
+        .bind(org_id)
+        .fetch_all(executor)
         .await
     }
 
     /// List action items with filters.
-    pub async fn list_action_items(
+    pub async fn list_action_items<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: ActionItemQuery,
-    ) -> Result<Vec<ActionItemSummary>, sqlx::Error> {
+    ) -> Result<Vec<ActionItemSummary>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let page = query.page.unwrap_or(1).max(1);
         let per_page = query.per_page.unwrap_or(20).min(100);
         let offset = (page - 1) * per_page;
@@ -1110,16 +1595,21 @@ impl BoardMeetingRepository {
         .bind(query.overdue_only)
         .bind(per_page)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
-    /// Update an action item.
-    pub async fn update_action_item(
+    /// Update an action item, keyed through the root meeting's organization.
+    pub async fn update_action_item<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
+        org_id: Uuid,
         input: UpdateActionItem,
-    ) -> Result<MeetingActionItem, sqlx::Error> {
+    ) -> Result<Option<MeetingActionItem>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MeetingActionItem>(
             r#"
             UPDATE meeting_action_items SET
@@ -1134,6 +1624,11 @@ impl BoardMeetingRepository {
                 completion_notes = COALESCE($10, completion_notes),
                 updated_at = NOW()
             WHERE id = $1
+                AND EXISTS (
+                    SELECT 1 FROM board_meetings bm
+                    WHERE bm.id = meeting_action_items.meeting_id
+                        AND bm.organization_id = $11
+                )
             RETURNING *
             "#,
         )
@@ -1147,16 +1642,22 @@ impl BoardMeetingRepository {
         .bind(input.priority)
         .bind(input.notes)
         .bind(input.completion_notes)
-        .fetch_one(&self.pool)
+        .bind(org_id)
+        .fetch_optional(executor)
         .await
     }
 
-    /// Complete an action item.
-    pub async fn complete_action_item(
+    /// Complete an action item, keyed through the root meeting's organization.
+    pub async fn complete_action_item<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
+        org_id: Uuid,
         completion_notes: Option<String>,
-    ) -> Result<MeetingActionItem, sqlx::Error> {
+    ) -> Result<Option<MeetingActionItem>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MeetingActionItem>(
             r#"
             UPDATE meeting_action_items SET
@@ -1165,21 +1666,46 @@ impl BoardMeetingRepository {
                 completion_notes = COALESCE($2, completion_notes),
                 updated_at = NOW()
             WHERE id = $1
+                AND EXISTS (
+                    SELECT 1 FROM board_meetings bm
+                    WHERE bm.id = meeting_action_items.meeting_id
+                        AND bm.organization_id = $3
+                )
             RETURNING *
             "#,
         )
         .bind(id)
         .bind(completion_notes)
-        .fetch_one(&self.pool)
+        .bind(org_id)
+        .fetch_optional(executor)
         .await
     }
 
-    /// Delete an action item.
-    pub async fn delete_action_item(&self, id: Uuid) -> Result<bool, sqlx::Error> {
-        let result = sqlx::query("DELETE FROM meeting_action_items WHERE id = $1")
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
+    /// Delete an action item, keyed through the root meeting's organization.
+    pub async fn delete_action_item<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let result = sqlx::query(
+            r#"
+            DELETE FROM meeting_action_items
+            WHERE id = $1
+                AND EXISTS (
+                    SELECT 1 FROM board_meetings bm
+                    WHERE bm.id = meeting_action_items.meeting_id
+                        AND bm.organization_id = $2
+                )
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .execute(executor)
+        .await?;
         Ok(result.rows_affected() > 0)
     }
 
@@ -1188,11 +1714,18 @@ impl BoardMeetingRepository {
     // ========================================================================
 
     /// Upload a meeting document.
-    pub async fn upload_document(
+    ///
+    /// Callers must validate that `input.meeting_id` belongs to the caller's
+    /// organization first (root-meeting fetch via [`Self::get_meeting`]).
+    pub async fn upload_document<'e, E>(
         &self,
+        executor: E,
         uploaded_by: Uuid,
         input: UploadMeetingDocument,
-    ) -> Result<MeetingDocument, sqlx::Error> {
+    ) -> Result<MeetingDocument, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MeetingDocument>(
             r#"
             INSERT INTO meeting_documents (
@@ -1216,29 +1749,63 @@ impl BoardMeetingRepository {
         .bind(input.is_public.unwrap_or(false))
         .bind(input.board_only.unwrap_or(true))
         .bind(uploaded_by)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
-    /// List documents for a meeting.
-    pub async fn list_meeting_documents(
+    /// List documents for a meeting, keyed through the root meeting's
+    /// organization.
+    pub async fn list_meeting_documents<'e, E>(
         &self,
+        executor: E,
         meeting_id: Uuid,
-    ) -> Result<Vec<MeetingDocument>, sqlx::Error> {
+        org_id: Uuid,
+    ) -> Result<Vec<MeetingDocument>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MeetingDocument>(
-            "SELECT * FROM meeting_documents WHERE meeting_id = $1 ORDER BY created_at",
+            r#"
+            SELECT md.* FROM meeting_documents md
+            WHERE md.meeting_id = $1
+                AND EXISTS (
+                    SELECT 1 FROM board_meetings bm
+                    WHERE bm.id = md.meeting_id AND bm.organization_id = $2
+                )
+            ORDER BY md.created_at
+            "#,
         )
         .bind(meeting_id)
-        .fetch_all(&self.pool)
+        .bind(org_id)
+        .fetch_all(executor)
         .await
     }
 
-    /// Delete a document.
-    pub async fn delete_document(&self, id: Uuid) -> Result<bool, sqlx::Error> {
-        let result = sqlx::query("DELETE FROM meeting_documents WHERE id = $1")
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
+    /// Delete a document, keyed through the root meeting's organization.
+    pub async fn delete_document<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let result = sqlx::query(
+            r#"
+            DELETE FROM meeting_documents
+            WHERE id = $1
+                AND EXISTS (
+                    SELECT 1 FROM board_meetings bm
+                    WHERE bm.id = meeting_documents.meeting_id
+                        AND bm.organization_id = $2
+                )
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .execute(executor)
+        .await?;
         Ok(result.rows_affected() > 0)
     }
 
@@ -1247,7 +1814,11 @@ impl BoardMeetingRepository {
     // ========================================================================
 
     /// Get meeting dashboard data.
-    pub async fn get_dashboard(&self, org_id: Uuid) -> Result<MeetingDashboard, sqlx::Error> {
+    pub async fn get_dashboard(
+        &self,
+        conn: &mut PgConnection,
+        org_id: Uuid,
+    ) -> Result<MeetingDashboard, sqlx::Error> {
         let upcoming_meetings = sqlx::query_as::<_, MeetingSummary>(
             r#"
             SELECT
@@ -1264,7 +1835,7 @@ impl BoardMeetingRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await?;
 
         let recent_meetings = sqlx::query_as::<_, MeetingSummary>(
@@ -1282,7 +1853,7 @@ impl BoardMeetingRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await?;
 
         let open_action_items = sqlx::query_as::<_, ActionItemSummary>(
@@ -1300,7 +1871,7 @@ impl BoardMeetingRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await?;
 
         let pending_minutes: (i64,) = sqlx::query_as(
@@ -1314,17 +1885,17 @@ impl BoardMeetingRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         let board_member_count: (i64,) = sqlx::query_as(
             "SELECT COUNT(*) FROM board_members WHERE organization_id = $1 AND is_active = true",
         )
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
-        let statistics = self.get_latest_statistics(org_id).await?;
+        let statistics = self.get_latest_statistics(&mut *conn, org_id).await?;
 
         Ok(MeetingDashboard {
             upcoming_meetings,
@@ -1337,23 +1908,31 @@ impl BoardMeetingRepository {
     }
 
     /// Get latest statistics for organization.
-    pub async fn get_latest_statistics(
+    pub async fn get_latest_statistics<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
-    ) -> Result<Option<MeetingStatistics>, sqlx::Error> {
+    ) -> Result<Option<MeetingStatistics>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MeetingStatistics>(
             "SELECT * FROM meeting_statistics WHERE organization_id = $1 ORDER BY calculated_at DESC LIMIT 1",
         )
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Get meeting type counts.
-    pub async fn get_meeting_type_counts(
+    pub async fn get_meeting_type_counts<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
-    ) -> Result<Vec<MeetingTypeCount>, sqlx::Error> {
+    ) -> Result<Vec<MeetingTypeCount>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MeetingTypeCount>(
             r#"
             SELECT meeting_type, COUNT(*) as count
@@ -1364,15 +1943,19 @@ impl BoardMeetingRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Get motion status counts.
-    pub async fn get_motion_status_counts(
+    pub async fn get_motion_status_counts<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
-    ) -> Result<Vec<MotionStatusCount>, sqlx::Error> {
+    ) -> Result<Vec<MotionStatusCount>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, MotionStatusCount>(
             r#"
             SELECT mm.status, COUNT(*) as count
@@ -1384,16 +1967,21 @@ impl BoardMeetingRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
-    /// Get board member attendance history.
+    /// Get board member attendance history, scoped to the owning organization.
     pub async fn get_member_attendance_history(
         &self,
+        conn: &mut PgConnection,
         board_member_id: Uuid,
+        org_id: Uuid,
     ) -> Result<Option<AttendanceHistory>, sqlx::Error> {
-        let member = match self.get_board_member(board_member_id).await? {
+        let member = match self
+            .get_board_member(&mut *conn, board_member_id, org_id)
+            .await?
+        {
             Some(m) => m,
             None => return Ok(None),
         };
@@ -1411,7 +1999,7 @@ impl BoardMeetingRepository {
             "#,
         )
         .bind(board_member_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         let (total, attended, absent, excused, remote) = attendance;

--- a/backend/servers/api-server/src/routes/board_meetings.rs
+++ b/backend/servers/api-server/src/routes/board_meetings.rs
@@ -8,9 +8,27 @@
 //! - Attendance tracking
 //! - Minutes management
 //! - Action items
+//!
+//! # RLS (PAP-137)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` on the board-meeting
+//! tables, so every query MUST run on a connection that has
+//! `app.current_org_id` set or it collapses to deny-all. Each handler
+//! therefore acquires an [`RlsConnection`] (which validates tenant membership
+//! and sets the org/user GUCs on a dedicated connection) and passes
+//! `&mut **rls.conn()` to the repository. The authoritative organization is
+//! `rls.tenant_id()` — the tenant the caller was validated against — never a
+//! client-supplied value, so the SQL org filter and the RLS context can never
+//! disagree. By-id repo queries stay keyed on `(id, organization_id)` (child
+//! tables via the root meeting) as defense-in-depth, so a cross-tenant probe
+//! resolves to no row → `404` even on an RLS-exempt pool. Child-table inserts
+//! (`agenda`, `motions`, `votes`, `attendance`, `minutes`, `actions`,
+//! `documents`) validate the root meeting/motion org first.
+//! `rls.release()` clears the context before the connection returns to the
+//! pool.
 
 use crate::state::AppState;
-use api_core::extractors::AuthUser;
+use api_core::extractors::RlsConnection;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -45,16 +63,25 @@ fn not_found(resource: &str) -> (StatusCode, Json<ErrorResponse>) {
     )
 }
 
-fn require_tenant(tenant_id: Option<Uuid>) -> ApiResult<Uuid> {
-    tenant_id.ok_or_else(|| {
-        (
-            StatusCode::UNAUTHORIZED,
-            Json(ErrorResponse::new(
-                "UNAUTHORIZED",
-                "Organization context required",
-            )),
-        )
-    })
+/// Validate that `meeting_id` belongs to the caller's organization.
+///
+/// Root-meeting org check for child-table operations (agenda items, motions,
+/// attendance, minutes, action items, documents). A meeting owned by another
+/// organization surfaces as `404 NOT_FOUND` — indistinguishable from a
+/// missing meeting.
+async fn require_meeting_in_org(
+    state: &AppState,
+    rls: &mut RlsConnection,
+    meeting_id: Uuid,
+) -> ApiResult<()> {
+    let org_id = rls.tenant_id();
+    state
+        .board_meeting_repo
+        .get_meeting(&mut **rls.conn(), meeting_id, org_id)
+        .await
+        .map_err(internal_error)?
+        .ok_or_else(|| not_found("Meeting"))?;
+    Ok(())
 }
 
 /// Create router for board meeting endpoints.
@@ -128,16 +155,17 @@ pub fn router() -> Router<AppState> {
 /// Get board meeting dashboard.
 async fn get_dashboard(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
 ) -> ApiResult<Json<db::models::board_meetings::MeetingDashboard>> {
-    let org_id = require_tenant(user.tenant_id)?;
-    let dashboard = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .get_dashboard(org_id)
+        .get_dashboard(rls.conn(), org_id)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(dashboard))
+        .map(Json)
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -147,96 +175,114 @@ async fn get_dashboard(
 /// List board members.
 async fn list_board_members(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<BoardMemberQuery>,
 ) -> ApiResult<Json<Vec<db::models::board_meetings::BoardMemberSummary>>> {
-    let org_id = require_tenant(user.tenant_id)?;
-    let members = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .list_board_members(org_id, query)
+        .list_board_members(&mut **rls.conn(), org_id, query)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(members))
+        .map(Json)
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 /// Create a board member.
 async fn create_board_member(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Json(input): Json<CreateBoardMember>,
 ) -> ApiResult<Json<db::models::board_meetings::BoardMember>> {
-    let org_id = require_tenant(user.tenant_id)?;
-    let member = state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .board_meeting_repo
-        .create_board_member(org_id, user.user_id, input)
+        .create_board_member(&mut **rls.conn(), org_id, user_id, input)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(member))
+        .map(Json)
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 /// Get a board member by ID.
 async fn get_board_member(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::board_meetings::BoardMember>> {
-    let member = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .get_board_member(id)
+        .get_board_member(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(internal_error)?
-        .ok_or_else(|| not_found("Board member"))?;
-
-    Ok(Json(member))
+        .map_err(internal_error)
+        .and_then(|m| m.ok_or_else(|| not_found("Board member")))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 /// Update a board member.
 async fn update_board_member(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(input): Json<UpdateBoardMember>,
 ) -> ApiResult<Json<db::models::board_meetings::BoardMember>> {
-    let member = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .update_board_member(id, input)
+        .update_board_member(&mut **rls.conn(), id, org_id, input)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(member))
+        .map_err(internal_error)
+        .and_then(|m| m.ok_or_else(|| not_found("Board member")))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 /// Delete a board member.
 async fn delete_board_member(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> ApiResult<StatusCode> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .delete_board_member(id)
+        .delete_board_member(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(internal_error)?;
-
-    Ok(StatusCode::NO_CONTENT)
+        .map_err(internal_error)
+        .and_then(|deleted| {
+            if deleted {
+                Ok(StatusCode::NO_CONTENT)
+            } else {
+                Err(not_found("Board member"))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 /// Get board member attendance history.
 async fn get_member_attendance(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::board_meetings::AttendanceHistory>> {
-    let history = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .get_member_attendance_history(id)
+        .get_member_attendance_history(rls.conn(), id, org_id)
         .await
-        .map_err(internal_error)?
-        .ok_or_else(|| not_found("Board member"))?;
-
-    Ok(Json(history))
+        .map_err(internal_error)
+        .and_then(|h| h.ok_or_else(|| not_found("Board member")))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -246,125 +292,150 @@ async fn get_member_attendance(
 /// List meetings.
 async fn list_meetings(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<MeetingQuery>,
 ) -> ApiResult<Json<Vec<db::models::board_meetings::MeetingSummary>>> {
-    let org_id = require_tenant(user.tenant_id)?;
-    let meetings = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .list_meetings(org_id, query)
+        .list_meetings(&mut **rls.conn(), org_id, query)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(meetings))
+        .map(Json)
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 /// Create a meeting.
 async fn create_meeting(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Json(input): Json<CreateBoardMeeting>,
 ) -> ApiResult<Json<db::models::board_meetings::BoardMeeting>> {
-    let org_id = require_tenant(user.tenant_id)?;
-    let meeting = state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .board_meeting_repo
-        .create_meeting(org_id, user.user_id, input)
+        .create_meeting(&mut **rls.conn(), org_id, user_id, input)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(meeting))
+        .map(Json)
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 /// Get a meeting by ID.
 async fn get_meeting(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::board_meetings::MeetingDetail>> {
-    let detail = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .get_meeting_detail(id)
+        .get_meeting_detail(rls.conn(), id, org_id)
         .await
-        .map_err(internal_error)?
-        .ok_or_else(|| not_found("Meeting"))?;
-
-    Ok(Json(detail))
+        .map_err(internal_error)
+        .and_then(|d| d.ok_or_else(|| not_found("Meeting")))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 /// Update a meeting.
 async fn update_meeting(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(input): Json<UpdateBoardMeeting>,
 ) -> ApiResult<Json<db::models::board_meetings::BoardMeeting>> {
-    let meeting = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .update_meeting(id, input)
+        .update_meeting(&mut **rls.conn(), id, org_id, input)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(meeting))
+        .map_err(internal_error)
+        .and_then(|m| m.ok_or_else(|| not_found("Meeting")))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 /// Delete a meeting.
 async fn delete_meeting(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> ApiResult<StatusCode> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .delete_meeting(id)
+        .delete_meeting(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(internal_error)?;
-
-    Ok(StatusCode::NO_CONTENT)
+        .map_err(internal_error)
+        .and_then(|deleted| {
+            if deleted {
+                Ok(StatusCode::NO_CONTENT)
+            } else {
+                Err(not_found("Meeting"))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 /// Start a meeting.
 async fn start_meeting(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::board_meetings::BoardMeeting>> {
-    let meeting = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .start_meeting(id)
+        .start_meeting(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(meeting))
+        .map_err(internal_error)
+        .and_then(|m| m.ok_or_else(|| not_found("Meeting")))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 /// End a meeting.
 async fn end_meeting(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::board_meetings::BoardMeeting>> {
-    let meeting = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .end_meeting(id)
+        .end_meeting(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(meeting))
+        .map_err(internal_error)
+        .and_then(|m| m.ok_or_else(|| not_found("Meeting")))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 /// Cancel a meeting.
 async fn cancel_meeting(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::board_meetings::BoardMeeting>> {
-    let meeting = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .cancel_meeting(id)
+        .cancel_meeting(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(meeting))
+        .map_err(internal_error)
+        .and_then(|m| m.ok_or_else(|| not_found("Meeting")))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -374,65 +445,78 @@ async fn cancel_meeting(
 /// List agenda items for a meeting.
 async fn list_agenda_items(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(meeting_id): Path<Uuid>,
 ) -> ApiResult<Json<Vec<db::models::board_meetings::MeetingAgendaItem>>> {
-    let items = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .list_agenda_items(meeting_id)
+        .list_agenda_items(&mut **rls.conn(), meeting_id, org_id)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(items))
+        .map(Json)
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 /// Add an agenda item.
 async fn add_agenda_item(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(meeting_id): Path<Uuid>,
     Json(mut input): Json<CreateAgendaItem>,
 ) -> ApiResult<Json<db::models::board_meetings::MeetingAgendaItem>> {
     input.meeting_id = meeting_id;
-    let item = state
-        .board_meeting_repo
-        .add_agenda_item(user.user_id, input)
-        .await
-        .map_err(internal_error)?;
-
-    Ok(Json(item))
+    let user_id = rls.user_id();
+    let out = async {
+        require_meeting_in_org(&state, &mut rls, meeting_id).await?;
+        state
+            .board_meeting_repo
+            .add_agenda_item(&mut **rls.conn(), user_id, input)
+            .await
+            .map(Json)
+            .map_err(internal_error)
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 /// Get an agenda item.
 async fn get_agenda_item(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::board_meetings::MeetingAgendaItem>> {
-    let item = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .get_agenda_item(id)
+        .get_agenda_item(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(internal_error)?
-        .ok_or_else(|| not_found("Agenda item"))?;
-
-    Ok(Json(item))
+        .map_err(internal_error)
+        .and_then(|i| i.ok_or_else(|| not_found("Agenda item")))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 /// Update an agenda item.
 async fn update_agenda_item(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(input): Json<UpdateAgendaItem>,
 ) -> ApiResult<Json<db::models::board_meetings::MeetingAgendaItem>> {
-    let item = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .update_agenda_item(id, input)
+        .update_agenda_item(&mut **rls.conn(), id, org_id, input)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(item))
+        .map_err(internal_error)
+        .and_then(|i| i.ok_or_else(|| not_found("Agenda item")))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 /// Complete an agenda item.
@@ -443,32 +527,43 @@ struct CompleteAgendaItemRequest {
 
 async fn complete_agenda_item(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(input): Json<CompleteAgendaItemRequest>,
 ) -> ApiResult<Json<db::models::board_meetings::MeetingAgendaItem>> {
-    let item = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .complete_agenda_item(id, input.outcome)
+        .complete_agenda_item(&mut **rls.conn(), id, org_id, input.outcome)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(item))
+        .map_err(internal_error)
+        .and_then(|i| i.ok_or_else(|| not_found("Agenda item")))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 /// Delete an agenda item.
 async fn delete_agenda_item(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> ApiResult<StatusCode> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .delete_agenda_item(id)
+        .delete_agenda_item(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(internal_error)?;
-
-    Ok(StatusCode::NO_CONTENT)
+        .map_err(internal_error)
+        .and_then(|deleted| {
+            if deleted {
+                Ok(StatusCode::NO_CONTENT)
+            } else {
+                Err(not_found("Agenda item"))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -478,161 +573,205 @@ async fn delete_agenda_item(
 /// List motions for a meeting.
 async fn list_meeting_motions(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(meeting_id): Path<Uuid>,
 ) -> ApiResult<Json<Vec<db::models::board_meetings::MeetingMotion>>> {
-    let motions = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .list_meeting_motions(meeting_id)
+        .list_meeting_motions(&mut **rls.conn(), meeting_id, org_id)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(motions))
+        .map(Json)
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 /// List all motions with filters.
 async fn list_motions(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<MotionQuery>,
 ) -> ApiResult<Json<Vec<db::models::board_meetings::MotionSummary>>> {
-    let org_id = require_tenant(user.tenant_id)?;
-    let motions = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .list_motions(org_id, query)
+        .list_motions(&mut **rls.conn(), org_id, query)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(motions))
+        .map(Json)
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 /// Create a motion.
 async fn create_motion(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(meeting_id): Path<Uuid>,
     Json(mut input): Json<CreateMotion>,
 ) -> ApiResult<Json<db::models::board_meetings::MeetingMotion>> {
     input.meeting_id = meeting_id;
-    let motion = state
-        .board_meeting_repo
-        .create_motion(user.user_id, input)
-        .await
-        .map_err(internal_error)?;
-
-    Ok(Json(motion))
+    let user_id = rls.user_id();
+    let out = async {
+        require_meeting_in_org(&state, &mut rls, meeting_id).await?;
+        state
+            .board_meeting_repo
+            .create_motion(&mut **rls.conn(), user_id, input)
+            .await
+            .map(Json)
+            .map_err(internal_error)
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 /// Get a motion by ID.
 async fn get_motion(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::board_meetings::MotionDetail>> {
-    let detail = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .get_motion_detail(id)
+        .get_motion_detail(rls.conn(), id, org_id)
         .await
-        .map_err(internal_error)?
-        .ok_or_else(|| not_found("Motion"))?;
-
-    Ok(Json(detail))
+        .map_err(internal_error)
+        .and_then(|d| d.ok_or_else(|| not_found("Motion")))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 /// Update a motion.
 async fn update_motion(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(input): Json<UpdateMotion>,
 ) -> ApiResult<Json<db::models::board_meetings::MeetingMotion>> {
-    let motion = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .update_motion(id, input)
+        .update_motion(&mut **rls.conn(), id, org_id, input)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(motion))
+        .map_err(internal_error)
+        .and_then(|m| m.ok_or_else(|| not_found("Motion")))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 /// Second a motion.
 async fn second_motion(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::board_meetings::MeetingMotion>> {
-    let motion = state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .board_meeting_repo
-        .second_motion(id, user.user_id)
+        .second_motion(&mut **rls.conn(), id, org_id, user_id)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(motion))
+        .map_err(internal_error)
+        .and_then(|m| m.ok_or_else(|| not_found("Motion")))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 /// Start voting on a motion.
 async fn start_motion_voting(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::board_meetings::MeetingMotion>> {
-    let motion = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .start_motion_voting(id)
+        .start_motion_voting(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(motion))
+        .map_err(internal_error)
+        .and_then(|m| m.ok_or_else(|| not_found("Motion")))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 /// End voting on a motion.
 async fn end_motion_voting(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::board_meetings::MeetingMotion>> {
-    let motion = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .end_motion_voting(id)
+        .end_motion_voting(rls.conn(), id, org_id)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(motion))
+        .map_err(internal_error)
+        .and_then(|m| m.ok_or_else(|| not_found("Motion")))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 /// Cast a vote on a motion.
 async fn cast_vote(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(motion_id): Path<Uuid>,
     Json(mut input): Json<CastVote>,
 ) -> ApiResult<Json<db::models::board_meetings::MotionVote>> {
     input.motion_id = motion_id;
-    // NOTE: In production, we'd look up the board_member_id from user.user_id
-    // For now, we'll use a placeholder - this should be retrieved from the board_members table
-    let board_member_id = motion_id; // Placeholder - should be actual board member lookup
-    let vote = state
-        .board_meeting_repo
-        .cast_vote(board_member_id, input)
-        .await
-        .map_err(internal_error)?;
-
-    Ok(Json(vote))
+    let org_id = rls.tenant_id();
+    let out = async {
+        // Root-motion org check before writing a vote row.
+        state
+            .board_meeting_repo
+            .get_motion(&mut **rls.conn(), motion_id, org_id)
+            .await
+            .map_err(internal_error)?
+            .ok_or_else(|| not_found("Motion"))?;
+        // NOTE: In production, we'd look up the board_member_id from user.user_id
+        // For now, we'll use a placeholder - this should be retrieved from the board_members table
+        let board_member_id = motion_id; // Placeholder - should be actual board member lookup
+        state
+            .board_meeting_repo
+            .cast_vote(&mut **rls.conn(), board_member_id, input)
+            .await
+            .map(Json)
+            .map_err(internal_error)
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 /// Delete a motion.
 async fn delete_motion(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> ApiResult<StatusCode> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .delete_motion(id)
+        .delete_motion(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(internal_error)?;
-
-    Ok(StatusCode::NO_CONTENT)
+        .map_err(internal_error)
+        .and_then(|deleted| {
+            if deleted {
+                Ok(StatusCode::NO_CONTENT)
+            } else {
+                Err(not_found("Motion"))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -642,39 +781,49 @@ async fn delete_motion(
 /// List attendance for a meeting.
 async fn list_attendance(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(meeting_id): Path<Uuid>,
 ) -> ApiResult<Json<Vec<db::models::board_meetings::MeetingAttendance>>> {
-    let attendance = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .list_meeting_attendance(meeting_id)
+        .list_meeting_attendance(&mut **rls.conn(), meeting_id, org_id)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(attendance))
+        .map(Json)
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 /// Record attendance.
 async fn record_attendance(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(meeting_id): Path<Uuid>,
     Json(mut input): Json<RecordAttendance>,
 ) -> ApiResult<Json<db::models::board_meetings::MeetingAttendance>> {
     input.meeting_id = meeting_id;
-    let attendance = state
-        .board_meeting_repo
-        .record_attendance(user.user_id, input)
-        .await
-        .map_err(internal_error)?;
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = async {
+        require_meeting_in_org(&state, &mut rls, meeting_id).await?;
+        let attendance = state
+            .board_meeting_repo
+            .record_attendance(&mut **rls.conn(), user_id, input)
+            .await
+            .map_err(internal_error)?;
 
-    // Update quorum status
-    let _ = state
-        .board_meeting_repo
-        .update_meeting_quorum(meeting_id)
-        .await;
+        // Update quorum status
+        let _ = state
+            .board_meeting_repo
+            .update_meeting_quorum(rls.conn(), meeting_id, org_id)
+            .await;
 
-    Ok(Json(attendance))
+        Ok(Json(attendance))
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -684,50 +833,61 @@ async fn record_attendance(
 /// Get minutes for a meeting.
 async fn get_minutes(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(meeting_id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::board_meetings::MeetingMinutes>> {
-    let minutes = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .get_meeting_minutes(meeting_id)
+        .get_meeting_minutes(&mut **rls.conn(), meeting_id, org_id)
         .await
-        .map_err(internal_error)?
-        .ok_or_else(|| not_found("Minutes"))?;
-
-    Ok(Json(minutes))
+        .map_err(internal_error)
+        .and_then(|m| m.ok_or_else(|| not_found("Minutes")))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 /// Create minutes.
 async fn create_minutes(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(meeting_id): Path<Uuid>,
     Json(mut input): Json<CreateMinutes>,
 ) -> ApiResult<Json<db::models::board_meetings::MeetingMinutes>> {
     input.meeting_id = meeting_id;
-    let minutes = state
-        .board_meeting_repo
-        .create_minutes(user.user_id, input)
-        .await
-        .map_err(internal_error)?;
-
-    Ok(Json(minutes))
+    let user_id = rls.user_id();
+    let out = async {
+        require_meeting_in_org(&state, &mut rls, meeting_id).await?;
+        state
+            .board_meeting_repo
+            .create_minutes(&mut **rls.conn(), user_id, input)
+            .await
+            .map(Json)
+            .map_err(internal_error)
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 /// Update minutes.
 async fn update_minutes(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(input): Json<UpdateMinutes>,
 ) -> ApiResult<Json<db::models::board_meetings::MeetingMinutes>> {
-    let minutes = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .update_minutes(id, input)
+        .update_minutes(&mut **rls.conn(), id, org_id, input)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(minutes))
+        .map_err(internal_error)
+        .and_then(|m| m.ok_or_else(|| not_found("Minutes")))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 /// Approve minutes.
@@ -738,17 +898,27 @@ struct ApproveMinutesRequest {
 
 async fn approve_minutes(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(input): Json<ApproveMinutesRequest>,
 ) -> ApiResult<Json<db::models::board_meetings::MeetingMinutes>> {
-    let minutes = state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .board_meeting_repo
-        .approve_minutes(id, user.user_id, input.approval_motion_id)
+        .approve_minutes(
+            &mut **rls.conn(),
+            id,
+            org_id,
+            user_id,
+            input.approval_motion_id,
+        )
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(minutes))
+        .map_err(internal_error)
+        .and_then(|m| m.ok_or_else(|| not_found("Minutes")))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -758,81 +928,95 @@ async fn approve_minutes(
 /// List action items for a meeting.
 async fn list_meeting_action_items(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(meeting_id): Path<Uuid>,
 ) -> ApiResult<Json<Vec<db::models::board_meetings::MeetingActionItem>>> {
-    let items = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .list_meeting_action_items(meeting_id)
+        .list_meeting_action_items(&mut **rls.conn(), meeting_id, org_id)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(items))
+        .map(Json)
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 /// List all action items with filters.
 async fn list_action_items(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<ActionItemQuery>,
 ) -> ApiResult<Json<Vec<db::models::board_meetings::ActionItemSummary>>> {
-    let org_id = require_tenant(user.tenant_id)?;
-    let items = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .list_action_items(org_id, query)
+        .list_action_items(&mut **rls.conn(), org_id, query)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(items))
+        .map(Json)
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 /// Create an action item.
 async fn create_action_item(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(meeting_id): Path<Uuid>,
     Json(mut input): Json<CreateActionItem>,
 ) -> ApiResult<Json<db::models::board_meetings::MeetingActionItem>> {
     input.meeting_id = meeting_id;
-    let item = state
-        .board_meeting_repo
-        .create_action_item(user.user_id, input)
-        .await
-        .map_err(internal_error)?;
-
-    Ok(Json(item))
+    let user_id = rls.user_id();
+    let out = async {
+        require_meeting_in_org(&state, &mut rls, meeting_id).await?;
+        state
+            .board_meeting_repo
+            .create_action_item(&mut **rls.conn(), user_id, input)
+            .await
+            .map(Json)
+            .map_err(internal_error)
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 /// Get an action item.
 async fn get_action_item(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<db::models::board_meetings::MeetingActionItem>> {
-    let item = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .get_action_item(id)
+        .get_action_item(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(internal_error)?
-        .ok_or_else(|| not_found("Action item"))?;
-
-    Ok(Json(item))
+        .map_err(internal_error)
+        .and_then(|i| i.ok_or_else(|| not_found("Action item")))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 /// Update an action item.
 async fn update_action_item(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(input): Json<UpdateActionItem>,
 ) -> ApiResult<Json<db::models::board_meetings::MeetingActionItem>> {
-    let item = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .update_action_item(id, input)
+        .update_action_item(&mut **rls.conn(), id, org_id, input)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(item))
+        .map_err(internal_error)
+        .and_then(|i| i.ok_or_else(|| not_found("Action item")))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 /// Complete an action item.
@@ -843,32 +1027,43 @@ struct CompleteActionItemRequest {
 
 async fn complete_action_item(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(input): Json<CompleteActionItemRequest>,
 ) -> ApiResult<Json<db::models::board_meetings::MeetingActionItem>> {
-    let item = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .complete_action_item(id, input.completion_notes)
+        .complete_action_item(&mut **rls.conn(), id, org_id, input.completion_notes)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(item))
+        .map_err(internal_error)
+        .and_then(|i| i.ok_or_else(|| not_found("Action item")))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 /// Delete an action item.
 async fn delete_action_item(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> ApiResult<StatusCode> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .delete_action_item(id)
+        .delete_action_item(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(internal_error)?;
-
-    Ok(StatusCode::NO_CONTENT)
+        .map_err(internal_error)
+        .and_then(|deleted| {
+            if deleted {
+                Ok(StatusCode::NO_CONTENT)
+            } else {
+                Err(not_found("Action item"))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -878,48 +1073,64 @@ async fn delete_action_item(
 /// List documents for a meeting.
 async fn list_documents(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(meeting_id): Path<Uuid>,
 ) -> ApiResult<Json<Vec<db::models::board_meetings::MeetingDocument>>> {
-    let docs = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .list_meeting_documents(meeting_id)
+        .list_meeting_documents(&mut **rls.conn(), meeting_id, org_id)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(docs))
+        .map(Json)
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 /// Upload a document.
 async fn upload_document(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(meeting_id): Path<Uuid>,
     Json(mut input): Json<UploadMeetingDocument>,
 ) -> ApiResult<Json<db::models::board_meetings::MeetingDocument>> {
     input.meeting_id = meeting_id;
-    let doc = state
-        .board_meeting_repo
-        .upload_document(user.user_id, input)
-        .await
-        .map_err(internal_error)?;
-
-    Ok(Json(doc))
+    let user_id = rls.user_id();
+    let out = async {
+        require_meeting_in_org(&state, &mut rls, meeting_id).await?;
+        state
+            .board_meeting_repo
+            .upload_document(&mut **rls.conn(), user_id, input)
+            .await
+            .map(Json)
+            .map_err(internal_error)
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 /// Delete a document.
 async fn delete_document(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> ApiResult<StatusCode> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .delete_document(id)
+        .delete_document(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(internal_error)?;
-
-    Ok(StatusCode::NO_CONTENT)
+        .map_err(internal_error)
+        .and_then(|deleted| {
+            if deleted {
+                Ok(StatusCode::NO_CONTENT)
+            } else {
+                Err(not_found("Document"))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -929,29 +1140,31 @@ async fn delete_document(
 /// Get meeting type counts.
 async fn get_meeting_type_counts(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
 ) -> ApiResult<Json<Vec<db::models::board_meetings::MeetingTypeCount>>> {
-    let org_id = require_tenant(user.tenant_id)?;
-    let counts = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .get_meeting_type_counts(org_id)
+        .get_meeting_type_counts(&mut **rls.conn(), org_id)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(counts))
+        .map(Json)
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 /// Get motion status counts.
 async fn get_motion_status_counts(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
 ) -> ApiResult<Json<Vec<db::models::board_meetings::MotionStatusCount>>> {
-    let org_id = require_tenant(user.tenant_id)?;
-    let counts = state
+    let org_id = rls.tenant_id();
+    let out = state
         .board_meeting_repo
-        .get_motion_status_counts(org_id)
+        .get_motion_status_counts(&mut **rls.conn(), org_id)
         .await
-        .map_err(internal_error)?;
-
-    Ok(Json(counts))
+        .map(Json)
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }

--- a/backend/servers/api-server/tests/board_meetings_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/board_meetings_cross_org_idor_tests.rs
@@ -1,0 +1,426 @@
+//! Regression tests for the cross-tenant IDOR fix on the board-meeting
+//! endpoints (`/api/v1/board-meetings/*`, Epic 143 — PAP-137).
+//!
+//! Audit history (PAP-136): every by-id board-meeting handler carried
+//! `_user: AuthUser` and performed no org scoping, and the repository ran on
+//! the raw pool with no `organization_id` predicate anywhere. A foreign caller
+//! could read/mutate/delete any other org's meetings, agenda items, motions,
+//! minutes, action items and documents by UUID.
+//!
+//! Since the PAP-137 RLS conversion, every handler acquires an
+//! `RlsConnection` (tenant validated against `organization_members`) and the
+//! repository is stateless: queries run on the request's RLS-scoped
+//! connection AND stay org-keyed — `board_meetings`/`board_members` directly
+//! on `organization_id`, child tables through the root meeting via `EXISTS`.
+//! A cross-tenant probe made with the attacker's own valid tenant context
+//! resolves to no row → `404`; "missing" and "forbidden" are
+//! indistinguishable. The CI test pool runs as superuser (bypasses FORCE
+//! RLS), so these tests specifically prove the org-keyed SQL layer.
+//!
+//! These tests exercise the HTTP surface end-to-end with real HS256 JWTs:
+//!   1. Seed two orgs (A, B), a member user in each, and a meeting (+ agenda
+//!      item / motion) in Org A.
+//!   2. Org B's member probes Org A's resources → rejected (4xx); no leak,
+//!      no write.
+//!   3. Org A's member reads its own meeting → allowed (2xx).
+
+#[allow(dead_code)]
+mod common;
+
+use axum::http::{Method, StatusCode};
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{RequestBuilder, TestApp, TestConfig};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active') RETURNING id
+        "#,
+    )
+    .bind(format!("BoardIDOR Org {slug}"))
+    .bind(format!("board-idor-org-{slug}"))
+    .bind(format!("{slug}@board-idor.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'test_hash', 'BoardIDOR User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Make `user_id` an active member of `org_id`.
+async fn seed_membership(pool: &PgPool, org_id: Uuid, user_id: Uuid) {
+    sqlx::query(
+        r#"
+        INSERT INTO organization_members (organization_id, user_id, role_type, status, joined_at)
+        VALUES ($1, $2, 'org_admin', 'active', NOW())
+        "#,
+    )
+    .bind(org_id)
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .expect("seed membership");
+}
+
+/// Seed a board meeting in `org_id` created by `created_by`, return its id.
+async fn seed_meeting(pool: &PgPool, org_id: Uuid, created_by: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO board_meetings (organization_id, title, scheduled_start, created_by)
+        VALUES ($1, 'Annual Budget Meeting', NOW() + INTERVAL '7 days', $2)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(created_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed meeting")
+}
+
+/// Seed an agenda item on `meeting_id`, return its id.
+async fn seed_agenda_item(pool: &PgPool, meeting_id: Uuid, added_by: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO meeting_agenda_items (meeting_id, item_number, title, added_by)
+        VALUES ($1, '1', 'Reserve fund review', $2)
+        RETURNING id
+        "#,
+    )
+    .bind(meeting_id)
+    .bind(added_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed agenda item")
+}
+
+/// Seed a motion on `meeting_id`, return its id.
+async fn seed_motion(pool: &PgPool, meeting_id: Uuid, proposed_by: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO meeting_motions (meeting_id, title, motion_text, proposed_by)
+        VALUES ($1, 'Approve budget', 'Motion to approve the 2026 budget', $2)
+        RETURNING id
+        "#,
+    )
+    .bind(meeting_id)
+    .bind(proposed_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed motion")
+}
+
+/// Mint a real HS256 access token for `user_id`, signed with the same secret
+/// the TestApp configures into `JWT_SECRET`.
+fn mint_token(user_id: Uuid, email: &str) -> String {
+    use api_server::services::JwtService;
+    let config = TestConfig::default();
+    let jwt = JwtService::new(&config.jwt_secret).expect("jwt service");
+    jwt.generate_access_token(user_id, email, "BoardIDOR User", None, None)
+        .expect("mint access token")
+}
+
+fn assert_rejected(status: StatusCode, ctx: &str) {
+    let code = status.as_u16();
+    assert!(
+        (400..500).contains(&code),
+        "{ctx}: cross-tenant/unauthenticated request must be rejected with 4xx, got {status}"
+    );
+}
+
+/// Seed two orgs with one member each plus a meeting in Org A.
+/// Returns (org_a, org_b, user_a, user_b, meeting_a).
+async fn seed_two_org_fixture(pool: &PgPool, tag: &str) -> (Uuid, Uuid, Uuid, Uuid, Uuid) {
+    let org_a = seed_org(pool, &format!("{tag}-a")).await;
+    let org_b = seed_org(pool, &format!("{tag}-b")).await;
+    let user_a = seed_user(pool, &format!("{tag}-a@board-idor.test")).await;
+    let user_b = seed_user(pool, &format!("{tag}-b@board-idor.test")).await;
+    seed_membership(pool, org_a, user_a).await;
+    seed_membership(pool, org_b, user_b).await;
+    let meeting_a = seed_meeting(pool, org_a, user_a).await;
+    (org_a, org_b, user_a, user_b, meeting_a)
+}
+
+// ---------------------------------------------------------------------------
+// T1 — unauthenticated get_meeting is rejected
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_meeting_without_auth_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "noauth-a").await;
+    let user_a = seed_user(&pool, "noauth-a@board-idor.test").await;
+    let meeting_a = seed_meeting(&pool, org_a, user_a).await;
+
+    let uri = format!("/api/v1/board-meetings/{meeting_a}");
+    let resp = app.execute(app.get(&uri).build()).await;
+
+    assert_rejected(resp.status, "get_meeting without bearer token");
+}
+
+// ---------------------------------------------------------------------------
+// T2 — cross-org get_meeting by UUID is rejected (IDOR)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_meeting_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (_org_a, org_b, _user_a, user_b, meeting_a) = seed_two_org_fixture(&pool, "get").await;
+
+    let token_b = mint_token(user_b, "get-b@board-idor.test");
+    let uri = format!("/api/v1/board-meetings/{meeting_a}");
+    // Valid context for the attacker's OWN org — the by-id probe must fail on
+    // row scoping (404), not on a missing tenant header.
+    let resp = app
+        .execute(
+            app.get(&uri)
+                .bearer(&token_b)
+                .header("X-Tenant-ID", &org_b.to_string())
+                .build(),
+        )
+        .await;
+
+    assert_rejected(resp.status, "get_meeting cross-tenant");
+    assert_ne!(
+        resp.status,
+        StatusCode::OK,
+        "Org A meeting must not be readable by Org B"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T3 — cross-org update_meeting is rejected (mutate IDOR)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn update_meeting_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (_org_a, org_b, _user_a, user_b, meeting_a) = seed_two_org_fixture(&pool, "upd").await;
+
+    let token_b = mint_token(user_b, "upd-b@board-idor.test");
+    let uri = format!("/api/v1/board-meetings/{meeting_a}");
+    let body = json!({ "title": "Hijacked Meeting" });
+    let resp = app
+        .execute(
+            RequestBuilder::new(Method::PUT, &uri)
+                .bearer(&token_b)
+                .header("X-Tenant-ID", &org_b.to_string())
+                .json(body)
+                .build(),
+        )
+        .await;
+
+    assert_rejected(resp.status, "update_meeting cross-tenant");
+
+    // The meeting title must be unchanged.
+    let title: String = sqlx::query_scalar("SELECT title FROM board_meetings WHERE id = $1")
+        .bind(meeting_a)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        title, "Annual Budget Meeting",
+        "Org A meeting must not be mutated cross-tenant"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T4 — cross-org delete_meeting is rejected (destructive IDOR)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn delete_meeting_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (_org_a, org_b, _user_a, user_b, meeting_a) = seed_two_org_fixture(&pool, "del").await;
+
+    let token_b = mint_token(user_b, "del-b@board-idor.test");
+    let uri = format!("/api/v1/board-meetings/{meeting_a}");
+    let resp = app
+        .execute(
+            app.delete(&uri)
+                .bearer(&token_b)
+                .header("X-Tenant-ID", &org_b.to_string())
+                .build(),
+        )
+        .await;
+
+    assert_rejected(resp.status, "delete_meeting cross-tenant");
+    assert_ne!(
+        resp.status,
+        StatusCode::NO_CONTENT,
+        "Org A meeting must not be deletable by Org B"
+    );
+
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM board_meetings WHERE id = $1")
+        .bind(meeting_a)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count, 1, "Org A meeting must not be deleted cross-tenant");
+}
+
+// ---------------------------------------------------------------------------
+// T5 — cross-org get_agenda_item is rejected (child table, EXISTS keying)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_agenda_item_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (_org_a, org_b, user_a, user_b, meeting_a) = seed_two_org_fixture(&pool, "agi").await;
+    let agenda_a = seed_agenda_item(&pool, meeting_a, user_a).await;
+
+    let token_b = mint_token(user_b, "agi-b@board-idor.test");
+    let uri = format!("/api/v1/board-meetings/agenda/{agenda_a}");
+    let resp = app
+        .execute(
+            app.get(&uri)
+                .bearer(&token_b)
+                .header("X-Tenant-ID", &org_b.to_string())
+                .build(),
+        )
+        .await;
+
+    assert_rejected(resp.status, "get_agenda_item cross-tenant");
+    assert_ne!(
+        resp.status,
+        StatusCode::OK,
+        "Org A agenda item must not be readable by Org B"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T6 — cross-org add_agenda_item is rejected (child insert, root-meeting
+// validation)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn add_agenda_item_to_other_org_meeting_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (_org_a, org_b, _user_a, user_b, meeting_a) = seed_two_org_fixture(&pool, "ins").await;
+
+    let token_b = mint_token(user_b, "ins-b@board-idor.test");
+    let uri = format!("/api/v1/board-meetings/{meeting_a}/agenda");
+    let body = json!({
+        "meeting_id": meeting_a,
+        "item_number": "99",
+        "title": "Injected agenda item",
+    });
+    let resp = app
+        .execute(
+            app.post(&uri)
+                .bearer(&token_b)
+                .header("X-Tenant-ID", &org_b.to_string())
+                .json(body)
+                .build(),
+        )
+        .await;
+
+    assert_rejected(resp.status, "add_agenda_item cross-tenant");
+
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM meeting_agenda_items WHERE meeting_id = $1")
+            .bind(meeting_a)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        count, 0,
+        "no agenda item may be inserted into another org's meeting"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T7 — cross-org motion mutation (start-voting) is rejected (grand-child IDOR)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn start_voting_on_other_org_motion_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (_org_a, org_b, user_a, user_b, meeting_a) = seed_two_org_fixture(&pool, "mot").await;
+    let motion_a = seed_motion(&pool, meeting_a, user_a).await;
+
+    let token_b = mint_token(user_b, "mot-b@board-idor.test");
+    let uri = format!("/api/v1/board-meetings/motions/{motion_a}/start-voting");
+    let resp = app
+        .execute(
+            app.post(&uri)
+                .bearer(&token_b)
+                .header("X-Tenant-ID", &org_b.to_string())
+                .json(json!({}))
+                .build(),
+        )
+        .await;
+
+    assert_rejected(resp.status, "start_motion_voting cross-tenant");
+
+    let status: String =
+        sqlx::query_scalar("SELECT status::text FROM meeting_motions WHERE id = $1")
+            .bind(motion_a)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        status, "proposed",
+        "Org A motion must not transition to voting cross-tenant"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T8 — legitimate same-org access succeeds
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_meeting_for_own_org_succeeds(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "own-a").await;
+    let user_a = seed_user(&pool, "own-a@board-idor.test").await;
+    seed_membership(&pool, org_a, user_a).await;
+    let meeting_a = seed_meeting(&pool, org_a, user_a).await;
+
+    let token_a = mint_token(user_a, "own-a@board-idor.test");
+    let uri = format!("/api/v1/board-meetings/{meeting_a}");
+    let resp = app
+        .execute(
+            app.get(&uri)
+                .bearer(&token_a)
+                .header("X-Tenant-ID", &org_a.to_string())
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "Org A member must be able to read its own meeting: {}",
+        resp.text()
+    );
+    let detail = resp.json_value();
+    assert_eq!(
+        detail
+            .get("meeting")
+            .and_then(|m| m.get("id"))
+            .and_then(|v| v.as_str()),
+        Some(meeting_a.to_string().as_str()),
+        "expected the owning org's meeting, got {detail}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes the P0 cross-tenant IDOR on the board-meeting surface (PAP-137, found by the PAP-136 audit). `board_meetings.rs` was the largest raw-pool repo: every query ran on `&self.pool` (so FORCE RLS from migration `00179` was never the active boundary — deny-all if the pool role is RLS-subject, full bypass if RLS-exempt) and all 27 by-id methods ignored the caller's organization. Any authenticated user could read, mutate, or delete any other org's meetings, agenda items, motions, votes, attendance, minutes, action items and documents by UUID.

## Changes

- **`crates/db/src/repositories/board_meetings.rs`** — converted to the PAP-67/PAP-80 stateless-repo pattern: every method takes an RLS-context-bearing `executor: E` / `conn: &mut PgConnection`; the repo holds no pool. By-id queries are org-keyed as defense-in-depth (PAP-133): `board_members`/`board_meetings` directly on `organization_id`, child tables through the root meeting via `EXISTS`; `motion_votes` through `meeting_motions → board_meetings`. Cascading reads (`get_meeting_detail`, `get_motion_detail`, `end_motion_voting`, `get_member_attendance_history`) validate org on the root fetch. Update/lifecycle methods return `Option` so cross-tenant probes surface as `404`, not `500 RowNotFound`.
- **`servers/api-server/src/routes/board_meetings.rs`** — all handlers switched from ignored `_user: AuthUser` to `RlsConnection` (validated tenant membership, org/user GUCs set on the request connection). The authoritative org is `rls.tenant_id()` — never path/body input. Child-table inserts (agenda, motions, votes, attendance, minutes, actions, documents) validate the root meeting/motion org first. `rls.release()` discipline throughout.
- **`servers/api-server/tests/board_meetings_cross_org_idor_tests.rs`** — new regression suite (pattern: `vendor_cross_org_idor_tests.rs`), end-to-end over the HTTP surface with real HS256 JWTs: cross-org meeting read/update/delete, child agenda-item read + insert, grand-child motion `start-voting`, unauthenticated probe, own-org happy path. The CI test pool runs as superuser (bypasses FORCE RLS), so these tests specifically prove the org-keyed SQL layer.

## Verification

- `cargo check -p db -p api-server` — green
- `cargo fmt --all -- --check` — green
- `cargo clippy -p api-server --lib -- -D warnings` — green; new test targets clippy-clean (the 7 pre-existing `--tests` clippy errors on dev baseline are PAP-124 debt, untouched)
- `cargo test -p api-server --test board_meetings_cross_org_idor_tests` — **8 passed, 0 failed** (mercury Postgres, fresh per-test migrated DBs)
- Failing-on-main proof: `get_meeting_from_other_org_is_rejected` run against dev's unfixed handlers+repo (fix reverted, test kept) — result will be posted as a PR comment; the old handlers never read the caller's org, so the cross-org probe returns `200`. Existing `board_meetings_auth_tests.rs` (strict 401) still passes — `RlsConnection` validates the JWT before tenant resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
