### PR TITLE
fix(api-server): convert work_orders service-history org-gate to RlsConnection (BIT-56)

### DIFF
--- a/backend/scripts/rls-handler-baseline.txt
+++ b/backend/scripts/rls-handler-baseline.txt
@@ -6,14 +6,6 @@
 # Paths relative to backend/. Baselined files WARN instead of failing
 # --strict; raw-pool access in any file NOT listed here fails CI. When a file
 # is cleaned up, REMOVE its line (the script warns on stale entries).
-
-# work_orders.rs: the service-history org-gate pre-lookups
-# (`SELECT organization_id FROM equipment|buildings WHERE id = $1` on
-# `&state.db`) added by #1372/#1430 to distinguish 404 (unknown id) from 403
-# (cross-org) before authorizing via verify_org_access(). They merged to dev
-# while the trunk was non-compiling (#1426), so the RLS step never ran to flag
-# them. Authorization is enforced by verify_org_access and the data query runs
-# on the caller's RlsConnection, so this is a defense-in-depth style violation,
-# not a cross-tenant data path. Baselined to unblock the trunk (BIT-55);
-# proper RlsConnection conversion tracked as a follow-up.
-servers/api-server/src/routes/work_orders.rs
+#
+# (Empty: work_orders.rs service-history org-gate lookups were converted to the
+# caller's RlsConnection in BIT-56, so they are no longer raw-pool offenders.)

