### PR TITLE
test(db): write-path RLS probes for developer OAuth/usage tables (closes #1594)

### DIFF
--- a/backend/crates/db/tests/api_ecosystem_developer_force_rls_tests.rs
+++ b/backend/crates/db/tests/api_ecosystem_developer_force_rls_tests.rs
@@ -428,6 +428,61 @@ async fn developer_portal_force_rls_cross_user_isolation(pool: PgPool) {
             "user A must see their own API key via the repo"
         );
 
+        // ── WRITE path (#1594). The policies are `FOR ALL USING (...)` with no
+        // explicit WITH CHECK, so Postgres reuses USING as the write check too.
+        // Assert that holds — otherwise a future FOR SELECT + weak write policy
+        // split would let A mutate B's rows while the read probes above stay green.
+        //
+        // Asymmetry to keep in mind: UPDATE/DELETE of a row hidden by USING
+        // silently affects 0 rows (NOT an error); an INSERT that violates the
+        // (implicit) WITH CHECK raises an error.
+        let upd = sqlx::query("UPDATE developer_oauth_apps SET name = 'hijack' WHERE id = $1")
+            .bind(app_b)
+            .execute(&mut *conn)
+            .await
+            .expect("update B oauth app under A must run (RLS hides the row, not error)");
+        assert_eq!(
+            upd.rows_affected(),
+            0,
+            "user A must NOT UPDATE user B's oauth app (USING hides it → 0 rows)"
+        );
+
+        let del = sqlx::query("DELETE FROM developer_oauth_grants WHERE id = $1")
+            .bind(grant_b)
+            .execute(&mut *conn)
+            .await
+            .expect("delete B oauth grant under A must run (RLS hides the row, not error)");
+        assert_eq!(
+            del.rows_affected(),
+            0,
+            "user A must NOT DELETE user B's oauth grant (USING hides it → 0 rows)"
+        );
+
+        let del_log = sqlx::query("DELETE FROM api_key_usage_logs WHERE id = $1")
+            .bind(usage_b)
+            .execute(&mut *conn)
+            .await
+            .expect("delete B usage log under A must run (RLS hides the row, not error)");
+        assert_eq!(
+            del_log.rows_affected(),
+            0,
+            "user A must NOT DELETE user B's api_key_usage_log (USING hides it → 0 rows)"
+        );
+
+        // INSERT attributed to B violates the (implicit) WITH CHECK → error.
+        let ins = sqlx::query(
+            "INSERT INTO developer_oauth_grants (oauth_app_id, user_id, scopes) \
+             VALUES ($1, $2, ARRAY['read'])",
+        )
+        .bind(app_b)
+        .bind(user_b)
+        .execute(&mut *conn)
+        .await;
+        assert!(
+            ins.is_err(),
+            "user A must NOT INSERT an oauth grant owned by user B (WITH CHECK denies)"
+        );
+
         sqlx::query("RESET ROLE")
             .execute(&mut *conn)
             .await


### PR DESCRIPTION
Follow-up to PR #1563's review. The behavioral test granted the role `SELECT/INSERT/UPDATE/DELETE` but only asserted the **read** path (`COUNT` + id probe). The three `00102` policies are `FOR ALL USING (...)` with **no explicit `WITH CHECK`** (Postgres reuses `USING` as the write check), so write enforcement exists but was untested — a future `FOR SELECT` + weaker write policy split would let A mutate B's rows while the read probes stayed green.

Under user A's context, added per-table write probes against B's rows:
- `UPDATE developer_oauth_apps` (B) → **0 rows affected** (`USING` hides it — not an error)
- `DELETE developer_oauth_grants` (B) → **0 rows affected**
- `DELETE api_key_usage_logs` (B) → **0 rows affected**
- `INSERT` oauth grant attributed to B → **Err** (implicit `WITH CHECK` denies)

A comment documents the asymmetry (UPDATE/DELETE of a `USING`-hidden row = 0 rows, *not* an error; INSERT violating `WITH CHECK` = error) so it isn't "fixed" the wrong way.

Verified on the remote builder: `api_ecosystem_developer_force_rls_tests` **2/2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)