### PR TITLE
test(marketplace): assert mark_invitation_viewed preserves first viewed_at (closes #1524)

### DIFF
--- a/backend/servers/api-server/tests/marketplace_voting_investor_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/marketplace_voting_investor_cross_org_idor_tests.rs
@@ -553,6 +553,22 @@ async fn mark_invitation_viewed_is_idempotent(pool: PgPool) {
         "repeat view must be idempotent (200), not 404: {}",
         second.text()
     );
+
+    // Idempotency is more than 200/200: the load-bearing half of the #1301 fix
+    // is `SET viewed_at = COALESCE(viewed_at, NOW())`, which preserves the FIRST
+    // view's timestamp. A regression back to a plain `NOW()` would overwrite it
+    // on every call yet still return 200/200 — so assert the timestamp is both
+    // stamped and stable across the repeat view.
+    let first_viewed = first.json_value()["viewed_at"].clone();
+    let second_viewed = second.json_value()["viewed_at"].clone();
+    assert!(
+        !first_viewed.is_null(),
+        "first view must stamp viewed_at, got {first_viewed}"
+    );
+    assert_eq!(
+        first_viewed, second_viewed,
+        "repeat view must preserve the original viewed_at, not overwrite it",
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## #1524 — follow-up to PR #1491 review

`mark_invitation_viewed_is_idempotent` asserted both the first and repeat view return 200 (the #1301 regression), but **not** the load-bearing half of the fix: `SET viewed_at = COALESCE(viewed_at, NOW())` preserves the **first** view's timestamp. A regression back to a plain `NOW()` (overwriting on every call) would still return 200/200 and the test would stay green — silently losing the "first viewed at" semantics downstream reporting relies on.

## What this adds (test-only)
After the two 200 assertions, asserts via `json_value()` that:
- the first view stamps `viewed_at` (non-null), and
- the repeat view returns the **same** `viewed_at` (COALESCE preserved it).

## Verification
Ran on the remote builder: **1/1 passed** (`mark_invitation_viewed_is_idempotent`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)