### PR TITLE
feat-build-configuration-by-environ-app-icon-variants-dev-mobile: per-environment app icon variants (DEV/STG badges)

### DIFF
--- a/frontend/apps/mobile/app.config.icon.test.ts
+++ b/frontend/apps/mobile/app.config.icon.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Regression for gap-85-2 (app icon variants): per-environment launcher icons
+ * with DEV / STG badges.
+ *
+ * `app.config.ts` resolves the launcher `icon` and the Android adaptive-icon
+ * foreground per `APP_ENV`:
+ *
+ *   development  =>  icon-dev.png      / adaptive-icon-dev.png      (DEV badge)
+ *   staging      =>  icon-staging.png  / adaptive-icon-staging.png  (STG badge)
+ *   production   =>  icon.png          / adaptive-icon.png          (no badge)
+ *
+ * When a badged variant PNG is missing on disk, the config falls back to the
+ * un-badged production asset (so prebuild / EAS build never fails on a missing
+ * file). These tests pin both the happy path (badged asset present) and the
+ * fallback path (badged asset absent).
+ *
+ * `app.config.ts` is a pure function of `{ config }` + `process.env.APP_ENV`,
+ * so we evaluate it directly with a fresh module per env. `fs.existsSync` is
+ * mocked so the test controls which badged assets "exist" without committing
+ * binary icon files.
+ */
+
+import type { ConfigContext, ExpoConfig } from 'expo/config';
+
+// Same rationale as app.config.push.test.ts: feed real URLs so the production
+// placeholder guard does not throw.
+jest.mock('dotenv', () => ({
+  config: () => ({
+    parsed: { API_BASE_URL: 'https://api.ppt.test', WS_BASE_URL: 'wss://api.ppt.test' },
+  }),
+}));
+
+// `loadConfig` calls `jest.resetModules()` so `app.config.ts` re-requires
+// `node:fs` fresh each time. The mock factory therefore delegates to a
+// mutable module-scoped predicate (set per test) rather than a captured
+// `jest.fn()` instance — otherwise a reset module would receive a brand-new,
+// unconfigured mock.
+let mockIconExistsPredicate: (path: string) => boolean = () => true;
+
+jest.mock('node:fs', () => {
+  const actual = jest.requireActual('node:fs');
+  return {
+    ...actual,
+    existsSync: (p: unknown) => mockIconExistsPredicate(String(p)),
+  };
+});
+
+type Env = 'development' | 'staging' | 'production';
+
+function loadConfig(appEnv: Env): ExpoConfig {
+  jest.resetModules();
+  process.env.APP_ENV = appEnv;
+  const mod = require('./app.config').default as (ctx: ConfigContext) => ExpoConfig;
+  const ctx: ConfigContext = {
+    projectRoot: '.',
+    staticConfigPath: null,
+    packageJsonPath: null,
+    config: {} as ExpoConfig,
+  };
+  return mod(ctx);
+}
+
+const ORIGINAL_APP_ENV = process.env.APP_ENV;
+
+afterEach(() => {
+  process.env.APP_ENV = ORIGINAL_APP_ENV;
+  mockIconExistsPredicate = () => true;
+});
+
+/** Make every referenced asset "present" on disk. */
+function allAssetsPresent() {
+  mockIconExistsPredicate = () => true;
+}
+
+/** Only the un-badged production assets exist (fresh-checkout scenario). */
+function onlyBaseAssetsPresent() {
+  mockIconExistsPredicate = (s: string) => !(s.includes('-dev') || s.includes('-staging'));
+}
+
+describe('per-environment launcher icon (badged variant present)', () => {
+  beforeEach(allAssetsPresent);
+
+  it('uses the DEV-badged icon for development', () => {
+    const cfg = loadConfig('development');
+    expect(cfg.icon).toContain('icon-dev.png');
+    expect(cfg.android?.adaptiveIcon?.foregroundImage).toContain('adaptive-icon-dev.png');
+  });
+
+  it('uses the STG-badged icon for staging', () => {
+    const cfg = loadConfig('staging');
+    expect(cfg.icon).toContain('icon-staging.png');
+    expect(cfg.android?.adaptiveIcon?.foregroundImage).toContain('adaptive-icon-staging.png');
+  });
+
+  it('uses the un-badged icon for production', () => {
+    const cfg = loadConfig('production');
+    expect(cfg.icon).toContain('icon.png');
+    expect(cfg.icon).not.toContain('-dev');
+    expect(cfg.icon).not.toContain('-staging');
+    expect(cfg.android?.adaptiveIcon?.foregroundImage).toContain('adaptive-icon.png');
+    expect(cfg.android?.adaptiveIcon?.foregroundImage).not.toContain('-dev');
+    expect(cfg.android?.adaptiveIcon?.foregroundImage).not.toContain('-staging');
+  });
+});
+
+describe('fallback when badged variant is missing', () => {
+  beforeEach(onlyBaseAssetsPresent);
+
+  it('falls back to the un-badged production icon for development', () => {
+    const cfg = loadConfig('development');
+    expect(cfg.icon).toContain('icon.png');
+    expect(cfg.icon).not.toContain('-dev');
+    expect(cfg.android?.adaptiveIcon?.foregroundImage).toContain('adaptive-icon.png');
+    expect(cfg.android?.adaptiveIcon?.foregroundImage).not.toContain('-dev');
+  });
+
+  it('falls back to the un-badged production icon for staging', () => {
+    const cfg = loadConfig('staging');
+    expect(cfg.icon).toContain('icon.png');
+    expect(cfg.icon).not.toContain('-staging');
+    expect(cfg.android?.adaptiveIcon?.foregroundImage).toContain('adaptive-icon.png');
+    expect(cfg.android?.adaptiveIcon?.foregroundImage).not.toContain('-staging');
+  });
+});

