### PR TITLE
feat(voting): PDF generation + archive for vote reports (PAP-288, Story 5.6/5.8)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -32,14 +32,14 @@ dependencies = [
  "bitflags 2.12.1",
  "bytes",
  "bytestring",
- "derive_more",
+ "derive_more 2.1.1",
  "encoding_rs",
  "foldhash 0.1.5",
  "futures-core",
  "http 0.2.12",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 1.0.18",
  "language-tags",
  "mime",
  "percent-encoding",
@@ -127,13 +127,13 @@ dependencies = [
  "bytes",
  "bytestring",
  "cfg-if",
- "derive_more",
+ "derive_more 2.1.1",
  "encoding_rs",
  "foldhash 0.1.5",
  "futures-core",
  "futures-util",
  "impl-more",
- "itoa",
+ "itoa 1.0.18",
  "language-tags",
  "log",
  "mime",
@@ -145,7 +145,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "socket2 0.6.4",
- "time",
+ "time 0.3.47",
  "tracing",
  "url",
 ]
@@ -391,6 +391,7 @@ dependencies = [
  "dialoguer",
  "dotenvy",
  "futures-util",
+ "genpdf",
  "hex",
  "hmac 0.13.0",
  "http-body-util",
@@ -430,6 +431,15 @@ dependencies = [
  "uuid",
  "validator",
  "wiremock",
+]
+
+[[package]]
+name = "approx"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -579,7 +589,7 @@ dependencies = [
  "hex",
  "http 1.4.1",
  "sha1 0.10.6",
- "time",
+ "time 0.3.47",
  "tokio",
  "tracing",
  "url",
@@ -782,7 +792,7 @@ dependencies = [
  "percent-encoding",
  "sha2 0.11.0",
  "subtle",
- "time",
+ "time 0.3.47",
  "tracing",
  "zeroize",
 ]
@@ -993,13 +1003,13 @@ dependencies = [
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
- "itoa",
+ "itoa 1.0.18",
  "num-integer",
  "pin-project-lite",
  "pin-utils",
  "ryu",
  "serde",
- "time",
+ "time 0.3.47",
  "tokio",
  "tokio-util",
 ]
@@ -1024,7 +1034,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",
  "aws-smithy-types",
- "rustc_version",
+ "rustc_version 0.4.1",
  "tracing",
 ]
 
@@ -1045,7 +1055,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.10.1",
  "hyper-util",
- "itoa",
+ "itoa 1.0.18",
  "matchit",
  "memchr",
  "mime",
@@ -1174,6 +1184,12 @@ dependencies = [
  "rustc-demangle",
  "windows-link",
 ]
+
+[[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
 name = "base16ct"
@@ -1353,6 +1369,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "tinyvec",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -1690,6 +1717,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_fn"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413d67b29ef1021b4d60f4aa1e925ca031751e213832b4b1d588fae623c05c60"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,7 +1752,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
- "time",
+ "time 0.3.47",
  "version_check",
 ]
 
@@ -1871,7 +1904,7 @@ checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
- "itoa",
+ "itoa 1.0.18",
  "phf 0.11.3",
  "smallvec",
 ]
@@ -1893,7 +1926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
 dependencies = [
  "csv-core",
- "itoa",
+ "itoa 1.0.18",
  "ryu",
  "serde_core",
 ]
@@ -1936,7 +1969,7 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "rustc_version",
+ "rustc_version 0.4.1",
  "subtle",
  "zeroize",
 ]
@@ -2015,6 +2048,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "common",
+ "genpdf",
  "hex",
  "integrations",
  "password-hash",
@@ -2144,6 +2178,17 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
@@ -2160,7 +2205,7 @@ dependencies = [
  "convert_case 0.10.0",
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.1",
  "syn 2.0.117",
  "unicode-xid",
 ]
@@ -2229,6 +2274,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2266,6 +2317,12 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
+name = "dtoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
@@ -2276,7 +2333,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
- "dtoa",
+ "dtoa 1.0.11",
 ]
 
 [[package]]
@@ -2383,6 +2440,70 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+dependencies = [
+ "encoding-index-japanese",
+ "encoding-index-korean",
+ "encoding-index-simpchinese",
+ "encoding-index-singlebyte",
+ "encoding-index-tradchinese",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 
 [[package]]
 name = "encoding_rs"
@@ -2790,6 +2911,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "genpdf"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1c422344482708cb32db843cf3f55f27918cd24fec7b505bde895a1e8702c34"
+dependencies = [
+ "derive_more 0.99.20",
+ "lopdf",
+ "printpdf",
+ "rusttype",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3085,7 +3218,7 @@ checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 1.0.18",
 ]
 
 [[package]]
@@ -3095,7 +3228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
- "itoa",
+ "itoa 1.0.18",
 ]
 
 [[package]]
