### PR TITLE
fix(api-server): tenant-scope registry parking_spot lookup + repair vehicle by-id read (PAP-143)

### DIFF
--- a/backend/crates/db/src/repositories/registry.rs
+++ b/backend/crates/db/src/repositories/registry.rs
@@ -331,8 +331,20 @@ impl RegistryRepository {
         tenant_id: Uuid,
         id: Uuid,
     ) -> Result<Option<VehicleRegistration>, sqlx::Error> {
+        // `vehicle_type` / `status` are Postgres ENUMs; the model decodes them as
+        // `String`, so cast them to text explicitly. A bare `SELECT *` only ever
+        // succeeded because FORCE RLS normally returns zero rows here — see PAP-143
+        // / PAP-136 "deny-all-masked decode" notes.
         sqlx::query_as::<_, VehicleRegistration>(
-            "SELECT * FROM vehicle_registrations WHERE id = $1 AND tenant_id = $2",
+            r#"
+            SELECT id, tenant_id, unit_id, owner_id,
+                   vehicle_type::text AS vehicle_type, make, model, year, color,
+                   license_plate, registration_document_id, insurance_document_id,
+                   parking_spot_id, status::text AS status, reviewed_by, reviewed_at,
+                   rejection_reason, notes, created_at, updated_at
+            FROM vehicle_registrations
+            WHERE id = $1 AND tenant_id = $2
+            "#,
         )
         .bind(id)
         .bind(tenant_id)
@@ -351,9 +363,10 @@ impl RegistryRepository {
             None => return Ok(None),
         };
 
+        // `units` has no `unit_number` column — the display value is `designation`.
         let unit_info: Option<(String, String)> = sqlx::query_as(
             r#"
-            SELECT u.unit_number, b.name as building_name
+            SELECT u.designation AS unit_number, b.name as building_name
             FROM units u
             JOIN buildings b ON b.id = u.building_id
             WHERE u.id = $1
@@ -379,10 +392,16 @@ impl RegistryRepository {
         };
 
         let parking_spot_number = if let Some(spot_id) = registration.parking_spot_id {
-            sqlx::query_scalar::<_, String>("SELECT spot_number FROM parking_spots WHERE id = $1")
-                .bind(spot_id)
-                .fetch_optional(&self.pool)
-                .await?
+            // Defense-in-depth: tenant-scope the secondary lookup like the rest of
+            // registry.rs, so a cross-tenant parking_spot_id can never leak a spot
+            // number even if FORCE RLS is bypassed (e.g. superuser pool). PAP-143.
+            sqlx::query_scalar::<_, String>(
+                "SELECT spot_number FROM parking_spots WHERE id = $1 AND tenant_id = $2",
+            )
+            .bind(spot_id)
+            .bind(tenant_id)
+            .fetch_optional(&self.pool)
+            .await?
         } else {
             None
         };

--- a/backend/crates/db/tests/registry_parking_spot_cross_tenant_tests.rs
+++ b/backend/crates/db/tests/registry_parking_spot_cross_tenant_tests.rs
@@ -1,0 +1,176 @@
+//! Regression test for PAP-143 — defense-in-depth on the secondary
+//! `parking_spots` lookup in
+//! [`RegistryRepository::get_vehicle_registration_with_details`].
+//!
+//! The primary `vehicle_registrations` read is keyed on `(id, tenant_id)`, but
+//! the follow-up `SELECT spot_number FROM parking_spots WHERE id = $1` was keyed
+//! on the spot id alone. `vehicle_registrations.parking_spot_id` carries no FK
+//! constraint, so a stale or tampered registration row can point at another
+//! tenant's spot — and the unscoped lookup would then leak that foreign tenant's
+//! `spot_number` into the response.
+//!
+//! The fix adds `AND tenant_id = $2`, threading the already-verified caller
+//! tenant. CI runs these repo tests against a superuser pool that bypasses
+//! FORCE RLS, so the SQL predicate (not RLS) is what this test exercises:
+//! pre-fix this returns the foreign spot number, post-fix it resolves to `None`.
+
+use db::repositories::RegistryRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Registry {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@registry.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'test_hash', 'Registry User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_building(pool: &PgPool, org_id: Uuid, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO buildings (organization_id, street, city, postal_code, country, name)
+        VALUES ($1, $2, 'Bratislava', '81101', 'Slovakia', $3)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(format!("{slug} Street 1"))
+    .bind(format!("{slug} Building"))
+    .fetch_one(pool)
+    .await
+    .expect("seed building")
+}
+
+async fn seed_unit(pool: &PgPool, building_id: Uuid, designation: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO units (building_id, designation) VALUES ($1, $2) RETURNING id",
+    )
+    .bind(building_id)
+    .bind(designation)
+    .fetch_one(pool)
+    .await
+    .expect("seed unit")
+}
+
+async fn seed_parking_spot(pool: &PgPool, org_id: Uuid, building_id: Uuid, spot: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO parking_spots (tenant_id, building_id, spot_number)
+        VALUES ($1, $2, $3)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(building_id)
+    .bind(spot)
+    .fetch_one(pool)
+    .await
+    .expect("seed parking spot")
+}
+
+/// Insert a vehicle registration raw so we can set a cross-tenant
+/// `parking_spot_id` (the repo create method does not accept one, and the
+/// column has no FK — exactly the hazard under test).
+async fn seed_vehicle_registration(
+    pool: &PgPool,
+    org_id: Uuid,
+    unit_id: Uuid,
+    owner_id: Uuid,
+    parking_spot_id: Uuid,
+) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO vehicle_registrations
+            (tenant_id, unit_id, owner_id, vehicle_type, make, model,
+             license_plate, parking_spot_id, status)
+        VALUES ($1, $2, $3, 'car', 'Skoda', 'Octavia', 'BL-123-AB', $4, 'approved')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(unit_id)
+    .bind(owner_id)
+    .bind(parking_spot_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed vehicle registration")
+}
+
+#[sqlx::test]
+async fn details_does_not_leak_cross_tenant_parking_spot(pool: PgPool) {
+    let org_a = seed_org(&pool, "registry-a").await;
+    let org_b = seed_org(&pool, "registry-b").await;
+    let owner = seed_user(&pool, "owner@registry.test").await;
+
+    let building_a = seed_building(&pool, org_a, "registry-a").await;
+    let unit_a = seed_unit(&pool, building_a, "A-1").await;
+
+    // Org B owns a parking spot in its own building.
+    let building_b = seed_building(&pool, org_b, "registry-b").await;
+    let spot_b = seed_parking_spot(&pool, org_b, building_b, "B-007").await;
+
+    // Org A's registration points (stale/tampered) at Org B's spot.
+    let reg_id = seed_vehicle_registration(&pool, org_a, unit_a, owner, spot_b).await;
+
+    let repo = RegistryRepository::new(pool.clone());
+
+    let details = repo
+        .get_vehicle_registration_with_details(org_a, reg_id)
+        .await
+        .expect("query details")
+        .expect("registration exists for its own tenant");
+
+    // The registration itself still resolves for its owning tenant…
+    assert_eq!(details.registration.id, reg_id);
+    // …but the foreign tenant's parking spot number must NOT leak (PAP-143).
+    assert_eq!(
+        details.parking_spot_number, None,
+        "cross-tenant parking_spot_id must not leak Org B's spot_number"
+    );
+}
+
+#[sqlx::test]
+async fn details_returns_same_tenant_parking_spot(pool: PgPool) {
+    let org_a = seed_org(&pool, "registry-ok").await;
+    let owner = seed_user(&pool, "owner@registry-ok.test").await;
+
+    let building_a = seed_building(&pool, org_a, "registry-ok").await;
+    let unit_a = seed_unit(&pool, building_a, "A-1").await;
+    let spot_a = seed_parking_spot(&pool, org_a, building_a, "A-042").await;
+
+    let reg_id = seed_vehicle_registration(&pool, org_a, unit_a, owner, spot_a).await;
+
+    let repo = RegistryRepository::new(pool.clone());
+
+    let details = repo
+        .get_vehicle_registration_with_details(org_a, reg_id)
+        .await
+        .expect("query details")
+        .expect("registration exists");
+
+    // A same-tenant spot is still resolved — the fix scopes, it does not break.
+    assert_eq!(details.parking_spot_number.as_deref(), Some("A-042"));
+}


### PR DESCRIPTION
## PAP-143 — WS-A IDOR defense-in-depth top-ups

### What
- **registry.rs (the actual PAP-143 ask):** `get_vehicle_registration_with_details` leaked another tenant's parking spot number. The secondary `SELECT spot_number FROM parking_spots WHERE id = $1` dropped the `AND tenant_id` predicate the rest of `registry.rs` uses. `vehicle_registrations.parking_spot_id` carries **no FK**, so a stale/tampered row can point cross-tenant. Added `AND tenant_id = $2`, threading the already-verified caller tenant.
- **vendor.rs residual (already on dev):** the `update_contract` / `delete_contract` / `update_invoice` org-keying called for in PAP-143 already landed via the PAP-129 org-keying sweep (#1260) — verified `crates/db/src/repositories/vendor.rs` is identical to `dev`. No change needed.

### Two pre-existing defects this surfaced (same by-id read path)
Both were masked because FORCE RLS normally returns zero rows here (the PAP-136 "deny-all-masked decode" pattern); the superuser-pool regression test exposed them:
- `get_vehicle_registration` ran `SELECT *`, but `vehicle_type`/`status` are Postgres ENUMs decoded into `String` → `ColumnDecode` on any real row. Now casts `::text` with an explicit column list.
- the `unit_info` subquery selected `u.unit_number`, a column that does not exist (`units` uses `designation`). Now aliases `designation AS unit_number`.

These make the method PAP-143 hardens actually function, so the fix is verifiable end-to-end.

### Tests
`backend/crates/db/tests/registry_parking_spot_cross_tenant_tests.rs` (db-crate, superuser pool — bypasses FORCE RLS so the SQL predicate is what's exercised):
- `details_does_not_leak_cross_tenant_parking_spot` — Org A registration points at Org B's spot → `parking_spot_number` is `None`.
- `details_returns_same_tenant_parking_spot` — same-tenant spot still resolves.

Both green on mercury (`cargo test -p db --test registry_parking_spot_cross_tenant_tests`). `cargo +1.94.1 fmt --check` and `clippy -p db --all-targets -D warnings` clean.

### Follow-up
The broader registry enum-decode / `unit_number` surface (pet `get`/`with_details` reads, vehicle & pet list summaries, `review_*_registration` RETURNING, parking-spot details) has the identical latent bug but is out of PAP-143's scope — filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)