### PR TITLE
feat-navigation-and-routing-navigation-state-preservation-mobile: prove navigation state preservation (AC-4)

### DIFF
--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/navigation/Navigation.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/navigation/Navigation.kt
@@ -132,11 +132,16 @@ fun RealityNavHost(
     val currentRoute = navBackStackEntry?.destination?.route
     val onSignInClick: () -> Unit = { navController.navigate(Screen.Login.route) }
 
+    // The tab-switch nav options come from the shared DeepLinkRouter so the
+    // state-preservation contract (popUpTo(home){saveState}; launchSingleTop;
+    // restoreState) has one definition that is unit-tested in commonTest and
+    // shared with iOS. Story 82-2, AC-4.
+    val tabOptions = DeepLinkRouter.TAB_NAV_OPTIONS
     val tabNavigate: (String) -> Unit = { route ->
         navController.navigate(route) {
-            popUpTo(Screen.Home.route) { saveState = true }
-            launchSingleTop = true
-            restoreState = true
+            popUpTo(tabOptions.popUpToRoute) { saveState = tabOptions.popUpToSaveState }
+            launchSingleTop = tabOptions.launchSingleTop
+            restoreState = tabOptions.restoreState
         }
     }
 

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/navigation/DeepLinkRouter.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/navigation/DeepLinkRouter.kt
@@ -57,6 +57,47 @@ object DeepLinkRouter {
     fun preservesState(route: String?): Boolean = route in TOP_LEVEL_ROUTES
 
     /**
+     * Platform-agnostic description of the Compose `navOptions` that make tab switches preserve
+     * back-stack state. It is the data behind the inline lambda in the Android nav graph:
+     * ```kotlin
+     * navController.navigate(route) {
+     *     popUpTo(popUpToRoute) { saveState = true }
+     *     launchSingleTop = true
+     *     restoreState = true
+     * }
+     * ```
+     *
+     * Keeping the option *values* here (rather than only in the Compose lambda) gives the
+     * state-preservation behaviour a framework-free unit-test surface and lets iOS adopt the same
+     * contract. Story 82-2, AC-4.
+     *
+     * @property popUpToRoute the route the back stack is popped up to before navigating — the graph
+     *   start destination ([ROUTE_HOME]) so each tab is a single saved sub-stack under it.
+     * @property popUpToSaveState save the popped destinations' state so it can be restored later.
+     * @property launchSingleTop don't stack duplicate copies of an already-current tab.
+     * @property restoreState restore any previously-saved state for the destination being navigated
+     *   to, so re-selecting a tab returns the user to where they left off.
+     */
+    data class TabNavOptions(
+        val popUpToRoute: String,
+        val popUpToSaveState: Boolean,
+        val launchSingleTop: Boolean,
+        val restoreState: Boolean,
+    )
+
+    /**
+     * The single set of nav options every bottom-bar tap must use to preserve and restore per-tab
+     * back-stack state. Pop up to [ROUTE_HOME] saving state, single-top, and restore on the way in.
+     */
+    val TAB_NAV_OPTIONS: TabNavOptions =
+        TabNavOptions(
+            popUpToRoute = ROUTE_HOME,
+            popUpToSaveState = true,
+            launchSingleTop = true,
+            restoreState = true,
+        )
+
+    /**
      * Parse a `reality://…` deep-link string into a [DeepLinkTarget], or `null` if the URI is
      * malformed, uses a foreign scheme, or targets an unknown host.
      */

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/navigation/NavigationStatePreservationTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/navigation/NavigationStatePreservationTest.kt
@@ -1,0 +1,76 @@
+package three.two.bit.ppt.reality.navigation
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Story 82-2, AC-4 — behaviour proof for **navigation state preservation** on Reality mobile.
+ *
+ * The Compose nav graph (`androidApp` `Navigation.kt`) preserves each bottom-bar tab's back stack
+ * by driving every tab tap through one shared set of nav options:
+ * ```kotlin
+ * navController.navigate(route) {
+ *     popUpTo(DeepLinkRouter.TAB_NAV_OPTIONS.popUpToRoute) {
+ *         saveState = DeepLinkRouter.TAB_NAV_OPTIONS.popUpToSaveState
+ *     }
+ *     launchSingleTop = DeepLinkRouter.TAB_NAV_OPTIONS.launchSingleTop
+ *     restoreState = DeepLinkRouter.TAB_NAV_OPTIONS.restoreState
+ * }
+ * ```
+ *
+ * The Compose `navigate { ... }` lambda itself needs the Android `NavController` (and therefore an
+ * instrumented test) to exercise, but the *correctness of state preservation* lives entirely in
+ * which option flags are set. By pinning those flags in framework-free [DeepLinkRouter.TabNavOptions]
+ * the graph consumes, this JVM unit test proves the contract without ADB:
+ *
+ * - `saveState`/`restoreState` true ⇒ a tab the user drilled into is restored when re-selected
+ *   (the AC-4 requirement).
+ * - `popUpTo(home)` ⇒ each tab is a single saved sub-stack rooted at the start destination, so the
+ *   back stack can't grow unbounded as the user hops tabs.
+ * - `launchSingleTop` ⇒ re-tapping the current tab doesn't push a duplicate copy.
+ *
+ * If any of these flags regress (e.g. an edit drops `restoreState`), this test fails — which is the
+ * proof that was missing before.
+ */
+class NavigationStatePreservationTest {
+
+    @Test
+    fun tab_nav_options_save_and_restore_state() {
+        val opts = DeepLinkRouter.TAB_NAV_OPTIONS
+        // Saving on the way out + restoring on the way in is what makes a tab return the user to
+        // where they left off — the core of AC-4 navigation state preservation.
+        assertTrue(opts.popUpToSaveState, "tab switches must save back-stack state")
+        assertTrue(opts.restoreState, "tab switches must restore back-stack state")
+    }
+
+    @Test
+    fun tab_nav_options_pop_up_to_home_single_top() {
+        val opts = DeepLinkRouter.TAB_NAV_OPTIONS
+        // Each tab is a saved sub-stack rooted at the start destination so the stack stays bounded.
+        assertEquals(DeepLinkRouter.ROUTE_HOME, opts.popUpToRoute)
+        // Re-tapping the active tab must not stack a duplicate copy.
+        assertTrue(opts.launchSingleTop, "tab switches must be single-top")
+    }
+
+    @Test
+    fun pop_up_to_target_is_a_state_preserving_top_level_tab() {
+        // The route we pop up to must itself be one of the state-preserving tabs, otherwise the
+        // saved/restored sub-stacks wouldn't hang off a preserved root.
+        assertTrue(DeepLinkRouter.preservesState(DeepLinkRouter.TAB_NAV_OPTIONS.popUpToRoute))
+    }
+
+    @Test
+    fun only_top_level_tabs_preserve_state() {
+        // Sanity-pin the partition the graph relies on: every bottom-bar tab preserves state...
+        for (tab in DeepLinkRouter.TOP_LEVEL_ROUTES) {
+            assertTrue(DeepLinkRouter.preservesState(tab), "$tab is a tab and must preserve state")
+        }
+        // ...and detail/auth/realtor routes do not, so they aren't saved/restored as tabs.
+        assertFalse(DeepLinkRouter.preservesState("listing/abc-123"))
+        assertFalse(DeepLinkRouter.preservesState("auth/login"))
+        assertFalse(DeepLinkRouter.preservesState("realtor/listings"))
+        assertFalse(DeepLinkRouter.preservesState(null))
+    }
+}

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/navigation/NavigationStatePreservationTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/navigation/NavigationStatePreservationTest.kt
@@ -22,11 +22,11 @@ import kotlin.test.assertTrue
  *
  * The Compose `navigate { ... }` lambda itself needs the Android `NavController` (and therefore an
  * instrumented test) to exercise, but the *correctness of state preservation* lives entirely in
- * which option flags are set. By pinning those flags in framework-free [DeepLinkRouter.TabNavOptions]
- * the graph consumes, this JVM unit test proves the contract without ADB:
- *
- * - `saveState`/`restoreState` true ⇒ a tab the user drilled into is restored when re-selected
- *   (the AC-4 requirement).
+ * which option flags are set. By pinning those flags in framework-free
+ * [DeepLinkRouter.TabNavOptions] the graph consumes, this JVM unit test proves the contract without
+ * ADB:
+ * - `saveState`/`restoreState` true ⇒ a tab the user drilled into is restored when re-selected (the
+ *   AC-4 requirement).
  * - `popUpTo(home)` ⇒ each tab is a single saved sub-stack rooted at the start destination, so the
  *   back stack can't grow unbounded as the user hops tabs.
  * - `launchSingleTop` ⇒ re-tapping the current tab doesn't push a duplicate copy.


### PR DESCRIPTION
## Task
navigation state preservation (AC-4) unverified (82-2-navigation-routing Navigation and Routing). Evidence/implement navigation state preservation for the Reality mobile (Kotlin Multiplatform, mobile-native/) Navigation & Routing screen — add the missing test/behavior proof.

## Owner
pm-frontend (specialist: kotlin-mp)

## What changed
AC-4 navigation state preservation was implemented in the Reality Android nav graph (`RealityNavHost.tabNavigate` used `popUpTo(home){saveState=true}; launchSingleTop=true; restoreState=true`) but had **no test/behavior proof** — the state-preservation flags lived only inside a Compose `navigate { ... }` lambda that can't be exercised without an instrumented (ADB) test.

This PR makes the contract testable without ADB:

1. `shared/.../navigation/DeepLinkRouter.kt` — adds a framework-free `TabNavOptions` data class and a single `TAB_NAV_OPTIONS` value that captures the state-preservation flags (`popUpToRoute=home`, `popUpToSaveState`, `launchSingleTop`, `restoreState`). Lives in `commonMain` so iOS can reuse it.
2. `androidApp/.../navigation/Navigation.kt` — `RealityNavHost` now consumes `DeepLinkRouter.TAB_NAV_OPTIONS` instead of hard-coding the flags inline. One definition, shared and tested.
3. `shared/.../navigation/NavigationStatePreservationTest.kt` (new) — JVM unit test that pins the contract: save+restore are on, popUpTo targets a state-preserving top-level tab, single-top is on, and only the five bottom-bar tabs preserve state (detail/auth/realtor routes do not). If any flag regresses, the test fails — the proof that was missing.

## Tested (Band A — fast check)
Gradle plugin resolution requires network in this sandbox, so the build is not runnable offline (`./gradlew :shared:compileKotlinJvm --offline` → exit 1: `com.android.application:9.2.1` not in offline cache). This matches prior reality-mobile PRs. Verification done statically:
- All new symbols (`TAB_NAV_OPTIONS`, `TabNavOptions`, `ROUTE_HOME`, `preservesState`, `TOP_LEVEL_ROUTES`) are defined in `DeepLinkRouter`.
- `Navigation.kt` and `DeepLinkRouter.kt` share package `three.two.bit.ppt.reality.navigation`, so no new import is needed.
- The new test references only existing/added public API in the same module.
- Remote branch verified byte-identical to local worktree (`git diff HEAD FETCH_HEAD` empty).

**Authoritative gate: CI `mobile-native.yml`** (Gradle build + unit tests), which will run `NavigationStatePreservationTest`.

## Built (Band B — full build)
skipped: Gradle not runnable offline in sandbox (see Band A); CI `mobile-native.yml` is the build gate.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change — UI navigation only).

## Scope drift
None. `scope-check.sh --owner pm-frontend` → exit 0. All three files are under `mobile-native/` UI/navigation.

## Code-reuse review
None. `reuse-grep.sh --specialist kotlin-mp` → no warnings. The change deliberately removes duplication (inline flags → single shared `TAB_NAV_OPTIONS`).

## Notes
- IG1/IG2 of the goal-check report FAIL because this is a **dispatcher-driven** task: there is no `.research/plans/<slug>.md` and the branch is `auto-impl/...` (dispatcher convention), whereas goal-check assumes the plan-flow `impl/<slug>` model. Those are structural N/A for this path, not goal failures. IG3 is satisfied in spirit (test: + refactor: commit pair). Substantive verify deferred to CI per the offline-Gradle constraint.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HUB3fD8ToovTQpeQCSFBBi)_