### PR TITLE
fix(api-server): route webhook handlers through RLS connections (PAP-170)

### DIFF
--- a/backend/crates/db/src/repositories/integration.rs
+++ b/backend/crates/db/src/repositories/integration.rs
@@ -912,6 +912,28 @@ impl IntegrationRepository {
         .await
     }
 
+    /// Find an e-signature workflow by its external provider envelope ID.
+    ///
+    /// Used by webhook handlers to resolve the owning organization (and the
+    /// originating user) from the unguessable, provider-signed envelope id
+    /// before binding RLS context for a status update. `LIMIT 1` keeps the
+    /// read total even if the (provider-unique) envelope id is ever duplicated.
+    pub async fn find_esignature_workflow_by_external_id<'e, E>(
+        &self,
+        executor: E,
+        external_envelope_id: &str,
+    ) -> Result<Option<ESignatureWorkflow>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        sqlx::query_as::<_, ESignatureWorkflow>(
+            "SELECT * FROM esignature_workflows WHERE external_envelope_id = $1 LIMIT 1",
+        )
+        .bind(external_envelope_id)
+        .fetch_optional(executor)
+        .await
+    }
+
     /// Update e-signature workflow status by external envelope ID.
     ///
     /// Used by webhook handlers to update workflow status based on external

--- a/backend/crates/db/src/repositories/rental.rs
+++ b/backend/crates/db/src/repositories/rental.rs
@@ -2316,6 +2316,33 @@ impl RentalRepository {
         Ok(conn)
     }
 
