### PR TITLE
fix(api-server): resolve clippy lints blocking dev fmt-clippy gate (accounting routes)

### DIFF
--- a/backend/servers/api-server/src/routes/accounting/invoices.rs
+++ b/backend/servers/api-server/src/routes/accounting/invoices.rs
@@ -61,11 +61,9 @@ fn validate_update_invoice(data: &UpdateInvoice) -> Result<(), StatusCode> {
             return Err(StatusCode::BAD_REQUEST);
         }
     }
-    if let Some(ref vs_opt) = data.variable_symbol {
-        if let Some(ref vs) = vs_opt {
-            if vs.len() > 20 {
-                return Err(StatusCode::BAD_REQUEST);
-            }
+    if let Some(Some(ref vs)) = data.variable_symbol {
+        if vs.len() > 20 {
+            return Err(StatusCode::BAD_REQUEST);
         }
     }
     if let Some(ref currency) = data.currency {
@@ -261,7 +259,7 @@ pub async fn create_invoice(
 
     let invoice = state
         .accounting_repo
-        .create_invoice_rls(&mut *tx, data)
+        .create_invoice_rls(&mut tx, data)
         .await
         .map_err(|e| {
             tracing::error!("Failed to create invoice: {}", e);

--- a/backend/servers/api-server/src/routes/accounting/matches.rs
+++ b/backend/servers/api-server/src/routes/accounting/matches.rs
@@ -46,7 +46,7 @@ pub async fn confirm_match(
 
     state
         .accounting_service
-        .confirm_match(&mut **rls, tenant_id, match_id, user_id)
+        .confirm_match(&mut rls, tenant_id, match_id, user_id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to confirm match: {}", e);
@@ -75,7 +75,7 @@ pub async fn reject_match(
 
     state
         .accounting_service
-        .reject_match(&mut **rls, match_id, user_id)
+        .reject_match(&mut rls, match_id, user_id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to reject match: {}", e);

--- a/backend/servers/api-server/src/routes/accounting/statements.rs
+++ b/backend/servers/api-server/src/routes/accounting/statements.rs
@@ -48,7 +48,7 @@ pub async fn upload_statement(
 
     let statement = state
         .accounting_service
-        .process_statement_upload(&mut **rls, tenant_id, filename, &data)
+        .process_statement_upload(&mut rls, tenant_id, filename, &data)
         .await
         .map_err(|e| {
             tracing::error!("Failed to process statement upload: {}", e);


### PR DESCRIPTION
## Why

`dev`'s workspace **`fmt-clippy`** CI gate (`cargo clippy --workspace -- -D warnings`) is currently **RED for every backend PR**. The CI runner's rust 1.94.0 clippy flags 5 pre-existing lints in `api-server` accounting routes that older clippy did not. Because `-D warnings` turns them into hard errors, `api-server` (lib + lib test) fails to compile under clippy, so **no backend PR can pass CI** until these are fixed (observed blocking PR #1510 and the merge pipeline generally).

This is a toolchain-bump regression, not new code — the accounting routes were last green under an older clippy.

## What changed (all clippy's own suggested rewrites — behaviour-preserving)

| File:line | Lint | Fix |
|---|---|---|
| `accounting/matches.rs:49` | `explicit_auto_deref` | `&mut **rls` → `&mut rls` (confirm_match) |
| `accounting/matches.rs:78` | `explicit_auto_deref` | `&mut **rls` → `&mut rls` (reject_match) |
| `accounting/statements.rs:51` | `explicit_auto_deref` | `&mut **rls` → `&mut rls` (process_statement_upload) |
| `accounting/invoices.rs:264` | `explicit_auto_deref` | `&mut *tx` → `&mut tx` (create_invoice_rls) |
| `accounting/invoices.rs:64` | `collapsible_match` | nested `if let Some(_) { if let Some(_) }` → `if let Some(Some(ref vs))` |

Only the 5 clippy-flagged sites were touched — the other `&mut **rls` call sites in the same files are NOT flagged by clippy (auto-deref does not apply there) and were left unchanged.

## Verification

Static / clippy-guided: each edit is the exact rewrite clippy emits in its `help:` suggestion, so the lints clear. Authoritative `fmt-clippy` (rust 1.94.0) on the CI runner is the gate — this PR's own CI run confirms green.

## Provenance

Opened by the research dispatcher after diagnosing the dev-CI block while reconciling PR #1510 (a test-only PR whose red CI was traced to this pre-existing breakage, not its own changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSYRY6ScZS6MiDr9nrAVBc

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSYRY6ScZS6MiDr9nrAVBc)_