### PR TITLE
feat(reality-server): in-app delivery for saved-search alerts (#983 story 16.3)

### DIFF
--- a/backend/crates/db/src/models/mod.rs
+++ b/backend/crates/db/src/models/mod.rs
@@ -471,8 +471,8 @@ pub use reality_portal::{
     ListingPriceHistory, PortalFavorite, PortalFavoriteWithListing, PortalImportJob,
     PortalImportJobWithStats, PortalSavedSearch, PriceChangeAlert, PublicRealtorProfile,
     RealityAgency, RealityAgencyInvitation, RealityAgencyMember, RealityFeedSubscription,
-    RealtorListing, RealtorProfile, ScheduleViewing, SearchAlertQueueEntry, SendInquiryMessage,
-    UpdateAgencyBranding, UpdateCrmConnection, UpdateFeedSubscription,
+    RealtorListing, RealtorProfile, SavedSearchAlert, ScheduleViewing, SearchAlertQueueEntry,
+    SendInquiryMessage, UpdateAgencyBranding, UpdateCrmConnection, UpdateFeedSubscription,
     UpdateImportJob as UpdatePortalImportJob, UpdatePortalFavorite, UpdatePortalSavedSearch,
     UpdateRealityAgency, UpdateRealtorProfile, UpdateViewing, ViewingSchedule,
 };

--- a/backend/crates/db/src/models/reality_portal.rs
+++ b/backend/crates/db/src/models/reality_portal.rs
@@ -101,6 +101,27 @@ pub struct PortalSavedSearch {
     pub updated_at: DateTime<Utc>,
 }
 
+/// A queued saved-search alert as surfaced to the owning portal user — the
+/// in-app delivery view of a `search_alert_queue` row joined to its saved
+/// search's name (Story 16.3, issue #983). The background matching engine
+/// (`SavedSearchAlertWorker`) enqueues these; this is how the user retrieves
+/// them.
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize, ToSchema)]
+pub struct SavedSearchAlert {
+    pub id: Uuid,
+    pub saved_search_id: Uuid,
+    /// Name of the saved search that produced the alert (joined).
+    pub saved_search_name: String,
+    /// Listings that newly matched the saved search.
+    pub matching_listing_ids: Vec<Uuid>,
+    /// `new_listing` (today); `price_change` is reserved for the favorites path.
+    pub alert_type: String,
+    /// `pending` (undelivered) | `sent` (read) | `failed`.
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+    pub processed_at: Option<DateTime<Utc>>,
+}
+
 /// Create portal saved search.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct CreatePortalSavedSearch {

--- a/backend/crates/db/src/repositories/reality_portal.rs
+++ b/backend/crates/db/src/repositories/reality_portal.rs
@@ -158,6 +158,89 @@ impl RealityPortalRepository {
         Ok(())
     }
 
