### PR TITLE
pm-qa-record-reserve-transaction-atomicity: concurrency test + FOR UPDATE for record_reserve_transaction (#1371)

### DIFF
--- a/backend/crates/db/src/repositories/budget.rs
+++ b/backend/crates/db/src/repositories/budget.rs
@@ -36,7 +36,7 @@ use crate::models::{
     UpdateCapitalPlan, UpdateFinancialForecast, UpdateReserveFund, YearlyCapitalSummary,
 };
 use rust_decimal::Decimal;
-use sqlx::{Executor, PgPool, Postgres};
+use sqlx::{Connection, Executor, PgPool, Postgres};
 use uuid::Uuid;
 
 /// Repository for budget and financial planning operations.
@@ -1310,6 +1310,15 @@ impl BudgetRepository {
     ///
     /// Reads the current balance and inserts the transaction on the same
     /// connection so RLS policies are enforced for both queries.
+    ///
+    /// Atomicity (#1371): the balance read-modify-write runs inside an explicit
+    /// transaction that locks the fund row with `SELECT ... FOR UPDATE`. Without
+    /// the lock two concurrent callers both read the same `current_balance` and
+    /// write conflicting `balance_after` ledger values — a lost-update race that
+    /// silently corrupts the running balance. `begin()` on the caller-supplied
+    /// `&mut PgConnection` yields a `Transaction` that holds the row lock until
+    /// commit while preserving RLS (request context is connection-scoped, so it
+    /// survives the in-connection transaction).
     pub async fn record_reserve_transaction(
         &self,
         conn: &mut sqlx::PgConnection,
@@ -1317,19 +1326,34 @@ impl BudgetRepository {
         user_id: Uuid,
         data: RecordReserveTransaction,
     ) -> Result<ReserveFundTransaction, sqlx::Error> {
-        let fund: ReserveFund = sqlx::query_as("SELECT * FROM reserve_funds WHERE id = $1")
-            .bind(reserve_fund_id)
-            .fetch_one(&mut *conn)
+        let mut tx = conn.begin().await?;
+
+        // Lock the fund row for the duration of the transaction. A concurrent
+        // writer on the same fund blocks here until this transaction commits,
+        // so it observes the updated balance instead of a stale snapshot.
+        let fund: ReserveFund =
+            sqlx::query_as("SELECT * FROM reserve_funds WHERE id = $1 FOR UPDATE")
+                .bind(reserve_fund_id)
+                .fetch_one(&mut *tx)
+                .await?;
+
+        // INSERT fires `trg_update_reserve_fund_balance` (migration 00057), which
+        // writes `reserve_funds.current_balance = NEW.balance_after`. Because the
+        // fund row is locked above, a concurrent writer cannot interleave between
+        // our read and that trigger-driven write, so the running balance is
+        // updated serially instead of being clobbered with a stale value.
+        let txn = self
+            .record_reserve_transaction_rls(
+                &mut *tx,
+                reserve_fund_id,
+                user_id,
+                fund.current_balance,
+                data,
+            )
             .await?;
 
-        self.record_reserve_transaction_rls(
-            conn,
-            reserve_fund_id,
-            user_id,
-            fund.current_balance,
-            data,
-        )
-        .await
+        tx.commit().await?;
+        Ok(txn)
     }
 
     /// Generate a reserve fund projection under the caller's RLS context.

--- a/backend/crates/db/tests/budget_reserve_atomicity_tests.rs
+++ b/backend/crates/db/tests/budget_reserve_atomicity_tests.rs
@@ -1,0 +1,239 @@
+//! Concurrency regression test for `BudgetRepository::record_reserve_transaction`
+//! atomicity (#1371, follow-up to PR #1327 / PAP-180).
+//!
+//! Background
+//! ----------
+//! `record_reserve_transaction` is a read-modify-write on a reserve fund:
+//!
+//!   1. `SELECT * FROM reserve_funds WHERE id = $1` → `current_balance`
+//!   2. compute `balance_after = current_balance ± amount` in application code
+//!   3. `INSERT INTO reserve_fund_transactions (... balance_after ...)`, whose
+//!      `AFTER INSERT` trigger writes `reserve_funds.current_balance = balance_after`
+//!
+//! PR #1327 moved both queries onto a single RLS-bound connection (fixing RLS
+//! enforcement) but left them **autocommitting independently** — no transaction,
+//! no row lock. Two concurrent callers against the same fund both read the same
+//! `current_balance`, compute the same `balance_after`, and the trigger writes
+//! that same value twice: a classic lost-update race that silently drops one
+//! contribution from the running balance.
+//!
+//! The fix (#1371) wraps the read-modify-write in an explicit transaction and
+//! locks the fund row with `SELECT ... FOR UPDATE`, so concurrent writers
+//! serialize: the second caller blocks until the first commits and then reads
+//! the *updated* balance.
+//!
+//! This test fires N concurrent `record_reserve_transaction` contributions of a
+//! fixed amount against one fund and asserts:
+//!   * the final `reserve_funds.current_balance` == start + N * amount (no lost
+//!     update), and
+//!   * the set of ledger `balance_after` values is exactly the monotonic ladder
+//!     `{start+amount, start+2*amount, …, start+N*amount}` with no duplicates
+//!     (each writer observed a distinct predecessor).
+//!
+//! Each writer runs on its own pool connection under the same org's RLS context
+//! and a `FORCE`-bound NOSUPERUSER role, mirroring the production owner-role path
+//! and the sibling `budget_rls_repo_tests.rs` / `reserve_funds_rls_repo_tests.rs`.
+//!
+//! ## STATUS: `#[ignore]`d — blocked on a missing-table migration
+//!
+//! Migration `00097_create_reserve_funds.sql` (Epic 141) `DROP TABLE IF EXISTS
+//! reserve_fund_transactions` (and its `trg_update_reserve_fund_balance`
+//! trigger) to "replace the simpler reserve_funds tables from migration 57", but
+//! **never recreates `reserve_fund_transactions` or the balance trigger**. At the
+//! migrated HEAD schema the table the repository writes to does not exist, so
+//! `record_reserve_transaction` would fail at runtime (the route at
+//! `POST /reserve-funds/{id}/transactions` is still wired). This is a pre-existing
+//! latent bug outside the QA test scope; restoring the table + trigger is a
+//! `db-migration` follow-up. The test below is written and ready: drop the
+//! `#[ignore]` once the table is restored.
+
+use db::models::budget::RecordReserveTransaction;
+use db::repositories::BudgetRepository;
+use rust_decimal::Decimal;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+const WRITERS: i64 = 8;
+const AMOUNT: i64 = 100; // each contribution adds 100.00
+const START_BALANCE: i64 = 1_000;
+
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Atomicity {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@atomicity.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'Atomicity User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Seed a reserve fund with a known starting balance (superuser, RLS-exempt).
+async fn seed_fund(pool: &PgPool, org_id: Uuid, name: &str, start: Decimal) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO reserve_funds (organization_id, name, current_balance)
+        VALUES ($1, $2, $3)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(name)
+    .bind(start)
+    .fetch_one(pool)
+    .await
+    .expect("seed reserve fund")
+}
+
+#[ignore = "blocked on #1371 schema follow-up: migration 00097 drops \
+            reserve_fund_transactions + its balance trigger and never recreates \
+            them; remove #[ignore] once a db-migration restores the table"]
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn record_reserve_transaction_is_atomic_under_concurrency(pool: PgPool) {
+    let repo = BudgetRepository::new(pool.clone());
+
+    // --- Seed as super-admin context (satisfies org roles-trigger). ---
+    set_ctx(&pool, None, None, true).await;
+    let org = seed_org(&pool, "rf-atomic").await;
+    let user = seed_user(&pool, "writer@atomicity.test").await;
+    let fund = seed_fund(&pool, org, "Concurrent Fund", Decimal::from(START_BALANCE)).await;
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds, like production. ---
+    let role = format!("ppt_rls_rf_atomic_{}", Uuid::new_v4().simple());
+    for stmt in [
+        format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
+        format!(
+            "GRANT SELECT, INSERT, UPDATE, DELETE ON reserve_funds, \
+             reserve_fund_transactions TO \"{role}\""
+        ),
+        format!(
+            "GRANT EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
+             get_current_org_not_deleted() TO \"{role}\""
+        ),
+        format!("GRANT SELECT ON organizations TO \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .expect("grant setup");
+    }
+
+    // --- Fire WRITERS concurrent contributions, each on its own connection. ---
+    let mut handles = Vec::new();
+    for i in 0..WRITERS {
+        let pool = pool.clone();
+        let repo = repo.clone();
+        let role = role.clone();
+        handles.push(tokio::spawn(async move {
+            let mut conn = pool.acquire().await.expect("acquire");
+            sqlx::query("SELECT set_request_context($1, $2, $3)")
+                .bind(org)
+                .bind(user)
+                .bind(false)
+                .execute(&mut *conn)
+                .await
+                .expect("set ctx");
+            sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+                .execute(&mut *conn)
+                .await
+                .expect("set role");
+
+            let txn = repo
+                .record_reserve_transaction(
+                    &mut conn,
+                    fund,
+                    user,
+                    RecordReserveTransaction {
+                        transaction_type: "contribution".to_string(),
+                        amount: Decimal::from(AMOUNT),
+                        description: Some(format!("concurrent #{i}")),
+                        reference_type: None,
+                        reference_id: None,
+                        transaction_date: chrono::Utc::now().date_naive(),
+                    },
+                )
+                .await
+                .expect("record_reserve_transaction");
+
+            sqlx::query("RESET ROLE").execute(&mut *conn).await.ok();
+            txn.balance_after
+        }));
+    }
+
+    let mut balances_after = Vec::new();
+    for h in handles {
+        balances_after.push(h.await.expect("writer task"));
+    }
+
+    // --- Assert: no lost update on the fund's running balance. ---
+    set_ctx(&pool, Some(org), Some(user), true).await;
+    let final_balance: Decimal =
+        sqlx::query_scalar("SELECT current_balance FROM reserve_funds WHERE id = $1")
+            .bind(fund)
+            .fetch_one(&pool)
+            .await
+            .expect("read final balance");
+
+    let expected_final = Decimal::from(START_BALANCE + WRITERS * AMOUNT);
+    assert_eq!(
+        final_balance, expected_final,
+        "#1371 lost-update regression: after {WRITERS} concurrent contributions of \
+         {AMOUNT} the fund balance must be {expected_final} (start {START_BALANCE} + \
+         {WRITERS}*{AMOUNT}); a smaller value means a contribution was clobbered by a \
+         stale read"
+    );
+
+    // --- Assert: balance_after values form the exact monotonic ladder. ---
+    balances_after.sort();
+    let expected_ladder: Vec<Decimal> = (1..=WRITERS)
+        .map(|n| Decimal::from(START_BALANCE + n * AMOUNT))
+        .collect();
+    assert_eq!(
+        balances_after, expected_ladder,
+        "#1371: each writer must observe a distinct predecessor balance — the set of \
+         balance_after values must be exactly {{start+amount … start+N*amount}} with no \
+         duplicates; duplicates prove two writers read the same stale balance"
+    );
+
+    // --- Cleanup the test role. ---
+    set_ctx(&pool, None, None, true).await;
+    for stmt in [
+        format!("REVOKE ALL ON reserve_funds, reserve_fund_transactions FROM \"{role}\""),
+        format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .ok();
+    }
+}

--- a/backend/crates/db/tests/record_payment_atomicity_tests.rs
+++ b/backend/crates/db/tests/record_payment_atomicity_tests.rs
@@ -188,7 +188,11 @@ async fn sequential_payments_accumulate_and_mark_paid(pool: PgPool) {
         .expect("query ok")
         .expect("action exists");
 
-    assert_eq!(payments_count(&pool, action_id).await, 2, "both rows persisted");
+    assert_eq!(
+        payments_count(&pool, action_id).await,
+        2,
+        "both rows persisted"
+    );
     assert_eq!(
         action.paid_amount,
         Some(Decimal::new(10000, 2)),
@@ -257,7 +261,10 @@ async fn concurrent_payments_accumulate_without_lost_update(pool: PgPool) {
 
     // 2. Ledger ground truth equals the intended total.
     let ledger = payments_sum(&pool, action_id).await;
-    assert_eq!(ledger, expected_total, "fine_payments ledger == {expected_total}");
+    assert_eq!(
+        ledger, expected_total,
+        "fine_payments ledger == {expected_total}"
+    );
 
     // 3. The crux: the denormalised aggregate must equal the ledger. A lost
     //    update from the non-transactional read-modify-write shows up here as

--- a/backend/crates/db/tests/work_order_rls_repo_tests.rs
+++ b/backend/crates/db/tests/work_order_rls_repo_tests.rs
@@ -339,7 +339,8 @@ async fn service_history_force_rls_blocks_cross_tenant(pool: PgPool) {
     // One COMPLETED work order in org A, keyed by both the equipment and the
     // building — it must surface in both service-history queries for org A and
     // in NEITHER for org B.
-    let _wo_a = seed_completed_work_order(&pool, org_a, bldg_a, equip_a, user_a, "alpha-service").await;
+    let _wo_a =
+        seed_completed_work_order(&pool, org_a, bldg_a, equip_a, user_a, "alpha-service").await;
 
     let repo = WorkOrderRepository::new(pool.clone());
 


### PR DESCRIPTION
## Task
Add concurrency test for `record_reserve_transaction` atomicity + COALESCE on budget aggregates (#1371)

## Owner
pm-qa

## What changed
1. **Atomicity fix** (`backend/crates/db/src/repositories/budget.rs`): `record_reserve_transaction` now wraps its reserve-fund read-modify-write in an explicit transaction and locks the fund row with `SELECT ... FOR UPDATE`, per the fix prescribed in #1371. Previously the `SELECT current_balance` and the balance-mutating `INSERT` autocommitted independently on the same connection — two concurrent callers read the same balance and the `AFTER INSERT` trigger (`trg_update_reserve_fund_balance`) wrote the same `balance_after` twice, silently dropping one contribution (lost-update race). `conn.begin()` holds the row lock until commit while preserving the connection-scoped RLS context. The redundant manual balance UPDATE was intentionally omitted — migration 00057's trigger already sets `current_balance = NEW.balance_after`.
2. **Concurrency regression test** (`backend/crates/db/tests/budget_reserve_atomicity_tests.rs`): fires N concurrent contributions against one fund under a FORCE-RLS NOSUPERUSER role (mirrors the sibling `budget_rls_repo_tests.rs` / `reserve_funds_rls_repo_tests.rs`) and asserts (a) final `current_balance == start + N*amount` and (b) the ledger `balance_after` set is the exact monotonic ladder with no duplicates.

### COALESCE on budget aggregates — already resolved on `dev`
The robustness half of #1371 (`get_budget_summary_rls` returning `UnexpectedNullError` for a zero-item active budget) is **already fixed** at HEAD: the aggregates use `COALESCE(SUM(...), 0)` and the `variance_percent` divisor is guarded with `CASE WHEN SUM(budgeted_amount) = 0 THEN 0`. No change needed; flagged here for the reviewer.

## Tested (Band A — fast check)
- `cargo check -p db` → exit 0
- `cargo check -p db --tests` → exit 0 (test compiles)

## Built (Band B — full build)
- `cargo clippy -p db --tests` → exit 0 (no warnings)

## CI parity (Band C — hot-path only)
The atomicity test itself cannot run green yet — see Blocker below. `#[sqlx::test]` requires a live Postgres (unavailable locally); the regression test runs in CI once the blocker is cleared.

## Remote-tested
skipped (no ppt-bridge MCP in session)

## Scope drift
`scope-check.sh --owner pm-qa` exits 2: the diff touches `backend/crates/db/src/repositories/budget.rs`, which is outside pm-qa's test-only owner area. This is **expected and justified** — an atomicity *test* is vacuous unless the method is actually atomic, and #1371 explicitly prescribes both the `FOR UPDATE` fix and the accompanying test as one unit of work. Reviewer to adjudicate.

## ⚠️ Blocker — `reserve_fund_transactions` table missing at HEAD (needs db-migration follow-up)
While writing the test I found that **migration `00097_create_reserve_funds.sql` (Epic 141) drops `reserve_fund_transactions` and its `trg_update_reserve_fund_balance` trigger and never recreates them.** Only `00057_create_budgets.sql` ever creates that table, and 00097 runs after it. So at the migrated HEAD schema:
- `BudgetRepository::record_reserve_transaction` / `record_reserve_transaction_rls` write to a non-existent table — the live route `POST /reserve-funds/{id}/transactions` would 500 in production. (It compiles because these use runtime `query_as`, not the compile-time-checked `query!` macro.)
- The `ReserveFund` model used by `BudgetRepository` (`annual_contribution`, `last_contribution_date`) also no longer matches 00097's reserve_funds shape.

Because of this, the concurrency test is committed with `#[ignore]` and a comment pointing here. **Recommend a `db-migration` follow-up** to restore `reserve_fund_transactions` + the balance trigger (or migrate `BudgetRepository` onto the 00097 fund-transactions schema), after which the `#[ignore]` is removed and the test runs in CI. The atomicity fix is correct and ready regardless.

## Notes
- Specialist: rust-backend. Verify gate green (check + clippy). Test ready-but-ignored pending the schema blocker above.

https://claude.ai/code/session_01B3FMeBnWfkw56ebaZAyA9M

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3FMeBnWfkw56ebaZAyA9M)_