### PR TITLE
pm-qa-service-history-cross-org-idor: add cross-org IDOR test coverage to service-history endpoints (#1372)

### DIFF
--- a/backend/crates/db/tests/work_order_rls_repo_tests.rs
+++ b/backend/crates/db/tests/work_order_rls_repo_tests.rs
@@ -93,6 +93,54 @@ async fn seed_work_order(
     .expect("seed work order")
 }
 
+async fn seed_equipment(pool: &PgPool, org_id: Uuid, building_id: Uuid, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO equipment (organization_id, building_id, name, category)
+        VALUES ($1, $2, $3, 'hvac')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(building_id)
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .expect("seed equipment")
+}
+
+/// Seed a `completed` work order so it shows up in the service-history queries
+/// (both `get_service_history` and `get_building_service_history` filter on
+/// `status = 'completed'`).
+#[allow(clippy::too_many_arguments)]
+async fn seed_completed_work_order(
+    pool: &PgPool,
+    org_id: Uuid,
+    building_id: Uuid,
+    equipment_id: Uuid,
+    created_by: Uuid,
+    title: &str,
+) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO work_orders (
+            organization_id, building_id, equipment_id, title, description,
+            created_by, status, completed_at, actual_cost
+        )
+        VALUES ($1, $2, $3, $4, 'seeded completed', $5, 'completed', NOW(), 123.45)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(building_id)
+    .bind(equipment_id)
+    .bind(title)
+    .bind(created_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed completed work order")
+}
+
 /// FORCE RLS on `work_orders` must:
 ///   1. deny ALL reads on a connection that has NO org context set
 ///      (the deny-all regression that 00179's FORCE introduces for any code
@@ -252,4 +300,177 @@ async fn work_orders_force_rls_requires_context_and_blocks_cross_tenant(pool: Pg
     .execute(&pool)
     .await
     .ok();
+}
+
+/// Cross-org IDOR regression for the service-history endpoints (issue #1372).
+///
+/// `get_service_history(equipment_id)` and `get_building_service_history(
+/// building_id)` are keyed ONLY by the resource UUID — neither query carries an
+/// `organization_id` predicate (see `WorkOrderRepository::get_service_history` /
+/// `get_building_service_history`: the SQL `WHERE` clause filters on
+/// `wo.equipment_id` / `wo.building_id` + `status = 'completed'` only). The sole
+/// tenant boundary is FORCE RLS on `work_orders` (migration 00179). The route
+/// handlers (`get_equipment_service_history` / `get_building_service_history`)
+/// run on the caller's `RlsConnection`, so under `FORCE` the join is scoped to
+/// the caller's org by the row-security policy — closing the #821 P2 / #1372
+/// cross-tenant gap at the database layer.
+///
+/// This test pins that contract behaviorally: an org-B caller who guesses org
+/// A's `equipment_id` / `building_id` must get an EMPTY history (not org A's
+/// service records), while org A still reads its own. Mirrors the role-switching
+/// FORCE-RLS harness used by
+/// `work_orders_force_rls_requires_context_and_blocks_cross_tenant` above.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn service_history_force_rls_blocks_cross_tenant(pool: PgPool) {
+    // --- Seed under super-admin context (satisfies the org roles-trigger). ---
+    sqlx::query("SELECT set_request_context(NULL, NULL, true)")
+        .execute(&pool)
+        .await
+        .expect("set super-admin context");
+
+    let org_a = seed_org(&pool, "wo-sh-a").await;
+    let org_b = seed_org(&pool, "wo-sh-b").await;
+    let user_a = seed_user(&pool, "a@work-orders-sh.test").await;
+    let user_b = seed_user(&pool, "b@work-orders-sh.test").await;
+    let bldg_a = seed_building(&pool, org_a, "1 Service St").await;
+    let _bldg_b = seed_building(&pool, org_b, "2 Service St").await;
+    let equip_a = seed_equipment(&pool, org_a, bldg_a, "Boiler A").await;
+
+    // One COMPLETED work order in org A, keyed by both the equipment and the
+    // building — it must surface in both service-history queries for org A and
+    // in NEITHER for org B.
+    let _wo_a = seed_completed_work_order(&pool, org_a, bldg_a, equip_a, user_a, "alpha-service").await;
+
+    let repo = WorkOrderRepository::new(pool.clone());
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    let role = format!("ppt_rls_sh_{}", Uuid::new_v4().simple());
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"
+    )))
+    .execute(&pool)
+    .await
+    .expect("create role");
+    // The service-history SQL reads `work_orders` LEFT JOIN `equipment`, so the
+    // bound role needs SELECT on both, plus the RLS helper functions and
+    // `organizations` (read by the SECURITY-INVOKER soft-delete guard).
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT SELECT ON work_orders, equipment TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant select on work_orders + equipment");
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
+         get_current_org_not_deleted() TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant execute on rls helpers");
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT SELECT ON organizations TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant select on organizations");
+
+    {
+        let mut conn = pool.acquire().await.expect("acquire connection");
+
+        // ---- Phase 1: org-A context → own service history IS visible. ----
+        sqlx::query("SELECT set_request_context($1, $2, false)")
+            .bind(org_a)
+            .bind(user_a)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A context");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let own_equip = repo
+            .get_service_history(&mut *conn, equip_a, 50, 0)
+            .await
+            .expect("get_service_history (org-A own)");
+        assert_eq!(
+            own_equip.len(),
+            1,
+            "org A must read its own equipment service history"
+        );
+
+        let own_bldg = repo
+            .get_building_service_history(&mut *conn, bldg_a, 50, 0)
+            .await
+            .expect("get_building_service_history (org-A own)");
+        assert_eq!(
+            own_bldg.len(),
+            1,
+            "org A must read its own building service history"
+        );
+
+        // ---- Phase 2: org-B context → org A's history is INVISIBLE. ----
+        // The cross-tenant attacker reuses the SAME equipment_id / building_id.
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role before re-setting context");
+        sqlx::query("SELECT set_request_context($1, $2, false)")
+            .bind(org_b)
+            .bind(user_b)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-B context");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let cross_equip = repo
+            .get_service_history(&mut *conn, equip_a, 50, 0)
+            .await
+            .expect("get_service_history (org-B cross-tenant)");
+        assert!(
+            cross_equip.is_empty(),
+            "cross-tenant IDOR: org B must NOT read org A's equipment service \
+             history by guessing the equipment_id"
+        );
+
+        let cross_bldg = repo
+            .get_building_service_history(&mut *conn, bldg_a, 50, 0)
+            .await
+            .expect("get_building_service_history (org-B cross-tenant)");
+        assert!(
+            cross_bldg.is_empty(),
+            "cross-tenant IDOR: org B must NOT read org A's building service \
+             history by guessing the building_id"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // --- Cleanup the test role. ---
+    sqlx::query("SELECT set_request_context(NULL, NULL, true)")
+        .execute(&pool)
+        .await
+        .expect("restore super-admin context");
+    for stmt in [
+        format!("REVOKE ALL ON work_orders FROM \"{role}\""),
+        format!("REVOKE ALL ON equipment FROM \"{role}\""),
+        format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        format!(
+            "REVOKE EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
+             get_current_org_not_deleted() FROM \"{role}\""
+        ),
+        format!("DROP OWNED BY \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .ok();
+    }
 }


### PR DESCRIPTION
## Task
Add cross-org IDOR test coverage to service-history endpoints (#1372).

## Owner
pm-qa

## What & why
The two service-history endpoints —
`GET /work-orders/equipment/{equipment_id}/service-history` and
`GET /work-orders/buildings/{building_id}/service-history` — are keyed ONLY by
the resource UUID. The underlying `WorkOrderRepository::get_service_history` /
`get_building_service_history` queries filter on `wo.equipment_id` /
`wo.building_id` + `status = 'completed'` and carry **no** `organization_id`
predicate. The sole cross-tenant boundary is **FORCE row-level security** on
`work_orders` (migration `00179` / PAP-179); the handlers run on the caller's
`RlsConnection`, so under `FORCE` the join is scoped to the caller's org by the
RLS policy. There was no behavioral regression test pinning that boundary for
these endpoints (gap #1372, related to the #821 P2 cross-tenant gap).

This PR adds `service_history_force_rls_blocks_cross_tenant` to the existing
`crates/db/tests/work_order_rls_repo_tests.rs`, reusing that file's
role-switching FORCE-RLS harness (a `NOSUPERUSER NOBYPASSRLS` role so `FORCE`
actually binds, since `#[sqlx::test]` connects as a superuser that bypasses
RLS). The test:

- seeds a `completed` work order in org A keyed by both an equipment and a
  building;
- asserts org A reads its own equipment + building service history (positive);
- asserts an org-B RLS context — reusing the **same** equipment_id /
  building_id (the IDOR attack) — gets an **empty** result for both endpoints
  (negative).

Test-only change; no production code is touched (the RLS protection already
ships — this PR adds the missing coverage).

## Tested (Band A — fast check)
Ran against an ephemeral local Postgres 16 cluster.

- `cargo check -p db --tests` → exit 0
- `cargo test -p db --test work_order_rls_repo_tests` → exit 0
  ```
  running 2 tests
  test work_orders_force_rls_requires_context_and_blocks_cross_tenant ... ok
  test service_history_force_rls_blocks_cross_tenant ... ok
  test result: ok. 2 passed; 0 failed; 0 ignored
  ```

## Built (Band B — full build)
Skipped: test-only change (no production code, public API, migration, or
config touched).

## CI parity (Band C — hot-path only)
Skipped: no production behavior change. The added test itself is the CI-parity
proof of the cross-tenant security contract; it runs in the `db` test job CI
already executes (with its Postgres service).

## Remote-tested
skipped (ppt-bridge MCP not connected)

## Scope drift
None. Single file under `backend/crates/db/tests/` — within pm-qa's owner
area (`scope-check.sh --owner pm-qa --base origin/dev` → exit 0).

## Code-reuse review
None. Reuses the existing `WorkOrderRepository` methods and the established
`seed_org` / `seed_user` / `seed_building` / role-setup fixtures already in
the file (`reuse-grep.sh` → no warnings).

## Notes
- This is a dispatcher action-list task, not a `.research/plans/<slug>.md`
  plan, so no plan-archive / IG1–IG2 plan-flow steps apply.
- IG3: pure test-addition for an already-shipped RLS fix — no paired
  production `fix:` commit is appropriate.

https://claude.ai/code/session_012z1wLLTE6newFskVUgpiTS

---
_Generated by [Claude Code](https://claude.ai/code/session_012z1wLLTE6newFskVUgpiTS)_