### PR TITLE
fix(marketplace): make mark_invitation_viewed idempotent (closes #1301)

### DIFF
--- a/backend/crates/db/src/repositories/marketplace.rs
+++ b/backend/crates/db/src/repositories/marketplace.rs
@@ -1068,10 +1068,15 @@ impl MarketplaceRepository {
         id: Uuid,
         provider_id: Uuid,
     ) -> Result<Option<RfqInvitation>, SqlxError> {
+        // Idempotent (#1301): key only on (id, provider_id) so a legitimate
+        // repeat view returns 200 with the invitation, not 404. `COALESCE`
+        // preserves the FIRST viewed_at timestamp on subsequent views. A None
+        // result now means only "this provider has no such invitation" (real
+        // 404), matching the sibling `decline_invitation` keying.
         sqlx::query_as::<_, RfqInvitation>(
             r#"
-            UPDATE rfq_invitations SET viewed_at = NOW()
-            WHERE id = $1 AND provider_id = $2 AND viewed_at IS NULL
+            UPDATE rfq_invitations SET viewed_at = COALESCE(viewed_at, NOW())
+            WHERE id = $1 AND provider_id = $2
             RETURNING *
             "#,
         )

--- a/backend/servers/api-server/tests/marketplace_voting_investor_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/marketplace_voting_investor_cross_org_idor_tests.rs
@@ -523,6 +523,38 @@ async fn mark_invitation_viewed_for_other_provider_is_rejected(pool: PgPool) {
     assert_not_ok(resp.status, "mark_invitation_viewed cross-provider");
 }
 
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn mark_invitation_viewed_is_idempotent(pool: PgPool) {
+    // #1301: a provider viewing its OWN invitation a second time must get 200
+    // (idempotent), not 404. The old `AND viewed_at IS NULL` guard returned no
+    // row on the repeat view, so the handler 404'd a legitimate re-view.
+    let app = TestApp::new(pool.clone()).await;
+    let org = seed_org(&pool, "inv-idem-org").await;
+    let user_a = seed_user(&pool, "inv-idem-a@provider-idor.test").await;
+    let provider_a = seed_provider(&pool, user_a, "inv-idem-a").await;
+    let rfq = seed_rfq(&pool, org, user_a).await;
+    let invitation = seed_invitation(&pool, rfq, provider_a).await;
+
+    let token = mint_token(user_a, "inv-idem-a@provider-idor.test", None);
+    let uri = format!("/api/v1/marketplace/invitations/{invitation}/view");
+
+    let first = app.execute(app.post(&uri).bearer(&token).build()).await;
+    assert_eq!(
+        first.status,
+        StatusCode::OK,
+        "first view must succeed: {}",
+        first.text()
+    );
+
+    let second = app.execute(app.post(&uri).bearer(&token).build()).await;
+    assert_eq!(
+        second.status,
+        StatusCode::OK,
+        "repeat view must be idempotent (200), not 404: {}",
+        second.text()
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Marketplace — verification read (owner-or-platform-admin; PAP-140)
 //


### PR DESCRIPTION
## Problem

`#1301`: `mark_invitation_viewed` updated `rfq_invitations` with `WHERE id = $1 AND provider_id = $2 AND viewed_at IS NULL RETURNING *`. A provider viewing its **own** invitation a second time matched no row → `None` → the handler returned **404**. The `viewed_at IS NULL` guard conflated "already viewed" with "not found".

## Fix

Drop the state guard; use `SET viewed_at = COALESCE(viewed_at, NOW())` keyed only on `(id, provider_id)` — mirroring the sibling `decline_invitation`. First view stamps `viewed_at`; repeat views preserve the original timestamp and return the row (200). `None` now means only "this provider has no such invitation" (a real 404), so the PAP-140 cross-provider IDOR guard is unchanged.

## Test (IG3)

Adds `mark_invitation_viewed_is_idempotent` to the existing marketplace IDOR suite (reusing its seed helpers + `TestApp` harness): a provider views its own invitation twice and both calls must return `200` — the second was `404` before the fix. The existing `mark_invitation_viewed_for_other_provider_is_rejected` IDOR test still guards cross-provider access.

## Verification

Fix is a SQL-string change + a test reusing the sibling test's proven helpers. (Local mercury compile-check timed out under tenant-overload; relying on the PR's `test` CI job to run the regression test before merge.)

Closes #1301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)