+    // ------------------------------------------------------------------------
+    // Saved-search alert delivery (in-app feed for the matching engine above).
+    //
+    // `search_alert_queue` is app-scoped by `user_id` (not RLS-gated), so these
+    // run on the request-path pool and scope every statement by the owning user
+    // — a portal user can only read/ack their own alerts (no IDOR).
+    // ------------------------------------------------------------------------
+
+    /// A portal user's saved-search alerts, newest first, each joined to the
+    /// originating saved search's name.
+    pub async fn get_search_alerts(
+        &self,
+        user_id: Uuid,
+        limit: i64,
+    ) -> Result<Vec<SavedSearchAlert>, SqlxError> {
+        sqlx::query_as::<_, SavedSearchAlert>(
+            r#"
+            SELECT
+                q.id,
+                q.saved_search_id,
+                s.name AS saved_search_name,
+                q.matching_listing_ids,
+                q.alert_type,
+                q.status,
+                q.created_at,
+                q.processed_at
+            FROM search_alert_queue q
+            JOIN portal_saved_searches s ON s.id = q.saved_search_id
+            WHERE q.user_id = $1
+            ORDER BY q.created_at DESC
+            LIMIT $2
+            "#,
+        )
+        .bind(user_id)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    /// Count a user's undelivered (`pending`) alerts — for an unread badge.
+    pub async fn count_pending_search_alerts(&self, user_id: Uuid) -> Result<i64, SqlxError> {
+        sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM search_alert_queue WHERE user_id = $1 AND status = 'pending'",
+        )
+        .bind(user_id)
+        .fetch_one(&self.pool)
+        .await
+    }
+
+    /// Mark one alert delivered (`pending` → `sent`), scoped to the owner.
+    /// Returns `true` when a row was updated (owned and still pending); `false`
+    /// when not found / owned by another user — the route returns 404, so a
+    /// cross-user id is indistinguishable from "not found" (no IDOR).
+    pub async fn mark_search_alert_read(&self, id: Uuid, user_id: Uuid) -> Result<bool, SqlxError> {
+        let res = sqlx::query(
+            r#"
+            UPDATE search_alert_queue
+            SET status = 'sent', processed_at = NOW()
+            WHERE id = $1 AND user_id = $2 AND status = 'pending'
+            "#,
+        )
+        .bind(id)
+        .bind(user_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(res.rows_affected() > 0)
+    }
+
+    /// Mark all of a user's pending alerts delivered. Returns the count updated.
+    pub async fn mark_all_search_alerts_read(&self, user_id: Uuid) -> Result<u64, SqlxError> {
+        let res = sqlx::query(
+            r#"
+            UPDATE search_alert_queue
+            SET status = 'sent', processed_at = NOW()
+            WHERE user_id = $1 AND status = 'pending'
+            "#,
+        )
+        .bind(user_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(res.rows_affected())
+    }
+
     // ========================================================================
     // Portal Favorites (Story 31.1, 31.4)
     // ========================================================================

--- a/backend/crates/db/tests/search_alert_delivery_tests.rs
+++ b/backend/crates/db/tests/search_alert_delivery_tests.rs
@@ -1,0 +1,144 @@
+//! Saved-search alert *delivery* tests (Story 16.3, issue #983).
+//!
+//! The background matching engine (`SavedSearchAlertWorker`) enqueues
+//! `search_alert_queue` rows; these tests cover the in-app delivery surface that
+//! lets a portal user retrieve and acknowledge their alerts:
+//! `get_search_alerts` / `count_pending_search_alerts` /
+//! `mark_search_alert_read` / `mark_all_search_alerts_read`.
+//!
+//! Run against a live Postgres (sqlx spins up a per-test database):
+//! `DATABASE_URL=... cargo test -p db --test search_alert_delivery_tests`.
+
+use db::models::CreatePortalSavedSearch;
+use db::repositories::RealityPortalRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Seed a portal user and return its id. Portal users live in `users`
+/// (`principal_kind = 'public'`) since migration 00148 dropped `portal_users` and
+/// re-pointed `portal_saved_searches` / `search_alert_queue` at `users(id)`.
+async fn seed_portal_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'Alert Tester', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .unwrap_or_else(|e| panic!("seed_portal_user({email}): {e}"))
+}
+
+async fn seed_saved_search(repo: &RealityPortalRepository, user_id: Uuid, name: &str) -> Uuid {
+    repo.create_saved_search(
+        user_id,
+        CreatePortalSavedSearch {
+            name: name.to_string(),
+            criteria: serde_json::json!({ "city": "Bratislava" }),
+            alerts_enabled: true,
+            alert_frequency: "daily".to_string(),
+        },
+    )
+    .await
+    .expect("create saved search")
+    .id
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn search_alert_delivery_lifecycle(pool: PgPool) {
+    let repo = RealityPortalRepository::new(pool.clone());
+    let user = seed_portal_user(&pool, "alerts-lifecycle@test.sk").await;
+    let search_id = seed_saved_search(&repo, user, "Bratislava flats").await;
+
+    let l1 = Uuid::new_v4();
+    let l2 = Uuid::new_v4();
+    repo.enqueue_search_alert(&pool, search_id, user, &[l1, l2], "new_listing")
+        .await
+        .expect("enqueue alert");
+
+    // List: one pending alert, joined to its search name, carrying the matches.
+    let alerts = repo
+        .get_search_alerts(user, 100)
+        .await
+        .expect("list alerts");
+    assert_eq!(alerts.len(), 1, "expected exactly one alert");
+    let alert = &alerts[0];
+    assert_eq!(alert.saved_search_name, "Bratislava flats");
+    assert_eq!(alert.matching_listing_ids, vec![l1, l2]);
+    assert_eq!(alert.alert_type, "new_listing");
+    assert_eq!(alert.status, "pending");
+    assert!(alert.processed_at.is_none());
+    assert_eq!(
+        repo.count_pending_search_alerts(user).await.unwrap(),
+        1,
+        "one unread alert"
+    );
+
+    // Acknowledge it: pending -> sent.
+    assert!(
+        repo.mark_search_alert_read(alert.id, user).await.unwrap(),
+        "marking an owned pending alert returns true"
+    );
+    assert_eq!(
+        repo.count_pending_search_alerts(user).await.unwrap(),
+        0,
+        "no unread alerts after ack"
+    );
+    let after = repo.get_search_alerts(user, 100).await.unwrap();
+    assert_eq!(after[0].status, "sent");
+    assert!(after[0].processed_at.is_some());
+
+    // Idempotent: a second ack of an already-sent alert reports no change.
+    assert!(
+        !repo.mark_search_alert_read(alert.id, user).await.unwrap(),
+        "re-acking an already-sent alert returns false"
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn search_alert_read_is_owner_scoped(pool: PgPool) {
+    let repo = RealityPortalRepository::new(pool.clone());
+    let owner = seed_portal_user(&pool, "alerts-owner@test.sk").await;
+    let attacker = seed_portal_user(&pool, "alerts-attacker@test.sk").await;
+    let search_id = seed_saved_search(&repo, owner, "Owner search").await;
+    repo.enqueue_search_alert(&pool, search_id, owner, &[Uuid::new_v4()], "new_listing")
+        .await
+        .expect("enqueue alert");
+    let alert_id = repo.get_search_alerts(owner, 100).await.unwrap()[0].id;
+
+    // The attacker cannot ack the owner's alert (no IDOR) and sees none of it.
+    assert!(
+        !repo
+            .mark_search_alert_read(alert_id, attacker)
+            .await
+            .unwrap(),
+        "a non-owner must not be able to mark another user's alert read"
+    );
+    assert!(
+        repo.get_search_alerts(attacker, 100)
+            .await
+            .unwrap()
+            .is_empty(),
+        "a user only sees their own alerts"
+    );
+    assert_eq!(
+        repo.count_pending_search_alerts(owner).await.unwrap(),
+        1,
+        "the owner's alert is still pending after the failed cross-user ack"
+    );
+
+    // mark-all is owner-scoped too.
+    assert_eq!(
+        repo.mark_all_search_alerts_read(attacker).await.unwrap(),
+        0,
+        "mark-all touches nothing for a user with no alerts"
+    );
+    assert_eq!(
+        repo.mark_all_search_alerts_read(owner).await.unwrap(),
+        1,
+        "mark-all clears the owner's pending alert"
+    );
+    assert_eq!(repo.count_pending_search_alerts(owner).await.unwrap(), 0);
+}

--- a/backend/servers/reality-server/src/routes/saved_searches.rs
+++ b/backend/servers/reality-server/src/routes/saved_searches.rs
@@ -10,7 +10,8 @@ use axum::{
     Json, Router,
 };
 use db::models::{
-    CreatePortalSavedSearch, PortalSavedSearch, PublicListingSummary, UpdatePortalSavedSearch,
+    CreatePortalSavedSearch, PortalSavedSearch, PublicListingSummary, SavedSearchAlert,
+    UpdatePortalSavedSearch,
 };
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -21,6 +22,11 @@ pub fn router() -> Router<AppState> {
     Router::new()
         .route("/", get(list_saved_searches))
         .route("/", post(create_saved_search))
+        // Alert delivery (#983) — registered before the `/{id}` params; matchit
+        // prioritises the static `alerts` segment, but keep them adjacent for clarity.
+        .route("/alerts", get(list_search_alerts))
+        .route("/alerts/read-all", post(mark_all_alerts_read))
+        .route("/alerts/{alert_id}/read", post(mark_alert_read))
         .route("/{id}", get(get_saved_search))
         .route("/{id}", put(update_saved_search))
         .route("/{id}", delete(delete_saved_search))
@@ -247,4 +253,113 @@ pub async fn run_saved_search(
         count,
         listings: results,
     }))
+}
+
+// ============================================================================
+// Saved-search alert delivery (Story 16.3, issue #983)
+//
+// The background `SavedSearchAlertWorker` matches alert-enabled saved searches
+// against newly published listings and enqueues `search_alert_queue` rows. These
+// endpoints are the in-app delivery surface: the user lists their alerts and acks
+// them. (reality-server has no email transport; in-app is the delivery channel.)
+// ============================================================================
+
+/// Saved-search alerts list response.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct SearchAlertsResponse {
+    pub alerts: Vec<SavedSearchAlert>,
+    /// Number of still-undelivered (`pending`) alerts — drives an unread badge.
+    pub unread_count: i64,
+}
+
+/// Mark-all-read response.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct MarkAllAlertsReadResponse {
+    pub marked_read: u64,
+}
+
+/// List the authenticated user's saved-search alerts (newest first).
+#[utoipa::path(
+    get,
+    path = "/api/v1/saved-searches/alerts",
+    tag = "SavedSearches",
+    responses(
+        (status = 200, description = "Saved-search alerts", body = SearchAlertsResponse),
+        (status = 401, description = "Unauthorized")
+    )
+)]
+pub async fn list_search_alerts(
+    State(state): State<AppState>,
+    principal: RequestPrincipal,
+) -> Result<Json<SearchAlertsResponse>, (axum::http::StatusCode, String)> {
+    let (alerts, unread_count) = tokio::try_join!(
+        state
+            .reality_portal_repo
+            .get_search_alerts(principal.user_id, 100),
+        state
+            .reality_portal_repo
+            .count_pending_search_alerts(principal.user_id),
+    )
+    .map_err(|e| crate::util::errors::db_error("list search alerts", e))?;
+
+    Ok(Json(SearchAlertsResponse {
+        alerts,
+        unread_count,
+    }))
+}
+
+/// Mark a single saved-search alert as read (delivered).
+#[utoipa::path(
+    post,
+    path = "/api/v1/saved-searches/alerts/{alert_id}/read",
+    tag = "SavedSearches",
+    params(("alert_id" = Uuid, Path, description = "Alert queue ID")),
+    responses(
+        (status = 204, description = "Alert marked read"),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Alert not found")
+    )
+)]
+pub async fn mark_alert_read(
+    State(state): State<AppState>,
+    principal: RequestPrincipal,
+    Path(alert_id): Path<Uuid>,
+) -> Result<axum::http::StatusCode, (axum::http::StatusCode, String)> {
+    let marked = state
+        .reality_portal_repo
+        .mark_search_alert_read(alert_id, principal.user_id)
+        .await
+        .map_err(|e| crate::util::errors::db_error("mark alert read", e))?;
+
+    if marked {
+        Ok(axum::http::StatusCode::NO_CONTENT)
+    } else {
+        Err((
+            axum::http::StatusCode::NOT_FOUND,
+            "Alert not found".to_string(),
+        ))
+    }
+}
+
+/// Mark all of the authenticated user's pending alerts as read.
+#[utoipa::path(
+    post,
+    path = "/api/v1/saved-searches/alerts/read-all",
+    tag = "SavedSearches",
+    responses(
+        (status = 200, description = "Pending alerts marked read", body = MarkAllAlertsReadResponse),
+        (status = 401, description = "Unauthorized")
+    )
+)]
+pub async fn mark_all_alerts_read(
+    State(state): State<AppState>,
+    principal: RequestPrincipal,
+) -> Result<Json<MarkAllAlertsReadResponse>, (axum::http::StatusCode, String)> {
+    let marked_read = state
+        .reality_portal_repo
+        .mark_all_search_alerts_read(principal.user_id)
+        .await
+        .map_err(|e| crate::util::errors::db_error("mark all alerts read", e))?;
+
+    Ok(Json(MarkAllAlertsReadResponse { marked_read }))
 }

