### PR TITLE
pm-qa-vote-partial-cmp-nan-fuzz: NaN-weight fuzz guard for vote winner selection

### DIFF
--- a/backend/crates/db/src/repositories/vote.rs
+++ b/backend/crates/db/src/repositories/vote.rs
@@ -54,13 +54,15 @@ fn select_winner(option_results: &[OptionResult]) -> Option<Uuid> {
         .max_by(|a, b| {
             a.weighted_count
                 .partial_cmp(&b.weighted_count)
-                .unwrap_or_else(|| match (a.weighted_count.is_nan(), b.weighted_count.is_nan()) {
-                    // Treat NaN as the smallest value so a real number always wins.
-                    (true, false) => std::cmp::Ordering::Less,
-                    (false, true) => std::cmp::Ordering::Greater,
-                    // NaN vs NaN (or any other unorderable pair): keep stable.
-                    _ => std::cmp::Ordering::Equal,
-                })
+                .unwrap_or_else(
+                    || match (a.weighted_count.is_nan(), b.weighted_count.is_nan()) {
+                        // Treat NaN as the smallest value so a real number always wins.
+                        (true, false) => std::cmp::Ordering::Less,
+                        (false, true) => std::cmp::Ordering::Greater,
+                        // NaN vs NaN (or any other unorderable pair): keep stable.
+                        _ => std::cmp::Ordering::Equal,
+                    },
+                )
         })
         .map(|r| r.option_id)
 }

--- a/backend/crates/db/src/repositories/vote.rs
+++ b/backend/crates/db/src/repositories/vote.rs
@@ -38,6 +38,33 @@ use sha2::{Digest, Sha256};
 use sqlx::{Error as SqlxError, Executor, FromRow, Postgres};
 use uuid::Uuid;
 
+/// Pick the winning option (highest `weighted_count`) from a set of results.
+///
+/// This is NaN-safe by construction: `f64::partial_cmp` returns `None` for any
+/// comparison involving `NaN`, so the previous `partial_cmp(..).unwrap()` would
+/// panic the moment a single `weighted_count` was `NaN`, taking down the
+/// `/votes/{id}/results` handler. We treat `NaN` as the smallest possible value
+/// (it loses every comparison) and fall back to `Ordering::Equal` for the
+/// `NaN`-vs-`NaN` case, giving `max_by` a total order it can never trip on.
+///
+/// Returns `None` only for an empty input slice.
+fn select_winner(option_results: &[OptionResult]) -> Option<Uuid> {
+    option_results
+        .iter()
+        .max_by(|a, b| {
+            a.weighted_count
+                .partial_cmp(&b.weighted_count)
+                .unwrap_or_else(|| match (a.weighted_count.is_nan(), b.weighted_count.is_nan()) {
+                    // Treat NaN as the smallest value so a real number always wins.
+                    (true, false) => std::cmp::Ordering::Less,
+                    (false, true) => std::cmp::Ordering::Greater,
+                    // NaN vs NaN (or any other unorderable pair): keep stable.
+                    _ => std::cmp::Ordering::Equal,
+                })
+        })
+        .map(|r| r.option_id)
+}
+
 /// Row struct for vote with details query.
 #[derive(Debug, FromRow)]
 struct VoteDetailsRow {
@@ -1759,11 +1786,12 @@ impl VoteRepository {
             }
         }
 
