### PR TITLE
test-notification-preference-sync-backend-v2: idempotent-apply tests for notification-preference realtime sync

### DIFF
--- a/backend/servers/api-server/tests/notification_preference_realtime_sync_tests.rs
+++ b/backend/servers/api-server/tests/notification_preference_realtime_sync_tests.rs
@@ -14,6 +14,19 @@
 //! | S3 | no  | The 409 "would disable all" guard fires **before** any publish, so a rejected update never emits a spurious `preference.updated`. |
 //! | S4 | yes (`#[ignore]`) | A real PATCH publishes `preference.updated` to `notifications:{user_id}` on Redis with `{channel, enabled}` payload; a different user's channel receives nothing (isolation). |
 //!
+//! Coverage 8a-3 (idempotent apply) — additive no-Redis cases that lock down the
+//! *idempotency* half of the realtime-sync contract (S1–S4 covered the publish
+//! leg). A realtime client may replay the same PATCH on reconnect, or two tabs
+//! may push the same desired state; the handler MUST converge on the same
+//! persisted state and the same HTTP outcome regardless of how many times the
+//! identical update is applied:
+//!
+//! | Case | Requires Redis | Asserts |
+//! |------|----------------|---------|
+//! | S5 | no  | Re-applying `enabled:false` to the same channel twice both return 200 and the channel stays disabled — `update_channel_rls` is an idempotent `UPDATE ... SET enabled=$3`, so a replayed PATCH is a safe no-op, not an error. |
+//! | S6 | no  | Re-applying `enabled:true` to an already-enabled channel both return 200 and never trips the "would disable all" 409 (the guard only runs on `!enabled`) — a redundant enable is always idempotent. |
+//! | S7 | no  | Disabling an **already-disabled** channel does not 409 even when another channel is the only enabled one: the guard keys off the *current* state of the channel being patched (`current.enabled`), so a replayed disable of a channel that is already off can never be the "last enabled" channel — proving repeated applies don't spuriously block. |
+//!
 //! The no-Redis cases run in CI (the default `AppState` has `pubsub_service =
 //! None`). The Redis case mirrors the `#[ignore]` style of the fanout test in
 //! `ws_integration_tests.rs` — run locally with:
