### PR TITLE
fix(db): board_meetings lists use u.name, not nonexistent u.full_name (closes #1586)

### DIFF
--- a/backend/crates/db/src/repositories/board_meetings.rs
+++ b/backend/crates/db/src/repositories/board_meetings.rs
@@ -135,7 +135,7 @@ impl BoardMeetingRepository {
             r#"
             SELECT
                 bm.id, bm.user_id, bm.role, bm.title,
-                u.full_name as user_name, u.email as user_email,
+                u.name as user_name, u.email as user_email,
                 bm.term_start, bm.term_end, bm.is_active
             FROM board_members bm
             LEFT JOIN users u ON u.id = bm.user_id
@@ -892,7 +892,7 @@ impl BoardMeetingRepository {
             r#"
             SELECT
                 mm.id, mm.motion_number, mm.title, mm.status,
-                u.full_name as proposed_by_name,
+                u.name as proposed_by_name,
                 mm.votes_in_favor, mm.votes_opposed, mm.votes_abstain,
                 mm.created_at
             FROM meeting_motions mm

--- a/backend/crates/db/tests/board_meetings_list_join_tests.rs
+++ b/backend/crates/db/tests/board_meetings_list_join_tests.rs
@@ -1,0 +1,116 @@
+//! Regression test for #1586 — `list_board_members` / `list_motions` joined
+//! `users` on `u.full_name`, but the `users` column is `name` (`full_name` was
+//! never created in any migration). Both queries therefore `42703`-failed at
+//! fetch → 500 on the board-member-list and motion-list routes, the identical
+//! failure mode fixed in `document.rs` by PR #1565.
+//!
+//! This drives both repo methods through a real joined user and asserts they
+//! return the populated joined name — it fails on the old `u.full_name` SQL and
+//! passes with `u.name`.
+
+use db::models::board_meetings::{BoardMemberQuery, MotionQuery};
+use db::repositories::BoardMeetingRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Board {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@board.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', $2, 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_board_members_and_motions_populate_joined_user_name(pool: PgPool) {
+    let org = seed_org(&pool, "board-join").await;
+    let user = seed_user(&pool, "director@board-join.test", "Jane Director").await;
+
+    sqlx::query(
+        r#"
+        INSERT INTO board_members (organization_id, user_id, role, title, term_start, is_active)
+        VALUES ($1, $2, 'president', 'Board President', DATE '2026-01-01', true)
+        "#,
+    )
+    .bind(org)
+    .bind(user)
+    .execute(&pool)
+    .await
+    .expect("seed board member");
+
+    let meeting = sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO board_meetings (organization_id, title, scheduled_start, created_by)
+        VALUES ($1, 'Annual General Meeting', NOW(), $2)
+        RETURNING id
+        "#,
+    )
+    .bind(org)
+    .bind(user)
+    .fetch_one(&pool)
+    .await
+    .expect("seed meeting");
+
+    sqlx::query(
+        r#"
+        INSERT INTO meeting_motions (meeting_id, title, motion_text, proposed_by)
+        VALUES ($1, 'Approve 2026 budget', 'Motion to approve the 2026 budget', $2)
+        "#,
+    )
+    .bind(meeting)
+    .bind(user)
+    .execute(&pool)
+    .await
+    .expect("seed motion");
+
+    let repo = BoardMeetingRepository::new(pool.clone());
+
+    // list_board_members joins users for `user_name`. With the old `u.full_name`
+    // this 42703-fails at fetch (→ 500 on the route); with `u.name` it returns
+    // the member with the populated name.
+    let members = repo
+        .list_board_members(&pool, org, BoardMemberQuery::default())
+        .await
+        .expect("list_board_members must not 42703 on the users join (#1586)");
+    assert_eq!(members.len(), 1, "the seeded board member must be listed");
+    assert_eq!(
+        members[0].user_name.as_deref(),
+        Some("Jane Director"),
+        "the joined users.name must populate user_name"
+    );
+
+    // list_motions joins users for `proposed_by_name` — same bug, same guard.
+    let motions = repo
+        .list_motions(&pool, org, MotionQuery::default())
+        .await
+        .expect("list_motions must not 42703 on the users join (#1586)");
+    assert_eq!(motions.len(), 1, "the seeded motion must be listed");
+    assert_eq!(
+        motions[0].proposed_by_name.as_deref(),
+        Some("Jane Director"),
+        "the joined users.name must populate proposed_by_name"
+    );
+}


### PR DESCRIPTION
Follow-up to PR #1565 — the same `u.full_name` (nonexistent column) bug was still **live** in `board_meetings.rs`.

`list_board_members` (`u.full_name as user_name`, :138) and `list_motions` (`u.full_name as proposed_by_name`, :895) join `users u`, but the column is **`name`** (`full_name` was never created in any migration). Both `42703`-failed at fetch → **500 on the board-member-list and motion-list routes** — identical failure mode to the document get-by-id path #1565 fixed.

**Fix:** `u.full_name` → `u.name` in both. These were the only remaining DB-query `u.full_name` references in the backend (the `airbnb.rs` `full_name` is an unrelated external-API struct field). No enum-decode cascade follows — `BoardMemberSummary.role` (`BoardRole`) and `MotionSummary.status` (`MotionStatus`) are typed sqlx enums, not `String`.

**Test:** `board_meetings_list_join_tests` drives both repo methods through a real joined user and asserts the populated `user_name` / `proposed_by_name` (fails-on-main with `u.full_name`, passes with `u.name`). Verified **1/1** on the remote builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)