### PR TITLE
fix(api-server): close esg_reporting cross-tenant IDOR — RLS executor + org keying (PAP-139)

### DIFF
--- a/backend/crates/db/src/repositories/esg_reporting.rs
+++ b/backend/crates/db/src/repositories/esg_reporting.rs
@@ -1,29 +1,55 @@
 // Epic 136: ESG Reporting Dashboard
 // Repository for ESG (Environmental, Social, Governance) reporting and compliance
+//
+// # RLS Integration (PAP-139 / PAP-72 / PAP-67 / PAP-80)
+//
+// Migration `00179` put `FORCE ROW LEVEL SECURITY` + the canonical
+// `get_current_org_id()` policy on every ESG table (`esg_configurations`,
+// `esg_metrics`, `carbon_footprints`, `esg_benchmarks`, `esg_targets`,
+// `esg_reports`, `eu_taxonomy_assessments`, `esg_dashboard_metrics`,
+// `esg_import_jobs`). Under `FORCE` the api-server's owner connection is no
+// longer exempt, so a query issued on a connection without
+// `app.current_org_id` set collapses to deny-all — this was PAP-72
+// (`/api/v1/esg` returning empty/deny under FORCE because the repository ran on
+// the raw pool).
+//
+// Every method therefore takes an **executor whose connection already has RLS
+// context set** (org + user GUCs) — in handlers this comes from the
+// `RlsConnection` extractor via `&mut **rls.conn()`. The repository holds
+// **no pool**, so there is no way to issue a query that bypasses RLS. This
+// mirrors the `board_meetings.rs` / `vendor.rs` / `work_order.rs` precedent.
+//
+// Cross-tenant safety (PAP-136 defense-in-depth): RLS is the primary boundary,
+// but by-id queries stay org-keyed — a connection whose role bypasses RLS
+// (superuser pools, BYPASSRLS) must still never resolve another tenant's row.
+// Every ESG table carries its own `organization_id`, so each by-id read /
+// update / delete is keyed `WHERE id = $1 AND organization_id = $N`; a
+// cross-tenant probe resolves to no row → `404`/`no-op`.
 
 use chrono::{Datelike, Utc};
 use rust_decimal::Decimal;
-use sqlx::PgPool;
+use sqlx::{Executor, PgConnection, Postgres};
 use uuid::Uuid;
 
 use crate::models::esg_reporting::*;
 use crate::DbPool;
 
 /// Repository for ESG reporting operations.
+///
+/// Stateless: every method receives an RLS-context-bearing executor. The repo
+/// holds no pool so it cannot issue an un-scoped (deny-all under `FORCE`) query.
 #[derive(Clone)]
