### PR TITLE
fix(api-server): mfa.rs RLS correction — RlsConnection in verify_recovery_code, unified tx in disable_mfa (BIT-78, #1302/#1304)

### DIFF
--- a/backend/scripts/check-rls-enforcement.sh
+++ b/backend/scripts/check-rls-enforcement.sh
@@ -69,6 +69,13 @@ VIOLATION_PATTERNS=(
     'self\.db\.acquire'
     'self\.db\.pool'
     '&self\.db[^_]'
+    # GH #1302/#1304: raw-pool transaction and clone evasions the patterns above
+    # missed. state.db.begin() opens a transaction with no RLS context; a bare
+    # state.db.clone() hands the raw pool to ad-hoc code. Constructor idiom
+    # (Repo::new(state.db.clone())) and struct-field init are allow-listed in
+    # is_sanctioned() — a *bare* raw-pool extraction is flagged.
+    'state\.db\.begin'
+    'self\.db\.begin'
 )
 
 # Directories to check (request-handling code that should use RLS).

--- a/backend/servers/api-server/src/routes/mfa.rs
+++ b/backend/servers/api-server/src/routes/mfa.rs
@@ -11,6 +11,7 @@ use axum::{
 use common::errors::ErrorResponse;
 use db::models::{AuditAction, CreateAuditLog, CreateTwoFactorAuth};
 use serde::{Deserialize, Serialize};
+use sqlx::Acquire;
 use utoipa::ToSchema;
 
 use crate::state::AppState;
@@ -599,11 +600,16 @@ pub async fn disable_mfa(
         ));
     }
 
-    // Disable MFA and invalidate all recovery codes atomically.
-    // mfa_recovery_codes is user-scoped (no org_id, no FORCE RLS) — raw pool transaction
-    // is equivalent to RLS here; WHERE user_id = $1 from the JWT subject provides the
-    // required isolation (P4 sanctioned, same rationale as confirm_mfa above).
-    let mut tx = state.db.begin().await.map_err(|e| {
+    // Disable MFA and invalidate all recovery codes atomically, on the SAME
+    // RLS connection used above — not a second `state.db.begin()` raw-pool
+    // connection. Keeping the whole auth-critical handler on one connection
+    // means one RLS context: `app.current_user_id` is set, so the self-policies
+    // on `mfa_recovery_codes` / `user_2fa` (migrations 00149 / 00024) enforce,
+    // and the `WHERE user_id = $1` literal is defense-in-depth rather than the
+    // sole isolation (same rationale as verify_mfa_setup above). Both writes
+    // share one transaction so a crash between them cannot leave MFA enabled
+    // with live recovery codes (or recovery codes wiped with MFA still on).
+    let mut tx = (&mut **rls.conn()).begin().await.map_err(|e| {
         tracing::error!(error = %e, "Failed to begin disable transaction");
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -632,21 +638,10 @@ pub async fn disable_mfa(
         )
     })?;
 
-    tx.commit().await.map_err(|e| {
-        tracing::error!(error = %e, "Failed to commit disable transaction");
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new(
-                "DATABASE_ERROR",
-                "Failed to disable MFA",
-            )),
-        )
-    })?;
-
-    // Disable in user_2fa (via RLS connection).
+    // Disable in user_2fa within the SAME transaction.
     state
         .two_factor_repo
-        .disable_rls(&mut **rls.conn(), user_id)
+        .disable_rls(&mut *tx, user_id)
         .await
         .map_err(|e| {
             tracing::error!(error = %e, "Failed to disable MFA");
@@ -658,6 +653,17 @@ pub async fn disable_mfa(
                 )),
             )
         })?;
+
+    tx.commit().await.map_err(|e| {
+        tracing::error!(error = %e, "Failed to commit disable transaction");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to disable MFA",
+            )),
+        )
+    })?;
 
     // Log MFA disabled (Story 9.6 - Audit logging)
     if let Err(e) = state
@@ -992,6 +998,7 @@ pub struct VerifyRecoveryCodeResponse {
 pub async fn verify_recovery_code(
     State(state): State<AppState>,
     headers: axum::http::HeaderMap,
+    mut rls: RlsConnection,
     Json(req): Json<VerifyRecoveryCodeRequest>,
 ) -> Result<Json<VerifyRecoveryCodeResponse>, (StatusCode, Json<ErrorResponse>)> {
     let token = extract_bearer_token(&headers)?;
@@ -1004,25 +1011,22 @@ pub async fn verify_recovery_code(
         )
     })?;
 
