### PR TITLE
fix(db): cast enum write paths on rental_guests + forms (#1008 encode/decode)

### DIFF
--- a/backend/crates/db/src/repositories/form.rs
+++ b/backend/crates/db/src/repositories/form.rs
@@ -74,8 +74,12 @@ impl FormRepository {
                 allow_multiple_submissions, submission_deadline, confirmation_message,
                 created_by
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-            RETURNING *
+            VALUES ($1, $2, $3, $4, $5, $6::form_status, $7, $8, $9, $10, $11, $12, $13)
+            RETURNING id, organization_id, building_id, title, description, category,
+                status::text AS status, version, target_type, target_ids, require_signatures,
+                allow_multiple_submissions, submission_deadline, confirmation_message,
+                pdf_template_settings, created_by, updated_by, published_by, published_at,
+                archived_at, created_at, updated_at, deleted_at
             "#,
         )
         .bind(org_id)
@@ -432,7 +436,11 @@ impl FormRepository {
                 updated_by = $11,
                 updated_at = NOW()
             WHERE id = $12 AND organization_id = $13 AND deleted_at IS NULL
-            RETURNING *
+            RETURNING id, organization_id, building_id, title, description, category,
+                status::text AS status, version, target_type, target_ids, require_signatures,
+                allow_multiple_submissions, submission_deadline, confirmation_message,
+                pdf_template_settings, created_by, updated_by, published_by, published_at,
+                archived_at, created_at, updated_at, deleted_at
             "#,
         )
         .bind(&data.title)
@@ -490,12 +498,16 @@ impl FormRepository {
         sqlx::query_as::<_, Form>(
             r#"
             UPDATE forms SET
-                status = $1,
+                status = $1::form_status,
                 published_by = $2,
                 published_at = NOW(),
                 updated_at = NOW()
-            WHERE id = $3 AND organization_id = $4 AND status = $5 AND deleted_at IS NULL
-            RETURNING *
+            WHERE id = $3 AND organization_id = $4 AND status = $5::form_status AND deleted_at IS NULL
+            RETURNING id, organization_id, building_id, title, description, category,
+                status::text AS status, version, target_type, target_ids, require_signatures,
+                allow_multiple_submissions, submission_deadline, confirmation_message,
+                pdf_template_settings, created_by, updated_by, published_by, published_at,
+                archived_at, created_at, updated_at, deleted_at
             "#,
         )
         .bind(form_status::PUBLISHED)
@@ -520,11 +532,15 @@ impl FormRepository {
         sqlx::query_as::<_, Form>(
             r#"
             UPDATE forms SET
-                status = $1,
+                status = $1::form_status,
                 archived_at = NOW(),
                 updated_at = NOW()
             WHERE id = $2 AND organization_id = $3 AND deleted_at IS NULL
-            RETURNING *
+            RETURNING id, organization_id, building_id, title, description, category,
+                status::text AS status, version, target_type, target_ids, require_signatures,
+                allow_multiple_submissions, submission_deadline, confirmation_message,
+                pdf_template_settings, created_by, updated_by, published_by, published_at,
+                archived_at, created_at, updated_at, deleted_at
             "#,
         )
         .bind(form_status::ARCHIVED)
@@ -570,8 +586,10 @@ impl FormRepository {
                 help_text, placeholder, default_value, validation_rules,
                 options, field_order, width, section, conditional_display
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-            RETURNING *
+            VALUES ($1, $2, $3, $4::form_field_type, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+            RETURNING id, form_id, field_key, label, field_type::text AS field_type, required,
+                help_text, placeholder, default_value, validation_rules, options, field_order,
+                width, section, conditional_display, created_at, updated_at
             "#,
         )
         .bind(form_id)
@@ -607,7 +625,10 @@ impl FormRepository {
     {
         sqlx::query_as::<_, FormField>(
             r#"
-            SELECT * FROM form_fields
+            SELECT id, form_id, field_key, label, field_type::text AS field_type, required,
+                help_text, placeholder, default_value, validation_rules, options, field_order,
+                width, section, conditional_display, created_at, updated_at
+            FROM form_fields
             WHERE form_id = $1
             ORDER BY field_order ASC
             "#,
@@ -644,7 +665,7 @@ impl FormRepository {
             r#"
             UPDATE form_fields SET
                 label = COALESCE($1, label),
-                field_type = COALESCE($2, field_type),
+                field_type = COALESCE($2::form_field_type, field_type),
                 required = COALESCE($3, required),
                 help_text = COALESCE($4, help_text),
                 placeholder = COALESCE($5, placeholder),
@@ -657,7 +678,9 @@ impl FormRepository {
                 conditional_display = COALESCE($12, conditional_display),
                 updated_at = NOW()
             WHERE id = $13 AND form_id = $14
-            RETURNING *
+            RETURNING id, form_id, field_key, label, field_type::text AS field_type, required,
+                help_text, placeholder, default_value, validation_rules, options, field_order,
+                width, section, conditional_display, created_at, updated_at
             "#,
         )
         .bind(&data.label)

--- a/backend/crates/db/src/repositories/rental.rs
+++ b/backend/crates/db/src/repositories/rental.rs
@@ -1289,7 +1289,7 @@ impl RentalRepository {
                 address_street, address_city, address_postal_code, address_country,
                 is_primary, status
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18::guest_registration_status)
             RETURNING {GUEST_COLUMNS}
             "#
         )))
@@ -1461,7 +1461,7 @@ impl RentalRepository {
         let guest = sqlx::query_as::<_, RentalGuest>(sqlx::AssertSqlSafe(format!(
             r#"
             UPDATE rental_guests SET
-                status = $2,
+                status = $2::guest_registration_status,
                 registered_at = NOW(),
                 updated_at = NOW()
             WHERE id = $1
@@ -1488,7 +1488,7 @@ impl RentalRepository {
         let guest = sqlx::query_as::<_, RentalGuest>(sqlx::AssertSqlSafe(format!(
             r#"
             UPDATE rental_guests SET
-                status = $2,
+                status = $2::guest_registration_status,
                 registered_at = NOW(),
                 updated_at = NOW()
             WHERE id = $1 AND organization_id = $3
@@ -1790,7 +1790,7 @@ impl RentalRepository {
         let report = sqlx::query_as::<_, RentalGuestReport>(
             r#"
             UPDATE rental_guest_reports SET
-                status = $2,
+                status = $2::guest_registration_status,
                 submitted_at = NOW(),
                 submitted_by = $3,
                 updated_at = NOW()
@@ -1840,7 +1840,7 @@ impl RentalRepository {
         let report = sqlx::query_as::<_, RentalGuestReport>(
             r#"
             UPDATE rental_guest_reports SET
-                status = $2,
+                status = $2::guest_registration_status,
                 submitted_at = NOW(),
                 submitted_by = $3,
                 updated_at = NOW()


### PR DESCRIPTION
## Problem

Two more dev `test`-job failures (introduced by newly-merged tests whose write paths were never cast), both the #1008 enum-encode surface (`42804: column is of type <enum> but expression is of type text`):

1. **`rental_guests.status`** (`guest_registration_status`) — #1492 cast the read side (`GUEST_COLUMNS` RETURNING `status::text`) but left `register_guest` / `register_guest_for_org` / both `submit_report*` / the `create_guest` INSERT binding text constants straight to the enum → reds `rental_guest_ical_enum_decode_tests::register_guest*_returning_decodes_status`.
2. **`forms.status`** (`form_status`) + **`form_fields.field_type`** (`form_field_type`) — `create_form`/`publish`/`archive`/`update_form` and `create_field`/`list_fields`/`update_field` bound text to the enum columns **and** read them back via `RETURNING *`/`SELECT *` (which can't decode the enum into the model's `String`) → reds `form_rls_repo_tests::form_repo_force_rls_write_paths`.

## Fix

Cast every write bind to the column enum (`$N::guest_registration_status`, `$N::form_status`, `$N::form_field_type`) and replace every `RETURNING *`/`SELECT *` on these tables with an explicit column list using `status::text AS status` / `field_type::text AS field_type` — both the encode and decode surfaces, consistently across all read/write methods (so the cascade doesn't re-surface).

## Verification (mercury)

- `rental_guest_ical_enum_decode_tests::register_guest*_returning_decodes_status` → **2 passed**.
- `form_rls_repo_tests::form_repo_force_rls_write_paths` → **1 passed**.

Refs #1331, #1332, #1008.

🤖 Generated with [Claude Code](https://claude.com/claude-code)