### PR TITLE
fix(reality-server): scope portal import/feed by-id endpoints to owner (PAP-142)

### DIFF
--- a/backend/crates/db/src/repositories/reality_portal.rs
+++ b/backend/crates/db/src/repositories/reality_portal.rs
@@ -1148,66 +1148,87 @@ impl RealityPortalRepository {
         .await
     }
 
-    /// Update import job.
+    /// Update import job. Scoped to the owning `user_id` so a portal user
+    /// cannot mutate another user's job by id (IDOR, PAP-142).
     pub async fn update_import_job(
         &self,
         id: Uuid,
+        user_id: Uuid,
         data: UpdateImportJob,
     ) -> Result<PortalImportJob, SqlxError> {
         sqlx::query_as::<_, PortalImportJob>(
             r#"
             UPDATE portal_import_jobs SET
-                source_url = COALESCE($2, source_url),
-                source_filename = COALESCE($3, source_filename)
-            WHERE id = $1
+                source_url = COALESCE($3, source_url),
+                source_filename = COALESCE($4, source_filename)
+            WHERE id = $1 AND user_id = $2
             RETURNING *
             "#,
         )
         .bind(id)
+        .bind(user_id)
         .bind(&data.source_url)
         .bind(&data.source_filename)
         .fetch_one(&self.pool)
         .await
     }
 