--- a/backend/servers/reality-server/src/services/saved_search_alerts.rs
+++ b/backend/servers/reality-server/src/services/saved_search_alerts.rs
@@ -16,11 +16,13 @@
 //! On a search's first sighting (no watermark) it only sets the watermark — it
 //! does not alert on the entire back-catalogue.
 //!
-//! Out of scope (documented follow-ups, blocked on missing infrastructure):
-//! - **Delivery**: turning queued `search_alert_queue` rows into emails/in-app
-//!   notifications. reality-server has no notification/email transport today;
-//!   delivery needs either a cross-server call to api-server's notification
-//!   pipeline or a dedicated drainer. The queue is the hand-off point.
+//! Delivery (#983): queued rows are surfaced to the owning portal user as an
+//! in-app feed via `GET /api/v1/saved-searches/alerts` (+ `…/{id}/read` and
+//! `…/read-all`) — see `routes::saved_searches`. reality-server has no email
+//! transport, so in-app pull is the delivery channel; an email/push drainer off
+//! the same queue remains a future follow-up.
+//!
+//! Out of scope (documented follow-up, blocked on a privilege decision):
 //! - **Favorite price-drop alerts (16.2)**: `portal_favorites` and
 //!   `listing_price_history` are `FORCE ROW LEVEL SECURITY` org-isolated, so a
 //!   context-less worker reads nothing; that half needs per-org / super-admin


