### PR TITLE
fix(disputes): watch subscription + flush-on-unmount + i18n keys (GH #1364, #1404)

### DIFF
--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -541,7 +541,12 @@
       "errors": {
         "detailsMinLength": "Podrobnosti musí obsahovat alespoň 10 znaků."
       }
-    }
+    },
+    "draftSavedAgo": "Návrh uložen · {{time}}",
+    "draftJustNow": "právě teď",
+    "draftSecondsAgo": "před {{count}}s",
+    "draftMinutesAgo": "před {{count}}m",
+    "draftRestored": "Obnovili jsme váš uložený návrh."
   },
   "packages": {
     "title": "Správa zásilek",

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -540,7 +540,12 @@
       "errors": {
         "detailsMinLength": "Details müssen mindestens 10 Zeichen enthalten."
       }
-    }
+    },
+    "draftSavedAgo": "Entwurf gespeichert · {{time}}",
+    "draftJustNow": "gerade eben",
+    "draftSecondsAgo": "vor {{count}}s",
+    "draftMinutesAgo": "vor {{count}}m",
+    "draftRestored": "Ihr gespeicherter Entwurf wurde wiederhergestellt."
   },
   "packages": {
     "title": "Paketverwaltung",

--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -601,7 +601,12 @@
       "errors": {
         "detailsMinLength": "Details must be at least 10 characters."
       }
-    }
+    },
+    "draftSavedAgo": "Draft saved · {{time}}",
+    "draftJustNow": "just now",
+    "draftSecondsAgo": "{{count}}s ago",
+    "draftMinutesAgo": "{{count}}m ago",
+    "draftRestored": "Restored your saved draft."
   },
   "packages": {
     "title": "Package Management",

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -540,7 +540,12 @@
       "errors": {
         "detailsMinLength": "A részleteknek legalább 10 karaktert kell tartalmazniuk."
       }
-    }
+    },
+    "draftSavedAgo": "Piszkozat mentve · {{time}}",
+    "draftJustNow": "épp most",
+    "draftSecondsAgo": "{{count}} másodperce",
+    "draftMinutesAgo": "{{count}} perce",
+    "draftRestored": "A mentett piszkozatot visszaállítottuk."
   },
   "packages": {
     "title": "Csomagkezelés",

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -542,7 +542,12 @@
       "errors": {
         "detailsMinLength": "Szczegóły muszą zawierać co najmniej 10 znaków."
       }
-    }
+    },
+    "draftSavedAgo": "Szkic zapisany · {{time}}",
+    "draftJustNow": "przed chwilą",
+    "draftSecondsAgo": "{{count}}s temu",
+    "draftMinutesAgo": "{{count}}m temu",
+    "draftRestored": "Przywrócono zapisany szkic."
   },
   "packages": {
     "title": "Zarządzanie przesyłkami",

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -542,7 +542,12 @@
       "errors": {
         "detailsMinLength": "Podrobnosti musia obsahovať aspoň 10 znakov."
       }
-    }
+    },
+    "draftSavedAgo": "Návrh uložený · {{time}}",
+    "draftJustNow": "práve teraz",
+    "draftSecondsAgo": "pred {{count}}s",
+    "draftMinutesAgo": "pred {{count}}m",
+    "draftRestored": "Obnovili sme váš uložený návrh."
   },
   "packages": {
     "title": "Správa zásielok",

--- a/frontend/apps/ppt-web/src/features/command-palette/hooks/useCommandPalette.tsx
+++ b/frontend/apps/ppt-web/src/features/command-palette/hooks/useCommandPalette.tsx
@@ -12,23 +12,11 @@ import {
   useMemo,
   useState,
 } from 'react';
+import { isLocalStorageAvailable } from '../../../lib/storage';
 import type { Command, CommandPaletteContextValue } from '../types';
 
 const RECENT_COMMANDS_KEY = 'ppt-command-palette-recent';
 const MAX_RECENT_COMMANDS = 5;
-
-/** Check if localStorage is available */
-function isLocalStorageAvailable(): boolean {
-  try {
-    if (typeof window === 'undefined') return false;
-    const test = '__storage_test__';
-    window.localStorage.setItem(test, test);
-    window.localStorage.removeItem(test);
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 const CommandPaletteContext = createContext<CommandPaletteContextValue | null>(null);
 

--- a/frontend/apps/ppt-web/src/features/disputes/hooks/useDraftStorage.ts
+++ b/frontend/apps/ppt-web/src/features/disputes/hooks/useDraftStorage.ts
@@ -13,19 +13,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-
-/** Check if localStorage is available (private mode / SSR guard). */
-function isLocalStorageAvailable(): boolean {
-  try {
-    if (typeof window === 'undefined') return false;
-    const test = '__draft_storage_test__';
-    window.localStorage.setItem(test, test);
-    window.localStorage.removeItem(test);
-    return true;
-  } catch {
-    return false;
-  }
-}
+import { isLocalStorageAvailable } from '../../../lib/storage';
 
 interface StoredDraft<T> {
   /** Persisted form values. */
@@ -90,6 +78,8 @@ export function useDraftStorage<T>(
   });
 
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingRef = useRef<T | null>(null);
+  const flushRef = useRef<(values: T) => void>(() => undefined);
 
   const flush = useCallback(
     (values: T) => {
@@ -98,16 +88,19 @@ export function useDraftStorage<T>(
         const payload: StoredDraft<T> = { values, savedAt: Date.now() };
         window.localStorage.setItem(key, JSON.stringify(payload));
         setSavedAt(payload.savedAt);
+        pendingRef.current = null;
       } catch {
         // Quota exceeded or serialisation error — best-effort, swallow.
       }
     },
     [available, key]
   );
+  flushRef.current = flush;
 
   const save = useCallback(
     (values: T) => {
       if (!available) return;
+      pendingRef.current = values;
       if (timerRef.current) clearTimeout(timerRef.current);
       timerRef.current = setTimeout(() => flush(values), debounceMs);
     },
@@ -119,6 +112,7 @@ export function useDraftStorage<T>(
       clearTimeout(timerRef.current);
       timerRef.current = null;
     }
+    pendingRef.current = null;
     setSavedAt(null);
     if (!available) return;
     try {
@@ -128,11 +122,17 @@ export function useDraftStorage<T>(
     }
   }, [available, key]);
 
-  // Flush any pending debounced save on unmount so a quick close-after-typing
-  // doesn't lose the last keystrokes.
+  // On unmount flush any pending debounced save so typing-then-closing doesn't
+  // lose the last keystrokes. Access flush via ref so this effect registers once.
   useEffect(() => {
     return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      if (pendingRef.current !== null) {
+        flushRef.current(pendingRef.current);
+      }
     };
   }, []);
 

--- a/frontend/apps/ppt-web/src/features/disputes/pages/FileDisputePage.tsx
+++ b/frontend/apps/ppt-web/src/features/disputes/pages/FileDisputePage.tsx
@@ -11,7 +11,7 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import React from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { Controller, useForm, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { z } from 'zod';
@@ -144,15 +144,24 @@ export function FileDisputePage({
   // serialisable by zod; they are passed alongside the validated values).
   const [evidence, setEvidence] = React.useState<PendingEvidence[]>([]);
 
-  // Persist the draft on every change (debounced inside the hook). Skip while a
-  // submit is in flight so we don't re-save a form that's about to be cleared.
-  const watchedValues = watch();
+  // Keep isSubmitting in a ref so the watch subscription closure doesn't
+  // re-register every time the flag toggles.
+  const isSubmittingRef = React.useRef(isSubmitting);
   React.useEffect(() => {
-    if (isSubmitting) return;
-    save(watchedValues);
-  }, [watchedValues, isSubmitting, save]);
+    isSubmittingRef.current = isSubmitting;
+  }, [isSubmitting]);
 
-  const descriptionLength = watchedValues.description?.length ?? 0;
+  // Subscribe to field changes (fires only on real changes, not on every render)
+  // and persist the draft debounced. Skips while a submit is in flight.
+  React.useEffect(() => {
+    const sub = watch((values) => {
+      if (!isSubmittingRef.current) save(values as Partial<DisputeFormValues>);
+    });
+    return () => sub.unsubscribe();
+  }, [watch, save]);
+
+  const descriptionValue = useWatch({ control, name: 'description' });
+  const descriptionLength = descriptionValue?.length ?? 0;
 
   const handleFormSubmit = handleSubmit(async (values) => {
     try {

--- a/frontend/apps/ppt-web/src/lib/storage.ts
+++ b/frontend/apps/ppt-web/src/lib/storage.ts
@@ -1,0 +1,12 @@
+/** Returns true when localStorage is accessible (guards against private-mode and SSR). */
+export function isLocalStorageAvailable(): boolean {
+  try {
+    if (typeof window === 'undefined') return false;
+    const key = '__storage_test__';
+    window.localStorage.setItem(key, key);
+    window.localStorage.removeItem(key);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Closes #1364. Closes #1404.

- **`FileDisputePage.tsx`** — replaces the `watch()` no-arg render-polling pattern with the `watch(cb)` subscription form so `save()` fires only on real field value changes, eliminating the re-render feedback loop and the save-on-mount churn. Tracks `isSubmitting` in a ref so the subscription closure does not re-register every time the mutation flag toggles. Uses `useWatch` for the description character counter to keep it reactive without re-introducing the polling anti-pattern.
- **`useDraftStorage.ts`** — adds `pendingRef` to track the latest queued values, and flushes it synchronously on unmount so a typing-then-navigate sequence no longer silently drops the last keystrokes. `flush` is accessed via a stable `flushRef` so the one-time cleanup `useEffect` has an empty dep array without triggering Biome's `useExhaustiveDependencies` rule.
- **i18n** — adds `disputes.draftSavedAgo`, `disputes.draftJustNow`, `disputes.draftSecondsAgo`, `disputes.draftMinutesAgo`, `disputes.draftRestored` keys to all 6 locale bundles (`en/sk/cs/de/pl/hu`). Previously these fell back silently to English `defaultValue` strings in non-English locales.

GH #1411 (mobile App.tsx wiring test) was closed separately — the issue itself acknowledges no action is required until the pre-existing `react-test-renderer` peer-dep mismatch is resolved.

## Test plan

- [ ] CI `frontend.yml` passes (Biome + typecheck + Vitest)
- [ ] Existing 33 dispute unit/page tests still green (no behaviour change in common path)
- [ ] Manual: on the filing form, the "Draft saved" pill does not appear on a freshly-loaded untouched form
- [ ] Manual: typing in any field triggers the pill after ~800 ms
- [ ] Manual: typing then immediately navigating away still persists the draft (flush-on-unmount)
- [ ] Manual: sk/cs/de/pl/hu locales render translated draft copy instead of English fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)