### PR TITLE
feat(api-server): list building/unit-scoped docs for members + unify preview gate (GH #1413)

### DIFF
--- a/backend/crates/common/src/lib.rs
+++ b/backend/crates/common/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod errors;
 pub mod i18n;
 pub mod log_hash;
+pub mod media;
 pub mod notifications;
 pub mod sitemap;
 pub mod tenant;
@@ -11,6 +12,7 @@ pub mod types;
 pub use errors::*;
 pub use i18n::{I18nResolver, Locale, MessageKey};
 pub use log_hash::{email_log_hash, EMAIL_LOG_HASH_LEN};
+pub use media::supports_inline_preview;
 pub use notifications::*;
 pub use sitemap::Sitemap;
 pub use tenant::*;

--- a/backend/crates/common/src/media.rs
+++ b/backend/crates/common/src/media.rs
@@ -15,12 +15,7 @@
 pub fn supports_inline_preview(content_type: &str) -> bool {
     matches!(
         content_type,
-        "application/pdf"
-            | "image/png"
-            | "image/jpeg"
-            | "image/gif"
-            | "image/webp"
-            | "text/plain"
+        "application/pdf" | "image/png" | "image/jpeg" | "image/gif" | "image/webp" | "text/plain"
     )
 }
 

--- a/backend/crates/common/src/media.rs
+++ b/backend/crates/common/src/media.rs
@@ -1,0 +1,56 @@
+//! Shared media-type helpers.
+
+/// Returns `true` for MIME types the platform renders **inline** (preview)
+/// rather than forcing a download.
+///
+/// This is the single source of truth shared by the document model
+/// (`db::models::Document::supports_preview`) and the storage presigner
+/// (`integrations::storage::supports_inline_preview`), so the preview gate and
+/// the `Content-Disposition: inline` decision can never diverge.
+///
+/// `text/plain` is intentionally included: browsers render it inline as plain
+/// text (no script execution), and the storage layer already serves it inline.
+/// Aligning the document preview gate to that — rather than 400-ing a file the
+/// presigner would happily stream inline — keeps the two consistent.
+pub fn supports_inline_preview(content_type: &str) -> bool {
+    matches!(
+        content_type,
+        "application/pdf"
+            | "image/png"
+            | "image/jpeg"
+            | "image/gif"
+            | "image/webp"
+            | "text/plain"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn previewable_types() {
+        for ct in [
+            "application/pdf",
+            "image/png",
+            "image/jpeg",
+            "image/gif",
+            "image/webp",
+            "text/plain",
+        ] {
+            assert!(supports_inline_preview(ct), "{ct} should preview inline");
+        }
+    }
+
+    #[test]
+    fn non_previewable_types() {
+        for ct in [
+            "application/zip",
+            "application/octet-stream",
+            "application/msword",
+            "text/csv",
+        ] {
+            assert!(!supports_inline_preview(ct), "{ct} should not preview");
+        }
+    }
+}

--- a/backend/crates/db/src/models/document.rs
+++ b/backend/crates/db/src/models/document.rs
@@ -171,11 +171,13 @@ impl Document {
     }
 
     /// Check if MIME type supports inline preview.
+    ///
+    /// Delegates to [`common::supports_inline_preview`] — the single source of
+    /// truth shared with the storage presigner
+    /// (`integrations::storage::supports_inline_preview`) so the preview gate
+    /// and the `Content-Disposition: inline` decision cannot diverge (GH #1413).
     pub fn supports_preview(&self) -> bool {
-        matches!(
-            self.mime_type.as_str(),
-            "application/pdf" | "image/png" | "image/jpeg" | "image/gif" | "image/webp"
-        )
+        common::supports_inline_preview(&self.mime_type)
     }
 
     /// Check if this is an image file.

--- a/backend/crates/db/src/repositories/document.rs
+++ b/backend/crates/db/src/repositories/document.rs
@@ -792,6 +792,62 @@ impl DocumentRepository {
         .await
     }
 
+    /// Count documents accessible by a specific user with RLS context (GH #1413).
+    ///
+    /// Counterpart to [`Self::list_accessible_rls`]; the `WHERE` predicate is
+    /// kept identical so the non-manager list and its total never disagree.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn count_accessible_rls<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+        user_id: Uuid,
+        user_building_ids: &[Uuid],
+        user_unit_ids: &[Uuid],
+        user_roles: &[String],
+        query: DocumentListQuery,
+    ) -> Result<i64, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        // `?|` is `jsonb ?| text[]` — right operand must be text[], not jsonb.
+        let building_ids: Vec<String> = user_building_ids.iter().map(Uuid::to_string).collect();
+        let unit_ids: Vec<String> = user_unit_ids.iter().map(Uuid::to_string).collect();
+        let roles: Vec<String> = user_roles.to_vec();
+
+        let row = sqlx::query(
+            r#"
+            SELECT COUNT(*) as count
+            FROM documents
+            WHERE organization_id = $1
+              AND deleted_at IS NULL
+              AND (
+                created_by = $2
+                OR access_scope = 'organization'
+                OR (access_scope = 'building' AND access_target_ids ?| $3::text[])
+                OR (access_scope = 'unit' AND access_target_ids ?| $4::text[])
+                OR (access_scope = 'role' AND access_roles ?| $5::text[])
+                OR (access_scope = 'users' AND access_target_ids ? $2::text)
+              )
+              AND ($6::uuid IS NULL OR folder_id = $6)
+              AND ($7::text IS NULL OR category = $7)
+              AND ($8::text IS NULL OR title ILIKE '%' || $8 || '%')
+            "#,
+        )
+        .bind(org_id)
+        .bind(user_id)
+        .bind(&building_ids)
+        .bind(&unit_ids)
+        .bind(&roles)
+        .bind(query.folder_id)
+        .bind(&query.category)
+        .bind(&query.search)
+        .fetch_one(executor)
+        .await?;
+
+        Ok(row.get("count"))
+    }
+
     /// List documents accessible by user (simplified) with RLS context.
     /// Used when building/unit context is not available.
     pub async fn list_accessible_simple_rls<'e, E>(

