### PR TITLE
verify-document-upload-metadata-promote-to-done-backend: verify 7A.1 upload + metadata + RLS; promote to done

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -57,7 +57,7 @@ development_status:
   6-5-direct-messaging: ready-for-dev
   6-6-neighbor-information: done
   # Epic 7A: Basic Document Management
-  7a-1-document-upload-metadata: ready-for-dev
+  7a-1-document-upload-metadata: done  # Verified 2026-06-17 (verify-document-upload-metadata): POST /api/v1/documents/upload present in documents/core.rs (multipart parse of file/title/description/category/folder_id, title/desc length + size + MIME allow-list + category validation, S3 upload, RLS-aware create_rls). Metadata persistence + RLS isolation covered by document_upload_tests.rs (T1-T15): auth guard, missing-file/MIME/category rejects + orphan guards, DB-row persistence (T5/T6/T7), S3 happy (wiremock T14)/failure-no-orphan (T8), 50 MiB boundary (T12/T13), cross-tenant (T9) + non-member (T10) RLS reject, AC-2/AC-3 error bodies, and new end-to-end metadata round-trip through GET /{id} (T15). Stale 'upload route missing' verify report superseded — route + tests are on dev.
   7a-2-folder-organization: review  # CI test job red (document_folder_tests FK/isolation fix in PR #1316 round 1); reverted from done pending green CI
   7a-3-permission-based-access: ready-for-dev
   7a-4-document-download-preview: ready-for-dev

--- a/backend/servers/api-server/tests/document_upload_tests.rs
+++ b/backend/servers/api-server/tests/document_upload_tests.rs
@@ -10,6 +10,8 @@
 //! - Validation failures: missing file, bad MIME type, bad category
 //! - MIME type allow-list: all 11 supported MIME types return 201 (T11)
 //! - File size limit: exactly 50 MiB succeeds (T12); 50 MiB + 1 byte rejected (T13)
+//! - Metadata round-trip: upload then GET /{id} returns the stored metadata
+//!   through the read handler, not just the raw DB row (T15)
 //!
 //! # Design notes
 //!
@@ -1117,6 +1119,142 @@ async fn test_upload_file_over_size_limit_rejected(pool: PgPool) {
     assert_eq!(
         count, 0,
         "no document record must be created for oversized upload"
+    );
+
+    cleanup_test_user(&pool, &user.email).await;
+}
+
+// ============================================================================
+// T15: End-to-end metadata round-trip — upload then GET /{id} returns metadata
+// ============================================================================
+
+/// Story 7A.1 promotion gate — "upload + metadata persistence" must be
+/// observable through the read API, not just the raw DB row.
+///
+/// Every existing test verifies persistence by reading the `documents` row
+/// directly (`SELECT ... FROM documents`). That proves the write hit the
+/// table but NOT that the metadata round-trips back to a client through the
+/// authenticated read handler. This test closes that contract gap: it uploads
+/// a document with the full metadata set (title, description, category,
+/// file_name, mime_type) and then fetches it via `GET /api/v1/documents/{id}`
+/// as the same authenticated tenant, asserting every uploaded field is
+/// faithfully returned in the `DocumentDetailResponse` (`document.*`, which
+/// flattens the `Document` model). This is the create→read path a real client
+/// exercises after an upload, and the missing end-to-end handler assertion the
+/// verify task asks for.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn test_upload_metadata_roundtrips_through_get_handler(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    cleanup_test_user(&pool, &user.email).await;
+    let (token, _) = create_authenticated_user(&app, &user).await;
+    let user_id = user_id_for(&pool, &user.email).await;
+    let org_id = seed_org(&pool, &Uuid::new_v4().to_string()[..8]).await;
+    add_org_member(&pool, org_id, user_id).await;
+
+    let unique_title = format!("Roundtrip Doc {}", Uuid::new_v4().simple());
+    let description = "Round-trip description body for the read path";
+    let category = "contracts";
+
+    let (ct, body) = build_multipart(
+        FAKE_PDF_BYTES,
+        "roundtrip.pdf",
+        "application/pdf",
+        &unique_title,
+        category,
+        Some(description),
+        None,
+    );
+
+    // --- Upload ---
+    let upload_req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/v1/documents/upload")
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .header("X-Tenant-ID", org_id.to_string())
+        .header(header::CONTENT_TYPE, ct)
+        .body(Body::from(body))
+        .unwrap();
+
+    let upload_resp = app.execute(upload_req).await;
+    assert_eq!(
+        upload_resp.status,
+        StatusCode::CREATED,
+        "upload must return 201. Body: {}",
+        upload_resp.text()
+    );
+    let upload_json = upload_resp.json_value();
+    let doc_id: Uuid = upload_json["id"]
+        .as_str()
+        .and_then(|s| s.parse().ok())
+        .expect("upload response must contain a valid id");
+
+    // --- Read back via the authenticated GET handler ---
+    let get_req = Request::builder()
+        .method(Method::GET)
+        .uri(format!("/api/v1/documents/{doc_id}"))
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .header("X-Tenant-ID", org_id.to_string())
+        .body(Body::empty())
+        .unwrap();
+
+    let get_resp = app.execute(get_req).await;
+    assert_eq!(
+        get_resp.status,
+        StatusCode::OK,
+        "GET /documents/{{id}} must return 200 for the owning tenant. Body: {}",
+        get_resp.text()
+    );
+
+    // DocumentDetailResponse { document: DocumentWithDetails } where
+    // DocumentWithDetails #[serde(flatten)]s the Document model, so the
+    // metadata fields live directly under the `document` object.
+    let json = get_resp.json_value();
+    let doc = &json["document"];
+
+    assert_eq!(
+        doc["id"].as_str().and_then(|s| s.parse::<Uuid>().ok()),
+        Some(doc_id),
+        "read-back id must match the uploaded document"
+    );
+    assert_eq!(
+        doc["title"].as_str(),
+        Some(unique_title.as_str()),
+        "title must round-trip through the read handler"
+    );
+    assert_eq!(
+        doc["description"].as_str(),
+        Some(description),
+        "description metadata must round-trip through the read handler"
+    );
+    assert_eq!(
+        doc["category"].as_str(),
+        Some(category),
+        "category metadata must round-trip through the read handler"
+    );
+    assert_eq!(
+        doc["file_name"].as_str(),
+        Some("roundtrip.pdf"),
+        "file_name must round-trip through the read handler"
+    );
+    assert_eq!(
+        doc["mime_type"].as_str(),
+        Some("application/pdf"),
+        "mime_type must round-trip through the read handler"
+    );
+    assert_eq!(
+        doc["organization_id"]
+            .as_str()
+            .and_then(|s| s.parse::<Uuid>().ok()),
+        Some(org_id),
+        "organization_id must reflect the uploading tenant"
+    );
+    assert_eq!(
+        doc["created_by"]
+            .as_str()
+            .and_then(|s| s.parse::<Uuid>().ok()),
+        Some(user_id),
+        "created_by must reflect the uploading user"
     );
 
     cleanup_test_user(&pool, &user.email).await;


