### PR TITLE
refactor(mobile): single source of truth for folder-tree flatten utils (#1589 finding 2)

### DIFF
--- a/frontend/apps/mobile/src/screens/documents/MoveDocumentSheet.tsx
+++ b/frontend/apps/mobile/src/screens/documents/MoveDocumentSheet.tsx
@@ -36,6 +36,7 @@ import {
 import { useApiMutation } from '../../hooks/useApi';
 import { type ApiFolderTreeNode, FOLDER_TREE_QUERY_KEY } from '../../hooks/useFolderTree';
 import { colors } from '../shared/screenStyles';
+import { type FlatFolder, flattenTree } from './folderTree';
 
 // ─── API types ────────────────────────────────────────────────────────────────
 
@@ -43,31 +44,10 @@ interface MoveDocumentRequest {
   folder_id: string | null;
 }
 
-// ─── Flatten tree to a depth-first list for the scrollable folder picker ─────────
-
-/** Shape of a depth-first flattened folder entry. Exported for unit tests. */
-export interface FlatFolder {
-  id: string;
-  name: string;
-  depth: number;
-}
-
-/**
- * Depth-first flatten of the folder tree into a scrollable list. Each node
- * gets a `depth` field used for visual indentation in the picker.
- *
- * Exported for unit-testing (feat-mobile-document-folder-organization).
- */
-export function flattenTree(nodes: ApiFolderTreeNode[], depth = 0): FlatFolder[] {
-  const result: FlatFolder[] = [];
-  for (const node of nodes) {
-    result.push({ id: node.id, name: node.name, depth });
-    if (node.children && node.children.length > 0) {
-      result.push(...flattenTree(node.children, depth + 1));
-    }
-  }
-  return result;
-}
+// `FlatFolder` + `flattenTree` now live in the shared `folderTree` util (single
+// source of truth, GH #1589). Re-exported here so existing `./MoveDocumentSheet`
+// importers (incl. DocumentFolderOrganization.test.ts) are unaffected.
+export { type FlatFolder, flattenTree };
 
 // ─── Props ─────────────────────────────────────────────────────────────────────────
 

--- a/frontend/apps/mobile/src/screens/documents/MoveFolderSheet.tsx
+++ b/frontend/apps/mobile/src/screens/documents/MoveFolderSheet.tsx
@@ -37,7 +37,7 @@ import { useApiMutation } from '../../hooks/useApi';
 import { FOLDER_TREE_QUERY_KEY } from '../../hooks/useFolderTree';
 import { colors } from '../shared/screenStyles';
 import type { ApiFolderTreeNode } from './DocumentsScreen';
-import type { FlatFolder } from './MoveDocumentSheet';
+import { collectDescendantIds, flattenTreeExcluding } from './folderTree';
 
 // ─── API types ────────────────────────────────────────────────────────────────
 
@@ -51,59 +51,11 @@ interface UpdateFolderResponse {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-/**
- * Collect all descendant folder ids of `targetId` within the tree (inclusive
- * of `targetId` itself). Used to exclude the subtree being moved from the
- * destination picker — prevents circular references on the client side before
- * the server validates them.
- *
- * Exported for unit-testing.
- */
-export function collectDescendantIds(nodes: ApiFolderTreeNode[], targetId: string): Set<string> {
-  const ids = new Set<string>();
-
-  function walk(current: ApiFolderTreeNode) {
-    ids.add(current.id);
-    for (const child of current.children ?? []) {
-      walk(child);
-    }
-  }
-
-  function findAndWalk(nodes: ApiFolderTreeNode[]): boolean {
-    for (const node of nodes) {
-      if (node.id === targetId) {
-        walk(node);
-        return true;
-      }
-      if (findAndWalk(node.children ?? [])) return true;
-    }
-    return false;
-  }
-
-  findAndWalk(nodes);
-  return ids;
-}
-
-/**
- * Flatten the full tree into a depth-first list, excluding the subtree rooted
- * at `excludeId` (which is the folder being moved — it cannot be its own
- * parent or a parent of its own ancestor).
- *
- * Exported for unit-testing.
- */
-export function flattenTreeExcluding(
-  nodes: ApiFolderTreeNode[],
-  excludeIds: Set<string>,
-  depth = 0
-): FlatFolder[] {
-  const result: FlatFolder[] = [];
-  for (const node of nodes) {
-    if (excludeIds.has(node.id)) continue;
-    result.push({ id: node.id, name: node.name, depth });
-    result.push(...flattenTreeExcluding(node.children ?? [], excludeIds, depth + 1));
-  }
-  return result;
-}
+// `collectDescendantIds` + `flattenTreeExcluding` now live in the shared
+// `folderTree` util (single source of truth, GH #1589). Re-exported here so
+// existing `./MoveFolderSheet` importers (incl. FolderManagement.test.ts) are
+// unaffected.
+export { collectDescendantIds, flattenTreeExcluding };
 
 // ─── Props ──────────────────────────────────────────────────────────────────────
 

--- a/frontend/apps/mobile/src/screens/documents/folderTree.ts
+++ b/frontend/apps/mobile/src/screens/documents/folderTree.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared folder-tree helpers for the document move/organization sheets.
+ *
+ * Single source of truth for the depth-first flatten used by both
+ * `MoveDocumentSheet` (whole tree) and `MoveFolderSheet` (tree minus the moving
+ * subtree). Previously each sheet carried its own near-identical flatten —
+ * `MoveFolderSheet`'s own test had to assert the two stayed in lock-step
+ * (GH #1589 finding 2). `flattenTree` now delegates to `flattenTreeExcluding`,
+ * so there is exactly one traversal to maintain.
+ */
+
+import type { ApiFolderTreeNode } from '../../hooks/useFolderTree';
+
+/** Shape of a depth-first flattened folder entry. */
+export interface FlatFolder {
+  id: string;
+  name: string;
+  depth: number;
+}
+
+/**
+ * Depth-first flatten of the folder tree into a scrollable list, skipping any
+ * node in `excludeIds` (and, implicitly, its subtree — children of a skipped
+ * node are never visited). Each entry carries a `depth` for indentation.
+ */
+export function flattenTreeExcluding(
+  nodes: ApiFolderTreeNode[],
+  excludeIds: ReadonlySet<string>,
+  depth = 0
+): FlatFolder[] {
+  const result: FlatFolder[] = [];
+  for (const node of nodes) {
+    if (excludeIds.has(node.id)) continue;
+    result.push({ id: node.id, name: node.name, depth });
+    result.push(...flattenTreeExcluding(node.children ?? [], excludeIds, depth + 1));
+  }
+  return result;
+}
+
+/** Shared empty exclusion set so `flattenTree` allocates nothing per call. */
+const NO_EXCLUSIONS: ReadonlySet<string> = new Set<string>();
+
+/**
+ * Depth-first flatten of the whole folder tree — `flattenTreeExcluding` with an
+ * empty exclusion set. Kept as a named helper for the common "no exclusions"
+ * call site.
+ */
+export function flattenTree(nodes: ApiFolderTreeNode[], depth = 0): FlatFolder[] {
+  return flattenTreeExcluding(nodes, NO_EXCLUSIONS, depth);
+}
+
+/**
+ * Collect `targetId` and all of its descendant ids — the subtree that must be
+ * excluded when moving a folder, since a folder cannot become its own parent or
+ * a child of one of its descendants.
+ */
+export function collectDescendantIds(nodes: ApiFolderTreeNode[], targetId: string): Set<string> {
+  const ids = new Set<string>();
+
+  function walk(current: ApiFolderTreeNode) {
+    ids.add(current.id);
+    for (const child of current.children ?? []) {
+      walk(child);
+    }
+  }
+
+  function findAndWalk(nodes: ApiFolderTreeNode[]): boolean {
+    for (const node of nodes) {
+      if (node.id === targetId) {
+        walk(node);
+        return true;
+      }
+      if (findAndWalk(node.children ?? [])) return true;
+    }
+    return false;
+  }
+
+  findAndWalk(nodes);
+  return ids;
+}


### PR DESCRIPTION
Follow-up to PR #1557's review (**finding 2**). `MoveDocumentSheet.flattenTree` and `MoveFolderSheet.flattenTreeExcluding` were two near-identical depth-first flattens kept in lock-step by hand (the PR's own test asserts `flattenTreeExcluding(tree, ∅)` deep-equals `flattenTree(tree)`).

Collapse to one shared `screens/documents/folderTree.ts` (`FlatFolder`, `flattenTreeExcluding`, `collectDescendantIds`, and `flattenTree` — which now delegates to `flattenTreeExcluding` with an empty exclusion set). Both sheets import for internal use and re-export the names, so existing importers (`DocumentFolderOrganization.test.ts`, `FolderManagement.test.ts`) are unchanged. No behavior change — verified via CI typecheck/biome + the existing util tests.

> **Does not resolve finding 1** (the "Root (top level)" move silent no-op) — that's a cross-stack backend + OpenAPI/client-regen change, [planned on the issue](https://github.com/martin-janci/property-management/issues/1589). #1589 stays open for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)