### PR TITLE
fix(api-server): cast registry enum reads + designation column on pet/vehicle/parking surface (PAP-158)

### DIFF
--- a/backend/crates/db/src/repositories/registry.rs
+++ b/backend/crates/db/src/repositories/registry.rs
@@ -46,7 +46,12 @@ impl RegistryRepository {
                 vaccination_date, vaccination_document_id, special_needs, notes, status
             )
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
-            RETURNING *
+            RETURNING
+                id, tenant_id, unit_id, owner_id, pet_name,
+                pet_type::text AS pet_type, breed, pet_size::text AS pet_size,
+                weight_kg, age_years, color, microchip_id, vaccination_date,
+                vaccination_document_id, special_needs, status::text AS status,
+                reviewed_by, reviewed_at, rejection_reason, notes, created_at, updated_at
             "#,
         )
         .bind(tenant_id)
@@ -75,8 +80,20 @@ impl RegistryRepository {
         tenant_id: Uuid,
         id: Uuid,
     ) -> Result<Option<PetRegistration>, sqlx::Error> {
+        // `pet_type` / `pet_size` / `status` are Postgres ENUMs; the model decodes
+        // them as `String`, so cast them to text explicitly. A bare `SELECT *` only
+        // ever succeeded because FORCE RLS normally returns zero rows here — see
+        // PAP-143 / PAP-136 "deny-all-masked decode" notes.
         sqlx::query_as::<_, PetRegistration>(
-            "SELECT * FROM pet_registrations WHERE id = $1 AND tenant_id = $2",
+            r#"
+            SELECT id, tenant_id, unit_id, owner_id, pet_name,
+                   pet_type::text AS pet_type, breed, pet_size::text AS pet_size,
+                   weight_kg, age_years, color, microchip_id, vaccination_date,
+                   vaccination_document_id, special_needs, status::text AS status,
+                   reviewed_by, reviewed_at, rejection_reason, notes, created_at, updated_at
+            FROM pet_registrations
+            WHERE id = $1 AND tenant_id = $2
+            "#,
         )
         .bind(id)
         .bind(tenant_id)
@@ -95,9 +112,10 @@ impl RegistryRepository {
             None => return Ok(None),
         };
 
+        // `units` has no `unit_number` column — the display value is `designation`.
         let unit_info: Option<(String, String)> = sqlx::query_as(
             r#"
-            SELECT u.unit_number, b.name as building_name
+            SELECT u.designation AS unit_number, b.name as building_name
             FROM units u
             JOIN buildings b ON b.id = u.building_id
             WHERE u.id = $1
@@ -164,9 +182,10 @@ impl RegistryRepository {
 
         let registrations = sqlx::query_as::<_, PetRegistrationSummary>(
             r#"
-            SELECT pr.id, pr.unit_id, u.unit_number,
+            SELECT pr.id, pr.unit_id, u.designation AS unit_number,
                    pr.owner_id, COALESCE(usr.name, usr.email) as owner_name,
-                   pr.pet_name, pr.pet_type, pr.breed, pr.pet_size, pr.status, pr.created_at
+                   pr.pet_name, pr.pet_type::text AS pet_type, pr.breed,
+                   pr.pet_size::text AS pet_size, pr.status::text AS status, pr.created_at
             FROM pet_registrations pr
             JOIN units u ON u.id = pr.unit_id
             LEFT JOIN users usr ON usr.id = pr.owner_id
@@ -217,7 +236,12 @@ impl RegistryRepository {
                 notes = COALESCE($13, notes),
                 updated_at = NOW()
             WHERE id = $1 AND tenant_id = $2
-            RETURNING *
+            RETURNING
+                id, tenant_id, unit_id, owner_id, pet_name,
+                pet_type::text AS pet_type, breed, pet_size::text AS pet_size,
+                weight_kg, age_years, color, microchip_id, vaccination_date,
+                vaccination_document_id, special_needs, status::text AS status,
+                reviewed_by, reviewed_at, rejection_reason, notes, created_at, updated_at
             "#,
         )
         .bind(id)
@@ -260,7 +284,12 @@ impl RegistryRepository {
                 rejection_reason = $6,
                 updated_at = NOW()
             WHERE id = $1 AND tenant_id = $2
-            RETURNING *
+            RETURNING
+                id, tenant_id, unit_id, owner_id, pet_name,
+                pet_type::text AS pet_type, breed, pet_size::text AS pet_size,
+                weight_kg, age_years, color, microchip_id, vaccination_date,
+                vaccination_document_id, special_needs, status::text AS status,
+                reviewed_by, reviewed_at, rejection_reason, notes, created_at, updated_at
             "#,
         )
         .bind(id)
@@ -305,7 +334,12 @@ impl RegistryRepository {
                 color, license_plate, registration_document_id, insurance_document_id, notes, status
             )
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-            RETURNING *
+            RETURNING
+                id, tenant_id, unit_id, owner_id,
+                vehicle_type::text AS vehicle_type, make, model, year, color,
+                license_plate, registration_document_id, insurance_document_id,
+                parking_spot_id, status::text AS status, reviewed_by, reviewed_at,
+                rejection_reason, notes, created_at, updated_at
             "#,
         )
         .bind(tenant_id)
@@ -449,14 +483,17 @@ impl RegistryRepository {
 
         let registrations = sqlx::query_as::<_, VehicleRegistrationSummary>(
             r#"
-            SELECT vr.id, vr.unit_id, u.unit_number,
+            SELECT vr.id, vr.unit_id, u.designation AS unit_number,
                    vr.owner_id, COALESCE(usr.name, usr.email) as owner_name,
-                   vr.vehicle_type, vr.make, vr.model, vr.license_plate, vr.status,
+                   vr.vehicle_type::text AS vehicle_type, vr.make, vr.model,
+                   vr.license_plate, vr.status::text AS status,
                    ps.spot_number as parking_spot_number, vr.created_at
             FROM vehicle_registrations vr
             JOIN units u ON u.id = vr.unit_id
             LEFT JOIN users usr ON usr.id = vr.owner_id
-            LEFT JOIN parking_spots ps ON ps.id = vr.parking_spot_id
+            -- Tenant-scope the spot join: parking_spot_id has no FK, so a stale
+            -- cross-tenant id must not leak a foreign spot_number here (PAP-143 DiD).
+            LEFT JOIN parking_spots ps ON ps.id = vr.parking_spot_id AND ps.tenant_id = vr.tenant_id
             WHERE vr.tenant_id = $1
                 AND ($2::uuid IS NULL OR u.building_id = $2)
                 AND ($3::uuid IS NULL OR vr.unit_id = $3)
@@ -502,7 +539,12 @@ impl RegistryRepository {
                 notes = COALESCE($11, notes),
                 updated_at = NOW()
             WHERE id = $1 AND tenant_id = $2
-            RETURNING *
+            RETURNING
+                id, tenant_id, unit_id, owner_id,
+                vehicle_type::text AS vehicle_type, make, model, year, color,
+                license_plate, registration_document_id, insurance_document_id,
+                parking_spot_id, status::text AS status, reviewed_by, reviewed_at,
+                rejection_reason, notes, created_at, updated_at
             "#,
         )
         .bind(id)
@@ -543,7 +585,12 @@ impl RegistryRepository {
                 rejection_reason = $6,
                 updated_at = NOW()
             WHERE id = $1 AND tenant_id = $2
-            RETURNING *
+            RETURNING
+                id, tenant_id, unit_id, owner_id,
+                vehicle_type::text AS vehicle_type, make, model, year, color,
+                license_plate, registration_document_id, insurance_document_id,
+                parking_spot_id, status::text AS status, reviewed_by, reviewed_at,
+                rejection_reason, notes, created_at, updated_at
             "#,
         )
         .bind(id)
@@ -655,7 +702,7 @@ impl RegistryRepository {
             SELECT ps.id, ps.tenant_id, ps.building_id, ps.spot_number, ps.spot_type,
                    ps.floor_level, ps.is_covered, ps.is_reserved, ps.assigned_to_unit_id,
                    ps.monthly_fee, ps.notes, ps.created_at, ps.updated_at,
-                   u.unit_number as assigned_unit_number, b.name as building_name
+                   u.designation as assigned_unit_number, b.name as building_name
             FROM parking_spots ps
             LEFT JOIN units u ON u.id = ps.assigned_to_unit_id
             JOIN buildings b ON b.id = ps.building_id

--- a/backend/crates/db/src/repositories/registry.rs
+++ b/backend/crates/db/src/repositories/registry.rs
@@ -45,7 +45,10 @@ impl RegistryRepository {
                 pet_size, weight_kg, age_years, color, microchip_id,
                 vaccination_date, vaccination_document_id, special_needs, notes, status
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+            -- pet_type / pet_size / status are ENUM columns; the String binds arrive
+            -- as text, so cast the placeholders explicitly (text -> enum is not an
+            -- implicit assignment cast in Postgres).
+            VALUES ($1, $2, $3, $4, $5::pet_type, $6, $7::pet_size, $8, $9, $10, $11, $12, $13, $14, $15, $16::registry_status)
             RETURNING
                 id, tenant_id, unit_id, owner_id, pet_name,
                 pet_type::text AS pet_type, breed, pet_size::text AS pet_size,
@@ -167,8 +170,8 @@ impl RegistryRepository {
                 AND ($2::uuid IS NULL OR u.building_id = $2)
                 AND ($3::uuid IS NULL OR pr.unit_id = $3)
                 AND ($4::uuid IS NULL OR pr.owner_id = $4)
-                AND ($5::text IS NULL OR pr.status = $5)
-                AND ($6::text IS NULL OR pr.pet_type = $6)
+                AND ($5::text IS NULL OR pr.status::text = $5)
+                AND ($6::text IS NULL OR pr.pet_type::text = $6)
             "#,
         )
         .bind(tenant_id)
@@ -193,8 +196,8 @@ impl RegistryRepository {
                 AND ($2::uuid IS NULL OR u.building_id = $2)
                 AND ($3::uuid IS NULL OR pr.unit_id = $3)
                 AND ($4::uuid IS NULL OR pr.owner_id = $4)
-                AND ($5::text IS NULL OR pr.status = $5)
-                AND ($6::text IS NULL OR pr.pet_type = $6)
+                AND ($5::text IS NULL OR pr.status::text = $5)
+                AND ($6::text IS NULL OR pr.pet_type::text = $6)
             ORDER BY pr.created_at DESC
             LIMIT $7 OFFSET $8
             "#,
@@ -225,7 +228,7 @@ impl RegistryRepository {
             UPDATE pet_registrations SET
                 pet_name = COALESCE($3, pet_name),
                 breed = COALESCE($4, breed),
-                pet_size = COALESCE($5, pet_size),
+                pet_size = COALESCE($5::pet_size, pet_size),
                 weight_kg = COALESCE($6, weight_kg),
                 age_years = COALESCE($7, age_years),
                 color = COALESCE($8, color),
@@ -278,7 +281,7 @@ impl RegistryRepository {
         sqlx::query_as::<_, PetRegistration>(
             r#"
             UPDATE pet_registrations SET
-                status = $3,
+                status = $3::registry_status,
                 reviewed_by = $4,
                 reviewed_at = $5,
                 rejection_reason = $6,
@@ -333,7 +336,9 @@ impl RegistryRepository {
                 tenant_id, unit_id, owner_id, vehicle_type, make, model, year,
                 color, license_plate, registration_document_id, insurance_document_id, notes, status
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+            -- vehicle_type / status are ENUM columns; cast the String-bound
+            -- placeholders explicitly (text -> enum is not an implicit cast).
+            VALUES ($1, $2, $3, $4::vehicle_type, $5, $6, $7, $8, $9, $10, $11, $12, $13::registry_status)
             RETURNING
                 id, tenant_id, unit_id, owner_id,
                 vehicle_type::text AS vehicle_type, make, model, year, color,
@@ -468,8 +473,8 @@ impl RegistryRepository {
                 AND ($2::uuid IS NULL OR u.building_id = $2)
                 AND ($3::uuid IS NULL OR vr.unit_id = $3)
                 AND ($4::uuid IS NULL OR vr.owner_id = $4)
-                AND ($5::text IS NULL OR vr.status = $5)
-                AND ($6::text IS NULL OR vr.vehicle_type = $6)
+                AND ($5::text IS NULL OR vr.status::text = $5)
+                AND ($6::text IS NULL OR vr.vehicle_type::text = $6)
             "#,
         )
         .bind(tenant_id)
@@ -498,8 +503,8 @@ impl RegistryRepository {
                 AND ($2::uuid IS NULL OR u.building_id = $2)
                 AND ($3::uuid IS NULL OR vr.unit_id = $3)
                 AND ($4::uuid IS NULL OR vr.owner_id = $4)
-                AND ($5::text IS NULL OR vr.status = $5)
-                AND ($6::text IS NULL OR vr.vehicle_type = $6)
+                AND ($5::text IS NULL OR vr.status::text = $5)
+                AND ($6::text IS NULL OR vr.vehicle_type::text = $6)
             ORDER BY vr.created_at DESC
             LIMIT $7 OFFSET $8
             "#,
@@ -579,7 +584,7 @@ impl RegistryRepository {
         sqlx::query_as::<_, VehicleRegistration>(
             r#"
             UPDATE vehicle_registrations SET
-                status = $3,
+                status = $3::registry_status,
                 reviewed_by = $4,
                 reviewed_at = $5,
                 rejection_reason = $6,

--- a/backend/crates/db/tests/registry_enum_decode_tests.rs
+++ b/backend/crates/db/tests/registry_enum_decode_tests.rs
@@ -1,0 +1,324 @@
+//! Regression tests for PAP-158 — enum-decode + `unit_number` column defects on
+//! the registry read/list/RETURNING surface in
+//! [`db::repositories::RegistryRepository`].
+//!
+//! PAP-143 fixed only the *vehicle by-id* read. The pet reads, both list
+//! summaries, the `review_*` / `create_*` / `update_*` `RETURNING` paths, and the
+//! parking-spot detail join carried the same two latent defects:
+//!
+//!   1. ENUM columns (`pet_type`, `pet_size`, `vehicle_type`, `status`) selected
+//!      bare into the `String` model fields. SQLx rejects an enum OID where it
+//!      expects text, so any query that actually returns a row fails to decode —
+//!      masked in production only because FORCE RLS normally returns zero rows
+//!      (the PAP-136 "deny-all-masked decode" pattern).
+//!   2. `units.unit_number` does not exist — the display column is `designation`.
+//!
+//! CI runs these repo tests against a superuser pool that bypasses FORCE RLS, so
+//! a real row IS returned here: pre-fix every query below errors on decode (or on
+//! the missing column); post-fix they resolve cleanly. A second test pins the
+//! defense-in-depth tenant scope added to the vehicle-list `parking_spots` join.
+
+use db::models::{
+    registry_status, CreatePetRegistration, CreateVehicleRegistration, PetRegistrationQuery,
+    ReviewRegistration, VehicleRegistrationQuery,
+};
+use db::repositories::RegistryRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Registry {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@registry.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'test_hash', 'Registry User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_building(pool: &PgPool, org_id: Uuid, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO buildings (organization_id, street, city, postal_code, country, name)
+        VALUES ($1, $2, 'Bratislava', '81101', 'Slovakia', $3)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(format!("{slug} Street 1"))
+    .bind(format!("{slug} Building"))
+    .fetch_one(pool)
+    .await
+    .expect("seed building")
+}
+
+async fn seed_unit(pool: &PgPool, building_id: Uuid, designation: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO units (building_id, designation) VALUES ($1, $2) RETURNING id",
+    )
+    .bind(building_id)
+    .bind(designation)
+    .fetch_one(pool)
+    .await
+    .expect("seed unit")
+}
+
+async fn seed_parking_spot(pool: &PgPool, org_id: Uuid, building_id: Uuid, spot: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO parking_spots (tenant_id, building_id, spot_number)
+        VALUES ($1, $2, $3)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(building_id)
+    .bind(spot)
+    .fetch_one(pool)
+    .await
+    .expect("seed parking spot")
+}
+
+/// Exercises every fixed read/list/RETURNING path in a single migrated DB:
+/// enum columns must decode into the `String` model fields, and `unit_number`
+/// must resolve from `units.designation`.
+#[sqlx::test]
+async fn registry_reads_decode_enums_and_resolve_designation(pool: PgPool) {
+    let org = seed_org(&pool, "pap158").await;
+    let owner = seed_user(&pool, "owner@pap158.test").await;
+    let building = seed_building(&pool, org, "pap158").await;
+    let unit = seed_unit(&pool, building, "A-101").await;
+
+    let repo = RegistryRepository::new(pool.clone());
+
+    // -- Pet: create RETURNING + by-id + with-details + list summary ----------
+    let pet = repo
+        .create_pet_registration(
+            org,
+            owner,
+            CreatePetRegistration {
+                unit_id: unit,
+                pet_name: "Rex".into(),
+                pet_type: "dog".into(),
+                breed: Some("Beagle".into()),
+                pet_size: "medium".into(),
+                weight_kg: None,
+                age_years: Some(3),
+                color: Some("brown".into()),
+                microchip_id: None,
+                vaccination_date: None,
+                vaccination_document_id: None,
+                special_needs: None,
+                notes: None,
+            },
+        )
+        .await
+        .expect("create pet registration decodes enums on RETURNING");
+    assert_eq!(pet.pet_type, "dog");
+    assert_eq!(pet.pet_size, "medium");
+    assert_eq!(pet.status, registry_status::PENDING);
+
+    let pet_by_id = repo
+        .get_pet_registration(org, pet.id)
+        .await
+        .expect("get_pet_registration decodes enums")
+        .expect("pet exists");
+    assert_eq!(pet_by_id.pet_type, "dog");
+    assert_eq!(pet_by_id.status, registry_status::PENDING);
+
+    let pet_details = repo
+        .get_pet_registration_with_details(org, pet.id)
+        .await
+        .expect("pet with-details query")
+        .expect("pet exists");
+    assert_eq!(pet_details.unit_number.as_deref(), Some("A-101"));
+    assert_eq!(
+        pet_details.building_name.as_deref(),
+        Some("pap158 Building")
+    );
+
+    let (pet_list, pet_total) = repo
+        .list_pet_registrations(org, PetRegistrationQuery::default())
+        .await
+        .expect("list pet registrations decodes enums + designation");
+    assert_eq!(pet_total, 1);
+    assert_eq!(pet_list.len(), 1);
+    assert_eq!(pet_list[0].pet_type, "dog");
+    assert_eq!(pet_list[0].pet_size, "medium");
+    assert_eq!(pet_list[0].status, registry_status::PENDING);
+    assert_eq!(pet_list[0].unit_number.as_deref(), Some("A-101"));
+
+    let reviewed_pet = repo
+        .review_pet_registration(
+            org,
+            pet.id,
+            owner,
+            ReviewRegistration {
+                approve: true,
+                rejection_reason: None,
+            },
+        )
+        .await
+        .expect("review pet decodes enums on RETURNING")
+        .expect("pet exists");
+    assert_eq!(reviewed_pet.status, registry_status::APPROVED);
+
+    // -- Vehicle: create RETURNING + with-details + list summary -------------
+    let vehicle = repo
+        .create_vehicle_registration(
+            org,
+            owner,
+            CreateVehicleRegistration {
+                unit_id: unit,
+                vehicle_type: "car".into(),
+                make: "Skoda".into(),
+                model: "Octavia".into(),
+                year: Some(2022),
+                color: Some("blue".into()),
+                license_plate: "BL-158-AB".into(),
+                registration_document_id: None,
+                insurance_document_id: None,
+                notes: None,
+            },
+        )
+        .await
+        .expect("create vehicle registration decodes enums on RETURNING");
+    assert_eq!(vehicle.vehicle_type, "car");
+    assert_eq!(vehicle.status, registry_status::PENDING);
+
+    let vehicle_details = repo
+        .get_vehicle_registration_with_details(org, vehicle.id)
+        .await
+        .expect("vehicle with-details query")
+        .expect("vehicle exists");
+    assert_eq!(vehicle_details.unit_number.as_deref(), Some("A-101"));
+
+    let (vehicle_list, vehicle_total) = repo
+        .list_vehicle_registrations(org, VehicleRegistrationQuery::default())
+        .await
+        .expect("list vehicle registrations decodes enums + designation");
+    assert_eq!(vehicle_total, 1);
+    assert_eq!(vehicle_list.len(), 1);
+    assert_eq!(vehicle_list[0].vehicle_type, "car");
+    assert_eq!(vehicle_list[0].status, registry_status::PENDING);
+    assert_eq!(vehicle_list[0].unit_number.as_deref(), Some("A-101"));
+
+    let reviewed_vehicle = repo
+        .review_vehicle_registration(
+            org,
+            vehicle.id,
+            owner,
+            ReviewRegistration {
+                approve: false,
+                rejection_reason: Some("missing insurance".into()),
+            },
+        )
+        .await
+        .expect("review vehicle decodes enums on RETURNING")
+        .expect("vehicle exists");
+    assert_eq!(reviewed_vehicle.status, registry_status::REJECTED);
+
+    // -- Parking spot detail join resolves the assigned unit designation -----
+    sqlx::query(
+        r#"
+        INSERT INTO parking_spots (tenant_id, building_id, spot_number, assigned_to_unit_id)
+        VALUES ($1, $2, 'P-1', $3)
+        "#,
+    )
+    .bind(org)
+    .bind(building)
+    .bind(unit)
+    .execute(&pool)
+    .await
+    .expect("seed assigned parking spot");
+
+    let (spots, spot_total) = repo
+        .list_parking_spots(org, Default::default())
+        .await
+        .expect("list parking spots resolves designation");
+    assert_eq!(spot_total, 1);
+    assert_eq!(spots.len(), 1);
+    assert_eq!(spots[0].assigned_unit_number.as_deref(), Some("A-101"));
+}
+
+/// Insert a vehicle registration raw so we can set a cross-tenant
+/// `parking_spot_id` (the repo create method does not accept one, and the column
+/// has no FK — exactly the hazard under test).
+async fn seed_vehicle_registration_with_spot(
+    pool: &PgPool,
+    org_id: Uuid,
+    unit_id: Uuid,
+    owner_id: Uuid,
+    parking_spot_id: Uuid,
+) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO vehicle_registrations
+            (tenant_id, unit_id, owner_id, vehicle_type, make, model,
+             license_plate, parking_spot_id, status)
+        VALUES ($1, $2, $3, 'car', 'Skoda', 'Octavia', 'BL-123-AB', $4, 'approved')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(unit_id)
+    .bind(owner_id)
+    .bind(parking_spot_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed vehicle registration")
+}
+
+/// The vehicle *list* summary joins `parking_spots` on `vr.parking_spot_id`.
+/// That column carries no FK, so without a tenant predicate on the join a stale
+/// cross-tenant id would leak a foreign tenant's `spot_number` into the list —
+/// the same leak PAP-143 closed on the by-id detail path. PAP-158 scopes the
+/// join; this test pins it (pre-fix: leaks "B-007"; post-fix: None).
+#[sqlx::test]
+async fn vehicle_list_does_not_leak_cross_tenant_parking_spot(pool: PgPool) {
+    let org_a = seed_org(&pool, "list-a").await;
+    let org_b = seed_org(&pool, "list-b").await;
+    let owner = seed_user(&pool, "owner@list.test").await;
+
+    let building_a = seed_building(&pool, org_a, "list-a").await;
+    let unit_a = seed_unit(&pool, building_a, "A-1").await;
+
+    let building_b = seed_building(&pool, org_b, "list-b").await;
+    let spot_b = seed_parking_spot(&pool, org_b, building_b, "B-007").await;
+
+    let _reg = seed_vehicle_registration_with_spot(&pool, org_a, unit_a, owner, spot_b).await;
+
+    let repo = RegistryRepository::new(pool.clone());
+
+    let (list, total) = repo
+        .list_vehicle_registrations(org_a, VehicleRegistrationQuery::default())
+        .await
+        .expect("list vehicle registrations");
+
+    assert_eq!(total, 1, "Org A sees its own registration");
+    assert_eq!(list.len(), 1);
+    assert_eq!(
+        list[0].parking_spot_number, None,
+        "cross-tenant parking_spot_id must not leak Org B's spot_number into the list"
+    );
+}

--- a/backend/crates/db/tests/registry_enum_decode_tests.rs
+++ b/backend/crates/db/tests/registry_enum_decode_tests.rs
@@ -20,7 +20,7 @@
 
 use db::models::{
     registry_status, CreatePetRegistration, CreateVehicleRegistration, PetRegistrationQuery,
-    ReviewRegistration, VehicleRegistrationQuery,
+    ReviewRegistration, UpdatePetRegistration, VehicleRegistrationQuery,
 };
 use db::repositories::RegistryRepository;
 use sqlx::PgPool;
@@ -167,6 +167,32 @@ async fn registry_reads_decode_enums_and_resolve_designation(pool: PgPool) {
     assert_eq!(pet_list[0].pet_size, "medium");
     assert_eq!(pet_list[0].status, registry_status::PENDING);
     assert_eq!(pet_list[0].unit_number.as_deref(), Some("A-101"));
+
+    // update RETURNING decode + the pet_size ENUM encode cast (COALESCE($n::pet_size)).
+    let updated_pet = repo
+        .update_pet_registration(
+            org,
+            pet.id,
+            UpdatePetRegistration {
+                pet_name: None,
+                breed: None,
+                pet_size: Some("large".into()),
+                weight_kg: None,
+                age_years: None,
+                color: None,
+                microchip_id: None,
+                vaccination_date: None,
+                vaccination_document_id: None,
+                special_needs: None,
+                notes: None,
+            },
+        )
+        .await
+        .expect("update pet decodes enums on RETURNING + encodes pet_size")
+        .expect("pet exists");
+    assert_eq!(updated_pet.pet_size, "large");
+    assert_eq!(updated_pet.pet_type, "dog");
+    assert_eq!(updated_pet.status, registry_status::PENDING);
 
     let reviewed_pet = repo
         .review_pet_registration(


### PR DESCRIPTION
## Summary

DiD top-up following **PAP-143** (PR #1271), which repaired only the *vehicle by-id* read. The rest of the registry read/list/RETURNING surface in `backend/crates/db/src/repositories/registry.rs` carried the same two latent defects, masked in production by FORCE RLS returning zero rows (the PAP-136 "deny-all-masked decode" pattern — they only surface when a real row is returned, e.g. the CI superuser pool or any future raw-pool path):

1. **ENUM → `String` decode.** `pet_type`, `pet_size`, `vehicle_type`, `status` are Postgres ENUMs; the models decode them as `String`. SQLx rejects an enum OID where it expects text, so bare `SELECT *` / `RETURNING *` fail to decode a returned row. Replaced with explicit column lists casting `::text`.
2. **Non-existent `units.unit_number`.** The display column is `designation`. Aliased `u.designation AS unit_number` everywhere it was read.

## Changes (`registry.rs`)

**Enum `::text` casts** — pet `create`/`get`/`update`/`review`; vehicle `create`/`update`/`review`; both list summaries.
**`u.designation AS unit_number`** — pet by-id details, pet list summary, vehicle list summary, parking-spot list (`assigned_unit_number`).
**DiD bonus** — tenant-scoped the vehicle-**list** `parking_spots` join (`AND ps.tenant_id = vr.tenant_id`); `parking_spot_id` has no FK, so a stale cross-tenant id could leak a foreign `spot_number` in the list. List-path analogue of PAP-143's by-id fix.

## Tests

`crates/db/tests/registry_enum_decode_tests.rs` (superuser pool bypasses FORCE RLS → a real row IS returned, exercising the decode prod masks):
- `registry_reads_decode_enums_and_resolve_designation` — one migrated DB exercising every fixed decode + designation path (pet/vehicle create→get→details→list→review, parking detail join).
- `vehicle_list_does_not_leak_cross_tenant_parking_spot` — pins the new join tenant-scope (pre-fix leaks `B-007`; post-fix `None`).

Compiles clean (`cargo test -p db --no-run`) + `cargo fmt --check` clean. Full `#[sqlx::test]` migrator run is the CI `backend.yml` gate.

## Out of scope → follow-up

PAP-159: `building_registry_rules.allowed_pet_types` is a `pet_type[]` enum **array** decoded into `Vec<String>` (same defect class, needs an encode-side bind cast too). Filed under PAP-136, routed to CTO.

## Notes

Pure read/decode correctness + DiD. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