-    // Acquire a connection for the user-scoped MFA tables (user_2fa,
-    // mfa_recovery_codes have no org_id and no FORCE RLS). acquire_public clears
-    // any stale RLS context left by a previous request on the pooled connection.
-    let mut conn = db::RlsPool::new(state.db.clone())
-        .acquire_public()
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "recovery/verify: pool acquire failed");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DATABASE_ERROR", "Failed to connect")),
-            )
-        })?;
+    // Run every query on the RLS connection so `app.current_user_id` is set for
+    // the duration of the handler. The self-policies on `user_2fa` /
+    // `mfa_recovery_codes` (migrations 00024 / 00149) gate on
+    // `app.current_user_id`, so this is what makes them enforce — the
+    // `WHERE user_id = $1` literal is then defense-in-depth, not the sole
+    // isolation. (Previously this acquired `acquire_public()`, which *clears*
+    // the GUC — leaving 100% of the isolation on the literal and silently
+    // turning into deny-all the moment these tables get FORCE RLS.)
+    // `rls.release()` is called before every return so the context is cleared
+    // before the connection returns to the pool.
 
     // Verify MFA is enabled for this user.
     let enrolled: Option<bool> =
         sqlx::query_scalar("SELECT enabled FROM user_2fa WHERE user_id = $1")
             .bind(user_id)
-            .fetch_optional(&mut **conn)
+            .fetch_optional(&mut **rls.conn())
             .await
             .map_err(|e| {
                 tracing::error!(error = %e, "recovery/verify: fetch enrollment failed");
@@ -1036,6 +1040,7 @@ pub async fn verify_recovery_code(
             })?;
 
     if !matches!(enrolled, Some(true)) {
+        rls.release().await;
         return Err((
             StatusCode::NOT_FOUND,
             Json(ErrorResponse::new(
@@ -1050,7 +1055,7 @@ pub async fn verify_recovery_code(
         "SELECT id, code_hash FROM mfa_recovery_codes WHERE user_id = $1 AND used_at IS NULL",
     )
     .bind(user_id)
-    .fetch_all(&mut **conn)
+    .fetch_all(&mut **rls.conn())
     .await
     .map_err(|e| {
         tracing::error!(error = %e, "recovery/verify: fetch codes failed");
@@ -1084,6 +1089,7 @@ pub async fn verify_recovery_code(
         {
             tracing::error!(error = %e, "Failed to write audit log for exhausted recovery codes");
         }
+        rls.release().await;
         return Err((
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -1129,6 +1135,7 @@ pub async fn verify_recovery_code(
         {
             tracing::error!(error = %e, "Failed to write audit log for invalid recovery code");
         }
+        rls.release().await;
         return Err((
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -1146,7 +1153,7 @@ pub async fn verify_recovery_code(
         "UPDATE mfa_recovery_codes SET used_at = NOW() WHERE id = $1 AND used_at IS NULL",
     )
     .bind(matched_id)
-    .execute(&mut **conn)
+    .execute(&mut **rls.conn())
     .await
     .map_err(|e| {
         tracing::error!(error = %e, "recovery/verify: mark used failed");
@@ -1175,7 +1182,7 @@ pub async fn verify_recovery_code(
         "SELECT COUNT(*) FROM mfa_recovery_codes WHERE user_id = $1 AND used_at IS NULL",
     )
     .bind(user_id)
-    .fetch_one(&mut **conn)
+    .fetch_one(&mut **rls.conn())
     .await
     .unwrap_or(0);
 
@@ -1202,6 +1209,8 @@ pub async fn verify_recovery_code(
     }
 
     tracing::info!(user_id = %user_id, remaining, "MFA recovery code consumed");
+
+    rls.release().await;
 
     Ok(Json(VerifyRecoveryCodeResponse {
         message: "Recovery code accepted.".to_string(),


### PR DESCRIPTION
## Summary

- **GH #1302**: `verify_recovery_code` was acquiring `acquire_public()` (clears all GUCs) — RLS self-policies on `user_2fa` / `mfa_recovery_codes` were never activated. Now takes the `RlsConnection` extractor so `app.current_user_id` is set for the connection lifetime; both tables' policies enforce as a second line of defence. Future `FORCE ROW LEVEL SECURITY` on these tables will work correctly instead of becoming deny-all.
- **GH #1304**: `disable_mfa` had a split connection model — SELECT on the RLS connection, UPDATE/DELETE in a separate `state.db.begin()` raw-pool transaction. Both writes are now on a single RLS connection transaction: one context, atomic commit. Fixed stale comment reference `confirm_mfa above` → `verify_mfa_setup above`.

## Files changed

- `backend/servers/api-server/src/routes/mfa.rs` — `verify_recovery_code` uses `RlsConnection` extractor; `disable_mfa` begins tx from RLS conn; stale comment fixed

## Test plan

- [ ] CI `check` gate (fmt + clippy + security gates) passes
- [ ] Existing `mfa_recovery_codes_tests.rs` (T1–T6) remain green
- [ ] No new `acquire_public` regressions flagged by RLS enforcement scanner

🤖 Generated with [Claude Code](https://claude.com/claude-code)