+    /// Record an inbound Airbnb webhook delivery in the dedup ledger.
+    ///
+    /// Airbnb guarantees at-least-once delivery; this inserts the delivery's
+    /// dedup key into the global `airbnb_webhook_events` ledger and reports
+    /// whether the row was newly recorded. `ON CONFLICT DO NOTHING` makes a
+    /// re-delivery a no-op, so `Ok(false)` means "already seen — suppress".
+    ///
+    /// PAP-170 (PAP-150): `airbnb_webhook_events` is a global, tenant-less dedup
+    /// table (no `organization_id`), so this lives in the repository layer
+    /// instead of a raw `state.db` pool access inside the webhook handler.
+    pub async fn record_airbnb_webhook_event(
+        &self,
+        event_id: &str,
+        event_type: &str,
+    ) -> Result<bool, SqlxError> {
+        let result = sqlx::query(
+            "INSERT INTO airbnb_webhook_events (event_id, event_type) \
+             VALUES ($1, $2) ON CONFLICT (event_id) DO NOTHING",
+        )
+        .bind(event_id)
+        .bind(event_type)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
     /// Get Airbnb status for organization (aggregated from all connections).
     pub async fn get_airbnb_status(
         &self,

--- a/backend/scripts/rls-handler-baseline.txt
+++ b/backend/scripts/rls-handler-baseline.txt
@@ -11,7 +11,5 @@ servers/api-server/src/routes/ai/llm.rs
 servers/api-server/src/routes/ai/sessions.rs
 servers/api-server/src/routes/api_ecosystem.rs
 servers/api-server/src/routes/integrations/sync.rs
-servers/api-server/src/routes/integrations/webhook.rs
 servers/api-server/src/routes/mfa.rs
 servers/api-server/src/routes/subscriptions.rs
-servers/api-server/src/routes/voice_webhooks.rs

--- a/backend/servers/api-server/src/routes/integrations/webhook.rs
+++ b/backend/servers/api-server/src/routes/integrations/webhook.rs
@@ -40,6 +40,7 @@ use db::models::{
     CreateWebhookSubscription, TestWebhookRequest, TestWebhookResponse, UpdateWebhookSubscription,
     WebhookDeliveryLog, WebhookDeliveryQuery, WebhookStatistics, WebhookSubscription,
 };
+use db::RlsPool;
 use hmac::{Hmac, KeyInit, Mac};
 use integrations::booking::ota_xml;
 use integrations::{AirbnbClient, AirbnbWebhookEventType};
@@ -892,19 +893,71 @@ pub async fn esignature_webhook(
         };
 
         if let Some(status) = new_status {
-            // PAP-105 (PAP-80): inbound provider webhook — no request
-            // principal, so no RLS context to bind. esignature_workflows is
-            // not FORCE-RLS and the write is scoped by the provider-signed
-            // envelope id, so the pool is the executor here.
-            if let Err(e) = state
-                .integration_repo
-                .update_esignature_workflow_by_external_id(&state.db, envelope_id, status)
-                .await
-            {
+            // PAP-170 (PAP-150 P5): inbound provider webhook — no request
+            // principal. Resolve the owning org from the provider-signed
+            // envelope id, then apply the status update under that tenant's RLS
+            // context (defense in depth — the write is confined to the resolved
+            // org instead of running on the raw pool).
+            let rls_pool = RlsPool::new(state.db.clone());
+
+            // Bootstrap read on a context-cleared connection: esignature_workflows
+            // is keyed by the unguessable, provider-signed envelope id.
+            let workflow = match rls_pool.acquire_public().await {
+                Ok(mut lookup) => state
+                    .integration_repo
+                    .find_esignature_workflow_by_external_id(&mut **lookup.conn(), envelope_id)
+                    .await
+                    .unwrap_or_else(|e| {
+                        tracing::warn!(
+                            error = %e,
+                            envelope_id = %envelope_id,
+                            "Failed to resolve workflow org from webhook envelope id"
+                        );
+                        None
+                    }),
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "Failed to acquire connection for e-signature webhook"
+                    );
+                    None
+                }
+            };
+
+            if let Some(wf) = workflow {
+                match rls_pool
+                    .acquire_with_rls(wf.organization_id, wf.created_by, false)
+                    .await
+                {
+                    Ok(mut guard) => {
+                        if let Err(e) = state
+                            .integration_repo
+                            .update_esignature_workflow_by_external_id(
+                                &mut **guard.conn(),
+                                envelope_id,
+                                status,
+                            )
+                            .await
+                        {
+                            tracing::warn!(
+                                error = %e,
+                                envelope_id = %envelope_id,
+                                "Failed to update workflow status from webhook"
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            envelope_id = %envelope_id,
+                            "Failed to bind RLS context for e-signature webhook update"
+                        );
+                    }
+                }
+            } else {
                 tracing::warn!(
-                    error = %e,
                     envelope_id = %envelope_id,
-                    "Failed to update workflow status from webhook"
+                    "E-signature webhook: no workflow matches envelope id, ignoring"
                 );
             }
         }
@@ -1135,17 +1188,16 @@ pub async fn handle_airbnb_webhook(
     // event_id-absent path that could still double-enqueue SYNC_EXTERNAL.
     let dedup_key = airbnb_dedup_key(&event);
     let event_type_label = format!("{:?}", event.event_type);
-    let insert = sqlx::query(
-        "INSERT INTO airbnb_webhook_events (event_id, event_type) \
-         VALUES ($1, $2) ON CONFLICT (event_id) DO NOTHING",
-    )
-    .bind(&dedup_key)
-    .bind(&event_type_label)
-    .execute(&state.db)
-    .await;
+    // PAP-170 (PAP-150): the dedup-ledger insert now lives in the repository
+    // layer (`airbnb_webhook_events` is a global, tenant-less table) instead of
+    // a raw `state.db` pool access here. `Ok(false)` ⇒ already seen ⇒ suppress.
+    let recorded = state
+        .rental_repo
+        .record_airbnb_webhook_event(&dedup_key, &event_type_label)
+        .await;
 
-    match insert {
-        Ok(result) if result.rows_affected() == 0 => {
+    match recorded {
+        Ok(false) => {
             tracing::info!(
                 dedup_key = %dedup_key,
                 event_type = %event_type_label,
@@ -1153,7 +1205,7 @@ pub async fn handle_airbnb_webhook(
             );
             return Ok(StatusCode::OK);
         }
-        Ok(_) => {
+        Ok(true) => {
             tracing::debug!(
                 dedup_key = %dedup_key,
                 event_type = %event_type_label,

--- a/backend/servers/api-server/src/routes/voice_webhooks.rs
+++ b/backend/servers/api-server/src/routes/voice_webhooks.rs
@@ -26,6 +26,7 @@ use db::models::{
     VoiceActionResult, VoiceOAuthExchangeRequest, VoiceOAuthExchangeResponse,
     VoiceTokenRefreshRequest, VoiceTokenRefreshResult, WebhookVerificationResult,
 };
+use db::RlsPool;
 use hmac::{Hmac, KeyInit, Mac};
 use integrations::{encrypt_optional_required, encrypt_required, CryptoError, IntegrationCrypto};
 use serde::Deserialize;
@@ -435,14 +436,27 @@ async fn oauth_token_exchange(
     let device_id = format!("{}_{}", request.platform, Uuid::new_v4());
 
     // Create the voice device with tokens.
-    // PAP-108 (PAP-80): the repo is stateless; `voice_assistant_devices` is not
-    // RLS-bound, and this handler is authenticated via `AuthUser` (no
-    // RlsConnection extractor), so the pool is the correct executor here. The
-    // org/user scoping comes from the verified PM access token above.
+    // PAP-170 (PAP-150 P2): bind the verified PM user's org/user RLS context for
+    // the device write instead of touching the raw `state.db` pool.
+    // `voice_assistant_devices` is not RLS-bound today, but binding context is
+    // defense in depth; org/user come from the verified PM access token above.
+    let mut guard = RlsPool::new(state.db.clone())
+        .acquire_with_rls(org_id, user_id, false)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to acquire RLS connection: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(
+                    "DEVICE_CREATION_FAILED",
+                    "Failed to link voice device",
+                )),
+            )
+        })?;
     let device = state
         .llm_document_repo
         .create_voice_device(
-            &state.db,
+            &mut **guard.conn(),
             org_id,
             user_id,
             None,
@@ -503,12 +517,21 @@ async fn oauth_token_refresh(
     use integrations::{decrypt_if_available, VoiceOAuthManager, VoicePlatform};
 
     // Find the device.
-    // PAP-108 (PAP-80): this endpoint is called by the voice platform (no PM
-    // principal, no RlsConnection); `voice_assistant_devices` is not RLS-bound,
-    // so the pool is the correct executor for the cross-org device lookup.
+    // PAP-170 (PAP-150 P5): this endpoint is called by the voice platform (no PM
+    // principal). Bootstrap the device on a context-cleared connection — it is
+    // addressed by an opaque, server-issued device_id and carries its owning
+    // org/user, which we bind below for the token write.
+    let rls_pool = RlsPool::new(state.db.clone());
+    let mut lookup = rls_pool.acquire_public().await.map_err(|e| {
+        tracing::error!("Database error: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new("DATABASE_ERROR", "Database error")),
+        )
+    })?;
     let device = state
         .llm_document_repo
-        .find_voice_device(&state.db, request.device_id)
+        .find_voice_device(&mut **lookup.conn(), request.device_id)
         .await
         .map_err(|e| {
             tracing::error!("Database error: {}", e);
@@ -526,6 +549,7 @@ async fn oauth_token_refresh(
                 )),
             )
         })?;
+    drop(lookup);
 
     // Check if device has refresh token
     let refresh_token_encrypted = match &device.refresh_token_encrypted {
@@ -597,11 +621,24 @@ async fn oauth_token_refresh(
         )
     };
 
-    // Update the device tokens
+    // Update the device tokens under the device's own org/user RLS context.
+    let mut guard = rls_pool
+        .acquire_with_rls(device.organization_id, device.user_id, false)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to acquire RLS connection: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(
+                    "TOKEN_UPDATE_FAILED",
+                    "Failed to update tokens",
+                )),
+            )
+        })?;
     state
         .llm_document_repo
         .update_voice_device_tokens(
-            &state.db,
+            &mut **guard.conn(),
             device.id,
             &new_access_encrypted,
             new_refresh_encrypted.as_deref(),


### PR DESCRIPTION
## What

PAP-150 burndown (PAP-170): convert the 6 raw `state.db` handler accesses across the two webhook files so the RLS-enforcement gate can drop both from `backend/scripts/rls-handler-baseline.txt`.

### `routes/integrations/webhook.rs`
- **`esignature_webhook` (P5)** — resolve the owning org from the provider-signed envelope id, then apply the status update under that tenant's RLS context (defense in depth instead of a raw pool write). Adds `IntegrationRepository::find_esignature_workflow_by_external_id` for the bootstrap lookup on a context-cleared connection.
- **`handle_airbnb_webhook`** — the global dedup-ledger insert moves into `RentalRepository::record_airbnb_webhook_event`. `airbnb_webhook_events` is a tenant-less table (no `organization_id`), so it belongs in the repo layer rather than as a handler pool hit.

### `routes/voice_webhooks.rs`
- **`oauth_token_exchange` (P2)** — bind the verified PM user's org/user RLS context for the voice-device write.
- **`oauth_token_refresh` (P5)** — bootstrap the device on a context-cleared connection (opaque server-issued `device_id`), then update its tokens under the device's own org/user context.

## Verification (IG3)
- `check-rls-enforcement.sh --strict` → **exit 0**, zero hits in `webhook.rs` / `voice_webhooks.rs`, no stale handler-baseline entries. Both baseline lines removed.
- `cargo check -p api-server` → green.
- `cargo test -p db --no-run` → compiles. The DB-backed esignature idempotency tests exercise `update_esignature_workflow_by_external_id`, which is unchanged by this PR.

## Notes
- Independent PR off `dev` (the shared `bugfix/pap-150-rls-handler-baseline` checkout has concurrent sibling burndown work; this isolates PAP-170). Removes only the `webhook.rs` + `voice_webhooks.rs` baseline lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)