### PR TITLE
fix(documents): allow detaching a folder to root via PUT parent_id=null (closes #1589)

### DIFF
--- a/backend/crates/db/src/models/document.rs
+++ b/backend/crates/db/src/models/document.rs
@@ -124,11 +124,14 @@ pub struct CreateFolder {
 }
 
 /// Data for updating a folder.
+///
+/// `parent_id` is tri-state (#1589): `None` = leave unchanged, `Some(None)` =
+/// detach to root (set NULL), `Some(Some(id))` = move under `id`.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct UpdateFolder {
     pub name: Option<String>,
     pub description: Option<String>,
-    pub parent_id: Option<Uuid>,
+    pub parent_id: Option<Option<Uuid>>,
 }
 
 // ============================================================================

--- a/backend/crates/db/src/repositories/document.rs
+++ b/backend/crates/db/src/repositories/document.rs
@@ -236,7 +236,11 @@ impl DocumentRepository {
             SET
                 name = COALESCE($2, name),
                 description = COALESCE($3, description),
-                parent_id = COALESCE($4, parent_id),
+                -- parent_id is tri-state (#1589): $4 = "the field was provided",
+                -- $5 = the new value (NULL detaches to root). A plain
+                -- COALESCE($5, parent_id) could never set NULL, so a move to
+                -- root was silently ignored.
+                parent_id = CASE WHEN $4 THEN $5 ELSE parent_id END,
                 updated_at = NOW()
             WHERE id = $1 AND deleted_at IS NULL
             RETURNING *
@@ -245,7 +249,8 @@ impl DocumentRepository {
         .bind(id)
         .bind(&data.name)
         .bind(&data.description)
-        .bind(data.parent_id)
+        .bind(data.parent_id.is_some())
+        .bind(data.parent_id.flatten())
         .fetch_one(executor)
         .await
     }

--- a/backend/servers/api-server/src/routes/documents/core.rs
+++ b/backend/servers/api-server/src/routes/documents/core.rs
@@ -277,12 +277,31 @@ pub struct CreateFolderRequest {
     pub parent_id: Option<Uuid>,
 }
 
+/// Deserialize a field as a double `Option` so a handler can tell "absent"
+/// (`None`) apart from "explicitly null" (`Some(None)`) and "set to a value"
+/// (`Some(Some(v))`). Paired with `#[serde(default)]`, which yields `None` when
+/// the key is absent; when present (null OR a value) this runs and wraps the
+/// inner `Option` in `Some`. (#1589)
+fn double_option<'de, T, D>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: serde::Deserializer<'de>,
+{
+    Option::<T>::deserialize(deserializer).map(Some)
+}
+
 /// Request for updating a folder.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct UpdateFolderRequest {
     pub name: Option<String>,
     pub description: Option<String>,
-    pub parent_id: Option<Uuid>,
+    /// New parent folder. Omit to leave unchanged; send `null` to detach the
+    /// folder to the top level; send an id to move it under that folder. The
+    /// double-`Option` lets the handler distinguish absent from explicit-null
+    /// (#1589). The wire shape is unchanged (optional, nullable UUID).
+    #[serde(default, deserialize_with = "double_option")]
+    #[schema(value_type = Option<Uuid>, nullable)]
+    pub parent_id: Option<Option<Uuid>>,
 }
 
 /// Request for deleting a folder.

--- a/backend/servers/api-server/src/routes/documents/folders.rs
+++ b/backend/servers/api-server/src/routes/documents/folders.rs
@@ -329,8 +329,10 @@ async fn update_folder(
         }
     }
 
