### PR TITLE
fix(api-server): re-land sensor.rs + reserve_funds.rs RLS conversions (PAP-151)

### DIFF
--- a/backend/crates/db/src/repositories/reserve_funds.rs
+++ b/backend/crates/db/src/repositories/reserve_funds.rs
@@ -1,7 +1,34 @@
 //! Reserve Fund Management repository for Epic 141.
+//!
+//! # RLS Integration (PAP-67 / PAP-79)
+//!
+//! Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on the reserve-fund cluster: `reserve_funds`,
+//! `fund_contribution_schedules`, `fund_transactions`, `fund_investment_policies`,
+//! `fund_projections`, `fund_projection_items`, `fund_components`, and
+//! `fund_alerts`. Under `FORCE` the api-server's table-owner connection is no
+//! longer exempt, so a query issued on a connection without `app.current_org_id`
+//! set collapses to deny-all (own-org reads return empty, writes fail the policy
+//! `WITH CHECK`).
+//!
+//! This repository therefore holds **no pool**. Every method takes an executor
+//! whose connection already has RLS context set — in handlers this comes from
+//! the `RlsConnection` extractor via `&mut **rls.conn()`:
+//!
+//! * single-statement methods take a generic `executor: E`;
+//! * multi-statement methods that compose helpers take `conn: &mut PgConnection`
+//!   and reborrow `&mut *conn` per call.
+//!
+//! Because the repo cannot reach a raw pool, there is no path that bypasses RLS.
+//! This mirrors the `work_order.rs` / `budget.rs` precedent.
+//!
+//! The explicit `organization_id = $n` predicates are retained as
+//! defense-in-depth: the authoritative org is the caller's `rls.tenant_id()`,
+//! so the SQL filter and the RLS context can never disagree, and cross-tenant
+//! by-id reads return no row (→ 404) under both layers.
 
 use rust_decimal::Decimal;
