### PR TITLE
bug-ios-deeplink-info-plist-missing: wire realityportal URL scheme + applinks entitlement

### DIFF
--- a/mobile-native/iosApp/Info.plist
+++ b/mobile-native/iosApp/Info.plist
@@ -31,5 +31,18 @@
     <array>
         <string>UIInterfaceOrientationPortrait</string>
     </array>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+            <key>CFBundleURLName</key>
+            <string>three.two.bit.ppt.reality</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>realityportal</string>
+            </array>
+        </dict>
+    </array>
 </dict>
 </plist>

--- a/mobile-native/iosApp/iosApp/iosApp.entitlements
+++ b/mobile-native/iosApp/iosApp/iosApp.entitlements
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+      Associated Domains — universal links (applinks:).
+
+      Re-enables `https://` deep links so iOS delivers matching URLs to
+      `RealityPortalApp.onOpenURL`, which forwards them to `DeepLinkHandler`.
+      Without this entitlement iOS opens the links in Safari instead of the app,
+      and the `applinks:` AASA negotiation never runs.
+
+      Hosts mirror the production/staging universal-link domains:
+        - `Environment.universalLinkDomain` in Core/Configuration.swift
+          (production: reality.example.com, staging: staging.reality.example.com)
+        - `DeepLinkHandler.allowedUniversalLinkHosts`
+          (reality.example.com, staging-reality.example.com)
+      Both host spellings are listed so whichever AASA the reality-web origin
+      serves resolves. Each host requires `/.well-known/apple-app-site-association`
+      served at that origin for the link to activate on-device.
+
+      The custom `realityportal://` scheme is registered separately via
+      CFBundleURLTypes in Resources/Info.plist (and the legacy top-level
+      Info.plist) — it does NOT need an entitlement.
+    -->
+    <key>com.apple.developer.associated-domains</key>
+    <array>
+        <string>applinks:reality.example.com</string>
+        <string>applinks:staging.reality.example.com</string>
+        <string>applinks:staging-reality.example.com</string>
+    </array>
+</dict>
+</plist>

--- a/mobile-native/iosApp/project.yml
+++ b/mobile-native/iosApp/project.yml
@@ -71,6 +71,13 @@ targets:
           - "**/.DS_Store"
     info:
       path: iosApp/Resources/Info.plist
+    # Associated-domains entitlement — enables universal links (applinks:) so
+    # iOS delivers matching https:// URLs to onOpenURL -> DeepLinkHandler.
+    # XcodeGen wires this as CODE_SIGN_ENTITLEMENTS for every configuration.
+    # The custom realityportal:// scheme is registered via CFBundleURLTypes in
+    # the Info.plist and does not need an entitlement.
+    entitlements:
+      path: iosApp/iosApp.entitlements
     # Per-config xcconfig also applied at the target level so PRODUCT_BUNDLE_*,
     # API_BASE_URL, ENVIRONMENT, ENABLE_LOGGING resolve into Info.plist.
     configFiles:


### PR DESCRIPTION
## Task
iOS deep-link layer is dead at runtime — `mobile-native/iosApp/Info.plist` is missing the `CFBundleURLTypes` entry for the `realityportal` URL scheme, and there is no `applinks:` associated-domains entitlement, so iOS never delivers `realityportal://` URLs to `onOpenURL` and universal links are also dead. Add the missing `CFBundleURLTypes` entry for scheme `realityportal` (matching `Configuration.urlScheme=realityportal`, pinned by `testEnvironmentDeepLinkSchemeIsStable`) and wire the `applinks:` associated-domains entitlement. This re-enables the SSO `realityportal://sso?token=&state=` callback path. NavigationCoordinator / DeepLinkHandler / NavigationStateRestorationService are already implemented + unit-tested (Issue #1267) — only the Info.plist / entitlement config is missing.

## Owner
pm-frontend (specialist: ios-swiftui)

## What changed
1. **`mobile-native/iosApp/Info.plist`** — added the `CFBundleURLTypes` entry registering the `realityportal` custom scheme (`CFBundleURLName = three.two.bit.ppt.reality`).
2. **`mobile-native/iosApp/iosApp/iosApp.entitlements`** (new) — `com.apple.developer.associated-domains` with `applinks:` entries enabling universal links.
3. **`mobile-native/iosApp/project.yml`** — wired the entitlement into the `iosApp` target via XcodeGen `entitlements:` (maps to `CODE_SIGN_ENTITLEMENTS` for all configs).

### Important finding — two Info.plist files
The task named `mobile-native/iosApp/Info.plist` as primary, but `project.yml` (line 73, `info.path`) builds against a **different** file: `mobile-native/iosApp/iosApp/Resources/Info.plist`, which **already contained** the `realityportal` `CFBundleURLTypes` entry. The top-level `Info.plist` is a legacy/unreferenced file (not used by any build script). I added the `CFBundleURLTypes` entry there too for consistency and because the task + `testEnvironmentDeepLinkSchemeIsStable` pin the scheme — but **the genuinely missing piece at runtime was the associated-domains entitlement**, which did not exist anywhere and was not wired in `project.yml`. That gap is now closed. Reviewer may wish to consider deleting the legacy top-level `Info.plist` in a follow-up to avoid confusion.

### applinks hosts
Entitlement lists `applinks:reality.example.com`, `applinks:staging.reality.example.com`, and `applinks:staging-reality.example.com`. These mirror `Environment.universalLinkDomain` (Core/Configuration.swift) and `DeepLinkHandler.allowedUniversalLinkHosts`. Note: those two sources disagree on the staging host spelling (`staging.reality` vs `staging-reality`); both are listed so the on-device AASA negotiation resolves whichever the reality-web origin serves. Each host still requires a `/.well-known/apple-app-site-association` served by reality-web for links to activate — tracked as ops follow-up.

## Tested (Band A — fast check)
A real Xcode/`xcodebuild` and the `./gradlew :shared:linkPodReleaseFrameworkIosArm64` link target both require a macOS + Kotlin/Native toolchain that is **not available on this Linux CI runner**. This change is config-only (plist + entitlements + XcodeGen YAML); it touches no Swift or Kotlin source, so the KMP framework link is unaffected. Files validated structurally:
- `plistlib.load(Info.plist)` → OK, `CFBundleURLSchemes = ['realityportal']`, exit 0
- `plistlib.load(iosApp.entitlements)` → OK, `associated-domains = ['applinks:reality.example.com', 'applinks:staging.reality.example.com', 'applinks:staging-reality.example.com']`, exit 0
- `plistlib.load(Resources/Info.plist)` → OK (already had scheme), exit 0
- `xmllint --noout` on both plist/entitlements → OK
- `yaml.safe_load(project.yml)` → valid YAML, exit 0
- `plutil -lint` → not available on Linux runner (noted)

## Built (Band B — full build)
Skipped: macOS/Xcode-gated. `./gradlew :shared:linkPodReleaseFrameworkIosArm64` cannot run on this Linux runner. **This PR must be merge-gated on a macOS Xcode build** (XcodeGen generate + `xcodebuild` for the `iosApp` target) by a reviewer with a Mac before merge.

## CI parity (Band C — hot-path only)
This is the SSO callback path (security-adjacent), but the change is pure iOS signing/URL config — no auth logic touched. The actual SSO token validation lives in `DeepLinkHandler` (already tested, #1267). No runnable Band C job on this Linux runner for iOS.

## Remote-tested
skipped (ppt-bridge MCP not connected; iOS not deployable via dev-stack).

## Notes
- **Requires a macOS reviewer** to run XcodeGen + `xcodebuild` to confirm the entitlement is wired and the app builds with code-signing. Cannot be verified on Linux.
- scope-check (owner `pm-frontend`) → exit 0, no scope drift.
- reuse-grep (specialist `ios-swiftui`) → no duplicate-helper warnings.
- goal-check IG1/IG2/IG8 failures are expected for this dispatcher-handed bug task (no `.research/plans/` file, `auto-impl/` branch prefix, no archive move) — not verify/build failures.

https://claude.ai/code/session_01XFpaGKUEwvj2cBLHwZDVjr

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFpaGKUEwvj2cBLHwZDVjr)_