@@ -182,6 +195,179 @@ async fn disable_all_guard_blocks_before_publish(pool: PgPool) {
         in_app["enabled"],
         json!(true),
         "S3: a 409-rejected disable-all must leave in_app enabled (no update, no spurious publish)"
+    );
+}
+
+// ============================================================================
+// S5 — idempotent disable: re-applying enabled:false is a safe 200 no-op
+// ============================================================================
+
+/// A realtime client may replay the same PATCH (reconnect, duplicate tab, retry
+/// after a dropped response). Disabling the email channel twice in a row must
+/// return 200 both times and leave email disabled — `update_channel_rls` is a
+/// plain `UPDATE ... SET enabled=$3`, so a redundant disable converges on the
+/// same persisted state rather than erroring. push + in_app stay enabled, so the
+/// disable-all guard never enters the picture for either apply.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn repeated_disable_is_idempotent(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    let (access_token, org) = create_authenticated_user_with_org(&app, &user, "s5").await;
+
+    // Apply the identical "disable email" PATCH twice; both must succeed.
+    for attempt in 0..2 {
+        let req = app
+            .patch("/api/v1/users/me/notification-preferences/email")
+            .bearer(&access_token)
+            .header("X-Tenant-ID", &org.to_string())
+            .json(json!({ "enabled": false, "confirmDisableAll": false }))
+            .build();
+        let resp = app.execute(req).await;
+        resp.assert_status(StatusCode::OK);
+        assert_eq!(
+            resp.json_value()["preference"]["enabled"],
+            json!(false),
+            "S5: apply #{attempt} must report email disabled"
+        );
+    }
+
+    // Final persisted state: email disabled, exactly once (idempotent — not
+    // toggled, not duplicated).
+    let get = app
+        .get("/api/v1/users/me/notification-preferences")
+        .bearer(&access_token)
+        .header("X-Tenant-ID", &org.to_string())
+        .build();
+    let body = app.execute(get).await.json_value();
+    let prefs = body["preferences"].as_array().expect("preferences array");
+    let email: Vec<_> = prefs
+        .iter()
+        .filter(|p| p["channel"] == json!("email"))
+        .collect();
+    assert_eq!(
+        email.len(),
+        1,
+        "S5: email must appear exactly once after a repeated disable (no duplicate rows)"
+    );
+    assert_eq!(
+        email[0]["enabled"],
+        json!(false),
+        "S5: email must remain disabled after the second identical PATCH"
+    );
+}
+
+// ============================================================================
+// S6 — idempotent enable: re-applying enabled:true never trips the 409 guard
+// ============================================================================
+
+/// The "would disable all" guard runs only on `!enabled`, so a redundant enable
+/// can never produce a 409. Re-enabling an already-enabled channel twice must
+/// return 200 both times and leave the channel enabled — the enable path has no
+/// state-dependent rejection, making it unconditionally idempotent.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn repeated_enable_is_idempotent_and_never_conflicts(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    let (access_token, org) = create_authenticated_user_with_org(&app, &user, "s6").await;
+
+    // in_app starts enabled by default; re-enable it twice.
+    for attempt in 0..2 {
+        let req = app
+            .patch("/api/v1/users/me/notification-preferences/in_app")
+            .bearer(&access_token)
+            .header("X-Tenant-ID", &org.to_string())
+            .json(json!({ "enabled": true, "confirmDisableAll": false }))
+            .build();
+        let resp = app.execute(req).await;
+        // A redundant enable must never be a 409 (the disable-all guard is gated
+        // on `!enabled`) — it is an unconditional 200.
+        resp.assert_status(StatusCode::OK);
+        assert_eq!(
+            resp.json_value()["preference"]["enabled"],
+            json!(true),
+            "S6: apply #{attempt} must report in_app enabled"
+        );
+    }
+
+    let get = app
+        .get("/api/v1/users/me/notification-preferences")
+        .bearer(&access_token)
+        .header("X-Tenant-ID", &org.to_string())
+        .build();
+    let body = app.execute(get).await.json_value();
+    let in_app = body["preferences"]
+        .as_array()
+        .expect("preferences array")
+        .iter()
+        .find(|p| p["channel"] == json!("in_app"))
+        .expect("in_app channel present");
+    assert_eq!(
+        in_app["enabled"],
+        json!(true),
+        "S6: in_app must remain enabled after repeated identical enables"
+    );
+}
+
+// ============================================================================
+// S7 — disabling an already-disabled channel never 409s, even as "last write"
+// ============================================================================
+
+/// The disable-all guard keys off the *current* state of the channel being
+/// patched: `would_disable_all = enabled_count == 1 && current.enabled`. A
+/// channel that is already disabled has `current.enabled == false`, so re-
+/// disabling it can never be the last-enabled channel — the guard cannot fire.
+///
+/// Setup: disable email (push + in_app still on), then disable push (in_app is
+/// now the only enabled channel). Re-disabling the already-off email channel
+/// must still return 200 — a replayed disable of an off channel is a pure no-op
+/// and must not be mistaken for "disabling the last channel". in_app stays on.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn redisable_of_off_channel_never_conflicts(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    let (access_token, org) = create_authenticated_user_with_org(&app, &user, "s7").await;
+
+    // Disable email then push — in_app becomes the sole enabled channel.
+    for channel in ["email", "push"] {
+        let req = app
+            .patch(&format!(
+                "/api/v1/users/me/notification-preferences/{channel}"
+            ))
+            .bearer(&access_token)
+            .header("X-Tenant-ID", &org.to_string())
+            .json(json!({ "enabled": false, "confirmDisableAll": false }))
+            .build();
+        app.execute(req).await.assert_status(StatusCode::OK);
+    }
+
+    // Re-disable the already-disabled email channel without confirmation. Even
+    // though in_app is the only enabled channel, this must NOT 409: email is
+    // already off, so it is not the "last enabled" channel.
+    let req = app
+        .patch("/api/v1/users/me/notification-preferences/email")
+        .bearer(&access_token)
+        .header("X-Tenant-ID", &org.to_string())
+        .json(json!({ "enabled": false, "confirmDisableAll": false }))
+        .build();
+    app.execute(req).await.assert_status(StatusCode::OK);
+
+    // in_app must still be enabled — the no-op redisable changed nothing.
+    let get = app
+        .get("/api/v1/users/me/notification-preferences")
+        .bearer(&access_token)
+        .header("X-Tenant-ID", &org.to_string())
+        .build();
+    let body = app.execute(get).await.json_value();
+    let in_app = body["preferences"]
+        .as_array()
+        .expect("preferences array")
+        .iter()
+        .find(|p| p["channel"] == json!("in_app"))
+        .expect("in_app channel present");
+    assert_eq!(
+        in_app["enabled"],
+        json!(true),
+        "S7: in_app must stay enabled — re-disabling an already-off channel is a no-op, not a last-channel disable"
     );
 }
 


