### PR TITLE
fix(db): FORCE RLS on developer_oauth_apps/grants/api_key_usage_logs (BIT-76, #1303)

### DIFF
--- a/backend/crates/db/migrations/00181_force_developer_oauth_rls.sql
+++ b/backend/crates/db/migrations/00181_force_developer_oauth_rls.sql
@@ -1,0 +1,9 @@
+-- Close the remaining 00102 owner-bypass gap left by 00180/PAP-171:
+-- developer_oauth_apps, developer_oauth_grants, and api_key_usage_logs already
+-- carry correct user-scoped RLS policies but were never FORCEd, so the owner
+-- app role remained exempt. This is the same bypass class 00180 addressed for
+-- the other eight api-ecosystem tables; client_secret_hash in
+-- developer_oauth_apps makes this the highest-value target of the three.
+ALTER TABLE developer_oauth_apps   FORCE ROW LEVEL SECURITY;
+ALTER TABLE developer_oauth_grants FORCE ROW LEVEL SECURITY;
+ALTER TABLE api_key_usage_logs     FORCE ROW LEVEL SECURITY;

--- a/backend/crates/db/tests/api_ecosystem_developer_force_rls_tests.rs
+++ b/backend/crates/db/tests/api_ecosystem_developer_force_rls_tests.rs
@@ -113,14 +113,18 @@ async fn seed_sandbox(pool: &PgPool, developer_id: Uuid, name: &str) -> Uuid {
     .expect("seed sandbox")
 }
 
-/// Fail-on-`dev` guard (IG3): the eight catalog + developer-portal tables must
+/// Fail-on-`dev` guard (IG3): the eleven catalog + developer-portal tables must
 /// carry `FORCE ROW LEVEL SECURITY`. A plain non-owner role (as the behavioral
 /// test below uses) is bound by ENABLE alone, so only this catalog-metadata
 /// assertion distinguishes the migration being present from absent — it fails
-/// before migration `00180` and passes after. `#[sqlx::test]` runs as a
-/// superuser, so a behavioral owner-bypass assertion would pass vacuously;
+/// before migrations `00180`/`00181` and passes after. `#[sqlx::test]` runs as
+/// a superuser, so a behavioral owner-bypass assertion would pass vacuously;
 /// asserting `pg_class.relforcerowsecurity` is the robust check (mirrors
 /// `epic11_org_guc_rls_tests.rs` / `notification_rls_guc_tests.rs`).
+///
+/// The three OAuth/usage tables (`developer_oauth_apps`, `developer_oauth_grants`,
+/// `api_key_usage_logs`) were forced in `00181` — `developer_oauth_apps` holds
+/// `client_secret_hash` (credential-class), making it the highest-value target.
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn api_ecosystem_catalog_and_developer_tables_are_force_rls(pool: PgPool) {
     let tables = [
@@ -132,6 +136,10 @@ async fn api_ecosystem_catalog_and_developer_tables_are_force_rls(pool: PgPool) 
         "developer_accounts",
         "developer_api_keys",
         "developer_sandboxes",
+        // Added by migration 00181 (GH #1303 — remaining 00102 owner-bypass gap):
+        "developer_oauth_apps",
+        "developer_oauth_grants",
+        "api_key_usage_logs",
     ];
 
     for table in tables {
@@ -145,8 +153,8 @@ async fn api_ecosystem_catalog_and_developer_tables_are_force_rls(pool: PgPool) 
 
         assert!(
             forced,
-            "PAP-171 regression: table `{table}` must be FORCE ROW LEVEL SECURITY \
-             (migration 00180) so the owner app role is not exempt from its RLS policy"
+            "PAP-171/GH-1303 regression: table `{table}` must be FORCE ROW LEVEL SECURITY \
+             (migrations 00180/00181) so the owner app role is not exempt from its RLS policy"
         );
 
         // RLS must also remain enabled (FORCE without ENABLE is meaningless).


### PR DESCRIPTION
## Summary

- **GH #1303**: Three api-ecosystem tables (`developer_oauth_apps`, `developer_oauth_grants`, `api_key_usage_logs`) from migration `00102` had correct user-scoped RLS policies but were never `FORCE`d — the owner app role was exempt, the same bypass class `00180`/PAP-171 closed for the other 8 tables.
- Migration `00181` adds `FORCE ROW LEVEL SECURITY` to all three. `developer_oauth_apps` holds `client_secret_hash` (credential-class), making it the highest-value target.
- The IG3 guard test `api_ecosystem_catalog_and_developer_tables_are_force_rls` is extended from 8 to 11 tables so a future regression fails fast on `dev`.

## Files changed

- `backend/crates/db/migrations/00181_force_developer_oauth_rls.sql` — new migration (FORCE RLS on 3 tables)
- `backend/crates/db/tests/api_ecosystem_developer_force_rls_tests.rs` — IG3 guard extended to cover all 11 api-ecosystem tables

## Test plan

- [ ] CI `check` gate passes (fmt + clippy + security scanners)
- [ ] `api_ecosystem_catalog_and_developer_tables_are_force_rls` asserts `relforcerowsecurity = true` for all 11 tables
- [ ] `api_ecosystem_developer_force_rls_tests` behavioral tests remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)