### PR TITLE
fix(api-server): PAP-179 — convert work_order.rs to RLS executor pattern

### DIFF
--- a/backend/crates/db/src/repositories/work_order.rs
+++ b/backend/crates/db/src/repositories/work_order.rs
@@ -1,4 +1,23 @@
 //! Work orders and maintenance scheduling repository (Epic 20).
+//!
+//! # RLS Integration (PAP-67 / PAP-151 / PAP-179)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on every work-order table (`work_orders`,
+//! `work_order_updates`, `maintenance_schedules`, `schedule_executions`).
+//! Under `FORCE` the api-server's owner connection is no longer exempt, so a
+//! query issued on a connection WITHOUT `app.current_org_id` set collapses to
+//! deny-all (own-org reads return empty, writes fail) — and on a
+//! BYPASSRLS/superuser pool the same query would run completely unscoped.
+//!
+//! Every method therefore takes an **executor whose connection already has RLS
+//! context set** (org + user GUCs) — in handlers this comes from the
+//! `RlsConnection` extractor via `&mut **rls.conn()`. Multi-statement methods
+//! (those that fire more than one query, e.g. an UPDATE plus an audit-trail
+//! INSERT) take a `&mut PgConnection` so every statement runs on the *same*
+//! context-bearing connection. The repository holds **no pool**, so there is no
+//! way to issue a query that bypasses RLS. This mirrors the `sensor.rs`
+//! (PAP-151) / `equipment.rs` (PAP-71) / `board_meetings.rs` (#1262) precedent.
 
 use crate::models::{
     AddWorkOrderUpdate, CreateMaintenanceSchedule, CreateWorkOrder, MaintenanceCostSummary,
@@ -7,19 +26,25 @@ use crate::models::{
     WorkOrderUpdate, WorkOrderWithDetails,
 };
 use chrono::NaiveDate;
-use sqlx::PgPool;
+use sqlx::{Executor, PgConnection, PgPool, Postgres};
 use uuid::Uuid;
 
 /// Repository for work order and maintenance schedule operations.
+///
+/// Stateless: every method receives an RLS-context-bearing executor. The repo
+/// holds no pool so it cannot issue an un-scoped (deny-all under `FORCE`) query.
 #[derive(Clone)]
-pub struct WorkOrderRepository {
-    pool: PgPool,
-}
+pub struct WorkOrderRepository;
 
 impl WorkOrderRepository {
     /// Create a new repository instance.
-    pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+    ///
+    /// The pool argument is retained for construction-site compatibility with
+    /// the other repositories on `AppState`; this repo deliberately does not
+    /// store it (see module docs — all queries run on a context-set connection
+    /// supplied by the handler's `RlsConnection`).
+    pub fn new(_pool: PgPool) -> Self {
+        Self
     }
 
     // ========================================================================
@@ -27,12 +52,16 @@ impl WorkOrderRepository {
     // ========================================================================
 
     /// Create a new work order.
-    pub async fn create_work_order(
+    pub async fn create_work_order<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         user_id: Uuid,
         data: CreateWorkOrder,
-    ) -> Result<WorkOrder, sqlx::Error> {
+    ) -> Result<WorkOrder, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO work_orders
@@ -59,14 +88,15 @@ impl WorkOrderRepository {
         .bind(data.tags.unwrap_or_default())
         .bind(sqlx::types::Json(data.metadata.unwrap_or_default()))
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Create work order from a fault (Story 20.2 - fault-triggered work orders).
     #[allow(clippy::too_many_arguments)]
-    pub async fn create_from_fault(
+    pub async fn create_from_fault<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         user_id: Uuid,
         fault_id: Uuid,
@@ -74,7 +104,10 @@ impl WorkOrderRepository {
         title: &str,
         description: &str,
         priority: &str,
-    ) -> Result<WorkOrder, sqlx::Error> {
+    ) -> Result<WorkOrder, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO work_orders
@@ -91,16 +124,20 @@ impl WorkOrderRepository {
         .bind(description)
         .bind(priority)
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Create work order from a maintenance schedule.
-    pub async fn create_from_schedule(
+    pub async fn create_from_schedule<'e, E>(
         &self,
+        executor: E,
         schedule: &MaintenanceSchedule,
         due_date: NaiveDate,
-    ) -> Result<WorkOrder, sqlx::Error> {
+    ) -> Result<WorkOrder, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO work_orders
@@ -123,24 +160,35 @@ impl WorkOrderRepository {
         .bind(schedule.estimated_cost)
         .bind(schedule.id)
         .bind(schedule.created_by)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Find work order by ID.
-    pub async fn find_by_id(&self, id: Uuid) -> Result<Option<WorkOrder>, sqlx::Error> {
+    pub async fn find_by_id<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+    ) -> Result<Option<WorkOrder>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as("SELECT * FROM work_orders WHERE id = $1")
             .bind(id)
-            .fetch_optional(&self.pool)
+            .fetch_optional(executor)
             .await
     }
 
     /// List work orders with filters.
-    pub async fn list(
+    pub async fn list<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: WorkOrderQuery,
-    ) -> Result<Vec<WorkOrder>, sqlx::Error> {
+    ) -> Result<Vec<WorkOrder>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50);
         let offset = query.offset.unwrap_or(0);
 
@@ -185,16 +233,20 @@ impl WorkOrderRepository {
         .bind(query.due_after)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// List work orders with details (building name, equipment name, assignee name).
-    pub async fn list_with_details(
+    pub async fn list_with_details<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: WorkOrderQuery,
-    ) -> Result<Vec<WorkOrderWithDetails>, sqlx::Error> {
+    ) -> Result<Vec<WorkOrderWithDetails>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50);
         let offset = query.offset.unwrap_or(0);
 
@@ -237,19 +289,26 @@ impl WorkOrderRepository {
         .bind(query.priority)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update work order.
+    ///
+    /// Multi-statement (load old row + UPDATE + audit-trail INSERT), so it takes
+    /// a connection and reborrows it for each query.
     pub async fn update(
         &self,
+        conn: &mut PgConnection,
         id: Uuid,
         user_id: Uuid,
         data: UpdateWorkOrder,
     ) -> Result<WorkOrder, sqlx::Error> {
         // Get old work order for tracking changes
-        let old = self.find_by_id(id).await?.ok_or(sqlx::Error::RowNotFound)?;
+        let old = self
+            .find_by_id(&mut *conn, id)
+            .await?
+            .ok_or(sqlx::Error::RowNotFound)?;
 
         // Update the work order
         let updated: WorkOrder = sqlx::query_as(
@@ -297,13 +356,14 @@ impl WorkOrderRepository {
         .bind(data.resolution_notes)
         .bind(data.tags)
         .bind(data.metadata.map(sqlx::types::Json))
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         // Track status change
         if let Some(new_status) = &data.status {
             if &old.status != new_status {
                 self.add_update(
+                    &mut *conn,
                     id,
                     user_id,
                     "status_change",
@@ -319,17 +379,23 @@ impl WorkOrderRepository {
     }
 
     /// Delete work order.
-    pub async fn delete(&self, id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete<'e, E>(&self, executor: E, id: Uuid) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM work_orders WHERE id = $1")
             .bind(id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
 
     /// Assign work order to user or vendor.
+    ///
+    /// Multi-statement (UPDATE + audit-trail INSERT), so it takes a connection.
     pub async fn assign(
         &self,
+        conn: &mut PgConnection,
         id: Uuid,
         user_id: Uuid,
         assigned_to: Option<Uuid>,
@@ -352,7 +418,7 @@ impl WorkOrderRepository {
         .bind(id)
         .bind(assigned_to)
         .bind(vendor_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         // Track assignment
@@ -365,6 +431,7 @@ impl WorkOrderRepository {
         };
 
         self.add_update(
+            &mut *conn,
             id,
             user_id,
             "assignment",
@@ -378,7 +445,14 @@ impl WorkOrderRepository {
     }
 
     /// Start work on a work order.
-    pub async fn start_work(&self, id: Uuid, user_id: Uuid) -> Result<WorkOrder, sqlx::Error> {
+    ///
+    /// Multi-statement (UPDATE + audit-trail INSERT), so it takes a connection.
+    pub async fn start_work(
+        &self,
+        conn: &mut PgConnection,
+        id: Uuid,
+        user_id: Uuid,
+    ) -> Result<WorkOrder, sqlx::Error> {
         let updated: WorkOrder = sqlx::query_as(
             r#"
             UPDATE work_orders SET
@@ -390,10 +464,11 @@ impl WorkOrderRepository {
             "#,
         )
         .bind(id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         self.add_update(
+            &mut *conn,
             id,
             user_id,
             "status_change",
@@ -407,8 +482,11 @@ impl WorkOrderRepository {
     }
 
     /// Complete work order.
+    ///
+    /// Multi-statement (UPDATE + audit-trail INSERT), so it takes a connection.
     pub async fn complete(
         &self,
+        conn: &mut PgConnection,
         id: Uuid,
         user_id: Uuid,
         actual_cost: Option<rust_decimal::Decimal>,
@@ -429,10 +507,11 @@ impl WorkOrderRepository {
         .bind(id)
         .bind(actual_cost)
         .bind(resolution_notes)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         self.add_update(
+            &mut *conn,
             id,
             user_id,
             "status_change",
@@ -446,13 +525,20 @@ impl WorkOrderRepository {
     }
 
     /// Put work order on hold.
+    ///
+    /// Multi-statement (load old row + UPDATE + audit-trail INSERT), so it takes
+    /// a connection.
     pub async fn put_on_hold(
         &self,
+        conn: &mut PgConnection,
         id: Uuid,
         user_id: Uuid,
         reason: &str,
     ) -> Result<WorkOrder, sqlx::Error> {
-        let old = self.find_by_id(id).await?.ok_or(sqlx::Error::RowNotFound)?;
+        let old = self
+            .find_by_id(&mut *conn, id)
+            .await?
+            .ok_or(sqlx::Error::RowNotFound)?;
 
         let updated: WorkOrder = sqlx::query_as(
             r#"
@@ -464,10 +550,11 @@ impl WorkOrderRepository {
             "#,
         )
         .bind(id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         self.add_update(
+            &mut *conn,
             id,
             user_id,
             "status_change",
@@ -481,15 +568,20 @@ impl WorkOrderRepository {
     }
 
     /// Add comment/update to work order.
-    pub async fn add_update(
+    #[allow(clippy::too_many_arguments)]
+    pub async fn add_update<'e, E>(
         &self,
+        executor: E,
         work_order_id: Uuid,
         user_id: Uuid,
         update_type: &str,
         content: &str,
         old_value: Option<&str>,
         new_value: Option<&str>,
-    ) -> Result<WorkOrderUpdate, sqlx::Error> {
+    ) -> Result<WorkOrderUpdate, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             INSERT INTO work_order_updates
@@ -504,18 +596,23 @@ impl WorkOrderRepository {
         .bind(content)
         .bind(old_value)
         .bind(new_value)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Add user comment to work order.
-    pub async fn add_comment(
+    pub async fn add_comment<'e, E>(
         &self,
+        executor: E,
         work_order_id: Uuid,
         user_id: Uuid,
         data: AddWorkOrderUpdate,
-    ) -> Result<WorkOrderUpdate, sqlx::Error> {
+    ) -> Result<WorkOrderUpdate, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         self.add_update(
+            executor,
             work_order_id,
             user_id,
             data.update_type.as_deref().unwrap_or("comment"),
@@ -527,12 +624,16 @@ impl WorkOrderRepository {
     }
 
     /// List updates/comments for a work order.
-    pub async fn list_updates(
+    pub async fn list_updates<'e, E>(
         &self,
+        executor: E,
         work_order_id: Uuid,
         limit: i32,
         offset: i32,
-    ) -> Result<Vec<WorkOrderUpdate>, sqlx::Error> {
+    ) -> Result<Vec<WorkOrderUpdate>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM work_order_updates
@@ -544,12 +645,19 @@ impl WorkOrderRepository {
         .bind(work_order_id)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Get work order statistics.
-    pub async fn get_statistics(&self, org_id: Uuid) -> Result<WorkOrderStatistics, sqlx::Error> {
+    pub async fn get_statistics<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+    ) -> Result<WorkOrderStatistics, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT
@@ -565,16 +673,20 @@ impl WorkOrderRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get overdue work orders.
-    pub async fn list_overdue(
+    pub async fn list_overdue<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         limit: i32,
-    ) -> Result<Vec<WorkOrder>, sqlx::Error> {
+    ) -> Result<Vec<WorkOrder>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM work_orders
@@ -587,7 +699,7 @@ impl WorkOrderRepository {
         )
         .bind(org_id)
         .bind(limit)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -596,12 +708,16 @@ impl WorkOrderRepository {
     // ========================================================================
 
     /// Create a maintenance schedule.
-    pub async fn create_schedule(
+    pub async fn create_schedule<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         user_id: Uuid,
         data: CreateMaintenanceSchedule,
-    ) -> Result<MaintenanceSchedule, sqlx::Error> {
+    ) -> Result<MaintenanceSchedule, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // Calculate first next_due_date based on start_date
         let next_due = data.start_date;
 
@@ -643,27 +759,35 @@ impl WorkOrderRepository {
         ))
         .bind(sqlx::types::Json(data.metadata.unwrap_or_default()))
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Find schedule by ID.
-    pub async fn find_schedule_by_id(
+    pub async fn find_schedule_by_id<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
-    ) -> Result<Option<MaintenanceSchedule>, sqlx::Error> {
+    ) -> Result<Option<MaintenanceSchedule>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as("SELECT * FROM maintenance_schedules WHERE id = $1")
             .bind(id)
-            .fetch_optional(&self.pool)
+            .fetch_optional(executor)
             .await
     }
 
     /// List schedules with filters.
-    pub async fn list_schedules(
+    pub async fn list_schedules<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         query: ScheduleQuery,
-    ) -> Result<Vec<MaintenanceSchedule>, sqlx::Error> {
+    ) -> Result<Vec<MaintenanceSchedule>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let limit = query.limit.unwrap_or(50);
         let offset = query.offset.unwrap_or(0);
 
@@ -688,16 +812,20 @@ impl WorkOrderRepository {
         .bind(query.due_before)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update schedule.
-    pub async fn update_schedule(
+    pub async fn update_schedule<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         data: UpdateMaintenanceSchedule,
-    ) -> Result<MaintenanceSchedule, sqlx::Error> {
+    ) -> Result<MaintenanceSchedule, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE maintenance_schedules SET
@@ -744,25 +872,32 @@ impl WorkOrderRepository {
                 .map(|c| sqlx::types::Json(serde_json::json!(c))),
         )
         .bind(data.metadata.map(sqlx::types::Json))
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Delete schedule.
-    pub async fn delete_schedule(&self, id: Uuid) -> Result<bool, sqlx::Error> {
+    pub async fn delete_schedule<'e, E>(&self, executor: E, id: Uuid) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let result = sqlx::query("DELETE FROM maintenance_schedules WHERE id = $1")
             .bind(id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
         Ok(result.rows_affected() > 0)
     }
 
     /// Activate/deactivate schedule.
-    pub async fn set_schedule_active(
+    pub async fn set_schedule_active<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         is_active: bool,
-    ) -> Result<MaintenanceSchedule, sqlx::Error> {
+    ) -> Result<MaintenanceSchedule, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             UPDATE maintenance_schedules SET
@@ -774,16 +909,20 @@ impl WorkOrderRepository {
         )
         .bind(id)
         .bind(is_active)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Get schedules due for execution.
-    pub async fn get_due_schedules(
+    pub async fn get_due_schedules<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         days_ahead: i32,
-    ) -> Result<Vec<MaintenanceSchedule>, sqlx::Error> {
+    ) -> Result<Vec<MaintenanceSchedule>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM maintenance_schedules
@@ -797,13 +936,17 @@ impl WorkOrderRepository {
         )
         .bind(org_id)
         .bind(days_ahead)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Update schedule after work order created.
+    ///
+    /// Multi-statement (execution INSERT + schedule UPDATE), so it takes a
+    /// connection.
     pub async fn mark_schedule_executed(
         &self,
+        conn: &mut PgConnection,
         id: Uuid,
         work_order_id: Uuid,
     ) -> Result<MaintenanceSchedule, sqlx::Error> {
@@ -818,7 +961,7 @@ impl WorkOrderRepository {
         )
         .bind(id)
         .bind(work_order_id)
-        .execute(&self.pool)
+        .execute(&mut *conn)
         .await?;
 
         // Update schedule next_due_date
@@ -835,13 +978,17 @@ impl WorkOrderRepository {
             "#,
         )
         .bind(id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
     }
 
     /// Skip a scheduled maintenance.
+    ///
+    /// Multi-statement (execution INSERT + schedule UPDATE), so it takes a
+    /// connection.
     pub async fn skip_schedule_execution(
         &self,
+        conn: &mut PgConnection,
         id: Uuid,
         reason: &str,
     ) -> Result<MaintenanceSchedule, sqlx::Error> {
@@ -856,7 +1003,7 @@ impl WorkOrderRepository {
         )
         .bind(id)
         .bind(reason)
-        .execute(&self.pool)
+        .execute(&mut *conn)
         .await?;
 
         // Update next_due_date
@@ -872,17 +1019,21 @@ impl WorkOrderRepository {
             "#,
         )
         .bind(id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
     }
 
     /// Get upcoming schedules.
-    pub async fn get_upcoming_schedules(
+    pub async fn get_upcoming_schedules<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         days_ahead: i32,
         limit: i32,
-    ) -> Result<Vec<UpcomingSchedule>, sqlx::Error> {
+    ) -> Result<Vec<UpcomingSchedule>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT
@@ -906,17 +1057,21 @@ impl WorkOrderRepository {
         .bind(org_id)
         .bind(days_ahead)
         .bind(limit)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Get execution history for a schedule.
-    pub async fn list_executions(
+    pub async fn list_executions<'e, E>(
         &self,
+        executor: E,
         schedule_id: Uuid,
         limit: i32,
         offset: i32,
-    ) -> Result<Vec<ScheduleExecution>, sqlx::Error> {
+    ) -> Result<Vec<ScheduleExecution>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT * FROM schedule_executions
@@ -928,7 +1083,7 @@ impl WorkOrderRepository {
         .bind(schedule_id)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -937,12 +1092,16 @@ impl WorkOrderRepository {
     // ========================================================================
 
     /// Get service history for equipment.
-    pub async fn get_service_history(
+    pub async fn get_service_history<'e, E>(
         &self,
+        executor: E,
         equipment_id: Uuid,
         limit: i32,
         offset: i32,
-    ) -> Result<Vec<ServiceHistoryEntry>, sqlx::Error> {
+    ) -> Result<Vec<ServiceHistoryEntry>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT
@@ -965,17 +1124,21 @@ impl WorkOrderRepository {
         .bind(equipment_id)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Get maintenance cost summary by type.
-    pub async fn get_cost_summary(
+    pub async fn get_cost_summary<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         start_date: NaiveDate,
         end_date: NaiveDate,
-    ) -> Result<Vec<MaintenanceCostSummary>, sqlx::Error> {
+    ) -> Result<Vec<MaintenanceCostSummary>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT
@@ -995,17 +1158,21 @@ impl WorkOrderRepository {
         .bind(org_id)
         .bind(start_date)
         .bind(end_date)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Get service history for building.
-    pub async fn get_building_service_history(
+    pub async fn get_building_service_history<'e, E>(
         &self,
+        executor: E,
         building_id: Uuid,
         limit: i32,
         offset: i32,
-    ) -> Result<Vec<ServiceHistoryEntry>, sqlx::Error> {
+    ) -> Result<Vec<ServiceHistoryEntry>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as(
             r#"
             SELECT
@@ -1028,7 +1195,7 @@ impl WorkOrderRepository {
         .bind(building_id)
         .bind(limit)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
@@ -1037,18 +1204,26 @@ impl WorkOrderRepository {
     // ========================================================================
 
     /// Process due schedules and create work orders.
-    pub async fn process_due_schedules(&self, org_id: Uuid) -> Result<Vec<WorkOrder>, sqlx::Error> {
-        let schedules = self.get_due_schedules(org_id, 0).await?;
+    ///
+    /// Multi-statement (reads due schedules, then per schedule creates a work
+    /// order and marks the schedule executed), so it takes a connection and
+    /// reborrows it for each downstream call.
+    pub async fn process_due_schedules(
+        &self,
+        conn: &mut PgConnection,
+        org_id: Uuid,
+    ) -> Result<Vec<WorkOrder>, sqlx::Error> {
+        let schedules = self.get_due_schedules(&mut *conn, org_id, 0).await?;
         let mut created_orders = Vec::new();
 
         for schedule in schedules {
             // Create work order from schedule
             let work_order = self
-                .create_from_schedule(&schedule, schedule.next_due_date)
+                .create_from_schedule(&mut *conn, &schedule, schedule.next_due_date)
                 .await?;
 
             // Mark schedule as executed
-            self.mark_schedule_executed(schedule.id, work_order.id)
+            self.mark_schedule_executed(&mut *conn, schedule.id, work_order.id)
                 .await?;
 
             created_orders.push(work_order);

--- a/backend/crates/db/tests/work_order_rls_repo_tests.rs
+++ b/backend/crates/db/tests/work_order_rls_repo_tests.rs
@@ -1,0 +1,255 @@
+//! Repo-level behavioral test for the work-order RLS routing (PAP-67 / PAP-179).
+//!
+//! Background
+//! ----------
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on every work-order table (`work_orders`,
+//! `work_order_updates`, `maintenance_schedules`, `schedule_executions`). Under
+//! `FORCE` the api-server's owner connection is no longer exempt, so a query
+//! issued on a connection WITHOUT `app.current_org_id` set collapses to
+//! deny-all. The `WorkOrderRepository` was reworked (PAP-179) to hold no pool
+//! and to take an RLS-context-bearing executor on every method (supplied by
+//! `RlsConnection` in handlers). This test exercises that contract directly
+//! against the repo.
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — even `FORCE` does not bind a superuser. To exercise the policy
+//! the way the production owner role does, the test creates a plain
+//! `NOSUPERUSER NOBYPASSRLS` role, grants it table access, and `SET ROLE`s to
+//! it. `FORCE` binds that role, so the org-scoped policy is enforced. The org
+//! context (`app.current_org_id`) is a session GUC and survives `SET ROLE`.
+
+use db::repositories::WorkOrderRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("WorkOrders {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@work-orders.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'WorkOrders User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_building(pool: &PgPool, org_id: Uuid, street: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO buildings (organization_id, street, city, postal_code)
+        VALUES ($1, $2, 'Bratislava', '81101')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(street)
+    .fetch_one(pool)
+    .await
+    .expect("seed building")
+}
+
+async fn seed_work_order(
+    pool: &PgPool,
+    org_id: Uuid,
+    building_id: Uuid,
+    created_by: Uuid,
+    title: &str,
+) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO work_orders (organization_id, building_id, title, description, created_by)
+        VALUES ($1, $2, $3, 'seeded', $4)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(building_id)
+    .bind(title)
+    .bind(created_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed work order")
+}
+
+/// FORCE RLS on `work_orders` must:
+///   1. deny ALL reads on a connection that has NO org context set
+///      (the deny-all regression that 00179's FORCE introduces for any code
+///      path that forgot to route through `RlsConnection`); and
+///   2. expose the caller's OWN org's work order while hiding another org's
+///      work order once the org context IS set.
+///
+/// Both assertions go through `WorkOrderRepository::find_by_id` — the exact repo
+/// method the work-order handlers call — so this is a behavioral test of the RLS
+/// routing, not just of the raw SQL policy.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn work_orders_force_rls_requires_context_and_blocks_cross_tenant(pool: PgPool) {
+    // --- Seed as superuser (super-admin context satisfies the roles-trigger
+    //     RLS WITH CHECK fired by INSERT INTO organizations). ---
+    sqlx::query("SELECT set_request_context(NULL, NULL, true)")
+        .execute(&pool)
+        .await
+        .expect("set super-admin context");
+
+    let org_a = seed_org(&pool, "wo-force-a").await;
+    let org_b = seed_org(&pool, "wo-force-b").await;
+    let user_a = seed_user(&pool, "a@work-orders.test").await;
+    let user_b = seed_user(&pool, "b@work-orders.test").await;
+    let bldg_a = seed_building(&pool, org_a, "1 Alpha St").await;
+    let bldg_b = seed_building(&pool, org_b, "1 Bravo St").await;
+
+    let wo_a = seed_work_order(&pool, org_a, bldg_a, user_a, "alpha-job").await;
+    let wo_b = seed_work_order(&pool, org_b, bldg_b, user_b, "bravo-job").await;
+
+    let repo = WorkOrderRepository::new(pool.clone());
+
+    // --- Create a NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    // Random suffix keeps the role name unique across parallel test DBs.
+    let role = format!("ppt_rls_test_{}", Uuid::new_v4().simple());
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"
+    )))
+    .execute(&pool)
+    .await
+    .expect("create role");
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT SELECT ON work_orders TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant select on work_orders");
+    // The policy calls helper functions (get_current_org_id, is_super_admin,
+    // get_current_org_not_deleted); the role must be able to EXECUTE them.
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
+         get_current_org_not_deleted() TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant execute on rls helpers");
+    // `get_current_org_not_deleted()` is SECURITY INVOKER; its body runs
+    // `SELECT 1 FROM organizations` with the CALLER's privileges, so the bound
+    // role must be able to read `organizations` or the soft-delete guard raises
+    // `permission denied for table organizations`. `organizations` has no RLS
+    // of its own, so a plain table-level SELECT grant is sufficient.
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT SELECT ON organizations TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant select on organizations");
+
+    // --- All role-bound work runs on ONE dedicated connection. `SET ROLE` and
+    //     the org-context GUC are session state, so they must not be spread
+    //     across pool acquisitions. ---
+    {
+        let mut conn = pool.acquire().await.expect("acquire connection");
+
+        // ---- Phase 1: NO org context → deny-all under FORCE. ----
+        // This is the deny-all regression a raw-pool repo would hit: without
+        // `app.current_org_id`, even the OWN-org row is invisible.
+        sqlx::query("SELECT set_request_context(NULL, NULL, false)")
+            .execute(&mut *conn)
+            .await
+            .expect("clear org context");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let no_ctx = repo
+            .find_by_id(&mut *conn, wo_a)
+            .await
+            .expect("find_by_id (no context)");
+        assert!(
+            no_ctx.is_none(),
+            "without org context a FORCE-RLS work order read must return None (deny-all)"
+        );
+
+        // ---- Phase 2: org-A context → own visible, cross-tenant hidden. ----
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role before re-setting context");
+        sqlx::query("SELECT set_request_context($1, $2, false)")
+            .bind(org_a)
+            .bind(user_a)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A context");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let own = repo
+            .find_by_id(&mut *conn, wo_a)
+            .await
+            .expect("find_by_id (org-A own)");
+        assert_eq!(
+            own.map(|w| w.id),
+            Some(wo_a),
+            "org A's own work order must be visible under its own context"
+        );
+
+        let cross = repo
+            .find_by_id(&mut *conn, wo_b)
+            .await
+            .expect("find_by_id (org-B cross-tenant)");
+        assert!(
+            cross.is_none(),
+            "org B's work order must NOT be visible to an org-A caller (cross-tenant IDOR)"
+        );
+
+        // Drop back to superuser on this connection before it returns to the pool.
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup the test role. ---
+    sqlx::query("SELECT set_request_context(NULL, NULL, true)")
+        .execute(&pool)
+        .await
+        .expect("restore super-admin context");
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "REVOKE ALL ON work_orders FROM \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .ok();
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "REVOKE ALL ON organizations FROM \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .ok();
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "DROP ROLE IF EXISTS \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .ok();
+}

--- a/backend/scripts/rls-pool-field-baseline.txt
+++ b/backend/scripts/rls-pool-field-baseline.txt
@@ -12,7 +12,6 @@
 # One basename per line. Comments after '#'.
 
 # --- PAP-67 original offender set, conversion still pending ---
-work_order.rs        # PAP-67 (PAP-151 child: full executor conversion + route migration)
 esg_reporting.rs     # PAP-72 (blocked on PAP-139)
 form.rs              # PAP-76
 workflow.rs          # PAP-77

--- a/backend/servers/api-server/src/routes/work_orders.rs
+++ b/backend/servers/api-server/src/routes/work_orders.rs
@@ -1,6 +1,23 @@
 //! Work orders and maintenance scheduling routes (Epic 20).
+//!
+//! # RLS routing (PAP-179)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` on every work-order table
+//! (`work_orders`, `work_order_updates`, `maintenance_schedules`,
+//! `schedule_executions`). Under `FORCE` the api-server's owner connection is no
+//! longer exempt, so a query on a connection without `app.current_org_id` set
+//! collapses to deny-all. Each handler therefore acquires an [`RlsConnection`]
+//! (which validates membership + sets the org/user GUCs on a dedicated
+//! connection) and passes `rls.conn()` to the now-stateless
+//! `WorkOrderRepository`.
+//!
+//! The explicit `verify_org_access` membership check and the
+//! `load_*_for_user` fetch-then-authorize helpers are retained as
+//! defense-in-depth: they are what produces the `403`/`404` semantics on the
+//! superuser-backed test pool (where `FORCE` is bypassed) and they guard the
+//! client-supplied `organization_id` on the create/list endpoints.
 
-use api_core::extractors::AuthUser;
+use api_core::extractors::RlsConnection;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -16,6 +33,7 @@ use db::models::{
     WorkOrderUpdate, WorkOrderWithDetails,
 };
 use serde::Deserialize;
+use sqlx::PgConnection;
 use utoipa::IntoParams;
 use uuid::Uuid;
 
@@ -107,16 +125,18 @@ async fn verify_org_access(
 /// Returns `404 NOT_FOUND` if the work order does not exist and `403 FORBIDDEN`
 /// if the caller is not a member of the organization that owns it. By-id
 /// handlers route through this so an org A caller can never read or address an
-/// org B work order. Mirrors the fetch-then-`verify_org_access` idiom in
-/// `integrations::sync`.
+/// org B work order. The fetch runs on the RLS-context connection supplied by
+/// the handler's `RlsConnection`, so under `FORCE` RLS a foreign-org row is
+/// invisible (404) even before the membership check.
 async fn load_work_order_for_user(
     state: &AppState,
+    conn: &mut PgConnection,
     user_id: Uuid,
     work_order_id: Uuid,
 ) -> Result<WorkOrder, (StatusCode, Json<ErrorResponse>)> {
     let work_order = state
         .work_order_repo
-        .find_by_id(work_order_id)
+        .find_by_id(&mut *conn, work_order_id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get work order: {:?}", e);
@@ -141,12 +161,13 @@ async fn load_work_order_for_user(
 /// owning org. Same contract as [`load_work_order_for_user`] for schedules.
 async fn load_schedule_for_user(
     state: &AppState,
+    conn: &mut PgConnection,
     user_id: Uuid,
     schedule_id: Uuid,
 ) -> Result<MaintenanceSchedule, (StatusCode, Json<ErrorResponse>)> {
     let schedule = state
         .work_order_repo
-        .find_schedule_by_id(schedule_id)
+        .find_schedule_by_id(&mut *conn, schedule_id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get schedule: {:?}", e);
@@ -310,85 +331,114 @@ pub struct SkipRequest {
 
 async fn create_work_order(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Json(payload): Json<CreateWorkOrderRequest>,
 ) -> Result<(StatusCode, Json<WorkOrder>), (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, payload.organization_id).await?;
-    state
-        .work_order_repo
-        .create_work_order(payload.organization_id, user.user_id, payload.data)
-        .await
-        .map(|wo| (StatusCode::CREATED, Json(wo)))
-        .map_err(|e| {
-            tracing::error!("Failed to create work order: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DB_ERROR",
-                    "Failed to create work order",
-                )),
+    let uid = rls.user_id();
+    let out: Result<(StatusCode, Json<WorkOrder>), (StatusCode, Json<ErrorResponse>)> = async {
+        verify_org_access(&state, uid, payload.organization_id).await?;
+        state
+            .work_order_repo
+            .create_work_order(
+                &mut **rls.conn(),
+                payload.organization_id,
+                uid,
+                payload.data,
             )
-        })
+            .await
+            .map(|wo| (StatusCode::CREATED, Json(wo)))
+            .map_err(|e| {
+                tracing::error!("Failed to create work order: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new(
+                        "DB_ERROR",
+                        "Failed to create work order",
+                    )),
+                )
+            })
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn list_work_orders(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<ListWorkOrdersQuery>,
 ) -> Result<Json<Vec<WorkOrder>>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, query.organization_id).await?;
-    state
-        .work_order_repo
-        .list(query.organization_id, (&query).into())
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list work orders: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to list work orders")),
-            )
-        })
+    let uid = rls.user_id();
+    let out: Result<Json<Vec<WorkOrder>>, (StatusCode, Json<ErrorResponse>)> = async {
+        verify_org_access(&state, uid, query.organization_id).await?;
+        state
+            .work_order_repo
+            .list(&mut **rls.conn(), query.organization_id, (&query).into())
+            .await
+            .map(Json)
+            .map_err(|e| {
+                tracing::error!("Failed to list work orders: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("DB_ERROR", "Failed to list work orders")),
+                )
+            })
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn list_work_orders_with_details(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<ListWorkOrdersQuery>,
 ) -> Result<Json<Vec<WorkOrderWithDetails>>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, query.organization_id).await?;
-    state
-        .work_order_repo
-        .list_with_details(query.organization_id, (&query).into())
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list work orders: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to list work orders")),
-            )
-        })
+    let uid = rls.user_id();
+    let out: Result<Json<Vec<WorkOrderWithDetails>>, (StatusCode, Json<ErrorResponse>)> = async {
+        verify_org_access(&state, uid, query.organization_id).await?;
+        state
+            .work_order_repo
+            .list_with_details(&mut **rls.conn(), query.organization_id, (&query).into())
+            .await
+            .map(Json)
+            .map_err(|e| {
+                tracing::error!("Failed to list work orders: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("DB_ERROR", "Failed to list work orders")),
+                )
+            })
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn get_statistics(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<OrgQuery>,
 ) -> Result<Json<WorkOrderStatistics>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, query.organization_id).await?;
-    state
-        .work_order_repo
-        .get_statistics(query.organization_id)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to get statistics: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to get statistics")),
-            )
-        })
+    let uid = rls.user_id();
+    let out: Result<Json<WorkOrderStatistics>, (StatusCode, Json<ErrorResponse>)> = async {
+        verify_org_access(&state, uid, query.organization_id).await?;
+        state
+            .work_order_repo
+            .get_statistics(&mut **rls.conn(), query.organization_id)
+            .await
+            .map(Json)
+            .map_err(|e| {
+                tracing::error!("Failed to get statistics: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("DB_ERROR", "Failed to get statistics")),
+                )
+            })
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 #[derive(Debug, Deserialize, IntoParams)]
@@ -399,476 +449,624 @@ pub struct OverdueQuery {
 
 async fn list_overdue(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<OverdueQuery>,
 ) -> Result<Json<Vec<WorkOrder>>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, query.organization_id).await?;
-    state
-        .work_order_repo
-        .list_overdue(query.organization_id, query.limit.unwrap_or(20))
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list overdue work orders: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to list overdue")),
+    let uid = rls.user_id();
+    let out: Result<Json<Vec<WorkOrder>>, (StatusCode, Json<ErrorResponse>)> = async {
+        verify_org_access(&state, uid, query.organization_id).await?;
+        state
+            .work_order_repo
+            .list_overdue(
+                &mut **rls.conn(),
+                query.organization_id,
+                query.limit.unwrap_or(20),
             )
-        })
+            .await
+            .map(Json)
+            .map_err(|e| {
+                tracing::error!("Failed to list overdue work orders: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("DB_ERROR", "Failed to list overdue")),
+                )
+            })
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn get_work_order(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<WorkOrder>, (StatusCode, Json<ErrorResponse>)> {
-    let work_order = load_work_order_for_user(&state, user.user_id, id).await?;
-    Ok(Json(work_order))
+    let uid = rls.user_id();
+    let out = load_work_order_for_user(&state, rls.conn(), uid, id)
+        .await
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 async fn update_work_order(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateWorkOrder>,
 ) -> Result<Json<WorkOrder>, (StatusCode, Json<ErrorResponse>)> {
-    load_work_order_for_user(&state, user.user_id, id).await?;
-    state
-        .work_order_repo
-        .update(id, user.user_id, data)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to update work order: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DB_ERROR",
-                    "Failed to update work order",
-                )),
-            )
-        })
+    let uid = rls.user_id();
+    let out: Result<Json<WorkOrder>, (StatusCode, Json<ErrorResponse>)> = async {
+        load_work_order_for_user(&state, rls.conn(), uid, id).await?;
+        state
+            .work_order_repo
+            .update(rls.conn(), id, uid, data)
+            .await
+            .map(Json)
+            .map_err(|e| {
+                tracing::error!("Failed to update work order: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new(
+                        "DB_ERROR",
+                        "Failed to update work order",
+                    )),
+                )
+            })
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn delete_work_order(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    load_work_order_for_user(&state, user.user_id, id).await?;
-    let deleted = state.work_order_repo.delete(id).await.map_err(|e| {
-        tracing::error!("Failed to delete work order: {:?}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new(
-                "DB_ERROR",
-                "Failed to delete work order",
-            )),
-        )
-    })?;
+    let uid = rls.user_id();
+    let out: Result<StatusCode, (StatusCode, Json<ErrorResponse>)> = async {
+        load_work_order_for_user(&state, rls.conn(), uid, id).await?;
+        let deleted = state
+            .work_order_repo
+            .delete(&mut **rls.conn(), id)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to delete work order: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new(
+                        "DB_ERROR",
+                        "Failed to delete work order",
+                    )),
+                )
+            })?;
 
-    if deleted {
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Work order not found")),
-        ))
+        if deleted {
+            Ok(StatusCode::NO_CONTENT)
+        } else {
+            Err((
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Work order not found")),
+            ))
+        }
     }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn assign_work_order(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<AssignRequest>,
 ) -> Result<Json<WorkOrder>, (StatusCode, Json<ErrorResponse>)> {
-    load_work_order_for_user(&state, user.user_id, id).await?;
-    state
-        .work_order_repo
-        .assign(id, user.user_id, data.assigned_to, data.vendor_id)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to assign work order: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DB_ERROR",
-                    "Failed to assign work order",
-                )),
-            )
-        })
+    let uid = rls.user_id();
+    let out: Result<Json<WorkOrder>, (StatusCode, Json<ErrorResponse>)> = async {
+        load_work_order_for_user(&state, rls.conn(), uid, id).await?;
+        state
+            .work_order_repo
+            .assign(rls.conn(), id, uid, data.assigned_to, data.vendor_id)
+            .await
+            .map(Json)
+            .map_err(|e| {
+                tracing::error!("Failed to assign work order: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new(
+                        "DB_ERROR",
+                        "Failed to assign work order",
+                    )),
+                )
+            })
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn start_work(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<WorkOrder>, (StatusCode, Json<ErrorResponse>)> {
-    load_work_order_for_user(&state, user.user_id, id).await?;
-    state
-        .work_order_repo
-        .start_work(id, user.user_id)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to start work: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to start work")),
-            )
-        })
+    let uid = rls.user_id();
+    let out: Result<Json<WorkOrder>, (StatusCode, Json<ErrorResponse>)> = async {
+        load_work_order_for_user(&state, rls.conn(), uid, id).await?;
+        state
+            .work_order_repo
+            .start_work(rls.conn(), id, uid)
+            .await
+            .map(Json)
+            .map_err(|e| {
+                tracing::error!("Failed to start work: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("DB_ERROR", "Failed to start work")),
+                )
+            })
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn complete_work_order(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<CompleteRequest>,
 ) -> Result<Json<WorkOrder>, (StatusCode, Json<ErrorResponse>)> {
-    load_work_order_for_user(&state, user.user_id, id).await?;
-    state
-        .work_order_repo
-        .complete(
-            id,
-            user.user_id,
-            data.actual_cost,
-            data.resolution_notes.as_deref(),
-        )
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to complete work order: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DB_ERROR",
-                    "Failed to complete work order",
-                )),
+    let uid = rls.user_id();
+    let out: Result<Json<WorkOrder>, (StatusCode, Json<ErrorResponse>)> = async {
+        load_work_order_for_user(&state, rls.conn(), uid, id).await?;
+        state
+            .work_order_repo
+            .complete(
+                rls.conn(),
+                id,
+                uid,
+                data.actual_cost,
+                data.resolution_notes.as_deref(),
             )
-        })
+            .await
+            .map(Json)
+            .map_err(|e| {
+                tracing::error!("Failed to complete work order: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new(
+                        "DB_ERROR",
+                        "Failed to complete work order",
+                    )),
+                )
+            })
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn put_on_hold(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<HoldRequest>,
 ) -> Result<Json<WorkOrder>, (StatusCode, Json<ErrorResponse>)> {
-    load_work_order_for_user(&state, user.user_id, id).await?;
-    state
-        .work_order_repo
-        .put_on_hold(id, user.user_id, &data.reason)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to put work order on hold: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to put on hold")),
-            )
-        })
+    let uid = rls.user_id();
+    let out: Result<Json<WorkOrder>, (StatusCode, Json<ErrorResponse>)> = async {
+        load_work_order_for_user(&state, rls.conn(), uid, id).await?;
+        state
+            .work_order_repo
+            .put_on_hold(rls.conn(), id, uid, &data.reason)
+            .await
+            .map(Json)
+            .map_err(|e| {
+                tracing::error!("Failed to put work order on hold: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("DB_ERROR", "Failed to put on hold")),
+                )
+            })
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn add_comment(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<AddWorkOrderUpdate>,
 ) -> Result<(StatusCode, Json<WorkOrderUpdate>), (StatusCode, Json<ErrorResponse>)> {
-    load_work_order_for_user(&state, user.user_id, id).await?;
-    state
-        .work_order_repo
-        .add_comment(id, user.user_id, data)
-        .await
-        .map(|u| (StatusCode::CREATED, Json(u)))
-        .map_err(|e| {
-            tracing::error!("Failed to add comment: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to add comment")),
-            )
-        })
+    let uid = rls.user_id();
+    let out: Result<(StatusCode, Json<WorkOrderUpdate>), (StatusCode, Json<ErrorResponse>)> =
+        async {
+            load_work_order_for_user(&state, rls.conn(), uid, id).await?;
+            state
+                .work_order_repo
+                .add_comment(&mut **rls.conn(), id, uid, data)
+                .await
+                .map(|u| (StatusCode::CREATED, Json(u)))
+                .map_err(|e| {
+                    tracing::error!("Failed to add comment: {:?}", e);
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorResponse::new("DB_ERROR", "Failed to add comment")),
+                    )
+                })
+        }
+        .await;
+    rls.release().await;
+    out
 }
 
 async fn list_comments(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<Vec<WorkOrderUpdate>>, (StatusCode, Json<ErrorResponse>)> {
-    load_work_order_for_user(&state, user.user_id, id).await?;
-    state
-        .work_order_repo
-        .list_updates(id, query.limit.unwrap_or(50), query.offset.unwrap_or(0))
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list comments: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to list comments")),
+    let uid = rls.user_id();
+    let out: Result<Json<Vec<WorkOrderUpdate>>, (StatusCode, Json<ErrorResponse>)> = async {
+        load_work_order_for_user(&state, rls.conn(), uid, id).await?;
+        state
+            .work_order_repo
+            .list_updates(
+                &mut **rls.conn(),
+                id,
+                query.limit.unwrap_or(50),
+                query.offset.unwrap_or(0),
             )
-        })
+            .await
+            .map(Json)
+            .map_err(|e| {
+                tracing::error!("Failed to list comments: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("DB_ERROR", "Failed to list comments")),
+                )
+            })
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 // ==================== Maintenance Schedules (Story 20.3) ====================
 
 async fn create_schedule(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Json(payload): Json<CreateScheduleRequest>,
 ) -> Result<(StatusCode, Json<MaintenanceSchedule>), (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, payload.organization_id).await?;
-    state
-        .work_order_repo
-        .create_schedule(payload.organization_id, user.user_id, payload.data)
-        .await
-        .map(|s| (StatusCode::CREATED, Json(s)))
-        .map_err(|e| {
-            tracing::error!("Failed to create schedule: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to create schedule")),
-            )
-        })
+    let uid = rls.user_id();
+    let out: Result<(StatusCode, Json<MaintenanceSchedule>), (StatusCode, Json<ErrorResponse>)> =
+        async {
+            verify_org_access(&state, uid, payload.organization_id).await?;
+            state
+                .work_order_repo
+                .create_schedule(
+                    &mut **rls.conn(),
+                    payload.organization_id,
+                    uid,
+                    payload.data,
+                )
+                .await
+                .map(|s| (StatusCode::CREATED, Json(s)))
+                .map_err(|e| {
+                    tracing::error!("Failed to create schedule: {:?}", e);
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorResponse::new("DB_ERROR", "Failed to create schedule")),
+                    )
+                })
+        }
+        .await;
+    rls.release().await;
+    out
 }
 
 async fn list_schedules(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<ListSchedulesQuery>,
 ) -> Result<Json<Vec<MaintenanceSchedule>>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, query.organization_id).await?;
-    state
-        .work_order_repo
-        .list_schedules(query.organization_id, (&query).into())
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list schedules: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to list schedules")),
-            )
-        })
+    let uid = rls.user_id();
+    let out: Result<Json<Vec<MaintenanceSchedule>>, (StatusCode, Json<ErrorResponse>)> = async {
+        verify_org_access(&state, uid, query.organization_id).await?;
+        state
+            .work_order_repo
+            .list_schedules(&mut **rls.conn(), query.organization_id, (&query).into())
+            .await
+            .map(Json)
+            .map_err(|e| {
+                tracing::error!("Failed to list schedules: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("DB_ERROR", "Failed to list schedules")),
+                )
+            })
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn get_upcoming_schedules(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<UpcomingQuery>,
 ) -> Result<Json<Vec<UpcomingSchedule>>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, query.organization_id).await?;
-    state
-        .work_order_repo
-        .get_upcoming_schedules(
-            query.organization_id,
-            query.days_ahead.unwrap_or(30),
-            query.limit.unwrap_or(20),
-        )
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to get upcoming schedules: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to get upcoming")),
+    let uid = rls.user_id();
+    let out: Result<Json<Vec<UpcomingSchedule>>, (StatusCode, Json<ErrorResponse>)> = async {
+        verify_org_access(&state, uid, query.organization_id).await?;
+        state
+            .work_order_repo
+            .get_upcoming_schedules(
+                &mut **rls.conn(),
+                query.organization_id,
+                query.days_ahead.unwrap_or(30),
+                query.limit.unwrap_or(20),
             )
-        })
+            .await
+            .map(Json)
+            .map_err(|e| {
+                tracing::error!("Failed to get upcoming schedules: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("DB_ERROR", "Failed to get upcoming")),
+                )
+            })
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn process_due_schedules(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<OrgQuery>,
 ) -> Result<Json<Vec<WorkOrder>>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, query.organization_id).await?;
-    state
-        .work_order_repo
-        .process_due_schedules(query.organization_id)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to process due schedules: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DB_ERROR",
-                    "Failed to process schedules",
-                )),
-            )
-        })
+    let uid = rls.user_id();
+    let out: Result<Json<Vec<WorkOrder>>, (StatusCode, Json<ErrorResponse>)> = async {
+        verify_org_access(&state, uid, query.organization_id).await?;
+        state
+            .work_order_repo
+            .process_due_schedules(rls.conn(), query.organization_id)
+            .await
+            .map(Json)
+            .map_err(|e| {
+                tracing::error!("Failed to process due schedules: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new(
+                        "DB_ERROR",
+                        "Failed to process schedules",
+                    )),
+                )
+            })
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn get_schedule(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<MaintenanceSchedule>, (StatusCode, Json<ErrorResponse>)> {
-    let schedule = load_schedule_for_user(&state, user.user_id, id).await?;
-    Ok(Json(schedule))
+    let uid = rls.user_id();
+    let out = load_schedule_for_user(&state, rls.conn(), uid, id)
+        .await
+        .map(Json);
+    rls.release().await;
+    out
 }
 
 async fn update_schedule(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateMaintenanceSchedule>,
 ) -> Result<Json<MaintenanceSchedule>, (StatusCode, Json<ErrorResponse>)> {
-    load_schedule_for_user(&state, user.user_id, id).await?;
-    state
-        .work_order_repo
-        .update_schedule(id, data)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to update schedule: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to update schedule")),
-            )
-        })
+    let uid = rls.user_id();
+    let out: Result<Json<MaintenanceSchedule>, (StatusCode, Json<ErrorResponse>)> = async {
+        load_schedule_for_user(&state, rls.conn(), uid, id).await?;
+        state
+            .work_order_repo
+            .update_schedule(&mut **rls.conn(), id, data)
+            .await
+            .map(Json)
+            .map_err(|e| {
+                tracing::error!("Failed to update schedule: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("DB_ERROR", "Failed to update schedule")),
+                )
+            })
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn delete_schedule(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    load_schedule_for_user(&state, user.user_id, id).await?;
-    let deleted = state
-        .work_order_repo
-        .delete_schedule(id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to delete schedule: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to delete schedule")),
-            )
-        })?;
+    let uid = rls.user_id();
+    let out: Result<StatusCode, (StatusCode, Json<ErrorResponse>)> = async {
+        load_schedule_for_user(&state, rls.conn(), uid, id).await?;
+        let deleted = state
+            .work_order_repo
+            .delete_schedule(&mut **rls.conn(), id)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to delete schedule: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("DB_ERROR", "Failed to delete schedule")),
+                )
+            })?;
 
