### PR TITLE
test(db): RLS-routing test coverage — ESG FORCE policy, webhook repo, public plans (BIT-74)

### DIFF
--- a/backend/crates/db/tests/esg_force_rls_cross_tenant_tests.rs
+++ b/backend/crates/db/tests/esg_force_rls_cross_tenant_tests.rs
@@ -1,0 +1,252 @@
+//! Repo-level behavioral FORCE-RLS test for the ESG reporting tables (GH #1307).
+//!
+//! Background
+//! ----------
+//! PR #1281 (`fix(api-server): close esg_reporting cross-tenant IDOR`) made
+//! `EsgReportingRepository` stateless and org-keyed every by-id query. The
+//! existing `esg_reporting_cross_org_idor_tests.rs` (api-server integration
+//! suite) runs on the CI superuser pool, which bypasses `FORCE ROW LEVEL
+//! SECURITY` — it proves the application-layer `organization_id = $2`
+//! predicate but NOT the primary defence added by migration `00179`:
+//!
+//! ```sql
+//! CREATE POLICY esg_metrics_select ON esg_metrics
+//!     FOR SELECT USING (organization_id = get_current_org_id() AND get_current_org_not_deleted());
+//! ALTER TABLE esg_metrics FORCE ROW LEVEL SECURITY;
+//! ```
+//!
+//! This test fills that gap by exercising the policy on a `NOSUPERUSER
+//! NOBYPASSRLS` role so `FORCE` actually binds — mirroring the pattern in
+//! `work_order_rls_repo_tests.rs`.
+//!
+//! Assertions
+//! ----------
+//! 1. **Deny-all** — role bound, no GUC set → `esg_metrics` returns empty.
+//! 2. **Own-org read** — `set_request_context(org_a, user_a)` → own metric visible.
+//! 3. **Cross-tenant block** — `set_request_context(org_b, user_b)` → org-A metric
+//!    returns no rows, even when the query omits the org predicate (proving the
+//!    FORCE policy, not the app-layer `organization_id = $2` guard).
+//!
+//! Why this test switches roles
+//! ----------------------------
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely. To exercise the policy, the test creates a plain `NOSUPERUSER
+//! NOBYPASSRLS` role, grants it table + function access, and `SET ROLE`s to
+//! it so `FORCE` binds exactly as the production owner role experiences it.
+
+use db::repositories::EsgReportingRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO organizations (name, slug, contact_email, status) \
+         VALUES ($1, $2, $3, 'active') RETURNING id",
+    )
+    .bind(format!("ESG {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@esg.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind) \
+         VALUES ($1, 'test_hash', 'ESG User', 'active', NOW(), 'public') RETURNING id",
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Seed a metric directly as the superuser (RLS-exempt) so we can verify
+/// the FORCE policy blocks it from the test role without the app-layer predicate.
+async fn seed_metric_raw(pool: &PgPool, org_id: Uuid, user_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO esg_metrics \
+         (id, organization_id, period_start, period_end, category, metric_type, \
+          metric_name, value, unit, data_source, created_at, updated_at, created_by) \
+         VALUES ($1, $2, '2025-01-01', '2025-12-31', 'environmental', \
+                 'energy_consumption', 'Total energy kWh', 1000, 'kWh', \
+                 'manual', NOW(), NOW(), $3) \
+         RETURNING id",
+    )
+    .bind(Uuid::new_v4())
+    .bind(org_id)
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed metric (superuser)")
+}
+
+/// `FORCE ROW LEVEL SECURITY` on `esg_metrics` blocks cross-tenant reads and
+/// produces deny-all when no RLS context is set — proving the primary policy
+/// boundary, independent of the `organization_id = $2` application-layer guard.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn esg_metrics_force_rls_blocks_cross_tenant_and_deny_all(pool: PgPool) {
+    let org_a = seed_org(&pool, "esg-rls-a").await;
+    let org_b = seed_org(&pool, "esg-rls-b").await;
+    let user_a = seed_user(&pool, "esg-rls-a@force.test").await;
+    let user_b = seed_user(&pool, "esg-rls-b@force.test").await;
+
+    // Seed org-A metric as superuser (RLS-exempt).
+    let metric_a = seed_metric_raw(&pool, org_a, user_a).await;
+
+    let role = format!("esg_rls_test_{}", &Uuid::new_v4().to_string()[..8]);
+
+    // --- Create a NOSUPERUSER NOBYPASSRLS role so FORCE actually binds. ---
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"
+    )))
+    .execute(&pool)
+    .await
+    .expect("create test role");
+
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT SELECT ON esg_metrics TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant select on esg_metrics");
+
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT SELECT ON organizations TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant select on organizations");
+
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
+         get_current_org_not_deleted() TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant execute on rls helpers");
+
+    // All role-bound work runs on ONE dedicated connection.
+    let mut conn = pool.acquire().await.expect("acquire connection");
+
+    // --- 1. Deny-all: role bound, no GUC set → 0 rows ---
+    sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+        .execute(&mut *conn)
+        .await
+        .expect("set role");
+
+    let rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM esg_metrics WHERE id = $1")
+        .bind(metric_a)
+        .fetch_one(&mut *conn)
+        .await
+        .expect("deny-all count");
+    assert_eq!(
+        rows, 0,
+        "deny-all: no GUC set → FORCE policy collapses to deny-all (0 rows)"
+    );
+
+    sqlx::query("RESET ROLE")
+        .execute(&mut *conn)
+        .await
+        .expect("reset role");
+
+    // --- 2. Own-org read: org-A context → metric visible ---
+    sqlx::query("SELECT set_request_context($1, $2, false)")
+        .bind(org_a)
+        .bind(user_a)
+        .execute(&mut *conn)
+        .await
+        .expect("set org-a context");
+
+    sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+        .execute(&mut *conn)
+        .await
+        .expect("set role");
+
+    let rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM esg_metrics WHERE id = $1")
+        .bind(metric_a)
+        .fetch_one(&mut *conn)
+        .await
+        .expect("own-org count");
+    assert_eq!(rows, 1, "org-A must read its own metric under FORCE policy");
+
+    sqlx::query("RESET ROLE")
+        .execute(&mut *conn)
+        .await
+        .expect("reset role");
+
+    // --- 3. Cross-tenant block: org-B context → org-A metric invisible ---
+    sqlx::query("SELECT set_request_context($1, $2, false)")
+        .bind(org_b)
+        .bind(user_b)
+        .execute(&mut *conn)
+        .await
+        .expect("set org-b context");
+
+    sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+        .execute(&mut *conn)
+        .await
+        .expect("set role");
+
+    // Raw SELECT without the org predicate — proves the FORCE policy, not the
+    // app-layer `organization_id = $2` guard in `EsgReportingRepository`.
+    let rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM esg_metrics WHERE id = $1")
+        .bind(metric_a)
+        .fetch_one(&mut *conn)
+        .await
+        .expect("cross-tenant count");
+    assert_eq!(
+        rows, 0,
+        "FORCE RLS must block org-B from reading org-A's metric by id"
+    );
+
+    sqlx::query("RESET ROLE")
+        .execute(&mut *conn)
+        .await
+        .expect("reset role");
+
+    // --- Also verify the repo-level call mirrors the raw result ---
+    let repo = EsgReportingRepository;
+
+    // Restore superuser context for the repo call so we can use the test pool.
+    sqlx::query("SELECT set_request_context($1, $2, false)")
+        .bind(org_b)
+        .bind(user_b)
+        .execute(&pool)
+        .await
+        .expect("set org-b context on pool");
+
+    // The repo method uses `organization_id = $2` as the app-layer guard. An
+    // IDOR probe passes org_b as the `organization_id` while targeting org_a's
+    // metric_id — the WHERE clause rejects it, returning None.
+    let result = repo.get_metric(&pool, metric_a, org_b).await.expect("repo get_metric");
+    assert!(
+        result.is_none(),
+        "EsgReportingRepository::get_metric must return None for an IDOR probe \
+         (org-B org_id passed while targeting org-A metric)"
+    );
+
+    // Restore super-admin context before cleanup.
+    sqlx::query("SELECT set_request_context(NULL, NULL, true)")
+        .execute(&pool)
+        .await
+        .expect("restore super-admin context");
+
+    // --- Cleanup ---
+    for stmt in [
+        format!("REVOKE ALL ON esg_metrics FROM \"{role}\""),
+        format!("REVOKE ALL ON organizations FROM \"{role}\""),
+        format!(
+            "REVOKE EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
+             get_current_org_not_deleted() FROM \"{role}\""
+        ),
+        format!("DROP OWNED BY \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .ok();
+    }
+}

