### PR TITLE
pm-qa-document-download-preview-tests: presigned-URL minting/expiry + access-gate allow-path tests (#1377)

### DIFF
--- a/backend/crates/integrations/src/storage.rs
+++ b/backend/crates/integrations/src/storage.rs
@@ -1131,4 +1131,179 @@ mod tests {
             );
         }
     }
+
+    // ========================================================================
+    // Presigned-URL minting / expiry coverage (#1377)
+    //
+    // SigV4 presigning is computed entirely client-side by the AWS SDK — no
+    // network call is made when we `.presigned(...)`. That lets us mint a real
+    // signed URL with a fixed (fake) credential and assert its shape + expiry
+    // deterministically in CI without any live S3 / MinIO. These tests guard
+    // the two minting entry points the document download/preview handlers call:
+    // `generate_download_url` (attachment) and `generate_preview_url` (inline).
+    // ========================================================================
+
+    /// Build a StorageService backed by a presigner-capable S3 client using a
+    /// static fake credential. Path-style + a dummy endpoint keep the SDK from
+    /// resolving any real region/endpoint. No I/O is performed by presigning.
+    async fn presigning_service(ttl: i64) -> StorageService {
+        let config = StorageConfig::new("test-bucket", "us-east-1", "AKIATEST", "secretkey")
+            .with_endpoint("http://s3.local:9000")
+            .with_download_ttl(ttl);
+        StorageService::with_s3_client(config)
+            .await
+            .expect("with_s3_client should build offline (no network for presign)")
+    }
+
+    /// Parse the `X-Amz-Expires` query parameter (seconds) out of a presigned
+    /// URL. Returns `None` if absent.
+    fn amz_expires_secs(url: &str) -> Option<i64> {
+        url.split(['?', '&'])
+            .find_map(|kv| kv.strip_prefix("X-Amz-Expires="))
+            .and_then(|v| v.parse::<i64>().ok())
+    }
+
+    #[tokio::test]
+    async fn test_generate_download_url_mints_signed_attachment_url() {
+        let service = presigning_service(DEFAULT_DOWNLOAD_EXPIRATION_SECS).await;
+        let before = Utc::now();
+        let presigned = service
+            .generate_download_url(
+                "org/2024/report.pdf",
+                "report.pdf",
+                "application/pdf",
+                Some(900),
+            )
+            .await
+            .expect("download URL should mint");
+
+        // SigV4 query params prove the URL is actually signed (P0-05 regression:
+        // an unsigned placeholder URL would lack these and be rejected by S3).
+        assert!(
+            presigned.url.contains("X-Amz-Signature="),
+            "minted URL must carry a SigV4 signature, got {}",
+            presigned.url
+        );
+        assert!(
+            presigned.url.contains("X-Amz-Credential="),
+            "minted URL must carry the SigV4 credential scope, got {}",
+            presigned.url
+        );
+        assert!(
+            presigned.url.contains("report.pdf"),
+            "minted URL must reference the object key, got {}",
+            presigned.url
+        );
+
+        // Expiry: expires_at must reflect the requested 900s TTL (allow a small
+        // window for clock advance during the call).
+        let delta = (presigned.expires_at - before).num_seconds();
+        assert!(
+            (895..=905).contains(&delta),
+            "expires_at should be ~900s in the future, was {delta}s"
+        );
+        // The signed URL itself must encode the same TTL.
+        assert_eq!(
+            amz_expires_secs(&presigned.url),
+            Some(900),
+            "X-Amz-Expires must match the requested TTL, got {}",
+            presigned.url
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generate_download_url_defaults_to_15_minute_expiry() {
+        let service = presigning_service(DEFAULT_DOWNLOAD_EXPIRATION_SECS).await;
+        let before = Utc::now();
+        // `None` TTL → DEFAULT_DOWNLOAD_EXPIRATION_SECS (15 min).
+        let presigned = service
+            .generate_download_url("org/k.pdf", "k.pdf", "application/pdf", None)
+            .await
+            .expect("download URL should mint");
+
+        let delta = (presigned.expires_at - before).num_seconds();
+        assert!(
+            (DEFAULT_DOWNLOAD_EXPIRATION_SECS - 5..=DEFAULT_DOWNLOAD_EXPIRATION_SECS + 5)
+                .contains(&delta),
+            "default download expiry should be {DEFAULT_DOWNLOAD_EXPIRATION_SECS}s, was {delta}s"
+        );
+        assert_eq!(
+            amz_expires_secs(&presigned.url),
+            Some(DEFAULT_DOWNLOAD_EXPIRATION_SECS),
+            "X-Amz-Expires must encode the 15-minute default"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generate_preview_url_mints_inline_url_with_default_one_hour() {
+        let service = presigning_service(DEFAULT_DOWNLOAD_EXPIRATION_SECS).await;
+        let before = Utc::now();
+        // `None` TTL → 1-hour preview default (longer than download).
+        let presigned = service
+            .generate_preview_url("org/img.png", "image/png", None)
+            .await
+            .expect("preview URL should mint");
+
+        assert!(
+            presigned.url.contains("X-Amz-Signature="),
+            "minted preview URL must be SigV4-signed, got {}",
+            presigned.url
+        );
+        // Inline disposition is the whole point of preview vs download. The SDK
+        // percent-encodes the `response-content-disposition` query value, so
+        // match the key and the (encoded or raw) `inline` token loosely.
+        assert!(
+            presigned.url.contains("response-content-disposition="),
+            "preview URL must set a response-content-disposition, got {}",
+            presigned.url
+        );
+        assert!(
+            presigned.url.contains("inline"),
+            "preview URL disposition must be inline, got {}",
+            presigned.url
+        );
+
+        let delta = (presigned.expires_at - before).num_seconds();
+        assert!(
+            (3595..=3605).contains(&delta),
+            "default preview expiry should be 3600s, was {delta}s"
+        );
+        assert_eq!(
+            amz_expires_secs(&presigned.url),
+            Some(3600),
+            "X-Amz-Expires must encode the 1-hour preview default"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generate_preview_url_honours_explicit_ttl() {
+        let service = presigning_service(DEFAULT_DOWNLOAD_EXPIRATION_SECS).await;
+        let presigned = service
+            .generate_preview_url("org/img.png", "image/png", Some(120))
+            .await
+            .expect("preview URL should mint");
+        assert_eq!(
+            amz_expires_secs(&presigned.url),
+            Some(120),
+            "explicit preview TTL must be honoured in the signed URL"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_minting_without_s3_client_errors_cleanly() {
+        // The download/preview handlers gate on storage being configured; this
+        // pins the no-client failure mode so a missing S3 client surfaces as a
+        // typed StorageError rather than a panic.
+        let service = StorageService::new(StorageConfig::new(
+            "b", "us-east-1", "AKIATEST", "secretkey",
+        ));
+        let err = service
+            .generate_download_url("k", "k.pdf", "application/pdf", Some(300))
+            .await
+            .expect_err("minting without an S3 client must error");
+        assert!(
+            matches!(err, StorageError::Configuration(_)),
+            "expected Configuration error, got {err:?}"
+        );
+    }
 }

--- a/backend/crates/integrations/src/storage.rs
+++ b/backend/crates/integrations/src/storage.rs
@@ -1295,7 +1295,10 @@ mod tests {
         // pins the no-client failure mode so a missing S3 client surfaces as a
         // typed StorageError rather than a panic.
         let service = StorageService::new(StorageConfig::new(
-            "b", "us-east-1", "AKIATEST", "secretkey",
+            "b",
+            "us-east-1",
+            "AKIATEST",
+            "secretkey",
         ));
         let err = service
             .generate_download_url("k", "k.pdf", "application/pdf", Some(300))

--- a/backend/servers/api-server/tests/document_download_preview_tests.rs
+++ b/backend/servers/api-server/tests/document_download_preview_tests.rs
@@ -386,6 +386,130 @@ async fn test_download_accessible_document_reaches_presigner(pool: PgPool) {
     cleanup_test_user(&pool, &user.email).await;
 }
 
+// ============================================================================
+// T7 — Access-gate ALLOW path (non-manager): a `users`-scoped document shared
+//      WITH the requesting tenant must clear the gate and reach the presigner
+//      → 503. This is the positive mirror of T4 (which asserts the deny side),
+//      proving the `document_access_allowed` "users" branch grants — not just
+//      denies — at the HTTP layer for a non-manager caller. (#1377)
+// ============================================================================
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn test_download_users_scoped_allows_listed_tenant(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    // Creator (manager) seeds a users-scoped doc shared with `tenant` below.
+    let creator = TestUser::new();
+    cleanup_test_user(&pool, &creator.email).await;
+    let (_ctok, _) = create_authenticated_user(&app, &creator).await;
+    let creator_id = user_id_for(&pool, &creator.email).await;
+    let org_id = seed_org(&pool, &Uuid::new_v4().to_string()[..8]).await;
+    seed_membership(&pool, org_id, creator_id, "org_admin").await;
+
+    // The tenant who WILL be on the share list.
+    let tenant = TestUser::new();
+    cleanup_test_user(&pool, &tenant.email).await;
+    let (tenant_token, _) = create_authenticated_user(&app, &tenant).await;
+    let tenant_id = user_id_for(&pool, &tenant.email).await;
+    seed_membership(&pool, org_id, tenant_id, "tenant").await;
+
+    let doc_id = seed_document(
+        &pool,
+        org_id,
+        creator_id,
+        "Shared with the tenant",
+        "application/pdf",
+        "shared.pdf",
+        "users",
+        serde_json::json!([tenant_id.to_string()]), // tenant IS listed
+    )
+    .await;
+
+    let response = app
+        .execute(get_request(
+            &format!("/api/v1/documents/{doc_id}/download"),
+            &tenant_token,
+            org_id,
+        ))
+        .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "users-scoped doc shared with the tenant must clear the gate and reach \
+         the presigner (503), got {} body {}",
+        response.status,
+        response.text()
+    );
+    assert_eq!(
+        response.json_value()["code"].as_str(),
+        Some("STORAGE_NOT_CONFIGURED"),
+        "gate-passed path must reach the presigner, body {}",
+        response.text()
+    );
+
+    cleanup_test_user(&pool, &creator.email).await;
+    cleanup_test_user(&pool, &tenant.email).await;
+}
+
+// ============================================================================
+// T8 — Access-gate ALLOW path (non-manager creator): the creator of a document
+//      keeps access even when the share scope would not otherwise grant it.
+//      A `tenant`-role user who authored the doc must clear the gate → 503.
+//      Pins the "creator-always-allowed wins over scope" branch end-to-end. (#1377)
+// ============================================================================
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn test_preview_non_manager_creator_reaches_presigner(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    // A non-manager (tenant) who authors their own previewable document.
+    let author = TestUser::new();
+    cleanup_test_user(&pool, &author.email).await;
+    let (author_token, _) = create_authenticated_user(&app, &author).await;
+    let author_id = user_id_for(&pool, &author.email).await;
+    let org_id = seed_org(&pool, &Uuid::new_v4().to_string()[..8]).await;
+    seed_membership(&pool, org_id, author_id, "tenant").await;
+
+    // users-scoped, shared with nobody but the author themselves authored it.
+    let doc_id = seed_document(
+        &pool,
+        org_id,
+        author_id,
+        "My own upload",
+        "image/png",
+        "mine.png",
+        "users",
+        serde_json::json!([Uuid::new_v4().to_string()]), // someone else, not the author
+    )
+    .await;
+
+    let response = app
+        .execute(get_request(
+            &format!("/api/v1/documents/{doc_id}/preview"),
+            &author_token,
+            org_id,
+        ))
+        .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "the document creator (even as a non-manager) must clear the gate and \
+         reach the presigner (503), got {} body {}",
+        response.status,
+        response.text()
+    );
+    assert_eq!(
+        response.json_value()["code"].as_str(),
+        Some("STORAGE_NOT_CONFIGURED"),
+        "creator path must reach the presigner, body {}",
+        response.text()
+    );
+
+    cleanup_test_user(&pool, &author.email).await;
+}
+
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn test_preview_accessible_document_reaches_presigner(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;


### PR DESCRIPTION
## Task
Add presigned-URL minting/expiry/access-gate allow-path tests for document download/preview (#1377).

## Owner
pm-qa

## What this adds (test-only, no production code changed)

Existing coverage already pinned the **deny** side of document download/preview (401 / 404 / 400 / 503 in `document_download_preview_tests.rs`) and the config-TTL knob (in `storage.rs`). The gaps were: actual presigned-URL **minting**, the minted-URL **expiry**, and the access-gate **allow** path at the HTTP layer. This PR fills them.

**`backend/crates/integrations/src/storage.rs`** — presigned-URL minting + expiry (5 new `#[tokio::test]`):
- `test_generate_download_url_mints_signed_attachment_url` — mints a real SigV4 URL (asserts `X-Amz-Signature` / `X-Amz-Credential` present), and both `expires_at` and the URL's `X-Amz-Expires` reflect the requested 900s TTL.
- `test_generate_download_url_defaults_to_15_minute_expiry` — `None` TTL → `DEFAULT_DOWNLOAD_EXPIRATION_SECS` (15 min), in both `expires_at` and `X-Amz-Expires`.
- `test_generate_preview_url_mints_inline_url_with_default_one_hour` — inline disposition, default 1-hour preview TTL.
- `test_generate_preview_url_honours_explicit_ttl` — explicit preview TTL honoured.
- `test_minting_without_s3_client_errors_cleanly` — no S3 client → typed `Configuration` error (no panic).

SigV4 presigning is computed client-side by the AWS SDK, so these run offline in CI — no live S3/MinIO.

**`backend/servers/api-server/tests/document_download_preview_tests.rs`** — access-gate ALLOW path (2 new `#[sqlx::test]`):
- T7 `test_download_users_scoped_allows_listed_tenant` — a users-scoped doc shared WITH the tenant clears the gate → reaches the presigner (503). Positive mirror of the existing T4 deny test.
- T8 `test_preview_non_manager_creator_reaches_presigner` — a non-manager creator clears the gate on their own doc (creator-always-allowed wins over scope).

## Tested (Band A — fast check)
- `SQLX_OFFLINE=true cargo test -p integrations --lib storage::tests` → **exit 0, 18 passed; 0 failed** (13 existing + 5 new).
- `SQLX_OFFLINE=true cargo test -p api-server --test document_download_preview_tests --no-run` → **exit 0, Finished, executable produced**. (The `#[sqlx::test]` cases need Postgres + RLS, which isn't available on the dispatcher runner; they run in CI `backend.yml`. `TestApp` leaves `storage_service = None`, so the allow-path tests assert 503 STORAGE_NOT_CONFIGURED, which only fires AFTER auth + RLS lookup + access gate pass.)

## Built (Band B — full build)
Skipped: change is test-only (no public API / migration / build-output change).

## CI parity (Band C — hot-path only)
Skipped: test-only PR; no security/auth/billing/data-integrity code change. The tests strengthen existing security-relevant coverage but add no production logic.

## Scope drift
`scope-check.sh --owner pm-qa` flags `backend/crates/integrations/src/storage.rs` as outside the strict pm-qa owner-area glob. Justified: the new minting/expiry tests must live inline in `storage.rs` (the only place they can drive the crate-private `build_presigned_*` paths through the public `generate_*` methods, alongside the existing `#[cfg(test)] mod tests`). All additions are inside `#[cfg(test)]` — no production code changed. The integration test file is in-scope and not flagged.

## Code-reuse review
None — the only new helpers (`presigning_service`, `amz_expires_secs`) are test-local inside `#[cfg(test)]`.

## Remote-tested
Skipped (no ppt-bridge MCP in session).

## Notes
Pure test-coverage addition; no production behaviour changed. Cargo.lock was left untouched (an unrelated workspace version bump that a local build introduced was reverted).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mori7pMFHYAG5J2ZzyXd4G)_