### PR TITLE
fix(api-server): convert mfa.rs handler raw-pool to RLS connection (PAP-168)

### DIFF
--- a/backend/scripts/rls-handler-baseline.txt
+++ b/backend/scripts/rls-handler-baseline.txt
@@ -10,5 +10,4 @@
 servers/api-server/src/routes/ai/llm.rs
 servers/api-server/src/routes/ai/sessions.rs
 servers/api-server/src/routes/integrations/sync.rs
-servers/api-server/src/routes/mfa.rs
 servers/api-server/src/routes/subscriptions.rs

--- a/backend/servers/api-server/src/routes/mfa.rs
+++ b/backend/servers/api-server/src/routes/mfa.rs
@@ -1,6 +1,7 @@
 //! Multi-Factor Authentication routes (Epic 9, Story 9.1 + 9.2).
 
 use api_core::extractors::RlsConnection;
+use db::RlsPool;
 use axum::{
     extract::State,
     http::StatusCode,
@@ -564,7 +565,7 @@ pub async fn disable_mfa(
             "SELECT id, code_hash FROM mfa_recovery_codes WHERE user_id = $1 AND used_at IS NULL",
         )
         .bind(user_id)
-        .fetch_all(&state.db)
+        .fetch_all(&mut **rls.conn())
         .await
         .unwrap_or_default();
 
@@ -600,6 +601,9 @@ pub async fn disable_mfa(
     }
 
     // Disable MFA and invalidate all recovery codes atomically.
+    // mfa_recovery_codes is user-scoped (no org_id, no FORCE RLS) — raw pool transaction
+    // is equivalent to RLS here; WHERE user_id = $1 from the JWT subject provides the
+    // required isolation (P4 sanctioned, same rationale as confirm_mfa above).
     let mut tx = state.db.begin().await.map_err(|e| {
         tracing::error!(error = %e, "Failed to begin disable transaction");
         (
@@ -1001,11 +1005,25 @@ pub async fn verify_recovery_code(
         )
     })?;
 
+    // Acquire a connection for the user-scoped MFA tables (user_2fa,
+    // mfa_recovery_codes have no org_id and no FORCE RLS). acquire_public clears
+    // any stale RLS context left by a previous request on the pooled connection.
+    let mut conn = db::RlsPool::new(state.db.clone())
+        .acquire_public()
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "recovery/verify: pool acquire failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DATABASE_ERROR", "Failed to connect")),
+            )
+        })?;
+
     // Verify MFA is enabled for this user.
     let enrolled: Option<bool> =
         sqlx::query_scalar("SELECT enabled FROM user_2fa WHERE user_id = $1")
             .bind(user_id)
-            .fetch_optional(&state.db)
+            .fetch_optional(&mut *conn)
             .await
             .map_err(|e| {
                 tracing::error!(error = %e, "recovery/verify: fetch enrollment failed");
@@ -1033,7 +1051,7 @@ pub async fn verify_recovery_code(
         "SELECT id, code_hash FROM mfa_recovery_codes WHERE user_id = $1 AND used_at IS NULL",
     )
     .bind(user_id)
-    .fetch_all(&state.db)
+    .fetch_all(&mut *conn)
     .await
     .map_err(|e| {
         tracing::error!(error = %e, "recovery/verify: fetch codes failed");
@@ -1129,7 +1147,7 @@ pub async fn verify_recovery_code(
         "UPDATE mfa_recovery_codes SET used_at = NOW() WHERE id = $1 AND used_at IS NULL",
     )
     .bind(matched_id)
-    .execute(&state.db)
+    .execute(&mut *conn)
     .await
     .map_err(|e| {
         tracing::error!(error = %e, "recovery/verify: mark used failed");
@@ -1158,7 +1176,7 @@ pub async fn verify_recovery_code(
         "SELECT COUNT(*) FROM mfa_recovery_codes WHERE user_id = $1 AND used_at IS NULL",
     )
     .bind(user_id)
-    .fetch_one(&state.db)
+    .fetch_one(&mut *conn)
     .await
     .unwrap_or(0);
 


### PR DESCRIPTION
## Summary

- `disable_mfa`: swaps recovery-code lookup from `&state.db` to `&mut **rls.conn()` (P1 — handler already holds `RlsConnection`)
- `disable_mfa`: documents the `state.db.begin()` transaction as P4 sanctioned (user-scoped MFA tables, no FORCE RLS, `.begin()` not in CI violation patterns)
- `verify_recovery_code`: replaces four raw `&state.db` executor calls with a single `RlsPool::acquire_public()` connection, clearing stale RLS context on the pooled connection
- Removes `mfa.rs` from `rls-handler-baseline.txt` — RLS enforcement CI scanner now passes at zero violations for this file

Part of [PAP-150](/PAP/issues/PAP-150) burndown. Closes [PAP-168](/PAP/issues/PAP-168).

## Test plan

- [ ] `cargo check -p api-server` passes (green on remote build)
- [ ] `bash scripts/check-rls-enforcement.sh` in `backend/` shows no violations for mfa.rs
- [ ] MFA enable/disable/recovery-code flows verified in CI