### PR TITLE
fix(api-server): rate-limit MFA recovery-code verify endpoint (closes #1523)

### DIFF
--- a/backend/servers/api-server/src/routes/mfa.rs
+++ b/backend/servers/api-server/src/routes/mfa.rs
@@ -12,9 +12,61 @@ use common::errors::ErrorResponse;
 use db::models::{AuditAction, CreateAuditLog, CreateTwoFactorAuth};
 use serde::{Deserialize, Serialize};
 use sqlx::Acquire;
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+use std::time::{Duration, Instant};
 use utoipa::ToSchema;
 
 use crate::state::AppState;
+
+// ── Brute-force throttle for recovery-code verification (GH #1523) ──────────
+//
+// `verify_recovery_code` is a full MFA-bypass surface on success, so repeated
+// guesses must be throttled. This mirrors the per-key in-process sliding-window
+// limiter in `routes/caddy_ask.rs`, keyed on `user_id` (the authenticated
+// subject) so one user's attempts can never lock out another. A successful
+// verification clears the user's window. NOTE: this counter is per-process; a
+// Redis-backed counter (the sessions Redis is already in the stack) would hold
+// the limit across instances — tracked as a follow-up.
+const MFA_RECOVERY_MAX_ATTEMPTS: u32 = 10;
+const MFA_RECOVERY_WINDOW: Duration = Duration::from_secs(900);
+
+struct RecoveryRateLimitEntry {
+    count: u32,
+    window_start: Instant,
+}
+
+static MFA_RECOVERY_RATE_LIMITER: LazyLock<Mutex<HashMap<uuid::Uuid, RecoveryRateLimitEntry>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Record an attempt for `user_id` and report whether it is within the limit.
+/// Returns `false` once more than `MFA_RECOVERY_MAX_ATTEMPTS` attempts occur in
+/// a rolling `MFA_RECOVERY_WINDOW`.
+fn recovery_attempt_allowed(user_id: uuid::Uuid) -> bool {
+    let mut map = match MFA_RECOVERY_RATE_LIMITER.lock() {
+        Ok(m) => m,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let now = Instant::now();
+    let entry = map.entry(user_id).or_insert(RecoveryRateLimitEntry {
+        count: 0,
+        window_start: now,
+    });
+    if now.duration_since(entry.window_start) >= MFA_RECOVERY_WINDOW {
+        entry.count = 0;
+        entry.window_start = now;
+    }
+    entry.count += 1;
+    entry.count <= MFA_RECOVERY_MAX_ATTEMPTS
+}
+
+/// Clear a user's attempt counter after a successful verification, so a
+/// legitimate user is never penalised by earlier mistyped codes.
+fn recovery_attempts_reset(user_id: uuid::Uuid) {
+    if let Ok(mut map) = MFA_RECOVERY_RATE_LIMITER.lock() {
+        map.remove(&user_id);
+    }
+}
 
 /// Create MFA router (mounted at `/api/v1/auth/mfa`).
 ///
@@ -1013,6 +1065,41 @@ pub async fn verify_recovery_code(
         )
     })?;
 
+    // Brute-force throttle (GH #1523): this endpoint is a full MFA bypass on
+    // success, so cap attempts per user within a rolling window before doing any
+    // work. The (N+1)th attempt in the window is rejected with 429; a successful
+    // verification later clears the counter.
+    if !recovery_attempt_allowed(user_id) {
+        if let Err(e) = state
+            .audit_log_repo
+            .create(CreateAuditLog {
+                user_id: Some(user_id),
+                action: AuditAction::MfaBackupCodeUsed,
+                resource_type: Some("mfa_recovery_rate_limited".to_string()),
+                resource_id: Some(user_id),
+                org_id: None,
+                details: Some(
+                    serde_json::json!({ "outcome": "denied", "reason": "rate_limited" }),
+                ),
+                old_values: None,
+                new_values: None,
+                ip_address: None,
+                user_agent: None,
+            })
+            .await
+        {
+            tracing::error!(error = %e, "Failed to write audit log for rate-limited recovery verify");
+        }
+        rls.release().await;
+        return Err((
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(ErrorResponse::new(
+                "RATE_LIMITED",
+                "Too many recovery-code attempts. Please try again later.",
+            )),
+        ));
+    }
+
     // Run every query on the RLS connection so `app.current_user_id` is set for
     // the duration of the handler. The self-policies on `user_2fa` /
     // `mfa_recovery_codes` (migrations 00024 / 00149) gate on