-    // Validate parent_id to prevent circular references
-    if let Some(new_parent_id) = req.parent_id {
+    // Validate parent_id to prevent circular references. Only a move under a
+    // concrete parent (Some(Some)) needs the check; Some(None) detaches to root
+    // and None leaves the parent unchanged (#1589).
+    if let Some(Some(new_parent_id)) = req.parent_id {
         // Cannot set a folder as its own parent
         if new_parent_id == id {
             return Err((

--- a/backend/servers/api-server/tests/document_folder_tests.rs
+++ b/backend/servers/api-server/tests/document_folder_tests.rs
@@ -1000,3 +1000,104 @@ async fn test_update_folder_into_descendant_is_rejected(pool: PgPool) {
         "rejected circular update must not mutate the folder's parent"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Move-to-root + tri-state parent_id — #1589 finding 1
+// ---------------------------------------------------------------------------
+
+/// PUT /folders/{id} with `{"parent_id": null}` must DETACH a nested folder to
+/// the top level. The old `parent_id = COALESCE($n, parent_id)` ignored an
+/// explicit null, so the move returned 200 while the folder stayed under its
+/// parent (a silent no-op). The tri-state fix makes null set parent_id = NULL.
+/// Fails-on-`dev` (the COALESCE leaves parent unchanged); passes with the fix.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn test_update_folder_move_to_root_detaches(pool: PgPool) {
+    let app = common::TestApp::new(pool.clone()).await;
+    let org = seed_org_f(&pool, "move-root").await;
+    let user = seed_user_f(&pool, "move-root-mgr").await;
+    common::seed_membership(&pool, org, user, "manager").await;
+    let token = mint_jwt_with_role(user, "manager");
+
+    let parent = seed_folder_f(&pool, org, None, "Parent", user).await;
+    let child = seed_folder_f(&pool, org, Some(parent), "Child", user).await;
+
+    let resp = app
+        .execute(
+            Request::builder()
+                .method(Method::PUT)
+                .uri(format!("/api/v1/documents/folders/{child}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .header("X-Tenant-ID", org.to_string())
+                .body(Body::from(r#"{"parent_id":null}"#))
+                .unwrap(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "move-to-root must return 200; got {} body: {}",
+        resp.status,
+        resp.text()
+    );
+
+    let parent_after: Option<Uuid> =
+        sqlx::query_scalar("SELECT parent_id FROM document_folders WHERE id = $1")
+            .bind(child)
+            .fetch_one(&pool)
+            .await
+            .expect("post-move parent check");
+    assert_eq!(
+        parent_after, None,
+        "child must be detached to root (parent_id IS NULL), not silently left \
+         under its parent (#1589)"
+    );
+}
+
+/// Guards the tri-state's "absent" arm: a name-only update must NOT touch
+/// parent_id (the COALESCE→CASE change must not regress this).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn test_update_folder_name_only_preserves_parent(pool: PgPool) {
+    let app = common::TestApp::new(pool.clone()).await;
+    let org = seed_org_f(&pool, "name-only").await;
+    let user = seed_user_f(&pool, "name-only-mgr").await;
+    common::seed_membership(&pool, org, user, "manager").await;
+    let token = mint_jwt_with_role(user, "manager");
+
+    let parent = seed_folder_f(&pool, org, None, "Parent2", user).await;
+    let child = seed_folder_f(&pool, org, Some(parent), "Child2", user).await;
+
+    let resp = app
+        .execute(
+            Request::builder()
+                .method(Method::PUT)
+                .uri(format!("/api/v1/documents/folders/{child}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .header("X-Tenant-ID", org.to_string())
+                .body(Body::from(r#"{"name":"Renamed"}"#))
+                .unwrap(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "name-only update must return 200; got {} body: {}",
+        resp.status,
+        resp.text()
+    );
+
+    let parent_after: Option<Uuid> =
+        sqlx::query_scalar("SELECT parent_id FROM document_folders WHERE id = $1")
+            .bind(child)
+            .fetch_one(&pool)
+            .await
+            .expect("post-rename parent check");
+    assert_eq!(
+        parent_after,
+        Some(parent),
+        "a name-only update must leave parent_id unchanged (absent != null)"
+    );
+}


### PR DESCRIPTION
Follow-up to PR #1557's review (**finding 1, HIGH**). Moving a nested folder to the top level (`PUT /api/v1/documents/folders/{id}` with `{"parent_id": null}`) was a **silent no-op**: `update_folder_rls` used `parent_id = COALESCE($n, parent_id)`, so an explicit `null` resolved to the existing parent — the folder was never detached, yet the request returned 200 and the mobile `MoveFolderSheet` closed as if it succeeded.

Makes `parent_id` **tri-state end-to-end without changing the wire contract** (still an optional, nullable UUID → **no TypeSpec/SDK regen**, and the existing client that already sends `{parent_id: null}` now works):
- `UpdateFolderRequest.parent_id: Option<Option<Uuid>>` via a small `double_option` deserializer (`#[serde(default)]` ⇒ `None` absent; `Some(None)` explicit null; `Some(Some(id))` a value). utoipa schema pinned to `Option<Uuid>` nullable via `#[schema(value_type)]` so the generated shape is unchanged.
- `UpdateFolder` model carries the same tri-state.
- `update_folder_rls`: `parent_id = CASE WHEN $4 THEN $5 ELSE parent_id END` ($4 = field provided, $5 = value/NULL) — a provided null detaches to root; an absent field leaves it unchanged.
- handler circular-ref guard only runs for a concrete parent (`Some(Some)`); root (`Some(None)`) needs no check.

**Tests:** `test_update_folder_move_to_root_detaches` asserts `parent_id IS NULL` after a null move (fails-on-`dev` under the old COALESCE); `test_update_folder_name_only_preserves_parent` guards the absent arm. Verified on the remote builder: **23/23**.

_(#1589 finding 2 — flatten-util dedup — landed in #1609.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)