-use sqlx::PgPool;
+use sqlx::{Executor, PgConnection, PgPool, Postgres};
 use uuid::Uuid;
 
 use crate::models::reserve_funds::{
@@ -14,15 +41,21 @@ use crate::models::reserve_funds::{
 };
 
 /// Repository for reserve fund operations.
+///
+/// Stateless: every method receives an RLS-context-bearing executor. The repo
+/// holds no pool so it cannot issue an un-scoped (deny-all under `FORCE`) query.
 #[derive(Clone)]
-pub struct ReserveFundRepository {
-    pool: PgPool,
-}
+pub struct ReserveFundRepository;
 
 impl ReserveFundRepository {
     /// Create a new repository instance.
-    pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+    ///
+    /// The pool argument is retained for construction-site compatibility with
+    /// the other repositories on `AppState`; this repo deliberately does not
+    /// store it (see module docs — all queries run on a context-set connection
+    /// supplied by the handler's `RlsConnection`).
+    pub fn new(_pool: PgPool) -> Self {
+        Self
     }
 
     // ========================================================================
@@ -30,12 +63,16 @@ impl ReserveFundRepository {
     // ========================================================================
 
     /// Create a new reserve fund.
-    pub async fn create_fund(
+    pub async fn create_fund<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         req: CreateReserveFund,
         created_by: Uuid,
-    ) -> Result<ReserveFund, sqlx::Error> {
+    ) -> Result<ReserveFund, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, ReserveFund>(
             r#"
             INSERT INTO reserve_funds (
@@ -55,7 +92,7 @@ impl ReserveFundRepository {
         .bind(req.minimum_balance)
         .bind(req.currency.unwrap_or_else(|| "EUR".to_string()))
         .bind(created_by)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
@@ -64,30 +101,43 @@ impl ReserveFundRepository {
     /// Returns `None` if the fund does not exist **or** belongs to a different
     /// organization, so callers cannot distinguish "not found" from "not yours"
     /// — the handler maps both to a 404 and cross-tenant reads (IDOR) are
-    /// impossible (see #810).
-    pub async fn get_fund(
+    /// impossible (see #810). Under FORCE-RLS the connection's org context is a
+    /// second, database-enforced guard on top of the explicit predicate.
+    pub async fn get_fund<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         fund_id: Uuid,
-    ) -> Result<Option<ReserveFund>, sqlx::Error> {
+    ) -> Result<Option<ReserveFund>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, ReserveFund>(
             "SELECT * FROM reserve_funds WHERE id = $1 AND organization_id = $2",
         )
         .bind(fund_id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Verify a fund belongs to `org_id`, returning [`sqlx::Error::RowNotFound`]
     /// otherwise so child-resource operations on the fund stay tenant-scoped.
-    async fn ensure_fund_in_org(&self, org_id: Uuid, fund_id: Uuid) -> Result<(), sqlx::Error> {
+    async fn ensure_fund_in_org<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+        fund_id: Uuid,
+    ) -> Result<(), sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let exists: Option<Uuid> = sqlx::query_scalar(
             "SELECT id FROM reserve_funds WHERE id = $1 AND organization_id = $2",
         )
         .bind(fund_id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await?;
 
         if exists.is_some() {
@@ -98,13 +148,17 @@ impl ReserveFundRepository {
     }
 
     /// List all funds for an organization.
-    pub async fn list_funds(
+    pub async fn list_funds<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         fund_type: Option<FundType>,
         building_id: Option<Uuid>,
         active_only: bool,
-    ) -> Result<Vec<ReserveFund>, sqlx::Error> {
+    ) -> Result<Vec<ReserveFund>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let mut query = String::from("SELECT * FROM reserve_funds WHERE organization_id = $1");
         let mut param_count = 1;
 
@@ -134,7 +188,7 @@ impl ReserveFundRepository {
             q = q.bind(bid);
         }
 
-        q.fetch_all(&self.pool).await
+        q.fetch_all(executor).await
     }
 
     /// Update a reserve fund, scoped to the caller's organization.
@@ -142,12 +196,16 @@ impl ReserveFundRepository {
     /// The `organization_id = $8` predicate means an update targeting another
     /// org's fund matches zero rows and surfaces as
     /// [`sqlx::Error::RowNotFound`] (→ 404), not a silent cross-tenant write.
-    pub async fn update_fund(
+    pub async fn update_fund<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         fund_id: Uuid,
         req: UpdateReserveFund,
-    ) -> Result<ReserveFund, sqlx::Error> {
+    ) -> Result<ReserveFund, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, ReserveFund>(
             r#"
             UPDATE reserve_funds SET
@@ -170,15 +228,18 @@ impl ReserveFundRepository {
         .bind(req.minimum_balance)
         .bind(req.is_active)
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Delete a reserve fund.
-    pub async fn delete_fund(&self, fund_id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete_fund<'e, E>(&self, executor: E, fund_id: Uuid) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM reserve_funds WHERE id = $1")
             .bind(fund_id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
@@ -188,13 +249,17 @@ impl ReserveFundRepository {
     // ========================================================================
 
     /// Create a contribution schedule for a fund the caller owns.
+    ///
+    /// Multi-statement (ownership check + insert), so it takes a connection and
+    /// reborrows it for each query.
     pub async fn create_contribution_schedule(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         fund_id: Uuid,
         req: CreateContributionSchedule,
     ) -> Result<FundContributionSchedule, sqlx::Error> {
-        self.ensure_fund_in_org(org_id, fund_id).await?;
+        self.ensure_fund_in_org(&mut *conn, org_id, fund_id).await?;
         sqlx::query_as::<_, FundContributionSchedule>(
             r#"
             INSERT INTO fund_contribution_schedules (
@@ -213,18 +278,19 @@ impl ReserveFundRepository {
         .bind(req.start_date)
         .bind(req.end_date)
         .bind(req.auto_collect.unwrap_or(false))
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
     }
 
     /// List contribution schedules for a fund the caller owns.
     pub async fn list_contribution_schedules(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         fund_id: Uuid,
         active_only: bool,
     ) -> Result<Vec<FundContributionSchedule>, sqlx::Error> {
-        self.ensure_fund_in_org(org_id, fund_id).await?;
+        self.ensure_fund_in_org(&mut *conn, org_id, fund_id).await?;
         let query = if active_only {
             "SELECT * FROM fund_contribution_schedules WHERE fund_id = $1 AND is_active = true ORDER BY next_due_date"
         } else {
@@ -233,7 +299,7 @@ impl ReserveFundRepository {
 
         sqlx::query_as::<_, FundContributionSchedule>(query)
             .bind(fund_id)
-            .fetch_all(&self.pool)
+            .fetch_all(&mut *conn)
             .await
     }
 
@@ -242,12 +308,16 @@ impl ReserveFundRepository {
     /// The `fund_id IN (… organization_id = $9)` subquery ensures a schedule
     /// owned by another org matches zero rows (→ 404), closing the #810 IDOR
     /// for the child resource.
-    pub async fn update_contribution_schedule(
+    pub async fn update_contribution_schedule<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         schedule_id: Uuid,
         req: UpdateContributionSchedule,
-    ) -> Result<FundContributionSchedule, sqlx::Error> {
+    ) -> Result<FundContributionSchedule, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, FundContributionSchedule>(
             r#"
             UPDATE fund_contribution_schedules SET
@@ -275,18 +345,22 @@ impl ReserveFundRepository {
         .bind(req.is_active)
         .bind(req.auto_collect)
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Delete a contribution schedule.
-    pub async fn delete_contribution_schedule(
+    pub async fn delete_contribution_schedule<'e, E>(
         &self,
+        executor: E,
         schedule_id: Uuid,
-    ) -> Result<bool, sqlx::Error> {
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM fund_contribution_schedules WHERE id = $1")
             .bind(schedule_id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
@@ -296,8 +370,12 @@ impl ReserveFundRepository {
     // ========================================================================
 
     /// Record a fund transaction against a fund the caller owns.
+    ///
+    /// Multi-statement (balance read + insert + balance update), so it takes a
+    /// connection and reborrows it for each query.
     pub async fn record_transaction(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         fund_id: Uuid,
         req: RecordFundTransaction,
@@ -305,9 +383,9 @@ impl ReserveFundRepository {
     ) -> Result<FundTransaction, sqlx::Error> {
         // Get current balance — org-scoped so a foreign fund yields RowNotFound.
         let fund = self
-            .get_fund(org_id, fund_id)
+            .get_fund(&mut *conn, org_id, fund_id)
             .await?
-            .ok_or_else(|| sqlx::Error::RowNotFound)?;
+            .ok_or(sqlx::Error::RowNotFound)?;
 
         // Calculate new balance
         let amount = req.amount;
@@ -351,7 +429,7 @@ impl ReserveFundRepository {
         .bind(req.transfer_to_fund_id)
         .bind(req.requires_approval.unwrap_or(false))
         .bind(created_by)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         // Update fund balance
@@ -360,7 +438,7 @@ impl ReserveFundRepository {
         )
         .bind(fund_id)
         .bind(new_balance)
-        .execute(&self.pool)
+        .execute(&mut *conn)
         .await?;
 
         Ok(transaction)
@@ -371,11 +449,15 @@ impl ReserveFundRepository {
     /// The `fund_id IN (… organization_id = $7)` predicate confines results to
     /// funds owned by the caller, so passing another org's `fund_id` returns an
     /// empty list rather than leaking transactions (#810).
-    pub async fn list_transactions(
+    pub async fn list_transactions<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: TransactionQuery,
-    ) -> Result<Vec<FundTransaction>, sqlx::Error> {
+    ) -> Result<Vec<FundTransaction>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(100);
         let offset = query.offset.unwrap_or(0);
 
@@ -400,7 +482,7 @@ impl ReserveFundRepository {
         .bind(limit)
         .bind(offset)
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -411,6 +493,7 @@ impl ReserveFundRepository {
     /// [`sqlx::Error::RowNotFound`] before any balance is mutated (#810).
     pub async fn transfer_funds(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         req: FundTransferRequest,
         created_by: Uuid,
@@ -418,6 +501,7 @@ impl ReserveFundRepository {
         // Record withdrawal from source
         let withdrawal = self
             .record_transaction(
+                &mut *conn,
                 org_id,
                 req.from_fund_id,
                 RecordFundTransaction {
@@ -436,6 +520,7 @@ impl ReserveFundRepository {
         // Record deposit to destination
         let deposit = self
             .record_transaction(
+                &mut *conn,
                 org_id,
                 req.to_fund_id,
                 RecordFundTransaction {
@@ -461,11 +546,12 @@ impl ReserveFundRepository {
     /// Create an investment policy for a fund the caller owns.
     pub async fn create_investment_policy(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         fund_id: Uuid,
         req: CreateInvestmentPolicy,
     ) -> Result<FundInvestmentPolicy, sqlx::Error> {
-        self.ensure_fund_in_org(org_id, fund_id).await?;
+        self.ensure_fund_in_org(&mut *conn, org_id, fund_id).await?;
         sqlx::query_as::<_, FundInvestmentPolicy>(
             r#"
             INSERT INTO fund_investment_policies (
@@ -489,17 +575,18 @@ impl ReserveFundRepository {
         .bind(req.max_single_investment)
         .bind(req.min_liquidity_pct)
         .bind(req.effective_date)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
     }
 
     /// Get active investment policy for a fund the caller owns.
     pub async fn get_active_investment_policy(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         fund_id: Uuid,
     ) -> Result<Option<FundInvestmentPolicy>, sqlx::Error> {
-        self.ensure_fund_in_org(org_id, fund_id).await?;
+        self.ensure_fund_in_org(&mut *conn, org_id, fund_id).await?;
         sqlx::query_as::<_, FundInvestmentPolicy>(
             r#"
             SELECT * FROM fund_investment_policies
@@ -511,22 +598,23 @@ impl ReserveFundRepository {
             "#,
         )
         .bind(fund_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *conn)
         .await
     }
 
     /// List investment policies for a fund the caller owns.
     pub async fn list_investment_policies(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         fund_id: Uuid,
     ) -> Result<Vec<FundInvestmentPolicy>, sqlx::Error> {
-        self.ensure_fund_in_org(org_id, fund_id).await?;
+        self.ensure_fund_in_org(&mut *conn, org_id, fund_id).await?;
         sqlx::query_as::<_, FundInvestmentPolicy>(
             "SELECT * FROM fund_investment_policies WHERE fund_id = $1 ORDER BY effective_date DESC",
         )
         .bind(fund_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await
     }
 
@@ -537,20 +625,21 @@ impl ReserveFundRepository {
     /// Create a fund projection for a fund the caller owns.
     pub async fn create_projection(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         fund_id: Uuid,
         req: CreateFundProjection,
     ) -> Result<FundProjection, sqlx::Error> {
         // Get current balance for starting balance — org-scoped (#810).
         let fund = self
-            .get_fund(org_id, fund_id)
+            .get_fund(&mut *conn, org_id, fund_id)
             .await?
-            .ok_or_else(|| sqlx::Error::RowNotFound)?;
+            .ok_or(sqlx::Error::RowNotFound)?;
 
         // Mark existing projections as not current
         sqlx::query("UPDATE fund_projections SET is_current = false WHERE fund_id = $1")
             .bind(fund_id)
-            .execute(&self.pool)
+            .execute(&mut *conn)
             .await?;
 
         sqlx::query_as::<_, FundProjection>(
@@ -573,33 +662,36 @@ impl ReserveFundRepository {
         .bind(fund.current_balance)
         .bind(req.recommended_annual_contribution)
         .bind(&req.prepared_by)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
     }
 
     /// Get current projection for a fund the caller owns.
     pub async fn get_current_projection(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         fund_id: Uuid,
     ) -> Result<Option<FundProjection>, sqlx::Error> {
-        self.ensure_fund_in_org(org_id, fund_id).await?;
+        self.ensure_fund_in_org(&mut *conn, org_id, fund_id).await?;
         sqlx::query_as::<_, FundProjection>(
             "SELECT * FROM fund_projections WHERE fund_id = $1 AND is_current = true LIMIT 1",
         )
         .bind(fund_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *conn)
         .await
     }
 
     /// Add projection line items to a projection the caller owns.
     pub async fn add_projection_items(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         projection_id: Uuid,
         items: Vec<CreateProjectionItem>,
     ) -> Result<Vec<FundProjectionItem>, sqlx::Error> {
-        self.ensure_projection_in_org(org_id, projection_id).await?;
+        self.ensure_projection_in_org(&mut *conn, org_id, projection_id)
+            .await?;
         let mut results = Vec::new();
 
         for item in items {
@@ -623,7 +715,7 @@ impl ReserveFundRepository {
             .bind(item.beginning_balance)
             .bind(item.ending_balance)
             .bind(&item.expenditure_details)
-            .fetch_one(&self.pool)
+            .fetch_one(&mut *conn)
             .await?;
 
             results.push(result);
@@ -635,25 +727,31 @@ impl ReserveFundRepository {
     /// Get projection items for a projection the caller owns.
     pub async fn get_projection_items(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         projection_id: Uuid,
     ) -> Result<Vec<FundProjectionItem>, sqlx::Error> {
-        self.ensure_projection_in_org(org_id, projection_id).await?;
+        self.ensure_projection_in_org(&mut *conn, org_id, projection_id)
+            .await?;
         sqlx::query_as::<_, FundProjectionItem>(
             "SELECT * FROM fund_projection_items WHERE projection_id = $1 ORDER BY projection_year",
         )
         .bind(projection_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await
     }
 
     /// Verify a projection's parent fund belongs to `org_id`, returning
     /// [`sqlx::Error::RowNotFound`] otherwise (#810).
-    async fn ensure_projection_in_org(
+    async fn ensure_projection_in_org<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         projection_id: Uuid,
-    ) -> Result<(), sqlx::Error> {
+    ) -> Result<(), sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let exists: Option<Uuid> = sqlx::query_scalar(
             r#"
             SELECT fp.id
@@ -664,7 +762,7 @@ impl ReserveFundRepository {
         )
         .bind(projection_id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await?;
 
         if exists.is_some() {
@@ -681,11 +779,12 @@ impl ReserveFundRepository {
     /// Create a fund component for a fund the caller owns.
     pub async fn create_component(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         fund_id: Uuid,
         req: CreateFundComponent,
     ) -> Result<FundComponent, sqlx::Error> {
-        self.ensure_fund_in_org(org_id, fund_id).await?;
+        self.ensure_fund_in_org(&mut *conn, org_id, fund_id).await?;
         sqlx::query_as::<_, FundComponent>(
             r#"
             INSERT INTO fund_components (
@@ -708,31 +807,36 @@ impl ReserveFundRepository {
         .bind(req.condition_rating)
         .bind(req.last_inspection_date)
         .bind(req.next_replacement_date)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
     }
 
     /// List components for a fund the caller owns.
     pub async fn list_components(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         fund_id: Uuid,
     ) -> Result<Vec<FundComponent>, sqlx::Error> {
-        self.ensure_fund_in_org(org_id, fund_id).await?;
-        self.list_components_unscoped(fund_id).await
+        self.ensure_fund_in_org(&mut *conn, org_id, fund_id).await?;
+        self.list_components_unscoped(&mut *conn, fund_id).await
     }
 
     /// List components without an organization check. Internal helper for
     /// methods that have already verified fund ownership.
-    async fn list_components_unscoped(
+    async fn list_components_unscoped<'e, E>(
         &self,
+        executor: E,
         fund_id: Uuid,
-    ) -> Result<Vec<FundComponent>, sqlx::Error> {
+    ) -> Result<Vec<FundComponent>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, FundComponent>(
             "SELECT * FROM fund_components WHERE fund_id = $1 ORDER BY next_replacement_date NULLS LAST",
         )
         .bind(fund_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -740,12 +844,16 @@ impl ReserveFundRepository {
     ///
     /// The `fund_id IN (… organization_id = $11)` subquery makes an update
     /// against another org's component match zero rows (→ 404) (#810).
-    pub async fn update_component(
+    pub async fn update_component<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         component_id: Uuid,
         req: UpdateFundComponent,
-    ) -> Result<FundComponent, sqlx::Error> {
+    ) -> Result<FundComponent, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, FundComponent>(
             r#"
             UPDATE fund_components SET
@@ -777,15 +885,22 @@ impl ReserveFundRepository {
         .bind(req.last_inspection_date)
         .bind(req.next_replacement_date)
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Delete a component.
-    pub async fn delete_component(&self, component_id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete_component<'e, E>(
+        &self,
+        executor: E,
+        component_id: Uuid,
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM fund_components WHERE id = $1")
             .bind(component_id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
@@ -796,8 +911,9 @@ impl ReserveFundRepository {
 
     /// Create a fund alert.
     #[allow(clippy::too_many_arguments)]
-    pub async fn create_alert(
+    pub async fn create_alert<'e, E>(
         &self,
+        executor: E,
         fund_id: Uuid,
         alert_type: &str,
         severity: &str,
@@ -805,7 +921,10 @@ impl ReserveFundRepository {
         message: &str,
         threshold_value: Option<Decimal>,
         current_value: Option<Decimal>,
-    ) -> Result<FundAlert, sqlx::Error> {
+    ) -> Result<FundAlert, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, FundAlert>(
             r#"
             INSERT INTO fund_alerts (
@@ -823,12 +942,19 @@ impl ReserveFundRepository {
         .bind(message)
         .bind(threshold_value)
         .bind(current_value)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// List active alerts for an organization.
-    pub async fn list_active_alerts(&self, org_id: Uuid) -> Result<Vec<FundAlert>, sqlx::Error> {
+    pub async fn list_active_alerts<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+    ) -> Result<Vec<FundAlert>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, FundAlert>(
             r#"
             SELECT fa.* FROM fund_alerts fa
@@ -838,7 +964,7 @@ impl ReserveFundRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -846,12 +972,16 @@ impl ReserveFundRepository {
     ///
     /// The `fund_id IN (… organization_id = $3)` subquery confines the update
     /// to alerts on funds the caller owns (#810).
-    pub async fn acknowledge_alert(
+    pub async fn acknowledge_alert<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         alert_id: Uuid,
         user_id: Uuid,
-    ) -> Result<FundAlert, sqlx::Error> {
+    ) -> Result<FundAlert, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, FundAlert>(
             r#"
             UPDATE fund_alerts SET
@@ -867,17 +997,21 @@ impl ReserveFundRepository {
         .bind(alert_id)
         .bind(user_id)
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Resolve an alert, scoped to the caller's organization (#810).
-    pub async fn resolve_alert(
+    pub async fn resolve_alert<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         alert_id: Uuid,
         user_id: Uuid,
-    ) -> Result<FundAlert, sqlx::Error> {
+    ) -> Result<FundAlert, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, FundAlert>(
             r#"
             UPDATE fund_alerts SET
@@ -894,7 +1028,7 @@ impl ReserveFundRepository {
         .bind(alert_id)
         .bind(user_id)
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
@@ -903,9 +1037,15 @@ impl ReserveFundRepository {
     // ========================================================================
 
     /// Get fund dashboard for an organization.
-    pub async fn get_fund_dashboard(&self, org_id: Uuid) -> Result<FundDashboard, sqlx::Error> {
+    pub async fn get_fund_dashboard(
+        &self,
+        conn: &mut PgConnection,
+        org_id: Uuid,
+    ) -> Result<FundDashboard, sqlx::Error> {
         // Get all funds
-        let funds = self.list_funds(org_id, None, None, true).await?;
+        let funds = self
+            .list_funds(&mut *conn, org_id, None, None, true)
+            .await?;
 
         let mut total_balance = Decimal::ZERO;
         let mut total_target = Decimal::ZERO;
@@ -938,7 +1078,7 @@ impl ReserveFundRepository {
 
             // Get upcoming contributions
             let schedules = self
-                .list_contribution_schedules(org_id, fund.id, true)
+                .list_contribution_schedules(&mut *conn, org_id, fund.id, true)
                 .await?;
             let upcoming = schedules.iter().map(|s| s.amount).sum();
 
@@ -947,7 +1087,7 @@ impl ReserveFundRepository {
                 "SELECT COUNT(*) FROM fund_alerts WHERE fund_id = $1 AND is_active = true",
             )
             .bind(fund.id)
-            .fetch_one(&self.pool)
+            .fetch_one(&mut *conn)
             .await?;
 
             fund_summaries.push(FundSummary {
@@ -978,7 +1118,7 @@ impl ReserveFundRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         Ok(FundDashboard {
@@ -994,13 +1134,14 @@ impl ReserveFundRepository {
     /// Get fund health report for a fund the caller owns.
     pub async fn get_fund_health_report(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         fund_id: Uuid,
     ) -> Result<FundHealthReport, sqlx::Error> {
         let fund = self
-            .get_fund(org_id, fund_id)
+            .get_fund(&mut *conn, org_id, fund_id)
             .await?
-            .ok_or_else(|| sqlx::Error::RowNotFound)?;
+            .ok_or(sqlx::Error::RowNotFound)?;
 
         let mut issues = Vec::new();
         let mut recommendations = Vec::new();
@@ -1044,7 +1185,7 @@ impl ReserveFundRepository {
             "SELECT * FROM fund_projections WHERE fund_id = $1 AND is_current = true LIMIT 1",
         )
         .bind(fund_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *conn)
         .await?;
         if projection.is_none() {
             issues.push("No current reserve study".to_string());
@@ -1053,7 +1194,7 @@ impl ReserveFundRepository {
         }
 
         // Check upcoming component replacements (fund ownership verified).
-        let components = self.list_components_unscoped(fund_id).await?;
+        let components = self.list_components_unscoped(&mut *conn, fund_id).await?;
         let urgent_components: Vec<_> = components
             .iter()
             .filter(|c| c.remaining_life_years.map(|y| y <= 2).unwrap_or(false))

--- a/backend/crates/db/src/repositories/sensor.rs
+++ b/backend/crates/db/src/repositories/sensor.rs
@@ -1,4 +1,20 @@
 //! IoT sensor repository (Epic 14).
+//!
+//! # RLS Integration (PAP-67)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on every sensor table (`sensors`,
+//! `sensor_readings`, `sensor_alerts`, `sensor_thresholds`,
+//! `sensor_threshold_templates`, `sensor_fault_correlations`). Under `FORCE`
+//! the api-server's owner connection is no longer exempt, so a query issued on
+//! a connection without `app.current_org_id` set collapses to deny-all (own-org
+//! reads return empty, writes fail).
+//!
+//! Every method therefore takes an **executor whose connection already has RLS
+//! context set** (org + user GUCs) — in handlers this comes from the
+//! `RlsConnection` extractor via `&mut **rls.conn()`. The repository holds **no
+//! pool**, so there is no way to issue a query that bypasses RLS. This mirrors
+//! the `work_order.rs` / `budget.rs` precedent.
 
 use crate::models::{
     AggregatedReading, AlertQuery, CreateSensor, CreateSensorAlert, CreateSensorFaultCorrelation,
@@ -7,19 +23,25 @@ use crate::models::{
     SensorTypeCount, UpdateSensor, UpdateSensorThreshold,
 };
 use chrono::{DateTime, Utc};
-use sqlx::PgPool;
+use sqlx::{Executor, PgConnection, PgPool, Postgres};
 use uuid::Uuid;
 
 /// Repository for IoT sensor operations.
+///
+/// Stateless: every method receives an RLS-context-bearing executor. The repo
+/// holds no pool so it cannot issue an un-scoped (deny-all under `FORCE`) query.
 #[derive(Clone)]
-pub struct SensorRepository {
-    pool: PgPool,
-}
+pub struct SensorRepository;
 
 impl SensorRepository {
     /// Create a new repository instance.
-    pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+    ///
+    /// The pool argument is retained for construction-site compatibility with
+    /// the other repositories on `AppState`; this repo deliberately does not
+    /// store it (see module docs — all queries run on a context-set connection
+    /// supplied by the handler's `RlsConnection`).
+    pub fn new(_pool: PgPool) -> Self {
+        Self
     }
 
     // ========================================================================
@@ -27,7 +49,10 @@ impl SensorRepository {
     // ========================================================================
 
     /// Create a new sensor.
-    pub async fn create(&self, data: CreateSensor) -> Result<Sensor, sqlx::Error> {
+    pub async fn create<'e, E>(&self, executor: E, data: CreateSensor) -> Result<Sensor, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO sensors
@@ -59,20 +84,31 @@ impl SensorRepository {
         .bind(data.installed_at)
         .bind(sqlx::types::Json(data.metadata.unwrap_or_default()))
         .bind(data.created_by)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get sensor by ID.
-    pub async fn find_by_id(&self, id: Uuid) -> Result<Option<Sensor>, sqlx::Error> {
+    pub async fn find_by_id<'e, E>(&self, executor: E, id: Uuid) -> Result<Option<Sensor>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as("SELECT * FROM sensors WHERE id = $1")
             .bind(id)
-            .fetch_optional(&self.pool)
+            .fetch_optional(executor)
             .await
     }
 
     /// List sensors with filters.
-    pub async fn list(&self, org_id: Uuid, query: SensorQuery) -> Result<Vec<Sensor>, sqlx::Error> {
+    pub async fn list<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+        query: SensorQuery,
+    ) -> Result<Vec<Sensor>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50);
         let offset = query.offset.unwrap_or(0);
 
@@ -97,12 +133,20 @@ impl SensorRepository {
         .bind(query.search)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update a sensor.
-    pub async fn update(&self, id: Uuid, data: UpdateSensor) -> Result<Sensor, sqlx::Error> {
+    pub async fn update<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+        data: UpdateSensor,
+    ) -> Result<Sensor, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE sensors SET
@@ -136,26 +180,33 @@ impl SensorRepository {
         .bind(data.model)
         .bind(data.firmware_version)
         .bind(data.metadata.map(sqlx::types::Json))
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Delete a sensor.
-    pub async fn delete(&self, id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete<'e, E>(&self, executor: E, id: Uuid) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM sensors WHERE id = $1")
             .bind(id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
 
     /// Update sensor status and timestamps.
-    pub async fn update_status(
+    pub async fn update_status<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         status: &str,
         last_error: Option<&str>,
-    ) -> Result<Sensor, sqlx::Error> {
+    ) -> Result<Sensor, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE sensors SET
@@ -171,12 +222,19 @@ impl SensorRepository {
         .bind(id)
         .bind(status)
         .bind(last_error)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get sensors count by type.
-    pub async fn count_by_type(&self, org_id: Uuid) -> Result<Vec<SensorTypeCount>, sqlx::Error> {
+    pub async fn count_by_type<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+    ) -> Result<Vec<SensorTypeCount>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT sensor_type, COUNT(*) as count
@@ -187,7 +245,7 @@ impl SensorRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -196,8 +254,12 @@ impl SensorRepository {
     // ========================================================================
 
     /// Create a sensor reading.
+    ///
+    /// Multi-statement (INSERT reading + UPDATE parent sensor), so it takes a
+    /// connection and reborrows it for each query.
     pub async fn create_reading(
         &self,
+        conn: &mut PgConnection,
         data: CreateSensorReading,
     ) -> Result<SensorReading, sqlx::Error> {
         // Also update the sensor's last_reading_at
@@ -214,7 +276,7 @@ impl SensorRepository {
         .bind(data.quality.unwrap_or_else(|| "good".to_string()))
         .bind(data.raw_data.map(sqlx::types::Json))
         .bind(data.timestamp)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         // Update sensor status
@@ -223,18 +285,22 @@ impl SensorRepository {
         )
         .bind(data.sensor_id)
         .bind(reading.timestamp)
-        .execute(&self.pool)
+        .execute(&mut *conn)
         .await?;
 
         Ok(reading)
     }
 
     /// Get readings for a sensor.
-    pub async fn list_readings(
+    pub async fn list_readings<'e, E>(
         &self,
+        executor: E,
         sensor_id: Uuid,
         query: ReadingQuery,
-    ) -> Result<Vec<SensorReading>, sqlx::Error> {
+    ) -> Result<Vec<SensorReading>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(100);
         let from = query
             .from_time
@@ -255,18 +321,22 @@ impl SensorRepository {
         .bind(from)
         .bind(to)
         .bind(limit)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Get aggregated readings.
-    pub async fn list_aggregated_readings(
+    pub async fn list_aggregated_readings<'e, E>(
         &self,
+        executor: E,
         sensor_id: Uuid,
         from: DateTime<Utc>,
         to: DateTime<Utc>,
         interval: &str,
-    ) -> Result<Vec<AggregatedReading>, sqlx::Error> {
+    ) -> Result<Vec<AggregatedReading>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let interval_sql = match interval {
             "minute" => "date_trunc('minute', timestamp)",
             "hour" => "date_trunc('hour', timestamp)",
@@ -296,15 +366,19 @@ impl SensorRepository {
             .bind(sensor_id)
             .bind(from)
             .bind(to)
-            .fetch_all(&self.pool)
+            .fetch_all(executor)
             .await
     }
 
     /// Get latest reading for a sensor.
-    pub async fn get_latest_reading(
+    pub async fn get_latest_reading<'e, E>(
         &self,
+        executor: E,
         sensor_id: Uuid,
-    ) -> Result<Option<SensorReading>, sqlx::Error> {
+    ) -> Result<Option<SensorReading>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM sensor_readings
@@ -314,7 +388,7 @@ impl SensorRepository {
             "#,
         )
         .bind(sensor_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
@@ -323,10 +397,14 @@ impl SensorRepository {
     // ========================================================================
 
     /// Create a threshold.
-    pub async fn create_threshold(
+    pub async fn create_threshold<'e, E>(
         &self,
+        executor: E,
         data: CreateSensorThreshold,
-    ) -> Result<SensorThreshold, sqlx::Error> {
+    ) -> Result<SensorThreshold, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO sensor_thresholds
@@ -344,27 +422,35 @@ impl SensorRepository {
         .bind(data.critical_value)
         .bind(data.critical_high)
         .bind(data.alert_cooldown_minutes)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get thresholds for a sensor.
-    pub async fn list_thresholds(
+    pub async fn list_thresholds<'e, E>(
         &self,
+        executor: E,
         sensor_id: Uuid,
-    ) -> Result<Vec<SensorThreshold>, sqlx::Error> {
+    ) -> Result<Vec<SensorThreshold>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as("SELECT * FROM sensor_thresholds WHERE sensor_id = $1 ORDER BY metric")
             .bind(sensor_id)
-            .fetch_all(&self.pool)
+            .fetch_all(executor)
             .await
     }
 
     /// Update a threshold.
-    pub async fn update_threshold(
+    pub async fn update_threshold<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         data: UpdateSensorThreshold,
-    ) -> Result<SensorThreshold, sqlx::Error> {
+    ) -> Result<SensorThreshold, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE sensor_thresholds SET
@@ -388,25 +474,32 @@ impl SensorRepository {
         .bind(data.critical_high)
         .bind(data.enabled)
         .bind(data.alert_cooldown_minutes)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Delete a threshold.
-    pub async fn delete_threshold(&self, id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete_threshold<'e, E>(&self, executor: E, id: Uuid) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM sensor_thresholds WHERE id = $1")
             .bind(id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
 
     /// Get threshold templates.
-    pub async fn list_threshold_templates(
+    pub async fn list_threshold_templates<'e, E>(
         &self,
+        executor: E,
         org_id: Option<Uuid>,
         sensor_type: Option<&str>,
-    ) -> Result<Vec<SensorThresholdTemplate>, sqlx::Error> {
+    ) -> Result<Vec<SensorThresholdTemplate>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM sensor_threshold_templates
@@ -417,7 +510,7 @@ impl SensorRepository {
         )
         .bind(org_id)
         .bind(sensor_type)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -426,7 +519,14 @@ impl SensorRepository {
     // ========================================================================
 
     /// Create an alert.
-    pub async fn create_alert(&self, data: CreateSensorAlert) -> Result<SensorAlert, sqlx::Error> {
+    pub async fn create_alert<'e, E>(
+        &self,
+        executor: E,
+        data: CreateSensorAlert,
+    ) -> Result<SensorAlert, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO sensor_alerts
@@ -441,16 +541,20 @@ impl SensorRepository {
         .bind(data.triggered_value)
         .bind(data.threshold_value)
         .bind(data.message)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// List alerts with filters.
-    pub async fn list_alerts(
+    pub async fn list_alerts<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: AlertQuery,
-    ) -> Result<Vec<SensorAlert>, sqlx::Error> {
+    ) -> Result<Vec<SensorAlert>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50);
         let offset = query.offset.unwrap_or(0);
 
@@ -480,17 +584,21 @@ impl SensorRepository {
         .bind(query.to_time)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Resolve an alert.
     /// resolved_value is optional - if None, only resolved_at is set.
-    pub async fn resolve_alert(
+    pub async fn resolve_alert<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         resolved_value: Option<f64>,
-    ) -> Result<SensorAlert, sqlx::Error> {
+    ) -> Result<SensorAlert, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE sensor_alerts SET
@@ -502,16 +610,20 @@ impl SensorRepository {
         )
         .bind(id)
         .bind(resolved_value)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Acknowledge an alert.
-    pub async fn acknowledge_alert(
+    pub async fn acknowledge_alert<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         user_id: Uuid,
-    ) -> Result<SensorAlert, sqlx::Error> {
+    ) -> Result<SensorAlert, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE sensor_alerts SET
@@ -523,12 +635,19 @@ impl SensorRepository {
         )
         .bind(id)
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Count unresolved alerts.
-    pub async fn count_unresolved_alerts(&self, org_id: Uuid) -> Result<i64, sqlx::Error> {
+    pub async fn count_unresolved_alerts<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+    ) -> Result<i64, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result: (i64,) = sqlx::query_as(
             r#"
             SELECT COUNT(*) FROM sensor_alerts a
@@ -537,7 +656,7 @@ impl SensorRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await?;
         Ok(result.0)
     }
@@ -547,10 +666,14 @@ impl SensorRepository {
     // ========================================================================
 
     /// Create a sensor-fault correlation.
-    pub async fn create_correlation(
+    pub async fn create_correlation<'e, E>(
         &self,
+        executor: E,
         data: CreateSensorFaultCorrelation,
-    ) -> Result<SensorFaultCorrelation, sqlx::Error> {
+    ) -> Result<SensorFaultCorrelation, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO sensor_fault_correlations
@@ -571,46 +694,61 @@ impl SensorRepository {
         .bind(data.sensor_data_end)
         .bind(data.summary)
         .bind(data.created_by)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get correlations for a fault.
-    pub async fn list_correlations_for_fault(
+    pub async fn list_correlations_for_fault<'e, E>(
         &self,
+        executor: E,
         fault_id: Uuid,
-    ) -> Result<Vec<SensorFaultCorrelation>, sqlx::Error> {
+    ) -> Result<Vec<SensorFaultCorrelation>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as("SELECT * FROM sensor_fault_correlations WHERE fault_id = $1")
             .bind(fault_id)
-            .fetch_all(&self.pool)
+            .fetch_all(executor)
             .await
     }
 
     /// Get correlations for a sensor.
-    pub async fn list_correlations_for_sensor(
+    pub async fn list_correlations_for_sensor<'e, E>(
         &self,
+        executor: E,
         sensor_id: Uuid,
-    ) -> Result<Vec<SensorFaultCorrelation>, sqlx::Error> {
+    ) -> Result<Vec<SensorFaultCorrelation>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as("SELECT * FROM sensor_fault_correlations WHERE sensor_id = $1")
             .bind(sensor_id)
-            .fetch_all(&self.pool)
+            .fetch_all(executor)
             .await
     }
 
     /// Delete a correlation.
-    pub async fn delete_correlation(&self, id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete_correlation<'e, E>(&self, executor: E, id: Uuid) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM sensor_fault_correlations WHERE id = $1")
             .bind(id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
 
     /// Get sensors near a location (for auto-correlation).
-    pub async fn get_sensors_for_building(
+    pub async fn get_sensors_for_building<'e, E>(
         &self,
+        executor: E,
         building_id: Uuid,
-    ) -> Result<Vec<Sensor>, sqlx::Error> {
+    ) -> Result<Vec<Sensor>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM sensors
@@ -619,13 +757,17 @@ impl SensorRepository {
             "#,
         )
         .bind(building_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Create batch readings using efficient bulk insert.
+    ///
+    /// Multi-statement (bulk INSERT + UPDATE parent sensor), so it takes a
+    /// connection and reborrows it for each query.
     pub async fn create_batch_readings(
         &self,
+        conn: &mut PgConnection,
         sensor_id: Uuid,
         readings: Vec<crate::models::SingleReading>,
     ) -> Result<i64, sqlx::Error> {
@@ -666,22 +808,26 @@ impl SensorRepository {
                 .bind(reading.timestamp);
         }
 
-        query_builder.execute(&self.pool).await?;
+        query_builder.execute(&mut *conn).await?;
 
         // Update sensor status
         sqlx::query(
             "UPDATE sensors SET last_reading_at = NOW(), last_seen_at = NOW(), status = 'active' WHERE id = $1",
         )
         .bind(sensor_id)
-        .execute(&self.pool)
+        .execute(&mut *conn)
         .await?;
 
         Ok(count)
     }
 
     /// Apply threshold template to a sensor.
+    ///
+    /// Multi-statement (SELECT template + upsert threshold), so it takes a
+    /// connection and reborrows it for each query.
     pub async fn apply_threshold_template(
         &self,
+        conn: &mut PgConnection,
         template_id: Uuid,
         sensor_id: Uuid,
     ) -> Result<SensorThreshold, sqlx::Error> {
@@ -689,7 +835,7 @@ impl SensorRepository {
         let template: SensorThresholdTemplate =
             sqlx::query_as("SELECT * FROM sensor_threshold_templates WHERE id = $1")
                 .bind(template_id)
-                .fetch_one(&self.pool)
+                .fetch_one(&mut *conn)
                 .await?;
 
         // Create threshold from template
@@ -715,13 +861,17 @@ impl SensorRepository {
         .bind(template.warning_high)
         .bind(template.critical_value)
         .bind(template.critical_high)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
     }
 
     /// Get dashboard data for an organization.
+    ///
+    /// Multi-statement (six aggregate reads), so it takes a connection and
+    /// reborrows it for each query.
     pub async fn get_dashboard(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         building_id: Option<Uuid>,
     ) -> Result<crate::models::SensorDashboard, sqlx::Error> {
@@ -731,7 +881,7 @@ impl SensorRepository {
         )
         .bind(org_id)
         .bind(building_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         let (active,): (i64,) = sqlx::query_as(
@@ -739,7 +889,7 @@ impl SensorRepository {
         )
         .bind(org_id)
         .bind(building_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         let (offline,): (i64,) = sqlx::query_as(
@@ -747,7 +897,7 @@ impl SensorRepository {
         )
         .bind(org_id)
         .bind(building_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         // Count unresolved alerts
@@ -761,7 +911,7 @@ impl SensorRepository {
         )
         .bind(org_id)
         .bind(building_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         // Get sensors by type
@@ -776,7 +926,7 @@ impl SensorRepository {
         )
         .bind(org_id)
         .bind(building_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await?;
 
         // Get recent alerts
@@ -791,7 +941,7 @@ impl SensorRepository {
         )
         .bind(org_id)
         .bind(building_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await?;
 
         Ok(crate::models::SensorDashboard {

--- a/backend/crates/db/tests/reserve_funds_rls_repo_tests.rs
+++ b/backend/crates/db/tests/reserve_funds_rls_repo_tests.rs
@@ -1,0 +1,287 @@
+//! Repo-level behavioral RLS regression test for PAP-79 (PAP-67 cluster).
+//!
+//! Background
+//! ----------
+//! Migration `00179` (PAP-62) put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on the reserve-fund tables (`reserve_funds` and
+//! the rest of the Epic-141 cluster). The production api-server connects as the
+//! table OWNER, which `FORCE` binds. `ReserveFundRepository` held a raw `PgPool`
+//! and ran every query WITHOUT ever calling `set_request_context`, so on `dev`
+//! `get_current_org_id()` returned NULL and the policy collapsed to
+//! `organization_id = NULL` → **deny-all**: own-org reads returned empty, writes
+//! failed. (PAP-79.)
+//!
+//! The fix routes the repo through an RLS-context connection (the `RlsConnection`
+//! extractor in handlers sets the org/user GUCs before any query). This test
+//! exercises the *repository methods themselves* on a `FORCE`-bound role and
+//! proves:
+//!
+//!   1. **Deny-all reproduction** — with the role bound but NO context set
+//!      (exactly what the raw-pool repo did on `dev`), an own-org `get_fund` /
+//!      `list_funds` returns nothing. This is the "would have failed on dev"
+//!      evidence.
+//!   2. **Fix** — with `set_request_context(org_a, user_a)` applied first (what
+//!      `RlsConnection` now does), the same repo calls return the own-org row.
+//!   3. **Cross-tenant** — org B's fund stays invisible to an org-A caller even
+//!      with context set.
+//!   4. **Write path** — a `create_fund` on a context-set connection succeeds and
+//!      the row is the caller's org. Without context the INSERT would fail the
+//!      policy `WITH CHECK`.
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — even `FORCE` does not bind a superuser, so a behavioral assertion
+//! would pass vacuously. The test creates a plain `NOSUPERUSER NOBYPASSRLS`
+//! role, grants it access, and `SET ROLE`s to it so `FORCE` actually enforces the
+//! policy the way the production owner role experiences it. Mirrors
+//! `work_order_rls_repo_tests.rs` (the PAP-67 precedent this follows).
+
+use db::models::reserve_funds::{CreateReserveFund, FundType};
+use db::repositories::ReserveFundRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("RF {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@rf.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'RF User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Seed a reserve fund directly (as superuser, RLS-exempt) for an org.
+async fn seed_fund(pool: &PgPool, org_id: Uuid, name: &str, user_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO reserve_funds
+            (organization_id, name, fund_type, current_balance, currency, created_by)
+        VALUES ($1, $2, 'reserve', 0, 'EUR', $3)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(name)
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed reserve fund")
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn reserve_fund_repo_force_rls_deny_all_and_fix(pool: PgPool) {
+    let repo = ReserveFundRepository::new(pool.clone());
+
+    // --- Seed as superuser / super-admin context (satisfies org roles-trigger). ---
+    set_ctx(&pool, None, None, true).await;
+    let org_a = seed_org(&pool, "force-rf-a").await;
+    let org_b = seed_org(&pool, "force-rf-b").await;
+    let user_a = seed_user(&pool, "a@rf.test").await;
+    let user_b = seed_user(&pool, "b@rf.test").await;
+    let fund_a = seed_fund(&pool, org_a, "Fund A", user_a).await;
+    let fund_b = seed_fund(&pool, org_b, "Fund B", user_b).await;
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    let role = format!("ppt_rls_rf_{}", Uuid::new_v4().simple());
+    for stmt in [
+        format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
+        format!("GRANT SELECT, INSERT, UPDATE, DELETE ON reserve_funds TO \"{role}\""),
+        // RLS policy helpers must be EXECUTE-able by the bound role; the
+        // soft-delete guard reads `organizations`.
+        format!(
+            "GRANT EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
+             get_current_org_not_deleted() TO \"{role}\""
+        ),
+        format!("GRANT SELECT ON organizations TO \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .expect("grant setup");
+    }
+
+    // ====================================================================
+    // (1) DENY-ALL reproduction: role bound, NO context set (the dev raw-pool
+    //     behavior). Own-org reads return nothing.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        // Explicitly clear any inherited context, then drop to the bound role.
+        sqlx::query("SELECT clear_request_context()")
+            .execute(&mut *conn)
+            .await
+            .expect("clear ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let found = repo
+            .get_fund(&mut *conn, org_a, fund_a)
+            .await
+            .expect("get_fund (no ctx)");
+        assert!(
+            found.is_none(),
+            "PAP-79 regression: without RLS context, own-org reserve fund must be \
+             invisible (deny-all) — this is what the raw-pool repo did on dev"
+        );
+
+        let listed = repo
+            .list_funds(&mut *conn, org_a, None, None, false)
+            .await
+            .expect("list_funds (no ctx)");
+        assert!(
+            listed.is_empty(),
+            "PAP-79 regression: without RLS context, list_funds returns deny-all empty"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (2) FIX + (3) cross-tenant: set context, drop to bound role, query repo.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        // (2) Own-org row IS now visible through the repo — the fix.
+        let found = repo
+            .get_fund(&mut *conn, org_a, fund_a)
+            .await
+            .expect("get_fund (ctx)");
+        assert_eq!(
+            found.map(|f| f.id),
+            Some(fund_a),
+            "PAP-79 fix: with RLS context set, the repo must return the own-org reserve fund"
+        );
+
+        let listed = repo
+            .list_funds(&mut *conn, org_a, None, None, false)
+            .await
+            .expect("list_funds (ctx)");
+        assert_eq!(
+            listed.iter().map(|f| f.id).collect::<Vec<_>>(),
+            vec![fund_a],
+            "PAP-79 fix: list_funds returns exactly the own-org fund under context"
+        );
+
+        // (3) Org B's fund stays invisible to an org-A caller.
+        let cross = repo
+            .get_fund(&mut *conn, org_a, fund_b)
+            .await
+            .expect("get_fund cross");
+        assert!(
+            cross.is_none(),
+            "cross-tenant: org B's reserve fund must NOT be visible to an org-A caller"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (4) WRITE path: a create on a context-set connection succeeds and the
+    //     row is the caller's org. Without context the INSERT would fail the
+    //     policy WITH CHECK (the write-side of deny-all).
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let created = repo
+            .create_fund(
+                &mut *conn,
+                org_a,
+                CreateReserveFund {
+                    building_id: None,
+                    name: "Created under RLS".to_string(),
+                    description: None,
+                    fund_type: FundType::Reserve,
+                    target_balance: None,
+                    minimum_balance: None,
+                    currency: None,
+                },
+                user_a,
+            )
+            .await
+            .expect("create_fund under context must succeed");
+        assert_eq!(created.organization_id, org_a);
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup the test role. ---
+    set_ctx(&pool, None, None, true).await;
+    let _ = user_b; // seeded for symmetry with org_b's fund
+    for stmt in [
+        format!("REVOKE ALL ON reserve_funds FROM \"{role}\""),
+        format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .ok();
+    }
+}

--- a/backend/crates/db/tests/sensor_rls_repo_tests.rs
+++ b/backend/crates/db/tests/sensor_rls_repo_tests.rs
@@ -1,0 +1,252 @@
+//! Repo-level behavioral test for the IoT sensor RLS routing (PAP-67 / PAP-78).
+//!
+//! Background
+//! ----------
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on every sensor table. Under `FORCE` the
+//! api-server's owner connection is no longer exempt, so a query issued on a
+//! connection WITHOUT `app.current_org_id` set collapses to deny-all. The
+//! `SensorRepository` was reworked to hold no pool and to take an
+//! RLS-context-bearing executor on every method (supplied by `RlsConnection`
+//! in handlers). This test exercises that contract directly against the repo.
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — even `FORCE` does not bind a superuser. To exercise the policy
+//! the way the production owner role does, the test creates a plain
+//! `NOSUPERUSER NOBYPASSRLS` role, grants it table access, and `SET ROLE`s to
+//! it. `FORCE` binds that role, so the org-scoped policy is enforced. The org
+//! context (`app.current_org_id`) is a session GUC and survives `SET ROLE`.
+
+use db::repositories::SensorRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Set the request context (mirrors `db::tenant_context::set_request_context`).
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Sensors {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@sensors.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'Sensors User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_building(pool: &PgPool, org_id: Uuid, street: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO buildings (organization_id, street, city, postal_code)
+        VALUES ($1, $2, 'Bratislava', '81101')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(street)
+    .fetch_one(pool)
+    .await
+    .expect("seed building")
+}
+
+async fn seed_sensor(pool: &PgPool, org_id: Uuid, building_id: Uuid, created_by: Uuid, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO sensors (organization_id, building_id, name, sensor_type, created_by)
+        VALUES ($1, $2, $3, 'temperature', $4)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(building_id)
+    .bind(name)
+    .bind(created_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed sensor")
+}
+
+/// FORCE RLS on `sensors` must:
+///   1. deny ALL reads on a connection that has NO org context set
+///      (the deny-all regression that 00179's FORCE introduces for any code
+///      path that forgot to route through `RlsConnection`); and
+///   2. expose the caller's OWN org's sensor while hiding another org's sensor
+///      once the org context IS set.
+///
+/// Both assertions go through `SensorRepository::find_by_id` — the exact repo
+/// method the IoT handlers call — so this is a behavioral test of the RLS
+/// routing, not just of the raw SQL policy.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn sensors_force_rls_requires_context_and_blocks_cross_tenant(pool: PgPool) {
+    // --- Seed as superuser (super-admin context satisfies the roles-trigger
+    //     RLS WITH CHECK fired by INSERT INTO organizations). ---
+    set_ctx(&pool, None, None, true).await;
+
+    let org_a = seed_org(&pool, "force-a").await;
+    let org_b = seed_org(&pool, "force-b").await;
+    let user_a = seed_user(&pool, "a@sensors.test").await;
+    let user_b = seed_user(&pool, "b@sensors.test").await;
+    let bldg_a = seed_building(&pool, org_a, "1 Alpha St").await;
+    let bldg_b = seed_building(&pool, org_b, "1 Bravo St").await;
+
+    let sensor_a = seed_sensor(&pool, org_a, bldg_a, user_a, "alpha-temp").await;
+    let sensor_b = seed_sensor(&pool, org_b, bldg_b, user_b, "bravo-temp").await;
+
+    let repo = SensorRepository::new(pool.clone());
+
+    // --- Create a NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    // Random suffix keeps the role name unique across parallel test DBs.
+    let role = format!("ppt_rls_test_{}", Uuid::new_v4().simple());
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"
+    )))
+    .execute(&pool)
+    .await
+    .expect("create role");
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT SELECT ON sensors TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant select on sensors");
+    // The policy calls helper functions (get_current_org_id, is_super_admin,
+    // get_current_org_not_deleted); the role must be able to EXECUTE them.
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
+         get_current_org_not_deleted() TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant execute on rls helpers");
+    // `get_current_org_not_deleted()` is SECURITY INVOKER; its body runs
+    // `SELECT 1 FROM organizations` with the CALLER's privileges, so the bound
+    // role must be able to read `organizations` or the soft-delete guard raises
+    // `permission denied for table organizations`. `organizations` has no RLS
+    // of its own, so a plain table-level SELECT grant is sufficient.
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT SELECT ON organizations TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant select on organizations");
+
+    // --- All role-bound work runs on ONE dedicated connection. `SET ROLE` and
+    //     the org-context GUC are session state, so they must not be spread
+    //     across pool acquisitions. ---
+    {
+        let mut conn = pool.acquire().await.expect("acquire connection");
+
+        // ---- Phase 1: NO org context → deny-all under FORCE. ----
+        // This is the deny-all regression a raw-pool repo would hit: without
+        // `app.current_org_id`, even the OWN-org row is invisible.
+        sqlx::query("SELECT set_request_context(NULL, NULL, false)")
+            .execute(&mut *conn)
+            .await
+            .expect("clear org context");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let no_ctx = repo
+            .find_by_id(&mut *conn, sensor_a)
+            .await
+            .expect("find_by_id (no context)");
+        assert!(
+            no_ctx.is_none(),
+            "without org context a FORCE-RLS sensor read must return None (deny-all)"
+        );
+
+        // ---- Phase 2: org-A context → own visible, cross-tenant hidden. ----
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role before re-setting context");
+        sqlx::query("SELECT set_request_context($1, $2, false)")
+            .bind(org_a)
+            .bind(user_a)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A context");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let own = repo
+            .find_by_id(&mut *conn, sensor_a)
+            .await
+            .expect("find_by_id (org-A own)");
+        assert_eq!(
+            own.map(|s| s.id),
+            Some(sensor_a),
+            "org A's own sensor must be visible under its own context"
+        );
+
+        let cross = repo
+            .find_by_id(&mut *conn, sensor_b)
+            .await
+            .expect("find_by_id (org-B cross-tenant)");
+        assert!(
+            cross.is_none(),
+            "org B's sensor must NOT be visible to an org-A caller (cross-tenant IDOR)"
+        );
+
+        // Drop back to superuser on this connection before it returns to the pool.
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup the test role. ---
+    set_ctx(&pool, None, None, true).await;
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "REVOKE ALL ON sensors FROM \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .ok();
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "REVOKE ALL ON organizations FROM \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .ok();
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "DROP ROLE IF EXISTS \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .ok();
+}

--- a/backend/scripts/rls-pool-field-baseline.txt
+++ b/backend/scripts/rls-pool-field-baseline.txt
@@ -12,13 +12,11 @@
 # One basename per line. Comments after '#'.
 
 # --- PAP-67 original offender set, conversion still pending ---
-work_order.rs        # PAP-67 (no child issue yet; PAP-80 umbrella)
-budget.rs            # PAP-67 (no child issue yet; PAP-80 umbrella)
+work_order.rs        # PAP-67 (PAP-151 child: full executor conversion + route migration)
+budget.rs            # PAP-67 (PAP-151 child: dual-API cleanup, drop pool field + deprecated wrappers)
 esg_reporting.rs     # PAP-72 (blocked on PAP-139)
 form.rs              # PAP-76
 workflow.rs          # PAP-77
-sensor.rs            # PAP-78 marked done but conversion never landed on dev
-reserve_funds.rs     # PAP-79 marked done but conversion never landed on dev
 
 # --- PAP-80 sweep: conversion PRs in flight ---
 ai_chat.rs           # PR #1232 (PAP-144/PAP-145)

--- a/backend/servers/api-server/src/routes/iot.rs
+++ b/backend/servers/api-server/src/routes/iot.rs
@@ -1,9 +1,25 @@
 //! IoT routes (Epic 14: IoT & Smart Building).
 //!
 //! Handles sensor registration, data ingestion, dashboards, alerts, and correlations.
+//!
+//! # RLS (PAP-67)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` on every sensor table
+//! (`sensors`, `sensor_readings`, `sensor_alerts`, `sensor_thresholds`,
+//! `sensor_threshold_templates`, `sensor_fault_correlations`), so every query
+//! MUST run on a connection that has `app.current_org_id` set or it collapses to
+//! deny-all. Each handler therefore acquires an [`RlsConnection`] (which
+//! validates tenant membership and sets the org/user GUCs on a dedicated
+//! connection) and passes `&mut **rls.conn()` to the repository. The
+//! authoritative organization is `rls.tenant_id()` — the tenant the caller was
+//! validated against — not a client-supplied `organization_id`, so the SQL org
+//! filter and the RLS context can never disagree. Cross-tenant access is blocked
+//! by RLS: a by-id read of another org's row returns no row (`404`), and a write
+//! targeting another org fails the policy's `WITH CHECK`. `rls.release()` clears
+//! the context before the connection returns to the pool.
 
 use crate::state::AppState;
-use api_core::extractors::principal::RequestPrincipal;
+use api_core::extractors::RlsConnection;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -21,33 +37,38 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 // ============================================================================
-// Helper Functions
+// Error Helpers
 // ============================================================================
-//
-// SECURITY: The previous `extract_tenant_context` helper deserialized the
-// client-supplied `X-Tenant-Context` JSON header directly into a
-// `TenantContext`. No JWT verification — any unauthenticated caller could
-// forge tenancy. That helper has been deleted; every handler now goes
-// through `RequestPrincipal` (verified bearer JWT + host-resolved tenant).
 
-/// Resolve the effective tenant id from a verified [`RequestPrincipal`].
-///
-/// IoT endpoints are per-tenant by definition (sensor inventory, alerts,
-/// dashboards). A platform-kind principal hitting the platform host has no
-/// `effective_org` — for those callers we refuse with 403 rather than fall
-/// back to a wildcard.
-fn require_tenant_id(
-    principal: &RequestPrincipal,
-) -> Result<Uuid, (StatusCode, Json<ErrorResponse>)> {
-    principal.effective_org.ok_or_else(|| {
-        (
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse::new(
-                "TENANT_REQUIRED",
-                "IoT endpoints require a tenant-resolved request",
-            )),
-        )
-    })
+/// Map a repository error to a `500` with a stable code, logging the cause.
+fn db_error(msg: &'static str, e: sqlx::Error) -> (StatusCode, Json<ErrorResponse>) {
+    tracing::error!("{}: {:?}", msg, e);
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse::new("INTERNAL_ERROR", msg)),
+    )
+}
+
+/// Build a `404` response.
+fn not_found(msg: &'static str) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::NOT_FOUND,
+        Json(ErrorResponse::new("NOT_FOUND", msg)),
+    )
+}
+
+/// Map a `fetch_one` error from a by-id write to either `404` (the row is not
+/// visible under the caller's RLS context — cross-tenant or genuinely missing)
+/// or `500` for any other database failure.
+fn write_error(
+    msg: &'static str,
+    not_found_msg: &'static str,
+    e: sqlx::Error,
+) -> (StatusCode, Json<ErrorResponse>) {
+    match e {
+        sqlx::Error::RowNotFound => not_found(not_found_msg),
+        other => db_error(msg, other),
+    }
 }
 
 // ============================================================================
@@ -115,23 +136,20 @@ pub fn sensor_router() -> Router<AppState> {
 )]
 async fn create_sensor(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
-    Json(req): Json<CreateSensor>,
+    mut rls: RlsConnection,
+    Json(mut req): Json<CreateSensor>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-    match state.sensor_repo.create(req).await {
-        Ok(sensor) => Ok((StatusCode::CREATED, Json(serde_json::json!(sensor)))),
-        Err(e) => {
-            tracing::error!("Failed to create sensor: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to create sensor",
-                )),
-            ))
-        }
-    }
+    // Pin the new sensor to the caller's validated org so the INSERT's
+    // organization_id and the RLS WITH CHECK can never disagree.
+    req.organization_id = rls.tenant_id();
+    let out = state
+        .sensor_repo
+        .create(&mut **rls.conn(), req)
+        .await
+        .map(|sensor| (StatusCode::CREATED, Json(serde_json::json!(sensor))))
+        .map_err(|e| db_error("Failed to create sensor", e));
+    rls.release().await;
+    out
 }
 
 #[utoipa::path(
@@ -146,93 +164,73 @@ async fn create_sensor(
 )]
 async fn list_sensors(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Query(query): Query<SensorQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
-
-    match state.sensor_repo.list(tenant_id, query).await {
-        Ok(sensors) => Ok(Json(serde_json::json!({ "sensors": sensors }))),
-        Err(e) => {
-            tracing::error!("Failed to list sensors: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to list sensors",
-                )),
-            ))
-        }
-    }
+    let org_id = rls.tenant_id();
+    let out = state
+        .sensor_repo
+        .list(&mut **rls.conn(), org_id, query)
+        .await
+        .map(|sensors| Json(serde_json::json!({ "sensors": sensors })))
+        .map_err(|e| db_error("Failed to list sensors", e));
+    rls.release().await;
+    out
 }
 
 async fn get_sensor(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-    match state.sensor_repo.find_by_id(id).await {
-        Ok(Some(sensor)) => Ok(Json(serde_json::json!(sensor))),
-        Ok(None) => Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Sensor not found")),
-        )),
-        Err(e) => {
-            tracing::error!("Failed to get sensor: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get sensor")),
-            ))
-        }
-    }
+    let out = state
+        .sensor_repo
+        .find_by_id(&mut **rls.conn(), id)
+        .await
+        .map_err(|e| db_error("Failed to get sensor", e))
+        .and_then(|maybe| match maybe {
+            Some(sensor) => Ok(Json(serde_json::json!(sensor))),
+            None => Err(not_found("Sensor not found")),
+        });
+    rls.release().await;
+    out
 }
 
 async fn update_sensor(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateSensor>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-    match state.sensor_repo.update(id, req).await {
-        Ok(sensor) => Ok(Json(serde_json::json!(sensor))),
-        Err(e) => {
-            tracing::error!("Failed to update sensor: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to update sensor",
-                )),
-            ))
-        }
-    }
+    let out = state
+        .sensor_repo
+        .update(&mut **rls.conn(), id, req)
+        .await
+        .map(|sensor| Json(serde_json::json!(sensor)))
+        .map_err(|e| write_error("Failed to update sensor", "Sensor not found", e));
+    rls.release().await;
+    out
 }
 
 async fn delete_sensor(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-    match state.sensor_repo.delete(id).await {
-        Ok(true) => Ok(StatusCode::NO_CONTENT),
-        Ok(false) => Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Sensor not found")),
-        )),
-        Err(e) => {
-            tracing::error!("Failed to delete sensor: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to delete sensor",
-                )),
-            ))
-        }
-    }
+    let out = state
+        .sensor_repo
+        .delete(&mut **rls.conn(), id)
+        .await
+        .map_err(|e| db_error("Failed to delete sensor", e))
+        .and_then(|deleted| {
+            if deleted {
+                Ok(StatusCode::NO_CONTENT)
+            } else {
+                Err(not_found("Sensor not found"))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -241,86 +239,59 @@ async fn delete_sensor(
 
 async fn list_readings(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Query(query): Query<ReadingQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-    match state.sensor_repo.list_readings(id, query).await {
-        Ok(readings) => Ok(Json(serde_json::json!({ "readings": readings }))),
-        Err(e) => {
-            tracing::error!("Failed to list readings: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to list readings",
-                )),
-            ))
-        }
-    }
+    let out = state
+        .sensor_repo
+        .list_readings(&mut **rls.conn(), id, query)
+        .await
+        .map(|readings| Json(serde_json::json!({ "readings": readings })))
+        .map_err(|e| db_error("Failed to list readings", e));
+    rls.release().await;
+    out
 }
 
 async fn add_reading(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(mut req): Json<CreateSensorReading>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
     req.sensor_id = id;
-
-    match state.sensor_repo.create_reading(req).await {
-        Ok(reading) => Ok((StatusCode::CREATED, Json(serde_json::json!(reading)))),
-        Err(e) => {
-            tracing::error!("Failed to add reading: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to add reading",
-                )),
-            ))
-        }
-    }
+    let out = state
+        .sensor_repo
+        .create_reading(&mut **rls.conn(), req)
+        .await
+        .map(|reading| (StatusCode::CREATED, Json(serde_json::json!(reading))))
+        .map_err(|e| db_error("Failed to add reading", e));
+    rls.release().await;
+    out
 }
 
 async fn add_batch_readings(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<BatchSensorReadings>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-    match state
+    let out = state
         .sensor_repo
-        .create_batch_readings(id, req.readings)
+        .create_batch_readings(&mut **rls.conn(), id, req.readings)
         .await
-    {
-        Ok(count) => Ok((
-            StatusCode::CREATED,
-            Json(serde_json::json!({ "inserted": count })),
-        )),
-        Err(e) => {
-            tracing::error!("Failed to add batch readings: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to add batch readings",
-                )),
-            ))
-        }
-    }
+        .map(|count| (StatusCode::CREATED, Json(serde_json::json!({ "inserted": count }))))
+        .map_err(|e| db_error("Failed to add batch readings", e));
+    rls.release().await;
+    out
 }
 
 async fn get_aggregated_readings(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Query(query): Query<ReadingQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
     let aggregation = query
         .aggregation
         .clone()
@@ -330,23 +301,14 @@ async fn get_aggregated_readings(
         .unwrap_or_else(|| chrono::Utc::now() - chrono::Duration::hours(24));
     let to = query.to_time.unwrap_or_else(chrono::Utc::now);
 
-    match state
+    let out = state
         .sensor_repo
-        .list_aggregated_readings(id, from, to, &aggregation)
+        .list_aggregated_readings(&mut **rls.conn(), id, from, to, &aggregation)
         .await
-    {
-        Ok(readings) => Ok(Json(serde_json::json!({ "aggregated_readings": readings }))),
-        Err(e) => {
-            tracing::error!("Failed to get aggregated readings: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to get aggregated readings",
-                )),
-            ))
-        }
-    }
+        .map(|readings| Json(serde_json::json!({ "aggregated_readings": readings })))
+        .map_err(|e| db_error("Failed to get aggregated readings", e));
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -355,94 +317,71 @@ async fn get_aggregated_readings(
 
 async fn list_thresholds(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-    match state.sensor_repo.list_thresholds(id).await {
-        Ok(thresholds) => Ok(Json(serde_json::json!({ "thresholds": thresholds }))),
-        Err(e) => {
-            tracing::error!("Failed to list thresholds: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to list thresholds",
-                )),
-            ))
-        }
-    }
+    let out = state
+        .sensor_repo
+        .list_thresholds(&mut **rls.conn(), id)
+        .await
+        .map(|thresholds| Json(serde_json::json!({ "thresholds": thresholds })))
+        .map_err(|e| db_error("Failed to list thresholds", e));
+    rls.release().await;
+    out
 }
 
 async fn create_threshold(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(mut req): Json<CreateSensorThreshold>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
     req.sensor_id = id;
-
-    match state.sensor_repo.create_threshold(req).await {
-        Ok(threshold) => Ok((StatusCode::CREATED, Json(serde_json::json!(threshold)))),
-        Err(e) => {
-            tracing::error!("Failed to create threshold: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to create threshold",
-                )),
-            ))
-        }
-    }
+    let out = state
+        .sensor_repo
+        .create_threshold(&mut **rls.conn(), req)
+        .await
+        .map(|threshold| (StatusCode::CREATED, Json(serde_json::json!(threshold))))
+        .map_err(|e| db_error("Failed to create threshold", e));
+    rls.release().await;
+    out
 }
 
 async fn update_threshold(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(threshold_id): Path<Uuid>,
     Json(req): Json<UpdateSensorThreshold>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-    match state.sensor_repo.update_threshold(threshold_id, req).await {
-        Ok(threshold) => Ok(Json(serde_json::json!(threshold))),
-        Err(e) => {
-            tracing::error!("Failed to update threshold: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to update threshold",
-                )),
-            ))
-        }
-    }
+    let out = state
+        .sensor_repo
+        .update_threshold(&mut **rls.conn(), threshold_id, req)
+        .await
+        .map(|threshold| Json(serde_json::json!(threshold)))
+        .map_err(|e| write_error("Failed to update threshold", "Threshold not found", e));
+    rls.release().await;
+    out
 }
 
 async fn delete_threshold(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(threshold_id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-    match state.sensor_repo.delete_threshold(threshold_id).await {
-        Ok(true) => Ok(StatusCode::NO_CONTENT),
-        Ok(false) => Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Threshold not found")),
-        )),
-        Err(e) => {
-            tracing::error!("Failed to delete threshold: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to delete threshold",
-                )),
-            ))
-        }
-    }
+    let out = state
+        .sensor_repo
+        .delete_threshold(&mut **rls.conn(), threshold_id)
+        .await
+        .map_err(|e| db_error("Failed to delete threshold", e))
+        .and_then(|deleted| {
+            if deleted {
+                Ok(StatusCode::NO_CONTENT)
+            } else {
+                Err(not_found("Threshold not found"))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -451,52 +390,36 @@ async fn delete_threshold(
 
 async fn list_sensor_alerts(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Query(mut query): Query<AlertQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
+    let org_id = rls.tenant_id();
     query.sensor_id = Some(id);
-
-    match state.sensor_repo.list_alerts(tenant_id, query).await {
-        Ok(alerts) => Ok(Json(serde_json::json!({ "alerts": alerts }))),
-        Err(e) => {
-            tracing::error!("Failed to list alerts: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to list alerts",
-                )),
-            ))
-        }
-    }
+    let out = state
+        .sensor_repo
+        .list_alerts(&mut **rls.conn(), org_id, query)
+        .await
+        .map(|alerts| Json(serde_json::json!({ "alerts": alerts })))
+        .map_err(|e| db_error("Failed to list alerts", e));
+    rls.release().await;
+    out
 }
 
 async fn acknowledge_alert(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(alert_id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-
-    match state
+    let user_id = rls.user_id();
+    let out = state
         .sensor_repo
-        .acknowledge_alert(alert_id, principal.user_id)
+        .acknowledge_alert(&mut **rls.conn(), alert_id, user_id)
         .await
-    {
-        Ok(alert) => Ok(Json(serde_json::json!(alert))),
-        Err(e) => {
-            tracing::error!("Failed to acknowledge alert: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to acknowledge alert",
-                )),
-            ))
-        }
-    }
+        .map(|alert| Json(serde_json::json!(alert)))
+        .map_err(|e| write_error("Failed to acknowledge alert", "Alert not found", e));
+    rls.release().await;
+    out
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -506,29 +429,19 @@ pub struct ResolveAlertRequest {
 
 async fn resolve_alert(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(alert_id): Path<Uuid>,
     Json(req): Json<ResolveAlertRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
     // Pass resolved_value as Option - NULL is valid when value wasn't captured
-    match state
+    let out = state
         .sensor_repo
-        .resolve_alert(alert_id, req.resolved_value)
+        .resolve_alert(&mut **rls.conn(), alert_id, req.resolved_value)
         .await
-    {
-        Ok(alert) => Ok(Json(serde_json::json!(alert))),
-        Err(e) => {
-            tracing::error!("Failed to resolve alert: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to resolve alert",
-                )),
-            ))
-        }
-    }
+        .map(|alert| Json(serde_json::json!(alert)))
+        .map_err(|e| write_error("Failed to resolve alert", "Alert not found", e));
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -537,73 +450,56 @@ async fn resolve_alert(
 
 async fn list_correlations(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-    match state.sensor_repo.list_correlations_for_sensor(id).await {
-        Ok(correlations) => Ok(Json(serde_json::json!({ "correlations": correlations }))),
-        Err(e) => {
-            tracing::error!("Failed to list correlations: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to list correlations",
-                )),
-            ))
-        }
-    }
+    let out = state
+        .sensor_repo
+        .list_correlations_for_sensor(&mut **rls.conn(), id)
+        .await
+        .map(|correlations| Json(serde_json::json!({ "correlations": correlations })))
+        .map_err(|e| db_error("Failed to list correlations", e));
+    rls.release().await;
+    out
 }
 
 async fn create_correlation(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(mut req): Json<CreateSensorFaultCorrelation>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
     req.sensor_id = id;
-    req.created_by = Some(principal.user_id);
-
-    match state.sensor_repo.create_correlation(req).await {
-        Ok(correlation) => Ok((StatusCode::CREATED, Json(serde_json::json!(correlation)))),
-        Err(e) => {
-            tracing::error!("Failed to create correlation: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to create correlation",
-                )),
-            ))
-        }
-    }
+    req.created_by = Some(rls.user_id());
+    let out = state
+        .sensor_repo
+        .create_correlation(&mut **rls.conn(), req)
+        .await
+        .map(|correlation| (StatusCode::CREATED, Json(serde_json::json!(correlation))))
+        .map_err(|e| db_error("Failed to create correlation", e));
+    rls.release().await;
+    out
 }
 
 async fn delete_correlation(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(correlation_id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-    match state.sensor_repo.delete_correlation(correlation_id).await {
-        Ok(true) => Ok(StatusCode::NO_CONTENT),
-        Ok(false) => Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Correlation not found")),
-        )),
-        Err(e) => {
-            tracing::error!("Failed to delete correlation: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to delete correlation",
-                )),
-            ))
-        }
-    }
+    let out = state
+        .sensor_repo
+        .delete_correlation(&mut **rls.conn(), correlation_id)
+        .await
+        .map_err(|e| db_error("Failed to delete correlation", e))
+        .and_then(|deleted| {
+            if deleted {
+                Ok(StatusCode::NO_CONTENT)
+            } else {
+                Err(not_found("Correlation not found"))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -612,28 +508,18 @@ async fn delete_correlation(
 
 async fn list_threshold_templates(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Query(query): Query<TemplateQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
-
-    match state
+    let org_id = rls.tenant_id();
+    let out = state
         .sensor_repo
-        .list_threshold_templates(Some(tenant_id), query.sensor_type.as_deref())
+        .list_threshold_templates(&mut **rls.conn(), Some(org_id), query.sensor_type.as_deref())
         .await
-    {
-        Ok(templates) => Ok(Json(serde_json::json!({ "templates": templates }))),
-        Err(e) => {
-            tracing::error!("Failed to list templates: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to list templates",
-                )),
-            ))
-        }
-    }
+        .map(|templates| Json(serde_json::json!({ "templates": templates })))
+        .map_err(|e| db_error("Failed to list templates", e));
+    rls.release().await;
+    out
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -643,28 +529,18 @@ pub struct TemplateQuery {
 
 async fn apply_template(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Path(template_id): Path<Uuid>,
     Json(req): Json<ApplyTemplateRequest>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
-    let _tenant_id = require_tenant_id(&principal)?;
-    match state
+    let out = state
         .sensor_repo
-        .apply_threshold_template(template_id, req.sensor_id)
+        .apply_threshold_template(&mut **rls.conn(), template_id, req.sensor_id)
         .await
-    {
-        Ok(threshold) => Ok((StatusCode::CREATED, Json(serde_json::json!(threshold)))),
-        Err(e) => {
-            tracing::error!("Failed to apply template: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to apply template",
-                )),
-            ))
-        }
-    }
+        .map(|threshold| (StatusCode::CREATED, Json(serde_json::json!(threshold))))
+        .map_err(|e| write_error("Failed to apply template", "Template not found", e));
+    rls.release().await;
+    out
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -678,28 +554,18 @@ pub struct ApplyTemplateRequest {
 
 async fn get_dashboard(
     State(state): State<AppState>,
-    principal: RequestPrincipal,
+    mut rls: RlsConnection,
     Query(query): Query<DashboardQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = require_tenant_id(&principal)?;
-
-    match state
+    let org_id = rls.tenant_id();
+    let out = state
         .sensor_repo
-        .get_dashboard(tenant_id, query.building_id)
+        .get_dashboard(&mut **rls.conn(), org_id, query.building_id)
         .await
-    {
-        Ok(dashboard) => Ok(Json(serde_json::json!(dashboard))),
-        Err(e) => {
-            tracing::error!("Failed to get dashboard: {}", e);
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to get dashboard",
-                )),
-            ))
-        }
-    }
+        .map(|dashboard| Json(serde_json::json!(dashboard)))
+        .map_err(|e| db_error("Failed to get dashboard", e));
+    rls.release().await;
+    out
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]

--- a/backend/servers/api-server/src/routes/reserve_funds.rs
+++ b/backend/servers/api-server/src/routes/reserve_funds.rs
@@ -8,7 +8,9 @@
 //! so every query MUST run on a connection that has `app.current_org_id` set or
 //! it collapses to deny-all. Each handler therefore acquires an [`RlsConnection`]
 //! (which validates tenant membership and sets the org/user GUCs on a dedicated
-//! connection) and passes `&mut **rls.conn()` to the repository. The
+//! connection) and passes that connection to the repository (`&mut **rls.conn()`
+//! to the generic-`Executor` methods, `rls.conn()` to the `&mut PgConnection`
+//! ones, which deref-coerce). The
 //! authoritative organization is `rls.tenant_id()` — the tenant the caller was
 //! validated against — not a client-supplied `organization_id`, so the SQL org
 //! filter and the RLS context can never disagree. Cross-tenant access is blocked
@@ -226,7 +228,7 @@ async fn get_dashboard(
     let org_id = rls.tenant_id();
     let out = state
         .reserve_fund_repo
-        .get_fund_dashboard(&mut **rls.conn(), org_id)
+        .get_fund_dashboard(rls.conn(), org_id)
         .await
         .map(Json)
         .map_err(|e| internal_error(&format!("Failed to get dashboard: {}", e)));
@@ -243,7 +245,7 @@ async fn get_fund_health(
     let org_id = rls.tenant_id();
     let out = state
         .reserve_fund_repo
-        .get_fund_health_report(&mut **rls.conn(), org_id, fund_id)
+        .get_fund_health_report(rls.conn(), org_id, fund_id)
         .await
         .map(Json)
         .map_err(|e| repo_error("get health report", "Fund not found", e));
@@ -266,7 +268,7 @@ async fn list_schedules(
     let out = state
         .reserve_fund_repo
         .list_contribution_schedules(
-            &mut **rls.conn(),
+            rls.conn(),
             org_id,
             fund_id,
             query.active_only.unwrap_or(false),
@@ -288,7 +290,7 @@ async fn create_schedule(
     let org_id = rls.tenant_id();
     let out = state
         .reserve_fund_repo
-        .create_contribution_schedule(&mut **rls.conn(), org_id, fund_id, req)
+        .create_contribution_schedule(rls.conn(), org_id, fund_id, req)
         .await
         .map(Json)
         .map_err(|e| repo_error("create schedule", "Fund not found", e));
@@ -349,7 +351,7 @@ async fn record_transaction(
     let user_id = rls.user_id();
     let out = state
         .reserve_fund_repo
-        .record_transaction(&mut **rls.conn(), org_id, fund_id, req, user_id)
+        .record_transaction(rls.conn(), org_id, fund_id, req, user_id)
         .await
         .map(Json)
         .map_err(|e| repo_error("record transaction", "Fund not found", e));
@@ -367,7 +369,7 @@ async fn transfer_funds(
     let user_id = rls.user_id();
     let out = state
         .reserve_fund_repo
-        .transfer_funds(&mut **rls.conn(), org_id, req, user_id)
+        .transfer_funds(rls.conn(), org_id, req, user_id)
         .await
         .map(Json)
         .map_err(|e| repo_error("transfer funds", "Fund not found", e));
@@ -388,7 +390,7 @@ async fn list_policies(
     let org_id = rls.tenant_id();
     let out = state
         .reserve_fund_repo
-        .list_investment_policies(&mut **rls.conn(), org_id, fund_id)
+        .list_investment_policies(rls.conn(), org_id, fund_id)
         .await
         .map(Json)
         .map_err(|e| repo_error("list policies", "Fund not found", e));
@@ -406,7 +408,7 @@ async fn create_policy(
     let org_id = rls.tenant_id();
     let out = state
         .reserve_fund_repo
-        .create_investment_policy(&mut **rls.conn(), org_id, fund_id, req)
+        .create_investment_policy(rls.conn(), org_id, fund_id, req)
         .await
         .map(Json)
         .map_err(|e| repo_error("create policy", "Fund not found", e));
@@ -423,7 +425,7 @@ async fn get_active_policy(
     let org_id = rls.tenant_id();
     let out = state
         .reserve_fund_repo
-        .get_active_investment_policy(&mut **rls.conn(), org_id, fund_id)
+        .get_active_investment_policy(rls.conn(), org_id, fund_id)
         .await
         .map(Json)
         .map_err(|e| repo_error("get active policy", "Fund not found", e));
@@ -445,7 +447,7 @@ async fn create_projection(
     let org_id = rls.tenant_id();
     let out = state
         .reserve_fund_repo
-        .create_projection(&mut **rls.conn(), org_id, fund_id, req)
+        .create_projection(rls.conn(), org_id, fund_id, req)
         .await
         .map(Json)
         .map_err(|e| repo_error("create projection", "Fund not found", e));
@@ -462,7 +464,7 @@ async fn get_current_projection(
     let org_id = rls.tenant_id();
     let out = state
         .reserve_fund_repo
-        .get_current_projection(&mut **rls.conn(), org_id, fund_id)
+        .get_current_projection(rls.conn(), org_id, fund_id)
         .await
         .map(Json)
         .map_err(|e| repo_error("get projection", "Fund not found", e));
@@ -479,7 +481,7 @@ async fn get_projection_items(
     let org_id = rls.tenant_id();
     let out = state
         .reserve_fund_repo
-        .get_projection_items(&mut **rls.conn(), org_id, projection_id)
+        .get_projection_items(rls.conn(), org_id, projection_id)
         .await
         .map(Json)
         .map_err(|e| repo_error("get projection items", "Projection not found", e));
@@ -497,7 +499,7 @@ async fn add_projection_items(
     let org_id = rls.tenant_id();
     let out = state
         .reserve_fund_repo
-        .add_projection_items(&mut **rls.conn(), org_id, projection_id, items)
+        .add_projection_items(rls.conn(), org_id, projection_id, items)
         .await
         .map(Json)
         .map_err(|e| repo_error("add projection items", "Projection not found", e));
@@ -518,7 +520,7 @@ async fn list_components(
     let org_id = rls.tenant_id();
     let out = state
         .reserve_fund_repo
-        .list_components(&mut **rls.conn(), org_id, fund_id)
+        .list_components(rls.conn(), org_id, fund_id)
         .await
         .map(Json)
         .map_err(|e| repo_error("list components", "Fund not found", e));
@@ -536,7 +538,7 @@ async fn create_component(
     let org_id = rls.tenant_id();
     let out = state
         .reserve_fund_repo
-        .create_component(&mut **rls.conn(), org_id, fund_id, req)
+        .create_component(rls.conn(), org_id, fund_id, req)
         .await
         .map(Json)
         .map_err(|e| repo_error("create component", "Fund not found", e));

--- a/backend/servers/api-server/src/routes/reserve_funds.rs
+++ b/backend/servers/api-server/src/routes/reserve_funds.rs
@@ -1,9 +1,24 @@
 //! Reserve Fund Management routes for Epic 141.
 //!
 //! REST API endpoints for HOA/Condo reserve fund management.
+//!
+//! # RLS (PAP-67 / PAP-79)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` on the reserve-fund cluster,
+//! so every query MUST run on a connection that has `app.current_org_id` set or
+//! it collapses to deny-all. Each handler therefore acquires an [`RlsConnection`]
+//! (which validates tenant membership and sets the org/user GUCs on a dedicated
+//! connection) and passes `&mut **rls.conn()` to the repository. The
+//! authoritative organization is `rls.tenant_id()` — the tenant the caller was
+//! validated against — not a client-supplied `organization_id`, so the SQL org
+//! filter and the RLS context can never disagree. Cross-tenant access is blocked
+//! by RLS: a by-id read of another org's row returns no row (`404`), and a write
+//! targeting another org fails the policy's `WITH CHECK`. `rls.release()` clears
+//! the context before the connection returns to the pool (both on the Ok and Err
+//! paths).
 
 use crate::state::AppState;
-use api_core::extractors::AuthUser;
+use api_core::extractors::RlsConnection;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -101,10 +116,6 @@ fn internal_error(msg: &str) -> (StatusCode, Json<ErrorResponse>) {
     )
 }
 
-fn forbidden_error(msg: &str) -> (StatusCode, Json<ErrorResponse>) {
-    (StatusCode::FORBIDDEN, Json(ErrorResponse::forbidden(msg)))
-}
-
 fn not_found_error(msg: &str) -> (StatusCode, Json<ErrorResponse>) {
     (StatusCode::NOT_FOUND, Json(ErrorResponse::not_found(msg)))
 }
@@ -134,121 +145,110 @@ fn repo_error(
 /// List reserve funds.
 async fn list_funds(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<FundListQuery>,
 ) -> ApiResult<Json<Vec<ReserveFund>>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let funds = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
         .list_funds(
+            &mut **rls.conn(),
             org_id,
             query.fund_type,
             query.building_id,
             query.active_only.unwrap_or(false),
         )
         .await
-        .map_err(|e| internal_error(&format!("Failed to list funds: {}", e)))?;
-
-    Ok(Json(funds))
+        .map(Json)
+        .map_err(|e| internal_error(&format!("Failed to list funds: {}", e)));
+    rls.release().await;
+    out
 }
 
 /// Create a reserve fund.
 async fn create_fund(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Json(req): Json<CreateReserveFund>,
 ) -> ApiResult<Json<ReserveFund>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let fund = state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .reserve_fund_repo
-        .create_fund(org_id, req, user.user_id)
+        .create_fund(&mut **rls.conn(), org_id, req, user_id)
         .await
-        .map_err(|e| internal_error(&format!("Failed to create fund: {}", e)))?;
-
-    Ok(Json(fund))
+        .map(Json)
+        .map_err(|e| internal_error(&format!("Failed to create fund: {}", e)));
+    rls.release().await;
+    out
 }
 
 /// Get a reserve fund by ID.
 async fn get_fund(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
 ) -> ApiResult<Json<ReserveFund>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let fund = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .get_fund(org_id, fund_id)
+        .get_fund(&mut **rls.conn(), org_id, fund_id)
         .await
-        .map_err(|e| internal_error(&format!("Failed to get fund: {}", e)))?
-        .ok_or_else(|| not_found_error("Fund not found"))?;
-
-    Ok(Json(fund))
+        .map_err(|e| internal_error(&format!("Failed to get fund: {}", e)))
+        .and_then(|f| f.map(Json).ok_or_else(|| not_found_error("Fund not found")));
+    rls.release().await;
+    out
 }
 
 /// Update a reserve fund.
 async fn update_fund(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
     Json(req): Json<UpdateReserveFund>,
 ) -> ApiResult<Json<ReserveFund>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let fund = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .update_fund(org_id, fund_id, req)
+        .update_fund(&mut **rls.conn(), org_id, fund_id, req)
         .await
-        .map_err(|e| repo_error("update fund", "Fund not found", e))?;
-
-    Ok(Json(fund))
+        .map(Json)
+        .map_err(|e| repo_error("update fund", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 /// Get fund dashboard.
 async fn get_dashboard(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
 ) -> ApiResult<Json<FundDashboard>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let dashboard = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .get_fund_dashboard(org_id)
+        .get_fund_dashboard(&mut **rls.conn(), org_id)
         .await
-        .map_err(|e| internal_error(&format!("Failed to get dashboard: {}", e)))?;
-
-    Ok(Json(dashboard))
+        .map(Json)
+        .map_err(|e| internal_error(&format!("Failed to get dashboard: {}", e)));
+    rls.release().await;
+    out
 }
 
 /// Get fund health report.
 async fn get_fund_health(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
 ) -> ApiResult<Json<FundHealthReport>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let report = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .get_fund_health_report(org_id, fund_id)
+        .get_fund_health_report(&mut **rls.conn(), org_id, fund_id)
         .await
-        .map_err(|e| repo_error("get health report", "Fund not found", e))?;
-
-    Ok(Json(report))
+        .map(Json)
+        .map_err(|e| repo_error("get health report", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -258,61 +258,60 @@ async fn get_fund_health(
 /// List contribution schedules.
 async fn list_schedules(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
     Query(query): Query<ActiveOnlyQuery>,
 ) -> ApiResult<Json<Vec<FundContributionSchedule>>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let schedules = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .list_contribution_schedules(org_id, fund_id, query.active_only.unwrap_or(false))
+        .list_contribution_schedules(
+            &mut **rls.conn(),
+            org_id,
+            fund_id,
+            query.active_only.unwrap_or(false),
+        )
         .await
-        .map_err(|e| repo_error("list schedules", "Fund not found", e))?;
-
-    Ok(Json(schedules))
+        .map(Json)
+        .map_err(|e| repo_error("list schedules", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 /// Create a contribution schedule.
 async fn create_schedule(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
     Json(req): Json<CreateContributionSchedule>,
 ) -> ApiResult<Json<FundContributionSchedule>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let schedule = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .create_contribution_schedule(org_id, fund_id, req)
+        .create_contribution_schedule(&mut **rls.conn(), org_id, fund_id, req)
         .await
-        .map_err(|e| repo_error("create schedule", "Fund not found", e))?;
-
-    Ok(Json(schedule))
+        .map(Json)
+        .map_err(|e| repo_error("create schedule", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 /// Update a contribution schedule.
 async fn update_schedule(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path((_fund_id, schedule_id)): Path<(Uuid, Uuid)>,
     Json(req): Json<UpdateContributionSchedule>,
 ) -> ApiResult<Json<FundContributionSchedule>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let schedule = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .update_contribution_schedule(org_id, schedule_id, req)
+        .update_contribution_schedule(&mut **rls.conn(), org_id, schedule_id, req)
         .await
-        .map_err(|e| repo_error("update schedule", "Schedule not found", e))?;
-
-    Ok(Json(schedule))
+        .map(Json)
+        .map_err(|e| repo_error("update schedule", "Schedule not found", e));
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -322,62 +321,58 @@ async fn update_schedule(
 /// List transactions.
 async fn list_transactions(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
     Query(mut query): Query<TransactionQuery>,
 ) -> ApiResult<Json<Vec<FundTransaction>>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
+    let org_id = rls.tenant_id();
     query.fund_id = Some(fund_id);
 
-    let transactions = state
+    let out = state
         .reserve_fund_repo
-        .list_transactions(org_id, query)
+        .list_transactions(&mut **rls.conn(), org_id, query)
         .await
-        .map_err(|e| internal_error(&format!("Failed to list transactions: {}", e)))?;
-
-    Ok(Json(transactions))
+        .map(Json)
+        .map_err(|e| internal_error(&format!("Failed to list transactions: {}", e)));
+    rls.release().await;
+    out
 }
 
 /// Record a transaction.
 async fn record_transaction(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
     Json(req): Json<RecordFundTransaction>,
 ) -> ApiResult<Json<FundTransaction>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let transaction = state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .reserve_fund_repo
-        .record_transaction(org_id, fund_id, req, user.user_id)
+        .record_transaction(&mut **rls.conn(), org_id, fund_id, req, user_id)
         .await
-        .map_err(|e| repo_error("record transaction", "Fund not found", e))?;
-
-    Ok(Json(transaction))
+        .map(Json)
+        .map_err(|e| repo_error("record transaction", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 /// Transfer funds between accounts.
 async fn transfer_funds(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Json(req): Json<FundTransferRequest>,
 ) -> ApiResult<Json<(FundTransaction, FundTransaction)>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let transactions = state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .reserve_fund_repo
-        .transfer_funds(org_id, req, user.user_id)
+        .transfer_funds(&mut **rls.conn(), org_id, req, user_id)
         .await
-        .map_err(|e| repo_error("transfer funds", "Fund not found", e))?;
-
-    Ok(Json(transactions))
+        .map(Json)
+        .map_err(|e| repo_error("transfer funds", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -387,59 +382,53 @@ async fn transfer_funds(
 /// List investment policies.
 async fn list_policies(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
 ) -> ApiResult<Json<Vec<FundInvestmentPolicy>>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let policies = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .list_investment_policies(org_id, fund_id)
+        .list_investment_policies(&mut **rls.conn(), org_id, fund_id)
         .await
-        .map_err(|e| repo_error("list policies", "Fund not found", e))?;
-
-    Ok(Json(policies))
+        .map(Json)
+        .map_err(|e| repo_error("list policies", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 /// Create an investment policy.
 async fn create_policy(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
     Json(req): Json<CreateInvestmentPolicy>,
 ) -> ApiResult<Json<FundInvestmentPolicy>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let policy = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .create_investment_policy(org_id, fund_id, req)
+        .create_investment_policy(&mut **rls.conn(), org_id, fund_id, req)
         .await
-        .map_err(|e| repo_error("create policy", "Fund not found", e))?;
-
-    Ok(Json(policy))
+        .map(Json)
+        .map_err(|e| repo_error("create policy", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 /// Get active investment policy.
 async fn get_active_policy(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
 ) -> ApiResult<Json<Option<FundInvestmentPolicy>>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let policy = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .get_active_investment_policy(org_id, fund_id)
+        .get_active_investment_policy(&mut **rls.conn(), org_id, fund_id)
         .await
-        .map_err(|e| repo_error("get active policy", "Fund not found", e))?;
-
-    Ok(Json(policy))
+        .map(Json)
+        .map_err(|e| repo_error("get active policy", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -449,79 +438,71 @@ async fn get_active_policy(
 /// Create a projection.
 async fn create_projection(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
     Json(req): Json<CreateFundProjection>,
 ) -> ApiResult<Json<FundProjection>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let projection = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .create_projection(org_id, fund_id, req)
+        .create_projection(&mut **rls.conn(), org_id, fund_id, req)
         .await
-        .map_err(|e| repo_error("create projection", "Fund not found", e))?;
-
-    Ok(Json(projection))
+        .map(Json)
+        .map_err(|e| repo_error("create projection", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 /// Get current projection.
 async fn get_current_projection(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
 ) -> ApiResult<Json<Option<FundProjection>>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let projection = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .get_current_projection(org_id, fund_id)
+        .get_current_projection(&mut **rls.conn(), org_id, fund_id)
         .await
-        .map_err(|e| repo_error("get projection", "Fund not found", e))?;
-
-    Ok(Json(projection))
+        .map(Json)
+        .map_err(|e| repo_error("get projection", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 /// Get projection items.
 async fn get_projection_items(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path((_fund_id, projection_id)): Path<(Uuid, Uuid)>,
 ) -> ApiResult<Json<Vec<FundProjectionItem>>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let items = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .get_projection_items(org_id, projection_id)
+        .get_projection_items(&mut **rls.conn(), org_id, projection_id)
         .await
-        .map_err(|e| repo_error("get projection items", "Projection not found", e))?;
-
-    Ok(Json(items))
+        .map(Json)
+        .map_err(|e| repo_error("get projection items", "Projection not found", e));
+    rls.release().await;
+    out
 }
 
 /// Add projection items.
 async fn add_projection_items(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path((_fund_id, projection_id)): Path<(Uuid, Uuid)>,
     Json(items): Json<Vec<CreateProjectionItem>>,
 ) -> ApiResult<Json<Vec<FundProjectionItem>>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let created = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .add_projection_items(org_id, projection_id, items)
+        .add_projection_items(&mut **rls.conn(), org_id, projection_id, items)
         .await
-        .map_err(|e| repo_error("add projection items", "Projection not found", e))?;
-
-    Ok(Json(created))
+        .map(Json)
+        .map_err(|e| repo_error("add projection items", "Projection not found", e));
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -531,60 +512,54 @@ async fn add_projection_items(
 /// List components.
 async fn list_components(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
 ) -> ApiResult<Json<Vec<FundComponent>>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let components = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .list_components(org_id, fund_id)
+        .list_components(&mut **rls.conn(), org_id, fund_id)
         .await
-        .map_err(|e| repo_error("list components", "Fund not found", e))?;
-
-    Ok(Json(components))
+        .map(Json)
+        .map_err(|e| repo_error("list components", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 /// Create a component.
 async fn create_component(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(fund_id): Path<Uuid>,
     Json(req): Json<CreateFundComponent>,
 ) -> ApiResult<Json<FundComponent>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let component = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .create_component(org_id, fund_id, req)
+        .create_component(&mut **rls.conn(), org_id, fund_id, req)
         .await
-        .map_err(|e| repo_error("create component", "Fund not found", e))?;
-
-    Ok(Json(component))
+        .map(Json)
+        .map_err(|e| repo_error("create component", "Fund not found", e));
+    rls.release().await;
+    out
 }
 
 /// Update a component.
 async fn update_component(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path((_fund_id, component_id)): Path<(Uuid, Uuid)>,
     Json(req): Json<UpdateFundComponent>,
 ) -> ApiResult<Json<FundComponent>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let component = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .update_component(org_id, component_id, req)
+        .update_component(&mut **rls.conn(), org_id, component_id, req)
         .await
-        .map_err(|e| repo_error("update component", "Component not found", e))?;
-
-    Ok(Json(component))
+        .map(Json)
+        .map_err(|e| repo_error("update component", "Component not found", e));
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -594,55 +569,51 @@ async fn update_component(
 /// List active alerts.
 async fn list_alerts(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
 ) -> ApiResult<Json<Vec<FundAlert>>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let alerts = state
+    let org_id = rls.tenant_id();
+    let out = state
         .reserve_fund_repo
-        .list_active_alerts(org_id)
+        .list_active_alerts(&mut **rls.conn(), org_id)
         .await
-        .map_err(|e| internal_error(&format!("Failed to list alerts: {}", e)))?;
-
-    Ok(Json(alerts))
+        .map(Json)
+        .map_err(|e| internal_error(&format!("Failed to list alerts: {}", e)));
+    rls.release().await;
+    out
 }
 
 /// Acknowledge an alert.
 async fn acknowledge_alert(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(alert_id): Path<Uuid>,
 ) -> ApiResult<Json<FundAlert>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let alert = state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .reserve_fund_repo
-        .acknowledge_alert(org_id, alert_id, user.user_id)
+        .acknowledge_alert(&mut **rls.conn(), org_id, alert_id, user_id)
         .await
-        .map_err(|e| repo_error("acknowledge alert", "Alert not found", e))?;
-
-    Ok(Json(alert))
+        .map(Json)
+        .map_err(|e| repo_error("acknowledge alert", "Alert not found", e));
+    rls.release().await;
+    out
 }
 
 /// Resolve an alert.
 async fn resolve_alert(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(alert_id): Path<Uuid>,
 ) -> ApiResult<Json<FundAlert>> {
-    let org_id = user
-        .tenant_id
-        .ok_or_else(|| forbidden_error("No organization context"))?;
-
-    let alert = state
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let out = state
         .reserve_fund_repo
-        .resolve_alert(org_id, alert_id, user.user_id)
+        .resolve_alert(&mut **rls.conn(), org_id, alert_id, user_id)
         .await
-        .map_err(|e| repo_error("resolve alert", "Alert not found", e))?;
-
-    Ok(Json(alert))
+        .map(Json)
+        .map_err(|e| repo_error("resolve alert", "Alert not found", e));
+    rls.release().await;
+    out
 }


### PR DESCRIPTION
## What

Re-lands two RLS executor-pattern conversions that were marked **done** under PAP-78 / PAP-79 but **never landed on `dev`** (the "done ≠ landed" / merge-stall pattern from PAP-57). Both repos query FORCE-RLS tables, so the prior raw `pool: PgPool` fields were **deny-all** for own-org traffic under FORCE ROW LEVEL SECURITY (and unscoped on a BYPASSRLS/superuser pool).

- **`sensor.rs`** (PAP-78) — recovered from the orphaned `pap-67-sensor-rls` branch. `SensorRepository` is now stateless; every method takes an RLS-context-bearing executor and `routes/iot.rs` threads `rls.conn()` (47 call-sites). Tables `sensors` / `sensor_readings` are FORCE-RLS. *(equipment.rs from that orphan branch was intentionally dropped — dev already converted equipment via PAP-71 #1226.)*
- **`reserve_funds.rs`** (PAP-79) — recovered from the orphaned `pap-79-reserve-funds-rls` branch (cherry-picked clean onto current dev). `routes/reserve_funds.rs` threads `rls.conn()` (54 call-sites). Tables `reserve_funds` / `fund_transactions` are FORCE-RLS.

Both ship their cross-org-isolation RLS repo tests (`sensor_rls_repo_tests.rs`, `reserve_funds_rls_repo_tests.rs`, NOSUPERUSER role).

## Baseline

Removes `sensor.rs` and `reserve_funds.rs` from `backend/scripts/rls-pool-field-baseline.txt` (PAP-68 pool-field detector). The remaining two original PAP-67 offenders, `work_order.rs` and `budget.rs`, stay baselined and are split into dedicated child issues (see below).

## Out of scope (follow-ups)

The other two PAP-67 offenders are larger conversions warranting their own PRs (bundling four large conversions into one mega-PR is what stalled PAP-78/79 at merge):

- **PAP-179** — convert `work_order.rs` (1059 lines, full executor conversion + route migration)
- **PAP-180** — convert `budget.rs` (2148 lines, drop pool field + delete deprecated `&self.pool` wrappers; routes already use the `_rls` API)

## Verification

- `cargo check -p db -p api-server` — clean
- `cargo clippy -p db -p api-server --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `./scripts/check-rls-enforcement.sh --strict` — **green** (`✓ No RLS violations found`); sensor.rs and reserve_funds.rs no longer flagged, no stale-baseline warning for them.

Refs PAP-151, PAP-78, PAP-79, PAP-67, PAP-68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
