### PR TITLE
fix(work-orders): add explicit org gate to service-history endpoints (#1372)

### DIFF
--- a/backend/servers/api-server/src/routes/work_orders.rs
+++ b/backend/servers/api-server/src/routes/work_orders.rs
@@ -1063,26 +1063,39 @@ async fn get_equipment_service_history(
     Path(equipment_id): Path<Uuid>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<Vec<ServiceHistoryEntry>>, (StatusCode, Json<ErrorResponse>)> {
-    let out = state
-        .work_order_repo
-        .get_service_history(
-            &mut **rls.conn(),
-            equipment_id,
-            query.limit.unwrap_or(50),
-            query.offset.unwrap_or(0),
+    let uid = rls.user_id();
+    let out: Result<Json<Vec<ServiceHistoryEntry>>, (StatusCode, Json<ErrorResponse>)> = async {
+        // Resolve the owning org before touching RLS — 404 on unknown id, 403 for cross-org.
+        let org_id: Option<Uuid> = sqlx::query_scalar(
+            "SELECT organization_id FROM equipment WHERE id = $1",
         )
+        .bind(equipment_id)
+        .fetch_optional(&state.db)
         .await
-        .map(Json)
         .map_err(|e| {
-            tracing::error!("Failed to get service history: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DB_ERROR",
-                    "Failed to get service history",
-                )),
+            tracing::error!(error = ?e, "Failed to look up equipment org");
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(ErrorResponse::new("DB_ERROR", "Database error")))
+        })?;
+        let org_id = org_id.ok_or_else(|| {
+            (StatusCode::NOT_FOUND, Json(ErrorResponse::new("NOT_FOUND", "Equipment not found")))
+        })?;
+        verify_org_access(&state, uid, org_id).await?;
+        state
+            .work_order_repo
+            .get_service_history(
+                &mut **rls.conn(),
+                equipment_id,
+                query.limit.unwrap_or(50),
+                query.offset.unwrap_or(0),
             )
-        });
+            .await
+            .map(Json)
+            .map_err(|e| {
+                tracing::error!("Failed to get service history: {:?}", e);
+                (StatusCode::INTERNAL_SERVER_ERROR, Json(ErrorResponse::new("DB_ERROR", "Failed to get service history")))
+            })
+    }
+    .await;
     rls.release().await;
     out
 }
@@ -1093,26 +1106,39 @@ async fn get_building_service_history(
     Path(building_id): Path<Uuid>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<Vec<ServiceHistoryEntry>>, (StatusCode, Json<ErrorResponse>)> {
-    let out = state
-        .work_order_repo
-        .get_building_service_history(
-            &mut **rls.conn(),
-            building_id,
-            query.limit.unwrap_or(50),
-            query.offset.unwrap_or(0),
+    let uid = rls.user_id();
+    let out: Result<Json<Vec<ServiceHistoryEntry>>, (StatusCode, Json<ErrorResponse>)> = async {
+        // Resolve the owning org before touching RLS — 404 on unknown id, 403 for cross-org.
+        let org_id: Option<Uuid> = sqlx::query_scalar(
+            "SELECT organization_id FROM buildings WHERE id = $1",
         )
+        .bind(building_id)
+        .fetch_optional(&state.db)
         .await
-        .map(Json)
         .map_err(|e| {
-            tracing::error!("Failed to get service history: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "DB_ERROR",
-                    "Failed to get service history",
-                )),
+            tracing::error!(error = ?e, "Failed to look up building org");
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(ErrorResponse::new("DB_ERROR", "Database error")))
+        })?;
+        let org_id = org_id.ok_or_else(|| {
+            (StatusCode::NOT_FOUND, Json(ErrorResponse::new("NOT_FOUND", "Building not found")))
+        })?;
+        verify_org_access(&state, uid, org_id).await?;
+        state
+            .work_order_repo
+            .get_building_service_history(
+                &mut **rls.conn(),
+                building_id,
+                query.limit.unwrap_or(50),
+                query.offset.unwrap_or(0),
             )
-        });
+            .await
+            .map(Json)
+            .map_err(|e| {
+                tracing::error!("Failed to get building service history: {:?}", e);
+                (StatusCode::INTERNAL_SERVER_ERROR, Json(ErrorResponse::new("DB_ERROR", "Failed to get building service history")))
+            })
+    }
+    .await;
     rls.release().await;
     out
 }

