### PR TITLE
chore(db): fix tracker-id in registry_rules_enum_decode_tests (BIT-114, GH #1366)

### DIFF
--- a/backend/crates/db/src/models/mod.rs
+++ b/backend/crates/db/src/models/mod.rs
@@ -396,9 +396,9 @@ pub use budget::{
     variance_alert_type, AcknowledgeVarianceAlert, Budget, BudgetActual, BudgetCategory,
     BudgetDashboard, BudgetItem, BudgetQuery, BudgetSummary, BudgetVarianceAlert, CapitalPlan,
     CapitalPlanQuery, CategoryVariance, CreateBudget, CreateBudgetCategory, CreateBudgetItem,
-    CreateCapitalPlan, CreateFinancialForecast, FinancialForecast, ForecastQuery, RecordBudgetActual,
-    UpdateBudget, UpdateBudgetCategory, UpdateBudgetItem, UpdateCapitalPlan, UpdateFinancialForecast,
-    YearlyCapitalSummary,
+    CreateCapitalPlan, CreateFinancialForecast, FinancialForecast, ForecastQuery,
+    RecordBudgetActual, UpdateBudget, UpdateBudgetCategory, UpdateBudgetItem, UpdateCapitalPlan,
+    UpdateFinancialForecast, YearlyCapitalSummary,
 };
 
 // Epic 25: Legal Document & Compliance

--- a/backend/crates/db/tests/registry_rules_enum_decode_tests.rs
+++ b/backend/crates/db/tests/registry_rules_enum_decode_tests.rs
@@ -1,4 +1,4 @@
-//! Regression tests for BIT-11 — allowed_pet_types pet_type[] decode+bind fix
+//! Regression tests for PAP-159 — allowed_pet_types pet_type[] decode+bind fix
 //! in [`db::repositories::RegistryRepository`].
 
 use db::models::UpdateRegistryRules;

--- a/backend/servers/api-server/src/routes/budgets.rs
+++ b/backend/servers/api-server/src/routes/budgets.rs
@@ -13,8 +13,9 @@ use axum::{
 use common::ErrorResponse;
 use db::models::{
     AcknowledgeVarianceAlert, BudgetQuery, CapitalPlanQuery, CreateBudget, CreateBudgetCategory,
-    CreateBudgetItem, CreateCapitalPlan, CreateFinancialForecast, ForecastQuery, RecordBudgetActual,
-    UpdateBudget, UpdateBudgetCategory, UpdateBudgetItem, UpdateCapitalPlan, UpdateFinancialForecast,
+    CreateBudgetItem, CreateCapitalPlan, CreateFinancialForecast, ForecastQuery,
+    RecordBudgetActual, UpdateBudget, UpdateBudgetCategory, UpdateBudgetItem, UpdateCapitalPlan,
+    UpdateFinancialForecast,
 };
 use rust_decimal::Decimal;
 use serde::Deserialize;


### PR DESCRIPTION
## Summary

- Change `BIT-11` → `PAP-159` in the module-level docstring of `registry_rules_enum_decode_tests.rs` line 1
- The test was introduced in PR #1337 (PAP-159 fix) but the doc comment referenced a stale internal tracker ID

Closes GH #1366.

## Test plan
- [ ] CI passes (no Rust code changes, only a comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)