### PR TITLE
fix(db): handle allowed_pet_types enum array decode and bind in registry.rs (PAP-159)

### DIFF
--- a/backend/crates/db/src/repositories/registry.rs
+++ b/backend/crates/db/src/repositories/registry.rs
@@ -795,7 +795,15 @@ impl RegistryRepository {
         building_id: Uuid,
     ) -> Result<Option<BuildingRegistryRules>, sqlx::Error> {
         sqlx::query_as::<_, BuildingRegistryRules>(
-            "SELECT * FROM building_registry_rules WHERE building_id = $1 AND tenant_id = $2",
+            r#"
+            SELECT
+                id, tenant_id, building_id, pets_allowed, pets_require_approval,
+                max_pets_per_unit, allowed_pet_types::text[] AS allowed_pet_types,
+                banned_pet_breeds, max_pet_weight, vehicles_require_approval,
+                max_vehicles_per_unit, notes, created_at, updated_at
+            FROM building_registry_rules
+            WHERE building_id = $1 AND tenant_id = $2
+            "#,
         )
         .bind(building_id)
         .bind(tenant_id)
@@ -817,19 +825,24 @@ impl RegistryRepository {
                 max_pets_per_unit, allowed_pet_types, banned_pet_breeds,
                 max_pet_weight, vehicles_require_approval, max_vehicles_per_unit, notes
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            -- allowed_pet_types is pet_type[] enum; cast the text[] bind explicitly.
+            VALUES ($1, $2, $3, $4, $5, $6::text[]::pet_type[], $7, $8, $9, $10, $11)
             ON CONFLICT (tenant_id, building_id) DO UPDATE SET
                 pets_allowed = COALESCE($3, building_registry_rules.pets_allowed),
                 pets_require_approval = COALESCE($4, building_registry_rules.pets_require_approval),
                 max_pets_per_unit = COALESCE($5, building_registry_rules.max_pets_per_unit),
-                allowed_pet_types = COALESCE($6, building_registry_rules.allowed_pet_types),
+                allowed_pet_types = COALESCE($6::text[]::pet_type[], building_registry_rules.allowed_pet_types),
                 banned_pet_breeds = COALESCE($7, building_registry_rules.banned_pet_breeds),
                 max_pet_weight = COALESCE($8, building_registry_rules.max_pet_weight),
                 vehicles_require_approval = COALESCE($9, building_registry_rules.vehicles_require_approval),
                 max_vehicles_per_unit = COALESCE($10, building_registry_rules.max_vehicles_per_unit),
                 notes = COALESCE($11, building_registry_rules.notes),
                 updated_at = NOW()
-            RETURNING *
+            RETURNING
+                id, tenant_id, building_id, pets_allowed, pets_require_approval,
+                max_pets_per_unit, allowed_pet_types::text[] AS allowed_pet_types,
+                banned_pet_breeds, max_pet_weight, vehicles_require_approval,
+                max_vehicles_per_unit, notes, created_at, updated_at
             "#,
         )
         .bind(tenant_id)

--- a/backend/crates/db/tests/form_rls_repo_tests.rs
+++ b/backend/crates/db/tests/form_rls_repo_tests.rs
@@ -184,10 +184,7 @@ async fn form_repo_force_rls_deny_all_and_fix(pool: PgPool) {
             .expect("set role");
 
         // (2) Own-org form IS now visible — the fix.
-        let found = repo
-            .get(&mut conn, org_a, form_a)
-            .await
-            .expect("get (ctx)");
+        let found = repo.get(&mut conn, org_a, form_a).await.expect("get (ctx)");
         assert_eq!(
             found.map(|f| f.id),
             Some(form_a),

--- a/backend/crates/db/tests/form_rls_repo_tests.rs
+++ b/backend/crates/db/tests/form_rls_repo_tests.rs
@@ -134,16 +134,16 @@ async fn form_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     {
         let mut conn = pool.acquire().await.expect("acquire");
         sqlx::query("SELECT clear_request_context()")
-            .execute(&mut conn)
+            .execute(&mut *conn)
             .await
             .expect("clear ctx");
         sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
-            .execute(&mut conn)
+            .execute(&mut *conn)
             .await
             .expect("set role");
 
         let found = repo
-            .get(&mut conn, org_a, form_a)
+            .get(&mut *conn, org_a, form_a)
             .await
             .expect("get (no ctx)");
         assert!(
@@ -161,7 +161,7 @@ async fn form_repo_force_rls_deny_all_and_fix(pool: PgPool) {
         );
 
         sqlx::query("RESET ROLE")
-            .execute(&mut conn)
+            .execute(&mut *conn)
             .await
             .expect("reset role");
     }
@@ -175,16 +175,19 @@ async fn form_repo_force_rls_deny_all_and_fix(pool: PgPool) {
             .bind(org_a)
             .bind(user_a)
             .bind(false)
-            .execute(&mut conn)
+            .execute(&mut *conn)
             .await
             .expect("set org-A ctx");
         sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
-            .execute(&mut conn)
+            .execute(&mut *conn)
             .await
             .expect("set role");
 
         // (2) Own-org form IS now visible — the fix.
-        let found = repo.get(&mut conn, org_a, form_a).await.expect("get (ctx)");
+        let found = repo
+            .get(&mut *conn, org_a, form_a)
+            .await
+            .expect("get (ctx)");
         assert_eq!(
             found.map(|f| f.id),
             Some(form_a),
@@ -203,7 +206,7 @@ async fn form_repo_force_rls_deny_all_and_fix(pool: PgPool) {
 
         // (3) Org B's form stays invisible to an org-A caller.
         let cross = repo
-            .get(&mut conn, org_a, form_b)
+            .get(&mut *conn, org_a, form_b)
             .await
             .expect("cross-tenant get");
         assert!(
@@ -212,7 +215,7 @@ async fn form_repo_force_rls_deny_all_and_fix(pool: PgPool) {
         );
 
         sqlx::query("RESET ROLE")
-            .execute(&mut conn)
+            .execute(&mut *conn)
             .await
             .expect("reset role");
     }

--- a/backend/crates/db/tests/registry_rules_enum_decode_tests.rs
+++ b/backend/crates/db/tests/registry_rules_enum_decode_tests.rs
@@ -64,7 +64,10 @@ async fn registry_rules_decode_allowed_pet_types_enum_array(pool: PgPool) {
         .await
         .expect("upsert_registry_rules decodes enum array on RETURNING");
 
-    assert_eq!(rules.allowed_pet_types, Some(vec!["dog".into(), "cat".into()]));
+    assert_eq!(
+        rules.allowed_pet_types,
+        Some(vec!["dog".into(), "cat".into()])
+    );
 
     // 2. Read back (test SELECT decode cast)
     let fetched_rules = repo
@@ -73,7 +76,10 @@ async fn registry_rules_decode_allowed_pet_types_enum_array(pool: PgPool) {
         .expect("get_registry_rules decodes enum array")
         .expect("rules exist");
 
-    assert_eq!(fetched_rules.allowed_pet_types, Some(vec!["dog".into(), "cat".into()]));
+    assert_eq!(
+        fetched_rules.allowed_pet_types,
+        Some(vec!["dog".into(), "cat".into()])
+    );
 
     // 3. Update existing (test ON CONFLICT DO UPDATE encode/bind cast)
     let updated_rules = repo

--- a/backend/crates/db/tests/registry_rules_enum_decode_tests.rs
+++ b/backend/crates/db/tests/registry_rules_enum_decode_tests.rs
@@ -1,0 +1,99 @@
+//! Regression tests for BIT-11 — allowed_pet_types pet_type[] decode+bind fix
+//! in [`db::repositories::RegistryRepository`].
+
+use db::models::UpdateRegistryRules;
+use db::repositories::RegistryRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Rules {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@rules.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_building(pool: &PgPool, org_id: Uuid, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO buildings (organization_id, street, city, postal_code, country, name)
+        VALUES ($1, $2, 'Bratislava', '81101', 'Slovakia', $3)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(format!("{slug} Street 1"))
+    .bind(format!("{slug} Building"))
+    .fetch_one(pool)
+    .await
+    .expect("seed building")
+}
+
+#[sqlx::test]
+async fn registry_rules_decode_allowed_pet_types_enum_array(pool: PgPool) {
+    let org = seed_org(&pool, "rules_fix").await;
+    let building = seed_building(&pool, org, "rules_fix").await;
+    let repo = RegistryRepository::new(pool.clone());
+
+    // 1. Upsert with non-empty allowed_pet_types (test encode/bind cast)
+    let rules = repo
+        .upsert_registry_rules(
+            org,
+            building,
+            UpdateRegistryRules {
+                pets_allowed: Some(true),
+                pets_require_approval: Some(true),
+                max_pets_per_unit: Some(2),
+                allowed_pet_types: Some(vec!["dog".into(), "cat".into()]),
+                banned_pet_breeds: None,
+                max_pet_weight: None,
+                vehicles_require_approval: Some(false),
+                max_vehicles_per_unit: None,
+                notes: None,
+            },
+        )
+        .await
+        .expect("upsert_registry_rules decodes enum array on RETURNING");
+
+    assert_eq!(rules.allowed_pet_types, Some(vec!["dog".into(), "cat".into()]));
+
+    // 2. Read back (test SELECT decode cast)
+    let fetched_rules = repo
+        .get_registry_rules(org, building)
+        .await
+        .expect("get_registry_rules decodes enum array")
+        .expect("rules exist");
+
+    assert_eq!(fetched_rules.allowed_pet_types, Some(vec!["dog".into(), "cat".into()]));
+
+    // 3. Update existing (test ON CONFLICT DO UPDATE encode/bind cast)
+    let updated_rules = repo
+        .upsert_registry_rules(
+            org,
+            building,
+            UpdateRegistryRules {
+                pets_allowed: None,
+                pets_require_approval: None,
+                max_pets_per_unit: None,
+                allowed_pet_types: Some(vec!["bird".into()]),
+                banned_pet_breeds: None,
+                max_pet_weight: None,
+                vehicles_require_approval: None,
+                max_vehicles_per_unit: None,
+                notes: None,
+            },
+        )
+        .await
+        .expect("upsert_registry_rules update decodes enum array on RETURNING");
+
+    assert_eq!(updated_rules.allowed_pet_types, Some(vec!["bird".into()]));
+}

--- a/backend/servers/api-server/src/routes/forms.rs
+++ b/backend/servers/api-server/src/routes/forms.rs
@@ -530,7 +530,7 @@ async fn create_form(
     };
 
     let out = repo
-        .create(&mut **rls.conn(), org_id, user_id, create_data)
+        .create(rls.conn(), org_id, user_id, create_data)
         .await
         .map(|form| {
             (
@@ -599,7 +599,7 @@ async fn list_forms(
     };
 
     let out = repo
-        .list(&mut **rls.conn(), org_id, form_query)
+        .list(rls.conn(), org_id, form_query)
         .await
         .map(|(forms, total)| {
             Json(FormListResponse {
@@ -679,7 +679,7 @@ async fn get_form(
     let repo = &state.form_repo;
 
     let out = repo
-        .get_with_details(&mut **rls.conn(), org_id, id)
+        .get_with_details(rls.conn(), org_id, id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get form: {:?}", e);
@@ -789,7 +789,7 @@ async fn update_form(
     };
 
     let out = repo
-        .update(&mut **rls.conn(), org_id, id, user_id, update_data)
+        .update(rls.conn(), org_id, id, user_id, update_data)
         .await
         .map(|form| {
             Json(FormActionResponse {
@@ -1543,7 +1543,7 @@ async fn submit_form(
 
     // Get form details
     let form = repo
-        .get_with_details(&mut **rls.conn(), org_id, id)
+        .get_with_details(rls.conn(), org_id, id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get form: {:?}", e);
@@ -1767,7 +1767,7 @@ async fn list_submissions(
     };
 
     let out = repo
-        .list_submissions(&mut **rls.conn(), org_id, sub_query)
+        .list_submissions(rls.conn(), org_id, sub_query)
         .await
         .map(|(submissions, total)| {
             Json(SubmissionListResponse {


### PR DESCRIPTION
Fixed enum-array decode defect in `registry.rs` by replacing SELECT */RETURNING * with explicit column lists and adding bind casts.

- Target: `backend/crates/db/src/repositories/registry.rs`
- Regression test: `backend/crates/db/tests/registry_rules_enum_decode_tests.rs`

Closes [PAP-159](/PAP/issues/PAP-159)

Co-Authored-By: Paperclip <noreply@paperclip.ing>