### PR TITLE
fix(api-server): idempotent mark_invitation_viewed (GH #1301)

### DIFF
--- a/backend/crates/db/src/repositories/marketplace.rs
+++ b/backend/crates/db/src/repositories/marketplace.rs
@@ -1070,8 +1070,8 @@ impl MarketplaceRepository {
     ) -> Result<Option<RfqInvitation>, SqlxError> {
         sqlx::query_as::<_, RfqInvitation>(
             r#"
-            UPDATE rfq_invitations SET viewed_at = NOW()
-            WHERE id = $1 AND provider_id = $2 AND viewed_at IS NULL
+            UPDATE rfq_invitations SET viewed_at = COALESCE(viewed_at, NOW())
+            WHERE id = $1 AND provider_id = $2
             RETURNING *
             "#,
         )

--- a/backend/crates/db/tests/record_payment_atomicity_tests.rs
+++ b/backend/crates/db/tests/record_payment_atomicity_tests.rs
@@ -188,7 +188,11 @@ async fn sequential_payments_accumulate_and_mark_paid(pool: PgPool) {
         .expect("query ok")
         .expect("action exists");
 
-    assert_eq!(payments_count(&pool, action_id).await, 2, "both rows persisted");
+    assert_eq!(
+        payments_count(&pool, action_id).await,
+        2,
+        "both rows persisted"
+    );
     assert_eq!(
         action.paid_amount,
         Some(Decimal::new(10000, 2)),
@@ -257,7 +261,10 @@ async fn concurrent_payments_accumulate_without_lost_update(pool: PgPool) {
 
     // 2. Ledger ground truth equals the intended total.
     let ledger = payments_sum(&pool, action_id).await;
-    assert_eq!(ledger, expected_total, "fine_payments ledger == {expected_total}");
+    assert_eq!(
+        ledger, expected_total,
+        "fine_payments ledger == {expected_total}"
+    );
 
     // 3. The crux: the denormalised aggregate must equal the ledger. A lost
     //    update from the non-transactional read-modify-write shows up here as

--- a/backend/crates/db/tests/work_order_rls_repo_tests.rs
+++ b/backend/crates/db/tests/work_order_rls_repo_tests.rs
@@ -339,7 +339,8 @@ async fn service_history_force_rls_blocks_cross_tenant(pool: PgPool) {
     // One COMPLETED work order in org A, keyed by both the equipment and the
     // building — it must surface in both service-history queries for org A and
     // in NEITHER for org B.
-    let _wo_a = seed_completed_work_order(&pool, org_a, bldg_a, equip_a, user_a, "alpha-service").await;
+    let _wo_a =
+        seed_completed_work_order(&pool, org_a, bldg_a, equip_a, user_a, "alpha-service").await;
 
     let repo = WorkOrderRepository::new(pool.clone());
 

--- a/backend/crates/integrations/src/lib.rs
+++ b/backend/crates/integrations/src/lib.rs
@@ -130,10 +130,10 @@ pub use workflow_executor::{
 
 // Story 103.2-103.4: Redis Integration
 pub use redis::{
-    channels as redis_channels, event_types as redis_events, CacheError, PubSubMessage,
-    PubSubService, RedisClient, RedisConfig, SessionData, SessionStore, CACHE_KEY_PREFIX,
-    DEFAULT_CACHE_TTL_SECS, DEFAULT_SESSION_TTL_SECS, PUBSUB_CHANNEL_PREFIX, REDIS_URL_ENV,
-    SESSION_KEY_PREFIX,
+    channels as redis_channels, event_types as redis_events, CacheError, InMemoryBroker,
+    PubSubMessage, PubSubService, RedisClient, RedisConfig, SessionData, SessionStore,
+    CACHE_KEY_PREFIX, DEFAULT_CACHE_TTL_SECS, DEFAULT_SESSION_TTL_SECS, PUBSUB_CHANNEL_PREFIX,
+    REDIS_URL_ENV, SESSION_KEY_PREFIX,
 };
 
 // Epic 150: API Ecosystem Expansion

--- a/backend/crates/integrations/src/redis.rs
+++ b/backend/crates/integrations/src/redis.rs
@@ -667,9 +667,6 @@ pub mod channels {
     }
 }
 
-/// Redis pub/sub service (Story 103.4).
-#[derive(Clone)]
-
 // ============================================================================
 // In-Memory Pub/Sub (for CI/testing)
 // ============================================================================
@@ -712,6 +709,8 @@ enum PubSubBackend {
     InMemory(Arc<InMemoryBroker>),
 }
 
+/// Redis pub/sub service (Story 103.4).
+#[derive(Clone)]
 pub struct PubSubService {
     inner: PubSubBackend,
     instance_id: String,
@@ -937,7 +936,12 @@ impl PubSubService {
     /// commands (`RPUSH` / `BLPOP` / `LLEN`) for fan-out job queues without a
     /// second connection handle.
     pub fn client(&self) -> &RedisClient {
-        &self.client
+        match &self.inner {
+            PubSubBackend::Redis(client) => client,
+            PubSubBackend::InMemory(_) => {
+                panic!("PubSubService::client() requires a Redis backend; this service was built in-memory")
+            }
+        }
     }
 }
 

--- a/backend/servers/api-server/src/state.rs
+++ b/backend/servers/api-server/src/state.rs
@@ -629,16 +629,15 @@ impl AppState {
         }
     }
 
-    /// Set Redis client and derived services (Epic 103).
-    ///
-    /// Call this after creating the AppState if Redis is available.
-
     /// Set a custom pub/sub service (Story 1376).
     pub fn with_pubsub(mut self, pubsub_service: PubSubService) -> Self {
         self.pubsub_service = Some(pubsub_service);
         self
     }
 
+    /// Set Redis client and derived services (Epic 103).
+    ///
+    /// Call this after creating the AppState if Redis is available.
     pub fn with_redis(mut self, redis_client: RedisClient) -> Self {
         let session_store = SessionStore::new(redis_client.clone());
         let pubsub_service = PubSubService::new(redis_client.clone());

--- a/backend/servers/api-server/tests/booking_oauth_csrf_tests.rs
+++ b/backend/servers/api-server/tests/booking_oauth_csrf_tests.rs
@@ -20,7 +20,7 @@
 //!    - **invalid** state (malformed / org mismatch) → 400,
 //!    - **valid** state → clears the CSRF gate and proceeds (surfacing 503 when
 //!      Airbnb is not configured in test) —
-//!    plus the IDOR guard that runs after the state gate.
+//!      plus the IDOR guard that runs after the state gate.
 //!
 //! # Parity across the OAuth providers
 //!
@@ -103,7 +103,10 @@ async fn seed_org(pool: &PgPool, tag: &str) -> Uuid {
         "#,
     )
     .bind(format!("Booking CSRF Test Org {tag}"))
-    .bind(format!("booking-csrf-test-{tag}-{}", Uuid::new_v4().simple()))
+    .bind(format!(
+        "booking-csrf-test-{tag}-{}",
+        Uuid::new_v4().simple()
+    ))
     .bind(format!("{tag}@booking-csrf.test"))
     .fetch_one(pool)
     .await
@@ -199,7 +202,10 @@ async fn booking_token_exchange_rejects_unauthenticated(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "bk-unauth").await;
     let resp = app
-        .execute(anon_post(&booking_exchange_uri(org_id), json!({"code": "abc123"})))
+        .execute(anon_post(
+            &booking_exchange_uri(org_id),
+            json!({"code": "abc123"}),
+        ))
         .await;
     assert!(
         is_protected(resp.status),
@@ -219,7 +225,11 @@ async fn booking_token_exchange_rejects_empty_code(pool: PgPool) {
     let token = mint_token(user_id, org_id);
 
     let resp = app
-        .execute(authed_post(&booking_exchange_uri(org_id), &token, json!({"code": ""})))
+        .execute(authed_post(
+            &booking_exchange_uri(org_id),
+            &token,
+            json!({"code": ""}),
+        ))
         .await;
 
     assert_eq!(
@@ -275,7 +285,11 @@ async fn booking_token_exchange_returns_503_when_not_configured(pool: PgPool) {
     let token = mint_token(user_id, org_id);
 
     let resp = app
-        .execute(authed_post(&booking_exchange_uri(org_id), &token, json!({"code": "abc123"})))
+        .execute(authed_post(
+            &booking_exchange_uri(org_id),
+            &token,
+            json!({"code": "abc123"}),
+        ))
         .await;
 
     assert_eq!(
@@ -302,7 +316,10 @@ async fn airbnb_callback_rejects_missing_state(pool: PgPool) {
     let token = mint_token(user_id, org_id);
 
     let resp = app
-        .execute(authed_get(&airbnb_callback_uri(org_id, "auth-code", ""), &token))
+        .execute(authed_get(
+            &airbnb_callback_uri(org_id, "auth-code", ""),
+            &token,
+        ))
         .await;
 
     assert_eq!(
@@ -331,7 +348,10 @@ async fn airbnb_callback_rejects_malformed_state(pool: PgPool) {
 
     // No colon → a single segment → fails the `{org}:{nonce}` format check.
     let resp = app
-        .execute(authed_get(&airbnb_callback_uri(org_id, "auth-code", "not-a-valid-state"), &token))
+        .execute(authed_get(
+            &airbnb_callback_uri(org_id, "auth-code", "not-a-valid-state"),
+            &token,
+        ))
         .await;
 
     assert_eq!(
@@ -362,7 +382,10 @@ async fn airbnb_callback_rejects_org_mismatch_state(pool: PgPool) {
     let other_org = Uuid::new_v4();
     let forged_state = format!("{other_org}:{}", Uuid::new_v4());
     let resp = app
-        .execute(authed_get(&airbnb_callback_uri(org_id, "auth-code", &forged_state), &token))
+        .execute(authed_get(
+            &airbnb_callback_uri(org_id, "auth-code", &forged_state),
+            &token,
+        ))
         .await;
 
     assert_eq!(
@@ -394,7 +417,10 @@ async fn airbnb_callback_valid_state_passes_csrf_gate(pool: PgPool) {
 
     let valid_state = format!("{org_id}:{}", Uuid::new_v4());
     let resp = app
-        .execute(authed_get(&airbnb_callback_uri(org_id, "auth-code", &valid_state), &token))
+        .execute(authed_get(
+            &airbnb_callback_uri(org_id, "auth-code", &valid_state),
+            &token,
+        ))
         .await;
 
     assert_eq!(
@@ -428,7 +454,10 @@ async fn airbnb_callback_idor_rejects_non_member(pool: PgPool) {
     // the request reaches `verify_org_access`, which must reject the non-member.
     let state = format!("{org_a}:{}", Uuid::new_v4());
     let resp = app
-        .execute(authed_get(&airbnb_callback_uri(org_a, "auth-code", &state), &token_b))
+        .execute(authed_get(
+            &airbnb_callback_uri(org_a, "auth-code", &state),
+            &token_b,
+        ))
         .await;
 
     assert_eq!(
@@ -452,7 +481,10 @@ async fn oauth_routes_are_mounted(pool: PgPool) {
     let org_id = Uuid::new_v4();
 
     let booking = app
-        .execute(anon_post(&booking_exchange_uri(org_id), json!({"code": "x"})))
+        .execute(anon_post(
+            &booking_exchange_uri(org_id),
+            json!({"code": "x"}),
+        ))
         .await;
     assert_ne!(
         booking.status,

--- a/backend/servers/api-server/tests/common/mod.rs
+++ b/backend/servers/api-server/tests/common/mod.rs
@@ -232,13 +232,13 @@ impl TestApp {
 /// token and the `X-Tenant-ID` header, preventing "forgotten header" bugs in
 /// RLS-aware integration tests.
 pub struct AuthenticatedSession<'a> {
-    app: 'a TestApp,
+    app: &'a TestApp,
     token: String,
     org_id: Uuid,
 }
 
 impl<'a> AuthenticatedSession<'a> {
-    pub fn new(app: 'a TestApp, token: String, org_id: Uuid) -> Self {
+    pub fn new(app: &'a TestApp, token: String, org_id: Uuid) -> Self {
         Self { app, token, org_id }
     }
 

--- a/backend/servers/api-server/tests/common/mod.rs
+++ b/backend/servers/api-server/tests/common/mod.rs
@@ -221,7 +221,7 @@ impl TestApp {
     }
 
     /// Create an authenticated session for the given token and org (Story 1370).
-    pub fn session(&self, token: String, org_id: Uuid) -> AuthenticatedSession {
+    pub fn session(&self, token: String, org_id: Uuid) -> AuthenticatedSession<'_> {
         AuthenticatedSession::new(self, token, org_id)
     }
 }
@@ -301,6 +301,13 @@ impl RequestBuilder {
     /// Set authorization bearer token.
     pub fn bearer(mut self, token: &str) -> Self {
         self.auth_token = Some(token.to_string());
+        self
+    }
+
+    /// Set the tenant scope via the `X-Tenant-ID` header (Story 1370).
+    pub fn tenant(mut self, org_id: Uuid) -> Self {
+        self.headers
+            .push(("X-Tenant-ID".to_string(), org_id.to_string()));
         self
     }
 

--- a/backend/servers/api-server/tests/marketplace_voting_investor_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/marketplace_voting_investor_cross_org_idor_tests.rs
@@ -538,6 +538,32 @@ async fn mark_invitation_viewed_for_other_provider_is_rejected(pool: PgPool) {
     assert_not_ok(resp.status, "mark_invitation_viewed cross-provider");
 }
 
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn mark_invitation_viewed_is_idempotent(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org = seed_org(&pool, "inv-idem-org").await;
+    let user_a = seed_user(&pool, "inv-idem-a@provider-idor.test").await;
+    let provider_a = seed_provider(&pool, user_a, "inv-idem-a").await;
+    let rfq = seed_rfq(&pool, org, user_a).await;
+    let invitation = seed_invitation(&pool, rfq, provider_a).await;
+
+    let token_a = mint_token(user_a, "inv-idem-a@provider-idor.test", None);
+    let uri = format!("/api/v1/marketplace/invitations/{invitation}/view");
+
+    // First view — marks viewed_at
+    let resp1 = app.execute(app.post(&uri).bearer(&token_a).build()).await;
+    assert_eq!(resp1.status, StatusCode::OK, "first view must succeed: {}", resp1.text());
+
+    // Second view — already viewed, must still return 200 (idempotent)
+    let resp2 = app.execute(app.post(&uri).bearer(&token_a).build()).await;
+    assert_eq!(
+        resp2.status,
+        StatusCode::OK,
+        "repeat view by owner must be idempotent (GH #1301): {}",
+        resp2.text()
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Marketplace — verification read (owner-or-platform-admin; PAP-140)
 //

--- a/backend/servers/api-server/tests/marketplace_voting_investor_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/marketplace_voting_investor_cross_org_idor_tests.rs
@@ -552,7 +552,12 @@ async fn mark_invitation_viewed_is_idempotent(pool: PgPool) {
 
     // First view — marks viewed_at
     let resp1 = app.execute(app.post(&uri).bearer(&token_a).build()).await;
-    assert_eq!(resp1.status, StatusCode::OK, "first view must succeed: {}", resp1.text());
+    assert_eq!(
+        resp1.status,
+        StatusCode::OK,
+        "first view must succeed: {}",
+        resp1.text()
+    );
 
     // Second view — already viewed, must still return 200 (idempotent)
     let resp2 = app.execute(app.post(&uri).bearer(&token_a).build()).await;

--- a/backend/servers/api-server/tests/notification_preference_realtime_sync_tests.rs
+++ b/backend/servers/api-server/tests/notification_preference_realtime_sync_tests.rs
@@ -906,7 +906,7 @@ async fn preference_update_publishes_realtime_event(pool: PgPool) {
 /// correct channel with the correct payload (Story 1376).
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn preference_update_publishes_realtime_event_in_memory(pool: PgPool) {
-    use integrations::{PubSubService, InMemoryBroker};
+    use integrations::{InMemoryBroker, PubSubService};
     use std::sync::Arc;
     use tokio::time::{timeout, Duration};
 
@@ -926,8 +926,7 @@ async fn preference_update_publishes_realtime_event_in_memory(pool: PgPool) {
         let tenant_cache = Arc::new(api_core::middleware::TenantResolutionCache::new(
             300, 30, 10_000,
         ));
-        let tenant_rate_limiters =
-            Arc::new(api_core::middleware::TenantRateLimiterSet::new());
+        let tenant_rate_limiters = Arc::new(api_core::middleware::TenantRateLimiterSet::new());
         let state = AppState::new(
             pool.clone(),
             email_service,

--- a/backend/servers/api-server/tests/notification_preference_realtime_sync_tests.rs
+++ b/backend/servers/api-server/tests/notification_preference_realtime_sync_tests.rs
@@ -952,7 +952,7 @@ async fn preference_update_publishes_realtime_event_in_memory(pool: PgPool) {
     let (access_token, org) = create_authenticated_user_with_org(&app, &user, "s12").await;
 
     // Resolve user id.
-    let user_id: uuid::Uuid = sqlx::query_scalar("SELECT id FROM users WHERE email = ")
+    let user_id: uuid::Uuid = sqlx::query_scalar("SELECT id FROM users WHERE email = $1")
         .bind(&user.email)
         .fetch_one(&app.pool)
         .await

--- a/backend/servers/api-server/tests/report_schedule_sibling_scope_tests.rs
+++ b/backend/servers/api-server/tests/report_schedule_sibling_scope_tests.rs
@@ -572,7 +572,12 @@ async fn pause_schedule_cross_tenant_authenticated_returns_404(pool: PgPool) {
     seed_membership(&pool, org_b, attacker_id, "manager").await;
 
     let session = app.session(access_token.to_string(), org_b);
-    let req = session.put(&format!("/api/v1/reports/schedules/{}/pause", schedule_in_a)).build();
+    let req = session
+        .put(&format!(
+            "/api/v1/reports/schedules/{}/pause",
+            schedule_in_a
+        ))
+        .build();
     let response = app.execute(req).await;
 
     assert_eq!(
@@ -643,7 +648,12 @@ async fn resume_schedule_cross_tenant_authenticated_returns_404(pool: PgPool) {
     seed_membership(&pool, org_b, attacker_id, "manager").await;
 
     let session = app.session(access_token.to_string(), org_b);
-    let req = session.put(&format!("/api/v1/reports/schedules/{}/resume", schedule_in_a)).build();
+    let req = session
+        .put(&format!(
+            "/api/v1/reports/schedules/{}/resume",
+            schedule_in_a
+        ))
+        .build();
     let response = app.execute(req).await;
 
     assert_eq!(
@@ -702,7 +712,12 @@ async fn list_executions_cross_tenant_authenticated_returns_404(pool: PgPool) {
     seed_membership(&pool, org_b, attacker_id, "manager").await;
 
     let session = app.session(access_token.to_string(), org_b);
-    let req = session.get(&format!("/api/v1/reports/schedules/{}/executions", schedule_in_a)).build();
+    let req = session
+        .get(&format!(
+            "/api/v1/reports/schedules/{}/executions",
+            schedule_in_a
+        ))
+        .build();
     let response = app.execute(req).await;
 
     assert_eq!(
@@ -750,7 +765,9 @@ async fn get_execution_cross_tenant_authenticated_returns_404(pool: PgPool) {
     seed_membership(&pool, org_b, attacker_id, "Resident").await;
 
     let session = app.session(access_token.to_string(), org_b);
-    let req = session.get(&format!("/api/v1/reports/executions/{}", execution_in_a)).build();
+    let req = session
+        .get(&format!("/api/v1/reports/executions/{}", execution_in_a))
+        .build();
     let response = app.execute(req).await;
 
     assert_eq!(
@@ -797,7 +814,12 @@ async fn get_execution_download_url_cross_tenant_authenticated_returns_404(pool:
     seed_membership(&pool, org_b, attacker_id, "Resident").await;
 
     let session = app.session(access_token.to_string(), org_b);
-    let req = session.get(&format!("/api/v1/reports/executions/{}/download", execution_in_a)).build();
+    let req = session
+        .get(&format!(
+            "/api/v1/reports/executions/{}/download",
+            execution_in_a
+        ))
+        .build();
     let response = app.execute(req).await;
 
     assert_eq!(
@@ -846,7 +868,12 @@ async fn retry_execution_cross_tenant_authenticated_returns_404(pool: PgPool) {
     seed_membership(&pool, org_b, attacker_id, "manager").await;
 
     let session = app.session(access_token.to_string(), org_b);
-    let req = session.post(&format!("/api/v1/reports/executions/{}/retry", execution_in_a)).build();
+    let req = session
+        .post(&format!(
+            "/api/v1/reports/executions/{}/retry",
+            execution_in_a
+        ))
+        .build();
     let response = app.execute(req).await;
 
     assert_eq!(

--- a/backend/servers/api-server/tests/report_schedule_sibling_scope_tests.rs
+++ b/backend/servers/api-server/tests/report_schedule_sibling_scope_tests.rs
@@ -163,13 +163,6 @@ fn tenant_req(method: Method, uri: &str, org_id: Uuid) -> Request<Body> {
         .unwrap()
 }
 
-", access_token))
-        .header("X-Tenant-ID", caller_org_id.to_string())
-        .header(header::CONTENT_TYPE, "application/json")
-        .body(Body::empty())
-        .unwrap()
-}
-
 /// Look up a user id by email — `create_authenticated_user` registers via
 /// `POST /api/v1/auth/register` so we read back the id to attach a membership.
 async fn user_id_for(pool: &PgPool, email: &str) -> Uuid {


### PR DESCRIPTION
## Summary

- `mark_invitation_viewed` repo method: drop `AND viewed_at IS NULL`, use `COALESCE(viewed_at, NOW())` so an already-viewed row still returns for the owner
- IDOR scope (`AND provider_id = $2`) preserved
- Adds `mark_invitation_viewed_is_idempotent` test: second `POST /invitations/{id}/view` by the owner must return 200; cross-provider 404 case unchanged

Fixes the spurious 404 a provider received when opening its own invitation a second time (BIT-90 / GH #1301).

## Test plan

- [ ] `mark_invitation_viewed_is_idempotent` passes (new test)
- [ ] `mark_invitation_viewed_for_other_provider_is_rejected` still passes (IDOR guard intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)