@@ -3202,7 +3335,7 @@ dependencies = [
  "http-body 0.4.6",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 1.0.18",
  "pin-project-lite",
  "socket2 0.5.10",
  "tokio",
@@ -3226,7 +3359,7 @@ dependencies = [
  "http-body 1.0.1",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 1.0.18",
  "pin-project-lite",
  "smallvec",
  "tokio",
@@ -3620,6 +3753,12 @@ dependencies = [
 
 [[package]]
 name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
@@ -3649,7 +3788,7 @@ checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.1",
  "simd_cesu8",
  "syn 2.0.117",
 ]
@@ -3811,6 +3950,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3855,6 +4000,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
+name = "lopdf"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49a0272112719d0037ab63d4bb67f73ba659e1e90bc38f235f163a457ac16f3"
+dependencies = [
+ "chrono",
+ "dtoa 0.4.8",
+ "encoding",
+ "flate2",
+ "itoa 0.4.8",
+ "linked-hash-map",
+ "log",
+ "lzw",
+ "pom",
+ "time 0.2.27",
+]
+
+[[package]]
 name = "lru"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3868,6 +4031,12 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lzw"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d947cbb889ed21c2a84be6ffbaebf5b4e0f4340638cba0444907e38b56be084"
 
 [[package]]
 name = "mac"
@@ -4551,6 +4720,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4903,6 +5081,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pom"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c972d8f86e943ad532d0b04e8965a749ad1d18bb981a9c7b3ae72fe7fd7744b"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4968,6 +5155,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "printpdf"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2472a184bcb128d0e3db65b59ebd11d010259a5e14fd9d048cba8f2c9302d4"
+dependencies = [
+ "js-sys",
+ "lopdf",
+ "rusttype",
+ "time 0.2.27",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4997,6 +5196,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -5372,7 +5577,7 @@ dependencies = [
  "combine",
  "futures-channel",
  "futures-util",
- "itoa",
+ "itoa 1.0.18",
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
@@ -5713,11 +5918,20 @@ checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -5828,6 +6042,17 @@ dependencies = [
  "ring",
  "rustls-pki-types",
  "untrusted",
+]
+
+[[package]]
+name = "rusttype"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f61411055101f7b60ecf1041d87fb74205fb20b0c7a723f07ef39174cf6b4c0"
+dependencies = [
+ "approx",
+ "ordered-float",
+ "stb_truetype",
 ]
 
 [[package]]
@@ -5951,9 +6176,24 @@ checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sentry"
@@ -6010,7 +6250,7 @@ dependencies = [
  "hostname",
  "libc",
  "os_info",
- "rustc_version",
+ "rustc_version 0.4.1",
  "sentry-core",
  "uname",
 ]
@@ -6087,7 +6327,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "time",
+ "time 0.3.47",
  "url",
  "uuid",
 ]
@@ -6140,7 +6380,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
- "itoa",
+ "itoa 1.0.18",
  "memchr",
  "serde",
  "serde_core",
@@ -6153,7 +6393,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
 dependencies = [
- "itoa",
+ "itoa 1.0.18",
  "serde",
  "serde_core",
 ]
@@ -6195,7 +6435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 1.0.18",
  "ryu",
  "serde",
 ]
@@ -6216,7 +6456,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde_core",
  "serde_json",
- "time",
+ "time 0.3.47",
 ]
 
 [[package]]
@@ -6226,10 +6466,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
  "indexmap 2.14.0",
- "itoa",
+ "itoa 1.0.18",
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
+dependencies = [
+ "sha1_smol",
 ]
 
 [[package]]
@@ -6344,7 +6593,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.4.1",
  "simdutf8",
 ]
 
@@ -6369,7 +6618,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror 2.0.18",
- "time",
+ "time 0.3.47",
 ]
 
 [[package]]
