### PR TITLE
fix(db): scope nil-unit_id Airbnb/Booking upserts to per-org conflict target (BIT-79, #1405)

### DIFF
--- a/backend/crates/db/migrations/00182_rental_platform_org_conflict_index.sql
+++ b/backend/crates/db/migrations/00182_rental_platform_org_conflict_index.sql
@@ -1,0 +1,14 @@
+-- GH #1405: close the cross-tenant token-binding hazard in the Airbnb/Booking
+-- OAuth upserts. When unit_id is unknown at token-exchange time the Rust code
+-- falls back to Uuid::nil() as a placeholder. The existing UNIQUE(unit_id,
+-- platform) constraint is shared across all organizations, so two orgs using
+-- the nil placeholder would conflict and the DO UPDATE would write one org's
+-- tokens under the other org's row.
+--
+-- This partial unique index scopes the nil-placeholder conflict to
+-- (organization_id, platform), ensuring each organization's nil-unit_id
+-- connection is a distinct row that can only be upserted by the same org.
+-- The upsert in rental.rs uses this as the ON CONFLICT target for nil rows.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_rental_platform_org_nil_platform
+    ON rental_platform_connections (organization_id, platform)
+    WHERE unit_id = '00000000-0000-0000-0000-000000000000';

--- a/backend/crates/db/src/repositories/rental.rs
+++ b/backend/crates/db/src/repositories/rental.rs
@@ -2304,36 +2304,75 @@ impl RentalRepository {
             }
         };
 
-        let conn = sqlx::query_as::<_, RentalPlatformConnection>(
-            r#"
-            INSERT INTO rental_platform_connections (
-                organization_id, unit_id, platform,
-                access_token, refresh_token, token_expires_at,
-                encrypted_token, encrypted_refresh_token,
-                external_property_id, is_active
+        // For nil-unit_id org-level connections use the partial unique index
+        // (organization_id, platform) WHERE unit_id = nil (migration 00182) as
+        // the conflict target so each org has its own row rather than sharing
+        // one cross-tenant nil-placeholder row (GH #1405 cross-tenant hazard).
+        let conn = if effective_unit_id == Uuid::nil() {
+            sqlx::query_as::<_, RentalPlatformConnection>(
+                r#"
+                INSERT INTO rental_platform_connections (
+                    organization_id, unit_id, platform,
+                    access_token, refresh_token, token_expires_at,
+                    encrypted_token, encrypted_refresh_token,
+                    external_property_id, is_active
+                )
+                VALUES ($1, $2, 'airbnb', $3, $4, $5, $3, $4, $6, true)
+                ON CONFLICT (organization_id, platform)
+                    WHERE unit_id = '00000000-0000-0000-0000-000000000000'
+                DO UPDATE SET
+                    access_token             = $3,
+                    refresh_token            = COALESCE($4, rental_platform_connections.refresh_token),
+                    encrypted_token          = $3,
+                    encrypted_refresh_token  = COALESCE($4, rental_platform_connections.encrypted_refresh_token),
+                    token_expires_at         = $5,
+                    external_property_id     = COALESCE($6, rental_platform_connections.external_property_id),
+                    is_active                = true,
+                    sync_error               = NULL,
+                    updated_at               = NOW()
+                RETURNING *
+                "#,
             )
-            VALUES ($1, $2, 'airbnb', $3, $4, $5, $3, $4, $6, true)
-            ON CONFLICT (unit_id, platform) DO UPDATE SET
-                access_token             = $3,
-                refresh_token            = COALESCE($4, rental_platform_connections.refresh_token),
-                encrypted_token          = $3,
-                encrypted_refresh_token  = COALESCE($4, rental_platform_connections.encrypted_refresh_token),
-                token_expires_at         = $5,
-                external_property_id     = COALESCE($6, rental_platform_connections.external_property_id),
-                is_active                = true,
-                sync_error               = NULL,
-                updated_at               = NOW()
-            RETURNING *
-            "#,
-        )
-        .bind(org_id)
-        .bind(effective_unit_id)
-        .bind(access_token)
-        .bind(refresh_token)
-        .bind(expires_at)
-        .bind(external_account_id)
-        .fetch_one(&self.pool)
-        .await?;
+            .bind(org_id)
+            .bind(effective_unit_id)
+            .bind(access_token)
+            .bind(refresh_token)
+            .bind(expires_at)
+            .bind(external_account_id)
+            .fetch_one(&self.pool)
+            .await?
+        } else {
+            sqlx::query_as::<_, RentalPlatformConnection>(
+                r#"
+                INSERT INTO rental_platform_connections (
+                    organization_id, unit_id, platform,
+                    access_token, refresh_token, token_expires_at,
+                    encrypted_token, encrypted_refresh_token,
+                    external_property_id, is_active
+                )
+                VALUES ($1, $2, 'airbnb', $3, $4, $5, $3, $4, $6, true)
+                ON CONFLICT (unit_id, platform) DO UPDATE SET
+                    access_token             = $3,
+                    refresh_token            = COALESCE($4, rental_platform_connections.refresh_token),
+                    encrypted_token          = $3,
+                    encrypted_refresh_token  = COALESCE($4, rental_platform_connections.encrypted_refresh_token),
+                    token_expires_at         = $5,
+                    external_property_id     = COALESCE($6, rental_platform_connections.external_property_id),
+                    is_active                = true,
+                    sync_error               = NULL,
+                    updated_at               = NOW()
+                RETURNING *
+                "#,
+            )
+            .bind(org_id)
+            .bind(effective_unit_id)
+            .bind(access_token)
+            .bind(refresh_token)
+            .bind(expires_at)
+            .bind(external_account_id)
+            .fetch_one(&self.pool)
+            .await?
+        };
 
         Ok(conn)
     }