-        // Determine winner (highest weighted count)
-        let winner = option_results
-            .iter()
-            .max_by(|a, b| a.weighted_count.partial_cmp(&b.weighted_count).unwrap())
-            .map(|r| r.option_id);
+        // Determine winner (highest weighted count).
+        // NaN-safe: a NaN `weighted_count` (e.g. from a degenerate float
+        // accumulation) must never reach `partial_cmp(..).unwrap()` — that
+        // would panic and take down the /votes/{id}/results handler. See
+        // `select_winner` for the total-ordering used here.
+        let winner = select_winner(&option_results);
 
         Ok(QuestionResult {
             question_id: question.id,
@@ -2048,5 +2076,121 @@ impl VoteRepository {
         .await?;
 
         Ok(rows)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::select_winner;
+    use crate::models::vote::OptionResult;
+    use uuid::Uuid;
+
+    fn opt(weighted_count: f64) -> OptionResult {
+        OptionResult {
+            option_id: Uuid::new_v4(),
+            option_text: "opt".to_string(),
+            count: 0,
+            weighted_count,
+            percentage: 0.0,
+        }
+    }
+
+    #[test]
+    fn select_winner_empty_is_none() {
+        assert_eq!(select_winner(&[]), None);
+    }
+
+    #[test]
+    fn select_winner_picks_highest() {
+        let results = vec![opt(1.0), opt(5.0), opt(3.0)];
+        assert_eq!(select_winner(&results), Some(results[1].option_id));
+    }
+
+    /// Regression guard for the Phase 1.5 finding: a `NaN` `weighted_count`
+    /// used to reach `partial_cmp(..).unwrap()` and panic the
+    /// `/votes/{id}/results` handler. A real option must still win over any
+    /// number of `NaN`-weighted options, and the call must never panic.
+    #[test]
+    fn select_winner_real_value_beats_nan() {
+        // NaN options surround the only real winner.
+        let results = vec![opt(f64::NAN), opt(2.0), opt(f64::NAN)];
+        assert_eq!(select_winner(&results), Some(results[1].option_id));
+    }
+
+    /// All-`NaN` input must not panic; any deterministic option is acceptable.
+    #[test]
+    fn select_winner_all_nan_does_not_panic() {
+        let results = vec![opt(f64::NAN), opt(f64::NAN), opt(f64::NAN)];
+        // Must return *some* option without panicking.
+        assert!(select_winner(&results).is_some());
+    }
+
+    /// Fuzz: random mixes of NaN / +/-inf / normal / subnormal / signed-zero
+    /// weights must never panic the winner selection, and whenever at least
+    /// one finite weight is present the winner must be finite (a NaN/inf must
+    /// never be reported as "highest" over a real result).
+    #[test]
+    fn select_winner_nan_weight_fuzz_never_panics() {
+        // Small deterministic xorshift PRNG — no external rand dependency.
+        let mut state: u64 = 0x9E37_79B9_7F4A_7C15;
+        let mut next = || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            state
+        };
+
+        // Pool of adversarial f64 values that can appear after float math.
+        let pool: [f64; 11] = [
+            f64::NAN,
+            -f64::NAN,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+            0.0,
+            -0.0,
+            1.0,
+            -1.0,
+            f64::MIN_POSITIVE, // subnormal-adjacent
+            f64::MAX,
+            123.456,
+        ];
+
+        for _ in 0..5_000 {
+            let len = (next() % 8) as usize; // 0..=7 options
+            let mut results = Vec::with_capacity(len);
+            let mut max_finite: Option<f64> = None;
+            for _ in 0..len {
+                let w = pool[(next() as usize) % pool.len()];
+                if w.is_finite() {
+                    max_finite = Some(match max_finite {
+                        Some(m) if m >= w => m,
+                        _ => w,
+                    });
+                }
+                results.push(opt(w));
+            }
+
+            // Must never panic.
+            let winner_id = select_winner(&results);
+
+            match (len, &winner_id) {
+                (0, w) => assert!(w.is_none(), "empty input must yield None"),
+                (_, Some(id)) => {
+                    let chosen = results
+                        .iter()
+                        .find(|r| &r.option_id == id)
+                        .expect("winner id must be present in input");
+                    // If any finite weight existed, a NaN must never be picked
+                    // as the winner over a real value.
+                    if max_finite.is_some() {
+                        assert!(
+                            !chosen.weighted_count.is_nan(),
+                            "winner must never be NaN when a finite option exists"
+                        );
+                    }
+                }
+                (_, None) => panic!("non-empty input must yield Some"),
+            }
+        }
     }
 }

--- a/backend/crates/db/tests/record_payment_atomicity_tests.rs
+++ b/backend/crates/db/tests/record_payment_atomicity_tests.rs
@@ -188,7 +188,11 @@ async fn sequential_payments_accumulate_and_mark_paid(pool: PgPool) {
         .expect("query ok")
         .expect("action exists");
 
-    assert_eq!(payments_count(&pool, action_id).await, 2, "both rows persisted");
+    assert_eq!(
+        payments_count(&pool, action_id).await,
+        2,
+        "both rows persisted"
+    );
     assert_eq!(
         action.paid_amount,
         Some(Decimal::new(10000, 2)),
@@ -257,7 +261,10 @@ async fn concurrent_payments_accumulate_without_lost_update(pool: PgPool) {
 
     // 2. Ledger ground truth equals the intended total.
     let ledger = payments_sum(&pool, action_id).await;
-    assert_eq!(ledger, expected_total, "fine_payments ledger == {expected_total}");
+    assert_eq!(
+        ledger, expected_total,
+        "fine_payments ledger == {expected_total}"
+    );
 
     // 3. The crux: the denormalised aggregate must equal the ledger. A lost
     //    update from the non-transactional read-modify-write shows up here as

--- a/backend/crates/db/tests/work_order_rls_repo_tests.rs
+++ b/backend/crates/db/tests/work_order_rls_repo_tests.rs
@@ -339,7 +339,8 @@ async fn service_history_force_rls_blocks_cross_tenant(pool: PgPool) {
     // One COMPLETED work order in org A, keyed by both the equipment and the
     // building — it must surface in both service-history queries for org A and
     // in NEITHER for org B.
-    let _wo_a = seed_completed_work_order(&pool, org_a, bldg_a, equip_a, user_a, "alpha-service").await;
+    let _wo_a =
+        seed_completed_work_order(&pool, org_a, bldg_a, equip_a, user_a, "alpha-service").await;
 
     let repo = WorkOrderRepository::new(pool.clone());
 


### PR DESCRIPTION
## Task
Add NaN-weight fuzz test for /votes/{id}/results to guard partial_cmp().unwrap() panic (Phase 1.5 finding)

## Owner
pm-qa

## Finding & fix
`VoteRepository::calculate_question_result` (in `backend/crates/db/src/repositories/vote.rs`) selected the winning option with:

```rust
.max_by(|a, b| a.weighted_count.partial_cmp(&b.weighted_count).unwrap())
```

`f64::partial_cmp` returns `None` for any comparison involving `NaN`, so a single `NaN` `weighted_count` would `unwrap()`-panic and take down the `/votes/{id}/results` handler. Phase 1.5 flagged this.

This PR:
1. Extracts a small pure helper `select_winner(&[OptionResult]) -> Option<Uuid>` that is NaN-safe by construction — it falls back to a total order (`NaN` treated as smallest, `NaN`-vs-`NaN` → `Equal`) so `max_by` can never trip.
2. Replaces the panicking call site with `select_winner(&option_results)`.
3. Adds a `#[cfg(test)]` unit + fuzz suite, including `select_winner_nan_weight_fuzz_never_panics` — a deterministic 5,000-iteration fuzz over an adversarial f64 pool (NaN, ±NaN, ±inf, ±0.0, subnormal-adjacent, MAX, normals) that asserts the call never panics and a `NaN` is never reported as winner over a finite option.

The unit/fuzz tests are pure (no DB), so they run in CI and locally without Postgres.

## Tested (Band A — fast check)
- `cd backend && cargo check -p db` → exit 0
- `cd backend && cargo test -p db --lib select_winner` → exit 0 (5 passed; 0 failed)
  - select_winner_empty_is_none ok
  - select_winner_picks_highest ok
  - select_winner_real_value_beats_nan ok
  - select_winner_all_nan_does_not_panic ok
  - select_winner_nan_weight_fuzz_never_panics ok

## Built (Band B — full build)
- `cd backend && cargo clippy -p db --lib` → exit 0 (no warnings)
- Band B release build skipped: change is a single-file localized fix + tests, no public API/migration/config touch. The clippy gate above is the substantive non-trivial check.

## CI parity (Band C — hot-path only)
skipped: not a hot-path change in the security/auth/billing sense; it is a panic-hardening fix in a results aggregation path. CI will run the `db` crate tests on push.

## Remote-tested
skipped: ppt-bridge MCP not used.

## Scope drift
`scope-check.sh --owner pm-qa` exits 2: pm-qa's owner-area is `**/tests/**`, but Rust unit tests live inline in `src/...` via `#[cfg(test)] mod tests`, and the one-line panic fix is in production `vote.rs`. This is the idiomatic Rust test location, not a separate `tests/` dir — the drift is expected and confined to a single file. Reviewer to confirm.

## Notes
- The production change is intentionally minimal (one call site swapped for a documented helper); the bulk of the diff is the test module.
- `Cargo.lock` was deliberately NOT included — `cargo check` re-synced workspace version strings (0.3.177 → 0.3.210) unrelated to this task; reverted to keep the PR focused.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B3FMeBnWfkw56ebaZAyA9M)_