@@ -1212,6 +1299,9 @@ pub async fn verify_recovery_code(
     }
 
     tracing::info!(user_id = %user_id, remaining, "MFA recovery code consumed");
+
+    // Successful verification clears the brute-force counter (GH #1523).
+    recovery_attempts_reset(user_id);
 
     rls.release().await;
 

--- a/backend/servers/api-server/tests/mfa_recovery_cross_user_idor_tests.rs
+++ b/backend/servers/api-server/tests/mfa_recovery_cross_user_idor_tests.rs
@@ -231,3 +231,53 @@ async fn test_user_a_consumption_does_not_affect_user_b_codes(pool: PgPool) {
     cleanup_test_user(&pool, &user_a.email).await;
     cleanup_test_user(&pool, &user_b.email).await;
 }
+
+// ─── brute-force throttle (GH #1523) ─────────────────────────────────────────
+
+/// The recovery-verify endpoint is a full MFA bypass on success, so repeated
+/// guesses must be throttled. After `MFA_RECOVERY_MAX_ATTEMPTS` (10) attempts in
+/// the rolling window, the next attempt is rejected with `429` instead of doing
+/// the hash comparison. The limiter is keyed on `user_id`, so this user's
+/// lockout does not affect the other tests' (distinct) users.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn test_recovery_verify_is_rate_limited_per_user(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let user = TestUser::new();
+    cleanup_test_user(&pool, &user.email).await;
+    let (token, org) = create_authenticated_user_with_org(&app, &user, "rl").await;
+    let id = user_id_for(&pool, &user.email).await;
+
+    enroll_user_2fa(&pool, id).await;
+    // Issue real codes so the handler reaches the comparison step (an empty set
+    // short-circuits to 400 for a different reason).
+    let _codes = issue_recovery_codes(&pool, id, 10).await;
+
+    // The first 10 wrong attempts are each rejected as an invalid code (400) —
+    // within the window, not yet throttled.
+    for i in 0..10 {
+        let (status, body) = post_recovery_verify(&app, &token, org, "WRONGCODE").await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "attempt {i} (within the limit) must be a normal 400 invalid-code; body: {body}"
+        );
+    }
+
+    // The 11th attempt in the window is throttled with 429 before any work.
+    let (status, body) = post_recovery_verify(&app, &token, org, "WRONGCODE").await;
+    assert_eq!(
+        status,
+        StatusCode::TOO_MANY_REQUESTS,
+        "the (N+1)th recovery-code attempt must be rate-limited (429); body: {body}"
+    );
+
+    // None of the user's codes were consumed by the failed/throttled attempts.
+    assert_eq!(
+        unused_code_count(&pool, id).await,
+        10,
+        "failed and throttled attempts must not consume any recovery codes"
+    );
+
+    cleanup_test_user(&pool, &user.email).await;
+}


### PR DESCRIPTION
## #1523 — follow-up to PR #1467 review

`POST /api/v1/users/me/mfa/recovery-codes/verify` is a full MFA-bypass surface on success but had **no brute-force protection** — failed attempts were audit-logged, but nothing throttled repeated guesses (the IDOR threat model #1467 addressed is itself an unthrottled-guessing scenario).

## Fix
Per-user in-process sliding-window throttle, mirroring the established limiter in `routes/caddy_ask.rs`, **keyed on `user_id`** so one user's attempts can never lock out another:
- > 10 attempts in a rolling 15-minute window → **429 TOO_MANY_REQUESTS** (audit-logged `outcome: denied, reason: rate_limited`) **before** any hash work;
- a successful verification **clears** the counter, so a legitimate user is never penalised by earlier mistyped codes.

## Test
`test_recovery_verify_is_rate_limited_per_user`: the first 10 wrong attempts return 400 (invalid code), the 11th returns 429, and no recovery codes are consumed. The two existing cross-user IDOR tests still pass (the throttle is per-user).

**Verified on the remote builder: 3/3 passed.**

## Noted follow-ups (out of scope here)
- Per-process counter → a Redis-backed counter (sessions Redis is already in the stack) would hold the limit across instances.
- The sibling TOTP `verify_mfa` path can take the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)