@@ -2359,36 +2398,73 @@ impl RentalRepository {
             }
         };
 
-        let conn = sqlx::query_as::<_, RentalPlatformConnection>(
-            r#"
-            INSERT INTO rental_platform_connections (
-                organization_id, unit_id, platform,
-                access_token, refresh_token, token_expires_at,
-                encrypted_token, encrypted_refresh_token,
-                external_property_id, is_active
+        // Same nil-unit_id branch strategy as upsert_airbnb_connection; see that
+        // function for the GH #1405 cross-tenant rationale.
+        let conn = if effective_unit_id == Uuid::nil() {
+            sqlx::query_as::<_, RentalPlatformConnection>(
+                r#"
+                INSERT INTO rental_platform_connections (
+                    organization_id, unit_id, platform,
+                    access_token, refresh_token, token_expires_at,
+                    encrypted_token, encrypted_refresh_token,
+                    external_property_id, is_active
+                )
+                VALUES ($1, $2, 'booking', $3, $4, $5, $3, $4, $6, true)
+                ON CONFLICT (organization_id, platform)
+                    WHERE unit_id = '00000000-0000-0000-0000-000000000000'
+                DO UPDATE SET
+                    access_token             = $3,
+                    refresh_token            = COALESCE($4, rental_platform_connections.refresh_token),
+                    encrypted_token          = $3,
+                    encrypted_refresh_token  = COALESCE($4, rental_platform_connections.encrypted_refresh_token),
+                    token_expires_at         = $5,
+                    external_property_id     = COALESCE($6, rental_platform_connections.external_property_id),
+                    is_active                = true,
+                    sync_error               = NULL,
+                    updated_at               = NOW()
+                RETURNING *
+                "#,
             )
-            VALUES ($1, $2, 'booking', $3, $4, $5, $3, $4, $6, true)
-            ON CONFLICT (unit_id, platform) DO UPDATE SET
-                access_token             = $3,
-                refresh_token            = COALESCE($4, rental_platform_connections.refresh_token),
-                encrypted_token          = $3,
-                encrypted_refresh_token  = COALESCE($4, rental_platform_connections.encrypted_refresh_token),
-                token_expires_at         = $5,
-                external_property_id     = COALESCE($6, rental_platform_connections.external_property_id),
-                is_active                = true,
-                sync_error               = NULL,
-                updated_at               = NOW()
-            RETURNING *
-            "#,
-        )
-        .bind(org_id)
-        .bind(effective_unit_id)
-        .bind(access_token)
-        .bind(refresh_token)
-        .bind(expires_at)
-        .bind(external_property_id)
-        .fetch_one(&self.pool)
-        .await?;
+            .bind(org_id)
+            .bind(effective_unit_id)
+            .bind(access_token)
+            .bind(refresh_token)
+            .bind(expires_at)
+            .bind(external_property_id)
+            .fetch_one(&self.pool)
+            .await?
+        } else {
+            sqlx::query_as::<_, RentalPlatformConnection>(
+                r#"
+                INSERT INTO rental_platform_connections (
+                    organization_id, unit_id, platform,
+                    access_token, refresh_token, token_expires_at,
+                    encrypted_token, encrypted_refresh_token,
+                    external_property_id, is_active
+                )
+                VALUES ($1, $2, 'booking', $3, $4, $5, $3, $4, $6, true)
+                ON CONFLICT (unit_id, platform) DO UPDATE SET
+                    access_token             = $3,
+                    refresh_token            = COALESCE($4, rental_platform_connections.refresh_token),
+                    encrypted_token          = $3,
+                    encrypted_refresh_token  = COALESCE($4, rental_platform_connections.encrypted_refresh_token),
+                    token_expires_at         = $5,
+                    external_property_id     = COALESCE($6, rental_platform_connections.external_property_id),
+                    is_active                = true,
+                    sync_error               = NULL,
+                    updated_at               = NOW()
+                RETURNING *
+                "#,
+            )
+            .bind(org_id)
+            .bind(effective_unit_id)
+            .bind(access_token)
+            .bind(refresh_token)
+            .bind(expires_at)
+            .bind(external_property_id)
+            .fetch_one(&self.pool)
+            .await?
+        };
 
         Ok(conn)
     }


### PR DESCRIPTION
## Summary

**GH #1405 (cross-tenant token-binding hazard):** `upsert_airbnb_connection` and `upsert_booking_oauth_connection` fell back to `Uuid::nil()` as a `unit_id` placeholder when no unit was known. The existing `UNIQUE(unit_id, platform)` constraint is shared across all orgs — two orgs sharing the nil placeholder would conflict and `DO UPDATE` would silently write one org's tokens under the other org's row.

- **Migration `00182`**: adds a partial unique index `(organization_id, platform) WHERE unit_id = '00000000-...'` so each org has its own nil-placeholder row.
- Both upsert functions branch on `effective_unit_id == Uuid::nil()`: the nil case targets the per-org partial index (`ON CONFLICT (organization_id, platform) WHERE unit_id = '...'`), the non-nil case keeps the existing `ON CONFLICT (unit_id, platform)`.

## Files changed

- `backend/crates/db/migrations/00182_rental_platform_org_conflict_index.sql` — new partial unique index
- `backend/crates/db/src/repositories/rental.rs` — nil-branch in both upsert functions

## Test plan

- [ ] CI `check` gate passes (fmt + clippy + security scanners)
- [ ] Existing rental integration tests remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)