### PR TITLE
chore(scripts): stale RLS baseline entries fail --strict (BIT-111, GH #1340)

### DIFF
--- a/backend/crates/db/src/models/mod.rs
+++ b/backend/crates/db/src/models/mod.rs
@@ -396,9 +396,9 @@ pub use budget::{
     variance_alert_type, AcknowledgeVarianceAlert, Budget, BudgetActual, BudgetCategory,
     BudgetDashboard, BudgetItem, BudgetQuery, BudgetSummary, BudgetVarianceAlert, CapitalPlan,
     CapitalPlanQuery, CategoryVariance, CreateBudget, CreateBudgetCategory, CreateBudgetItem,
-    CreateCapitalPlan, CreateFinancialForecast, FinancialForecast, ForecastQuery, RecordBudgetActual,
-    UpdateBudget, UpdateBudgetCategory, UpdateBudgetItem, UpdateCapitalPlan, UpdateFinancialForecast,
-    YearlyCapitalSummary,
+    CreateCapitalPlan, CreateFinancialForecast, FinancialForecast, ForecastQuery,
+    RecordBudgetActual, UpdateBudget, UpdateBudgetCategory, UpdateBudgetItem, UpdateCapitalPlan,
+    UpdateFinancialForecast, YearlyCapitalSummary,
 };
 
 // Epic 25: Legal Document & Compliance

--- a/backend/scripts/check-rls-enforcement.sh
+++ b/backend/scripts/check-rls-enforcement.sh
@@ -217,8 +217,13 @@ done
 sort -u "$TMP_PREFIX/handler_hits" > "$TMP_PREFIX/handler_hits_sorted"
 while IFS= read -r stale; do
     [[ -n "$stale" ]] || continue
-    ((WARNINGS+=1))
-    echo -e "${YELLOW}WARNING${NC} stale baseline entry '$stale' — file no longer flagged; remove it from $(basename "$HANDLER_BASELINE_FILE")"
+    if $STRICT_MODE; then
+        ((VIOLATIONS+=1))
+        echo -e "${RED}VIOLATION${NC} stale baseline entry '$stale' — file no longer flagged; remove it from $(basename "$HANDLER_BASELINE_FILE")"
+    else
+        ((WARNINGS+=1))
+        echo -e "${YELLOW}WARNING${NC} stale baseline entry '$stale' — file no longer flagged; remove it from $(basename "$HANDLER_BASELINE_FILE")"
+    fi
     echo ""
 done < <(comm -23 "$TMP_PREFIX/handler_baseline" "$TMP_PREFIX/handler_hits_sorted")
 
@@ -352,8 +357,13 @@ if [[ -d "$REPO_DIR" && -d "$MIGRATIONS_DIR" ]]; then
     sort -u "$TMP_PREFIX/hit_names" > "$TMP_PREFIX/hit_names_sorted"
     while IFS= read -r stale; do
         [[ -n "$stale" ]] || continue
-        ((WARNINGS+=1))
-        echo -e "${YELLOW}WARNING${NC} stale baseline entry '$stale' — repo no longer flagged; remove it from $(basename "$BASELINE_FILE")"
+        if $STRICT_MODE; then
+            ((VIOLATIONS+=1))
+            echo -e "${RED}VIOLATION${NC} stale baseline entry '$stale' — repo no longer flagged; remove it from $(basename "$BASELINE_FILE")"
+        else
+            ((WARNINGS+=1))
+            echo -e "${YELLOW}WARNING${NC} stale baseline entry '$stale' — repo no longer flagged; remove it from $(basename "$BASELINE_FILE")"
+        fi
         echo ""
     done < <(comm -23 "$TMP_PREFIX/baseline" "$TMP_PREFIX/hit_names_sorted")
 

--- a/backend/servers/api-server/src/routes/budgets.rs
+++ b/backend/servers/api-server/src/routes/budgets.rs
@@ -13,8 +13,9 @@ use axum::{
 use common::ErrorResponse;
 use db::models::{
     AcknowledgeVarianceAlert, BudgetQuery, CapitalPlanQuery, CreateBudget, CreateBudgetCategory,
-    CreateBudgetItem, CreateCapitalPlan, CreateFinancialForecast, ForecastQuery, RecordBudgetActual,
-    UpdateBudget, UpdateBudgetCategory, UpdateBudgetItem, UpdateCapitalPlan, UpdateFinancialForecast,
+    CreateBudgetItem, CreateCapitalPlan, CreateFinancialForecast, ForecastQuery,
+    RecordBudgetActual, UpdateBudget, UpdateBudgetCategory, UpdateBudgetItem, UpdateCapitalPlan,
+    UpdateFinancialForecast,
 };
 use rust_decimal::Decimal;
 use serde::Deserialize;


### PR DESCRIPTION
## Summary

- In `check-rls-enforcement.sh`, stale handler-baseline and pool-field-baseline entries previously only incremented `WARNINGS`, so `--strict` still exited 0 even when a converted-but-not-delisted entry was present.
- Now: under `--strict`, stale baseline entries increment `VIOLATIONS` and print in red (VIOLATION), while non-strict runs keep the yellow WARNING behavior.
- Effect: CI (which calls `--strict`) will fail if a baseline entry is left behind after a repo is converted, tightening the ratchet automatically.

Closes GH #1340.

## Test plan
- [ ] Existing CI smoke-test (`rls-smoke-test` job) should still pass — no baseline entries are currently stale.
- [ ] Manually verify: add a fake entry to `rls-pool-field-baseline.txt`, run `./scripts/check-rls-enforcement.sh --strict`, confirm exit 1 with VIOLATION; run without `--strict`, confirm exit 0 with WARNING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)