### PR TITLE
test(api-server): dedupe inline seed_membership onto common::seed_membership (GH #1341)

### DIFF
--- a/backend/servers/api-server/tests/building_manager_rbac_tests.rs
+++ b/backend/servers/api-server/tests/building_manager_rbac_tests.rs
@@ -21,7 +21,7 @@ use serde_json::json;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use common::{create_authenticated_user, TestApp, TestUser};
+use common::{create_authenticated_user, seed_membership, TestApp, TestUser};
 
 async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(
@@ -34,21 +34,6 @@ async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
     .fetch_one(pool)
     .await
     .expect("seed org")
-}
-
-async fn seed_membership(pool: &PgPool, org_id: Uuid, user_id: Uuid, role: &str) {
-    sqlx::query(
-        r#"INSERT INTO organization_members
-               (id, organization_id, user_id, role_type, status, created_at)
-           VALUES ($1, $2, $3, $4, 'active', NOW()) ON CONFLICT DO NOTHING"#,
-    )
-    .bind(Uuid::new_v4())
-    .bind(org_id)
-    .bind(user_id)
-    .bind(role)
-    .execute(pool)
-    .await
-    .expect("seed membership");
 }
 
 async fn user_id_for(pool: &PgPool, email: &str) -> Uuid {

--- a/backend/servers/api-server/tests/lease_review_rbac_tests.rs
+++ b/backend/servers/api-server/tests/lease_review_rbac_tests.rs
@@ -22,7 +22,7 @@ use serde_json::json;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use common::{create_authenticated_user, TestApp, TestUser};
+use common::{create_authenticated_user, seed_membership, TestApp, TestUser};
 
 async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(
@@ -35,21 +35,6 @@ async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
     .fetch_one(pool)
     .await
     .expect("seed org")
-}
-
-async fn seed_membership(pool: &PgPool, org_id: Uuid, user_id: Uuid, role: &str) {
-    sqlx::query(
-        r#"INSERT INTO organization_members
-               (id, organization_id, user_id, role_type, status, created_at)
-           VALUES ($1, $2, $3, $4, 'active', NOW()) ON CONFLICT DO NOTHING"#,
-    )
-    .bind(Uuid::new_v4())
-    .bind(org_id)
-    .bind(user_id)
-    .bind(role)
-    .execute(pool)
-    .await
-    .expect("seed membership");
 }
 
 async fn user_id_for(pool: &PgPool, email: &str) -> Uuid {

--- a/backend/servers/api-server/tests/lease_send_for_signature_rbac_tests.rs
+++ b/backend/servers/api-server/tests/lease_send_for_signature_rbac_tests.rs
@@ -22,7 +22,7 @@ use serde_json::json;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use common::{create_authenticated_user, TestApp, TestUser};
+use common::{create_authenticated_user, seed_membership, TestApp, TestUser};
 
 async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(
@@ -35,21 +35,6 @@ async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
     .fetch_one(pool)
     .await
     .expect("seed org")
-}
-
-async fn seed_membership(pool: &PgPool, org_id: Uuid, user_id: Uuid, role: &str) {
-    sqlx::query(
-        r#"INSERT INTO organization_members
-               (id, organization_id, user_id, role_type, status, created_at)
-           VALUES ($1, $2, $3, $4, 'active', NOW()) ON CONFLICT DO NOTHING"#,
-    )
-    .bind(Uuid::new_v4())
-    .bind(org_id)
-    .bind(user_id)
-    .bind(role)
-    .execute(pool)
-    .await
-    .expect("seed membership");
 }
 
 async fn user_id_for(pool: &PgPool, email: &str) -> Uuid {

--- a/backend/servers/api-server/tests/report_schedule_rbac_tests.rs
+++ b/backend/servers/api-server/tests/report_schedule_rbac_tests.rs
@@ -50,7 +50,7 @@ use serde_json::json;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use common::{create_authenticated_user, TestApp, TestUser};
+use common::{create_authenticated_user, seed_membership, TestApp, TestUser};
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -69,30 +69,6 @@ async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
     .fetch_one(pool)
     .await
     .expect("seed org")
-}
-
-/// Insert a membership row so the user is a recognised tenant member.
-///
-/// Uses `organization_members` (the table queried by
-/// `OrganizationMemberRepository` via `ValidatedTenantExtractor`). The role
-/// string is normalized case-insensitively in `extractors/tenant.rs`, so
-/// `"manager"` and `"Resident"` both round-trip to the right `TenantRole`.
-async fn seed_membership(pool: &PgPool, org_id: Uuid, user_id: Uuid, role: &str) {
-    sqlx::query(
-        r#"
-        INSERT INTO organization_members
-            (id, organization_id, user_id, role_type, status, created_at)
-        VALUES ($1, $2, $3, $4, 'active', NOW())
-        ON CONFLICT DO NOTHING
-        "#,
-    )
-    .bind(Uuid::new_v4())
-    .bind(org_id)
-    .bind(user_id)
-    .bind(role)
-    .execute(pool)
-    .await
-    .expect("seed membership");
 }
 
 /// Insert a `report_schedules` row in the given org and return its id.

--- a/backend/servers/api-server/tests/service_history_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/service_history_cross_org_idor_tests.rs
@@ -19,7 +19,7 @@ use axum::http::StatusCode;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use common::{create_authenticated_user, TestApp, TestUser};
+use common::{create_authenticated_user, seed_membership, TestApp, TestUser};
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -38,24 +38,6 @@ async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
     .fetch_one(pool)
     .await
     .expect("seed org")
-}
-
-async fn seed_membership(pool: &PgPool, org_id: Uuid, user_id: Uuid, role: &str) {
-    sqlx::query(
-        r#"
-        INSERT INTO organization_members
-            (id, organization_id, user_id, role_type, status, created_at)
-        VALUES ($1, $2, $3, $4, 'active', NOW())
-        ON CONFLICT DO NOTHING
-        "#,
-    )
-    .bind(Uuid::new_v4())
-    .bind(org_id)
-    .bind(user_id)
-    .bind(role)
-    .execute(pool)
-    .await
-    .expect("seed membership");
 }
 
 async fn seed_building(pool: &PgPool, org_id: Uuid) -> Uuid {


### PR DESCRIPTION
## What

Removes the private `seed_membership` helper from 5 IDOR/RBAC test files and imports the canonical `common::seed_membership` instead.

| File | Before | After |
|------|--------|-------|
| `building_manager_rbac_tests.rs` | private fn | `common::seed_membership` |
| `lease_review_rbac_tests.rs` | private fn | `common::seed_membership` |
| `lease_send_for_signature_rbac_tests.rs` | private fn | `common::seed_membership` |
| `report_schedule_rbac_tests.rs` | private fn | `common::seed_membership` |
| `service_history_cross_org_idor_tests.rs` | private fn | `common::seed_membership` |

## Why

Test-only maintainability (BIT-112 / GH #1341, PR #1335 follow-up). The inline copies were behavior-equivalent to the canonical helper — same `INSERT INTO organization_members ... status='active' ON CONFLICT DO NOTHING`, identical signature `(pool, org_id, user_id, role)`. The canonical helper additionally lets the DB default `id`/`created_at`, which is harmless for these tests.

## Verification

- Confirmed the canonical `pub async fn seed_membership` exists in `tests/common/mod.rs`.
- Confirmed each file still uses `PgPool`/`Uuid` elsewhere (`seed_org`, `user_id_for`, etc.), so no imports are orphaned by `-D warnings`.
- No private `fn seed_membership` definitions remain in the 5 files; all call sites unchanged.
- CI `backend.yml` (`cargo fmt` + `clippy -D warnings` + `cargo test`) is the authoritative gate (no local Rust toolchain on this host).

Net: 5 insertions, 92 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)