### PR TITLE
fix(reality-web): unbreak production build — /accounting QueryClient prerender + favorites pl/hu i18n

### DIFF
--- a/frontend/apps/reality-web/messages/hu.json
+++ b/frontend/apps/reality-web/messages/hu.json
@@ -502,7 +502,8 @@
     },
     "favorites": {
       "title": "Kedvenceim",
-      "description": "Az Ön által mentett ingatlanok."
+      "description": "Az Ön által mentett ingatlanok.",
+      "h1": "Kedvenceim"
     },
     "login": {
       "title": "Sign in",

--- a/frontend/apps/reality-web/messages/pl.json
+++ b/frontend/apps/reality-web/messages/pl.json
@@ -502,7 +502,8 @@
     },
     "favorites": {
       "title": "Moje ulubione",
-      "description": "Nieruchomości, które zapisałeś."
+      "description": "Nieruchomości, które zapisałeś.",
+      "h1": "Moje ulubione"
     },
     "login": {
       "title": "Sign in",

--- a/frontend/apps/reality-web/src/app/accounting/layout.tsx
+++ b/frontend/apps/reality-web/src/app/accounting/layout.tsx
@@ -1,0 +1,32 @@
+import { NextIntlClientProvider } from 'next-intl';
+import { getMessages, setRequestLocale } from 'next-intl/server';
+import { AuthProvider } from '@/lib/auth-context';
+import { QueryProvider } from '@/lib/query-provider';
+import { defaultLocale } from '@/i18n/config';
+
+// The /accounting payment-matching review is auth-gated and entirely
+// data-driven (TanStack Query against the live API), so it must never be
+// statically prerendered — during SSG there is no QueryClient in scope.
+// Setting `force-dynamic` in this server layout (route-segment config is
+// ignored when exported from a `'use client'` page) opts the segment out of
+// static generation. This route lives outside the `[locale]` tree, so it does
+// not inherit that layout's providers; we supply the same QueryProvider,
+// NextIntl, and Auth providers here using the default locale's messages.
+export const dynamic = 'force-dynamic';
+
+export default async function AccountingLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  setRequestLocale(defaultLocale);
+  const messages = await getMessages({ locale: defaultLocale });
+
+  return (
+    <NextIntlClientProvider locale={defaultLocale} messages={messages}>
+      <QueryProvider>
+        <AuthProvider>{children}</AuthProvider>
+      </QueryProvider>
+    </NextIntlClientProvider>
+  );
+}


### PR DESCRIPTION
## Problem

The `Build Reality Portal Web` CI job (frontend.yml) was RED on `dev`, breaking reality-web builds/deploys. Two distinct SSG prerender failures:

1. **`/accounting` — `No QueryClient set, use QueryClientProvider to set one`.** The `/accounting` page (PAP-210, added in #1453) is a `'use client'`, auth-gated, data-driven payment-matching review rendering `PaymentMatchingPage`, which calls TanStack Query `useQuery`. The route lives at the app root (outside `[locale]`), so it inherited none of `[locale]/layout.tsx`'s providers, and static prerender had no QueryClient.
2. **`MISSING_MESSAGE: pages.favorites.h1 (pl)` and `(hu)`.** The favorites page references `pages.favorites.h1`, present in en/sk/cs/de but missing from the Polish and Hungarian catalogs.

## Fix

1. Added a server `src/app/accounting/layout.tsx` that:
   - sets `export const dynamic = 'force-dynamic'` (segment config is ignored when exported from a `'use client'` page, so it must live in a server layout) — opts the auth-gated, data-driven route out of static generation;
   - supplies `QueryProvider` / `NextIntlClientProvider` / `AuthProvider` (default locale messages) so the page subtree (and its Suspense-fallback `Header`) has the providers `[locale]` would otherwise give it.
2. Added `pages.favorites.h1` to `messages/pl.json` (`"Moje ulubione"`) and `messages/hu.json` (`"Kedvenceim"`), matching the existing per-locale wording.

No functionality removed; `/accounting` is now server-rendered on demand.

## Verification

- `pnpm --filter reality-web build` is green locally: `✓ Generating static pages (247/247)`, exit 0, `/accounting` listed as `ƒ (Dynamic)`.
- `pnpm biome check` on touched files: No issues found.

Co-Authored-By: Paperclip <noreply@paperclip.ing>