### PR TITLE
fix(api-server): mfa verify_recovery_code RLS-enforce + cross-user IDOR test (BIT-78, #1302/#1304)

### DIFF
--- a/backend/scripts/check-rls-enforcement.sh
+++ b/backend/scripts/check-rls-enforcement.sh
@@ -69,6 +69,17 @@ VIOLATION_PATTERNS=(
     'self\.db\.acquire'
     'self\.db\.pool'
     '&self\.db[^_]'
+    # BIT-78 (GH #1302/#1304): two evasions the patterns above missed.
+    # `state.db.begin()` opens a raw-pool transaction with NO RLS context (the
+    # mfa.rs disable_mfa / verify_recovery_code defect). `state.db.clone()` hands
+    # the raw pool to ad-hoc code. The constructor idiom
+    # (`Repo::new(state.db.clone())`) and struct-field init (`db: self.db.clone(),`)
+    # are allow-listed in is_sanctioned(); a *bare* `let x = state.db.clone();`
+    # raw-pool extraction is flagged.
+    'state\.db\.begin'
+    'self\.db\.begin'
+    'state\.db\.clone'
+    'self\.db\.clone'
 )
 
 # Directories to check (request-handling code that should use RLS).
@@ -129,6 +140,20 @@ is_sanctioned() {
     # Line directly calls the sanctioned helper.
     if [[ "$content" == *"$SANCTIONED_HELPER"* ]]; then
         return 0
+    fi
+
+    # BIT-78: `.clone()` of the raw pool is the canonical way to construct a
+    # repository / service / RlsPool (`Repo::new(state.db.clone())`) or to seed
+    # a struct field (`db: self.db.clone(),`). Those hand the pool to an
+    # RLS-aware abstraction, so they are sanctioned. The evasion this guards
+    # against is *binding the raw pool to a local* and querying it directly
+    # (`let pool = state.db.clone();`). Sanction the wrapped/arg/field form;
+    # flag a bare binding whose entire right-hand side is the clone.
+    if [[ "$content" == *".db.clone("* ]]; then
+        if [[ "$content" =~ =[[:space:]]*(state|self)\.db\.clone\(\)[[:space:]]*\;?[[:space:]]*$ ]]; then
+            return 1   # bare `let x = state.db.clone();` → not sanctioned
+        fi
+        return 0       # passed into a constructor/call or a struct field
     fi
 
     # RLS plumbing implementations are allowed to touch the raw pool.

--- a/backend/scripts/rls-handler-baseline.txt
+++ b/backend/scripts/rls-handler-baseline.txt
@@ -7,5 +7,23 @@
 # --strict; raw-pool access in any file NOT listed here fails CI. When a file
 # is cleaned up, REMOVE its line (the script warns on stale entries).
 #
-# (Empty: work_orders.rs service-history org-gate lookups were converted to the
-# caller's RlsConnection in BIT-56, so they are no longer raw-pool offenders.)
+# work_orders.rs service-history org-gate lookups were converted to the
+# caller's RlsConnection in BIT-56, so they are no longer raw-pool offenders.
+#
+# BIT-78 (GH #1302/#1304) added the `state.db.begin` / `state.db.clone`
+# patterns. They surfaced three PRE-EXISTING, reviewed-as-acceptable handler
+# sites (NOT mfa.rs — that file was fully converted off the raw pool in the same
+# change). Each is a deliberate non-RLS path; baselined here rather than
+# converted because converting them is out of scope for the MFA fix:
+#
+#   agency_provisioning.rs — `state.db.begin()` provisions a BRAND-NEW org
+#     before any tenant/RLS context can exist (the org row is what it creates),
+#     so a raw-pool transaction is correct here.
+#   organizations/settings.rs — `let pool = state.db.clone();` after
+#     `rls.release()` to run the org-export job on the service-role pool in a
+#     detached `tokio::spawn` (documented in-situ; same org, already authorized).
+#   integrations/sync.rs — `let db = state.db.clone();` for a fire-and-forget
+#     background sync-status write to a non-FORCE-RLS table (documented in-situ).
+servers/api-server/src/routes/agency_provisioning.rs
+servers/api-server/src/routes/organizations/settings.rs
+servers/api-server/src/routes/integrations/sync.rs

--- a/backend/servers/api-server/src/routes/mfa.rs
+++ b/backend/servers/api-server/src/routes/mfa.rs
@@ -11,6 +11,7 @@ use axum::{
 use common::errors::ErrorResponse;
 use db::models::{AuditAction, CreateAuditLog, CreateTwoFactorAuth};
 use serde::{Deserialize, Serialize};
+use sqlx::Acquire;
 use utoipa::ToSchema;
 
 use crate::state::AppState;
@@ -326,11 +327,13 @@ pub async fn verify_mfa_setup(
     // Enable MFA and issue recovery codes in a single transaction so a crash
     // between the two steps cannot leave MFA enabled with zero recovery codes.
     //
-    // state.db (raw pool) is used rather than the RlsConnection because the
-    // mfa_recovery_codes and user_2fa tables both allow application-role writes
-    // without a per-session RLS context — the WHERE user_id = $1 clause scoped
-    // to the verified JWT subject provides the equivalent tenant isolation.
-    let mut tx = state.db.begin().await.map_err(|e| {
+    // The transaction runs on the SAME RLS connection used above (not a second
+    // `state.db.begin()` raw-pool connection), so `app.current_user_id` is set
+    // and the self-policies on `user_2fa` / `mfa_recovery_codes` (migrations
+    // 00024 / 00149) enforce — the `WHERE user_id = $1` clause scoped to the
+    // verified JWT subject is then defense-in-depth rather than the sole
+    // isolation, and the handler stays on one connection / one RLS context.
+    let mut tx = (&mut **rls.conn()).begin().await.map_err(|e| {
         tracing::error!(error = %e, "Failed to begin recovery codes transaction");
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -599,11 +602,16 @@ pub async fn disable_mfa(
         ));
     }
 
-    // Disable MFA and invalidate all recovery codes atomically.
-    // mfa_recovery_codes is user-scoped (no org_id, no FORCE RLS) — raw pool transaction
-    // is equivalent to RLS here; WHERE user_id = $1 from the JWT subject provides the
-    // required isolation (P4 sanctioned, same rationale as confirm_mfa above).
-    let mut tx = state.db.begin().await.map_err(|e| {
+    // Disable MFA and invalidate all recovery codes atomically, on the SAME
+    // RLS connection used above — not a second `state.db.begin()` raw-pool
+    // connection. Keeping the whole auth-critical handler on one connection
+    // means one RLS context: `app.current_user_id` is set, so the self-policies
+    // on `mfa_recovery_codes` / `user_2fa` (migrations 00149 / 00024) enforce,
+    // and the `WHERE user_id = $1` literal is defense-in-depth rather than the
+    // sole isolation (same rationale as verify_mfa_setup above). Both writes
+    // share one transaction so a crash between them cannot leave MFA enabled
+    // with live recovery codes (or recovery codes wiped with MFA still on).
+    let mut tx = (&mut **rls.conn()).begin().await.map_err(|e| {
         tracing::error!(error = %e, "Failed to begin disable transaction");
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -632,21 +640,10 @@ pub async fn disable_mfa(
         )
     })?;
 
-    tx.commit().await.map_err(|e| {
-        tracing::error!(error = %e, "Failed to commit disable transaction");
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new(
-                "DATABASE_ERROR",
-                "Failed to disable MFA",
-            )),
-        )
-    })?;
-
-    // Disable in user_2fa (via RLS connection).
+    // Disable in user_2fa within the SAME transaction.
     state
         .two_factor_repo
-        .disable_rls(&mut **rls.conn(), user_id)
+        .disable_rls(&mut *tx, user_id)
         .await
         .map_err(|e| {
             tracing::error!(error = %e, "Failed to disable MFA");
@@ -658,6 +655,17 @@ pub async fn disable_mfa(
                 )),
             )
         })?;
+
+    tx.commit().await.map_err(|e| {
+        tracing::error!(error = %e, "Failed to commit disable transaction");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "DATABASE_ERROR",
+                "Failed to disable MFA",
+            )),
+        )
+    })?;
 
     // Log MFA disabled (Story 9.6 - Audit logging)
     if let Err(e) = state
@@ -992,6 +1000,7 @@ pub struct VerifyRecoveryCodeResponse {
 pub async fn verify_recovery_code(
     State(state): State<AppState>,
     headers: axum::http::HeaderMap,
+    mut rls: RlsConnection,
     Json(req): Json<VerifyRecoveryCodeRequest>,
 ) -> Result<Json<VerifyRecoveryCodeResponse>, (StatusCode, Json<ErrorResponse>)> {
     let token = extract_bearer_token(&headers)?;
@@ -1004,25 +1013,22 @@ pub async fn verify_recovery_code(
         )
     })?;
 
-    // Acquire a connection for the user-scoped MFA tables (user_2fa,
-    // mfa_recovery_codes have no org_id and no FORCE RLS). acquire_public clears
-    // any stale RLS context left by a previous request on the pooled connection.
-    let mut conn = db::RlsPool::new(state.db.clone())
-        .acquire_public()
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "recovery/verify: pool acquire failed");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DATABASE_ERROR", "Failed to connect")),
-            )
-        })?;
+    // Run every query on the RLS connection so `app.current_user_id` is set for
+    // the duration of the handler. The self-policies on `user_2fa` /
+    // `mfa_recovery_codes` (migrations 00024 / 00149) gate on
+    // `app.current_user_id`, so this is what makes them enforce — the
+    // `WHERE user_id = $1` literal is then defense-in-depth, not the sole
+    // isolation. (Previously this acquired `acquire_public()`, which *clears*
+    // the GUC — leaving 100% of the isolation on the literal and silently
+    // turning into deny-all the moment these tables get FORCE RLS.)
+    // `rls.release()` is called before every return so the context is cleared
+    // before the connection returns to the pool.
 
     // Verify MFA is enabled for this user.
     let enrolled: Option<bool> =
         sqlx::query_scalar("SELECT enabled FROM user_2fa WHERE user_id = $1")
             .bind(user_id)
