### PR TITLE
pm-devops-pre-push-fmt-gate-scope: add CI fmt+clippy lint gate mirroring local pre-push hook

### DIFF
--- a/.github/workflows/backend-fmt-clippy-gate.yml
+++ b/.github/workflows/backend-fmt-clippy-gate.yml
@@ -1,0 +1,82 @@
+# Backend fmt + clippy lint gate (pm-devops-pre-push-fmt-gate-scope).
+#
+# WHY this exists — the #1426 -> #1437 episode:
+#   PR #1431 (gh-1375) added a *local* pre-push git hook (scripts/pre-push) that
+#   runs `cargo fmt --all -- --check && cargo clippy --workspace -- -D warnings`.
+#   A local hook is bypassable with `git push --no-verify` and never runs on the
+#   merge commit, so a fmt/clippy-breaking change still reached `dev`. This
+#   workflow mirrors that exact gate as a CI status check so it CANNOT be
+#   bypassed — it runs on the GitHub side on every backend PR.
+#
+# HOW it differs from the two adjacent gates (do NOT duplicate them):
+#   - `backend-dev-push-gate.yml` (PR #1452) is the *compile* smoke gate
+#     (`cargo check --workspace --tests`) and fires on PUSH to `dev`. This is the
+#     complementary *lint* (fmt + clippy) gate, and it fires on PULL_REQUEST so
+#     the feedback lands before merge.
+#   - `backend.yml`'s heavyweight `check` job also runs fmt + clippy, but only as
+#     one step inside a long job that boots Docker-Postgres, installs ripgrep, and
+#     runs four RLS/WS enforcement scripts + `cargo check`. This gate is the
+#     minimal, fast, independently-named status check that mirrors the documented
+#     local pre-flight 1:1 — so a fmt/clippy break is surfaced in seconds as a
+#     dedicated red check rather than buried in (and blocked behind) that job.
+#
+# This keeps the existing local hook (scripts/pre-push) in place — the two are
+# defence-in-depth: the hook gives instant local feedback, this gate makes it
+# unbypassable on the merge path.
+name: Backend fmt + clippy gate
+
+on:
+  pull_request:
+    paths:
+      - 'backend/**'
+      # Trigger when this workflow itself changes — otherwise edits here never
+      # fire CI and the PR sits without this status (same rationale as
+      # backend.yml's self-path trigger).
+      - '.github/workflows/backend-fmt-clippy-gate.yml'
+  # Lets maintainers re-run the lint gate on demand (e.g. after a toolchain bump)
+  # without waiting for the next backend/** PR.
+  workflow_dispatch:
+
+# A newer push to the PR branch makes an in-flight run obsolete — cancel it so
+# the gate always reflects the PR's current tip.
+concurrency:
+  group: backend-fmt-clippy-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt-clippy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.94.1
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: backend
+
+      # Mirrors the local pre-push hook (scripts/pre-push) and the documented
+      # pre-flight in CLAUDE.md.
+      - name: Check formatting
+        working-directory: backend
+        run: cargo fmt --all -- --check
+
+      # `--all-targets` includes test/bench targets — the local hook does NOT
+      # pass it (one of the gaps that let lint debt through), so the CI gate is
+      # the stricter mirror and matches backend.yml's clippy step + the
+      # documented `cargo clippy --workspace --all-targets -- -D warnings`
+      # pre-flight. SQLX_OFFLINE keeps it DB-free and fast (the repo uses runtime
+      # sqlx queries — no DATABASE_URL needed for a pure lint).
+      - name: Clippy
+        working-directory: backend
+        env:
+          SQLX_OFFLINE: true
+        run: cargo clippy --workspace --all-targets -- -D warnings


### PR DESCRIPTION
## Task
The local-only pre-push fmt/clippy git hook (#1431) did NOT catch the #1426 -> #1437 compile regression that reached dev. Mirror the fmt+clippy gate as a CI status check so it cannot be bypassed with --no-verify. Add a GitHub Actions workflow (`.github/workflows/backend-fmt-clippy-gate.yml`) running `cargo fmt --all --check` + `cargo clippy --workspace --all-targets -- -D warnings` on pull_request for backend changes. A sibling dev-push *compile* gate (`backend-dev-push-gate.yml`, `cargo check --workspace --tests`, #1452) already exists — this adds the complementary fmt+clippy lint gate. Keeps the existing local hook.

## Owner
pm-devops

## What changed
New workflow `.github/workflows/backend-fmt-clippy-gate.yml`:
- Triggers: `pull_request` filtered to `backend/**` (+ self-path) and `workflow_dispatch`.
- One `fmt-clippy` job: `cargo fmt --all -- --check` then `cargo clippy --workspace --all-targets -- -D warnings` (`SQLX_OFFLINE=true`, DB-free).
- `concurrency` cancel-in-progress so it reflects the PR's current tip.

Defence-in-depth and explicitly non-duplicative:
- vs `backend-dev-push-gate.yml` (#1452): that is the *compile* gate on push-to-dev; this is the *lint* gate on PR.
- vs `backend.yml` `check` job: that runs fmt+clippy buried inside a long Docker-Postgres/RLS job; this is the minimal, independently-named, fast status check that mirrors the local hook 1:1 and surfaces a fmt/clippy break in seconds.
- The local hook (`scripts/pre-push`) is kept — the gate just makes it unbypassable on the merge path (no `--no-verify` / missing-merge-commit gap).
- `--all-targets` is the stricter mirror (the local hook omits it), so test-target lint debt is caught too.

## Tested (Band A — fast check)
- `python3 -c "yaml.safe_load(...)"` -> `YAML OK` (exit 0)
- `git diff --check` -> clean (exit 0)
- actionlint not installed on runner — skipped.

## Built (Band B — full build)
skipped: CI-config-only change, no compilable source touched.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (CI workflow definition only; no security/auth/billing/data-integrity code).

## Scope drift
None — `scope-check.sh --owner pm-devops` exit 0 (`.github/**` is in pm-devops scope).

## Code-reuse review
None — `reuse-grep.sh` exit 0, no added helpers.

## Remote-tested
skipped

## Notes
The workflow's own first run won't appear on this PR unless the PR touches `backend/**`; the `workflow_dispatch` trigger lets a maintainer fire it on demand to confirm it's green. To make it a *required* status check it must be added to the branch-protection rule for `dev` (see `branch-protection-setup.yml`).

https://claude.ai/code/session_01DzvVdG6cwQL6fejLW9hH1r

---
_Generated by [Claude Code](https://claude.ai/code/session_01DzvVdG6cwQL6fejLW9hH1r)_