### PR TITLE
fix(frontend): resolve test follow-ups #1349 and #1350 (BIT-21)

### DIFF
--- a/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.test.ts
+++ b/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.test.ts
@@ -207,15 +207,10 @@ describe('formatRelativeDate', () => {
   });
 
   it('returns an absolute month-day label beyond a week', () => {
-    // The absolute label is produced by `toLocaleDateString('en-US', …)`,
-    // whose exact text depends on the runtime ICU build. Compare against the
-    // same formatter rather than a hard-coded string so the test cannot drift
-    // with the environment's locale data.
+    // The absolute label is produced by `toLocaleDateString('en-US', …)`.
+    // Assert against the known output for this date to ensure the formatter
+    // logic hasn't changed.
     const old = '2026-05-01T12:00:00Z';
-    const expected = new Date(old).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-    });
-    expect(formatRelativeDate(old, now)).toBe(expected);
+    expect(formatRelativeDate(old, now)).toBe('May 1');
   });
 });

--- a/frontend/apps/ppt-web/src/routes/groups/faults.route.test.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/faults.route.test.tsx
@@ -19,7 +19,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Suspense } from 'react';
 import { MemoryRouter, Routes } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ── i18n ──
 vi.mock('react-i18next', () => ({


### PR DESCRIPTION
Resolves the ppt-web/frontend test follow-ups from the merged-review batch.

- **#1349** — fixed the tautological/self-referential absolute-label test
- **#1350** — added the missing `beforeEach` import in `faults.route.test.tsx`

Closes #1349
Closes #1350

Paperclip: BIT-21 (parent BIT-20). Branch was pushed earlier; PR opened now that GitHub access is provisioned.