### PR TITLE
GH #1376 #1370

### DIFF
--- a/backend/crates/integrations/src/redis.rs
+++ b/backend/crates/integrations/src/redis.rs
@@ -13,6 +13,9 @@ use thiserror::Error;
 use tokio::sync::broadcast;
 use tracing::Instrument;
 use uuid::Uuid;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
 // ============================================================================
 // Configuration
@@ -666,17 +669,79 @@ pub mod channels {
 
 /// Redis pub/sub service (Story 103.4).
 #[derive(Clone)]
+
+// ============================================================================
+// In-Memory Pub/Sub (for CI/testing)
+// ============================================================================
+
+/// In-memory message broker for testing without a real Redis.
+pub struct InMemoryBroker {
+    senders: Mutex<HashMap<String, broadcast::Sender<PubSubMessage>>>,
+}
+
+impl InMemoryBroker {
+    /// Create a new in-memory broker.
+    pub fn new() -> Self {
+        Self {
+            senders: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Get or create a sender for the given channel.
+    async fn get_sender(&self, channel: &str) -> broadcast::Sender<PubSubMessage> {
+        let mut senders = self.senders.lock().await;
+        if let Some(sender) = senders.get(channel) {
+            sender.clone()
+        } else {
+            let (tx, _) = broadcast::channel(100);
+            senders.insert(channel.to_string(), tx.clone());
+            tx
+        }
+    }
+}
+
+impl Default for InMemoryBroker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Clone)]
+enum PubSubBackend {
+    Redis(RedisClient),
+    InMemory(Arc<InMemoryBroker>),
+}
+
 pub struct PubSubService {
-    client: RedisClient,
+    inner: PubSubBackend,
     instance_id: String,
 }
 
 impl PubSubService {
-    /// Create a new pub/sub service.
+    /// Create a new pub/sub service using Redis.
     pub fn new(client: RedisClient) -> Self {
         let instance_id = Uuid::new_v4().to_string();
         Self {
-            client,
+            inner: PubSubBackend::Redis(client),
+            instance_id,
+        }
+    }
+
+    /// Create an in-memory pub/sub service (Story 1376).
+    pub fn in_memory() -> Self {
+        let instance_id = Uuid::new_v4().to_string();
+        Self {
+            inner: PubSubBackend::InMemory(Arc::new(InMemoryBroker::new())),
+            instance_id,
+        }
+    }
+
+    /// Create with an explicit in-memory broker (Story 1376).
+    /// Use this to share a broker between multiple service instances (e.g. publisher and observer).
+    pub fn with_broker(broker: Arc<InMemoryBroker>) -> Self {
+        let instance_id = Uuid::new_v4().to_string();
+        Self {
+            inner: PubSubBackend::InMemory(broker),
             instance_id,
         }
     }
@@ -684,7 +749,7 @@ impl PubSubService {
     /// Create with a custom instance ID.
     pub fn with_instance_id(client: RedisClient, instance_id: impl Into<String>) -> Self {
         Self {
-            client,
+            inner: PubSubBackend::Redis(client),
             instance_id: instance_id.into(),
         }
     }
@@ -702,11 +767,19 @@ impl PubSubService {
             ..message
         };
 
-        let serialized = serde_json::to_string(&message_with_source)
-            .map_err(|e| CacheError::Serialization(e.to_string()))?;
+        match &self.inner {
+            PubSubBackend::Redis(client) => {
+                let serialized = serde_json::to_string(&message_with_source)
+                    .map_err(|e| CacheError::Serialization(e.to_string()))?;
 
-        let mut conn = self.client.connection_manager.clone();
-        let _: () = conn.publish(&full_channel, &serialized).await?;
+                let mut conn = client.connection_manager.clone();
+                let _: () = conn.publish(&full_channel, &serialized).await?;
+            }
+            PubSubBackend::InMemory(broker) => {
+                let tx = broker.get_sender(channel).await;
+                let _ = tx.send(message_with_source.clone());
+            }
+        }
 
         tracing::debug!(
             channel = %full_channel,
@@ -741,52 +814,73 @@ impl PubSubService {
     ) -> Result<broadcast::Receiver<PubSubMessage>, CacheError> {
         let full_channel = self.build_channel(channel);
         let instance_id = self.instance_id.clone();
-        let url = self.client.config.url.clone();
 
-        // Create a broadcast channel for distributing messages
-        let (tx, rx) = broadcast::channel::<PubSubMessage>(100);
+        match &self.inner {
+            PubSubBackend::Redis(client) => {
+                let url = client.config.url.clone();
 
-        // Create a new client for subscription (pub/sub requires dedicated connection)
-        let client = RedisClientInner::open(url.as_str())
-            .map_err(|e| CacheError::Connection(format!("Failed to create client: {}", e)))?;
+                // Create a broadcast channel for distributing messages
+                let (tx, rx) = broadcast::channel::<PubSubMessage>(100);
 
-        let mut pubsub = client
-            .get_async_pubsub()
-            .await
-            .map_err(|e| CacheError::Connection(format!("Failed to get connection: {}", e)))?;
+                // Create a new client for subscription (pub/sub requires dedicated connection)
+                let client = RedisClientInner::open(url.as_str())
+                    .map_err(|e| CacheError::Connection(format!("Failed to create client: {}", e)))?;
 
-        pubsub
-            .subscribe(&full_channel)
-            .await
-            .map_err(|e| CacheError::PubSub(format!("Subscribe failed: {}", e)))?;
+                let mut pubsub = client
+                    .get_async_pubsub()
+                    .await
+                    .map_err(|e| CacheError::Connection(format!("Failed to get connection: {}", e)))?;
 
-        tracing::info!(channel = %full_channel, "Subscribed to channel");
+                pubsub
+                    .subscribe(&full_channel)
+                    .await
+                    .map_err(|e| CacheError::PubSub(format!("Subscribe failed: {}", e)))?;
 
-        // Spawn a task to forward messages
-        let span_channel = full_channel.clone();
-        tokio::spawn(
-            async move {
-                let mut pubsub_stream = pubsub.into_on_message();
+                tracing::info!(channel = %full_channel, "Subscribed to channel");
 
-                while let Some(msg) = futures_lite::StreamExt::next(&mut pubsub_stream).await {
-                    let payload: Result<String, RedisError> = msg.get_payload();
-                    if let Ok(payload) = payload {
-                        if let Ok(message) = serde_json::from_str::<PubSubMessage>(&payload) {
-                            // Filter out messages from same instance
-                            if message.source_instance.as_ref() != Some(&instance_id) {
-                                let _ = tx.send(message);
+                // Spawn a task to forward messages
+                let span_channel = full_channel.clone();
+                tokio::spawn(
+                    async move {
+                        let mut pubsub_stream = pubsub.into_on_message();
+
+                        while let Some(msg) = futures_lite::StreamExt::next(&mut pubsub_stream).await {
+                            let payload: Result<String, RedisError> = msg.get_payload();
+                            if let Ok(payload) = payload {
+                                if let Ok(message) = serde_json::from_str::<PubSubMessage>(&payload) {
+                                    // Filter out messages from same instance
+                                    if message.source_instance.as_ref() != Some(&instance_id) {
+                                        let _ = tx.send(message);
+                                    }
+                                }
                             }
                         }
                     }
-                }
-            }
-            .instrument(tracing::info_span!(
-                "bg.redis_pubsub",
-                channel = %span_channel,
-            )),
-        );
+                    .instrument(tracing::info_span!(
+                        "bg.redis_pubsub",
+                        channel = %span_channel,
+                    )),
+                );
 
-        Ok(rx)
+                Ok(rx)
+            }
+            PubSubBackend::InMemory(broker) => {
+                let tx = broker.get_sender(channel).await;
+                let mut rx = tx.subscribe();
+                let (filtered_tx, filtered_rx) = broadcast::channel(100);
+
+                tokio::spawn(async move {
+                    while let Ok(message) = rx.recv().await {
+                        // Filter out messages from same instance
+                        if message.source_instance.as_ref() != Some(&instance_id) {
+                            let _ = filtered_tx.send(message);
+                        }
+                    }
+                });
+
+                Ok(filtered_rx)
+            }
+        }
     }
 
     /// Broadcast cache invalidation (Story 103.4).

--- a/backend/servers/api-server/src/state.rs
+++ b/backend/servers/api-server/src/state.rs
@@ -560,6 +560,13 @@ impl AppState {
     /// Set Redis client and derived services (Epic 103).
     ///
     /// Call this after creating the AppState if Redis is available.
+
+    /// Set a custom pub/sub service (Story 1376).
+    pub fn with_pubsub(mut self, pubsub_service: PubSubService) -> Self {
+        self.pubsub_service = Some(pubsub_service);
+        self
+    }
+
     pub fn with_redis(mut self, redis_client: RedisClient) -> Self {
         let session_store = SessionStore::new(redis_client.clone());
         let pubsub_service = PubSubService::new(redis_client.clone());

--- a/backend/servers/api-server/tests/common/mod.rs
+++ b/backend/servers/api-server/tests/common/mod.rs
@@ -157,6 +157,57 @@ impl TestApp {
     pub fn patch(&self, uri: &str) -> RequestBuilder {
         RequestBuilder::new(Method::PATCH, uri)
     }
+
+    /// Create an authenticated session for the given token and org (Story 1370).
+    pub fn session(&self, token: String, org_id: Uuid) -> AuthenticatedSession {
+        AuthenticatedSession::new(self, token, org_id)
+    }
+}
+
+/// A session authenticated for a specific user and tenant (Story 1370).
+///
+/// Use this to build requests that automatically include both the Bearer
+/// token and the `X-Tenant-ID` header, preventing "forgotten header" bugs in
+/// RLS-aware integration tests.
+pub struct AuthenticatedSession<'a> {
+    app: 'a TestApp,
+    token: String,
+    org_id: Uuid,
+}
+
+impl<'a> AuthenticatedSession<'a> {
+    pub fn new(app: 'a TestApp, token: String, org_id: Uuid) -> Self {
+        Self { app, token, org_id }
+    }
+
+    /// Create a GET request with session credentials.
+    pub fn get(&self, uri: &str) -> RequestBuilder {
+        self.app.get(uri).bearer(&self.token).tenant(self.org_id)
+    }
+
+    /// Create a POST request with session credentials.
+    pub fn post(&self, uri: &str) -> RequestBuilder {
+        self.app.post(uri).bearer(&self.token).tenant(self.org_id)
+    }
+
+    /// Create a PUT request with session credentials.
+    pub fn put(&self, uri: &str) -> RequestBuilder {
+        self.app.put(uri).bearer(&self.token).tenant(self.org_id)
+    }
+
+    /// Create a PATCH request with session credentials.
+    pub fn patch(&self, uri: &str) -> RequestBuilder {
+        self.app.patch(uri).bearer(&self.token).tenant(self.org_id)
+    }
+
+    /// Create a DELETE request with session credentials.
+    pub fn delete(&self, uri: &str) -> RequestBuilder {
+        self.app.delete(uri).bearer(&self.token).tenant(self.org_id)
+    }
+
+    pub fn org_id(&self) -> Uuid {
+        self.org_id
+    }
 }
 
 /// Request builder for test requests.

--- a/backend/servers/api-server/tests/notification_preference_realtime_sync_tests.rs
+++ b/backend/servers/api-server/tests/notification_preference_realtime_sync_tests.rs
@@ -754,3 +754,91 @@ async fn preference_update_publishes_realtime_event(pool: PgPool) {
         "S4: a different user's channel must not receive this preference.updated event"
     );
 }
+
+// ============================================================================
+// S12 — (CI Coverage) preference update publishes realtime event via in-memory
+// ============================================================================
+
+/// CI-runnable version of S4: exercises the publish leg using an in-memory
+/// broker instead of a real Redis. Proves the event is published to the
+/// correct channel with the correct payload (Story 1376).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn preference_update_publishes_realtime_event_in_memory(pool: PgPool) {
+    use integrations::{PubSubService, InMemoryBroker};
+    use std::sync::Arc;
+    use tokio::time::{timeout, Duration};
+
+    // Shared in-memory broker for publisher and observer.
+    let broker = Arc::new(InMemoryBroker::new());
+
+    // Build a TestApp with the in-memory pubsub service.
+    let app = {
+        use api_server::services::{EmailService, JwtService};
+        use api_server::state::AppState;
+
+        let config = common::TestConfig::default();
+        let _ = TestApp::new(pool.clone()).await;
+
+        let email_service = EmailService::new(config.base_url.clone(), config.email_enabled);
+        let jwt_service = JwtService::new(&config.jwt_secret).unwrap();
+        let tenant_cache = Arc::new(api_core::middleware::TenantResolutionCache::new(
+            300, 30, 10_000,
+        ));
+        let tenant_rate_limiters =
+            Arc::new(api_core::middleware::TenantRateLimiterSet::new());
+        let state = AppState::new(
+            pool.clone(),
+            email_service,
+            jwt_service,
+            tenant_cache,
+            tenant_rate_limiters,
+        )
+        .with_pubsub(PubSubService::with_broker(broker.clone()));
+
+        let router =
+            api_server::create_router(state).layer(axum::extract::connect_info::MockConnectInfo(
+                std::net::SocketAddr::from(([127, 0, 0, 1], 0)),
+            ));
+        TestApp {
+            router,
+            pool: pool.clone(),
+            config,
+        }
+    };
+
+    let user = TestUser::new();
+    let (access_token, org) = create_authenticated_user_with_org(&app, &user, "s12").await;
+
+    // Resolve user id.
+    let user_id: uuid::Uuid = sqlx::query_scalar("SELECT id FROM users WHERE email = ")
+        .bind(&user.email)
+        .fetch_one(&app.pool)
+        .await
+        .expect("lookup user id");
+
+    // Independent observer using the SAME broker but a DIFFERENT instance_id
+    // (PubSubService::with_broker generates a new instance_id).
+    let observer = PubSubService::with_broker(broker.clone());
+    let mut rx = observer
+        .subscribe(&format!("notifications:{user_id}"))
+        .await
+        .expect("subscribe");
+
+    // Disable the email channel.
+    let session = app.session(access_token, org);
+    let req = session
+        .patch("/api/v1/users/me/notification-preferences/email")
+        .json(json!({ "enabled": false, "confirmDisableAll": false }))
+        .build();
+    app.execute(req).await.assert_status(StatusCode::OK);
+
+    // The observer must receive the event.
+    let received = timeout(Duration::from_secs(1), rx.recv())
+        .await
+        .expect("preference.updated must arrive")
+        .expect("message should be present");
+
+    assert_eq!(received.event_type, "preference.updated");
+    assert_eq!(received.payload["channel"], json!("email"));
+    assert_eq!(received.payload["enabled"], json!(false));
+}

--- a/backend/servers/api-server/tests/report_schedule_sibling_scope_tests.rs
+++ b/backend/servers/api-server/tests/report_schedule_sibling_scope_tests.rs
@@ -163,14 +163,7 @@ fn tenant_req(method: Method, uri: &str, org_id: Uuid) -> Request<Body> {
         .unwrap()
 }
 
-/// Build an authenticated request: Bearer JWT + `X-Tenant-ID` of the caller's
-/// own org. The handler reaches the repository, and the org-scoped WHERE
-/// clause must filter out resources belonging to other orgs.
-fn auth_req(method: Method, uri: &str, caller_org_id: Uuid, access_token: &str) -> Request<Body> {
-    Request::builder()
-        .method(method)
-        .uri(uri)
-        .header(header::AUTHORIZATION, format!("Bearer {}", access_token))
+", access_token))
         .header("X-Tenant-ID", caller_org_id.to_string())
         .header(header::CONTENT_TYPE, "application/json")
         .body(Body::empty())
@@ -585,12 +578,8 @@ async fn pause_schedule_cross_tenant_authenticated_returns_404(pool: PgPool) {
     let attacker_id = user_id_for(&pool, &attacker.email).await;
     seed_membership(&pool, org_b, attacker_id, "manager").await;
 
-    let req = auth_req(
-        Method::PUT,
-        &format!("/api/v1/reports/schedules/{}/pause", schedule_in_a),
-        org_b,
-        &access_token,
-    );
+    let session = app.session(access_token.to_string(), org_b);
+    let req = session.put(&format!("/api/v1/reports/schedules/{}/pause", schedule_in_a)).build();
     let response = app.execute(req).await;
 
     assert_eq!(
@@ -660,12 +649,8 @@ async fn resume_schedule_cross_tenant_authenticated_returns_404(pool: PgPool) {
     let attacker_id = user_id_for(&pool, &attacker.email).await;
     seed_membership(&pool, org_b, attacker_id, "manager").await;
 
-    let req = auth_req(
-        Method::PUT,
-        &format!("/api/v1/reports/schedules/{}/resume", schedule_in_a),
-        org_b,
-        &access_token,
-    );
+    let session = app.session(access_token.to_string(), org_b);
+    let req = session.put(&format!("/api/v1/reports/schedules/{}/resume", schedule_in_a)).build();
     let response = app.execute(req).await;
 
     assert_eq!(
@@ -723,12 +708,8 @@ async fn list_executions_cross_tenant_authenticated_returns_404(pool: PgPool) {
     let attacker_id = user_id_for(&pool, &attacker.email).await;
     seed_membership(&pool, org_b, attacker_id, "manager").await;
 
-    let req = auth_req(
-        Method::GET,
-        &format!("/api/v1/reports/schedules/{}/executions", schedule_in_a),
-        org_b,
-        &access_token,
-    );
+    let session = app.session(access_token.to_string(), org_b);
+    let req = session.get(&format!("/api/v1/reports/schedules/{}/executions", schedule_in_a)).build();
     let response = app.execute(req).await;
 
     assert_eq!(
@@ -775,12 +756,8 @@ async fn get_execution_cross_tenant_authenticated_returns_404(pool: PgPool) {
     let attacker_id = user_id_for(&pool, &attacker.email).await;
     seed_membership(&pool, org_b, attacker_id, "Resident").await;
 
-    let req = auth_req(
-        Method::GET,
-        &format!("/api/v1/reports/executions/{}", execution_in_a),
-        org_b,
-        &access_token,
-    );
+    let session = app.session(access_token.to_string(), org_b);
+    let req = session.get(&format!("/api/v1/reports/executions/{}", execution_in_a)).build();
     let response = app.execute(req).await;
 
     assert_eq!(
@@ -826,12 +803,8 @@ async fn get_execution_download_url_cross_tenant_authenticated_returns_404(pool:
     let attacker_id = user_id_for(&pool, &attacker.email).await;
     seed_membership(&pool, org_b, attacker_id, "Resident").await;
 
-    let req = auth_req(
-        Method::GET,
-        &format!("/api/v1/reports/executions/{}/download", execution_in_a),
-        org_b,
-        &access_token,
-    );
+    let session = app.session(access_token.to_string(), org_b);
+    let req = session.get(&format!("/api/v1/reports/executions/{}/download", execution_in_a)).build();
     let response = app.execute(req).await;
 
     assert_eq!(
@@ -879,12 +852,8 @@ async fn retry_execution_cross_tenant_authenticated_returns_404(pool: PgPool) {
     let attacker_id = user_id_for(&pool, &attacker.email).await;
     seed_membership(&pool, org_b, attacker_id, "manager").await;
 
-    let req = auth_req(
-        Method::POST,
-        &format!("/api/v1/reports/executions/{}/retry", execution_in_a),
-        org_b,
-        &access_token,
-    );
+    let session = app.session(access_token.to_string(), org_b);
+    let req = session.post(&format!("/api/v1/reports/executions/{}/retry", execution_in_a)).build();
     let response = app.execute(req).await;
 
     assert_eq!(

--- a/backend/servers/api-server/tests/vendor_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/vendor_cross_org_idor_tests.rs
@@ -334,15 +334,9 @@ async fn get_vendor_for_own_org_succeeds(pool: PgPool) {
     let vendor_a = seed_vendor(&pool, org_a).await;
 
     let token_a = mint_token(user_a, "own-a@vendor-idor.test");
+    let session_a = app.session(token_a, org_a);
     let uri = format!("/api/v1/vendors/{vendor_a}");
-    let resp = app
-        .execute(
-            app.get(&uri)
-                .bearer(&token_a)
-                .header("X-Tenant-ID", &org_a.to_string())
-                .build(),
-        )
-        .await;
+    let resp = app.execute(session_a.get(&uri).build()).await;
 
     assert_eq!(
         resp.status,


### PR DESCRIPTION
Adds CI-executable test for realtime preference-sync publish leg; introduces tenant-aware request helper that sets X-Tenant-ID by default, migrates sample RLS tests to use it. Closes #1376, closes #1370.