### PR TITLE
fix(api-server): X-Tenant-ID in reserve_funds IDOR tests (PAP-151 follow-up)

### DIFF
--- a/backend/servers/api-server/tests/reserve_funds_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/reserve_funds_cross_org_idor_tests.rs
@@ -139,6 +139,7 @@ async fn get_fund_same_org_succeeds(pool: PgPool) {
     let req = app
         .get(&format!("/api/v1/reserve-funds/{fund_id}"))
         .bearer(&token)
+        .header("X-Tenant-ID", &org_a.to_string())
         .build();
     let resp = app.execute(req).await;
 
@@ -172,6 +173,7 @@ async fn get_fund_cross_org_is_not_found(pool: PgPool) {
     let req = app
         .get(&format!("/api/v1/reserve-funds/{fund_id}"))
         .bearer(&token)
+        .header("X-Tenant-ID", &org_b.to_string())
         .build();
     let resp = app.execute(req).await;
 
@@ -203,6 +205,7 @@ async fn update_fund_cross_org_does_not_mutate(pool: PgPool) {
     let req = app
         .put(&format!("/api/v1/reserve-funds/{fund_id}"))
         .bearer(&token)
+        .header("X-Tenant-ID", &org_b.to_string())
         .json(serde_json::json!({ "name": "Hijacked Fund" }))
         .build();
     let resp = app.execute(req).await;


### PR DESCRIPTION
## What

The dev Backend `test` job is red on `api-server --test reserve_funds_cross_org_idor_tests` (3/3 fail: `400 Missing or invalid X-Tenant-ID header`) — the **only** failing binary. Surfaced after #1322 cleared the fmt regression that was short-circuiting the pipeline.

## Root cause

PR #1321 (PAP-151) RLS-converted `reserve_funds.rs` handlers to the `RlsConnection` extractor, which resolves the caller org via `ValidatedTenantExtractor`. Under `TestApp` (no `host_tenant_middleware`) that **requires an `X-Tenant-ID` header**. The pre-existing IDOR tests (old pool/JWT-claim contract) were never updated in #1321, so they 400 before reaching the handler.

## Fix

Add `X-Tenant-ID` = caller's own org to the 3 requests (org_a same-org→200; org_b cross-org→404), matching the documented convention every other RLS IDOR test follows (see `work_order_cross_org_idor_tests.rs` header). **Test-only; security semantics unchanged.** (Identical change is already bundled in the PAP-179 branch commit `f5425dfaa`; this lands it on `dev` standalone.)

## Why it matters

Restores **Green CI on `dev`** — the last exit gate for **PAP-54** (Stable Beta T4 release readiness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)