### PR TITLE
bug-ios-searchview-uncompilable: restore iOS SearchView performSearch/scheduleSearch + resultsGrid

### DIFF
--- a/mobile-native/iosApp/iosApp/Features/Search/SearchView.swift
+++ b/mobile-native/iosApp/iosApp/Features/Search/SearchView.swift
@@ -29,6 +29,14 @@ struct SearchView: View {
     /// Cancellable token for the in-flight debounce task.
     @State private var debounceTask: Task<Void, Never>?
 
+    /// Monotonic sequence for the stale-response guard. Each fresh (page-1)
+    /// `performSearch()` increments this and captures the value before the
+    /// `await`; if a newer search started meanwhile, the older response is
+    /// dropped so an out-of-order completion can't clobber newer results.
+    /// Mirrors the Android `SearchScreen.kt` searchGeneration guard, scoped to
+    /// the SwiftUI side (see plan: Android-side race is a separate backlog item).
+    @State private var requestSeq = 0
+
     /// Drives the location-denied alert; set by .onChange(of: locationManager.locationError).
     @State private var showLocationDeniedAlert = false
 
@@ -266,12 +274,73 @@ struct SearchView: View {
     private var resultsGrid: some View {
         ScrollView {
             LazyVStack(spacing: 12) {
-            filters: searchFilters,
+                ForEach(Array(results.enumerated()), id: \.element.id) { index, listing in
+                    SearchResultCard(listing: listing) {
+                        coordinator.navigate(to: .listingDetail(id: listing.id))
+                    }
+                    .onAppear {
+                        // AC-4: infinite scroll. When the last loaded cell appears,
+                        // fetch the next page. `loadMoreResults()` self-guards on
+                        // currentPage/totalPages so trailing onAppears are no-ops.
+                        if index == results.count - 1 {
+                            Task { await loadMoreResults() }
+                        }
+                    }
+                }
+                if isLoadingMore {
+                    ProgressView()
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                }
+            }
+            .padding(.vertical, 8)
+        }
+    }
+
+    // MARK: - Search
+
+    /// Debounce free-text query changes before hitting the network (AC-2).
+    ///
+    /// Cancels any in-flight debounce token and starts a fresh `debounceNs`
+    /// (350 ms) sleep; only after the sleep survives cancellation does the
+    /// actual search fire. Mirrors the Android `SearchScreen.kt`
+    /// `.debounce(SEARCH_DEBOUNCE_MS)` collector so three quick keystrokes
+    /// coalesce into a single repository call.
+    private func scheduleSearch(for _: String) {
+        debounceTask?.cancel()
+        debounceTask = Task {
+            try? await Task.sleep(nanoseconds: debounceNs)
+            if Task.isCancelled { return }
+            await performSearch()
+        }
+    }
+
+    /// Run a fresh (page-1) search against the KMP `ListingRepository` and
+    /// replace the current result set. Mirrors the Android `SearchScreen.kt`
+    /// `performSearch()` contract (request assembly + success/failure fold)
+    /// plus a SwiftUI-side stale-response guard (`requestSeq`).
+    private func performSearch() async {
+        isLoading = true
+        currentPage = 1
+
+        // Stale-response guard: capture the sequence for this search before the
+        // await; if a newer search bumps `requestSeq` while we're suspended,
+        // discard this (older) response on resume.
+        requestSeq += 1
+        let seq = requestSeq
+
+        let request = ListingSearchRequest(
+            query: searchText.isEmpty ? nil : searchText,
+            filters: buildKMPFilters(),
             sort: sortOption.kmpSortOption,
             page: Int32(currentPage),
             pageSize: 20
         )
         let result = await listingRepository.searchListings(request: request)
+
+        // Drop responses superseded by a newer search.
+        guard seq == requestSeq else { return }
+
         if let response = result.getOrNull() {
             results = response.listings.map { KMPBridge.toListingPreview($0) }
             totalPages = Int(response.totalPages)
@@ -283,6 +352,8 @@ struct SearchView: View {
             }
             #endif
             results = []
+            totalPages = 1
+            totalCount = 0
         }
         isLoading = false
     }
@@ -294,7 +365,7 @@ struct SearchView: View {
         currentPage += 1
         let request = ListingSearchRequest(
             query: searchText.isEmpty ? nil : searchText,
-            filters: searchFilters,
+            filters: buildKMPFilters(),
             sort: sortOption.kmpSortOption,
             page: Int32(currentPage),
             pageSize: 20

--- a/mobile-native/iosApp/iosAppTests/SearchViewTests.swift
+++ b/mobile-native/iosApp/iosAppTests/SearchViewTests.swift
@@ -1,0 +1,95 @@
+//
+//  SearchViewTests.swift
+//  iosAppTests
+//
+//  Regression coverage for `bug-ios-searchview-uncompilable` (Issue #1266).
+//
+//  The whole `Features/Search/SearchView.swift` file used to be uncompilable:
+//  `performSearch()` was called from ~9 sites and `scheduleSearch(for:)` from
+//  one, but neither was defined, and `resultsGrid` had lost its `ForEach` body.
+//  Because the file didn't compile, the `iosApp` test host didn't build, so
+//  EVERY test in this target failed. That is the IG3 driver for this fix:
+//  these assertions cannot even be compiled against `dev`, and pass on the
+//  branch once the helpers + grid body are restored.
+//
+//  `ListingRepository` is a `final` KMP class (no protocol seam), so a true
+//  network-stubbed `performSearch()` unit test isn't expressible from Swift
+//  without a host running reality-server. We therefore assert the pure,
+//  non-private logic that the restored file exposes (the `SortOption` <-> KMP
+//  mapping and `SearchFilters` activation) — touching these symbols forces the
+//  SUT to compile, which is exactly what regressed. A live `performSearch()`
+//  behaviour test is left for the macOS reviewer's `xcodebuild test` run
+//  against the dev stack (see PR notes).
+//
+
+import XCTest
+import shared
+@testable import iosApp
+
+// MARK: - SortOption <-> KMP mapping
+
+/// Pins the `SortOption.kmpSortOption` bridge so the SwiftUI sort picker and
+/// the KMP `ListingSearchRequest.sort` field can't drift apart. Every Swift
+/// case must map to its KMP `ListingSortOption` peer.
+final class SearchViewSortOptionTests: XCTestCase {
+
+    func testEverySortOptionMapsToItsKMPPeer() {
+        XCTAssertEqual(SortOption.newest.kmpSortOption, ListingSortOption.newest)
+        XCTAssertEqual(SortOption.oldest.kmpSortOption, ListingSortOption.oldest)
+        XCTAssertEqual(SortOption.priceAsc.kmpSortOption, ListingSortOption.priceAsc)
+        XCTAssertEqual(SortOption.priceDesc.kmpSortOption, ListingSortOption.priceDesc)
+        XCTAssertEqual(SortOption.areaAsc.kmpSortOption, ListingSortOption.areaAsc)
+        XCTAssertEqual(SortOption.areaDesc.kmpSortOption, ListingSortOption.areaDesc)
+        XCTAssertEqual(SortOption.relevance.kmpSortOption, ListingSortOption.relevance)
+    }
+
+    func testAllCasesAreMappedAndHaveDisplayNames() {
+        // Guards against a new SortOption case being added without a KMP
+        // mapping / localized label — both are exhaustive switches, so a gap
+        // would fail to compile, but this also documents the count.
+        XCTAssertEqual(SortOption.allCases.count, 7)
+        for option in SortOption.allCases {
+            XCTAssertFalse(option.displayName.isEmpty)
+        }
+    }
+}
+
+// MARK: - SearchFilters activation
+
+/// `SearchView` decides between the empty-results, search-prompt, and results
+/// states using `filters.hasActiveFilters`; `performSearch()` only attaches a
+/// KMP filter payload when filters are active. Pin that activation logic so the
+/// debounce/search path keeps the correct empty-state semantics.
+final class SearchViewFiltersTests: XCTestCase {
+
+    func testDefaultFiltersAreInactive() {
+        XCTAssertFalse(SearchFilters().hasActiveFilters)
+    }
+
+    func testPriceFilterActivates() {
+        var filters = SearchFilters()
+        filters.priceMin = 100_000
+        XCTAssertTrue(filters.hasActiveFilters)
+    }
+
+    func testPropertyTypeFilterActivates() {
+        var filters = SearchFilters()
+        filters.propertyTypes.insert(.apartment)
+        XCTAssertTrue(filters.hasActiveFilters)
+    }
+
+    func testRadiusFilterActivates() {
+        var filters = SearchFilters()
+        filters.radiusKm = 10
+        XCTAssertTrue(filters.hasActiveFilters)
+    }
+
+    func testResetClearsActivation() {
+        var filters = SearchFilters()
+        filters.priceMin = 100_000
+        filters.propertyTypes.insert(.house)
+        filters.radiusKm = 5
+        filters.reset()
+        XCTAssertFalse(filters.hasActiveFilters)
+    }
+}


### PR DESCRIPTION
## Task
iOS SearchView.swift does not compile — performSearch/scheduleSearch undefined, resultsGrid corrupted. Fixes Issue #1266 (follow-up from the `verify-redesign-search-promote` review of PR #1257).

## Owner
pm-frontend (specialist: ios-swiftui)

## What regressed
`mobile-native/iosApp/iosApp/Features/Search/SearchView.swift` was born broken:
- `performSearch()` was called from ~9 sites and `scheduleSearch(for:)` from one `.onChange`, but **neither function was defined**.
- The `resultsGrid` computed property had lost its `ForEach` body — its declaration opened `ScrollView { LazyVStack { ... }` and then the file spliced straight into the orphaned tail of `performSearch()` (the `filters:/sort:/page:/pageSize:` args + the success/failure fold), leaving the grid empty and `performSearch` headless.
- Both `performSearch()` and `loadMoreResults()` referenced an **undefined `searchFilters`** symbol (the helper is `buildKMPFilters()`).

## Fix
Restored the SwiftUI search path, mirroring the Android `SearchScreen.kt` contract:
- **`performSearch()`** — assembles `ListingSearchRequest` from `searchText` / `buildKMPFilters()` / `sortOption.kmpSortOption` (page 1, pageSize 20), awaits `listingRepository.searchListings(request:)`, replaces `results`/`totalPages`/`totalCount` on success, clears them on failure (`#if DEBUG` error print). Brackets `isLoading`.
- **`scheduleSearch(for:)`** — cancellable 350 ms debounce (`debounceNs`) before `performSearch()`, matching the existing `.onChange(of: searchText)` wiring (AC-2).
- **`resultsGrid`** — `ForEach` over `results` → `SearchResultCard` with `coordinator.navigate(to: .listingDetail(id:))`, plus `.onAppear` infinite-scroll trigger on the last cell (AC-4) and a trailing `isLoadingMore` spinner.
- **`loadMoreResults()`** — fixed to use `buildKMPFilters()` instead of the undefined `searchFilters`.
- **Stale-response guard** — added a SwiftUI-side `requestSeq` (capture-before-await, drop superseded responses), scoped to iOS only. The Android-side race (`code-review-mobile-native-kmp-search-stale-response-race`) is intentionally **out of scope** per the plan.

Brace/paren balance verified ({ 185 / } 185, ( 392 / ) 392). All ~10 `performSearch()` / `scheduleSearch(for:)` call sites are now backed by definitions; no remaining undefined `searchFilters` references.

## Tested (Band A — fast check)
> ⚠️ **macOS reviewer must run `xcodebuild`** — this is a Linux runner with no Xcode/`swiftc`, so the Swift target cannot be compiled or run here (same constraint as the macOS-build-gated PR #1298). Please run before approving:
> ```
> cd mobile-native/iosApp && xcodegen generate
> xcodebuild -scheme RealityPortal-Dev -destination 'platform=iOS Simulator,name=iPhone 15' build \
>   test -only-testing:iosAppTests/SearchViewSortOptionTests -only-testing:iosAppTests/SearchViewFiltersTests
> ```

Verification performed on this Linux runner (structural, since Swift compile is macOS-only):
- `tr -cd '{'|wc` vs `'}'` → `185 == 185`; `(` vs `)` → `392 == 392` (exit 0) — brace/paren balanced.
- `grep` audit: every `performSearch()` / `scheduleSearch(for:)` call site resolves to a definition; zero remaining `searchFilters` references (the undefined symbol) — exit 0.
- KMP contract cross-checked against `shared/.../listing/ListingModels.kt`: `ListingSearchRequest(query:filters:sort:page:pageSize:)` and `ListingSearchResponse.{listings,total,totalPages}` match the restored call.
- `cd mobile-native && ./gradlew :shared:compileKotlinJvm` → **environmentally blocked** (exit 1): AGP `9.2.1` plugin can't resolve from the sandbox (no plugin-repo network). This path doesn't touch the iOS Swift sources changed here and is unrelated to the change.

## Built (Band B — full build)
skipped: the specialist's Band B command (`./gradlew :shared:linkPodReleaseFrameworkIosArm64`) is a Darwin-target link that requires macOS; not runnable on this Linux runner. Folded into the macOS reviewer request above.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change). Note: the repo-wide backend `test` CI job is currently red dev-wide (blocker #1332) and is unrelated to this frontend/iOS change — the relevant gate here is `mobile-native.yml` (Gradle + the macOS Swift build a reviewer runs).

## Remote-tested
skipped (no ppt-bridge MCP / no iOS toolchain remotely).

## Scope drift
`scope_drift=true`. The dispatcher-assigned `owner_role=pm-frontend` does not own `mobile-native/**` in `owner-areas.json` (that maps to `pm-mobile`). The actual diff is correctly scoped to the iOS app — exactly the two files in the plan's `## Files`:
- `mobile-native/iosApp/iosApp/Features/Search/SearchView.swift`
- `mobile-native/iosApp/iosAppTests/SearchViewTests.swift` (new)

No backend/web/KMP-shared files touched; the KMP `searchListings` contract is consumed, not changed. The drift is a label mismatch (frontend vs mobile owner area), not an out-of-area code change.

## Code-reuse review
`code_reuse_warn=none` — `reuse-grep.sh --specialist ios-swiftui` returned no warnings. The restored helpers reuse the existing `buildKMPFilters()`, `KMPBridge.toListingPreview`, `DependencyContainer.shared.listingRepository`, and `SortOption.kmpSortOption` already in the file; no duplicated helpers introduced.

## Notes
- IG3: `iosAppTests/SearchViewTests.swift` only compiles once the SUT compiles. On `dev` the whole `iosApp` test host fails to build (the SUT is uncompilable), so these tests fail there and pass on this branch.
- `ListingRepository` is a `final` KMP class with no protocol seam, so a network-stubbed `performSearch()` behaviour unit test isn't expressible from Swift without a live reality-server. The added tests pin the compile-forcing pure logic (`SortOption` ↔ KMP mapping, `SearchFilters` activation); a live `performSearch()` behaviour test is left to the macOS reviewer's `xcodebuild test` against the dev stack.

https://claude.ai/code/session_01MPMJ6Vwyf68Hz77YCYbE7y

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPMJ6Vwyf68Hz77YCYbE7y)_