### PR TITLE
feat(api-server): org-wide payment management backend (#975.5)

### DIFF
--- a/backend/crates/db/src/repositories/financial.rs
+++ b/backend/crates/db/src/repositories/financial.rs
@@ -763,21 +763,10 @@ impl FinancialRepository {
         .fetch_one(&self.pool)
         .await?;
 
-        // Update invoice balance and status
-        sqlx::query(
-            r#"
-            UPDATE invoices
-            SET amount_paid = amount_paid + $2,
-                balance_due = balance_due - $2,
-                updated_at = NOW()
-            WHERE id = $1
-            "#,
-        )
-        .bind(invoice_id)
-        .bind(amount)
-        .execute(&self.pool)
-        .await?;
-
+        // The invoice's amount_paid / balance_due / status are recomputed from the
+        // sum of allocations by the `update_invoice_on_allocation` trigger. A manual
+        // `balance_due = balance_due - amount` update here double-counts the
+        // allocation (the balance goes negative) — so it is intentionally omitted.
         Ok(allocation)
     }
 
@@ -857,6 +846,235 @@ impl FinancialRepository {
         .bind(offset)
         .fetch_all(&self.pool)
         .await
+    }
+
+    // ------------------------------------------------------------------------
+    // Org-wide payment management (Story 11.4 — Payment Management page).
+    //
+    // The page needs an org-scoped view of all payments plus reconciliation
+    // (which payments are still unallocated, allocate one to an invoice, and a
+    // bulk auto-match). Every query is scoped on `organization_id` so a payment
+    // or invoice from another org is never touched.
+    // ------------------------------------------------------------------------
+
+    /// List all payments for an organization, newest first, optionally filtered
+    /// by status (compared as text to avoid enum-encode pitfalls).
+    pub async fn list_payments(
+        &self,
+        organization_id: Uuid,
+        status: Option<String>,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<Payment>, SqlxError> {
+        sqlx::query_as::<_, Payment>(
+            r#"
+            SELECT * FROM payments
+            WHERE organization_id = $1
+              AND ($2::text IS NULL OR status::text = $2)
+            ORDER BY payment_date DESC, created_at DESC
+            LIMIT $3 OFFSET $4
+            "#,
+        )
+        .bind(organization_id)
+        .bind(&status)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    /// Count payments for an organization (matching the same status filter as
+    /// [`list_payments`](Self::list_payments)) so paginated routes can report a
+    /// true total instead of the current page's length.
+    pub async fn count_payments(
+        &self,
+        organization_id: Uuid,
+        status: Option<String>,
+    ) -> Result<i64, SqlxError> {
+        sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT COUNT(*) FROM payments
+            WHERE organization_id = $1
+              AND ($2::text IS NULL OR status::text = $2)
+            "#,
+        )
+        .bind(organization_id)
+        .bind(&status)
+        .fetch_one(&self.pool)
+        .await
+    }
+
+    /// List payments that still have an unallocated balance (sum of their
+    /// allocations is less than the payment amount) — the reconciliation queue.
+    pub async fn list_unallocated_payments(
+        &self,
+        organization_id: Uuid,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<Payment>, SqlxError> {
+        sqlx::query_as::<_, Payment>(
+            r#"
+            SELECT p.*
+            FROM payments p
+            LEFT JOIN payment_allocations pa ON pa.payment_id = p.id
+            WHERE p.organization_id = $1
+            GROUP BY p.id
+            HAVING p.amount - COALESCE(SUM(pa.amount), 0) > 0
+            ORDER BY p.payment_date DESC, p.created_at DESC
+            LIMIT $2 OFFSET $3
+            "#,
+        )
+        .bind(organization_id)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    /// Allocate an already-recorded payment to an invoice (the manual "match"
+    /// action). Both the payment and invoice must belong to `organization_id`,
+    /// else `Ok(None)` (the route returns 404 — no cross-org leakage). The
+    /// allocated amount is clamped to both the payment's remaining unallocated
+    /// balance and the invoice's outstanding balance; if nothing can be
+    /// allocated, returns `Ok(None)`.
+    pub async fn allocate_existing_payment(
+        &self,
+        organization_id: Uuid,
+        payment_id: Uuid,
+        invoice_id: Uuid,
+        amount: Option<Decimal>,
+    ) -> Result<Option<PaymentAllocation>, SqlxError> {
+        let mut tx = self.pool.begin().await?;
+
+        let payment = sqlx::query_as::<_, Payment>(
+            "SELECT * FROM payments WHERE id = $1 AND organization_id = $2",
+        )
+        .bind(payment_id)
+        .bind(organization_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+        let Some(payment) = payment else {
+            return Ok(None);
+        };
+
+        let invoice = sqlx::query_as::<_, Invoice>(
+            "SELECT * FROM invoices WHERE id = $1 AND organization_id = $2",
+        )
+        .bind(invoice_id)
+        .bind(organization_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+        let Some(invoice) = invoice else {
+            return Ok(None);
+        };
+
+        let allocated: Decimal = sqlx::query_scalar(
+            "SELECT COALESCE(SUM(amount), 0) FROM payment_allocations WHERE payment_id = $1",
+        )
+        .bind(payment_id)
+        .fetch_one(&mut *tx)
+        .await?;
+        let payment_remaining = payment.amount - allocated;
+
+        let requested = amount.unwrap_or(payment_remaining);
+        let to_allocate = requested.min(payment_remaining).min(invoice.balance_due);
+        if to_allocate <= Decimal::ZERO {
+            return Ok(None);
+        }
+
+        // Inserting the allocation is sufficient: the `update_invoice_on_allocation`
+        // trigger recomputes the invoice's amount_paid / balance_due / status from
+        // the sum of allocations. Do NOT also update the invoice here or the
+        // balance is decremented twice.
+        let allocation = sqlx::query_as::<_, PaymentAllocation>(
+            r#"
+            INSERT INTO payment_allocations (payment_id, invoice_id, amount)
+            VALUES ($1, $2, $3)
+            RETURNING *
+            "#,
+        )
+        .bind(payment_id)
+        .bind(invoice_id)
+        .bind(to_allocate)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(Some(allocation))
+    }
+
+    /// Bulk auto-match: for every payment in the org with an unallocated
+    /// balance, allocate it (oldest-due first) against that unit's outstanding
+    /// invoices — the same oldest-first rule [`record_payment`](Self::record_payment)
+    /// applies at record time. Returns the number of allocations created.
+    pub async fn auto_match_payments(&self, organization_id: Uuid) -> Result<u64, SqlxError> {
+        let mut tx = self.pool.begin().await?;
+
+        let payments = sqlx::query_as::<_, Payment>(
+            r#"
+            SELECT p.*
+            FROM payments p
+            LEFT JOIN payment_allocations pa ON pa.payment_id = p.id
+            WHERE p.organization_id = $1
+            GROUP BY p.id
+            HAVING p.amount - COALESCE(SUM(pa.amount), 0) > 0
+            ORDER BY p.payment_date ASC
+            "#,
+        )
+        .bind(organization_id)
+        .fetch_all(&mut *tx)
+        .await?;
+
+        let mut created: u64 = 0;
+        for payment in payments {
+            let allocated: Decimal = sqlx::query_scalar(
+                "SELECT COALESCE(SUM(amount), 0) FROM payment_allocations WHERE payment_id = $1",
+            )
+            .bind(payment.id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let mut remaining = payment.amount - allocated;
+            if remaining <= Decimal::ZERO {
+                continue;
+            }
+
+            let invoices = sqlx::query_as::<_, Invoice>(
+                r#"
+                SELECT * FROM invoices
+                WHERE unit_id = $1 AND organization_id = $2 AND balance_due > 0
+                ORDER BY due_date ASC, created_at ASC
+                "#,
+            )
+            .bind(payment.unit_id)
+            .bind(organization_id)
+            .fetch_all(&mut *tx)
+            .await?;
+
+            for invoice in invoices {
+                if remaining <= Decimal::ZERO {
+                    break;
+                }
+                let to_allocate = remaining.min(invoice.balance_due);
+                if to_allocate <= Decimal::ZERO {
+                    continue;
+                }
+                // The `update_invoice_on_allocation` trigger updates the invoice
+                // balance/status; inserting the allocation is all that's needed.
+                sqlx::query(
+                    "INSERT INTO payment_allocations (payment_id, invoice_id, amount) VALUES ($1, $2, $3)",
+                )
+                .bind(payment.id)
+                .bind(invoice.id)
+                .bind(to_allocate)
+                .execute(&mut *tx)
+                .await?;
+                remaining -= to_allocate;
+                created += 1;
+            }
+        }
+
+        tx.commit().await?;
+        Ok(created)
     }
 
     // ========================================================================

--- a/backend/crates/db/tests/payment_management_tests.rs
+++ b/backend/crates/db/tests/payment_management_tests.rs
@@ -1,0 +1,230 @@
+//! Org-wide payment management repo tests (Story 11.4, #975.5).
+//!
+//! Cover the new `FinancialRepository` methods backing the Payment Management
+//! page: `list_payments` / `count_payments`, `list_unallocated_payments`,
+//! `allocate_existing_payment` (manual match, org-scoped), and
+//! `auto_match_payments` (bulk oldest-first allocation).
+//!
+//! Run against a live Postgres (sqlx spins up a per-test database):
+//! `DATABASE_URL=... cargo test -p db --test payment_management_tests`.
+
+use db::repositories::FinancialRepository;
+use rust_decimal::Decimal;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+fn money(units: i64) -> Decimal {
+    Decimal::new(units * 100, 2) // whole-euro helper: money(100) == 100.00
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("PayMgmt {slug}"))
+    .bind(format!("pay-mgmt-{slug}"))
+    .bind(format!("{slug}@pay-mgmt.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_unit(pool: &PgPool, org: Uuid) -> Uuid {
+    let building = sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO buildings (organization_id, name, street, city, postal_code, country, status)
+        VALUES ($1, 'B', 'Street 1', 'City', '00000', 'SK', 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(org)
+    .fetch_one(pool)
+    .await
+    .expect("seed building");
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO units (building_id, designation) VALUES ($1, '1A') RETURNING id",
+    )
+    .bind(building)
+    .fetch_one(pool)
+    .await
+    .expect("seed unit")
+}
+
+/// Seed an invoice with a given outstanding balance, due `days_from_today`.
+async fn seed_invoice(
+    pool: &PgPool,
+    org: Uuid,
+    unit: Uuid,
+    number: &str,
+    total: Decimal,
+    balance: Decimal,
+    days_from_today: i64,
+) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO invoices (organization_id, unit_id, invoice_number, due_date, total, balance_due)
+        VALUES ($1, $2, $3, CURRENT_DATE + ($4 || ' days')::interval, $5, $6)
+        RETURNING id
+        "#,
+    )
+    .bind(org)
+    .bind(unit)
+    .bind(number)
+    .bind(days_from_today.to_string())
+    .bind(total)
+    .bind(balance)
+    .fetch_one(pool)
+    .await
+    .expect("seed invoice")
+}
+
+async fn seed_payment(pool: &PgPool, org: Uuid, unit: Uuid, amount: Decimal) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO payments (organization_id, unit_id, amount, payment_method)
+        VALUES ($1, $2, $3, 'bank_transfer')
+        RETURNING id
+        "#,
+    )
+    .bind(org)
+    .bind(unit)
+    .bind(amount)
+    .fetch_one(pool)
+    .await
+    .expect("seed payment")
+}
+
+async fn invoice_balance(pool: &PgPool, invoice_id: Uuid) -> Decimal {
+    sqlx::query_scalar::<_, Decimal>("SELECT balance_due FROM invoices WHERE id = $1")
+        .bind(invoice_id)
+        .fetch_one(pool)
+        .await
+        .expect("invoice balance")
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_payments_is_org_scoped_and_counted(pool: PgPool) {
+    let repo = FinancialRepository::new(pool.clone());
+    let org_a = seed_org(&pool, "list-a").await;
+    let org_b = seed_org(&pool, "list-b").await;
+    let unit_a = seed_unit(&pool, org_a).await;
+    let unit_b = seed_unit(&pool, org_b).await;
+
+    seed_payment(&pool, org_a, unit_a, money(100)).await;
+    seed_payment(&pool, org_a, unit_a, money(50)).await;
+    seed_payment(&pool, org_b, unit_b, money(70)).await;
+
+    let payments = repo.list_payments(org_a, None, 100, 0).await.unwrap();
+    assert_eq!(payments.len(), 2, "only org A's payments are listed");
+    assert!(payments.iter().all(|p| p.organization_id == org_a));
+    assert_eq!(repo.count_payments(org_a, None).await.unwrap(), 2);
+
+    // Status filter (all seeded payments default to 'completed').
+    assert_eq!(
+        repo.list_payments(org_a, Some("completed".into()), 100, 0)
+            .await
+            .unwrap()
+            .len(),
+        2
+    );
+    assert_eq!(
+        repo.list_payments(org_a, Some("failed".into()), 100, 0)
+            .await
+            .unwrap()
+            .len(),
+        0
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn unallocated_list_drops_a_payment_once_fully_allocated(pool: PgPool) {
+    let repo = FinancialRepository::new(pool.clone());
+    let org = seed_org(&pool, "unalloc").await;
+    let unit = seed_unit(&pool, org).await;
+    let payment = seed_payment(&pool, org, unit, money(100)).await;
+    let invoice = seed_invoice(&pool, org, unit, "INV-1", money(100), money(100), 10).await;
+
+    // Initially unallocated.
+    let before = repo.list_unallocated_payments(org, 100, 0).await.unwrap();
+    assert_eq!(before.len(), 1);
+    assert_eq!(before[0].id, payment);
+
+    // Allocate the full amount → no longer unallocated.
+    let alloc = repo
+        .allocate_existing_payment(org, payment, invoice, None)
+        .await
+        .unwrap()
+        .expect("allocation created");
+    assert_eq!(alloc.amount, money(100));
+    assert_eq!(invoice_balance(&pool, invoice).await, Decimal::ZERO);
+
+    let after = repo.list_unallocated_payments(org, 100, 0).await.unwrap();
+    assert!(after.is_empty(), "fully-allocated payment leaves the queue");
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn allocate_clamps_to_invoice_balance_and_is_org_scoped(pool: PgPool) {
+    let repo = FinancialRepository::new(pool.clone());
+    let org = seed_org(&pool, "alloc").await;
+    let other = seed_org(&pool, "alloc-other").await;
+    let unit = seed_unit(&pool, org).await;
+    let payment = seed_payment(&pool, org, unit, money(100)).await;
+    let invoice = seed_invoice(&pool, org, unit, "INV-1", money(60), money(60), 10).await;
+
+    // No `amount` → clamp to the invoice's 60 balance, not the payment's 100.
+    let alloc = repo
+        .allocate_existing_payment(org, payment, invoice, None)
+        .await
+        .unwrap()
+        .expect("allocation");
+    assert_eq!(alloc.amount, money(60));
+    assert_eq!(invoice_balance(&pool, invoice).await, Decimal::ZERO);
+
+    // 40 of the payment is still unallocated.
+    assert_eq!(
+        repo.list_unallocated_payments(org, 100, 0)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+
+    // Cross-org: the wrong org cannot allocate this payment/invoice → None (404).
+    let cross = repo
+        .allocate_existing_payment(other, payment, invoice, None)
+        .await
+        .unwrap();
+    assert!(cross.is_none(), "cross-org allocation must be refused");
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn auto_match_allocates_oldest_first(pool: PgPool) {
+    let repo = FinancialRepository::new(pool.clone());
+    let org = seed_org(&pool, "auto").await;
+    let unit = seed_unit(&pool, org).await;
+    seed_payment(&pool, org, unit, money(100)).await;
+    // Two invoices on the same unit; older due-date should be paid first.
+    let older = seed_invoice(&pool, org, unit, "INV-OLD", money(60), money(60), 1).await;
+    let newer = seed_invoice(&pool, org, unit, "INV-NEW", money(80), money(80), 30).await;
+
+    let matched = repo.auto_match_payments(org).await.unwrap();
+    assert_eq!(matched, 2, "100 splits across the two oldest invoices");
+
+    // 60 → older (fully paid), remaining 40 → newer (partial).
+    assert_eq!(invoice_balance(&pool, older).await, Decimal::ZERO);
+    assert_eq!(invoice_balance(&pool, newer).await, money(40));
+
+    // Payment is now fully allocated → reconciliation queue empty.
+    assert!(repo
+        .list_unallocated_payments(org, 100, 0)
+        .await
+        .unwrap()
+        .is_empty());
+
+    // Idempotent-ish: a second run finds nothing left to match.
+    assert_eq!(repo.auto_match_payments(org).await.unwrap(), 0);
+}

--- a/backend/servers/api-server/src/routes/financial.rs
+++ b/backend/servers/api-server/src/routes/financial.rs
@@ -14,7 +14,7 @@ use chrono::NaiveDate;
 use common::errors::ErrorResponse;
 use db::models::{
     CreateFeeSchedule, CreateFinancialAccount, CreateInvoice, CreateTransaction, InvoiceStatus,
-    RecordPayment,
+    Payment, PaymentAllocation, RecordPayment,
 };
 use rust_decimal::Decimal;
 use serde::Deserialize;
@@ -150,7 +150,12 @@ pub fn router() -> Router<AppState> {
         .route("/units/{unit_id}/invoices", get(list_unit_invoices))
         // Payments (Story 11.4)
         .route("/payments", post(record_payment))
+        .route("/payments", get(list_payments))
+        // Static segments before `/{id}` so they aren't captured as an id.
+        .route("/payments/unallocated", get(list_unallocated_payments))
+        .route("/payments/auto-match", post(auto_match_payments))
         .route("/payments/{id}", get(get_payment))
+        .route("/payments/{id}/allocate", post(allocate_payment))
         .route("/units/{unit_id}/payments", get(list_unit_payments))
         // Payment reminders (Story 11.6)
         .route("/reminder-schedules", get(get_reminder_schedules))
@@ -197,6 +202,69 @@ pub struct UnitPaymentsQuery {
     /// Page offset
     #[serde(default)]
     pub offset: i64,
+}
+
+/// Org-wide payments list query (Story 11.4 Payment Management).
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListPaymentsQuery {
+    /// Organization whose payments to list (membership is verified)
+    pub organization_id: Uuid,
+    /// Optional payment-status filter (pending|completed|failed|refunded|cancelled)
+    #[serde(default)]
+    pub status: Option<String>,
+    /// Page limit
+    #[serde(default = "default_limit")]
+    pub limit: i64,
+    /// Page offset
+    #[serde(default)]
+    pub offset: i64,
+}
+
+/// Unallocated-payments query.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct UnallocatedPaymentsQuery {
+    /// Organization whose unallocated payments to list (membership is verified)
+    pub organization_id: Uuid,
+    /// Page limit
+    #[serde(default = "default_limit")]
+    pub limit: i64,
+    /// Page offset
+    #[serde(default)]
+    pub offset: i64,
+}
+
+/// Paginated payments list response.
+#[derive(Debug, serde::Serialize, ToSchema)]
+pub struct PaymentListResponse {
+    pub payments: Vec<Payment>,
+    pub total: i64,
+}
+
+/// Request to allocate an existing payment to an invoice (the manual match).
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct AllocatePaymentRequest {
+    /// Organization that owns both the payment and the invoice (verified)
+    pub organization_id: Uuid,
+    /// Invoice to allocate the payment against
+    pub invoice_id: Uuid,
+    /// Amount to allocate (defaults to the lesser of the payment's remaining
+    /// balance and the invoice's outstanding balance)
+    #[serde(default)]
+    pub amount: Option<Decimal>,
+}
+
+/// Request to bulk auto-match unallocated payments in an organization.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct AutoMatchRequest {
+    /// Organization whose unallocated payments to auto-match (verified)
+    pub organization_id: Uuid,
+}
+
+/// Auto-match result.
+#[derive(Debug, serde::Serialize, ToSchema)]
+pub struct AutoMatchResponse {
+    /// Number of allocations created
+    pub matched: i64,
 }
 
 /// List invoices query parameters.
@@ -852,6 +920,123 @@ async fn list_unit_payments(
         .filter(|p| p.organization_id == query.organization_id)
         .collect::<Vec<_>>();
     Ok(Json(scoped))
+}
+
+/// List all payments for an organization (paginated, optional status filter).
+async fn list_payments(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Query(query): Query<ListPaymentsQuery>,
+) -> Result<Json<PaymentListResponse>, (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, auth.user_id, query.organization_id).await?;
+    let limit = query.limit.min(MAX_LIST_LIMIT);
+    let (payments, total) = tokio::try_join!(
+        state.financial_repo.list_payments(
+            query.organization_id,
+            query.status.clone(),
+            limit,
+            query.offset,
+        ),
+        state
+            .financial_repo
+            .count_payments(query.organization_id, query.status.clone()),
+    )
+    .map_err(|e| {
+        tracing::error!("Failed to list payments: {:?}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new("DB_ERROR", "Failed to list payments")),
+        )
+    })?;
+    Ok(Json(PaymentListResponse { payments, total }))
+}
+
+/// List payments with an unallocated balance (the reconciliation queue).
+async fn list_unallocated_payments(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Query(query): Query<UnallocatedPaymentsQuery>,
+) -> Result<Json<Vec<Payment>>, (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, auth.user_id, query.organization_id).await?;
+    let limit = query.limit.min(MAX_LIST_LIMIT);
+    let payments = state
+        .financial_repo
+        .list_unallocated_payments(query.organization_id, limit, query.offset)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to list unallocated payments: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(
+                    "DB_ERROR",
+                    "Failed to list unallocated payments",
+                )),
+            )
+        })?;
+    Ok(Json(payments))
+}
+
+/// Allocate an existing payment to an invoice (manual match).
+async fn allocate_payment(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path(id): Path<Uuid>,
+    Json(payload): Json<AllocatePaymentRequest>,
+) -> Result<(StatusCode, Json<PaymentAllocation>), (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, auth.user_id, payload.organization_id).await?;
+    let allocation = state
+        .financial_repo
+        .allocate_existing_payment(
+            payload.organization_id,
+            id,
+            payload.invoice_id,
+            payload.amount,
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to allocate payment: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", "Failed to allocate payment")),
+            )
+        })?;
+    match allocation {
+        Some(a) => Ok((StatusCode::CREATED, Json(a))),
+        // payment/invoice not in org, or nothing left to allocate.
+        None => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new(
+                "NOT_FOUND",
+                "Payment or invoice not found, or nothing to allocate",
+            )),
+        )),
+    }
+}
+
+/// Bulk auto-match unallocated payments in an organization.
+async fn auto_match_payments(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Json(payload): Json<AutoMatchRequest>,
+) -> Result<Json<AutoMatchResponse>, (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, auth.user_id, payload.organization_id).await?;
+    let matched = state
+        .financial_repo
+        .auto_match_payments(payload.organization_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to auto-match payments: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(
+                    "DB_ERROR",
+                    "Failed to auto-match payments",
+                )),
+            )
+        })?;
+    Ok(Json(AutoMatchResponse {
+        matched: matched as i64,
+    }))
 }
 
 // ==================== Reminder/Late Fee Handlers ====================


