### PR TITLE
feat-environment-variable-setup-ios-info: add API_BASE_URL/ENVIRONMENT keys to legacy iOS Info.plist

### DIFF
--- a/mobile-native/iosApp/Info.plist
+++ b/mobile-native/iosApp/Info.plist
@@ -44,5 +44,11 @@
             </array>
         </dict>
     </array>
+    <key>API_BASE_URL</key>
+    <string>$(API_BASE_URL)</string>
+    <key>ENVIRONMENT</key>
+    <string>$(ENVIRONMENT)</string>
+    <key>ENABLE_LOGGING</key>
+    <string>$(ENABLE_LOGGING)</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Task
iOS Info.plist lacks API_BASE_URL/ENVIRONMENT keys (85-1-environment-variables Environment Variable Setup)

## Owner
pm-frontend (hint) — actual specialist: `ios-swiftui` (task targets `mobile-native/iosApp/Info.plist`)

## What changed
Added the three xcconfig-injected keys to the **legacy top-level** `mobile-native/iosApp/Info.plist`:
- `API_BASE_URL` → `$(API_BASE_URL)`
- `ENVIRONMENT` → `$(ENVIRONMENT)`
- `ENABLE_LOGGING` → `$(ENABLE_LOGGING)`

### Context (important for reviewer)
There are two Info.plist files in the iOS app:
- `iosApp/Resources/Info.plist` — the **build-time** plist (referenced by `project.yml` `info.path`). It **already** had all three keys on `dev` (committed previously).
- `iosApp/Info.plist` — the **legacy top-level** plist (called "legacy top-level Info.plist" in `iosApp.entitlements`). It lacked the keys, leaving the two plists inconsistent.

This PR brings the legacy plist into parity. All three values are defined per-environment in `Configurations/{Development,Staging,Production}.xcconfig`, and `Core/Configuration.swift` reads all three keys at runtime (with safe fallbacks for the unresolved `$(VAR)` placeholder).

## Tested (Band A — fast check)
Plist-only change (XML, no Swift/Kotlin source touched), so the `ios-swiftui` Kotlin-link Band A compile does not exercise it. Validated the plist instead:
```
python3 -c "import plistlib; plistlib.load(open('Info.plist','rb'))"  → exit 0
keys present: ['API_BASE_URL', 'ENVIRONMENT', 'ENABLE_LOGGING']
```

## Built (Band B — full build)
skipped: change <50 LOC (+6 lines), no public API surface, no code compiled from this file by Gradle.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change). `eas-build-ios.yml` / `mobile-native.yml` build matrix uses `Resources/Info.plist` and is unaffected by this legacy-plist addition.

## Scope drift
The advisory `scope-check.sh` flagged drift because `owner_role=pm-frontend` maps to `frontend/apps/**` globs that exclude `mobile-native/iosApp/`. This is an owner-role taxonomy gap, not real scope creep — the single changed file (`mobile-native/iosApp/Info.plist`) is exactly the file named in the task. `commit-scope-guard.sh --allow 'mobile-native/iosApp/**'` passes (exit 0).

## Code-reuse review
none — config/plist change, no new helpers added.

## Notes
- Diff vs `origin/dev` is exactly 1 file, +6 lines.
- The placeholder `$(API_BASE_URL)` etc. resolve only when the iOS project is generated via XcodeGen with the active xcconfig; `Configuration.swift` already guards against the literal unresolved placeholder.

https://claude.ai/code/session_01YVwdPZEbsWoEjZDhxwMF9A

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVwdPZEbsWoEjZDhxwMF9A)_