### PR TITLE
fix(api-server): clippy fixes in accounting routes (post-#1454)

### DIFF
--- a/backend/servers/api-server/src/routes/accounting/invoices.rs
+++ b/backend/servers/api-server/src/routes/accounting/invoices.rs
@@ -61,11 +61,9 @@ fn validate_update_invoice(data: &UpdateInvoice) -> Result<(), StatusCode> {
             return Err(StatusCode::BAD_REQUEST);
         }
     }
-    if let Some(ref vs_opt) = data.variable_symbol {
-        if let Some(ref vs) = vs_opt {
-            if vs.len() > 20 {
-                return Err(StatusCode::BAD_REQUEST);
-            }
+    if let Some(Some(vs)) = &data.variable_symbol {
+        if vs.len() > 20 {
+            return Err(StatusCode::BAD_REQUEST);
         }
     }
     if let Some(ref currency) = data.currency {
@@ -261,7 +259,7 @@ pub async fn create_invoice(
 
     let invoice = state
         .accounting_repo
-        .create_invoice_rls(&mut *tx, data)
+        .create_invoice_rls(&mut tx, data)
         .await
         .map_err(|e| {
             tracing::error!("Failed to create invoice: {}", e);

--- a/backend/servers/api-server/src/routes/accounting/matches.rs
+++ b/backend/servers/api-server/src/routes/accounting/matches.rs
@@ -46,7 +46,7 @@ pub async fn confirm_match(
 
     state
         .accounting_service
-        .confirm_match(&mut **rls, tenant_id, match_id, user_id)
+        .confirm_match(&mut rls, tenant_id, match_id, user_id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to confirm match: {}", e);
@@ -75,7 +75,7 @@ pub async fn reject_match(
 
     state
         .accounting_service
-        .reject_match(&mut **rls, match_id, user_id)
+        .reject_match(&mut rls, match_id, user_id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to reject match: {}", e);

--- a/backend/servers/api-server/src/routes/accounting/statements.rs
+++ b/backend/servers/api-server/src/routes/accounting/statements.rs
@@ -48,7 +48,7 @@ pub async fn upload_statement(
 
     let statement = state
         .accounting_service
-        .process_statement_upload(&mut **rls, tenant_id, filename, &data)
+        .process_statement_upload(&mut rls, tenant_id, filename, &data)
         .await
         .map_err(|e| {
             tracing::error!("Failed to process statement upload: {}", e);


### PR DESCRIPTION
## What
Resolves 5 clippy errors introduced by #1454 (accounting MVP) that turned dev's `fmt-clippy` job red (inherited by every new PR). The required `check` job (cargo check) did not catch them.

## Fixes (clippy's own suggestions, lint-only — no behavior change)
- `routes/accounting/invoices.rs:65` — collapsible_match: `if let Some(ref vs_opt) = ... { if let Some(ref vs) = vs_opt {` → `if let Some(Some(vs)) = &data.variable_symbol {`
- `routes/accounting/invoices.rs:264` — explicit_auto_deref: `&mut *tx` → `&mut tx`
- `routes/accounting/matches.rs:49` — explicit_auto_deref: `&mut **rls` → `&mut rls`
- `routes/accounting/matches.rs:78` — explicit_auto_deref: `&mut **rls` → `&mut rls`
- `routes/accounting/statements.rs:51` — explicit_auto_deref: `&mut **rls` → `&mut rls`

## Verification (local)
- `cargo clippy -p api-server --all-targets -- -D warnings` → exit 0
- `cargo check -p api-server` → exit 0
- `cargo fmt --all --check` → clean

Co-Authored-By: Paperclip <noreply@paperclip.ing>