### PR TITLE
fix(api-server): close marketplace provider-side IDOR + admin gaps (PAP-140)

### DIFF
--- a/backend/crates/db/src/repositories/marketplace.rs
+++ b/backend/crates/db/src/repositories/marketplace.rs
@@ -1058,37 +1058,49 @@ impl MarketplaceRepository {
     }
 
     /// Mark invitation as viewed.
+    ///
+    /// Keyed on `provider_id` as well as `id` so a provider can only act on its
+    /// own invitations. Threading the caller's verified provider id closes the
+    /// cross-provider IDOR (PAP-140): without it any authenticated provider
+    /// could flip another provider's invitation by guessing its UUID.
     pub async fn mark_invitation_viewed(
         &self,
         id: Uuid,
+        provider_id: Uuid,
     ) -> Result<Option<RfqInvitation>, SqlxError> {
         sqlx::query_as::<_, RfqInvitation>(
             r#"
             UPDATE rfq_invitations SET viewed_at = NOW()
-            WHERE id = $1 AND viewed_at IS NULL
+            WHERE id = $1 AND provider_id = $2 AND viewed_at IS NULL
             RETURNING *
             "#,
         )
         .bind(id)
+        .bind(provider_id)
         .fetch_optional(&self.pool)
         .await
     }
 
     /// Decline an invitation.
