### PR TITLE
feat-airbnb-integration-list-api-routes-backend: DB-backed Airbnb linked-listing list route

### DIFF
--- a/backend/crates/db/src/repositories/rental.rs
+++ b/backend/crates/db/src/repositories/rental.rs
@@ -2307,6 +2307,36 @@ impl RentalRepository {
         Ok(conn)
     }
 
+    /// List all stored Airbnb connections (linked listings) for an organisation.
+    ///
+    /// Coverage 83-1: this is the DB-backed read of the org's *stored* Airbnb
+    /// connection rows, as opposed to the live-proxied `/airbnb/listings` route
+    /// which calls the Airbnb Partner API through the stored token. It returns
+    /// every `platform = 'airbnb'` row for the org (active or not) so the
+    /// management UI can render the linked-listing list without any external
+    /// network round-trip — including org-level (nil `unit_id`) connections that
+    /// the `units`-joined `get_connections_for_org` summary would drop.
+    ///
+    /// Scoped to `organization_id = $1`; rows are returned newest-first.
+    pub async fn list_airbnb_connections(
+        &self,
+        org_id: Uuid,
+    ) -> Result<Vec<RentalPlatformConnection>, SqlxError> {
+        let connections =
+            sqlx::query_as::<_, RentalPlatformConnection>(sqlx::AssertSqlSafe(format!(
+                r#"
+            SELECT {PLATFORM_CONNECTION_COLUMNS} FROM rental_platform_connections
+            WHERE organization_id = $1 AND platform = 'airbnb'
+            ORDER BY created_at DESC
+            "#
+            )))
+            .bind(org_id)
+            .fetch_all(&self.pool)
+            .await?;
+
+        Ok(connections)
+    }
+
     /// Record an inbound Airbnb webhook delivery in the dedup ledger.
     ///
     /// Airbnb guarantees at-least-once delivery; this inserts the delivery's

