### PR TITLE
refactor(ppt-web): adopt generated accounting SDK in payment-matching data layer

### DIFF
--- a/frontend/apps/ppt-web/src/features/accounting/api/paymentMatching.test.ts
+++ b/frontend/apps/ppt-web/src/features/accounting/api/paymentMatching.test.ts
@@ -1,8 +1,10 @@
 /**
- * Tests for the payment-matching data layer (#1521).
+ * Tests for the payment-matching data layer (#1521 / #1623).
  *
- * The headline regression: the upload must authenticate from the shared token /
- * active-org providers (api-server, real session) — not the never-written
+ * Reads/decisions now delegate to the generated `@ppt/api-client` functions (the
+ * accounting endpoints are modelled in TypeSpec), so those are mocked here. The
+ * headline regression remains the upload: it must authenticate from the shared
+ * token / active-org providers (real session) — not the never-written
  * `auth_token` / `current_tenant_id` localStorage keys the original reality-web
  * page used, which sent `Bearer null`.
  */
@@ -10,14 +12,21 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
-  get: vi.fn(),
-  post: vi.fn(),
+  statementsApiList: vi.fn(),
+  statementsApiListLines: vi.fn(),
+  statementLinesApiListMatches: vi.fn(),
+  paymentMatchesApiConfirm: vi.fn(),
+  paymentMatchesApiReject: vi.fn(),
   getToken: vi.fn(),
   getOrg: vi.fn(),
 }));
 
 vi.mock('@ppt/api-client', () => ({
-  client: { get: mocks.get, post: mocks.post },
+  statementsApiList: mocks.statementsApiList,
+  statementsApiListLines: mocks.statementsApiListLines,
+  statementLinesApiListMatches: mocks.statementLinesApiListMatches,
+  paymentMatchesApiConfirm: mocks.paymentMatchesApiConfirm,
+  paymentMatchesApiReject: mocks.paymentMatchesApiReject,
   getToken: mocks.getToken,
   getOrg: mocks.getOrg,
 }));
