### PR TITLE
fix(mobile-native): close infinite-scroll in-flight double-fetch race + pin transition (closes #1533)

### DIFF
--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/search/SearchScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/search/SearchScreen.kt
@@ -130,9 +130,17 @@ fun SearchScreen(
         }
         val generation = searchGeneration[0].toLong()
 
+        // Flip the in-flight flag SYNCHRONOUSLY on the calling/collecting thread, before the
+        // fetch is launched. The infinite-scroll trigger snapshots `isLoading` on every emission
+        // (see the nextPageTriggerFlow LaunchedEffect below); if this flip lived only inside the
+        // launched coroutine body, two bottom-of-list emissions arriving back-to-back could both
+        // observe isLoading=false and re-emit the same next page — double-fetching, and for
+        // page > 1 (which reuses the search generation, so shouldApplyResponse can't discard the
+        // duplicate) double-appending via mergePage. Setting it here closes that window. (#1533)
+        isLoading = true
+
         searchJob[0] =
             scope.launch {
-                isLoading = true
                 errorMessage = null
 
                 val request =

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/SearchStateTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/SearchStateTest.kt
@@ -327,6 +327,29 @@ class SearchStateTest {
         assertEquals(listOf(3), secondFlow.toList())
     }
 
+    @Test
+    fun nextPageTriggerFlow_inFlightSnapshotSuppressesDuplicateFetch() = runTest {
+        // In-flight-guard transition WITHIN a single collection — the gap the other cases miss:
+        // they each use a constant snapshot, so none exercise isLoading flipping *between*
+        // emissions of one flow, which is exactly the runtime contract that prevents a double
+        // page-2 fetch on rapid scroll. Two threshold-crossing indices (16 then 17) arrive
+        // back-to-back; the first fires page 2 and the screen flips isLoading=true synchronously
+        // when it dispatches that fetch (SearchScreen.performSearch, #1533), so the second index
+        // must observe a load in flight and emit nothing.
+        var snap = pageSnapshot(loadedCount = 20, total = 100, currentPage = 1)
+        val indices =
+            flow<Int?> {
+                emit(16)
+                // Screen flipped isLoading synchronously when page 2 was dispatched downstream.
+                snap = snap.copy(isLoading = true)
+                emit(17)
+            }
+
+        // Exactly one fetch — the in-flight snapshot on the second emission suppresses the dup.
+        val pages = SearchState.nextPageTriggerFlow(indices, snapshot = { snap }).toList()
+        assertEquals(listOf(2), pages)
+    }
+
     private fun pageSnapshot(
         loadedCount: Int,
         total: Int,


### PR DESCRIPTION
Closes #1533 (post-merge review follow-up of PR #1447).

### Finding 1 — latent double-fetch race (fixed)
`SearchScreen.performSearch(page)` set `isLoading = true` **inside** `scope.launch { … }` (async). The infinite-scroll trigger snapshots `isLoading` on every bottom-of-list emission and fires `currentPage + 1` when no load is in flight. Two threshold crossings arriving back-to-back before the launched body flipped the flag could both see `isLoading = false` → re-emit the same page → duplicate fetch. For `page > 1` those appends reuse the search generation (so `shouldApplyResponse` can't discard them) and both `mergePage(page = N)` → **duplicated rows**.

**Fix:** flip `isLoading = true` **synchronously** on the collecting thread, before `scope.launch`. Emissions are collected sequentially on the main dispatcher, so the next emission's snapshot observes the in-flight load and `shouldLoadNextPage` suppresses the duplicate at the root — no duplicate emission, hence no double-append. (This closes the window that made the `page > 1` no-stale-guard gap reachable.)

### Finding 2 — test gap (fixed)
The 7 existing `nextPageTriggerFlow` cases each use a *constant* snapshot, so none exercise `isLoading` flipping **between** emissions of one flow. Added `nextPageTriggerFlow_inFlightSnapshotSuppressesDuplicateFetchWithinOneCollection`: two crossings in a single collection over a mutable snapshot that flips `isLoading` after the first, asserting exactly one page-2 fetch — pinning the single-fetch-per-boundary contract end-to-end.

### Finding 3 — iOS divergence (informational)
`iosApp/.../SearchView.swift` still inlines its own trigger (it already has a `!isLoadingMore` in-flight guard) and doesn't consume the shared `nextPageTriggerFlow`. Left for a separate convergence story.

Verification: KMP can't build on the remote builder; **`mobile-native.yml` (Gradle build + unit tests) is the verification authority** — this PR is gated on it being green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)