-    if deleted {
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Schedule not found")),
-        ))
+        if deleted {
+            Ok(StatusCode::NO_CONTENT)
+        } else {
+            Err((
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Schedule not found")),
+            ))
+        }
     }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn activate_schedule(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<MaintenanceSchedule>, (StatusCode, Json<ErrorResponse>)> {
-    load_schedule_for_user(&state, user.user_id, id).await?;
-    state
-        .work_order_repo
-        .set_schedule_active(id, true)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to activate schedule: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DB_ERROR",
-                    "Failed to activate schedule",
-                )),
-            )
-        })
+    let uid = rls.user_id();
+    let out: Result<Json<MaintenanceSchedule>, (StatusCode, Json<ErrorResponse>)> = async {
+        load_schedule_for_user(&state, rls.conn(), uid, id).await?;
+        state
+            .work_order_repo
+            .set_schedule_active(&mut **rls.conn(), id, true)
+            .await
+            .map(Json)
+            .map_err(|e| {
+                tracing::error!("Failed to activate schedule: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new(
+                        "DB_ERROR",
+                        "Failed to activate schedule",
+                    )),
+                )
+            })
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn deactivate_schedule(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<MaintenanceSchedule>, (StatusCode, Json<ErrorResponse>)> {
-    load_schedule_for_user(&state, user.user_id, id).await?;
-    state
-        .work_order_repo
-        .set_schedule_active(id, false)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to deactivate schedule: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DB_ERROR",
-                    "Failed to deactivate schedule",
-                )),
-            )
-        })
+    let uid = rls.user_id();
+    let out: Result<Json<MaintenanceSchedule>, (StatusCode, Json<ErrorResponse>)> = async {
+        load_schedule_for_user(&state, rls.conn(), uid, id).await?;
+        state
+            .work_order_repo
+            .set_schedule_active(&mut **rls.conn(), id, false)
+            .await
+            .map(Json)
+            .map_err(|e| {
+                tracing::error!("Failed to deactivate schedule: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new(
+                        "DB_ERROR",
+                        "Failed to deactivate schedule",
+                    )),
+                )
+            })
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn skip_schedule(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(data): Json<SkipRequest>,
 ) -> Result<Json<MaintenanceSchedule>, (StatusCode, Json<ErrorResponse>)> {
-    load_schedule_for_user(&state, user.user_id, id).await?;
-    state
-        .work_order_repo
-        .skip_schedule_execution(id, &data.reason)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to skip schedule: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to skip schedule")),
-            )
-        })
+    let uid = rls.user_id();
+    let out: Result<Json<MaintenanceSchedule>, (StatusCode, Json<ErrorResponse>)> = async {
+        load_schedule_for_user(&state, rls.conn(), uid, id).await?;
+        state
+            .work_order_repo
+            .skip_schedule_execution(rls.conn(), id, &data.reason)
+            .await
+            .map(Json)
+            .map_err(|e| {
+                tracing::error!("Failed to skip schedule: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("DB_ERROR", "Failed to skip schedule")),
+                )
+            })
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 async fn list_executions(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<Vec<ScheduleExecution>>, (StatusCode, Json<ErrorResponse>)> {
-    load_schedule_for_user(&state, user.user_id, id).await?;
-    state
-        .work_order_repo
-        .list_executions(id, query.limit.unwrap_or(50), query.offset.unwrap_or(0))
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list executions: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to list executions")),
+    let uid = rls.user_id();
+    let out: Result<Json<Vec<ScheduleExecution>>, (StatusCode, Json<ErrorResponse>)> = async {
+        load_schedule_for_user(&state, rls.conn(), uid, id).await?;
+        state
+            .work_order_repo
+            .list_executions(
+                &mut **rls.conn(),
+                id,
+                query.limit.unwrap_or(50),
+                query.offset.unwrap_or(0),
             )
-        })
+            .await
+            .map(Json)
+            .map_err(|e| {
+                tracing::error!("Failed to list executions: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("DB_ERROR", "Failed to list executions")),
+                )
+            })
+    }
+    .await;
+    rls.release().await;
+    out
 }
 
 // ==================== Service History (Story 20.4) ====================
 //
