### PR TITLE
fix(mobile): wire useFolderTree / FOLDER_TREE_QUERY_KEY into document screens (closes #1532)

### DIFF
--- a/frontend/apps/mobile/src/hooks/useFolderTree.ts
+++ b/frontend/apps/mobile/src/hooks/useFolderTree.ts
@@ -12,10 +12,27 @@
  */
 
 import type { UseQueryOptions } from '@tanstack/react-query';
-import type { ApiFolderTreeNode } from '../screens/documents/DocumentsScreen';
 import { useApiQuery } from './useApi';
 
 // ─── API shape ────────────────────────────────────────────────────────────────
+
+/**
+ * Node of `GET /api/v1/documents/folders/tree` (`FolderTreeNode` on the
+ * server). The server nests children under each node; `parent_id` is the id of
+ * the containing folder (null for root-level folders) and `document_count` is
+ * the number of documents directly in the folder.
+ *
+ * Owned here (the folder-tree data layer) and re-exported from
+ * `DocumentsScreen` for existing importers — the hook must not depend on a
+ * screen module.
+ */
+export interface ApiFolderTreeNode {
+  id: string;
+  name: string;
+  parent_id?: string | null;
+  document_count: number;
+  children?: ApiFolderTreeNode[] | null;
+}
 
 export interface FolderTreeResponse {
   tree: ApiFolderTreeNode[];

--- a/frontend/apps/mobile/src/screens/documents/DocumentsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentsScreen.tsx
@@ -10,6 +10,7 @@ import {
   View,
 } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
+import { type ApiFolderTreeNode, useFolderTree } from '../../hooks/useFolderTree';
 import { colors } from '../shared/screenStyles';
 import type { AccessScope } from './DocumentPermissionsScreen';
 import { MoveDocumentSheet } from './MoveDocumentSheet';
@@ -80,23 +81,10 @@ interface ApiDocumentListResponse {
   total?: number;
 }
 
-/**
- * Node of `GET /api/v1/documents/folders/tree` (`FolderTreeNode` on the
- * server). The server nests children under each node; `parent_id` is the
- * id of the containing folder (null for root-level folders) and
- * `document_count` is the number of documents directly in the folder.
- */
-export interface ApiFolderTreeNode {
-  id: string;
-  name: string;
-  parent_id?: string | null;
-  document_count: number;
-  children?: ApiFolderTreeNode[] | null;
-}
-
-interface ApiFolderTreeResponse {
-  tree: ApiFolderTreeNode[];
-}
+// `ApiFolderTreeNode` is owned by the folder-tree hook (the data layer it
+// describes). Re-exported here so existing `./DocumentsScreen` importers
+// (index barrel, sheets, tests) keep working without a screen→hook coupling.
+export type { ApiFolderTreeNode };
 
 /** Lightweight breadcrumb entry: just enough to render + look up children. */
 interface FolderCrumb {
@@ -214,20 +202,12 @@ export function DocumentsScreen({ onNavigate: _onNavigate }: DocumentsScreenProp
   // Drives the breadcrumb drill-down. Tenant scoping is enforced server-side
   // by the RLS connection behind GET /api/v1/documents/folders/tree.
   const {
-    data: folderData,
+    folderTree,
     isLoading: foldersLoading,
     error: foldersError,
     refetch: refetchFolders,
     isFetching: foldersFetching,
-  } = useApiQuery<ApiFolderTreeResponse>(
-    ['documents', 'folders', 'tree'],
-    '/api/v1/documents/folders/tree',
-    {
-      staleTime: 60_000,
-    }
-  );
-
-  const folderTree = folderData?.tree ?? [];
+  } = useFolderTree();
 
   // ── Documents in the current folder ───────────────────────────────────────
   // When inside a folder we scope the list by `folder_id`. At the root we omit

--- a/frontend/apps/mobile/src/screens/documents/MoveDocumentSheet.tsx
+++ b/frontend/apps/mobile/src/screens/documents/MoveDocumentSheet.tsx
@@ -34,11 +34,8 @@ import {
   View,
 } from 'react-native';
 import { useApiMutation } from '../../hooks/useApi';
+import { type ApiFolderTreeNode, FOLDER_TREE_QUERY_KEY } from '../../hooks/useFolderTree';
 import { colors } from '../shared/screenStyles';
-// `ApiFolderTreeNode` is the canonical folder-tree node shape owned by
-// DocumentsScreen. This is a type-only import — erased at compile time, so it
-// does not introduce a runtime circular dependency.
-import type { ApiFolderTreeNode } from './DocumentsScreen';
 
 // ─── API types ────────────────────────────────────────────────────────────────
 
@@ -129,7 +126,7 @@ export function MoveDocumentSheet({
 
       // Invalidate both the document list and the folder tree so counts update
       await queryClient.invalidateQueries({ queryKey: ['documents', 'list'] });
-      await queryClient.invalidateQueries({ queryKey: ['documents', 'folders', 'tree'] });
+      await queryClient.invalidateQueries({ queryKey: FOLDER_TREE_QUERY_KEY });
 
       setSelectedId(currentFolderId);
       onMoved();

--- a/frontend/apps/mobile/src/screens/documents/NewFolderSheet.tsx
+++ b/frontend/apps/mobile/src/screens/documents/NewFolderSheet.tsx
@@ -31,6 +31,7 @@ import {
   View,
 } from 'react-native';
 import { useApiMutation } from '../../hooks/useApi';
+import { FOLDER_TREE_QUERY_KEY } from '../../hooks/useFolderTree';
 import { colors } from '../shared/screenStyles';
 
 // ─── API types ────────────────────────────────────────────────────────────────
@@ -115,7 +116,7 @@ export function NewFolderSheet({
       });
 
       // Invalidate the folder tree so DocumentsScreen refetches
-      await queryClient.invalidateQueries({ queryKey: ['documents', 'folders', 'tree'] });
+      await queryClient.invalidateQueries({ queryKey: FOLDER_TREE_QUERY_KEY });
 
       reset();
       onCreated();


### PR DESCRIPTION
## #1532 — follow-up to PR #1464 review
The `useFolderTree` hook + `FOLDER_TREE_QUERY_KEY` constant shipped as a **dead abstraction** — no consumers, and the three sites that should share the key still hard-coded `['documents','folders','tree']`. The advertised cache-sharing was never realized and the pin-test guarded a constant nothing depended on.

## Changes
- **DocumentsScreen** — replace the inline `useApiQuery(['documents','folders','tree'], '/api/v1/documents/folders/tree', {staleTime})` with `useFolderTree()` (its `folderTree` accessor). Removes the duplicated endpoint path + cache options.
- **MoveDocumentSheet / NewFolderSheet** — invalidate with `FOLDER_TREE_QUERY_KEY` instead of the hard-coded literal → the constant is now load-bearing and the pin-test meaningful.
- **Reverse-coupling fix (finding 3)** — `ApiFolderTreeNode` now lives in the `useFolderTree` hook (the data layer it describes); `DocumentsScreen` re-exports it so existing `./DocumentsScreen` importers (barrel, sheets, `DocumentFolderOrganization.test.ts`) are unaffected. The hook no longer imports a screen module.

No behavior change — identical query key, endpoint, and `staleTime`. Verified via CI typecheck + biome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)