### PR TITLE
fix(api-client): send auth from the financial client (#975)

### DIFF
--- a/frontend/packages/api-client/src/financial/api.test.ts
+++ b/frontend/packages/api-client/src/financial/api.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for the financial API client's auth wiring (#975).
+ *
+ * The hand-written `fetchApi` does NOT go through the generated @hey-api client,
+ * so it doesn't get the centralized auth interceptor (#1616). Before this fix it
+ * sent no Authorization / X-Tenant-ID, so every Epic 52 financial request 401'd.
+ * These pin that requests now carry auth from the shared providers and target the
+ * configured base URL.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getToken: vi.fn(),
+  getOrg: vi.fn(),
+  getConfig: vi.fn(),
+}));
+
+vi.mock('../auth', () => ({ getToken: mocks.getToken, getOrg: mocks.getOrg }));
+vi.mock('../generated/client.gen', () => ({ client: { getConfig: mocks.getConfig } }));
+
+import { listAccounts } from './api';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getConfig.mockReturnValue({ baseUrl: 'https://api.example.test' });
+});
+
+describe('financial fetchApi auth wiring', () => {
+  it('sends Authorization + X-Tenant-ID from the providers and prefixes the base URL', async () => {
+    mocks.getToken.mockReturnValue('tok-123');
+    mocks.getOrg.mockReturnValue('org-9');
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await listAccounts({ organization_id: 'org-9' });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain('https://api.example.test/api/v1/financial/accounts');
+    expect(init.headers.Authorization).toBe('Bearer tok-123');
+    expect(init.headers['X-Tenant-ID']).toBe('org-9');
+    // The bug was a missing header / `Bearer null`.
+    expect(init.headers.Authorization).not.toContain('null');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('omits auth headers when there is no session rather than sending Bearer null', async () => {
+    mocks.getToken.mockReturnValue(null);
+    mocks.getOrg.mockReturnValue(null);
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await listAccounts({ organization_id: 'org-9' });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers.Authorization).toBeUndefined();
+    expect(init.headers['X-Tenant-ID']).toBeUndefined();
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/frontend/packages/api-client/src/financial/api.ts
+++ b/frontend/packages/api-client/src/financial/api.ts
@@ -4,6 +4,8 @@
  * Client functions for financial management endpoints.
  */
 
+import { getOrg, getToken } from '../auth';
+import { client } from '../generated/client.gen';
 import type {
   AccountsReceivableReport,
   AccountTransaction,
@@ -33,10 +35,21 @@ import type {
 const API_BASE = '/api/v1/financial';
 
 async function fetchApi<T>(url: string, options?: RequestInit): Promise<T> {
-  const response = await fetch(url, {
+  // These are raw `fetch` calls (not the generated @hey-api client), so they
+  // don't get the centralized auth interceptor (#1616). Without this, every
+  // financial request went out with no Authorization / X-Tenant-ID and 401'd
+  // against the api-server. Draw auth from the same token / active-org providers
+  // and prefix the same configured base URL the generated client uses.
+  const token = getToken();
+  const org = getOrg();
+  const baseUrl = client.getConfig().baseUrl ?? '';
+
+  const response = await fetch(`${baseUrl}${url}`, {
     ...options,
     headers: {
       'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(org ? { 'X-Tenant-ID': org } : {}),
       ...options?.headers,
     },
   });


### PR DESCRIPTION
The hand-written financial API client (`financial/api.ts`) makes raw `fetch` calls, so unlike the generated @hey-api client it never gets the centralized auth interceptor (#1616). `fetchApi` set only `Content-Type` → every Epic 52 financial request (dashboard #975.1, invoices #975.2, the new Payment Management endpoints in #1628) went out with **no `Authorization` / `X-Tenant-ID`** and 401'd against api-server. The whole financial frontend was non-functional.

### Fix
Inject auth at the single `fetchApi` chokepoint (covers all 23 functions):
- `Authorization: Bearer <getToken()>` + `X-Tenant-ID: <getOrg()>` from the shared auth providers (omitted when there's no session — no `Bearer null`).
- Prefix `client.getConfig().baseUrl` (the same base the generated client uses) instead of a bare same-origin relative URL.
- Per-call `options.headers` still override.

### Tests
`financial/api.test.ts` pins that requests carry auth from the providers + target the base URL, and omit auth when unauthenticated.

Verified on the remote builder: `@ppt/api-client` typecheck clean, vitest **2/2**, biome clean.

This unblocks the financial frontend so the Payment Management page (#1628 backend) and dashboard can actually authenticate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)