--- a/backend/servers/api-server/src/routes/integrations/airbnb_connections.rs
+++ b/backend/servers/api-server/src/routes/integrations/airbnb_connections.rs
@@ -1,0 +1,202 @@
+//! Airbnb linked-listing read surface (Coverage 83-1).
+//!
+//! | Method | Path | Purpose |
+//! |--------|------|---------|
+//! | GET | `/organizations/{org_id}/airbnb/connections` | DB-backed list of the org's stored Airbnb connections (linked listings) |
+//!
+//! # Why this exists alongside `/airbnb/listings`
+//!
+//! The pre-existing `GET /airbnb/listings` route (in [`super::oauth`]) proxies
+//! the Airbnb Partner API through the org's stored OAuth token, auto-refreshing
+//! it as needed. That route requires a valid token plus outbound network access
+//! and answers `404` / `502` when the org is not connected or Airbnb is down.
+//!
+//! This route is the complementary *local* read: it returns the connection rows
+//! the system already stores for the org — the "linked listings" — without any
+//! external round-trip. It is the surface a management dashboard uses to render
+//! the list of linked listings and their last-sync / error state, even when the
+//! token is expired or Airbnb is unreachable.
+//!
+//! # Tenant scoping
+//!
+//! Every handler runs [`verify_org_access`] (membership IDOR guard, issue #765)
+//! before touching the repository, and the repository query is itself scoped to
+//! `organization_id = $1`. Secrets are never serialised: the response uses
+//! [`PlatformConnectionDetail`], the token-free DTO (issue #887 / #804).
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    routing::get,
+    Json, Router,
+};
+use db::models::rental::PlatformConnectionDetail;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use super::sync::{verify_org_access, OrgIdPath};
+use crate::state::AppState;
+use common::errors::ErrorResponse;
+
+// ==================== Types ====================
+
+/// Response body for the Airbnb linked-listing list.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AirbnbConnectionsResponse {
+    /// The org's stored Airbnb connections, newest-first. Token-free.
+    pub connections: Vec<PlatformConnectionDetail>,
+    /// Number of connections returned.
+    pub count: usize,
+}
+
+// ==================== Router ====================
+
+/// Airbnb linked-listing read sub-router.
+pub fn router() -> Router<AppState> {
+    Router::new().route(
+        "/organizations/{org_id}/airbnb/connections",
+        get(list_airbnb_connections),
+    )
+}
+
+// ==================== Handlers ====================
+
+/// List the organisation's stored Airbnb connections (linked listings).
+///
+/// Returns the DB-backed connection rows for `platform = 'airbnb'`, scoped to
+/// the path organisation. Unlike `/airbnb/listings`, this never calls the
+/// Airbnb API — so it succeeds (with an empty list) even when the org has no
+/// connection, the token is expired, or Airbnb is unreachable.
+#[utoipa::path(
+    get,
+    path = "/api/v1/integrations/organizations/{org_id}/airbnb/connections",
+    params(OrgIdPath),
+    responses(
+        (status = 200, description = "Stored Airbnb connections for the org", body = AirbnbConnectionsResponse),
+        (status = 403, description = "Caller is not a member of the organisation"),
+        (status = 500, description = "Internal server error")
+    ),
+    security(("bearer_auth" = [])),
+    tag = "Integrations - Airbnb"
+)]
+pub async fn list_airbnb_connections(
+    State(state): State<AppState>,
+    auth: api_core::AuthUser,
+    Path(path): Path<OrgIdPath>,
+) -> Result<Json<AirbnbConnectionsResponse>, (StatusCode, Json<ErrorResponse>)> {
+    tracing::info!(
+        user_id = %auth.user_id,
+        org_id = %path.org_id,
+        "Listing stored Airbnb connections"
+    );
+
+    // IDOR guard (issue #765): caller must belong to this org.
+    verify_org_access(&state, auth.user_id, path.org_id).await?;
+
+    let connections = state
+        .rental_repo
+        .list_airbnb_connections(path.org_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "Failed to list Airbnb connections");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(
+                    "DATABASE_ERROR",
+                    "Failed to list Airbnb connections",
+                )),
+            )
+        })?;
+
+    // Map to the token-free DTO so access/refresh tokens are never serialised.
+    let connections: Vec<PlatformConnectionDetail> = connections
+        .into_iter()
+        .map(PlatformConnectionDetail::from)
+        .collect();
+    let count = connections.len();
+
+    Ok(Json(AirbnbConnectionsResponse { connections, count }))
+}
+
+// ==================== Tests ====================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use db::models::rental::RentalPlatformConnection;
+    use uuid::Uuid;
+
+    fn sample_connection(with_token: bool) -> RentalPlatformConnection {
+        RentalPlatformConnection {
+            id: Uuid::new_v4(),
+            organization_id: Uuid::new_v4(),
+            unit_id: Uuid::nil(),
+            platform: "airbnb".to_string(),
+            access_token: if with_token {
+                Some("enc:secret".to_string())
+            } else {
+                None
+            },
+            refresh_token: if with_token {
+                Some("enc:refresh".to_string())
+            } else {
+                None
+            },
+            token_expires_at: None,
+            encrypted_token: None,
+            encrypted_refresh_token: None,
+            external_property_id: Some("LISTING-123".to_string()),
+            external_listing_url: Some("https://airbnb.com/rooms/123".to_string()),
+            is_active: true,
+            last_sync_at: Some(Utc::now()),
+            sync_error: None,
+            sync_calendar: true,
+            sync_interval_minutes: 15,
+            block_other_platforms: true,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn response_serializes_with_count_and_no_tokens() {
+        let detail = PlatformConnectionDetail::from(sample_connection(true));
+        let resp = AirbnbConnectionsResponse {
+            connections: vec![detail],
+            count: 1,
+        };
+
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["count"], 1);
+        assert_eq!(json["connections"][0]["platform"], "airbnb");
+        assert_eq!(
+            json["connections"][0]["external_property_id"],
+            "LISTING-123"
+        );
+        // is_connected is derived from token presence; the token itself must
+        // never appear in the serialised payload.
+        assert_eq!(json["connections"][0]["is_connected"], true);
+        assert!(json["connections"][0].get("access_token").is_none());
+        assert!(json["connections"][0].get("refresh_token").is_none());
+    }
+
+    #[test]
+    fn detail_marks_tokenless_connection_disconnected() {
+        let detail = PlatformConnectionDetail::from(sample_connection(false));
+        let json = serde_json::to_value(&detail).unwrap();
+        assert_eq!(json["is_connected"], false);
+        assert!(json.get("access_token").is_none());
+    }
+
+    #[test]
+    fn empty_response_serializes() {
+        let resp = AirbnbConnectionsResponse {
+            connections: vec![],
+            count: 0,
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["count"], 0);
+        assert!(json["connections"].as_array().unwrap().is_empty());
+    }
+}

