### PR TITLE
feat-swiftui-project-setup-vs-implementation-mapping-mobile: document epic-82 story-vs-implementation mapping

### DIFF
--- a/_bmad-output/epics-007.md
+++ b/_bmad-output/epics-007.md
@@ -602,6 +602,14 @@ So that **UI buttons work**.
 #### Epic 82: Mobile Native Completion
 **Goal:** Fix broken functionality in the iOS Reality Portal app and complete API integration.
 
+> **Note — story-number collision.** This Epic 82 (the authoritative one) is a
+> *completion/fix* epic on an already-built iOS app. A separate, legacy *build*
+> story set under `_bmad-output/implementation-artifacts/stories/82-*.md` reuses
+> the same numbers (e.g. its "82.1" is "SwiftUI Project Setup", not "Remove
+> Broken Direct Login Form" below). For the full reconciliation of both
+> definitions against the actual `mobile-native/iosApp/` implementation, see
+> [`docs/superpowers/plans/epic-82-story-mapping.md`](../docs/superpowers/plans/epic-82-story-mapping.md).
+
 **Target Apps:** mobile-native (iosApp, shared)
 **Estimate:** 6 stories, ~2 weeks
 **Dependencies:** Epic 79 (Security)

--- a/_bmad-output/implementation-artifacts/stories/82-1-swiftui-project-setup.md
+++ b/_bmad-output/implementation-artifacts/stories/82-1-swiftui-project-setup.md
@@ -2,6 +2,14 @@
 
 Status: pending
 
+> **Note (2026-06-17):** This is a *legacy build* story. It is **implemented in
+> code** — see `mobile-native/iosApp/` and `docs/superpowers/plans/gap-82-1-swiftui-audit.md`.
+> The `Status: pending` above is stale. Note also that its story number (82.1)
+> collides with a *different* story in `_bmad-output/epics-007.md` Epic 82
+> ("Remove Broken Direct Login Form"). The authoritative Epic 82 is the
+> `epics-007.md` "Mobile Native Completion" epic. Reconciliation:
+> `docs/superpowers/plans/epic-82-story-mapping.md`.
+
 ## Story
 
 As a **mobile developer**,

--- a/docs/screens/reality-mobile/README.md
+++ b/docs/screens/reality-mobile/README.md
@@ -6,6 +6,13 @@ This directory contains screen maps for the SwiftUI iOS app at
 Screen maps here complement the shared `docs/screens/reality/` web screen maps.
 They document iOS-specific implementation status, route bindings, and gaps.
 
+> **Story numbering:** the "Story" column below uses the **build** story set
+> (`_bmad-output/implementation-artifacts/stories/82-*.md`, e.g. 82.2 =
+> Navigation, 82.3 = Home & Search). This is *not* the same numbering as
+> `epics-007.md` Epic 82 (Mobile Native Completion). See
+> [`docs/superpowers/plans/epic-82-story-mapping.md`](../../superpowers/plans/epic-82-story-mapping.md)
+> for the reconciliation.
+
 ## Epic-82 Screen Coverage
 
 | Screen Map | Component | Story | buildStatus |

--- a/docs/superpowers/plans/epic-82-story-mapping.md
+++ b/docs/superpowers/plans/epic-82-story-mapping.md
@@ -1,0 +1,147 @@
+# Epic 82 — Story-vs-Implementation Mapping (Reality Portal iOS)
+
+**Date:** 2026-06-17
+**Task ID:** feat-swiftui-project-setup-vs-implementation-mapping-mobile
+**Owner:** pm-frontend
+**Type:** Documentation (mapping note — no code changes)
+
+---
+
+## Why this note exists
+
+"Epic 82" is defined **two different ways** in this repository, and the two
+definitions disagree on what Story 82.1 ("SwiftUI Project Setup") is and
+whether it is even in scope. A research task surfaced the ambiguity:
+
+> story-vs-implementation mapping unclear — epic 82 in `epics-007.md` targets a
+> different scope than `82-1-swiftui-project-setup` "SwiftUI Project Setup".
+
+This document reconciles the two and maps each story onto the **actual**
+`mobile-native/iosApp/` implementation. It is the single source of truth for
+"which Epic 82 are we talking about?".
+
+---
+
+## The two Epic-82 definitions
+
+| | Source A — "SwiftUI build" | Source B — "Mobile Native Completion" |
+|---|---|---|
+| **File** | `_bmad-output/implementation-artifacts/stories/82-*.md` | `_bmad-output/epics-007.md` (§ Epic 82) |
+| **Date / origin** | Greenfield iOS build plan | 2025-12-31, gap-remediation epics 79–85 |
+| **Epic goal** | Build the iOS Reality Portal app from scratch with KMP | Fix broken functionality / complete API integration in the **already-built** iOS app |
+| **Story 82.1** | **SwiftUI Project Setup** (Xcode project, KMP framework, xcconfig, Info.plist, schemes) | **Remove Broken Direct Login Form** |
+| **Story 82.2** | Navigation and Routing | Fix Session Restoration Race Condition |
+| **Story 82.3** | Home and Search Screens | Wire Category Filter Chips |
+| **Story 82.4** | Listing Detail and Favorites | Persist Recent Searches |
+| **Story 82.5** | Inquiries and Account | Add Map Integration |
+| **Story 82.6** | — (5 stories) | Initialize ApiConfig at Startup |
+
+**Key takeaway:** the story *numbers* collide but the story *content* does not.
+Source A is the **build** epic; Source B is the **finish/fix** epic. They are
+sequential, not duplicates: Source B presupposes Source A is done.
+
+### Which one is authoritative?
+
+- **`epics-007.md` (Source B) is the authoritative epic backlog.** It is the
+  curated, dated epic breakdown that downstream planning (`sprint-status.yaml`,
+  research backlog) tracks. When someone says "Epic 82" without qualification,
+  they mean **Mobile Native Completion**.
+- **The `implementation-artifacts/stories/82-*.md` files (Source A) are the
+  historical build stories** that produced the current `iosApp/` tree. They are
+  retained for traceability of the original implementation, but their story
+  numbering (82.1 = SwiftUI Project Setup, etc.) is **legacy** and should not be
+  cited as the current backlog.
+
+> Existing docs that reference "82.2 / 82.3 / 82.4 / 82.5" — namely
+> `docs/screens/reality-mobile/README.md` and
+> `docs/superpowers/plans/gap-82-1-swiftui-audit.md` — use the **Source A**
+> (build-story) numbering. That is correct for those documents (they describe
+> the build), but readers must not conflate them with the `epics-007.md`
+> completion stories of the same number.
+
+---
+
+## Source A (SwiftUI build) → implementation mapping
+
+The build stories map cleanly onto the current `mobile-native/iosApp/` tree.
+All are effectively **implemented in code** (some screens still have stub
+destinations — see the audit).
+
+| Build story | Description | Implemented by | Status |
+|---|---|---|---|
+| **82.1** | SwiftUI Project Setup | `iosApp/iosApp/App/RealityPortalApp.swift` (@main), `Core/Configuration.swift`, `Configurations/{Base,Development,Staging,Production}.xcconfig`, `Resources/Info.plist`, `Resources/Assets.xcassets/AppIcon*.appiconset`, KMP framework export in `shared/build.gradle.kts` | **Done** (verified by `gap-82-1-swiftui-audit.md` § Project Setup Verification) |
+| **82.2** | Navigation and Routing | `Core/Navigation/{NavigationCoordinator,DeepLinkHandler,Route,NavigationStateRestorationService}.swift`, `App/MainTabView.swift` | **Done** (shipped) |
+| **82.3** | Home and Search Screens | `Features/Home/HomeView.swift`, `Features/Search/SearchView.swift` | In-progress (category chips unwired) |
+| **82.4** | Listing Detail and Favorites | `Features/Listing/ListingDetailView.swift`, `Features/Favorites/FavoritesView.swift` | In-progress |
+| **82.5** | Inquiries and Account | `Features/Inquiries/InquiriesView.swift`, `Features/Account/AccountView.swift`, `Features/Auth/LoginView.swift` | In-progress |
+
+Beyond the build epic, the iosApp also already ships `SavedSearchesView`,
+`CompareListingsView`, `RealtorsView`, and `AgenciesView` (mapped to UCs, not to
+Epic 82).
+
+### Story 82.1 "SwiftUI Project Setup" specifically
+
+This is the story the research task called out. Its acceptance criteria (AC-1
+Xcode structure / AC-2 KMP framework / AC-3 dependencies / AC-4 Info.plist &
+icons / AC-5 build schemes) are **all satisfied** by the current tree:
+
+- AC-1 / AC-4 — Xcode project under `iosApp/`, bundle ID
+  `three.two.bit.ppt.reality` (`.dev` suffix for Development), `Info.plist`,
+  `Assets.xcassets` per-env app icons. ✓
+- AC-2 — KMP `shared` framework exported and consumed from Swift
+  (`Core/DI/DependencyContainer.swift`, `KMPBridge`). ✓
+- AC-3 — dependencies resolved (Keychain via native `KeychainService.swift`;
+  imaging via Coil/Kingfisher per stack). ✓
+- AC-5 — `Base/Development/Staging/Production` xcconfig + per-env API URL via
+  `$(API_BASE_URL)` token. ✓
+
+So the **build** 82.1 is complete. The `Status: pending` header in
+`82-1-swiftui-project-setup.md` is **stale** — it predates the implementation
+and was never flipped. Treat the code + audit as ground truth over that header.
+
+---
+
+## Source B (Mobile Native Completion) → implementation mapping
+
+These are the *current* Epic-82 stories from `epics-007.md`. They are
+fix/finish tasks on top of the build above.
+
+| Completion story | Description | Touch point | Notes |
+|---|---|---|---|
+| **82.1** | Remove Broken Direct Login Form | `Features/Auth/LoginView.swift` | Audit confirms email/password `login()` always throws `AuthError.ssoRequired`; form is UI-only. This story removes it or makes SSO-only messaging explicit. |
+| **82.2** | Fix Session Restoration Race Condition | `Core/AuthManager.swift`, `App/RealityPortalApp.swift` | Make `restoreSession` async; add loading state to `MainTabView`. |
+| **82.3** | Wire Category Filter Chips | `Features/Home/HomeView.swift`, `Features/Search/SearchView.swift` | Audit flags `HomeView.categoryFilters` chips have empty tap closures. |
+| **82.4** | Persist Recent Searches | `Features/Search/SearchView.swift` | Replace hardcoded suggestions with `UserDefaults`-persisted history. |
+| **82.5** | Add Map Integration | `Features/Listing/ListingDetailView.swift` (and `Features/Listing/ListingMapView.swift`) | Replace map placeholder with MapKit + pin + directions. |
+| **82.6** | Initialize ApiConfig at Startup | `App/RealityPortalApp.swift`, `shared/.../api/ApiConfig.kt` | Initialize `ApiConfig.baseUrl` in `configureApp()`. |
+
+Several of these line up with gaps already recorded in
+`gap-82-1-swiftui-audit.md` (login form throws, category chips unwired, map
+placeholder) — the audit is the technical evidence backing the completion
+stories.
+
+---
+
+## Practical guidance for agents
+
+1. **A task that says "Epic 82" / "82.x" with no other qualifier** → use the
+   **`epics-007.md` Mobile Native Completion** definition (Source B).
+2. **A task or doc citing "SwiftUI Project Setup", "Navigation and Routing",
+   "Home and Search Screens"** etc. → that is the **build** numbering
+   (Source A); it is historical. The work is already in `iosApp/`.
+3. **Do not re-do Source A 82.1 ("SwiftUI Project Setup")** — the project is set
+   up. Any remaining iOS work is Source-B completion or the stub destinations
+   listed in the audit and `docs/screens/reality-mobile/README.md`.
+4. When you finish a Source-B story, update `epics-007.md` is **not** required
+   (it is a frozen breakdown); record status in the research backlog /
+   sprint-status instead.
+
+---
+
+## References
+
+- `_bmad-output/epics-007.md` § Epic 82 (Mobile Native Completion) — authoritative epic.
+- `_bmad-output/implementation-artifacts/stories/82-{1..5}-*.md` — legacy build stories (Source A).
+- `docs/superpowers/plans/gap-82-1-swiftui-audit.md` — implementation audit of the built iOS app.
+- `docs/screens/reality-mobile/README.md` — per-screen build status (uses Source-A numbering).
+- `mobile-native/iosApp/` — the actual SwiftUI implementation.


### PR DESCRIPTION
## Task
story-vs-implementation mapping unclear (epic 82 in epics-007.md targets different scope) (82-1-swiftui-project-setup SwiftUI Project Setup). Clarify/document the mapping between epic-82 SwiftUI Project Setup stories and the actual `mobile-native/` implementation. Docs deliverable; do not refactor code.

## Owner
pm-frontend

## What changed (docs only)
There are **two colliding "Epic 82" definitions** in the repo:

| | Source A (legacy build) | Source B (authoritative) |
|---|---|---|
| File | `_bmad-output/implementation-artifacts/stories/82-*.md` | `_bmad-output/epics-007.md` § Epic 82 |
| 82.1 | **SwiftUI Project Setup** | **Remove Broken Direct Login Form** |
| Goal | Build the iOS app from scratch | Fix/complete the already-built iOS app |

The story *numbers* collide but the *content* does not — Source B presupposes Source A is done. No prior doc reconciled them.

This PR adds:
- **New** `docs/superpowers/plans/epic-82-story-mapping.md` — declares `epics-007.md` (Mobile Native Completion) as authoritative, marks the build stories as legacy, and maps **each** build story + each completion story onto the actual `mobile-native/iosApp/` tree. Confirms build-82.1 "SwiftUI Project Setup" (Xcode project, KMP framework, xcconfig, Info.plist, schemes) is **already implemented** (its `Status: pending` header is stale).
- Cross-reference notes added to: `epics-007.md` Epic 82, the legacy `82-1-swiftui-project-setup.md` story, and `docs/screens/reality-mobile/README.md` (which uses the build numbering).

Grounded in the existing `gap-82-1-swiftui-audit.md` and a scan of `mobile-native/iosApp/`.

## Tested (Band A — fast check)
- `git diff --cached --check` → exit 0 (no whitespace/conflict markers).
- Cross-reference relative links verified to resolve on disk (epics-007.md → ../docs/..., screens README → ../../superpowers/...).

## Built (Band B — full build)
skipped: docs-only change, no code / public API / config touched.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (docs only).

## Remote-tested
skipped.

## Notes
- No code refactor — scope kept tight to documentation per task.
- Scope: 4 files, all docs (`_bmad-output/**`, `docs/**`). No `.research/**`, no backend, no app code touched.
- The legacy story's `Status: pending` was annotated as stale rather than flipped, to avoid implying a process change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSYRY6ScZS6MiDr9nrAVBc

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSYRY6ScZS6MiDr9nrAVBc)_