### PR TITLE
fix(db tests): DROP OWNED BY before DROP ROLE in RLS test teardown — unblocks dev-wide test job (#1332)

### DIFF
--- a/backend/crates/db/tests/ai_chat_rls_repo_tests.rs
+++ b/backend/crates/db/tests/ai_chat_rls_repo_tests.rs
@@ -252,6 +252,11 @@ async fn ai_chat_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     for stmt in [
         format!("REVOKE ALL ON ai_chat_sessions FROM \"{role}\""),
         format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        // DROP OWNED severs every remaining privilege this role holds in the
+        // test database — the explicit REVOKEs above miss the RLS helper-function
+        // EXECUTE grants, so DROP ROLE failed with "objects depend on it" and
+        // leaked the cluster-global role (#1332 / PAP-134).
+        format!("DROP OWNED BY \"{role}\""),
         format!("DROP ROLE IF EXISTS \"{role}\""),
     ] {
         sqlx::query(sqlx::AssertSqlSafe(stmt))

--- a/backend/crates/db/tests/budget_rls_repo_tests.rs
+++ b/backend/crates/db/tests/budget_rls_repo_tests.rs
@@ -343,6 +343,11 @@ async fn budget_repo_force_rls_deny_all_and_fix(pool: PgPool) {
              budget_variance_alerts, reserve_funds FROM \"{role}\""
         ),
         format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        // DROP OWNED severs every remaining privilege this role holds in the
+        // test database — the explicit REVOKEs above miss the RLS helper-function
+        // EXECUTE grants, so DROP ROLE failed with "objects depend on it" and
+        // leaked the cluster-global role (#1332 / PAP-134).
+        format!("DROP OWNED BY \"{role}\""),
         format!("DROP ROLE IF EXISTS \"{role}\""),
     ] {
         sqlx::query(sqlx::AssertSqlSafe(stmt))

--- a/backend/crates/db/tests/building_certification_rls_repo_tests.rs
+++ b/backend/crates/db/tests/building_certification_rls_repo_tests.rs
@@ -311,6 +311,11 @@ async fn building_certification_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     for stmt in [
         format!("REVOKE ALL ON building_certifications FROM \"{role}\""),
         format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        // DROP OWNED severs every remaining privilege this role holds in the
+        // test database — the explicit REVOKEs above miss the RLS helper-function
+        // EXECUTE grants, so DROP ROLE failed with "objects depend on it" and
+        // leaked the cluster-global role (#1332 / PAP-134).
+        format!("DROP OWNED BY \"{role}\""),
         format!("DROP ROLE IF EXISTS \"{role}\""),
     ] {
         sqlx::query(sqlx::AssertSqlSafe(stmt))

--- a/backend/crates/db/tests/form_rls_repo_tests.rs
+++ b/backend/crates/db/tests/form_rls_repo_tests.rs
@@ -228,6 +228,11 @@ async fn form_repo_force_rls_deny_all_and_fix(pool: PgPool) {
             "REVOKE ALL ON forms, form_fields, form_submissions, form_downloads FROM \"{role}\""
         ),
         format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        // DROP OWNED severs every remaining privilege this role holds in the
+        // test database — the explicit REVOKEs above miss the RLS helper-function
+        // EXECUTE grants, so DROP ROLE failed with "objects depend on it" and
+        // leaked the cluster-global role (#1332 / PAP-134).
+        format!("DROP OWNED BY \"{role}\""),
         format!("DROP ROLE IF EXISTS \"{role}\""),
     ] {
         sqlx::query(sqlx::AssertSqlSafe(stmt))

--- a/backend/crates/db/tests/reserve_funds_rls_repo_tests.rs
+++ b/backend/crates/db/tests/reserve_funds_rls_repo_tests.rs
@@ -277,6 +277,11 @@ async fn reserve_fund_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     for stmt in [
         format!("REVOKE ALL ON reserve_funds FROM \"{role}\""),
         format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        // DROP OWNED severs every remaining privilege this role holds in the
+        // test database — the explicit REVOKEs above miss the RLS helper-function
+        // EXECUTE grants, so DROP ROLE failed with "objects depend on it" and
+        // leaked the cluster-global role (#1332 / PAP-134).
+        format!("DROP OWNED BY \"{role}\""),
         format!("DROP ROLE IF EXISTS \"{role}\""),
     ] {
         sqlx::query(sqlx::AssertSqlSafe(stmt))

--- a/backend/crates/db/tests/sensor_rls_repo_tests.rs
+++ b/backend/crates/db/tests/sensor_rls_repo_tests.rs
@@ -249,6 +249,14 @@ async fn sensors_force_rls_requires_context_and_blocks_cross_tenant(pool: PgPool
     .execute(&pool)
     .await
     .ok();
+    // DROP OWNED severs every remaining privilege this role holds in the test
+    // database — the explicit REVOKEs above miss the RLS helper-function EXECUTE
+    // grants, so DROP ROLE failed with "objects depend on it" and leaked the
+    // cluster-global role (#1332 / PAP-134).
+    sqlx::query(sqlx::AssertSqlSafe(format!("DROP OWNED BY \"{role}\"")))
+        .execute(&pool)
+        .await
+        .ok();
     sqlx::query(sqlx::AssertSqlSafe(format!(
         "DROP ROLE IF EXISTS \"{role}\""
     )))

--- a/backend/crates/db/tests/work_order_rls_repo_tests.rs
+++ b/backend/crates/db/tests/work_order_rls_repo_tests.rs
@@ -246,6 +246,14 @@ async fn work_orders_force_rls_requires_context_and_blocks_cross_tenant(pool: Pg
     .execute(&pool)
     .await
     .ok();
+    // DROP OWNED severs every remaining privilege this role holds in the test
+    // database — the explicit REVOKEs above miss the RLS helper-function EXECUTE
+    // grants, so DROP ROLE failed with "objects depend on it" and leaked the
+    // cluster-global role (#1332 / PAP-134).
+    sqlx::query(sqlx::AssertSqlSafe(format!("DROP OWNED BY \"{role}\"")))
+        .execute(&pool)
+        .await
+        .ok();
     sqlx::query(sqlx::AssertSqlSafe(format!(
         "DROP ROLE IF EXISTS \"{role}\""
     )))


### PR DESCRIPTION
## Fixes the dev-wide backend `test` job red tracked in #1332

### Root cause (confirmed in code + matches the #1332 bisect)

The `test` job has been red on **every** open backend PR since `41eda6c4` (PAP-76), stalling the entire merge pipeline. The failure is **not** a per-PR fault and **not** disk/resource — it's a leaked-role teardown bug.

Seven RLS repo test files grant the per-test role EXECUTE on the RLS helper functions in setup:

```rust
GRANT EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(),
      get_current_org_not_deleted() TO "{role}"
```

…but their teardown only `REVOKE`s the **table** grants before `DROP ROLE`. The leftover function-EXECUTE grants make `DROP ROLE` fail:

```
ERROR: role "ppt_rls_test_<hex>" cannot be dropped because some objects depend on it
DETAIL: privileges for function get_current_org_id() / is_super_admin() / get_current_org_not_deleted()
```

The `#[sqlx::test]` binary then aborts non-zero (exit 101) with no `test result:` summary, so the target is reported "failed". This is the systemic red across `form_rls_repo_tests`, `registry_rules_enum_decode_tests`, and `document_download_preview_tests` (cluster-global roles leak across targets).

### Fix

Add `DROP OWNED BY "{role}"` immediately before `DROP ROLE` in each of the **seven** broken teardowns, matching the canonical pattern the other **15** RLS test files already use (PAP-134 — see e.g. `vendor_rls_repo_tests.rs`). `DROP OWNED BY` severs every remaining privilege the role holds, so `DROP ROLE` cascades cleanly.

Files (test-only, +41 lines): `ai_chat`, `budget`, `building_certification`, `form`, `reserve_funds`, `sensor`, `work_order` RLS repo tests.

### Verification

- `cargo fmt -p db` — clean.
- `cargo check -p db` for all 7 affected test targets — **exit 0** (4m09s).
- The real proof is **this PR's own `test` job**: it is the check that has been red. If it goes green here, #1332 is resolved and the held PRs (#1318 approve, #1319) auto-merge next dispatcher cycle and #1316 can be un-quarantined.

### Scope

`pm-backend` / test-infrastructure only. No production code, no migration, no API surface change.

---
_Filed by the PPT research dispatcher (2026-06-14 run) — surgical pipeline unblock._

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPor9SKTBeGbsAd2uVoyuS)_