--- a/backend/servers/api-server/src/routes/integrations/mod.rs
+++ b/backend/servers/api-server/src/routes/integrations/mod.rs
@@ -8,7 +8,9 @@
 //! | webhook | `webhook` | inbound webhook receivers (subscription CRUD unmounted, PAP-122) |
 //! | booking_channel | `booking_channel` | Booking.com listing push + conflict detection (Gap 83-2) |
 //! | token_rotation | `token_rotation` | Airbnb OAuth token refresh, rotation, revocation (Gap 83-1) |
+//! | airbnb_connections | `airbnb_connections` | DB-backed Airbnb linked-listing list (Coverage 83-1) |
 
+pub mod airbnb_connections;
 pub mod booking_channel;
 pub mod install;
 pub mod oauth;
@@ -34,4 +36,5 @@ pub fn router() -> Router<AppState> {
         .merge(webhook::router())
         .merge(booking_channel::router())
         .merge(token_rotation::router())
+        .merge(airbnb_connections::router())
 }

--- a/backend/servers/api-server/tests/airbnb_connections_routes_tests.rs
+++ b/backend/servers/api-server/tests/airbnb_connections_routes_tests.rs
@@ -1,0 +1,326 @@
+//! Integration tests for the Airbnb linked-listing list route (Coverage 83-1):
+//! `GET /api/v1/integrations/organizations/{org_id}/airbnb/connections`.
+//!
+//! # What is tested
+//!
+//! - Rejects unauthenticated requests (401/403).
+//! - IDOR guard: a caller who is NOT a member of the target org is rejected
+//!   with 403 before any DB read.
+//! - Returns 200 with an empty list when the org has no Airbnb connection
+//!   (unlike the live-proxy `/airbnb/listings`, which returns 404).
+//! - Returns the org's stored Airbnb connections, token-free, and is scoped to
+//!   the path org (rows for other orgs / other platforms are not leaked).
+//!
+//! These tests run fully offline — the route never calls the Airbnb API.
+
+#[allow(dead_code)]
+mod common;
+
+use axum::{
+    body::Body,
+    http::{header, Method, Request, StatusCode},
+};
+use chrono::{Duration, Utc};
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::Serialize;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{seed_membership, TestApp};
+
+// Must match `TestConfig::default().jwt_secret`.
+const JWT_SECRET: &str = "test-secret-key-that-is-at-least-64-characters-long-for-testing-purposes";
+
+/// Mirror of `api_core::extractors::auth::Claims`.
+#[derive(Serialize)]
+struct AccessClaims {
+    sub: Uuid,
+    exp: i64,
+    iat: i64,
+    token_type: String,
+    tenant_id: Option<Uuid>,
+    role: Option<String>,
+    email: String,
+    name: String,
+}
+
+fn mint_token(user_id: Uuid, tenant_id: Uuid) -> String {
+    let now = Utc::now();
+    let claims = AccessClaims {
+        sub: user_id,
+        iat: now.timestamp(),
+        exp: (now + Duration::hours(1)).timestamp(),
+        token_type: "access".to_string(),
+        tenant_id: Some(tenant_id),
+        role: Some("manager".to_string()),
+        email: "airbnb-conn-test@test.local".to_string(),
+        name: "Airbnb Conn Test".to_string(),
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(JWT_SECRET.as_bytes()),
+    )
+    .expect("mint access token")
+}
+
+// ---------------------------------------------------------------------------
+// Database fixtures
+// ---------------------------------------------------------------------------
+
+async fn seed_org(pool: &PgPool, tag: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active') RETURNING id
+        "#,
+    )
+    .bind(format!("Airbnb Conn Test Org {tag}"))
+    .bind(format!(
+        "airbnb-conn-test-{tag}-{}",
+        Uuid::new_v4().simple()
+    ))
+    .bind(format!("{tag}@airbnb-conn.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'hash', 'Airbnb Conn User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_building(pool: &PgPool, org_id: Uuid, tag: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO buildings (organization_id, street, city, postal_code, country)
+        VALUES ($1, $2, 'Bratislava', '81101', 'Slovakia') RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(format!("{tag} Street"))
+    .fetch_one(pool)
+    .await
+    .expect("seed building")
+}
+
+async fn seed_unit(pool: &PgPool, building_id: Uuid, designation: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO units (building_id, designation, floor)
+        VALUES ($1, $2, 1) RETURNING id
+        "#,
+    )
+    .bind(building_id)
+    .bind(designation)
+    .fetch_one(pool)
+    .await
+    .expect("seed unit")
+}
+
+/// Seed an Airbnb connection row for the given org/unit, returning its id.
+async fn seed_airbnb_connection(
+    pool: &PgPool,
+    org_id: Uuid,
+    unit_id: Uuid,
+    listing_id: &str,
+) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO rental_platform_connections (
+            organization_id, unit_id, platform,
+            access_token, external_property_id, is_active
+        )
+        VALUES ($1, $2, 'airbnb', 'test-plaintext-token', $3, true)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(unit_id)
+    .bind(listing_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed airbnb connection")
+}
+
+/// Seed a non-Airbnb (booking) connection so we can assert platform scoping.
+async fn seed_booking_connection(pool: &PgPool, org_id: Uuid, unit_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO rental_platform_connections (
+            organization_id, unit_id, platform,
+            access_token, external_property_id, is_active
+        )
+        VALUES ($1, $2, 'booking', 'booking-token', 'HOTEL-1', true)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(unit_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed booking connection")
+}
+
+// ---------------------------------------------------------------------------
+// Request helpers
+// ---------------------------------------------------------------------------
+
+fn authed_get(uri: &str, token: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::GET)
+        .uri(uri)
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn anon_get(uri: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::GET)
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn is_protected(status: StatusCode) -> bool {
+    matches!(
+        status,
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN | StatusCode::BAD_REQUEST
+    )
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+/// Unauthenticated GET must be rejected.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn connections_rejects_unauthenticated(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_id = seed_org(&pool, "cx-unauth").await;
+    let uri = format!("/api/v1/integrations/organizations/{org_id}/airbnb/connections");
+    let resp = app.execute(anon_get(&uri)).await;
+    assert!(
+        is_protected(resp.status),
+        "unauthenticated connections request must be rejected; got {}",
+        resp.status
+    );
+}
+
+/// Non-member caller must be rejected with 403 (IDOR guard fires before DB read).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn connections_idor_guard_rejects_non_member(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_a = seed_org(&pool, "cx-idor-a").await;
+    let org_b = seed_org(&pool, "cx-idor-b").await;
+    let user_b = seed_user(&pool, "cx-idor-b@test.local").await;
+    seed_membership(&pool, org_b, user_b, "manager").await;
+
+    let token_b = mint_token(user_b, org_b);
+    let uri = format!("/api/v1/integrations/organizations/{org_a}/airbnb/connections");
+    let resp = app.execute(authed_get(&uri, &token_b)).await;
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "non-member connections request must be 403; got {}: {}",
+        resp.status,
+        resp.text()
+    );
+}
+
+/// With no Airbnb connection, the route returns 200 + empty list (not 404).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn connections_returns_empty_list_when_none(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_id = seed_org(&pool, "cx-empty").await;
+    let user_id = seed_user(&pool, "cx-empty@test.local").await;
+    seed_membership(&pool, org_id, user_id, "manager").await;
+
+    let token = mint_token(user_id, org_id);
+    let uri = format!("/api/v1/integrations/organizations/{org_id}/airbnb/connections");
+    let resp = app.execute(authed_get(&uri, &token)).await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "empty connection list must return 200; got {}: {}",
+        resp.status,
+        resp.text()
+    );
+    let body: serde_json::Value = serde_json::from_str(&resp.text()).expect("parse body");
+    assert_eq!(body["count"], 0);
+    assert!(body["connections"].as_array().unwrap().is_empty());
+}
+
+/// Returns the org's stored Airbnb connections, token-free, scoped to the org
+/// and the airbnb platform (no leakage of other orgs / other platforms).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn connections_returns_org_scoped_airbnb_rows_without_tokens(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_id = seed_org(&pool, "cx-list").await;
+    let other_org = seed_org(&pool, "cx-list-other").await;
+    let user_id = seed_user(&pool, "cx-list@test.local").await;
+    seed_membership(&pool, org_id, user_id, "manager").await;
+
+    let building = seed_building(&pool, org_id, "Cx").await;
+    let unit1 = seed_unit(&pool, building, "A1").await;
+    let unit2 = seed_unit(&pool, building, "A2").await;
+    seed_airbnb_connection(&pool, org_id, unit1, "LISTING-1").await;
+    seed_airbnb_connection(&pool, org_id, unit2, "LISTING-2").await;
+    // Same org, different platform — must be excluded.
+    seed_booking_connection(&pool, org_id, unit1).await;
+    // Different org — must not leak even though caller could in theory enumerate.
+    let other_building = seed_building(&pool, other_org, "Other").await;
+    let other_unit = seed_unit(&pool, other_building, "B1").await;
+    seed_airbnb_connection(&pool, other_org, other_unit, "OTHER-LISTING").await;
+
+    let token = mint_token(user_id, org_id);
+    let uri = format!("/api/v1/integrations/organizations/{org_id}/airbnb/connections");
+    let resp = app.execute(authed_get(&uri, &token)).await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "connections list must return 200; got {}: {}",
+        resp.status,
+        resp.text()
+    );
+
+    let raw = resp.text();
+    let body: serde_json::Value = serde_json::from_str(&raw).expect("parse body");
+    assert_eq!(body["count"], 2, "only the org's 2 airbnb rows: {raw}");
+    let conns = body["connections"].as_array().unwrap();
+    assert_eq!(conns.len(), 2);
+
+    let listing_ids: Vec<&str> = conns
+        .iter()
+        .map(|c| c["external_property_id"].as_str().unwrap())
+        .collect();
+    assert!(listing_ids.contains(&"LISTING-1"));
+    assert!(listing_ids.contains(&"LISTING-2"));
+    assert!(!listing_ids.contains(&"OTHER-LISTING"));
+
+    for c in conns {
+        assert_eq!(c["platform"], "airbnb");
+        assert_eq!(c["organization_id"], org_id.to_string());
+        // Secrets must never be serialised.
+        assert!(
+            c.get("access_token").is_none(),
+            "leaked access_token: {raw}"
+        );
+        assert!(
+            c.get("refresh_token").is_none(),
+            "leaked refresh_token: {raw}"
+        );
+        assert_eq!(c["is_connected"], true);
+    }
+}


