### PR TITLE
feat-web-announcements-faults-api-hooks-wiring: wire ppt-web pages to TanStack Query hooks

### DIFF
--- a/frontend/apps/ppt-web/src/routes/groups/announcements.list.route.test.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/announcements.list.route.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * Announcements route group — AnnouncementsPageRoute API wiring tests (Story 79.1).
+ *
+ * Sibling of `faults.route.test.tsx`: the faults *list* route already had a
+ * wired-data-path test, but the announcements *list* route did not — only the
+ * announcement-detail wiring was covered (`announcements.route.test.tsx`). This
+ * file closes that coverage gap by pinning the contract between the live
+ * `@ppt/api-client` hooks and the `AnnouncementsPage` list component:
+ *
+ *  (a) loading state propagates (useAnnouncements.isLoading) → empty state absent
+ *  (b) error state propagates → inline alert rendered + retry button calls refetch
+ *  (c) successful data renders an announcement title (item → AnnouncementCard)
+ *  (d) empty list (no error) → "No announcements found." empty state
+ *  (e) pinned-band query (usePinnedAnnouncements) feeds the sticky band
+ *
+ * Renders the real route via MemoryRouter + Routes + TanStack
+ * QueryClientProvider, exactly as in production. A dedicated test file (rather
+ * than extending `announcements.route.test.tsx`) is required because that file's
+ * module-level `vi.mock('@ppt/api-client')` is shaped for the detail view.
+ */
+
+/// <reference types="vitest/globals" />
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Suspense } from 'react';
+import { MemoryRouter, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── i18n ──
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? key,
+  }),
+}));
+
+// ── toast ──
+const mockShowToast = vi.fn();
+vi.mock('../../components', () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+// ── auth ──
+vi.mock('../../contexts', () => ({
+  useAuth: () => ({ user: { role: 'manager' } }),
+}));
+
+// ── api-client stubs ──
+const mockUseAnnouncements = vi.fn();
+const mockUsePinnedAnnouncements = vi.fn();
+vi.mock('@ppt/api-client', () => ({
+  useAnnouncements: (...args: unknown[]) => mockUseAnnouncements(...args),
+  usePinnedAnnouncements: (...args: unknown[]) => mockUsePinnedAnnouncements(...args),
+  useDeleteAnnouncement: () => ({ mutateAsync: vi.fn() }),
+  usePublishAnnouncement: () => ({ mutateAsync: vi.fn() }),
+  useArchiveAnnouncement: () => ({ mutateAsync: vi.fn() }),
+  usePinAnnouncement: () => ({ mutateAsync: vi.fn() }),
+  // The other announcement routes (create/view/edit) import these at module load.
+  useAnnouncement: () => ({ data: undefined, isLoading: true, error: null }),
+  useCreateAnnouncement: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdateAnnouncement: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useMarkReadAnnouncement: () => ({ mutate: vi.fn(), mutateAsync: vi.fn() }),
+  useAcknowledgeAnnouncement: () => ({ mutateAsync: vi.fn() }),
+  useAnnouncementAcknowledgmentStats: () => ({ data: undefined }),
+  useAnnouncementComments: () => ({ data: undefined, isLoading: false }),
+  useCreateAnnouncementComment: () => ({ mutateAsync: vi.fn() }),
+  useDeleteAnnouncementComment: () => ({ mutateAsync: vi.fn() }),
+}));
+
+// Import the route group AFTER mocks are in place.
+import { announcementRoutes } from './announcements';
+
+const noopRefetch = vi.fn().mockResolvedValue(undefined);
+
+function makeSummary(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'ann-1',
+    title: 'Roof repair scheduled',
+    status: 'published',
+    targetType: 'all',
+    pinned: false,
+    authorName: 'Jane Manager',
+    createdAt: '2026-06-01T00:00:00Z',
+    publishedAt: '2026-06-01T00:00:00Z',
+    readCount: 0,
+    commentCount: 0,
+    ...overrides,
+  };
+}
+
+function renderAnnouncementsRoute() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/announcements']}>
+        <Suspense fallback={<div>loading…</div>}>
+          <Routes>{announcementRoutes()}</Routes>
+        </Suspense>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('AnnouncementsPageRoute API wiring (Story 79.1)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: pinned band empty unless a test overrides it.
+    mockUsePinnedAnnouncements.mockReturnValue({ data: { items: [] } });
+  });
+
+  it('(a) does not show empty state while loading', async () => {
+    mockUseAnnouncements.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+      refetch: noopRefetch,
+    });
+
+    renderAnnouncementsRoute();
+    // The "Create Announcement" button is rendered by AnnouncementList regardless
+    // of loading/error state; wait for the lazy chunk to resolve via it.
+    await screen.findByRole('button', { name: 'Create Announcement' }, { timeout: 3000 });
+
+    expect(screen.queryByText('No announcements found.')).not.toBeInTheDocument();
+  });
+
+  it('(b) shows error alert when useAnnouncements errors, retry calls refetch', async () => {
+    mockUseAnnouncements.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('network error'),
+      refetch: noopRefetch,
+    });
+
+    renderAnnouncementsRoute();
+
+    const alert = await screen.findByRole('alert', {}, { timeout: 5000 });
+    expect(alert).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(noopRefetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('(c) renders the announcement title when useAnnouncements returns data', async () => {
+    mockUseAnnouncements.mockReturnValue({
+      data: { items: [makeSummary({ title: 'Lift maintenance Friday' })], total: 1 },
+      isLoading: false,
+      error: null,
+      refetch: noopRefetch,
+    });
+
+    renderAnnouncementsRoute();
+
+    expect(
+      await screen.findByText('Lift maintenance Friday', {}, { timeout: 5000 })
+    ).toBeInTheDocument();
+  });
+
+  it('(d) shows empty state when list is empty and no error', async () => {
+    mockUseAnnouncements.mockReturnValue({
+      data: { items: [], total: 0 },
+      isLoading: false,
+      error: null,
+      refetch: noopRefetch,
+    });
+
+    renderAnnouncementsRoute();
+
+    expect(
+      await screen.findByText('No announcements found.', {}, { timeout: 5000 })
+    ).toBeInTheDocument();
+  });
+
+  it('(e) feeds the pinned-band query result into the sticky band', async () => {
+    mockUseAnnouncements.mockReturnValue({
+      data: { items: [], total: 0 },
+      isLoading: false,
+      error: null,
+      refetch: noopRefetch,
+    });
+    mockUsePinnedAnnouncements.mockReturnValue({
+      data: { items: [makeSummary({ id: 'pin-1', title: 'Water shutoff notice', pinned: true })] },
+    });
+
+    renderAnnouncementsRoute();
+
+    expect(
+      await screen.findByText('Water shutoff notice', {}, { timeout: 5000 })
+    ).toBeInTheDocument();
+    // The list query result is independent of the pinned-band query.
+    expect(mockUsePinnedAnnouncements).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Coverage 79-1 — complete the api-client integration for ppt-web's Announcements and Faults pages.

On inspection of `origin/dev`, the data wiring was **already complete**: both `routes/groups/announcements.tsx` and `routes/groups/faults.tsx` drive their pages entirely from generated `@ppt/api-client` TanStack Query hooks (`useAnnouncements` / `usePinnedAnnouncements` / `useFaults` and the full mutation set), with loading/error/empty states and retry→refetch already threaded through `AnnouncementsPage`/`FaultsPage`. No stubbed or static data remained in either page or its route wrapper (only input `placeholder` attributes, which are not data stubs).

The genuine remaining gap was **test coverage of the wired data path**: the faults *list* route had `faults.route.test.tsx`, but the announcements *list* route had no equivalent — `announcements.route.test.tsx` only covered the announcement-*detail* wiring. This PR closes that asymmetry.

## Changes

- Added `frontend/apps/ppt-web/src/routes/groups/announcements.list.route.test.tsx` — a route-wiring test for `AnnouncementsPageRoute`, mirroring `faults.route.test.tsx`. Renders the real route via `MemoryRouter` + `Routes` + TanStack `QueryClientProvider` and pins:
  - (a) loading state → empty state absent
  - (b) error state → inline `role="alert"` + Retry button calls `refetch`
  - (c) data → announcement title reaches `AnnouncementCard`
  - (d) empty list → "No announcements found." empty state
  - (e) `usePinnedAnnouncements` result feeds the sticky pinned band, independent of the list query

## Tested

- `pnpm install --frozen-lockfile` — clean
- `pnpm --filter @ppt/web typecheck` — pass (note: repo package is `@ppt/web`, not `@ppt/ppt-web`)
- `pnpm --filter @ppt/web test` — **60 files / 678 tests pass** (incl. 5 new)
- `pnpm check` (Biome) — exit 0; only pre-existing warnings in untouched files (e.g. `packages/ui-kit/.../ListingCard.tsx`), none on the new file

## Scope drift

None. Single new file under `frontend/apps/ppt-web/` (pm-frontend area). `scope-check.sh --owner pm-frontend` → exit 0.

## Code reuse

Reuses the established `faults.route.test.tsx` harness pattern (MemoryRouter + Routes + QueryClientProvider + module-level `vi.mock('@ppt/api-client')`). A dedicated file (rather than extending `announcements.route.test.tsx`) is required because that file's module mock is shaped for the detail view and cannot be reshaped per-test.

https://claude.ai/code/session_01TmVVAqzhYkgRFK2c1d3fo1

---
_Generated by [Claude Code](https://claude.ai/code/session_01TmVVAqzhYkgRFK2c1d3fo1)_