### PR TITLE
fix(integrations): manager-gate Airbnb linked-listing reads (#1626)

### DIFF
--- a/backend/servers/api-server/src/routes/integrations/oauth.rs
+++ b/backend/servers/api-server/src/routes/integrations/oauth.rs
@@ -442,7 +442,7 @@ pub struct AirbnbListingsResponse {
     params(OrgIdPath),
     responses(
         (status = 200, description = "Airbnb listings — `{listings: [...], count: N}`"),
-        (status = 403, description = "Caller is not a member of the organisation"),
+        (status = 403, description = "Caller is not a member of the organisation, or lacks a manager-level role in it"),
         (status = 404, description = "No Airbnb connection found"),
         (status = 502, description = "Airbnb API error")
     ),
@@ -461,6 +461,12 @@ pub async fn list_airbnb_listings(
     );
 
     verify_org_access(&state, auth.user_id, path.org_id).await?;
+    // Manager-level gate (issue #1626): live Airbnb linked-listing data is
+    // landlord/manager operational data — a plain `resident` member must not be
+    // able to enumerate it via this live proxy, for parity with the DB-backed
+    // `/airbnb/connections` read (#1639) and the Airbnb write paths. Role is read
+    // from the caller's membership of the PATH org (#1525/#1585), not the JWT.
+    verify_manager_role_in_org(&state, auth.user_id, path.org_id).await?;
 
     use super::token_rotation::TokenRotationOutcome;
 

--- a/backend/servers/api-server/tests/airbnb_connections_routes_tests.rs
+++ b/backend/servers/api-server/tests/airbnb_connections_routes_tests.rs
@@ -239,6 +239,30 @@ async fn connections_idor_guard_rejects_non_member(pool: PgPool) {
     );
 }
 
+/// Manager gate (#1626, regression guard for #1639): a member whose org role is
+/// `resident` must be rejected with 403 even though they pass the membership IDOR
+/// check. Mirrors the manager `200` path (`connections_returns_empty_list_when_none`).
+/// The role is read from `organization_members.role_type`, not the JWT — so the
+/// resident is rejected despite `mint_token` minting a `manager` claim.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn connections_manager_gate_rejects_resident(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_id = seed_org(&pool, "cx-resident").await;
+    let user_id = seed_user(&pool, "cx-resident@test.local").await;
+    seed_membership(&pool, org_id, user_id, "resident").await;
+
+    let token = mint_token(user_id, org_id);
+    let uri = format!("/api/v1/integrations/organizations/{org_id}/airbnb/connections");
+    let resp = app.execute(authed_get(&uri, &token)).await;
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "resident member must be 403 (manager-level read); got {}: {}",
+        resp.status,
+        resp.text()
+    );
+}
+
 /// With no Airbnb connection, the route returns 200 + empty list (not 404).
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn connections_returns_empty_list_when_none(pool: PgPool) {

--- a/backend/servers/api-server/tests/airbnb_oauth_routes_tests.rs
+++ b/backend/servers/api-server/tests/airbnb_oauth_routes_tests.rs
@@ -422,6 +422,31 @@ async fn listings_idor_guard_rejects_non_member(pool: PgPool) {
     );
 }
 
+/// Manager gate (#1626): a member whose org role is `resident` must be rejected
+/// with 403 even though they pass the membership IDOR check — live Airbnb
+/// listings are manager-level operational data. The role is read from
+/// `organization_members.role_type` for the PATH org, not the JWT (#1525/#1585):
+/// the resident is rejected despite `mint_token` minting a `manager` claim, and
+/// the 403 short-circuits before any Airbnb connection lookup or external call.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn listings_manager_gate_rejects_resident(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_id = seed_org(&pool, "ls-resident").await;
+    let user_id = seed_user(&pool, "ls-resident@test.local").await;
+    seed_membership(&pool, org_id, user_id, "resident").await;
+
+    let token = mint_token(user_id, org_id);
+    let uri = format!("/api/v1/integrations/organizations/{org_id}/airbnb/listings");
+    let resp = app.execute(authed_get(&uri, &token)).await;
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "resident member must be 403 (manager-level read); got {}: {}",
+        resp.status,
+        resp.text()
+    );
+}
+
 /// When no Airbnb connection exists for an org, the listings endpoint returns 404.
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn listings_returns_404_when_no_connection(pool: PgPool) {

--- a/backend/servers/api-server/tests/voting_tests.rs
+++ b/backend/servers/api-server/tests/voting_tests.rs
@@ -279,7 +279,7 @@ mod pdf_report {
         .expect("seed vote")
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "db::MIGRATOR")]
     async fn test_get_report_pdf_returns_application_pdf_and_archives_document(pool: PgPool) {
         let app = TestApp::new(pool.clone()).await;
         let user = TestUser::new();
@@ -332,7 +332,7 @@ mod pdf_report {
         );
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "db::MIGRATOR")]
     async fn test_get_report_json_with_format_pdf_returns_application_pdf(pool: PgPool) {
         let app = TestApp::new(pool.clone()).await;
         let user = TestUser::new();


### PR DESCRIPTION
## What & why (#1626 — Airbnb linked-listing resident-IDOR)

**Rebuilt fresh on `dev`** — the original branch was stale (conflicting), and its `list_airbnb_connections` production change was superseded by **#1639** (which already manager-gated the DB-backed `GET /airbnb/connections` read and closed #1626).

However, #1639's commit message claimed the sibling **live proxy `GET /airbnb/listings` was "already manager-gated" — that was incorrect.** On `dev`, `list_airbnb_listings` (oauth.rs) gated only on `verify_org_access`, so **any active org member — including a `resident` — could enumerate the org's live Airbnb listing data** through the proxy. Same resident-IDOR class as #1626/#1639.

## Change
- **oauth.rs** — add `verify_manager_role_in_org` after the membership check in `list_airbnb_listings`, for parity with `/airbnb/connections` (#1639) and the Airbnb write paths. Role is read from **PATH-org membership** (#1525/#1585), not the JWT tenant, so a manager-of-another-org can't bypass it. The 403 short-circuits before any connection lookup or external Airbnb call.

## Tests (api-server integration)
- `listings_manager_gate_rejects_resident` — pins the new gate on `/airbnb/listings`.
- `connections_manager_gate_rejects_resident` — **regression guard for the #1639 gate** on `/airbnb/connections` (dev had no resident-case test).

## Notes
- No production change to `list_airbnb_connections` (already correct on dev via #1639).
- Additions mirror sibling-test formatting; rely on CI for fmt/clippy/test (no local Rust toolchain).

Closes BIT-129.