### PR TITLE
fix(PAP-138): org-key all violations mutations + IDOR tests

### DIFF
--- a/backend/crates/db/src/repositories/violations.rs
+++ b/backend/crates/db/src/repositories/violations.rs
@@ -120,31 +120,33 @@ impl ViolationRepository {
         }
     }
 
-    /// Update a community rule.
+    /// Update a community rule (tenant-scoped).
     pub async fn update_rule(
         &self,
         rule_id: Uuid,
+        org_id: Uuid,
         req: UpdateCommunityRule,
     ) -> Result<CommunityRule, sqlx::Error> {
         sqlx::query_as::<_, CommunityRule>(
             r#"
             UPDATE community_rules SET
-                title = COALESCE($2, title),
-                description = COALESCE($3, description),
-                first_offense_fine = COALESCE($4, first_offense_fine),
-                second_offense_fine = COALESCE($5, second_offense_fine),
-                third_offense_fine = COALESCE($6, third_offense_fine),
-                max_fine = COALESCE($7, max_fine),
-                fine_escalation_days = COALESCE($8, fine_escalation_days),
-                expiry_date = COALESCE($9, expiry_date),
-                is_active = COALESCE($10, is_active),
-                requires_board_approval = COALESCE($11, requires_board_approval),
+                title = COALESCE($3, title),
+                description = COALESCE($4, description),
+                first_offense_fine = COALESCE($5, first_offense_fine),
+                second_offense_fine = COALESCE($6, second_offense_fine),
+                third_offense_fine = COALESCE($7, third_offense_fine),
+                max_fine = COALESCE($8, max_fine),
+                fine_escalation_days = COALESCE($9, fine_escalation_days),
+                expiry_date = COALESCE($10, expiry_date),
+                is_active = COALESCE($11, is_active),
+                requires_board_approval = COALESCE($12, requires_board_approval),
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             RETURNING *
             "#,
         )
         .bind(rule_id)
+        .bind(org_id)
         .bind(&req.title)
         .bind(&req.description)
         .bind(req.first_offense_fine)
@@ -159,12 +161,14 @@ impl ViolationRepository {
         .await
     }
 
-    /// Delete a community rule.
-    pub async fn delete_rule(&self, rule_id: Uuid) -> Result<bool, sqlx::Error> {
-        let result = sqlx::query("DELETE FROM community_rules WHERE id = $1")
-            .bind(rule_id)
-            .execute(&self.pool)
-            .await?;
+    /// Delete a community rule (tenant-scoped).
+    pub async fn delete_rule(&self, rule_id: Uuid, org_id: Uuid) -> Result<bool, sqlx::Error> {
+        let result =
+            sqlx::query("DELETE FROM community_rules WHERE id = $1 AND organization_id = $2")
+                .bind(rule_id)
+                .bind(org_id)
+                .execute(&self.pool)
+                .await?;
         Ok(result.rows_affected() > 0)
     }
 
@@ -336,10 +340,11 @@ impl ViolationRepository {
         .await
     }
 
-    /// Update a violation.
+    /// Update a violation (tenant-scoped).
     pub async fn update_violation(
         &self,
         violation_id: Uuid,
+        org_id: Uuid,
         req: UpdateViolation,
     ) -> Result<Violation, sqlx::Error> {
         let now = if req.status == Some(ViolationStatus::Resolved) {
@@ -351,18 +356,19 @@ impl ViolationRepository {
         sqlx::query_as::<_, Violation>(
             r#"
             UPDATE violations SET
-                severity = COALESCE($2, severity),
-                status = COALESCE($3, status),
-                assigned_to = COALESCE($4, assigned_to),
-                resolution_notes = COALESCE($5, resolution_notes),
-                resolution_type = COALESCE($6, resolution_type),
-                resolved_at = COALESCE($7, resolved_at),
+                severity = COALESCE($3, severity),
+                status = COALESCE($4, status),
+                assigned_to = COALESCE($5, assigned_to),
+                resolution_notes = COALESCE($6, resolution_notes),
+                resolution_type = COALESCE($7, resolution_type),
+                resolved_at = COALESCE($8, resolved_at),
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             RETURNING *
             "#,
         )
         .bind(violation_id)
+        .bind(org_id)
         .bind(req.severity)
         .bind(req.status)
         .bind(req.assigned_to)
@@ -373,24 +379,26 @@ impl ViolationRepository {
         .await
     }
 
-    /// Assign a violation to staff.
+    /// Assign a violation to staff (tenant-scoped).
     pub async fn assign_violation(
         &self,
         violation_id: Uuid,
+        org_id: Uuid,
         assigned_to: Uuid,
     ) -> Result<Violation, sqlx::Error> {
         sqlx::query_as::<_, Violation>(
             r#"
             UPDATE violations SET
-                assigned_to = $2,
+                assigned_to = $3,
                 status = CASE WHEN status = 'reported' THEN 'under_review' ELSE status END,
                 reviewed_at = CASE WHEN reviewed_at IS NULL THEN NOW() ELSE reviewed_at END,
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             RETURNING *
             "#,
         )
         .bind(violation_id)
+        .bind(org_id)
         .bind(assigned_to)
         .fetch_one(&self.pool)
         .await
@@ -442,12 +450,26 @@ impl ViolationRepository {
         .await
     }
 
-    /// Delete evidence.
-    pub async fn delete_evidence(&self, evidence_id: Uuid) -> Result<bool, sqlx::Error> {
-        let result = sqlx::query("DELETE FROM violation_evidence WHERE id = $1")
-            .bind(evidence_id)
-            .execute(&self.pool)
-            .await?;
+    /// Delete evidence (tenant-scoped via parent violation).
+    pub async fn delete_evidence(
+        &self,
+        evidence_id: Uuid,
+        org_id: Uuid,
+    ) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query(
+            r#"
+            DELETE FROM violation_evidence ve
+            WHERE ve.id = $1
+              AND EXISTS (
+                  SELECT 1 FROM violations v
+                  WHERE v.id = ve.violation_id AND v.organization_id = $2
+              )
+            "#,
+        )
+        .bind(evidence_id)
+        .bind(org_id)
+        .execute(&self.pool)
+        .await?;
         Ok(result.rows_affected() > 0)
     }
 
@@ -537,25 +559,27 @@ impl ViolationRepository {
         .await
     }
 
-    /// Update an enforcement action.
+    /// Update an enforcement action (tenant-scoped).
     pub async fn update_enforcement_action(
         &self,
         action_id: Uuid,
+        org_id: Uuid,
         req: UpdateEnforcementAction,
     ) -> Result<EnforcementAction, sqlx::Error> {
         sqlx::query_as::<_, EnforcementAction>(
             r#"
             UPDATE enforcement_actions SET
-                status = COALESCE($2, status),
-                notice_sent_at = COALESCE($3, notice_sent_at),
-                notice_method = COALESCE($4, notice_method),
-                notes = COALESCE($5, notes),
+                status = COALESCE($3, status),
+                notice_sent_at = COALESCE($4, notice_sent_at),
+                notice_method = COALESCE($5, notice_method),
+                notes = COALESCE($6, notes),
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             RETURNING *
             "#,
         )
         .bind(action_id)
+        .bind(org_id)
         .bind(req.status)
         .bind(req.notice_sent_at)
         .bind(&req.notice_method)
@@ -564,10 +588,11 @@ impl ViolationRepository {
         .await
     }
 
-    /// Mark enforcement action as sent.
+    /// Mark enforcement action as sent (tenant-scoped).
     pub async fn mark_action_sent(
         &self,
         action_id: Uuid,
+        org_id: Uuid,
         method: &str,
     ) -> Result<EnforcementAction, sqlx::Error> {
         sqlx::query_as::<_, EnforcementAction>(
@@ -575,13 +600,14 @@ impl ViolationRepository {
             UPDATE enforcement_actions SET
                 status = 'sent',
                 notice_sent_at = NOW(),
-                notice_method = $2,
+                notice_method = $3,
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             RETURNING *
             "#,
         )
         .bind(action_id)
+        .bind(org_id)
         .bind(method)
         .fetch_one(&self.pool)
         .await
@@ -646,17 +672,6 @@ impl ViolationRepository {
         .await
     }
 
-    /// Get an appeal by ID.
-    pub async fn get_appeal(
-        &self,
-        appeal_id: Uuid,
-    ) -> Result<Option<ViolationAppeal>, sqlx::Error> {
-        sqlx::query_as::<_, ViolationAppeal>("SELECT * FROM violation_appeals WHERE id = $1")
-            .bind(appeal_id)
-            .fetch_optional(&self.pool)
-            .await
-    }
-
     /// Get a single appeal scoped to an organization (tenant-safe read).
     pub async fn get_appeal_for_org(
         &self,
@@ -700,10 +715,11 @@ impl ViolationRepository {
         .await
     }
 
-    /// Update an appeal.
+    /// Update an appeal (tenant-scoped).
     pub async fn update_appeal(
         &self,
         appeal_id: Uuid,
+        org_id: Uuid,
         req: UpdateViolationAppeal,
         decided_by: Option<Uuid>,
     ) -> Result<ViolationAppeal, sqlx::Error> {
@@ -716,20 +732,21 @@ impl ViolationRepository {
         sqlx::query_as::<_, ViolationAppeal>(
             r#"
             UPDATE violation_appeals SET
-                status = COALESCE($2, status),
-                hearing_date = COALESCE($3, hearing_date),
-                hearing_location = COALESCE($4, hearing_location),
-                hearing_notes = COALESCE($5, hearing_notes),
-                decision = COALESCE($6, decision),
-                decision_date = COALESCE($7, decision_date),
-                decided_by = COALESCE($8, decided_by),
-                fine_adjustment = COALESCE($9, fine_adjustment),
+                status = COALESCE($3, status),
+                hearing_date = COALESCE($4, hearing_date),
+                hearing_location = COALESCE($5, hearing_location),
+                hearing_notes = COALESCE($6, hearing_notes),
+                decision = COALESCE($7, decision),
+                decision_date = COALESCE($8, decision_date),
+                decided_by = COALESCE($9, decided_by),
+                fine_adjustment = COALESCE($10, fine_adjustment),
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             RETURNING *
             "#,
         )
         .bind(appeal_id)
+        .bind(org_id)
         .bind(req.status)
         .bind(req.hearing_date)
         .bind(&req.hearing_location)
@@ -742,10 +759,13 @@ impl ViolationRepository {
         .await
     }
 
-    /// Decide on an appeal.
+    /// Decide on an appeal (tenant-scoped). The lookup and every cascade write
+    /// are keyed by `org_id` so a caller cannot decide another tenant's appeal
+    /// or mutate its violation / enforcement-action records.
     pub async fn decide_appeal(
         &self,
         appeal_id: Uuid,
+        org_id: Uuid,
         approved: bool,
         decision: &str,
         fine_adjustment: Option<Decimal>,
@@ -757,25 +777,27 @@ impl ViolationRepository {
             AppealStatus::Denied
         };
 
-        // Get the appeal to update related records
+        // Get the appeal (org-scoped) to update related records
         let appeal = self
-            .get_appeal(appeal_id)
+            .get_appeal_for_org(appeal_id, org_id)
             .await?
             .ok_or(sqlx::Error::RowNotFound)?;
 
         // If approved, update violation status
         if approved {
-            sqlx::query("UPDATE violations SET status = 'dismissed', resolution_notes = $2, updated_at = NOW() WHERE id = $1")
+            sqlx::query("UPDATE violations SET status = 'dismissed', resolution_notes = $2, updated_at = NOW() WHERE id = $1 AND organization_id = $3")
                 .bind(appeal.violation_id)
                 .bind(format!("Appeal approved: {}", decision))
+                .bind(org_id)
                 .execute(&self.pool)
                 .await?;
         } else {
             // If denied, restore violation to confirmed
             sqlx::query(
-                "UPDATE violations SET status = 'confirmed', updated_at = NOW() WHERE id = $1",
+                "UPDATE violations SET status = 'confirmed', updated_at = NOW() WHERE id = $1 AND organization_id = $2",
             )
             .bind(appeal.violation_id)
+            .bind(org_id)
             .execute(&self.pool)
             .await?;
         }
@@ -784,10 +806,11 @@ impl ViolationRepository {
         if let (Some(action_id), Some(adjustment)) = (appeal.enforcement_action_id, fine_adjustment)
         {
             sqlx::query(
-                "UPDATE enforcement_actions SET fine_amount = GREATEST(0, fine_amount - $2), updated_at = NOW() WHERE id = $1",
+                "UPDATE enforcement_actions SET fine_amount = GREATEST(0, fine_amount - $2), updated_at = NOW() WHERE id = $1 AND organization_id = $3",
             )
             .bind(action_id)
             .bind(adjustment)
+            .bind(org_id)
             .execute(&self.pool)
             .await?;
         }
@@ -795,17 +818,18 @@ impl ViolationRepository {
         sqlx::query_as::<_, ViolationAppeal>(
             r#"
             UPDATE violation_appeals SET
-                status = $2,
-                decision = $3,
+                status = $3,
+                decision = $4,
                 decision_date = NOW(),
-                decided_by = $4,
-                fine_adjustment = $5,
+                decided_by = $5,
+                fine_adjustment = $6,
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             RETURNING *
             "#,
         )
         .bind(appeal_id)
+        .bind(org_id)
         .bind(status)
         .bind(decision)
         .bind(decided_by)
@@ -876,6 +900,19 @@ impl ViolationRepository {
         req: RecordFinePayment,
         recorded_by: Uuid,
     ) -> Result<FinePayment, sqlx::Error> {
+        // Verify the enforcement action belongs to this org before recording a
+        // payment against it (prevents cross-tenant payment injection).
+        let owns_action: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM enforcement_actions WHERE id = $1 AND organization_id = $2)",
+        )
+        .bind(action_id)
+        .bind(org_id)
+        .fetch_one(&self.pool)
+        .await?;
+        if !owns_action {
+            return Err(sqlx::Error::RowNotFound);
+        }
+
         // Record the payment
         let payment = sqlx::query_as::<_, FinePayment>(
             r#"
@@ -899,7 +936,7 @@ impl ViolationRepository {
         .fetch_one(&self.pool)
         .await?;
 
-        // Update enforcement action paid amount
+        // Update enforcement action paid amount (tenant-scoped)
         sqlx::query(
             r#"
             UPDATE enforcement_actions SET
@@ -907,11 +944,12 @@ impl ViolationRepository {
                 paid_at = CASE WHEN COALESCE(paid_amount, 0) + $2 >= fine_amount THEN NOW() ELSE paid_at END,
                 status = CASE WHEN COALESCE(paid_amount, 0) + $2 >= fine_amount THEN 'paid' ELSE status END,
                 updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $3
             "#,
         )
         .bind(action_id)
         .bind(req.amount)
+        .bind(org_id)
         .execute(&self.pool)
         .await?;
 

--- a/backend/crates/db/tests/violations_cross_org_idor_tests.rs
+++ b/backend/crates/db/tests/violations_cross_org_idor_tests.rs
@@ -1,0 +1,509 @@
+//! Cross-tenant IDOR regression tests for `ViolationRepository` (Epic 142,
+//! PAP-138 — derived from the PAP-136 audit).
+//!
+//! Audit history: every by-id mutation on the violations surface took the
+//! target UUID but no organization id, so the `UPDATE … WHERE id = $1` /
+//! `DELETE … WHERE id = $1` statements would mutate *any* tenant's row. The
+//! `decide_appeal` cascade was the worst case — it looked the appeal up with an
+//! unkeyed `get_appeal` and then cascaded `UPDATE`s to `violations` and
+//! `enforcement_actions` with no org scoping at all.
+//!
+//! The fix threads the caller's verified `organization_id` into each repository
+//! method and keys every statement on `(id, organization_id)` (child tables via
+//! an `EXISTS` check on the parent `violations` row). These tests prove the gap
+//! is closed at the repository layer: CI runs them against a superuser pool that
+//! bypasses FORCE-RLS, so a missing `organization_id` predicate in the SQL would
+//! let the cross-tenant write through and fail the assertion.
+//!
+//! Each test seeds two orgs (A, B) and asserts that an Org B caller cannot
+//! touch Org A's rows, while the legitimate Org A caller still can.
+
+use chrono::Utc;
+use db::models::violations::{
+    AppealStatus, CreateCommunityRule, CreateEnforcementAction, CreateViolation,
+    CreateViolationAppeal, CreateViolationEvidence, EnforcementActionType, RecordFinePayment,
+    UpdateCommunityRule, UpdateEnforcementAction, UpdateViolation, UpdateViolationAppeal,
+    ViolationCategory, ViolationStatus,
+};
+use db::repositories::ViolationRepository;
+use rust_decimal::Decimal;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("ViolationsIDOR {slug}"))
+    .bind(format!("violations-idor-{slug}"))
+    .bind(format!("{slug}@violations-idor.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'test_hash', 'ViolationsIDOR User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+fn new_violation_req() -> CreateViolation {
+    CreateViolation {
+        building_id: None,
+        unit_id: None,
+        rule_id: None,
+        category: ViolationCategory::Noise,
+        severity: None,
+        title: "Loud music".into(),
+        description: "After midnight".into(),
+        location: None,
+        violator_id: None,
+        violator_name: Some("Tenant".into()),
+        violator_unit: Some("4B".into()),
+        occurred_at: Utc::now(),
+        evidence_description: None,
+        witness_count: None,
+    }
+}
+
+fn new_rule_req(code: &str) -> CreateCommunityRule {
+    CreateCommunityRule {
+        building_id: None,
+        rule_code: code.into(),
+        title: "Quiet hours".into(),
+        description: None,
+        category: ViolationCategory::Noise,
+        first_offense_fine: None,
+        second_offense_fine: None,
+        third_offense_fine: None,
+        max_fine: None,
+        fine_escalation_days: None,
+        effective_date: None,
+        expiry_date: None,
+        requires_board_approval: None,
+        source_document_id: None,
+        section_reference: None,
+    }
+}
+
+fn new_action_req() -> CreateEnforcementAction {
+    CreateEnforcementAction {
+        action_type: EnforcementActionType::FirstFine,
+        fine_amount: Some(Decimal::new(10000, 2)), // 100.00
+        due_date: None,
+        description: Some("Fine notice".into()),
+        notes: None,
+        suspended_privileges: None,
+        suspension_start: None,
+        suspension_end: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Community rules — update_rule / delete_rule
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn community_rule_cross_org_mutations_rejected(pool: PgPool) {
+    let repo = ViolationRepository::new(pool.clone());
+    let org_a = seed_org(&pool, "rule-a").await;
+    let org_b = seed_org(&pool, "rule-b").await;
+    let author = seed_user(&pool, "rule@violations-idor.test").await;
+
+    let rule = repo
+        .create_rule(org_a, new_rule_req("R-1"), author)
+        .await
+        .expect("create rule");
+
+    // Org B cannot update Org A's rule (no row matches → RowNotFound).
+    let hijack = UpdateCommunityRule {
+        title: Some("Hijacked".into()),
+        description: None,
+        first_offense_fine: None,
+        second_offense_fine: None,
+        third_offense_fine: None,
+        max_fine: None,
+        fine_escalation_days: None,
+        expiry_date: None,
+        is_active: None,
+        requires_board_approval: None,
+    };
+    let res = repo.update_rule(rule.id, org_b, hijack).await;
+    assert!(
+        matches!(res, Err(sqlx::Error::RowNotFound)),
+        "Org B must not update Org A's rule, got {res:?}"
+    );
+
+    // Org B cannot delete it either.
+    let deleted = repo
+        .delete_rule(rule.id, org_b)
+        .await
+        .expect("delete query ok");
+    assert!(!deleted, "Org B must not delete Org A's rule");
+
+    // The rule is untouched.
+    let after = repo
+        .get_rule_for_org(rule.id, org_a)
+        .await
+        .expect("query ok")
+        .expect("rule still exists");
+    assert_eq!(after.title, "Quiet hours", "title must be unchanged");
+
+    // The legitimate owner can still update and delete.
+    let ok = UpdateCommunityRule {
+        title: Some("Quiet hours v2".into()),
+        description: None,
+        first_offense_fine: None,
+        second_offense_fine: None,
+        third_offense_fine: None,
+        max_fine: None,
+        fine_escalation_days: None,
+        expiry_date: None,
+        is_active: None,
+        requires_board_approval: None,
+    };
+    let updated = repo
+        .update_rule(rule.id, org_a, ok)
+        .await
+        .expect("owner update");
+    assert_eq!(updated.title, "Quiet hours v2");
+    assert!(repo
+        .delete_rule(rule.id, org_a)
+        .await
+        .expect("owner delete"));
+}
+
+// ---------------------------------------------------------------------------
+// Violations — update_violation / assign_violation / delete_evidence
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn violation_cross_org_mutations_rejected(pool: PgPool) {
+    let repo = ViolationRepository::new(pool.clone());
+    let org_a = seed_org(&pool, "vio-a").await;
+    let org_b = seed_org(&pool, "vio-b").await;
+    let user_a = seed_user(&pool, "vio-a@violations-idor.test").await;
+    let user_b = seed_user(&pool, "vio-b@violations-idor.test").await;
+
+    let violation = repo
+        .create_violation(org_a, new_violation_req(), user_a)
+        .await
+        .expect("create violation");
+    let evidence = repo
+        .add_evidence(
+            violation.id,
+            CreateViolationEvidence {
+                file_name: "photo.jpg".into(),
+                file_type: "image/jpeg".into(),
+                file_size: Some(1024),
+                storage_path: Some("s3://evidence/photo.jpg".into()),
+                description: None,
+                captured_at: None,
+            },
+            user_a,
+        )
+        .await
+        .expect("add evidence");
+
+    // update_violation cross-org → RowNotFound.
+    let res = repo
+        .update_violation(
+            violation.id,
+            org_b,
+            UpdateViolation {
+                severity: None,
+                status: Some(ViolationStatus::Dismissed),
+                assigned_to: None,
+                resolution_notes: Some("Hijacked".into()),
+                resolution_type: None,
+            },
+        )
+        .await;
+    assert!(
+        matches!(res, Err(sqlx::Error::RowNotFound)),
+        "Org B must not update Org A's violation, got {res:?}"
+    );
+
+    // assign_violation cross-org → RowNotFound.
+    let res = repo.assign_violation(violation.id, org_b, user_b).await;
+    assert!(
+        matches!(res, Err(sqlx::Error::RowNotFound)),
+        "Org B must not assign Org A's violation, got {res:?}"
+    );
+
+    // delete_evidence cross-org → no-op (child keyed via parent violation).
+    let deleted = repo
+        .delete_evidence(evidence.id, org_b)
+        .await
+        .expect("delete query ok");
+    assert!(!deleted, "Org B must not delete Org A's evidence");
+
+    // Nothing changed: violation still 'reported', evidence still present.
+    let after = repo
+        .get_violation_for_org(violation.id, org_a)
+        .await
+        .expect("query ok")
+        .expect("violation exists");
+    assert_eq!(after.status, ViolationStatus::Reported);
+    assert!(after.resolution_notes.is_none());
+    assert!(after.assigned_to.is_none());
+    let ev_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM violation_evidence WHERE id = $1")
+        .bind(evidence.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(ev_count, 1, "evidence must survive a cross-tenant delete");
+
+    // Owner can still mutate + delete.
+    repo.assign_violation(violation.id, org_a, user_a)
+        .await
+        .expect("owner assign");
+    assert!(repo
+        .delete_evidence(evidence.id, org_a)
+        .await
+        .expect("owner delete evidence"));
+}
+
+// ---------------------------------------------------------------------------
+// Enforcement actions — update / mark_sent / record_payment
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn enforcement_cross_org_mutations_rejected(pool: PgPool) {
+    let repo = ViolationRepository::new(pool.clone());
+    let org_a = seed_org(&pool, "enf-a").await;
+    let org_b = seed_org(&pool, "enf-b").await;
+    let user_a = seed_user(&pool, "enf-a@violations-idor.test").await;
+
+    let violation = repo
+        .create_violation(org_a, new_violation_req(), user_a)
+        .await
+        .expect("create violation");
+    let action = repo
+        .create_enforcement_action(violation.id, org_a, new_action_req(), user_a)
+        .await
+        .expect("create action");
+
+    // update_enforcement_action cross-org → RowNotFound.
+    let res = repo
+        .update_enforcement_action(
+            action.id,
+            org_b,
+            UpdateEnforcementAction {
+                status: None,
+                notice_sent_at: None,
+                notice_method: None,
+                notes: Some("Hijacked".into()),
+            },
+        )
+        .await;
+    assert!(
+        matches!(res, Err(sqlx::Error::RowNotFound)),
+        "Org B must not update Org A's action, got {res:?}"
+    );
+
+    // mark_action_sent cross-org → RowNotFound.
+    let res = repo.mark_action_sent(action.id, org_b, "email").await;
+    assert!(
+        matches!(res, Err(sqlx::Error::RowNotFound)),
+        "Org B must not mark Org A's action sent, got {res:?}"
+    );
+
+    // record_payment cross-org → RowNotFound and no payment row inserted.
+    let res = repo
+        .record_payment(
+            action.id,
+            org_b,
+            RecordFinePayment {
+                amount: Decimal::new(5000, 2),
+                payment_method: Some("cash".into()),
+                transaction_reference: None,
+                payer_id: None,
+                payer_name: Some("Attacker".into()),
+                notes: None,
+            },
+            user_a,
+        )
+        .await;
+    assert!(
+        matches!(res, Err(sqlx::Error::RowNotFound)),
+        "Org B must not record a payment against Org A's action, got {res:?}"
+    );
+    let pay_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM fine_payments WHERE enforcement_action_id = $1")
+            .bind(action.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(pay_count, 0, "no payment row may be created cross-tenant");
+
+    // Action is unchanged (still pending, no notice method).
+    let after = repo
+        .get_enforcement_action_for_org(action.id, org_a)
+        .await
+        .expect("query ok")
+        .expect("action exists");
+    assert!(after.notice_method.is_none());
+
+    // Owner can still record a payment.
+    repo.record_payment(
+        action.id,
+        org_a,
+        RecordFinePayment {
+            amount: Decimal::new(5000, 2),
+            payment_method: Some("cash".into()),
+            transaction_reference: None,
+            payer_id: None,
+            payer_name: Some("Tenant".into()),
+            notes: None,
+        },
+        user_a,
+    )
+    .await
+    .expect("owner payment");
+}
+
+// ---------------------------------------------------------------------------
+// Appeals — update_appeal / decide_appeal cascade
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn appeal_cross_org_mutations_rejected(pool: PgPool) {
+    let repo = ViolationRepository::new(pool.clone());
+    let org_a = seed_org(&pool, "app-a").await;
+    let org_b = seed_org(&pool, "app-b").await;
+    let user_a = seed_user(&pool, "app-a@violations-idor.test").await;
+
+    let violation = repo
+        .create_violation(org_a, new_violation_req(), user_a)
+        .await
+        .expect("create violation");
+    let action = repo
+        .create_enforcement_action(violation.id, org_a, new_action_req(), user_a)
+        .await
+        .expect("create action");
+    let appeal = repo
+        .create_appeal(
+            violation.id,
+            org_a,
+            CreateViolationAppeal {
+                enforcement_action_id: Some(action.id),
+                reason: "Unfair".into(),
+                requested_outcome: None,
+                supporting_evidence: None,
+            },
+            user_a,
+        )
+        .await
+        .expect("create appeal");
+
+    // update_appeal cross-org → RowNotFound.
+    let res = repo
+        .update_appeal(
+            appeal.id,
+            org_b,
+            UpdateViolationAppeal {
+                status: Some(AppealStatus::Approved),
+                hearing_date: None,
+                hearing_location: None,
+                hearing_notes: None,
+                decision: Some("Hijacked".into()),
+                fine_adjustment: None,
+            },
+            Some(user_a),
+        )
+        .await;
+    assert!(
+        matches!(res, Err(sqlx::Error::RowNotFound)),
+        "Org B must not update Org A's appeal, got {res:?}"
+    );
+
+    // decide_appeal cross-org → RowNotFound; the cascade must NOT fire.
+    let res = repo
+        .decide_appeal(
+            appeal.id,
+            org_b,
+            true,
+            "Hijacked decision",
+            Some(Decimal::new(5000, 2)),
+            user_a,
+        )
+        .await;
+    assert!(
+        matches!(res, Err(sqlx::Error::RowNotFound)),
+        "Org B must not decide Org A's appeal, got {res:?}"
+    );
+
+    // Appeal still submitted, violation still disputed (create_appeal set it),
+    // and the enforcement-action fine was NOT reduced by the cascade.
+    let appeal_after = repo
+        .get_appeal_for_org(appeal.id, org_a)
+        .await
+        .expect("query ok")
+        .expect("appeal exists");
+    assert_eq!(appeal_after.status, AppealStatus::Submitted);
+    assert!(appeal_after.decision.is_none());
+    let vio_after = repo
+        .get_violation_for_org(violation.id, org_a)
+        .await
+        .expect("query ok")
+        .expect("violation exists");
+    assert_eq!(vio_after.status, ViolationStatus::Disputed);
+    let action_after = repo
+        .get_enforcement_action_for_org(action.id, org_a)
+        .await
+        .expect("query ok")
+        .expect("action exists");
+    assert_eq!(
+        action_after.fine_amount,
+        Some(Decimal::new(10000, 2)),
+        "cross-tenant decide must not adjust the fine"
+    );
+
+    // The legitimate owner can decide the appeal and the cascade fires.
+    let decided = repo
+        .decide_appeal(
+            appeal.id,
+            org_a,
+            true,
+            "Approved",
+            Some(Decimal::new(4000, 2)),
+            user_a,
+        )
+        .await
+        .expect("owner decide");
+    assert_eq!(decided.status, AppealStatus::Approved);
+    let vio_final = repo
+        .get_violation_for_org(violation.id, org_a)
+        .await
+        .expect("query ok")
+        .expect("violation exists");
+    assert_eq!(vio_final.status, ViolationStatus::Dismissed);
+    let action_final = repo
+        .get_enforcement_action_for_org(action.id, org_a)
+        .await
+        .expect("query ok")
+        .expect("action exists");
+    assert_eq!(
+        action_final.fine_amount,
+        Some(Decimal::new(6000, 2)),
+        "owner decide reduces the fine by the adjustment"
+    );
+}

--- a/backend/servers/api-server/src/routes/violations.rs
+++ b/backend/servers/api-server/src/routes/violations.rs
@@ -159,13 +159,17 @@ async fn list_rules(
 
 async fn update_rule(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(rule_id): Path<Uuid>,
     Json(req): Json<UpdateCommunityRule>,
 ) -> ApiResult<Json<db::models::violations::CommunityRule>> {
+    let org_id = user
+        .tenant_id
+        .ok_or_else(|| forbidden_error("No organization context"))?;
+
     state
         .violation_repo
-        .update_rule(rule_id, req)
+        .update_rule(rule_id, org_id, req)
         .await
         .map(Json)
         .map_err(|e| internal_error(&format!("Failed to update rule: {}", e)))
@@ -173,12 +177,16 @@ async fn update_rule(
 
 async fn delete_rule(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(rule_id): Path<Uuid>,
 ) -> ApiResult<StatusCode> {
+    let org_id = user
+        .tenant_id
+        .ok_or_else(|| forbidden_error("No organization context"))?;
+
     let deleted = state
         .violation_repo
-        .delete_rule(rule_id)
+        .delete_rule(rule_id, org_id)
         .await
         .map_err(|e| internal_error(&format!("Failed to delete rule: {}", e)))?;
 
@@ -247,13 +255,17 @@ async fn list_violations(
 
 async fn update_violation(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(violation_id): Path<Uuid>,
     Json(req): Json<UpdateViolation>,
 ) -> ApiResult<Json<db::models::violations::Violation>> {
+    let org_id = user
+        .tenant_id
+        .ok_or_else(|| forbidden_error("No organization context"))?;
+
     state
         .violation_repo
-        .update_violation(violation_id, req)
+        .update_violation(violation_id, org_id, req)
         .await
         .map(Json)
         .map_err(|e| internal_error(&format!("Failed to update violation: {}", e)))
@@ -266,13 +278,17 @@ struct AssignRequest {
 
 async fn assign_violation(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(violation_id): Path<Uuid>,
     Json(req): Json<AssignRequest>,
 ) -> ApiResult<Json<db::models::violations::Violation>> {
+    let org_id = user
+        .tenant_id
+        .ok_or_else(|| forbidden_error("No organization context"))?;
+
     state
         .violation_repo
-        .assign_violation(violation_id, req.assigned_to)
+        .assign_violation(violation_id, org_id, req.assigned_to)
         .await
         .map(Json)
         .map_err(|e| internal_error(&format!("Failed to assign violation: {}", e)))
@@ -311,12 +327,16 @@ async fn list_evidence(
 
 async fn delete_evidence(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path((_violation_id, evidence_id)): Path<(Uuid, Uuid)>,
 ) -> ApiResult<StatusCode> {
+    let org_id = user
+        .tenant_id
+        .ok_or_else(|| forbidden_error("No organization context"))?;
+
     let deleted = state
         .violation_repo
-        .delete_evidence(evidence_id)
+        .delete_evidence(evidence_id, org_id)
         .await
         .map_err(|e| internal_error(&format!("Failed to delete evidence: {}", e)))?;
 
@@ -388,13 +408,17 @@ async fn list_actions(
 
 async fn update_action(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path((_violation_id, action_id)): Path<(Uuid, Uuid)>,
     Json(req): Json<UpdateEnforcementAction>,
 ) -> ApiResult<Json<db::models::violations::EnforcementAction>> {
+    let org_id = user
+        .tenant_id
+        .ok_or_else(|| forbidden_error("No organization context"))?;
+
     state
         .violation_repo
-        .update_enforcement_action(action_id, req)
+        .update_enforcement_action(action_id, org_id, req)
         .await
         .map(Json)
         .map_err(|e| internal_error(&format!("Failed to update action: {}", e)))
@@ -407,13 +431,17 @@ struct SendNoticeRequest {
 
 async fn mark_action_sent(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path((_violation_id, action_id)): Path<(Uuid, Uuid)>,
     Json(req): Json<SendNoticeRequest>,
 ) -> ApiResult<Json<db::models::violations::EnforcementAction>> {
+    let org_id = user
+        .tenant_id
+        .ok_or_else(|| forbidden_error("No organization context"))?;
+
     state
         .violation_repo
-        .mark_action_sent(action_id, &req.method)
+        .mark_action_sent(action_id, org_id, &req.method)
         .await
         .map(Json)
         .map_err(|e| internal_error(&format!("Failed to mark action sent: {}", e)))
@@ -513,9 +541,13 @@ async fn update_appeal(
     Path(appeal_id): Path<Uuid>,
     Json(req): Json<UpdateViolationAppeal>,
 ) -> ApiResult<Json<db::models::violations::ViolationAppeal>> {
+    let org_id = user
+        .tenant_id
+        .ok_or_else(|| forbidden_error("No organization context"))?;
+
     state
         .violation_repo
-        .update_appeal(appeal_id, req, Some(user.user_id))
+        .update_appeal(appeal_id, org_id, req, Some(user.user_id))
         .await
         .map(Json)
         .map_err(|e| internal_error(&format!("Failed to update appeal: {}", e)))
@@ -534,10 +566,15 @@ async fn decide_appeal(
     Path(appeal_id): Path<Uuid>,
     Json(req): Json<DecideAppealRequest>,
 ) -> ApiResult<Json<db::models::violations::ViolationAppeal>> {
+    let org_id = user
+        .tenant_id
+        .ok_or_else(|| forbidden_error("No organization context"))?;
+
     state
         .violation_repo
         .decide_appeal(
             appeal_id,
+            org_id,
             req.approved,
             &req.decision,
             req.fine_adjustment,


### PR DESCRIPTION
## Summary

- All 11 by-id mutation handlers in `violations.rs` now extract `org_id` from `user.tenant_id` and thread it to every repository method
- Each `UPDATE`/`DELETE` is keyed on `(id, organization_id)` — or via `EXISTS` on the parent `violations` row for `violation_evidence` (no org column on that table)
- `decide_appeal` now uses `get_appeal_for_org` instead of the removed unkeyed `get_appeal`, and all three cascade writes (violations, enforcement_actions, violation_appeals) are scoped on `org_id`
- `record_payment` adds an ownership pre-check (`SELECT EXISTS`) before the `INSERT`
- Adds `violations_cross_org_idor_tests.rs`: 4 `#[sqlx::test(migrator = "db::MIGRATOR")]` tests — all passing (verified locally against `ppt-pap103-pg:55432`)

## Test coverage

| Test | What it verifies |
|------|-----------------|
| `community_rule_cross_org_mutations_rejected` | Org B update/delete returns RowNotFound; Org A rule unchanged; Org A owner can still mutate |
| `violation_cross_org_mutations_rejected` | Org B update/assign returns RowNotFound; evidence delete returns false; evidence row survives |
| `enforcement_cross_org_mutations_rejected` | Org B update/mark-sent returns RowNotFound; record_payment returns RowNotFound and inserts no row |
| `appeal_cross_org_mutations_rejected` | Org B update/decide returns RowNotFound; cascade does NOT fire; Org A owner's decide fires cascade correctly |

## Test plan

- [ ] CI `backend.yml` green (fmt, clippy, cargo test)
- [ ] Verify no regressions in violations-related integration tests

Closes PAP-138