### PR TITLE
fix(api-server): FORCE-RLS api_ecosystem catalog + developer-portal tables (PAP-171)

### DIFF
--- a/backend/crates/db/migrations/00180_force_api_ecosystem_catalog_rls.sql
+++ b/backend/crates/db/migrations/00180_force_api_ecosystem_catalog_rls.sql
@@ -1,0 +1,58 @@
+-- PAP-171 (defense-in-depth follow-up to PAP-167 / PAP-150): put the
+-- api-ecosystem catalog + developer-portal tables under FORCE ROW LEVEL
+-- SECURITY so the app role — which connects as the table OWNER — is no longer
+-- exempt from their RLS policies.
+--
+-- Background
+-- ----------
+-- Migration 00102 ENABLEd RLS on these tables and attached correct policies,
+-- but never FORCEd them. PostgreSQL exempts a table's OWNER from RLS unless
+-- FORCE is set, and the production api-server connects as the owner, so the
+-- policies were never a real backstop: authorization was enforced ONLY in the
+-- handlers (`is_platform_admin()` gate for catalog writes, `user_id` owner
+-- check for developer rows). This is the same owner-bypass class PAP-62 fixed
+-- for the org-scoped tables in migration 00179; this migration closes it for
+-- the user-scoped / global-catalog tables PAP-167 left on `acquire_public`.
+--
+-- The existing 00102 policies already key on the CANONICAL GUCs
+-- (`app.current_user_id` for developer rows, `app.is_super_admin` for catalog
+-- writes — both set by `set_request_context()`), so — unlike 00179 — no policy
+-- needs its GUC expression rewritten. We only add FORCE. The matching handler
+-- change routes these handlers from `acquire_public` to `acquire_with_rls`
+-- (user + super-admin context) so the policies are actually exercised.
+--
+-- `integration_ratings` (the marketplace ratings table) is intentionally NOT
+-- here: it is org-scoped and migration 00179 already FORCEd it + fixed its GUC.
+--
+-- Rollback
+-- --------
+-- This is a pure RLS tightening. To restore the prior behavior, run the down
+-- block at the bottom (commented) which drops FORCE from each table; the 00102
+-- policies and ENABLE stay intact, returning the owner role to exempt.
+
+-- Global catalog: public read, super-admin write (policies USING is_super_admin()).
+ALTER TABLE marketplace_integrations FORCE ROW LEVEL SECURITY;
+ALTER TABLE connectors FORCE ROW LEVEL SECURITY;
+ALTER TABLE connector_actions FORCE ROW LEVEL SECURITY;
+ALTER TABLE api_documentation FORCE ROW LEVEL SECURITY;
+ALTER TABLE api_code_samples FORCE ROW LEVEL SECURITY;
+
+-- Developer portal: user-scoped (policies USING user_id = app.current_user_id
+-- OR is_super_admin). These hold credential-class data, so the policy backstop
+-- matters most here.
+ALTER TABLE developer_accounts FORCE ROW LEVEL SECURITY;
+ALTER TABLE developer_api_keys FORCE ROW LEVEL SECURITY;
+ALTER TABLE developer_sandboxes FORCE ROW LEVEL SECURITY;
+
+-- ---------------------------------------------------------------------------
+-- Down (manual rollback — sqlx migrations are forward-only):
+--
+-- ALTER TABLE marketplace_integrations NO FORCE ROW LEVEL SECURITY;
+-- ALTER TABLE connectors NO FORCE ROW LEVEL SECURITY;
+-- ALTER TABLE connector_actions NO FORCE ROW LEVEL SECURITY;
+-- ALTER TABLE api_documentation NO FORCE ROW LEVEL SECURITY;
+-- ALTER TABLE api_code_samples NO FORCE ROW LEVEL SECURITY;
+-- ALTER TABLE developer_accounts NO FORCE ROW LEVEL SECURITY;
+-- ALTER TABLE developer_api_keys NO FORCE ROW LEVEL SECURITY;
+-- ALTER TABLE developer_sandboxes NO FORCE ROW LEVEL SECURITY;
+-- ---------------------------------------------------------------------------

