### PR TITLE
fix(research): correct dispatcher Tier-2 kick payload + anthropic-version header (closes #1151)

### DIFF
--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -835,14 +835,20 @@ export BUFFER_FLOOR BUFFER_TARGET BUFFER_CEIL
 
   **Self-test impact.** `"deferred"` is a new action-list `status` value not present in any existing fixture. Self-tests that classify rows by status (T24 one-open-per-stem, the legacy-dependency invariants, any coverage of `action-list.json` rows) must treat `deferred` as a **non-terminal claimable-pool exclusion** — equivalent to `open` for stem-uniqueness and dep-graph checks, but NOT counted toward `open_claimable_count`. When adding fixtures, include at least one `deferred` row so the predicates are exercised.
 - **Tier 1 (self-refill):** if `open_claimable_count < BUFFER_FLOOR` (half of the `BUFFER_TARGET` target) → **first, re-open any deferred rows** (inverse of Tier 0): flip `status` from `deferred` back to `open` in `pri_rank` *descending* order (id ascending tiebreaker) until either no deferred rows remain OR `open_claimable_count == BUFFER_TARGET`. This is the closing half of the Tier 0 / Tier 1 cycle — without it, deferred rows would accumulate and the buffer could starve while a valid backlog sits idle. Log `Tier 1: re-opened <N> deferred [<id>, …]` when any flip occurs. **Then**, if still below `BUFFER_FLOOR`, **NOW read `coverage.json`** (was previously loaded in Phase 1; deferred to here in issue #9). If coverage has stories → refill using rubric, appending only up to the cap: `refill_n = min(BUFFER_TARGET, BUFFER_CEIL) - open_claimable_count` (the `min` is belt-and-suspenders — `BUFFER_TARGET <= BUFFER_CEIL` by construction, so Tier 1 alone can never overshoot the GC3 ceiling). Log `Tier 1: <old_claimable> → <new_claimable> (+N, cap=BUFFER_CEIL)`. When `open_claimable_count >= BUFFER_FLOOR` the file is never opened, saving ~10k tokens / run.
-- **Tier 2 (upstream kick):** if `open_claimable_count` still `< BUFFER_FLOOR/2` (default 18 — deep-starvation last resort, scaled with the floor so it stays proportional to throughput; raised from a hardcoded 12 alongside `BUFFER_FLOOR` 18→36 so Tier-2 doesn't leave a wide dead band below the Tier-1 floor) OR coverage missing → `curl POST $DISPATCHER_URL` with `Bearer $DISPATCHER_TOKEN`, `--max-time 10`. **Capture the response code AND first 200 chars of body** (NEW — issue #5: HTTP 400 from the planner used to vanish into fire-and-forget; now we see it):
+- **Tier 2 (upstream kick):** if `open_claimable_count` still `< BUFFER_FLOOR/2` (default 18 — deep-starvation last resort, scaled with the floor so it stays proportional to throughput; raised from a hardcoded 12 alongside `BUFFER_FLOOR` 18→36 so Tier-2 doesn't leave a wide dead band below the Tier-1 floor) OR coverage missing → `curl POST $DISPATCHER_URL` with `Bearer $DISPATCHER_TOKEN`, the `anthropic-version` header, a `{"text": …}` body, and `--max-time 10`. **Capture the response code AND first 200 chars of body** (NEW — issue #5: HTTP 400 from the planner used to vanish into fire-and-forget; now we see it. The body/header shape is fixed per issue #1151 / #1380 — see the comment below):
 
   ```bash
   T2_TMP=$(mktemp)
+  # The $DISPATCHER_URL routine-fire endpoint accepts ONLY a `{"text": "..."}`
+  # body and REQUIRES the `anthropic-version` header (issue #1151 / #1380): the
+  # old `{"reason","claimable"}` body 400'd with `claimable` rejected as an extra
+  # input, so the deep-starvation kick never fired. Carry the buffer context in
+  # the `text` trigger message instead.
   T2_CODE=$(curl -sS -X POST "$DISPATCHER_URL" \
     -H "Authorization: Bearer $DISPATCHER_TOKEN" \
+    -H "anthropic-version: 2023-06-01" \
     -H "Content-Type: application/json" \
-    -d '{"reason":"buffer-low","claimable":'"$open_claimable_count"'}' \
+    -d '{"text":"buffer-low: claimable='"$open_claimable_count"'/'"$BUFFER_TARGET"' — refill planner"}' \
     -o "$T2_TMP" -w '%{http_code}' --max-time 10 2>/dev/null || echo "curl-error")
   T2_BODY=$(head -c 200 "$T2_TMP" 2>/dev/null | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g')
   rm -f "$T2_TMP"


### PR DESCRIPTION
## Problem

`#1151` root cause #3 (also `#1380`): the Phase 2.6 **Tier-2 upstream planner kick** — the deep-buffer-starvation last resort that asks the planner to generate fresh work when the claimable buffer runs dry — POSTed the wrong shape to `$DISPATCHER_URL`:

```
-d '{"reason":"buffer-low","claimable":N}'   # 400: "claimable" not permitted + missing anthropic-version
```

That routine-fire endpoint accepts **only** a `{"text": "..."}` body and **requires** an `anthropic-version` header, so the kick always 400'd and the planner was never triggered. The HTTP 400 was only *surfaced* (issue #5 body-capture) but never *fixed*.

## Fix

```
-H "anthropic-version: 2023-06-01"
-d '{"text":"buffer-low: claimable=N/<target> — refill planner"}'
```

Buffer context now rides in the only accepted field. Shape verified working in a prior dispatcher run (returns `200 {type:routine_fire, …}`, recorded in `.research/self-improvement/findings.json`).

## #1151's other root causes — already resolved on dev (verified)

- **RC#1 (flat-id GC1 "archive-terminal leak", no drain):** both `goal-check.sh` GC1 and `gc1-reconcile.sh` are now gap-scoped; on current dev state they report `orphans=0 archive_terminal_leak=0` (GC1 passes).
- **RC#2 (Tier-1 refill re-adds previously-failed archived ids → unclaimable padding):** 0 open action-list rows duplicate any archived terminal id.
- The "claimable=53 but true=0" stale-metric mismatch is gone — current `open_claimable_count` reflects real open rows.

This PR closes the last actionable item.

## Verification
`bash .research/dispatcher-self-test.sh` → **PASS** (no self-test asserts the Tier-2 payload; nothing to update).

Closes #1151. Refs #1380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)