--- a/backend/crates/integrations/src/storage.rs
+++ b/backend/crates/integrations/src/storage.rs
@@ -945,11 +945,11 @@ pub fn get_content_type(filename: &str) -> &'static str {
 }
 
 /// Check if a content type supports inline preview (not download).
+///
+/// Thin re-export of [`common::supports_inline_preview`] — the single source of
+/// truth shared with `db::models::Document::supports_preview` (GH #1413).
 pub fn supports_inline_preview(content_type: &str) -> bool {
-    matches!(
-        content_type,
-        "application/pdf" | "image/png" | "image/jpeg" | "image/gif" | "image/webp" | "text/plain"
-    )
+    common::supports_inline_preview(content_type)
 }
 
 /// Generate a unique storage key for a file.

--- a/backend/servers/api-server/src/routes/documents/core.rs
+++ b/backend/servers/api-server/src/routes/documents/core.rs
@@ -620,24 +620,47 @@ async fn list_documents(
             .unwrap_or(0);
         (docs, total)
     } else {
-        // Use simplified access control for non-managers
-        // Shows: org-wide documents + own documents + role-based documents
-        // TODO: Full implementation needs building/unit context from TenantContext
+        // Full access control for non-managers (GH #1413). Shows org-wide docs,
+        // own docs, role-based docs, plus building/unit-scoped docs the caller is
+        // a member of. Building/unit membership is resolved via the same
+        // `user_scope_memberships_rls` resolver the download/preview gate uses, so
+        // the list and the gate agree: a building/unit doc the caller can open is
+        // also listed (no openable-but-not-listed divergence). A DB error fails
+        // closed (no memberships → building/unit scopes omitted, never widened).
         let user_role = tenant.role.to_string().to_lowercase().replace(' ', "_");
+        let (building_ids, unit_ids) = state
+            .document_repo
+            .user_scope_memberships_rls(&mut **rls.conn(), user_id)
+            .await
+            .unwrap_or_else(|e| {
+                tracing::error!(error = %e, "Failed to resolve user scope memberships");
+                (Vec::new(), Vec::new())
+            });
+        let roles = [user_role];
         let docs = state
             .document_repo
-            .list_accessible_simple_rls(
+            .list_accessible_rls(
                 &mut **rls.conn(),
                 org_id,
                 user_id,
-                &user_role,
+                &building_ids,
+                &unit_ids,
+                &roles,
                 list_query.clone(),
             )
             .await
             .unwrap_or_default();
         let total = state
             .document_repo
-            .count_accessible_simple_rls(&mut **rls.conn(), org_id, user_id, &user_role, list_query)
+            .count_accessible_rls(
+                &mut **rls.conn(),
+                org_id,
+                user_id,
+                &building_ids,
+                &unit_ids,
+                &roles,
+                list_query,
+            )
             .await
             .unwrap_or(0);
         (docs, total)

--- a/backend/servers/api-server/tests/document_download_preview_tests.rs
+++ b/backend/servers/api-server/tests/document_download_preview_tests.rs
@@ -294,14 +294,16 @@ async fn test_preview_unsupported_type_returns_400(pool: PgPool) {
     let org_id = seed_org(&pool, &Uuid::new_v4().to_string()[..8]).await;
     seed_membership(&pool, org_id, user_id, "org_admin").await;
 
-    // text/plain is NOT in Document::supports_preview's allow-list.
+    // A binary archive is NOT in the inline-preview allow-list
+    // (`common::supports_inline_preview`). NB: as of GH #1413 `text/plain` IS
+    // previewable, so a genuinely unsupported type is used here.
     let doc_id = seed_document(
         &pool,
         org_id,
         user_id,
-        "Plain notes",
-        "text/plain",
-        "notes.txt",
+        "Archive",
+        "application/zip",
+        "bundle.zip",
         "organization",
         serde_json::json!([]),
     )
@@ -326,6 +328,56 @@ async fn test_preview_unsupported_type_returns_400(pool: PgPool) {
         response.json_value()["code"].as_str(),
         Some("PREVIEW_NOT_SUPPORTED"),
         "error code must be PREVIEW_NOT_SUPPORTED, body {}",
+        response.text()
+    );
+
+    cleanup_test_user(&pool, &user.email).await;
+}
+
+// ============================================================================
+// T5b — text/plain IS previewable (GH #1413 deliberate decision).
+//       `Document::supports_preview` now delegates to
+//       `common::supports_inline_preview`, which includes text/plain — the same
+//       list the storage presigner uses for inline disposition. So a text/plain
+//       preview must clear supports_preview and reach the presigner (503), not
+//       400 PREVIEW_NOT_SUPPORTED.
+// ============================================================================
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn test_preview_text_plain_is_supported(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    cleanup_test_user(&pool, &user.email).await;
+    let (token, _) = create_authenticated_user(&app, &user).await;
+    let user_id = user_id_for(&pool, &user.email).await;
+    let org_id = seed_org(&pool, &Uuid::new_v4().to_string()[..8]).await;
+    seed_membership(&pool, org_id, user_id, "org_admin").await;
+    let doc_id = seed_document(
+        &pool,
+        org_id,
+        user_id,
+        "Plain notes",
+        "text/plain",
+        "notes.txt",
+        "organization",
+        serde_json::json!([]),
+    )
+    .await;
+
+    let response = app
+        .execute(get_request(
+            &format!("/api/v1/documents/{doc_id}/preview"),
+            &token,
+            org_id,
+        ))
+        .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "text/plain preview must clear supports_preview and reach the presigner \
+         (503), got {} body {}",
+        response.status,
         response.text()
     );
 
@@ -744,6 +796,101 @@ async fn test_preview_unit_scoped_allows_member_denies_outsider(pool: PgPool) {
         StatusCode::NOT_FOUND,
         "unit-scoped doc must be denied (404) to a resident of a different unit, got {} body {}",
         outsider_resp.status,
+        outsider_resp.text()
+    );
+
+    cleanup_test_user(&pool, &creator.email).await;
+    cleanup_test_user(&pool, &member.email).await;
+    cleanup_test_user(&pool, &outsider.email).await;
+}
+
+// ============================================================================
+// T11 — List path building/unit scope (GH #1413): the non-manager document
+//       list must INCLUDE a building/unit-scoped document for a member and
+//       EXCLUDE it for a same-org non-member. Before the fix the non-manager
+//       list used `list_accessible_simple_rls` (creator/org/role only), so a
+//       building/unit doc the member could now open via /download was still
+//       missing from their list — the inverse of the original divergence. This
+//       pins list ↔ gate consistency.
+// ============================================================================
+
+/// Returns `true` when the document list response body contains `doc_id`.
+fn list_contains(body: &serde_json::Value, doc_id: Uuid) -> bool {
+    body["documents"]
+        .as_array()
+        .is_some_and(|docs| docs.iter().any(|d| d["id"].as_str() == Some(&doc_id.to_string())))
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn test_list_building_scoped_visible_to_member_only(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    // Manager creator seeds a building-scoped doc.
+    let creator = TestUser::new();
+    cleanup_test_user(&pool, &creator.email).await;
+    let (_ctok, _) = create_authenticated_user(&app, &creator).await;
+    let creator_id = user_id_for(&pool, &creator.email).await;
+    let org_id = seed_org(&pool, &Uuid::new_v4().to_string()[..8]).await;
+    seed_membership(&pool, org_id, creator_id, "org_admin").await;
+
+    // Member: a tenant residing in a unit of the targeted building.
+    let member = TestUser::new();
+    cleanup_test_user(&pool, &member.email).await;
+    let (member_token, _) = create_authenticated_user(&app, &member).await;
+    let member_id = user_id_for(&pool, &member.email).await;
+    seed_membership(&pool, org_id, member_id, "tenant").await;
+    let (building_id, _unit_id) = seed_unit_with_resident(&pool, org_id, member_id).await;
+
+    // Outsider: same-org tenant, no residency in the building.
+    let outsider = TestUser::new();
+    cleanup_test_user(&pool, &outsider.email).await;
+    let (outsider_token, _) = create_authenticated_user(&app, &outsider).await;
+    let outsider_id = user_id_for(&pool, &outsider.email).await;
+    seed_membership(&pool, org_id, outsider_id, "tenant").await;
+
+    let doc_id = seed_document(
+        &pool,
+        org_id,
+        creator_id,
+        "Building handbook",
+        "application/pdf",
+        "building.pdf",
+        "building",
+        serde_json::json!([building_id.to_string()]),
+    )
+    .await;
+
+    // Member's list must include the building-scoped doc.
+    let member_resp = app
+        .execute(get_request("/api/v1/documents", &member_token, org_id))
+        .await;
+    assert_eq!(
+        member_resp.status,
+        StatusCode::OK,
+        "member list must be 200, got {} body {}",
+        member_resp.status,
+        member_resp.text()
+    );
+    assert!(
+        list_contains(&member_resp.json_value(), doc_id),
+        "building-scoped doc must be listed for a building member, body {}",
+        member_resp.text()
+    );
+
+    // Outsider's list must NOT include it.
+    let outsider_resp = app
+        .execute(get_request("/api/v1/documents", &outsider_token, org_id))
+        .await;
+    assert_eq!(
+        outsider_resp.status,
+        StatusCode::OK,
+        "outsider list must be 200, got {} body {}",
+        outsider_resp.status,
+        outsider_resp.text()
+    );
+    assert!(
+        !list_contains(&outsider_resp.json_value(), doc_id),
+        "building-scoped doc must NOT be listed for a non-member tenant, body {}",
         outsider_resp.text()
     );
 

--- a/backend/servers/api-server/tests/document_download_preview_tests.rs
+++ b/backend/servers/api-server/tests/document_download_preview_tests.rs
@@ -816,9 +816,10 @@ async fn test_preview_unit_scoped_allows_member_denies_outsider(pool: PgPool) {
 
 /// Returns `true` when the document list response body contains `doc_id`.
 fn list_contains(body: &serde_json::Value, doc_id: Uuid) -> bool {
-    body["documents"]
-        .as_array()
-        .is_some_and(|docs| docs.iter().any(|d| d["id"].as_str() == Some(&doc_id.to_string())))
+    body["documents"].as_array().is_some_and(|docs| {
+        docs.iter()
+            .any(|d| d["id"].as_str() == Some(&doc_id.to_string()))
+    })
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]


### PR DESCRIPTION
Closes the remaining **BIT-117 / GH #1413** scope left after PR #1463.

## Context
PR #1463 fixed the document **download/preview access gate** so a building/unit-scoped doc is openable by its target members. But it left two items:

1. **List path divergence (inverse of the original bug).** The non-manager `GET /api/v1/documents` branch still used `list_accessible_simple_rls` (creator/org/role only). So a member could `/download` a building/unit doc that **never appeared in their list** — openable-but-not-listed.
2. **Two preview predicates had drifted.** `Document::supports_preview` (no `text/plain`) vs `storage::supports_inline_preview` (has `text/plain`).

## Changes
- **List path:** non-manager list now resolves the caller's building/unit memberships via the same `DocumentRepository::user_scope_memberships_rls` resolver the gate uses, and calls `list_accessible_rls` + a new `count_accessible_rls` (count counterpart, identical `WHERE`). DB error → **fails closed** (memberships empty, scopes omitted, never widened).
- **Preview single source of truth:** `Document::supports_preview` and `storage::supports_inline_preview` both delegate to new `common::supports_inline_preview`. `text/plain` is **deliberately previewable** (browser renders inline as plain text, no script exec; presigner already serves it inline) — the document gate is aligned to that rather than 400-ing it.

## Tests
- `test_list_building_scoped_visible_to_member_only` — building-scoped doc listed for a member, hidden from a same-org non-member (list ↔ gate consistency).
- `test_preview_text_plain_is_supported` — text/plain preview reaches the presigner (503).
- `test_preview_unsupported_type_returns_400` updated to `application/zip` (text/plain is no longer unsupported).
- Repo-level `list_accessible_rls` scope coverage already exists in `document_access_rls_tests.rs`; gate building/unit tests added by #1463.

## Verification
Local `cargo fmt`/`clippy`/`test` unavailable in this container (remote build host down). Relying on **backend.yml CI** for compile + test — same posture as merged #1463.

## Domain lenses
- **Blast radius:** non-manager document list + two preview predicates; managers unaffected. Reuses the membership resolver from #1463 (no new query surface).
- **Secure by default:** membership-resolution errors fail closed; building/unit scope omission narrows, never widens.
- **Interface stability:** no signature change to the public gate (`document_access_allowed` untouched, per #1463's design); only an additive repo method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)