### PR TITLE
feat-environment-variable-setup-env-setup-documentation-mobile: add env-setup developer docs for mobile app

### DIFF
--- a/frontend/apps/mobile/README.md
+++ b/frontend/apps/mobile/README.md
@@ -1,0 +1,134 @@
+# ppt-mobile — Property Management (Expo / React Native)
+
+The Property Management mobile app (`three.two.bit.ppt.management`). Built with
+Expo + React Native and talks to `api-server` (port 8080).
+
+For agent-specific conventions, see [`CLAUDE.md`](./CLAUDE.md).
+
+## Environment variable setup
+
+The app is configured per environment (development / staging / production)
+through `.env.<APP_ENV>` files. This section is the developer-facing reference
+for which variables exist, how `APP_ENV` selects a file, and how to run each
+environment.
+
+### How config flows (single source of truth)
+
+```
+.env.<APP_ENV>  ──dotenv──▶  app.config.ts  ──▶  Constants.expoConfig.extra  ──▶  src/config/api.ts (JS)
+                                            └──▶  ios.infoPlist (native iOS keys)
+```
+
+- `app.config.ts` is the **only** loader. On startup it picks an environment
+  (see below), loads the matching `.env.<env>` via `dotenv`, and injects the
+  values into both `Constants.expoConfig.extra` (read by JS) and
+  `ios.infoPlist` (read by native iOS).
+- JS code never reads `process.env` directly — it calls helpers in
+  [`src/config/api.ts`](./src/config/api.ts), which only consult
+  `Constants.expoConfig.extra`.
+- `EXPO_PUBLIC_*` variables are **not** used here (removed in issue #523).
+  They cannot reach the iOS `Info.plist` and would require hand-syncing two
+  copies of every value. Do not reintroduce them.
+
+### How `APP_ENV` selects the config file
+
+`app.config.ts` resolves the environment in this order:
+
+| `APP_ENV` value | Loads          |
+| --------------- | -------------- |
+| `development`   | `.env.development` |
+| `staging`       | `.env.staging` |
+| `production`    | `.env.production` |
+
+If `APP_ENV` is unset, it defaults to `development` in `__DEV__` (Metro dev
+server) and `production` in release builds. Set it inline on the command:
+
+```bash
+APP_ENV=staging expo start
+```
+
+### Variables
+
+| Variable        | Required | Example (development)        | Description |
+| --------------- | :------: | ---------------------------- | ----------- |
+| `API_BASE_URL`  | yes      | `http://localhost:8080`      | REST base URL for `api-server`. |
+| `WS_BASE_URL`   | yes      | `ws://localhost:8080`        | WebSocket base URL (derived from `API_BASE_URL` if omitted). |
+| `ENVIRONMENT`   | yes      | `development`                | Logical environment label exposed to the app and iOS `Info.plist`. |
+| `DEBUG_MODE`    | yes      | `true`                       | Enables verbose/debug behaviour; `false` in production. |
+| `APP_LINK_HOST` | yes      | `app.ppt.example.com`        | HTTPS host for Universal Links (iOS) / App Links (Android). Drives `ios.associatedDomains`, the Android `https` intent filter, and the JS route matcher (`src/qrcode/universalLinks.ts`). The matching `/.well-known/apple-app-site-association` and `/.well-known/assetlinks.json` files must be served from this host. |
+
+### Per-environment values
+
+| Variable        | development             | staging                                | production |
+| --------------- | ----------------------- | -------------------------------------- | ---------- |
+| `API_BASE_URL`  | `http://localhost:8080` | `https://staging-api.ppt.example.com`  | `__SET_BY_CI__` (overridden by CI) |
+| `WS_BASE_URL`   | `ws://localhost:8080`   | `wss://staging-api.ppt.example.com`    | `__SET_BY_CI__` (overridden by CI) |
+| `ENVIRONMENT`   | `development`           | `staging`                              | `production` |
+| `DEBUG_MODE`    | `true`                  | `true`                                 | `false` |
+| `APP_LINK_HOST` | `app.ppt.example.com`   | `staging-app.ppt.example.com`          | `app.ppt.example.com` (override in CI) |
+
+> **Production secrets:** `.env.production` intentionally ships the
+> `__SET_BY_CI__` sentinel for `API_BASE_URL` / `WS_BASE_URL`. `app.config.ts`
+> has a placeholder guard that **fails the build** if that sentinel reaches a
+> real production build. CI must supply the real hosts via EAS project secrets:
+>
+> ```bash
+> eas secret:create --scope project --name API_BASE_URL --value https://api.<prod-host>
+> eas secret:create --scope project --name WS_BASE_URL  --value wss://api.<prod-host>
+> ```
+>
+> These land in `process.env` at build time and are picked up by
+> `app.config.ts`. See the `production` profile in [`eas.json`](./eas.json).
+
+### First-time setup
+
+The committed `.env.development`, `.env.staging`, and `.env.production` files
+already carry the non-secret defaults above, so a local dev run works out of
+the box. To customise values locally, copy the template and edit:
+
+```bash
+cp .env.example .env.development   # then edit API_BASE_URL etc. as needed
+```
+
+`.env.example` is the documented template; `.env.local` (if you create one) is
+gitignored for machine-specific overrides.
+
+## Running per environment
+
+`pnpm`-friendly scripts are defined in [`package.json`](./package.json). Run
+them from the repo root with `-F mobile` or from this directory directly.
+
+| Goal | Command |
+| ---- | ------- |
+| Dev (default `development`) | `pnpm -F mobile start` |
+| Staging (Metro dev server)  | `pnpm -F mobile start:staging` |
+| Production (Metro dev server) | `pnpm -F mobile start:production` |
+| Dev on Android device/emulator | `pnpm -F mobile android` |
+| Staging on Android | `pnpm -F mobile android:staging` |
+| Dev on iOS simulator | `pnpm -F mobile ios` |
+| Staging on iOS | `pnpm -F mobile ios:staging` |
+
+Any environment can also be selected by setting `APP_ENV` inline:
+
+```bash
+APP_ENV=staging expo start
+APP_ENV=production expo start
+```
+
+> **Android localhost note:** when `API_BASE_URL` is unset in `__DEV__`, the app
+> falls back to `http://10.0.2.2:8080` on Android (emulator → host loopback) and
+> `http://localhost:8080` on iOS. See `getApiBaseUrl()` in `src/config/api.ts`.
+
+### Release builds (EAS)
+
+EAS build profiles in [`eas.json`](./eas.json) set `APP_ENV` for you:
+
+```bash
+pnpm -F mobile build:android:staging      # eas build --platform android --profile staging
+pnpm -F mobile build:android:production    # eas build --platform android --profile production
+pnpm -F mobile build:ios:staging
+pnpm -F mobile build:ios:production
+```
+
+The `eas` CLI must be installed globally (`npm install -g eas-cli`) — it is
+intentionally not a devDependency. See [`CLAUDE.md`](./CLAUDE.md) for details.


### PR DESCRIPTION
## Task
env setup documentation missing (85-1-environment-variables Environment Variable Setup). The Property Management mobile app is at frontend/apps/mobile (Expo). A frontend/apps/mobile/.env.example exists but there is no developer-facing documentation of the environment-variable setup (which vars, per-env values, how APP_ENV selects config, how to run dev/staging/prod). Add concise env-setup documentation (e.g. a README section or docs page) covering the existing .env.example + app.config.ts environment mechanism.

## What changed
Added `frontend/apps/mobile/README.md` (the app had no README). It documents, for developers:
- The config flow: `.env.<APP_ENV>` → `app.config.ts` (dotenv) → `Constants.expoConfig.extra` + `ios.infoPlist` → `src/config/api.ts`.
- How `APP_ENV` selects the env file (and the `__DEV__`/release defaults).
- Each variable (`API_BASE_URL`, `WS_BASE_URL`, `ENVIRONMENT`, `DEBUG_MODE`, `APP_LINK_HOST`), with a per-environment values table.
- The `__SET_BY_CI__` production sentinel + the EAS secrets workflow.
- Run commands per environment (`pnpm -F mobile start[:staging|:production]`, `android`/`ios` variants, inline `APP_ENV=...`), plus the EAS release-build scripts.

Verified no pre-existing developer-facing env-setup doc: `frontend/apps/mobile` had no README; `grep -ri APP_ENV docs/` returned nothing. The existing `CLAUDE.md` "Env config" section is terse agent-instruction text, not the requested developer reference. Content is cross-checked against the actual `.env.*` files, `app.config.ts`, `package.json` scripts, and `eas.json`.

## Owner
pm-frontend (note: this task's files live in `frontend/apps/mobile/**`, which the scope map assigns to `pm-mobile`)

## Tested (Band A — fast check)
Docs-only change (one new Markdown file, no TS/JS). Biome does not lint/format Markdown by default, and `pnpm -F mobile typecheck`/`lint` operate on TS/JS only — neither can be affected by a README.
- `git diff --check` → exit 0 (no whitespace errors)

## Built (Band B — full build)
skipped: docs-only change, no public API / config / build-output touch.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped

## Scope drift
`scope-check.sh --owner pm-frontend` exits 2 because `frontend/apps/mobile/README.md` maps to `pm-mobile`, not `pm-frontend`. The drift is purely an owner-label mismatch from the dispatch (`owner_role=pm-frontend` for a mobile-app task); the single changed file is squarely in scope for the actual task. No code outside the mobile app was touched (diff vs `origin/dev` = `frontend/apps/mobile/README.md` only).

## Code-reuse review
none (docs only).

## Notes
- IG goal-check (IG1/IG2/IG8) flags absence of a `.research/plans/<slug>.md`, the `impl/<slug>` branch name, and an archive move. Those are artifacts of the standard dispatcher plan workflow; this task was hand-dispatched with an `auto-impl/*` branch and no plan file, so they are not applicable. IG3 (regression test) is N/A for a pure-docs change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BtQriSv7Rt1P6EgR129ZK2)_