### PR TITLE
fix(db): cast form_submissions.status enum to text in form queries (fixes form_repo_force_rls_deny_all_and_fix)

### DIFF
--- a/backend/crates/db/src/repositories/form.rs
+++ b/backend/crates/db/src/repositories/form.rs
@@ -808,7 +808,13 @@ impl FormRepository {
         let row = sqlx::query(
             r#"
             SELECT
-                s.*,
+                s.id, s.form_id, s.organization_id, s.building_id, s.unit_id,
+                s.submitted_by, s.submitted_at, s.data, s.attachments, s.signature_data,
+                -- `status` is the `form_submission_status` enum; the model decodes it
+                -- as `String`, so cast to text or `FromRow` trips ColumnDecode.
+                s.status::text AS status,
+                s.reviewed_by, s.reviewed_at, s.review_notes, s.ip_address, s.user_agent,
+                s.created_at, s.updated_at,
                 f.title as form_title,
                 u.name as submitted_by_name,
                 r.name as reviewed_by_name,
@@ -874,7 +880,9 @@ impl FormRepository {
             count_conditions.push("s.form_id = $2");
         }
         if query.status.is_some() {
-            count_conditions.push("s.status = $3");
+            // `status` is the `form_submission_status` enum; cast to text so the
+            // text-bound `$3` comparison parses (avoids 42883 operator mismatch).
+            count_conditions.push("s.status::text = $3");
         }
 
         let count_where = count_conditions.join(" AND ");
@@ -904,7 +912,7 @@ impl FormRepository {
                 s.submitted_by,
                 u.name as submitted_by_name,
                 s.submitted_at,
-                s.status,
+                s.status::text AS status,
                 s.signature_data IS NOT NULL as has_signature,
                 un.designation AS unit_number,
                 b.name as building_name
@@ -915,7 +923,7 @@ impl FormRepository {
             LEFT JOIN buildings b ON b.id = s.building_id
             WHERE s.organization_id = $1
                 AND ($2::uuid IS NULL OR s.form_id = $2)
-                AND ($3::text IS NULL OR s.status = $3)
+                AND ($3::text IS NULL OR s.status::text = $3)
                 AND ($4::uuid IS NULL OR s.building_id = $4)
                 AND ($5::uuid IS NULL OR s.unit_id = $5)
                 AND ($6::uuid IS NULL OR s.submitted_by = $6)


### PR DESCRIPTION
## Why

`form_repo_force_rls_deny_all_and_fix` is **still red on `dev`** after the prior fixes (#1469 column drift, #1495 RLS grants). With the grants in place the test now reaches `get_submission` and panics at `form.rs:843`:

```
ColumnDecode { index: "status",
  source: "Rust type String (as SQL type TEXT) is not compatible with SQL type form_submission_status" }
```

`form_submissions.status` is the `form_submission_status` enum, but `FormSubmission`/`FormSubmissionSummary` decode it as `String`. `get_submission` used `SELECT s.*`, so `status` came through as the raw enum and tripped `FromRow`.

This is the **next layer of the same enum-decode / schema-drift class** already fixed for `document.category` (#1469) and `rental_platform_connections.platform` (#1495).

## Fix

- **`get_submission`** — expanded `SELECT s.*` to explicit columns with `s.status::text AS status` (all other `FormSubmission` fields preserved by name).
- **`list_submissions`** — `s.status::text AS status` in the projection, plus `s.status::text = $3` in both the main query and the count query WHERE clauses (the text-bound status filter would otherwise trip `42883` enum-vs-text, the next latent failure).

## Verification

✅ Verified locally against Postgres 16 — `cargo test -p db --test form_rls_repo_tests` passes **1/1** (`form_repo_force_rls_deny_all_and_fix`). (Earlier local runs were blocked by a sqlx-0.9 deterministic-temp-DB collision with concurrent builds on the shared host; restarting the test container cleared the zombie connections and the suite ran clean.)

This should finally green the dev backend `test` job for the form path. Other enum-decode sites in `rental.rs` (PAP-158, ~9 `RentalPlatformConnection` queries) remain a separate follow-up if they surface.