--- a/backend/crates/db/tests/api_ecosystem_developer_force_rls_tests.rs
+++ b/backend/crates/db/tests/api_ecosystem_developer_force_rls_tests.rs
@@ -1,0 +1,416 @@
+//! Behavioral RLS regression test for PAP-171 (defense-in-depth follow-up to
+//! PAP-167 / PAP-150).
+//!
+//! Background
+//! ----------
+//! Migration `00102` ENABLEd RLS on the api-ecosystem catalog
+//! (`marketplace_integrations`, …) and developer-portal
+//! (`developer_accounts`, `developer_api_keys`, `developer_sandboxes`) tables
+//! and attached correct policies, but never FORCEd them. The production
+//! api-server connects as the table OWNER, which RLS exempts unless FORCE is
+//! set — so those policies were never a real backstop and authorization was
+//! enforced only in the handlers (`is_platform_admin()` gate for catalog
+//! writes, `user_id` owner check for developer rows). Migration `00180`
+//! (PAP-171) adds `FORCE ROW LEVEL SECURITY`, and the handlers were routed from
+//! `acquire_public` to `acquire_with_rls(user / super-admin context)` so the
+//! policies are actually exercised.
+//!
+//! This test proves, on a `FORCE`-bound NOSUPERUSER role (the way the
+//! production owner experiences it):
+//!
+//!   1. **Cross-user isolation** — under user A's context, A sees only A's own
+//!      developer account / API key / sandbox; user B's credential-class rows
+//!      are invisible (a future handler bug cannot leak them across users).
+//!      Exercised both with raw SQL counts and through the repository method
+//!      the handler uses (`list_developer_api_keys`).
+//!   2. **Deny-all without context** — with no RLS context set (what
+//!      `acquire_public` would leave), the developer tables collapse to
+//!      deny-all, confirming FORCE binds.
+//!   3. **Catalog write authorization** — a super-admin context can INSERT into
+//!      `marketplace_integrations` (platform-admin catalog writes still pass)
+//!      while a plain user context is denied by the policy WITH CHECK.
+//!   4. **Catalog public read** — the `USING (TRUE)` read policy keeps the
+//!      catalog publicly readable even under FORCE with no super-admin context.
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — even FORCE does not bind a superuser, so a behavioral assertion
+//! would pass vacuously. The test creates a plain `NOSUPERUSER NOBYPASSRLS`
+//! role, grants it table access, and `SET ROLE`s to it so FORCE enforces the
+//! policy. Mirrors `api_ecosystem_rls_repo_tests.rs` (the PAP-110 precedent).
+
+use db::repositories::ApiEcosystemRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn set_ctx(pool: &PgPool, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(Option::<Uuid>::None) // no org — developer/catalog tables are user/global-scoped
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'Dev User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_developer_account(pool: &PgPool, user_id: Uuid, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO developer_accounts (user_id, email, status)
+        VALUES ($1, $2, 'approved')
+        RETURNING id
+        "#,
+    )
+    .bind(user_id)
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed developer account")
+}
+
+async fn seed_api_key(pool: &PgPool, developer_id: Uuid, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO developer_api_keys (developer_id, name, key_prefix, key_hash)
+        VALUES ($1, $2, 'ppt_live', 'sha256:deadbeef')
+        RETURNING id
+        "#,
+    )
+    .bind(developer_id)
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .expect("seed api key")
+}
+
+async fn seed_sandbox(pool: &PgPool, developer_id: Uuid, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO developer_sandboxes (developer_id, name)
+        VALUES ($1, $2)
+        RETURNING id
+        "#,
+    )
+    .bind(developer_id)
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .expect("seed sandbox")
+}
+
+/// Fail-on-`dev` guard (IG3): the eight catalog + developer-portal tables must
+/// carry `FORCE ROW LEVEL SECURITY`. A plain non-owner role (as the behavioral
+/// test below uses) is bound by ENABLE alone, so only this catalog-metadata
+/// assertion distinguishes the migration being present from absent — it fails
+/// before migration `00180` and passes after. `#[sqlx::test]` runs as a
+/// superuser, so a behavioral owner-bypass assertion would pass vacuously;
+/// asserting `pg_class.relforcerowsecurity` is the robust check (mirrors
+/// `epic11_org_guc_rls_tests.rs` / `notification_rls_guc_tests.rs`).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn api_ecosystem_catalog_and_developer_tables_are_force_rls(pool: PgPool) {
+    let tables = [
+        "marketplace_integrations",
+        "connectors",
+        "connector_actions",
+        "api_documentation",
+        "api_code_samples",
+        "developer_accounts",
+        "developer_api_keys",
+        "developer_sandboxes",
+    ];
+
+    for table in tables {
+        let forced: bool = sqlx::query_scalar(
+            "SELECT relforcerowsecurity FROM pg_class WHERE relname = $1 AND relkind = 'r'",
+        )
+        .bind(table)
+        .fetch_one(&pool)
+        .await
+        .unwrap_or_else(|e| panic!("query relforcerowsecurity for {table}: {e}"));
+
+        assert!(
+            forced,
+            "PAP-171 regression: table `{table}` must be FORCE ROW LEVEL SECURITY \
+             (migration 00180) so the owner app role is not exempt from its RLS policy"
+        );
+
+        // RLS must also remain enabled (FORCE without ENABLE is meaningless).
+        let enabled: bool =
+            sqlx::query_scalar("SELECT relrowsecurity FROM pg_class WHERE relname = $1")
+                .bind(table)
+                .fetch_one(&pool)
+                .await
+                .unwrap_or_else(|e| panic!("query relrowsecurity for {table}: {e}"));
+        assert!(enabled, "table `{table}` must have RLS enabled");
+    }
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn developer_portal_force_rls_cross_user_isolation(pool: PgPool) {
+    let repo = ApiEcosystemRepository::new(pool.clone());
+
+    // --- Seed as superuser. ---
+    set_ctx(&pool, None, true).await;
+    let user_a = seed_user(&pool, "force-a@dev.test").await;
+    let user_b = seed_user(&pool, "force-b@dev.test").await;
+    let dev_a = seed_developer_account(&pool, user_a, "force-a@dev.test").await;
+    let dev_b = seed_developer_account(&pool, user_b, "force-b@dev.test").await;
+    let _key_a = seed_api_key(&pool, dev_a, "A live key").await;
+    let key_b = seed_api_key(&pool, dev_b, "B confidential key").await;
+    let _sandbox_a = seed_sandbox(&pool, dev_a, "A sandbox").await;
+    let _sandbox_b = seed_sandbox(&pool, dev_b, "B sandbox").await;
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    let role = format!("ppt_rls_devportal_{}", Uuid::new_v4().simple());
+    for stmt in [
+        format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
+        format!("GRANT SELECT, INSERT, UPDATE, DELETE ON developer_accounts TO \"{role}\""),
+        format!("GRANT SELECT, INSERT, UPDATE, DELETE ON developer_api_keys TO \"{role}\""),
+        format!("GRANT SELECT, INSERT, UPDATE, DELETE ON developer_sandboxes TO \"{role}\""),
+        format!("GRANT SELECT, INSERT, UPDATE, DELETE ON marketplace_integrations TO \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .expect("grant setup");
+    }
+
+    // ====================================================================
+    // (2) DENY-ALL without context: role bound, NO context set (what
+    //     `acquire_public` leaves). Developer tables collapse to deny-all.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT clear_request_context()")
+            .execute(&mut *conn)
+            .await
+            .expect("clear ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let visible: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM developer_api_keys")
+            .fetch_one(&mut *conn)
+            .await
+            .expect("count keys (no ctx)");
+        assert_eq!(
+            visible, 0,
+            "without RLS context the developer_api_keys table must be deny-all under FORCE"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (1) CROSS-USER ISOLATION: under user A's context, A sees only A's rows.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(Option::<Uuid>::None)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set user-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        // Raw-SQL visibility: exactly one account / key / sandbox — all A's.
+        let accounts: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM developer_accounts")
+            .fetch_one(&mut *conn)
+            .await
+            .expect("count accounts");
+        assert_eq!(
+            accounts, 1,
+            "user A must see only their own developer account"
+        );
+
+        let keys: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM developer_api_keys")
+            .fetch_one(&mut *conn)
+            .await
+            .expect("count keys");
+        assert_eq!(keys, 1, "user A must see only their own API key");
+
+        let sandboxes: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM developer_sandboxes")
+            .fetch_one(&mut *conn)
+            .await
+            .expect("count sandboxes");
+        assert_eq!(sandboxes, 1, "user A must see only their own sandbox");
+
+        // Probing B's account / key by id surfaces nothing.
+        let cross_account: Option<Uuid> =
+            sqlx::query_scalar("SELECT id FROM developer_accounts WHERE id = $1")
+                .bind(dev_b)
+                .fetch_optional(&mut *conn)
+                .await
+                .expect("probe B account");
+        assert!(
+            cross_account.is_none(),
+            "user A must NOT be able to read user B's developer account by id"
+        );
+
+        let cross_key: Option<Uuid> =
+            sqlx::query_scalar("SELECT id FROM developer_api_keys WHERE id = $1")
+                .bind(key_b)
+                .fetch_optional(&mut *conn)
+                .await
+                .expect("probe B key");
+        assert!(
+            cross_key.is_none(),
+            "user A must NOT be able to read user B's API key by id"
+        );
+
+        // Through the repository method the handler uses: asking for B's keys by
+        // developer_id returns empty under A's context (RLS backstops the
+        // handler's owner check).
+        let cross_repo_keys = repo
+            .list_developer_api_keys(&mut *conn, dev_b)
+            .await
+            .expect("list B keys under A ctx");
+        assert!(
+            cross_repo_keys.is_empty(),
+            "list_developer_api_keys(dev_b) under user A's context must be empty — \
+             the RLS backstop, not just the handler check, hides cross-user keys"
+        );
+
+        // Own keys are visible through the same repo method.
+        let own_repo_keys = repo
+            .list_developer_api_keys(&mut *conn, dev_a)
+            .await
+            .expect("list A keys under A ctx");
+        assert_eq!(
+            own_repo_keys.len(),
+            1,
+            "user A must see their own API key via the repo"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (3a) CATALOG WRITE under super-admin context succeeds.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(Option::<Uuid>::None)
+            .bind(Option::<Uuid>::None)
+            .bind(true) // is_super_admin
+            .execute(&mut *conn)
+            .await
+            .expect("set super-admin ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let admin_insert = sqlx::query(
+            r#"
+            INSERT INTO marketplace_integrations (slug, name, description, vendor_name)
+            VALUES ('pap171-admin', 'PAP-171 Admin Integration', 'desc', 'Vendor')
+            "#,
+        )
+        .execute(&mut *conn)
+        .await;
+        assert!(
+            admin_insert.is_ok(),
+            "platform-admin (super-admin context) catalog write must still pass under FORCE: {admin_insert:?}"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (4) CATALOG public read + (3b) non-admin write denied, under a plain
+    //     user context.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(Option::<Uuid>::None)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set plain user ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        // (4) Public read: USING (TRUE) keeps the catalog readable even with no
+        //     super-admin context — the admin-inserted row is visible.
+        let catalog_visible: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM marketplace_integrations")
+                .fetch_one(&mut *conn)
+                .await
+                .expect("count catalog");
+        assert!(
+            catalog_visible >= 1,
+            "the catalog public-read policy must keep marketplace_integrations readable under FORCE"
+        );
+
+        // (3b) Plain user context: catalog write is denied by the policy WITH CHECK.
+        let user_insert = sqlx::query(
+            r#"
+            INSERT INTO marketplace_integrations (slug, name, description, vendor_name)
+            VALUES ('pap171-user', 'PAP-171 User Integration', 'desc', 'Vendor')
+            "#,
+        )
+        .execute(&mut *conn)
+        .await;
+        assert!(
+            user_insert.is_err(),
+            "a non-super-admin catalog write must be denied by the FORCE-RLS write policy"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup the test role. ---
+    set_ctx(&pool, None, true).await;
+    for stmt in [
+        format!("REVOKE ALL ON developer_accounts FROM \"{role}\""),
+        format!("REVOKE ALL ON developer_api_keys FROM \"{role}\""),
+        format!("REVOKE ALL ON developer_sandboxes FROM \"{role}\""),
+        format!("REVOKE ALL ON marketplace_integrations FROM \"{role}\""),
+        format!("DROP OWNED BY \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .ok();
+    }
+}

--- a/backend/servers/api-server/src/routes/api_ecosystem.rs
+++ b/backend/servers/api-server/src/routes/api_ecosystem.rs
@@ -73,11 +73,52 @@ use crate::state::AppState;
 /// pool — so the RLS-enforcement CI gate stays green — while clearing any stale
 /// RLS context left on the pooled connection by a previous request before we
 /// reuse it. That is strictly safer than the bare pool it replaces.
+///
+/// As of PAP-171 (migration `00180`) these tables are under `FORCE ROW LEVEL
+/// SECURITY`, so the owner role is no longer exempt. `catalog_conn` is now used
+/// ONLY by the **public read** handlers (catalog list/get with no caller
+/// identity), whose policies are `USING (TRUE)` / `USING (is_published)` and so
+/// still resolve correctly with no RLS context. Authenticated writes and
+/// developer-portal handlers use [`rls_conn`] instead so the user / super-admin
+/// policy backstop is actually exercised.
 async fn catalog_conn(
     state: &AppState,
 ) -> Result<db::PublicConnection, (StatusCode, Json<ErrorResponse>)> {
     RlsPool::new(state.db.clone())
         .acquire_public()
+        .await
+        .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))
+}
+
+/// Acquire an RLS-scoped connection carrying the caller's user + super-admin
+/// context for the FORCE-RLS catalog-write and developer-portal handlers
+/// (PAP-171, migration `00180`).
+///
+/// The catalog tables' write policies are `USING (is_super_admin())` and the
+/// developer-portal tables' policies are `USING (user_id = app.current_user_id
+/// OR is_super_admin())`. Under `FORCE ROW LEVEL SECURITY` the owner role is no
+/// longer exempt, so those policies now require the connection to carry the
+/// caller's identity. This helper sets it: platform admins
+/// ([`AuthUser::is_platform_admin`]) map to the super-admin RLS bypass — the
+/// same boundary the in-handler `is_platform_admin()` gate enforces — and every
+/// other caller is scoped to their own `user_id`. The developer-portal policies
+/// key on `user_id`, not org, so the tenant slot is filled with
+/// `auth.tenant_id` when present and a nil sentinel otherwise (developers need
+/// not belong to an org).
+///
+/// Callers should `release().await` the returned guard before returning so RLS
+/// context is cleared eagerly; the guard's `Drop` is a best-effort fallback on
+/// error paths (mirrors the `RlsConnection` discipline the org handlers use).
+async fn rls_conn(
+    state: &AppState,
+    auth: &AuthUser,
+) -> Result<db::RlsGuard, (StatusCode, Json<ErrorResponse>)> {
+    RlsPool::new(state.db.clone())
+        .acquire_with_rls(
+            auth.tenant_id.unwrap_or_else(Uuid::nil),
+            auth.user_id,
+            auth.is_platform_admin(),
+        )
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))
 }
@@ -359,7 +400,7 @@ async fn create_marketplace_integration(
         ));
     }
 
