### PR TITLE
PAP-68: pool-field RLS detector + un-break the silently no-op RLS CI gate

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -58,6 +58,14 @@ jobs:
           SQLX_OFFLINE: true
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+      # check-rls-enforcement.sh is ripgrep-based and now hard-fails when rg
+      # is missing — without this install the gate was a silent no-op for the
+      # entire life of the repo (every `rg … || true` swallowed exit 127 and
+      # the script printed green; 68 handler-side raw-pool violations merged
+      # behind it — PAP-68).
+      - name: Install ripgrep (required by RLS enforcement check)
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq ripgrep
+
       - name: RLS Enforcement Check
         working-directory: backend
         run: ./scripts/check-rls-enforcement.sh --strict

--- a/backend/scripts/check-rls-enforcement.sh
+++ b/backend/scripts/check-rls-enforcement.sh
@@ -21,6 +21,33 @@ if [[ "${1:-}" == "--strict" ]]; then
     STRICT_MODE=true
 fi
 
+# The handler scan below is built on ripgrep. Every rg call is suffixed with
+# `|| true` (rg exits 1 on no-match), which also swallows exit 127 when rg is
+# NOT INSTALLED — on a runner without ripgrep the whole script degrades to a
+# silent no-op that prints "No RLS violations found" (this is how 68 handler
+# violations merged to dev behind a green gate; see PAP-68). Hard-fail instead.
+if ! command -v rg >/dev/null 2>&1; then
+    echo "ERROR: ripgrep (rg) is required by this check but is not installed." >&2
+    echo "       Install it (apt-get install -y ripgrep / brew install ripgrep)" >&2
+    echo "       — refusing to pass silently without it." >&2
+    exit 2
+fi
+
+TMP_PREFIX=$(mktemp -d)
+trap 'rm -rf "$TMP_PREFIX"' EXIT
+
+# File-level baseline of KNOWN handler-side raw-pool offenders (pre-existing
+# debt that merged while the gate was a no-op). Paths are relative to
+# backend/. Baselined files warn instead of failing; new offenders in any
+# other file still fail --strict. Remove entries as files are cleaned up.
+HANDLER_BASELINE_FILE="$SCRIPT_DIR/rls-handler-baseline.txt"
+: > "$TMP_PREFIX/handler_baseline"
+if [[ -f "$HANDLER_BASELINE_FILE" ]]; then
+    { grep -vE '^[[:space:]]*(#|$)' "$HANDLER_BASELINE_FILE" || true; } | awk '{print $1}' | sort -u > "$TMP_PREFIX/handler_baseline"
+fi
+: > "$TMP_PREFIX/handler_hits"
+HANDLER_BASELINED=0
+
 echo "🔍 Checking for direct database pool access in handlers..."
 echo ""
 