-    /// Start import job.
-    pub async fn start_import_job(&self, id: Uuid) -> Result<PortalImportJob, SqlxError> {
+    /// Start import job. Scoped to the owning `user_id` (IDOR, PAP-142).
+    pub async fn start_import_job(
+        &self,
+        id: Uuid,
+        user_id: Uuid,
+    ) -> Result<PortalImportJob, SqlxError> {
         sqlx::query_as::<_, PortalImportJob>(
             r#"
             UPDATE portal_import_jobs SET
                 status = 'processing',
                 started_at = NOW()
-            WHERE id = $1 AND status = 'pending'
+            WHERE id = $1 AND user_id = $2 AND status = 'pending'
             RETURNING *
             "#,
         )
         .bind(id)
+        .bind(user_id)
         .fetch_one(&self.pool)
         .await
     }
 
-    /// Cancel import job.
-    pub async fn cancel_import_job(&self, id: Uuid) -> Result<PortalImportJob, SqlxError> {
+    /// Cancel import job. Scoped to the owning `user_id` (IDOR, PAP-142).
+    pub async fn cancel_import_job(
+        &self,
+        id: Uuid,
+        user_id: Uuid,
+    ) -> Result<PortalImportJob, SqlxError> {
         sqlx::query_as::<_, PortalImportJob>(
             r#"
             UPDATE portal_import_jobs SET
                 status = 'cancelled',
                 completed_at = NOW()
-            WHERE id = $1 AND status IN ('pending', 'processing')
+            WHERE id = $1 AND user_id = $2 AND status IN ('pending', 'processing')
             RETURNING *
             "#,
         )
         .bind(id)
+        .bind(user_id)
         .fetch_one(&self.pool)
         .await
     }
 
-    /// Get import job status.
-    pub async fn get_import_job(&self, id: Uuid) -> Result<Option<PortalImportJob>, SqlxError> {
-        sqlx::query_as::<_, PortalImportJob>("SELECT * FROM portal_import_jobs WHERE id = $1")
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await
+    /// Get import job status. Scoped to the owning `user_id` so a portal user
+    /// cannot read another user's job by id (IDOR, PAP-142).
+    pub async fn get_import_job(
+        &self,
+        id: Uuid,
+        user_id: Uuid,
+    ) -> Result<Option<PortalImportJob>, SqlxError> {
+        sqlx::query_as::<_, PortalImportJob>(
+            "SELECT * FROM portal_import_jobs WHERE id = $1 AND user_id = $2",
+        )
+        .bind(id)
+        .bind(user_id)
+        .fetch_optional(&self.pool)
+        .await
     }
 
     /// Update import job progress.
@@ -1275,39 +1296,44 @@ impl RealityPortalRepository {
         .await
     }
 
-    /// Get feed subscription by ID.
+    /// Get feed subscription by ID. Scoped to the owning `agency_id` so an
+    /// agency cannot read another agency's feed by id (IDOR, PAP-142).
     pub async fn get_feed_subscription(
         &self,
         id: Uuid,
+        agency_id: Uuid,
     ) -> Result<Option<RealityFeedSubscription>, SqlxError> {
         sqlx::query_as::<_, RealityFeedSubscription>(
-            "SELECT * FROM feed_subscriptions WHERE id = $1",
+            "SELECT * FROM feed_subscriptions WHERE id = $1 AND agency_id = $2",
         )
         .bind(id)
+        .bind(agency_id)
         .fetch_optional(&self.pool)
         .await
     }
 
-    /// Update feed subscription.
+    /// Update feed subscription. Scoped to the owning `agency_id` (IDOR, PAP-142).
     pub async fn update_feed_subscription(
         &self,
         id: Uuid,
+        agency_id: Uuid,
         data: UpdateFeedSubscription,
     ) -> Result<RealityFeedSubscription, SqlxError> {
         sqlx::query_as::<_, RealityFeedSubscription>(
             r#"
             UPDATE feed_subscriptions SET
-                name = COALESCE($2, name),
-                feed_url = COALESCE($3, feed_url),
-                feed_type = COALESCE($4, feed_type),
-                sync_interval = COALESCE($5, sync_interval),
-                is_active = COALESCE($6, is_active),
+                name = COALESCE($3, name),
+                feed_url = COALESCE($4, feed_url),
+                feed_type = COALESCE($5, feed_type),
+                sync_interval = COALESCE($6, sync_interval),
+                is_active = COALESCE($7, is_active),
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND agency_id = $2
             RETURNING *
             "#,
         )
         .bind(id)
+        .bind(agency_id)
         .bind(&data.name)
         .bind(&data.feed_url)
         .bind(&data.feed_type)
@@ -1317,18 +1343,23 @@ impl RealityPortalRepository {
         .await
     }
 
-    /// Trigger immediate feed sync.
-    pub async fn trigger_feed_sync(&self, id: Uuid) -> Result<RealityFeedSubscription, SqlxError> {
+    /// Trigger immediate feed sync. Scoped to the owning `agency_id` (IDOR, PAP-142).
+    pub async fn trigger_feed_sync(
+        &self,
+        id: Uuid,
+        agency_id: Uuid,
+    ) -> Result<RealityFeedSubscription, SqlxError> {
         // Mark as syncing and update last sync time
         sqlx::query_as::<_, RealityFeedSubscription>(
             r#"
             UPDATE feed_subscriptions SET
                 last_sync_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND agency_id = $2
             RETURNING *
             "#,
         )
         .bind(id)
+        .bind(agency_id)
         .fetch_one(&self.pool)
         .await
     }

--- a/backend/crates/db/tests/portal_imports_cross_org_idor_tests.rs
+++ b/backend/crates/db/tests/portal_imports_cross_org_idor_tests.rs
@@ -1,0 +1,226 @@
+//! Cross-tenant IDOR regression tests for reality-portal import jobs and feed
+//! subscriptions (PAP-142).
+//!
+//! Before the fix, the by-id repo methods keyed only on `id`, so any
+//! authenticated portal user could read or mutate another user's import job
+//! (`get/update/start/cancel_import_job`) or another agency's feed
+//! (`get/update_feed_subscription`, `trigger_feed_sync`) by guessing the id.
+//! The handlers in `reality-server/src/routes/imports.rs` now thread the
+//! verified `principal.user_id` (import jobs key on `user_id`; feeds key on
+//! `agency_id`) and the repo methods scope the WHERE clause accordingly.
+//!
+//! The CI pool runs as a superuser that bypasses FORCE RLS, so these tests
+//! exercise the application-layer ownership keying directly — exactly the gap
+//! RLS would not catch in CI.
+//!
+//! Run with:
+//! ```bash
+//! cargo test -p db --test portal_imports_cross_org_idor_tests
+//! ```
+
+// NB: the reality-portal import-job models are re-exported under `Portal`-prefixed
+// aliases (`db::models::CreateImportJob` is a *different* struct from another domain).
+use db::models::{
+    CreateFeedSubscription, CreatePortalImportJob, UpdateFeedSubscription, UpdatePortalImportJob,
+};
+use db::repositories::RealityPortalRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'Portal User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_agency(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO reality_agencies (name, slug, email, status)
+        VALUES ($1, $2, $3, 'verified')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Agency {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@agency.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed agency")
+}
+
+#[sqlx::test]
+async fn import_job_by_id_is_scoped_to_owning_user(pool: PgPool) {
+    let user_a = seed_user(&pool, "import-a@idor.test").await;
+    let user_b = seed_user(&pool, "import-b@idor.test").await;
+
+    let repo = RealityPortalRepository::new(pool.clone());
+
+    // user_a creates an import job.
+    let job = repo
+        .create_import_job(
+            user_a,
+            CreatePortalImportJob {
+                agency_id: None,
+                source_type: "csv".to_string(),
+                source_url: None,
+                source_filename: Some("a.csv".to_string()),
+            },
+        )
+        .await
+        .expect("create import job");
+
+    // --- user_b must NOT be able to read user_a's job by id ---
+    let leaked = repo.get_import_job(job.id, user_b).await.expect("get call");
+    assert!(
+        leaked.is_none(),
+        "user_b must not read user_a's import job (IDOR PAP-142)"
+    );
+
+    // --- user_b must NOT be able to mutate it ---
+    let updated = repo
+        .update_import_job(
+            job.id,
+            user_b,
+            UpdatePortalImportJob {
+                source_url: Some("https://evil.test".to_string()),
+                source_filename: None,
+            },
+        )
+        .await;
+    assert!(
+        matches!(updated, Err(sqlx::Error::RowNotFound)),
+        "user_b must not update user_a's import job (IDOR PAP-142), got {updated:?}"
+    );
+
+    let started = repo.start_import_job(job.id, user_b).await;
+    assert!(
+        matches!(started, Err(sqlx::Error::RowNotFound)),
+        "user_b must not start user_a's import job (IDOR PAP-142), got {started:?}"
+    );
+
+    let cancelled = repo.cancel_import_job(job.id, user_b).await;
+    assert!(
+        matches!(cancelled, Err(sqlx::Error::RowNotFound)),
+        "user_b must not cancel user_a's import job (IDOR PAP-142), got {cancelled:?}"
+    );
+
+    // Row must be untouched by the IDOR attempts.
+    let (status, source_filename): (String, Option<String>) =
+        sqlx::query_as("SELECT status, source_filename FROM portal_import_jobs WHERE id = $1")
+            .bind(job.id)
+            .fetch_one(&pool)
+            .await
+            .expect("select job");
+    assert_eq!(status, "pending", "status must be unchanged");
+    assert_eq!(
+        source_filename.as_deref(),
+        Some("a.csv"),
+        "source_filename must be unchanged"
+    );
+
+    // --- the owner still has full access ---
+    let owned = repo
+        .get_import_job(job.id, user_a)
+        .await
+        .expect("owner get");
+    assert!(owned.is_some(), "owner must read its own import job");
+
+    let started = repo
+        .start_import_job(job.id, user_a)
+        .await
+        .expect("owner start");
+    assert_eq!(started.status, "processing", "owner must start its own job");
+}
+
+#[sqlx::test]
+async fn feed_subscription_by_id_is_scoped_to_owning_agency(pool: PgPool) {
+    let agency_a = seed_agency(&pool, "feed-idor-a").await;
+    let agency_b = seed_agency(&pool, "feed-idor-b").await;
+
+    let repo = RealityPortalRepository::new(pool.clone());
+
+    // agency_a creates a feed subscription.
+    let feed = repo
+        .create_feed_subscription(
+            agency_a,
+            CreateFeedSubscription {
+                name: "A feed".to_string(),
+                feed_url: "https://a.test/feed.xml".to_string(),
+                feed_type: None,
+                sync_interval: None,
+            },
+        )
+        .await
+        .expect("create feed");
+
+    // --- agency_b must NOT read agency_a's feed by id ---
+    let leaked = repo
+        .get_feed_subscription(feed.id, agency_b)
+        .await
+        .expect("get call");
+    assert!(
+        leaked.is_none(),
+        "agency_b must not read agency_a's feed (IDOR PAP-142)"
+    );
+
+    // --- agency_b must NOT mutate it ---
+    let updated = repo
+        .update_feed_subscription(
+            feed.id,
+            agency_b,
+            UpdateFeedSubscription {
+                name: Some("hijacked".to_string()),
+                feed_url: None,
+                feed_type: None,
+                sync_interval: None,
+                is_active: Some(false),
+            },
+        )
+        .await;
+    assert!(
+        matches!(updated, Err(sqlx::Error::RowNotFound)),
+        "agency_b must not update agency_a's feed (IDOR PAP-142), got {updated:?}"
+    );
+
+    let synced = repo.trigger_feed_sync(feed.id, agency_b).await;
+    assert!(
+        matches!(synced, Err(sqlx::Error::RowNotFound)),
+        "agency_b must not sync agency_a's feed (IDOR PAP-142), got {synced:?}"
+    );
+
+    // Row must be untouched.
+    let name: String = sqlx::query_scalar("SELECT name FROM feed_subscriptions WHERE id = $1")
+        .bind(feed.id)
+        .fetch_one(&pool)
+        .await
+        .expect("select feed");
+    assert_eq!(
+        name, "A feed",
+        "feed name must be unchanged after IDOR attempt"
+    );
+
+    // --- the owning agency still has full access ---
+    let owned = repo
+        .get_feed_subscription(feed.id, agency_a)
+        .await
+        .expect("owner get");
+    assert!(owned.is_some(), "owner agency must read its own feed");
+
+    let synced = repo
+        .trigger_feed_sync(feed.id, agency_a)
+        .await
+        .expect("owner sync");
+    assert!(
+        synced.last_sync_at.is_some(),
+        "owner agency must sync its own feed"
+    );
+}

--- a/backend/servers/reality-server/src/routes/imports.rs
+++ b/backend/servers/reality-server/src/routes/imports.rs
@@ -153,11 +153,12 @@ pub async fn create_import_job(
 )]
 pub async fn get_import_job(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ImportJobResponse>, (axum::http::StatusCode, String)> {
     let job = state
         .reality_portal_repo
-        .get_import_job(id)
+        .get_import_job(id, principal.user_id)
         .await
         .map_err(|e| {
             (
@@ -190,12 +191,13 @@ pub async fn get_import_job(
 )]
 pub async fn update_import_job(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdatePortalImportJob>,
 ) -> Result<Json<ImportJobResponse>, (axum::http::StatusCode, String)> {
     let job = state
         .reality_portal_repo
-        .update_import_job(id, data)
+        .update_import_job(id, principal.user_id, data)
         .await
         .map_err(|e| match e {
             SqlxError::RowNotFound => (
@@ -226,17 +228,22 @@ pub async fn update_import_job(
 )]
 pub async fn start_import_job(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ImportJobResponse>, (axum::http::StatusCode, String)> {
     let job = state
         .reality_portal_repo
-        .start_import_job(id)
+        .start_import_job(id, principal.user_id)
         .await
-        .map_err(|e| {
-            (
+        .map_err(|e| match e {
+            SqlxError::RowNotFound => (
+                axum::http::StatusCode::NOT_FOUND,
+                "Import job not found".to_string(),
+            ),
+            other => (
                 axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to start import job: {}", e),
-            )
+                format!("Failed to start import job: {}", other),
+            ),
         })?;
 
     Ok(Json(ImportJobResponse { job }))
@@ -256,17 +263,22 @@ pub async fn start_import_job(
 )]
 pub async fn cancel_import_job(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ImportJobResponse>, (axum::http::StatusCode, String)> {
     let job = state
         .reality_portal_repo
-        .cancel_import_job(id)
+        .cancel_import_job(id, principal.user_id)
         .await
-        .map_err(|e| {
-            (
+        .map_err(|e| match e {
+            SqlxError::RowNotFound => (
+                axum::http::StatusCode::NOT_FOUND,
+                "Import job not found".to_string(),
+            ),
+            other => (
                 axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to cancel import job: {}", e),
-            )
+                format!("Failed to cancel import job: {}", other),
+            ),
         })?;
 
     Ok(Json(ImportJobResponse { job }))
@@ -346,11 +358,12 @@ pub async fn create_feed(
 )]
 pub async fn get_feed(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(id): Path<Uuid>,
 ) -> Result<Json<FeedResponse>, (axum::http::StatusCode, String)> {
     let feed = state
         .reality_portal_repo
-        .get_feed_subscription(id)
+        .get_feed_subscription(id, principal.user_id)
         .await
         .map_err(|e| {
             (
@@ -383,12 +396,13 @@ pub async fn get_feed(
 )]
 pub async fn update_feed(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateFeedSubscription>,
 ) -> Result<Json<FeedResponse>, (axum::http::StatusCode, String)> {
     let feed = state
         .reality_portal_repo
-        .update_feed_subscription(id, data)
+        .update_feed_subscription(id, principal.user_id, data)
         .await
         .map_err(|e| match e {
             SqlxError::RowNotFound => (
@@ -418,17 +432,22 @@ pub async fn update_feed(
 )]
 pub async fn sync_feed(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(id): Path<Uuid>,
 ) -> Result<Json<FeedResponse>, (axum::http::StatusCode, String)> {
     let feed = state
         .reality_portal_repo
-        .trigger_feed_sync(id)
+        .trigger_feed_sync(id, principal.user_id)
         .await
-        .map_err(|e| {
-            (
+        .map_err(|e| match e {
+            SqlxError::RowNotFound => (
+                axum::http::StatusCode::NOT_FOUND,
+                "Feed not found".to_string(),
+            ),
+            other => (
                 axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to trigger feed sync: {}", e),
-            )
+                format!("Failed to trigger feed sync: {}", other),
+            ),
         })?;
 
     Ok(Json(FeedResponse { feed }))


### PR DESCRIPTION
## PAP-142 — WS-A IDOR: reality-portal import jobs + feed subscriptions

### Problem
The 7 **by-id** handlers in `reality-server`'s `routes/imports.rs` (mounted at `/api/v1/imports` in `main.rs`) took **no** `RequestPrincipal` and their `RealityPortalRepository` methods keyed only on the row `id`:

- `GET/PUT /jobs/{id}`, `POST /jobs/{id}/start`, `POST /jobs/{id}/cancel`
- `GET/PUT /feeds/{id}`, `POST /feeds/{id}/sync`

Any authenticated portal user could read or mutate **another user's import job** or **another agency's feed subscription** by guessing the id (cross-tenant IDOR). The `list`/`create` handlers already scoped on the principal; the by-id ones did not.

### Fix (pattern per PR #1260)
- Thread the verified `principal.user_id` from each handler (never the path/body).
- Scope the repo queries: import jobs `WHERE id=$1 AND user_id=$2`; feed subscriptions `WHERE id=$1 AND agency_id=$2` — keyed on `principal.user_id` as the agency id, matching the existing `list_feeds`/`create_feed` convention.
- Cross-tenant ids now return `RowNotFound` → mapped to `404`.

### meter.rs — already secure, no change
The meter handlers named in the audit (`get_reading`, `validate_reading`, `get_provider`, `resolve_alert`) all call `verify_meter_access`/`verify_org_access` **before** returning data or executing the mutation. The by-id fetch only resolves the parent meter for the membership check; no data leaks and no pre-check mutation. Verified by reading; left untouched.

### Test
`crates/db/tests/portal_imports_cross_org_idor_tests.rs` — 2 `#[sqlx::test]`, both passing:
- `import_job_by_id_is_scoped_to_owning_user`
- `feed_subscription_by_id_is_scoped_to_owning_agency`

Each creates a row via the real repo, asserts cross-tenant get/update/start/cancel/sync are rejected and the row is untouched, and that the owner still succeeds. The CI superuser pool bypasses FORCE RLS, so these exercise the app-layer keying directly.

### Verification
- `cargo check -p db -p reality-server` ✅
- `cargo clippy -p db -p reality-server --all-targets` ✅ (clean)
- `cargo fmt --check` ✅
- `cargo test -p db --test portal_imports_cross_org_idor_tests` ✅ 2 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)