### PR TITLE
pm-qa-cron-validator-drift-test: Add silent-regression test for cron validator to prevent #616 reintroduction (#1368)

### DIFF
--- a/frontend/apps/ppt-web/src/features/reports/components/cron-validator-drift.test.ts
+++ b/frontend/apps/ppt-web/src/features/reports/components/cron-validator-drift.test.ts
@@ -1,0 +1,172 @@
+/// <reference types="vitest/globals" />
+/**
+ * Silent-regression guard for the cron-validator drift that can reintroduce
+ * issue #616 (lossy report-schedule round-trip) — see issue #1368.
+ *
+ * Background
+ * ----------
+ * #616 was the original lossy round-trip: a custom cron edit was persisted by
+ * the backend but, on re-open, `scheduleToInitialCron()` reconstructed the
+ * expression from the overloaded `time` / `frequency` / `day_*` fields and
+ * silently flattened the user's expression.
+ *
+ * The shipped fix surfaces the dedicated `cron_expression` column verbatim —
+ * BUT only when the frontend `isValidCron()` accepts it (EditScheduleModal.tsx
+ * `scheduleToInitialCron`, the `stored && isValidCron(stored)` guard). #1368
+ * pointed out the trap: the frontend `isValidCron` and the backend
+ * `validate_cron_expression` (backend/servers/api-server/src/routes/reports.rs)
+ * are independent reimplementations that DISAGREE on at least one combined
+ * form. For any expression the backend accepts but the frontend rejects, the
+ * read path silently falls back to lossy reconstruction — i.e. #616 comes back
+ * for that subset, invisibly (no error surfaced).
+ *
+ * This file is the regression net the #1368 "Tests" finding asked for. It does
+ * two things, both load-bearing:
+ *
+ *   1. Pins the verbatim round-trip for combined `,`/`/`/`-` expressions that
+ *      BOTH validators currently accept, so the happy-path fix can't regress.
+ *
+ *   2. Pins the KNOWN drift fixture (`1-5/2,10 * * * *`) as a documented
+ *      cross-validator disagreement. This test is intentionally an assertion
+ *      about the *current* (buggy-for-this-subset) behaviour: the moment
+ *      anyone changes either validator OR the read-path guard, this test goes
+ *      red and forces a deliberate decision — reconcile the validators and
+ *      surface the stored cron, or update the contract on purpose. That is
+ *      exactly what stops #616 from silently creeping back in.
+ *
+ * NOTE (QA scope): this guard does not change product behaviour. The proper
+ * fix (#1368: make the backend the single validation authority and stop
+ * gating the read path on a frontend false-negative) is owned by the frontend
+ * specialist. When that fix lands, the `drift — current behaviour` block below
+ * must be flipped to assert verbatim surfacing (the `EXPECTED AFTER FIX`
+ * comments mark each line).
+ */
+
+import type { ReportSchedule } from '@ppt/api-client';
+import { describe, expect, it } from 'vitest';
+import { isValidCron } from './CronPicker';
+import { scheduleToInitialCron } from './EditScheduleModal';
+
+/** Build a ReportSchedule fixture with sane defaults, overridable per-test. */
+function makeSchedule(overrides: Partial<ReportSchedule> = {}): ReportSchedule {
+  return {
+    id: 'sched-1',
+    report_id: 'rep-1',
+    organization_id: 'org-1',
+    name: 'Test Schedule',
+    frequency: 'daily',
+    time: '08:00',
+    timezone: 'Europe/Bratislava',
+    format: 'pdf',
+    recipients: ['a@example.com'],
+    is_active: true,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+/**
+ * Mirror of the backend `validate_cron_expression`
+ * (backend/servers/api-server/src/routes/reports.rs ~L1894). Field parsing
+ * order is the load-bearing difference vs. the frontend `isValidCron`: the
+ * backend splits each field on `,` FIRST, then `/`, then `-`. Kept here so the
+ * drift assertions document the *backend* contract they pin against, without a
+ * network/cargo dependency in a frontend unit test.
+ */
+function backendValidateCron(expr: string): boolean {
+  const fields = expr.split(/\s+/).filter(Boolean);
+  if (fields.length !== 5) return false;
+
+  const validField = (field: string, min: number, max: number): boolean => {
+    for (const part of field.split(',')) {
+      const [base, step] = part.includes('/') ? part.split('/') : [part, undefined];
+      if (step !== undefined) {
+        const s = Number(step);
+        if (!Number.isInteger(s) || s === 0) return false;
+      }
+      if (base !== '*') {
+        if (base.includes('-')) {
+          const [lo, hi] = base.split('-').map(Number);
+          if (
+            !(Number.isInteger(lo) && Number.isInteger(hi) && lo >= min && hi <= max && lo <= hi)
+          ) {
+            return false;
+          }
+        } else {
+          const v = Number(base);
+          if (!(Number.isInteger(v) && v >= min && v <= max)) return false;
+        }
+      }
+    }
+    return true;
+  };
+
+  return (
+    validField(fields[0], 0, 59) &&
+    validField(fields[1], 0, 23) &&
+    validField(fields[2], 1, 31) &&
+    validField(fields[3], 1, 12) &&
+    validField(fields[4], 0, 7)
+  );
+}
+
+describe('cron validator drift — #616 reintroduction guard (#1368)', () => {
+  describe('combined forms accepted by BOTH validators round-trip verbatim', () => {
+    // These are the safe cases: when the frontend validator agrees with the
+    // backend, the dedicated cron_expression must be surfaced unflattened.
+    it.each([
+      '0,30 9-17 1-31 1-12 0-7', // explicit list + ranges in every field
+      '5-15/3 * * * *', // range-with-step in the minute field
+      '0,15,30,45 9-17 * * 1-5', // list minute + range hour + range dow
+      '*/15 9-17 * * 1-5', // step + range (the canonical #616 custom expr)
+    ])('surfaces %s verbatim (backend-valid AND frontend-valid)', (expr) => {
+      // Precondition: both validators agree this is valid.
+      expect(backendValidateCron(expr)).toBe(true);
+      expect(isValidCron(expr)).toBe(true);
+
+      const schedule = makeSchedule({
+        cron_expression: expr,
+        // Legacy fields present but must be ignored when a cron is stored.
+        time: '08:00',
+        frequency: 'daily',
+        day_of_week: 3,
+        day_of_month: 15,
+      });
+      expect(scheduleToInitialCron(schedule)).toBe(expr);
+    });
+  });
+
+  describe('cross-validator drift fixture (the #1368 trap)', () => {
+    // `1-5/2,10` is accepted by the backend (splits on `,` first → `1-5/2` and
+    // `10`) but REJECTED by the frontend `isValidCron` (takes the `/` branch on
+    // the whole `2,10` token → Number("2,10") = NaN → false).
+    const DRIFT_EXPR = '1-5/2,10 * * * *';
+
+    it('the two validators genuinely disagree on the drift fixture', () => {
+      expect(backendValidateCron(DRIFT_EXPR)).toBe(true);
+      // Frontend false-negative — this is the root cause of the silent #616
+      // reintroduction. Pinned so a future "fix" to either validator is
+      // forced to be deliberate.
+      expect(isValidCron(DRIFT_EXPR)).toBe(false);
+    });
+
+    it('CURRENT behaviour: a backend-accepted cron the frontend rejects is silently flattened (#616 reintroduced)', () => {
+      const schedule = makeSchedule({
+        cron_expression: DRIFT_EXPR, // backend persisted this exact value
+        frequency: 'daily',
+        time: '07:15',
+      });
+
+      // EXPECTED AFTER #1368 FIX: scheduleToInitialCron should return DRIFT_EXPR
+      // verbatim (backend is the validation authority; never silently flatten a
+      // persisted cron). Until that fix lands, the read path flattens it back
+      // to the legacy time-derived expression — this assertion documents the
+      // live bug so the fix has a red→green target and so the regression can't
+      // slip back in unnoticed.
+      const flattened = scheduleToInitialCron(schedule);
+      expect(flattened).not.toBe(DRIFT_EXPR); // <-- flip to .toBe(DRIFT_EXPR) when #1368 is fixed
+      expect(flattened).toBe('15 7 * * *'); // lossy reconstruction from `time`
+    });
+  });
+});


### PR DESCRIPTION
## Task
Add silent-regression test for cron validator to prevent #616 reintroduction (#1368)

## Owner
pm-qa

## What & why
Issue #1368 (post-merge review of PR #1358) flagged that the report-schedule cron read path can silently reintroduce the #616 lossy round-trip. `scheduleToInitialCron()` only surfaces a stored `cron_expression` when the frontend `isValidCron()` (CronPicker.tsx) accepts it; otherwise it falls back to lossy `time`/`frequency` reconstruction. The frontend `isValidCron` and the backend `validate_cron_expression` (reports.rs ~L1894) are independent reimplementations that disagree on combined forms — e.g. `1-5/2,10 * * * *` is accepted by the backend (splits on `,` first) but rejected by the frontend (takes the `/` branch on `2,10` → `NaN`). So a manager-saved, backend-persisted cron gets silently flattened on re-open. The #1368 "Tests" finding asked for a guard for exactly this drift.

This PR adds that guard (`cron-validator-drift.test.ts`). QA scope: **test only**, no product behaviour change. The actual fix (make the backend the single validation authority; stop gating the read path on a frontend false-negative) is frontend-owned per #1368.

The test:
1. Pins verbatim round-trip for combined `,`/`/`/`-` expressions that BOTH validators accept (the happy-path fix can't silently regress).
2. Pins the known drift fixture (`1-5/2,10`) — asserting the two validators disagree AND documenting the current lossy-flatten behaviour, so any change to either validator or the read-path guard goes red and forces a deliberate decision. `EXPECTED AFTER FIX` comments mark the lines to flip when the #1368 fix lands.

It includes a small local `backendValidateCron` mirror of the backend validator as a test fixture (documented inline) so the parity assertions have no network/cargo dependency in a frontend unit test.

## Tested (Band A — fast check)
- `pnpm -F @ppt/web exec vitest run src/features/reports/components/cron-validator-drift.test.ts` → exit 0 (Test Files 1 passed, Tests 6 passed)
- `pnpm exec biome check <file>` → exit 0 (clean after `biome check --write` formatting)
- `cd apps/ppt-web && npx tsc --noEmit` → exit 0

## Built (Band B — full build)
skipped: test-only addition, no public API / migration / config / build-output change

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change; QA test only)

## Remote-tested
skipped

## Scope drift
`scope-check.sh --owner pm-qa` reports exit 2 for `frontend/apps/ppt-web/src/features/reports/components/cron-validator-drift.test.ts`. This is a glob/layout mismatch, not an out-of-area change: the `pm-qa` owner-areas globs expect `frontend/**/tests/**` or `frontend/**/__tests__/**`, but ppt-web colocates tests next to source (vitest `include: ['src/**/*.test.ts']`, 62 existing colocated test files, no `tests/`/`__tests__/` dirs). The change is a pure test file in the conventional location next to its subject (`EditScheduleModal`/`CronPicker`). No production code touched. Reviewer to adjudicate; consider extending `owner-areas.json` `pm-qa` to include `frontend/**/*.test.ts` / `frontend/**/*.spec.ts`.

## Code-reuse review
`reuse-grep.sh --specialist react-web` → no warnings. The `backendValidateCron` helper is an intentional, documented test-only mirror (not a duplicated production helper).

## Notes
- The drift-fixture test currently asserts the *buggy* behaviour (`flattened !== DRIFT_EXPR`, equals the lossy `15 7 * * *`). When the #1368 frontend fix lands, flip the marked assertion to `.toBe(DRIFT_EXPR)`.
- IG goal-check (IG1/IG2/IG3) flags relate to the plan-driven `ppt-research-flow` path (no `.research/plans/*.md` for this dispatcher action-list task; branch is the dispatcher-assigned `auto-impl/*`; intentionally a test-only commit with no paired `fix:`). Step 3's authoritative verify gate is green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUB3fD8ToovTQpeQCSFBBi)_