--- a/frontend/apps/mobile/app.config.ts
+++ b/frontend/apps/mobile/app.config.ts
@@ -61,6 +61,89 @@ function loadEnvFile(env: AppEnvironment): dotenv.DotenvParseOutput {
   return result.parsed ?? {};
 }
 
+/**
+ * gap-85-2 (app icon variants): per-environment launcher icons.
+ *
+ * So a tester can tell a development / staging build apart from production on
+ * the home screen at a glance, each environment ships its own badged icon:
+ *
+ *   development  =>  assets/images/icon-dev.png      / adaptive-icon-dev.png     (DEV badge)
+ *   staging      =>  assets/images/icon-staging.png  / adaptive-icon-staging.png (STG badge)
+ *   production   =>  assets/images/icon.png          / adaptive-icon.png         (no badge)
+ *
+ * The badged PNGs are *design assets* dropped into `assets/images/` by the
+ * design team (1024x1024). They are intentionally not generated in code. If a
+ * badged variant is missing (e.g. a fresh checkout that only has the base
+ * production icon yet), we fall back to the un-badged production asset so
+ * `expo prebuild` / EAS build never fails on a missing file. The fallback is
+ * logged so the gap is visible in build output.
+ *
+ * See assets/images/README.md for the icon-asset convention.
+ */
+const ICON_DIR = 'assets/images';
+
+interface IconVariant {
+  /** Square launcher icon (iOS + Android legacy), relative project path. */
+  icon: string;
+  /** Android adaptive-icon foreground layer, relative project path. */
+  adaptiveForeground: string;
+}
+
+/** Base (production, un-badged) icon assets — the fallback for every env. */
+const BASE_ICON_VARIANT: IconVariant = {
+  icon: `./${ICON_DIR}/icon.png`,
+  adaptiveForeground: `./${ICON_DIR}/adaptive-icon.png`,
+};
+
+/** Per-environment badged-icon basenames (suffix appended before `.png`). */
+const ICON_SUFFIX_BY_ENV: Record<AppEnvironment, string> = {
+  development: '-dev',
+  staging: '-staging',
+  production: '',
+};
+
+/** Returns true when an icon asset exists on disk beside this config. */
+function iconAssetExists(relativePath: string): boolean {
+  // relativePath is like './assets/images/icon-dev.png'
+  return fs.existsSync(path.resolve(__dirname, relativePath));
+}
+
+/**
+ * Resolve the launcher-icon variant for the given environment, falling back to
+ * the un-badged production assets when the badged variant file is absent.
+ */
+function resolveIconVariant(env: AppEnvironment): IconVariant {
+  const suffix = ICON_SUFFIX_BY_ENV[env];
+  if (suffix === '') {
+    return BASE_ICON_VARIANT;
+  }
+
+  const candidate: IconVariant = {
+    icon: `./${ICON_DIR}/icon${suffix}.png`,
+    adaptiveForeground: `./${ICON_DIR}/adaptive-icon${suffix}.png`,
+  };
+
+  const resolved: IconVariant = {
+    icon: iconAssetExists(candidate.icon) ? candidate.icon : BASE_ICON_VARIANT.icon,
+    adaptiveForeground: iconAssetExists(candidate.adaptiveForeground)
+      ? candidate.adaptiveForeground
+      : BASE_ICON_VARIANT.adaptiveForeground,
+  };
+
+  if (
+    resolved.icon !== candidate.icon ||
+    resolved.adaptiveForeground !== candidate.adaptiveForeground
+  ) {
+    console.warn(
+      `[app.config.ts] Badged ${env} icon variant missing — falling back to the un-badged ` +
+        `production icon (expected ${candidate.icon} / ${candidate.adaptiveForeground}). ` +
+        'Add the badged asset under assets/images/ — see assets/images/README.md.'
+    );
+  }
+
+  return resolved;
+}
+
 function getAppEnv(): AppEnvironment {
   const raw = process.env.APP_ENV ?? '';
   if (raw === 'staging' || raw === 'production' || raw === 'development') {
@@ -145,6 +228,9 @@ export default ({ config }: ConfigContext): ExpoConfig => {
   //   - the JS route matcher (src/qrcode/universalLinks.ts → extra.appLinkHost)
   const appLinkHost = envVars.APP_LINK_HOST ?? process.env.APP_LINK_HOST ?? 'app.ppt.example.com';
 
+  // gap-85-2: per-environment launcher icon (DEV / STG badge vs. clean prod).
+  const iconVariant = resolveIconVariant(appEnv);
+
   return {
     ...config,
     name: config.name ?? 'PPT Management',
@@ -153,6 +239,10 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     orientation: 'portrait',
     scheme: 'ppt-management',
     platforms: ['ios', 'android'],
+
+    // gap-85-2: top-level launcher icon — used by iOS and as the Android
+    // legacy (pre-adaptive) icon. Per-environment badged variant resolved above.
+    icon: iconVariant.icon,
 
     ios: {
       ...config.ios,
@@ -236,8 +326,10 @@ export default ({ config }: ConfigContext): ExpoConfig => {
 
       // Adaptive icon -- required for Android 8.0+ (API level 26+).
       // Asset: assets/images/adaptive-icon.png (1024x1024, transparent bg).
+      // gap-85-2: foreground layer is the per-environment badged variant
+      // (DEV / STG) resolved above, falling back to the un-badged prod asset.
       adaptiveIcon: {
-        foregroundImage: './assets/images/adaptive-icon.png',
+        foregroundImage: iconVariant.adaptiveForeground,
         backgroundColor: '#1A73E8',
       },
 

--- a/frontend/apps/mobile/assets/images/README.md
+++ b/frontend/apps/mobile/assets/images/README.md
@@ -1,0 +1,48 @@
+# App icon assets (Property Management mobile)
+
+Epic 85 — Story 85.2: Build Configuration by Environment (app icon variants).
+
+`app.config.ts` selects the launcher icon **per environment** (`APP_ENV`) so a
+DEV or staging build is instantly distinguishable from production on the home
+screen. The selection logic lives in `resolveIconVariant()` in `app.config.ts`;
+this file documents the asset convention it expects.
+
+## Required assets
+
+All icons are **1024 × 1024 PNG**. Adaptive-icon foregrounds use a transparent
+background (Android draws the `#1A73E8` background layer behind them).
+
+| Environment   | `APP_ENV`     | Launcher icon (`icon`)          | Android adaptive foreground            | Badge |
+| ------------- | ------------- | ------------------------------- | -------------------------------------- | ----- |
+| Production    | `production`  | `icon.png`                      | `adaptive-icon.png`                    | none  |
+| Staging       | `staging`     | `icon-staging.png`              | `adaptive-icon-staging.png`            | `STG` |
+| Development   | `development` | `icon-dev.png`                  | `adaptive-icon-dev.png`                | `DEV` |
+
+Plus the push-notification icon referenced by the `expo-notifications` plugin:
+
+| Purpose            | File                    |
+| ------------------ | ----------------------- |
+| Notification icon  | `notification-icon.png` |
+
+## Badge convention
+
+The badged variants are the **production** icon with a small ribbon/banner in
+the lower portion reading `DEV` or `STG`. Keep the badge inside the adaptive
+icon safe zone (centre 66% diameter) so it is not clipped by round/squircle
+masks on Android.
+
+These are **design assets** — produce them in the design tool and drop them
+here. They are intentionally not generated in code (the repo does not commit
+binary icon assets in this branch). Until the badged variants are added,
+`app.config.ts` falls back to the un-badged production icon and logs a warning
+at build time, so builds never fail on a missing file.
+
+## How selection works
+
+`APP_ENV` is set per EAS build profile (see `eas.json`):
+
+- `development` / `simulator` profiles → `APP_ENV=development` → DEV-badged icon
+- `staging` profile → `APP_ENV=staging` → STG-badged icon
+- `production` profile → `APP_ENV=production` → clean icon
+
+Locally: `APP_ENV=staging expo start` previews the staging icon.


### PR DESCRIPTION
## Task
app icon variants with DEV/STG badges not created (85-2-build-configuration Build Configuration by Environment)

Property Management mobile app (`frontend/apps/mobile`, Expo) had no per-environment launcher icon: `app.config.ts` set no top-level `icon` and used a single static `adaptive-icon.png` regardless of `APP_ENV`. So development / staging / production builds were visually indistinguishable on the home screen.

This wires the **build-configuration mechanism** that selects a badged launcher icon per environment:

| Environment | `APP_ENV` | `icon` | Android adaptive foreground | Badge |
| --- | --- | --- | --- | --- |
| Production | `production` | `icon.png` | `adaptive-icon.png` | none |
| Staging | `staging` | `icon-staging.png` | `adaptive-icon-staging.png` | `STG` |
| Development | `development` | `icon-dev.png` | `adaptive-icon-dev.png` | `DEV` |

`resolveIconVariant()` falls back to the un-badged production asset (with a build-time `console.warn`) when a badged variant PNG is absent, so `expo prebuild` / EAS builds never fail on a missing file.

## Owner
pm-frontend (mobile / `react-native` specialist)

## Tested (Band A — fast check)
- `pnpm -F mobile typecheck` → exit 0
- `biome check apps/mobile/app.config.ts apps/mobile/app.config.icon.test.ts` → exit 0 (mobile has no `lint` script; Biome is the workspace linter)
- `pnpm -F mobile test -- app.config.icon.test.ts` → 5/5 pass (exit 0)
- `pnpm -F mobile test -- app.config.push.test.ts` → 4/4 pass (no regression in the sibling app.config test)

New regression test `app.config.icon.test.ts` pins per-env icon resolution (badged-present happy path) **and** the missing-asset fallback path. Both the test and the feature are absent on `dev` (confirmed via `git ls-tree origin/dev` + `git show origin/dev:...app.config.ts`), so the test exercises genuinely new behavior.

## Built (Band B — full build)
skipped: config-only change (~80 LOC in app.config.ts + test + doc). No public runtime API / migration. `pnpm -F mobile build` is a Metro bundle of `src/` and does not evaluate `app.config.ts`; the pure-function evaluation is fully covered by the Band A jest tests.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped (no ppt-bridge MCP in session)

## Scope drift
`scope-check.sh --owner pm-frontend` exits 2 on all three changed paths:
- `frontend/apps/mobile/app.config.ts`
- `frontend/apps/mobile/app.config.icon.test.ts`
- `frontend/apps/mobile/assets/images/README.md`

This is a **mapping gap, not real drift**: `owner-areas.json` lists `pm-frontend` areas as `ppt-web` / `reality-web` / `admin-web` / `packages` / `docs/screens`, but omits `frontend/apps/mobile/**`. The `react-native` specialist explicitly owns `frontend/apps/mobile/` (see `.claude/skills/ppt-implement/agents/react-native.md`). Every changed file is inside `frontend/apps/mobile/` — squarely where this mobile task belongs. Suggest adding `frontend/apps/mobile/**` to `pm-frontend` (or a `pm-mobile` owner) in `owner-areas.json`.

## Code-reuse review
`reuse-grep.sh --specialist react-native` → no warnings. The icon resolver reuses the existing `node:fs` / `node:path` + `__dirname` pattern already used by `hasGoogleServicesJson()` in the same file.

## Notes
- **Binary icon assets are NOT fabricated.** The badged PNGs (`icon-dev.png`, `icon-staging.png`, `adaptive-icon-*.png`) are design-team deliverables. The convention + safe-zone/badge guidance is documented in the new `frontend/apps/mobile/assets/images/README.md`. Until those PNGs land, every environment falls back to the un-badged production icon and logs a warning — no build breakage.
- This also fills a pre-existing gap: there was previously **no** top-level `icon` in `app.config.ts` at all (only the Android `adaptiveIcon`). iOS now gets a launcher icon too.
- The base assets themselves (`icon.png`, `adaptive-icon.png`, `notification-icon.png`) are referenced by config but not committed in the repo on `dev` either — they are provided at build/prebuild time. This PR does not change that contract; it only adds env-aware selection on top of it.

---
_Generated by [Claude Code](https://claude.ai/code/session_0144vyWADuYbfrSyEtrQgXf6)_