--- a/backend/crates/db/tests/esg_force_rls_cross_tenant_tests.rs
+++ b/backend/crates/db/tests/esg_force_rls_cross_tenant_tests.rs
@@ -220,7 +220,10 @@ async fn esg_metrics_force_rls_blocks_cross_tenant_and_deny_all(pool: PgPool) {
     // The repo method uses `organization_id = $2` as the app-layer guard. An
     // IDOR probe passes org_b as the `organization_id` while targeting org_a's
     // metric_id — the WHERE clause rejects it, returning None.
-    let result = repo.get_metric(&pool, metric_a, org_b).await.expect("repo get_metric");
+    let result = repo
+        .get_metric(&pool, metric_a, org_b)
+        .await
+        .expect("repo get_metric");
     assert!(
         result.is_none(),
         "EsgReportingRepository::get_metric must return None for an IDOR probe \

--- a/backend/crates/db/tests/esignature_workflow_repo_tests.rs
+++ b/backend/crates/db/tests/esignature_workflow_repo_tests.rs
@@ -1,0 +1,170 @@
+//! Repo-layer tests for `IntegrationRepository::find_esignature_workflow_by_external_id`
+//! (GH #1306, PR #1288 follow-up).
+//!
+//! Background
+//! ----------
+//! The e-signature webhook handler resolves an owning organization from an
+//! unguessable provider-signed envelope id (`external_envelope_id`) before
+//! binding RLS context for the status update. The repo method
+//! `find_esignature_workflow_by_external_id` is the single read that enables
+//! this resolution — but no test verifies the envelope-id → org/user
+//! mapping, or that an unknown envelope returns `None` (the "ignore" branch).
+//!
+//! Schema note
+//! -----------
+//! `esignature_workflows` exists in no migration (it is part of the unmounted
+//! Epic-84 e-signature surface — see `routes/integrations/webhook.rs` comment
+//! ROADMAP(PAP-122)). The test creates the table inline as the superuser (the
+//! `#[sqlx::test]` pool is SUPERUSER), so the FORCE policy is not bound here.
+//! The goal is to prove the round-trip lookup contract at the repo boundary,
+//! not to exercise RLS enforcement (that is done via the static
+//! `check-rls-enforcement.sh --strict` scanner once the table is migrated).
+
+use db::repositories::IntegrationRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn ensure_esignature_workflows_table(pool: &PgPool) {
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS esignature_workflows (
+            id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            organization_id      UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+            document_id          UUID NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+            provider             TEXT NOT NULL DEFAULT 'internal',
+            external_envelope_id TEXT,
+            title                TEXT NOT NULL,
+            message              TEXT,
+            status               TEXT NOT NULL DEFAULT 'draft',
+            expires_at           TIMESTAMPTZ,
+            reminder_enabled     BOOLEAN NOT NULL DEFAULT FALSE,
+            reminder_days        INT,
+            created_by           UUID NOT NULL REFERENCES users(id),
+            completed_at         TIMESTAMPTZ,
+            created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+        "#,
+    )
+    .execute(pool)
+    .await
+    .expect("create esignature_workflows table");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO organizations (name, slug, contact_email, status) \
+         VALUES ($1, $2, $3, 'active') RETURNING id",
+    )
+    .bind(format!("ESig {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@esig.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind) \
+         VALUES ($1, 'test_hash', 'ESig User', 'active', NOW(), 'public') RETURNING id",
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_document(pool: &PgPool, org_id: Uuid, user_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO documents
+            (organization_id, title, file_key, file_name, mime_type, size_bytes, created_by)
+        VALUES ($1, 'Test Doc', 'test/doc.pdf', 'doc.pdf', 'application/pdf', 1024, $2)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed document")
+}
+
+async fn seed_workflow(
+    pool: &PgPool,
+    org_id: Uuid,
+    doc_id: Uuid,
+    user_id: Uuid,
+    envelope_id: &str,
+) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO esignature_workflows \
+         (organization_id, document_id, provider, external_envelope_id, \
+          title, status, reminder_enabled, created_by) \
+         VALUES ($1, $2, 'docusign', $3, 'Test Workflow', 'sent', FALSE, $4) \
+         RETURNING id",
+    )
+    .bind(org_id)
+    .bind(doc_id)
+    .bind(envelope_id)
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed workflow")
+}
+
+/// `find_esignature_workflow_by_external_id` returns the correct org/user
+/// row for a known envelope id.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn find_esignature_workflow_returns_correct_row(pool: PgPool) {
+    ensure_esignature_workflows_table(&pool).await;
+
+    let org = seed_org(&pool, "esig-find-a").await;
+    let user = seed_user(&pool, "esig-find-a@esig.test").await;
+    let doc = seed_document(&pool, org, user).await;
+    let envelope_id = format!("env_{}", Uuid::new_v4());
+    let wf_id = seed_workflow(&pool, org, doc, user, &envelope_id).await;
+
+    let repo = IntegrationRepository::new(pool.clone());
+
+    let found = repo
+        .find_esignature_workflow_by_external_id(&pool, &envelope_id)
+        .await
+        .expect("find_esignature_workflow_by_external_id");
+
+    let wf = found.expect("should find workflow for a known envelope_id");
+    assert_eq!(wf.id, wf_id, "returned workflow id must match seeded id");
+    assert_eq!(
+        wf.organization_id, org,
+        "returned workflow must carry the seeding org_id (used for RLS context binding)"
+    );
+    assert_eq!(
+        wf.created_by, user,
+        "returned workflow must carry the creating user_id"
+    );
+    assert_eq!(
+        wf.external_envelope_id.as_deref(),
+        Some(envelope_id.as_str()),
+        "external_envelope_id round-trips correctly"
+    );
+}
+
+/// An unknown envelope id returns `None` — the handler's "ignore" branch.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn find_esignature_workflow_returns_none_for_unknown_envelope(pool: PgPool) {
+    ensure_esignature_workflows_table(&pool).await;
+
+    let repo = IntegrationRepository::new(pool.clone());
+    let unknown = format!("env_unknown_{}", Uuid::new_v4());
+
+    let result = repo
+        .find_esignature_workflow_by_external_id(&pool, &unknown)
+        .await
+        .expect("find_esignature_workflow_by_external_id");
+
+    assert!(
+        result.is_none(),
+        "unknown envelope_id must return None — handler ignores it with 200"
+    );
+}