### PR DESCRIPTION
Part of #975 (Epic 11/52). Builds the missing backend for the financial **Payment Management** page (Story 11.4), which previously had no org-wide endpoints to consume (payments could only be listed per-unit).

### Endpoints (all behind `verify_org_access`)
| Method | Path | Purpose |
|---|---|---|
| GET | `/financial/payments` | org-scoped paginated list (+ total), optional status filter |
| GET | `/financial/payments/unallocated` | reconciliation queue (payments not fully allocated) |
| POST | `/financial/payments/{id}/allocate` | manual match: allocate an existing payment to an invoice |
| POST | `/financial/payments/auto-match` | bulk allocate unallocated payments, oldest-due first |

Backed by new `FinancialRepository` methods (`list_payments`/`count_payments`, `list_unallocated_payments`, `allocate_existing_payment`, `auto_match_payments`). Allocation is org-scoped (cross-org → `Ok(None)` → 404) and clamped to both the payment's remaining balance and the invoice's outstanding balance.

### Bug fix found by the tests
Inserting a `payment_allocations` row already fires the `update_invoice_on_allocation` trigger, which recomputes `amount_paid`/`balance_due`/`status` from the sum of allocations. The pre-existing private `allocate_payment` *also* did a manual `balance_due -= amount` update — **double-counting** the allocation (balance went negative). Removed that redundant update (and omitted it from the new methods), which also fixes `record_payment`'s allocation path.

### Tests
`payment_management_tests` (4× `#[sqlx::test]` vs live Postgres): org-scoped list/count/status-filter, unallocated-queue drop after allocation, allocate clamping + cross-org refusal, oldest-first auto-match. Verified on the remote builder: clippy `-D warnings` clean, `cargo fmt` clean, **4/4 pass**.

### Follow-up (documented)
Wiring the ppt-web page to these endpoints is blocked on a **separate pre-existing bug**: the hand-written financial api-client (`financial/api.ts` `fetchApi`) sends **no `Authorization` header**, so the whole Epic 52 financial frontend can't authenticate. That gap must be fixed before the page works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)