### PR TITLE
style(db): rustfmt budget use-lists after reserve-fund retirement (fix dev check)

### DIFF
--- a/backend/crates/db/src/models/mod.rs
+++ b/backend/crates/db/src/models/mod.rs
@@ -396,9 +396,9 @@ pub use budget::{
     variance_alert_type, AcknowledgeVarianceAlert, Budget, BudgetActual, BudgetCategory,
     BudgetDashboard, BudgetItem, BudgetQuery, BudgetSummary, BudgetVarianceAlert, CapitalPlan,
     CapitalPlanQuery, CategoryVariance, CreateBudget, CreateBudgetCategory, CreateBudgetItem,
-    CreateCapitalPlan, CreateFinancialForecast, FinancialForecast, ForecastQuery, RecordBudgetActual,
-    UpdateBudget, UpdateBudgetCategory, UpdateBudgetItem, UpdateCapitalPlan, UpdateFinancialForecast,
-    YearlyCapitalSummary,
+    CreateCapitalPlan, CreateFinancialForecast, FinancialForecast, ForecastQuery,
+    RecordBudgetActual, UpdateBudget, UpdateBudgetCategory, UpdateBudgetItem, UpdateCapitalPlan,
+    UpdateFinancialForecast, YearlyCapitalSummary,
 };
 
 // Epic 25: Legal Document & Compliance

--- a/backend/servers/api-server/src/routes/budgets.rs
+++ b/backend/servers/api-server/src/routes/budgets.rs
@@ -13,8 +13,9 @@ use axum::{
 use common::ErrorResponse;
 use db::models::{
     AcknowledgeVarianceAlert, BudgetQuery, CapitalPlanQuery, CreateBudget, CreateBudgetCategory,
-    CreateBudgetItem, CreateCapitalPlan, CreateFinancialForecast, ForecastQuery, RecordBudgetActual,
-    UpdateBudget, UpdateBudgetCategory, UpdateBudgetItem, UpdateCapitalPlan, UpdateFinancialForecast,
+    CreateBudgetItem, CreateCapitalPlan, CreateFinancialForecast, ForecastQuery,
+    RecordBudgetActual, UpdateBudget, UpdateBudgetCategory, UpdateBudgetItem, UpdateCapitalPlan,
+    UpdateFinancialForecast,
 };
 use rust_decimal::Decimal;
 use serde::Deserialize;


### PR DESCRIPTION
PR #1481 (reserve-fund retirement) merged with a `cargo fmt --check` violation — the hand-edited `use budget::{…}` lists in `models/mod.rs:396` and `budgets.rs:13` didn't match rustfmt's wrapping, reddening dev's **`check`** job (which gates the backend pipeline).

Reflow both `use` lists with the pinned `+1.94.1` toolchain. Formatting-only, no code change.

**Verification:** `cargo +1.94.1 fmt --all -- --check` → clean (exit 0) on mercury.

Refs #1481, #1331, #1332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)