### PR TITLE
ci(backend): enforce rustfmt in the required check job (closes #1592)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -72,6 +72,14 @@ jobs:
         with:
           workspaces: backend
 
+      # Formatting is enforced here in the REQUIRED `check` job, not only in the
+      # non-blocking `lint` job — so a rustfmt violation blocks merge into dev
+      # instead of landing and needing a fixup PR. This recurred on #1563/#1580
+      # (merged red-`lint` on green `check`) → #1581; tracked as GH #1592.
+      - name: Check formatting
+        working-directory: backend
+        run: cargo fmt --all -- --check
+
       # check-rls-enforcement.sh is ripgrep-based and now hard-fails when rg
       # is missing — without this install the gate was a silent no-op for the
       # entire life of the repo (every `rg … || true` swallowed exit 127 and


### PR DESCRIPTION
`cargo fmt --all -- --check` ran only in the **non-blocking `lint`** job, so PRs merged into `dev` on a green required `check` while `lint` was red — non-rustfmt-clean code reached `dev` twice (#1563/#1580) and needed the #1581 fixup. This adds the same fmt check as a step in the **required `check` job**, so a formatting violation blocks merge.

- Fast-fails early (right after the Cargo cache, before the heavier RLS/clippy/check steps).
- `lint` keeps its own fmt+clippy for parallel signal; this just makes the gate binding.
- `dev` is already fmt-clean (post-#1581), so `check` stays green — this PR's own `check` run exercises the new step.

Closes the recurring red-`lint`-on-green-`check` class (cf. #1538 for the analogous `test`-not-required gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)