### PR TITLE
fix(api-server): PAP-76 route form repo through RLS-context connection

### DIFF
--- a/backend/crates/db/src/repositories/form.rs
+++ b/backend/crates/db/src/repositories/form.rs
@@ -1,6 +1,26 @@
 //! Form repository for Epic 54.
 //!
 //! Handles all database operations for forms, fields, and submissions.
+//!
+//! # RLS Integration (PAP-67 / PAP-76)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on the form tables (`forms`, `form_fields`,
+//! `form_submissions`, `form_downloads`). Under `FORCE` the api-server's owner
+//! connection is no longer exempt, so a query issued on a connection WITHOUT
+//! `app.current_org_id` set collapses to deny-all (own-org reads return empty,
+//! writes fail) — and on a BYPASSRLS/superuser pool the same query would run
+//! completely unscoped.
+//!
+//! Every method therefore takes an **executor whose connection already has RLS
+//! context set** (org + user GUCs) — in handlers this comes from the
+//! `RlsConnection` extractor via `&mut **rls.conn()`. Multi-statement methods
+//! (those that fire more than one query, e.g. a count plus a page fetch, or an
+//! INSERT that fans out into child-row INSERTs) take a `&mut PgConnection` so
+//! every statement runs on the *same* context-bearing connection. The
+//! repository holds **no pool**, so there is no way to issue a query that
+//! bypasses RLS. This mirrors the `work_order.rs` (PAP-179) /
+//! `budget.rs` (PAP-180) precedent.
 
 use crate::models::{
     form::FormSubmissionParams, form_status, submission_status, CreateForm, CreateFormField, Form,
@@ -8,19 +28,25 @@ use crate::models::{
     FormSubmissionWithDetails, FormSummary, FormWithDetails, ReviewSubmission, SubmissionListQuery,
     UpdateForm, UpdateFormField,
 };
-use sqlx::{PgPool, Row};
+use sqlx::{Executor, PgConnection, PgPool, Postgres, Row};
 use uuid::Uuid;
 
 /// Repository for form-related database operations.
+///
+/// Stateless: every method receives an RLS-context-bearing executor. The repo
+/// holds no pool so it cannot issue an un-scoped (deny-all under `FORCE`) query.
 #[derive(Clone)]
-pub struct FormRepository {
-    pool: PgPool,
-}
+pub struct FormRepository;
 
 impl FormRepository {
     /// Creates a new form repository.
-    pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+    ///
+    /// The pool argument is retained for construction-site compatibility with
+    /// the other repositories on `AppState`; this repo deliberately does not
+    /// store it (see module docs — all queries run on a context-set connection
+    /// supplied by the handler's `RlsConnection`).
+    pub fn new(_pool: PgPool) -> Self {
+        Self
     }
 
     // ========================================================================
@@ -30,6 +56,7 @@ impl FormRepository {
     /// Creates a new form.
     pub async fn create(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         user_id: Uuid,
         data: CreateForm,
@@ -64,7 +91,7 @@ impl FormRepository {
         .bind(data.submission_deadline)
         .bind(&data.confirmation_message)
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         // Create fields if provided
@@ -72,14 +99,23 @@ impl FormRepository {
         // The performance benefit is minimal for typical form creation (< 20 fields).
         // Keeping the simple approach for maintainability.
         for (index, field) in data.fields.into_iter().enumerate() {
-            self.create_field(form.id, field, index as i32).await?;
+            self.create_field(&mut *conn, form.id, field, index as i32)
+                .await?;
         }
 
         Ok(form)
     }
 
     /// Gets a form by ID.
-    pub async fn get(&self, org_id: Uuid, form_id: Uuid) -> Result<Option<Form>, sqlx::Error> {
+    pub async fn get<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+        form_id: Uuid,
+    ) -> Result<Option<Form>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, Form>(
             r#"
             SELECT * FROM forms
@@ -88,41 +124,42 @@ impl FormRepository {
         )
         .bind(form_id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await
     }
 
     /// Gets a form with all its details.
     pub async fn get_with_details(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         form_id: Uuid,
     ) -> Result<Option<FormWithDetails>, sqlx::Error> {
-        let form = match self.get(org_id, form_id).await? {
+        let form = match self.get(&mut *conn, org_id, form_id).await? {
             Some(f) => f,
             None => return Ok(None),
         };
 
-        let fields = self.get_fields(form_id).await?;
+        let fields = self.get_fields(&mut *conn, form_id).await?;
 
         let submission_count = sqlx::query_scalar::<_, i64>(
             "SELECT COUNT(*) FROM form_submissions WHERE form_id = $1",
         )
         .bind(form_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         let created_by_name = sqlx::query_scalar::<_, String>(
             "SELECT COALESCE(name, email) FROM users WHERE id = $1",
         )
         .bind(form.created_by)
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *conn)
         .await?;
 
         let published_by_name = if let Some(published_by) = form.published_by {
             sqlx::query_scalar::<_, String>("SELECT COALESCE(name, email) FROM users WHERE id = $1")
                 .bind(published_by)
-                .fetch_optional(&self.pool)
+                .fetch_optional(&mut *conn)
                 .await?
         } else {
             None
@@ -140,6 +177,7 @@ impl FormRepository {
     /// Lists forms for an organization with filtering and pagination.
     pub async fn list(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         query: FormListQuery,
     ) -> Result<(Vec<FormSummary>, i64), sqlx::Error> {
@@ -168,7 +206,7 @@ impl FormRepository {
         .bind(&query.category)
         .bind(query.building_id)
         .bind(query.search.as_ref().map(|s| format!("%{}%", s)))
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await?;
 
         // Build complete SQL with safe ORDER BY - avoid format!() with user input
@@ -327,7 +365,7 @@ impl FormRepository {
             .bind(query.search.as_ref().map(|s| format!("%{}%", s)))
             .bind(per_page)
             .bind(offset)
-            .fetch_all(&self.pool)
+            .fetch_all(&mut *conn)
             .await?;
 
         let forms: Vec<FormSummary> = rows
@@ -354,13 +392,14 @@ impl FormRepository {
     /// Updates a form.
     pub async fn update(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         form_id: Uuid,
         user_id: Uuid,
         data: UpdateForm,
     ) -> Result<Form, sqlx::Error> {
         // Check if form exists and is in draft status
-        let existing = self.get(org_id, form_id).await?;
+        let existing = self.get(&mut *conn, org_id, form_id).await?;
         if existing.is_none() {
             return Err(sqlx::Error::RowNotFound);
         }
@@ -402,12 +441,20 @@ impl FormRepository {
         .bind(user_id)
         .bind(form_id)
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *conn)
         .await
     }
 
     /// Soft deletes a form.
-    pub async fn delete(&self, org_id: Uuid, form_id: Uuid) -> Result<(), sqlx::Error> {
+    pub async fn delete<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+        form_id: Uuid,
+    ) -> Result<(), sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query(
             r#"
             UPDATE forms SET deleted_at = NOW()
@@ -416,19 +463,23 @@ impl FormRepository {
         )
         .bind(form_id)
         .bind(org_id)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
 
         Ok(())
     }
 
     /// Publishes a form.
-    pub async fn publish(
+    pub async fn publish<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         form_id: Uuid,
         user_id: Uuid,
-    ) -> Result<Form, sqlx::Error> {
+    ) -> Result<Form, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, Form>(
             r#"
             UPDATE forms SET
@@ -445,12 +496,20 @@ impl FormRepository {
         .bind(form_id)
         .bind(org_id)
         .bind(form_status::DRAFT)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Archives a form.
-    pub async fn archive(&self, org_id: Uuid, form_id: Uuid) -> Result<Form, sqlx::Error> {
+    pub async fn archive<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+        form_id: Uuid,
+    ) -> Result<Form, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, Form>(
             r#"
             UPDATE forms SET
@@ -464,7 +523,7 @@ impl FormRepository {
         .bind(form_status::ARCHIVED)
         .bind(form_id)
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
@@ -473,12 +532,16 @@ impl FormRepository {
     // ========================================================================
 
     /// Creates a new field for a form.
-    pub async fn create_field(
+    pub async fn create_field<'e, E>(
         &self,
+        executor: E,
         form_id: Uuid,
         data: CreateFormField,
         order: i32,
-    ) -> Result<FormField, sqlx::Error> {
+    ) -> Result<FormField, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let validation_rules = data
             .validation_rules
             .map(|r| serde_json::to_value(r).unwrap_or_default())
@@ -522,12 +585,19 @@ impl FormRepository {
         .bind(&data.width)
         .bind(&data.section)
         .bind(&conditional_display)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Gets all fields for a form.
-    pub async fn get_fields(&self, form_id: Uuid) -> Result<Vec<FormField>, sqlx::Error> {
+    pub async fn get_fields<'e, E>(
+        &self,
+        executor: E,
+        form_id: Uuid,
+    ) -> Result<Vec<FormField>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, FormField>(
             r#"
             SELECT * FROM form_fields
@@ -536,17 +606,21 @@ impl FormRepository {
             "#,
         )
         .bind(form_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
     }
 
     /// Updates a form field.
-    pub async fn update_field(
+    pub async fn update_field<'e, E>(
         &self,
+        executor: E,
         form_id: Uuid,
         field_id: Uuid,
         data: UpdateFormField,
-    ) -> Result<FormField, sqlx::Error> {
+    ) -> Result<FormField, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let validation_rules = data
             .validation_rules
             .map(|r| serde_json::to_value(r).unwrap_or_default());
@@ -593,27 +667,39 @@ impl FormRepository {
         .bind(&conditional_display)
         .bind(field_id)
         .bind(form_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Deletes a form field.
-    pub async fn delete_field(&self, form_id: Uuid, field_id: Uuid) -> Result<(), sqlx::Error> {
+    pub async fn delete_field<'e, E>(
+        &self,
+        executor: E,
+        form_id: Uuid,
+        field_id: Uuid,
+    ) -> Result<(), sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query("DELETE FROM form_fields WHERE id = $1 AND form_id = $2")
             .bind(field_id)
             .bind(form_id)
-            .execute(&self.pool)
+            .execute(executor)
             .await?;
 
         Ok(())
     }
 
     /// Reorders form fields.
-    pub async fn reorder_fields(
+    pub async fn reorder_fields<'e, E>(
         &self,
+        executor: E,
         form_id: Uuid,
         field_orders: Vec<(Uuid, i32)>,
-    ) -> Result<(), sqlx::Error> {
+    ) -> Result<(), sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         // If there are no fields to reorder, avoid running a no-op query.
         if field_orders.is_empty() {
             return Ok(());
@@ -640,7 +726,7 @@ impl FormRepository {
         .bind(&field_ids)
         .bind(&orders)
         .bind(form_id)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
 
         Ok(())
@@ -651,10 +737,14 @@ impl FormRepository {
     // ========================================================================
 
     /// Submits a form.
-    pub async fn submit(
+    pub async fn submit<'e, E>(
         &self,
+        executor: E,
         params: FormSubmissionParams,
-    ) -> Result<FormSubmission, sqlx::Error> {
+    ) -> Result<FormSubmission, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let attachments = params
             .data
             .attachments
@@ -688,16 +778,20 @@ impl FormRepository {
         .bind(submission_status::PENDING)
         .bind(&params.ip_address)
         .bind(&params.user_agent)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
     /// Gets a submission by ID.
-    pub async fn get_submission(
+    pub async fn get_submission<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         submission_id: Uuid,
-    ) -> Result<Option<FormSubmissionWithDetails>, sqlx::Error> {
+    ) -> Result<Option<FormSubmissionWithDetails>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let row = sqlx::query(
             r#"
             SELECT
@@ -718,7 +812,7 @@ impl FormRepository {
         )
         .bind(submission_id)
         .bind(org_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(executor)
         .await?;
 
         Ok(row.map(|r| FormSubmissionWithDetails {
@@ -753,6 +847,7 @@ impl FormRepository {
     /// Lists form submissions with filtering and pagination.
     pub async fn list_submissions(
         &self,
+        conn: &mut PgConnection,
         org_id: Uuid,
         query: SubmissionListQuery,
     ) -> Result<(Vec<FormSubmissionSummary>, i64), sqlx::Error> {
@@ -784,7 +879,7 @@ impl FormRepository {
             count_query = count_query.bind(status);
         }
 
-        let total = count_query.fetch_one(&self.pool).await?;
+        let total = count_query.fetch_one(&mut *conn).await?;
 
         // Main query
         let rows = sqlx::query(
@@ -827,7 +922,7 @@ impl FormRepository {
         .bind(query.to_date)
         .bind(per_page)
         .bind(offset)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await?;
 
         let submissions: Vec<FormSubmissionSummary> = rows
@@ -850,13 +945,17 @@ impl FormRepository {
     }
 
     /// Reviews a submission (approve/reject).
-    pub async fn review_submission(
+    pub async fn review_submission<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         submission_id: Uuid,
         reviewer_id: Uuid,
         data: ReviewSubmission,
-    ) -> Result<FormSubmission, sqlx::Error> {
+    ) -> Result<FormSubmission, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, FormSubmission>(
             r#"
             UPDATE form_submissions SET
@@ -874,7 +973,7 @@ impl FormRepository {
         .bind(&data.review_notes)
         .bind(submission_id)
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
     }
 
@@ -883,7 +982,14 @@ impl FormRepository {
     // ========================================================================
 
     /// Gets form statistics for an organization.
-    pub async fn get_statistics(&self, org_id: Uuid) -> Result<FormStatistics, sqlx::Error> {
+    pub async fn get_statistics<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+    ) -> Result<FormStatistics, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let row = sqlx::query(
             r#"
             SELECT
@@ -898,7 +1004,7 @@ impl FormRepository {
             "#,
         )
         .bind(org_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await?;
 
         Ok(FormStatistics {
@@ -918,13 +1024,17 @@ impl FormRepository {
     // ========================================================================
 
     /// Records a form download.
-    pub async fn record_download(
+    pub async fn record_download<'e, E>(
         &self,
+        executor: E,
         form_id: Uuid,
         user_id: Uuid,
         ip_address: Option<String>,
         user_agent: Option<String>,
-    ) -> Result<(), sqlx::Error> {
+    ) -> Result<(), sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query(
             r#"
             INSERT INTO form_downloads (form_id, downloaded_by, ip_address, user_agent)
@@ -935,17 +1045,24 @@ impl FormRepository {
         .bind(user_id)
         .bind(&ip_address)
         .bind(&user_agent)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
 
         Ok(())
     }
 
     /// Gets download count for a form.
-    pub async fn get_download_count(&self, form_id: Uuid) -> Result<i64, sqlx::Error> {
+    pub async fn get_download_count<'e, E>(
+        &self,
+        executor: E,
+        form_id: Uuid,
+    ) -> Result<i64, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM form_downloads WHERE form_id = $1")
             .bind(form_id)
-            .fetch_one(&self.pool)
+            .fetch_one(executor)
             .await
     }
 
@@ -954,12 +1071,16 @@ impl FormRepository {
     // ========================================================================
 
     /// Lists published forms available to a user.
-    pub async fn list_available_forms(
+    pub async fn list_available_forms<'e, E>(
         &self,
+        executor: E,
         org_id: Uuid,
         building_id: Option<Uuid>,
         _user_role: &str,
-    ) -> Result<Vec<FormSummary>, sqlx::Error> {
+    ) -> Result<Vec<FormSummary>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let rows = sqlx::query(
             r#"
             SELECT
@@ -996,7 +1117,7 @@ impl FormRepository {
         )
         .bind(org_id)
         .bind(building_id)
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await?;
 
         Ok(rows
@@ -1019,17 +1140,21 @@ impl FormRepository {
     }
 
     /// Checks if a user has already submitted a form.
-    pub async fn has_user_submitted(
+    pub async fn has_user_submitted<'e, E>(
         &self,
+        executor: E,
         form_id: Uuid,
         user_id: Uuid,
-    ) -> Result<bool, sqlx::Error> {
+    ) -> Result<bool, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let count = sqlx::query_scalar::<_, i64>(
             "SELECT COUNT(*) FROM form_submissions WHERE form_id = $1 AND submitted_by = $2",
         )
         .bind(form_id)
         .bind(user_id)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await?;
 
         Ok(count > 0)

--- a/backend/crates/db/tests/form_rls_repo_tests.rs
+++ b/backend/crates/db/tests/form_rls_repo_tests.rs
@@ -134,16 +134,16 @@ async fn form_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     {
         let mut conn = pool.acquire().await.expect("acquire");
         sqlx::query("SELECT clear_request_context()")
-            .execute(&mut *conn)
+            .execute(&mut conn)
             .await
             .expect("clear ctx");
         sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
-            .execute(&mut *conn)
+            .execute(&mut conn)
             .await
             .expect("set role");
 
         let found = repo
-            .get(&mut *conn, org_a, form_a)
+            .get(&mut conn, org_a, form_a)
             .await
             .expect("get (no ctx)");
         assert!(
@@ -152,7 +152,7 @@ async fn form_repo_force_rls_deny_all_and_fix(pool: PgPool) {
         );
 
         let (listed, total) = repo
-            .list(&mut *conn, org_a, FormListQuery::default())
+            .list(&mut conn, org_a, FormListQuery::default())
             .await
             .expect("list (no ctx)");
         assert!(
@@ -161,7 +161,7 @@ async fn form_repo_force_rls_deny_all_and_fix(pool: PgPool) {
         );
 
         sqlx::query("RESET ROLE")
-            .execute(&mut *conn)
+            .execute(&mut conn)
             .await
             .expect("reset role");
     }
@@ -175,17 +175,17 @@ async fn form_repo_force_rls_deny_all_and_fix(pool: PgPool) {
             .bind(org_a)
             .bind(user_a)
             .bind(false)
-            .execute(&mut *conn)
+            .execute(&mut conn)
             .await
             .expect("set org-A ctx");
         sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
-            .execute(&mut *conn)
+            .execute(&mut conn)
             .await
             .expect("set role");
 
         // (2) Own-org form IS now visible — the fix.
         let found = repo
-            .get(&mut *conn, org_a, form_a)
+            .get(&mut conn, org_a, form_a)
             .await
             .expect("get (ctx)");
         assert_eq!(
@@ -195,7 +195,7 @@ async fn form_repo_force_rls_deny_all_and_fix(pool: PgPool) {
         );
 
         let (listed, total) = repo
-            .list(&mut *conn, org_a, FormListQuery::default())
+            .list(&mut conn, org_a, FormListQuery::default())
             .await
             .expect("list (ctx)");
         assert!(
@@ -206,7 +206,7 @@ async fn form_repo_force_rls_deny_all_and_fix(pool: PgPool) {
 
         // (3) Org B's form stays invisible to an org-A caller.
         let cross = repo
-            .get(&mut *conn, org_a, form_b)
+            .get(&mut conn, org_a, form_b)
             .await
             .expect("cross-tenant get");
         assert!(
@@ -215,7 +215,7 @@ async fn form_repo_force_rls_deny_all_and_fix(pool: PgPool) {
         );
 
         sqlx::query("RESET ROLE")
-            .execute(&mut *conn)
+            .execute(&mut conn)
             .await
             .expect("reset role");
     }

--- a/backend/crates/db/tests/form_rls_repo_tests.rs
+++ b/backend/crates/db/tests/form_rls_repo_tests.rs
@@ -1,0 +1,238 @@
+//! Repo-level behavioral RLS regression test for PAP-76 (PAP-67 cluster).
+//!
+//! Background
+//! ----------
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` + the canonical
+//! `get_current_org_id()` policy on the form tables (`forms`, `form_fields`,
+//! `form_submissions`, `form_downloads`). Under `FORCE` the api-server's owner
+//! connection is no longer exempt, so a query issued on a connection WITHOUT
+//! `app.current_org_id` set collapses to deny-all — own-org reads return
+//! empty, writes fail.
+//!
+//! PAP-76 converted `FormRepository` to the stateless executor pattern
+//! (handlers pass `&mut **rls.conn()`), so every query runs under the
+//! caller's RLS context. This test exercises the repository methods
+//! themselves on a `FORCE`-bound NOSUPERUSER role and proves:
+//!
+//!   1. **Deny-all** — with the role bound but NO context set (exactly what
+//!      the old raw-pool repo did), an own-org `FormRepository::get` /
+//!      `list` returns nothing.
+//!   2. **Fix** — with `set_request_context(org, user)` applied first
+//!      (what `RlsConnection` does), the same calls surface the own-org row.
+//!   3. **Cross-tenant** — org B's form stays invisible to an org-A context.
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — even `FORCE` does not bind a superuser. The test creates a
+//! plain `NOSUPERUSER NOBYPASSRLS` role, grants it access, and `SET ROLE`s
+//! to it so `FORCE` actually enforces the policy the way the production
+//! owner role experiences it. Mirrors `budget_rls_repo_tests.rs`.
+
+use db::models::FormListQuery;
+use db::repositories::FormRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Form {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@form.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'Form User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Insert a form directly as the (RLS-exempt) superuser for an org.
+async fn seed_form(pool: &PgPool, org_id: Uuid, user_id: Uuid, title: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO forms (
+            organization_id, title, status, target_type, target_ids,
+            require_signatures, allow_multiple_submissions, created_by
+        )
+        VALUES ($1, $2, 'draft', 'all', '[]'::jsonb, false, true, $3)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(title)
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed form")
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn form_repo_force_rls_deny_all_and_fix(pool: PgPool) {
+    let repo = FormRepository::new(pool.clone());
+
+    // --- Seed as superuser / super-admin context ---
+    set_ctx(&pool, None, None, true).await;
+    let org_a = seed_org(&pool, "force-form-a").await;
+    let org_b = seed_org(&pool, "force-form-b").await;
+    let user_a = seed_user(&pool, "a@form.test").await;
+    let user_b = seed_user(&pool, "b@form.test").await;
+    let form_a = seed_form(&pool, org_a, user_a, "Form A").await;
+    let form_b = seed_form(&pool, org_b, user_b, "Form B").await;
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds ---
+    let role = format!("ppt_rls_form_{}", Uuid::new_v4().simple());
+    for stmt in [
+        format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
+        format!(
+            "GRANT SELECT, INSERT, UPDATE, DELETE ON \
+             forms, form_fields, form_submissions, form_downloads TO \"{role}\""
+        ),
+        format!(
+            "GRANT EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
+             get_current_org_not_deleted() TO \"{role}\""
+        ),
+        format!("GRANT SELECT ON organizations TO \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .expect("grant setup");
+    }
+
+    // ====================================================================
+    // (1) DENY-ALL: role bound, NO context set.
+    //     Own-org reads must return nothing.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT clear_request_context()")
+            .execute(&mut *conn)
+            .await
+            .expect("clear ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let found = repo
+            .get(&mut *conn, org_a, form_a)
+            .await
+            .expect("get (no ctx)");
+        assert!(
+            found.is_none(),
+            "PAP-76 regression: without RLS context, own-org form must be invisible (deny-all)"
+        );
+
+        let (listed, total) = repo
+            .list(&mut *conn, org_a, FormListQuery::default())
+            .await
+            .expect("list (no ctx)");
+        assert!(
+            listed.is_empty() && total == 0,
+            "PAP-76 regression: without RLS context, list must return deny-all empty"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // ====================================================================
+    // (2) FIX + (3) cross-tenant: set context, drop to role, query repo.
+    // ====================================================================
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(user_a)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A ctx");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        // (2) Own-org form IS now visible — the fix.
+        let found = repo
+            .get(&mut *conn, org_a, form_a)
+            .await
+            .expect("get (ctx)");
+        assert_eq!(
+            found.map(|f| f.id),
+            Some(form_a),
+            "PAP-76 fix: with RLS context set, the repo must return the own-org form"
+        );
+
+        let (listed, total) = repo
+            .list(&mut *conn, org_a, FormListQuery::default())
+            .await
+            .expect("list (ctx)");
+        assert!(
+            listed.iter().any(|f| f.id == form_a),
+            "PAP-76 fix: list returns own-org form under context"
+        );
+        assert!(total > 0, "total must be non-zero when context is set");
+
+        // (3) Org B's form stays invisible to an org-A caller.
+        let cross = repo
+            .get(&mut *conn, org_a, form_b)
+            .await
+            .expect("cross-tenant get");
+        assert!(
+            cross.is_none(),
+            "cross-tenant: org B's form must NOT be visible to an org-A caller"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup ---
+    set_ctx(&pool, None, None, true).await;
+    let _ = (form_b, user_b); // seeded for symmetry
+    for stmt in [
+        format!(
+            "REVOKE ALL ON forms, form_fields, form_submissions, form_downloads FROM \"{role}\""
+        ),
+        format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .ok();
+    }
+}

--- a/backend/scripts/rls-pool-field-baseline.txt
+++ b/backend/scripts/rls-pool-field-baseline.txt
@@ -13,7 +13,6 @@
 
 # --- PAP-67 original offender set, conversion still pending ---
 esg_reporting.rs     # PAP-72 (blocked on PAP-139)
-form.rs              # PAP-76
 workflow.rs          # PAP-77
 
 # --- PAP-80 sweep: conversion PRs in flight ---

--- a/backend/servers/api-server/src/routes/forms.rs
+++ b/backend/servers/api-server/src/routes/forms.rs
@@ -1,9 +1,18 @@
 //! Form routes (Epic 54: Forms Management).
 //!
 //! Provides endpoints for form templates, fields, and submissions.
+//!
+//! # RLS (PAP-76)
+//!
+//! Migration `00179` put `FORCE ROW LEVEL SECURITY` on the form tables so
+//! every query MUST run on a connection that has `app.current_org_id` set.
+//! Each handler acquires an [`RlsConnection`] (authenticates the caller,
+//! validates tenant membership, sets org/user GUCs on a dedicated connection)
+//! and passes `&mut **rls.conn()` to the repository. `rls.release()` clears
+//! the context before the connection returns to the pool.
 
 use crate::state::AppState;
-use api_core::{AuthUser, TenantExtractor};
+use api_core::extractors::RlsConnection;
 use axum::{
     extract::{ConnectInfo, Path, Query, State},
     http::StatusCode,
@@ -391,12 +400,12 @@ pub fn router() -> Router<AppState> {
 )]
 async fn create_form(
     State(state): State<AppState>,
-    auth: AuthUser,
-    tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Json(req): Json<CreateFormRequest>,
 ) -> Result<(StatusCode, Json<CreateFormResponse>), (StatusCode, Json<ErrorResponse>)> {
     // Authorization: require manager-level role
-    if !tenant.role.is_manager() {
+    if !rls.role().is_manager() {
+        rls.release().await;
         return Err((
             StatusCode::FORBIDDEN,
             Json(ErrorResponse::new(
@@ -408,12 +417,14 @@ async fn create_form(
 
     // Validate title
     if req.title.trim().is_empty() {
+        rls.release().await;
         return Err((
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new("BAD_REQUEST", "Title is required")),
         ));
     }
     if req.title.len() > MAX_TITLE_LENGTH {
+        rls.release().await;
         return Err((
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -429,6 +440,7 @@ async fn create_form(
     // Validate description
     if let Some(ref desc) = req.description {
         if desc.len() > MAX_DESCRIPTION_LENGTH {
+            rls.release().await;
             return Err((
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse::new(
@@ -444,6 +456,7 @@ async fn create_form(
 
     // Validate fields count
     if req.fields.len() > MAX_FIELDS_PER_FORM {
+        rls.release().await;
         return Err((
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -453,6 +466,8 @@ async fn create_form(
         ));
     }
 
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
     let repo = &state.form_repo;
 
     // Validate and convert fields, returning error on malformed JSON
@@ -514,9 +529,18 @@ async fn create_form(
         fields,
     };
 
-    let form = repo
-        .create(tenant.tenant_id, auth.user_id, create_data)
+    let out = repo
+        .create(&mut **rls.conn(), org_id, user_id, create_data)
         .await
+        .map(|form| {
+            (
+                StatusCode::CREATED,
+                Json(CreateFormResponse {
+                    id: form.id,
+                    message: "Form created successfully".to_string(),
+                }),
+            )
+        })
         .map_err(|e| {
             tracing::error!("Failed to create form: {:?}", e);
             (
@@ -526,15 +550,9 @@ async fn create_form(
                     "Failed to create form",
                 )),
             )
-        })?;
-
-    Ok((
-        StatusCode::CREATED,
-        Json(CreateFormResponse {
-            id: form.id,
-            message: "Form created successfully".to_string(),
-        }),
-    ))
+        });
+    rls.release().await;
+    out
 }
 
 /// List all forms (Story 54.1).
@@ -551,11 +569,12 @@ async fn create_form(
 )]
 async fn list_forms(
     State(state): State<AppState>,
-    tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Query(query): Query<ListFormsQuery>,
 ) -> Result<Json<FormListResponse>, (StatusCode, Json<ErrorResponse>)> {
     // Only managers can see all forms including drafts
-    if !tenant.role.is_manager() {
+    if !rls.role().is_manager() {
+        rls.release().await;
         return Err((
             StatusCode::FORBIDDEN,
             Json(ErrorResponse::new(
@@ -565,6 +584,7 @@ async fn list_forms(
         ));
     }
 
+    let org_id = rls.tenant_id();
     let repo = &state.form_repo;
 
     let form_query = FormListQuery {
@@ -578,20 +598,26 @@ async fn list_forms(
         sort_order: query.sort_order,
     };
 
-    let (forms, total) = repo.list(tenant.tenant_id, form_query).await.map_err(|e| {
-        tracing::error!("Failed to list forms: {:?}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to list forms")),
-        )
-    })?;
-
-    Ok(Json(FormListResponse {
-        forms,
-        total,
-        page: query.page.unwrap_or(1),
-        per_page: query.per_page.unwrap_or(20),
-    }))
+    let out = repo
+        .list(&mut **rls.conn(), org_id, form_query)
+        .await
+        .map(|(forms, total)| {
+            Json(FormListResponse {
+                forms,
+                total,
+                page: query.page.unwrap_or(1),
+                per_page: query.per_page.unwrap_or(20),
+            })
+        })
+        .map_err(|e| {
+            tracing::error!("Failed to list forms: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to list forms")),
+            )
+        });
+    rls.release().await;
+    out
 }
 
 /// List available forms for users (Story 54.2).
@@ -607,13 +633,15 @@ async fn list_forms(
 )]
 async fn list_available_forms(
     State(state): State<AppState>,
-    tenant: TenantExtractor,
+    mut rls: RlsConnection,
 ) -> Result<Json<AvailableFormsResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = rls.tenant_id();
     let repo = &state.form_repo;
 
-    let forms = repo
-        .list_available_forms(tenant.tenant_id, None, "")
+    let out = repo
+        .list_available_forms(&mut **rls.conn(), org_id, None, "")
         .await
+        .map(|forms| Json(AvailableFormsResponse { forms }))
         .map_err(|e| {
             tracing::error!("Failed to list available forms: {:?}", e);
             (
@@ -623,9 +651,9 @@ async fn list_available_forms(
                     "Failed to list available forms",
                 )),
             )
-        })?;
-
-    Ok(Json(AvailableFormsResponse { forms }))
+        });
+    rls.release().await;
+    out
 }
 
 /// Get form details.
@@ -643,13 +671,15 @@ async fn list_available_forms(
 )]
 async fn get_form(
     State(state): State<AppState>,
-    tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<FormDetailResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = rls.tenant_id();
+    let is_manager = rls.role().is_manager();
     let repo = &state.form_repo;
 
-    let form = repo
-        .get_with_details(tenant.tenant_id, id)
+    let out = repo
+        .get_with_details(&mut **rls.conn(), org_id, id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get form: {:?}", e);
@@ -657,23 +687,28 @@ async fn get_form(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get form")),
             )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Form not found")),
-            )
-        })?;
-
-    // Non-managers can only see published forms
-    if !tenant.role.is_manager() && form.form.status != form_status::PUBLISHED {
-        return Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Form not found")),
-        ));
-    }
-
-    Ok(Json(FormDetailResponse { form }))
+        })
+        .and_then(|opt| {
+            opt.ok_or_else(|| {
+                (
+                    StatusCode::NOT_FOUND,
+                    Json(ErrorResponse::new("NOT_FOUND", "Form not found")),
+                )
+            })
+        })
+        .and_then(|form| {
+            // Non-managers can only see published forms
+            if !is_manager && form.form.status != form_status::PUBLISHED {
+                Err((
+                    StatusCode::NOT_FOUND,
+                    Json(ErrorResponse::new("NOT_FOUND", "Form not found")),
+                ))
+            } else {
+                Ok(Json(FormDetailResponse { form }))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 /// Update a form.
@@ -694,12 +729,12 @@ async fn get_form(
 )]
 async fn update_form(
     State(state): State<AppState>,
-    auth: AuthUser,
-    tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateFormRequest>,
 ) -> Result<Json<FormActionResponse>, (StatusCode, Json<ErrorResponse>)> {
-    if !tenant.role.is_manager() {
+    if !rls.role().is_manager() {
+        rls.release().await;
         return Err((
             StatusCode::FORBIDDEN,
             Json(ErrorResponse::new(
@@ -709,10 +744,12 @@ async fn update_form(
         ));
     }
 
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
     let repo = &state.form_repo;
 
     // Check if form exists and is editable
-    let existing = repo.get(tenant.tenant_id, id).await.map_err(|e| {
+    let existing = repo.get(&mut **rls.conn(), org_id, id).await.map_err(|e| {
         tracing::error!("Failed to get form: {:?}", e);
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -728,6 +765,7 @@ async fn update_form(
     })?;
 
     if existing.status != form_status::DRAFT {
+        rls.release().await;
         return Err((
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -750,9 +788,15 @@ async fn update_form(
         confirmation_message: req.confirmation_message,
     };
 
-    let form = repo
-        .update(tenant.tenant_id, id, auth.user_id, update_data)
+    let out = repo
+        .update(&mut **rls.conn(), org_id, id, user_id, update_data)
         .await
+        .map(|form| {
+            Json(FormActionResponse {
+                message: "Form updated successfully".to_string(),
+                form,
+            })
+        })
         .map_err(|e| {
             tracing::error!("Failed to update form: {:?}", e);
             (
@@ -762,12 +806,9 @@ async fn update_form(
                     "Failed to update form",
                 )),
             )
-        })?;
-
-    Ok(Json(FormActionResponse {
-        message: "Form updated successfully".to_string(),
-        form,
-    }))
+        });
+    rls.release().await;
+    out
 }
 
 /// Delete a form.
@@ -786,10 +827,11 @@ async fn update_form(
 )]
 async fn delete_form(
     State(state): State<AppState>,
-    tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    if !tenant.role.is_manager() {
+    if !rls.role().is_manager() {
+        rls.release().await;
         return Err((
             StatusCode::FORBIDDEN,
             Json(ErrorResponse::new(
@@ -799,20 +841,25 @@ async fn delete_form(
         ));
     }
 
+    let org_id = rls.tenant_id();
     let repo = &state.form_repo;
 
-    repo.delete(tenant.tenant_id, id).await.map_err(|e| {
-        tracing::error!("Failed to delete form: {:?}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new(
-                "INTERNAL_ERROR",
-                "Failed to delete form",
-            )),
-        )
-    })?;
-
-    Ok(StatusCode::NO_CONTENT)
+    let out = repo
+        .delete(&mut **rls.conn(), org_id, id)
+        .await
+        .map(|_| StatusCode::NO_CONTENT)
+        .map_err(|e| {
+            tracing::error!("Failed to delete form: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(
+                    "INTERNAL_ERROR",
+                    "Failed to delete form",
+                )),
+            )
+        });
+    rls.release().await;
+    out
 }
 
 /// Publish a form.
@@ -832,11 +879,11 @@ async fn delete_form(
 )]
 async fn publish_form(
     State(state): State<AppState>,
-    auth: AuthUser,
-    tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<FormActionResponse>, (StatusCode, Json<ErrorResponse>)> {
-    if !tenant.role.is_manager() {
+    if !rls.role().is_manager() {
+        rls.release().await;
         return Err((
             StatusCode::FORBIDDEN,
             Json(ErrorResponse::new(
@@ -846,10 +893,12 @@ async fn publish_form(
         ));
     }
 
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
     let repo = &state.form_repo;
 
     // Check that form has at least one field
-    let fields = repo.get_fields(id).await.map_err(|e| {
+    let fields = repo.get_fields(&mut **rls.conn(), id).await.map_err(|e| {
         tracing::error!("Failed to get form fields: {:?}", e);
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -861,6 +910,7 @@ async fn publish_form(
     })?;
 
     if fields.is_empty() {
+        rls.release().await;
         return Err((
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -870,9 +920,15 @@ async fn publish_form(
         ));
     }
 
-    let form = repo
-        .publish(tenant.tenant_id, id, auth.user_id)
+    let out = repo
+        .publish(&mut **rls.conn(), org_id, id, user_id)
         .await
+        .map(|form| {
+            Json(FormActionResponse {
+                message: "Form published successfully".to_string(),
+                form,
+            })
+        })
         .map_err(|e| {
             tracing::error!("Failed to publish form: {:?}", e);
             (
@@ -882,12 +938,9 @@ async fn publish_form(
                     "Cannot publish form - it may already be published",
                 )),
             )
-        })?;
-
-    Ok(Json(FormActionResponse {
-        message: "Form published successfully".to_string(),
-        form,
-    }))
+        });
+    rls.release().await;
+    out
 }
 
 /// Archive a form.
@@ -906,10 +959,11 @@ async fn publish_form(
 )]
 async fn archive_form(
     State(state): State<AppState>,
-    tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<FormActionResponse>, (StatusCode, Json<ErrorResponse>)> {
-    if !tenant.role.is_manager() {
+    if !rls.role().is_manager() {
+        rls.release().await;
         return Err((
             StatusCode::FORBIDDEN,
             Json(ErrorResponse::new(
@@ -919,23 +973,30 @@ async fn archive_form(
         ));
     }
 
+    let org_id = rls.tenant_id();
     let repo = &state.form_repo;
 
-    let form = repo.archive(tenant.tenant_id, id).await.map_err(|e| {
-        tracing::error!("Failed to archive form: {:?}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new(
-                "INTERNAL_ERROR",
-                "Failed to archive form",
-            )),
-        )
-    })?;
-
-    Ok(Json(FormActionResponse {
-        message: "Form archived successfully".to_string(),
-        form,
-    }))
+    let out = repo
+        .archive(&mut **rls.conn(), org_id, id)
+        .await
+        .map(|form| {
+            Json(FormActionResponse {
+                message: "Form archived successfully".to_string(),
+                form,
+            })
+        })
+        .map_err(|e| {
+            tracing::error!("Failed to archive form: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(
+                    "INTERNAL_ERROR",
+                    "Failed to archive form",
+                )),
+            )
+        });
+    rls.release().await;
+    out
 }
 
 /// Get form statistics.
@@ -952,9 +1013,10 @@ async fn archive_form(
 )]
 async fn get_statistics(
     State(state): State<AppState>,
-    tenant: TenantExtractor,
+    mut rls: RlsConnection,
 ) -> Result<Json<FormStatisticsResponse>, (StatusCode, Json<ErrorResponse>)> {
-    if !tenant.role.is_manager() {
+    if !rls.role().is_manager() {
+        rls.release().await;
         return Err((
             StatusCode::FORBIDDEN,
             Json(ErrorResponse::new(
@@ -964,20 +1026,25 @@ async fn get_statistics(
         ));
     }
 
+    let org_id = rls.tenant_id();
     let repo = &state.form_repo;
 
-    let statistics = repo.get_statistics(tenant.tenant_id).await.map_err(|e| {
-        tracing::error!("Failed to get statistics: {:?}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new(
-                "INTERNAL_ERROR",
-                "Failed to get statistics",
-            )),
-        )
-    })?;
-
-    Ok(Json(FormStatisticsResponse { statistics }))
+    let out = repo
+        .get_statistics(&mut **rls.conn(), org_id)
+        .await
+        .map(|statistics| Json(FormStatisticsResponse { statistics }))
+        .map_err(|e| {
+            tracing::error!("Failed to get statistics: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(
+                    "INTERNAL_ERROR",
+                    "Failed to get statistics",
+                )),
+            )
+        });
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -999,13 +1066,14 @@ async fn get_statistics(
 )]
 async fn list_fields(
     State(state): State<AppState>,
-    tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<Json<FieldsResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = rls.tenant_id();
     let repo = &state.form_repo;
 
     // Verify form exists and user has access
-    let form = repo.get(tenant.tenant_id, id).await.map_err(|e| {
+    let form = repo.get(&mut **rls.conn(), org_id, id).await.map_err(|e| {
         tracing::error!("Failed to get form: {:?}", e);
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -1014,21 +1082,26 @@ async fn list_fields(
     })?;
 
     if form.is_none() {
+        rls.release().await;
         return Err((
             StatusCode::NOT_FOUND,
             Json(ErrorResponse::new("NOT_FOUND", "Form not found")),
         ));
     }
 
-    let fields = repo.get_fields(id).await.map_err(|e| {
-        tracing::error!("Failed to get fields: {:?}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get fields")),
-        )
-    })?;
-
-    Ok(Json(FieldsResponse { fields }))
+    let out = repo
+        .get_fields(&mut **rls.conn(), id)
+        .await
+        .map(|fields| Json(FieldsResponse { fields }))
+        .map_err(|e| {
+            tracing::error!("Failed to get fields: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get fields")),
+            )
+        });
+    rls.release().await;
+    out
 }
 
 /// Add a field to a form.
@@ -1049,11 +1122,12 @@ async fn list_fields(
 )]
 async fn add_field(
     State(state): State<AppState>,
-    tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<CreateFormFieldRequest>,
 ) -> Result<(StatusCode, Json<FieldActionResponse>), (StatusCode, Json<ErrorResponse>)> {
-    if !tenant.role.is_manager() {
+    if !rls.role().is_manager() {
+        rls.release().await;
         return Err((
             StatusCode::FORBIDDEN,
             Json(ErrorResponse::new(
@@ -1063,10 +1137,11 @@ async fn add_field(
         ));
     }
 
+    let org_id = rls.tenant_id();
     let repo = &state.form_repo;
 
     // Verify form exists and is editable
-    let form = repo.get(tenant.tenant_id, id).await.map_err(|e| {
+    let form = repo.get(&mut **rls.conn(), org_id, id).await.map_err(|e| {
         tracing::error!("Failed to get form: {:?}", e);
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -1082,6 +1157,7 @@ async fn add_field(
     })?;
 
     if form.status != form_status::DRAFT {
+        rls.release().await;
         return Err((
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -1116,9 +1192,18 @@ async fn add_field(
         conditional_display: None,
     };
 
-    let field = repo
-        .create_field(id, field_data, req.field_order)
+    let out = repo
+        .create_field(&mut **rls.conn(), id, field_data, req.field_order)
         .await
+        .map(|field| {
+            (
+                StatusCode::CREATED,
+                Json(FieldActionResponse {
+                    message: "Field added successfully".to_string(),
+                    field,
+                }),
+            )
+        })
         .map_err(|e| {
             tracing::error!("Failed to add field: {:?}", e);
             (
@@ -1128,15 +1213,9 @@ async fn add_field(
                     "Failed to add field - field key may already exist",
                 )),
             )
-        })?;
-
-    Ok((
-        StatusCode::CREATED,
-        Json(FieldActionResponse {
-            message: "Field added successfully".to_string(),
-            field,
-        }),
-    ))
+        });
+    rls.release().await;
+    out
 }
 
 /// Update a form field.
@@ -1160,11 +1239,12 @@ async fn add_field(
 )]
 async fn update_field(
     State(state): State<AppState>,
-    tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Path((id, field_id)): Path<(Uuid, Uuid)>,
     Json(req): Json<UpdateFormFieldRequest>,
 ) -> Result<Json<FieldActionResponse>, (StatusCode, Json<ErrorResponse>)> {
-    if !tenant.role.is_manager() {
+    if !rls.role().is_manager() {
+        rls.release().await;
         return Err((
             StatusCode::FORBIDDEN,
             Json(ErrorResponse::new(
@@ -1174,10 +1254,11 @@ async fn update_field(
         ));
     }
 
+    let org_id = rls.tenant_id();
     let repo = &state.form_repo;
 
     // Verify form exists and is editable
-    let form = repo.get(tenant.tenant_id, id).await.map_err(|e| {
+    let form = repo.get(&mut **rls.conn(), org_id, id).await.map_err(|e| {
         tracing::error!("Failed to get form: {:?}", e);
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -1193,6 +1274,7 @@ async fn update_field(
     })?;
 
     if form.status != form_status::DRAFT {
+        rls.release().await;
         return Err((
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -1226,21 +1308,24 @@ async fn update_field(
         conditional_display: None,
     };
 
-    let field = repo
-        .update_field(id, field_id, update_data)
+    let out = repo
+        .update_field(&mut **rls.conn(), id, field_id, update_data)
         .await
+        .map(|field| {
+            Json(FieldActionResponse {
+                message: "Field updated successfully".to_string(),
+                field,
+            })
+        })
         .map_err(|e| {
             tracing::error!("Failed to update field: {:?}", e);
             (
                 StatusCode::NOT_FOUND,
                 Json(ErrorResponse::new("NOT_FOUND", "Field not found")),
             )
-        })?;
-
-    Ok(Json(FieldActionResponse {
-        message: "Field updated successfully".to_string(),
-        field,
-    }))
+        });
+    rls.release().await;
+    out
 }
 
 /// Delete a form field.
@@ -1262,10 +1347,11 @@ async fn update_field(
 )]
 async fn delete_field(
     State(state): State<AppState>,
-    tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Path((id, field_id)): Path<(Uuid, Uuid)>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    if !tenant.role.is_manager() {
+    if !rls.role().is_manager() {
+        rls.release().await;
         return Err((
             StatusCode::FORBIDDEN,
             Json(ErrorResponse::new(
@@ -1275,10 +1361,11 @@ async fn delete_field(
         ));
     }
 
+    let org_id = rls.tenant_id();
     let repo = &state.form_repo;
 
     // Verify form exists and is editable
-    let form = repo.get(tenant.tenant_id, id).await.map_err(|e| {
+    let form = repo.get(&mut **rls.conn(), org_id, id).await.map_err(|e| {
         tracing::error!("Failed to get form: {:?}", e);
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -1294,6 +1381,7 @@ async fn delete_field(
     })?;
 
     if form.status != form_status::DRAFT {
+        rls.release().await;
         return Err((
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -1303,18 +1391,22 @@ async fn delete_field(
         ));
     }
 
-    repo.delete_field(id, field_id).await.map_err(|e| {
-        tracing::error!("Failed to delete field: {:?}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new(
-                "INTERNAL_ERROR",
-                "Failed to delete field",
-            )),
-        )
-    })?;
-
-    Ok(StatusCode::NO_CONTENT)
+    let out = repo
+        .delete_field(&mut **rls.conn(), id, field_id)
+        .await
+        .map(|_| StatusCode::NO_CONTENT)
+        .map_err(|e| {
+            tracing::error!("Failed to delete field: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(
+                    "INTERNAL_ERROR",
+                    "Failed to delete field",
+                )),
+            )
+        });
+    rls.release().await;
+    out
 }
 
 /// Reorder form fields.
@@ -1335,11 +1427,12 @@ async fn delete_field(
 )]
 async fn reorder_fields(
     State(state): State<AppState>,
-    tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<ReorderFieldsRequest>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    if !tenant.role.is_manager() {
+    if !rls.role().is_manager() {
+        rls.release().await;
         return Err((
             StatusCode::FORBIDDEN,
             Json(ErrorResponse::new(
@@ -1349,10 +1442,11 @@ async fn reorder_fields(
         ));
     }
 
+    let org_id = rls.tenant_id();
     let repo = &state.form_repo;
 
     // Verify form exists and is editable
-    let form = repo.get(tenant.tenant_id, id).await.map_err(|e| {
+    let form = repo.get(&mut **rls.conn(), org_id, id).await.map_err(|e| {
         tracing::error!("Failed to get form: {:?}", e);
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -1368,6 +1462,7 @@ async fn reorder_fields(
     })?;
 
     if form.status != form_status::DRAFT {
+        rls.release().await;
         return Err((
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -1383,18 +1478,22 @@ async fn reorder_fields(
         .map(|fo| (fo.field_id, fo.order))
         .collect();
 
-    repo.reorder_fields(id, field_orders).await.map_err(|e| {
-        tracing::error!("Failed to reorder fields: {:?}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new(
-                "INTERNAL_ERROR",
-                "Failed to reorder fields",
-            )),
-        )
-    })?;
-
-    Ok(StatusCode::OK)
+    let out = repo
+        .reorder_fields(&mut **rls.conn(), id, field_orders)
+        .await
+        .map(|_| StatusCode::OK)
+        .map_err(|e| {
+            tracing::error!("Failed to reorder fields: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(
+                    "INTERNAL_ERROR",
+                    "Failed to reorder fields",
+                )),
+            )
+        });
+    rls.release().await;
+    out
 }
 
 // ============================================================================
@@ -1418,8 +1517,7 @@ async fn reorder_fields(
 )]
 async fn submit_form(
     State(state): State<AppState>,
-    auth: AuthUser,
-    tenant: TenantExtractor,
+    mut rls: RlsConnection,
     headers: axum::http::HeaderMap,
     ConnectInfo(addr): ConnectInfo<std::net::SocketAddr>,
     Path(id): Path<Uuid>,
@@ -1438,11 +1536,14 @@ async fn submit_form(
         .get(axum::http::header::USER_AGENT)
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string());
+
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
     let repo = &state.form_repo;
 
     // Get form details
     let form = repo
-        .get_with_details(tenant.tenant_id, id)
+        .get_with_details(&mut **rls.conn(), org_id, id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get form: {:?}", e);
@@ -1460,6 +1561,7 @@ async fn submit_form(
 
     // Verify form is published
     if form.form.status != form_status::PUBLISHED {
+        rls.release().await;
         return Err((
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -1472,7 +1574,7 @@ async fn submit_form(
     // Check if user already submitted and multiple submissions not allowed
     if !form.form.allow_multiple_submissions {
         let has_submitted = repo
-            .has_user_submitted(id, auth.user_id)
+            .has_user_submitted(&mut **rls.conn(), id, user_id)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to check submission: {:?}", e);
@@ -1486,6 +1588,7 @@ async fn submit_form(
             })?;
 
         if has_submitted {
+            rls.release().await;
             return Err((
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse::new(
@@ -1499,6 +1602,7 @@ async fn submit_form(
     // Check deadline
     if let Some(deadline) = form.form.submission_deadline {
         if chrono::Utc::now() > deadline {
+            rls.release().await;
             return Err((
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse::new(
@@ -1520,6 +1624,7 @@ async fn submit_form(
                     .map(|s| s.is_empty())
                     .unwrap_or(false)
             {
+                rls.release().await;
                 return Err((
                     StatusCode::BAD_REQUEST,
                     Json(ErrorResponse::new(
@@ -1533,6 +1638,7 @@ async fn submit_form(
 
     // Check signature requirement
     if form.form.require_signatures && req.signature_data.is_none() {
+        rls.release().await;
         return Err((
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -1570,18 +1676,33 @@ async fn submit_form(
         },
     };
 
-    let submission = repo
-        .submit(FormSubmissionParams {
-            org_id: tenant.tenant_id,
-            form_id: id,
-            user_id: auth.user_id,
-            building_id: None, // could be extracted from user context if needed
-            unit_id: None,     // could be extracted from user context if needed
-            data: submit_data,
-            ip_address: ip_address.clone(),
-            user_agent: user_agent.clone(),
-        })
+    let confirmation_message = form.form.confirmation_message.clone();
+
+    let out = repo
+        .submit(
+            &mut **rls.conn(),
+            FormSubmissionParams {
+                org_id,
+                form_id: id,
+                user_id,
+                building_id: None, // could be extracted from user context if needed
+                unit_id: None,     // could be extracted from user context if needed
+                data: submit_data,
+                ip_address: ip_address.clone(),
+                user_agent: user_agent.clone(),
+            },
+        )
         .await
+        .map(|submission| {
+            (
+                StatusCode::CREATED,
+                Json(SubmitFormResponse {
+                    id: submission.id,
+                    message: "Form submitted successfully".to_string(),
+                    confirmation_message,
+                }),
+            )
+        })
         .map_err(|e| {
             tracing::error!("Failed to submit form: {:?}", e);
             (
@@ -1591,16 +1712,9 @@ async fn submit_form(
                     "Failed to submit form",
                 )),
             )
-        })?;
-
-    Ok((
-        StatusCode::CREATED,
-        Json(SubmitFormResponse {
-            id: submission.id,
-            message: "Form submitted successfully".to_string(),
-            confirmation_message: form.form.confirmation_message,
-        }),
-    ))
+        });
+    rls.release().await;
+    out
 }
 
 /// List submissions for a form (Story 54.4).
@@ -1622,11 +1736,12 @@ async fn submit_form(
 )]
 async fn list_submissions(
     State(state): State<AppState>,
-    tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Query(query): Query<ListSubmissionsQuery>,
 ) -> Result<Json<SubmissionListResponse>, (StatusCode, Json<ErrorResponse>)> {
-    if !tenant.role.is_manager() {
+    if !rls.role().is_manager() {
+        rls.release().await;
         return Err((
             StatusCode::FORBIDDEN,
             Json(ErrorResponse::new(
@@ -1636,6 +1751,7 @@ async fn list_submissions(
         ));
     }
 
+    let org_id = rls.tenant_id();
     let repo = &state.form_repo;
 
     let sub_query = SubmissionListQuery {
@@ -1650,9 +1766,17 @@ async fn list_submissions(
         per_page: query.per_page,
     };
 
-    let (submissions, total) = repo
-        .list_submissions(tenant.tenant_id, sub_query)
+    let out = repo
+        .list_submissions(&mut **rls.conn(), org_id, sub_query)
         .await
+        .map(|(submissions, total)| {
+            Json(SubmissionListResponse {
+                submissions,
+                total,
+                page: query.page.unwrap_or(1),
+                per_page: query.per_page.unwrap_or(20),
+            })
+        })
         .map_err(|e| {
             tracing::error!("Failed to list submissions: {:?}", e);
             (
@@ -1662,14 +1786,9 @@ async fn list_submissions(
                     "Failed to list submissions",
                 )),
             )
-        })?;
-
-    Ok(Json(SubmissionListResponse {
-        submissions,
-        total,
-        page: query.page.unwrap_or(1),
-        per_page: query.per_page.unwrap_or(20),
-    }))
+        });
+    rls.release().await;
+    out
 }
 
 /// Get submission details.
@@ -1691,14 +1810,16 @@ async fn list_submissions(
 )]
 async fn get_submission(
     State(state): State<AppState>,
-    auth: AuthUser,
-    tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Path((_id, submission_id)): Path<(Uuid, Uuid)>,
 ) -> Result<Json<SubmissionDetailResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+    let is_manager = rls.role().is_manager();
     let repo = &state.form_repo;
 
-    let submission = repo
-        .get_submission(tenant.tenant_id, submission_id)
+    let out = repo
+        .get_submission(&mut **rls.conn(), org_id, submission_id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get submission: {:?}", e);
@@ -1709,26 +1830,31 @@ async fn get_submission(
                     "Failed to get submission",
                 )),
             )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Submission not found")),
-            )
-        })?;
-
-    // Non-managers can only view their own submissions
-    if !tenant.role.is_manager() && submission.submission.submitted_by != auth.user_id {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse::new(
-                "FORBIDDEN",
-                "You can only view your own submissions",
-            )),
-        ));
-    }
-
-    Ok(Json(SubmissionDetailResponse { submission }))
+        })
+        .and_then(|opt| {
+            opt.ok_or_else(|| {
+                (
+                    StatusCode::NOT_FOUND,
+                    Json(ErrorResponse::new("NOT_FOUND", "Submission not found")),
+                )
+            })
+        })
+        .and_then(|submission| {
+            // Non-managers can only view their own submissions
+            if !is_manager && submission.submission.submitted_by != user_id {
+                Err((
+                    StatusCode::FORBIDDEN,
+                    Json(ErrorResponse::new(
+                        "FORBIDDEN",
+                        "You can only view your own submissions",
+                    )),
+                ))
+            } else {
+                Ok(Json(SubmissionDetailResponse { submission }))
+            }
+        });
+    rls.release().await;
+    out
 }
 
 /// Review a submission (approve/reject).
@@ -1752,12 +1878,12 @@ async fn get_submission(
 )]
 async fn review_submission(
     State(state): State<AppState>,
-    auth: AuthUser,
-    tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Path((_id, submission_id)): Path<(Uuid, Uuid)>,
     Json(req): Json<ReviewSubmissionRequest>,
 ) -> Result<Json<SubmissionDetailResponse>, (StatusCode, Json<ErrorResponse>)> {
-    if !tenant.role.is_manager() {
+    if !rls.role().is_manager() {
+        rls.release().await;
         return Err((
             StatusCode::FORBIDDEN,
             Json(ErrorResponse::new(
@@ -1769,6 +1895,7 @@ async fn review_submission(
 
     // Validate status
     if req.status != "approved" && req.status != "rejected" {
+        rls.release().await;
         return Err((
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -1778,6 +1905,8 @@ async fn review_submission(
         ));
     }
 
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
     let repo = &state.form_repo;
 
     let review_data = ReviewSubmission {
@@ -1785,19 +1914,25 @@ async fn review_submission(
         review_notes: req.review_notes,
     };
 
-    repo.review_submission(tenant.tenant_id, submission_id, auth.user_id, review_data)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to review submission: {:?}", e);
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Submission not found")),
-            )
-        })?;
+    repo.review_submission(
+        &mut **rls.conn(),
+        org_id,
+        submission_id,
+        user_id,
+        review_data,
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!("Failed to review submission: {:?}", e);
+        (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("NOT_FOUND", "Submission not found")),
+        )
+    })?;
 
     // Get updated submission
-    let submission = repo
-        .get_submission(tenant.tenant_id, submission_id)
+    let out = repo
+        .get_submission(&mut **rls.conn(), org_id, submission_id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get submission: {:?}", e);
@@ -1808,15 +1943,18 @@ async fn review_submission(
                     "Failed to get submission",
                 )),
             )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::new("NOT_FOUND", "Submission not found")),
-            )
-        })?;
-
-    Ok(Json(SubmissionDetailResponse { submission }))
+        })
+        .and_then(|opt| {
+            opt.ok_or_else(|| {
+                (
+                    StatusCode::NOT_FOUND,
+                    Json(ErrorResponse::new("NOT_FOUND", "Submission not found")),
+                )
+            })
+        })
+        .map(|submission| Json(SubmissionDetailResponse { submission }));
+    rls.release().await;
+    out
 }
 
 /// Record form download (Story 54.2).
@@ -1834,14 +1972,15 @@ async fn review_submission(
 )]
 async fn record_download(
     State(state): State<AppState>,
-    auth: AuthUser,
-    tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
     let repo = &state.form_repo;
 
     // Verify form exists
-    let form = repo.get(tenant.tenant_id, id).await.map_err(|e| {
+    let form = repo.get(&mut **rls.conn(), org_id, id).await.map_err(|e| {
         tracing::error!("Failed to get form: {:?}", e);
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -1850,14 +1989,17 @@ async fn record_download(
     })?;
 
     if form.is_none() {
+        rls.release().await;
         return Err((
             StatusCode::NOT_FOUND,
             Json(ErrorResponse::new("NOT_FOUND", "Form not found")),
         ));
     }
 
-    repo.record_download(id, auth.user_id, None, None)
+    let out = repo
+        .record_download(&mut **rls.conn(), id, user_id, None, None)
         .await
+        .map(|_| StatusCode::OK)
         .map_err(|e| {
             tracing::error!("Failed to record download: {:?}", e);
             (
@@ -1867,7 +2009,7 @@ async fn record_download(
                     "Failed to record download",
                 )),
             )
-        })?;
-
-    Ok(StatusCode::OK)
+        });
+    rls.release().await;
+    out
 }


### PR DESCRIPTION
## PAP-76 — `form.rs` queries FORCE-RLS tables via a raw pool → deny-all on `dev`

Under migration `00179`'s `FORCE ROW LEVEL SECURITY`, the api-server's owner connection is no longer RLS-exempt. `FormRepository` held a raw `PgPool` and ran every query via `&self.pool` without ever setting request context, so own-org reads returned empty and writes failed (`/api/v1/forms`). On a BYPASSRLS/superuser pool the same queries would run completely unscoped.

Follows the proven **`work_order` (PAP-179)** / **`budget.rs` (PAP-180)** executor-conversion precedent.

### Changes
- **Repo (`crates/db/src/repositories/form.rs`)** — `FormRepository` is now a stateless unit struct (no pool field, cannot issue an un-scoped query). Single-statement methods take `executor: E where E: Executor<'e, Database = Postgres>`; the 5 multi-statement methods (`create`, `get_with_details`, `list`, `update`, `list_submissions`) take `conn: &mut PgConnection` and reborrow `&mut *conn` per query. `new(_pool)` retained so the `AppState` construction site is unchanged.
- **Route (`servers/api-server/src/routes/forms.rs`)** — all 19 handlers acquire `RlsConnection`; `org_id = rls.tenant_id()` (authoritative tenant) and `user_id = rls.user_id()`; every repo call passes `&mut **rls.conn()`; `rls.release().await` before return. `AuthUser`/`TenantExtractor` extractors removed.
- **Test (`crates/db/tests/form_rls_repo_tests.rs`)** — repo-level behavioral test mirroring `budget_rls_repo_tests.rs`: a `NOSUPERUSER NOBYPASSRLS` role so `FORCE` binds; asserts **deny-all without context**, **own-org visibility with context**, and **cross-tenant isolation**.
- Remove `form.rs` from `scripts/rls-pool-field-baseline.txt` (no longer a raw-pool offender).

### Verification
- `cargo check -p db -p api-server` — green
- `cargo check -p db --tests` — green (new test compiles)
- `cargo fmt` — clean
- DB execution of the `#[sqlx::test]` runs in CI (`rls-smoke`) / QA.

Parent: PAP-67. See PAP-68 for the matching `check-rls-enforcement.sh` detection guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)