### PR TITLE
fix-report-schedule-editing-cron-edits-round-trip-through-frontend: round-trip cron edits through cron_expression (frontend)

### DIFF
--- a/frontend/apps/ppt-web/src/features/reports/components/EditScheduleModal.test.ts
+++ b/frontend/apps/ppt-web/src/features/reports/components/EditScheduleModal.test.ts
@@ -1,0 +1,100 @@
+/// <reference types="vitest/globals" />
+/**
+ * Round-trip regression for report-schedule editing — gap-81-1 / issue #616.
+ *
+ * The bug: cron edits were saved to the backend but, on re-open, the edit
+ * modal reconstructed the cron expression from the overloaded `time` /
+ * `frequency` / `day_*` fields rather than reading the value the backend
+ * actually persisted. A custom expression (e.g. every-15-min weekday business
+ * hours) was therefore silently flattened on the next edit.
+ *
+ * The fix wires the read side to the dedicated `cron_expression` field while
+ * keeping the legacy `time`-derived reconstruction as a back-compat fallback
+ * for rows that predate the column. These tests pin both halves of that
+ * contract.
+ */
+
+import type { ReportSchedule } from '@ppt/api-client';
+import { describe, expect, it } from 'vitest';
+import { scheduleToInitialCron } from './EditScheduleModal';
+
+/** Build a ReportSchedule fixture with sane defaults, overridable per-test. */
+function makeSchedule(overrides: Partial<ReportSchedule> = {}): ReportSchedule {
+  return {
+    id: 'sched-1',
+    report_id: 'rep-1',
+    organization_id: 'org-1',
+    name: 'Test Schedule',
+    frequency: 'daily',
+    time: '08:00',
+    timezone: 'Europe/Bratislava',
+    format: 'pdf',
+    recipients: ['a@example.com'],
+    is_active: true,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('scheduleToInitialCron — cron round-trip (gap-81-1 / #616)', () => {
+  it('surfaces a stored cron_expression verbatim instead of reconstructing from time', () => {
+    // Custom expression that CANNOT be reconstructed from time/frequency:
+    // every 15 min, weekday business hours.
+    const custom = '*/15 9-17 * * 1-5';
+    const schedule = makeSchedule({
+      cron_expression: custom,
+      // Legacy fields are present but must be ignored when a cron is stored.
+      time: '08:00',
+      frequency: 'daily',
+    });
+
+    expect(scheduleToInitialCron(schedule)).toBe(custom);
+  });
+
+  it('preserves a stored cron even when frequency/time would derive a different one', () => {
+    const schedule = makeSchedule({
+      cron_expression: '0 6 * * 0', // weekly Sunday 06:00
+      frequency: 'monthly',
+      day_of_month: 15,
+      time: '23:30',
+    });
+
+    expect(scheduleToInitialCron(schedule)).toBe('0 6 * * 0');
+  });
+
+  it('ignores trailing/leading whitespace around the stored cron', () => {
+    const schedule = makeSchedule({ cron_expression: '  30 14 * * *  ' });
+    expect(scheduleToInitialCron(schedule)).toBe('30 14 * * *');
+  });
+
+  it('falls back to time-derived reconstruction when cron_expression is absent (legacy row)', () => {
+    const schedule = makeSchedule({
+      cron_expression: undefined,
+      frequency: 'weekly',
+      day_of_week: 3,
+      time: '09:30',
+    });
+    // Reconstructed: minute hour * * dow
+    expect(scheduleToInitialCron(schedule)).toBe('30 9 * * 3');
+  });
+
+  it('falls back to reconstruction when the stored cron is invalid', () => {
+    const schedule = makeSchedule({
+      cron_expression: 'not a cron',
+      frequency: 'daily',
+      time: '07:15',
+    });
+    expect(scheduleToInitialCron(schedule)).toBe('15 7 * * *');
+  });
+
+  it('reconstructs monthly schedules from day_of_month for legacy rows', () => {
+    const schedule = makeSchedule({
+      cron_expression: undefined,
+      frequency: 'monthly',
+      day_of_month: 12,
+      time: '06:00',
+    });
+    expect(scheduleToInitialCron(schedule)).toBe('0 6 12 * *');
+  });
+});

--- a/frontend/apps/ppt-web/src/features/reports/components/EditScheduleModal.tsx
+++ b/frontend/apps/ppt-web/src/features/reports/components/EditScheduleModal.tsx
@@ -47,6 +47,12 @@ interface FormErrors {
  * can still display a sensible starting value.
  */
 export function scheduleToInitialCron(schedule: ReportSchedule): string {
+  // Prefer the dedicated cron column when the backend returned a usable one.
+  const stored = schedule.cron_expression?.trim();
+  if (stored && isValidCron(stored)) {
+    return stored;
+  }
+
   const [hh, mm] = (schedule.time || '08:00').split(':');
   const h = String(Number(hh) || 0);
   const m = String(Number(mm) || 0);

--- a/frontend/apps/ppt-web/src/features/reports/components/EditScheduleModal.tsx
+++ b/frontend/apps/ppt-web/src/features/reports/components/EditScheduleModal.tsx
@@ -34,11 +34,19 @@ interface FormErrors {
 /**
  * Derive an initial cron expression from a schedule.
  *
- * The `time` field on legacy schedules stores "HH:mm"; we convert that +
- * the frequency/day fields into a 5-field cron expression so the picker
- * can display a sensible starting value.
+ * Round-trip contract (gap-81-1 / issue #616): the backend now persists the
+ * edited expression to a dedicated `cron_expression` column and returns it on
+ * read, so when that field is present and valid we surface it verbatim — a
+ * custom every-15-minutes-on-weekday-business-hours expression survives an
+ * edit round-trip instead of being flattened back into the overloaded
+ * `time`/`frequency` fields.
+ *
+ * Back-compat fallback: legacy rows predating the column have no
+ * `cron_expression`. For those, the `time` field stores "HH:mm"; we convert
+ * that + the frequency/day fields into a 5-field cron expression so the picker
+ * can still display a sensible starting value.
  */
-function scheduleToInitialCron(schedule: ReportSchedule): string {
+export function scheduleToInitialCron(schedule: ReportSchedule): string {
   const [hh, mm] = (schedule.time || '08:00').split(':');
   const h = String(Number(hh) || 0);
   const m = String(Number(mm) || 0);

--- a/frontend/apps/ppt-web/src/features/reports/components/index.ts
+++ b/frontend/apps/ppt-web/src/features/reports/components/index.ts
@@ -8,7 +8,7 @@ export { BuildingMetricsCard } from './BuildingMetricsCard';
 export type { CronPickerProps } from './CronPicker';
 // Story 81.1 - Report Schedule Editing
 export { CronPicker } from './CronPicker';
-export { EditScheduleModal } from './EditScheduleModal';
+export { EditScheduleModal, scheduleToInitialCron } from './EditScheduleModal';
 // Story 81.2 - Report Execution History
 export { ExecutionHistory } from './ExecutionHistory';
 // Story 53.1 - Report Builder

--- a/frontend/packages/api-client/src/reports/types.ts
+++ b/frontend/packages/api-client/src/reports/types.ts
@@ -95,7 +95,16 @@ export interface ReportSchedule {
   frequency: ScheduleFrequency;
   day_of_week?: number; // 0-6 for weekly
   day_of_month?: number; // 1-31 for monthly
-  time: string; // HH:mm format
+  time: string; // HH:mm format (legacy; prefer cron_expression for new code)
+  /**
+   * 5-field UNIX cron expression (gap-81-1 / issue #616).
+   *
+   * Source of truth for the schedule when present — the dedicated
+   * `cron_expression` column lets edits round-trip losslessly instead of
+   * being reconstructed from the overloaded `time`/`frequency` fields.
+   * Optional for back-compat with legacy rows that predate the column.
+   */
+  cron_expression?: string;
   timezone: string;
   format: ReportFormat;
   recipients: string[];


### PR DESCRIPTION
## Task
cron edits round-trip through the overloaded `time` field — no dedicated cron_expression column (backlog bug-report-schedule-update-no-sql / issue #616) (81-1-report-schedule-editing Report Schedule Editing). This is the FRONTEND half: wire the ppt-web report-schedule editing UI to round-trip cron edits through the dedicated `cron_expression` field. The BACKEND half (the `cron_expression` column + handler) is already on `dev`. Read/write `cron_expression` instead of overloading `time`, keeping `time` back-compat.

## Owner
pm-frontend

## What changed
The ppt-web edit modal already *wrote* `cron_expression` (it emits a `CronScheduleUpdateRequest`), but the **read** side was lossy: on re-open, `scheduleToInitialCron()` reconstructed the expression from the overloaded `time`/`frequency`/`day_*` fields and ignored the `cron_expression` the backend now persists and returns. A custom expression (e.g. `*/15 9-17 * * 1-5`) was silently flattened on the next edit — the round-trip was broken on read.

- `frontend/packages/api-client/src/reports/types.ts` — add `cron_expression?: string` to the `ReportSchedule` read model (this type is hand-rolled, not OpenAPI-generated; the backend `ReportSchedule` already serializes the field via `skip_serializing_if = "Option::is_none"`, so no client regeneration is needed).
- `frontend/apps/ppt-web/src/features/reports/components/EditScheduleModal.tsx` — `scheduleToInitialCron()` now prefers `schedule.cron_expression` when present **and** valid (`isValidCron`), keeping the legacy `time`-derived reconstruction as a back-compat fallback for rows predating the column. Function exported for testing.
- `frontend/apps/ppt-web/src/features/reports/components/EditScheduleModal.test.ts` — new round-trip regression test (6 cases).
- `index.ts` — export `scheduleToInitialCron`.

Commit shape is TDD: `test:` commit fails on its own (3 assertions red — read side ignores `cron_expression`), `fix:` commit makes it green.

## Tested (Band A — fast check)
- `pnpm -F @ppt/api-client build` → exit 0
- `pnpm -F @ppt/web typecheck` (tsc --noEmit + e2e tsconfig) → exit 0
- `npx @biomejs/biome check <4 changed files>` → exit 0 (CI gate is Biome per CLAUDE.md; the package `lint` script is a stale ESLint stub that errors on a missing `eslint.config.js` repo-wide — pre-existing, unrelated to this diff)
- `npx vitest run EditScheduleModal.test.ts` → 6 passed
- IG3 evidence: reverting the fix block → 3 tests fail by assertion; at the `test:` commit alone → 3 fail by assertion.

## Built (Band B — full build)
skipped: change <50 LOC of substantive logic, no public API/config/build-output change (hand-rolled type addition + a 5-line read-preference guard). api-client tsc build already run in Band A.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change — UI read-preference + a TS field).

## Remote-tested
skipped

## Notes
- The api-client `reports` types are hand-rolled (`packages/api-client/src/reports/types.ts`), not generated from OpenAPI — confirmed `generated/models.ts` does not define `ReportSchedule`, so no client regeneration was required.
- Scope drift: false (diff confined to ppt-web reports feature + api-client reports types). Code-reuse pre-flight: clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_014wk6Ys5Nz5otazZ4KipPKT)_