### PR TITLE
fix(api-server): route api_ecosystem.rs catalog handlers off the raw pool (PAP-167)

### DIFF
--- a/backend/scripts/rls-handler-baseline.txt
+++ b/backend/scripts/rls-handler-baseline.txt
@@ -9,7 +9,6 @@
 
 servers/api-server/src/routes/ai/llm.rs
 servers/api-server/src/routes/ai/sessions.rs
-servers/api-server/src/routes/api_ecosystem.rs
 servers/api-server/src/routes/integrations/sync.rs
 servers/api-server/src/routes/integrations/webhook.rs
 servers/api-server/src/routes/mfa.rs

--- a/backend/servers/api-server/src/routes/api_ecosystem.rs
+++ b/backend/servers/api-server/src/routes/api_ecosystem.rs
@@ -49,11 +49,38 @@ use db::models::{
     UpdateConnector, UpdateEnhancedWebhookSubscription, UpdateMarketplaceIntegration,
     UpdateOrganizationIntegration, UpdatePreBuiltIntegrationConnection,
 };
+use db::RlsPool;
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 
 use crate::state::AppState;
+
+/// Acquire a connection for this router's global-catalog and developer-portal
+/// tables (PAP-150 / PAP-167).
+///
+/// These tables — `marketplace_integrations`, `connectors`, `connector_actions`,
+/// `api_documentation`, `api_code_samples`, `developer_accounts`,
+/// `developer_api_keys`, `developer_sandboxes` — have RLS *enabled* but are NOT
+/// under `FORCE ROW LEVEL SECURITY` (migration `00102`), so the app role stays
+/// owner-exempt: the catalog is public-read / super-admin-write and the
+/// developer-portal rows are user-scoped, with authorization enforced in the
+/// handlers (platform-admin gate / `user_id` owner check). They are therefore
+/// not org-scoped and don't go through the [`RlsConnection`] extractor (which
+/// the org-scoped handlers in this file use).
+///
+/// [`RlsPool::acquire_public`] keeps handler DB access off the raw `state.db`
+/// pool — so the RLS-enforcement CI gate stays green — while clearing any stale
+/// RLS context left on the pooled connection by a previous request before we
+/// reuse it. That is strictly safer than the bare pool it replaces.
+async fn catalog_conn(
+    state: &AppState,
+) -> Result<db::PublicConnection, (StatusCode, Json<ErrorResponse>)> {
+    RlsPool::new(state.db.clone())
+        .acquire_public()
+        .await
+        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))
+}
 
 /// Create API ecosystem router.
 pub fn router() -> Router<AppState> {
@@ -295,9 +322,10 @@ async fn list_marketplace_integrations(
     State(state): State<AppState>,
     Query(query): Query<MarketplaceIntegrationQuery>,
 ) -> Result<Json<Vec<MarketplaceIntegrationSummary>>, (StatusCode, Json<ErrorResponse>)> {
+    let mut conn = catalog_conn(&state).await?;
     let integrations = state
         .api_ecosystem_repo
-        .list_marketplace_integrations(&state.db, &query)
+        .list_marketplace_integrations(&mut **conn, &query)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -331,9 +359,11 @@ async fn create_marketplace_integration(
         ));
     }
 
+    let mut conn = catalog_conn(&state).await?;
+
     let integration = state
         .api_ecosystem_repo
-        .create_marketplace_integration(&state.db, &request)
+        .create_marketplace_integration(&mut **conn, &request)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -355,9 +385,10 @@ async fn get_marketplace_integration(
     State(state): State<AppState>,
     Path(path): Path<IntegrationIdPath>,
 ) -> Result<Json<MarketplaceIntegration>, (StatusCode, Json<ErrorResponse>)> {
+    let mut conn = catalog_conn(&state).await?;
     let integration = state
         .api_ecosystem_repo
-        .get_marketplace_integration(&state.db, path.id)
+        .get_marketplace_integration(&mut **conn, path.id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| not_found("Integration", path.id))?;
@@ -392,9 +423,11 @@ async fn update_marketplace_integration(
             )),
         ));
     }
