### PR TITLE
fix(api-server): MFA recovery limiter — evict stale entries + dedicated audit action (closes #1583)

### DIFF
--- a/backend/crates/db/migrations/00185_audit_action_mfa_recovery_rate_limited.sql
+++ b/backend/crates/db/migrations/00185_audit_action_mfa_recovery_rate_limited.sql
@@ -1,0 +1,10 @@
+-- Migration: 00185_audit_action_mfa_recovery_rate_limited.sql
+-- GH #1583: the MFA recovery-code verify rate-limit DENIAL (PR #1580) was
+-- logged with `mfa_backup_code_used` — a SUCCESS action ("a backup code was
+-- used") — disambiguated only via `resource_type`/`details`. That pollutes any
+-- query/alert that counts `mfa_backup_code_used` as a successful MFA bypass and
+-- makes the throttle event invisible to action-level filtering.
+--
+-- Add a dedicated denial variant so the rate-limit event is action-filterable,
+-- following the `refresh_token_replay_detected` precedent (00154).
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'mfa_recovery_rate_limited';

--- a/backend/crates/db/src/models/audit_log.rs
+++ b/backend/crates/db/src/models/audit_log.rs
@@ -70,6 +70,10 @@ pub enum AuditAction {
     // row is replayed; on emit, every active refresh token for the
     // affected user is revoked.
     RefreshTokenReplayDetected,
+    // GH #1583: emitted when a recovery-code verify attempt is rejected by the
+    // per-user brute-force throttle. A DENIAL, distinct from the success
+    // `MfaBackupCodeUsed`, so it does not pollute MFA-bypass success queries.
+    MfaRecoveryRateLimited,
 }
 
 impl AuditAction {
@@ -127,6 +131,7 @@ impl AuditAction {
             Self::OAuthClientSecretRegenerate => "OAuthClientSecretRegenerate",
             Self::OAuthTokenDeniedPrincipalKind => "OAuthTokenDeniedPrincipalKind",
             Self::RefreshTokenReplayDetected => "RefreshTokenReplayDetected",
+            Self::MfaRecoveryRateLimited => "MfaRecoveryRateLimited",
         }
     }
 }

--- a/backend/servers/api-server/src/routes/mfa.rs
+++ b/backend/servers/api-server/src/routes/mfa.rs
@@ -30,6 +30,9 @@ use crate::state::AppState;
 // the limit across instances — tracked as a follow-up.
 const MFA_RECOVERY_MAX_ATTEMPTS: u32 = 10;
 const MFA_RECOVERY_WINDOW: Duration = Duration::from_secs(900);
+/// Only sweep expired limiter entries once the map exceeds this size, so the
+/// `retain` walk is amortized rather than run on every request (GH #1583).
+const MFA_RECOVERY_SWEEP_THRESHOLD: usize = 1024;
 
 struct RecoveryRateLimitEntry {
     count: u32,
@@ -48,6 +51,17 @@ fn recovery_attempt_allowed(user_id: uuid::Uuid) -> bool {
         Err(poisoned) => poisoned.into_inner(),
     };
     let now = Instant::now();
+
+    // Evict entries whose window has fully elapsed (GH #1583). Unlike the
+    // loopback-only caddy_ask limiter this mirrors, this map is keyed on the
+    // whole user population on a PUBLIC auth path, so without eviction an
+    // attacker enumerating user_ids could grow it without bound (slow
+    // memory-exhaustion DoS). The sweep only runs once the map crosses a size
+    // threshold so it is not an O(n) walk on every request under normal load.
+    if map.len() > MFA_RECOVERY_SWEEP_THRESHOLD {
+        map.retain(|_, e| now.duration_since(e.window_start) < MFA_RECOVERY_WINDOW);
+    }
+
     let entry = map.entry(user_id).or_insert(RecoveryRateLimitEntry {
         count: 0,
         window_start: now,
@@ -61,8 +75,9 @@ fn recovery_attempt_allowed(user_id: uuid::Uuid) -> bool {
 }
 
 /// Clear a user's attempt counter after a successful verification, so a
-/// legitimate user is never penalised by earlier mistyped codes.
-fn recovery_attempts_reset(user_id: uuid::Uuid) {
+/// legitimate user is never penalised by earlier mistyped codes. Also used by
+/// tests to reset the process-global limiter for a given user (GH #1583).
+pub fn recovery_attempts_reset(user_id: uuid::Uuid) {
     if let Ok(mut map) = MFA_RECOVERY_RATE_LIMITER.lock() {
         map.remove(&user_id);
     }
@@ -1074,7 +1089,7 @@ pub async fn verify_recovery_code(
             .audit_log_repo
             .create(CreateAuditLog {
                 user_id: Some(user_id),
-                action: AuditAction::MfaBackupCodeUsed,
+                action: AuditAction::MfaRecoveryRateLimited,
                 resource_type: Some("mfa_recovery_rate_limited".to_string()),
                 resource_id: Some(user_id),
                 org_id: None,

--- a/backend/servers/api-server/tests/mfa_recovery_cross_user_idor_tests.rs
+++ b/backend/servers/api-server/tests/mfa_recovery_cross_user_idor_tests.rs
@@ -248,6 +248,10 @@ async fn test_recovery_verify_is_rate_limited_per_user(pool: PgPool) {
     let (token, org) = create_authenticated_user_with_org(&app, &user, "rl").await;
     let id = user_id_for(&pool, &user.email).await;
 
+    // The limiter is a process-global static; clear this user's slot so the test
+    // is independent of any earlier attempt for the same id in the binary (#1583).
+    api_server::routes::mfa::recovery_attempts_reset(id);
+
     enroll_user_2fa(&pool, id).await;
     // Issue real codes so the handler reaches the comparison step (an empty set
     // short-circuits to 400 for a different reason).


### PR DESCRIPTION
Follow-up to PR #1580's review — three fixes to the recovery-verify brute-force throttle.

**1. Availability / DoS (medium).** `MFA_RECOVERY_RATE_LIMITER` never pruned — every distinct user who ever failed a recovery-verify left a permanent entry. Keyed on the whole user population on a **public** auth path, an attacker enumerating `user_id`s could grow the map without bound (slow memory exhaustion). Added an amortized eviction sweep in `recovery_attempt_allowed` (`retain` entries whose window hasn't elapsed, only once the map crosses `MFA_RECOVERY_SWEEP_THRESHOLD = 1024`, so it isn't an O(n) walk per request).

**2. Observability (medium).** The denial was logged as `MfaBackupCodeUsed` — a **success** action — polluting MFA-bypass success queries. Added a dedicated `AuditAction::MfaRecoveryRateLimited` (migration **00185** `ALTER TYPE audit_action ADD VALUE 'mfa_recovery_rate_limited'`, following the `refresh_token_replay_detected` precedent 00154) + `canonical_name`, emitted from the rate-limit branch.

**3. Tests.** Made `recovery_attempts_reset` `pub` and called it at the top of `test_recovery_verify_is_rate_limited_per_user` so the test is independent of the process-global limiter state.

Verified on the remote builder: `mfa_recovery_cross_user_idor_tests` **3/3** (migration applies, new audit action inserts cleanly, sweep + reset compile/work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)