### PR TITLE
feat-airbnb-oauth-and-sync-no-oauth-token-exchange-backend: Airbnb OAuth token-exchange serde unit tests

### DIFF
--- a/backend/servers/api-server/src/routes/integrations/oauth.rs
+++ b/backend/servers/api-server/src/routes/integrations/oauth.rs
@@ -980,7 +980,10 @@ mod tests {
         let value: serde_json::Value = serde_json::to_value(&resp).unwrap();
         assert_eq!(value["success"], serde_json::json!(true));
         assert_eq!(value["connection_id"], serde_json::json!(id.to_string()));
-        assert_eq!(value["message"], serde_json::json!("Airbnb connected successfully"));
+        assert_eq!(
+            value["message"],
+            serde_json::json!("Airbnb connected successfully")
+        );
         assert_eq!(value["listings_count"], serde_json::json!(3));
     }
 

--- a/backend/servers/api-server/src/routes/integrations/oauth.rs
+++ b/backend/servers/api-server/src/routes/integrations/oauth.rs
@@ -921,4 +921,82 @@ mod tests {
         assert_eq!(value["success"], serde_json::json!(false));
         assert!(value["connection_id"].is_null());
     }
+
+    // ---- Airbnb token-exchange serde (Story 83.1 / Coverage 83-1) ----
+    //
+    // Mirrors the Booking.com coverage above for the primary Airbnb flow.
+    // These are pure (de)serialization checks of the request/response wire
+    // contract for `POST /organizations/{org_id}/airbnb/token/exchange`; they
+    // do not touch the network or a DB. See `tests/airbnb_oauth_routes_tests.rs`
+    // for the auth/IDOR integration coverage of the same endpoint.
+
+    #[test]
+    fn test_airbnb_token_exchange_request_deserialization_full() {
+        let json = r#"{"code":"airbnb-auth-code-123","redirect_uri":"https://app.example.com/airbnb/callback"}"#;
+        let req: AirbnbTokenExchangeRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.code, "airbnb-auth-code-123");
+        assert_eq!(
+            req.redirect_uri.as_deref(),
+            Some("https://app.example.com/airbnb/callback")
+        );
+    }
+
+    #[test]
+    fn test_airbnb_token_exchange_request_minimal() {
+        // Only `code` is required; `redirect_uri` falls back to the
+        // server-configured AIRBNB_REDIRECT_URI when omitted.
+        let json = r#"{"code":"airbnb-auth-code-only"}"#;
+        let req: AirbnbTokenExchangeRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.code, "airbnb-auth-code-only");
+        assert!(req.redirect_uri.is_none());
+    }
+
+    #[test]
+    fn test_airbnb_token_exchange_request_missing_code_fails() {
+        // A body without `code` must be rejected at deserialization so the
+        // handler never forwards an empty authorization code to Airbnb.
+        let json = r#"{"redirect_uri":"https://example.com/cb"}"#;
+        let parsed: Result<AirbnbTokenExchangeRequest, _> = serde_json::from_str(json);
+        assert!(parsed.is_err(), "missing code must fail to deserialize");
+    }
+
+    #[test]
+    fn test_airbnb_token_exchange_request_rejects_null_code() {
+        // `code` is a non-optional String — an explicit JSON null must fail.
+        let json = r#"{"code":null}"#;
+        let parsed: Result<AirbnbTokenExchangeRequest, _> = serde_json::from_str(json);
+        assert!(parsed.is_err(), "null code must fail to deserialize");
+    }
+
+    #[test]
+    fn test_airbnb_token_exchange_response_serialization() {
+        let id = Uuid::new_v4();
+        let resp = AirbnbTokenExchangeResponse {
+            success: true,
+            connection_id: Some(id),
+            message: "Airbnb connected successfully".to_string(),
+            listings_count: Some(3),
+        };
+        let value: serde_json::Value = serde_json::to_value(&resp).unwrap();
+        assert_eq!(value["success"], serde_json::json!(true));
+        assert_eq!(value["connection_id"], serde_json::json!(id.to_string()));
+        assert_eq!(value["message"], serde_json::json!("Airbnb connected successfully"));
+        assert_eq!(value["listings_count"], serde_json::json!(3));
+    }
+
+    #[test]
+    fn test_airbnb_token_exchange_response_failure_shape() {
+        // On failure the optional fields must serialize to JSON null rather
+        // than being dropped, so the frontend can distinguish "not set" cleanly.
+        let resp = AirbnbTokenExchangeResponse {
+            success: false,
+            connection_id: None,
+            message: "failed".to_string(),
+            listings_count: None,
+        };
+        let value: serde_json::Value = serde_json::to_value(&resp).unwrap();
+        assert_eq!(value["success"], serde_json::json!(false));
+        assert!(value["connection_id"].is_null());
+        assert!(value["listings_count"].is_null());
+    }
 }


