### PR TITLE
fix: harden forms submit/download org scope

### DIFF
--- a/backend/crates/db/src/repositories/form.rs
+++ b/backend/crates/db/src/repositories/form.rs
@@ -1034,28 +1034,35 @@ impl FormRepository {
     pub async fn record_download<'e, E>(
         &self,
         executor: E,
+        org_id: Uuid,
         form_id: Uuid,
         user_id: Uuid,
         ip_address: Option<String>,
         user_agent: Option<String>,
-    ) -> Result<(), sqlx::Error>
+    ) -> Result<bool, sqlx::Error>
     where
         E: Executor<'e, Database = Postgres>,
     {
-        sqlx::query(
+        let inserted = sqlx::query_scalar::<_, Uuid>(
             r#"
             INSERT INTO form_downloads (form_id, downloaded_by, ip_address, user_agent)
-            VALUES ($1, $2, $3::inet, $4)
+            SELECT f.id, $3, $4::inet, $5
+            FROM forms f
+            WHERE f.id = $1
+              AND f.organization_id = $2
+              AND f.deleted_at IS NULL
+            RETURNING form_id
             "#,
         )
         .bind(form_id)
+        .bind(org_id)
         .bind(user_id)
         .bind(&ip_address)
         .bind(&user_agent)
-        .execute(executor)
+        .fetch_optional(executor)
         .await?;
 
-        Ok(())
+        Ok(inserted.is_some())
     }
 
     /// Gets download count for a form.

--- a/backend/crates/db/tests/form_rls_repo_tests.rs
+++ b/backend/crates/db/tests/form_rls_repo_tests.rs
@@ -29,8 +29,9 @@
 //! to it so `FORCE` actually enforces the policy the way the production
 //! owner role experiences it. Mirrors `budget_rls_repo_tests.rs`.
 
-use db::models::FormListQuery;
+use db::models::{FormListQuery, FormSubmissionParams, SubmitForm};
 use db::repositories::FormRepository;
+use serde_json::json;
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -75,23 +76,34 @@ async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
 }
 
 /// Insert a form directly as the (RLS-exempt) superuser for an org.
