### PR TITLE
test(db): INSERT-branch fail-on-main test for registry NOT-NULL COALESCE fix (GH #1406)

### DIFF
--- a/backend/crates/db/tests/registry_rules_enum_decode_tests.rs
+++ b/backend/crates/db/tests/registry_rules_enum_decode_tests.rs
@@ -103,3 +103,51 @@ async fn registry_rules_decode_allowed_pet_types_enum_array(pool: PgPool) {
 
     assert_eq!(updated_rules.allowed_pet_types, Some(vec!["bird".into()]));
 }
+
+#[sqlx::test]
+async fn registry_rules_insert_branch_none_booleans_use_schema_defaults(pool: PgPool) {
+    // GH #1406 — the NOT-NULL COALESCE on the INSERT branch of upsert_registry_rules
+    // (COALESCE($3, TRUE) / COALESCE($4, TRUE) / COALESCE($9, FALSE)) was added to
+    // fix a 23502 "null value in column" error when all three booleans are None.
+    // The pre-existing test only binds all-Some on the INSERT path, so it cannot
+    // catch a regression to the INSERT branch. This test binds None for all three and
+    // asserts the schema DEFAULTs apply without a 23502.
+    //
+    // Reverting any of the three COALESCE(…, <default>) on the INSERT branch of
+    // upsert_registry_rules in registry.rs should make this test fail.
+    let org = seed_org(&pool, "coalesce_defaults").await;
+    let building = seed_building(&pool, org, "coalesce_defaults").await;
+    let repo = RegistryRepository::new(pool.clone());
+
+    // First upsert on a fresh (org, building) — hits the INSERT branch, not ON CONFLICT.
+    // All three NOT NULL boolean columns left as None → must COALESCE to schema DEFAULT.
+    let rules = repo
+        .upsert_registry_rules(
+            org,
+            building,
+            UpdateRegistryRules {
+                pets_allowed: None,            // DEFAULT TRUE
+                pets_require_approval: None,   // DEFAULT TRUE
+                max_pets_per_unit: None,
+                allowed_pet_types: None,
+                banned_pet_breeds: None,
+                max_pet_weight: None,
+                vehicles_require_approval: None, // DEFAULT FALSE
+                max_vehicles_per_unit: None,
+                notes: None,
+            },
+        )
+        .await
+        .expect("INSERT with None booleans applies COALESCE defaults (no 23502)");
+
+    // Schema DEFAULTs from 00067_create_building_registries.sql.
+    assert!(rules.pets_allowed, "pets_allowed should default to TRUE");
+    assert!(
+        rules.pets_require_approval,
+        "pets_require_approval should default to TRUE"
+    );
+    assert!(
+        !rules.vehicles_require_approval,
+        "vehicles_require_approval should default to FALSE"
+    );
+}

--- a/backend/crates/db/tests/registry_rules_enum_decode_tests.rs
+++ b/backend/crates/db/tests/registry_rules_enum_decode_tests.rs
@@ -126,8 +126,8 @@ async fn registry_rules_insert_branch_none_booleans_use_schema_defaults(pool: Pg
             org,
             building,
             UpdateRegistryRules {
-                pets_allowed: None,            // DEFAULT TRUE
-                pets_require_approval: None,   // DEFAULT TRUE
+                pets_allowed: None,          // DEFAULT TRUE
+                pets_require_approval: None, // DEFAULT TRUE
                 max_pets_per_unit: None,
                 allowed_pet_types: None,
                 banned_pet_breeds: None,


### PR DESCRIPTION
## What

The existing `registry_rules_decode_allowed_pet_types_enum_array` test (BIT-11, PR #1337) binds **all-`Some` booleans** on the INSERT path of `upsert_registry_rules`, so it cannot detect a regression to the `COALESCE($3, TRUE)` / `COALESCE($4, TRUE)` / `COALESCE($9, FALSE)` guards added on the INSERT branch in PR #1379.

GH #1406 identified this gap: the test passes regardless of whether the INSERT-branch COALESCEs are present or removed — it only exercises the `ON CONFLICT DO UPDATE` path for the `None` binds (step 3), which was already guarded pre-#1379.

## Fix

Added a second `#[sqlx::test]` — `registry_rules_insert_branch_none_booleans_use_schema_defaults` — that:

1. Seeds a fresh `(org, building)` pair with no existing `building_registry_rules` row.
2. Calls `upsert_registry_rules` with all three NOT NULL boolean fields as `None` → hits the **INSERT branch** (no `ON CONFLICT`).
3. Asserts the schema DEFAULTs apply (`pets_allowed = TRUE`, `pets_require_approval = TRUE`, `vehicles_require_approval = FALSE`) with no 23502 error.

Reverting any of the three `COALESCE(…, <default>)` on the INSERT branch of `upsert_registry_rules` in `registry.rs` makes this test fail with `23502 null value in column`.

## Test / IG3

- `backend/crates/db/tests/registry_rules_enum_decode_tests.rs` — appended test case. Runs under `backend.yml` (`cargo test`, `#[sqlx::test]` migrated pool).
- Test-only change; no production code touched.
- No local Rust toolchain on this host; relying on CI `backend.yml` for fmt/clippy/test.

Part of [BIT-116](/BIT/issues/BIT-116) / [BIT-70](/BIT/issues/BIT-70) (Tier 3 test-coverage batch), parent epic BIT-67. Follow-up to GH #1406 / PR #1379.

🤖 Generated with [Claude Code](https://claude.com/claude-code)