### PR TITLE
fix(mobile-native): remove unused import failing spotless on dev (post-#1447)

### DIFF
--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/search/SearchScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/search/SearchScreen.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import three.two.bit.ppt.reality.R
 import three.two.bit.ppt.reality.listing.*


### PR DESCRIPTION
#1447's rebase added a now-unused `import kotlinx.coroutines.flow.distinctUntilChanged` to SearchScreen.kt (it's only used in SearchState.kt). spotlessKotlinCheck fails on dev because of it, inherited by all mobile PRs (e.g. #1516). Removing the unused import. Deterministic fix — spotless's own diff flagged this exact line.