+    ///
+    /// Keyed on `provider_id` as well as `id` (PAP-140) so a provider can only
+    /// decline invitations addressed to it.
     pub async fn decline_invitation(
         &self,
         id: Uuid,
+        provider_id: Uuid,
         reason: Option<String>,
     ) -> Result<Option<RfqInvitation>, SqlxError> {
         sqlx::query_as::<_, RfqInvitation>(
             r#"
             UPDATE rfq_invitations
-            SET declined = TRUE, decline_reason = $2, responded_at = NOW()
-            WHERE id = $1
+            SET declined = TRUE, decline_reason = $3, responded_at = NOW()
+            WHERE id = $1 AND provider_id = $2
             RETURNING *
             "#,
         )
         .bind(id)
+        .bind(provider_id)
         .bind(reason)
         .fetch_optional(&self.pool)
         .await

--- a/backend/servers/api-server/src/routes/marketplace.rs
+++ b/backend/servers/api-server/src/routes/marketplace.rs
@@ -173,6 +173,56 @@ async fn load_rfq_for_org(
     Ok(rfq)
 }
 
+/// Resolve the caller's service-provider profile id, or 403 if they don't have
+/// one. Provider-owned resources (invitations, quotes, verifications) are gated
+/// on this id so a provider can only act on its own rows.
+async fn current_provider_id(
+    state: &AppState,
+    user_id: Uuid,
+) -> Result<Uuid, (StatusCode, Json<ErrorResponse>)> {
+    let provider = state
+        .marketplace_repo
+        .find_profile_by_user_id(user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "Failed to find provider profile");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", "Database error")),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::FORBIDDEN,
+                Json(ErrorResponse::new(
+                    "NOT_PROVIDER",
+                    "You must have a provider profile to perform this action",
+                )),
+            )
+        })?;
+
+    Ok(provider.id)
+}
+
+/// Gate platform-moderation endpoints (verification review, badge award/revoke,
+/// verification queues) on the platform-admin role. These operate on cross-org
+/// provider trust data and were previously callable by any authenticated user
+/// (PAP-140), letting an org member approve verifications or revoke badges
+/// platform-wide.
+fn require_platform_admin(user: &AuthUser) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    if user.is_platform_admin() {
+        Ok(())
+    } else {
+        Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "FORBIDDEN",
+                "Platform administrator role required",
+            )),
+        ))
+    }
+}
+
 /// Create marketplace router with all sub-routes.
 pub fn router() -> Router<AppState> {
     Router::new()
@@ -1189,12 +1239,16 @@ async fn list_my_invitations(
 /// Mark an invitation as viewed.
 async fn mark_invitation_viewed(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<Json<RfqInvitation>, (StatusCode, Json<ErrorResponse>)> {
+    // Only the invited provider may act on the invitation — key the update on
+    // the caller's verified provider id (PAP-140).
+    let provider_id = current_provider_id(&state, user.user_id).await?;
+
     let invitation = state
         .marketplace_repo
-        .mark_invitation_viewed(id)
+        .mark_invitation_viewed(id, provider_id)
         .await
         .map_err(|e| {
             tracing::error!(error = %e, "Failed to mark invitation viewed");
@@ -1224,13 +1278,17 @@ pub struct DeclineInvitationRequest {
 
 async fn decline_invitation(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
     Json(data): Json<DeclineInvitationRequest>,
 ) -> Result<Json<RfqInvitation>, (StatusCode, Json<ErrorResponse>)> {
+    // Only the invited provider may decline — key on the caller's verified
+    // provider id (PAP-140; previously had zero ownership check).
+    let provider_id = current_provider_id(&state, user.user_id).await?;
+
     let invitation = state
         .marketplace_repo
-        .decline_invitation(id, data.reason)
+        .decline_invitation(id, provider_id, data.reason)
         .await
         .map_err(|e| {
             tracing::error!(error = %e, "Failed to decline invitation");
@@ -1309,9 +1367,12 @@ async fn submit_verification(
 /// List verifications.
 async fn list_verifications(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Query(query): Query<ListVerificationsQuery>,
 ) -> Result<Json<Vec<ProviderVerification>>, (StatusCode, Json<ErrorResponse>)> {
+    // Cross-provider verification listing is a platform-moderation view (PAP-140).
+    require_platform_admin(&user)?;
+
     let verification_query: VerificationQuery = (&query).into();
 
     let verifications = state
@@ -1335,9 +1396,11 @@ async fn list_verifications(
 /// Get verification queue for admin review.
 async fn get_verification_queue(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<Vec<VerificationQueueItem>>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&user)?;
+
     let queue = state
         .marketplace_repo
         .get_verification_queue(query.limit.unwrap_or(20), query.offset.unwrap_or(0))
@@ -1356,9 +1419,11 @@ async fn get_verification_queue(
 /// Get expiring verifications.
 async fn get_expiring_verifications(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Query(query): Query<ExpiringQuery>,
 ) -> Result<Json<Vec<ExpiringVerification>>, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&user)?;
+
     let days = query.days.unwrap_or(30);
 
     let expiring = state
@@ -1379,7 +1444,7 @@ async fn get_expiring_verifications(
 /// Get a specific verification.
 async fn get_verification(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ProviderVerification>, (StatusCode, Json<ErrorResponse>)> {
     let verification = state
@@ -1403,6 +1468,22 @@ async fn get_verification(
             )
         })?;
 
+    // Verification documents carry sensitive data (document numbers, URLs). Only
+    // the owning provider or a platform admin (reviewer) may read one by id;
+    // anyone else gets 404 so the row's existence isn't disclosed (PAP-140).
+    if !user.is_platform_admin() {
+        let provider_id = current_provider_id(&state, user.user_id).await?;
+        if provider_id != verification.provider_id {
+            return Err((
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new(
+                    "NOT_FOUND",
+                    format!("Verification {} not found", id),
+                )),
+            ));
+        }
+    }
+
     Ok(Json(verification))
 }
 
@@ -1413,6 +1494,10 @@ async fn review_verification(
     Path(id): Path<Uuid>,
     Json(data): Json<ReviewVerificationRequest>,
 ) -> Result<Json<ProviderVerification>, (StatusCode, Json<ErrorResponse>)> {
+    // Approving/rejecting a verification and awarding badges is platform
+    // moderation, not an org-scoped action (PAP-140).
+    require_platform_admin(&user)?;
+
     let verification = state
         .marketplace_repo
         .review_verification(
@@ -1498,6 +1583,9 @@ async fn award_badge(
     Path(id): Path<Uuid>,
     Json(data): Json<AwardBadgeRequest>,
 ) -> Result<(StatusCode, Json<ProviderBadge>), (StatusCode, Json<ErrorResponse>)> {
+    // Badges are global provider-trust markers — platform moderation only (PAP-140).
+    require_platform_admin(&user)?;
+
     let badge = state
         .marketplace_repo
         .award_badge(
@@ -1534,6 +1622,8 @@ async fn revoke_badge(
     user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    require_platform_admin(&user)?;
+
     let revoked = state.marketplace_repo.revoke_badge(id).await.map_err(|e| {
         tracing::error!(error = %e, "Failed to revoke badge");
         (
@@ -1565,6 +1655,11 @@ async fn create_review(
     Path(provider_id): Path<Uuid>,
     Json(payload): Json<CreateReviewRequest>,
 ) -> Result<(StatusCode, Json<ProviderReview>), (StatusCode, Json<ErrorResponse>)> {
+    // The review is stamped with `organization_id` from the body; verify the
+    // caller actually belongs to that org so they can't post a review under
+    // another tenant's name (PAP-140).
+    verify_org_access(&state, user.user_id, payload.organization_id).await?;
+
     let review = state
         .marketplace_repo
         .create_review(

--- a/backend/servers/api-server/tests/marketplace_voting_investor_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/marketplace_voting_investor_cross_org_idor_tests.rs
@@ -184,6 +184,58 @@ async fn seed_portfolio(pool: &PgPool, org_id: Uuid) -> Uuid {
     .expect("seed portfolio")
 }
 
+/// Seed a service-provider profile owned by `user_id`; return its id.
+/// Provider profiles are intentionally cross-org/public (PAP-140 keeps them so);
+/// ownership is by `user_id`, not org.
+async fn seed_provider(pool: &PgPool, user_id: Uuid, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO service_provider_profiles
+            (user_id, company_name, contact_name, contact_email, status)
+        VALUES ($1, $2, 'Contact', $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(user_id)
+    .bind(format!("Provider {slug}"))
+    .bind(format!("{slug}@provider-idor.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed provider")
+}
+
+/// Seed an RFQ invitation addressed to `provider_id` and return its id.
+async fn seed_invitation(pool: &PgPool, rfq_id: Uuid, provider_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO rfq_invitations (rfq_id, provider_id)
+        VALUES ($1, $2)
+        RETURNING id
+        "#,
+    )
+    .bind(rfq_id)
+    .bind(provider_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed invitation")
+}
+
+/// Seed a verification document for `provider_id` and return its id.
+async fn seed_verification(pool: &PgPool, provider_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO provider_verifications
+            (provider_id, verification_type, document_name, document_number, status)
+        VALUES ($1, 'business_license', 'License.pdf', 'SECRET-DOC-123', 'pending')
+        RETURNING id
+        "#,
+    )
+    .bind(provider_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed verification")
+}
+
 /// Claims shape that matches `api_core::extractors::auth::Claims`. We mint with
 /// this (rather than `JwtService`, which serializes the org as `org_id`) so the
 /// `tenant_id` claim deserializes into `AuthUser.tenant_id` for the
@@ -211,6 +263,29 @@ fn mint_token(user_id: Uuid, email: &str, org_id: Option<Uuid>) -> String {
         token_type: "access".to_string(),
         tenant_id: org_id,
         role: Some("manager".to_string()),
+        email: email.to_string(),
+        name: "MVI User".to_string(),
+    };
+    let secret = TestConfig::default().jwt_secret;
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .expect("encode test JWT")
+}
+
+/// Mint a token carrying an explicit `role` claim (e.g. `super_admin`), used to
+/// exercise the platform-admin gates on the verification/badge endpoints.
+fn mint_token_with_role(user_id: Uuid, email: &str, org_id: Option<Uuid>, role: &str) -> String {
+    let now = chrono::Utc::now().timestamp();
+    let claims = TestClaims {
+        sub: user_id,
+        exp: now + 3600,
+        iat: now,
+        token_type: "access".to_string(),
+        tenant_id: org_id,
+        role: Some(role.to_string()),
         email: email.to_string(),
         name: "MVI User".to_string(),
     };
@@ -378,6 +453,198 @@ async fn list_portfolio_properties_for_own_org_succeeds(pool: PgPool) {
         resp.status,
         StatusCode::OK,
         "Org A member must be able to list its own portfolio properties: {}",
+        resp.text()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Marketplace — RFQ invitations (provider-owned; PAP-140)
+//
+// `mark_invitation_viewed` / `decline_invitation` previously discarded the auth
+// context entirely (zero pre-check), so any authenticated provider could flip
+// another provider's invitation by guessing its UUID. The repo methods now key
+// on the caller's verified provider id.
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn decline_invitation_for_other_provider_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org = seed_org(&pool, "inv-org").await;
+    let user_a = seed_user(&pool, "inv-prov-a@provider-idor.test").await;
+    let user_b = seed_user(&pool, "inv-prov-b@provider-idor.test").await;
+    let provider_a = seed_provider(&pool, user_a, "inv-a").await;
+    let _provider_b = seed_provider(&pool, user_b, "inv-b").await;
+    let rfq = seed_rfq(&pool, org, user_a).await;
+    let invitation = seed_invitation(&pool, rfq, provider_a).await;
+
+    // Provider B (own profile) tries to decline provider A's invitation → 404.
+    let token_b = mint_token(user_b, "inv-prov-b@provider-idor.test", None);
+    let uri = format!("/api/v1/marketplace/invitations/{invitation}/decline");
+    let resp = app
+        .execute(
+            app.post(&uri)
+                .bearer(&token_b)
+                .json(serde_json::json!({ "reason": "not interested" }))
+                .build(),
+        )
+        .await;
+
+    assert_not_ok(resp.status, "decline_invitation cross-provider");
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn decline_invitation_for_own_provider_succeeds(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org = seed_org(&pool, "inv-own-org").await;
+    let user_a = seed_user(&pool, "inv-own-a@provider-idor.test").await;
+    let provider_a = seed_provider(&pool, user_a, "inv-own-a").await;
+    let rfq = seed_rfq(&pool, org, user_a).await;
+    let invitation = seed_invitation(&pool, rfq, provider_a).await;
+
+    let token_a = mint_token(user_a, "inv-own-a@provider-idor.test", None);
+    let uri = format!("/api/v1/marketplace/invitations/{invitation}/decline");
+    let resp = app
+        .execute(
+            app.post(&uri)
+                .bearer(&token_a)
+                .json(serde_json::json!({ "reason": "busy" }))
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "Provider must be able to decline its own invitation: {}",
+        resp.text()
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn mark_invitation_viewed_for_other_provider_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org = seed_org(&pool, "inv-view-org").await;
+    let user_a = seed_user(&pool, "inv-view-a@provider-idor.test").await;
+    let user_b = seed_user(&pool, "inv-view-b@provider-idor.test").await;
+    let provider_a = seed_provider(&pool, user_a, "inv-view-a").await;
+    let _provider_b = seed_provider(&pool, user_b, "inv-view-b").await;
+    let rfq = seed_rfq(&pool, org, user_a).await;
+    let invitation = seed_invitation(&pool, rfq, provider_a).await;
+
+    let token_b = mint_token(user_b, "inv-view-b@provider-idor.test", None);
+    let uri = format!("/api/v1/marketplace/invitations/{invitation}/view");
+    let resp = app.execute(app.post(&uri).bearer(&token_b).build()).await;
+
+    assert_not_ok(resp.status, "mark_invitation_viewed cross-provider");
+}
+
+// ---------------------------------------------------------------------------
+// Marketplace — verification read (owner-or-platform-admin; PAP-140)
+//
+// `GET /verifications/{id}` returned sensitive document data (numbers, URLs)
+// keyed on id alone. It now requires the owning provider or a platform admin.
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_verification_for_other_provider_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user_a = seed_user(&pool, "ver-a@provider-idor.test").await;
+    let user_b = seed_user(&pool, "ver-b@provider-idor.test").await;
+    let provider_a = seed_provider(&pool, user_a, "ver-a").await;
+    let _provider_b = seed_provider(&pool, user_b, "ver-b").await;
+    let verification = seed_verification(&pool, provider_a).await;
+
+    let token_b = mint_token(user_b, "ver-b@provider-idor.test", None);
+    let uri = format!("/api/v1/marketplace/verifications/{verification}");
+    let resp = app.execute(app.get(&uri).bearer(&token_b).build()).await;
+
+    assert_not_ok(resp.status, "get_verification cross-provider");
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_verification_for_owner_succeeds(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user_a = seed_user(&pool, "ver-own-a@provider-idor.test").await;
+    let provider_a = seed_provider(&pool, user_a, "ver-own-a").await;
+    let verification = seed_verification(&pool, provider_a).await;
+
+    let token_a = mint_token(user_a, "ver-own-a@provider-idor.test", None);
+    let uri = format!("/api/v1/marketplace/verifications/{verification}");
+    let resp = app.execute(app.get(&uri).bearer(&token_a).build()).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "Owning provider must be able to read its own verification: {}",
+        resp.text()
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_verification_as_platform_admin_succeeds(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user_a = seed_user(&pool, "ver-adm-a@provider-idor.test").await;
+    let admin = seed_user(&pool, "ver-admin@provider-idor.test").await;
+    let provider_a = seed_provider(&pool, user_a, "ver-adm-a").await;
+    let verification = seed_verification(&pool, provider_a).await;
+
+    let token = mint_token_with_role(admin, "ver-admin@provider-idor.test", None, "super_admin");
+    let uri = format!("/api/v1/marketplace/verifications/{verification}");
+    let resp = app.execute(app.get(&uri).bearer(&token).build()).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "Platform admin must be able to read any verification: {}",
+        resp.text()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Marketplace — platform-moderation gates (PAP-140)
+//
+// Verification review and badge revoke were callable by any authenticated user.
+// They now require the platform-admin role; the gate runs before any DB work.
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn review_verification_as_non_admin_is_forbidden(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = seed_user(&pool, "rev-nonadmin@provider-idor.test").await;
+
+    // Non-admin (manager) token; random verification id — the role gate fires first.
+    let token = mint_token(user, "rev-nonadmin@provider-idor.test", None);
+    let uri = format!("/api/v1/marketplace/verifications/{}/review", Uuid::new_v4());
+    let resp = app
+        .execute(
+            app.post(&uri)
+                .bearer(&token)
+                .json(serde_json::json!({ "status": "verified" }))
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "Non-admin must not be able to review verifications: {}",
+        resp.text()
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn revoke_badge_as_non_admin_is_forbidden(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = seed_user(&pool, "badge-nonadmin@provider-idor.test").await;
+
+    let token = mint_token(user, "badge-nonadmin@provider-idor.test", None);
+    let uri = format!("/api/v1/marketplace/badges/{}", Uuid::new_v4());
+    let resp = app.execute(app.delete(&uri).bearer(&token).build()).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "Non-admin must not be able to revoke badges: {}",
         resp.text()
     );
 }

--- a/backend/servers/api-server/tests/marketplace_voting_investor_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/marketplace_voting_investor_cross_org_idor_tests.rs
@@ -226,7 +226,7 @@ async fn seed_verification(pool: &PgPool, provider_id: Uuid) -> Uuid {
         r#"
         INSERT INTO provider_verifications
             (provider_id, verification_type, document_name, document_number, status)
-        VALUES ($1, 'business_license', 'License.pdf', 'SECRET-DOC-123', 'pending')
+        VALUES ($1, 'license', 'License.pdf', 'SECRET-DOC-123', 'pending')
         RETURNING id
         "#,
     )

--- a/backend/servers/api-server/tests/marketplace_voting_investor_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/marketplace_voting_investor_cross_org_idor_tests.rs
@@ -614,7 +614,10 @@ async fn review_verification_as_non_admin_is_forbidden(pool: PgPool) {
 
     // Non-admin (manager) token; random verification id — the role gate fires first.
     let token = mint_token(user, "rev-nonadmin@provider-idor.test", None);
-    let uri = format!("/api/v1/marketplace/verifications/{}/review", Uuid::new_v4());
+    let uri = format!(
+        "/api/v1/marketplace/verifications/{}/review",
+        Uuid::new_v4()
+    );
     let resp = app
         .execute(
             app.post(&uri)


### PR DESCRIPTION
## PAP-140 — WS-A IDOR: marketplace.rs (rfq/quote/review/invitation paths)

PR #778 already org-scoped the **RFQ / quote / review reads** via `verify_org_access` / `verify_quote_owner` / `load_rfq_for_org`. This PR closes the **provider-side and platform-moderation** paths that #778 left open.

### Fixed
| Path | Before | After |
|------|--------|-------|
| `POST /invitations/{id}/view` (`mark_invitation_viewed`) | `_user` ignored — **zero pre-check**; any provider could flip any invitation by UUID | repo UPDATE keyed on caller's verified `provider_id` |
| `POST /invitations/{id}/decline` (`decline_invitation`) | same zero pre-check | keyed on `provider_id` |
| `GET /verifications/{id}` (`find_verification_by_id`) | returned sensitive doc data (numbers, URLs) by id alone | owning provider **or** platform admin; else 404 |
| `POST /verifications/{id}/review` (`review_verification`) | callable by any auth user (approve + award badges) | `require_platform_admin` |
| `POST /providers/{id}/badges` (`award_badge`) | any auth user | `require_platform_admin` |
| `DELETE /badges/{id}` (`revoke_badge`) | any auth user | `require_platform_admin` |
| `GET /verifications`, `/verifications/queue`, `/verifications/expiring` | dumped all providers' verification data | `require_platform_admin` |
| `POST /providers/{id}/reviews` (`create_review`) | stamped body-supplied `organization_id` unchecked (org spoofing) | `verify_org_access(payload.organization_id)` |

`service_provider_profiles` stays **public / cross-org** by design (search & profile reads untouched).

### Approach
- Invitation methods take the **verified** provider id (`find_profile_by_user_id`), never path/body — mirrors `verify_quote_owner` and the PR #1260 pattern.
- Platform-moderation ops gate on `AuthUser::is_platform_admin()` (SuperAdmin / PlatformAdmin) — provider verification & badges are global trust markers, not org-scoped.
- New gates are application-layer (membership / provider-ownership / role), so they hold even under CI's superuser pool that bypasses FORCE RLS.

### Tests
Added to `marketplace_voting_investor_cross_org_idor_tests.rs`:
- invitation decline/view cross-provider → rejected; own provider → 200
- verification read: other provider → 404, owner → 200, platform admin → 200
- `review_verification` / `revoke_badge` as non-admin → 403

`cargo check --tests` + `cargo clippy -D warnings` green on mercury.

🤖 Generated with [Claude Code](https://claude.com/claude-code)