### PR TITLE
fix(db): round invoice lines once so header totals equal sum of stored items (#1522)

### DIFF
--- a/backend/crates/db/src/repositories/accounting.rs
+++ b/backend/crates/db/src/repositories/accounting.rs
@@ -101,13 +101,19 @@ impl AccountingRepository {
         conn: &mut sqlx::PgConnection,
         data: CreateInvoice,
     ) -> Result<Invoice, sqlx::Error> {
-        // Calculate totals
+        // Single pass: resolve VAT, round each line to 2dp, and accumulate the
+        // header totals from the SAME rounded values. The invoice_item rows are
+        // stored as NUMERIC(18,2) (rounded by Postgres on insert), so summing
+        // full-precision lines into the header (the old two-loop approach) could
+        // diverge from the sum of the stored rows by up to a cent. Rounding once
+        // here makes the header always equal the sum of the line rows. (#1522)
         let mut total_amount = Decimal::ZERO;
         let mut base_amount = Decimal::ZERO;
         let mut vat_amount = Decimal::ZERO;
+        let mut lines = Vec::with_capacity(data.items.len());
 
-        for mut item in data.items.clone() {
-            // Resolve VAT rate from type if provided
+        for mut item in data.items {
+            // Resolve VAT rate from type if provided.
             if let Some(rate_type) = item.vat_rate_type {
                 item.vat_rate = match data.country.as_deref() {
                     Some("SK") => rate_type.sk_percentage(),
@@ -115,13 +121,15 @@ impl AccountingRepository {
                 };
             }
 
-            let line_base = item.qty * item.unit_price;
-            let line_vat = line_base * (item.vat_rate / Decimal::from(100));
+            let line_base = (item.qty * item.unit_price).round_dp(2);
+            let line_vat = (line_base * (item.vat_rate / Decimal::from(100))).round_dp(2);
             let line_total = line_base + line_vat;
 
             base_amount += line_base;
             vat_amount += line_vat;
             total_amount += line_total;
+
+            lines.push((item, line_base, line_vat, line_total));
         }
 
         let invoice = sqlx::query_as::<_, Invoice>(
@@ -151,19 +159,9 @@ impl AccountingRepository {
         .fetch_one(&mut *conn)
         .await?;
 
-        for mut item in data.items {
-            // Resolve VAT rate from type if provided (again for insertion)
-            if let Some(rate_type) = item.vat_rate_type {
-                item.vat_rate = match data.country.as_deref() {
-                    Some("SK") => rate_type.sk_percentage(),
-                    _ => rate_type.cz_percentage(), // Default to CZ
-                };
-            }
-
-            let line_base = item.qty * item.unit_price;
-            let line_vat = line_base * (item.vat_rate / Decimal::from(100));
-            let line_total = line_base + line_vat;
-
+        // Insert each line from the SAME rounded values used for the header
+        // totals above (single source of truth — no re-resolution, no drift).
+        for (item, line_base, line_vat, line_total) in lines {
             sqlx::query(
                 r#"
                 INSERT INTO invoice_item (

--- a/backend/crates/db/tests/accounting_rls_repo_tests.rs
+++ b/backend/crates/db/tests/accounting_rls_repo_tests.rs
@@ -1,7 +1,9 @@
 //! RLS isolation tests for native Accounting MVP (PAP-206).
 
-use db::models::accounting::{Contact, Invoice};
+use db::models::accounting::{Contact, CreateInvoice, CreateInvoiceItem, Invoice};
 use db::repositories::accounting::AccountingRepository;
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -820,4 +822,88 @@ async fn accounting_confirm_match_cross_tenant_denied(pool: PgPool) {
     .execute(&pool)
     .await
     .ok();
+}
+
+/// #1522 finding 3: the invoice header totals must equal the sum of the stored
+/// (rounded NUMERIC(18,2)) line rows. The old two-loop code summed full-precision
+/// lines into the header while each item row was rounded on insert, so a line
+/// whose VAT carries a third decimal (e.g. 0.10 * 15% = 0.015) could leave the
+/// header off by a cent from the sum of its items. The single-pass round-once
+/// fix makes the header == sum(items) by construction.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_invoice_header_totals_equal_sum_of_rounded_lines(pool: PgPool) {
+    let org = seed_org(&pool, "inv-round").await;
+    set_ctx(&pool, Some(org), None, true).await;
+
+    let contact_id = sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO contact (tenant_id, name) VALUES ($1, 'Rounding Contact') RETURNING id",
+    )
+    .bind(org)
+    .fetch_one(&pool)
+    .await
+    .expect("seed contact");
+
+    let repo = AccountingRepository::new(pool.clone());
+    let mut conn = pool.acquire().await.expect("acquire");
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(Some(org))
+        .bind(Option::<Uuid>::None)
+        .bind(true)
+        .execute(&mut *conn)
+        .await
+        .expect("set ctx on conn");
+
+    // Three lines whose per-line VAT (0.10 * 15% = 0.015) rounds individually —
+    // the scenario where summing-then-rounding and rounding-then-summing differ.
+    let item = CreateInvoiceItem {
+        description: "Fractional VAT line".to_string(),
+        qty: dec!(1),
+        unit_price: dec!(0.10),
+        vat_rate: dec!(15),
+        vat_rate_type: None,
+    };
+    let invoice = repo
+        .create_invoice_rls(
+            &mut conn,
+            CreateInvoice {
+                tenant_id: org,
+                contact_id,
+                number: "INV-ROUND-1".to_string(),
+                issue_date: chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+                due_date: chrono::NaiveDate::from_ymd_opt(2026, 1, 15).unwrap(),
+                taxable_supply_date: None,
+                currency: "EUR".to_string(),
+                variable_symbol: None,
+                status: None,
+                items: vec![item.clone(), item.clone(), item],
+                country: Some("SK".to_string()),
+            },
+        )
+        .await
+        .expect("create invoice");
+
+    let (base_sum, vat_sum, total_sum): (Decimal, Decimal, Decimal) = sqlx::query_as(
+        r#"
+        SELECT COALESCE(SUM(base_amount), 0), COALESCE(SUM(vat_amount), 0),
+               COALESCE(SUM(total_amount), 0)
+        FROM invoice_item WHERE invoice_id = $1
+        "#,
+    )
+    .bind(invoice.id)
+    .fetch_one(&mut *conn)
+    .await
+    .expect("sum line rows");
+
+    assert_eq!(
+        invoice.base_amount, base_sum,
+        "header base_amount must equal the sum of stored line base_amounts"
+    );
+    assert_eq!(
+        invoice.vat_amount, vat_sum,
+        "header vat_amount must equal the sum of stored line vat_amounts"
+    );
+    assert_eq!(
+        invoice.total_amount, total_sum,
+        "header total_amount must equal the sum of stored line total_amounts"
+    );
 }


### PR DESCRIPTION
Addresses **#1522 finding 3** (money rounding).

`create_invoice_rls` summed **full-precision** line values into the invoice header in one loop, then inserted each `invoice_item` (stored `NUMERIC(18,2)`, rounded by Postgres) in a second loop that re-resolved VAT and recomputed the math. Summing-then-rounding (header) can diverge by up to a cent from the sum of the rounded line rows, and the VAT/line math was duplicated.

**Fix:** single pass — resolve VAT, `.round_dp(2)` each line's base/vat once, accumulate the header from those rounded values, and insert the line rows from the same values. Header == `SUM(line rows)` by construction.

**Test:** `create_invoice_header_totals_equal_sum_of_rounded_lines` drives a fractional-VAT invoice (`0.10 * 15% = 0.015`/line) and asserts header base/vat/total each equal `SUM()` of the `invoice_item` rows.

Verified on the remote builder: `accounting_rls_repo_tests` **9/9** (new test + the 8 existing cross-tenant RLS tests).

_#1522 findings 1-2 (frontend `@hey-api` auth-interceptor centralization + queryKeys/console.log) remain — implementation plan posted on the issue._

🤖 Generated with [Claude Code](https://claude.com/claude-code)