### PR TITLE
fix(faults): confirm delete + use closed_count + refresh stats on delete (closes #1588)

### DIFF
--- a/frontend/apps/ppt-web/src/features/faults/pages/FaultsPage.tsx
+++ b/frontend/apps/ppt-web/src/features/faults/pages/FaultsPage.tsx
@@ -30,6 +30,7 @@ interface FaultListParams {
 export interface FaultStatsSummary {
   total_count: number;
   open_count: number;
+  closed_count: number;
 }
 
 interface FaultsPageProps {
@@ -119,9 +120,7 @@ export function FaultsPage({
             <p className="text-sm text-gray-500">Open</p>
           </div>
           <div className="text-center">
-            <p className="text-2xl font-bold text-gray-400">
-              {stats.total_count - stats.open_count}
-            </p>
+            <p className="text-2xl font-bold text-gray-400">{stats.closed_count}</p>
             <p className="text-sm text-gray-500">Closed</p>
           </div>
         </div>

--- a/frontend/apps/ppt-web/src/routes/groups/faults.route.test.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/faults.route.test.tsx
@@ -17,7 +17,7 @@
 
 /// <reference types="vitest/globals" />
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Suspense } from 'react';
 import { MemoryRouter, Routes } from 'react-router-dom';
@@ -108,6 +108,10 @@ describe('FaultsPageRoute API wiring (gap-79-1)', () => {
     vi.clearAllMocks();
     // Default stats: no data (stats bar hidden).
     mockUseFaultStatistics.mockReturnValue({ data: undefined });
+    // Delete is now confirmation-gated (#1588 F1); default to "confirmed" so
+    // the existing happy-path delete test still exercises the mutation. Tests
+    // that need the dismissed case override this.
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
   });
 
   it('(a) does not show empty state while loading', async () => {
@@ -229,5 +233,49 @@ describe('FaultsPageRoute API wiring (gap-79-1)', () => {
     expect(statsBar).toBeInTheDocument();
     expect(statsBar).toHaveTextContent('42');
     expect(statsBar).toHaveTextContent('30');
+    // Closed renders the API's first-class closed_count (not total - open). #1588 F2
+    expect(statsBar).toHaveTextContent('12');
+  });
+
+  it('(g) Delete does NOT call mutateAsync when the confirmation is dismissed', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    mockUseFaults.mockReturnValue({
+      data: {
+        faults: [makeApiFault({ id: 'f-del', title: 'Broken pipe', status: 'new' })],
+        count: 1,
+      },
+      isLoading: false,
+      error: null,
+      refetch: noopRefetch,
+    });
+
+    renderFaultsRoute();
+    await screen.findByText('Broken pipe', {}, { timeout: 5000 });
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(window.confirm).toHaveBeenCalledTimes(1);
+    expect(mockDeleteFaultMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('(h) Delete shows an error toast when the mutation rejects', async () => {
+    mockDeleteFaultMutateAsync.mockRejectedValueOnce(new Error('boom'));
+    mockUseFaults.mockReturnValue({
+      data: {
+        faults: [makeApiFault({ id: 'f-del', title: 'Broken pipe', status: 'new' })],
+        count: 1,
+      },
+      isLoading: false,
+      error: null,
+      refetch: noopRefetch,
+    });
+
+    renderFaultsRoute();
+    await screen.findByText('Broken pipe', {}, { timeout: 5000 });
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(mockDeleteFaultMutateAsync).toHaveBeenCalledWith('f-del');
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    });
   });
 });

--- a/frontend/apps/ppt-web/src/routes/groups/faults.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/faults.tsx
@@ -233,6 +233,18 @@ function FaultsPageRoute() {
   const total = data?.count ?? 0;
 
   const handleDelete = async (id: string) => {
+    // Deleting a fault is destructive and irreversible — confirm first, matching
+    // the rest of the app's destructive actions (registry/news/accounting, and
+    // FaultDetailPage's own confirm). #1588 F1.
+    if (
+      !window.confirm(
+        t('faults.confirmDelete', {
+          defaultValue: 'Delete this fault? This action cannot be undone.',
+        })
+      )
+    ) {
+      return;
+    }
     try {
       await deleteFault.mutateAsync(id);
       showToast({
@@ -273,7 +285,14 @@ function FaultsPageRoute() {
   );
 
   const stats = statsData
-    ? { total_count: statsData.total_count, open_count: statsData.open_count }
+    ? {
+        total_count: statsData.total_count,
+        open_count: statsData.open_count,
+        // Use the API's first-class closed_count rather than re-deriving
+        // total - open, so the figure can't silently break if open/closed
+        // partition semantics change (#1588 F2).
+        closed_count: statsData.closed_count,
+      }
     : undefined;
 
   return (

--- a/frontend/packages/api-client/src/faults/hooks.ts
+++ b/frontend/packages/api-client/src/faults/hooks.ts
@@ -124,6 +124,10 @@ export function useDeleteFault() {
     onSuccess: (_, faultId) => {
       queryClient.removeQueries({ queryKey: faultKeys.detail(faultId) });
       queryClient.invalidateQueries({ queryKey: faultKeys.lists() });
+      // The Total/Open/Closed stats bar sits above the deletable list, so it
+      // must refresh after a delete too (#1588 F3). Prefix-invalidate every
+      // statistics query (any buildingId variant).
+      queryClient.invalidateQueries({ queryKey: [...faultKeys.all, 'statistics'] });
     },
   });
 }


### PR DESCRIPTION
Follow-up to PR #1555's review (gap-79-1). Four hardening items on `FaultsPage`:

- **F1 (UX/safety, medium):** the Delete button fired `mutateAsync` on a single click with **no guard** — destructive + irreversible, inconsistent with the rest of the app (registry/news/accounting + `FaultDetailPage` all confirm). Gated `handleDelete` behind `window.confirm` (i18n `faults.confirmDelete`).
- **F2 (maintainability):** render the API's first-class `closed_count` instead of re-deriving `total - open`, so the figure can't silently break if the open/closed partition changes. Threaded through `FaultStatsSummary`.
- **F3 (correctness):** `useDeleteFault` only invalidated `lists()` + removed the detail, so the Total/Open/Closed bar (directly above the list) went **stale after a delete**. Now prefix-invalidates the statistics queries on success.
- **F4 (tests):** `window.confirm` mocked `true` by default; added **(g)** delete NOT called when confirmation dismissed, **(h)** error-toast branch on rejection; **(f)** now asserts the closed figure renders.

Verified via CI typecheck/biome + the faults route vitest suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)