-// NOTE (#821 P2 — deferred): the two service-history endpoints below are keyed
-// by `equipment_id` / `building_id`, neither of which carries an
-// `organization_id` the handler can authorize against without a cross-resource
-// lookup (equipment/building → owning org). The work_order_repo exposes no
-// org-scoped variant for these queries, so closing the cross-tenant gap here
-// requires an org-scoped repo method (or threading the equipment/building repo
-// RLS lookup) — a separate slice tracked as the #821 P2 follow-up. The P1
-// IDOR on the work-order and schedule handlers (read/mutate by id, plus the
-// org-supplied create/list endpoints) is fixed above.
+// These two endpoints are keyed by `equipment_id` / `building_id`, neither of
+// which carries an `organization_id` the handler can authorize against without
+// a cross-resource lookup. With the PAP-179 conversion they now run on the
+// caller's `RlsConnection`, so under `FORCE` RLS the `work_orders` join is
+// scoped to the caller's org by the row-security policy — closing the #821 P2
+// cross-tenant gap at the database layer (a foreign org's equipment/building id
+// yields an empty history rather than another tenant's service records).
 
 async fn get_equipment_service_history(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(equipment_id): Path<Uuid>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<Vec<ServiceHistoryEntry>>, (StatusCode, Json<ErrorResponse>)> {
-    state
+    let out = state
         .work_order_repo
         .get_service_history(
+            &mut **rls.conn(),
             equipment_id,
             query.limit.unwrap_or(50),
             query.offset.unwrap_or(0),
@@ -884,18 +1082,21 @@ async fn get_equipment_service_history(
                     "Failed to get service history",
                 )),
             )
-        })
+        });
+    rls.release().await;
+    out
 }
 
 async fn get_building_service_history(
     State(state): State<AppState>,
-    _user: AuthUser,
+    mut rls: RlsConnection,
     Path(building_id): Path<Uuid>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<Vec<ServiceHistoryEntry>>, (StatusCode, Json<ErrorResponse>)> {
-    state
+    let out = state
         .work_order_repo
         .get_building_service_history(
+            &mut **rls.conn(),
             building_id,
             query.limit.unwrap_or(50),
             query.offset.unwrap_or(0),
@@ -911,25 +1112,38 @@ async fn get_building_service_history(
                     "Failed to get service history",
                 )),
             )
-        })
+        });
+    rls.release().await;
+    out
 }
 
 async fn get_cost_summary(
     State(state): State<AppState>,
-    user: AuthUser,
+    mut rls: RlsConnection,
     Query(query): Query<CostSummaryQuery>,
 ) -> Result<Json<Vec<MaintenanceCostSummary>>, (StatusCode, Json<ErrorResponse>)> {
-    verify_org_access(&state, user.user_id, query.organization_id).await?;
-    state
-        .work_order_repo
-        .get_cost_summary(query.organization_id, query.start_date, query.end_date)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to get cost summary: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to get cost summary")),
+    let uid = rls.user_id();
+    let out: Result<Json<Vec<MaintenanceCostSummary>>, (StatusCode, Json<ErrorResponse>)> = async {
+        verify_org_access(&state, uid, query.organization_id).await?;
+        state
+            .work_order_repo
+            .get_cost_summary(
+                &mut **rls.conn(),
+                query.organization_id,
+                query.start_date,
+                query.end_date,
             )
-        })
+            .await
+            .map(Json)
+            .map_err(|e| {
+                tracing::error!("Failed to get cost summary: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("DB_ERROR", "Failed to get cost summary")),
+                )
+            })
+    }
+    .await;
+    rls.release().await;
+    out
 }