+
+    let mut conn = catalog_conn(&state).await?;
     let integration = state
         .api_ecosystem_repo
-        .update_marketplace_integration(&state.db, path.id, &request)
+        .update_marketplace_integration(&mut **conn, path.id, &request)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| not_found("Integration", path.id))?;
@@ -427,9 +460,11 @@ async fn delete_marketplace_integration(
             )),
         ));
     }
+
+    let mut conn = catalog_conn(&state).await?;
     let deleted = state
         .api_ecosystem_repo
-        .delete_marketplace_integration(&state.db, path.id)
+        .delete_marketplace_integration(&mut **conn, path.id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -452,9 +487,10 @@ async fn delete_marketplace_integration(
 async fn list_integration_categories(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<IntegrationCategoryCount>>, (StatusCode, Json<ErrorResponse>)> {
+    let mut conn = catalog_conn(&state).await?;
     let categories = state
         .api_ecosystem_repo
-        .get_integration_category_counts(&state.db)
+        .get_integration_category_counts(&mut **conn)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -492,11 +528,12 @@ async fn list_integration_ratings(
     Path(path): Path<IntegrationIdPath>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<Vec<IntegrationRatingWithUser>>, (StatusCode, Json<ErrorResponse>)> {
+    let mut conn = catalog_conn(&state).await?;
     let limit = query.limit.clamp(1, 100);
     let offset = query.offset.max(0);
     let ratings = state
         .api_ecosystem_repo
-        .list_integration_ratings(&state.db, path.id, limit, offset)
+        .list_integration_ratings(&mut **conn, path.id, limit, offset)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -701,9 +738,10 @@ async fn sync_integration(
 async fn list_connectors(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<Connector>>, (StatusCode, Json<ErrorResponse>)> {
+    let mut conn = catalog_conn(&state).await?;
     let connectors = state
         .api_ecosystem_repo
-        .list_all_connectors(&state.db)
+        .list_all_connectors(&mut **conn)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -727,9 +765,11 @@ async fn create_connector(
         ));
     }
 
+    let mut conn = catalog_conn(&state).await?;
+
     let connector = state
         .api_ecosystem_repo
-        .create_connector(&state.db, &request)
+        .create_connector(&mut **conn, &request)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -741,9 +781,10 @@ async fn get_connector(
     State(state): State<AppState>,
     Path(path): Path<IntegrationIdPath>,
 ) -> Result<Json<Connector>, (StatusCode, Json<ErrorResponse>)> {
+    let mut conn = catalog_conn(&state).await?;
     let connector = state
         .api_ecosystem_repo
-        .get_connector(&state.db, path.id)
+        .get_connector(&mut **conn, path.id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| not_found("Connector", path.id))?;
@@ -768,9 +809,11 @@ async fn update_connector(
         ));
     }
 
+    let mut conn = catalog_conn(&state).await?;
+
     let connector = state
         .api_ecosystem_repo
-        .update_connector(&state.db, path.id, &request)
+        .update_connector(&mut **conn, path.id, &request)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| not_found("Connector", path.id))?;
@@ -794,9 +837,11 @@ async fn delete_connector(
         ));
     }
 
+    let mut conn = catalog_conn(&state).await?;
+
     let deleted = state
         .api_ecosystem_repo
-        .delete_connector(&state.db, path.id)
+        .delete_connector(&mut **conn, path.id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -812,9 +857,10 @@ async fn list_connector_actions(
     State(state): State<AppState>,
     Path(path): Path<IntegrationIdPath>,
 ) -> Result<Json<Vec<ConnectorAction>>, (StatusCode, Json<ErrorResponse>)> {
+    let mut conn = catalog_conn(&state).await?;
     let actions = state
         .api_ecosystem_repo
-        .list_connector_actions(&state.db, path.id)
+        .list_connector_actions(&mut **conn, path.id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -828,9 +874,10 @@ async fn create_connector_action(
     Path(_path): Path<IntegrationIdPath>,
     Json(request): Json<CreateConnectorAction>,
 ) -> Result<Json<ConnectorAction>, (StatusCode, Json<ErrorResponse>)> {
+    let mut conn = catalog_conn(&state).await?;
     let action = state
         .api_ecosystem_repo
-        .create_connector_action(&state.db, &request)
+        .create_connector_action(&mut **conn, &request)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -1373,9 +1420,10 @@ async fn register_developer(
     auth: AuthUser,
     Json(request): Json<CreateDeveloperRegistration>,
 ) -> Result<Json<DeveloperRegistration>, (StatusCode, Json<ErrorResponse>)> {
+    let mut conn = catalog_conn(&state).await?;
     let registration = state
         .api_ecosystem_repo
-        .register_developer(&state.db, auth.user_id, &request)
+        .register_developer(&mut **conn, auth.user_id, &request)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -1388,9 +1436,10 @@ async fn get_developer_registration(
     _auth: AuthUser,
     Path(path): Path<DeveloperIdPath>,
 ) -> Result<Json<DeveloperRegistration>, (StatusCode, Json<ErrorResponse>)> {
+    let mut conn = catalog_conn(&state).await?;
     let registration = state
         .api_ecosystem_repo
-        .get_developer_registration(&state.db, path.id)
+        .get_developer_registration(&mut **conn, path.id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| not_found("Developer", path.id))?;
@@ -1414,9 +1463,11 @@ async fn review_developer_registration(
             )),
         ));
     }
+
+    let mut conn = catalog_conn(&state).await?;
     let registration = state
         .api_ecosystem_repo
-        .review_developer_registration(&state.db, path.id, auth.user_id, &request)
+        .review_developer_registration(&mut **conn, path.id, auth.user_id, &request)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| not_found("Developer", path.id))?;
@@ -1431,10 +1482,11 @@ async fn list_developer_api_keys(
     Path(path): Path<DeveloperIdPath>,
 ) -> Result<Json<Vec<DeveloperApiKeyDisplay>>, (StatusCode, Json<ErrorResponse>)> {
     // Verify ownership or admin access
+    let mut conn = catalog_conn(&state).await?;
     if !auth.is_platform_admin() {
         let dev_account = state
             .api_ecosystem_repo
-            .get_developer_registration(&state.db, path.id)
+            .get_developer_registration(&mut **conn, path.id)
             .await
             .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
             .ok_or_else(|| not_found("Developer", path.id))?;
@@ -1451,7 +1503,7 @@ async fn list_developer_api_keys(
 
     let keys = state
         .api_ecosystem_repo
-        .list_developer_api_keys(&state.db, path.id)
+        .list_developer_api_keys(&mut **conn, path.id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -1483,10 +1535,11 @@ async fn create_developer_api_key(
     Json(request): Json<CreateDeveloperApiKey>,
 ) -> Result<Json<CreateDeveloperApiKeyResponse>, (StatusCode, Json<ErrorResponse>)> {
     // Verify the caller owns this developer account or is platform admin
+    let mut conn = catalog_conn(&state).await?;
     if !auth.is_platform_admin() {
         let dev_account = state
             .api_ecosystem_repo
-            .get_developer_registration(&state.db, path.id)
+            .get_developer_registration(&mut **conn, path.id)
             .await
             .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
             .ok_or_else(|| not_found("Developer", path.id))?;
@@ -1517,7 +1570,7 @@ async fn create_developer_api_key(
 
     let api_key = state
         .api_ecosystem_repo
-        .create_developer_api_key(&state.db, path.id, &request, &key_prefix, &key_hash)
+        .create_developer_api_key(&mut **conn, path.id, &request, &key_prefix, &key_hash)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -1550,9 +1603,10 @@ async fn revoke_developer_api_key(
     auth: AuthUser,
     Path(path): Path<DeveloperKeyPath>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let mut conn = catalog_conn(&state).await?;
     let revoked = state
         .api_ecosystem_repo
-        .revoke_api_key(&state.db, path.key_id, auth.user_id)
+        .revoke_api_key(&mut **conn, path.key_id, auth.user_id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -1569,10 +1623,15 @@ async fn rotate_developer_api_key(
     auth: AuthUser,
     Path(path): Path<DeveloperKeyPath>,
 ) -> Result<Json<CreateDeveloperApiKeyResponse>, (StatusCode, Json<ErrorResponse>)> {
+    // `developer_api_keys` is not FORCE-RLS (see `catalog_conn`); the rotate
+    // below is multi-statement (revoke old + insert new in one transaction) and
+    // runs on this dedicated public connection.
+    let mut conn = catalog_conn(&state).await?;
+
     // Fetch existing key to determine sandbox status for the new key prefix
     let existing_keys = state
         .api_ecosystem_repo
-        .list_developer_api_keys(&state.db, path.id)
+        .list_developer_api_keys(&mut **conn, path.id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
     let old_key = existing_keys
@@ -1588,14 +1647,6 @@ async fn rotate_developer_api_key(
     );
     let key_prefix = key.chars().take(8).collect::<String>();
     let key_hash = format!("sha256:{}", sha256_simple(&key));
-
-    // The rotate is multi-statement (revoke old + insert new in one
-    // transaction), so it needs a dedicated connection from the pool.
-    let mut conn = state
-        .db
-        .acquire()
-        .await
-        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
     let api_key = state
         .api_ecosystem_repo
@@ -1624,10 +1675,11 @@ async fn get_developer_usage_stats(
     Path(path): Path<DeveloperIdPath>,
 ) -> Result<Json<DeveloperUsageStats>, (StatusCode, Json<ErrorResponse>)> {
     // Verify ownership or admin access
+    let mut conn = catalog_conn(&state).await?;
     if !auth.is_platform_admin() {
         let dev_account = state
             .api_ecosystem_repo
-            .get_developer_registration(&state.db, path.id)
+            .get_developer_registration(&mut **conn, path.id)
             .await
             .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
             .ok_or_else(|| not_found("Developer", path.id))?;
@@ -1644,7 +1696,7 @@ async fn get_developer_usage_stats(
 
     let stats = state
         .api_ecosystem_repo
-        .get_developer_usage_stats(&state.db, path.id)
+        .get_developer_usage_stats(&mut **conn, path.id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -1659,10 +1711,11 @@ async fn create_sandbox_environment(
     Json(request): Json<CreateSandboxConfig>,
 ) -> Result<Json<SandboxConfig>, (StatusCode, Json<ErrorResponse>)> {
     // Verify ownership or admin access
+    let mut conn = catalog_conn(&state).await?;
     if !auth.is_platform_admin() {
         let dev_account = state
             .api_ecosystem_repo
-            .get_developer_registration(&state.db, path.id)
+            .get_developer_registration(&mut **conn, path.id)
             .await
             .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
             .ok_or_else(|| not_found("Developer", path.id))?;
@@ -1683,7 +1736,7 @@ async fn create_sandbox_environment(
 
     let sandbox = state
         .api_ecosystem_repo
-        .create_sandbox_environment(&state.db, path.id, &request, expires_at)
+        .create_sandbox_environment(&mut **conn, path.id, &request, expires_at)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -1697,10 +1750,11 @@ async fn get_sandbox_environment(
     Path(path): Path<DeveloperIdPath>,
 ) -> Result<Json<SandboxConfig>, (StatusCode, Json<ErrorResponse>)> {
     // Verify ownership or admin access
+    let mut conn = catalog_conn(&state).await?;
     if !auth.is_platform_admin() {
         let dev_account = state
             .api_ecosystem_repo
-            .get_developer_registration(&state.db, path.id)
+            .get_developer_registration(&mut **conn, path.id)
             .await
             .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
             .ok_or_else(|| not_found("Developer", path.id))?;
@@ -1717,7 +1771,7 @@ async fn get_sandbox_environment(
 
     let sandbox = state
         .api_ecosystem_repo
-        .get_sandbox_environment(&state.db, path.id)
+        .get_sandbox_environment(&mut **conn, path.id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| error_response("NOT_FOUND", "Sandbox environment not found"))?;
@@ -1733,10 +1787,11 @@ async fn test_sandbox_request(
     Json(request): Json<SandboxTestRequestPayload>,
 ) -> Result<Json<SandboxTestResponsePayload>, (StatusCode, Json<ErrorResponse>)> {
     // Verify ownership or admin access
+    let mut conn = catalog_conn(&state).await?;
     if !auth.is_platform_admin() {
         let dev_account = state
             .api_ecosystem_repo
-            .get_developer_registration(&state.db, path.id)
+            .get_developer_registration(&mut **conn, path.id)
             .await
             .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
             .ok_or_else(|| not_found("Developer", path.id))?;
@@ -1754,7 +1809,7 @@ async fn test_sandbox_request(
     // Verify sandbox exists
     let _sandbox = state
         .api_ecosystem_repo
-        .get_sandbox_environment(&state.db, path.id)
+        .get_sandbox_environment(&mut **conn, path.id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| error_response("NOT_FOUND", "Sandbox environment not found"))?;
@@ -1829,10 +1884,11 @@ async fn test_sandbox_request(
 async fn list_api_documentation(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<ApiDocumentation>>, (StatusCode, Json<ErrorResponse>)> {
+    let mut conn = catalog_conn(&state).await?;
     // Public endpoint - list only published docs
     let docs = state
         .api_ecosystem_repo
-        .list_api_documentation(&state.db, true)
+        .list_api_documentation(&mut **conn, true)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -1855,9 +1911,11 @@ async fn create_api_documentation(
         ));
     }
 
+    let mut conn = catalog_conn(&state).await?;
+
     let doc = state
         .api_ecosystem_repo
-        .create_api_documentation(&state.db, &request)
+        .create_api_documentation(&mut **conn, &request)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -1869,9 +1927,10 @@ async fn get_api_documentation(
     State(state): State<AppState>,
     Path(path): Path<DocSlugPath>,
 ) -> Result<Json<ApiDocumentation>, (StatusCode, Json<ErrorResponse>)> {
+    let mut conn = catalog_conn(&state).await?;
     let doc = state
         .api_ecosystem_repo
-        .get_api_documentation(&state.db, &path.slug)
+        .get_api_documentation(&mut **conn, &path.slug)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| not_found("Documentation", &path.slug))?;
@@ -1896,9 +1955,11 @@ async fn update_api_documentation(
         ));
     }
 
+    let mut conn = catalog_conn(&state).await?;
+
     let doc = state
         .api_ecosystem_repo
-        .update_api_documentation(&state.db, &path.slug, &request)
+        .update_api_documentation(&mut **conn, &path.slug, &request)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| not_found("Documentation", &path.slug))?;
@@ -1922,9 +1983,11 @@ async fn delete_api_documentation(
         ));
     }
 
+    let mut conn = catalog_conn(&state).await?;
+
     let deleted = state
         .api_ecosystem_repo
-        .delete_api_documentation(&state.db, &path.slug)
+        .delete_api_documentation(&mut **conn, &path.slug)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -1940,10 +2003,11 @@ async fn list_code_samples(
     State(state): State<AppState>,
     Path(path): Path<DocSlugPath>,
 ) -> Result<Json<Vec<ApiCodeSample>>, (StatusCode, Json<ErrorResponse>)> {
+    let mut conn = catalog_conn(&state).await?;
     let endpoint_path = format!("/api/v1/{}", path.slug);
     let samples = state
         .api_ecosystem_repo
-        .list_code_samples(&state.db, &endpoint_path)
+        .list_code_samples(&mut **conn, &endpoint_path)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -1967,9 +2031,11 @@ async fn create_code_sample(
         ));
     }
 
+    let mut conn = catalog_conn(&state).await?;
+
     let sample = state
         .api_ecosystem_repo
-        .create_code_sample(&state.db, &request)
+        .create_code_sample(&mut **conn, &request)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
@@ -1991,9 +2057,11 @@ async fn get_developer_portal_stats(
         ));
     }
 
+    let mut conn = catalog_conn(&state).await?;
+
     let stats = state
         .api_ecosystem_repo
-        .get_developer_portal_stats(&state.db)
+        .get_developer_portal_stats(&mut **conn)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 


### PR DESCRIPTION
## PAP-167 — PAP-150 burndown: `routes/api_ecosystem.rs` (the largest file, 40 handler-side raw `state.db` accesses)

Converts every remaining handler-side raw `state.db` access in `api_ecosystem.rs` to an RLS-managed connection and removes the file from `backend/scripts/rls-handler-baseline.txt`, so the RLS-enforcement CI gate now covers it.

### Approach (triaged per the PAP-150 playbook + migration `00102`)
The **org-scoped** handlers in this file already use the `RlsConnection` extractor (PAP-110) and are untouched. Every remaining access touches the **global-catalog / developer-portal** tables: `marketplace_integrations`, `connectors`, `connector_actions`, `api_documentation`, `api_code_samples`, `developer_accounts`, `developer_api_keys`, `developer_sandboxes`.

Per migration `00102` these tables have RLS **enabled but not `FORCE`d**, so the app role stays owner-exempt:
- catalog tables → public-read / super-admin-write
- developer tables → user-scoped (`user_id = current_user_id`)
- authorization is enforced in the handlers (platform-admin gate / `user_id` owner check) — **unchanged here**

They are **not org-scoped**, so the org-context `RlsConnection` extractor (pattern **P2**, suggested in the issue) does not fit. Each is converted via a shared `catalog_conn()` helper calling `RlsPool::acquire_public()` (pattern **P4**):
- keeps handler DB access off the raw `state.db` pool → satisfies the gate
- clears any stale RLS context left on the pooled connection by a prior request before reuse → **strictly safer** than the bare pool it replaces
- **no behavior change** for these non-FORCE tables

All `ApiEcosystemRepository` methods were already generic over `E: Executor<'e, Database = Postgres>`, so **no signature widening** was needed.

> ⚠️ **Decision flag for CTO/WS-A:** the issue suggested **P2 (`RlsConnection`)** for the AuthUser handlers. I diverged to **P4 (`acquire_public`)** because the schema proves these tables are global-catalog/user-scoped and not FORCE-RLS — imposing org-membership validation would be semantically wrong and could reject platform-admin / developer self-service flows. Hardening these tables to `FORCE` + `acquire_with_rls(user/super-admin context)` is a recommended **follow-up** (separate migration, like `00179` did for the org tables); happy to switch to P2 if you prefer consistency over correctness here.

### Verification (rbuild→mercury)
- `cargo check -p api-server` ✅
- `cargo clippy -p api-server -- -D warnings` ✅ (kept `&mut **conn` for generic-`E` calls; `&mut conn` for the one concrete `&mut PgConnection` rotate call — auto-deref)
- `cargo fmt -p api-server -- --check` ✅
- `./scripts/check-rls-enforcement.sh --strict` exits **0**, no `api_ecosystem.rs` violation, no stale baseline entry ✅
- Developer-portal handlers confirmed to retain their app-level ownership checks → no IDOR introduced/masked.

CI runs the full `cargo test`. QA: please smoke the ecosystem endpoints (marketplace browse, connectors, developer portal, docs) on staging.

Closes PAP-167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)