-async fn seed_form(pool: &PgPool, org_id: Uuid, user_id: Uuid, title: &str) -> Uuid {
+async fn seed_form_with_status(
+    pool: &PgPool,
+    org_id: Uuid,
+    user_id: Uuid,
+    title: &str,
+    status: &str,
+) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(
         r#"
         INSERT INTO forms (
             organization_id, title, status, target_type, target_ids,
             require_signatures, allow_multiple_submissions, created_by
         )
-        VALUES ($1, $2, 'draft', 'all', '[]'::jsonb, false, true, $3)
+        VALUES ($1, $2, $4::form_status, 'all', '[]'::jsonb, false, true, $3)
         RETURNING id
         "#,
     )
     .bind(org_id)
     .bind(title)
     .bind(user_id)
+    .bind(status)
     .fetch_one(pool)
     .await
     .expect("seed form")
+}
+
+async fn seed_form(pool: &PgPool, org_id: Uuid, user_id: Uuid, title: &str) -> Uuid {
+    seed_form_with_status(pool, org_id, user_id, title, "draft").await
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -106,6 +118,8 @@ async fn form_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     let user_b = seed_user(&pool, "b@form.test").await;
     let form_a = seed_form(&pool, org_a, user_a, "Form A").await;
     let form_b = seed_form(&pool, org_b, user_b, "Form B").await;
+    let published_form_a =
+        seed_form_with_status(&pool, org_a, user_a, "Published Form A", "published").await;
 
     // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds ---
     let role = format!("ppt_rls_form_{}", Uuid::new_v4().simple());
@@ -216,6 +230,47 @@ async fn form_repo_force_rls_deny_all_and_fix(pool: PgPool) {
         assert!(
             cross.is_none(),
             "cross-tenant: org B's form must NOT be visible to an org-A caller"
+        );
+
+        let submission = repo
+            .submit(
+                &mut *conn,
+                FormSubmissionParams {
+                    org_id: org_a,
+                    form_id: published_form_a,
+                    user_id: user_a,
+                    building_id: None,
+                    unit_id: None,
+                    data: SubmitForm {
+                        data: json!({}),
+                        attachments: None,
+                        signature_data: None,
+                    },
+                    ip_address: None,
+                    user_agent: None,
+                },
+            )
+            .await
+            .expect("submit (ctx)");
+        let fetched_submission = repo
+            .get_submission(&mut *conn, org_a, submission.id)
+            .await
+            .expect("get submission (ctx)");
+        assert!(
+            fetched_submission.is_some(),
+            "PAP-76 fix: submit/get_submission round-trip must work under RLS context"
+        );
+
+        repo.record_download(&mut *conn, org_a, published_form_a, user_a, None, None)
+            .await
+            .expect("record download (ctx)");
+        let downloads = repo
+            .get_download_count(&mut *conn, published_form_a)
+            .await
+            .expect("download count (ctx)");
+        assert_eq!(
+            downloads, 1,
+            "PAP-76 fix: record_download/get_download_count round-trip must work under RLS context"
         );
 
         sqlx::query("RESET ROLE")

--- a/backend/servers/api-server/src/routes/forms.rs
+++ b/backend/servers/api-server/src/routes/forms.rs
@@ -749,20 +749,24 @@ async fn update_form(
     let repo = &state.form_repo;
 
     // Check if form exists and is editable
-    let existing = repo.get(&mut **rls.conn(), org_id, id).await.map_err(|e| {
-        tracing::error!("Failed to get form: {:?}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get form")),
-        )
-    })?;
-
-    let existing = existing.ok_or_else(|| {
-        (
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Form not found")),
-        )
-    })?;
+    let existing = match repo.get(&mut **rls.conn(), org_id, id).await {
+        Ok(Some(existing)) => existing,
+        Ok(None) => {
+            rls.release().await;
+            return Err((
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Form not found")),
+            ));
+        }
+        Err(e) => {
+            tracing::error!("Failed to get form: {:?}", e);
+            rls.release().await;
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get form")),
+            ));
+        }
+    };
 
     if existing.status != form_status::DRAFT {
         rls.release().await;
@@ -898,16 +902,20 @@ async fn publish_form(
     let repo = &state.form_repo;
 
     // Check that form has at least one field
-    let fields = repo.get_fields(&mut **rls.conn(), id).await.map_err(|e| {
-        tracing::error!("Failed to get form fields: {:?}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new(
-                "INTERNAL_ERROR",
-                "Failed to get form fields",
-            )),
-        )
-    })?;
+    let fields = match repo.get_fields(&mut **rls.conn(), id).await {
+        Ok(fields) => fields,
+        Err(e) => {
+            tracing::error!("Failed to get form fields: {:?}", e);
+            rls.release().await;
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(
+                    "INTERNAL_ERROR",
+                    "Failed to get form fields",
+                )),
+            ));
+        }
+    };
 
     if fields.is_empty() {
         rls.release().await;
@@ -1073,20 +1081,23 @@ async fn list_fields(
     let repo = &state.form_repo;
 
     // Verify form exists and user has access
-    let form = repo.get(&mut **rls.conn(), org_id, id).await.map_err(|e| {
-        tracing::error!("Failed to get form: {:?}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get form")),
-        )
-    })?;
-
-    if form.is_none() {
-        rls.release().await;
-        return Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Form not found")),
-        ));
+    match repo.get(&mut **rls.conn(), org_id, id).await {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            rls.release().await;
+            return Err((
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Form not found")),
+            ));
+        }
+        Err(e) => {
+            tracing::error!("Failed to get form: {:?}", e);
+            rls.release().await;
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get form")),
+            ));
+        }
     }
 
     let out = repo
