### PR TITLE
fix(oauth): reject public client supplying a client_secret with invalid_client

### DIFF
--- a/backend/servers/api-server/src/routes/oauth.rs
+++ b/backend/servers/api-server/src/routes/oauth.rs
@@ -324,14 +324,19 @@ pub async fn token(
             .validate_client_credentials(client_id, client_secret)
             .await
             .map_err(|e| (StatusCode::UNAUTHORIZED, Json(e.into())))?;
-    } else if let Some(client_secret) = request.client_secret.as_ref() {
-        // Public client that supplied a secret anyway — still validate it
-        // so a misconfigured public client surfaces the mismatch.
-        state
-            .oauth_service
-            .validate_client_credentials(client_id, client_secret)
-            .await
-            .map_err(|e| (StatusCode::UNAUTHORIZED, Json(e.into())))?;
+    } else if request.client_secret.is_some() {
+        // Public client (RFC 6749 §2.3.1 has no credentials) that supplied a
+        // client_secret anyway → client-authentication failure. Reject with
+        // `invalid_client` directly: a public client has no usable secret hash,
+        // so routing into `validate_client_credentials` would `verify_password`
+        // against an empty hash and surface `InternalError`/`server_error`
+        // instead of the correct `invalid_client`.
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            Json(OAuthError::invalid_client(
+                "public client must not authenticate with a client_secret",
+            )),
+        ));
     }
 
     // Phase 6 C17 + review R5: audit the principal_kind rejection as a real


### PR DESCRIPTION
## Problem

`oauth_authz_server_edge_tests::test_public_client_wrong_secret_rejected_at_token` was red on `dev`. A **public** OAuth client (RFC 6749 §2.3.1 — has no credentials) that supplied a `client_secret` at the token endpoint was routed into `validate_client_credentials`, which `verify_password()`s the supplied secret against the public client's empty/unusable secret hash → maps to `InternalError`/`server_error` rather than the spec-correct `invalid_client`. So the wrong error code came back (and the path arguably surfaced a 500-class error for an auth failure).

## Fix

In the token endpoint's client-auth (`routes/oauth.rs`), a public client presenting **any** `client_secret` is now rejected directly with `401 invalid_client` — a public client has no credentials, so supplying one is a client-authentication failure, not a server error. (Confidential-client validation is unchanged.)

## Verification (mercury)

`cargo test -p api-server --test oauth_authz_server_edge_tests test_public_client_wrong_secret_rejected_at_token` → **1 passed**.

Refs #1331, #1332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)