### PR DESCRIPTION
## Task
Coverage 8a-3: add backend tests for notification-preference realtime sync (preference update -> pub/sub propagation, idempotent apply). Additive backend tests, no schema change.

(Retry -v2 of a task whose prior attempt failed only on a sandbox timeout — no code problem. Work was still needed.)

## Owner
pm-backend

## What changed
Adds three additive `#[sqlx::test]` cases (S5–S7) to the existing
`backend/servers/api-server/tests/notification_preference_realtime_sync_tests.rs`,
covering the **idempotent-apply** half of the realtime preference-sync contract.
S1–S4 (already on `dev`) cover the publish leg; these lock down convergence under
replayed/duplicate PATCHes — the realistic reconnect / multi-tab case for a
realtime client:

- **S5 `repeated_disable_is_idempotent`** — disabling `email` twice both return 200; email ends disabled, appears exactly once (no duplicate rows). `update_channel_rls` is a plain `UPDATE ... SET enabled=$3`, so a replayed disable is a safe no-op.
- **S6 `repeated_enable_is_idempotent_and_never_conflicts`** — re-enabling an already-enabled channel twice both return 200 and never trip the "would disable all" 409 (the guard is gated on `!enabled`); a redundant enable is unconditionally idempotent.
- **S7 `redisable_of_off_channel_never_conflicts`** — re-disabling an already-off `email` channel returns 200 even when `in_app` is the sole enabled channel: the disable-all guard keys off the *current* state of the patched channel (`would_disable_all = enabled_count == 1 && current.enabled`), so a replayed disable of an off channel can never be mistaken for the last-channel disable.

No production code change, no schema change, no migration. Pure additive test
coverage of already-shipped behavior. Tests follow the existing no-Redis
`#[sqlx::test]` pattern in this file and run in CI where Postgres is provisioned.

## Tested (Band A — fast check)
```
SQLX_OFFLINE=true cargo check -p api-server --tests
Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 05s
EXIT=0
```
Compiles clean against the api-server test harness. Test *execution* requires a
live Postgres (`#[sqlx::test]`), which is not available in the implementer
sandbox but is provisioned in CI — identical to the pre-existing S1–S4 in this
same file.

## Built (Band B — full build)
skipped: test-only change (no production code, no public API/config/migration touch). Band A `cargo check --tests` is the relevant gate for an additive test file.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR — no security/auth/billing/data-integrity production change. CI `backend.yml` (fmt + clippy + `cargo test`) is the authoritative gate for the new tests.

## Remote-tested
skipped (no ppt-bridge MCP in this session).

## Scope drift
None. `scope-check.sh --owner pm-backend` → exit 0 (only `backend/servers/api-server/tests/...` touched). `scope_drift=false`.

## Code-reuse review
None. `reuse-grep.sh --specialist rust-backend` → empty (no new helpers/symbols; uses the shared `common::create_authenticated_user_with_org` fixture and existing repo methods). `code_reuse_warn=none`.

## Notes
- IG2/IG3 of the implement goal-check WARN/FAIL by design for this vector: it is a coverage task (no `.research/plans/` doc, no `fix:`/`feat:` commit) — additive tests of shipped behavior need no paired production change (IG3 test-only exception). Branch name `auto-impl/...` is the dispatcher-chosen name.

https://claude.ai/code/session_01RVsbD1fT4cxdsmdnXCeWgZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVsbD1fT4cxdsmdnXCeWgZ)_