### PR TITLE
verify-reality-mobile-listing-detail-favorites-acs: KMP commonTest coverage for listing-detail fetch + favorite-toggle

### DIFF
--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoritesToggleRepositoryTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoritesToggleRepositoryTest.kt
@@ -8,6 +8,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.ByteReadChannel
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoritesToggleRepositoryTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoritesToggleRepositoryTest.kt
@@ -93,7 +93,10 @@ class FavoritesToggleRepositoryTest {
 
         assertTrue(result.isFailure, "409 should surface as failure, got $result")
         val ex = result.exceptionOrNull()
-        assertTrue(ex is FavoritesException, "expected FavoritesException, got ${ex?.let { it::class }}")
+        assertTrue(
+            ex is FavoritesException,
+            "expected FavoritesException, got ${ex?.let { it::class }}",
+        )
         assertEquals("Already in favorites", ex?.message)
     }
 

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoritesToggleRepositoryTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoritesToggleRepositoryTest.kt
@@ -1,0 +1,214 @@
+package three.two.bit.ppt.reality.favorites
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+
+/**
+ * Repository-level coroutine tests for the *write* half of the favorite toggle:
+ * [FavoritesRepository.addFavorite] and [FavoritesRepository.removeFavorite].
+ *
+ * The existing [FavoritesRepositoryTest] pins the *read* half (`isFavorite`). The favorite toggle
+ * on a listing-detail screen is add-or-remove driven by that read; the two write calls are what
+ * actually flip server state, so their status-code contracts (201 decode, 409 Conflict, 401, 404,
+ * 5xx) and the path/method/body shape need their own coverage. Verifies the gap-82-7 endpoint
+ * contract: `POST/DELETE /api/v1/favorites/{listing_id}` with the id as a path segment.
+ */
+class FavoritesToggleRepositoryTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+    }
+
+    private class Captured {
+        var method: HttpMethod? = null
+        var path: String? = null
+    }
+
+    private fun repoCapturing(
+        captured: Captured,
+        status: HttpStatusCode,
+        body: String,
+    ): FavoritesRepository {
+        val engine = MockEngine { request ->
+            captured.method = request.method
+            captured.path = request.url.encodedPath
+            respond(
+                content = ByteReadChannel(body),
+                status = status,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = HttpClient(engine) { install(ContentNegotiation) { json(json) } }
+        return FavoritesRepository(
+            baseUrl = "https://example.test",
+            sessionToken = "test-token",
+            client = client,
+        )
+    }
+
+    // --- addFavorite ---
+
+    @Test
+    fun addFavorite_posts_to_path_segment_and_decodes_201_portal_favorite() = runTest {
+        val cap = Captured()
+        val repo =
+            repoCapturing(
+                cap,
+                HttpStatusCode.Created,
+                """{"id":"fav-1","listing_id":"lst-1","created_at":"2026-04-26T10:00:00Z"}""",
+            )
+
+        val result = repo.addFavorite("lst-1")
+
+        assertTrue(result.isSuccess, "expected success, got $result")
+        assertEquals("fav-1", result.getOrNull()?.id)
+        assertEquals("lst-1", result.getOrNull()?.listingId)
+        // Endpoint contract: listing id is a path segment, POST, not a body field.
+        assertEquals(HttpMethod.Post, cap.method)
+        assertEquals("/api/v1/favorites/lst-1", cap.path)
+    }
+
+    @Test
+    fun addFavorite_maps_409_conflict_to_already_in_favorites() = runTest {
+        val cap = Captured()
+        val repo = repoCapturing(cap, HttpStatusCode.Conflict, """{"error":"exists"}""")
+
+        val result = repo.addFavorite("lst-1")
+
+        assertTrue(result.isFailure, "409 should surface as failure, got $result")
+        val ex = result.exceptionOrNull()
+        assertTrue(ex is FavoritesException, "expected FavoritesException, got ${ex?.let { it::class }}")
+        assertEquals("Already in favorites", ex?.message)
+    }
+
+    @Test
+    fun addFavorite_maps_401_to_sign_in_prompt() = runTest {
+        val cap = Captured()
+        val repo = repoCapturing(cap, HttpStatusCode.Unauthorized, """{"error":"unauth"}""")
+
+        val result = repo.addFavorite("lst-1")
+
+        assertTrue(result.isFailure)
+        assertEquals("Please sign in to save favorites", result.exceptionOrNull()?.message)
+    }
+
+    @Test
+    fun addFavorite_url_encodes_listing_id_path_segment() = runTest {
+        val cap = Captured()
+        val repo =
+            repoCapturing(
+                cap,
+                HttpStatusCode.Created,
+                """{"id":"fav-1","listing_id":"x","created_at":"2026-04-26T10:00:00Z"}""",
+            )
+
+        repo.addFavorite("../admin/secret")
+
+        // `/` must be percent-encoded; the request stays anchored under /favorites/.
+        assertEquals("/api/v1/favorites/..%2Fadmin%2Fsecret", cap.path)
+    }
+
+    // --- removeFavorite ---
+
+    @Test
+    fun removeFavorite_deletes_path_segment_and_succeeds_on_2xx() = runTest {
+        val cap = Captured()
+        val repo = repoCapturing(cap, HttpStatusCode.NoContent, "")
+
+        val result = repo.removeFavorite("lst-1")
+
+        assertTrue(result.isSuccess, "expected success, got $result")
+        assertEquals(HttpMethod.Delete, cap.method)
+        assertEquals("/api/v1/favorites/lst-1", cap.path)
+    }
+
+    @Test
+    fun removeFavorite_maps_404_to_favorite_not_found() = runTest {
+        val cap = Captured()
+        val repo = repoCapturing(cap, HttpStatusCode.NotFound, """{"error":"missing"}""")
+
+        val result = repo.removeFavorite("lst-1")
+
+        assertTrue(result.isFailure, "404 should surface as failure, got $result")
+        assertEquals("Favorite not found", result.exceptionOrNull()?.message)
+    }
+
+    @Test
+    fun removeFavorite_maps_401_to_sign_in_prompt() = runTest {
+        val cap = Captured()
+        val repo = repoCapturing(cap, HttpStatusCode.Unauthorized, """{"error":"unauth"}""")
+
+        val result = repo.removeFavorite("lst-1")
+
+        assertTrue(result.isFailure)
+        assertEquals("Please sign in to manage favorites", result.exceptionOrNull()?.message)
+    }
+
+    @Test
+    fun removeFavorite_url_encodes_listing_id_path_segment() = runTest {
+        val cap = Captured()
+        val repo = repoCapturing(cap, HttpStatusCode.NoContent, "")
+
+        repo.removeFavorite("../admin/secret")
+
+        assertEquals("/api/v1/favorites/..%2Fadmin%2Fsecret", cap.path)
+    }
+
+    // --- toggle round-trip shape ---
+
+    /**
+     * A favorite-toggle UI reads `isFavorite` then calls add or remove. This pins that the read
+     * reflects each write: false -> add (201) -> true, then true -> remove -> false, driven purely
+     * by the documented status/body contracts above.
+     */
+    @Test
+    fun toggle_sequence_add_then_remove_matches_check_states() = runTest {
+        // Start un-favorited.
+        val checkBefore =
+            repoCapturing(Captured(), HttpStatusCode.OK, """{"is_favorited": false}""")
+                .isFavorite("lst-1")
+        assertFalse(checkBefore.getOrThrow())
+
+        // Add -> 201.
+        val add =
+            repoCapturing(
+                    Captured(),
+                    HttpStatusCode.Created,
+                    """{"id":"fav-1","listing_id":"lst-1","created_at":"2026-04-26T10:00:00Z"}""",
+                )
+                .addFavorite("lst-1")
+        assertTrue(add.isSuccess)
+
+        // Now check reports favorited.
+        val checkAfterAdd =
+            repoCapturing(Captured(), HttpStatusCode.OK, """{"is_favorited": true}""")
+                .isFavorite("lst-1")
+        assertTrue(checkAfterAdd.getOrThrow())
+
+        // Remove -> 204, check reports un-favorited again.
+        val remove = repoCapturing(Captured(), HttpStatusCode.NoContent, "").removeFavorite("lst-1")
+        assertTrue(remove.isSuccess)
+        val checkAfterRemove =
+            repoCapturing(Captured(), HttpStatusCode.OK, """{"is_favorited": false}""")
+                .isFavorite("lst-1")
+        assertFalse(checkAfterRemove.getOrThrow())
+
+        assertNull(remove.exceptionOrNull())
+    }
+}

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingDetailRepositoryTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingDetailRepositoryTest.kt
@@ -8,6 +8,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.ByteReadChannel
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingDetailRepositoryTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingDetailRepositoryTest.kt
@@ -1,0 +1,164 @@
+package three.two.bit.ppt.reality.listing
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+
+/**
+ * Repository-level coroutine tests for [ListingRepository.getListingDetail] — the fetch that feeds
+ * the Reality Portal listing-detail screen.
+ *
+ * The [ListingModelsContractTest] pins the raw DTO encode/decode; this pins the *render contract* as
+ * seen through the repository: the GET hits `/api/v1/listings/{id}`, a 200 decodes a full
+ * [ListingDetail] (so the detail screen can render title/price/images/features/realtor), a 404 maps
+ * to the user-facing "Listing not found", and other non-2xx surface a [ListingException].
+ */
+class ListingDetailRepositoryTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+    }
+
+    private class Captured {
+        var method: HttpMethod? = null
+        var path: String? = null
+    }
+
+    private fun repoCapturing(
+        captured: Captured,
+        status: HttpStatusCode,
+        body: String,
+    ): ListingRepository {
+        val engine = MockEngine { request ->
+            captured.method = request.method
+            captured.path = request.url.encodedPath
+            respond(
+                content = ByteReadChannel(body),
+                status = status,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = HttpClient(engine) { install(ContentNegotiation) { json(json) } }
+        return ListingRepository(
+            baseUrl = "https://example.test",
+            sessionToken = "test-token",
+            client = client,
+        )
+    }
+
+    private val fullDetailBody =
+        """
+        {
+          "id": "lst-99",
+          "title": "Bright 3br with terrace",
+          "description": "A lovely flat in Old Town.",
+          "type": "sale",
+          "category": "apartment",
+          "status": "active",
+          "price": 285000,
+          "currency": "EUR",
+          "price_per_sqm": 3800,
+          "area_sqm": 75.0,
+          "rooms": 3,
+          "bedrooms": 2,
+          "bathrooms": 1,
+          "year_built": 2008,
+          "address": {
+            "street": "Hlavna 1",
+            "city": "Bratislava",
+            "postal_code": "81101",
+            "country": "SK",
+            "coordinates": { "latitude": 48.15, "longitude": 17.10 }
+          },
+          "images": [
+            { "id": "img-1", "url": "https://cdn.example.com/a.jpg", "is_primary": true },
+            { "id": "img-2", "url": "https://cdn.example.com/b.jpg", "thumbnail_url": "https://cdn.example.com/b-thumb.jpg" }
+          ],
+          "features": ["balcony", "elevator", "parking"],
+          "energy_rating": "B",
+          "realtor": {
+            "id": "rlt-1",
+            "name": "Jana Realitka",
+            "phone": "+421900000000",
+            "agency": { "id": "ag-1", "name": "TopReality" }
+          },
+          "view_count": 120,
+          "inquiry_count": 4,
+          "created_at": "2026-04-26T10:00:00Z",
+          "updated_at": "2026-04-27T09:00:00Z"
+        }
+        """
+            .trimIndent()
+
+    @Test
+    fun getListingDetail_gets_by_id_path_and_decodes_render_fields() = runTest {
+        val cap = Captured()
+        val repo = repoCapturing(cap, HttpStatusCode.OK, fullDetailBody)
+
+        val result = repo.getListingDetail("lst-99")
+
+        assertTrue(result.isSuccess, "expected success, got $result")
+        val detail = assertNotNull(result.getOrNull())
+
+        // Endpoint contract.
+        assertEquals(HttpMethod.Get, cap.method)
+        assertEquals("/api/v1/listings/lst-99", cap.path)
+
+        // Render-contract: the fields the detail screen binds must all decode.
+        assertEquals("Bright 3br with terrace", detail.title)
+        assertEquals(ListingType.SALE, detail.type)
+        assertEquals(PropertyCategory.APARTMENT, detail.category)
+        assertEquals(ListingStatus.ACTIVE, detail.status)
+        assertEquals(285_000L, detail.price)
+        assertEquals(3_800L, detail.pricePerSqm)
+        assertEquals(75.0, detail.areaSqm)
+        assertEquals(3, detail.rooms)
+        assertEquals(listOf("balcony", "elevator", "parking"), detail.features)
+        assertEquals(2, detail.images.size)
+        assertTrue(detail.images.first().isPrimary)
+        assertEquals("Bratislava", detail.address.city)
+        assertNotNull(detail.address.coordinates)
+        val realtor = assertNotNull(detail.realtor)
+        assertEquals("Jana Realitka", realtor.name)
+        assertEquals("TopReality", realtor.agency?.name)
+        assertEquals(120, detail.viewCount)
+    }
+
+    @Test
+    fun getListingDetail_maps_404_to_listing_not_found() = runTest {
+        val cap = Captured()
+        val repo = repoCapturing(cap, HttpStatusCode.NotFound, """{"error":"missing"}""")
+
+        val result = repo.getListingDetail("nope")
+
+        assertTrue(result.isFailure, "404 should surface as failure, got $result")
+        val ex = result.exceptionOrNull()
+        assertTrue(ex is ListingException, "expected ListingException, got ${ex?.let { it::class }}")
+        assertEquals("Listing not found", ex?.message)
+    }
+
+    @Test
+    fun getListingDetail_maps_server_error_to_failure() = runTest {
+        val cap = Captured()
+        val repo = repoCapturing(cap, HttpStatusCode.InternalServerError, """{"error":"boom"}""")
+
+        val result = repo.getListingDetail("lst-99")
+
+        assertTrue(result.isFailure, "5xx should surface as failure, got $result")
+        assertTrue(result.exceptionOrNull() is ListingException)
+    }
+}

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingDetailRepositoryTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingDetailRepositoryTest.kt
@@ -17,11 +17,11 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 
 /**
- * Repository-level coroutine tests for [ListingRepository.getListingDetail] — the fetch that feeds
- * the Reality Portal listing-detail screen.
+ * Repository-level coroutine tests for [ListingRepository.getListingDetail] — the fetch that
+ * feeds the Reality Portal listing-detail screen.
  *
- * The [ListingModelsContractTest] pins the raw DTO encode/decode; this pins the *render contract* as
- * seen through the repository: the GET hits `/api/v1/listings/{id}`, a 200 decodes a full
+ * The [ListingModelsContractTest] pins the raw DTO encode/decode; this pins the *render contract*
+ * as seen through the repository: the GET hits `/api/v1/listings/{id}`, a 200 decodes a full
  * [ListingDetail] (so the detail screen can render title/price/images/features/realtor), a 404 maps
  * to the user-facing "Listing not found", and other non-2xx surface a [ListingException].
  */
@@ -86,7 +86,8 @@ class ListingDetailRepositoryTest {
           },
           "images": [
             { "id": "img-1", "url": "https://cdn.example.com/a.jpg", "is_primary": true },
-            { "id": "img-2", "url": "https://cdn.example.com/b.jpg", "thumbnail_url": "https://cdn.example.com/b-thumb.jpg" }
+            { "id": "img-2", "url": "https://cdn.example.com/b.jpg",
+              "thumbnail_url": "https://cdn.example.com/b-thumb.jpg" }
           ],
           "features": ["balcony", "elevator", "parking"],
           "energy_rating": "B",
@@ -147,7 +148,10 @@ class ListingDetailRepositoryTest {
 
         assertTrue(result.isFailure, "404 should surface as failure, got $result")
         val ex = result.exceptionOrNull()
-        assertTrue(ex is ListingException, "expected ListingException, got ${ex?.let { it::class }}")
+        assertTrue(
+            ex is ListingException,
+            "expected ListingException, got ${ex?.let { it::class }}",
+        )
         assertEquals("Listing not found", ex?.message)
     }
 

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingDetailRepositoryTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingDetailRepositoryTest.kt
@@ -17,8 +17,8 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 
 /**
- * Repository-level coroutine tests for [ListingRepository.getListingDetail] — the fetch that
- * feeds the Reality Portal listing-detail screen.
+ * Repository-level coroutine tests for [ListingRepository.getListingDetail] — the fetch that feeds
+ * the Reality Portal listing-detail screen.
  *
  * The [ListingModelsContractTest] pins the raw DTO encode/decode; this pins the *render contract*
  * as seen through the repository: the GET hits `/api/v1/listings/{id}`, a 200 decodes a full


### PR DESCRIPTION
## Task
Coverage 82-4: verify the Reality Portal mobile (KMP) listing-detail & favorites story against its ACs. Read the commonMain listing-detail/favorites logic, add or confirm commonTest unit coverage for the favorite-toggle and detail-rendering contract, and record verification notes. mobile-native; no device build required (verify + KMP commonTest only).

## Owner
pm-frontend (NOTE: this task is `mobile-native/**`, which maps to `pm-mobile` in `owner-areas.json`, not `pm-frontend` — see Scope drift below).

## Verification findings (AC read)
Read `shared/src/commonMain/.../listing/{ListingRepository,ListingModels}.kt` and `.../favorites/{FavoritesRepository,FavoritesModels}.kt` plus existing commonTest.

Existing coverage already present and adequate for part of the ACs:
- `FavoritesRepositoryTest` — pins the **read** half of the toggle (`isFavorite`: 200 true/false, 401→false, 5xx→failure, path-encoding). Issue #697 / gap-82-7 regression.
- `FavoritesModelsContractTest` — favorites + saved-search DTO wire shapes (flat `PortalFavoriteWithListing`, `is_favorited`, add-response).
- `ListingModelsContractTest` — raw `ListingDetail`/`ListingSummary` encode/decode + enum SerialNames.

Gaps closed by this PR (repository-level, were untested):
- **Favorite-toggle write half** — `addFavorite` (201 decode + path-segment contract, 409 Conflict→"Already in favorites", 401) and `removeFavorite` (204, 404→"Favorite not found", 401), both with path-injection encoding, plus an add→check→remove→check sequence.
- **Detail-rendering contract** — `getListingDetail` GET-by-id path, full `ListingDetail` decode of every field the detail screen binds (title/price/pricePerSqm/area/rooms/features/images/address+coordinates/realtor+agency/viewCount), 404→"Listing not found", 5xx→failure.

New files:
- `mobile-native/shared/src/commonTest/.../favorites/FavoritesToggleRepositoryTest.kt`
- `mobile-native/shared/src/commonTest/.../listing/ListingDetailRepositoryTest.kt`

## Tested (Band A — fast check)
`cd mobile-native && ./gradlew --offline :shared:jvmTest --tests FavoritesToggleRepositoryTest --tests ListingDetailRepositoryTest`
**Could not execute in the implementer sandbox** — exit 1 at plugin resolution: `com.android.application:9.2.1` (AGP) and all ktor jars are absent from the Gradle cache and the sandbox proxy blocks Maven/Google downloads, so the root build graph cannot even configure. This is an environment/toolchain-fetch limitation, not red code.

Mitigation: the new tests use **only** the same testing APIs already exercised by the existing green commonTest files in this module (`MockEngine`/`respond`/`ByteReadChannel`, `ContentNegotiation`+`Json`, `runTest`, `request.url.encodedPath`, `request.method`, `HttpMethod`, `response.body()` decode). No new dependency, no new API surface. They must run on CI (`mobile-native.yml`, which has network to fetch AGP + ktor) — **CI is the verify gate for this PR; do not merge until `mobile-native.yml` is green.**

## Built (Band B — full build)
skipped: test-only change, no production/public-API/config touch; and unrunnable locally for the same toolchain-fetch reason as Band A.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (test-only; no security/auth/billing/data-integrity production change).

## Remote-tested
skipped (no ppt-bridge MCP in session).

## Scope drift
The diff (`origin/dev...HEAD`) touches only the two intended files under `mobile-native/shared/src/commonTest/**`. However the assigned `owner_role` is `pm-frontend`, whose areas in `owner-areas.json` are `frontend/apps/**` + `frontend/packages/**` + `docs/screens/**` — `mobile-native/**` belongs to `pm-mobile`. So against the assigned owner this reads as out-of-area (`scope_drift=true`). The drift is a **dispatcher owner-assignment mismatch** (KMP task tagged pm-frontend), not an implementer reaching outside its lane — the work is exactly the KMP mobile-native test coverage the task asked for. Reviewer: please confirm and consider re-tagging the task owner to `pm-mobile`.

## Code-reuse review
`reuse-grep.sh --specialist kotlin-mp` — clean, no warnings. (Tests reuse existing repositories/DTOs; no new helpers added.)

## Notes
- Test-only; zero production code changed.
- `commit-scope-guard`/scope-check base-ref note: the local `dev` ref in the worktree was one commit behind `origin/dev`, so scope-check reported a phantom `.research/management/assignments.json` path that is **not** part of this branch's diff (confirmed via `git diff origin/dev...HEAD`, which shows only the two `.kt` files).

https://claude.ai/code/session_01UdgHMmdqe7ELA9qb45MoYs

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdgHMmdqe7ELA9qb45MoYs)_