### PR TITLE
fix(db): cast document_category in count_accessible_rls filter (closes #1528)

### DIFF
--- a/backend/crates/db/src/repositories/document.rs
+++ b/backend/crates/db/src/repositories/document.rs
@@ -830,7 +830,7 @@ impl DocumentRepository {
                 OR (access_scope = 'users' AND access_target_ids ? $2::text)
               )
               AND ($6::uuid IS NULL OR folder_id = $6)
-              AND ($7::text IS NULL OR category = $7)
+              AND ($7::text IS NULL OR category = $7::document_category)
               AND ($8::text IS NULL OR title ILIKE '%' || $8 || '%')
             "#,
         )


### PR DESCRIPTION
## Problem

`#1528`: `count_accessible_rls` was the lone `documents.category` filter left uncast (`category = $7`) after the list/by-id sites were fixed. When a non-manager lists documents with a `?category=` filter, the COUNT query 42883s (`operator does not exist: document_category = text`), breaking the list total / pagination for filtered queries.

## Fix

`category = $7::document_category` — matching the 8 sibling readers already cast on `dev`.

## Verification

`cargo check -p db` clean (mercury). One-line predicate cast identical to the proven sibling sites.

Closes #1528. Refs #1008.

🤖 Generated with [Claude Code](https://claude.com/claude-code)