### PR TITLE
style(db): rustfmt budget export line-wrap after #1481 reserve-fund removal

### DIFF
--- a/backend/crates/db/src/models/mod.rs
+++ b/backend/crates/db/src/models/mod.rs
@@ -396,9 +396,9 @@ pub use budget::{
     variance_alert_type, AcknowledgeVarianceAlert, Budget, BudgetActual, BudgetCategory,
     BudgetDashboard, BudgetItem, BudgetQuery, BudgetSummary, BudgetVarianceAlert, CapitalPlan,
     CapitalPlanQuery, CategoryVariance, CreateBudget, CreateBudgetCategory, CreateBudgetItem,
-    CreateCapitalPlan, CreateFinancialForecast, FinancialForecast, ForecastQuery, RecordBudgetActual,
-    UpdateBudget, UpdateBudgetCategory, UpdateBudgetItem, UpdateCapitalPlan, UpdateFinancialForecast,
-    YearlyCapitalSummary,
+    CreateCapitalPlan, CreateFinancialForecast, FinancialForecast, ForecastQuery,
+    RecordBudgetActual, UpdateBudget, UpdateBudgetCategory, UpdateBudgetItem, UpdateCapitalPlan,
+    UpdateFinancialForecast, YearlyCapitalSummary,
 };
 
 // Epic 25: Legal Document & Compliance

--- a/backend/servers/api-server/src/routes/budgets.rs
+++ b/backend/servers/api-server/src/routes/budgets.rs
@@ -13,8 +13,9 @@ use axum::{
 use common::ErrorResponse;
 use db::models::{
     AcknowledgeVarianceAlert, BudgetQuery, CapitalPlanQuery, CreateBudget, CreateBudgetCategory,
-    CreateBudgetItem, CreateCapitalPlan, CreateFinancialForecast, ForecastQuery, RecordBudgetActual,
-    UpdateBudget, UpdateBudgetCategory, UpdateBudgetItem, UpdateCapitalPlan, UpdateFinancialForecast,
+    CreateBudgetItem, CreateCapitalPlan, CreateFinancialForecast, ForecastQuery,
+    RecordBudgetActual, UpdateBudget, UpdateBudgetCategory, UpdateBudgetItem, UpdateCapitalPlan,
+    UpdateFinancialForecast,
 };
 use rust_decimal::Decimal;
 use serde::Deserialize;


### PR DESCRIPTION
## Summary

PR #1481 removed `RecordReserveTransaction`/`ReserveFund` exports from the budget `pub use` block. The shorter line now fits `RecordBudgetActual` at the end of the previous line, but `cargo fmt` prefers a different break point. The `backend-dev-push-gate.yml` (compile-only) did not catch this; the `backend-fmt-clippy-gate.yml` (PR gate) does, so every PR branched from the current dev tip fails the fmt check.

- `backend/crates/db/src/models/mod.rs` — budget `pub use` line-wrap
- `backend/servers/api-server/src/routes/budgets.rs` — same `use db::models::{ ... }` block

No logic change; purely whitespace/line-wrapping to match what `cargo fmt --all` produces.

## Test plan
- [ ] `check` job (`cargo fmt --all -- --check`) passes on this PR
- [ ] After merge, all downstream PRs that were blocked by this unformatted state should pass the fmt gate