@@ -1141,20 +1152,24 @@ async fn add_field(
     let repo = &state.form_repo;
 
     // Verify form exists and is editable
-    let form = repo.get(&mut **rls.conn(), org_id, id).await.map_err(|e| {
-        tracing::error!("Failed to get form: {:?}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get form")),
-        )
-    })?;
-
-    let form = form.ok_or_else(|| {
-        (
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Form not found")),
-        )
-    })?;
+    let form = match repo.get(&mut **rls.conn(), org_id, id).await {
+        Ok(Some(form)) => form,
+        Ok(None) => {
+            rls.release().await;
+            return Err((
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Form not found")),
+            ));
+        }
+        Err(e) => {
+            tracing::error!("Failed to get form: {:?}", e);
+            rls.release().await;
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get form")),
+            ));
+        }
+    };
 
     if form.status != form_status::DRAFT {
         rls.release().await;
@@ -1258,20 +1273,24 @@ async fn update_field(
     let repo = &state.form_repo;
 
     // Verify form exists and is editable
-    let form = repo.get(&mut **rls.conn(), org_id, id).await.map_err(|e| {
-        tracing::error!("Failed to get form: {:?}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get form")),
-        )
-    })?;
-
-    let form = form.ok_or_else(|| {
-        (
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Form not found")),
-        )
-    })?;
+    let form = match repo.get(&mut **rls.conn(), org_id, id).await {
+        Ok(Some(form)) => form,
+        Ok(None) => {
+            rls.release().await;
+            return Err((
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Form not found")),
+            ));
+        }
+        Err(e) => {
+            tracing::error!("Failed to get form: {:?}", e);
+            rls.release().await;
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get form")),
+            ));
+        }
+    };
 
     if form.status != form_status::DRAFT {
         rls.release().await;
@@ -1365,20 +1384,24 @@ async fn delete_field(
     let repo = &state.form_repo;
 
     // Verify form exists and is editable
-    let form = repo.get(&mut **rls.conn(), org_id, id).await.map_err(|e| {
-        tracing::error!("Failed to get form: {:?}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get form")),
-        )
-    })?;
-
-    let form = form.ok_or_else(|| {
-        (
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Form not found")),
-        )
-    })?;
+    let form = match repo.get(&mut **rls.conn(), org_id, id).await {
+        Ok(Some(form)) => form,
+        Ok(None) => {
+            rls.release().await;
+            return Err((
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Form not found")),
+            ));
+        }
+        Err(e) => {
+            tracing::error!("Failed to get form: {:?}", e);
+            rls.release().await;
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get form")),
+            ));
+        }
+    };
 
     if form.status != form_status::DRAFT {
         rls.release().await;
@@ -1446,20 +1469,24 @@ async fn reorder_fields(
     let repo = &state.form_repo;
 
     // Verify form exists and is editable
-    let form = repo.get(&mut **rls.conn(), org_id, id).await.map_err(|e| {
-        tracing::error!("Failed to get form: {:?}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get form")),
-        )
-    })?;
-
-    let form = form.ok_or_else(|| {
-        (
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Form not found")),
-        )
-    })?;
+    let form = match repo.get(&mut **rls.conn(), org_id, id).await {
+        Ok(Some(form)) => form,
+        Ok(None) => {
+            rls.release().await;
+            return Err((
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Form not found")),
+            ));
+        }
+        Err(e) => {
+            tracing::error!("Failed to get form: {:?}", e);
+            rls.release().await;
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get form")),
+            ));
+        }
+    };
 
     if form.status != form_status::DRAFT {
         rls.release().await;
@@ -1542,22 +1569,24 @@ async fn submit_form(
     let repo = &state.form_repo;
 
     // Get form details
-    let form = repo
-        .get_with_details(rls.conn(), org_id, id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to get form: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get form")),
-            )
-        })?
-        .ok_or_else(|| {
-            (
+    let form = match repo.get_with_details(rls.conn(), org_id, id).await {
+        Ok(Some(form)) => form,
+        Ok(None) => {
+            rls.release().await;
+            return Err((
                 StatusCode::NOT_FOUND,
                 Json(ErrorResponse::new("NOT_FOUND", "Form not found")),
-            )
-        })?;
+            ));
+        }
+        Err(e) => {
+            tracing::error!("Failed to get form: {:?}", e);
+            rls.release().await;
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get form")),
+            ));
+        }
+    };
 
     // Verify form is published
     if form.form.status != form_status::PUBLISHED {
@@ -1573,19 +1602,20 @@ async fn submit_form(
 
     // Check if user already submitted and multiple submissions not allowed
     if !form.form.allow_multiple_submissions {
-        let has_submitted = repo
-            .has_user_submitted(&mut **rls.conn(), id, user_id)
-            .await
-            .map_err(|e| {
+        let has_submitted = match repo.has_user_submitted(&mut **rls.conn(), id, user_id).await {
+            Ok(has_submitted) => has_submitted,
+            Err(e) => {
                 tracing::error!("Failed to check submission: {:?}", e);
-                (
+                rls.release().await;
+                return Err((
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Json(ErrorResponse::new(
                         "INTERNAL_ERROR",
                         "Failed to check submission",
                     )),
-                )
-            })?;
+                ));
+            }
+        };
 
         if has_submitted {
             rls.release().await;
@@ -1914,21 +1944,23 @@ async fn review_submission(
         review_notes: req.review_notes,
     };
 
-    repo.review_submission(
-        &mut **rls.conn(),
-        org_id,
-        submission_id,
-        user_id,
-        review_data,
-    )
-    .await
-    .map_err(|e| {
+    if let Err(e) = repo
+        .review_submission(
+            &mut **rls.conn(),
+            org_id,
+            submission_id,
+            user_id,
+            review_data,
+        )
+        .await
+    {
         tracing::error!("Failed to review submission: {:?}", e);
-        (
+        rls.release().await;
+        return Err((
             StatusCode::NOT_FOUND,
             Json(ErrorResponse::new("NOT_FOUND", "Submission not found")),
-        )
-    })?;
+        ));
+    }
 
     // Get updated submission
     let out = repo
@@ -1979,36 +2011,32 @@ async fn record_download(
     let user_id = rls.user_id();
     let repo = &state.form_repo;
 
-    // Verify form exists
-    let form = repo.get(&mut **rls.conn(), org_id, id).await.map_err(|e| {
-        tracing::error!("Failed to get form: {:?}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get form")),
-        )
-    })?;
-
-    if form.is_none() {
-        rls.release().await;
-        return Err((
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::new("NOT_FOUND", "Form not found")),
-        ));
-    }
-
     let out = repo
-        .record_download(&mut **rls.conn(), id, user_id, None, None)
+        .record_download(&mut **rls.conn(), org_id, id, user_id, None, None)
         .await
-        .map(|_| StatusCode::OK)
+        .and_then(|inserted| {
+            if inserted {
+                Ok(StatusCode::OK)
+            } else {
+                Err(sqlx::Error::RowNotFound)
+            }
+        })
         .map_err(|e| {
-            tracing::error!("Failed to record download: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INTERNAL_ERROR",
-                    "Failed to record download",
-                )),
-            )
+            if matches!(e, sqlx::Error::RowNotFound) {
+                (
+                    StatusCode::NOT_FOUND,
+                    Json(ErrorResponse::new("NOT_FOUND", "Form not found")),
+                )
+            } else {
+                tracing::error!("Failed to record download: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new(
+                        "INTERNAL_ERROR",
+                        "Failed to record download",
+                    )),
+                )
+            }
         });
     rls.release().await;
     out