### PR DESCRIPTION
## Task
no OAuth token exchange route (models only) (83-1-airbnb-integration Airbnb OAuth and Sync).

This is the operator-intended **recovery** of the serde/unit-test coverage for the Airbnb token-exchange contract. Investigation of current `dev` (HEAD `f0cb234`) confirmed:

- The Airbnb OAuth token-exchange **route already exists** — `airbnb_token_exchange` handler mounted at `POST /api/v1/integrations/organizations/{org_id}/airbnb/token/exchange` (shipped via PR #1177), plus `AirbnbClient::exchange_code` in `crates/integrations/src/airbnb.rs`.
- Integration tests (`tests/airbnb_oauth_routes_tests.rs`) already cover auth / IDOR / shape for the endpoint.
- The `#[cfg(test)] mod tests` in `routes/integrations/oauth.rs` had serde unit tests for **Booking.com**'s request/response types but **none for the Airbnb** `AirbnbTokenExchangeRequest` / `AirbnbTokenExchangeResponse` types — the primary Story 83.1 flow. PR #1318 authored these but is QUARANTINED (unrelated-histories, unmergeable).

This PR adds the missing Airbnb serde unit tests, **recreated fresh off current dev** (not cherry-picked from #1318). No route/model code was changed — the implementation is identical to dev; only 6 `#[test]` functions were appended to the existing test module.

### Added tests
- `test_airbnb_token_exchange_request_deserialization_full` — code + redirect_uri
- `test_airbnb_token_exchange_request_minimal` — code only, redirect_uri None
- `test_airbnb_token_exchange_request_missing_code_fails` — missing required code rejected
- `test_airbnb_token_exchange_request_rejects_null_code` — explicit null code rejected
- `test_airbnb_token_exchange_response_serialization` — success shape incl. listings_count
- `test_airbnb_token_exchange_response_failure_shape` — optional fields serialize to null

## Owner
pm-backend

## Tested (Band A — fast check)
```
SQLX_OFFLINE=true cargo check -p api-server      # exit 0
SQLX_OFFLINE=true cargo test -p api-server --lib airbnb_token_exchange   # exit 0
```
```
running 6 tests
test routes::integrations::oauth::tests::test_airbnb_token_exchange_request_deserialization_full ... ok
test routes::integrations::oauth::tests::test_airbnb_token_exchange_request_minimal ... ok
test routes::integrations::oauth::tests::test_airbnb_token_exchange_request_missing_code_fails ... ok
test routes::integrations::oauth::tests::test_airbnb_token_exchange_request_rejects_null_code ... ok
test routes::integrations::oauth::tests::test_airbnb_token_exchange_response_serialization ... ok
test routes::integrations::oauth::tests::test_airbnb_token_exchange_response_failure_shape ... ok

test result: ok. 6 passed; 0 failed; 0 ignored
```

## Built (Band B — full build)
skipped: test-only change (~80 LOC of `#[test]` fns), no public API / migration / config touch.

## CI parity (Band C — hot-path only)
skipped: test-only addition; no production-code change to security/auth/billing/data-integrity logic (the auth/IDOR logic under test is unchanged and already covered by integration tests).

## Remote-tested
skipped

## Notes
- Scope-drift: `scope-check.sh --owner pm-backend` → exit 0 (single file under `backend/`, in pm-backend's area).
- Code-reuse: `reuse-grep.sh` → no warnings.
- IG goal-check: IG1 (no `.research/plans/` file) and IG2 (branch is the dispatcher-assigned `auto-impl/...` name, not `impl/...`) report FAIL — both are harness/plan-flow structural mismatches, not code defects. IG3 is a test-only recovery (the production code already shipped in PR #1177), so there is no paired `fix:` commit by design.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BtQriSv7Rt1P6EgR129ZK2)_