-    let mut conn = catalog_conn(&state).await?;
+    let mut conn = rls_conn(&state, &auth).await?;
 
     let integration = state
         .api_ecosystem_repo
@@ -367,6 +408,7 @@ async fn create_marketplace_integration(
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
+    conn.release().await;
     Ok(Json(integration))
 }
 
@@ -424,7 +466,7 @@ async fn update_marketplace_integration(
         ));
     }
 
-    let mut conn = catalog_conn(&state).await?;
+    let mut conn = rls_conn(&state, &auth).await?;
     let integration = state
         .api_ecosystem_repo
         .update_marketplace_integration(&mut **conn, path.id, &request)
@@ -432,6 +474,7 @@ async fn update_marketplace_integration(
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| not_found("Integration", path.id))?;
 
+    conn.release().await;
     Ok(Json(integration))
 }
 
@@ -461,13 +504,14 @@ async fn delete_marketplace_integration(
         ));
     }
 
-    let mut conn = catalog_conn(&state).await?;
+    let mut conn = rls_conn(&state, &auth).await?;
     let deleted = state
         .api_ecosystem_repo
         .delete_marketplace_integration(&mut **conn, path.id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
+    conn.release().await;
     if deleted {
         Ok(StatusCode::NO_CONTENT)
     } else {
@@ -765,7 +809,7 @@ async fn create_connector(
         ));
     }
 