@@ -147,6 +174,16 @@ scan_target() {
                 continue
             fi
 
+            local REL="${FILE#"$BACKEND_DIR"/}"
+            if grep -qxF "$REL" "$TMP_PREFIX/handler_baseline"; then
+                ((HANDLER_BASELINED+=1))
+                echo "$REL" >> "$TMP_PREFIX/handler_hits"
+                echo -e "${YELLOW}KNOWN OFFENDER${NC} [$FILE:$LINE] (baselined, cleanup pending)"
+                echo "  $CONTENT"
+                echo ""
+                continue
+            fi
+
             ((VIOLATIONS+=1))
             echo -e "${RED}VIOLATION${NC} [$FILE:$LINE]"
             echo "  $CONTENT"
@@ -175,6 +212,21 @@ for f in "${CHECK_FILES[@]}"; do
     scan_target "$FULL_FILE"
 done
 
+# Stale handler-baseline entries: listed but no longer flagged — remove them
+# so the ratchet only ever tightens.
+sort -u "$TMP_PREFIX/handler_hits" > "$TMP_PREFIX/handler_hits_sorted"
+while IFS= read -r stale; do
+    [[ -n "$stale" ]] || continue
+    ((WARNINGS+=1))
+    echo -e "${YELLOW}WARNING${NC} stale baseline entry '$stale' — file no longer flagged; remove it from $(basename "$HANDLER_BASELINE_FILE")"
+    echo ""
+done < <(comm -23 "$TMP_PREFIX/handler_baseline" "$TMP_PREFIX/handler_hits_sorted")
+
+if [[ $HANDLER_BASELINED -gt 0 ]]; then
+    echo -e "${YELLOW}⚠ $HANDLER_BASELINED known handler-side raw-pool access(es) pending cleanup (baselined)${NC}"
+    echo ""
+fi
+
 # Also check for repository methods that take raw pool instead of RlsConnection
 echo "🔍 Checking repository patterns..."
 
@@ -194,6 +246,125 @@ if [[ -d "$REPO_DIR" ]]; then
             echo ""
         fi
     done < <(rg -n 'pub async fn.*\(&self.*pool.*DbPool' "$REPO_DIR" 2>/dev/null || true)
+fi
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Pool-field detector (PAP-68): repositories that OWN a raw pool and query
+# FORCE-RLS tables without ever setting RLS context.
+#
+# The missed pattern behind PAP-67: a repository struct holds `pool: PgPool` /
+# `db: DbPool`, is built once at startup with the raw pool, and runs every
+# query via `&self.pool`. Under `FORCE ROW LEVEL SECURITY` (migration 00179
+# et al.) the owner connection is no longer exempt, `get_current_org_id()`
+# returns NULL, and the policy collapses to deny-all. The detectors above only
+# catch handler-side raw acquires and pool-typed *parameters* — not pool
+# *fields* — so this class merged green.
+#
+# A repo is flagged when ALL of the following hold:
+#   1. a struct field `pool:`/`db:` typed PgPool/DbPool (incl. pub / qualified)
+#   2. at least one `&self.pool` / `&self.db` use (a query or helper pass-through)
+#   3. zero `set_request_context` calls anywhere in the file
+#   4. the file's SQL references at least one table that a migration put under
+#      FORCE ROW LEVEL SECURITY
+#
+# Known-but-not-yet-converted repos live in rls-pool-field-baseline.txt next to
+# this script (one basename per line, '#' comments). Baselined hits warn;
+# anything NOT in the baseline is a violation (fails --strict). Fixing a repo
+# without removing its baseline entry produces a stale-baseline warning so the
+# ratchet only ever tightens.
+# ──────────────────────────────────────────────────────────────────────────────
+echo "🔍 Checking repository structs holding a raw pool field (FORCE-RLS guard)..."
+
+MIGRATIONS_DIR="$BACKEND_DIR/crates/db/migrations"
+BASELINE_FILE="$SCRIPT_DIR/rls-pool-field-baseline.txt"
+
+POOL_FIELD_VIOLATIONS=0
+POOL_FIELD_BASELINED=0
+
+if [[ -d "$REPO_DIR" && -d "$MIGRATIONS_DIR" ]]; then
+    # FORCE-RLS table set, derived from migrations (source of truth). Tables
+    # later relaxed with NO FORCE are subtracted.
+    { grep -hE 'ALTER TABLE[[:space:]]+[A-Za-z0-9_."]+[[:space:]]+FORCE ROW LEVEL SECURITY' \
+        "$MIGRATIONS_DIR"/*.sql 2>/dev/null || true; } \
+        | sed -E 's/.*ALTER TABLE[[:space:]]+([A-Za-z0-9_."]+)[[:space:]]+FORCE ROW LEVEL SECURITY.*/\1/' \
+        | tr -d '"' | sed 's/^public\.//' | sort -u > "$TMP_PREFIX/force"
+    { grep -hE 'ALTER TABLE[[:space:]]+[A-Za-z0-9_."]+[[:space:]]+NO FORCE ROW LEVEL SECURITY' \
+        "$MIGRATIONS_DIR"/*.sql 2>/dev/null || true; } \
+        | sed -E 's/.*ALTER TABLE[[:space:]]+([A-Za-z0-9_."]+)[[:space:]]+NO FORCE ROW LEVEL SECURITY.*/\1/' \
+        | tr -d '"' | sed 's/^public\.//' | sort -u > "$TMP_PREFIX/noforce"
+    comm -23 "$TMP_PREFIX/force" "$TMP_PREFIX/noforce" > "$TMP_PREFIX/force_final"
+
+    FORCE_COUNT=$(wc -l < "$TMP_PREFIX/force_final")
+    echo "   ($FORCE_COUNT FORCE-RLS tables derived from migrations)"
+
+    # Baseline of known offenders (pending conversion, each tracked by issue).
+    : > "$TMP_PREFIX/baseline"
+    if [[ -f "$BASELINE_FILE" ]]; then
+        { grep -vE '^[[:space:]]*(#|$)' "$BASELINE_FILE" || true; } | awk '{print $1}' | sort -u > "$TMP_PREFIX/baseline"
+    fi
+    : > "$TMP_PREFIX/hit_names"
+
+    POOL_FIELD_RE='^[[:space:]]*(pub([[:space:]]*\([^)]*\))?[[:space:]]+)?(pool|db):[[:space:]]*(sqlx::|crate::)?(PgPool|DbPool)'
+
+    for repo_file in "$REPO_DIR"/*.rs; do
+        [[ -f "$repo_file" ]] || continue
+        base=$(basename "$repo_file")
+        case "$base" in mod.rs|*_test.rs|*_tests.rs) continue ;; esac
+
+        # Strip line comments so doc-prose about pools/tables can't false-positive.
+        grep -vE '^[[:space:]]*//' "$repo_file" > "$TMP_PREFIX/code" || true
+
+        grep -qE "$POOL_FIELD_RE" "$TMP_PREFIX/code" || continue
+        grep -qE '&self\.(pool|db)\b' "$TMP_PREFIX/code" || continue
+        grep -q 'set_request_context' "$TMP_PREFIX/code" && continue
+
+        # Tables this file's SQL touches, intersected with the FORCE-RLS set.
+        grep -ohiE '\b(from|join|into|update)[[:space:]]+[A-Za-z_][A-Za-z0-9_]*' "$TMP_PREFIX/code" \
+            | awk '{print tolower($2)}' | sort -u > "$TMP_PREFIX/touched" || true
+        comm -12 "$TMP_PREFIX/touched" "$TMP_PREFIX/force_final" > "$TMP_PREFIX/hit_tables"
+        [[ -s "$TMP_PREFIX/hit_tables" ]] || continue
+
+        echo "$base" >> "$TMP_PREFIX/hit_names"
+        tables_short=$(head -5 "$TMP_PREFIX/hit_tables" | paste -sd, -)
+        total_tables=$(wc -l < "$TMP_PREFIX/hit_tables")
+        field_line=$(grep -nE "$POOL_FIELD_RE" "$repo_file" | head -1 | cut -d: -f1)
+
+        if grep -qxF "$base" "$TMP_PREFIX/baseline"; then
+            ((POOL_FIELD_BASELINED+=1))
+            echo -e "${YELLOW}KNOWN OFFENDER${NC} [$repo_file:${field_line:-?}] (baselined, conversion pending)"
+            echo "  raw pool field + 0 set_request_context; FORCE-RLS tables ($total_tables): $tables_short"
+            echo ""
+        else
+            ((POOL_FIELD_VIOLATIONS+=1))
+            ((VIOLATIONS+=1))
+            echo -e "${RED}VIOLATION${NC} [$repo_file:${field_line:-?}]"
+            echo "  Repository holds a raw pool field and queries FORCE-RLS tables"
+            echo "  with zero set_request_context calls → deny-all under FORCE RLS"
+            echo "  FORCE-RLS tables touched ($total_tables): $tables_short"
+            echo "  → Convert to the executor pattern (take impl Executor / &mut PgConnection"
+            echo "    from the RlsConnection extractor) like document.rs / board_meetings.rs,"
+            echo "    or add a baseline entry with a tracking issue."
+            echo ""
+        fi
+    done
+
+    # Stale baseline entries: listed but no longer flagged — tighten the ratchet.
+    sort -u "$TMP_PREFIX/hit_names" > "$TMP_PREFIX/hit_names_sorted"
+    while IFS= read -r stale; do
+        [[ -n "$stale" ]] || continue
+        ((WARNINGS+=1))
+        echo -e "${YELLOW}WARNING${NC} stale baseline entry '$stale' — repo no longer flagged; remove it from $(basename "$BASELINE_FILE")"
+        echo ""
+    done < <(comm -23 "$TMP_PREFIX/baseline" "$TMP_PREFIX/hit_names_sorted")
+
+    if [[ $POOL_FIELD_VIOLATIONS -eq 0 ]]; then
+        if [[ $POOL_FIELD_BASELINED -gt 0 ]]; then
+            echo -e "${YELLOW}⚠ $POOL_FIELD_BASELINED known pool-field offender(s) pending conversion (baselined)${NC}"
+        else
+            echo -e "${GREEN}✓ No repositories holding raw pool fields against FORCE-RLS tables${NC}"
+        fi
+        echo ""
+    fi
 fi
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/backend/scripts/rls-handler-baseline.txt
+++ b/backend/scripts/rls-handler-baseline.txt
@@ -1,0 +1,17 @@
+# Known handler-side raw-pool accesses (state.db / self.db) that merged to dev
+# while the RLS Enforcement CI gate was silently a no-op (ripgrep was not
+# installed on the runner — every `rg … || true` swallowed exit 127 and the
+# script printed green; found during PAP-68).
+#
+# Paths relative to backend/. Baselined files WARN instead of failing
+# --strict; raw-pool access in any file NOT listed here fails CI. When a file
+# is cleaned up, REMOVE its line (the script warns on stale entries).
+
+servers/api-server/src/routes/ai/llm.rs
+servers/api-server/src/routes/ai/sessions.rs
+servers/api-server/src/routes/api_ecosystem.rs
+servers/api-server/src/routes/integrations/sync.rs
+servers/api-server/src/routes/integrations/webhook.rs
+servers/api-server/src/routes/mfa.rs
+servers/api-server/src/routes/subscriptions.rs
+servers/api-server/src/routes/voice_webhooks.rs

--- a/backend/scripts/rls-pool-field-baseline.txt
+++ b/backend/scripts/rls-pool-field-baseline.txt
@@ -1,0 +1,60 @@
+# Known repositories that hold a raw pool field, query FORCE-RLS tables, and
+# never call set_request_context (deny-all under FORCE ROW LEVEL SECURITY,
+# RLS-bypass on BYPASSRLS/superuser pools). Detected by
+# check-rls-enforcement.sh (PAP-68 pool-field detector).
+#
+# Every entry here is PRE-EXISTING debt pending conversion to the executor
+# pattern (see document.rs / board_meetings.rs precedent). Baselined entries
+# WARN instead of failing --strict; any repo NOT listed here that regresses
+# to the pattern fails CI. When a repo is converted, REMOVE its line (the
+# script warns on stale entries).
+#
+# One basename per line. Comments after '#'.
+
+# --- PAP-67 original offender set, conversion still pending ---
+work_order.rs        # PAP-67 (no child issue yet; PAP-80 umbrella)
+budget.rs            # PAP-67 (no child issue yet; PAP-80 umbrella)
+esg_reporting.rs     # PAP-72 (blocked on PAP-139)
+form.rs              # PAP-76
+workflow.rs          # PAP-77
+sensor.rs            # PAP-78 marked done but conversion never landed on dev
+reserve_funds.rs     # PAP-79 marked done but conversion never landed on dev
+
+# --- PAP-80 sweep: conversion PRs in flight ---
+ai_chat.rs           # PR #1232 (PAP-144/PAP-145)
+building_certification.rs  # PR #1227 (PAP-144/PAP-145)
+
+# --- PAP-80 sweep: latent raw-pool readers of FORCE-RLS tables (00110-series
+# --- and 00179 migrations), discovered by the PAP-68 detector ---
+agency.rs
+announcement.rs
+automation.rs
+building.rs
+community.rs
+compliance.rs
+critical_notification.rs
+data_export.rs
+device_push_token.rs
+dispute.rs
+edd.rs
+energy.rs
+feature_analytics.rs
+feature_package.rs
+listing.rs
+marketplace.rs
+membership.rs
+messaging.rs
+notification_preference.rs
+onboarding.rs
+organization.rs
+organization_member.rs
+owner_analytics.rs
+platform_admin.rs
+portal.rs
+portfolio_performance.rs
+reality_portal.rs
+rental.rs
+report_schedule.rs
+role.rs
+unified_portal_user.rs
+user_invite.rs


### PR DESCRIPTION
## Why

PAP-67's FORCE-RLS deny-all regression merged to `dev` behind a green `check-rls-enforcement.sh --strict` gate. Investigating PAP-68 found **two** detection gaps, not one:

1. **Pool-field blind spot (the PAP-68 ask):** repository structs that *hold* `pool: PgPool` / `db: DbPool` and query FORCE-RLS tables via `&self.pool` with zero `set_request_context` calls were invisible — the script only caught handler-side acquires and pool-typed *parameters*.
2. **The gate never ran at all:** ripgrep is not installed on `ubuntu-latest`, and every `rg … || true` swallowed exit 127. In CI the entire scan completed in ~30 ms and printed "No RLS violations found" without scanning a single file ([example green run on dev](https://github.com/martin-janci/property-management/actions/runs/27281120686) — the step output shows no scan results at all). 68 real handler-side raw-pool accesses merged behind it.

## What

- **New pool-field detector** in `check-rls-enforcement.sh`: flags any `crates/db/src/repositories/*.rs` struct holding a `PgPool`/`DbPool` field whose code uses `&self.pool`/`&self.db`, has zero `set_request_context`, and whose SQL touches a table under `FORCE ROW LEVEL SECURITY`. The FORCE table set (230 tables) is derived live from migrations (`ALTER TABLE … FORCE ROW LEVEL SECURITY`, minus `NO FORCE`).
- **rg hard-fail:** the script exits 2 with a clear error when ripgrep is missing; `backend.yml` installs ripgrep before the check so the strict gate actually gates.
- **Two ratchet baselines** (pre-existing debt warns; anything new fails `--strict`; stale entries warn for removal):
  - `rls-pool-field-baseline.txt` — 41 repos pending executor-pattern conversion (incl. the 7 unfixed PAP-67 repos: work_order, budget, esg_reporting, form, workflow, sensor, reserve_funds)
  - `rls-handler-baseline.txt` — 8 route files with the 68 handler-side raw `state.db` accesses

## Validation (acceptance criteria from PAP-68)

| Check | Result |
|---|---|
| Pre-fix dev (`0b7d4d593`, right after migration 00179): `--strict` | exit 1, **all 12 PAP-67 offender repos named** (55 pool-field repos total) |
| Current dev + baselines: `--strict` | exit 0 (68 + 41 baselined warnings) |
| 5 converted repos (vendor, equipment, insurance, enhanced_tenant_screening, board_meetings) | not flagged (GREEN after fix — guard pins them) |
| `document.rs` known-good control (5× `set_request_context`) | not flagged on any tree |
| Stale baseline entry | removal warning, no strict failure |
| Missing rg | exit 2 hard error |

## Notable findings surfaced

- `sensor.rs` (PAP-78) and `reserve_funds.rs` (PAP-79) are marked done but their conversions **never landed on dev** — both still raw-pool, now pinned in the baseline.
- The latent raw-pool-vs-FORCE-RLS surface is 41 repos, much larger than PAP-80's "11 additional readers".

🤖 Generated with [Claude Code](https://claude.com/claude-code)