### PR TITLE
[PM #1627] saved-search alerts list: signal truncation past LIMIT 100

### DIFF
--- a/backend/crates/db/src/repositories/reality_portal.rs
+++ b/backend/crates/db/src/repositories/reality_portal.rs
@@ -171,6 +171,8 @@ impl RealityPortalRepository {
     pub async fn get_search_alerts(
         &self,
         user_id: Uuid,
+        before_created_at: Option<DateTime<Utc>>,
+        before_id: Option<Uuid>,
         limit: i64,
     ) -> Result<Vec<SavedSearchAlert>, SqlxError> {
         sqlx::query_as::<_, SavedSearchAlert>(
@@ -187,12 +189,19 @@ impl RealityPortalRepository {
             FROM search_alert_queue q
             JOIN portal_saved_searches s ON s.id = q.saved_search_id
             WHERE q.user_id = $1
-            ORDER BY q.created_at DESC
+              AND (
+                $3::timestamptz IS NULL
+                OR q.created_at < $3::timestamptz
+                OR (q.created_at = $3::timestamptz AND q.id < $4::uuid)
+              )
+            ORDER BY q.created_at DESC, q.id DESC
             LIMIT $2
             "#,
         )
         .bind(user_id)
         .bind(limit)
+        .bind(before_created_at)
+        .bind(before_id)
         .fetch_all(&self.pool)
         .await
     }

--- a/backend/crates/db/tests/search_alert_delivery_tests.rs
+++ b/backend/crates/db/tests/search_alert_delivery_tests.rs
@@ -106,7 +106,11 @@ async fn search_alert_read_is_owner_scoped(pool: PgPool) {
     repo.enqueue_search_alert(&pool, search_id, owner, &[Uuid::new_v4()], "new_listing")
         .await
         .expect("enqueue alert");
-    let alert_id = repo.get_search_alerts(owner, None, None, 100).await.unwrap()[0].id;
+    let alert_id = repo
+        .get_search_alerts(owner, None, None, 100)
+        .await
+        .unwrap()[0]
+        .id;
 
     // The attacker cannot ack the owner's alert (no IDOR) and sees none of it.
     assert!(
@@ -162,17 +166,22 @@ async fn search_alert_pagination_and_has_more(pool: PgPool) {
         .get_search_alerts(user, None, None, 4)
         .await
         .expect("fetch page 1");
-    
+
     // We should get 4 alerts (since we enqueued 5).
     assert_eq!(alerts_page1.len(), 4, "expected 4 alerts (limit + 1)");
 
     // The has_more check in list_search_alerts would see alerts_page1.len() > limit (4 > 3), which is true.
     // To simulate pagination, the client uses the 3rd alert's created_at and id as the cursor.
     let cursor_alert = &alerts_page1[2]; // index 2 is the 3rd alert
-    
+
     // Query page 2 using the cursor.
     let alerts_page2 = repo
-        .get_search_alerts(user, Some(cursor_alert.created_at), Some(cursor_alert.id), 4)
+        .get_search_alerts(
+            user,
+            Some(cursor_alert.created_at),
+            Some(cursor_alert.id),
+            4,
+        )
         .await
         .expect("fetch page 2");
 
@@ -180,6 +189,8 @@ async fn search_alert_pagination_and_has_more(pool: PgPool) {
     assert_eq!(alerts_page2.len(), 2, "expected remaining 2 alerts");
 
     // Check that the first alert of page 2 is indeed the 4th alert from page 1.
-    assert_eq!(alerts_page2[0].id, alerts_page1[3].id, "expected page 2 first alert to match page 1 fourth alert");
+    assert_eq!(
+        alerts_page2[0].id, alerts_page1[3].id,
+        "expected page 2 first alert to match page 1 fourth alert"
+    );
 }
-

--- a/backend/crates/db/tests/search_alert_delivery_tests.rs
+++ b/backend/crates/db/tests/search_alert_delivery_tests.rs
@@ -60,7 +60,7 @@ async fn search_alert_delivery_lifecycle(pool: PgPool) {
 
     // List: one pending alert, joined to its search name, carrying the matches.
     let alerts = repo
-        .get_search_alerts(user, 100)
+        .get_search_alerts(user, None, None, 100)
         .await
         .expect("list alerts");
     assert_eq!(alerts.len(), 1, "expected exactly one alert");
@@ -86,7 +86,7 @@ async fn search_alert_delivery_lifecycle(pool: PgPool) {
         0,
         "no unread alerts after ack"
     );
-    let after = repo.get_search_alerts(user, 100).await.unwrap();
+    let after = repo.get_search_alerts(user, None, None, 100).await.unwrap();
     assert_eq!(after[0].status, "sent");
     assert!(after[0].processed_at.is_some());
 
@@ -106,7 +106,7 @@ async fn search_alert_read_is_owner_scoped(pool: PgPool) {
     repo.enqueue_search_alert(&pool, search_id, owner, &[Uuid::new_v4()], "new_listing")
         .await
         .expect("enqueue alert");
-    let alert_id = repo.get_search_alerts(owner, 100).await.unwrap()[0].id;
+    let alert_id = repo.get_search_alerts(owner, None, None, 100).await.unwrap()[0].id;
 
     // The attacker cannot ack the owner's alert (no IDOR) and sees none of it.
     assert!(
@@ -117,7 +117,7 @@ async fn search_alert_read_is_owner_scoped(pool: PgPool) {
         "a non-owner must not be able to mark another user's alert read"
     );
     assert!(
-        repo.get_search_alerts(attacker, 100)
+        repo.get_search_alerts(attacker, None, None, 100)
             .await
             .unwrap()
             .is_empty(),
@@ -142,3 +142,44 @@ async fn search_alert_read_is_owner_scoped(pool: PgPool) {
     );
     assert_eq!(repo.count_pending_search_alerts(owner).await.unwrap(), 0);
 }
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn search_alert_pagination_and_has_more(pool: PgPool) {
+    let repo = RealityPortalRepository::new(pool.clone());
+    let user = seed_portal_user(&pool, "alerts-pagination@test.sk").await;
+    let search_id = seed_saved_search(&repo, user, "Paginated search").await;
+
+    // Enqueue 5 alerts.
+    for _ in 0..5 {
+        repo.enqueue_search_alert(&pool, search_id, user, &[Uuid::new_v4()], "new_listing")
+            .await
+            .expect("enqueue alert");
+    }
+
+    // Query page 1 with limit of 3 alerts.
+    // To check if there's a next page, we fetch limit + 1 = 4.
+    let alerts_page1 = repo
+        .get_search_alerts(user, None, None, 4)
+        .await
+        .expect("fetch page 1");
+    
+    // We should get 4 alerts (since we enqueued 5).
+    assert_eq!(alerts_page1.len(), 4, "expected 4 alerts (limit + 1)");
+
+    // The has_more check in list_search_alerts would see alerts_page1.len() > limit (4 > 3), which is true.
+    // To simulate pagination, the client uses the 3rd alert's created_at and id as the cursor.
+    let cursor_alert = &alerts_page1[2]; // index 2 is the 3rd alert
+    
+    // Query page 2 using the cursor.
+    let alerts_page2 = repo
+        .get_search_alerts(user, Some(cursor_alert.created_at), Some(cursor_alert.id), 4)
+        .await
+        .expect("fetch page 2");
+
+    // We should get 2 alerts (the 4th and 5th alerts).
+    assert_eq!(alerts_page2.len(), 2, "expected remaining 2 alerts");
+
+    // Check that the first alert of page 2 is indeed the 4th alert from page 1.
+    assert_eq!(alerts_page2[0].id, alerts_page1[3].id, "expected page 2 first alert to match page 1 fourth alert");
+}
+

--- a/backend/servers/api-server/tests/voting_tests.rs
+++ b/backend/servers/api-server/tests/voting_tests.rs
@@ -279,7 +279,7 @@ mod pdf_report {
         .expect("seed vote")
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "db::MIGRATOR")]
     async fn test_get_report_pdf_returns_application_pdf_and_archives_document(pool: PgPool) {
         let app = TestApp::new(pool.clone()).await;
         let user = TestUser::new();
@@ -332,7 +332,7 @@ mod pdf_report {
         );
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "db::MIGRATOR")]
     async fn test_get_report_json_with_format_pdf_returns_application_pdf(pool: PgPool) {
         let app = TestApp::new(pool.clone()).await;
         let user = TestUser::new();

--- a/backend/servers/reality-server/src/routes/saved_searches.rs
+++ b/backend/servers/reality-server/src/routes/saved_searches.rs
@@ -5,16 +5,17 @@
 use crate::state::AppState;
 use api_core::extractors::RequestPrincipal;
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     routing::{delete, get, post, put},
     Json, Router,
 };
+use chrono::{DateTime, Utc};
 use db::models::{
     CreatePortalSavedSearch, PortalSavedSearch, PublicListingSummary, SavedSearchAlert,
     UpdatePortalSavedSearch,
 };
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
+use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 
 /// Create saved searches router.
@@ -264,12 +265,22 @@ pub async fn run_saved_search(
 // them. (reality-server has no email transport; in-app is the delivery channel.)
 // ============================================================================
 
+/// Saved-search alerts query parameters.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct SearchAlertsQuery {
+    /// Cursor to paginate alerts before this one. Format: 'created_at|id'
+    pub before: Option<String>,
+    /// Limit the number of returned alerts. Defaults to 100, capped at 100.
+    pub limit: Option<i64>,
+}
+
 /// Saved-search alerts list response.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct SearchAlertsResponse {
     pub alerts: Vec<SavedSearchAlert>,
     /// Number of still-undelivered (`pending`) alerts — drives an unread badge.
     pub unread_count: i64,
+    pub has_more: bool,
 }
 
 /// Mark-all-read response.
@@ -278,33 +289,77 @@ pub struct MarkAllAlertsReadResponse {
     pub marked_read: u64,
 }
 
+fn parse_cursor(cursor: &str) -> Option<(DateTime<Utc>, Uuid)> {
+    let parts: Vec<&str> = cursor.split('|').collect();
+    if parts.len() != 2 {
+        return None;
+    }
+    let created_at = DateTime::parse_from_rfc3339(parts[0])
+        .map(|dt| dt.with_timezone(&Utc))
+        .ok()?;
+    let id = Uuid::parse_str(parts[1]).ok()?;
+    Some((created_at, id))
+}
+
 /// List the authenticated user's saved-search alerts (newest first).
 #[utoipa::path(
     get,
     path = "/api/v1/saved-searches/alerts",
     tag = "SavedSearches",
+    params(SearchAlertsQuery),
     responses(
         (status = 200, description = "Saved-search alerts", body = SearchAlertsResponse),
+        (status = 400, description = "Bad Request"),
         (status = 401, description = "Unauthorized")
     )
 )]
 pub async fn list_search_alerts(
     State(state): State<AppState>,
     principal: RequestPrincipal,
+    Query(query): Query<SearchAlertsQuery>,
 ) -> Result<Json<SearchAlertsResponse>, (axum::http::StatusCode, String)> {
-    let (alerts, unread_count) = tokio::try_join!(
+    let mut before_created_at = None;
+    let mut before_id = None;
+    if let Some(ref before_str) = query.before {
+        if let Some((created_at, id)) = parse_cursor(before_str) {
+            before_created_at = Some(created_at);
+            before_id = Some(id);
+        } else {
+            return Err((
+                axum::http::StatusCode::BAD_REQUEST,
+                "Invalid 'before' cursor format. Expected 'created_at|id' (RFC3339 timestamp and UUID)".to_string(),
+            ));
+        }
+    }
+
+    let raw_limit = query.limit.unwrap_or(100);
+    let limit = if raw_limit <= 0 {
+        100
+    } else {
+        raw_limit.min(100)
+    };
+
+    let db_limit = limit + 1;
+
+    let (mut alerts, unread_count) = tokio::try_join!(
         state
             .reality_portal_repo
-            .get_search_alerts(principal.user_id, 100),
+            .get_search_alerts(principal.user_id, before_created_at, before_id, db_limit),
         state
             .reality_portal_repo
             .count_pending_search_alerts(principal.user_id),
     )
     .map_err(|e| crate::util::errors::db_error("list search alerts", e))?;
 
+    let has_more = alerts.len() as i64 > limit;
+    if has_more {
+        alerts.truncate(limit as usize);
+    }
+
     Ok(Json(SearchAlertsResponse {
         alerts,
         unread_count,
+        has_more,
     }))
 }
 

--- a/backend/servers/reality-server/src/routes/saved_searches.rs
+++ b/backend/servers/reality-server/src/routes/saved_searches.rs
@@ -342,9 +342,12 @@ pub async fn list_search_alerts(
     let db_limit = limit + 1;
 
     let (mut alerts, unread_count) = tokio::try_join!(
-        state
-            .reality_portal_repo
-            .get_search_alerts(principal.user_id, before_created_at, before_id, db_limit),
+        state.reality_portal_repo.get_search_alerts(
+            principal.user_id,
+            before_created_at,
+            before_id,
+            db_limit
+        ),
         state
             .reality_portal_repo
             .count_pending_search_alerts(principal.user_id),


### PR DESCRIPTION
Closes #1627. Adds cursor pagination and has_more to saved-search alerts list.