@@ -33,53 +42,56 @@ import {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.get.mockResolvedValue({ data: [] });
-  mocks.post.mockResolvedValue({ data: undefined });
+  mocks.statementsApiList.mockResolvedValue({ data: [] });
+  mocks.statementsApiListLines.mockResolvedValue({ data: [] });
+  mocks.statementLinesApiListMatches.mockResolvedValue({ data: [] });
+  mocks.paymentMatchesApiConfirm.mockResolvedValue({ data: undefined });
+  mocks.paymentMatchesApiReject.mockResolvedValue({ data: undefined });
 });
 
 describe('payment-matching reads', () => {
-  it('fetchStatements queries the api-server statements endpoint and unwraps data', async () => {
-    mocks.get.mockResolvedValueOnce({ data: [{ id: 's1' }] });
+  it('fetchStatements calls statementsApiList (throwing) and unwraps data', async () => {
+    mocks.statementsApiList.mockResolvedValueOnce({ data: [{ id: 's1' }] });
     const result = await fetchStatements();
 
-    expect(mocks.get).toHaveBeenCalledWith(
-      expect.objectContaining({ url: '/api/v1/accounting/statements', throwOnError: true })
+    expect(mocks.statementsApiList).toHaveBeenCalledWith(
+      expect.objectContaining({ throwOnError: true })
     );
     expect(result).toEqual([{ id: 's1' }]);
   });
 
   it('fetchStatements falls back to [] when the body is empty', async () => {
-    mocks.get.mockResolvedValueOnce({ data: undefined });
+    mocks.statementsApiList.mockResolvedValueOnce({ data: undefined });
     expect(await fetchStatements()).toEqual([]);
   });
 
-  it('fetchStatementLines scopes by statement id', async () => {
+  it('fetchStatementLines scopes by statement id (path param)', async () => {
     await fetchStatementLines('stmt-9');
-    expect(mocks.get).toHaveBeenCalledWith(
-      expect.objectContaining({ url: '/api/v1/accounting/statements/stmt-9/lines' })
+    expect(mocks.statementsApiListLines).toHaveBeenCalledWith(
+      expect.objectContaining({ path: { id: 'stmt-9' }, throwOnError: true })
     );
   });
 
-  it('fetchLineMatches scopes by line id', async () => {
+  it('fetchLineMatches scopes by line id (path param)', async () => {
     await fetchLineMatches('line-7');
-    expect(mocks.get).toHaveBeenCalledWith(
-      expect.objectContaining({ url: '/api/v1/accounting/lines/line-7/matches' })
+    expect(mocks.statementLinesApiListMatches).toHaveBeenCalledWith(
+      expect.objectContaining({ path: { id: 'line-7' }, throwOnError: true })
     );
   });
 });
 
 describe('payment-matching mutations', () => {
-  it('confirmMatch posts to the confirm endpoint for the given match', async () => {
+  it('confirmMatch confirms the given match id', async () => {
     await confirmMatch('m-1');
-    expect(mocks.post).toHaveBeenCalledWith(
-      expect.objectContaining({ url: '/api/v1/accounting/matches/m-1/confirm', throwOnError: true })
+    expect(mocks.paymentMatchesApiConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ path: { id: 'm-1' }, throwOnError: true })
     );
   });
 
-  it('rejectMatch posts to the reject endpoint for the given match', async () => {
+  it('rejectMatch rejects the given match id', async () => {
     await rejectMatch('m-2');
-    expect(mocks.post).toHaveBeenCalledWith(
-      expect.objectContaining({ url: '/api/v1/accounting/matches/m-2/reject', throwOnError: true })
+    expect(mocks.paymentMatchesApiReject).toHaveBeenCalledWith(
+      expect.objectContaining({ path: { id: 'm-2' }, throwOnError: true })
     );
   });
 });

--- a/frontend/apps/ppt-web/src/features/accounting/api/paymentMatching.ts
+++ b/frontend/apps/ppt-web/src/features/accounting/api/paymentMatching.ts
@@ -1,81 +1,60 @@
 /**
  * Data layer for the payment-matching screen (#1521).
  *
- * All calls go to the manager-only api-server accounting endpoints. JSON calls go
- * through the shared `@ppt/api-client` client, so the `Authorization` /
- * `X-Tenant-ID` headers are injected by the centralized request interceptor
- * (#1616). The multipart statement upload uses a raw fetch (the generated client
- * serialises JSON bodies) but draws auth from the SAME providers — never the
- * bespoke `auth_token` / `current_tenant_id` localStorage keys the original
+ * The JSON reads/decisions go through the generated `@ppt/api-client` functions
+ * now that the accounting bank-statement / payment-matching endpoints are modelled
+ * in TypeSpec (#1623) — so request/response types come from the contract and auth
+ * headers are injected by the centralized request interceptor (#1616). Only the
+ * multipart statement upload stays a raw fetch (the generated client serialises
+ * JSON bodies, and the upload isn't modelled), but it draws auth from the SAME
+ * token / active-org providers — never the bespoke localStorage keys the original
  * reality-web page invented (which sent `Bearer null`).
  */
 
-import { client, getOrg, getToken } from '@ppt/api-client';
+import {
+  type AccountingBankStatement,
+  type AccountingBankStatementLine,
+  type AccountingPaymentMatch,
+  getOrg,
+  getToken,
+  paymentMatchesApiConfirm,
+  paymentMatchesApiReject,
+  statementLinesApiListMatches,
+  statementsApiList,
+  statementsApiListLines,
+} from '@ppt/api-client';
 
-export interface BankStatement {
-  id: string;
-  source_filename: string;
-  imported_at: string;
-  account_iban: string;
+export type { AccountingBankStatement, AccountingBankStatementLine, AccountingPaymentMatch };
+
+export async function fetchStatements(): Promise<AccountingBankStatement[]> {
+  const { data } = await statementsApiList({ throwOnError: true });
+  return data ?? [];
 }
 
-export interface BankStatementLine {
-  id: string;
-  statement_id: string;
-  booking_date: string;
-  amount: string;
-  currency: string;
-  counterparty_iban?: string;
-  variable_symbol?: string;
-  raw_ref?: string;
-  match_state: 'unmatched' | 'suggested' | 'matched';
-}
-
-export interface PaymentMatch {
-  id: string;
-  statement_line_id: string;
-  invoice_id: string;
-  /** Decimal arrives as a string. */
-  confidence: string;
-  state: 'suggested' | 'confirmed' | 'rejected';
-}
-
-export async function fetchStatements(): Promise<BankStatement[]> {
-  const { data } = await client.get<BankStatement[], unknown, true>({
-    url: '/api/v1/accounting/statements',
+export async function fetchStatementLines(
+  statementId: string
+): Promise<AccountingBankStatementLine[]> {
+  const { data } = await statementsApiListLines({
+    path: { id: statementId },
     throwOnError: true,
   });
   return data ?? [];
 }
 
-export async function fetchStatementLines(statementId: string): Promise<BankStatementLine[]> {
-  const { data } = await client.get<BankStatementLine[], unknown, true>({
-    url: `/api/v1/accounting/statements/${statementId}/lines`,
-    throwOnError: true,
-  });
-  return data ?? [];
-}
-
-export async function fetchLineMatches(lineId: string): Promise<PaymentMatch[]> {
-  const { data } = await client.get<PaymentMatch[], unknown, true>({
-    url: `/api/v1/accounting/lines/${lineId}/matches`,
+export async function fetchLineMatches(lineId: string): Promise<AccountingPaymentMatch[]> {
+  const { data } = await statementLinesApiListMatches({
+    path: { id: lineId },
     throwOnError: true,
   });
   return data ?? [];
 }
 
 export async function confirmMatch(matchId: string): Promise<void> {
-  await client.post<unknown, unknown, true>({
-    url: `/api/v1/accounting/matches/${matchId}/confirm`,
-    throwOnError: true,
-  });
+  await paymentMatchesApiConfirm({ path: { id: matchId }, throwOnError: true });
 }
 
 export async function rejectMatch(matchId: string): Promise<void> {
-  await client.post<unknown, unknown, true>({
-    url: `/api/v1/accounting/matches/${matchId}/reject`,
-    throwOnError: true,
-  });
+  await paymentMatchesApiReject({ path: { id: matchId }, throwOnError: true });
 }
 
 export async function uploadStatement(file: File): Promise<void> {


### PR DESCRIPTION
Follow-up to #1623 (which added the accounting bank-statement / payment-matching TypeSpec) and #1521 (the page relocation). Swaps the payment-matching data layer's hand-rolled types + raw `client.get`/`client.post` for the generated `@ppt/api-client` functions — the approach the #1521 review preferred ("use generated hooks").

- `statementsApiList` / `statementsApiListLines` / `statementLinesApiListMatches` / `paymentMatchesApiConfirm` / `paymentMatchesApiReject`. Types come from the contract (`AccountingBankStatement` etc.); the local interfaces are deleted.
- `uploadStatement` stays a raw fetch (multipart isn't modelled) with the same token/active-org auth source.
- Tests mock the generated functions + assert path params; upload auth-wiring tests unchanged.

Verified on the remote builder: ppt-web typecheck clean, vitest **9/9**, biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)