### PR DESCRIPTION
## Task
Coverage 83-1 (gap): no /integrations/airbnb/* API routes exist beyond models. Add the read/list routes (connection status, linked-listing list) under the integrations surface with proper RLS/tenant scoping. Backend api-server; include route tests.

## Owner
pm-backend (specialist: rust-backend)

## Finding on task premise (read first)
The premise "no /integrations/airbnb/* API routes exist beyond models" is **stale**. The Airbnb surface already ships several read routes:
- `GET /integrations/organizations/{org_id}/airbnb/status` — connection status (aggregated counts, last sync, error) — `install.rs`
- `GET /integrations/organizations/{org_id}/airbnb/listings` — **live-proxied** listings via the Partner API (auto-refresh) — `oauth.rs`
- `GET /integrations/organizations/{org_id}/airbnb/reservations` — live-proxied reservations — `oauth.rs`
- plus connect / callback / token-exchange / token-revoke.

So "connection status" already exists. The genuine remaining gap is a **DB-backed linked-listing list**: the existing `/airbnb/listings` calls the external Airbnb API (needs a valid token + network; returns 404/502 when not connected), so there is no local read of the org's *stored* Airbnb connection rows. This PR adds exactly that.

## What changed
- New route: `GET /api/v1/integrations/organizations/{org_id}/airbnb/connections` — returns the org's stored Airbnb connections (linked listings), token-free, newest-first. Succeeds with an empty list when not connected (no external round-trip).
- New repo method `RentalRepository::list_airbnb_connections(org_id)` — scoped to `organization_id = $1 AND platform = 'airbnb'`; includes org-level (nil `unit_id`) rows that the `units`-joined `get_connections_for_org` summary drops.
- New module `routes/integrations/airbnb_connections.rs`, mounted in `integrations::router()`.
- Tenant scoping: `verify_org_access` IDOR guard (issue #765) before any DB read; query scoped by org. Secrets never serialised — response uses the token-free `PlatformConnectionDetail` DTO (issue #887 / #804).

## Tested (Band A — fast check)
- `SQLX_OFFLINE=true cargo check -p api-server` → exit 0
- `SQLX_OFFLINE=true cargo test -p api-server --lib airbnb_connections` → exit 0 (3 passed: token-free serialization, tokenless=disconnected, empty-list)
- `cargo fmt -p api-server -p db` → exit 0

## Built (Band B — full build)
- `SQLX_OFFLINE=true cargo clippy -p api-server -- -D warnings` → exit 0

Note: the `#[sqlx::test]` integration suite (`tests/airbnb_connections_routes_tests.rs`) covers unauthenticated rejection, the IDOR 403, the 200+empty-list path, and org+platform scoping (no cross-org / cross-platform leakage, no token leakage). It requires a live Postgres and will run in CI; it was not executed on the DB-less dispatcher runner.

## CI parity (Band C — hot-path only)
skipped: read-only list route, no auth/billing/data-integrity mutation. RLS/tenant scoping is exercised by the integration suite above.

## Remote-tested
skipped

## Scope drift
none (`scope-check.sh --owner pm-backend` → exit 0)

## Code-reuse review
none (`reuse-grep.sh --specialist rust-backend` → exit 0). Reuses existing `verify_org_access`, `PlatformConnectionDetail`, and `PLATFORM_CONNECTION_COLUMNS`.

## Notes
- No migration touched — `rental_platform_connections` already exists.
- Reviewer decision point: if the intent was instead to make the *existing* `/airbnb/listings` also serve a DB fallback, say so and I'll fold that in; this PR deliberately adds a distinct local read rather than changing the live-proxy contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AbTJMvZGhHPJgBvT7pHFzL

---
_Generated by [Claude Code](https://claude.ai/code/session_01AbTJMvZGhHPJgBvT7pHFzL)_