### PR TITLE
refactor(accounting): use queryKeys factory + drop console.log stub (#1522 finding 2)

### DIFF
--- a/frontend/apps/ppt-web/src/features/accounting/pages/AccountingInvoiceManagementPage.tsx
+++ b/frontend/apps/ppt-web/src/features/accounting/pages/AccountingInvoiceManagementPage.tsx
@@ -11,6 +11,7 @@ import {
 } from '@ppt/api-client';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
+import { queryKeys } from '../../../lib/queryKeys';
 import { AccountingInvoiceForm } from '../components/AccountingInvoiceForm';
 import { AccountingInvoiceList } from '../components/AccountingInvoiceList';
 import { useAccountingAuth } from '../hooks/useAccountingAuth';
@@ -21,7 +22,7 @@ export function AccountingInvoiceManagementPage() {
   const auth = useAccountingAuth();
 
   const { data: invoices, isLoading: invoicesLoading } = useQuery({
-    queryKey: ['accounting', 'invoices'],
+    queryKey: queryKeys.accounting.invoices(),
     queryFn: () => {
       if (!auth) throw new Error('Not authenticated');
       return invoicesApiList({
@@ -32,7 +33,7 @@ export function AccountingInvoiceManagementPage() {
   });
 
   const { data: contacts, isLoading: contactsLoading } = useQuery({
-    queryKey: ['accounting', 'contacts'],
+    queryKey: queryKeys.accounting.contacts(),
     queryFn: () => {
       if (!auth) throw new Error('Not authenticated');
       return contactsApiList({
@@ -53,7 +54,7 @@ export function AccountingInvoiceManagementPage() {
       });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['accounting', 'invoices'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.accounting.invoices() });
       setIsCreating(false);
     },
   });
@@ -67,7 +68,7 @@ export function AccountingInvoiceManagementPage() {
       });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['accounting', 'invoices'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.accounting.invoices() });
     },
   });
 
@@ -103,7 +104,11 @@ export function AccountingInvoiceManagementPage() {
         <AccountingInvoiceList
           invoices={invoices?.data || []}
           isLoading={isLoading}
-          onViewInvoice={(id) => console.log('View', id)}
+          onViewInvoice={() => {
+            // TODO(#1522): wire invoice-detail navigation once the detail route
+            // exists. Intentionally a no-op (not console.log) so nothing logs in
+            // production.
+          }}
           onDeleteInvoice={(id) => {
             if (confirm('Are you sure you want to delete this invoice?')) {
               deleteMutation.mutate(id);

--- a/frontend/apps/ppt-web/src/lib/queryKeys.ts
+++ b/frontend/apps/ppt-web/src/lib/queryKeys.ts
@@ -137,6 +137,15 @@ export interface FormSubmissionFilters extends PaginationParams {
  */
 export const queryKeys = {
   // ========================================================================
+  // Accounting (native accounting MVP — PAP-232)
+  // ========================================================================
+  accounting: {
+    all: ['accounting'] as const,
+    invoices: () => [...queryKeys.accounting.all, 'invoices'] as const,
+    contacts: () => [...queryKeys.accounting.all, 'contacts'] as const,
+  },
+
+  // ========================================================================
   // Announcements (UC-06)
   // ========================================================================
   announcements: {


### PR DESCRIPTION
Follow-up to PR #1454's review (**finding 2**, conventions). `AccountingInvoiceManagementPage` used ad-hoc inline query keys (`['accounting','invoices']` / `['accounting','contacts']`) rather than the `lib/queryKeys` factory mandated by `agents/react-web.md`, and shipped a `console.log('View', id)` stub view handler in merged code.

- Added an `accounting` namespace to `lib/queryKeys.ts` (`all`/`invoices`/`contacts`), used for the list queries + both invalidations (single source of truth for the keys).
- Replaced the `console.log` view handler with a no-op + `TODO(#1522)` so nothing logs in production until the invoice-detail route exists.

Conventions-only; keys are byte-identical (no behavior change). Verified via CI typecheck/biome.

> Addresses finding 2 only. Finding 1 (the `@hey-api` auth-interceptor centralization) is an app-wide-auth change tracked on the issue; #1522 stays open for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)