@@ -6591,7 +6840,7 @@ dependencies = [
  "hex",
  "hkdf 0.13.0",
  "hmac 0.13.0",
- "itoa",
+ "itoa 1.0.18",
  "log",
  "md-5",
  "memchr",
@@ -6640,6 +6889,73 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "standback"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "stb_truetype"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f77b6b07e862c66a9f3e62a07588fee67cd90a9135a2b942409f195507b4fb51"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "stdweb"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
+dependencies = [
+ "discard",
+ "rustc_version 0.2.3",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1 0.6.1",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "string_cache"
@@ -6877,17 +7193,32 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
+dependencies = [
+ "const_fn",
+ "libc",
+ "standback",
+ "stdweb",
+ "time-macros 0.1.1",
+ "version_check",
+ "winapi",
+]
+
+[[package]]
+name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
- "itoa",
+ "itoa 1.0.18",
  "num-conv",
  "powerfmt",
  "serde_core",
  "time-core",
- "time-macros",
+ "time-macros 0.2.27",
 ]
 
 [[package]]
@@ -6898,12 +7229,35 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
+dependencies = [
+ "proc-macro-hack",
+ "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "standback",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7785,7 +8139,7 @@ dependencies = [
  "bitflags 2.12.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
- "semver",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -8219,7 +8573,7 @@ dependencies = [
  "id-arena",
  "indexmap 2.14.0",
  "log",
- "semver",
+ "semver 1.0.28",
  "serde",
  "serde_derive",
  "serde_json",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -106,6 +106,7 @@ redis = { version = "1.2", features = ["tokio-comp", "connection-manager"] }
 # CLI (Epic 110)
 clap = { version = "4.4", features = ["derive", "env"] }
 dialoguer = "0.12"
+genpdf = "0.2.0"
 
 # i18n (Epic 111)
 fluent = "0.16"

--- a/backend/crates/db/Cargo.toml
+++ b/backend/crates/db/Cargo.toml
@@ -22,6 +22,7 @@ hex = { workspace = true }
 sha2 = { workspace = true }
 argon2 = "=0.6.0-rc.8"
 password-hash = "0.6"
+genpdf = { workspace = true }
 url = "2.5"
 tokio = { workspace = true, features = ["rt"] }
 async-trait = { workspace = true }

--- a/backend/servers/api-server/Cargo.toml
+++ b/backend/servers/api-server/Cargo.toml
@@ -27,6 +27,7 @@ common = { workspace = true }
 api-core = { workspace = true }
 admin-core = { workspace = true }
 db = { workspace = true }
+genpdf = { workspace = true }
 integrations = { workspace = true }
 tenant-ops = { workspace = true }
 sqlx = { workspace = true }

--- a/backend/servers/api-server/src/routes/voting.rs
+++ b/backend/servers/api-server/src/routes/voting.rs
@@ -1463,10 +1463,13 @@ async fn get_report_pdf(
 ) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     let pdf_bytes = generate_and_archive_pdf(&state, &mut rls, id).await?;
     rls.release().await;
-    
+
     let headers = [
         (axum::http::header::CONTENT_TYPE, "application/pdf"),
-        (axum::http::header::CONTENT_DISPOSITION, "attachment; filename=\"report.pdf\""),
+        (
+            axum::http::header::CONTENT_DISPOSITION,
+            "attachment; filename=\"report.pdf\"",
+        ),
     ];
     Ok((StatusCode::OK, headers, pdf_bytes).into_response())
 }
@@ -1531,7 +1534,10 @@ async fn get_report_data(
         rls.release().await;
         let pdf_headers = [
             (axum::http::header::CONTENT_TYPE, "application/pdf"),
-            (axum::http::header::CONTENT_DISPOSITION, "attachment; filename=\"report.pdf\""),
+            (
+                axum::http::header::CONTENT_DISPOSITION,
+                "attachment; filename=\"report.pdf\"",
+            ),
         ];
         Ok((StatusCode::OK, pdf_headers, pdf_bytes).into_response())
     } else {
@@ -1618,7 +1624,10 @@ async fn generate_and_archive_pdf_internal(
         organization_id: org_id,
         folder_id: None,
         title: format!("Vote Report: {}", report.vote.title),
-        description: Some(format!("Auto-generated PDF report for vote: {}", report.vote.title)),
+        description: Some(format!(
+            "Auto-generated PDF report for vote: {}",
+            report.vote.title
+        )),
         category: "reports".to_string(), // db::models::document_category::REPORTS
         file_key: file_key.clone(),
         file_name,
@@ -1648,8 +1657,12 @@ async fn generate_and_archive_pdf_internal(
 }
 
 fn render_pdf_report(report: &VoteReportData) -> Result<Vec<u8>, String> {
-    let font_family = genpdf::fonts::from_files("/usr/share/fonts/truetype/liberation", "LiberationSans", None)
-        .map_err(|e| format!("Failed to load font LiberationSans: {}", e))?;
+    let font_family = genpdf::fonts::from_files(
+        "/usr/share/fonts/truetype/liberation",
+        "LiberationSans",
+        None,
+    )
+    .map_err(|e| format!("Failed to load font LiberationSans: {}", e))?;
 
     let mut doc = genpdf::Document::new(font_family);
     doc.set_title(format!("Vote Report: {}", report.vote.title));
@@ -1669,46 +1682,61 @@ fn render_pdf_report(report: &VoteReportData) -> Result<Vec<u8>, String> {
 
     // Metadata
     let mut metadata_layout = genpdf::elements::LinearLayout::vertical();
-    
-    let generated_at_str = report.generated_at.format("%Y-%m-%d %H:%M:%S UTC").to_string();
-    
+
+    let generated_at_str = report
+        .generated_at
+        .format("%Y-%m-%d %H:%M:%S UTC")
+        .to_string();
+
     metadata_layout.push(
         genpdf::elements::Paragraph::default()
             .string("Vote ID: ")
-            .styled_string(report.vote.id.to_string(), genpdf::style::Style::new().bold())
+            .styled_string(
+                report.vote.id.to_string(),
+                genpdf::style::Style::new().bold(),
+            ),
     );
     metadata_layout.push(
         genpdf::elements::Paragraph::default()
             .string("Building ID: ")
-            .styled_string(report.vote.building_id.to_string(), genpdf::style::Style::new().bold())
+            .styled_string(
+                report.vote.building_id.to_string(),
+                genpdf::style::Style::new().bold(),
+            ),
     );
     metadata_layout.push(
         genpdf::elements::Paragraph::default()
             .string("Quorum Type: ")
-            .styled_string(report.vote.quorum_type.clone(), genpdf::style::Style::new().bold())
+            .styled_string(
+                report.vote.quorum_type.clone(),
+                genpdf::style::Style::new().bold(),
+            ),
     );
     if let Some(qp) = report.vote.quorum_percentage {
         metadata_layout.push(
             genpdf::elements::Paragraph::default()
                 .string("Quorum Percentage: ")
-                .styled_string(format!("{}%", qp), genpdf::style::Style::new().bold())
+                .styled_string(format!("{}%", qp), genpdf::style::Style::new().bold()),
         );
     }
-    
+
     // Status
     metadata_layout.push(
         genpdf::elements::Paragraph::default()
             .string("Status: ")
-            .styled_string(report.vote.status.clone(), genpdf::style::Style::new().bold())
+            .styled_string(
+                report.vote.status.clone(),
+                genpdf::style::Style::new().bold(),
+            ),
     );
-    
+
     // Generated At Timestamp
     metadata_layout.push(
         genpdf::elements::Paragraph::default()
             .string("Report Generated At: ")
-            .styled_string(generated_at_str, genpdf::style::Style::new().bold())
+            .styled_string(generated_at_str, genpdf::style::Style::new().bold()),
     );
-    
+
     doc.push(metadata_layout);
     doc.push(genpdf::elements::Break::new(2));
 
@@ -1727,67 +1755,99 @@ fn render_pdf_report(report: &VoteReportData) -> Result<Vec<u8>, String> {
         genpdf::elements::Paragraph::new("Voting Results Summary")
             .styled(genpdf::style::Style::new().bold().with_font_size(14)),
     );
-    
+
     if let Some(results) = &report.results {
         let quorum_met_str = if results.quorum_met { "YES" } else { "NO" };
         let part_rate = format!("{:.2}%", results.participation_rate * 100.0);
-        
+
         let mut results_summary = genpdf::elements::LinearLayout::vertical();
         results_summary.push(
             genpdf::elements::Paragraph::default()
                 .string("Quorum Met: ")
-                .styled_string(quorum_met_str, genpdf::style::Style::new().bold())
+                .styled_string(quorum_met_str, genpdf::style::Style::new().bold()),
         );
         results_summary.push(
             genpdf::elements::Paragraph::default()
                 .string("Participation: ")
                 .styled_string(
-                    format!("{} of {} units (Rate: {})", results.participation_count, results.eligible_count, part_rate),
-                    genpdf::style::Style::new().bold()
-                )
+                    format!(
+                        "{} of {} units (Rate: {})",
+                        results.participation_count, results.eligible_count, part_rate
+                    ),
+                    genpdf::style::Style::new().bold(),
+                ),
         );
         doc.push(results_summary);
         doc.push(genpdf::elements::Break::new(1));
-        
+
         // Questions Results Detail
         for (idx, q_res) in results.questions.iter().enumerate() {
             doc.push(
-                genpdf::elements::Paragraph::new(format!("Question {}: {}", idx + 1, q_res.question_text))
-                    .styled(genpdf::style::Style::new().bold().with_font_size(12)),
+                genpdf::elements::Paragraph::new(format!(
+                    "Question {}: {}",
+                    idx + 1,
+                    q_res.question_text
+                ))
+                .styled(genpdf::style::Style::new().bold().with_font_size(12)),
             );
-            doc.push(genpdf::elements::Paragraph::new(format!("Type: {}  |  Total Ballots: {}  |  Weighted Total: {}", q_res.question_type, q_res.total_votes, q_res.weighted_total)));
-            
+            doc.push(genpdf::elements::Paragraph::new(format!(
+                "Type: {}  |  Total Ballots: {}  |  Weighted Total: {}",
+                q_res.question_type, q_res.total_votes, q_res.weighted_total
+            )));
+
             doc.push(genpdf::elements::Break::new(1));
-            
+
             // Results table
             // Table header: Option, Votes, Weighted Count, Percentage
             let mut table = genpdf::elements::TableLayout::new(vec![3, 1, 2, 2]);
             let decorator = genpdf::elements::FrameCellDecorator::new(true, true, false);
             table.set_cell_decorator(decorator);
-            
-            table.row()
-                .element(genpdf::elements::Paragraph::new("Option").styled(genpdf::style::Style::new().bold()))
-                .element(genpdf::elements::Paragraph::new("Count").styled(genpdf::style::Style::new().bold()))
-                .element(genpdf::elements::Paragraph::new("Weighted").styled(genpdf::style::Style::new().bold()))
-                .element(genpdf::elements::Paragraph::new("Percentage").styled(genpdf::style::Style::new().bold()))
+
+            table
+                .row()
+                .element(
+                    genpdf::elements::Paragraph::new("Option")
+                        .styled(genpdf::style::Style::new().bold()),
+                )
+                .element(
+                    genpdf::elements::Paragraph::new("Count")
+                        .styled(genpdf::style::Style::new().bold()),
+                )
+                .element(
+                    genpdf::elements::Paragraph::new("Weighted")
+                        .styled(genpdf::style::Style::new().bold()),
+                )
+                .element(
+                    genpdf::elements::Paragraph::new("Percentage")
+                        .styled(genpdf::style::Style::new().bold()),
+                )
                 .push()
                 .map_err(|e| format!("Failed to add table header: {}", e))?;
-            
+
             for opt in &q_res.results {
-                table.row()
+                table
+                    .row()
                     .element(genpdf::elements::Paragraph::new(&opt.option_text))
                     .element(genpdf::elements::Paragraph::new(opt.count.to_string()))
-                    .element(genpdf::elements::Paragraph::new(format!("{:.4}", opt.weighted_count)))
-                    .element(genpdf::elements::Paragraph::new(format!("{:.2}%", opt.percentage)))
+                    .element(genpdf::elements::Paragraph::new(format!(
+                        "{:.4}",
+                        opt.weighted_count
+                    )))
+                    .element(genpdf::elements::Paragraph::new(format!(
+                        "{:.2}%",
+                        opt.percentage
+                    )))
                     .push()
                     .map_err(|e| format!("Failed to add table row: {}", e))?;
             }
-            
+
             doc.push(table);
             doc.push(genpdf::elements::Break::new(2));
         }
     } else {
-        doc.push(genpdf::elements::Paragraph::new("No results calculated yet."));
+        doc.push(genpdf::elements::Paragraph::new(
+            "No results calculated yet.",
+        ));
         doc.push(genpdf::elements::Break::new(2));
     }
 
@@ -1797,33 +1857,50 @@ fn render_pdf_report(report: &VoteReportData) -> Result<Vec<u8>, String> {
             .styled(genpdf::style::Style::new().bold().with_font_size(14)),
     );
     doc.push(genpdf::elements::Break::new(1));
-    
+
     // Table header: Unit, Voted, Weight
     let mut part_table = genpdf::elements::TableLayout::new(vec![4, 2, 2]);
     let decorator = genpdf::elements::FrameCellDecorator::new(true, true, false);
     part_table.set_cell_decorator(decorator);
-    
-    part_table.row()
-        .element(genpdf::elements::Paragraph::new("Unit Designation").styled(genpdf::style::Style::new().bold()))
-        .element(genpdf::elements::Paragraph::new("Voted").styled(genpdf::style::Style::new().bold()))
-        .element(genpdf::elements::Paragraph::new("Vote Weight").styled(genpdf::style::Style::new().bold()))
+
+    part_table
+        .row()
+        .element(
+            genpdf::elements::Paragraph::new("Unit Designation")
+                .styled(genpdf::style::Style::new().bold()),
+        )
+        .element(
+            genpdf::elements::Paragraph::new("Voted").styled(genpdf::style::Style::new().bold()),
+        )
+        .element(
+            genpdf::elements::Paragraph::new("Vote Weight")
+                .styled(genpdf::style::Style::new().bold()),
+        )
         .push()
         .map_err(|e| format!("Failed to add participation header: {}", e))?;
-    
+
     for detail in &report.participation_details {
-        part_table.row()
+        part_table
+            .row()
             .element(genpdf::elements::Paragraph::new(&detail.unit_designation))
-            .element(genpdf::elements::Paragraph::new(if detail.voted { "Yes" } else { "No" }))
-            .element(genpdf::elements::Paragraph::new(detail.vote_weight.to_string()))
+            .element(genpdf::elements::Paragraph::new(if detail.voted {
+                "Yes"
+            } else {
+                "No"
+            }))
+            .element(genpdf::elements::Paragraph::new(
+                detail.vote_weight.to_string(),
+            ))
             .push()
             .map_err(|e| format!("Failed to add participation row: {}", e))?;
     }
-    
+
     doc.push(part_table);
 
     // Render to bytes
     let mut bytes = Vec::new();
-    doc.render(&mut bytes).map_err(|e| format!("Failed to render PDF: {}", e))?;
+    doc.render(&mut bytes)
+        .map_err(|e| format!("Failed to render PDF: {}", e))?;
 
     Ok(bytes)
 }

--- a/backend/servers/api-server/src/routes/voting.rs
+++ b/backend/servers/api-server/src/routes/voting.rs
@@ -5,6 +5,7 @@ use api_core::extractors::RlsConnection;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
+    response::{IntoResponse, Response},
     routing::{delete, get, post, put},
     Json, Router,
 };
@@ -53,6 +54,7 @@ pub fn router() -> Router<AppState> {
         .route("/{id}/results", get(get_results))
         // Reports
         .route("/{id}/report", get(get_report_data))
+        .route("/{id}/report.pdf", get(get_report_pdf))
         // Audit
         .route("/{id}/audit", get(get_audit_log))
         // Building votes
@@ -1433,6 +1435,41 @@ async fn get_results(
 // Report Handlers
 // ============================================================================
 
+/// Request query for report formatting.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ReportQuery {
+    pub format: Option<String>,
+}
+
+/// Get vote report PDF.
+#[utoipa::path(
+    get,
+    path = "/api/v1/voting/{id}/report.pdf",
+    params(
+        ("id" = Uuid, Path, description = "Vote ID")
+    ),
+    responses(
+        (status = 200, description = "Report PDF", body = Vec<u8>),
+        (status = 404, description = "Vote not found"),
+        (status = 401, description = "Unauthorized"),
+    ),
+    tag = "Voting"
+)]
+async fn get_report_pdf(
+    State(state): State<AppState>,
+    mut rls: RlsConnection,
+    Path(id): Path<Uuid>,
+) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
+    let pdf_bytes = generate_and_archive_pdf(&state, &mut rls, id).await?;
+    rls.release().await;
+    
+    let headers = [
+        (axum::http::header::CONTENT_TYPE, "application/pdf"),
+        (axum::http::header::CONTENT_DISPOSITION, "attachment; filename=\"report.pdf\""),
+    ];
+    Ok((StatusCode::OK, headers, pdf_bytes).into_response())
+}
+
 /// Get vote report data (stub - returns data for PDF generation).
 #[utoipa::path(
     get,
@@ -1451,7 +1488,9 @@ async fn get_report_data(
     State(state): State<AppState>,
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
-) -> Result<Json<VoteReportData>, (StatusCode, Json<ErrorResponse>)> {
+    headers: axum::http::HeaderMap,
+    Query(query): Query<ReportQuery>,
+) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     // Note: generate_report_data() doesn't have an RLS version yet
     let report = state
         .vote_repo
@@ -1471,8 +1510,321 @@ async fn get_report_data(
             ),
         })?;
 