--- a/backend/servers/api-server/tests/form_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/form_cross_org_idor_tests.rs
@@ -1,0 +1,159 @@
+//! Regression tests for form submit/download org isolation (#1369).
+//!
+//! The forms routes now run under `RlsConnection`, so the caller's effective
+//! org comes from the authenticated membership-backed `X-Tenant-ID` context.
+//! These tests prove the write/download endpoints honor that scope:
+//! same-org submit still works, while cross-org submit/download attempts
+//! return 404 and leave the target org's rows untouched.
+
+#[allow(dead_code)]
+mod common;
+
+use axum::http::StatusCode;
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{create_authenticated_user_with_org, TestApp, TestUser};
+
+async fn user_id_for(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(email)
+        .fetch_one(pool)
+        .await
+        .expect("fetch user id")
+}
+
+async fn seed_published_form(pool: &PgPool, org_id: Uuid, created_by: Uuid, title: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO forms (
+            organization_id, title, status, target_type, target_ids,
+            require_signatures, allow_multiple_submissions, created_by
+        )
+        VALUES ($1, $2, 'published', 'all', '[]'::jsonb, false, true, $3)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(title)
+    .bind(created_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed published form")
+}
+
+async fn submission_count(pool: &PgPool, form_id: Uuid) -> i64 {
+    sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM form_submissions WHERE form_id = $1")
+        .bind(form_id)
+        .fetch_one(pool)
+        .await
+        .expect("count submissions")
+}
+
+async fn download_count(pool: &PgPool, form_id: Uuid) -> i64 {
+    sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM form_downloads WHERE form_id = $1")
+        .bind(form_id)
+        .fetch_one(pool)
+        .await
+        .expect("count downloads")
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn submit_form_same_org_succeeds(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let user = TestUser::new();
+    let (token, org_id) = create_authenticated_user_with_org(&app, &user, "forms-submit-ok").await;
+    let user_id = user_id_for(&pool, &user.email).await;
+    let form_id = seed_published_form(&pool, org_id, user_id, "Resident intake").await;
+
+    let response = app
+        .execute(
+            app.session(token, org_id)
+                .post(&format!("/api/v1/forms/{form_id}/submit"))
+                .json(json!({ "data": {} }))
+                .build(),
+        )
+        .await;
+
+    assert_eq!(response.status, StatusCode::CREATED, "same-org submit must succeed");
+    assert_eq!(
+        submission_count(&pool, form_id).await,
+        1,
+        "same-org submit must insert exactly one submission"
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn submit_form_cross_org_is_not_found_and_does_not_insert(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let owner = TestUser::new();
+    let (_owner_token, org_a) =
+        create_authenticated_user_with_org(&app, &owner, "forms-submit-owner").await;
+    let owner_id = user_id_for(&pool, &owner.email).await;
+    let form_id = seed_published_form(&pool, org_a, owner_id, "Org A only").await;
+
+    let attacker = TestUser::new();
+    let (attacker_token, org_b) =
+        create_authenticated_user_with_org(&app, &attacker, "forms-submit-attacker").await;
+
+    let response = app
+        .execute(
+            app.session(attacker_token, org_b)
+                .post(&format!("/api/v1/forms/{form_id}/submit"))
+                .json(json!({ "data": {} }))
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::NOT_FOUND,
+        "cross-org submit must be hidden behind org scope, got {} body={}",
+        response.status,
+        response.text()
+    );
+    assert_eq!(
+        submission_count(&pool, form_id).await,
+        0,
+        "cross-org submit must not insert a submission"
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn download_form_cross_org_is_not_found_and_does_not_insert(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let owner = TestUser::new();
+    let (_owner_token, org_a) =
+        create_authenticated_user_with_org(&app, &owner, "forms-download-owner").await;
+    let owner_id = user_id_for(&pool, &owner.email).await;
+    let form_id = seed_published_form(&pool, org_a, owner_id, "Downloadable form").await;
+
+    let attacker = TestUser::new();
+    let (attacker_token, org_b) =
+        create_authenticated_user_with_org(&app, &attacker, "forms-download-attacker").await;
+
+    let response = app
+        .execute(
+            app.session(attacker_token, org_b)
+                .post(&format!("/api/v1/forms/{form_id}/download"))
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::NOT_FOUND,
+        "cross-org download must be hidden behind org scope, got {} body={}",
+        response.status,
+        response.text()
+    );
+    assert_eq!(
+        download_count(&pool, form_id).await,
+        0,
+        "cross-org download must not insert a download row"
+    );
+}


### PR DESCRIPTION
## Summary
- harden `FormRepository::record_download` with an org-scoped insert and 404-on-miss behavior
- normalize `forms.rs` early-error paths to call `rls.release().await` inline instead of relying on `Drop`
- add focused repo/API regression coverage for same-org submit and cross-org submit/download isolation

## Verification
- Unable to run the focused Rust tests in this environment: `cargo test -p db --test form_rls_repo_tests form_repo_force_rls_deny_all_and_fix` and `cargo test -p api-server --test form_cross_org_idor_tests` both require the offloaded Rust runner, and `mercury` is currently unreachable (`ssh 127.0.0.1:2200: Connection refused`).

## Issue
- Closes BIT-47 / GH #1369 follow-up scope