### PR TITLE
fix(api-server): PAP-79 — seed tenant membership in reserve_funds IDOR tests (unblock dev backend gate)

### DIFF
--- a/backend/servers/api-server/tests/reserve_funds_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/reserve_funds_cross_org_idor_tests.rs
@@ -107,6 +107,26 @@ async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     .expect("seed user")
 }
 
+/// Make `user_id` an active member of `org_id`. Required because the
+/// reserve-fund handlers now run through the `RlsConnection` extractor
+/// (PAP-79 / #1321), which validates tenant membership via
+/// `OrganizationMemberRepository::is_member` before any handler executes.
+/// Without a membership row the extractor returns 403 ("not a member of this
+/// tenant") before the org-scoped query can surface the 404 these tests assert.
+async fn seed_membership(pool: &PgPool, org_id: Uuid, user_id: Uuid) {
+    sqlx::query(
+        r#"
+        INSERT INTO organization_members (organization_id, user_id, role_type, status, joined_at)
+        VALUES ($1, $2, 'org_admin', 'active', NOW())
+        "#,
+    )
+    .bind(org_id)
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .expect("seed membership");
+}
+
 async fn seed_fund(pool: &PgPool, org_id: Uuid, created_by: Uuid) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(
         r#"
@@ -133,6 +153,7 @@ async fn get_fund_same_org_succeeds(pool: PgPool) {
 
     let user = seed_user(&pool, "same-org@reserve-idor.test").await;
     let org_a = seed_org(&pool, "same-a").await;
+    seed_membership(&pool, org_a, user).await;
     let fund_id = seed_fund(&pool, org_a, user).await;
 
     let token = access_token(user, org_a);
@@ -166,6 +187,9 @@ async fn get_fund_cross_org_is_not_found(pool: PgPool) {
     let user_b = seed_user(&pool, "attacker@reserve-idor.test").await;
     let org_a = seed_org(&pool, "x-a").await;
     let org_b = seed_org(&pool, "x-b").await;
+    // The attacker (user_b) is a legitimate member of their own org_b; the
+    // org-scoped query, not the membership gate, is what must block the read.
+    seed_membership(&pool, org_b, user_b).await;
     let fund_id = seed_fund(&pool, org_a, user_a).await;
 
     // Org B token targeting Org A's fund.
@@ -199,6 +223,8 @@ async fn update_fund_cross_org_does_not_mutate(pool: PgPool) {
     let user_b = seed_user(&pool, "upd-attacker@reserve-idor.test").await;
     let org_a = seed_org(&pool, "u-a").await;
     let org_b = seed_org(&pool, "u-b").await;
+    // user_b is a member of org_b; the org-scoped UPDATE must still 404.
+    seed_membership(&pool, org_b, user_b).await;
     let fund_id = seed_fund(&pool, org_a, user_a).await;
 
     let token = access_token(user_b, org_b);


### PR DESCRIPTION
## Problem

The `dev` Backend `test` job has been **red since #1321 landed** (`d81ced31d`, 2026-06-12 ~08:34 UTC). All three cases in `reserve_funds_cross_org_idor_tests.rs` fail:

```
get_fund_same_org_succeeds         ... FAILED  (expected 200, got 403 "User is not a member of this tenant")
get_fund_cross_org_is_not_found    ... FAILED  (expected 404, got 403)
update_fund_cross_org_does_not_mutate ... FAILED  (expected 404, got 403)
```

This reds **every backend PR** (the suite runs `cargo test --workspace --no-fail-fast`), including the in-flight RLS-conversion PRs (e.g. #1328 PAP-179).

## Root cause

#1321 (PAP-79/PAP-151) converted the reserve-fund handlers to the `RlsConnection` extractor. That extractor validates tenant membership via `OrganizationMemberRepository::is_member` (`api-core/src/extractors/tenant.rs:234`) **before** any handler runs, returning 403 if the JWT user has no `organization_members` row. The IDOR suite mints JWTs and seeds orgs/users/funds but never seeded a membership row — so every acting user 403'd before the org-scoped query could surface the asserted 200/404.

The conversion is correct (membership gate is a security improvement); only the test fixture lagged.

## Fix

Add a `seed_membership` helper and make each acting user an active `org_admin` of the org in their JWT — exact precedent: `board_meetings_cross_org_idor_tests.rs` (#1262). The cross-org cases keep the attacker a member of *their own* org, so the org-scoped query (not the membership gate) is what blocks the read/update → 404.

**Test-only change. No production code touched.**

## Verification

- Compiles clean via rbuild.
- Full-workspace `test` job on this PR is the authoritative check that the suite goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)