-    rls.release().await;
-    Ok(Json(report))
+    // Secure by default: check organization matches RLS tenant context
+    if report.vote.organization_id != rls.tenant_id() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("NOT_FOUND", "Vote not found")),
+        ));
+    }
+
+    // Check if PDF format is requested via query param or Accept header
+    let accept_header = headers
+        .get(axum::http::header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    let is_pdf = query.format.as_deref() == Some("pdf") || accept_header == "application/pdf";
+
+    if is_pdf {
+        let pdf_bytes = generate_and_archive_pdf_internal(&state, &mut rls, &report).await?;
+        rls.release().await;
+        let pdf_headers = [
+            (axum::http::header::CONTENT_TYPE, "application/pdf"),
+            (axum::http::header::CONTENT_DISPOSITION, "attachment; filename=\"report.pdf\""),
+        ];
+        Ok((StatusCode::OK, pdf_headers, pdf_bytes).into_response())
+    } else {
+        rls.release().await;
+        Ok(Json(report).into_response())
+    }
+}
+
+async fn generate_and_archive_pdf(
+    state: &AppState,
+    rls: &mut RlsConnection,
+    id: Uuid,
+) -> Result<Vec<u8>, (StatusCode, Json<ErrorResponse>)> {
+    let report = state
+        .vote_repo
+        .generate_report_data(id)
+        .await
+        .map_err(|e| match e {
+            SqlxError::RowNotFound => (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Vote not found")),
+            ),
+            _ => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(
+                    "DATABASE_ERROR",
+                    format!("Failed to generate report: {}", e),
+                )),
+            ),
+        })?;
+
+    // Secure by default: check organization matches RLS tenant context
+    if report.vote.organization_id != rls.tenant_id() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("NOT_FOUND", "Vote not found")),
+        ));
+    }
+
+    generate_and_archive_pdf_internal(state, rls, &report).await
+}
+
+async fn generate_and_archive_pdf_internal(
+    state: &AppState,
+    rls: &mut RlsConnection,
+    report: &VoteReportData,
+) -> Result<Vec<u8>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
+
+    // Render the report to PDF
+    let pdf_bytes = render_pdf_report(report).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "PDF_GENERATION_ERROR",
+                format!("Failed to render PDF: {}", e),
+            )),
+        )
+    })?;
+
+    // Archive the PDF in the documents system
+    let file_name = format!("vote_report_{}.pdf", report.vote.id);
+    let file_key = integrations::generate_storage_key(org_id, &file_name);
+
+    if let Some(ref storage_service) = state.storage_service {
+        if storage_service.has_s3_client() {
+            storage_service
+                .upload(&file_key, pdf_bytes.clone(), "application/pdf")
+                .await
+                .map_err(|e| {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorResponse::new(
+                            "STORAGE_ERROR",
+                            format!("Failed to upload report to S3: {}", e),
+                        )),
+                    )
+                })?;
+        }
+    }
+
+    let create_doc = db::models::CreateDocument {
+        organization_id: org_id,
+        folder_id: None,
+        title: format!("Vote Report: {}", report.vote.title),
+        description: Some(format!("Auto-generated PDF report for vote: {}", report.vote.title)),
+        category: "reports".to_string(), // db::models::document_category::REPORTS
+        file_key: file_key.clone(),
+        file_name,
+        mime_type: "application/pdf".to_string(),
+        size_bytes: pdf_bytes.len() as i64,
+        access_scope: Some("organization".to_string()),
+        access_target_ids: None,
+        access_roles: None,
+        created_by: user_id,
+    };
+
+    state
+        .document_repo
+        .create_rls(&mut **rls.conn(), create_doc)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(
+                    "DATABASE_ERROR",
+                    format!("Failed to create document record for report: {}", e),
+                )),
+            )
+        })?;
+
+    Ok(pdf_bytes)
+}
+
+fn render_pdf_report(report: &VoteReportData) -> Result<Vec<u8>, String> {
+    let font_family = genpdf::fonts::from_files("/usr/share/fonts/truetype/liberation", "LiberationSans", None)
+        .map_err(|e| format!("Failed to load font LiberationSans: {}", e))?;
+
+    let mut doc = genpdf::Document::new(font_family);
+    doc.set_title(format!("Vote Report: {}", report.vote.title));
+
+    let mut decorator = genpdf::SimplePageDecorator::new();
+    decorator.set_margins(15);
+    doc.set_page_decorator(decorator);
+
+    // Document Title
+    doc.push(
+        genpdf::elements::Paragraph::new(&report.vote.title)
+            .styled(genpdf::style::Style::new().bold().with_font_size(18)),
+    );
+
+    // Spacing
+    doc.push(genpdf::elements::Break::new(1));
+
+    // Metadata
+    let mut metadata_layout = genpdf::elements::LinearLayout::vertical();
+    
+    let generated_at_str = report.generated_at.format("%Y-%m-%d %H:%M:%S UTC").to_string();
+    
+    metadata_layout.push(
+        genpdf::elements::Paragraph::default()
+            .string("Vote ID: ")
+            .styled_string(report.vote.id.to_string(), genpdf::style::Style::new().bold())
+    );
+    metadata_layout.push(
+        genpdf::elements::Paragraph::default()
+            .string("Building ID: ")
+            .styled_string(report.vote.building_id.to_string(), genpdf::style::Style::new().bold())
+    );
+    metadata_layout.push(
+        genpdf::elements::Paragraph::default()
+            .string("Quorum Type: ")
+            .styled_string(report.vote.quorum_type.clone(), genpdf::style::Style::new().bold())
+    );
+    if let Some(qp) = report.vote.quorum_percentage {
+        metadata_layout.push(
+            genpdf::elements::Paragraph::default()
+                .string("Quorum Percentage: ")
+                .styled_string(format!("{}%", qp), genpdf::style::Style::new().bold())
+        );
+    }
+    
+    // Status
+    metadata_layout.push(
+        genpdf::elements::Paragraph::default()
+            .string("Status: ")
+            .styled_string(report.vote.status.clone(), genpdf::style::Style::new().bold())
+    );
+    
+    // Generated At Timestamp
+    metadata_layout.push(
+        genpdf::elements::Paragraph::default()
+            .string("Report Generated At: ")
+            .styled_string(generated_at_str, genpdf::style::Style::new().bold())
+    );
+    
+    doc.push(metadata_layout);
+    doc.push(genpdf::elements::Break::new(2));
+
+    // Description
+    if let Some(desc) = &report.vote.description {
+        doc.push(
+            genpdf::elements::Paragraph::new("Description")
+                .styled(genpdf::style::Style::new().bold().with_font_size(14)),
+        );
+        doc.push(genpdf::elements::Paragraph::new(desc));
+        doc.push(genpdf::elements::Break::new(2));
+    }
+
+    // Results section
+    doc.push(
+        genpdf::elements::Paragraph::new("Voting Results Summary")
+            .styled(genpdf::style::Style::new().bold().with_font_size(14)),
+    );
+    
+    if let Some(results) = &report.results {
+        let quorum_met_str = if results.quorum_met { "YES" } else { "NO" };
+        let part_rate = format!("{:.2}%", results.participation_rate * 100.0);
+        
+        let mut results_summary = genpdf::elements::LinearLayout::vertical();
+        results_summary.push(
+            genpdf::elements::Paragraph::default()
+                .string("Quorum Met: ")
+                .styled_string(quorum_met_str, genpdf::style::Style::new().bold())
+        );
+        results_summary.push(
+            genpdf::elements::Paragraph::default()
+                .string("Participation: ")
+                .styled_string(
+                    format!("{} of {} units (Rate: {})", results.participation_count, results.eligible_count, part_rate),
+                    genpdf::style::Style::new().bold()
+                )
+        );
+        doc.push(results_summary);
+        doc.push(genpdf::elements::Break::new(1));
+        
+        // Questions Results Detail
+        for (idx, q_res) in results.questions.iter().enumerate() {
+            doc.push(
+                genpdf::elements::Paragraph::new(format!("Question {}: {}", idx + 1, q_res.question_text))
+                    .styled(genpdf::style::Style::new().bold().with_font_size(12)),
+            );
+            doc.push(genpdf::elements::Paragraph::new(format!("Type: {}  |  Total Ballots: {}  |  Weighted Total: {}", q_res.question_type, q_res.total_votes, q_res.weighted_total)));
+            
+            doc.push(genpdf::elements::Break::new(1));
+            
+            // Results table
+            // Table header: Option, Votes, Weighted Count, Percentage
+            let mut table = genpdf::elements::TableLayout::new(vec![3, 1, 2, 2]);
+            let decorator = genpdf::elements::FrameCellDecorator::new(true, true, false);
+            table.set_cell_decorator(decorator);
+            
+            table.row()
+                .element(genpdf::elements::Paragraph::new("Option").styled(genpdf::style::Style::new().bold()))
+                .element(genpdf::elements::Paragraph::new("Count").styled(genpdf::style::Style::new().bold()))
+                .element(genpdf::elements::Paragraph::new("Weighted").styled(genpdf::style::Style::new().bold()))
+                .element(genpdf::elements::Paragraph::new("Percentage").styled(genpdf::style::Style::new().bold()))
+                .push()
+                .map_err(|e| format!("Failed to add table header: {}", e))?;
+            
+            for opt in &q_res.results {
+                table.row()
+                    .element(genpdf::elements::Paragraph::new(&opt.option_text))
+                    .element(genpdf::elements::Paragraph::new(opt.count.to_string()))
+                    .element(genpdf::elements::Paragraph::new(format!("{:.4}", opt.weighted_count)))
+                    .element(genpdf::elements::Paragraph::new(format!("{:.2}%", opt.percentage)))
+                    .push()
+                    .map_err(|e| format!("Failed to add table row: {}", e))?;
+            }
+            
+            doc.push(table);
+            doc.push(genpdf::elements::Break::new(2));
+        }
+    } else {
+        doc.push(genpdf::elements::Paragraph::new("No results calculated yet."));
+        doc.push(genpdf::elements::Break::new(2));
+    }
+
+    // Participation Details section
+    doc.push(
+        genpdf::elements::Paragraph::new("Participation Details")
+            .styled(genpdf::style::Style::new().bold().with_font_size(14)),
+    );
+    doc.push(genpdf::elements::Break::new(1));
+    
+    // Table header: Unit, Voted, Weight
+    let mut part_table = genpdf::elements::TableLayout::new(vec![4, 2, 2]);
+    let decorator = genpdf::elements::FrameCellDecorator::new(true, true, false);
+    part_table.set_cell_decorator(decorator);
+    
+    part_table.row()
+        .element(genpdf::elements::Paragraph::new("Unit Designation").styled(genpdf::style::Style::new().bold()))
+        .element(genpdf::elements::Paragraph::new("Voted").styled(genpdf::style::Style::new().bold()))
+        .element(genpdf::elements::Paragraph::new("Vote Weight").styled(genpdf::style::Style::new().bold()))
+        .push()
+        .map_err(|e| format!("Failed to add participation header: {}", e))?;
+    
+    for detail in &report.participation_details {
+        part_table.row()
+            .element(genpdf::elements::Paragraph::new(&detail.unit_designation))
+            .element(genpdf::elements::Paragraph::new(if detail.voted { "Yes" } else { "No" }))
+            .element(genpdf::elements::Paragraph::new(detail.vote_weight.to_string()))
+            .push()
+            .map_err(|e| format!("Failed to add participation row: {}", e))?;
+    }
+    
+    doc.push(part_table);
+
+    // Render to bytes
+    let mut bytes = Vec::new();
+    doc.render(&mut bytes).map_err(|e| format!("Failed to render PDF: {}", e))?;
+
+    Ok(bytes)
 }
 
 // ============================================================================