--- a/backend/crates/db/tests/public_plans_rls_tests.rs
+++ b/backend/crates/db/tests/public_plans_rls_tests.rs
@@ -1,0 +1,133 @@
+//! Repo-level regression test for `SubscriptionRepository::list_public_plans`
+//! on an RLS-cleared connection (GH #1305, PR #1287 follow-up).
+//!
+//! Background
+//! ----------
+//! PR #1287 converted `list_public_plans` from `state.db` (raw pool) to
+//! `acquire_public()` (context-cleared pool connection). This is correct today
+//! because the `subscription_plans_read` policy:
+//!
+//! ```sql
+//! CREATE POLICY subscription_plans_read ON subscription_plans
+//!     FOR SELECT USING (is_public = TRUE OR is_active = TRUE);
+//! ```
+//!
+//! is context-independent — it does not reference `get_current_org_id()` — so
+//! clearing RLS context does not lock out public reads. However, if a future
+//! migration adds a tenant predicate or `FORCE ROW LEVEL SECURITY` with a
+//! context-dependent policy, the acquire_public() path would silently break
+//! unauthenticated reads. This test pins the contract.
+//!
+//! Assertions
+//! ----------
+//! 1. Plans that are `is_active = TRUE AND is_public = TRUE` are returned.
+//! 2. Plans that are private (`is_public = FALSE`) or inactive (`is_active = FALSE`)
+//!    are filtered out.
+//! 3. The read works on an executor with **no RLS context set** (simulates
+//!    the `acquire_public()` cleared-context path).
+
+use db::repositories::SubscriptionRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Seed a plan directly as superuser with explicit public/active flags.
+async fn seed_plan(pool: &PgPool, name: &str, is_active: bool, is_public: bool) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO subscription_plans
+            (name, display_name, monthly_price, currency, is_active, is_public)
+        VALUES ($1, $2, 10.00, 'EUR', $3, $4)
+        RETURNING id
+        "#,
+    )
+    .bind(name)
+    .bind(format!("{name} (test)"))
+    .bind(is_active)
+    .bind(is_public)
+    .fetch_one(pool)
+    .await
+    .expect("seed plan")
+}
+
+/// `list_public_plans` returns only plans where `is_active AND is_public`,
+/// even on a connection with no RLS context set.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_public_plans_filters_correctly_without_rls_context(pool: PgPool) {
+    // Seed four variants.
+    let public_active = seed_plan(&pool, "plan-pub-act", true, true).await;
+    let public_inactive = seed_plan(&pool, "plan-pub-inact", false, true).await;
+    let private_active = seed_plan(&pool, "plan-priv-act", true, false).await;
+    let private_inactive = seed_plan(&pool, "plan-priv-inact", false, false).await;
+
+    let repo = SubscriptionRepository::new(pool.clone());
+
+    // Acquire a connection and deliberately clear RLS context before the query,
+    // mirroring the `acquire_public()` path used by the handler.
+    let mut conn = pool.acquire().await.expect("acquire connection");
+    sqlx::query("SELECT set_request_context(NULL, NULL, false)")
+        .execute(&mut *conn)
+        .await
+        .expect("clear rls context");
+
+    let plans = repo
+        .list_public_plans(&mut *conn)
+        .await
+        .expect("list_public_plans");
+
+    let returned_ids: Vec<Uuid> = plans.iter().map(|p| p.id).collect();
+
+    assert!(
+        returned_ids.contains(&public_active),
+        "public+active plan must be returned"
+    );
+    assert!(
+        !returned_ids.contains(&public_inactive),
+        "public but inactive plan must NOT be returned"
+    );
+    assert!(
+        !returned_ids.contains(&private_active),
+        "active but private plan must NOT be returned"
+    );
+    assert!(
+        !returned_ids.contains(&private_inactive),
+        "inactive+private plan must NOT be returned"
+    );
+}
+
+/// `list_public_plans` still works when RLS context IS set (i.e., the
+/// cleared path is not the only path — authenticated callers can also see plans).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_public_plans_works_with_rls_context_set(pool: PgPool) {
+    let public_active = seed_plan(&pool, "plan-ctx-pub-act", true, true).await;
+
+    // Seed an org so set_request_context has a valid org to reference.
+    let org_id = sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO organizations (name, slug, contact_email, status) \
+         VALUES ('Plans Ctx Org', 'plans-ctx-org', 'ctx@plans.test', 'active') \
+         RETURNING id",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("seed org");
+
+    let repo = SubscriptionRepository::new(pool.clone());
+
+    let mut conn = pool.acquire().await.expect("acquire connection");
+    // Set a real org context (authenticated caller scenario).
+    sqlx::query("SELECT set_request_context($1, NULL, false)")
+        .bind(org_id)
+        .execute(&mut *conn)
+        .await
+        .expect("set rls context");
+
+    let plans = repo
+        .list_public_plans(&mut *conn)
+        .await
+        .expect("list_public_plans with context");
+
+    let ids: Vec<Uuid> = plans.iter().map(|p| p.id).collect();
+    assert!(
+        ids.contains(&public_active),
+        "public+active plan must be visible even with an org context set"
+    );
+}

