### PR TITLE
chore(api-server): remove stale RLS baseline entries ai_chat.rs + building_certification.rs (GH #1367)

### DIFF
--- a/backend/scripts/rls-pool-field-baseline.txt
+++ b/backend/scripts/rls-pool-field-baseline.txt
@@ -12,8 +12,6 @@
 # One basename per line. Comments after '#'.
 
 # --- PAP-80 sweep: conversion PRs in flight ---
-ai_chat.rs           # PR #1232 (PAP-144/PAP-145)
-building_certification.rs  # PR #1227 (PAP-144/PAP-145)
 
 # --- PAP-80 sweep: latent raw-pool readers of FORCE-RLS tables (00110-series
 # --- and 00179 migrations), discovered by the PAP-68 detector ---


### PR DESCRIPTION
Resolves GH #1367.

Removes two stale entries from `backend/scripts/rls-pool-field-baseline.txt` — `ai_chat.rs` and `building_certification.rs` — that were already converted to use RLS-context connections but not removed from the known-offenders baseline. Verified with `./scripts/check-rls-enforcement.sh` (exit 0).

Closes #1367.