### PR TITLE
perf(research): extract dispatcher merge-path subagent prompts (PAP-164)

### DIFF
--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -1485,28 +1485,13 @@ to Phase 5.5's normal classification.
 **Action.** Spawn ONE Task subagent per qualifying row (cap 2 parallel,
 same as Phase 5.6's rebaser cap — both serialize on `dev` base):
 
-> You are a pre-merge mechanical autofixer for PR #<n>.
->
-> 0. **Workspace isolation (MANDATORY — issue #7).** Run the standard
->    worktree preamble: `TASK_ID=premerge-<n>`, `BRANCH=<row.branch>`.
->    NEVER `gh pr checkout` in the dispatcher's working tree.
-> 1. Invoke `.claude/skills/ppt-pr-merge/SKILL.md` Step 2 (conflict
->    auto-resolution) directly — that's the existing function that
->    rebases against `dev` and regenerates SQLx / Cargo.lock /
->    generated clients. Do NOT call `gh pr merge` from inside the skill
->    yet (Phase 5.5 owns the merge).
-> 2. `git push --force-with-lease origin <branch>`.
-> 3. Re-trigger CI explicitly so we observe the new head's result
->    before Phase 5.5 sees the row:
->    `gh workflow run <workflow-on-the-pr> --ref <branch>` (best-effort).
-> 4. Return EXACTLY:
->    `premerge=<applied|skipped|failed> pr=<n> note=<short>`.
->
-> Failure mode: if the rebase produces any real (non-mechanical) conflict
-> after starting, `git rebase --abort` and return
-> `premerge=failed note=conflict-in:<paths>`. Phase 5.5's normal flow
-> will see `mergeable=CONFLICTING` next run and route to Phase 5.6 as
-> usual — no double-handling.
+> You are a pre-merge mechanical autofixer for PR #<n>, branch `<branch>`.
+> Read `.research/management/premerge-autofix-prompt.md` and follow it exactly
+> — it is your complete instruction set (worktree preamble, ppt-pr-merge Step 2
+> conflict auto-resolution, force-push, CI re-trigger). Substitute the runtime
+> values above wherever the file references `<n>` / `<branch>` /
+> `<workflow-on-the-pr>`. Return ONLY the single
+> `premerge=<applied|skipped|failed> pr=<n> note=<short>` line it specifies.
 
 **Bookkeeping.** Each `premerge=applied` bumps `rebase_attempts += 1`
 (single-owner rule — dispatcher does the write; subagent only returns).
@@ -1608,26 +1593,13 @@ For each row `status == "review"` where:
 Spawn ONE Task subagent (cap 1 parallel — rebases serialize on the same base):
 
 > You are a PR rebaser for a stale approved PR. Inputs: `pr_number=<n>`,
-> `branch=<head_ref>`, `base=dev`. Do this exactly:
->
-> 0. **Workspace isolation (MANDATORY — issue #7).** Run the standard
->    worktree preamble from the "Subagent workspace isolation" section
->    above (export `TASK_ID=pr-<n>`, `BRANCH=<head_ref>`). All subsequent
->    git operations run inside `/tmp/ppt-worktrees/pr-<n>/`. NEVER
->    `gh pr checkout` in the dispatcher's working tree — it displaces
->    `dev` and breaks Phase 6 of this run.
-> 1. `gh pr checkout <n> --repo martin-janci/property-management`
-> 2. `git fetch origin dev`
-> 3. `git rebase origin/dev`
->    - If conflicts ONLY in mechanical paths (sqlx, Cargo.lock, generated
->      openapi/api-client, pnpm-lock.yaml, VERSION) → resolve per
->      `ppt-pr-merge` Step 2 table, `git rebase --continue`.
->    - Any other conflict → `git rebase --abort` and
->      `gh pr comment <n> --body "Auto-rebase aborted: real code conflict in
->      <paths>. Manual rebase required."`, return
->      `rebased=false note=conflict-in:<paths>`.
-> 4. `git push --force-with-lease origin <branch>`
-> 5. Return EXACTLY: `rebased=<true|false> pr=<n> note=<short>`
+> `branch=<head_ref>`, `base=dev`. Read `.research/management/rebaser-prompt.md`
+> and follow it exactly — it is your complete instruction set (worktree
+> preamble, checkout, `git rebase origin/dev`, mechanical-only conflict
+> resolution per ppt-pr-merge Step 2, force-push-with-lease). Substitute the
+> runtime values above wherever the file references `<n>` / `<head_ref>` /
+> `<branch>`. Return ONLY the single `rebased=<true|false> pr=<n> note=<short>`
+> line it specifies. Do NOT touch `rebase_attempts` — the dispatcher owns it.
 
 Capture line. Bump `last_updated = now`.
 
@@ -1689,29 +1661,13 @@ starts with `"verdict=changes"` AND `fix_rounds < 3`:
 
 Spawn ONE Task subagent (cap `DISPATCHER_CLAIM_CAP` parallel, default 6 — same as Phase 4's implementer cap):
 
-> You are the PR follow-up driver. Invoke
-> `.claude/skills/ppt-pr-followup/SKILL.md` in dispatcher mode for PR #<n>.
->
-> 0. **Workspace isolation (MANDATORY — issue #7).** When step 2 below
->    spawns the original specialist via Task, the brief you pass that
->    specialist MUST include the standard worktree preamble from the
->    "Subagent workspace isolation" section above (export
->    `TASK_ID=<task_id>`, `BRANCH=<row.branch>`). The followup script
->    itself runs read-only `gh` calls and is safe in the dispatcher's
->    tree.
-> 1. Run `bash .claude/skills/ppt-pr-followup/scripts/dispatcher-followup.sh --pr <n>`.
-> 2. If the script's stdout contains a `=== ppt-pr-followup respawn brief ===`
->    block, take that brief and spawn the original specialist via the `Task`
->    tool (same channel Phase 4 uses), waiting for it to return.
-> 3. After the spawned implementer returns, set `status=review` on the row
->    and bump `last_updated`. (The script already cleared `reviewer_summary`
->    and flipped `status=in-progress`; this flip back to `review` is what
->    re-arms Phase 5 for a fresh reviewer pass on the new commits.)
-> 4. Return EXACTLY the script's final line, e.g.
->    `followup=respawned pr=<n> specialist=<sp> round=<k>`.
->
-> If the script exits non-zero (failed/round-cap), do not spawn; just return
-> the script's last line.
+> You are the PR follow-up driver for PR #<n>, task `<task_id>`, specialist
+> `<sp>`. Read `.research/management/pr-followup-prompt.md` and follow it
+> exactly — it is your complete instruction set (workspace-isolation brief,
+> `ppt-pr-followup` dispatcher-mode script, respawn-brief handling, post-respawn
+> `status=review` flip). Substitute the runtime values above wherever the file
+> references `<n>` / `<task_id>` / `<row.branch>` / `<sp>` / `<k>`. Return ONLY
+> the single `followup=<...> pr=<n> specialist=<sp> round=<k>` line it specifies.
 
 Capture line. The script already mutated `assignments.json`; this phase
 adds nothing further to the file beyond the post-respawn `status=review`

--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -1359,108 +1359,25 @@ is unbounded by phase contract; the cost ceiling is the count of pending
 
 For each row where `status == "review"` AND (`reviewer_summary` is null OR `PR.headRefOid != row.last_reviewed_oid`):
 
+**Spawn the reviewer subagent** with the verbatim prompt at
+`.research/management/pr-reviewer-prompt.md`. Do NOT inline the rubric here —
+pass the Task subagent the runtime values for this row, then a one-line
+instruction to read that file and follow it exactly, e.g.:
+
 > You are a code reviewer for PR #<n>. Task: `<task_id>: <action>`. Specialist:
 > `<sp>`. Owner: `<role>`. The implementer flagged: `scope_drift=<bool>`,
-> `code_reuse_warn=<short|none>`.
->
-> 0. **Dedup guard (NEW — issue #3: prevents duplicate bot reviews when two
->    dispatcher runs overlap before the Phase 1 skip-gate kicks in).** Before
->    posting anything, check existing reviews on this PR:
->
->    ```bash
->    HEAD_OID=$(gh pr view <n> --repo martin-janci/property-management --json headRefOid --jq .headRefOid)
->    EXISTING=$(gh api repos/martin-janci/property-management/pulls/<n>/reviews \
->      --jq '[.[] | select(.user.type=="Bot" or (.user.login|test("^claude|^github-actions"))) | {sha:.commit_id, state, at:.submitted_at}] | sort_by(.at) | last')
->    EX_SHA=$(echo "$EXISTING" | jq -r '.sha // empty')
->    EX_STATE=$(echo "$EXISTING" | jq -r '.state // empty')
->    EX_AT=$(echo "$EXISTING" | jq -r '.at // empty')
->    ```
->
->    If `$EX_SHA == $HEAD_OID` AND `$EX_STATE` in `{APPROVED, CHANGES_REQUESTED}`
->    AND `(now - $EX_AT) < 2h`: a bot review for this exact SHA already exists.
->    SKIP posting a new review. Map state → verdict (`APPROVED→approve`,
->    `CHANGES_REQUESTED→changes`) and return:
->    `verdict=<v> head_oid=$HEAD_OID note=dedup-existing-review-at-$EX_AT`.
->
-> 1. **Smart-triage metadata pull (issue #9 — token spending).** Do NOT
->    `gh pr diff <n>` blind — for big PRs that's 50-100k tokens of unfiltered
->    text into your context, most of it lockfile / generated-client noise.
->    Pull metadata first:
->
->    ```bash
->    gh pr view <n> --repo martin-janci/property-management \
->      --json title,body,checks,headRefOid,files \
->      --jq '{title, body, headRefOid,
->             checks: [.checks[] | {name, conclusion}],
->             files: [.files[] | {path, additions, deletions}]
->                    | sort_by(-(.additions + .deletions))}'
->    ```
->
->    You now have: title/body, CI status, and every changed file ranked by
->    LOC. **Total cost: a few hundred tokens** regardless of PR size.
->
-> 1.5. **Triage which files actually need a full diff.** Apply these rules
->      in order and build the path-include / path-exclude lists:
->
->    | Path pattern | Decision |
->    |---|---|
->    | `**/*auth*`, `**/*security*`, `**/middleware/*`, `**/jwt*`, `**/rbac*`, `**/rls*` | **MUST full-diff** (hot path) |
->    | `backend/crates/db/migrations/**` | **MUST full-diff** + check for `DROP`, `NOT NULL`, `DEFAULT` clauses |
->    | `**/Cargo.lock`, `**/pnpm-lock.yaml`, `frontend/packages/api-client/src/**` (generated) | **SKIP** — note in body, do not diff |
->    | Files with `additions + deletions > 800` LOC | **Header + tail only**: `gh pr diff <n> -- <path> \| head -200; echo '...'; gh pr diff <n> -- <path> \| tail -100` |
->    | Test files (`**/tests/**`, `**/*_test.rs`, `**/*.test.ts`) | **Skim**: read assertions but don't deeply audit fixtures |
->    | Everything else | Full diff per file via `gh pr diff <n> -- <path>` |
->
->    Heuristic limit: target ≤ 25k tokens of diff content into your context
->    across all `gh pr diff` calls combined. If the budget is blown by hot-path
->    files alone, that's fine — security review needs the bytes. But never
->    spend the budget on lockfile diffs or generated clients.
->
-> 2. After triage, run the targeted diff calls. Example for a typical PR:
->    ```bash
->    # Hot-path mandatory:
->    gh pr diff <n> -- 'backend/**/auth*' 'backend/**/security*' 'backend/**/middleware/*'
->    # Migration check:
->    gh pr diff <n> -- 'backend/crates/db/migrations/*'
->    # Normal-LOC files (under 800 each):
->    gh pr diff <n> -- 'backend/servers/api-server/src/routes/documents/*' \
->                    -- ':!**/generated/**'
->    # Big file headers only:
->    gh pr diff <n> -- 'backend/servers/api-server/src/routes/admin/big.rs' | head -200
->    ```
->
->    For tiny PRs (`additions + deletions < 500` total), skip the triage
->    overhead — the full `gh pr diff <n>` is cheap and clearer. Triage pays
->    off above ~1k LOC of changes.
->
-> 3. Review against `.claude/skills/ppt-implement/agents/<sp>.md` conventions,
->    security (RLS for db-migration, auth for pm-security), regressions, tests,
->    verify bands (Tested/Built/CI parity).
-> 4. **If `scope_drift=true`**: explicitly judge whether the off-area changes
->    are necessary, and if not, demand a revert in the changes verdict.
-> 5. **If `code_reuse_warn != none`**: explicitly judge whether the new code
->    duplicates an existing helper named in the warning, and if so, demand
->    delegation in the changes verdict.
-> 6. **JSON-key-case sanity check (NEW — item #5)**: if the triage in step 1.5
->    found any Rust test paths in the changeset, run the check on **just those
->    paths** (issue #9 — don't reload the full diff):
->
->    ```bash
->    # Find DTOs the tests touch that carry rename_all = camelCase
->    rg -n '#\[serde\(rename_all\s*=\s*"camelCase"\)\]' backend/ --type rust | head -20
->    # Path-filtered diff for snake_case JSON accessors in test files only
->    gh pr diff <n> -- 'backend/**/tests/**' 'backend/**/*_test.rs' \
->      | rg -n '^\+.*json\[\s*"[a-z]+_[a-z_]+"\s*\]' | head -20
->    ```
->
->    Skip the check entirely if no Rust test paths are in the changeset.
->    If both produce hits AND they refer to the same DTO type, demand a fix
->    in the changes verdict (this is the bug class that bit PR #473 on 2026-05-24).
-> 7. `gh pr review <n> --approve --body '<summary>'` OR
->    `gh pr review <n> --request-changes --body '<bullet list>'`.
->
-> Return EXACTLY (one line):
-> `verdict=<approve|changes> head_oid=<PR.headRefOid> note=<short>`
+> `code_reuse_warn=<short|none>`. Read `.research/management/pr-reviewer-prompt.md`
+> and follow it exactly — it is your complete instruction set (dedup guard,
+> smart-triage, hot-path rules, JSON-key-case check (item #5), verdict steps).
+> Substitute the runtime values
+> above wherever the file references `<n>` / `<task_id>` / `<action>` / `<sp>` /
+> `<role>` / `scope_drift` / `code_reuse_warn`. Return ONLY the single
+> `verdict=<approve|changes> head_oid=<PR.headRefOid> note=<short>` line it specifies.
+
+The subagent reads its ~100-line triage rubric/schema in its own context, so
+those lines never load into the dispatcher run. Keep the spawn config above,
+the capture/invariant logic, and the human-gate sweep below inline — they are
+dispatcher-side.
 
 Capture → `reviewer_summary`, **`last_reviewed_oid = head_oid` (item #10 — MANDATORY)**,
 `last_updated = now`. STATUS UNCHANGED.

--- a/.research/dispatcher-self-test.sh
+++ b/.research/dispatcher-self-test.sh
@@ -620,6 +620,46 @@ else
 fi
 echo
 
+# --- T27: merge-path subagent prompt extraction integrity (PAP-164) --------
+# PAP-164 moved the verbatim Phase 5 / 5.4 / 5.6 / 5.7 subagent prompts out of
+# dispatcher-prompt.md into .research/management/*-prompt.md (token economy).
+# These sit on the merge-decision hot path, so the extraction MUST stay intact:
+#   (a) each extracted file exists and carries its anchor strings (a truncated,
+#       empty, or corrupted file would silently strip the subagent's rubric —
+#       exactly the failure a live dispatcher dry-run would otherwise catch); AND
+#   (b) dispatcher-prompt.md still POINTS at each file (a spawn site that lost
+#       its pointer would spawn a subagent with no instructions).
+# Hard-fail on any violation — this is the merge hot path.
+echo "T27 merge-path subagent prompt extraction integrity (PAP-164)"
+MGMT_DIR="${MGMT_DIR:-.research/management}"
+# file :: anchor1|anchor2|anchor3  (all anchors must be present, grep -F literal)
+declare -a T27_SPECS=(
+  "pr-reviewer-prompt.md::You are a code reviewer::verdict=<approve|changes>::head_oid"
+  "premerge-autofix-prompt.md::pre-merge mechanical autofixer::premerge=<applied|skipped|failed>::ppt-pr-merge"
+  "rebaser-prompt.md::PR rebaser::rebased=<true|false>"
+  "pr-followup-prompt.md::PR follow-up driver::ppt-pr-followup::followup="
+)
+for spec in "${T27_SPECS[@]}"; do
+  f="${spec%%::*}"
+  rest="${spec#*::}"
+  fpath="$MGMT_DIR/$f"
+  if [ ! -f "$fpath" ]; then fail "missing extracted prompt: $fpath"; continue; fi
+  if ! grep -qF -- "$f" "$PROMPT"; then
+    fail "dispatcher-prompt.md no longer points at $f (spawn site lost its pointer)"
+  fi
+  ok_anchors=1
+  while [ -n "$rest" ]; do
+    anchor="${rest%%::*}"
+    if [ "$anchor" = "$rest" ]; then rest=""; else rest="${rest#*::}"; fi
+    if ! grep -qF -- "$anchor" "$fpath"; then
+      fail "$fpath missing anchor: '$anchor' (extraction corrupted/truncated)"
+      ok_anchors=0
+    fi
+  done
+  [ "$ok_anchors" = "1" ] && note "$f intact + referenced by dispatcher-prompt.md"
+done
+echo
+
 # --- Summary ---------------------------------------------------------------
 if [ "$FAIL" = "0" ]; then
   echo "==> dispatcher-self-test: PASS"

--- a/.research/management/pr-followup-prompt.md
+++ b/.research/management/pr-followup-prompt.md
@@ -1,0 +1,36 @@
+# Dispatcher Phase 5.7 — PR follow-up driver subagent prompt
+
+> Extracted from `dispatcher-prompt.md` Phase 5.7 for token economy (PAP-164).
+> The dispatcher spawns this subagent (cap DISPATCHER_CLAIM_CAP parallel) for a
+> `verdict=changes` row that has NOT exhausted its fix rounds, and points it
+> here; the subagent reads this file in its own fresh context.
+>
+> **Runtime inputs** (the dispatcher passes concrete values in its spawn
+> message): `<n>` (PR number), `<task_id>`, `<row.branch>` (head branch),
+> `<sp>` (specialist), `<k>` (round). Substitute wherever they appear below.
+
+---
+
+You are the PR follow-up driver. Invoke
+`.claude/skills/ppt-pr-followup/SKILL.md` in dispatcher mode for PR #<n>.
+
+0. **Workspace isolation (MANDATORY — issue #7).** When step 2 below
+   spawns the original specialist via Task, the brief you pass that
+   specialist MUST include the standard worktree preamble from the
+   "Subagent workspace isolation" section above (export
+   `TASK_ID=<task_id>`, `BRANCH=<row.branch>`). The followup script
+   itself runs read-only `gh` calls and is safe in the dispatcher's
+   tree.
+1. Run `bash .claude/skills/ppt-pr-followup/scripts/dispatcher-followup.sh --pr <n>`.
+2. If the script's stdout contains a `=== ppt-pr-followup respawn brief ===`
+   block, take that brief and spawn the original specialist via the `Task`
+   tool (same channel Phase 4 uses), waiting for it to return.
+3. After the spawned implementer returns, set `status=review` on the row
+   and bump `last_updated`. (The script already cleared `reviewer_summary`
+   and flipped `status=in-progress`; this flip back to `review` is what
+   re-arms Phase 5 for a fresh reviewer pass on the new commits.)
+4. Return EXACTLY the script's final line, e.g.
+   `followup=respawned pr=<n> specialist=<sp> round=<k>`.
+
+If the script exits non-zero (failed/round-cap), do not spawn; just return
+the script's last line.

--- a/.research/management/pr-reviewer-prompt.md
+++ b/.research/management/pr-reviewer-prompt.md
@@ -1,0 +1,118 @@
+# Dispatcher Phase 5 — PR reviewer subagent prompt
+
+> Extracted from `dispatcher-prompt.md` Phase 5 for token economy (PAP-164,
+> follow-up to PAP-163): the dispatcher no longer carries these ~100 lines in
+> its own context every run. Phase 5 spawns one reviewer subagent **per
+> pending `review` row** and points it here; the subagent reads this file in
+> its own fresh context. Edit this file to change reviewer behaviour — it is
+> the verbatim Task prompt.
+>
+> **Runtime inputs.** The dispatcher passes the concrete values for the
+> placeholders below in its spawn message — `<n>` (PR number), `<task_id>`,
+> `<action>`, `<sp>` (specialist), `<role>` (owner), `scope_drift=<bool>`,
+> `code_reuse_warn=<short|none>`. Substitute them wherever they appear.
+
+---
+
+You are a code reviewer for PR #<n>. Task: `<task_id>: <action>`. Specialist:
+`<sp>`. Owner: `<role>`. The implementer flagged: `scope_drift=<bool>`,
+`code_reuse_warn=<short|none>`.
+
+0. **Dedup guard (NEW — issue #3: prevents duplicate bot reviews when two
+   dispatcher runs overlap before the Phase 1 skip-gate kicks in).** Before
+   posting anything, check existing reviews on this PR:
+
+   ```bash
+   HEAD_OID=$(gh pr view <n> --repo martin-janci/property-management --json headRefOid --jq .headRefOid)
+   EXISTING=$(gh api repos/martin-janci/property-management/pulls/<n>/reviews \
+     --jq '[.[] | select(.user.type=="Bot" or (.user.login|test("^claude|^github-actions"))) | {sha:.commit_id, state, at:.submitted_at}] | sort_by(.at) | last')
+   EX_SHA=$(echo "$EXISTING" | jq -r '.sha // empty')
+   EX_STATE=$(echo "$EXISTING" | jq -r '.state // empty')
+   EX_AT=$(echo "$EXISTING" | jq -r '.at // empty')
+   ```
+
+   If `$EX_SHA == $HEAD_OID` AND `$EX_STATE` in `{APPROVED, CHANGES_REQUESTED}`
+   AND `(now - $EX_AT) < 2h`: a bot review for this exact SHA already exists.
+   SKIP posting a new review. Map state → verdict (`APPROVED→approve`,
+   `CHANGES_REQUESTED→changes`) and return:
+   `verdict=<v> head_oid=$HEAD_OID note=dedup-existing-review-at-$EX_AT`.
+
+1. **Smart-triage metadata pull (issue #9 — token spending).** Do NOT
+   `gh pr diff <n>` blind — for big PRs that's 50-100k tokens of unfiltered
+   text into your context, most of it lockfile / generated-client noise.
+   Pull metadata first:
+
+   ```bash
+   gh pr view <n> --repo martin-janci/property-management \
+     --json title,body,checks,headRefOid,files \
+     --jq '{title, body, headRefOid,
+            checks: [.checks[] | {name, conclusion}],
+            files: [.files[] | {path, additions, deletions}]
+                   | sort_by(-(.additions + .deletions))}'
+   ```
+
+   You now have: title/body, CI status, and every changed file ranked by
+   LOC. **Total cost: a few hundred tokens** regardless of PR size.
+
+1.5. **Triage which files actually need a full diff.** Apply these rules
+     in order and build the path-include / path-exclude lists:
+
+   | Path pattern | Decision |
+   |---|---|
+   | `**/*auth*`, `**/*security*`, `**/middleware/*`, `**/jwt*`, `**/rbac*`, `**/rls*` | **MUST full-diff** (hot path) |
+   | `backend/crates/db/migrations/**` | **MUST full-diff** + check for `DROP`, `NOT NULL`, `DEFAULT` clauses |
+   | `**/Cargo.lock`, `**/pnpm-lock.yaml`, `frontend/packages/api-client/src/**` (generated) | **SKIP** — note in body, do not diff |
+   | Files with `additions + deletions > 800` LOC | **Header + tail only**: `gh pr diff <n> -- <path> \| head -200; echo '...'; gh pr diff <n> -- <path> \| tail -100` |
+   | Test files (`**/tests/**`, `**/*_test.rs`, `**/*.test.ts`) | **Skim**: read assertions but don't deeply audit fixtures |
+   | Everything else | Full diff per file via `gh pr diff <n> -- <path>` |
+
+   Heuristic limit: target ≤ 25k tokens of diff content into your context
+   across all `gh pr diff` calls combined. If the budget is blown by hot-path
+   files alone, that's fine — security review needs the bytes. But never
+   spend the budget on lockfile diffs or generated clients.
+
+2. After triage, run the targeted diff calls. Example for a typical PR:
+   ```bash
+   # Hot-path mandatory:
+   gh pr diff <n> -- 'backend/**/auth*' 'backend/**/security*' 'backend/**/middleware/*'
+   # Migration check:
+   gh pr diff <n> -- 'backend/crates/db/migrations/*'
+   # Normal-LOC files (under 800 each):
+   gh pr diff <n> -- 'backend/servers/api-server/src/routes/documents/*' \
+                   -- ':!**/generated/**'
+   # Big file headers only:
+   gh pr diff <n> -- 'backend/servers/api-server/src/routes/admin/big.rs' | head -200
+   ```
+
+   For tiny PRs (`additions + deletions < 500` total), skip the triage
+   overhead — the full `gh pr diff <n>` is cheap and clearer. Triage pays
+   off above ~1k LOC of changes.
+
+3. Review against `.claude/skills/ppt-implement/agents/<sp>.md` conventions,
+   security (RLS for db-migration, auth for pm-security), regressions, tests,
+   verify bands (Tested/Built/CI parity).
+4. **If `scope_drift=true`**: explicitly judge whether the off-area changes
+   are necessary, and if not, demand a revert in the changes verdict.
+5. **If `code_reuse_warn != none`**: explicitly judge whether the new code
+   duplicates an existing helper named in the warning, and if so, demand
+   delegation in the changes verdict.
+6. **JSON-key-case sanity check (NEW — item #5)**: if the triage in step 1.5
+   found any Rust test paths in the changeset, run the check on **just those
+   paths** (issue #9 — don't reload the full diff):
+
+   ```bash
+   # Find DTOs the tests touch that carry rename_all = camelCase
+   rg -n '#\[serde\(rename_all\s*=\s*"camelCase"\)\]' backend/ --type rust | head -20
+   # Path-filtered diff for snake_case JSON accessors in test files only
+   gh pr diff <n> -- 'backend/**/tests/**' 'backend/**/*_test.rs' \
+     | rg -n '^\+.*json\[\s*"[a-z]+_[a-z_]+"\s*\]' | head -20
+   ```
+
+   Skip the check entirely if no Rust test paths are in the changeset.
+   If both produce hits AND they refer to the same DTO type, demand a fix
+   in the changes verdict (this is the bug class that bit PR #473 on 2026-05-24).
+7. `gh pr review <n> --approve --body '<summary>'` OR
+   `gh pr review <n> --request-changes --body '<bullet list>'`.
+
+Return EXACTLY (one line):
+`verdict=<approve|changes> head_oid=<PR.headRefOid> note=<short>`

--- a/.research/management/premerge-autofix-prompt.md
+++ b/.research/management/premerge-autofix-prompt.md
@@ -1,0 +1,35 @@
+# Dispatcher Phase 5.4 — pre-merge mechanical autofixer subagent prompt
+
+> Extracted from `dispatcher-prompt.md` Phase 5.4 for token economy (PAP-164).
+> The dispatcher spawns this subagent for an approved PR whose only failing
+> paths are mechanical (sqlx / Cargo.lock / generated clients / lockfiles) and
+> points it here; the subagent reads this file in its own fresh context.
+>
+> **Runtime inputs** (the dispatcher passes concrete values in its spawn
+> message): `<n>` (PR number), `<branch>` / `<row.branch>` (head branch),
+> `<workflow-on-the-pr>`. Substitute wherever they appear below.
+
+---
+
+You are a pre-merge mechanical autofixer for PR #<n>.
+
+0. **Workspace isolation (MANDATORY — issue #7).** Run the standard
+   worktree preamble: `TASK_ID=premerge-<n>`, `BRANCH=<row.branch>`.
+   NEVER `gh pr checkout` in the dispatcher's working tree.
+1. Invoke `.claude/skills/ppt-pr-merge/SKILL.md` Step 2 (conflict
+   auto-resolution) directly — that's the existing function that
+   rebases against `dev` and regenerates SQLx / Cargo.lock /
+   generated clients. Do NOT call `gh pr merge` from inside the skill
+   yet (Phase 5.5 owns the merge).
+2. `git push --force-with-lease origin <branch>`.
+3. Re-trigger CI explicitly so we observe the new head's result
+   before Phase 5.5 sees the row:
+   `gh workflow run <workflow-on-the-pr> --ref <branch>` (best-effort).
+4. Return EXACTLY:
+   `premerge=<applied|skipped|failed> pr=<n> note=<short>`.
+
+Failure mode: if the rebase produces any real (non-mechanical) conflict
+after starting, `git rebase --abort` and return
+`premerge=failed note=conflict-in:<paths>`. Phase 5.5's normal flow
+will see `mergeable=CONFLICTING` next run and route to Phase 5.6 as
+usual — no double-handling.

--- a/.research/management/rebaser-prompt.md
+++ b/.research/management/rebaser-prompt.md
@@ -1,0 +1,35 @@
+# Dispatcher Phase 5.6 — stale-approved-PR rebaser subagent prompt
+
+> Extracted from `dispatcher-prompt.md` Phase 5.6 for token economy (PAP-164).
+> The dispatcher spawns this subagent (cap 1 parallel) for an approved PR that
+> is `CONFLICTING` and stale, and points it here; the subagent reads this file
+> in its own fresh context.
+>
+> **Runtime inputs** (the dispatcher passes concrete values in its spawn
+> message): `<n>` (PR number), `<head_ref>` / `<branch>` (head branch).
+> Substitute wherever they appear below. NOTE: the subagent MUST NOT touch
+> `rebase_attempts` — the dispatcher owns that counter (single-writer rule).
+
+---
+
+You are a PR rebaser for a stale approved PR. Inputs: `pr_number=<n>`,
+`branch=<head_ref>`, `base=dev`. Do this exactly:
+
+0. **Workspace isolation (MANDATORY — issue #7).** Run the standard
+   worktree preamble from the "Subagent workspace isolation" section
+   above (export `TASK_ID=pr-<n>`, `BRANCH=<head_ref>`). All subsequent
+   git operations run inside `/tmp/ppt-worktrees/pr-<n>/`. NEVER
+   `gh pr checkout` in the dispatcher's working tree — it displaces
+   `dev` and breaks Phase 6 of this run.
+1. `gh pr checkout <n> --repo martin-janci/property-management`
+2. `git fetch origin dev`
+3. `git rebase origin/dev`
+   - If conflicts ONLY in mechanical paths (sqlx, Cargo.lock, generated
+     openapi/api-client, pnpm-lock.yaml, VERSION) → resolve per
+     `ppt-pr-merge` Step 2 table, `git rebase --continue`.
+   - Any other conflict → `git rebase --abort` and
+     `gh pr comment <n> --body "Auto-rebase aborted: real code conflict in
+     <paths>. Manual rebase required."`, return
+     `rebased=false note=conflict-in:<paths>`.
+4. `git push --force-with-lease origin <branch>`
+5. Return EXACTLY: `rebased=<true|false> pr=<n> note=<short>`


### PR DESCRIPTION
## What

Follow-up to PAP-163 (PR #1283). Extracts the verbatim merge-path subagent
prompt templates out of `.research/dispatcher-prompt.md` into linked files the
subagent reads in its own fresh context, so they no longer cost tokens on every
dispatcher run. Same extraction pattern PAP-163 used for the Phase 8 self-review
prompt.

| Phase | Template | Extracted to |
|---|---|---|
| 5 | PR reviewer (~100 lines) | `.research/management/pr-reviewer-prompt.md` |
| 5.4 | pre-merge mechanical autofixer | `.research/management/premerge-autofix-prompt.md` |
| 5.6 | stale-approved-PR rebaser | `.research/management/rebaser-prompt.md` |
| 5.7 | PR follow-up driver | `.research/management/pr-followup-prompt.md` |

**Phase 5.5 (merger) deliberately left inline** — its blockquote is already a
5-line `ppt-pr-merge` skill invocation; extracting it would net zero token
saving while adding a file.

Each spawn site keeps only the runtime placeholders inline (`PR #<n>`,
`<task_id>`, specialist, branch, `scope_drift`, `code_reuse_warn`) plus a
one-line pointer to read the extracted file and follow it.

## Behavior preservation

- Every extracted body is **byte-identical** to the original de-blockquoted
  prompt (verified with `diff` per file during extraction).
- `item #5` marker (T10) and all `ppt-*` skill refs (T9) kept inline.
- `dispatcher-self-test.sh` PASS after each of the three commits.

## New safety guard (T27)

The acceptance criteria call for a live dispatcher dry-run to confirm
claim/review/merge decisions are unchanged. **No dispatcher dry-run mechanism
exists** — there is no `--dry-run` flag, and per PAP-163 a real cloud dispatcher
run is not runnable from any implementer env; only `dispatcher-self-test.sh`
static checks are. To compensate for the merge-hot-path blast radius, this PR
adds **T27**, which hard-fails if any extracted prompt is missing, truncated, or
no longer referenced by `dispatcher-prompt.md`. That converts the one runtime
risk a dry-run would catch — a merge-path subagent spawned without its rubric —
into a deterministic pre-merge gate. Verified T27 bites on both a
corrupted-anchor file and a deleted file, and passes on the intact tree.

## Token reduction (measured)

`dispatcher-prompt.md`: **6.6 KB / 127 net lines removed** (126,396 → 119,826
bytes) ≈ **~1.3–1.6k tok/run**. This is below the issue's ~8–12k estimate — the
templates were smaller than estimated and Phase 5.5 was already skill-thin; the
honest measured figure is ~1.3–1.6k.

## Verification ceiling / reviewer ask

The genuine end-to-end validation is the **next scheduled cloud dispatcher run**
reading the merged prompt (it reads `dispatcher-prompt.md` fresh from `dev`
every run). Merging is the point at which that validation occurs — please gate
the merge on your comfort with the byte-identity + T27 evidence above. If you'd
prefer a live pre-merge dry-run, that has to run on the dispatcher's cloud infra,
not an implementer checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)