-            .fetch_optional(&mut **conn)
+            .fetch_optional(&mut **rls.conn())
             .await
             .map_err(|e| {
                 tracing::error!(error = %e, "recovery/verify: fetch enrollment failed");
@@ -1036,6 +1042,7 @@ pub async fn verify_recovery_code(
             })?;
 
     if !matches!(enrolled, Some(true)) {
+        rls.release().await;
         return Err((
             StatusCode::NOT_FOUND,
             Json(ErrorResponse::new(
@@ -1050,7 +1057,7 @@ pub async fn verify_recovery_code(
         "SELECT id, code_hash FROM mfa_recovery_codes WHERE user_id = $1 AND used_at IS NULL",
     )
     .bind(user_id)
-    .fetch_all(&mut **conn)
+    .fetch_all(&mut **rls.conn())
     .await
     .map_err(|e| {
         tracing::error!(error = %e, "recovery/verify: fetch codes failed");
@@ -1084,6 +1091,7 @@ pub async fn verify_recovery_code(
         {
             tracing::error!(error = %e, "Failed to write audit log for exhausted recovery codes");
         }
+        rls.release().await;
         return Err((
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -1129,6 +1137,7 @@ pub async fn verify_recovery_code(
         {
             tracing::error!(error = %e, "Failed to write audit log for invalid recovery code");
         }
+        rls.release().await;
         return Err((
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -1146,7 +1155,7 @@ pub async fn verify_recovery_code(
         "UPDATE mfa_recovery_codes SET used_at = NOW() WHERE id = $1 AND used_at IS NULL",
     )
     .bind(matched_id)
-    .execute(&mut **conn)
+    .execute(&mut **rls.conn())
     .await
     .map_err(|e| {
         tracing::error!(error = %e, "recovery/verify: mark used failed");
@@ -1161,6 +1170,7 @@ pub async fn verify_recovery_code(
 
     if upd.rows_affected() == 0 {
         // Lost race to a concurrent caller — fail closed.
+        rls.release().await;
         return Err((
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -1175,7 +1185,7 @@ pub async fn verify_recovery_code(
         "SELECT COUNT(*) FROM mfa_recovery_codes WHERE user_id = $1 AND used_at IS NULL",
     )
     .bind(user_id)
-    .fetch_one(&mut **conn)
+    .fetch_one(&mut **rls.conn())
     .await
     .unwrap_or(0);
 
@@ -1202,6 +1212,8 @@ pub async fn verify_recovery_code(
     }
 
     tracing::info!(user_id = %user_id, remaining, "MFA recovery code consumed");
+
+    rls.release().await;
 
     Ok(Json(VerifyRecoveryCodeResponse {
         message: "Recovery code accepted.".to_string(),

--- a/backend/servers/api-server/tests/mfa_recovery_cross_user_idor_tests.rs
+++ b/backend/servers/api-server/tests/mfa_recovery_cross_user_idor_tests.rs
@@ -39,6 +39,7 @@
 //!   `/mfa/setup` + `/mfa/verify` flow, so the test exercises only the endpoint
 //!   under audit and does not depend on TOTP timing / encryption config.
 
+#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/mfa_recovery_cross_user_idor_tests.rs
+++ b/backend/servers/api-server/tests/mfa_recovery_cross_user_idor_tests.rs
@@ -1,0 +1,232 @@
+//! Cross-user IDOR regression test for
+//! `POST /api/v1/users/me/mfa/recovery-codes/verify` (BIT-78 / GH #1302 + #1304).
+//!
+//! # Why this lives at the top level of `tests/`
+//!
+//! The functional flows for this endpoint exist under
+//! `tests/integration/mfa_recovery_codes_tests.rs` (T1–T6), but that directory
+//! is **never compiled** — nothing declares `mod integration;` and there is no
+//! `tests/integration/main.rs`, so Cargo's auto-discovery skips it (see the note
+//! in `tests/auth_enumeration_tests.rs`). A test placed there proves nothing
+//! because it never runs. This file is a real top-level test target and runs
+//! under `cargo test --workspace`.
+//!
+//! # What it proves (IG3)
+//!
+//!   **user A cannot consume or observe user B's recovery code.**
+//!
+//! It is constructed so it FAILS if the `WHERE user_id = $1` scoping were
+//! dropped from the handler's queries. `#[sqlx::test]` connects as a pool that
+//! is not subject to RLS enforcement, so the per-user isolation under test is
+//! carried by the handler's `WHERE user_id` predicate running on a connection
+//! whose `app.current_user_id` GUC is set (the BIT-78 `RlsConnection`
+//! conversion) — defense-in-depth that also holds once these tables get
+//! `FORCE ROW LEVEL SECURITY`. With the filter gone, user A's request would
+//! load user B's unused codes, match B's plaintext against B's hash, and
+//! consume it (200 + B's row marked `used_at`). The assertions below require
+//! the opposite: A is rejected (400), every one of B's codes stays unused, and
+//! B can still use the code afterwards.
+//!
+//! # Wiring notes
+//!
+//! * `TestApp` mounts the full router but no `host_tenant_middleware`, so the
+//!   MFA handlers' `RlsConnection` extractor resolves the tenant from the
+//!   `X-Tenant-ID` header + an active `organization_members` row. Each user is
+//!   provisioned via `create_authenticated_user_with_org`, and every request
+//!   carries `.tenant(org_id)`.
+//! * 2FA enrolment + recovery codes are seeded directly in the DB (mirroring the
+//!   live `admin_mfa_recovery_tests.rs`) rather than driven through the HTTP
+//!   `/mfa/setup` + `/mfa/verify` flow, so the test exercises only the endpoint
+//!   under audit and does not depend on TOTP timing / encryption config.
+
+mod common;
+
+use axum::http::StatusCode;
+use serde_json::{json, Value};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use api_server::services::TotpService;
+use common::{cleanup_test_user, create_authenticated_user_with_org, TestApp, TestUser};
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+async fn user_id_for(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(email)
+        .fetch_one(pool)
+        .await
+        .expect("resolve user id")
+}
+
+/// Enable 2FA for `user_id` with an encrypted TOTP secret (enrolment state the
+/// recovery-verify handler requires: `user_2fa.enabled = true`).
+async fn enroll_user_2fa(pool: &PgPool, user_id: Uuid) {
+    let totp = TotpService::new("Property Management".to_string());
+    let secret = totp.generate_secret().expect("gen secret");
+    let encrypted = totp.encrypt_secret(&secret).expect("encrypt secret");
+    sqlx::query(
+        r#"
+        INSERT INTO user_2fa (user_id, secret, enabled, enabled_at, backup_codes, backup_codes_remaining)
+        VALUES ($1, $2, true, NOW(), '[]'::jsonb, 0)
+        ON CONFLICT (user_id) DO UPDATE SET enabled = true, enabled_at = NOW()
+        "#,
+    )
+    .bind(user_id)
+    .bind(&encrypted)
+    .execute(pool)
+    .await
+    .expect("seed user_2fa");
+}
+
+/// Insert `n` single-use recovery codes for `user_id`; return the plaintext.
+async fn issue_recovery_codes(pool: &PgPool, user_id: Uuid, n: usize) -> Vec<String> {
+    let totp = TotpService::new("Property Management".to_string());
+    let (plain, hashed) = totp.generate_backup_codes().expect("gen backup codes");
+    let plain: Vec<String> = plain.into_iter().take(n).collect();
+    let hashed: Vec<String> = hashed.into_iter().take(n).collect();
+    for hash in &hashed {
+        sqlx::query("INSERT INTO mfa_recovery_codes (user_id, code_hash) VALUES ($1, $2)")
+            .bind(user_id)
+            .bind(hash)
+            .execute(pool)
+            .await
+            .expect("insert recovery code");
+    }
+    plain
+}
+
+async fn unused_code_count(pool: &PgPool, user_id: Uuid) -> i64 {
+    sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM mfa_recovery_codes WHERE user_id = $1 AND used_at IS NULL",
+    )
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .expect("count unused recovery codes")
+}
+
+async fn post_recovery_verify(
+    app: &TestApp,
+    token: &str,
+    org_id: Uuid,
+    code: &str,
+) -> (StatusCode, Value) {
+    let req = app
+        .post("/api/v1/users/me/mfa/recovery-codes/verify")
+        .bearer(token)
+        .tenant(org_id)
+        .json(json!({ "code": code }))
+        .build();
+    let resp = app.execute(req).await;
+    (resp.status, resp.json_value())
+}
+
+// ─── A cannot consume B's recovery code ──────────────────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn test_user_a_cannot_consume_user_b_recovery_code(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let user_a = TestUser::new();
+    let user_b = TestUser::new();
+    cleanup_test_user(&pool, &user_a.email).await;
+    cleanup_test_user(&pool, &user_b.email).await;
+
+    let (token_a, org_a) = create_authenticated_user_with_org(&app, &user_a, "a").await;
+    let (token_b, org_b) = create_authenticated_user_with_org(&app, &user_b, "b").await;
+    let id_a = user_id_for(&pool, &user_a.email).await;
+    let id_b = user_id_for(&pool, &user_b.email).await;
+
+    // Both users enrol in MFA and receive their own single-use codes.
+    enroll_user_2fa(&pool, id_a).await;
+    enroll_user_2fa(&pool, id_b).await;
+    let _codes_a = issue_recovery_codes(&pool, id_a, 10).await;
+    let codes_b = issue_recovery_codes(&pool, id_b, 10).await;
+    assert_eq!(unused_code_count(&pool, id_b).await, 10);
+
+    // ── The attack: A presents B's plaintext recovery code on A's own session.
+    // With per-user scoping intact this matches no row A may see, so it is
+    // rejected exactly like any other wrong code.
+    let victim_code = &codes_b[0];
+    let (status, body) = post_recovery_verify(&app, &token_a, org_a, victim_code).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "user A presenting user B's recovery code must be rejected (400), \
+         not silently consume B's code; body: {body}"
+    );
+
+    // ── Isolation invariant: B's codes are all untouched. If the WHERE user_id
+    // filter were dropped, A's request above would have consumed B's code and
+    // this count would be 9.
+    assert_eq!(
+        unused_code_count(&pool, id_b).await,
+        10,
+        "user A's attempt must NOT consume any of user B's recovery codes"
+    );
+
+    // ── And the code is genuinely valid: B can still consume it themselves,
+    // ruling out a false pass where the code was simply malformed.
+    let (b_status, b_body) = post_recovery_verify(&app, &token_b, org_b, victim_code).await;
+    assert_eq!(
+        b_status,
+        StatusCode::OK,
+        "user B must still consume their own (untouched) code; body: {b_body}"
+    );
+    assert_eq!(
+        b_body["codesRemaining"],
+        json!(9),
+        "after B consumes one of their own codes, 9 remain"
+    );
+
+    cleanup_test_user(&pool, &user_a.email).await;
+    cleanup_test_user(&pool, &user_b.email).await;
+}
+
+// ─── A's own consumption never touches B's codes ─────────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn test_user_a_consumption_does_not_affect_user_b_codes(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let user_a = TestUser::new();
+    let user_b = TestUser::new();
+    cleanup_test_user(&pool, &user_a.email).await;
+    cleanup_test_user(&pool, &user_b.email).await;
+
+    let (token_a, org_a) = create_authenticated_user_with_org(&app, &user_a, "a").await;
+    let (_token_b, _org_b) = create_authenticated_user_with_org(&app, &user_b, "b").await;
+    let id_a = user_id_for(&pool, &user_a.email).await;
+    let id_b = user_id_for(&pool, &user_b.email).await;
+
+    enroll_user_2fa(&pool, id_a).await;
+    enroll_user_2fa(&pool, id_b).await;
+    let codes_a = issue_recovery_codes(&pool, id_a, 10).await;
+    let _codes_b = issue_recovery_codes(&pool, id_b, 10).await;
+
+    // A consumes one of A's own codes successfully.
+    let (status, body) = post_recovery_verify(&app, &token_a, org_a, &codes_a[0]).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "A's own code must be accepted; body: {body}"
+    );
+    assert_eq!(body["codesRemaining"], json!(9));
+
+    // A's consumption is fully isolated to A: B still has all 10, and the
+    // remaining count A observed (9) reflects A's own rows, never B's.
+    assert_eq!(
+        unused_code_count(&pool, id_a).await,
+        9,
+        "A consumed exactly one of A's own codes"
+    );
+    assert_eq!(
+        unused_code_count(&pool, id_b).await,
+        10,
+        "B's codes are untouched by A's activity"
+    );
+
+    cleanup_test_user(&pool, &user_a.email).await;
+    cleanup_test_user(&pool, &user_b.email).await;
+}


### PR DESCRIPTION
Closes #1302, closes #1304. Parent BIT-68.

## The defect
PR #1292 "converted" `verify_recovery_code` (`backend/servers/api-server/src/routes/mfa.rs`) by swapping `&state.db` for `db::RlsPool::new(state.db.clone()).acquire_public()`. But `acquire_public()` **clears** `app.current_user_id`, so the RLS self-policies on `user_2fa` / `mfa_recovery_codes` (migrations `00024` / `00149`) never activate — isolation rested 100% on the `WHERE user_id = $1` literal. Latent fragility: once these tables get `FORCE ROW LEVEL SECURITY`, the cleared GUC → `''` → NULL → **deny-all**, locking users out of account recovery.

## Changes
1. **`verify_recovery_code`** — now takes the `RlsConnection` extractor (like the other handlers in this file) and runs all four queries on `&mut **rls.conn()` so `app.current_user_id` is set; `rls.release()` on every return. The `WHERE user_id` literal is now defense-in-depth, not the sole isolation.
2. **`disable_mfa`** — the recovery-code invalidation tx now begins on the RLS connection and the `user_2fa` disable runs in that **same** transaction (was a separate `state.db.begin()` raw-pool tx → two connections / two RLS contexts). One connection, one RLS context, one atomic tx.
3. **`verify_mfa_setup`** — same convergence onto the RLS connection's tx (it also used `state.db.begin()`), so `mfa.rs` no longer touches the raw pool at all.
4. **Comment fix** — `mfa.rs:~605` "same rationale as confirm_mfa above" → `verify_mfa_setup` (there is no `confirm_mfa`).
5. **Scanner** — `scripts/check-rls-enforcement.sh` `VIOLATION_PATTERNS` gains `state.db.begin` / `self.db.begin` and `state.db.clone` / `self.db.clone`. `is_sanctioned()` allow-lists the legitimate clone idioms (`Repo::new(state.db.clone())`, `db: self.db.clone(),`) so only a **bare** `let x = state.db.clone();` raw-pool extraction is flagged. Re-baselined three pre-existing, reviewed-as-acceptable non-RLS sites (`agency_provisioning` provisions a brand-new org before any tenant exists; `organizations/settings` + `integrations/sync` clone the service-role pool for detached background jobs after `rls.release()`). `mfa.rs` is **not** baselined — it is fully clean.

## IG3 test
`backend/servers/api-server/tests/mfa_recovery_cross_user_idor_tests.rs` — **user A cannot consume or observe user B's recovery code.**

> ⚠️ Note for reviewers: the issue asked for the test under `tests/integration/`, but that directory is **dead — never compiled** (no `mod integration;` anywhere, no `tests/integration/main.rs`, no `[[test]]`; see the note in `tests/auth_enumeration_tests.rs`). The existing T1–T6 there never run. I placed the IG3 test **top-level** so it actually runs under `cargo test --workspace`.

The test seeds 2FA + recovery codes directly in the DB (mirroring the live `admin_mfa_recovery_tests.rs`, avoiding the TOTP-timing/encryption dependency of the HTTP setup flow), then: user A presents user B's plaintext code on A's own session → asserts **400** and that **all of B's codes remain unused** and B can still consume the code. Because `#[sqlx::test]` runs on a pool not subject to RLS enforcement, the isolation is carried by the `WHERE user_id` predicate — so if that filter were dropped, A would load and consume B's code and the test would fail. That is exactly the regression guard the ticket asked for.

## Verify
```
cd backend && cargo test -p api-server --test mfa_recovery_cross_user_idor_tests
cd backend && bash scripts/check-rls-enforcement.sh --strict   # exit 0, mfa.rs clean
cd backend && cargo clippy -p api-server --all-targets -- -D warnings
```
⚠️ This implementer container has **no local Rust toolchain** (compiles offload to a remote host that is currently unreachable). `fmt`/`clippy`/`test` could not be run locally — **CI `backend.yml` is the verification path.** The scanner (`bash scripts/check-rls-enforcement.sh --strict`) **was** run locally and passes (exit 0) with `mfa.rs` clean and the three pre-existing sites baselined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)