### PR TITLE
fix(api-server): route ai/llm.rs post-LLM writes through RLS connection (PAP-150)

### DIFF
--- a/backend/scripts/rls-handler-baseline.txt
+++ b/backend/scripts/rls-handler-baseline.txt
@@ -7,7 +7,6 @@
 # --strict; raw-pool access in any file NOT listed here fails CI. When a file
 # is cleaned up, REMOVE its line (the script warns on stale entries).
 
-servers/api-server/src/routes/ai/llm.rs
 servers/api-server/src/routes/ai/sessions.rs
 servers/api-server/src/routes/api_ecosystem.rs
 servers/api-server/src/routes/integrations/sync.rs

--- a/backend/servers/api-server/src/routes/ai/llm.rs
+++ b/backend/servers/api-server/src/routes/ai/llm.rs
@@ -18,6 +18,7 @@ use axum::{
     Json, Router,
 };
 use common::errors::ErrorResponse;
+use db::RlsPool;
 use db::models::{
     EnhancePhotoRequest, EnhancedChatRequest, GenerateLeaseRequest,
     GenerateListingDescriptionRequest, UpdateEscalationConfig,
@@ -156,9 +157,10 @@ async fn generate_lease(
             req.template_id,
         )
         .await;
-    // Release before the LLM round-trip; the post-LLM status update runs on
-    // the pool (llm_generation_requests is not RLS-bound) scoped by the row id
-    // we created under this tenant.
+    // Release the request-scoped RLS connection before the (slow) LLM
+    // round-trip so we don't pin a pooled connection across it. The post-LLM
+    // status update re-acquires a short-lived org-context connection via
+    // RlsPool::acquire_with_rls (PAP-150: no handler-side raw `state.db`).
     rls.release().await;
     let request = request.map_err(|e| {
         tracing::error!("Failed to create generation request: {}", e);
@@ -220,21 +222,28 @@ async fn generate_lease(
 
     match result {
         Ok(lease_result) => {
-            // Update the generation request with the result
+            // Update the generation request with the result on a short-lived
+            // org-context connection (best-effort; status row is non-critical).
             let result_json = serde_json::to_value(&lease_result).unwrap_or_default();
-            let _ = state
-                .llm_document_repo
-                .update_generation_status(
-                    &state.db,
-                    request.id,
-                    "completed",
-                    Some(result_json.clone()),
-                    None,
-                    Some(lease_result.tokens_used),
-                    None,
-                    Some(latency_ms),
-                )
-                .await;
+            if let Ok(mut guard) = RlsPool::new(state.db.clone())
+                .acquire_with_rls(tenant_id, user_id, false)
+                .await
+            {
+                let _ = state
+                    .llm_document_repo
+                    .update_generation_status(
+                        &mut **guard.conn(),
+                        request.id,
+                        "completed",
+                        Some(result_json.clone()),
+                        None,
+                        Some(lease_result.tokens_used),
+                        None,
+                        Some(latency_ms),
+                    )
+                    .await;
+                guard.release().await;
+            }
 
             tracing::info!(
                 "Lease generated successfully for unit {} (tokens: {}, latency: {}ms)",
@@ -264,20 +273,27 @@ async fn generate_lease(
             tracing::error!("Lease generation failed: {}", e);
             let error_msg = format!("{}", e);
 
-            // Update the generation request with the error
-            let _ = state
-                .llm_document_repo
-                .update_generation_status(
-                    &state.db,
-                    request.id,
-                    "failed",
-                    None,
-                    Some(&error_msg),
-                    None,
-                    None,
-                    Some(latency_ms),
-                )
-                .await;
+            // Update the generation request with the error on a short-lived
+            // org-context connection (best-effort).
+            if let Ok(mut guard) = RlsPool::new(state.db.clone())
+                .acquire_with_rls(tenant_id, user_id, false)
+                .await
+            {
+                let _ = state
+                    .llm_document_repo
+                    .update_generation_status(
+                        &mut **guard.conn(),
+                        request.id,
+                        "failed",
+                        None,
+                        Some(&error_msg),
+                        None,
+                        None,
+                        Some(latency_ms),
+                    )
+                    .await;
+                guard.release().await;
+            }
 
             Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -521,11 +537,28 @@ async fn generate_listing_description(
 
     let latency_ms = start_time.elapsed().as_millis() as i32;
 
+    // Persist on a short-lived org-context connection (the request-scoped RLS
+    // conn was released before the LLM round-trip above). PAP-150: no
+    // handler-side raw `state.db`.
+    let mut gen_guard = RlsPool::new(state.db.clone())
+        .acquire_with_rls(tenant_id, user_id, false)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to acquire db connection: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(
+                    "INTERNAL_ERROR",
+                    "Failed to store description",
+                )),
+            )
+        })?;
+
     // Store the generated description
-    let description = state
+    let description = match state
         .llm_document_repo
         .create_listing_description(
-            &state.db,
+            &mut **gen_guard.conn(),
             tenant_id,
             req.listing_id,
             user_id,
@@ -536,22 +569,26 @@ async fn generate_listing_description(
             request.id,
         )
         .await
-        .map_err(|e| {
+    {
+        Ok(d) => d,
+        Err(e) => {
+            gen_guard.release().await;
             tracing::error!("Failed to store description: {}", e);
-            (
+            return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new(
                     "INTERNAL_ERROR",
                     "Failed to store description",
                 )),
-            )
-        })?;
+            ));
+        }
+    };
 
-    // Update the generation request status
+    // Update the generation request status (best-effort).
     let _ = state
         .llm_document_repo
         .update_generation_status(
-            &state.db,
+            &mut **gen_guard.conn(),
             request.id,
             "completed",
             Some(serde_json::json!({ "description": description_text })),
@@ -561,6 +598,7 @@ async fn generate_listing_description(
             Some(latency_ms),
         )
         .await;
+    gen_guard.release().await;
 
     tracing::info!(
         "Listing description generated for listing {:?} in {} (tokens: {}, latency: {}ms)",

--- a/backend/servers/api-server/src/routes/ai/llm.rs
+++ b/backend/servers/api-server/src/routes/ai/llm.rs
@@ -18,11 +18,11 @@ use axum::{
     Json, Router,
 };
 use common::errors::ErrorResponse;
-use db::RlsPool;
 use db::models::{
     EnhancePhotoRequest, EnhancedChatRequest, GenerateLeaseRequest,
     GenerateListingDescriptionRequest, UpdateEscalationConfig,
 };
+use db::RlsPool;
 use serde::{Deserialize, Serialize};
 use std::time::Instant;
 use uuid::Uuid;


### PR DESCRIPTION
## What

First slice of the PAP-150 handler-side raw-pool burndown: converts `servers/api-server/src/routes/ai/llm.rs` (4 sites) and removes it from `backend/scripts/rls-handler-baseline.txt`.

`generate_lease` / `generate_listing_description` release their request-scoped `RlsConnection` before the slow LLM round-trip, then recorded results on the raw `state.db` pool — handler-side raw-pool access baselined when the RLS enforcement gate was a no-op (PAP-68). Now re-acquire a short-lived org-context connection via `RlsPool::acquire_with_rls` for the post-call status writes (pattern P3).

## Notes

- `llm_generation_requests` / `generated_listing_descriptions` are not under FORCE RLS, so the prior best-effort writes weren't silently denied — this makes them gate-clean and future-proof.
- Build gotcha (documented in the PAP-150 playbook): generic `E: Executor` repo methods need `&mut **guard.conn()` (deref to `&mut PgConnection`); `guard.conn()` alone is `&mut PoolConnection`, which is not an `Executor`.

## Verification

- `cargo check -p api-server` green (mercury).
- `cd backend && ./scripts/check-rls-enforcement.sh --strict` exits 0; `ai/llm.rs` no longer flagged and no stale-baseline warning.

## Scope

Reference conversion for the burndown. Remaining 7 files are tracked in children PAP-167..170 under umbrella PAP-150. The shared `rls-handler-baseline.txt` will need a rebase as each child lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)