--- a/backend/servers/api-server/tests/work_order_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/work_order_cross_org_idor_tests.rs
@@ -412,3 +412,159 @@ async fn get_work_order_same_org_succeeds(pool: PgPool) {
         "#821: same-org GET must return the requested work order"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Fixtures (service-history)
+// ---------------------------------------------------------------------------
+
+async fn seed_equipment(pool: &PgPool, org_id: Uuid, building_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO equipment (organization_id, building_id, name, category)
+        VALUES ($1, $2, 'Test HVAC Unit', 'hvac')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(building_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed equipment")
+}
+
+async fn seed_completed_work_order(pool: &PgPool, org_id: Uuid, building_id: Uuid, equipment_id: Uuid, created_by: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO work_orders
+            (organization_id, building_id, equipment_id, title, description, created_by, status, completed_at)
+        VALUES ($1, $2, $3, 'Service visit', 'Completed maintenance', $4, 'completed', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(building_id)
+    .bind(equipment_id)
+    .bind(created_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed completed work order")
+}
+
+// ---------------------------------------------------------------------------
+// GH #1372 — service-history cross-org negative coverage
+// ---------------------------------------------------------------------------
+
+/// An attacker in Org B requests service history for equipment owned by Org A.
+/// The handler resolves the equipment's org and calls verify_org_access; the
+/// attacker is not an Org A member, so the request is rejected with 403.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn equipment_service_history_cross_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org_a = seed_org(&pool, "svc-a").await;
+    let org_b = seed_org(&pool, "svc-b").await;
+
+    // Attacker is a member of Org B only.
+    let attacker = TestUser::new();
+    let (b_token, _) = create_authenticated_user(&app, &attacker).await;
+    let attacker_id = user_id_for(&pool, &attacker.email).await;
+    seed_membership(&pool, org_b, attacker_id, "member").await;
+
+    // Legitimate owner in Org A creates equipment.
+    let owner = TestUser::new();
+    let (_, _) = create_authenticated_user(&app, &owner).await;
+    let owner_id = user_id_for(&pool, &owner.email).await;
+    seed_membership(&pool, org_a, owner_id, "manager").await;
+    let building_a = seed_building(&pool, org_a).await;
+    let equipment_a = seed_equipment(&pool, org_a, building_a).await;
+
+    let response = app
+        .execute(
+            app.get(&format!("/api/v1/work-orders/equipment/{}/service-history", equipment_a))
+                .bearer(&b_token)
+                .header("X-Tenant-ID", &org_b.to_string())
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::FORBIDDEN,
+        "#1372: cross-org equipment service history must be rejected (403), got {} body={}",
+        response.status,
+        response.text()
+    );
+}
+
+/// An attacker in Org B requests service history for a building owned by Org A.
+/// Same pattern as equipment — 403 before any repo call.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn building_service_history_cross_org_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org_a = seed_org(&pool, "bsvc-a").await;
+    let org_b = seed_org(&pool, "bsvc-b").await;
+
+    let attacker = TestUser::new();
+    let (b_token, _) = create_authenticated_user(&app, &attacker).await;
+    let attacker_id = user_id_for(&pool, &attacker.email).await;
+    seed_membership(&pool, org_b, attacker_id, "member").await;
+
+    let owner = TestUser::new();
+    let (_, _) = create_authenticated_user(&app, &owner).await;
+    let owner_id = user_id_for(&pool, &owner.email).await;
+    seed_membership(&pool, org_a, owner_id, "manager").await;
+    let building_a = seed_building(&pool, org_a).await;
+
+    let response = app
+        .execute(
+            app.get(&format!("/api/v1/work-orders/buildings/{}/service-history", building_a))
+                .bearer(&b_token)
+                .header("X-Tenant-ID", &org_b.to_string())
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::FORBIDDEN,
+        "#1372: cross-org building service history must be rejected (403), got {} body={}",
+        response.status,
+        response.text()
+    );
+}
+
+/// A member of Org A reading Org A equipment service history succeeds — proves
+/// the fix does not over-block legitimate same-org access.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn equipment_service_history_same_org_succeeds(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org_a = seed_org(&pool, "svc-same").await;
+
+    let member = TestUser::new();
+    let (token, _) = create_authenticated_user(&app, &member).await;
+    let member_id = user_id_for(&pool, &member.email).await;
+    seed_membership(&pool, org_a, member_id, "member").await;
+
+    let building_a = seed_building(&pool, org_a).await;
+    let equipment_a = seed_equipment(&pool, org_a, building_a).await;
+    seed_completed_work_order(&pool, org_a, building_a, equipment_a, member_id).await;
+
+    let response = app
+        .execute(
+            app.get(&format!("/api/v1/work-orders/equipment/{}/service-history", equipment_a))
+                .bearer(&token)
+                .header("X-Tenant-ID", &org_a.to_string())
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::OK,
+        "#1372: same-org equipment service history must succeed (200), got {} body={}",
+        response.status,
+        response.text()
+    );
+}


### PR DESCRIPTION
Resolves GH #1372.

Both `get_equipment_service_history` and `get_building_service_history` previously relied solely on RLS; under the `#[sqlx::test]` superuser pool, `FORCE` RLS is bypassed so org A could read org B's service history. Now both handlers resolve the resource's `organization_id` from `equipment`/`buildings` before acquiring the RLS context and call `verify_org_access` — returning 403 for cross-org callers and 404 for unknown ids.

Three new regression tests: two negative (cross-org 403) and one positive (same-org 200).

Closes #1372.