### PR TITLE
style(backend): rustfmt #1527/#1523 (fix red lint job)

### DIFF
--- a/backend/crates/db/tests/api_ecosystem_developer_force_rls_tests.rs
+++ b/backend/crates/db/tests/api_ecosystem_developer_force_rls_tests.rs
@@ -287,12 +287,11 @@ async fn developer_portal_force_rls_cross_user_isolation(pool: PgPool) {
             ("developer_oauth_grants", "OAuth grants"),
             ("api_key_usage_logs", "API key usage logs"),
         ] {
-            let n: i64 = sqlx::query_scalar(sqlx::AssertSqlSafe(format!(
-                "SELECT COUNT(*) FROM {table}"
-            )))
-            .fetch_one(&mut *conn)
-            .await
-            .unwrap_or_else(|e| panic!("count {table} (no ctx): {e}"));
+            let n: i64 =
+                sqlx::query_scalar(sqlx::AssertSqlSafe(format!("SELECT COUNT(*) FROM {table}")))
+                    .fetch_one(&mut *conn)
+                    .await
+                    .unwrap_or_else(|e| panic!("count {table} (no ctx): {e}"));
             assert_eq!(
                 n, 0,
                 "without RLS context `{label}` ({table}) must be deny-all under FORCE"
@@ -351,12 +350,11 @@ async fn developer_portal_force_rls_cross_user_isolation(pool: PgPool) {
             ("developer_oauth_grants", "OAuth grant"),
             ("api_key_usage_logs", "API key usage log"),
         ] {
-            let n: i64 = sqlx::query_scalar(sqlx::AssertSqlSafe(format!(
-                "SELECT COUNT(*) FROM {table}"
-            )))
-            .fetch_one(&mut *conn)
-            .await
-            .unwrap_or_else(|e| panic!("count {table} under A: {e}"));
+            let n: i64 =
+                sqlx::query_scalar(sqlx::AssertSqlSafe(format!("SELECT COUNT(*) FROM {table}")))
+                    .fetch_one(&mut *conn)
+                    .await
+                    .unwrap_or_else(|e| panic!("count {table} under A: {e}"));
             assert_eq!(n, 1, "user A must see only their own {label} ({table})");
         }
 

--- a/backend/servers/api-server/src/routes/mfa.rs
+++ b/backend/servers/api-server/src/routes/mfa.rs
@@ -1078,9 +1078,7 @@ pub async fn verify_recovery_code(
                 resource_type: Some("mfa_recovery_rate_limited".to_string()),
                 resource_id: Some(user_id),
                 org_id: None,
-                details: Some(
-                    serde_json::json!({ "outcome": "denied", "reason": "rate_limited" }),
-                ),
+                details: Some(serde_json::json!({ "outcome": "denied", "reason": "rate_limited" })),
                 old_values: None,
                 new_values: None,
                 ip_address: None,


### PR DESCRIPTION
The `lint` job's **Check formatting** step is red on `dev`: PR #1563 (#1527) and #1580 (#1523) merged on a green `check` job, but `lint` (a separate job) flagged two non-rustfmt-clean spots:
- `api_ecosystem_developer_force_rls_tests.rs` — the `AssertSqlSafe(format!("SELECT COUNT(*) FROM {table}"))` blocks (rustfmt one-lines the `format!`).
- `mfa.rs` — the rate-limited audit `details: Some(serde_json::json!({...}))` line.

`cargo fmt --all` output, whitespace only, no behavior change. Verified `cargo fmt --all -- --check` is clean for the rest of the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)