-    let mut conn = catalog_conn(&state).await?;
+    let mut conn = rls_conn(&state, &auth).await?;
 
     let connector = state
         .api_ecosystem_repo
@@ -773,6 +817,7 @@ async fn create_connector(
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
+    conn.release().await;
     Ok(Json(connector))
 }
 
@@ -809,7 +854,7 @@ async fn update_connector(
         ));
     }
 
-    let mut conn = catalog_conn(&state).await?;
+    let mut conn = rls_conn(&state, &auth).await?;
 
     let connector = state
         .api_ecosystem_repo
@@ -818,6 +863,7 @@ async fn update_connector(
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| not_found("Connector", path.id))?;
 
+    conn.release().await;
     Ok(Json(connector))
 }
 
@@ -837,7 +883,7 @@ async fn delete_connector(
         ));
     }
 
-    let mut conn = catalog_conn(&state).await?;
+    let mut conn = rls_conn(&state, &auth).await?;
 
     let deleted = state
         .api_ecosystem_repo
@@ -845,6 +891,7 @@ async fn delete_connector(
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
+    conn.release().await;
     if deleted {
         Ok(StatusCode::NO_CONTENT)
     } else {
@@ -870,17 +917,32 @@ async fn list_connector_actions(
 /// Create connector action.
 async fn create_connector_action(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(_path): Path<IntegrationIdPath>,
     Json(request): Json<CreateConnectorAction>,
 ) -> Result<Json<ConnectorAction>, (StatusCode, Json<ErrorResponse>)> {
-    let mut conn = catalog_conn(&state).await?;
+    // Connector actions are part of the global catalog (super-admin write). The
+    // PAP-171 FORCE-RLS backstop denies non-admins, but gate explicitly so the
+    // caller gets a clean 403 rather than an opaque RLS denial. (This sibling of
+    // `create_connector` was previously missing the gate — see PAP-171.)
+    if !auth.is_platform_admin() {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "FORBIDDEN",
+                "Platform admin privileges required",
+            )),
+        ));
+    }
+
+    let mut conn = rls_conn(&state, &auth).await?;
     let action = state
         .api_ecosystem_repo
         .create_connector_action(&mut **conn, &request)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
