### PR TITLE
test(integrations): make XXE/entity guards non-vacuous (closes #1591)

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -78,6 +78,10 @@ url = "2.5"
 reqwest = { version = "0.13", features = ["json", "form", "query", "http2"] }
 
 # XML parsing/generation (for OTA/Booking.com integration)
+# NOTE: the inbound OTA parsers rely on quick-xml NOT resolving custom DTD
+# entities (XXE / billion-laughs safety). That posture is load-bearing and pinned
+# by the entity guards in integrations `booking.rs` (`ota_xml::tests`) — a bump
+# that changes entity normalization will turn those tests red. See GH #1519/#1591.
 quick-xml = { version = "0.40", features = ["serialize"] }
 
 # Observability (Epic 95)

--- a/backend/crates/integrations/src/booking.rs
+++ b/backend/crates/integrations/src/booking.rs
@@ -1392,15 +1392,16 @@ pub mod ota_xml {
 <OTA_HotelAvailNotifRQ xmlns="http://www.opentravel.org/OTA/2003/05">
   <AvailStatusMessages HotelCode="&inj;"/>
 </OTA_HotelAvailNotifRQ>"#;
-            // Whether the parser errors or drops the field, the sentinel must
-            // never appear — the entity is not expanded.
-            if let Ok(parsed) = parse_avail_notif_rq(xml) {
-                assert!(
-                    !parsed.hotel_code.contains("INJECTED_SENTINEL"),
-                    "internal entity was expanded into HotelCode: {:?}",
-                    parsed.hotel_code
-                );
-            }
+            // Pin the concrete safe outcome (not just "no sentinel", which is
+            // vacuously true for an empty/errored result): parsing must still
+            // SUCCEED and the poisoned attribute must be dropped to empty — the
+            // custom entity is never resolved/expanded. #1591
+            let parsed =
+                parse_avail_notif_rq(xml).expect("DTD input must still parse (entity dropped)");
+            assert_eq!(
+                parsed.hotel_code, "",
+                "internal entity must be dropped to empty, not expanded into HotelCode"
+            );
         }
 
         #[test]
@@ -1412,13 +1413,11 @@ pub mod ota_xml {
 <OTA_HotelAvailNotifRQ xmlns="http://www.opentravel.org/OTA/2003/05">
   <AvailStatusMessages HotelCode="&xxe;"/>
 </OTA_HotelAvailNotifRQ>"#;
-            if let Ok(parsed) = parse_avail_notif_rq(xml) {
-                assert!(
-                    !parsed.hotel_code.contains("root:") && !parsed.hotel_code.contains('/'),
-                    "external entity disclosed file contents into HotelCode: {:?}",
-                    parsed.hotel_code
-                );
-            }
+            let parsed = parse_avail_notif_rq(xml).expect("DTD input must still parse");
+            assert_eq!(
+                parsed.hotel_code, "",
+                "external entity must yield no value (no file contents, no expansion)"
+            );
         }
 
         #[test]
@@ -1428,13 +1427,11 @@ pub mod ota_xml {
 <OTA_HotelRateAmountNotifRQ xmlns="http://www.opentravel.org/OTA/2003/05">
   <RateAmountMessages HotelCode="&xxe;"/>
 </OTA_HotelRateAmountNotifRQ>"#;
-            if let Ok(parsed) = parse_rate_amount_notif_rq(xml) {
-                assert!(
-                    !parsed.hotel_code.contains("root:") && !parsed.hotel_code.contains('/'),
-                    "external entity disclosed file contents into HotelCode: {:?}",
-                    parsed.hotel_code
-                );
-            }
+            let parsed = parse_rate_amount_notif_rq(xml).expect("DTD input must still parse");
+            assert_eq!(
+                parsed.hotel_code, "",
+                "external entity must yield no value (no file contents, no expansion)"
+            );
         }
 
         #[test]
@@ -1452,18 +1449,11 @@ pub mod ota_xml {
 <OTA_HotelAvailNotifRQ xmlns="http://www.opentravel.org/OTA/2003/05">
   <AvailStatusMessages HotelCode="&lol4;"/>
 </OTA_HotelAvailNotifRQ>"#;
-            if let Ok(parsed) = parse_avail_notif_rq(xml) {
-                assert!(
-                    parsed.hotel_code.len() < 64,
-                    "billion-laughs amplified HotelCode to {} bytes",
-                    parsed.hotel_code.len()
-                );
-                assert!(
-                    !parsed.hotel_code.contains("lollol"),
-                    "billion-laughs entity expanded: {:?}",
-                    parsed.hotel_code
-                );
-            }
+            let parsed = parse_avail_notif_rq(xml).expect("DTD input must still parse");
+            assert_eq!(
+                parsed.hotel_code, "",
+                "billion-laughs entity must not amplify (or appear at all) in HotelCode"
+            );
         }
 
         #[test]


### PR DESCRIPTION
Follow-up to PR #1562's review. The four entity guards wrapped their assertion in `if let Ok(parsed) = parse_...(xml) { assert!(...) }` — if the parser ever returned `Err` the assertion was **skipped and the test passed vacuously**. The `!contains(...)` checks were also trivially true for the empty-string result, so a future behavior change (errors, different sentinel) would leave them green.

**Fix:** pin the concrete safe outcome unconditionally — parsing must **succeed** (`.expect(...)`) and the poisoned attribute must be dropped to empty (`assert_eq!(hotel_code, "")`), since the custom entity is never resolved. Applied to all four (internal-entity, XXE avail, XXE rate, billion-laughs). Now fails loudly on either an expansion regression *or* a swap to erroring.

Also added a note at the `quick-xml` pin in `Cargo.toml` flagging that its non-resolution of custom DTD entities is load-bearing and pinned by these tests (finding 2).

Verified on the remote builder: `booking::ota_xml::tests` **29/29**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)