### PR TITLE
feat-home-and-search-screens-filtersheet-location-features-mobile: FilterSheet Near Me location filter (Android/shared parity)

### DIFF
--- a/mobile-native/androidApp/src/main/AndroidManifest.xml
+++ b/mobile-native/androidApp/src/main/AndroidManifest.xml
@@ -3,6 +3,15 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <!-- Coarse location for the Search "Near Me" radius filter (epic-82 story 82.3 FilterSheet).
+         Coarse precision is sufficient for a city-scale radius search and is the lighter-weight
+         permission; we never request ACCESS_FINE_LOCATION. The feature degrades gracefully when
+         the permission is denied (the toggle simply has no effect). -->
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-feature
+        android:name="android.hardware.location"
+        android:required="false" />
+
     <application
         android:name=".RealityPortalApplication"
         android:allowBackup="false"

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/search/NearMeLocation.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/search/NearMeLocation.kt
@@ -1,0 +1,93 @@
+package three.two.bit.ppt.reality.ui.search
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+
+/**
+ * Resolved device coordinate for the Search "Near Me" radius filter.
+ *
+ * Epic 82 - Story 82.3: this is the Android counterpart of the iOS `LocationManager`
+ * (`mobile-native/iosApp/iosApp/Core/Location/LocationManager.swift`) used by the SwiftUI
+ * `FilterSheet.nearMeSection`. Kept intentionally tiny — a single one-shot coordinate fetch is all
+ * the radius filter needs; we don't stream location updates.
+ */
+data class NearMeCoordinate(val latitude: Double, val longitude: Double)
+
+/**
+ * A composable handle the FilterSheet uses to turn the "Near Me" toggle on: it owns the runtime
+ * permission launcher and the one-shot location request, and reports the resolved coordinate (or a
+ * denial) back through [onResolved].
+ *
+ * Behaviour mirrors the iOS flow:
+ * - If coarse-location permission is already granted, fetch the current coordinate immediately.
+ * - Otherwise request the permission; on grant, fetch; on denial, report `null` so the caller can
+ *   revert the toggle (graceful degradation — the search simply has no location centre).
+ */
+class NearMeLocationRequester internal constructor(
+    private val request: (onResolved: (NearMeCoordinate?) -> Unit) -> Unit,
+) {
+    /** Begin acquiring the device coordinate; [onResolved] receives null when unavailable/denied. */
+    fun acquire(onResolved: (NearMeCoordinate?) -> Unit) = request(onResolved)
+}
+
+/**
+ * Remembers a [NearMeLocationRequester] bound to the current activity. Must be called from
+ * composable scope (it registers an activity-result launcher).
+ */
+@Composable
+fun rememberNearMeLocationRequester(): NearMeLocationRequester {
+    val context = LocalContext.current
+    // Holds the callback for the in-flight request so the permission-result lambda can complete it.
+    val pending = remember { arrayOfNulls<(NearMeCoordinate?) -> Unit>(1) }
+
+    val permissionLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            val cb = pending[0]
+            pending[0] = null
+            if (granted) fetchLastLocation(context, cb ?: return@rememberLauncherForActivityResult)
+            else cb?.invoke(null)
+        }
+
+    return remember {
+        NearMeLocationRequester { onResolved ->
+            if (hasCoarseLocationPermission(context)) {
+                fetchLastLocation(context, onResolved)
+            } else {
+                pending[0] = onResolved
+                permissionLauncher.launch(Manifest.permission.ACCESS_COARSE_LOCATION)
+            }
+        }
+    }
+}
+
+private fun hasCoarseLocationPermission(context: Context): Boolean =
+    // Framework API (API 23+) — minSdk is 24, so no ContextCompat shim needed.
+    context.checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) ==
+        PackageManager.PERMISSION_GRANTED
+
+private fun fetchLastLocation(context: Context, onResolved: (NearMeCoordinate?) -> Unit) {
+    val client = LocationServices.getFusedLocationProviderClient(context)
+    try {
+        // getCurrentLocation triggers a fresh fix when no recent one is cached, unlike
+        // lastLocation which can be stale/null on a cold start.
+        client
+            .getCurrentLocation(Priority.PRIORITY_BALANCED_POWER_ACCURACY, null)
+            .addOnSuccessListener { location ->
+                onResolved(
+                    location?.let { NearMeCoordinate(it.latitude, it.longitude) }
+                )
+            }
+            .addOnFailureListener { onResolved(null) }
+    } catch (_: SecurityException) {
+        // Permission revoked between the check and the call — degrade gracefully.
+        onResolved(null)
+    }
+}

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/search/NearMeLocation.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/search/NearMeLocation.kt
@@ -31,10 +31,11 @@ data class NearMeCoordinate(val latitude: Double, val longitude: Double)
  * - Otherwise request the permission; on grant, fetch; on denial, report `null` so the caller can
  *   revert the toggle (graceful degradation — the search simply has no location centre).
  */