+    conn.release().await;
     Ok(Json(action))
 }
 
@@ -1420,23 +1482,24 @@ async fn register_developer(
     auth: AuthUser,
     Json(request): Json<CreateDeveloperRegistration>,
 ) -> Result<Json<DeveloperRegistration>, (StatusCode, Json<ErrorResponse>)> {
-    let mut conn = catalog_conn(&state).await?;
+    let mut conn = rls_conn(&state, &auth).await?;
     let registration = state
         .api_ecosystem_repo
         .register_developer(&mut **conn, auth.user_id, &request)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
+    conn.release().await;
     Ok(Json(registration))
 }
 
 /// Get developer registration.
 async fn get_developer_registration(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    auth: AuthUser,
     Path(path): Path<DeveloperIdPath>,
 ) -> Result<Json<DeveloperRegistration>, (StatusCode, Json<ErrorResponse>)> {
-    let mut conn = catalog_conn(&state).await?;
+    let mut conn = rls_conn(&state, &auth).await?;
     let registration = state
         .api_ecosystem_repo
         .get_developer_registration(&mut **conn, path.id)
@@ -1444,6 +1507,7 @@ async fn get_developer_registration(
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| not_found("Developer", path.id))?;
 
+    conn.release().await;
     Ok(Json(registration))
 }
 