### PR DESCRIPTION
Part of #983 (Epic 16 gap-sweep). Completes the **saved-search alert** half of story 16.3 ("new listing matches your search → you're notified") end-to-end.

### Context
The matching engine already exists: `SavedSearchAlertWorker` matches alert-enabled saved searches against newly published listings and enqueues `search_alert_queue` rows. But nothing let a portal user **retrieve** them — the worker's own doc flagged delivery as the open hand-off (reality-server has no email transport). This adds the in-app delivery surface.

### Change
- **Repo** (`RealityPortalRepository`): `get_search_alerts` (newest-first, joined to the saved search's name), `count_pending_search_alerts`, `mark_search_alert_read` (pending→sent, owner-scoped), `mark_all_search_alerts_read`. `search_alert_queue` is app-scoped by `user_id` (not RLS-gated), so every statement scopes to the owner — a cross-user id reads/acks nothing (no IDOR).
- **Model**: `SavedSearchAlert` (queue row + joined search name; distinct from the existing on-demand `portal::SearchAlert`).
- **Routes** (`RequestPrincipal`-gated): `GET /api/v1/saved-searches/alerts`, `POST …/alerts/{alert_id}/read` (204/404), `POST …/alerts/read-all`.
- **Tests**: `search_alert_delivery_tests` — full lifecycle (enqueue → list → unread count → ack → sent) + owner-scoping (non-owner cannot ack/see another user's alert; mark-all is per-user).

Verified on the remote builder against a live Postgres: `clippy -D warnings` clean, `cargo fmt --check` clean, **2/2** delivery tests pass.

### Deferred (documented)
- **Favorite price-drop alerts (16.2)** — `portal_favorites` / `listing_price_history` are FORCE-RLS org-isolated; a background worker reading them cross-org needs a deliberate super-admin/privilege decision. (Favorite price changes are already available **on demand** via `get_price_change_alerts`.)
- An **email/push drainer** off the same queue — future follow-up once a transport exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)