### PR TITLE
fix(api-server): derive OTA manager-gate from TenantRole + airbnb cross-org test (closes #1585)

### DIFF
--- a/backend/crates/common/src/tenant.rs
+++ b/backend/crates/common/src/tenant.rs
@@ -145,6 +145,20 @@ impl TenantRole {
                 | TenantRole::TechnicalManager
         )
     }
+
+    /// Parse the canonical snake_case `role_type` string — as stored in
+    /// `organization_members.role_type` and serialized in JWT claims — into a
+    /// [`TenantRole`]. Returns `None` for an unknown/legacy value.
+    ///
+    /// Reuses the same serde `rename_all = "snake_case"` mapping as
+    /// serialization, so it cannot drift from the wire/DB representation: a new
+    /// variant becomes parseable the moment it is added to the enum.
+    /// Authorization gates should derive their decision from
+    /// [`is_manager`](Self::is_manager) via this parser rather than hard-coding a
+    /// mirror of the variant strings.
+    pub fn from_role_type(role_type: &str) -> Option<Self> {
+        serde_json::from_value(serde_json::Value::String(role_type.to_owned())).ok()
+    }
 }
 
 impl std::fmt::Display for TenantRole {
@@ -336,6 +350,59 @@ mod tests {
     }
 
     // ---- Serde JSON contract ----
+
+    #[test]
+    fn from_role_type_round_trips_snake_case_and_drives_is_manager() {
+        // The canonical role_type strings stored in organization_members /
+        // serialized in JWT claims must parse back to the right variant.
+        for role in [
+            TenantRole::SuperAdmin,
+            TenantRole::PlatformAdmin,
+            TenantRole::OrgAdmin,
+            TenantRole::Manager,
+            TenantRole::TechnicalManager,
+            TenantRole::Owner,
+            TenantRole::OwnerDelegate,
+            TenantRole::Tenant,
+            TenantRole::Resident,
+            TenantRole::PropertyManager,
+            TenantRole::RealEstateAgent,
+            TenantRole::Guest,
+        ] {
+            let s = serde_json::to_value(role).unwrap();
+            let s = s.as_str().unwrap();
+            assert_eq!(
+                TenantRole::from_role_type(s),
+                Some(role),
+                "role_type string {s:?} must parse back to its variant"
+            );
+        }
+
+        // The exact manager set the OTA gate depends on (#1525/#1585).
+        for s in [
+            "super_admin",
+            "platform_admin",
+            "org_admin",
+            "manager",
+            "technical_manager",
+        ] {
+            assert!(
+                TenantRole::from_role_type(s).is_some_and(|r| r.is_manager()),
+                "{s} must parse and be a manager role"
+            );
+        }
+        for s in ["owner", "tenant", "resident", "guest", "real_estate_agent"] {
+            assert!(
+                TenantRole::from_role_type(s).is_some_and(|r| !r.is_manager()),
+                "{s} must parse and NOT be a manager role"
+            );
+        }
+
+        // Unknown/legacy values are rejected (gate fails closed → 403).
+        assert_eq!(TenantRole::from_role_type("Manager"), None);
+        assert_eq!(TenantRole::from_role_type("not_a_role"), None);
+        assert_eq!(TenantRole::from_role_type(""), None);
+    }
 
     #[test]
     fn role_serializes_to_snake_case() {

--- a/backend/servers/api-server/src/routes/integrations/oauth.rs
+++ b/backend/servers/api-server/src/routes/integrations/oauth.rs
@@ -109,6 +109,9 @@ pub struct BookingTokenExchangeResponse {
 )]
 pub async fn booking_token_exchange(
     State(state): State<AppState>,
+    // Retained for its side effect: TenantExtractor rejects requests without a
+    // valid tenant header before the handler runs. Not read directly — org-scope
+    // authz is enforced by verify_manager_role_in_org(path.org_id) below.
     _tenant: TenantExtractor,
     auth: api_core::AuthUser,
     Path(path): Path<OrgIdPath>,
@@ -276,6 +279,9 @@ pub struct AirbnbTokenExchangeResponse {
 )]
 pub async fn airbnb_token_exchange(
     State(state): State<AppState>,
+    // Retained for its side effect: TenantExtractor rejects requests without a
+    // valid tenant header before the handler runs. Not read directly — org-scope
+    // authz is enforced by verify_manager_role_in_org(path.org_id) below.
     _tenant: TenantExtractor,
     auth: api_core::AuthUser,
     Path(path): Path<OrgIdPath>,

--- a/backend/servers/api-server/src/routes/integrations/sync.rs
+++ b/backend/servers/api-server/src/routes/integrations/sync.rs
@@ -37,6 +37,7 @@ use axum::{
 };
 use chrono::{Duration, Utc};
 use common::errors::ErrorResponse;
+use common::tenant::TenantRole;
 use db::models::{
     accounting_system, calendar_provider, AccountingExport, AccountingExportSettings,
     CalendarConnection, CalendarSyncResult, CreateAccountingExport, CreateCalendarConnection,
@@ -155,7 +156,8 @@ pub(super) async fn verify_org_access(
 /// `verify_manager_role` passes on the A-role from the JWT). This reads the
 /// caller's `role_type` from `organization_members` for `org_id` itself — the
 /// same active-membership row `verify_org_access` checks — and rejects
-/// non-managers. The manager set mirrors `TenantRole::is_manager`.
+/// non-managers. The manager decision is derived from `TenantRole::is_manager`
+/// (the canonical predicate), not a hand-rolled mirror of the role strings.
 pub(super) async fn verify_manager_role_in_org(
     state: &AppState,
     user_id: uuid::Uuid,
@@ -173,10 +175,15 @@ pub(super) async fn verify_manager_role_in_org(
             )
         })?;
 
-    let is_manager = matches!(
-        role_type.as_deref(),
-        Some("super_admin" | "platform_admin" | "org_admin" | "manager" | "technical_manager")
-    );
+    // Derive the manager decision from the canonical `TenantRole::is_manager`
+    // predicate (single source of truth) rather than mirroring its variant
+    // strings here — so a future manager-tier role added to the enum is covered
+    // automatically and this authz gate cannot silently drift.
+    let is_manager = role_type
+        .as_deref()
+        .and_then(TenantRole::from_role_type)
+        .map(|role| role.is_manager())
+        .unwrap_or(false);
     if !is_manager {
         return Err((
             StatusCode::FORBIDDEN,

--- a/backend/servers/api-server/tests/airbnb_oauth_routes_tests.rs
+++ b/backend/servers/api-server/tests/airbnb_oauth_routes_tests.rs
@@ -316,6 +316,42 @@ async fn token_exchange_idor_guard_rejects_non_member(pool: PgPool) {
     );
 }
 
+/// #1585: the manager gate must read the caller's role for the PATH org, not
+/// trust the JWT role / X-Tenant-ID. A user who is a manager in org A but only a
+/// plain member of org B must NOT be able to bind org B's Airbnb integration.
+/// Mirrors `token_exchange_rejects_manager_of_a_different_org` in the booking
+/// suite — the gate is shared (`verify_manager_role_in_org`), but this pins that
+/// the airbnb handler actually invokes it before exchanging.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn token_exchange_rejects_manager_of_a_different_org(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "te-mgr-desync-a").await;
+    let org_b = seed_org(&pool, "te-mgr-desync-b").await;
+    let user_id = seed_user(&pool, "te-mgr-desync@test.local").await;
+    seed_membership(&pool, org_a, user_id, "manager").await; // manager in A
+    seed_membership(&pool, org_b, user_id, "tenant").await; //  plain member in B
+
+    // JWT carries role=manager + tenant_id = A (X-Tenant-ID = A), but the path
+    // org being mutated is B, where the caller is only a plain member.
+    let token = mint_token(user_id, org_a);
+    let uri = format!("/api/v1/integrations/organizations/{org_b}/airbnb/token/exchange");
+    let resp = app
+        .execute(authed_post_with_tenant(
+            &uri,
+            &token,
+            org_a, // X-Tenant-ID = A (where the caller is a manager)
+            json!({"code": "valid-looking-code"}),
+        ))
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "manager of org A must not bind org B's Airbnb integration as a plain member; got {}: {}",
+        resp.status,
+        resp.text()
+    );
+}
+
 /// When Airbnb credentials are not configured (empty `AIRBNB_CLIENT_ID`), the
 /// endpoint must return 503 SERVICE_UNAVAILABLE rather than forwarding a bad
 /// request to Airbnb.  This test relies on the fact that no `AIRBNB_CLIENT_ID`


### PR DESCRIPTION
Follow-up to PR #1552's review — three hardening items on the OTA token-exchange manager gate.

**1. Drift hazard (authz).** `verify_manager_role_in_org` hand-rolled the manager set as `matches!(role, "super_admin" | … | "technical_manager")`, mirroring `TenantRole::is_manager`. A new manager-tier role added to the enum would not update this gate → silent under/over-authorization. Now derives from the canonical predicate.

> **Correction to the review:** `TenantRole` had **no `FromStr`** (the `parse::<TenantRole>()` sketch wouldn't compile). Added `TenantRole::from_role_type` next to the enum, which reuses the same serde `rename_all = "snake_case"` mapping as serialization (so it can't drift from the wire/DB representation), plus a unit test pinning the round-trip and the exact manager set. The gate is now `role_type.and_then(TenantRole::from_role_type).map(|r| r.is_manager()).unwrap_or(false)`.

**2. Coverage.** Mirrored `token_exchange_rejects_manager_of_a_different_org` into `airbnb_oauth_routes_tests.rs` (manager in org A + plain member of org B, JWT/X-Tenant-ID = A, mutate B → 403) — pins that the airbnb handler actually invokes the shared gate.

**3. Clarity.** Commented both `_tenant: TenantExtractor` bindings (retained for the header-validation side effect, not dead code).

Verified on the remote builder: `common` tenant **15/15**, `booking_oauth_routes` **9/9**, `airbnb_oauth_routes` **15/15**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)