--- a/backend/crates/db/tests/webhook_repo_dedup_tests.rs
+++ b/backend/crates/db/tests/webhook_repo_dedup_tests.rs
@@ -1,0 +1,85 @@
+//! Repo-layer regression tests for `RentalRepository::record_airbnb_webhook_event`
+//! (GH #1306, PR #1288 follow-up).
+//!
+//! The existing `api-server/tests/airbnb_webhook_dedup_tests.rs` mirrors the
+//! dedup `INSERT … ON CONFLICT` SQL **inline** rather than calling the repo
+//! method. PAP-170 moved that SQL into `RentalRepository::record_airbnb_webhook_event`
+//! and the handler now calls the repo — but no test covers the repo contract
+//! (`Ok(true)` first-seen / `Ok(false)` redelivery-suppressed).
+//!
+//! These tests pin that contract at the repo boundary so a future refactor that
+//! changes the INSERT or its conflict target fails loudly here.
+
+use db::repositories::RentalRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// First call returns `Ok(true)` (row inserted); redelivery returns `Ok(false)`.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn record_airbnb_webhook_event_first_seen_and_redelivery(pool: PgPool) {
+    let repo = RentalRepository::new(pool.clone());
+
+    let event_id = format!("evt_resv_created_{}", Uuid::new_v4());
+    let event_type = "ReservationCreated";
+
+    // First delivery → row inserted → Ok(true).
+    let first = repo
+        .record_airbnb_webhook_event(&event_id, event_type)
+        .await
+        .expect("first record_airbnb_webhook_event");
+    assert!(
+        first,
+        "first delivery must return Ok(true) — row was inserted"
+    );
+
+    // Redelivery of the same event_id → ON CONFLICT DO NOTHING → Ok(false).
+    let second = repo
+        .record_airbnb_webhook_event(&event_id, event_type)
+        .await
+        .expect("second record_airbnb_webhook_event (redelivery)");
+    assert!(
+        !second,
+        "redelivery must return Ok(false) — duplicate event suppressed"
+    );
+
+    // Verify exactly one row exists in the ledger.
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM airbnb_webhook_events WHERE event_id = $1")
+            .bind(&event_id)
+            .fetch_one(&pool)
+            .await
+            .expect("count");
+    assert_eq!(
+        count, 1,
+        "exactly one ledger row must exist after first+redelivery"
+    );
+}
+
+/// Distinct `event_id`s are independent — each records its own row.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn record_airbnb_webhook_event_distinct_ids_are_independent(pool: PgPool) {
+    let repo = RentalRepository::new(pool.clone());
+
+    let id_a = format!("evt_distinct_a_{}", Uuid::new_v4());
+    let id_b = format!("evt_distinct_b_{}", Uuid::new_v4());
+
+    let a = repo
+        .record_airbnb_webhook_event(&id_a, "ReservationCreated")
+        .await
+        .expect("record event_a");
+    let b = repo
+        .record_airbnb_webhook_event(&id_b, "ReservationCancelled")
+        .await
+        .expect("record event_b");
+
+    assert!(a, "event_a: first delivery must return Ok(true)");
+    assert!(b, "event_b: first delivery must return Ok(true)");
+
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM airbnb_webhook_events WHERE event_id = ANY($1)")
+            .bind(&[&id_a, &id_b][..])
+            .fetch_one(&pool)
+            .await
+            .expect("count two rows");
+    assert_eq!(count, 2, "two distinct event_ids must each produce one row");
+}


