### PR TITLE
fix(api-server): org-scope create_appeal/add_evidence/add_comment writes (BIT-75, #1342/#1339)

### DIFF
--- a/backend/crates/db/src/repositories/violations.rs
+++ b/backend/crates/db/src/repositories/violations.rs
@@ -408,10 +408,15 @@ impl ViolationRepository {
     // EVIDENCE
     // =========================================================================
 
-    /// Add evidence to a violation.
+    /// Add evidence to a violation (tenant-scoped via parent violation).
+    ///
+    /// The INSERT is gated on the parent `violations` row matching `org_id`, so
+    /// an Org B caller cannot attach evidence to an Org A violation. If no parent
+    /// row matches, no row is inserted and `RowNotFound` is returned.
     pub async fn add_evidence(
         &self,
         violation_id: Uuid,
+        org_id: Uuid,
         req: CreateViolationEvidence,
         uploaded_by: Uuid,
     ) -> Result<ViolationEvidence, sqlx::Error> {
@@ -421,11 +426,14 @@ impl ViolationRepository {
                 violation_id, file_name, file_type, file_size, storage_path,
                 description, captured_at, uploaded_by
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            SELECT v.id, $3, $4, $5, $6, $7, $8, $9
+            FROM violations v
+            WHERE v.id = $1 AND v.organization_id = $2
             RETURNING *
             "#,
         )
         .bind(violation_id)
+        .bind(org_id)
         .bind(&req.file_name)
         .bind(&req.file_type)
         .bind(req.file_size)
@@ -433,8 +441,9 @@ impl ViolationRepository {
         .bind(&req.description)
         .bind(req.captured_at)
         .bind(uploaded_by)
-        .fetch_one(&self.pool)
-        .await
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or(sqlx::Error::RowNotFound)
     }
 
     /// List evidence for a violation.
@@ -636,18 +645,31 @@ impl ViolationRepository {
         let year = Utc::now().format("%Y");
         let appeal_number = format!("APP-{}-{:04}", year, count.0 + 1);
 
-        // Update violation status to disputed
-        sqlx::query("UPDATE violations SET status = 'disputed', updated_at = NOW() WHERE id = $1")
+        // Update violation status to disputed — org-scoped. If the violation
+        // does not belong to this org, no row is updated; bail out *before*
+        // inserting the appeal so an Org B caller cannot cascade onto Org A.
+        let vio_updated = sqlx::query(
+            "UPDATE violations SET status = 'disputed', updated_at = NOW() WHERE id = $1 AND organization_id = $2",
+        )
+        .bind(violation_id)
+        .bind(org_id)
+        .execute(&self.pool)
+        .await?;
+        if vio_updated.rows_affected() == 0 {
+            return Err(sqlx::Error::RowNotFound);
+        }
+
+        // Update enforcement action status if specified — scoped on org and on
+        // the parent violation so the cascade can only touch this org's action.
+        if let Some(action_id) = req.enforcement_action_id {
+            sqlx::query(
+                "UPDATE enforcement_actions SET status = 'appealed', updated_at = NOW() WHERE id = $1 AND organization_id = $2 AND violation_id = $3",
+            )
+            .bind(action_id)
+            .bind(org_id)
             .bind(violation_id)
             .execute(&self.pool)
             .await?;
-
-        // Update enforcement action status if specified
-        if let Some(action_id) = req.enforcement_action_id {
-            sqlx::query("UPDATE enforcement_actions SET status = 'appealed', updated_at = NOW() WHERE id = $1")
-                .bind(action_id)
-                .execute(&self.pool)
-                .await?;
         }
 
         sqlx::query_as::<_, ViolationAppeal>(
@@ -842,27 +864,37 @@ impl ViolationRepository {
     // COMMENTS
     // =========================================================================
 
-    /// Add a comment to a violation.
+    /// Add a comment to a violation (tenant-scoped via parent violation).
+    ///
+    /// The INSERT is gated on the parent `violations` row matching `org_id`, so
+    /// an Org B caller cannot inject a comment (including `is_internal` notes)
+    /// onto an Org A violation. If no parent row matches, no row is inserted and
+    /// `RowNotFound` is returned.
     pub async fn add_comment(
         &self,
         violation_id: Uuid,
+        org_id: Uuid,
         req: CreateViolationComment,
         author_id: Uuid,
     ) -> Result<ViolationComment, sqlx::Error> {
         sqlx::query_as::<_, ViolationComment>(
             r#"
             INSERT INTO violation_comments (violation_id, comment_type, content, is_internal, author_id)
-            VALUES ($1, $2, $3, $4, $5)
+            SELECT v.id, $3, $4, $5, $6
+            FROM violations v
+            WHERE v.id = $1 AND v.organization_id = $2
             RETURNING *
             "#,
         )
         .bind(violation_id)
+        .bind(org_id)
         .bind(&req.comment_type)
         .bind(&req.content)
         .bind(req.is_internal.unwrap_or(false))
         .bind(author_id)
-        .fetch_one(&self.pool)
-        .await
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or(sqlx::Error::RowNotFound)
     }
 
     /// List comments for a violation.

--- a/backend/crates/db/tests/violations_cross_org_idor_tests.rs
+++ b/backend/crates/db/tests/violations_cross_org_idor_tests.rs
@@ -21,9 +21,9 @@
 use chrono::Utc;
 use db::models::violations::{
     AppealStatus, CreateCommunityRule, CreateEnforcementAction, CreateViolation,
-    CreateViolationAppeal, CreateViolationEvidence, EnforcementActionType, RecordFinePayment,
-    UpdateCommunityRule, UpdateEnforcementAction, UpdateViolation, UpdateViolationAppeal,
-    ViolationCategory, ViolationStatus,
+    CreateViolationAppeal, CreateViolationComment, CreateViolationEvidence, EnforcementActionType,
+    RecordFinePayment, UpdateCommunityRule, UpdateEnforcementAction, UpdateViolation,
+    UpdateViolationAppeal, ViolationCategory, ViolationStatus,
 };
 use db::repositories::ViolationRepository;
 use rust_decimal::Decimal;
@@ -209,6 +209,7 @@ async fn violation_cross_org_mutations_rejected(pool: PgPool) {
     let evidence = repo
         .add_evidence(
             violation.id,
+            org_a,
             CreateViolationEvidence {
                 file_name: "photo.jpg".into(),
                 file_type: "image/jpeg".into(),
@@ -221,6 +222,96 @@ async fn violation_cross_org_mutations_rejected(pool: PgPool) {
         )
         .await
         .expect("add evidence");
+
+    // add_evidence cross-org → RowNotFound, and no evidence row is inserted.
+    let res = repo
+        .add_evidence(
+            violation.id,
+            org_b,
+            CreateViolationEvidence {
+                file_name: "inject.jpg".into(),
+                file_type: "image/jpeg".into(),
+                file_size: Some(2048),
+                storage_path: Some("s3://evidence/inject.jpg".into()),
+                description: Some("cross-tenant".into()),
+                captured_at: None,
+            },
+            user_b,
+        )
+        .await;
+    assert!(
+        matches!(res, Err(sqlx::Error::RowNotFound)),
+        "Org B must not add evidence to Org A's violation, got {res:?}"
+    );
+    let injected_evidence: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM violation_evidence WHERE violation_id = $1 AND file_name = 'inject.jpg'",
+    )
+    .bind(violation.id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        injected_evidence, 0,
+        "no evidence row may be inserted cross-tenant"
+    );
+
+    // add_comment cross-org → RowNotFound, and no comment row is inserted
+    // (is_internal comments are a cross-tenant injection vector).
+    let res = repo
+        .add_comment(
+            violation.id,
+            org_b,
+            CreateViolationComment {
+                comment_type: "general".into(),
+                content: "internal cross-tenant note".into(),
+                is_internal: Some(true),
+            },
+            user_b,
+        )
+        .await;
+    assert!(
+        matches!(res, Err(sqlx::Error::RowNotFound)),
+        "Org B must not add a comment to Org A's violation, got {res:?}"
+    );
+    let injected_comments: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM violation_comments WHERE violation_id = $1")
+            .bind(violation.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        injected_comments, 0,
+        "no comment row may be inserted cross-tenant"
+    );
+
+    // The legitimate owner can still add evidence and a comment.
+    repo.add_evidence(
+        violation.id,
+        org_a,
+        CreateViolationEvidence {
+            file_name: "owner.jpg".into(),
+            file_type: "image/jpeg".into(),
+            file_size: Some(512),
+            storage_path: Some("s3://evidence/owner.jpg".into()),
+            description: None,
+            captured_at: None,
+        },
+        user_a,
+    )
+    .await
+    .expect("owner add evidence");
+    repo.add_comment(
+        violation.id,
+        org_a,
+        CreateViolationComment {
+            comment_type: "general".into(),
+            content: "owner note".into(),
+            is_internal: Some(false),
+        },
+        user_a,
+    )
+    .await
+    .expect("owner add comment");
 
     // update_violation cross-org → RowNotFound.
     let res = repo
@@ -399,6 +490,60 @@ async fn appeal_cross_org_mutations_rejected(pool: PgPool) {
         .create_enforcement_action(violation.id, org_a, new_action_req(), user_a)
         .await
         .expect("create action");
+
+    // create_appeal cross-org → RowNotFound, and the cascade must NOT fire:
+    // no appeal row inserted, the violation must stay 'reported', and the
+    // enforcement action must stay 'pending'.
+    let res = repo
+        .create_appeal(
+            violation.id,
+            org_b,
+            CreateViolationAppeal {
+                enforcement_action_id: Some(action.id),
+                reason: "Hijacked appeal".into(),
+                requested_outcome: None,
+                supporting_evidence: None,
+            },
+            user_a,
+        )
+        .await;
+    assert!(
+        matches!(res, Err(sqlx::Error::RowNotFound)),
+        "Org B must not create an appeal against Org A's violation, got {res:?}"
+    );
+    let appeals_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM violation_appeals WHERE violation_id = $1")
+            .bind(violation.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        appeals_count, 0,
+        "no appeal row may be inserted cross-tenant"
+    );
+    let vio_status: ViolationStatus =
+        sqlx::query_scalar("SELECT status FROM violations WHERE id = $1")
+            .bind(violation.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        vio_status,
+        ViolationStatus::Reported,
+        "cross-tenant create_appeal must not flip the violation to disputed"
+    );
+    let action_status: db::models::violations::EnforcementStatus =
+        sqlx::query_scalar("SELECT status FROM enforcement_actions WHERE id = $1")
+            .bind(action.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        action_status,
+        db::models::violations::EnforcementStatus::Pending,
+        "cross-tenant create_appeal must not mark the action appealed"
+    );
+
     let appeal = repo
         .create_appeal(
             violation.id,

--- a/backend/servers/api-server/src/routes/violations.rs
+++ b/backend/servers/api-server/src/routes/violations.rs
@@ -304,12 +304,19 @@ async fn add_evidence(
     Path(violation_id): Path<Uuid>,
     Json(req): Json<CreateViolationEvidence>,
 ) -> ApiResult<Json<db::models::violations::ViolationEvidence>> {
+    let org_id = user
+        .tenant_id
+        .ok_or_else(|| forbidden_error("No organization context"))?;
+
     state
         .violation_repo
-        .add_evidence(violation_id, req, user.user_id)
+        .add_evidence(violation_id, org_id, req, user.user_id)
         .await
+        .map_err(|e| match e {
+            sqlx::Error::RowNotFound => not_found_error("Violation not found"),
+            _ => internal_error(&format!("Failed to add evidence: {}", e)),
+        })
         .map(Json)
-        .map_err(|e| internal_error(&format!("Failed to add evidence: {}", e)))
 }
 
 async fn list_evidence(
@@ -595,12 +602,19 @@ async fn add_comment(
     Path(violation_id): Path<Uuid>,
     Json(req): Json<CreateViolationComment>,
 ) -> ApiResult<Json<db::models::violations::ViolationComment>> {
+    let org_id = user
+        .tenant_id
+        .ok_or_else(|| forbidden_error("No organization context"))?;
+
     state
         .violation_repo
-        .add_comment(violation_id, req, user.user_id)
+        .add_comment(violation_id, org_id, req, user.user_id)
         .await
+        .map_err(|e| match e {
+            sqlx::Error::RowNotFound => not_found_error("Violation not found"),
+            _ => internal_error(&format!("Failed to add comment: {}", e)),
+        })
         .map(Json)
-        .map_err(|e| internal_error(&format!("Failed to add comment: {}", e)))
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## What

Closes the residual cross-org IDOR **write** paths on the violations surface (BIT-75 / parent BIT-68). Fixes GitHub issues **#1342** and **#1339**.

Three `ViolationRepository` mutation handlers keyed their writes on `id`/`violation_id` only, so an authenticated **Org B** caller could mutate/attach to **Org A** rows:

| Handler | Before | After |
|---------|--------|-------|
| `create_appeal` (#1342) | two cascade `UPDATE`s (`violations → disputed`, `enforcement_actions → appealed`) keyed on `id` only | both scoped on `organization_id` (action also on `violation_id`); the `violations` UPDATE returns `RowNotFound` **before** the appeal `INSERT` if no org-owned row matches |
| `add_evidence` (#1339) | `INSERT INTO violation_evidence` keyed on `violation_id` only | `INSERT … SELECT … FROM violations v WHERE v.id=$1 AND v.organization_id=$2` → `RowNotFound`/404 when parent not owned |
| `add_comment` (#1339) | `INSERT INTO violation_comments` keyed on `violation_id` only (`is_internal` → cross-tenant injection vector) | same parent-gated `INSERT … SELECT` |

Routes extract the verified org via `user.tenant_id` and thread it down, mirroring the already-hardened `delete_evidence` / `record_payment`. `RowNotFound` maps to a 404 in the routes.

## IG3 evidence (failing-on-`dev`, green-with-fix)

Extends `backend/crates/db/tests/violations_cross_org_idor_tests.rs`:

- **`violation_cross_org_mutations_rejected`** — adds Org-B `add_evidence` and `add_comment` cases: both assert `RowNotFound`, and a raw `COUNT` (run on the superuser pool that bypasses FORCE-RLS, so a missing `organization_id` predicate would fail the assertion) confirms **zero** rows inserted; the legitimate Org-A owner still succeeds. Also updates the existing org-unscoped `add_evidence` seeding call.
- **`appeal_cross_org_mutations_rejected`** — adds an Org-B `create_appeal` case: asserts `RowNotFound`, **no** appeal row inserted, violation stays `reported`, action stays `pending` (cascade must not fire); the Org-A owner path is unchanged.

Verify:
```
cd backend && cargo test -p db --test violations_cross_org_idor_tests
cd backend && cargo clippy -p db -p api-server --all-targets -- -D warnings
```

> ⚠️ **Local verification note:** this fleet host offloads all `cargo` to a remote builder (`mercury`) that is unreachable this session (no toolchain locally), so `cargo test`/`clippy`/`fmt` could not be run on my machine. The two commits follow the existing rustfmt style and mirror the proven `record_payment`/`delete_evidence` patterns. **CI (`backend.yml`) is the authoritative gate for fmt + clippy + the new tests** — please confirm green before merge. /cc QA for staging/browser verification of the 403 paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