--- a/backend/servers/api-server/src/routes/voting.rs
+++ b/backend/servers/api-server/src/routes/voting.rs
@@ -18,6 +18,7 @@ use db::models::{
     VoteCommentWithUser, VoteEligibility, VoteListQuery, VoteQuestion, VoteReceipt, VoteReportData,
     VoteResults, VoteSummary, VoteWithDetails,
 };
+use genpdf::Element;
 use serde::Deserialize;
 use sqlx::Error as SqlxError;
 use utoipa::{IntoParams, ToSchema};

--- a/backend/servers/api-server/tests/voting_tests.rs
+++ b/backend/servers/api-server/tests/voting_tests.rs
@@ -246,8 +246,8 @@ mod tenant_header {
 
 #[cfg(test)]
 mod pdf_report {
+    use super::common::{create_authenticated_user_with_org, TestUser};
     use super::*;
-    use common::{create_authenticated_user_with_org, TestUser};
 
     async fn seed_building(pool: &PgPool, org_id: Uuid, slug: &str) -> Uuid {
         sqlx::query_scalar::<_, Uuid>(
@@ -297,7 +297,7 @@ mod pdf_report {
 
         let request = Request::builder()
             .method(Method::GET)
-            .uri(&format!("/api/v1/voting/{}/report.pdf", vote_id))
+            .uri(format!("/api/v1/voting/{}/report.pdf", vote_id))
             .header(header::AUTHORIZATION, format!("Bearer {token}"))
             .header("X-Tenant-ID", org_id.to_string())
             .body(Body::empty())
@@ -351,7 +351,7 @@ mod pdf_report {
         // Query parameter: ?format=pdf
         let request = Request::builder()
             .method(Method::GET)
-            .uri(&format!("/api/v1/voting/{}/report?format=pdf", vote_id))
+            .uri(format!("/api/v1/voting/{}/report?format=pdf", vote_id))
             .header(header::AUTHORIZATION, format!("Bearer {token}"))
             .header("X-Tenant-ID", org_id.to_string())
             .body(Body::empty())
@@ -370,7 +370,7 @@ mod pdf_report {
         // Accept header: Accept: application/pdf
         let request_accept = Request::builder()
             .method(Method::GET)
-            .uri(&format!("/api/v1/voting/{}/report", vote_id))
+            .uri(format!("/api/v1/voting/{}/report", vote_id))
             .header(header::AUTHORIZATION, format!("Bearer {token}"))
             .header("X-Tenant-ID", org_id.to_string())
             .header(header::ACCEPT, "application/pdf")

--- a/backend/servers/api-server/tests/voting_tests.rs
+++ b/backend/servers/api-server/tests/voting_tests.rs
@@ -239,3 +239,146 @@ mod tenant_header {
         assert_eq!(response.status, StatusCode::UNAUTHORIZED);
     }
 }
+
+// =============================================================================
+// PDF Report E2E Tests (Story 5.6 / 5.8)
+// =============================================================================
+
+#[cfg(test)]
+mod pdf_report {
+    use super::*;
+    use common::{create_authenticated_user_with_org, TestUser};
+
+    async fn seed_building(pool: &PgPool, org_id: Uuid, slug: &str) -> Uuid {
+        sqlx::query_scalar::<_, Uuid>(
+            r#"
+            INSERT INTO buildings (organization_id, street, city, postal_code, country)
+            VALUES ($1, $2, 'Bratislava', '81101', 'Slovakia') RETURNING id
+            "#,
+        )
+        .bind(org_id)
+        .bind(format!("{slug} Street 1"))
+        .fetch_one(pool)
+        .await
+        .expect("seed building")
+    }
+
+    async fn seed_vote(pool: &PgPool, org_id: Uuid, building_id: Uuid, created_by: Uuid) -> Uuid {
+        sqlx::query_scalar::<_, Uuid>(
+            r#"
+            INSERT INTO votes (organization_id, building_id, title, end_at, created_by)
+            VALUES ($1, $2, 'Annual budget vote', NOW() + interval '7 days', $3)
+            RETURNING id
+            "#,
+        )
+        .bind(org_id)
+        .bind(building_id)
+        .bind(created_by)
+        .fetch_one(pool)
+        .await
+        .expect("seed vote")
+    }
+
+    #[sqlx::test]
+    async fn test_get_report_pdf_returns_application_pdf_and_archives_document(pool: PgPool) {
+        let app = TestApp::new(pool.clone()).await;
+        let user = TestUser::new();
+        
+        let (token, org_id) = create_authenticated_user_with_org(&app, &user, "test-org").await;
+        
+        let user_id = sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+            .bind(&user.email)
+            .fetch_one(&app.pool)
+            .await
+            .expect("resolve user id");
+            
+        let building_id = seed_building(&app.pool, org_id, "vote-building").await;
+        let vote_id = seed_vote(&app.pool, org_id, building_id, user_id).await;
+
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri(&format!("/api/v1/voting/{}/report.pdf", vote_id))
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header("X-Tenant-ID", org_id.to_string())
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.execute(request).await;
+        assert_eq!(response.status, StatusCode::OK);
+        
+        // Assert content type is application/pdf
+        let content_type = response
+            .headers
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert_eq!(content_type, "application/pdf");
+        
+        // Assert body is not empty
+        assert!(!response.body.is_empty(), "PDF response body should not be empty");
+
+        // Assert that a document was archived in the database
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM documents WHERE organization_id = $1 AND category = 'reports'::document_category")
+            .bind(org_id)
+            .fetch_one(&app.pool)
+            .await
+            .expect("query documents count");
+        assert_eq!(count, 1, "There should be exactly one archived document for the vote report");
+    }
+
+    #[sqlx::test]
+    async fn test_get_report_json_with_format_pdf_returns_application_pdf(pool: PgPool) {
+        let app = TestApp::new(pool.clone()).await;
+        let user = TestUser::new();
+        
+        let (token, org_id) = create_authenticated_user_with_org(&app, &user, "test-org-2").await;
+        
+        let user_id = sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+            .bind(&user.email)
+            .fetch_one(&app.pool)
+            .await
+            .expect("resolve user id");
+            
+        let building_id = seed_building(&app.pool, org_id, "vote-building-2").await;
+        let vote_id = seed_vote(&app.pool, org_id, building_id, user_id).await;
+
+        // Query parameter: ?format=pdf
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri(&format!("/api/v1/voting/{}/report?format=pdf", vote_id))
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header("X-Tenant-ID", org_id.to_string())
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.execute(request).await;
+        assert_eq!(response.status, StatusCode::OK);
+        
+        let content_type = response
+            .headers
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert_eq!(content_type, "application/pdf");
+
+        // Accept header: Accept: application/pdf
+        let request_accept = Request::builder()
+            .method(Method::GET)
+            .uri(&format!("/api/v1/voting/{}/report", vote_id))
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header("X-Tenant-ID", org_id.to_string())
+            .header(header::ACCEPT, "application/pdf")
+            .body(Body::empty())
+            .unwrap();
+
+        let response_accept = app.execute(request_accept).await;
+        assert_eq!(response_accept.status, StatusCode::OK);
+        
+        let content_type_accept = response_accept
+            .headers
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert_eq!(content_type_accept, "application/pdf");
+    }
+}

--- a/backend/servers/api-server/tests/voting_tests.rs
+++ b/backend/servers/api-server/tests/voting_tests.rs
@@ -283,15 +283,15 @@ mod pdf_report {
     async fn test_get_report_pdf_returns_application_pdf_and_archives_document(pool: PgPool) {
         let app = TestApp::new(pool.clone()).await;
         let user = TestUser::new();
-        
+
         let (token, org_id) = create_authenticated_user_with_org(&app, &user, "test-org").await;
-        
+
         let user_id = sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
             .bind(&user.email)
             .fetch_one(&app.pool)
             .await
             .expect("resolve user id");
-            
+
         let building_id = seed_building(&app.pool, org_id, "vote-building").await;
         let vote_id = seed_vote(&app.pool, org_id, building_id, user_id).await;
 
@@ -305,7 +305,7 @@ mod pdf_report {
 
         let response = app.execute(request).await;
         assert_eq!(response.status, StatusCode::OK);
-        
+
         // Assert content type is application/pdf
         let content_type = response
             .headers
@@ -313,9 +313,12 @@ mod pdf_report {
             .and_then(|v| v.to_str().ok())
             .unwrap_or("");
         assert_eq!(content_type, "application/pdf");
-        
+
         // Assert body is not empty
-        assert!(!response.body.is_empty(), "PDF response body should not be empty");
+        assert!(
+            !response.body.is_empty(),
+            "PDF response body should not be empty"
+        );
 
         // Assert that a document was archived in the database
         let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM documents WHERE organization_id = $1 AND category = 'reports'::document_category")
@@ -323,22 +326,25 @@ mod pdf_report {
             .fetch_one(&app.pool)
             .await
             .expect("query documents count");
-        assert_eq!(count, 1, "There should be exactly one archived document for the vote report");
+        assert_eq!(
+            count, 1,
+            "There should be exactly one archived document for the vote report"
+        );
     }
 
     #[sqlx::test]
     async fn test_get_report_json_with_format_pdf_returns_application_pdf(pool: PgPool) {
         let app = TestApp::new(pool.clone()).await;
         let user = TestUser::new();
-        
+
         let (token, org_id) = create_authenticated_user_with_org(&app, &user, "test-org-2").await;
-        
+
         let user_id = sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
             .bind(&user.email)
             .fetch_one(&app.pool)
             .await
             .expect("resolve user id");
-            
+
         let building_id = seed_building(&app.pool, org_id, "vote-building-2").await;
         let vote_id = seed_vote(&app.pool, org_id, building_id, user_id).await;
 
@@ -353,7 +359,7 @@ mod pdf_report {
 
         let response = app.execute(request).await;
         assert_eq!(response.status, StatusCode::OK);
-        
+
         let content_type = response
             .headers
             .get(header::CONTENT_TYPE)
@@ -373,7 +379,7 @@ mod pdf_report {
 
         let response_accept = app.execute(request_accept).await;
         assert_eq!(response_accept.status, StatusCode::OK);
-        
+
         let content_type_accept = response_accept
             .headers
             .get(header::CONTENT_TYPE)


### PR DESCRIPTION
## Summary

- Adds server-side PDF rendering for vote reports using `genpdf` (pure-Rust, no headless browser or system deps beyond Liberation Sans fonts)
- New `GET /api/v1/voting/{id}/report.pdf` endpoint returns `application/pdf`
- Extends existing `GET /api/v1/voting/{id}/report` to accept `?format=pdf` or `Accept: application/pdf` header (JSON contract preserved)
- PDF content: vote title, building/org metadata, quorum type, status, generated_at timestamp, per-question results table with weighted counts, participation details table
- Archived into documents system via `DocumentRepository.create_rls` (category: `reports`); uploads to S3 when storage_service is configured
- Tenant-scope guard: checks `organization_id == rls.tenant_id()` matching existing authz pattern

## Test plan

- [ ] `cargo build -p api-server` clean
- [ ] `cargo clippy -p api-server` clean  
- [ ] `cargo test -p api-server` — voting tests: `test_get_report_pdf_returns_application_pdf_and_archives_document` passes
- [ ] JSON `VoteReportData` response still works (no regression on existing callers)

Closes PAP-288 (Epic 5 Gap 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)