### PR TITLE
test(mobile): pin useFolderTree wiring, not just the constant (closes #1590)

### DIFF
--- a/frontend/apps/mobile/src/hooks/useFolderTree.test.ts
+++ b/frontend/apps/mobile/src/hooks/useFolderTree.test.ts
@@ -5,15 +5,33 @@
  * key, the endpoint path, and a default staleTime. These tests verify:
  *
  *   1. FOLDER_TREE_QUERY_KEY is exported and has the expected shape.
- *   2. The `folderTree` convenience accessor defaults to [] when data is
- *      undefined (loading / error path).
- *   3. The hook forwards a non-default staleTime option to useApiQuery.
+ *   2. The hook actually *queries* under FOLDER_TREE_QUERY_KEY with the tree
+ *      endpoint and default staleTime — i.e. the constant is load-bearing, not
+ *      just a value that happens to match a literal (#1590).
+ *   3. Caller options are forwarded to useApiQuery (staleTime override etc.).
+ *   4. The `folderTree` convenience accessor defaults to [] when data is
+ *      undefined (loading / error path) and unwraps `data.tree` otherwise.
  *
- * We test the pure-function / constant parts directly; the network layer is
- * already covered by the useApiQuery contract tests elsewhere.
+ * useApiQuery is mocked, so `useFolderTree()` invokes no real React hooks and
+ * can be called directly — we deliberately avoid `@testing-library/react-native`
+ * / `renderHook`, which currently breaks every importing test via the
+ * `react-test-renderer` 19.2.0-vs-19.2.6 peer-dep mismatch (PR #918 finding #7).
  */
 
-import { FOLDER_TREE_QUERY_KEY } from './useFolderTree';
+import { useApiQuery } from './useApi';
+import { FOLDER_TREE_QUERY_KEY, useFolderTree } from './useFolderTree';
+
+jest.mock('./useApi', () => ({
+  useApiQuery: jest.fn(() => ({ data: undefined, isLoading: true })),
+}));
+
+const mockedUseApiQuery = useApiQuery as jest.Mock;
+const TREE_ENDPOINT = '/api/v1/documents/folders/tree';
+
+beforeEach(() => {
+  mockedUseApiQuery.mockClear();
+  mockedUseApiQuery.mockReturnValue({ data: undefined, isLoading: true });
+});
 
 // ─── FOLDER_TREE_QUERY_KEY ────────────────────────────────────────────────────
 
@@ -26,10 +44,69 @@ describe('FOLDER_TREE_QUERY_KEY', () => {
     });
   });
 
-  it('matches the canonical key used by DocumentsScreen', () => {
-    // DocumentsScreen hard-codes ['documents', 'folders', 'tree'] in its
-    // useApiQuery call. This test pins that string contract so a rename of
-    // either would be caught immediately.
+  it('has the canonical value documents/folders/tree', () => {
+    // FOLDER_TREE_QUERY_KEY is the single source of truth: useFolderTree()
+    // queries under it (asserted below) and the invalidation sites
+    // (MoveDocumentSheet, NewFolderSheet) invalidate it, so a rename of the
+    // constant propagates to every consumer automatically.
     expect(FOLDER_TREE_QUERY_KEY).toEqual(['documents', 'folders', 'tree']);
+  });
+});
+
+// ─── Wiring: the hook queries under the constant ──────────────────────────────
+
+describe('useFolderTree wiring', () => {
+  it('queries useApiQuery under FOLDER_TREE_QUERY_KEY with the tree endpoint + default staleTime', () => {
+    // This is the load-bearing assertion the constant pin-test alone cannot
+    // make: it would still pass if someone changed the hook's *actual* query
+    // key while leaving the exported constant alone.
+    useFolderTree();
+
+    expect(mockedUseApiQuery).toHaveBeenCalledTimes(1);
+    expect(mockedUseApiQuery).toHaveBeenCalledWith(
+      FOLDER_TREE_QUERY_KEY,
+      TREE_ENDPOINT,
+      expect.objectContaining({ staleTime: 60_000 })
+    );
+  });
+
+  it('forwards caller options (e.g. enabled) to useApiQuery without dropping the default staleTime', () => {
+    useFolderTree({ enabled: false });
+
+    expect(mockedUseApiQuery).toHaveBeenCalledWith(
+      FOLDER_TREE_QUERY_KEY,
+      TREE_ENDPOINT,
+      expect.objectContaining({ staleTime: 60_000, enabled: false })
+    );
+  });
+
+  it('lets a caller override the default staleTime', () => {
+    useFolderTree({ staleTime: 0 });
+
+    expect(mockedUseApiQuery).toHaveBeenCalledWith(
+      FOLDER_TREE_QUERY_KEY,
+      TREE_ENDPOINT,
+      expect.objectContaining({ staleTime: 0 })
+    );
+  });
+});
+
+// ─── folderTree accessor ──────────────────────────────────────────────────────
+
+describe('useFolderTree folderTree accessor', () => {
+  it('defaults to [] while data is undefined (loading / error)', () => {
+    const { folderTree } = useFolderTree();
+    expect(folderTree).toEqual([]);
+  });
+
+  it('unwraps data.tree when the query has resolved', () => {
+    mockedUseApiQuery.mockReturnValueOnce({
+      data: { tree: [{ id: '1', name: 'Root', document_count: 0 }] },
+      isLoading: false,
+    });
+
+    const { folderTree } = useFolderTree();
+    expect(folderTree).toHaveLength(1);
+    expect(folderTree[0]).toMatchObject({ id: '1', name: 'Root' });
   });
 });


### PR DESCRIPTION
Closes #1590 (post-merge review follow-up of PR #1582).

### Problem
The pin-test in `useFolderTree.test.ts` only asserted `FOLDER_TREE_QUERY_KEY` against a freshly-written literal. That passes even if someone changes the hook's **actual** `useApiQuery` query key while leaving the exported constant alone — so it pinned the value, not the wiring. The "counts update after move/create" behavior depends on the consumer (`DocumentsScreen` → `useFolderTree()`) and the invalidation sites (`MoveDocumentSheet`, `NewFolderSheet`) sharing one key, and nothing tested that.

### Change
- New `useFolderTree wiring` suite mocks `useApiQuery` and asserts the hook **queries under `FOLDER_TREE_QUERY_KEY`** with the `/api/v1/documents/folders/tree` endpoint + default `staleTime: 60_000`, that caller options are forwarded, and that `staleTime` is overridable.
- `folderTree` accessor tests (`[]` while loading; unwraps `data.tree`).
- Fixed the **stale comment** that described the pre-#1582 state (`DocumentsScreen hard-codes …`) — the constant is now the single source of truth.

### Why not `renderHook` + a real invalidate→refetch round trip?
`@testing-library/react-native` / `renderHook` currently break every importing test via the `react-test-renderer` 19.2.0-vs-19.2.6 peer-dep mismatch (PR #918 finding #7). Since `useFolderTree` invokes no real React hooks once `useApiQuery` is mocked, calling it as a plain function pins the wiring without rendering React — the achievable equivalent.

Verified on the remote builder: `pnpm jest src/hooks/useFolderTree.test.ts` → **7/7 pass**, biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)