--- a/backend/servers/api-server/src/routes/work_orders.rs
+++ b/backend/servers/api-server/src/routes/work_orders.rs
@@ -1056,6 +1056,17 @@ async fn list_executions(
 // scoped to the caller's org by the row-security policy — closing the #821 P2
 // cross-tenant gap at the database layer (a foreign org's equipment/building id
 // yields an empty history rather than another tenant's service records).
+//
+// BIT-56: the org-gate pre-lookup also runs on the caller's `RlsConnection`
+// (not the raw pool). `equipment` and `buildings` are tenant-isolation RLS
+// tables, so the lookup is scoped to the caller's org: an unknown id AND a
+// foreign-org id both resolve to empty -> 404. This deliberately supersedes
+// #1372's 404-vs-403 split: returning 403 for a foreign-org id is a
+// cross-tenant existence oracle (it confirms the resource exists in another
+// tenant), so 404 for both is the more secure contract. `verify_org_access`
+// is retained as defense-in-depth — under correct RLS the resolved org is
+// always the caller's own, so it is a belt-and-suspenders guard against RLS
+// being misconfigured or disabled.
 
 async fn get_equipment_service_history(
     State(state): State<AppState>,
@@ -1065,11 +1076,12 @@ async fn get_equipment_service_history(
 ) -> Result<Json<Vec<ServiceHistoryEntry>>, (StatusCode, Json<ErrorResponse>)> {
     let uid = rls.user_id();
     let out: Result<Json<Vec<ServiceHistoryEntry>>, (StatusCode, Json<ErrorResponse>)> = async {
-        // Resolve the owning org before touching RLS — 404 on unknown id, 403 for cross-org.
+        // Resolve the owning org on the caller's RLS connection — unknown id
+        // and foreign-org id both resolve to empty -> 404 (see BIT-56 note above).
         let org_id: Option<Uuid> =
             sqlx::query_scalar("SELECT organization_id FROM equipment WHERE id = $1")
                 .bind(equipment_id)
-                .fetch_optional(&state.db)
+                .fetch_optional(&mut **rls.conn())
                 .await
                 .map_err(|e| {
                     tracing::error!(error = ?e, "Failed to look up equipment org");
@@ -1119,11 +1131,12 @@ async fn get_building_service_history(
 ) -> Result<Json<Vec<ServiceHistoryEntry>>, (StatusCode, Json<ErrorResponse>)> {
     let uid = rls.user_id();
     let out: Result<Json<Vec<ServiceHistoryEntry>>, (StatusCode, Json<ErrorResponse>)> = async {
-        // Resolve the owning org before touching RLS — 404 on unknown id, 403 for cross-org.
+        // Resolve the owning org on the caller's RLS connection — unknown id
+        // and foreign-org id both resolve to empty -> 404 (see BIT-56 note above).
         let org_id: Option<Uuid> =
             sqlx::query_scalar("SELECT organization_id FROM buildings WHERE id = $1")
                 .bind(building_id)
-                .fetch_optional(&state.db)
+                .fetch_optional(&mut **rls.conn())
                 .await
                 .map_err(|e| {
                     tracing::error!(error = ?e, "Failed to look up building org");

--- a/backend/servers/api-server/tests/work_order_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/work_order_cross_org_idor_tests.rs
@@ -461,8 +461,13 @@ async fn seed_completed_work_order(
 // ---------------------------------------------------------------------------
 
 /// An attacker in Org B requests service history for equipment owned by Org A.
-/// The handler resolves the equipment's org and calls verify_org_access; the
-/// attacker is not an Org A member, so the request is rejected with 403.
+/// BIT-56 moved the org-gate lookup onto the caller's `RlsConnection`. In
+/// PRODUCTION (app role) the tenant-isolation policy hides the foreign-org row,
+/// so the id resolves to empty and the handler returns 404 (no cross-tenant
+/// existence oracle). Under THIS test's `#[sqlx::test]` superuser pool, `FORCE`
+/// RLS does not bind (see module note), so the row is still visible and the
+/// retained `verify_org_access` defense-in-depth gate rejects with 403. The
+/// test therefore asserts 403 — the floor guaranteed even if RLS were disabled.
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn equipment_service_history_cross_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -499,14 +504,16 @@ async fn equipment_service_history_cross_org_is_rejected(pool: PgPool) {
     assert_eq!(
         response.status,
         StatusCode::FORBIDDEN,
-        "#1372: cross-org equipment service history must be rejected (403), got {} body={}",
+        "BIT-56: cross-org equipment service history rejected by verify_org_access (403) under the superuser test pool; prod returns 404 via RLS-scoped lookup. got {} body={}",
         response.status,
         response.text()
     );
 }
 
 /// An attacker in Org B requests service history for a building owned by Org A.
-/// Same pattern as equipment — 403 before any repo call.
+/// Same pattern as equipment (BIT-56): prod returns 404 via the RLS-scoped
+/// lookup; this superuser test pool bypasses RLS, so `verify_org_access` is the
+/// gate that fires and the assertion is 403.
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn building_service_history_cross_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -540,7 +547,7 @@ async fn building_service_history_cross_org_is_rejected(pool: PgPool) {
     assert_eq!(
         response.status,
         StatusCode::FORBIDDEN,
-        "#1372: cross-org building service history must be rejected (403), got {} body={}",
+        "BIT-56: cross-org building service history rejected by verify_org_access (403) under the superuser test pool; prod returns 404 via RLS-scoped lookup. got {} body={}",
         response.status,
         response.text()
     );


### PR DESCRIPTION
## What

Converts the two service-history org-gate pre-lookups in `work_orders.rs` off the raw pool (`&state.db`) and onto the caller's `RlsConnection` — the RLS-baseline cleanup follow-up to BIT-55.

- `get_equipment_service_history` — `SELECT organization_id FROM equipment WHERE id = $1`
- `get_building_service_history` — `SELECT organization_id FROM buildings WHERE id = $1`

Both now run on `&mut **rls.conn()`, the same connection the data query already uses.

## 404-vs-403 contract (deliberate re-decision)

`equipment` / `buildings` are tenant-isolation RLS tables. In **production** (app role) a foreign-org id is invisible → the lookup resolves to empty → **404**, indistinguishable from an unknown id. This supersedes #1372's cross-org **403**: a 403 is a cross-tenant *existence oracle* (it confirms the resource exists in another tenant), so 404 is the more secure contract (secure-by-default lens). `verify_org_access()` is retained as defense-in-depth.

## Tests

The `#[sqlx::test]` pool connects as **superuser**, so `FORCE` RLS does not bind there (documented in the test module header): the foreign-org row stays visible and `verify_org_access` returns **403**. The two cross-org tests therefore continue to assert **403** — the defense-in-depth floor guaranteed even if RLS were disabled — with docstrings explaining the prod (404) vs test (403) split. No assertion would have observed the prod 404 under a superuser pool.

## Baseline

Removes the `servers/api-server/src/routes/work_orders.rs` line from `scripts/rls-handler-baseline.txt`.

## Verification

`./scripts/check-rls-enforcement.sh --strict` → exit 0, `✓ No RLS violations found`, no `work_orders.rs` handler offender, no stale-baseline warning. (The 32 remaining KNOWN OFFENDERs are the separate `rls-pool-field-baseline.txt` repo list, untouched here.)

Full Rust build/clippy/test runs in CI (no local toolchain on this host; conversion uses the exact `&mut **rls.conn()` idiom already present in these handlers).

## Stacking / merge order

Stacked on #1435 (BIT-55 trunk-fix), which carries the compiling trunk **and** the baseline entry this PR removes. **Blocked by #1435** — merge that first; GitHub will auto-retarget this PR to `dev`.

Closes BIT-56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)