### PR TITLE
fix(ci): remove empty ${{ }} expression breaking auto-rebase workflow (PAP-176)

### DIFF
--- a/.github/workflows/auto-rebase-stale-drafts.yml
+++ b/.github/workflows/auto-rebase-stale-drafts.yml
@@ -101,7 +101,8 @@ jobs:
           git fetch origin dev
 
           # Iterate using jq -r index access so we never interpolate PR
-          # data into the shell via `${{ }}` (env-var indirection pattern).
+          # data into the shell via GitHub Actions expressions (env-var
+          # indirection pattern).
           for i in $(seq 0 $((COUNT - 1))); do
             PR=$(echo "$CANDIDATES"   | jq -r ".[$i].number")
             HEAD=$(echo "$CANDIDATES" | jq -r ".[$i].head")


### PR DESCRIPTION
## Summary

Fixes the persistent **startup failure** of `.github/workflows/auto-rebase-stale-drafts.yml` that produced a red ❌ on every push to `dev` (PAP-176, "Fix broken CI").

### Root cause
A bash comment inside the workflow's `run:` block contained a literal **empty** `${{ }}` token:

```yaml
# data into the shell via `${{ }}` (env-var indirection pattern).
```

GitHub Actions evaluates `${{ … }}` expressions **anywhere** in a run script — including comments. An empty expression fails to compile, so GitHub couldn't load the workflow and emitted a startup-failure run on every push (0 jobs, run displayed by file path, "This run likely failed because of a workflow file issue"). All other `${{ }}` tokens in the file have content; this was the only empty one.

### Fix
Reworded the comment to drop the empty-expression token. No behavioral change to the workflow logic.

### Verification
- `actionlint v1.7.7` — **clean** (was: `unexpected end of input while parsing … [expression]` at the run block).
- Diff is a single comment line; no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)