### PR TITLE
chore(api-server): remove stale PAP-67 baseline entries (esg_reporting + workflow already converted)

### DIFF
--- a/backend/scripts/rls-pool-field-baseline.txt
+++ b/backend/scripts/rls-pool-field-baseline.txt
@@ -11,10 +11,6 @@
 #
 # One basename per line. Comments after '#'.
 
-# --- PAP-67 original offender set, conversion still pending ---
-esg_reporting.rs     # PAP-72 (blocked on PAP-139)
-workflow.rs          # PAP-77
-
 # --- PAP-80 sweep: conversion PRs in flight ---
 ai_chat.rs           # PR #1232 (PAP-144/PAP-145)
 building_certification.rs  # PR #1227 (PAP-144/PAP-145)


### PR DESCRIPTION
## Summary
- Removes `esg_reporting.rs` and `workflow.rs` stale entries from `rls-pool-field-baseline.txt`
- Both repos were already converted to the stateless executor pattern (PAP-139 / PAP-77) but entries were never cleaned up
- Prevents `check-rls-enforcement.sh --strict` from warning on already-converted repos

## Test plan
- [ ] `check-rls-enforcement.sh --strict` passes without stale-entry warnings
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)