### PR TITLE
docs(research): resolve dangling "section above" in extracted merge-path prompts

### DIFF
--- a/.research/management/pr-followup-prompt.md
+++ b/.research/management/pr-followup-prompt.md
@@ -16,9 +16,10 @@ You are the PR follow-up driver. Invoke
 
 0. **Workspace isolation (MANDATORY — issue #7).** When step 2 below
    spawns the original specialist via Task, the brief you pass that
-   specialist MUST include the standard worktree preamble from the
-   "Subagent workspace isolation" section above (export
-   `TASK_ID=<task_id>`, `BRANCH=<row.branch>`). The followup script
+   specialist MUST include the standard worktree preamble (the "Subagent
+   workspace isolation" preamble; canonical source: the "Subagent workspace
+   isolation" section of `.research/dispatcher-prompt.md`) — export
+   `TASK_ID=<task_id>`, `BRANCH=<row.branch>`. The followup script
    itself runs read-only `gh` calls and is safe in the dispatcher's
    tree.
 1. Run `bash .claude/skills/ppt-pr-followup/scripts/dispatcher-followup.sh --pr <n>`.

--- a/.research/management/rebaser-prompt.md
+++ b/.research/management/rebaser-prompt.md
@@ -16,8 +16,10 @@ You are a PR rebaser for a stale approved PR. Inputs: `pr_number=<n>`,
 `branch=<head_ref>`, `base=dev`. Do this exactly:
 
 0. **Workspace isolation (MANDATORY — issue #7).** Run the standard
-   worktree preamble from the "Subagent workspace isolation" section
-   above (export `TASK_ID=pr-<n>`, `BRANCH=<head_ref>`). All subsequent
+   worktree preamble injected into your brief (the "Subagent workspace
+   isolation" preamble; canonical source: the "Subagent workspace
+   isolation" section of `.research/dispatcher-prompt.md`) — export
+   `TASK_ID=pr-<n>`, `BRANCH=<head_ref>`. All subsequent
    git operations run inside `/tmp/ppt-worktrees/pr-<n>/`. NEVER
    `gh pr checkout` in the dispatcher's working tree — it displaces
    `dev` and breaks Phase 6 of this run.


### PR DESCRIPTION
## Problem

`#1309` (post-merge review of PR #1284 / PAP-164): the merge-path subagent prompts were extracted from `dispatcher-prompt.md` **byte-identically**, so their step-0 worktree-preamble instruction kept a relative cross-reference that no longer resolves once the file is read in a fresh subagent context:

- `.research/management/rebaser-prompt.md` — *"...the 'Subagent workspace isolation' section **above**"*
- `.research/management/pr-followup-prompt.md` — same

There is no "section above" in the extracted file — that section lives at `.research/dispatcher-prompt.md:214` and is injected into the brief dispatcher-side.

## Fix (docs-only, no behavior change)

Replace the dangling relative reference in both files with a context-independent one naming the canonical source (the "Subagent workspace isolation" section of `.research/dispatcher-prompt.md`). The preamble still reaches the subagent via brief injection (`dispatcher-prompt.md:246`) — this only fixes the confusing/latent-trap wording for a future human/agent editing these files.

`premerge-autofix-prompt.md` already inlines its step-0 (no "above" ref) — left as-is.

## Verification

- `bash .research/dispatcher-self-test.sh` → **PASS**; T27 anchors (`rebased=`, `followup=`, "intact + referenced") unchanged.
- Confirmed `## Subagent workspace isolation` exists at `dispatcher-prompt.md:214` (reference is accurate).
- No `section above` string remains in either file.

Closes #1309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)