-class NearMeLocationRequester internal constructor(
-    private val request: (onResolved: (NearMeCoordinate?) -> Unit) -> Unit,
-) {
-    /** Begin acquiring the device coordinate; [onResolved] receives null when unavailable/denied. */
+class NearMeLocationRequester
+internal constructor(private val request: (onResolved: (NearMeCoordinate?) -> Unit) -> Unit) {
+    /**
+     * Begin acquiring the device coordinate; [onResolved] receives null when unavailable/denied.
+     */
     fun acquire(onResolved: (NearMeCoordinate?) -> Unit) = request(onResolved)
 }
 
@@ -81,9 +82,7 @@ private fun fetchLastLocation(context: Context, onResolved: (NearMeCoordinate?) 
         client
             .getCurrentLocation(Priority.PRIORITY_BALANCED_POWER_ACCURACY, null)
             .addOnSuccessListener { location ->
-                onResolved(
-                    location?.let { NearMeCoordinate(it.latitude, it.longitude) }
-                )
+                onResolved(location?.let { NearMeCoordinate(it.latitude, it.longitude) })
             }
             .addOnFailureListener { onResolved(null) }
     } catch (_: SecurityException) {

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/search/SearchScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/search/SearchScreen.kt
@@ -103,6 +103,13 @@ fun SearchScreen(
     var maxPrice by remember { mutableStateOf("") }
     var minRooms by remember { mutableStateOf<Int?>(null) }
     var selectedSort by remember { mutableStateOf(ListingSortOption.NEWEST) }
+    // "Near Me" location filter (epic-82 story 82.3 FilterSheet). radiusKm drives the toggle;
+    // nearLat/nearLng are filled once the device coordinate resolves. The shared SearchState
+    // only sends a radius once a centre point is known (see buildSearchRequest).
+    var nearLat by remember { mutableStateOf<Double?>(null) }
+    var nearLng by remember { mutableStateOf<Double?>(null) }
+    var radiusKm by remember { mutableStateOf<Double?>(null) }
+    val nearMeRequester = rememberNearMeLocationRequester()
 
     val networkErrorMsg = stringResource(R.string.error_network)
     val searchFailedMsg = stringResource(R.string.error_generic)
@@ -141,6 +148,9 @@ fun SearchScreen(
                         minRooms = minRooms,
                         sort = selectedSort,
                         page = page,
+                        nearLat = nearLat,
+                        nearLng = nearLng,
+                        radiusKm = radiusKm,
                     )
                 val result = repository.searchListings(request)
 
@@ -204,13 +214,25 @@ fun SearchScreen(
     }
 
     val activeFilterCount =
-        remember(selectedType, selectedCategory, minRooms, minPrice, maxPrice) {
+        remember(
+            selectedType,
+            selectedCategory,
+            minRooms,
+            minPrice,
+            maxPrice,
+            nearLat,
+            nearLng,
+            radiusKm,
+        ) {
             SearchState.activeFilterCount(
                 type = selectedType,
                 category = selectedCategory,
                 minRooms = minRooms,
                 minPrice = minPrice,
                 maxPrice = maxPrice,
+                nearLat = nearLat,
+                nearLng = nearLng,
+                radiusKm = radiusKm,
             )
         }
 
@@ -223,13 +245,25 @@ fun SearchScreen(
             minPrice = minPrice,
             maxPrice = maxPrice,
             selectedSort = selectedSort,
+            radiusKm = radiusKm,
+            hasLocation = nearLat != null && nearLng != null,
+            locationRequester = nearMeRequester,
             onDismiss = { showFilters = false },
-            onApply = { type, category, minP, maxP, sort ->
+            onApply = { type, category, minP, maxP, sort, draftRadiusKm, coordinate ->
                 selectedType = type
                 selectedCategory = category
                 minPrice = minP
                 maxPrice = maxP
                 selectedSort = sort
+                radiusKm = draftRadiusKm
+                // A resolved coordinate overwrites the previous one; clearing the radius drops it.
+                if (draftRadiusKm == null) {
+                    nearLat = null
+                    nearLng = null
+                } else if (coordinate != null) {
+                    nearLat = coordinate.latitude
+                    nearLng = coordinate.longitude
+                }
                 showFilters = false
                 performSearch()
             },
@@ -239,6 +273,9 @@ fun SearchScreen(
                 minPrice = ""
                 maxPrice = ""
                 selectedSort = ListingSortOption.NEWEST
+                radiusKm = null
+                nearLat = null
+                nearLng = null
                 showFilters = false
                 performSearch()
             },
@@ -552,8 +589,20 @@ private fun FilterSheet(
     minPrice: String,
     maxPrice: String,
     selectedSort: ListingSortOption,
+    radiusKm: Double?,
+    hasLocation: Boolean,
+    locationRequester: NearMeLocationRequester,
     onDismiss: () -> Unit,
-    onApply: (ListingType?, PropertyCategory?, String, String, ListingSortOption) -> Unit,
+    onApply:
+        (
+            ListingType?,
+            PropertyCategory?,
+            String,
+            String,
+            ListingSortOption,
+            Double?,
+            NearMeCoordinate?,
+        ) -> Unit,
     onReset: () -> Unit,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -564,6 +613,17 @@ private fun FilterSheet(
     var draftMinPrice by remember { mutableStateOf(minPrice) }
     var draftMaxPrice by remember { mutableStateOf(maxPrice) }
     var draftSort by remember { mutableStateOf(selectedSort) }
+    // Near Me draft. draftRadiusKm null = toggle off. draftCoordinate is filled once the device
+    // location resolves; isLocating tracks the in-flight permission/fetch so the UI can show a
+    // spinner. If the filter was already active (hasLocation), the previously-committed coordinate
+    // is reused unless a fresh one is fetched.
+    var draftRadiusKm by remember { mutableStateOf(radiusKm) }
+    var draftCoordinate by remember { mutableStateOf<NearMeCoordinate?>(null) }
+    var isLocating by remember { mutableStateOf(false) }
+    // The toggle is "on" while a radius is selected; it stays on optimistically while locating.
+    val nearMeEnabled = draftRadiusKm != null
+    // Whether we have (or had) a usable centre point for the search.
+    val hasCoordinate = draftCoordinate != null || (hasLocation && radiusKm != null)
 
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
         Column(
@@ -683,6 +743,92 @@ private fun FilterSheet(
                     )
                 }
             }
+            Spacer(modifier = Modifier.height(12.dp))
+            // Near Me — location-radius filter (mirrors iOS FilterSheet.nearMeSection).
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        Icons.Default.LocationOn,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = stringResource(R.string.filter_near_me),
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+                Switch(
+                    checked = nearMeEnabled,
+                    onCheckedChange = { enabled ->
+                        if (enabled) {
+                            draftRadiusKm = SearchState.DEFAULT_NEAR_ME_RADIUS_KM
+                            if (!hasCoordinate) {
+                                isLocating = true
+                                locationRequester.acquire { coord ->
+                                    isLocating = false
+                                    if (coord != null) {
+                                        draftCoordinate = coord
+                                    } else {
+                                        // Permission denied / unavailable — revert the toggle.
+                                        draftRadiusKm = null
+                                    }
+                                }
+                            }
+                        } else {
+                            draftRadiusKm = null
+                            draftCoordinate = null
+                        }
+                    },
+                )
+            }
+            if (nearMeEnabled) {
+                when {
+                    isLocating ->
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(16.dp),
+                                strokeWidth = 2.dp,
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = stringResource(R.string.locating),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    hasCoordinate -> {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = stringResource(R.string.filter_radius),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(bottom = 8.dp),
+                        )
+                        LazyRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            items(SearchState.RADIUS_OPTIONS_KM) { km ->
+                                FilterChip(
+                                    selected = draftRadiusKm == km,
+                                    onClick = { draftRadiusKm = km },
+                                    label = {
+                                        Text(
+                                            stringResource(
+                                                R.string.radius_km_format,
+                                                km.toInt(),
+                                            )
+                                        )
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
             Spacer(modifier = Modifier.height(20.dp))
             // Action row — Reset (text) + Apply (filled).
             Row(
@@ -695,7 +841,15 @@ private fun FilterSheet(
                 }
                 Button(
                     onClick = {
-                        onApply(draftType, draftCategory, draftMinPrice, draftMaxPrice, draftSort)
+                        onApply(
+                            draftType,
+                            draftCategory,
+                            draftMinPrice,
+                            draftMaxPrice,
+                            draftSort,
+                            draftRadiusKm,
+                            draftCoordinate,
+                        )
                     },
                     modifier = Modifier.weight(1f),
                 ) {

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/search/SearchScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/search/SearchScreen.kt
@@ -816,12 +816,7 @@ private fun FilterSheet(
                                     selected = draftRadiusKm == km,
                                     onClick = { draftRadiusKm = km },
                                     label = {
-                                        Text(
-                                            stringResource(
-                                                R.string.radius_km_format,
-                                                km.toInt(),
-                                            )
-                                        )
+                                        Text(stringResource(R.string.radius_km_format, km.toInt()))
                                     },
                                 )
                             }

--- a/mobile-native/androidApp/src/main/res/values-cs/strings.xml
+++ b/mobile-native/androidApp/src/main/res/values-cs/strings.xml
@@ -212,6 +212,10 @@
     <string name="filter_any">Jakékoliv</string>
     <string name="filter_rooms">Pokoje</string>
     <string name="filter_price_range_eur">Cenové rozpětí (EUR)</string>
+    <string name="filter_near_me">V mém okolí</string>
+    <string name="filter_radius">Okruh</string>
+    <string name="radius_km_format">%1$d km</string>
+    <string name="locating">Zjišťuji vaši polohu…</string>
     <string name="filter_min">Min</string>
     <string name="filter_max">Max</string>
     <string name="filter_apply">Použít</string>

--- a/mobile-native/androidApp/src/main/res/values-de/strings.xml
+++ b/mobile-native/androidApp/src/main/res/values-de/strings.xml
@@ -212,6 +212,10 @@
     <string name="filter_any">Beliebig</string>
     <string name="filter_rooms">Zimmer</string>
     <string name="filter_price_range_eur">Preisspanne (EUR)</string>
+    <string name="filter_near_me">In meiner Nähe</string>
+    <string name="filter_radius">Umkreis</string>
+    <string name="radius_km_format">%1$d km</string>
+    <string name="locating">Standort wird ermittelt…</string>
     <string name="filter_min">Min</string>
     <string name="filter_max">Max</string>
     <string name="filter_apply">Anwenden</string>

--- a/mobile-native/androidApp/src/main/res/values-hu/strings.xml
+++ b/mobile-native/androidApp/src/main/res/values-hu/strings.xml
@@ -212,6 +212,10 @@
     <string name="filter_any">Bármely</string>
     <string name="filter_rooms">Szobák</string>
     <string name="filter_price_range_eur">Ártartomány (EUR)</string>
+    <string name="filter_near_me">A közelemben</string>
+    <string name="filter_radius">Sugár</string>
+    <string name="radius_km_format">%1$d km</string>
+    <string name="locating">Helymeghatározás…</string>
     <string name="filter_min">Min</string>
     <string name="filter_max">Max</string>
     <string name="filter_apply">Alkalmaz</string>

--- a/mobile-native/androidApp/src/main/res/values-pl/strings.xml
+++ b/mobile-native/androidApp/src/main/res/values-pl/strings.xml
@@ -212,6 +212,10 @@
     <string name="filter_any">Dowolna</string>
     <string name="filter_rooms">Pokoje</string>
     <string name="filter_price_range_eur">Zakres cenowy (EUR)</string>
+    <string name="filter_near_me">W pobliżu</string>
+    <string name="filter_radius">Promień</string>
+    <string name="radius_km_format">%1$d km</string>
+    <string name="locating">Ustalanie lokalizacji…</string>
     <string name="filter_min">Min</string>
     <string name="filter_max">Max</string>
     <string name="filter_apply">Zastosuj</string>

--- a/mobile-native/androidApp/src/main/res/values-sk/strings.xml
+++ b/mobile-native/androidApp/src/main/res/values-sk/strings.xml
@@ -314,6 +314,10 @@
     <string name="filter_any">Akékoľvek</string>
     <string name="filter_rooms">Izby</string>
     <string name="filter_price_range_eur">Cenové rozpätie (EUR)</string>
+    <string name="filter_near_me">V mojom okolí</string>
+    <string name="filter_radius">Okruh</string>
+    <string name="radius_km_format">%1$d km</string>
+    <string name="locating">Zisťujem vašu polohu…</string>
     <string name="filter_min">Min</string>
     <string name="filter_max">Max</string>
     <string name="filter_apply">Použiť</string>

--- a/mobile-native/androidApp/src/main/res/values/strings.xml
+++ b/mobile-native/androidApp/src/main/res/values/strings.xml
@@ -314,6 +314,10 @@
     <string name="filter_any">Any</string>
     <string name="filter_rooms">Rooms</string>
     <string name="filter_price_range_eur">Price Range (EUR)</string>
+    <string name="filter_near_me">Near me</string>
+    <string name="filter_radius">Radius</string>
+    <string name="radius_km_format">%1$d km</string>
+    <string name="locating">Finding your location…</string>
     <string name="filter_min">Min</string>
     <string name="filter_max">Max</string>
     <string name="filter_apply">Apply</string>

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/SearchState.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/SearchState.kt
@@ -33,6 +33,18 @@ object SearchState {
      */
     const val PREFETCH_THRESHOLD: Int = 5
 
+    /**
+     * Default radius (km) applied when the user enables the FilterSheet "Near Me" toggle without
+     * having picked an explicit radius yet. Mirrors the iOS `nearMeSection` default of 10 km.
+     */
+    const val DEFAULT_NEAR_ME_RADIUS_KM: Double = 10.0
+
+    /**
+     * Radius options (km) offered by the FilterSheet "Near Me" picker. Mirrors the iOS
+     * `radiusOptions` list so both platforms present the same choices.
+     */
+    val RADIUS_OPTIONS_KM: List<Double> = listOf(1.0, 3.0, 5.0, 10.0, 20.0, 50.0)
+
     /** Build the search request payload from the raw screen inputs. */
     fun buildSearchRequest(
         query: String,
@@ -43,6 +55,9 @@ object SearchState {
         minRooms: Int? = null,
         sort: ListingSortOption = ListingSortOption.NEWEST,
         page: Int = 1,
+        nearLat: Double? = null,
+        nearLng: Double? = null,
+        radiusKm: Double? = null,
     ): ListingSearchRequest =
         ListingSearchRequest(
             query = query.takeIf { it.isNotBlank() },
@@ -53,11 +68,24 @@ object SearchState {
                     minPrice = minPrice.toLongOrNull(),
                     maxPrice = maxPrice.toLongOrNull(),
                     minRooms = minRooms,
+                    // A radius is only meaningful with a centre point: drop the radius unless we
+                    // actually have device coordinates, so the server never receives a dangling
+                    // radius_km with no near_lat/near_lng (which it would otherwise ignore or 400).
+                    nearLat = nearLat.takeIf { radiusKm != null },
+                    nearLng = nearLng.takeIf { radiusKm != null },
+                    radiusKm = radiusKm.takeIf { nearLat != null && nearLng != null },
                 ),
             sort = sort,
             page = page,
             pageSize = PAGE_SIZE,
         )
+
+    /**
+     * Whether a "Near Me" location filter is active — i.e. a radius AND a centre coordinate are
+     * both present. A radius with no coordinate (location not yet resolved) is not yet active.
+     */
+    fun isNearMeActive(nearLat: Double?, nearLng: Double?, radiusKm: Double?): Boolean =
+        radiusKm != null && nearLat != null && nearLng != null
 
     /** Count of distinct active filters, for the filter-chip badge. */
     fun activeFilterCount(
@@ -66,9 +94,13 @@ object SearchState {
         minRooms: Int?,
         minPrice: String,
         maxPrice: String,
+        nearLat: Double? = null,
+        nearLng: Double? = null,
+        radiusKm: Double? = null,
     ): Int =
         listOf(type, category, minRooms).count { it != null } +
-            (if (minPrice.isNotBlank() || maxPrice.isNotBlank()) 1 else 0)
+            (if (minPrice.isNotBlank() || maxPrice.isNotBlank()) 1 else 0) +
+            (if (isNearMeActive(nearLat, nearLng, radiusKm)) 1 else 0)
 
     /**
      * Infinite-scroll trigger (AC-4).

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/SearchStateTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/SearchStateTest.kt
@@ -53,6 +53,64 @@ class SearchStateTest {
         assertNull(req.filters?.maxPrice)
     }
 
+    // ── buildSearchRequest: Near Me / radius (FilterSheet location) ──────
+
+    @Test
+    fun buildSearchRequest_nearMe_mapsCoordinateAndRadius() {
+        val req =
+            SearchState.buildSearchRequest(
+                query = "byt",
+                nearLat = 48.1486,
+                nearLng = 17.1077,
+                radiusKm = 5.0,
+            )
+        assertEquals(48.1486, req.filters?.nearLat)
+        assertEquals(17.1077, req.filters?.nearLng)
+        assertEquals(5.0, req.filters?.radiusKm)
+    }
+
+    @Test
+    fun buildSearchRequest_radiusWithoutCoordinate_isDropped() {
+        // Radius enabled but location not yet resolved → no centre point, so the radius must not
+        // be sent on its own (server can't apply a radius without near_lat/near_lng).
+        val req = SearchState.buildSearchRequest(query = "x", radiusKm = 10.0)
+        assertNull(req.filters?.radiusKm)
+        assertNull(req.filters?.nearLat)
+        assertNull(req.filters?.nearLng)
+    }
+
+    @Test
+    fun buildSearchRequest_coordinateWithoutRadius_isDropped() {
+        // Coordinate present but Near Me toggle off (no radius) → don't send a location centre.
+        val req = SearchState.buildSearchRequest(query = "x", nearLat = 48.0, nearLng = 17.0)
+        assertNull(req.filters?.nearLat)
+        assertNull(req.filters?.nearLng)
+        assertNull(req.filters?.radiusKm)
+    }
+
+    // ── isNearMeActive ───────────────────────────────────────────────────
+
+    @Test
+    fun isNearMeActive_trueOnlyWithCoordinateAndRadius() {
+        assertTrue(SearchState.isNearMeActive(48.0, 17.0, 10.0))
+    }
+
+    @Test
+    fun isNearMeActive_falseWithoutCoordinate() {
+        assertFalse(SearchState.isNearMeActive(null, null, 10.0))
+    }
+
+    @Test
+    fun isNearMeActive_falseWithoutRadius() {
+        assertFalse(SearchState.isNearMeActive(48.0, 17.0, null))
+    }
+
+    @Test
+    fun radiusOptions_matchIosNearMePicker() {
+        assertEquals(listOf(1.0, 3.0, 5.0, 10.0, 20.0, 50.0), SearchState.RADIUS_OPTIONS_KM)
+        assertTrue(SearchState.DEFAULT_NEAR_ME_RADIUS_KM in SearchState.RADIUS_OPTIONS_KM)
+    }
+
     // ── activeFilterCount ────────────────────────────────────────────────
 
     @Test
@@ -77,6 +135,32 @@ class SearchStateTest {
     @Test
     fun activeFilterCount_priceRangeCountsOnceEvenWithBothBounds() {
         assertEquals(1, SearchState.activeFilterCount(null, null, null, "100", "900"))
+    }
+
+    @Test
+    fun activeFilterCount_nearMeCountsWhenLocationResolved() {
+        // type (1) + active Near-Me location (1) = 2
+        val count =
+            SearchState.activeFilterCount(
+                type = ListingType.SALE,
+                category = null,
+                minRooms = null,
+                minPrice = "",
+                maxPrice = "",
+                nearLat = 48.0,
+                nearLng = 17.0,
+                radiusKm = 10.0,
+            )
+        assertEquals(2, count)
+    }
+
+    @Test
+    fun activeFilterCount_nearMeNotCountedUntilLocationResolved() {
+        // Radius chosen but no coordinate yet → not an active filter, badge stays at 0.
+        assertEquals(
+            0,
+            SearchState.activeFilterCount(null, null, null, "", "", radiusKm = 10.0),
+        )
     }
 
     // ── shouldLoadNextPage (AC-4 infinite scroll) ────────────────────────

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/SearchStateTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/SearchStateTest.kt
@@ -157,10 +157,7 @@ class SearchStateTest {
     @Test
     fun activeFilterCount_nearMeNotCountedUntilLocationResolved() {
         // Radius chosen but no coordinate yet → not an active filter, badge stays at 0.
-        assertEquals(
-            0,
-            SearchState.activeFilterCount(null, null, null, "", "", radiusKm = 10.0),
-        )
+        assertEquals(0, SearchState.activeFilterCount(null, null, null, "", "", radiusKm = 10.0))
     }
 
     // ── shouldLoadNextPage (AC-4 infinite scroll) ────────────────────────


### PR DESCRIPTION
## Task
FilterSheet location features (82-3-home-search-screens — Home and Search Screens). Bring the Reality mobile Search **FilterSheet** to iOS parity by adding the "Near Me" radius location filter on the Android/Compose + shared (KMP) path. iOS already ships `FilterSheet.nearMeSection` + CoreLocation (`mobile-native/iosApp/.../SearchView.swift`); the Android/shared path had **no** location/radius filter — `SearchState.buildSearchRequest` and `activeFilterCount` ignored `near_lat/near_lng/radius_km` even though `ListingSearchFilters` already carries them.

## Owner
pm-frontend (task routed here; actual code lives in the Reality KMP mobile app under `mobile-native/` — see Scope drift).

## What changed
- **`shared/.../listing/SearchState.kt`** (commonMain, pure logic):
  - `buildSearchRequest` now takes `nearLat/nearLng/radiusKm`. Gating: a radius is only sent with a centre point and vice-versa, so the server never receives a dangling `radius_km` with no coordinate.
  - `activeFilterCount` counts an active Near-Me location (badge).
  - Adds `isNearMeActive`, `DEFAULT_NEAR_ME_RADIUS_KM = 10.0`, `RADIUS_OPTIONS_KM = [1,3,5,10,20,50]` mirroring the iOS `radiusOptions`/default.
- **`shared/.../listing/SearchStateTest.kt`**: +9 unit cases (radius/coordinate gating both directions, `isNearMeActive`, badge counting, radius-option parity).
- **`androidApp/.../ui/search/SearchScreen.kt`**: FilterSheet gains a "Near Me" `Switch` + radius `FilterChip` row; near-me state plumbed through `performSearch`, `activeFilterCount`, Apply/Reset.
- **`androidApp/.../ui/search/NearMeLocation.kt`** (new): self-contained coarse-location requester — runtime permission launcher (`ActivityResultContracts.RequestPermission`) + `FusedLocationProvider.getCurrentLocation`. Graceful degradation: permission denied / unavailable → `null` → toggle reverts.
- **`androidApp/.../AndroidManifest.xml`**: `ACCESS_COARSE_LOCATION` (coarse only; optional `android.hardware.location` feature).
- **strings**: `filter_near_me`, `filter_radius`, `radius_km_format`, `locating` added to en, sk, cs, de, pl, hu.

## Tested (Band A — fast check)
The kotlin-mp Band A command (`./gradlew :shared:compileKotlinJvm :androidApp:assembleDebug`) is **not runnable in this sandbox** — AGP `com.android.application:9.2.1` and the Kotlin stdlib/compiler artifacts are unresolvable offline (the Gradle/Maven caches lack them). This is the same documented limitation recorded in `docs/screens/reality-mobile/search.md` (2026-06-10: "KMP Gradle build not runnable in this sandbox … verified by source audit").

Verification performed statically instead:
- `./gradlew :shared:compileKotlinJvm --offline` → fails at plugin resolution (AGP 9.2.1 not in offline cache), exit 1 — environment limitation, not a code error.
- Brace/paren/bracket balance check on all 4 changed code files → balanced.
- Manual review: all new symbols resolve against existing wildcard imports (`material3.*`, `material.icons.filled.*`, `foundation.layout.*`, `foundation.lazy.items`); `play-services-location` 21.3.0 (`getCurrentLocation`, `Priority`) and `activity-compose` (`rememberLauncherForActivityResult`) are already declared deps; `Context.checkSelfPermission` is framework API 23+ (minSdk 24) so no androidx-core dependency is taken.
- The 9 new `SearchStateTest` cases exercise pure `SearchState` logic and assert the exact gating/badge semantics.

**CI (`mobile-native.yml`) will run the real Gradle build + unit tests** — that is the authoritative gate for this change.

## Built (Band B — full build)
Skipped: cannot run `:androidApp:assembleRelease` offline (same AGP-unresolvable limitation as Band A). CI covers it.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change — location is a coarse, opt-in search filter).

## Remote-tested
Skipped (no ppt-bridge MCP; the KMP app isn't part of the dev-stack).

## Scope drift
`scope-check.sh --owner pm-frontend` reports exit 2: the diff is entirely under `mobile-native/` (Reality Portal KMP/Android), which is outside `pm-frontend`'s `owner-areas.json` globs (those cover `frontend/apps/{ppt,reality,admin}-web` + `frontend/packages`). This is an owner-mapping artifact: the "Home and Search Screens / FilterSheet location" feature (epic-82 story 82.3) physically lives in the KMP mobile app, not the web frontend. All 11 changed paths are cohesive within the Reality mobile Search feature. Reviewer to confirm the drift is acceptable.

## Notes
- Scoped to the FilterSheet/location area only, to avoid conflicting with the in-flight sibling task `feat-home-and-search-screens-debounced-search-evidenced-mobile`. The new `SearchState` params are additive and default-null; the debounce path (`SEARCH_DEBOUNCE_MS`, `shouldApplyResponse`) is untouched.
- iOS already has this feature; this PR closes the Android/shared parity gap. The screen-map (`docs/screens/reality-mobile/search.md`) Agent Log should be updated when this lands (CLAUDE.md screen-map Rule A) — not done here to avoid touching shared docs the sibling task may also edit.

https://claude.ai/code/session_01Mori7pMFHYAG5J2ZzyXd4G

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mori7pMFHYAG5J2ZzyXd4G)_