### PR TITLE
fix(db): cast booking-create enum binds + dedupe BOOKING_COLUMNS; cover NULL-fee write path (closes #1535)

### DIFF
--- a/backend/crates/db/src/repositories/rental.rs
+++ b/backend/crates/db/src/repositories/rental.rs
@@ -569,7 +569,7 @@ impl RentalRepository {
                 total_amount, currency, platform_fee, cleaning_fee,
                 guest_notes, internal_notes, status
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
+            VALUES ($1, $2, $3::rental_platform, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19::rental_booking_status)
             RETURNING {}
             "#,
             Self::BOOKING_COLUMNS
@@ -664,21 +664,14 @@ impl RentalRepository {
         // `String`; a bare `SELECT *` fails to decode (42804, FORCE-RLS-masked,
         // PAP-158), so cast both enum columns to text. `platform = $1` keeps the
         // text param comparing against the enum via the column's implicit cast.
-        let booking = sqlx::query_as::<_, RentalBooking>(
+        let booking = sqlx::query_as::<_, RentalBooking>(sqlx::AssertSqlSafe(format!(
             r#"
-            SELECT
-                id, organization_id, unit_id, connection_id,
-                platform::text AS platform, external_booking_id, external_booking_url,
-                guest_name, guest_email, guest_phone, guest_count,
-                check_in, check_out, check_in_time, check_out_time,
-                total_amount, currency, platform_fee, cleaning_fee,
-                status::text AS status, cancelled_at, cancellation_reason,
-                guest_notes, internal_notes, synced_at, raw_data,
-                created_at, updated_at
+            SELECT {}
             FROM rental_bookings
             WHERE platform = $1::rental_platform AND external_booking_id = $2
             "#,
-        )
+            Self::BOOKING_COLUMNS
+        )))
         .bind(platform)
         .bind(external_id)
         .fetch_optional(&self.pool)
@@ -835,7 +828,7 @@ impl RentalRepository {
         // `text`, so the assignment fails with 42804 (FORCE-RLS-masked, see
         // PAP-158). `RETURNING *` likewise must cast the enum columns to text or
         // the row fails to decode into `RentalBooking`.
-        let booking = sqlx::query_as::<_, RentalBooking>(
+        let booking = sqlx::query_as::<_, RentalBooking>(sqlx::AssertSqlSafe(format!(
             r#"
             UPDATE rental_bookings SET
                 status = $2::rental_booking_status,
@@ -843,17 +836,10 @@ impl RentalRepository {
                 cancellation_reason = COALESCE($3, cancellation_reason),
                 updated_at = NOW()
             WHERE id = $1 AND organization_id = $4
-            RETURNING
-                id, organization_id, unit_id, connection_id,
-                platform::text AS platform, external_booking_id, external_booking_url,
-                guest_name, guest_email, guest_phone, guest_count,
-                check_in, check_out, check_in_time, check_out_time,
-                total_amount, currency, platform_fee, cleaning_fee,
-                status::text AS status, cancelled_at, cancellation_reason,
-                guest_notes, internal_notes, synced_at, raw_data,
-                created_at, updated_at
+            RETURNING {}
             "#,
-        )
+            Self::BOOKING_COLUMNS
+        )))
         .bind(id)
         .bind(&data.status)
         .bind(&data.cancellation_reason)

--- a/backend/crates/db/tests/rental_booking_nullable_decimal_tests.rs
+++ b/backend/crates/db/tests/rental_booking_nullable_decimal_tests.rs
@@ -10,6 +10,8 @@
 //! passes once the `try_from` attributes are dropped (plain `Option<Decimal>`
 //! decodes nullable NUMERIC natively).
 
+use chrono::NaiveDate;
+use db::models::CreateBooking;
 use db::repositories::RentalRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -83,4 +85,82 @@ async fn find_booking_by_id_decodes_null_fees(pool: PgPool) {
     assert_eq!(booking.total_amount, None);
     assert_eq!(booking.platform_fee, None);
     assert_eq!(booking.cleaning_fee, None);
+}
+
+/// End-to-end IG3 for #1422: the repository WRITE path must also round-trip NULL
+/// fees. `create_booking` binds NULL `total_amount`/`platform_fee`/`cleaning_fee`
+/// and decodes the inserted row back via `RETURNING {BOOKING_COLUMNS}`, so this
+/// covers both the model decode AND the create RETURNING projection in one shot
+/// (the read-path test above only seeds a literal row and reads it).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_booking_round_trips_null_fees(pool: PgPool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(Option::<Uuid>::None)
+        .bind(Option::<Uuid>::None)
+        .bind(true)
+        .execute(&pool)
+        .await
+        .expect("set super-admin context");
+
+    let org_id = sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ('Rental Create Null Org', 'rental-create-null-org', 'rental-create@null.test', 'active')
+        RETURNING id
+        "#,
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("seed org");
+
+    let building_id = sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO buildings (organization_id, name, street, city, postal_code, country, status)
+        VALUES ($1, 'Rental Create Null Building', 'Street 1', 'City', '00000', 'Country', 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .fetch_one(&pool)
+    .await
+    .expect("seed building");
+
+    let unit_id = sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO units (building_id, designation) VALUES ($1, '2B') RETURNING id"#,
+    )
+    .bind(building_id)
+    .fetch_one(&pool)
+    .await
+    .expect("seed unit");
+
+    let repo = RentalRepository::new(pool.clone());
+    let created = repo
+        .create_booking(
+            org_id,
+            CreateBooking {
+                unit_id,
+                platform: "airbnb".to_string(),
+                external_booking_id: None,
+                guest_name: "Null Fee Create Guest".to_string(),
+                guest_email: None,
+                guest_phone: None,
+                guest_count: 1,
+                check_in: NaiveDate::from_ymd_opt(2026, 2, 1).unwrap(),
+                check_out: NaiveDate::from_ymd_opt(2026, 2, 5).unwrap(),
+                check_in_time: None,
+                check_out_time: None,
+                total_amount: None,
+                currency: None,
+                platform_fee: None,
+                cleaning_fee: None,
+                guest_notes: None,
+                internal_notes: None,
+            },
+        )
+        .await
+        .expect("create_booking with NULL fees must round-trip via RETURNING (issue #1422)");
+
+    assert_eq!(created.total_amount, None);
+    assert_eq!(created.platform_fee, None);
+    assert_eq!(created.cleaning_fee, None);
 }


### PR DESCRIPTION
## #1535 — follow-up to PR #1489 review (+ a latent bug the test exposed)

### 1. New test (requested) — `create_booking_round_trips_null_fees`
The existing IG3 only seeds a literal row and reads it. This drives the repo **write** path: `create_booking` with `total_amount`/`platform_fee`/`cleaning_fee = None`, asserting the `RETURNING` row decodes all three as `None` — covering the model decode **and** the create RETURNING projection in one shot.

### 2. Bug found by that test — `create_booking` enum encode (#1008)
The new test failed with `42804: column "platform" is of type rental_platform but expression is of type text`. `create_booking`'s INSERT bound `platform` and `status` (both `&str`) directly into the `rental_platform` / `rental_booking_status` enum columns — the encode surface of the #1008 class, FORCE-RLS-masked and never exercised through the repo before. Fixed with `$3::rental_platform` / `$19::rental_booking_status`.

### 3. Dedupe (requested) — single source of truth for the projection
`find_booking_by_external_id` and `update_booking_status_for_org` hand-inlined the ~28-column enum-cast list (byte-identical to `BOOKING_COLUMNS`). Both now reuse `Self::BOOKING_COLUMNS` via the existing `AssertSqlSafe(format!(...))` pattern, so a future enum/nullable column can't silently miss a copy (the drift #1422/#1486/#1492 kept re-fixing).

## Verification (remote builder)
- db `rental_booking_nullable_decimal_tests`: **2/2** (new write-path test + existing read-path test).
- api-server `airbnb_sync_reconciliation_tests` (2 passed) + `rental_connection_token_leak_tests` (5 passed) — both exercise the dedup'd methods, including `update_booking_status_for_org`.

_(Two further latent enum bugs surfaced by `#[ignore]`'d tests — `find_airbnb_connection_by_listing_id` `SELECT *` decode — are out of scope here and tracked for a separate fix.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)