### PR TITLE
verify-report-execution-history-presigned-download-retry-frontend: cover presigned download + retry on ppt-web execution history

### DIFF
--- a/frontend/apps/ppt-web/src/features/reports/pages/ScheduleDetailPage.download-retry.test.tsx
+++ b/frontend/apps/ppt-web/src/features/reports/pages/ScheduleDetailPage.download-retry.test.tsx
@@ -1,0 +1,272 @@
+/// <reference types="vitest/globals" />
+/**
+ * Integration test for the report execution-history download + retry path
+ * (Story 81.2 — Coverage 81-2).
+ *
+ * This renders the presentational `ScheduleDetailPage` wired through the *real*
+ * api-client hooks (`useDownloadReport`, `useRetryReportExecution`) inside a
+ * real `QueryClientProvider`, mocking only the network boundary (`fetch`). It
+ * confirms the presigned-download + retry flow end-to-end on the surface a
+ * manager actually sees:
+ *
+ *   - Download: GET /api/v1/reports/executions/:id/download returns a presigned
+ *     `{ url, fileName }`, and the hook triggers a real anchor click whose
+ *     `href`/`download` match the presigned response.
+ *   - Retry: POST /api/v1/reports/executions/:id/retry is fired for a failed
+ *     execution, the in-row button shows the "Retrying…" state while the
+ *     mutation is in flight, and the execution-history query is invalidated on
+ *     success.
+ *   - Download failure surfaces an error toast (via the route container's
+ *     onError wiring is covered separately; here we pin the hook rejecting so
+ *     the awaited promise path is exercised without an unhandled rejection).
+ */
+
+import type { ReportExecution, ReportSchedule } from '@ppt/api-client';
+import { reportKeys, useDownloadReport, useRetryReportExecution } from '@ppt/api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { type ReactNode, useCallback, useState } from 'react';
+import { ScheduleDetailPage } from './ScheduleDetailPage';
+
+// ── Fixtures ──
+
+const SCHEDULE_ID = 'sched-1';
+
+const schedule: ReportSchedule = {
+  id: SCHEDULE_ID,
+  report_id: 'rep-1',
+  organization_id: 'org-1',
+  name: 'Monthly Building Report',
+  frequency: 'monthly',
+  time: '08:00',
+  timezone: 'UTC',
+  format: 'pdf',
+  recipients: [],
+  is_active: true,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+const completedExecution: ReportExecution = {
+  id: 'exec-completed',
+  scheduleId: SCHEDULE_ID,
+  status: 'completed',
+  startedAt: '2026-06-01T08:00:00Z',
+  completedAt: '2026-06-01T08:00:05Z',
+  fileName: 'building-report-2026-06.pdf',
+  fileSize: 2_500_000,
+  createdAt: '2026-06-01T08:00:00Z',
+};
+
+const failedExecution: ReportExecution = {
+  id: 'exec-failed',
+  scheduleId: SCHEDULE_ID,
+  status: 'failed',
+  startedAt: '2026-06-02T08:00:00Z',
+  completedAt: '2026-06-02T08:00:02Z',
+  error: { code: 'GEN_ERROR', message: 'Generation failed' },
+  createdAt: '2026-06-02T08:00:00Z',
+};
+
+const PRESIGNED_URL = 'https://s3.example.com/reports/building-report-2026-06.pdf?sig=abc';
+
+// ── Helpers ──
+
+function okJson(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as Response;
+}
+
+function errJson(status: number, body: unknown): Response {
+  return { ok: false, status, json: async () => body } as Response;
+}
+
+function newClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+function Wrapper({ client, children }: { client: QueryClient; children: ReactNode }) {
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+/**
+ * Container that wires the *real* download/retry hooks into the presentational
+ * page exactly like the route does (routes/groups/reports.tsx), minus the
+ * Toast/Router shell that isn't relevant to the network path.
+ */
+function Harness({ executions }: { executions: ReportExecution[] }) {
+  const downloadReport = useDownloadReport();
+  const retryExecution = useRetryReportExecution();
+
+  const handleDownload = useCallback(
+    (executionId: string) => {
+      downloadReport.mutate(executionId);
+    },
+    [downloadReport]
+  );
+
+  const [retryError, setRetryError] = useState(false);
+  const handleRetry = useCallback(
+    async (executionId: string) => {
+      // Mirrors the route container's onError handling. We surface the failure
+      // via state rather than re-throwing: the page's own `handleRetry` awaits
+      // this callback inside a `try/finally` with no catch, so re-throwing here
+      // would escape as an unhandled rejection in the test environment (and the
+      // surface only needs the error reflected back to the user, which the toast
+      // / state does).
+      try {
+        await retryExecution.mutateAsync(executionId);
+      } catch {
+        setRetryError(true);
+      }
+    },
+    [retryExecution]
+  );
+
+  return (
+    <>
+      {retryError && <div data-testid="retry-error" />}
+      <ScheduleDetailPage
+        schedule={schedule}
+        executions={executions}
+        onDownload={handleDownload}
+        onRetry={handleRetry}
+      />
+    </>
+  );
+}
+
+describe('ScheduleDetailPage — presigned download + retry path (81.2)', () => {
+  let clickSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Prevent jsdom "Not implemented: navigation" noise from the real anchor click.
+    clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('downloads via the presigned URL: fetches /download then clicks an anchor with the presigned href + fileName', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      okJson({
+        url: PRESIGNED_URL,
+        fileName: completedExecution.fileName,
+        expiresAt: '2026-06-01T09:00:00Z',
+        contentType: 'application/pdf',
+      })
+    );
+
+    render(
+      <Wrapper client={newClient()}>
+        <Harness executions={[completedExecution]} />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /download report/i }));
+
+    // The presigned-URL endpoint is hit (GET by default).
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [calledUrl, calledOpts] = fetchMock.mock.calls[0];
+    expect(String(calledUrl)).toBe(`/api/v1/reports/executions/${completedExecution.id}/download`);
+    expect((calledOpts as RequestInit | undefined)?.method ?? 'GET').toBe('GET');
+
+    // The anchor is created with the presigned href + the server-provided filename
+    // and is actually clicked (download triggered).
+    await waitFor(() => expect(clickSpy).toHaveBeenCalledTimes(1));
+    const anchor = clickSpy.mock.instances[0] as HTMLAnchorElement;
+    expect(anchor.href).toBe(PRESIGNED_URL);
+    expect(anchor.download).toBe(completedExecution.fileName);
+
+    // Anchor is cleaned up out of the DOM after the click.
+    expect(document.querySelector(`a[download="${completedExecution.fileName}"]`)).toBeNull();
+  });
+
+  it('does not trigger an anchor click when the presigned-URL request fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(errJson(403, { message: 'Forbidden' }));
+
+    render(
+      <Wrapper client={newClient()}>
+        <Harness executions={[completedExecution]} />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /download report/i }));
+
+    // Give the rejected mutation a tick to settle.
+    await waitFor(() => {
+      // fetch was attempted but no download anchor was clicked.
+      expect(globalThis.fetch).toHaveBeenCalled();
+    });
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
+  it('retries a failed execution: POSTs /retry, shows the in-flight state, and invalidates the history query', async () => {
+    const client = newClient();
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+
+    let resolveRetry: (value: ReportExecution) => void = () => {};
+    const retryResponse = new Promise<Response>((resolve) => {
+      resolveRetry = (value) => resolve(okJson(value));
+    });
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockReturnValue(retryResponse);
+
+    render(
+      <Wrapper client={client}>
+        <Harness executions={[failedExecution]} />
+      </Wrapper>
+    );
+
+    const retryBtn = screen.getByRole('button', { name: /retry execution/i });
+    fireEvent.click(retryBtn);
+
+    // In-flight: button disabled + "Retrying…" copy while the POST is pending.
+    await waitFor(() => expect(retryBtn).toBeDisabled());
+    expect(screen.getByText(/retrying/i)).toBeInTheDocument();
+
+    // The retry endpoint is hit with POST.
+    const [calledUrl, calledOpts] = fetchMock.mock.calls[0];
+    expect(String(calledUrl)).toBe(`/api/v1/reports/executions/${failedExecution.id}/retry`);
+    expect((calledOpts as RequestInit | undefined)?.method).toBe('POST');
+
+    // Resolve with a freshly-queued execution; the hook must invalidate the
+    // execution-history query for this schedule.
+    resolveRetry({
+      id: 'exec-retried',
+      scheduleId: SCHEDULE_ID,
+      status: 'pending',
+      startedAt: '2026-06-03T08:00:00Z',
+      createdAt: '2026-06-03T08:00:00Z',
+    });
+
+    await waitFor(() =>
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryKey: reportKeys.executions(SCHEDULE_ID),
+        })
+      )
+    );
+
+    // Button returns to its idle, enabled state once the retry settles.
+    await waitFor(() => expect(retryBtn).not.toBeDisabled());
+    expect(screen.queryByTestId('retry-error')).toBeNull();
+  });
+
+  it('surfaces a retry failure to the caller (rejected mutateAsync) without crashing the surface', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(errJson(500, { message: 'boom' }));
+
+    render(
+      <Wrapper client={newClient()}>
+        <Harness executions={[failedExecution]} />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /retry execution/i }));
+
+    await waitFor(() => expect(screen.getByTestId('retry-error')).toBeInTheDocument());
+    // The failed row is still rendered (surface didn't unmount on the rejection).
+    expect(screen.getByRole('button', { name: /retry execution/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Task
Coverage 81-2: confirm presigned download + retry end-to-end on the report execution-history surface (ppt-web); add a component/integration test for the download + retry path.

## Owner
pm-frontend

## What was verified (end-to-end, ppt-web)
The presigned-download + retry flow on the report execution-history surface is **already correct on `dev`** — no production code change was needed:

- `routes/groups/reports.tsx` wires `useDownloadReport` / `useRetryReportExecution` into both `ReportsPage` (`ExecutionHistory` modal) and `ScheduleDetailPage`, with success/error toasts.
- `useDownloadReport` (`packages/api-client/src/reports/hooks.ts`) fetches `GET /api/v1/reports/executions/:id/download` → presigned `{ url, fileName }` (`ReportDownloadUrlResponse`) and triggers a real anchor-click download.
- `useRetryReportExecution` POSTs `/api/v1/reports/executions/:id/retry` and invalidates the execution-history query (`reportKeys.executions(scheduleId)`) on success.
- Backend e2e coverage for the same path already exists on `dev` (`backend/servers/api-server/tests/report_execution_download_retry_e2e_tests.rs`).

The missing piece was **frontend test coverage**, which this PR adds.

## Change
New file: `frontend/apps/ppt-web/src/features/reports/pages/ScheduleDetailPage.download-retry.test.tsx`

Integration test that renders the presentational `ScheduleDetailPage` wired through the *real* api-client hooks inside a `QueryClientProvider`, mocking only `fetch` (the network boundary). Cases:
1. Download fetches `GET …/download` and clicks an anchor whose `href`/`download` match the presigned `{ url, fileName }`, then removes the anchor from the DOM.
2. A failed presigned-URL request does **not** trigger an anchor click.
3. Retry POSTs `…/retry`, shows the in-flight "Retrying…" disabled state, and invalidates the execution-history query on success.
4. A rejected retry surfaces to the caller without unmounting the surface.

Test-only; no production code touched.

## Tested (Band A — fast check)
- `pnpm -F @ppt/web typecheck` → exit 0
- `pnpm exec biome check apps/.../ScheduleDetailPage.download-retry.test.tsx` → clean (after autofix)
- `pnpm -F @ppt/web exec vitest run src/features/reports/pages/ScheduleDetailPage.download-retry.test.tsx` → 4 passed
- `pnpm -F @ppt/web exec vitest run src/features/reports` (regression) → 57 passed

Note: the app-level `pnpm -F @ppt/web lint` script still invokes a stale `eslint` (no eslint.config) and errors; CI / repo convention uses Biome (`pnpm check` / `pnpm lint` at root = `biome`). Ran Biome directly to match CI.

## Built (Band B — full build)
skipped: test-only change (~250 LOC of test code, no public API/config touch).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (test-only; no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Scope drift
None — `scope-check.sh --owner pm-frontend` → exit 0. Single new file under `frontend/apps/ppt-web/src/features/reports/`.

## Code-reuse review
none — no new helpers added (reuses existing `okJson`-style stub pattern from sibling tests and the real hooks).

## Notes
- The stale remote `auto-impl/…` branch held superseded *backend* e2e commits; their content is already present (and since evolved) on `dev`, so the branch was force-replaced with this clean, dev-based frontend-only commit.
- IG goal-check reports IG1/IG2 FAIL only because this dispatcher verify task has no `.research/plans/<slug>.md` and uses the fixed `auto-impl/*` branch name (not the `impl/*` convention); the real verify gate (typecheck + tests) is green. IG3 is the legitimate "no fix: commit" case — this is a verify/test task and the flow was already correct on `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01313GsC8bNQ6XjoWS4EDu6X

---
_Generated by [Claude Code](https://claude.ai/code/session_01313GsC8bNQ6XjoWS4EDu6X)_