### PR TITLE
fix(research): broaden dispatcher self-test T21 to accept full-task_id epic_prefix

### DIFF
--- a/.research/dispatcher-self-test.sh
+++ b/.research/dispatcher-self-test.sh
@@ -501,7 +501,19 @@ if [ -f "$OBJECTIVE_FILE" ]; then
     case "$EP" in
       NONE) note "objective=NONE (no claimable work)";;
       gap-[0-9]*|pm-*) note "objective epic_prefix='$EP' is well-formed";;
-      *) fail "objective.epic_prefix='$EP' does not match gap-N[a-z]? or pm-<role> or NONE";;
+      "") fail "objective.epic_prefix is empty";;
+      # The dispatcher's epic_prefix() else-branch returns the full task_id,
+      # so the finish-first picker legitimately writes a flat kebab id here
+      # (feat-*/test-*/refactor-*/screen-*/triage-issue-* …). Accept any
+      # non-empty lowercase kebab token; reject malformed shapes (uppercase,
+      # spaces, leading separator) that signal a corrupt objective.json.
+      *)
+        if printf '%s' "$EP" | grep -Eq '^[a-z0-9][a-z0-9._-]*$'; then
+          note "objective epic_prefix='$EP' is a full task_id (epic_prefix else-branch)"
+        else
+          fail "objective.epic_prefix='$EP' is not NONE, gap-N[a-z]?, pm-<role>, or a kebab task_id"
+        fi
+        ;;
     esac
   fi
   echo


### PR DESCRIPTION
## Problem

`#1238` finding 1: T21 in `.research/dispatcher-self-test.sh` rejects the finish-first picker's `feat-*`/`test-*`/`refactor-*` epic_prefixes, so **Phase 3.5's claim-publish gate fails on every finish-first run** that selects a flat-id epic.

The dispatcher's `epic_prefix()` (and the mirroring `pick-target-epic.sh`) has three branches:
- `^gap-N[a-z]?`
- `^pm-<role>-`
- **else: the full `task_id`**

With the current backlog (mostly `feat-*`/`test-*`/`refactor-*` ids, ~1 task/epic), the picker legitimately writes e.g. `objective.epic_prefix="feat-swiftui-keychain-token-storage"`. But T21's `case` only accepted `gap-N[a-z]?`, `pm-<role>`, or `NONE` → hard FAIL.

## Fix

Broaden T21's `case "$EP"` to accept any non-empty lowercase kebab token (the else-branch shape), while still hard-failing on shapes that signal a corrupt `objective.json`:
- empty string
- uppercase / spaces
- leading separator

## Verification

- `feat-*` / `test-gap-hotfix-*` / `refactor-*` / `triage-issue-*` / `screen-*` epic_prefixes → **pass** (new `ok` note).
- `Feat-Bad-Caps`, `has space`, `-leading-hyphen` → still **FAIL**.
- Full `dispatcher-self-test.sh` on `origin/dev` base: identical result with/without this change apart from T21 — the one remaining FAIL is the pre-existing `#583` action-list `dependency`/`depends_on` data leak, unchanged by this PR.

Scope is `.research/dispatcher-self-test.sh` (outside the dispatcher's own `.research/management/**` commit scope), so it's a standalone PR exactly as the issue recommended.

Addresses #1238 (finding 1). Findings 2–4 are environment-specific (gh-unavailable / git-push-403 / MCP truncation) and remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)