### PR TITLE
pm-devops-confirm-eas-workflows-healthy: confirm EAS build workflow pins healthy

### DIFF
--- a/.github/workflows/eas-build-android.yml
+++ b/.github/workflows/eas-build-android.yml
@@ -2,6 +2,18 @@ name: EAS Android Build
 
 # Epic 85 - Story 85.2: Android Release Build Configuration
 #
+# Health confirmation (2026-06-17, pm-devops):
+#   A prior DevOps run (2026-05-27) flagged the action pins below as broken
+#   `@v6`. Re-verified against upstream tag listings: all pins resolve to real
+#   major-version tags and the workflow YAML parses cleanly.
+#     - actions/checkout@v6        -> v6.0.3 (v6 major tag exists)
+#     - actions/setup-node@v6      -> v6.4.0 (v6 major tag exists)
+#     - pnpm/action-setup@v6       -> v6.0.9 (v6 major tag exists)
+#     - actions/cache@v5           -> v5.0.5 (v5 major tag exists)
+#     - expo/expo-github-action@v9 -> 9.0.0  (v9 major tag exists)
+#   eas-cli is provisioned by expo/expo-github-action with `eas-version: latest`
+#   (no separate pin required). No fix needed — pins are valid as of this date.
+#
 # Triggers:
 #   - Manual dispatch (all profiles)
 #   - Push to dev touching mobile code => staging APK build (internal distribution)

--- a/.github/workflows/eas-build-ios.yml
+++ b/.github/workflows/eas-build-ios.yml
@@ -2,6 +2,18 @@ name: EAS iOS Build
 
 # Epic 85 - Story 85.2: iOS Release Build Configuration
 #
+# Health confirmation (2026-06-17, pm-devops):
+#   A prior DevOps run (2026-05-27) flagged the action pins below as broken
+#   `@v6`. Re-verified against upstream tag listings: all pins resolve to real
+#   major-version tags and the workflow YAML parses cleanly.
+#     - actions/checkout@v6        -> v6.0.3 (v6 major tag exists)
+#     - actions/setup-node@v6      -> v6.4.0 (v6 major tag exists)
+#     - pnpm/action-setup@v6       -> v6.0.9 (v6 major tag exists)
+#     - actions/cache@v5           -> v5.0.5 (v5 major tag exists)
+#     - expo/expo-github-action@v9 -> 9.0.0  (v9 major tag exists)
+#   eas-cli is provisioned by expo/expo-github-action with `eas-version: latest`
+#   (no separate pin required). No fix needed — pins are valid as of this date.
+#
 # Triggers:
 #   - Manual dispatch (all profiles)
 #   - Push to dev touching mobile code → staging build (ad-hoc distribution)


### PR DESCRIPTION
## Task
Confirm `eas-build-android.yml` + `eas-build-ios.yml` (in .github/workflows/) are healthy on a no-op push — verify action pins resolve and eas-cli is available/pinned. The last DevOps run (2026-05-27) flagged these as broken `@v6` pins. Deliverable: either fix the broken/outdated pins so the workflows are valid, or (if already healthy) add a short confirmation note in the workflow file headers / a DevOps doc with evidence. Keep scope tight — workflow YAML + minimal docs only.

## Owner
pm-devops

## Finding
The 2026-05-27 "broken `@v6` pins" flag is **stale**. As of 2026-06-17 every pinned action resolves to a real upstream major-version tag:

| Action | Pin | Resolves to | Major tag exists? |
| --- | --- | --- | --- |
| `actions/checkout` | `@v6` | v6.0.3 | yes |
| `actions/setup-node` | `@v6` | v6.4.0 | yes |
| `pnpm/action-setup` | `@v6` | v6.0.9 | yes |
| `actions/cache` | `@v5` | v5.0.5 | yes |
| `expo/expo-github-action` | `@v9` | 9.0.0 | yes |

`eas-cli` is provisioned by `expo/expo-github-action@v9` with `eas-version: latest` — no separate pin required and that is the documented/intended usage.

No fix to the pins was needed. Per the task's "if already healthy" branch, a dated confirmation note with this evidence was added to each workflow header.

## Tested (Band A — fast check)
- `python3 -c "yaml.safe_load(...)"` on both workflows → both parse OK (exit 0)
- `git diff --check` → exit 0 (no whitespace errors)
- Upstream tag listings verified for checkout/setup-node/pnpm-action-setup/cache/expo-github-action (all major tags present)

## Built (Band B — full build)
skipped: change <50 LOC, comment-only, no build-output impact

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (docs/comment-only workflow header change)

## Remote-tested
skipped

## Notes
- Comment-only edits to the two named workflow files; no job/step/pin logic changed.
- scope_drift=false (both files are within the pm-devops workflow area), code_reuse_warn=none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrBgcRL8ie5r4b6TaH5EDe

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrBgcRL8ie5r4b6TaH5EDe)_