### PR TITLE
test(api-server): migrate IDOR test seed_membership to canonical common helper (#1373)

### DIFF
--- a/backend/servers/api-server/tests/document_folder_tests.rs
+++ b/backend/servers/api-server/tests/document_folder_tests.rs
@@ -89,20 +89,6 @@ async fn seed_user_f(pool: &PgPool, tag: &str) -> Uuid {
     .expect("seed_user_f")
 }
 
-async fn seed_member_f(pool: &PgPool, org: Uuid, user: Uuid, role: &str) {
-    sqlx::query(
-        "INSERT INTO organization_members \
-             (organization_id,user_id,role_type,status,joined_at) \
-         VALUES ($1,$2,$3,'active',NOW()) ON CONFLICT DO NOTHING",
-    )
-    .bind(org)
-    .bind(user)
-    .bind(role)
-    .execute(pool)
-    .await
-    .expect("seed_member_f");
-}
-
 /// Mint a signed HS256 JWT with `role: <role_str>` for TenantExtractor.
 fn mint_jwt_with_role(user_id: Uuid, role_str: &str) -> String {
     use jsonwebtoken::{encode, EncodingKey, Header};
@@ -504,7 +490,7 @@ async fn test_cross_org_folder_idor_authenticated_get_returns_404(pool: PgPool) 
 
     // Attacker: a real user with a Manager membership in Org B.
     let attacker = seed_user_f(&pool, "idor-auth-get-b-attacker").await;
-    seed_member_f(&pool, org_b, attacker, "manager").await;
+    common::seed_membership(&pool, org_b, attacker, "manager").await;
     let token = mint_jwt_with_role(attacker, "manager");
 
     let resp = app
@@ -555,7 +541,7 @@ async fn test_cross_org_folder_idor_authenticated_update_returns_404(pool: PgPoo
     let folder_in_a = seed_folder_f(&pool, org_a, None, "OrgA Original", user_a).await;
 
     let attacker = seed_user_f(&pool, "idor-auth-put-b-attacker").await;
-    seed_member_f(&pool, org_b, attacker, "manager").await;
+    common::seed_membership(&pool, org_b, attacker, "manager").await;
     let token = mint_jwt_with_role(attacker, "manager");
 
     let resp = app
@@ -604,7 +590,7 @@ async fn test_cross_org_folder_idor_authenticated_delete_returns_404(pool: PgPoo
     let folder_in_a = seed_folder_f(&pool, org_a, None, "OrgA Survivor", user_a).await;
 
     let attacker = seed_user_f(&pool, "idor-auth-del-b-attacker").await;
-    seed_member_f(&pool, org_b, attacker, "manager").await;
+    common::seed_membership(&pool, org_b, attacker, "manager").await;
     let token = mint_jwt_with_role(attacker, "manager");
 
     let resp = app
@@ -659,7 +645,7 @@ async fn test_folder_depth_limit_returns_bad_request(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org_f(&pool, "depth-limit").await;
     let user_id = seed_user_f(&pool, "depth-limit-mgr").await;
-    seed_member_f(&pool, org_id, user_id, "manager").await;
+    common::seed_membership(&pool, org_id, user_id, "manager").await;
 
     // Seed levels 1-5 directly (bypasses HTTP; trigger fires at INSERT).
     let mut parent: Option<Uuid> = None;
@@ -795,7 +781,7 @@ async fn test_create_folder_manager_succeeds(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org_f(&pool, "create-ok").await;
     let user_id = seed_user_f(&pool, "create-ok-mgr").await;
-    seed_member_f(&pool, org_id, user_id, "manager").await;
+    common::seed_membership(&pool, org_id, user_id, "manager").await;
     let token = mint_jwt_with_role(user_id, "manager");
 
     let resp = app
@@ -854,7 +840,7 @@ async fn test_move_document_into_folder_succeeds(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org_f(&pool, "move-ok").await;
     let user_id = seed_user_f(&pool, "move-ok-mgr").await;
-    seed_member_f(&pool, org_id, user_id, "manager").await;
+    common::seed_membership(&pool, org_id, user_id, "manager").await;
     let token = mint_jwt_with_role(user_id, "manager");
 
     let folder = seed_folder_f(&pool, org_id, None, "Destination", user_id).await;
@@ -904,7 +890,7 @@ async fn test_delete_folder_detaches_documents_to_root(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org_f(&pool, "del-detach").await;
     let user_id = seed_user_f(&pool, "del-detach-mgr").await;
-    seed_member_f(&pool, org_id, user_id, "manager").await;
+    common::seed_membership(&pool, org_id, user_id, "manager").await;
     let token = mint_jwt_with_role(user_id, "manager");
 
     let folder = seed_folder_f(&pool, org_id, None, "ToDelete", user_id).await;
@@ -967,7 +953,7 @@ async fn test_update_folder_into_descendant_is_rejected(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org_f(&pool, "circular").await;
     let user_id = seed_user_f(&pool, "circular-mgr").await;
-    seed_member_f(&pool, org_id, user_id, "manager").await;
+    common::seed_membership(&pool, org_id, user_id, "manager").await;
     let token = mint_jwt_with_role(user_id, "manager");
 
     // root -> child  (try to set root.parent = child => cycle)

--- a/backend/servers/api-server/tests/document_share_access_tests.rs
+++ b/backend/servers/api-server/tests/document_share_access_tests.rs
@@ -37,7 +37,7 @@ use serde_json::json;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use common::{cleanup_test_user, create_authenticated_user, TestApp, TestUser};
+use common::{cleanup_test_user, create_authenticated_user, seed_membership, TestApp, TestUser};
 
 // ============================================================================
 // Seed helpers
@@ -54,20 +54,6 @@ async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
     .fetch_one(pool)
     .await
     .expect("seed_org")
-}
-
-async fn add_org_member(pool: &PgPool, org_id: Uuid, user_id: Uuid) {
-    sqlx::query(
-        "INSERT INTO organization_members \
-             (id, organization_id, user_id, role_type, status, created_at) \
-         VALUES ($1, $2, $3, 'admin', 'active', NOW()) ON CONFLICT DO NOTHING",
-    )
-    .bind(Uuid::new_v4())
-    .bind(org_id)
-    .bind(user_id)
-    .execute(pool)
-    .await
-    .expect("add_org_member");
 }
 
 async fn user_id_for(pool: &PgPool, email: &str) -> Uuid {
@@ -144,7 +130,7 @@ async fn setup(app: &TestApp, pool: &PgPool, user: &TestUser, title: &str) -> (U
     let (_token, _) = create_authenticated_user(app, user).await;
     let user_id = user_id_for(pool, &user.email).await;
     let org_id = seed_org(pool, &Uuid::new_v4().to_string()[..8]).await;
-    add_org_member(pool, org_id, user_id).await;
+    seed_membership(pool, org_id, user_id, "admin").await;
     let doc_id = seed_document(pool, org_id, user_id, title).await;
     (org_id, user_id, doc_id)
 }


### PR DESCRIPTION
## What

Consolidation seed for #1373: migrate byte-duplicated inline membership-seeding helpers in two IDOR/authz integration tests onto the canonical `common::seed_membership` already present in `backend/servers/api-server/tests/common/mod.rs` (landed via #1457).

This mirrors the canonical-helper pattern referenced by #1510 (`tests/common/mod.rs` with `seed_org`/`seed_membership`). The canonical `seed_membership` already exists on `dev`, so this PR delivers the migration half of the task.

## Changes

- **`document_share_access_tests.rs`** — drop local `add_org_member` (hardcoded `role_type='admin'`); call `common::seed_membership(.., "admin")` instead.
- **`document_folder_tests.rs`** — drop local `seed_member_f` (functionally identical insert into `organization_members`); use `common::seed_membership` at all 9 call-sites. The only difference was an explicit `joined_at=NOW()`, which the canonical helper leaves to the nullable DB default — no behavioral change for these tests.

Net: 10 insertions, 38 deletions.

## Intentionally NOT migrated (scope guard)

`faults_authz_gap_tests.rs` keeps its own `seed_membership` — it deliberately writes to the **legacy `user_memberships` table** (queried by `MembershipRepository::is_manager_in_org`), which is a *different table* from the canonical helper's `organization_members`. Migrating it would silently break the manager-gate assertions. The file's own doc-comment documents this.

## Verification

- `SQLX_OFFLINE=true cargo clippy --tests -p api-server` — clean, no warnings (DATABASE_URL unset in sandbox, so `#[sqlx::test]` bodies compile but don't execute).

> Note: the workspace `fmt-clippy` gate may be red until #1511/#1512 land (pre-existing accounting-routes clippy break, unrelated to this change). The `api-server` test build here is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSYRY6ScZS6MiDr9nrAVBc

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSYRY6ScZS6MiDr9nrAVBc)_