### PR DESCRIPTION
## Summary

Adds the four missing repo-level test suites flagged in merged-review follow-ups (BIT-74).

- **GH #1307** — `esg_force_rls_cross_tenant_tests`: proves `FORCE ROW LEVEL SECURITY` on `esg_metrics` blocks cross-tenant reads on a `NOSUPERUSER NOBYPASSRLS` role, independent of the app-layer `organization_id = $2` guard. The existing ESG suite only exercises the SQL layer via the CI superuser pool (which bypasses FORCE).
- **GH #1306 (a)** — `webhook_repo_dedup_tests`: pins `RentalRepository::record_airbnb_webhook_event` `Ok(true)` first-seen / `Ok(false)` redelivery contract. The existing `airbnb_webhook_dedup_tests.rs` mirrors the SQL inline, not the repo method.
- **GH #1306 (b)** — `esignature_workflow_repo_tests`: tests `find_esignature_workflow_by_external_id` round-trip lookup and `None` for unknown envelope. Table is created inline (scaffold-only; no migration — see ROADMAP PAP-122).
- **GH #1305** — `public_plans_rls_tests`: asserts `list_public_plans` returns only `is_active AND is_public` plans on a cleared-context (simulated `acquire_public()`) executor.

**GH #1344** already resolved by PR #1399 — closing with rationale (no code change needed).

**GH #1300** (imports IDOR handler-level test): repo-layer ownership is covered by existing `portal_imports_cross_org_idor_tests.rs`. A handler-level test requires a reality-server `TestApp` harness that doesn't exist yet; tracked as a follow-up.

## Test plan

- [ ] `cargo test -p db --test esg_force_rls_cross_tenant_tests` — FORCE RLS blocks cross-tenant (deny-all + org-B → org-A invisible)
- [ ] `cargo test -p db --test webhook_repo_dedup_tests` — dedup Ok(true)/Ok(false) contract
- [ ] `cargo test -p db --test esignature_workflow_repo_tests` — envelope-id lookup + None for unknown
- [ ] `cargo test -p db --test public_plans_rls_tests` — public plans filter on cleared context
- [ ] `cargo clippy -p db` + `cargo fmt` (offloaded to CI; mercury was down during local commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)