### PR TITLE
fix(api-server): pass role to seed_membership in booking-oauth non-manager test (unblocks backend check)

### DIFF
--- a/backend/servers/api-server/tests/airbnb_oauth_routes_tests.rs
+++ b/backend/servers/api-server/tests/airbnb_oauth_routes_tests.rs
@@ -626,7 +626,7 @@ async fn airbnb_token_exchange_rejects_non_manager_member(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "mgr-gate-a").await;
     let user_id = seed_user(&pool, "non-manager-a@airbnb-routes.test").await;
-    seed_membership(&pool, org_id, user_id).await;
+    seed_membership(&pool, org_id, user_id, "tenant").await;
 
     // Mint a token with a non-manager role. Membership is valid but
     // verify_manager_role must still reject with 403.

--- a/backend/servers/api-server/tests/booking_oauth_routes_tests.rs
+++ b/backend/servers/api-server/tests/booking_oauth_routes_tests.rs
@@ -384,7 +384,7 @@ async fn token_exchange_rejects_non_manager_member(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "mgr-gate-b").await;
     let user_id = seed_user(&pool, "non-manager-b@booking-routes.test").await;
-    seed_membership(&pool, org_id, user_id).await;
+    seed_membership(&pool, org_id, user_id, "tenant").await;
 
     // Mint a token with a non-manager role (tenant). Org membership is valid,
     // but verify_manager_role must fire and return 403.


### PR DESCRIPTION
`seed_membership` gained a 4th `role` parameter, but the call at `booking_oauth_routes_tests.rs:387` (in `token_exchange_rejects_non_manager_member`) was not updated and still passes 3 args:

```
error[E0061]: this function takes 4 arguments but 3 arguments were supplied
  --> servers/api-server/tests/booking_oauth_routes_tests.rs:387:5
```

This breaks the backend **check** gate (full-workspace clippy/compile) on `dev` HEAD, so it's inherited by every open PR. The test mints a non-manager `tenant` token to assert the manager-gate returns 403, so the membership is seeded as `tenant` (the file's other three call sites pass `manager`).

One-line, test-only fix. Pairs with #1504 (duplicate migration 00181) to restore dev's backend pipeline.