-pub struct EsgReportingRepository {
-    pool: DbPool,
-}
+pub struct EsgReportingRepository;
 
 impl EsgReportingRepository {
     /// Create a new repository instance.
-    pub fn new(pool: DbPool) -> Self {
-        Self { pool }
-    }
-
-    /// Get the underlying pool reference.
-    pub fn pool(&self) -> &PgPool {
-        &self.pool
+    ///
+    /// The pool argument is retained for construction-site compatibility with
+    /// the other repositories on `AppState`; this repo deliberately does not
+    /// store it (see module docs — all queries run on a context-set connection
+    /// supplied by the handler's `RlsConnection`).
+    pub fn new(_pool: DbPool) -> Self {
+        Self
     }
 
     // =========================================================================
@@ -31,10 +57,14 @@ impl EsgReportingRepository {
     // =========================================================================
 
     /// Get ESG configuration for an organization.
-    pub async fn get_configuration(
+    pub async fn get_configuration<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
-    ) -> Result<Option<EsgConfiguration>, sqlx::Error> {
+    ) -> Result<Option<EsgConfiguration>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EsgConfiguration>(
             r#"
             SELECT id, organization_id, reporting_currency, default_unit_system,
@@ -46,16 +76,20 @@ impl EsgReportingRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Create or update ESG configuration.
-    pub async fn upsert_configuration(
+    pub async fn upsert_configuration<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         input: CreateEsgConfiguration,
-    ) -> Result<EsgConfiguration, sqlx::Error> {
+    ) -> Result<EsgConfiguration, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EsgConfiguration>(
             r#"
             INSERT INTO esg_configurations (
@@ -92,7 +126,7 @@ impl EsgReportingRepository {
         .bind(input.carbon_reduction_target_pct)
         .bind(input.target_year)
         .bind(input.baseline_year)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
@@ -101,12 +135,16 @@ impl EsgReportingRepository {
     // =========================================================================
 
     /// Create an ESG metric.
-    pub async fn create_metric(
+    pub async fn create_metric<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         user_id: Uuid,
         input: CreateEsgMetric,
-    ) -> Result<EsgMetric, sqlx::Error> {
+    ) -> Result<EsgMetric, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EsgMetric>(
             r#"
             INSERT INTO esg_metrics (
@@ -135,12 +173,20 @@ impl EsgReportingRepository {
         .bind(input.confidence_level)
         .bind(input.notes.as_deref())
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
-    /// Get ESG metric by ID.
-    pub async fn get_metric(&self, id: Uuid) -> Result<Option<EsgMetric>, sqlx::Error> {
+    /// Get ESG metric by ID, scoped to the owning organization.
+    pub async fn get_metric<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        organization_id: Uuid,
+    ) -> Result<Option<EsgMetric>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EsgMetric>(
             r#"
             SELECT id, organization_id, building_id, period_start, period_end,
@@ -148,20 +194,25 @@ impl EsgReportingRepository {
                    data_source, confidence_level, verification_status, verified_by,
                    verified_at, notes, supporting_documents, created_at, updated_at, created_by
             FROM esg_metrics
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             "#,
         )
         .bind(id)
-        .fetch_optional(&self.pool)
+        .bind(organization_id)
+        .fetch_optional(executor)
         .await
     }
 
     /// List ESG metrics with filters.
-    pub async fn list_metrics(
+    pub async fn list_metrics<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         query: EsgMetricsQuery,
-    ) -> Result<Vec<EsgMetric>, sqlx::Error> {
+    ) -> Result<Vec<EsgMetric>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50).min(100);
         let offset = query.offset.unwrap_or(0);
 
@@ -190,26 +241,31 @@ impl EsgReportingRepository {
         .bind(query.period_end)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
-    /// Update an ESG metric.
-    pub async fn update_metric(
+    /// Update an ESG metric, scoped to the owning organization.
+    pub async fn update_metric<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
+        organization_id: Uuid,
         input: UpdateEsgMetric,
-    ) -> Result<Option<EsgMetric>, sqlx::Error> {
+    ) -> Result<Option<EsgMetric>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EsgMetric>(
             r#"
             UPDATE esg_metrics
-            SET value = COALESCE($2, value),
-                unit = COALESCE($3, unit),
-                normalized_value = COALESCE($4, normalized_value),
-                confidence_level = COALESCE($5, confidence_level),
-                notes = COALESCE($6, notes),
+            SET value = COALESCE($3, value),
+                unit = COALESCE($4, unit),
+                normalized_value = COALESCE($5, normalized_value),
+                confidence_level = COALESCE($6, confidence_level),
+                notes = COALESCE($7, notes),
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             RETURNING id, organization_id, building_id, period_start, period_end,
                       category, metric_type, metric_name, value, unit, normalized_value,
                       data_source, confidence_level, verification_status, verified_by,
@@ -217,30 +273,36 @@ impl EsgReportingRepository {
             "#,
         )
         .bind(id)
+        .bind(organization_id)
         .bind(input.value)
         .bind(input.unit.as_deref())
         .bind(input.normalized_value)
         .bind(input.confidence_level)
         .bind(input.notes.as_deref())
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
-    /// Verify an ESG metric.
-    pub async fn verify_metric(
+    /// Verify an ESG metric, scoped to the owning organization.
+    pub async fn verify_metric<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
+        organization_id: Uuid,
         verifier_id: Uuid,
         status: &str,
-    ) -> Result<Option<EsgMetric>, sqlx::Error> {
+    ) -> Result<Option<EsgMetric>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EsgMetric>(
             r#"
             UPDATE esg_metrics
-            SET verification_status = $2,
-                verified_by = $3,
+            SET verification_status = $3,
+                verified_by = $4,
                 verified_at = NOW(),
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             RETURNING id, organization_id, building_id, period_start, period_end,
                       category, metric_type, metric_name, value, unit, normalized_value,
                       data_source, confidence_level, verification_status, verified_by,
@@ -248,17 +310,27 @@ impl EsgReportingRepository {
             "#,
         )
         .bind(id)
+        .bind(organization_id)
         .bind(status)
         .bind(verifier_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
-    /// Delete an ESG metric.
-    pub async fn delete_metric(&self, id: Uuid) -> Result<bool, sqlx::Error> {
-        let result = sqlx::query("DELETE FROM esg_metrics WHERE id = $1")
+    /// Delete an ESG metric, scoped to the owning organization.
+    pub async fn delete_metric<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        organization_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let result = sqlx::query("DELETE FROM esg_metrics WHERE id = $1 AND organization_id = $2")
             .bind(id)
-            .execute(&self.pool)
+            .bind(organization_id)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
@@ -268,11 +340,15 @@ impl EsgReportingRepository {
     // =========================================================================
 
     /// Create a carbon footprint record.
-    pub async fn create_carbon_footprint(
+    pub async fn create_carbon_footprint<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         input: CreateCarbonFootprint,
-    ) -> Result<CarbonFootprint, sqlx::Error> {
+    ) -> Result<CarbonFootprint, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // Calculate CO2 equivalent
         let co2_equivalent_kg = input.consumption_value * input.emission_factor;
         let co2_per_sqm = input
@@ -314,15 +390,20 @@ impl EsgReportingRepository {
         .bind(co2_per_sqm)
         .bind(input.num_units)
         .bind(co2_per_unit)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
-    /// Get carbon footprint by ID.
-    pub async fn get_carbon_footprint(
+    /// Get carbon footprint by ID, scoped to the owning organization.
+    pub async fn get_carbon_footprint<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
-    ) -> Result<Option<CarbonFootprint>, sqlx::Error> {
+        organization_id: Uuid,
+    ) -> Result<Option<CarbonFootprint>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, CarbonFootprint>(
             r#"
             SELECT id, organization_id, building_id, year, month, source_type,
@@ -330,20 +411,25 @@ impl EsgReportingRepository {
                    co2_equivalent_kg, area_sqm, co2_per_sqm, num_units, co2_per_unit,
                    calculation_methodology, created_at, updated_at
             FROM carbon_footprints
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             "#,
         )
         .bind(id)
-        .fetch_optional(&self.pool)
+        .bind(organization_id)
+        .fetch_optional(executor)
         .await
     }
 
     /// List carbon footprints with filters.
-    pub async fn list_carbon_footprints(
+    pub async fn list_carbon_footprints<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         query: CarbonFootprintQuery,
-    ) -> Result<Vec<CarbonFootprint>, sqlx::Error> {
+    ) -> Result<Vec<CarbonFootprint>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, CarbonFootprint>(
             r#"
             SELECT id, organization_id, building_id, year, month, source_type,
@@ -363,16 +449,20 @@ impl EsgReportingRepository {
         .bind(query.building_id)
         .bind(query.year)
         .bind(query.source_type)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Get carbon footprint summary by year.
-    pub async fn get_carbon_summary(
+    pub async fn get_carbon_summary<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         year: i32,
-    ) -> Result<Option<CarbonFootprintSummary>, sqlx::Error> {
+    ) -> Result<Option<CarbonFootprintSummary>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, CarbonFootprintSummary>(
             r#"
             SELECT
@@ -392,16 +482,26 @@ impl EsgReportingRepository {
         )
         .bind(organization_id)
         .bind(year)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
-    /// Delete a carbon footprint record.
-    pub async fn delete_carbon_footprint(&self, id: Uuid) -> Result<bool, sqlx::Error> {
-        let result = sqlx::query("DELETE FROM carbon_footprints WHERE id = $1")
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
+    /// Delete a carbon footprint record, scoped to the owning organization.
+    pub async fn delete_carbon_footprint<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        organization_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let result =
+            sqlx::query("DELETE FROM carbon_footprints WHERE id = $1 AND organization_id = $2")
+                .bind(id)
+                .bind(organization_id)
+                .execute(executor)
+                .await?;
         Ok(result.rows_affected() > 0)
     }
 
@@ -410,11 +510,15 @@ impl EsgReportingRepository {
     // =========================================================================
 
     /// Create an ESG benchmark.
-    pub async fn create_benchmark(
+    pub async fn create_benchmark<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         input: CreateEsgBenchmark,
-    ) -> Result<EsgBenchmark, sqlx::Error> {
+    ) -> Result<EsgBenchmark, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EsgBenchmark>(
             r#"
             INSERT INTO esg_benchmarks (
@@ -437,16 +541,20 @@ impl EsgReportingRepository {
         .bind(input.source.as_deref())
         .bind(input.effective_date)
         .bind(input.expiry_date)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// List ESG benchmarks.
-    pub async fn list_benchmarks(
+    pub async fn list_benchmarks<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         category: Option<EsgBenchmarkCategory>,
-    ) -> Result<Vec<EsgBenchmark>, sqlx::Error> {
+    ) -> Result<Vec<EsgBenchmark>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EsgBenchmark>(
             r#"
             SELECT id, organization_id, name, category, metric_type, benchmark_value,
@@ -460,16 +568,26 @@ impl EsgReportingRepository {
         )
         .bind(organization_id)
         .bind(category)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
-    /// Delete an ESG benchmark.
-    pub async fn delete_benchmark(&self, id: Uuid) -> Result<bool, sqlx::Error> {
-        let result = sqlx::query("DELETE FROM esg_benchmarks WHERE id = $1")
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
+    /// Delete an ESG benchmark, scoped to the owning organization.
+    pub async fn delete_benchmark<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        organization_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let result =
+            sqlx::query("DELETE FROM esg_benchmarks WHERE id = $1 AND organization_id = $2")
+                .bind(id)
+                .bind(organization_id)
+                .execute(executor)
+                .await?;
         Ok(result.rows_affected() > 0)
     }
 
@@ -478,11 +596,15 @@ impl EsgReportingRepository {
     // =========================================================================
 
     /// Create an ESG target.
-    pub async fn create_target(
+    pub async fn create_target<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         input: CreateEsgTarget,
-    ) -> Result<EsgTarget, sqlx::Error> {
+    ) -> Result<EsgTarget, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EsgTarget>(
             r#"
             INSERT INTO esg_targets (
@@ -506,32 +628,45 @@ impl EsgReportingRepository {
         .bind(input.target_date)
         .bind(input.baseline_value)
         .bind(input.baseline_date)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
-    /// Get ESG target by ID.
-    pub async fn get_target(&self, id: Uuid) -> Result<Option<EsgTarget>, sqlx::Error> {
+    /// Get ESG target by ID, scoped to the owning organization.
+    pub async fn get_target<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        organization_id: Uuid,
+    ) -> Result<Option<EsgTarget>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EsgTarget>(
             r#"
             SELECT id, organization_id, building_id, name, category, metric_type,
                    target_value, unit, target_date, baseline_value, baseline_date,
                    current_value, progress_pct, status, created_at, updated_at
             FROM esg_targets
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             "#,
         )
         .bind(id)
-        .fetch_optional(&self.pool)
+        .bind(organization_id)
+        .fetch_optional(executor)
         .await
     }
 
     /// List ESG targets.
-    pub async fn list_targets(
+    pub async fn list_targets<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         building_id: Option<Uuid>,
-    ) -> Result<Vec<EsgTarget>, sqlx::Error> {
+    ) -> Result<Vec<EsgTarget>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EsgTarget>(
             r#"
             SELECT id, organization_id, building_id, name, category, metric_type,
@@ -545,51 +680,66 @@ impl EsgReportingRepository {
         )
         .bind(organization_id)
         .bind(building_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
-    /// Update an ESG target.
-    pub async fn update_target(
+    /// Update an ESG target, scoped to the owning organization.
+    pub async fn update_target<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
+        organization_id: Uuid,
         input: UpdateEsgTarget,
-    ) -> Result<Option<EsgTarget>, sqlx::Error> {
+    ) -> Result<Option<EsgTarget>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // Calculate progress if current_value and baseline are available
         sqlx::query_as::<_, EsgTarget>(
             r#"
             UPDATE esg_targets
-            SET target_value = COALESCE($2, target_value),
-                target_date = COALESCE($3, target_date),
-                current_value = COALESCE($4, current_value),
+            SET target_value = COALESCE($3, target_value),
+                target_date = COALESCE($4, target_date),
+                current_value = COALESCE($5, current_value),
                 progress_pct = CASE
-                    WHEN baseline_value IS NOT NULL AND COALESCE($4, current_value) IS NOT NULL
+                    WHEN baseline_value IS NOT NULL AND COALESCE($5, current_value) IS NOT NULL
                          AND baseline_value != target_value
-                    THEN ((baseline_value - COALESCE($4, current_value)) / (baseline_value - target_value)) * 100
+                    THEN ((baseline_value - COALESCE($5, current_value)) / (baseline_value - target_value)) * 100
                     ELSE progress_pct
                 END,
-                status = COALESCE($5, status),
+                status = COALESCE($6, status),
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             RETURNING id, organization_id, building_id, name, category, metric_type,
                       target_value, unit, target_date, baseline_value, baseline_date,
                       current_value, progress_pct, status, created_at, updated_at
             "#,
         )
         .bind(id)
+        .bind(organization_id)
         .bind(input.target_value)
         .bind(input.target_date)
         .bind(input.current_value)
         .bind(input.status.as_deref())
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
-    /// Delete an ESG target.
-    pub async fn delete_target(&self, id: Uuid) -> Result<bool, sqlx::Error> {
-        let result = sqlx::query("DELETE FROM esg_targets WHERE id = $1")
+    /// Delete an ESG target, scoped to the owning organization.
+    pub async fn delete_target<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        organization_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let result = sqlx::query("DELETE FROM esg_targets WHERE id = $1 AND organization_id = $2")
             .bind(id)
-            .execute(&self.pool)
+            .bind(organization_id)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
@@ -599,12 +749,16 @@ impl EsgReportingRepository {
     // =========================================================================
 
     /// Create an ESG report.
-    pub async fn create_report(
+    pub async fn create_report<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         user_id: Uuid,
         input: CreateEsgReport,
-    ) -> Result<EsgReport, sqlx::Error> {
+    ) -> Result<EsgReport, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EsgReport>(
             r#"
             INSERT INTO esg_reports (
@@ -626,12 +780,20 @@ impl EsgReportingRepository {
         .bind(input.period_end)
         .bind(serde_json::to_value(&input.frameworks).unwrap_or(serde_json::Value::Array(vec![])))
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
-    /// Get ESG report by ID.
-    pub async fn get_report(&self, id: Uuid) -> Result<Option<EsgReport>, sqlx::Error> {
+    /// Get ESG report by ID, scoped to the owning organization.
+    pub async fn get_report<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        organization_id: Uuid,
+    ) -> Result<Option<EsgReport>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EsgReport>(
             r#"
             SELECT id, organization_id, report_type, title, description,
@@ -639,20 +801,25 @@ impl EsgReportingRepository {
                    approved_by, approved_at, report_data, summary_scores,
                    pdf_url, xml_url, created_at, updated_at, created_by
             FROM esg_reports
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             "#,
         )
         .bind(id)
-        .fetch_optional(&self.pool)
+        .bind(organization_id)
+        .fetch_optional(executor)
         .await
     }
 
     /// List ESG reports.
-    pub async fn list_reports(
+    pub async fn list_reports<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         status: Option<EsgReportStatus>,
-    ) -> Result<Vec<EsgReport>, sqlx::Error> {
+    ) -> Result<Vec<EsgReport>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EsgReport>(
             r#"
             SELECT id, organization_id, report_type, title, description,
@@ -668,26 +835,31 @@ impl EsgReportingRepository {
         )
         .bind(organization_id)
         .bind(status)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
-    /// Update an ESG report.
-    pub async fn update_report(
+    /// Update an ESG report, scoped to the owning organization.
+    pub async fn update_report<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
+        organization_id: Uuid,
         input: UpdateEsgReport,
-    ) -> Result<Option<EsgReport>, sqlx::Error> {
+    ) -> Result<Option<EsgReport>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EsgReport>(
             r#"
             UPDATE esg_reports
-            SET title = COALESCE($2, title),
-                description = COALESCE($3, description),
-                status = COALESCE($4, status),
-                report_data = COALESCE($5, report_data),
-                summary_scores = COALESCE($6, summary_scores),
+            SET title = COALESCE($3, title),
+                description = COALESCE($4, description),
+                status = COALESCE($5, status),
+                report_data = COALESCE($6, report_data),
+                summary_scores = COALESCE($7, summary_scores),
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             RETURNING id, organization_id, report_type, title, description,
                       period_start, period_end, frameworks, status, submitted_at,
                       approved_by, approved_at, report_data, summary_scores,
@@ -695,24 +867,33 @@ impl EsgReportingRepository {
             "#,
         )
         .bind(id)
+        .bind(organization_id)
         .bind(input.title.as_deref())
         .bind(input.description.as_deref())
         .bind(input.status)
         .bind(&input.report_data)
         .bind(&input.summary_scores)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
-    /// Submit an ESG report for review.
-    pub async fn submit_report(&self, id: Uuid) -> Result<Option<EsgReport>, sqlx::Error> {
+    /// Submit an ESG report for review, scoped to the owning organization.
+    pub async fn submit_report<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        organization_id: Uuid,
+    ) -> Result<Option<EsgReport>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EsgReport>(
             r#"
             UPDATE esg_reports
             SET status = 'pending_review',
                 submitted_at = NOW(),
                 updated_at = NOW()
-            WHERE id = $1 AND status = 'draft'
+            WHERE id = $1 AND organization_id = $2 AND status = 'draft'
             RETURNING id, organization_id, report_type, title, description,
                       period_start, period_end, frameworks, status, submitted_at,
                       approved_by, approved_at, report_data, summary_scores,
@@ -720,24 +901,30 @@ impl EsgReportingRepository {
             "#,
         )
         .bind(id)
-        .fetch_optional(&self.pool)
+        .bind(organization_id)
+        .fetch_optional(executor)
         .await
     }
 
-    /// Approve an ESG report.
-    pub async fn approve_report(
+    /// Approve an ESG report, scoped to the owning organization.
+    pub async fn approve_report<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
+        organization_id: Uuid,
         approver_id: Uuid,
-    ) -> Result<Option<EsgReport>, sqlx::Error> {
+    ) -> Result<Option<EsgReport>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EsgReport>(
             r#"
             UPDATE esg_reports
             SET status = 'approved',
-                approved_by = $2,
+                approved_by = $3,
                 approved_at = NOW(),
                 updated_at = NOW()
-            WHERE id = $1 AND status = 'pending_review'
+            WHERE id = $1 AND organization_id = $2 AND status = 'pending_review'
             RETURNING id, organization_id, report_type, title, description,
                       period_start, period_end, frameworks, status, submitted_at,
                       approved_by, approved_at, report_data, summary_scores,
@@ -745,17 +932,29 @@ impl EsgReportingRepository {
             "#,
         )
         .bind(id)
+        .bind(organization_id)
         .bind(approver_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
-    /// Delete an ESG report.
-    pub async fn delete_report(&self, id: Uuid) -> Result<bool, sqlx::Error> {
-        let result = sqlx::query("DELETE FROM esg_reports WHERE id = $1 AND status = 'draft'")
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
+    /// Delete an ESG report, scoped to the owning organization.
+    pub async fn delete_report<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        organization_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let result = sqlx::query(
+            "DELETE FROM esg_reports WHERE id = $1 AND organization_id = $2 AND status = 'draft'",
+        )
+        .bind(id)
+        .bind(organization_id)
+        .execute(executor)
+        .await?;
         Ok(result.rows_affected() > 0)
     }
 
@@ -764,11 +963,15 @@ impl EsgReportingRepository {
     // =========================================================================
 
     /// Create an EU Taxonomy assessment.
-    pub async fn create_eu_taxonomy_assessment(
+    pub async fn create_eu_taxonomy_assessment<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         input: CreateEuTaxonomyAssessment,
-    ) -> Result<EuTaxonomyAssessment, sqlx::Error> {
+    ) -> Result<EuTaxonomyAssessment, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EuTaxonomyAssessment>(
             r#"
             INSERT INTO eu_taxonomy_assessments (
@@ -799,15 +1002,20 @@ impl EsgReportingRepository {
         .bind(input.primary_energy_demand)
         .bind(input.meets_nzeb_standard)
         .bind(input.notes.as_deref())
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
-    /// Get EU Taxonomy assessment by ID.
-    pub async fn get_eu_taxonomy_assessment(
+    /// Get EU Taxonomy assessment by ID, scoped to the owning organization.
+    pub async fn get_eu_taxonomy_assessment<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
-    ) -> Result<Option<EuTaxonomyAssessment>, sqlx::Error> {
+        organization_id: Uuid,
+    ) -> Result<Option<EuTaxonomyAssessment>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EuTaxonomyAssessment>(
             r#"
             SELECT id, organization_id, building_id, year, climate_mitigation_eligible,
@@ -819,20 +1027,25 @@ impl EsgReportingRepository {
                    oecd_guidelines_compliance, un_guiding_principles,
                    overall_alignment_pct, notes, created_at, updated_at
             FROM eu_taxonomy_assessments
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             "#,
         )
         .bind(id)
-        .fetch_optional(&self.pool)
+        .bind(organization_id)
+        .fetch_optional(executor)
         .await
     }
 
     /// List EU Taxonomy assessments.
-    pub async fn list_eu_taxonomy_assessments(
+    pub async fn list_eu_taxonomy_assessments<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         year: Option<i32>,
-    ) -> Result<Vec<EuTaxonomyAssessment>, sqlx::Error> {
+    ) -> Result<Vec<EuTaxonomyAssessment>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EuTaxonomyAssessment>(
             r#"
             SELECT id, organization_id, building_id, year, climate_mitigation_eligible,
@@ -851,56 +1064,61 @@ impl EsgReportingRepository {
         )
         .bind(organization_id)
         .bind(year)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
-    /// Update EU Taxonomy assessment.
-    pub async fn update_eu_taxonomy_assessment(
+    /// Update EU Taxonomy assessment, scoped to the owning organization.
+    pub async fn update_eu_taxonomy_assessment<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
+        organization_id: Uuid,
         input: UpdateEuTaxonomyAssessment,
-    ) -> Result<Option<EuTaxonomyAssessment>, sqlx::Error> {
+    ) -> Result<Option<EuTaxonomyAssessment>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // Calculate overall alignment based on DNSH criteria
         sqlx::query_as::<_, EuTaxonomyAssessment>(
             r#"
             UPDATE eu_taxonomy_assessments
-            SET climate_mitigation_eligible = COALESCE($2, climate_mitigation_eligible),
-                climate_mitigation_aligned = COALESCE($3, climate_mitigation_aligned),
-                climate_adaptation_eligible = COALESCE($4, climate_adaptation_eligible),
-                climate_adaptation_aligned = COALESCE($5, climate_adaptation_aligned),
-                energy_performance_class = COALESCE($6, energy_performance_class),
-                primary_energy_demand = COALESCE($7, primary_energy_demand),
-                meets_nzeb_standard = COALESCE($8, meets_nzeb_standard),
-                dnsh_water = COALESCE($9, dnsh_water),
-                dnsh_circular_economy = COALESCE($10, dnsh_circular_economy),
-                dnsh_pollution = COALESCE($11, dnsh_pollution),
-                dnsh_biodiversity = COALESCE($12, dnsh_biodiversity),
-                oecd_guidelines_compliance = COALESCE($13, oecd_guidelines_compliance),
-                un_guiding_principles = COALESCE($14, un_guiding_principles),
-                notes = COALESCE($15, notes),
+            SET climate_mitigation_eligible = COALESCE($3, climate_mitigation_eligible),
+                climate_mitigation_aligned = COALESCE($4, climate_mitigation_aligned),
+                climate_adaptation_eligible = COALESCE($5, climate_adaptation_eligible),
+                climate_adaptation_aligned = COALESCE($6, climate_adaptation_aligned),
+                energy_performance_class = COALESCE($7, energy_performance_class),
+                primary_energy_demand = COALESCE($8, primary_energy_demand),
+                meets_nzeb_standard = COALESCE($9, meets_nzeb_standard),
+                dnsh_water = COALESCE($10, dnsh_water),
+                dnsh_circular_economy = COALESCE($11, dnsh_circular_economy),
+                dnsh_pollution = COALESCE($12, dnsh_pollution),
+                dnsh_biodiversity = COALESCE($13, dnsh_biodiversity),
+                oecd_guidelines_compliance = COALESCE($14, oecd_guidelines_compliance),
+                un_guiding_principles = COALESCE($15, un_guiding_principles),
+                notes = COALESCE($16, notes),
                 overall_alignment_pct = CASE
-                    WHEN COALESCE($3, climate_mitigation_aligned) = true
-                         AND COALESCE($9, dnsh_water) = true
-                         AND COALESCE($10, dnsh_circular_economy) = true
-                         AND COALESCE($11, dnsh_pollution) = true
-                         AND COALESCE($12, dnsh_biodiversity) = true
-                         AND COALESCE($13, oecd_guidelines_compliance) = true
-                         AND COALESCE($14, un_guiding_principles) = true
+                    WHEN COALESCE($4, climate_mitigation_aligned) = true
+                         AND COALESCE($10, dnsh_water) = true
+                         AND COALESCE($11, dnsh_circular_economy) = true
+                         AND COALESCE($12, dnsh_pollution) = true
+                         AND COALESCE($13, dnsh_biodiversity) = true
+                         AND COALESCE($14, oecd_guidelines_compliance) = true
+                         AND COALESCE($15, un_guiding_principles) = true
                     THEN 100.0
                     ELSE (
-                        (CASE WHEN COALESCE($3, climate_mitigation_aligned) THEN 1 ELSE 0 END +
-                         CASE WHEN COALESCE($9, dnsh_water) THEN 1 ELSE 0 END +
-                         CASE WHEN COALESCE($10, dnsh_circular_economy) THEN 1 ELSE 0 END +
-                         CASE WHEN COALESCE($11, dnsh_pollution) THEN 1 ELSE 0 END +
-                         CASE WHEN COALESCE($12, dnsh_biodiversity) THEN 1 ELSE 0 END +
-                         CASE WHEN COALESCE($13, oecd_guidelines_compliance) THEN 1 ELSE 0 END +
-                         CASE WHEN COALESCE($14, un_guiding_principles) THEN 1 ELSE 0 END
+                        (CASE WHEN COALESCE($4, climate_mitigation_aligned) THEN 1 ELSE 0 END +
+                         CASE WHEN COALESCE($10, dnsh_water) THEN 1 ELSE 0 END +
+                         CASE WHEN COALESCE($11, dnsh_circular_economy) THEN 1 ELSE 0 END +
+                         CASE WHEN COALESCE($12, dnsh_pollution) THEN 1 ELSE 0 END +
+                         CASE WHEN COALESCE($13, dnsh_biodiversity) THEN 1 ELSE 0 END +
+                         CASE WHEN COALESCE($14, oecd_guidelines_compliance) THEN 1 ELSE 0 END +
+                         CASE WHEN COALESCE($15, un_guiding_principles) THEN 1 ELSE 0 END
                         )::decimal / 7.0 * 100.0
                     )
                 END,
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             RETURNING id, organization_id, building_id, year, climate_mitigation_eligible,
                       climate_mitigation_aligned, climate_mitigation_revenue_pct,
                       climate_adaptation_eligible, climate_adaptation_aligned,
@@ -912,6 +1130,7 @@ impl EsgReportingRepository {
             "#,
         )
         .bind(id)
+        .bind(organization_id)
         .bind(input.climate_mitigation_eligible)
         .bind(input.climate_mitigation_aligned)
         .bind(input.climate_adaptation_eligible)
@@ -926,7 +1145,7 @@ impl EsgReportingRepository {
         .bind(input.oecd_guidelines_compliance)
         .bind(input.un_guiding_principles)
         .bind(input.notes.as_deref())
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
@@ -935,12 +1154,16 @@ impl EsgReportingRepository {
     // =========================================================================
 
     /// Get ESG dashboard metrics.
-    pub async fn get_dashboard_metrics(
+    pub async fn get_dashboard_metrics<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         year: i32,
         building_id: Option<Uuid>,
-    ) -> Result<Option<EsgDashboardMetrics>, sqlx::Error> {
+    ) -> Result<Option<EsgDashboardMetrics>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EsgDashboardMetrics>(
             r#"
             SELECT id, organization_id, building_id, year, month,
@@ -960,22 +1183,31 @@ impl EsgReportingRepository {
         .bind(organization_id)
         .bind(year)
         .bind(building_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Refresh ESG dashboard metrics (recalculate from source data).
+    ///
+    /// Multi-query: reads carbon summaries for `year` and `year - 1` then
+    /// upserts the dashboard row. Takes `&mut PgConnection` so every statement
+    /// runs on the same RLS-context-bearing connection.
     pub async fn refresh_dashboard_metrics(
         &self,
+        conn: &mut PgConnection,
         organization_id: Uuid,
         year: i32,
         building_id: Option<Uuid>,
     ) -> Result<EsgDashboardMetrics, sqlx::Error> {
         // Get carbon footprint data
-        let carbon = self.get_carbon_summary(organization_id, year).await?;
+        let carbon = self
+            .get_carbon_summary(&mut *conn, organization_id, year)
+            .await?;
 
         // Get previous year for YoY comparison
-        let prev_carbon = self.get_carbon_summary(organization_id, year - 1).await?;
+        let prev_carbon = self
+            .get_carbon_summary(&mut *conn, organization_id, year - 1)
+            .await?;
 
         let yoy_change = match (&carbon, &prev_carbon) {
             (Some(c), Some(p)) if p.total_co2_kg > Decimal::ZERO => {
@@ -1012,7 +1244,7 @@ impl EsgReportingRepository {
         .bind(carbon.as_ref().map(|c| &c.total_co2_kg))
         .bind(carbon.as_ref().and_then(|c| c.avg_co2_per_sqm.as_ref()))
         .bind(yoy_change)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
     }
 
@@ -1021,12 +1253,16 @@ impl EsgReportingRepository {
     // =========================================================================
 
     /// Create an import job.
-    pub async fn create_import_job(
+    pub async fn create_import_job<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
         user_id: Uuid,
         input: CreateEsgImportJob,
-    ) -> Result<EsgImportJob, sqlx::Error> {
+    ) -> Result<EsgImportJob, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EsgImportJob>(
             r#"
             INSERT INTO esg_import_jobs (
@@ -1045,31 +1281,44 @@ impl EsgReportingRepository {
         .bind(&input.data_type)
         .bind(input.rows_total)
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
-    /// Get import job by ID.
-    pub async fn get_import_job(&self, id: Uuid) -> Result<Option<EsgImportJob>, sqlx::Error> {
+    /// Get import job by ID, scoped to the owning organization.
+    pub async fn get_import_job<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        organization_id: Uuid,
+    ) -> Result<Option<EsgImportJob>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EsgImportJob>(
             r#"
             SELECT id, organization_id, file_name, file_url, data_type, status,
                    rows_total, rows_processed, rows_failed, error_log,
                    started_at, completed_at, created_at, created_by
             FROM esg_import_jobs
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             "#,
         )
         .bind(id)
-        .fetch_optional(&self.pool)
+        .bind(organization_id)
+        .fetch_optional(executor)
         .await
     }
 
     /// List import jobs.
-    pub async fn list_import_jobs(
+    pub async fn list_import_jobs<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
-    ) -> Result<Vec<EsgImportJob>, sqlx::Error> {
+    ) -> Result<Vec<EsgImportJob>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, EsgImportJob>(
             r#"
             SELECT id, organization_id, file_name, file_url, data_type, status,
@@ -1082,19 +1331,25 @@ impl EsgReportingRepository {
             "#,
         )
         .bind(organization_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
-    /// Update import job status.
-    pub async fn update_import_job_status(
+    /// Update import job status, scoped to the owning organization.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn update_import_job_status<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
+        organization_id: Uuid,
         status: &str,
         rows_processed: Option<i32>,
         rows_failed: Option<i32>,
         error_log: Option<serde_json::Value>,
-    ) -> Result<Option<EsgImportJob>, sqlx::Error> {
+    ) -> Result<Option<EsgImportJob>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let now = Utc::now();
         let started_at = if status == "processing" {
             Some(now)
@@ -1110,26 +1365,27 @@ impl EsgReportingRepository {
         sqlx::query_as::<_, EsgImportJob>(
             r#"
             UPDATE esg_import_jobs
-            SET status = $2,
-                rows_processed = COALESCE($3, rows_processed),
-                rows_failed = COALESCE($4, rows_failed),
-                error_log = COALESCE($5, error_log),
-                started_at = COALESCE($6, started_at),
-                completed_at = COALESCE($7, completed_at)
-            WHERE id = $1
+            SET status = $3,
+                rows_processed = COALESCE($4, rows_processed),
+                rows_failed = COALESCE($5, rows_failed),
+                error_log = COALESCE($6, error_log),
+                started_at = COALESCE($7, started_at),
+                completed_at = COALESCE($8, completed_at)
+            WHERE id = $1 AND organization_id = $2
             RETURNING id, organization_id, file_name, file_url, data_type, status,
                       rows_total, rows_processed, rows_failed, error_log,
                       started_at, completed_at, created_at, created_by
             "#,
         )
         .bind(id)
+        .bind(organization_id)
         .bind(status)
         .bind(rows_processed)
         .bind(rows_failed)
         .bind(&error_log)
         .bind(started_at)
         .bind(completed_at)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
@@ -1138,10 +1394,14 @@ impl EsgReportingRepository {
     // =========================================================================
 
     /// Get ESG statistics for an organization.
-    pub async fn get_statistics(
+    pub async fn get_statistics<'e, E>(
         &self,
+        executor: E,
         organization_id: Uuid,
-    ) -> Result<EsgStatistics, sqlx::Error> {
+    ) -> Result<EsgStatistics, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let current_year = Utc::now().naive_utc().date().year();
 
         sqlx::query_as::<_, EsgStatistics>(
@@ -1162,7 +1422,7 @@ impl EsgReportingRepository {
         )
         .bind(organization_id)
         .bind(current_year)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 }

--- a/backend/servers/api-server/src/routes/esg_reporting.rs
+++ b/backend/servers/api-server/src/routes/esg_reporting.rs
@@ -1,5 +1,20 @@
 // Epic 136: ESG Reporting Dashboard
 // API routes for ESG (Environmental, Social, Governance) reporting and compliance
+//
+// # RLS (PAP-139 / PAP-72)
+//
+// Migration `00179` put `FORCE ROW LEVEL SECURITY` on every ESG table, so each
+// query MUST run on a connection that has `app.current_org_id` set or it
+// collapses to deny-all (PAP-72). Each handler therefore acquires an
+// [`RlsConnection`] (which validates tenant membership and sets the org/user
+// GUCs on a dedicated connection) and passes `&mut **rls.conn()` to the
+// repository. The authoritative organization is `rls.tenant_id()` — the tenant
+// the caller was validated against — never a client-supplied value, so the SQL
+// org filter and the RLS context can never disagree. By-id repo queries stay
+// keyed on `(id, organization_id)` (PAP-136 defense-in-depth), so a
+// cross-tenant probe resolves to no row → `404`/no-op even on an RLS-exempt
+// pool. `rls.release()` clears the context before the connection returns to
+// the pool.
 
 use axum::{
     extract::{Path, Query, State},
@@ -11,15 +26,7 @@ use db::models::esg_reporting::*;
 use uuid::Uuid;
 
 use crate::state::AppState;
-use api_core::extractors::AuthUser;
-
-/// Helper to extract organization ID from auth user.
-fn get_org_id(auth: &AuthUser) -> Result<Uuid, (StatusCode, String)> {
-    auth.tenant_id.ok_or((
-        StatusCode::BAD_REQUEST,
-        "No organization context".to_string(),
-    ))
-}
+use api_core::extractors::RlsConnection;
 
 /// Create ESG reporting router.
 pub fn router() -> Router<AppState> {
@@ -74,37 +81,44 @@ pub fn router() -> Router<AppState> {
         .route("/statistics", get(get_statistics))
 }
 
+/// Map a `sqlx::Error` to a 500 response.
+fn internal_error(e: sqlx::Error) -> (StatusCode, String) {
+    (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+}
+
 // =============================================================================
 // Configuration Handlers
 // =============================================================================
 
 async fn get_configuration(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
 ) -> Result<Json<Option<EsgConfiguration>>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .get_configuration(org_id)
+        .get_configuration(&mut **rls.conn(), org_id)
         .await
         .map(Json)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 async fn upsert_configuration(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(input): Json<CreateEsgConfiguration>,
 ) -> Result<Json<EsgConfiguration>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .upsert_configuration(org_id, input)
+        .upsert_configuration(&mut **rls.conn(), org_id, input)
         .await
         .map(Json)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 // =============================================================================
@@ -113,61 +127,70 @@ async fn upsert_configuration(
 
 async fn list_metrics(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<EsgMetricsQuery>,
 ) -> Result<Json<Vec<EsgMetric>>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .list_metrics(org_id, query)
+        .list_metrics(&mut **rls.conn(), org_id, query)
         .await
         .map(Json)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 async fn create_metric(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(input): Json<CreateEsgMetric>,
 ) -> Result<(StatusCode, Json<EsgMetric>), (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .esg_reporting_repo
-        .create_metric(org_id, auth.user_id, input)
+        .create_metric(&mut **rls.conn(), org_id, user_id, input)
         .await
         .map(|m| (StatusCode::CREATED, Json(m)))
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 async fn get_metric(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<EsgMetric>, (StatusCode, String)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .get_metric(id)
+        .get_metric(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .map(Json)
-        .ok_or((StatusCode::NOT_FOUND, "Metric not found".to_string()))
+        .map_err(internal_error)
+        .and_then(|m| m.ok_or((StatusCode::NOT_FOUND, "Metric not found".to_string())))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 async fn update_metric(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(input): Json<UpdateEsgMetric>,
 ) -> Result<Json<EsgMetric>, (StatusCode, String)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .update_metric(id, input)
+        .update_metric(&mut **rls.conn(), id, org_id, input)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .map(Json)
-        .ok_or((StatusCode::NOT_FOUND, "Metric not found".to_string()))
+        .map_err(internal_error)
+        .and_then(|m| m.ok_or((StatusCode::NOT_FOUND, "Metric not found".to_string())))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 #[derive(serde::Deserialize)]
@@ -177,30 +200,43 @@ pub struct VerifyMetricRequest {
 
 async fn verify_metric(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(input): Json<VerifyMetricRequest>,
 ) -> Result<Json<EsgMetric>, (StatusCode, String)> {
-    state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .esg_reporting_repo
-        .verify_metric(id, auth.user_id, &input.status)
+        .verify_metric(&mut **rls.conn(), id, org_id, user_id, &input.status)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .map(Json)
-        .ok_or((StatusCode::NOT_FOUND, "Metric not found".to_string()))
+        .map_err(internal_error)
+        .and_then(|m| m.ok_or((StatusCode::NOT_FOUND, "Metric not found".to_string())))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 async fn delete_metric(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, String)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .delete_metric(id)
+        .delete_metric(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    Ok(StatusCode::NO_CONTENT)
+        .map_err(internal_error)
+        .map(|deleted| {
+            if deleted {
+                StatusCode::NO_CONTENT
+            } else {
+                StatusCode::NOT_FOUND
+            }
+        });
+    rls.release().await;
+    out
 }
 
 // =============================================================================
@@ -209,77 +245,94 @@ async fn delete_metric(
 
 async fn list_carbon_footprints(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<CarbonFootprintQuery>,
 ) -> Result<Json<Vec<CarbonFootprint>>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .list_carbon_footprints(org_id, query)
+        .list_carbon_footprints(&mut **rls.conn(), org_id, query)
         .await
         .map(Json)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 async fn create_carbon_footprint(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(input): Json<CreateCarbonFootprint>,
 ) -> Result<(StatusCode, Json<CarbonFootprint>), (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .create_carbon_footprint(org_id, input)
+        .create_carbon_footprint(&mut **rls.conn(), org_id, input)
         .await
         .map(|c| (StatusCode::CREATED, Json(c)))
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 async fn get_carbon_footprint(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<CarbonFootprint>, (StatusCode, String)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .get_carbon_footprint(id)
+        .get_carbon_footprint(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .map(Json)
-        .ok_or((
-            StatusCode::NOT_FOUND,
-            "Carbon footprint not found".to_string(),
-        ))
+        .map_err(internal_error)
+        .and_then(|c| {
+            c.ok_or((
+                StatusCode::NOT_FOUND,
+                "Carbon footprint not found".to_string(),
+            ))
+        })
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 async fn get_carbon_summary(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(year): Path<i32>,
 ) -> Result<Json<Option<CarbonFootprintSummary>>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .get_carbon_summary(org_id, year)
+        .get_carbon_summary(&mut **rls.conn(), org_id, year)
         .await
         .map(Json)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 async fn delete_carbon_footprint(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, String)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .delete_carbon_footprint(id)
+        .delete_carbon_footprint(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    Ok(StatusCode::NO_CONTENT)
+        .map_err(internal_error)
+        .map(|deleted| {
+            if deleted {
+                StatusCode::NO_CONTENT
+            } else {
+                StatusCode::NOT_FOUND
+            }
+        });
+    rls.release().await;
+    out
 }
 
 // =============================================================================
@@ -293,45 +346,56 @@ pub struct BenchmarkQueryParams {
 
 async fn list_benchmarks(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Query(params): Query<BenchmarkQueryParams>,
 ) -> Result<Json<Vec<EsgBenchmark>>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .list_benchmarks(org_id, params.category)
+        .list_benchmarks(&mut **rls.conn(), org_id, params.category)
         .await
         .map(Json)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 async fn create_benchmark(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(input): Json<CreateEsgBenchmark>,
 ) -> Result<(StatusCode, Json<EsgBenchmark>), (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .create_benchmark(org_id, input)
+        .create_benchmark(&mut **rls.conn(), org_id, input)
         .await
         .map(|b| (StatusCode::CREATED, Json(b)))
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 async fn delete_benchmark(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, String)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .delete_benchmark(id)
+        .delete_benchmark(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    Ok(StatusCode::NO_CONTENT)
+        .map_err(internal_error)
+        .map(|deleted| {
+            if deleted {
+                StatusCode::NO_CONTENT
+            } else {
+                StatusCode::NOT_FOUND
+            }
+        });
+    rls.release().await;
+    out
 }
 
 // =============================================================================
@@ -345,74 +409,91 @@ pub struct TargetQueryParams {
 
 async fn list_targets(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Query(params): Query<TargetQueryParams>,
 ) -> Result<Json<Vec<EsgTarget>>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .list_targets(org_id, params.building_id)
+        .list_targets(&mut **rls.conn(), org_id, params.building_id)
         .await
         .map(Json)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 async fn create_target(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(input): Json<CreateEsgTarget>,
 ) -> Result<(StatusCode, Json<EsgTarget>), (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .create_target(org_id, input)
+        .create_target(&mut **rls.conn(), org_id, input)
         .await
         .map(|t| (StatusCode::CREATED, Json(t)))
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 async fn get_target(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<EsgTarget>, (StatusCode, String)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .get_target(id)
+        .get_target(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .map(Json)
-        .ok_or((StatusCode::NOT_FOUND, "Target not found".to_string()))
+        .map_err(internal_error)
+        .and_then(|t| t.ok_or((StatusCode::NOT_FOUND, "Target not found".to_string())))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 async fn update_target(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(input): Json<UpdateEsgTarget>,
 ) -> Result<Json<EsgTarget>, (StatusCode, String)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .update_target(id, input)
+        .update_target(&mut **rls.conn(), id, org_id, input)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .map(Json)
-        .ok_or((StatusCode::NOT_FOUND, "Target not found".to_string()))
+        .map_err(internal_error)
+        .and_then(|t| t.ok_or((StatusCode::NOT_FOUND, "Target not found".to_string())))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 async fn delete_target(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, String)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .delete_target(id)
+        .delete_target(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    Ok(StatusCode::NO_CONTENT)
+        .map_err(internal_error)
+        .map(|deleted| {
+            if deleted {
+                StatusCode::NO_CONTENT
+            } else {
+                StatusCode::NOT_FOUND
+            }
+        });
+    rls.release().await;
+    out
 }
 
 // =============================================================================
@@ -426,116 +507,140 @@ pub struct ReportQueryParams {
 
 async fn list_reports(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Query(params): Query<ReportQueryParams>,
 ) -> Result<Json<Vec<EsgReport>>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .list_reports(org_id, params.status)
+        .list_reports(&mut **rls.conn(), org_id, params.status)
         .await
         .map(Json)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 async fn create_report(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(input): Json<CreateEsgReport>,
 ) -> Result<(StatusCode, Json<EsgReport>), (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .esg_reporting_repo
-        .create_report(org_id, auth.user_id, input)
+        .create_report(&mut **rls.conn(), org_id, user_id, input)
         .await
         .map(|r| (StatusCode::CREATED, Json(r)))
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 async fn get_report(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<EsgReport>, (StatusCode, String)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .get_report(id)
+        .get_report(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .map(Json)
-        .ok_or((StatusCode::NOT_FOUND, "Report not found".to_string()))
+        .map_err(internal_error)
+        .and_then(|r| r.ok_or((StatusCode::NOT_FOUND, "Report not found".to_string())))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 async fn update_report(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(input): Json<UpdateEsgReport>,
 ) -> Result<Json<EsgReport>, (StatusCode, String)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .update_report(id, input)
+        .update_report(&mut **rls.conn(), id, org_id, input)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .map(Json)
-        .ok_or((StatusCode::NOT_FOUND, "Report not found".to_string()))
+        .map_err(internal_error)
+        .and_then(|r| r.ok_or((StatusCode::NOT_FOUND, "Report not found".to_string())))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 async fn submit_report(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<EsgReport>, (StatusCode, String)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .submit_report(id)
+        .submit_report(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .map(Json)
-        .ok_or((
-            StatusCode::BAD_REQUEST,
-            "Report cannot be submitted (not in draft status)".to_string(),
-        ))
+        .map_err(internal_error)
+        .and_then(|r| {
+            r.ok_or((
+                StatusCode::BAD_REQUEST,
+                "Report cannot be submitted (not in draft status)".to_string(),
+            ))
+        })
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 async fn approve_report(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<EsgReport>, (StatusCode, String)> {
-    state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .esg_reporting_repo
-        .approve_report(id, auth.user_id)
+        .approve_report(&mut **rls.conn(), id, org_id, user_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .map(Json)
-        .ok_or((
-            StatusCode::BAD_REQUEST,
-            "Report cannot be approved (not pending review)".to_string(),
-        ))
+        .map_err(internal_error)
+        .and_then(|r| {
+            r.ok_or((
+                StatusCode::BAD_REQUEST,
+                "Report cannot be approved (not pending review)".to_string(),
+            ))
+        })
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 async fn delete_report(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, String)> {
-    let deleted = state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .delete_report(id)
+        .delete_report(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-
-    if deleted {
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Err((
-            StatusCode::BAD_REQUEST,
-            "Report cannot be deleted (only draft reports can be deleted)".to_string(),
-        ))
-    }
+        .map_err(internal_error)
+        .and_then(|deleted| {
+            if deleted {
+                Ok(StatusCode::NO_CONTENT)
+            } else {
+                Err((
+                    StatusCode::BAD_REQUEST,
+                    "Report cannot be deleted (only draft reports can be deleted)".to_string(),
+                ))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 // =============================================================================
@@ -549,61 +654,69 @@ pub struct EuTaxonomyQueryParams {
 
 async fn list_eu_taxonomy_assessments(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Query(params): Query<EuTaxonomyQueryParams>,
 ) -> Result<Json<Vec<EuTaxonomyAssessment>>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .list_eu_taxonomy_assessments(org_id, params.year)
+        .list_eu_taxonomy_assessments(&mut **rls.conn(), org_id, params.year)
         .await
         .map(Json)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 async fn create_eu_taxonomy_assessment(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(input): Json<CreateEuTaxonomyAssessment>,
 ) -> Result<(StatusCode, Json<EuTaxonomyAssessment>), (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .create_eu_taxonomy_assessment(org_id, input)
+        .create_eu_taxonomy_assessment(&mut **rls.conn(), org_id, input)
         .await
         .map(|a| (StatusCode::CREATED, Json(a)))
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 async fn get_eu_taxonomy_assessment(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<EuTaxonomyAssessment>, (StatusCode, String)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .get_eu_taxonomy_assessment(id)
+        .get_eu_taxonomy_assessment(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .map(Json)
-        .ok_or((StatusCode::NOT_FOUND, "Assessment not found".to_string()))
+        .map_err(internal_error)
+        .and_then(|a| a.ok_or((StatusCode::NOT_FOUND, "Assessment not found".to_string())))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 async fn update_eu_taxonomy_assessment(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(input): Json<UpdateEuTaxonomyAssessment>,
 ) -> Result<Json<EuTaxonomyAssessment>, (StatusCode, String)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .update_eu_taxonomy_assessment(id, input)
+        .update_eu_taxonomy_assessment(&mut **rls.conn(), id, org_id, input)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .map(Json)
-        .ok_or((StatusCode::NOT_FOUND, "Assessment not found".to_string()))
+        .map_err(internal_error)
+        .and_then(|a| a.ok_or((StatusCode::NOT_FOUND, "Assessment not found".to_string())))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 // =============================================================================
@@ -617,34 +730,36 @@ pub struct DashboardQueryParams {
 
 async fn get_dashboard(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(year): Path<i32>,
     Query(params): Query<DashboardQueryParams>,
 ) -> Result<Json<Option<EsgDashboardMetrics>>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .get_dashboard_metrics(org_id, year, params.building_id)
+        .get_dashboard_metrics(&mut **rls.conn(), org_id, year, params.building_id)
         .await
         .map(Json)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 async fn refresh_dashboard(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Path(year): Path<i32>,
     Query(params): Query<DashboardQueryParams>,
 ) -> Result<Json<EsgDashboardMetrics>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .refresh_dashboard_metrics(org_id, year, params.building_id)
+        .refresh_dashboard_metrics(rls.conn(), org_id, year, params.building_id)
         .await
         .map(Json)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 // =============================================================================
@@ -653,45 +768,51 @@ async fn refresh_dashboard(
 
 async fn list_import_jobs(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
 ) -> Result<Json<Vec<EsgImportJob>>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .list_import_jobs(org_id)
+        .list_import_jobs(&mut **rls.conn(), org_id)
         .await
         .map(Json)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 async fn create_import_job(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
     Json(input): Json<CreateEsgImportJob>,
 ) -> Result<(StatusCode, Json<EsgImportJob>), (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .esg_reporting_repo
-        .create_import_job(org_id, auth.user_id, input)
+        .create_import_job(&mut **rls.conn(), org_id, user_id, input)
         .await
         .map(|j| (StatusCode::CREATED, Json(j)))
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }
 
 async fn get_import_job(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<EsgImportJob>, (StatusCode, String)> {
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .get_import_job(id)
+        .get_import_job(&mut **rls.conn(), id, org_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .map(Json)
-        .ok_or((StatusCode::NOT_FOUND, "Import job not found".to_string()))
+        .map_err(internal_error)
+        .and_then(|j| j.ok_or((StatusCode::NOT_FOUND, "Import job not found".to_string())))
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 // =============================================================================
@@ -700,14 +821,15 @@ async fn get_import_job(
 
 async fn get_statistics(
     State(state): State<AppState>,
-    auth: AuthUser,
+    mut rls: RlsConnection,
 ) -> Result<Json<EsgStatistics>, (StatusCode, String)> {
-    let org_id = get_org_id(&auth)?;
-
-    state
+    let org_id = rls.tenant_id();
+    let out = state
         .esg_reporting_repo
-        .get_statistics(org_id)
+        .get_statistics(&mut **rls.conn(), org_id)
         .await
         .map(Json)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        .map_err(internal_error);
+    rls.release().await;
+    out
 }

--- a/backend/servers/api-server/tests/esg_reporting_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/esg_reporting_cross_org_idor_tests.rs
@@ -1,0 +1,446 @@
+//! Regression tests for the cross-tenant IDOR fix on the ESG reporting
+//! endpoints (`/api/v1/esg/*`, Epic 136 — PAP-139, unblocks PAP-72).
+//!
+//! Audit history (PAP-136): every by-id ESG handler carried `_auth: AuthUser`
+//! and performed no org scoping, and the repository ran on the raw pool with
+//! no `organization_id` predicate on any by-id query (get/update/verify/
+//! delete/submit/approve across esg_metrics, carbon_footprints, esg_targets,
+//! esg_reports, eu_taxonomy_assessments, esg_import_jobs). A foreign caller
+//! could read/mutate/delete any other org's ESG data by UUID.
+//!
+//! Since the PAP-139 RLS conversion, every handler acquires an `RlsConnection`
+//! (tenant validated against `organization_members`) and the repository is
+//! stateless: queries run on the request's RLS-scoped connection AND stay
+//! org-keyed — every ESG table carries `organization_id`, so each by-id query
+//! is `WHERE id = $1 AND organization_id = $2`. A cross-tenant probe made with
+//! the attacker's own valid tenant context resolves to no row → `404`/no-op;
+//! "missing" and "forbidden" are indistinguishable. The CI test pool runs as
+//! superuser (bypasses FORCE RLS), so these tests specifically prove the
+//! org-keyed SQL layer.
+//!
+//! These tests exercise the HTTP surface end-to-end with real HS256 JWTs:
+//!   1. Seed two orgs (A, B), a member user in each, and an ESG metric +
+//!      report in Org A.
+//!   2. Org B's member probes Org A's resources → rejected (4xx); no leak,
+//!      no write.
+//!   3. Org A's member reads its own metric → allowed (2xx).
+
+#[allow(dead_code)]
+mod common;
+
+use axum::http::{Method, StatusCode};
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{RequestBuilder, TestApp, TestConfig};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active') RETURNING id
+        "#,
+    )
+    .bind(format!("EsgIDOR Org {slug}"))
+    .bind(format!("esg-idor-org-{slug}"))
+    .bind(format!("{slug}@esg-idor.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'test_hash', 'EsgIDOR User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Make `user_id` an active member of `org_id`.
+async fn seed_membership(pool: &PgPool, org_id: Uuid, user_id: Uuid) {
+    sqlx::query(
+        r#"
+        INSERT INTO organization_members (organization_id, user_id, role_type, status, joined_at)
+        VALUES ($1, $2, 'org_admin', 'active', NOW())
+        "#,
+    )
+    .bind(org_id)
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .expect("seed membership");
+}
+
+/// Seed an ESG metric in `org_id` created by `created_by`, return its id.
+async fn seed_metric(pool: &PgPool, org_id: Uuid, created_by: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO esg_metrics (
+            organization_id, period_start, period_end, category, metric_type,
+            metric_name, value, unit, data_source, created_by
+        ) VALUES (
+            $1, '2026-01-01', '2026-03-31', 'environmental', 'energy_consumption',
+            'Total electricity', 12345.0, 'kWh', 'manual', $2
+        )
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(created_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed metric")
+}
+
+/// Seed a draft ESG report in `org_id` created by `created_by`, return its id.
+async fn seed_report(pool: &PgPool, org_id: Uuid, created_by: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO esg_reports (
+            organization_id, report_type, title, period_start, period_end,
+            status, created_by
+        ) VALUES (
+            $1, 'annual', 'Confidential ESG Report 2026', '2026-01-01', '2026-12-31',
+            'draft', $2
+        )
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(created_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed report")
+}
+
+/// Mint a real HS256 access token for `user_id`, signed with the same secret
+/// the TestApp configures into `JWT_SECRET`.
+fn mint_token(user_id: Uuid, email: &str) -> String {
+    use api_server::services::JwtService;
+    let config = TestConfig::default();
+    let jwt = JwtService::new(&config.jwt_secret).expect("jwt service");
+    jwt.generate_access_token(user_id, email, "EsgIDOR User", None, None)
+        .expect("mint access token")
+}
+
+fn assert_rejected(status: StatusCode, ctx: &str) {
+    let code = status.as_u16();
+    assert!(
+        (400..500).contains(&code),
+        "{ctx}: cross-tenant/unauthenticated request must be rejected with 4xx, got {status}"
+    );
+}
+
+/// Seed two orgs with one member each plus a metric + report in Org A.
+/// Returns (org_a, org_b, user_a, user_b, metric_a, report_a).
+async fn seed_two_org_fixture(pool: &PgPool, tag: &str) -> (Uuid, Uuid, Uuid, Uuid, Uuid, Uuid) {
+    let org_a = seed_org(pool, &format!("{tag}-a")).await;
+    let org_b = seed_org(pool, &format!("{tag}-b")).await;
+    let user_a = seed_user(pool, &format!("{tag}-a@esg-idor.test")).await;
+    let user_b = seed_user(pool, &format!("{tag}-b@esg-idor.test")).await;
+    seed_membership(pool, org_a, user_a).await;
+    seed_membership(pool, org_b, user_b).await;
+    let metric_a = seed_metric(pool, org_a, user_a).await;
+    let report_a = seed_report(pool, org_a, user_a).await;
+    (org_a, org_b, user_a, user_b, metric_a, report_a)
+}
+
+// ---------------------------------------------------------------------------
+// T1 — unauthenticated get_metric is rejected
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_metric_without_auth_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "noauth-a").await;
+    let user_a = seed_user(&pool, "noauth-a@esg-idor.test").await;
+    let metric_a = seed_metric(&pool, org_a, user_a).await;
+
+    let uri = format!("/api/v1/esg/metrics/{metric_a}");
+    let resp = app.execute(app.get(&uri).build()).await;
+
+    assert_rejected(resp.status, "get_metric without bearer token");
+}
+
+// ---------------------------------------------------------------------------
+// T2 — cross-org get_metric by UUID is rejected (IDOR)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_metric_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (_org_a, org_b, _user_a, user_b, metric_a, _report_a) =
+        seed_two_org_fixture(&pool, "get").await;
+
+    let token_b = mint_token(user_b, "get-b@esg-idor.test");
+    let uri = format!("/api/v1/esg/metrics/{metric_a}");
+    // Valid context for the attacker's OWN org — the by-id probe must fail on
+    // row scoping (404), not on a missing tenant header.
+    let resp = app
+        .execute(
+            app.get(&uri)
+                .bearer(&token_b)
+                .header("X-Tenant-ID", &org_b.to_string())
+                .build(),
+        )
+        .await;
+
+    assert_rejected(resp.status, "get_metric cross-tenant");
+    assert_ne!(
+        resp.status,
+        StatusCode::OK,
+        "Org A metric must not be readable by Org B"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T3 — cross-org update_metric is rejected (mutate IDOR)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn update_metric_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (_org_a, org_b, _user_a, user_b, metric_a, _report_a) =
+        seed_two_org_fixture(&pool, "upd").await;
+
+    let token_b = mint_token(user_b, "upd-b@esg-idor.test");
+    let uri = format!("/api/v1/esg/metrics/{metric_a}");
+    let body = json!({ "value": "99999.0" });
+    let resp = app
+        .execute(
+            RequestBuilder::new(Method::PUT, &uri)
+                .bearer(&token_b)
+                .header("X-Tenant-ID", &org_b.to_string())
+                .json(body)
+                .build(),
+        )
+        .await;
+
+    assert_rejected(resp.status, "update_metric cross-tenant");
+
+    // The metric value must be unchanged.
+    let value: rust_decimal::Decimal =
+        sqlx::query_scalar("SELECT value FROM esg_metrics WHERE id = $1")
+            .bind(metric_a)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        value.to_string(),
+        "12345.0000",
+        "Org A metric must not be mutated cross-tenant"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T4 — cross-org verify_metric is rejected (mutate IDOR)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn verify_metric_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (_org_a, org_b, _user_a, user_b, metric_a, _report_a) =
+        seed_two_org_fixture(&pool, "ver").await;
+
+    let token_b = mint_token(user_b, "ver-b@esg-idor.test");
+    let uri = format!("/api/v1/esg/metrics/{metric_a}/verify");
+    let resp = app
+        .execute(
+            app.post(&uri)
+                .bearer(&token_b)
+                .header("X-Tenant-ID", &org_b.to_string())
+                .json(json!({ "status": "verified" }))
+                .build(),
+        )
+        .await;
+
+    assert_rejected(resp.status, "verify_metric cross-tenant");
+
+    let status: String =
+        sqlx::query_scalar("SELECT verification_status FROM esg_metrics WHERE id = $1")
+            .bind(metric_a)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        status, "unverified",
+        "Org A metric must not be verified cross-tenant"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T5 — cross-org delete_metric is rejected (destructive IDOR)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn delete_metric_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (_org_a, org_b, _user_a, user_b, metric_a, _report_a) =
+        seed_two_org_fixture(&pool, "del").await;
+
+    let token_b = mint_token(user_b, "del-b@esg-idor.test");
+    let uri = format!("/api/v1/esg/metrics/{metric_a}/delete");
+    let resp = app
+        .execute(
+            app.post(&uri)
+                .bearer(&token_b)
+                .header("X-Tenant-ID", &org_b.to_string())
+                .json(json!({}))
+                .build(),
+        )
+        .await;
+
+    assert_rejected(resp.status, "delete_metric cross-tenant");
+
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM esg_metrics WHERE id = $1")
+        .bind(metric_a)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count, 1, "Org A metric must not be deleted cross-tenant");
+}
+
+// ---------------------------------------------------------------------------
+// T6 — cross-org get_report by UUID is rejected (IDOR)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_report_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (_org_a, org_b, _user_a, user_b, _metric_a, report_a) =
+        seed_two_org_fixture(&pool, "rep").await;
+
+    let token_b = mint_token(user_b, "rep-b@esg-idor.test");
+    let uri = format!("/api/v1/esg/reports/{report_a}");
+    let resp = app
+        .execute(
+            app.get(&uri)
+                .bearer(&token_b)
+                .header("X-Tenant-ID", &org_b.to_string())
+                .build(),
+        )
+        .await;
+
+    assert_rejected(resp.status, "get_report cross-tenant");
+    assert_ne!(
+        resp.status,
+        StatusCode::OK,
+        "Org A report must not be readable by Org B"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T7 — cross-org submit_report is rejected (status-transition IDOR)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn submit_report_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (_org_a, org_b, _user_a, user_b, _metric_a, report_a) =
+        seed_two_org_fixture(&pool, "sub").await;
+
+    let token_b = mint_token(user_b, "sub-b@esg-idor.test");
+    let uri = format!("/api/v1/esg/reports/{report_a}/submit");
+    let resp = app
+        .execute(
+            app.post(&uri)
+                .bearer(&token_b)
+                .header("X-Tenant-ID", &org_b.to_string())
+                .json(json!({}))
+                .build(),
+        )
+        .await;
+
+    assert_rejected(resp.status, "submit_report cross-tenant");
+
+    let status: String = sqlx::query_scalar("SELECT status::text FROM esg_reports WHERE id = $1")
+        .bind(report_a)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        status, "draft",
+        "Org A report must not transition to pending_review cross-tenant"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T8 — cross-org delete_report is rejected (destructive IDOR)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn delete_report_from_other_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (_org_a, org_b, _user_a, user_b, _metric_a, report_a) =
+        seed_two_org_fixture(&pool, "rdl").await;
+
+    let token_b = mint_token(user_b, "rdl-b@esg-idor.test");
+    let uri = format!("/api/v1/esg/reports/{report_a}/delete");
+    let resp = app
+        .execute(
+            app.post(&uri)
+                .bearer(&token_b)
+                .header("X-Tenant-ID", &org_b.to_string())
+                .json(json!({}))
+                .build(),
+        )
+        .await;
+
+    assert_rejected(resp.status, "delete_report cross-tenant");
+
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM esg_reports WHERE id = $1")
+        .bind(report_a)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count, 1, "Org A report must not be deleted cross-tenant");
+}
+
+// ---------------------------------------------------------------------------
+// T9 — legitimate same-org access succeeds
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_metric_for_own_org_succeeds(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "own-a").await;
+    let user_a = seed_user(&pool, "own-a@esg-idor.test").await;
+    seed_membership(&pool, org_a, user_a).await;
+    let metric_a = seed_metric(&pool, org_a, user_a).await;
+
+    let token_a = mint_token(user_a, "own-a@esg-idor.test");
+    let uri = format!("/api/v1/esg/metrics/{metric_a}");
+    let resp = app
+        .execute(
+            app.get(&uri)
+                .bearer(&token_a)
+                .header("X-Tenant-ID", &org_a.to_string())
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "Org A member must be able to read its own metric: {}",
+        resp.text()
+    );
+    let detail = resp.json_value();
+    assert_eq!(
+        detail.get("id").and_then(|v| v.as_str()),
+        Some(metric_a.to_string().as_str()),
+        "own-org read must return the seeded metric"
+    );
+}


### PR DESCRIPTION
## Summary

Closes the PAP-136 cross-tenant IDOR finding on the ESG reporting surface (`/api/v1/esg/*`, Epic 136) and delivers the raw-pool→RLS-executor conversion that **unblocks PAP-72** (FORCE-RLS deny-all on `/api/v1/esg`).

Before this change, every by-id ESG handler carried `_auth: AuthUser` and did no org scoping, and `EsgReportingRepository` ran on the raw `DbPool` — so under the migration-00179 `FORCE ROW LEVEL SECURITY` the whole surface collapsed to deny-all on a non-exempt role (PAP-72), while an RLS-exempt/superuser pool leaked every other tenant's rows by UUID (PAP-136).

## Changes

- **`crates/db/src/repositories/esg_reporting.rs`** — repository is now **stateless**: every method takes an RLS-context-bearing executor (`executor: E`, or `&mut PgConnection` for the multi-query `refresh_dashboard_metrics`), the PAP-67/PAP-80/PAP-137 pattern. The repo holds **no pool**, so it cannot issue an un-scoped query. All 18 by-id queries (get/update/verify/delete/submit/approve across `esg_metrics`, `carbon_footprints`, `esg_benchmarks`, `esg_targets`, `esg_reports`, `eu_taxonomy_assessments`, `esg_import_jobs`) are org-keyed `WHERE id = $1 AND organization_id = $N` as defense-in-depth. Every esg_* table carries `organization_id` directly, so no EXISTS-through-parent keying is needed.
- **`servers/api-server/src/routes/esg_reporting.rs`** — every handler switched `AuthUser` → `RlsConnection`, threading `rls.tenant_id()` (the verified tenant, never path/body) and calling `rls.release()` before returning the connection to the pool. Cross-tenant by-id probes resolve to no row → `404`/no-op.
- **`servers/api-server/tests/esg_reporting_cross_org_idor_tests.rs`** — new cross-tenant IDOR regression suite (9 cases: metric read/update/verify/delete, report read/submit/delete, unauthenticated, same-org success), modeled on `board_meetings_cross_org_idor_tests.rs`. The CI test pool runs as superuser (bypasses FORCE RLS), so the suite specifically proves the org-keyed SQL layer.

## Verification

- `cargo check -p db -p api-server` ✅
- `cargo clippy -p db -p api-server --all-targets -- -D warnings` ✅
- `cargo fmt --check` ✅
- IDOR test compiles; full execution validated by `backend.yml` (proper Postgres + superuser pool).

Pattern mirrors merged PR #1262 (PAP-137, board_meetings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)