### PR TITLE
fix(api-server): route workflow repo through RLS-context connection (PAP-77)

### DIFF
--- a/backend/crates/db/src/repositories/workflow.rs
+++ b/backend/crates/db/src/repositories/workflow.rs
@@ -1,4 +1,32 @@
 //! Workflow automation repository (Epic 13, Story 13.6 & 13.7).
+//!
+//! # RLS Integration (PAP-77 / PAP-67 / PAP-80)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on the workflow tables (`workflows`,
+//! `workflow_actions`, `workflow_executions`, `workflow_execution_steps`,
+//! `workflow_schedules`). Under `FORCE` the api-server's owner connection is
+//! no longer exempt, so a query issued on a connection without
+//! `app.current_org_id` set collapses to deny-all.
+//!
+//! Every method therefore takes an **executor whose connection already has
+//! RLS context set** (org + user GUCs) — in handlers this comes from the
+//! `RlsConnection` extractor via `&mut **rls.conn()`; in the background
+//! workflow executor from `RlsPool::acquire_with_rls` with the org derived
+//! from the already-loaded workflow row. The repository holds **no pool**, so
+//! there is no way to issue a query that bypasses RLS. This mirrors the
+//! `board_meetings.rs` / `vendor.rs` / `budget.rs` precedent.
+//!
+//! Cross-tenant safety (PAP-133 defense-in-depth): RLS is the primary
+//! boundary, but by-id queries stay org-keyed — a connection whose role
+//! bypasses RLS (superuser pools, BYPASSRLS) must still never resolve another
+//! tenant's row. `workflows` carries its own `organization_id`; the child
+//! tables (`workflow_actions`, `workflow_executions`,
+//! `workflow_execution_steps`) are keyed through `workflows.organization_id`
+//! via JOIN / EXISTS. The previously-unscoped internal variants
+//! (`find_by_id`, `find_execution_by_id`, `list_execution_steps`) were
+//! removed: the executor now receives the loaded `Workflow` row from its
+//! caller, so no unscoped by-id read remains.
 
 use crate::models::{
     CreateWorkflow, CreateWorkflowAction, ExecutionQuery, TriggerWorkflow, UpdateWorkflow,
@@ -6,7 +34,7 @@ use crate::models::{
     WorkflowSchedule, WorkflowSummary,
 };
 use chrono::{DateTime, Utc};
-use sqlx::PgPool;
+use sqlx::{Executor, PgConnection, PgPool, Postgres};
 use uuid::Uuid;
 
 /// Hard ceiling on `retry_count` per action (H4).
@@ -25,29 +53,39 @@ pub const MAX_RETRY_COUNT: i32 = 10;
 pub const MAX_RETRY_DELAY_SECONDS: i32 = 3600;
 
 /// Repository for workflow operations.
-#[derive(Clone)]
-pub struct WorkflowRepository {
-    pool: PgPool,
-}
+///
+/// Stateless: every method receives an RLS-context-bearing executor. The repo
+/// holds no pool so it cannot issue an un-scoped (deny-all under `FORCE`)
+/// query.
+#[derive(Debug, Clone)]
+pub struct WorkflowRepository;
 
 impl WorkflowRepository {
     /// Create a new repository instance.
-    pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+    ///
+    /// The pool argument is retained for construction-site compatibility with
+    /// the other repositories on `AppState`; this repo deliberately does not
+    /// store it (see module docs — all queries run on a context-set
+    /// connection supplied by the caller).
+    pub fn new(_pool: PgPool) -> Self {
+        Self
     }
 
-    /// Create a new workflow.
     /// Create a workflow.
     ///
     /// `organization_id` and `created_by` are passed explicitly by the caller
     /// and must originate from the verified request principal, never from
     /// client input in `data`.
-    pub async fn create(
+    pub async fn create<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         created_by: Uuid,
         data: CreateWorkflow,
-    ) -> Result<Workflow, sqlx::Error> {
+    ) -> Result<Workflow, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO workflows
@@ -63,21 +101,8 @@ impl WorkflowRepository {
         .bind(sqlx::types::Json(data.trigger_config.unwrap_or_default()))
         .bind(sqlx::types::Json(data.conditions.unwrap_or_default()))
         .bind(created_by)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
-    }
-
-    /// Get workflow by ID (no tenant scoping — internal use by the executor only).
-    ///
-    /// Handlers must use [`Self::find_by_id_for_org`] to enforce tenant
-    /// isolation. This unscoped variant is retained for the workflow executor,
-    /// which loads workflows during background execution where the
-    /// `organization_id` is derived from the persisted row itself.
-    pub async fn find_by_id(&self, id: Uuid) -> Result<Option<Workflow>, sqlx::Error> {
-        sqlx::query_as("SELECT * FROM workflows WHERE id = $1")
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await
     }
 
     /// Get workflow by ID, scoped to the caller's organization.
@@ -85,24 +110,32 @@ impl WorkflowRepository {
     /// Returns `Ok(None)` when the workflow does not exist OR belongs to a
     /// different organization — the caller MUST surface this as a 404 to
     /// avoid disclosing cross-tenant existence.
-    pub async fn find_by_id_for_org(
+    pub async fn find_by_id_for_org<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
-    ) -> Result<Option<Workflow>, sqlx::Error> {
+    ) -> Result<Option<Workflow>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as("SELECT * FROM workflows WHERE id = $1 AND organization_id = $2")
             .bind(id)
             .bind(org_id)
-            .fetch_optional(&self.pool)
+            .fetch_optional(executor)
             .await
     }
 
     /// List workflows with filters.
-    pub async fn list(
+    pub async fn list<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: WorkflowQuery,
-    ) -> Result<Vec<WorkflowSummary>, sqlx::Error> {
+    ) -> Result<Vec<WorkflowSummary>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50);
         let offset = query.offset.unwrap_or(0);
 
@@ -133,7 +166,7 @@ impl WorkflowRepository {
         .bind(query.search)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -141,12 +174,16 @@ impl WorkflowRepository {
     ///
     /// Returns `Ok(None)` when the workflow does not exist OR belongs to a
     /// different organization. The caller MUST surface this as 404.
-    pub async fn update(
+    pub async fn update<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
         data: UpdateWorkflow,
-    ) -> Result<Option<Workflow>, sqlx::Error> {
+    ) -> Result<Option<Workflow>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE workflows SET
@@ -169,16 +206,24 @@ impl WorkflowRepository {
         .bind(data.trigger_config.map(sqlx::types::Json))
         .bind(data.conditions.map(sqlx::types::Json))
         .bind(data.enabled)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Delete a workflow, scoped to the caller's organization.
-    pub async fn delete(&self, id: Uuid, org_id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM workflows WHERE id = $1 AND organization_id = $2")
             .bind(id)
             .bind(org_id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
@@ -194,6 +239,7 @@ impl WorkflowRepository {
     /// — see [`MAX_RETRY_COUNT`] / [`MAX_RETRY_DELAY_SECONDS`] (H4 defense).
     pub async fn add_action(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         data: CreateWorkflowAction,
     ) -> Result<Option<WorkflowAction>, sqlx::Error> {
@@ -202,7 +248,7 @@ impl WorkflowRepository {
             sqlx::query_as("SELECT id FROM workflows WHERE id = $1 AND organization_id = $2")
                 .bind(data.workflow_id)
                 .bind(org_id)
-                .fetch_optional(&self.pool)
+                .fetch_optional(&mut *conn)
                 .await?;
         if belongs.is_none() {
             return Ok(None);
@@ -233,7 +279,7 @@ impl WorkflowRepository {
         .bind(data.on_failure.unwrap_or_else(|| "stop".to_string()))
         .bind(retry_count)
         .bind(retry_delay_seconds)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
         Ok(Some(action))
     }
@@ -244,6 +290,7 @@ impl WorkflowRepository {
     /// different organization. The caller MUST surface this as 404.
     pub async fn list_actions(
         &self,
+        conn: &mut PgConnection,
         workflow_id: Uuid,
         org_id: Uuid,
     ) -> Result<Option<Vec<WorkflowAction>>, sqlx::Error> {
@@ -253,7 +300,7 @@ impl WorkflowRepository {
             sqlx::query_as("SELECT id FROM workflows WHERE id = $1 AND organization_id = $2")
                 .bind(workflow_id)
                 .bind(org_id)
-                .fetch_optional(&self.pool)
+                .fetch_optional(&mut *conn)
                 .await?;
         if belongs.is_none() {
             return Ok(None);
@@ -263,7 +310,7 @@ impl WorkflowRepository {
             "SELECT * FROM workflow_actions WHERE workflow_id = $1 ORDER BY action_order",
         )
         .bind(workflow_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await?;
         Ok(Some(actions))
     }
@@ -273,7 +320,15 @@ impl WorkflowRepository {
     /// The action is identified by its own ID. We JOIN through workflows to
     /// confirm the parent workflow belongs to `org_id`; otherwise the delete
     /// is a no-op and returns `false`, which the caller surfaces as 404.
-    pub async fn delete_action(&self, id: Uuid, org_id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete_action<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        org_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query(
             r#"
             DELETE FROM workflow_actions a
@@ -285,14 +340,20 @@ impl WorkflowRepository {
         )
         .bind(id)
         .bind(org_id)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
         Ok(result.rows_affected() > 0)
     }
 
     /// Create an execution record.
+    ///
+    /// The caller must have verified that `data.workflow_id` belongs to the
+    /// org whose RLS context is set on `conn` — under `FORCE` RLS the INSERT
+    /// fails the policy otherwise (the policy keys `workflow_executions`
+    /// through the parent workflow's org).
     pub async fn create_execution(
         &self,
+        conn: &mut PgConnection,
         data: TriggerWorkflow,
     ) -> Result<WorkflowExecution, sqlx::Error> {
         let execution: WorkflowExecution = sqlx::query_as(
@@ -305,7 +366,7 @@ impl WorkflowRepository {
         .bind(data.workflow_id)
         .bind(sqlx::types::Json(data.trigger_event))
         .bind(sqlx::types::Json(data.context.unwrap_or_default()))
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         // Update workflow trigger stats
@@ -313,23 +374,10 @@ impl WorkflowRepository {
             "UPDATE workflows SET last_triggered_at = NOW(), trigger_count = trigger_count + 1 WHERE id = $1",
         )
         .bind(data.workflow_id)
-        .execute(&self.pool)
+        .execute(&mut *conn)
         .await?;
 
         Ok(execution)
-    }
-
-    /// Get execution by ID (no tenant scoping — internal use only).
-    ///
-    /// HTTP handlers must use [`Self::find_execution_by_id_for_org`].
-    pub async fn find_execution_by_id(
-        &self,
-        id: Uuid,
-    ) -> Result<Option<WorkflowExecution>, sqlx::Error> {
-        sqlx::query_as("SELECT * FROM workflow_executions WHERE id = $1")
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await
     }
 
     /// Get execution by ID, scoped to the caller's organization.
@@ -337,11 +385,15 @@ impl WorkflowRepository {
     /// Returns `Ok(None)` when the execution does not exist OR belongs to a
     /// workflow in a different organization. The caller MUST surface this
     /// as 404.
-    pub async fn find_execution_by_id_for_org(
+    pub async fn find_execution_by_id_for_org<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         org_id: Uuid,
-    ) -> Result<Option<WorkflowExecution>, sqlx::Error> {
+    ) -> Result<Option<WorkflowExecution>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT e.* FROM workflow_executions e
@@ -351,16 +403,20 @@ impl WorkflowRepository {
         )
         .bind(id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// List executions with filters.
-    pub async fn list_executions(
+    pub async fn list_executions<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: ExecutionQuery,
-    ) -> Result<Vec<WorkflowExecution>, sqlx::Error> {
+    ) -> Result<Vec<WorkflowExecution>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50);
         let offset = query.offset.unwrap_or(0);
 
@@ -384,17 +440,25 @@ impl WorkflowRepository {
         .bind(query.to_date)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update execution status.
-    pub async fn update_execution_status(
+    ///
+    /// Internal use by the workflow executor only — the execution is
+    /// identified by its own ID; the RLS context on the connection (set from
+    /// the owning workflow's org) is what scopes the write.
+    pub async fn update_execution_status<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         status: &str,
         error_message: Option<&str>,
-    ) -> Result<WorkflowExecution, sqlx::Error> {
+    ) -> Result<WorkflowExecution, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE workflow_executions SET
@@ -408,16 +472,20 @@ impl WorkflowRepository {
         .bind(id)
         .bind(status)
         .bind(error_message)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
-    /// Create an execution step record.
-    pub async fn create_execution_step(
+    /// Create an execution step record (internal use by the executor).
+    pub async fn create_execution_step<'e, E>(
         &self,
+        executor: E,
         execution_id: Uuid,
         action_id: Uuid,
-    ) -> Result<WorkflowExecutionStep, sqlx::Error> {
+    ) -> Result<WorkflowExecutionStep, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO workflow_execution_steps (execution_id, action_id, status, started_at)
@@ -427,19 +495,23 @@ impl WorkflowRepository {
         )
         .bind(execution_id)
         .bind(action_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
-    /// Update execution step.
-    pub async fn update_execution_step(
+    /// Update execution step (internal use by the executor).
+    pub async fn update_execution_step<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         status: &str,
         output: serde_json::Value,
         error_message: Option<&str>,
         duration_ms: Option<i32>,
-    ) -> Result<WorkflowExecutionStep, sqlx::Error> {
+    ) -> Result<WorkflowExecutionStep, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE workflow_execution_steps SET
@@ -457,27 +529,7 @@ impl WorkflowRepository {
         .bind(sqlx::types::Json(output))
         .bind(error_message)
         .bind(duration_ms)
-        .fetch_one(&self.pool)
-        .await
-    }
-
-    /// Get execution steps (no tenant scoping — internal use only).
-    ///
-    /// HTTP handlers must use [`Self::list_execution_steps_for_org`].
-    pub async fn list_execution_steps(
-        &self,
-        execution_id: Uuid,
-    ) -> Result<Vec<WorkflowExecutionStep>, sqlx::Error> {
-        sqlx::query_as(
-            r#"
-            SELECT s.* FROM workflow_execution_steps s
-            JOIN workflow_actions a ON a.id = s.action_id
-            WHERE s.execution_id = $1
-            ORDER BY a.action_order
-            "#,
-        )
-        .bind(execution_id)
-        .fetch_all(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
@@ -488,6 +540,7 @@ impl WorkflowRepository {
     /// as 404 — disclosing presence/absence cross-tenant is itself a leak.
     pub async fn list_execution_steps_for_org(
         &self,
+        conn: &mut PgConnection,
         execution_id: Uuid,
         org_id: Uuid,
     ) -> Result<Option<Vec<WorkflowExecutionStep>>, sqlx::Error> {
@@ -501,7 +554,7 @@ impl WorkflowRepository {
         )
         .bind(execution_id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *conn)
         .await?;
         if belongs.is_none() {
             return Ok(None);
@@ -516,34 +569,42 @@ impl WorkflowRepository {
             "#,
         )
         .bind(execution_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await?;
         Ok(Some(steps))
     }
 
     /// Get workflows by trigger type (for event matching).
-    pub async fn list_by_trigger_type(
+    pub async fn list_by_trigger_type<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         trigger_type: &str,
-    ) -> Result<Vec<Workflow>, sqlx::Error> {
+    ) -> Result<Vec<Workflow>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             "SELECT * FROM workflows WHERE organization_id = $1 AND trigger_type = $2 AND enabled = TRUE",
         )
         .bind(org_id)
         .bind(trigger_type)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Create or update workflow schedule.
-    pub async fn upsert_schedule(
+    pub async fn upsert_schedule<'e, E>(
         &self,
+        executor: E,
         workflow_id: Uuid,
         cron_expression: &str,
         timezone: &str,
         next_run_at: DateTime<Utc>,
-    ) -> Result<WorkflowSchedule, sqlx::Error> {
+    ) -> Result<WorkflowSchedule, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO workflow_schedules (workflow_id, cron_expression, timezone, next_run_at)
@@ -560,25 +621,39 @@ impl WorkflowRepository {
         .bind(cron_expression)
         .bind(timezone)
         .bind(next_run_at)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get due scheduled workflows.
-    pub async fn list_due_schedules(&self) -> Result<Vec<WorkflowSchedule>, sqlx::Error> {
+    ///
+    /// Under `FORCE` RLS this returns the due schedules of the org whose
+    /// context is set on the connection — a future cross-org scheduler must
+    /// iterate orgs with per-org contexts, not bypass RLS.
+    pub async fn list_due_schedules<'e, E>(
+        &self,
+        executor: E,
+    ) -> Result<Vec<WorkflowSchedule>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             "SELECT * FROM workflow_schedules WHERE enabled = TRUE AND next_run_at <= NOW()",
         )
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update schedule after execution.
-    pub async fn update_schedule_after_run(
+    pub async fn update_schedule_after_run<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         next_run_at: DateTime<Utc>,
-    ) -> Result<WorkflowSchedule, sqlx::Error> {
+    ) -> Result<WorkflowSchedule, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE workflow_schedules
@@ -589,7 +664,7 @@ impl WorkflowRepository {
         )
         .bind(id)
         .bind(next_run_at)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 }

--- a/backend/crates/db/tests/workflow_rls_repo_tests.rs
+++ b/backend/crates/db/tests/workflow_rls_repo_tests.rs
@@ -284,7 +284,7 @@ async fn workflow_repo_force_rls_deny_all_and_fix(pool: PgPool) {
                 CreateWorkflowAction {
                     workflow_id: created.id,
                     action_order: 1,
-                    action_type: "notification".to_string(),
+                    action_type: "send_notification".to_string(),
                     action_config: serde_json::json!({}),
                     on_failure: None,
                     retry_count: None,

--- a/backend/crates/db/tests/workflow_rls_repo_tests.rs
+++ b/backend/crates/db/tests/workflow_rls_repo_tests.rs
@@ -1,0 +1,342 @@
+//! Repo-level behavioral RLS regression test for PAP-77 (parent PAP-67 / PAP-80).
+//!
+//! Background
+//! ----------
+//! Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on the workflow tables (`workflows`,
+//! `workflow_actions`, `workflow_executions`, `workflow_execution_steps`,
+//! `workflow_schedules`). The production api-server connects as the table
+//! OWNER, which `FORCE` binds. `WorkflowRepository` held a raw `PgPool` and
+//! ran every query WITHOUT ever calling `set_request_context`, so on `dev`
+//! `get_current_org_id()` returned NULL and the policies collapsed to
+//! deny-all: own-org reads returned empty, writes failed. (PAP-80.)
+//!
+//! The fix routes the repo through an RLS-context connection (the
+//! `RlsConnection` extractor in handlers, `RlsPool::acquire_with_rls` in the
+//! background workflow executor). This test exercises the *repository methods
+//! themselves* on a `FORCE`-bound role and proves:
+//!
+//!   1. **Deny-all reproduction** — with the role bound but NO context set
+//!      (exactly what the raw-pool repo did on `dev`), an own-org
+//!      `find_by_id_for_org` / `list` returns nothing.
+//!   2. **Fix** — with `set_request_context(org_a, user_a)` applied first,
+//!      the same repo calls return the own-org row.
+//!   3. **Cross-tenant** — org B's workflow stays invisible to an org-A
+//!      caller even when the caller passes org B's own ids (RLS is the
+//!      boundary, not just the SQL org filter).
+//!   4. **Write path** — `create` / `add_action` / `create_execution` on a
+//!      context-set connection succeed (the handler + background-executor
+//!      paths); without context the INSERT fails the policy.
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — even `FORCE` does not bind a superuser, so a behavioral
+//! assertion would pass vacuously. The test creates a plain `NOSUPERUSER
+//! NOBYPASSRLS` role, grants it access, and `SET ROLE`s to it so `FORCE`
+//! actually enforces the policy the way the production owner role
+//! experiences it. Mirrors `legal_rls_repo_tests.rs` /
+//! `vendor_rls_repo_tests.rs` (the PAP-67 precedent PAP-77 follows).
+
+use db::models::{CreateWorkflow, CreateWorkflowAction, TriggerWorkflow, WorkflowQuery};
+use db::repositories::WorkflowRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("WORKFLOW {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@workflow.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'Workflow User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Seed a workflow directly (as superuser, RLS-exempt) for an org.
+async fn seed_workflow(pool: &PgPool, org_id: Uuid, user_id: Uuid, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO workflows
+            (organization_id, name, trigger_type, trigger_config, conditions, created_by, enabled)
+        VALUES ($1, $2, 'manual', '{}'::jsonb, '[]'::jsonb, $3, TRUE)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(name)
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed workflow")
+}
+
+fn sample_create() -> CreateWorkflow {
+    CreateWorkflow {
+        name: "Created under RLS".to_string(),
+        description: None,
+        trigger_type: "manual".to_string(),
+        trigger_config: None,
+        conditions: None,
+    }
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn workflow_repo_force_rls_deny_all_and_fix(pool: PgPool) {
+    let repo = WorkflowRepository::new(pool.clone());
+
+    // --- Seed as superuser / super-admin context (satisfies org roles-trigger). ---
+    set_ctx(&pool, None, None, true).await;
+    let org_a = seed_org(&pool, "workflow-force-a").await;
+    let org_b = seed_org(&pool, "workflow-force-b").await;
+    let user_a = seed_user(&pool, "a@workflow.test").await;
+    let user_b = seed_user(&pool, "b@workflow.test").await;
+    let wf_a = seed_workflow(&pool, org_a, user_a, "Org A workflow").await;
+    let wf_b = seed_workflow(&pool, org_b, user_b, "Org B workflow").await;
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    let role = format!("ppt_rls_workflow_{}", Uuid::new_v4().simple());
+    for stmt in [
+        format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
+        format!(
+            "GRANT SELECT, INSERT, UPDATE, DELETE ON workflows, workflow_actions, \
+             workflow_executions, workflow_execution_steps TO \"{role}\""
+        ),
+        format!(
+            "GRANT EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
+             get_current_org_not_deleted() TO \"{role}\""
+        ),
+        format!("GRANT SELECT ON organizations TO \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .expect("grant setup");
+    }
+
+    // ====================================================================
+    // (1) DENY-ALL reproduction: role bound, NO context set (the dev raw-pool
+    //     behavior). Own-org reads return nothing.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT clear_request_context()")
+            .execute(&mut *conn)
+            .await
+            .expect("clear ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let found = repo
+            .find_by_id_for_org(&mut *conn, wf_a, org_a)
+            .await
+            .expect("find_by_id_for_org (no ctx)");
+        assert!(
+            found.is_none(),
+            "PAP-80 regression: without RLS context, own-org workflow must be \
+             invisible (deny-all) — this is what the raw-pool repo did on dev"
+        );
+
+        let listed = repo
+            .list(&mut *conn, org_a, WorkflowQuery::default())
+            .await
+            .expect("list (no ctx)");
+        assert!(
+            listed.is_empty(),
+            "PAP-80 regression: without RLS context, list returns deny-all empty"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (2) FIX + (3) cross-tenant: set context, drop to bound role, query repo.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        // (2) Own-org row IS now visible through the repo — the fix.
+        let found = repo
+            .find_by_id_for_org(&mut *conn, wf_a, org_a)
+            .await
+            .expect("find_by_id_for_org (ctx)");
+        assert_eq!(
+            found.map(|w| w.id),
+            Some(wf_a),
+            "PAP-80 fix: with RLS context set, the repo must return the own-org workflow"
+        );
+
+        let listed = repo
+            .list(&mut *conn, org_a, WorkflowQuery::default())
+            .await
+            .expect("list (ctx)");
+        assert_eq!(
+            listed.iter().map(|w| w.id).collect::<Vec<_>>(),
+            vec![wf_a],
+            "PAP-80 fix: list returns exactly the own-org workflow under context"
+        );
+
+        // (3) Org B's workflow stays invisible to an org-A caller — even
+        // when the caller passes org B's own ids, proving RLS (not just the
+        // SQL org key) is what scopes the read.
+        let cross = repo
+            .find_by_id_for_org(&mut *conn, wf_b, org_a)
+            .await
+            .expect("find_by_id_for_org cross (keyed)");
+        assert!(
+            cross.is_none(),
+            "cross-tenant: org B's workflow must NOT be visible to an org-A caller"
+        );
+        let cross_rls_only = repo
+            .find_by_id_for_org(&mut *conn, wf_b, org_b)
+            .await
+            .expect("find_by_id_for_org cross (RLS boundary)");
+        assert!(
+            cross_rls_only.is_none(),
+            "cross-tenant: even passing org B's own ids, the org-A RLS context \
+             must hide org B's workflow"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (4) WRITE path: create / add_action / create_execution on a context-set
+    //     connection succeed — the handler and background-executor paths.
+    //     Without context the INSERTs would fail the policy WITH CHECK (the
+    //     write-side of deny-all).
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let created = repo
+            .create(&mut *conn, org_a, user_a, sample_create())
+            .await
+            .expect("create under context must succeed");
+        assert_eq!(created.organization_id, org_a);
+
+        // add_action is the multi-statement (&mut PgConnection) shape: a
+        // tenant check followed by the insert, both on the same connection.
+        let action = repo
+            .add_action(
+                &mut conn,
+                org_a,
+                CreateWorkflowAction {
+                    workflow_id: created.id,
+                    action_order: 1,
+                    action_type: "notification".to_string(),
+                    action_config: serde_json::json!({}),
+                    on_failure: None,
+                    retry_count: None,
+                    retry_delay_seconds: None,
+                },
+            )
+            .await
+            .expect("add_action under context must succeed");
+        assert!(
+            action.is_some(),
+            "add_action must attach the action to the own-org workflow"
+        );
+
+        // create_execution is what the background executor runs on its
+        // RlsPool-acquired connection.
+        let execution = repo
+            .create_execution(
+                &mut conn,
+                TriggerWorkflow {
+                    workflow_id: created.id,
+                    trigger_event: serde_json::json!({"manual": true}),
+                    context: None,
+                },
+            )
+            .await
+            .expect("create_execution under context must succeed");
+        assert_eq!(execution.workflow_id, created.id);
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup the test role. ---
+    set_ctx(&pool, None, None, true).await;
+    for stmt in [
+        format!(
+            "REVOKE ALL ON workflows, workflow_actions, workflow_executions, \
+             workflow_execution_steps FROM \"{role}\""
+        ),
+        format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        // DROP OWNED severs every remaining privilege this role holds in the
+        // test database — explicit REVOKEs keep missing the RLS
+        // helper-function EXECUTE grants, so DROP ROLE would fail with
+        // "objects depend on it" and leak the cluster-global role (PAP-134).
+        format!("DROP OWNED BY \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .ok();
+    }
+}

--- a/backend/servers/api-server/src/routes/ai/workflows.rs
+++ b/backend/servers/api-server/src/routes/ai/workflows.rs
@@ -1,9 +1,30 @@
 //! Workflow automation (Story 13.6 & 13.7), event handling (Story 94.2),
 //! and the templates marketplace (Story 94.4).
+//!
+//! # RLS (PAP-77)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` on the workflow tables,
+//! so every query MUST run on a connection that has `app.current_org_id` set
+//! or it collapses to deny-all. Each database handler therefore acquires an
+//! [`RlsConnection`] (which validates tenant membership and sets the org/user
+//! GUCs on a dedicated connection) and passes `&mut **rls.conn()` to the
+//! repository. The authoritative organization is `rls.tenant_id()` — the
+//! tenant the caller was validated against — never a client-supplied value,
+//! so the SQL org filter and the RLS context can never disagree. By-id repo
+//! queries stay keyed on `(id, organization_id)` (child tables via the parent
+//! workflow) as defense-in-depth, so a cross-tenant probe resolves to no row
+//! → `404` even on an RLS-exempt pool. `rls.release()` clears the context
+//! before the connection returns to the pool. The background
+//! `WorkflowExecutor` acquires its own org-context connections from an
+//! `RlsPool` (org derived from the org-scoped-loaded workflow row).
+//!
+//! Template marketplace endpoints that serve only built-in (non-database)
+//! templates keep the lighter `RequestPrincipal` auth gate.
 
-use crate::routes::ai::{not_found, require_tenant_id};
+use crate::routes::ai::not_found;
 use crate::state::AppState;
 use api_core::extractors::principal::RequestPrincipal;
+use api_core::extractors::RlsConnection;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -15,8 +36,16 @@ use db::models::{
     get_builtin_templates, template_category, CreateWorkflow, CreateWorkflowAction, ExecutionQuery,
     ImportTemplateRequest, TriggerWorkflow, UpdateWorkflow, WorkflowQuery,
 };
+use db::RlsPool;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+
+fn internal_error(e: impl std::fmt::Display) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse::new("INTERNAL_ERROR", e.to_string())),
+    )
+}
 
 // ============================================================================
 // Workflow Router (Story 13.6 & 13.7)
@@ -47,221 +76,234 @@ pub fn workflow_router() -> Router<AppState> {
 
 async fn create_workflow(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Json(req): Json<CreateWorkflow>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
-    // SECURITY: owning org and creator are derived from the verified principal,
-    // never from the request body.
-    let organization_id = require_tenant_id(&principal)?;
-    match state
+    // SECURITY: owning org and creator are derived from the validated tenant
+    // context, never from the request body.
+    let organization_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let result = state
         .workflow_repo
-        .create(organization_id, principal.user_id, req)
-        .await
-    {
+        .create(&mut **rls.conn(), organization_id, user_id, req)
+        .await;
+    rls.release().await;
+    match result {
         Ok(workflow) => Ok((StatusCode::CREATED, Json(serde_json::json!(workflow)))),
         Err(e) => {
             tracing::error!("Failed to create workflow: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to create")),
-            ))
+            Err(internal_error("Failed to create"))
         }
     }
 }
 
 async fn list_workflows(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Query(query): Query<WorkflowQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
-
-    match state.workflow_repo.list(tenant_id, query).await {
+    let tenant_id = rls.tenant_id();
+    let result = state
+        .workflow_repo
+        .list(&mut **rls.conn(), tenant_id, query)
+        .await;
+    rls.release().await;
+    match result {
         Ok(workflows) => Ok(Json(serde_json::json!({ "workflows": workflows }))),
         Err(e) => {
             tracing::error!("Failed to list workflows: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to list")),
-            ))
+            Err(internal_error("Failed to list"))
         }
     }
 }
 
 async fn get_workflow(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_tenant_id(&principal)?;
-    match state.workflow_repo.find_by_id_for_org(id, org_id).await {
+    let org_id = rls.tenant_id();
+    let workflow = state
+        .workflow_repo
+        .find_by_id_for_org(&mut **rls.conn(), id, org_id)
+        .await;
+    let result = match workflow {
         Ok(Some(workflow)) => {
             // list_actions is scoped by the same org_id, so we cannot leak
             // actions from a workflow we just verified, but pass org_id
             // anyway for symmetry / future-proofing against ID swaps.
             let actions = state
                 .workflow_repo
-                .list_actions(id, org_id)
-                .await
-                .map_err(|e| {
+                .list_actions(rls.conn(), id, org_id)
+                .await;
+            match actions {
+                Ok(actions) => Ok(Json(serde_json::json!({
+                    "workflow": workflow,
+                    "actions": actions.unwrap_or_default()
+                }))),
+                Err(e) => {
                     tracing::error!("Failed to list actions: {}", e);
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get")),
-                    )
-                })?
-                .unwrap_or_default();
-            Ok(Json(serde_json::json!({
-                "workflow": workflow,
-                "actions": actions
-            })))
+                    Err(internal_error("Failed to get"))
+                }
+            }
         }
         Ok(None) => Err(not_found("Workflow not found")),
         Err(e) => {
             tracing::error!("Failed to get workflow: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get")),
-            ))
+            Err(internal_error("Failed to get"))
         }
-    }
+    };
+    rls.release().await;
+    result
 }
 
 async fn update_workflow(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateWorkflow>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_tenant_id(&principal)?;
-    match state.workflow_repo.update(id, org_id, req).await {
+    let org_id = rls.tenant_id();
+    let result = state
+        .workflow_repo
+        .update(&mut **rls.conn(), id, org_id, req)
+        .await;
+    rls.release().await;
+    match result {
         Ok(Some(workflow)) => Ok(Json(serde_json::json!(workflow))),
         Ok(None) => Err(not_found("Workflow not found")),
         Err(e) => {
             tracing::error!("Failed to update workflow: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to update")),
-            ))
+            Err(internal_error("Failed to update"))
         }
     }
 }
 
 async fn delete_workflow(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_tenant_id(&principal)?;
-    match state.workflow_repo.delete(id, org_id).await {
+    let org_id = rls.tenant_id();
+    let result = state
+        .workflow_repo
+        .delete(&mut **rls.conn(), id, org_id)
+        .await;
+    rls.release().await;
+    match result {
         Ok(true) => Ok(StatusCode::NO_CONTENT),
         Ok(false) => Err(not_found("Workflow not found")),
         Err(e) => {
             tracing::error!("Failed to delete workflow: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to delete")),
-            ))
+            Err(internal_error("Failed to delete"))
         }
     }
 }
 
 async fn list_actions(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_tenant_id(&principal)?;
-    match state.workflow_repo.list_actions(id, org_id).await {
+    let org_id = rls.tenant_id();
+    let result = state
+        .workflow_repo
+        .list_actions(rls.conn(), id, org_id)
+        .await;
+    rls.release().await;
+    match result {
         Ok(Some(actions)) => Ok(Json(serde_json::json!({ "actions": actions }))),
         Ok(None) => Err(not_found("Workflow not found")),
         Err(e) => {
             tracing::error!("Failed to list actions: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to list")),
-            ))
+            Err(internal_error("Failed to list"))
         }
     }
 }
 
 async fn add_action(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(mut req): Json<CreateWorkflowAction>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_tenant_id(&principal)?;
+    let org_id = rls.tenant_id();
     // Pin the workflow_id to the path parameter so a caller can't
     // shadow-target a different workflow via the JSON body.
     req.workflow_id = id;
-    match state.workflow_repo.add_action(org_id, req).await {
+    let result = state
+        .workflow_repo
+        .add_action(rls.conn(), org_id, req)
+        .await;
+    rls.release().await;
+    match result {
         Ok(Some(action)) => Ok((StatusCode::CREATED, Json(serde_json::json!(action)))),
         Ok(None) => Err(not_found("Workflow not found")),
         Err(e) => {
             tracing::error!("Failed to add action: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to add")),
-            ))
+            Err(internal_error("Failed to add"))
         }
     }
 }
 
 async fn delete_action(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(action_id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_tenant_id(&principal)?;
-    match state.workflow_repo.delete_action(action_id, org_id).await {
+    let org_id = rls.tenant_id();
+    let result = state
+        .workflow_repo
+        .delete_action(&mut **rls.conn(), action_id, org_id)
+        .await;
+    rls.release().await;
+    match result {
         Ok(true) => Ok(StatusCode::NO_CONTENT),
         Ok(false) => Err(not_found("Action not found")),
         Err(e) => {
             tracing::error!("Failed to delete action: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to delete")),
-            ))
+            Err(internal_error("Failed to delete"))
         }
     }
 }
 
 async fn trigger_workflow(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<TriggerWorkflow>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
     use crate::services::WorkflowExecutor;
 
-    let org_id = require_tenant_id(&principal)?;
+    let org_id = rls.tenant_id();
 
-    // SECURITY (H1): verify the workflow belongs to the caller's org BEFORE
-    // we hand off to the executor. A 404 (not 403) is the correct response
-    // — distinguishing "no such workflow" from "wrong tenant" would let a
-    // caller enumerate workflow IDs cross-tenant.
-    let workflow_exists = state
+    // SECURITY (H1): load the workflow org-scoped BEFORE handing off to the
+    // executor. A 404 (not 403) is the correct response — distinguishing "no
+    // such workflow" from "wrong tenant" would let a caller enumerate
+    // workflow IDs cross-tenant. The loaded row is what the executor runs:
+    // it never re-fetches by bare ID.
+    let workflow = state
         .workflow_repo
-        .find_by_id_for_org(id, org_id)
-        .await
-        .map_err(|e| {
+        .find_by_id_for_org(&mut **rls.conn(), id, org_id)
+        .await;
+    rls.release().await;
+    let workflow = match workflow {
+        Ok(Some(workflow)) => workflow,
+        Ok(None) => return Err(not_found("Workflow not found")),
+        Err(e) => {
             tracing::error!("Failed to load workflow for tenant check: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to trigger")),
-            )
-        })?;
-    if workflow_exists.is_none() {
-        return Err(not_found("Workflow not found"));
-    }
+            return Err(internal_error("Failed to trigger"));
+        }
+    };
 
-    // Create the workflow executor using the repository
-    let executor = WorkflowExecutor::new(state.workflow_repo.clone());
+    // Create the workflow executor; it acquires its own RLS-context
+    // connections (org derived from the row loaded above).
+    let executor =
+        WorkflowExecutor::new(RlsPool::new(state.db.clone()), state.workflow_repo.clone());
 
     // Execute the workflow asynchronously (Epic 94)
     match executor
-        .execute_workflow(id, req.trigger_event, req.context)
+        .execute_workflow(workflow, req.trigger_event, req.context)
         .await
     {
         Ok(execution_id) => {
@@ -281,92 +323,85 @@ async fn trigger_workflow(
         }
         Err(e) => {
             tracing::error!("Failed to trigger workflow: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("INTERNAL_ERROR", e.to_string())),
-            ))
+            Err(internal_error(e))
         }
     }
 }
 
 async fn list_executions(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Query(query): Query<ExecutionQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
-
-    match state.workflow_repo.list_executions(tenant_id, query).await {
+    let tenant_id = rls.tenant_id();
+    let result = state
+        .workflow_repo
+        .list_executions(&mut **rls.conn(), tenant_id, query)
+        .await;
+    rls.release().await;
+    match result {
         Ok(executions) => Ok(Json(serde_json::json!({ "executions": executions }))),
         Err(e) => {
             tracing::error!("Failed to list executions: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to list")),
-            ))
+            Err(internal_error("Failed to list"))
         }
     }
 }
 
 async fn get_execution(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_tenant_id(&principal)?;
-    match state
+    let org_id = rls.tenant_id();
+    let execution = state
         .workflow_repo
-        .find_execution_by_id_for_org(id, org_id)
-        .await
-    {
+        .find_execution_by_id_for_org(&mut **rls.conn(), id, org_id)
+        .await;
+    let result = match execution {
         Ok(Some(execution)) => {
             let steps = state
                 .workflow_repo
-                .list_execution_steps_for_org(id, org_id)
-                .await
-                .map_err(|e| {
+                .list_execution_steps_for_org(rls.conn(), id, org_id)
+                .await;
+            match steps {
+                Ok(steps) => Ok(Json(serde_json::json!({
+                    "execution": execution,
+                    "steps": steps.unwrap_or_default()
+                }))),
+                Err(e) => {
                     tracing::error!("Failed to list steps: {}", e);
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get")),
-                    )
-                })?
-                .unwrap_or_default();
-            Ok(Json(serde_json::json!({
-                "execution": execution,
-                "steps": steps
-            })))
+                    Err(internal_error("Failed to get"))
+                }
+            }
         }
         Ok(None) => Err(not_found("Execution not found")),
         Err(e) => {
             tracing::error!("Failed to get execution: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get")),
-            ))
+            Err(internal_error("Failed to get"))
         }
-    }
+    };
+    rls.release().await;
+    result
 }
 
 async fn list_execution_steps(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let org_id = require_tenant_id(&principal)?;
-    match state
+    let org_id = rls.tenant_id();
+    let result = state
         .workflow_repo
-        .list_execution_steps_for_org(id, org_id)
-        .await
-    {
+        .list_execution_steps_for_org(rls.conn(), id, org_id)
+        .await;
+    rls.release().await;
+    match result {
         Ok(Some(steps)) => Ok(Json(serde_json::json!({ "steps": steps }))),
         Ok(None) => Err(not_found("Execution not found")),
         Err(e) => {
             tracing::error!("Failed to list steps: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to list")),
-            ))
+            Err(internal_error("Failed to list"))
         }
     }
 }
@@ -389,15 +424,20 @@ pub struct WorkflowEventRequest {
 /// Handle workflow trigger events (Story 94.2).
 async fn handle_workflow_event(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Json(req): Json<WorkflowEventRequest>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
     use crate::services::{WorkflowEvent, WorkflowExecutor};
 
-    let tenant_id = require_tenant_id(&principal)?;
+    // The RlsConnection validated tenant membership; the executor acquires
+    // its own org-context connections, so release this one immediately.
+    let tenant_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    rls.release().await;
 
     // Create the workflow executor
-    let executor = WorkflowExecutor::new(state.workflow_repo.clone());
+    let executor =
+        WorkflowExecutor::new(RlsPool::new(state.db.clone()), state.workflow_repo.clone());
 
     // Create the event
     let mut event = WorkflowEvent::new(&req.event_type, tenant_id, req.data);
@@ -405,7 +445,7 @@ async fn handle_workflow_event(
         event = event.with_building(building_id);
     }
     // Set the user who triggered the event
-    event = event.with_user(principal.user_id);
+    event = event.with_user(user_id);
 
     // Handle the event - this finds matching workflows and executes them
     match executor.handle_event(event).await {
@@ -425,10 +465,7 @@ async fn handle_workflow_event(
         }
         Err(e) => {
             tracing::error!("Failed to handle workflow event: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("INTERNAL_ERROR", e.to_string())),
-            ))
+            Err(internal_error(e))
         }
     }
 }
@@ -572,11 +609,12 @@ async fn get_workflow_template(
 /// Import a workflow template.
 async fn import_workflow_template(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<String>,
     Json(req): Json<ImportTemplateRequest>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
+    let tenant_id = rls.tenant_id();
+    let user_id = rls.user_id();
 
     // Get the template
     let (template, actions) = if id.starts_with("builtin-") {
@@ -617,21 +655,20 @@ async fn import_workflow_template(
         conditions: template.conditions,
     };
 
-    // Create the workflow. Org and creator come from the verified principal.
-    let workflow = state
+    // Create the workflow. Org and creator come from the validated tenant
+    // context.
+    let created = state
         .workflow_repo
-        .create(tenant_id, principal.user_id, create_workflow)
-        .await
-        .map_err(|e| {
+        .create(&mut **rls.conn(), tenant_id, user_id, create_workflow)
+        .await;
+    let workflow = match created {
+        Ok(workflow) => workflow,
+        Err(e) => {
+            rls.release().await;
             tracing::error!("Failed to create workflow from template: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to import template",
-                )),
-            )
-        })?;
+            return Err(internal_error("Failed to import template"));
+        }
+    };
 
     // Add actions
     for action in actions {
@@ -649,7 +686,7 @@ async fn import_workflow_template(
         // construction, so this is the correct org scope.
         if let Err(e) = state
             .workflow_repo
-            .add_action(tenant_id, create_action)
+            .add_action(rls.conn(), tenant_id, create_action)
             .await
         {
             tracing::warn!("Failed to add action to imported workflow: {}", e);
@@ -661,6 +698,7 @@ async fn import_workflow_template(
         let _ = state
             .workflow_repo
             .update(
+                &mut **rls.conn(),
                 workflow.id,
                 tenant_id,
                 UpdateWorkflow {
@@ -674,6 +712,8 @@ async fn import_workflow_template(
             )
             .await;
     }
+
+    rls.release().await;
 
     tracing::info!(
         workflow_id = %workflow.id,

--- a/backend/servers/api-server/src/services/workflow_executor.rs
+++ b/backend/servers/api-server/src/services/workflow_executor.rs
@@ -11,6 +11,7 @@ use db::models::{
     WorkflowAction,
 };
 use db::repositories::{WorkflowRepository, MAX_RETRY_COUNT, MAX_RETRY_DELAY_SECONDS};
+use db::{RlsGuard, RlsPool};
 use serde::{Deserialize, Serialize};
 use std::time::{Duration, Instant};
 use thiserror::Error;
@@ -188,7 +189,15 @@ impl Default for WorkflowExecutorConfig {
 }
 
 /// The workflow executor service.
+///
+/// RLS (PAP-77): the executor runs outside an HTTP request, so it cannot use
+/// the `RlsConnection` extractor. It instead holds an [`RlsPool`] and
+/// acquires a context-set connection per database operation, with the org
+/// derived from the **already-loaded workflow row** (or the verified event)
+/// — never from client input. Guards are scoped tightly so no pooled
+/// connection is held across action execution or retry sleeps.
 pub struct WorkflowExecutor {
+    db: RlsPool,
     workflow_repo: WorkflowRepository,
     action_registry: ActionRegistry,
     config: WorkflowExecutorConfig,
@@ -196,51 +205,68 @@ pub struct WorkflowExecutor {
 
 impl WorkflowExecutor {
     /// Create a new workflow executor.
-    pub fn new(workflow_repo: WorkflowRepository) -> Self {
-        Self::with_config(workflow_repo, WorkflowExecutorConfig::default())
+    pub fn new(db: RlsPool, workflow_repo: WorkflowRepository) -> Self {
+        Self::with_config(db, workflow_repo, WorkflowExecutorConfig::default())
     }
 
     /// Create a new workflow executor with custom configuration.
-    pub fn with_config(workflow_repo: WorkflowRepository, config: WorkflowExecutorConfig) -> Self {
+    pub fn with_config(
+        db: RlsPool,
+        workflow_repo: WorkflowRepository,
+        config: WorkflowExecutorConfig,
+    ) -> Self {
         Self {
+            db,
             workflow_repo,
             action_registry: ActionRegistry::new(),
             config,
         }
     }
 
-    /// Execute a workflow by ID.
+    /// Execute a workflow.
+    ///
+    /// Takes the **already-loaded** workflow row: callers (the trigger route,
+    /// `handle_event`) have necessarily fetched it org-scoped, so no unscoped
+    /// by-id read exists anymore. The RLS context for all execution writes is
+    /// derived from `workflow.organization_id`.
     pub async fn execute_workflow(
         &self,
-        workflow_id: Uuid,
+        workflow: Workflow,
         trigger_event: serde_json::Value,
         context: Option<serde_json::Value>,
     ) -> Result<Uuid, WorkflowError> {
-        // Get the workflow
-        let workflow = self
-            .workflow_repo
-            .find_by_id(workflow_id)
-            .await?
-            .ok_or(WorkflowError::NotFound(workflow_id))?;
+        let workflow_id = workflow.id;
 
         if !workflow.enabled {
             return Err(WorkflowError::Disabled(workflow_id));
         }
 
-        // Create execution record
+        // Create execution record on an org-context connection.
+        let mut guard = self
+            .db
+            .acquire_with_rls(workflow.organization_id, workflow.created_by, false)
+            .await?;
         let execution = self
             .workflow_repo
-            .create_execution(TriggerWorkflow {
-                workflow_id,
-                trigger_event: trigger_event.clone(),
-                context: context.clone(),
-            })
-            .await?;
+            .create_execution(
+                guard.conn(),
+                TriggerWorkflow {
+                    workflow_id,
+                    trigger_event: trigger_event.clone(),
+                    context: context.clone(),
+                },
+            )
+            .await;
+        guard.release().await;
+        let execution = execution?;
 
         let execution_id = execution.id;
 
         // Spawn async execution
         let executor = WorkflowExecutorTask {
+            db: self.db.clone(),
+            org_id: workflow.organization_id,
+            acting_user: workflow.created_by,
             workflow_repo: self.workflow_repo.clone(),
             action_registry: ActionRegistry::new(),
             config: self.config.clone(),
@@ -278,11 +304,29 @@ impl WorkflowExecutor {
             "Processing workflow trigger event"
         );
 
-        // Find matching workflows
+        // Find matching workflows on an org-context connection. The org is
+        // the verified event org (set by the route from the request
+        // principal, never client input). `triggered_by` is always set on the
+        // route path; nil only pads the user GUC, which the workflow
+        // policies don't consult.
+        let mut guard = self
+            .db
+            .acquire_with_rls(
+                event.organization_id,
+                event.triggered_by.unwrap_or(Uuid::nil()),
+                false,
+            )
+            .await?;
         let workflows = self
             .workflow_repo
-            .list_by_trigger_type(event.organization_id, &event.event_type)
-            .await?;
+            .list_by_trigger_type(
+                &mut **guard.conn(),
+                event.organization_id,
+                &event.event_type,
+            )
+            .await;
+        guard.release().await;
+        let workflows = workflows?;
 
         let mut execution_ids = Vec::new();
 
@@ -315,10 +359,11 @@ impl WorkflowExecutor {
                 continue;
             }
 
-            // Execute the workflow
+            // Execute the workflow (moves the loaded row into the executor).
+            let workflow_id = workflow.id;
             match self
                 .execute_workflow(
-                    workflow.id,
+                    workflow,
                     event.data.clone(),
                     Some(serde_json::json!({
                         "event_type": event.event_type,
@@ -334,7 +379,7 @@ impl WorkflowExecutor {
                 }
                 Err(e) => {
                     tracing::warn!(
-                        workflow_id = %workflow.id,
+                        workflow_id = %workflow_id,
                         error = %e,
                         "Failed to start workflow execution"
                     );
@@ -661,13 +706,46 @@ impl WorkflowExecutor {
 }
 
 /// Task that runs the actual workflow execution.
+///
+/// RLS (PAP-77): `org_id` / `acting_user` come from the workflow row loaded
+/// org-scoped by the caller. Every database operation acquires its own
+/// short-lived context-set connection via [`Self::rls_conn`] — a guard is
+/// never held across action execution or retry sleeps (which can last up to
+/// an hour), so the pool cannot be starved by slow actions.
 struct WorkflowExecutorTask {
+    db: RlsPool,
+    org_id: Uuid,
+    acting_user: Uuid,
     workflow_repo: WorkflowRepository,
     action_registry: ActionRegistry,
     config: WorkflowExecutorConfig,
 }
 
 impl WorkflowExecutorTask {
+    /// Acquire a connection with this execution's RLS context set.
+    async fn rls_conn(&self) -> Result<RlsGuard, sqlx::Error> {
+        self.db
+            .acquire_with_rls(self.org_id, self.acting_user, false)
+            .await
+    }
+
+    /// Update the execution status on a fresh org-context connection.
+    async fn set_execution_status(
+        &self,
+        execution_id: Uuid,
+        status: &str,
+        error_message: Option<&str>,
+    ) -> Result<(), WorkflowError> {
+        let mut guard = self.rls_conn().await?;
+        let res = self
+            .workflow_repo
+            .update_execution_status(&mut **guard.conn(), execution_id, status, error_message)
+            .await;
+        guard.release().await;
+        res?;
+        Ok(())
+    }
+
     /// Run the workflow execution.
     async fn run(
         &self,
@@ -685,11 +763,13 @@ impl WorkflowExecutorTask {
         // Get workflow actions. The executor is internal — we already
         // loaded `workflow`, so the organization scope is derived from the
         // row itself (no risk of cross-tenant leakage here).
+        let mut guard = self.rls_conn().await?;
         let actions = self
             .workflow_repo
-            .list_actions(workflow.id, workflow.organization_id)
-            .await?
-            .unwrap_or_default();
+            .list_actions(guard.conn(), workflow.id, workflow.organization_id)
+            .await;
+        guard.release().await;
+        let actions = actions?.unwrap_or_default();
 
         if actions.is_empty() {
             tracing::warn!(
@@ -697,8 +777,7 @@ impl WorkflowExecutorTask {
                 execution_id = %execution_id,
                 "Workflow has no actions"
             );
-            self.workflow_repo
-                .update_execution_status(execution_id, execution_status::COMPLETED, None)
+            self.set_execution_status(execution_id, execution_status::COMPLETED, None)
                 .await?;
             return Ok(());
         }
@@ -751,13 +830,12 @@ impl WorkflowExecutorTask {
                                 error = %e,
                                 "Action failed, stopping execution"
                             );
-                            self.workflow_repo
-                                .update_execution_status(
-                                    execution_id,
-                                    execution_status::FAILED,
-                                    Some(&e.to_string()),
-                                )
-                                .await?;
+                            self.set_execution_status(
+                                execution_id,
+                                execution_status::FAILED,
+                                Some(&e.to_string()),
+                            )
+                            .await?;
                             return Err(e);
                         }
                     }
@@ -766,8 +844,7 @@ impl WorkflowExecutorTask {
         }
 
         // Mark execution as completed
-        self.workflow_repo
-            .update_execution_status(execution_id, execution_status::COMPLETED, None)
+        self.set_execution_status(execution_id, execution_status::COMPLETED, None)
             .await?;
 
         tracing::info!(
@@ -786,10 +863,13 @@ impl WorkflowExecutorTask {
         context: &mut ActionContext,
     ) -> Result<ActionResult, WorkflowError> {
         // Create execution step record
+        let mut guard = self.rls_conn().await?;
         let step = self
             .workflow_repo
-            .create_execution_step(context.execution_id, action.id)
-            .await?;
+            .create_execution_step(&mut **guard.conn(), context.execution_id, action.id)
+            .await;
+        guard.release().await;
+        let step = step?;
 
         let start = Instant::now();
 
@@ -827,15 +907,20 @@ impl WorkflowExecutorTask {
                     let duration_ms = start.elapsed().as_millis() as i32;
 
                     // Update step record
-                    self.workflow_repo
+                    let mut guard = self.rls_conn().await?;
+                    let updated = self
+                        .workflow_repo
                         .update_execution_step(
+                            &mut **guard.conn(),
                             step.id,
                             step_status::COMPLETED,
                             result.output.clone(),
                             None,
                             Some(duration_ms),
                         )
-                        .await?;
+                        .await;
+                    guard.release().await;
+                    updated?;
 
                     return Ok(result);
                 }
@@ -859,15 +944,20 @@ impl WorkflowExecutorTask {
         let duration_ms = start.elapsed().as_millis() as i32;
 
         // Update step record with failure
-        self.workflow_repo
+        let mut guard = self.rls_conn().await?;
+        let updated = self
+            .workflow_repo
             .update_execution_step(
+                &mut **guard.conn(),
                 step.id,
                 step_status::FAILED,
                 serde_json::json!({}),
                 Some(&error.to_string()),
                 Some(duration_ms),
             )
-            .await?;
+            .await;
+        guard.release().await;
+        updated?;
 
         Err(WorkflowError::ActionFailed(error))
     }


### PR DESCRIPTION
## PAP-77 — `workflow.rs` FORCE-RLS deny-all fix

`workflow.rs` held a raw `PgPool` and ran every query context-less. Under migration `00179`'s `FORCE ROW LEVEL SECURITY` (tables: `workflows`, `workflow_executions`, `workflow_actions`, `workflow_execution_steps`, `workflow_schedules`) the owner connection is no longer exempt, so own-org reads returned empty and writes failed. Router: `/api/v1/ai/workflows`.

Follows the proven pattern from PR #1262 (board_meetings, PAP-137).

### Changes
- **`crates/db/src/repositories/workflow.rs`** — dropped the raw `pool` field; stateless repo. Single-statement methods take a generic `Executor`; multi-statement methods take `&mut PgConnection`. All by-id queries stay org-keyed (defense-in-depth). Removed the unscoped `find_by_id` / `find_execution_by_id` / `list_execution_steps` variants entirely — `execute_workflow` now takes the already-loaded org-scoped `Workflow` row, so no unscoped by-id read remains.
- **`routes/ai/workflows.rs`** — handlers use the `RlsConnection` extractor, org = `rls.tenant_id()`, explicit `release()` on both Ok/Err; dropped now-redundant `verify_org_access`.
- **`services/workflow_executor.rs`** — background executor acquires short-lived org-context guards (`RlsPool`) per DB op (org/user from the workflow row); never holds a connection across action execution or retry sleeps.
- **`crates/db/tests/workflow_rls_repo_tests.rs`** — new repo-level behavioral test with a `NOSUPERUSER NOBYPASSRLS` role: deny-all without context, own-org visibility with context, cross-tenant invisibility, and the write path (`create` / `add_action` / `create_execution`).

### Verification
- `cargo check -p db -p api-server` ✅
- `cargo clippy -p db -p api-server --all-targets -- -D warnings` ✅
- `cargo fmt --check` ✅
- New `#[sqlx::test]` compiles; DB execution runs in CI (`rls-smoke`) / QA.

Parent: PAP-67. Detection guard: PAP-68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)