### PR TITLE
fix(db): correct document get-by-id read path (u.name + enum ::text decode)

### DIFF
--- a/backend/crates/db/src/repositories/document.rs
+++ b/backend/crates/db/src/repositories/document.rs
@@ -605,7 +605,9 @@ impl DocumentRepository {
             r#"
             SELECT
                 d.*,
-                u.full_name as created_by_name,
+                d.category::text AS category_text,
+                d.access_scope::text AS access_scope_text,
+                u.name as created_by_name,
                 f.name as folder_name,
                 COALESCE(s.share_count, 0) as share_count
             FROM documents d
@@ -631,12 +633,15 @@ impl DocumentRepository {
                 folder_id: r.get("folder_id"),
                 title: r.get("title"),
                 description: r.get("description"),
-                category: r.get("category"),
+                // `category` / `access_scope` are PG enums; `d.*` returns them
+                // raw, which fails a `String` decode (#1008). Read the ::text
+                // aliases instead (matches the sibling find methods).
+                category: r.get("category_text"),
                 file_key: r.get("file_key"),
                 file_name: r.get("file_name"),
                 mime_type: r.get("mime_type"),
                 size_bytes: r.get("size_bytes"),
-                access_scope: r.get("access_scope"),
+                access_scope: r.get("access_scope_text"),
                 access_target_ids: r.get("access_target_ids"),
                 access_roles: r.get("access_roles"),
                 created_by: r.get("created_by"),
@@ -1556,7 +1561,7 @@ impl DocumentRepository {
             SELECT
                 s.*,
                 d.title as document_title,
-                u.full_name as shared_by_name
+                u.name as shared_by_name
             FROM document_shares s
             JOIN documents d ON d.id = s.document_id
             JOIN users u ON u.id = s.shared_by


### PR DESCRIPTION
## Problem
`GET /api/v1/documents/{id}` returns **500 "Failed to get document"** — dev's backend `test` job has been red on `test_upload_metadata_roundtrips_through_get_handler` (`document_upload_tests.rs`). Upload succeeds (201) but the read-back 500s. This is the failure that outlived #1300 on the `test` job.

## Root cause — two bugs in `document.rs`, both masked by `SELECT d.*` + untyped `Row::get`
1. **Wrong column name (surfaces first):** `find_by_id_with_details_rls` (and `get_shares_rls`) selected `u.full_name` — the `users` column is **`name`**, not `full_name` (migration 00001). → `42703 undefined column` at fetch → `.await?` returns `Err` → handler 500 (a clean Err, not a panic — which is why it reads like a logic 500). This query-level error masked bug 2.
2. **Enum decode (#1008):** `d.*` returns `category` (`document_category`) and `access_scope` (`document_access_scope`) as raw PG enums; reading them into the `String` struct fields fails `ColumnDecode`. You can't `category::text AS category` under `d.*` (duplicate column → ambiguous `get`), so added distinct `d.category::text AS category_text` / `d.access_scope::text AS access_scope_text` aliases and read those.

Sibling find methods (document.rs:1866/1941) already used `u.name` + per-column `::text` casts — this brings the by-id detail path in line.

## Verification
Remote builder: **`document_upload_tests` 18/18 pass** (was 17 passed / 1 failed).

Part of the #1538 cleanup (red-`test`-PRs keep re-redding `dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)