@@ -1464,7 +1528,7 @@ async fn review_developer_registration(
         ));
     }
 
-    let mut conn = catalog_conn(&state).await?;
+    let mut conn = rls_conn(&state, &auth).await?;
     let registration = state
         .api_ecosystem_repo
         .review_developer_registration(&mut **conn, path.id, auth.user_id, &request)
@@ -1472,6 +1536,7 @@ async fn review_developer_registration(
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| not_found("Developer", path.id))?;
 
+    conn.release().await;
     Ok(Json(registration))
 }
 
@@ -1482,7 +1547,7 @@ async fn list_developer_api_keys(
     Path(path): Path<DeveloperIdPath>,
 ) -> Result<Json<Vec<DeveloperApiKeyDisplay>>, (StatusCode, Json<ErrorResponse>)> {
     // Verify ownership or admin access
-    let mut conn = catalog_conn(&state).await?;
+    let mut conn = rls_conn(&state, &auth).await?;
     if !auth.is_platform_admin() {
         let dev_account = state
             .api_ecosystem_repo
@@ -1524,6 +1589,7 @@ async fn list_developer_api_keys(
         })
         .collect();
 
+    conn.release().await;
     Ok(Json(display_keys))
 }
 
@@ -1535,7 +1601,7 @@ async fn create_developer_api_key(
     Json(request): Json<CreateDeveloperApiKey>,
 ) -> Result<Json<CreateDeveloperApiKeyResponse>, (StatusCode, Json<ErrorResponse>)> {
     // Verify the caller owns this developer account or is platform admin
-    let mut conn = catalog_conn(&state).await?;
+    let mut conn = rls_conn(&state, &auth).await?;
     if !auth.is_platform_admin() {
         let dev_account = state
             .api_ecosystem_repo
@@ -1585,6 +1651,7 @@ async fn create_developer_api_key(
         expires_at: api_key.expires_at,
     };
 
+    conn.release().await;
     Ok(Json(response))
 }
 
@@ -1603,13 +1670,14 @@ async fn revoke_developer_api_key(
     auth: AuthUser,
     Path(path): Path<DeveloperKeyPath>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let mut conn = catalog_conn(&state).await?;
+    let mut conn = rls_conn(&state, &auth).await?;
     let revoked = state
         .api_ecosystem_repo
         .revoke_api_key(&mut **conn, path.key_id, auth.user_id)
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
+    conn.release().await;
     if revoked {
         Ok(StatusCode::NO_CONTENT)
     } else {
@@ -1623,10 +1691,11 @@ async fn rotate_developer_api_key(
     auth: AuthUser,
     Path(path): Path<DeveloperKeyPath>,
 ) -> Result<Json<CreateDeveloperApiKeyResponse>, (StatusCode, Json<ErrorResponse>)> {
-    // `developer_api_keys` is not FORCE-RLS (see `catalog_conn`); the rotate
+    // `developer_api_keys` is FORCE-RLS (PAP-171, migration 00180); the rotate
     // below is multi-statement (revoke old + insert new in one transaction) and
-    // runs on this dedicated public connection.
-    let mut conn = catalog_conn(&state).await?;
+    // runs on this dedicated RLS-scoped connection carrying the caller's user
+    // context, so the owner policy backstops the `auth.user_id` scoping below.
+    let mut conn = rls_conn(&state, &auth).await?;
 
     // Fetch existing key to determine sandbox status for the new key prefix
     let existing_keys = state
@@ -1665,6 +1734,7 @@ async fn rotate_developer_api_key(
         expires_at: api_key.expires_at,
     };
 
+    conn.release().await;
     Ok(Json(response))
 }
 
@@ -1675,7 +1745,7 @@ async fn get_developer_usage_stats(
     Path(path): Path<DeveloperIdPath>,
 ) -> Result<Json<DeveloperUsageStats>, (StatusCode, Json<ErrorResponse>)> {
     // Verify ownership or admin access
-    let mut conn = catalog_conn(&state).await?;
+    let mut conn = rls_conn(&state, &auth).await?;
     if !auth.is_platform_admin() {
         let dev_account = state
             .api_ecosystem_repo
@@ -1700,6 +1770,7 @@ async fn get_developer_usage_stats(
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
+    conn.release().await;
     Ok(Json(stats))
 }
 
@@ -1711,7 +1782,7 @@ async fn create_sandbox_environment(
     Json(request): Json<CreateSandboxConfig>,
 ) -> Result<Json<SandboxConfig>, (StatusCode, Json<ErrorResponse>)> {
     // Verify ownership or admin access
-    let mut conn = catalog_conn(&state).await?;
+    let mut conn = rls_conn(&state, &auth).await?;
     if !auth.is_platform_admin() {
         let dev_account = state
             .api_ecosystem_repo
@@ -1740,6 +1811,7 @@ async fn create_sandbox_environment(
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
+    conn.release().await;
     Ok(Json(sandbox))
 }
 
@@ -1750,7 +1822,7 @@ async fn get_sandbox_environment(
     Path(path): Path<DeveloperIdPath>,
 ) -> Result<Json<SandboxConfig>, (StatusCode, Json<ErrorResponse>)> {
     // Verify ownership or admin access
-    let mut conn = catalog_conn(&state).await?;
+    let mut conn = rls_conn(&state, &auth).await?;
     if !auth.is_platform_admin() {
         let dev_account = state
             .api_ecosystem_repo
@@ -1776,6 +1848,7 @@ async fn get_sandbox_environment(
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| error_response("NOT_FOUND", "Sandbox environment not found"))?;
 
+    conn.release().await;
     Ok(Json(sandbox))
 }
 
@@ -1787,7 +1860,7 @@ async fn test_sandbox_request(
     Json(request): Json<SandboxTestRequestPayload>,
 ) -> Result<Json<SandboxTestResponsePayload>, (StatusCode, Json<ErrorResponse>)> {
     // Verify ownership or admin access
-    let mut conn = catalog_conn(&state).await?;
+    let mut conn = rls_conn(&state, &auth).await?;
     if !auth.is_platform_admin() {
         let dev_account = state
             .api_ecosystem_repo
@@ -1877,6 +1950,7 @@ async fn test_sandbox_request(
         duration_ms,
     };
 
+    conn.release().await;
     Ok(Json(response))
 }
 
@@ -1911,7 +1985,7 @@ async fn create_api_documentation(
         ));
     }
 
-    let mut conn = catalog_conn(&state).await?;
+    let mut conn = rls_conn(&state, &auth).await?;
 
     let doc = state
         .api_ecosystem_repo
@@ -1919,6 +1993,7 @@ async fn create_api_documentation(
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
+    conn.release().await;
     Ok(Json(doc))
 }
 
@@ -1955,7 +2030,7 @@ async fn update_api_documentation(
         ));
     }
 
-    let mut conn = catalog_conn(&state).await?;
+    let mut conn = rls_conn(&state, &auth).await?;
 
     let doc = state
         .api_ecosystem_repo
@@ -1964,6 +2039,7 @@ async fn update_api_documentation(
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?
         .ok_or_else(|| not_found("Documentation", &path.slug))?;
 
+    conn.release().await;
     Ok(Json(doc))
 }
 
@@ -1983,7 +2059,7 @@ async fn delete_api_documentation(
         ));
     }
 
-    let mut conn = catalog_conn(&state).await?;
+    let mut conn = rls_conn(&state, &auth).await?;
 
     let deleted = state
         .api_ecosystem_repo
@@ -1991,6 +2067,7 @@ async fn delete_api_documentation(
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
+    conn.release().await;
     if deleted {
         Ok(StatusCode::NO_CONTENT)
     } else {
@@ -2031,7 +2108,7 @@ async fn create_code_sample(
         ));
     }
 
-    let mut conn = catalog_conn(&state).await?;
+    let mut conn = rls_conn(&state, &auth).await?;
 
     let sample = state
         .api_ecosystem_repo
@@ -2039,6 +2116,7 @@ async fn create_code_sample(
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
+    conn.release().await;
     Ok(Json(sample))
 }
 
@@ -2057,7 +2135,7 @@ async fn get_developer_portal_stats(
         ));
     }
 
-    let mut conn = catalog_conn(&state).await?;
+    let mut conn = rls_conn(&state, &auth).await?;
 
     let stats = state
         .api_ecosystem_repo
@@ -2065,6 +2143,7 @@ async fn get_developer_portal_stats(
         .await
         .map_err(|e| error_response("DATABASE_ERROR", &e.to_string()))?;
 
+    conn.release().await;
     Ok(Json(stats))
 }
 


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up to **PAP-167** (CTO-greenlit). Migration `00102` ENABLEd RLS on the api-ecosystem catalog + developer-portal tables but never `FORCE`d them, so the api-server's **owner role stayed exempt** and the policies were not a real backstop — authorization lived only in the handlers (`is_platform_admin()` gate / `user_id` owner check). This establishes the RLS backstop so a future handler bug can't leak across users.

Not a regression fix — PAP-167 introduced no IDOR. This is additive hardening.

## Changes

**Migration `00180_force_api_ecosystem_catalog_rls.sql`**
- `FORCE ROW LEVEL SECURITY` on `marketplace_integrations`, `connectors`, `connector_actions`, `api_documentation`, `api_code_samples`, `developer_accounts`, `developer_api_keys`, `developer_sandboxes`.
- The `00102` policies already key on the **canonical** GUCs (`app.current_user_id` for developer rows, `app.is_super_admin` for catalog writes), so only `FORCE` is added — no policy rewrite needed.
- `integration_ratings` (the issue's "marketplace_integration_ratings") is **already FORCEd by `00179`/PAP-62**, so it is intentionally excluded.

**Handlers (`routes/api_ecosystem.rs`)**
- New `rls_conn(&state, &auth)` helper → `acquire_with_rls` carrying the caller's user + platform-admin→super-admin context.
- 23 authenticated catalog-write + developer-portal handlers routed off `acquire_public` so the policies are exercised; each `release()`s context on the happy path.
- The 10 public-read handlers stay on `catalog_conn` (`USING (TRUE)` / `USING (is_published)` policies resolve without context).
- Closed a missing `is_platform_admin()` gate on `create_connector_action` (its sibling `create_connector` had one) — non-admins now get a clean 403 rather than an opaque RLS denial.

**Tests (`crates/db/tests/api_ecosystem_developer_force_rls_tests.rs`)**
- Cross-user isolation on `developer_*`: under user A's context, A cannot read B's developer account / API key / sandbox (raw SQL **and** via the `list_developer_api_keys` repo method the handler uses).
- Deny-all without context (what `acquire_public` leaves).
- Super-admin catalog write passes; plain-user write denied by the policy WITH CHECK; public read still works.
- `relforcerowsecurity` metadata guard — **fail-on-`dev`** (IG3), passes after `00180`.

## Verification
- `cargo check -p api-server` — green
- `cargo clippy -p api-server -p db --all-targets -- -D warnings` — green
- `./scripts/check-rls-enforcement.sh --strict` — clean (`✓ No RLS violations found`)
- both RLS tests green against Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)