### PR TITLE
fix(backend): unblock dev test job — form RLS grant + rental_platform_connections enum decode

### DIFF
--- a/backend/crates/db/src/repositories/rental.rs
+++ b/backend/crates/db/src/repositories/rental.rs
@@ -193,8 +193,23 @@ impl RentalRepository {
         unit_id: Uuid,
         platform: &str,
     ) -> Result<Option<RentalPlatformConnection>, SqlxError> {
+        // `platform` is the `rental_platform` enum; the model decodes it as
+        // `String`, so a bare `SELECT *` panics with "mismatched types … not
+        // compatible with SQL type rental_platform". Cast the column to text on
+        // read and the bound text arg to the enum in the predicate.
         let conn = sqlx::query_as::<_, RentalPlatformConnection>(
-            r#"SELECT * FROM rental_platform_connections WHERE unit_id = $1 AND platform = $2"#,
+            r#"
+            SELECT
+                id, organization_id, unit_id, platform::text AS platform,
+                access_token, refresh_token, token_expires_at,
+                encrypted_token, encrypted_refresh_token,
+                external_property_id, external_listing_url,
+                is_active, last_sync_at, sync_error,
+                sync_calendar, sync_interval_minutes, block_other_platforms,
+                created_at, updated_at
+            FROM rental_platform_connections
+            WHERE unit_id = $1 AND platform = $2::rental_platform
+            "#,
         )
         .bind(unit_id)
         .bind(platform)
@@ -456,7 +471,15 @@ impl RentalRepository {
     ) -> Result<Vec<RentalPlatformConnection>, SqlxError> {
         let connections = sqlx::query_as::<_, RentalPlatformConnection>(
             r#"
-            SELECT * FROM rental_platform_connections
+            SELECT
+                id, organization_id, unit_id, platform::text AS platform,
+                access_token, refresh_token, token_expires_at,
+                encrypted_token, encrypted_refresh_token,
+                external_property_id, external_listing_url,
+                is_active, last_sync_at, sync_error,
+                sync_calendar, sync_interval_minutes, block_other_platforms,
+                created_at, updated_at
+            FROM rental_platform_connections
             WHERE is_active = true
                 AND sync_calendar = true
                 AND access_token IS NOT NULL
@@ -2187,7 +2210,15 @@ impl RentalRepository {
     ) -> Result<Option<RentalPlatformConnection>, SqlxError> {
         let conn = sqlx::query_as::<_, RentalPlatformConnection>(
             r#"
-            SELECT * FROM rental_platform_connections
+            SELECT
+                id, organization_id, unit_id, platform::text AS platform,
+                access_token, refresh_token, token_expires_at,
+                encrypted_token, encrypted_refresh_token,
+                external_property_id, external_listing_url,
+                is_active, last_sync_at, sync_error,
+                sync_calendar, sync_interval_minutes, block_other_platforms,
+                created_at, updated_at
+            FROM rental_platform_connections
             WHERE organization_id = $1 AND platform = 'airbnb'
             ORDER BY created_at DESC
             LIMIT 1
@@ -2219,7 +2250,15 @@ impl RentalRepository {
     ) -> Result<Option<RentalPlatformConnection>, SqlxError> {
         let conn = sqlx::query_as::<_, RentalPlatformConnection>(
             r#"
-            SELECT * FROM rental_platform_connections
+            SELECT
+                id, organization_id, unit_id, platform::text AS platform,
+                access_token, refresh_token, token_expires_at,
+                encrypted_token, encrypted_refresh_token,
+                external_property_id, external_listing_url,
+                is_active, last_sync_at, sync_error,
+                sync_calendar, sync_interval_minutes, block_other_platforms,
+                created_at, updated_at
+            FROM rental_platform_connections
             WHERE platform = 'airbnb' AND external_property_id = $1 AND is_active = true
             ORDER BY updated_at DESC
             LIMIT 1
@@ -2517,7 +2556,15 @@ impl RentalRepository {
 
         let connections = sqlx::query_as::<_, RentalPlatformConnection>(
             r#"
-            SELECT * FROM rental_platform_connections
+            SELECT
+                id, organization_id, unit_id, platform::text AS platform,
+                access_token, refresh_token, token_expires_at,
+                encrypted_token, encrypted_refresh_token,
+                external_property_id, external_listing_url,
+                is_active, last_sync_at, sync_error,
+                sync_calendar, sync_interval_minutes, block_other_platforms,
+                created_at, updated_at
+            FROM rental_platform_connections
             WHERE platform = 'airbnb'
               AND is_active = true
               AND (encrypted_refresh_token IS NOT NULL OR refresh_token IS NOT NULL)
@@ -2560,7 +2607,15 @@ impl RentalRepository {
     ) -> Result<Option<RentalPlatformConnection>, SqlxError> {
         let connection = sqlx::query_as::<_, RentalPlatformConnection>(
             r#"
-            SELECT * FROM rental_platform_connections
+            SELECT
+                id, organization_id, unit_id, platform::text AS platform,
+                access_token, refresh_token, token_expires_at,
+                encrypted_token, encrypted_refresh_token,
+                external_property_id, external_listing_url,
+                is_active, last_sync_at, sync_error,
+                sync_calendar, sync_interval_minutes, block_other_platforms,
+                created_at, updated_at
+            FROM rental_platform_connections
             WHERE organization_id = $1 AND platform = 'booking'
             ORDER BY created_at DESC
             LIMIT 1

--- a/backend/crates/db/tests/form_rls_repo_tests.rs
+++ b/backend/crates/db/tests/form_rls_repo_tests.rs
@@ -138,6 +138,10 @@ async fn form_repo_force_rls_deny_all_and_fix(pool: PgPool) {
         // so the NOSUPERUSER RLS role needs SELECT on `users` or the join trips
         // Postgres 42501 (permission denied on `users`).
         format!("GRANT SELECT ON users TO \"{role}\""),
+        // `get_submission` LEFT JOINs `units` (un.designation) and `buildings`
+        // (b.name) for the submission detail view, so the role likewise needs
+        // SELECT on both or the join trips 42501 (permission denied on `units`).
+        format!("GRANT SELECT ON units, buildings TO \"{role}\""),
     ] {
         sqlx::query(sqlx::AssertSqlSafe(stmt))
             .execute(&pool)


### PR DESCRIPTION
## Problem

After the document/form/reserve schema-drift fixes (#1469/#1481) landed, dev's backend `test` job still failed on **2** tests:

1. **`form_repo_force_rls_deny_all_and_fix`** — the `un.unit_number`→`un.designation` fix (#1469) made `get_submission`'s `LEFT JOIN units`/`buildings` resolve, which then tripped `42501 permission denied for table units` under the test's NOSUPERUSER FORCE-RLS role. The role was granted `SELECT` on `forms*`/`organizations`/`users` but **not `units`/`buildings`** (the join was always present; it previously failed earlier at `42703` on the missing column, masking the missing grant).

2. **`booking_connect_persists_ciphertext_not_plaintext`** — `find_connection_by_unit_platform` did a bare `SELECT * FROM rental_platform_connections`, decoding the `rental_platform` ENUM `platform` column into the model's `String` field → `ColumnDecode` (#1008 class).

## Fix

1. Grant `SELECT ON units, buildings` to the form test's RLS role.
2. Cast the `platform` enum on read. An audit of `rental.rs` found **6 total** bare-`SELECT *` readers of `rental_platform_connections` with the same latent decode bug (the one the test hit + 5 more: list-active, find-by-airbnb-property, etc.) — convert **all** to the explicit column list with `platform::text AS platform` (matching the already-correct `find_connection_for_org`), and add `$2::rental_platform` to the one parameterized predicate. The whole decode surface is now consistent.

## Verification

`cargo check -p db -p api-server --tests` → clean (Finished, exit 0) on mercury. The 5 latent-site fixes are byte-identical to the proven `find_connection_for_org` projection (string-only, no Rust change).

Completes the backend `test`-job unblock alongside #1469/#1481. Refs #1331, #1332, #1008.

🤖 Generated with [Claude Code](https://claude.com/claude-code)