### PR TITLE
test(db): grant SELECT on units/buildings to form RLS test role (fixes form_repo_force_rls_deny_all_and_fix)

### DIFF
--- a/backend/crates/db/tests/form_rls_repo_tests.rs
+++ b/backend/crates/db/tests/form_rls_repo_tests.rs
@@ -138,6 +138,11 @@ async fn form_repo_force_rls_deny_all_and_fix(pool: PgPool) {
         // so the NOSUPERUSER RLS role needs SELECT on `users` or the join trips
         // Postgres 42501 (permission denied on `users`).
         format!("GRANT SELECT ON users TO \"{role}\""),
+        // `get_submission` / `list_submissions` LEFT JOIN `units` (for the
+        // `un.designation` unit label) and `buildings` (for `building_name`),
+        // so the role needs SELECT on both or those joins trip 42501.
+        format!("GRANT SELECT ON units TO \"{role}\""),
+        format!("GRANT SELECT ON buildings TO \"{role}\""),
     ] {
         sqlx::query(sqlx::AssertSqlSafe(stmt))
             .execute(&pool)


### PR DESCRIPTION
## Why

`form_repo_force_rls_deny_all_and_fix` is **red on `dev`**. After the column-drift fix (#1469 — `un.unit_number` → `un.designation`) let the test reach the query, it now fails one layer deeper:

```
get submission (ctx): 42501 permission denied for table units
```

The test creates a `NOSUPERUSER NOBYPASSRLS` role (so FORCE RLS actually binds) and grants it only the form tables + `organizations` + `users`. But `FormRepository::get_submission` and `list_submissions` `LEFT JOIN units` (for the `un.designation` unit label) and `LEFT JOIN buildings` (for `building_name`) — under FORCE RLS the role hits `42501` on those un-granted tables.

## Fix

Grant `SELECT` on `units` and `buildings` to the test role — exactly mirroring the existing `users` grant (added for the `created_by_name` join, with the same rationale comment).

```rust
format!("GRANT SELECT ON units TO \"{role}\""),
format!("GRANT SELECT ON buildings TO \"{role}\""),
```

Test-only change; no production code touched.

## Verification

Local verification was blocked by a **sqlx 0.9 test-DB collision** on the shared dev host — the harness uses a deterministic temp-DB name and a concurrent build on the same machine repeatedly tripped `55006: database is being accessed by other users` at setup, before the test body runs. CI runs each backend job against a **dedicated** Postgres with no concurrent test runs, so the collision cannot occur there and the grant fix is exercised cleanly.

## Remaining dev `test` blocker (separate, not in this PR)

The dev `test` job has a **second, independent** failure I did not bundle here:

- `booking_connect_persists_ciphertext_not_plaintext` → `ColumnDecode { platform: Rust String vs SQL rental_platform }`. This is the **PAP-158** enum-decode class: `RentalRepository` queries read `rental_platform_connections` via `SELECT *` / `RETURNING *` into a struct whose `platform` field is `String`, but the column is the `rental_platform` enum. The established fix (see `update_booking_status_for_org`, ~rental.rs:760) is to project explicit columns with `platform::text AS platform`; ~9 `RentalPlatformConnection` query sites still need it. Recommend a dedicated PAP-158 PR for the full sweep.