### PR TITLE
test(forms): submit non-empty data to satisfy chk_submission_data_not_empty (BIT-60)

### DIFF
--- a/backend/crates/db/tests/form_rls_repo_tests.rs
+++ b/backend/crates/db/tests/form_rls_repo_tests.rs
@@ -242,7 +242,7 @@ async fn form_repo_force_rls_deny_all_and_fix(pool: PgPool) {
                     building_id: None,
                     unit_id: None,
                     data: SubmitForm {
-                        data: json!({}),
+                        data: json!({ "q1": "answer" }),
                         attachments: None,
                         signature_data: None,
                     },

--- a/backend/servers/api-server/tests/form_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/form_cross_org_idor_tests.rs
@@ -72,7 +72,7 @@ async fn submit_form_same_org_succeeds(pool: PgPool) {
         .execute(
             app.session(token, org_id)
                 .post(&format!("/api/v1/forms/{form_id}/submit"))
-                .json(json!({ "data": {} }))
+                .json(json!({ "data": { "q1": "answer" } }))
                 .build(),
         )
         .await;
@@ -107,7 +107,7 @@ async fn submit_form_cross_org_is_not_found_and_does_not_insert(pool: PgPool) {
         .execute(
             app.session(attacker_token, org_b)
                 .post(&format!("/api/v1/forms/{form_id}/submit"))
-                .json(json!({ "data": {} }))
+                .json(json!({ "data": { "q1": "answer" } }))
                 .build(),
         )
         .await;


### PR DESCRIPTION
Fixes the two advisory \`test\`-job failures surfaced once the suite compiled again after the trunk repair (#1435).

## Cause
`form_submissions` has a long-standing `CHECK (data != '{}'::jsonb)` (migration 00066). Two form-submit tests posted **empty** data, so once they actually ran they failed:
- `db` `form_repo_force_rls_deny_all_and_fix` → submit panics with PG `23514`.
- `api-server` `submit_form_same_org_succeeds` → handler returns 500 instead of 201.

## Fix
Give both tests realistic non-empty submission data (`{ "q1": "answer" }`). The cross-org negative test keeps empty→non-empty too but its behavior is unchanged (404 via org scope before any insert).

Restores the advisory `test` job to green for backend PRs. Closes BIT-60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)