--- a/backend/servers/api-server/tests/vendor_portal_stub_removal_tests.rs
+++ b/backend/servers/api-server/tests/vendor_portal_stub_removal_tests.rs
@@ -227,8 +227,13 @@ async fn work_orders_are_org_scoped(pool: PgPool) {
     let repo = WorkOrderRepository::new(pool.clone());
 
     // Org B sees NOTHING of Org A's jobs.
+    //
+    // The repo is now stateless (PAP-179): every method takes an
+    // RLS-context-bearing executor. This test runs on the `#[sqlx::test]`
+    // superuser pool (RLS bypassed), so the `WHERE organization_id = $1`
+    // predicate is what enforces org-scoping here; we pass `&pool` directly.
     let b_jobs = repo
-        .list(org_b, WorkOrderQuery::default())
+        .list(&pool, org_b, WorkOrderQuery::default())
         .await
         .expect("list org_b work orders");
     assert!(
@@ -243,7 +248,7 @@ async fn work_orders_are_org_scoped(pool: PgPool) {
 
     // Org A sees its own job (the legitimate success case).
     let a_jobs = repo
-        .list(org_a, WorkOrderQuery::default())
+        .list(&pool, org_a, WorkOrderQuery::default())
         .await
         .expect("list org_a work orders");
     assert!(

--- a/backend/servers/api-server/tests/work_order_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/work_order_cross_org_idor_tests.rs
@@ -38,9 +38,15 @@
 //!
 //! # TestApp wiring note
 //!
-//! `TestApp` mounts the full router but no `host_tenant_middleware`. The
-//! work-order routes use `AuthUser` (bearer JWT) and derive the org from the
-//! request/resource, so no `X-Tenant-ID` header is involved here.
+//! `TestApp` mounts the full router but no `host_tenant_middleware`. Since
+//! PAP-179 the work-order routes acquire an `RlsConnection`, which resolves the
+//! caller's org via `ValidatedTenantExtractor` — that requires an `X-Tenant-ID`
+//! header naming an org the caller is an active member of. Every request below
+//! therefore sets `X-Tenant-ID` to the caller's own org (Org B for the
+//! attacker, Org A for the legitimate member). The cross-tenant rejections then
+//! come from `verify_org_access` against the *resource's* org (the membership
+//! gate is bypassed at the DB layer here because the `#[sqlx::test]` pool
+//! connects as a superuser, so `FORCE` RLS does not bind).
 
 #[allow(dead_code)]
 mod common;
@@ -174,6 +180,7 @@ async fn get_work_order_from_other_org_is_rejected(pool: PgPool) {
         .execute(
             app.get(&format!("/api/v1/work-orders/{}", wo_in_a))
                 .bearer(&b_token)
+                .header("X-Tenant-ID", &org_b.to_string())
                 .build(),
         )
         .await;
@@ -222,6 +229,7 @@ async fn update_work_order_from_other_org_is_rejected(pool: PgPool) {
             axum::http::header::AUTHORIZATION,
             format!("Bearer {}", b_token),
         )
+        .header("X-Tenant-ID", org_b.to_string())
         .header(axum::http::header::CONTENT_TYPE, "application/json")
         .body(axum::body::Body::from(
             json!({ "title": "hijacked-title" }).to_string(),
@@ -275,6 +283,7 @@ async fn delete_work_order_from_other_org_is_rejected(pool: PgPool) {
         .execute(
             app.delete(&format!("/api/v1/work-orders/{}", wo_in_a))
                 .bearer(&b_token)
+                .header("X-Tenant-ID", &org_b.to_string())
                 .build(),
         )
         .await;
@@ -327,6 +336,7 @@ async fn create_work_order_for_other_org_is_rejected(pool: PgPool) {
         .execute(
             app.post("/api/v1/work-orders")
                 .bearer(&b_token)
+                .header("X-Tenant-ID", &org_b.to_string())
                 .json(json!({
                     "organization_id": org_a,
                     "building_id": building_a,
@@ -382,6 +392,7 @@ async fn get_work_order_same_org_succeeds(pool: PgPool) {
         .execute(
             app.get(&format!("/api/v1/work-orders/{}", wo_in_a))
                 .bearer(&token)
+                .header("X-Tenant-ID", &org_a.to_string())
                 .build(),
         )
         .await;


### PR DESCRIPTION
## Summary

- Make `WorkOrderRepository` stateless: unit struct, no `pool` field, `new(_pool)` is a marker ctor (same as `sensor.rs` / `equipment.rs` / `board_meetings.rs` precedents)
- 24 single-statement methods take `executor: E where E: Executor<'e, Database = Postgres>`; 8 multi-statement methods take `conn: &mut PgConnection` with per-statement `&mut *conn` reborrows
- All 28 route handlers converted from `AuthUser` to `RlsConnection`; executor calls thread `&mut **rls.conn()`, concrete `&mut PgConnection` calls use `rls.conn()` (auto-deref)
- `work_order_rls_repo_tests.rs`: NOSUPERUSER+NOBYPASSRLS role, Phase 1 (no context → deny-all) + Phase 2 (org-A context → own visible, org-B hidden)
- `work_order_cross_org_idor_tests.rs`: 5 IDOR tests verifying cross-tenant GET/PATCH/DELETE/POST rejection and same-org success (closes #821)
- Removes `work_order.rs` from `rls-pool-field-baseline.txt`; `check-rls-enforcement.sh --strict` stays green

## Verification

```
$ cd backend && rbuild cargo fmt --all -- --check
FMT_OK (exit 0)

$ rbuild cargo clippy -p db -p api-server --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.69s (exit 0)

$ ./scripts/check-rls-enforcement.sh --strict
✓ No RLS violations found (exit 0)
```

## Out-of-scope items I noticed

- `esg_reporting.rs` and `workflow.rs` are stale entries in `rls-pool-field-baseline.txt` (pre-existing warnings, not introduced here)

## Related

- PAP-151 (parent): sensor.rs + reserve_funds.rs already converted
- PAP-180: budget.rs conversion (sibling)