### PR DESCRIPTION
## Task
Coverage 7a-1: verify Document Upload with Metadata end-to-end and promote sprint-status ready-for-dev -> done (confirm upload + metadata persistence + RLS); add any missing handler test.

## Owner
pm-backend

## Verification summary
The Document Upload + Metadata + RLS feature is **already implemented and on `dev`** — the stale `.research` verify report claiming the route was missing is superseded.

- `POST /api/v1/documents/upload` lives in `backend/servers/api-server/src/routes/documents/core.rs` (`upload_document`): multipart parse of `file`/`title`/`description`/`category`/`folder_id` (unknown fields drained), title/description length + file-size + MIME allow-list + category validation, S3 upload via `storage_service` with a 503-on-failure / no-orphan-record guard, then RLS-aware persistence via `document_repo.create_rls` on an `RlsConnection` (org-scoped, `app.current_org_id` + FORCE ROW LEVEL SECURITY).
- Metadata persistence + RLS isolation are covered by `backend/servers/api-server/tests/document_upload_tests.rs` (T1–T14): auth guard (401), missing-file/unsupported-MIME/invalid-category rejects + orphan-record guards, DB-row persistence of all metadata (T5/T6/T7), S3 happy path via wiremock (T14), S3 failure → 503 with no orphan (T8), 50 MiB boundary (T12/T13), **cross-tenant upload rejected (T9)** and **non-member rejected (T10)** RLS, plus AC-2/AC-3 user-facing error bodies.

## Change in this PR
- **Added T15** (`test_upload_metadata_roundtrips_through_get_handler`): the missing end-to-end handler test. Uploads a document with full metadata, then reads it back via `GET /api/v1/documents/{id}` as the same tenant and asserts `title`/`description`/`category`/`file_name`/`mime_type`/`organization_id`/`created_by` are faithfully returned by the read handler. All prior tests only read the raw `documents` row directly — this closes the create→read API contract.
- **Promoted** `7a-1-document-upload-metadata` in `_bmad-output/implementation-artifacts/sprint-status.yaml` from `ready-for-dev` to `done` with a verification note.

## Tested (Band A — fast check)
- `SQLX_OFFLINE=true cargo check -p api-server --tests` → exit 0
- `SQLX_OFFLINE=true cargo clippy -p api-server --tests` → exit 0 (no warnings)

The upload tests use `#[sqlx::test]` and require a live Postgres, which this DB-less runner does not have, so the new T15 is compile-verified (exit 0) here; it runs in CI's backend job against the ephemeral migrated DB alongside the existing T1–T14.

## Built (Band B — full build)
skipped: change is a single new test + a status-doc edit (no public API/config/migration touch); Band A compile + clippy of the test crate is the relevant gate.

## CI parity (Band C — hot-path only)
skipped: no production code path changed (test-only + sprint-status doc). The existing upload handler — including the RLS isolation it enforces — is unchanged.

## Scope drift
`scope_drift=true` — `_bmad-output/implementation-artifacts/sprint-status.yaml` falls outside the pm-backend code-owner globs, but editing it **is** the task ("promote sprint-status ready-for-dev -> done"). The backend test file is in-area. Reviewer please confirm the status promotion is the intended deliverable.

## Code-reuse review
`code_reuse_warn=none` — reuse-grep clean; no new helpers added (test reuses existing `build_multipart` / `TestApp` / `create_authenticated_user` helpers).

## Remote-tested
skipped

## Notes
- The `.research/management/gap-7a-1-upload-verify-report.md` "route missing → cannot promote" finding is stale; the route and its test suite are on `dev`. `docs/EPIC_STORY_STATUS.md` already lists 7A.1 as done.
- No `.research/**` files were modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01313GsC8bNQ6XjoWS4EDu6X

---
_Generated by [Claude Code](https://claude.ai/code/session_01313GsC8bNQ6XjoWS4EDu6X)_