### PR TITLE
fix(reality-server): reconcile portal import authz + dedup principal extractor (#1584 findings 1,4)

### DIFF
--- a/backend/crates/api-core/src/extractors/principal.rs
+++ b/backend/crates/api-core/src/extractors/principal.rs
@@ -60,6 +60,97 @@ pub struct PrincipalClaims {
     pub token_type: Option<String>,
 }
 
+/// Shared bearer-token decode for the request extractors (GH #1584 finding 4).
+///
+/// Both [`RequestPrincipal`] and [`PortalPrincipal`] authenticate a request the
+/// same way: pull the bearer token, decode it with the default HS256 validation
+/// (so `exp`/`nbf` are enforced), reject any non-`access` `token_type`, and
+/// trust ONLY the `sub` claim. Keeping that security-critical sequence in a
+/// single place means a future change (enforcing `aud`/`iss`, a new token
+/// discriminator, a key rotation) cannot be applied to one extractor and
+/// silently missed on the other.
+fn decode_bearer_subject(parts: &Parts) -> Result<Uuid, (StatusCode, &'static str)> {
+    let auth_header = parts
+        .headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .ok_or((StatusCode::UNAUTHORIZED, "Missing Authorization header"))?;
+
+    let token = auth_header.strip_prefix("Bearer ").ok_or((
+        StatusCode::UNAUTHORIZED,
+        "Invalid Authorization header format",
+    ))?;
+
+    let secret = std::env::var("JWT_SECRET").map_err(|_| {
+        tracing::error!("JWT_SECRET environment variable not set");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Server configuration error",
+        )
+    })?;
+
+    // We deliberately use the default `Validation` (HS256, exp+nbf checked).
+    // We do NOT enforce any audience/issuer here — those are issuance concerns
+    // that a future hardening pass can layer on (in this one place).
+    let token_data = decode::<PrincipalClaims>(
+        token,
+        &DecodingKey::from_secret(secret.as_bytes()),
+        &Validation::default(),
+    )
+    .map_err(|_| (StatusCode::UNAUTHORIZED, "Invalid or expired token"))?;
+
+    // Reject refresh tokens (and any other non-access discriminator) BEFORE
+    // touching the DB. A token that omits `token_type` is treated as access for
+    // backward-compat; an explicit non-access value is denied so a refresh token
+    // cannot be replayed against an access-only route (mirrors `auth.rs`
+    // RUST-002).
+    if let Some(token_type) = token_data.claims.token_type.as_deref() {
+        if token_type != "access" {
+            tracing::warn!(
+                token_type = %token_type,
+                "principal: rejected non-access token on access-only route"
+            );
+            return Err((
+                StatusCode::UNAUTHORIZED,
+                "Invalid token type for this endpoint",
+            ));
+        }
+    }
+
+    Ok(token_data.claims.sub)
+}
+
+/// Re-derive `principal_kind` from the trusted `users` table (GH #1584 finding 4).
+///
+/// The `kind` claim in the JWT is informational only; both extractors re-derive
+/// it server-side (defense in depth — never trust the token's copy). A deleted
+/// or unknown user is rejected as `401`.
+async fn resolve_principal_kind(
+    pool: &sqlx::PgPool,
+    user_id: Uuid,
+) -> Result<PrincipalKind, (StatusCode, &'static str)> {
+    let kind_str: Option<String> = sqlx::query_scalar(
+        r#"SELECT principal_kind FROM users WHERE id = $1 AND status != 'deleted'"#,
+    )
+    .bind(user_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| {
+        tracing::error!(error = %e, user_id = %user_id, "principal_kind lookup failed");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to resolve principal",
+        )
+    })?;
+
+    let Some(kind_str) = kind_str else {
+        tracing::warn!(user_id = %user_id, "principal: user not found / deleted");
+        return Err((StatusCode::UNAUTHORIZED, "Unknown principal"));
+    };
+
+    Ok(PrincipalKind::parse(&kind_str))
+}
+
 /// The authoritative per-request principal. Built fresh on every request from
 /// trusted server-side state.
 ///
@@ -93,75 +184,13 @@ where
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         // ----- (1) Decode JWT — sub is the only trustworthy claim. -----
-        let auth_header = parts
-            .headers
-            .get(axum::http::header::AUTHORIZATION)
-            .and_then(|v| v.to_str().ok())
-            .ok_or((StatusCode::UNAUTHORIZED, "Missing Authorization header"))?;
-
-        let token = auth_header.strip_prefix("Bearer ").ok_or((
-            StatusCode::UNAUTHORIZED,
-            "Invalid Authorization header format",
-        ))?;
-
-        let secret = std::env::var("JWT_SECRET").map_err(|_| {
-            tracing::error!("JWT_SECRET environment variable not set");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Server configuration error",
-            )
-        })?;
-
-        // We deliberately use the default `Validation` (HS256, exp+nbf checked).
-        // We do NOT enforce any audience/issuer here — those are issuance
-        // concerns that a future hardening pass can layer on.
-        let token_data = decode::<PrincipalClaims>(
-            token,
-            &DecodingKey::from_secret(secret.as_bytes()),
-            &Validation::default(),
-        )
-        .map_err(|_| (StatusCode::UNAUTHORIZED, "Invalid or expired token"))?;
-
-        // Reject refresh tokens (and any other non-access discriminator)
-        // BEFORE touching the DB. A token that omits `token_type` is treated
-        // as access for backward-compat; an explicit "refresh" is denied so
-        // a refresh token cannot be replayed against an access-only route.
-        if let Some(token_type) = token_data.claims.token_type.as_deref() {
-            if token_type != "access" {
-                tracing::warn!(
-                    token_type = %token_type,
-                    "RequestPrincipal: rejected non-access token on access-only route"
-                );
-                return Err((
-                    StatusCode::UNAUTHORIZED,
-                    "Invalid token type for this endpoint",
-                ));
-            }
-        }
-
-        let user_id = token_data.claims.sub;
-
-        // ----- (2) Lookup the principal_kind from the trusted users table. -----
+        // ----- (2) Re-derive the principal_kind from the trusted users table. -----
+        // Both steps live in shared helpers so the security-critical JWT +
+        // kind-derivation path is identical to `PortalPrincipal` (GH #1584
+        // finding 4).
+        let user_id = decode_bearer_subject(parts)?;
         let pool = state.db_pool();
-        let kind_str: Option<String> = sqlx::query_scalar(
-            r#"SELECT principal_kind FROM users WHERE id = $1 AND status != 'deleted'"#,
-        )
-        .bind(user_id)
-        .fetch_optional(pool)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, user_id = %user_id, "principal_kind lookup failed");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Failed to resolve principal",
-            )
-        })?;
-
-        let Some(kind_str) = kind_str else {
-            tracing::warn!(user_id = %user_id, "RequestPrincipal: user not found / deleted");
-            return Err((StatusCode::UNAUTHORIZED, "Unknown principal"));
-        };
-        let kind = PrincipalKind::parse(&kind_str);
+        let kind = resolve_principal_kind(pool, user_id).await?;
 
         // ----- (3) Read host-resolved tenant (may be absent on platform host). -----
         let resolved = parts.extensions.get::<ResolvedTenant>().copied();
@@ -183,7 +212,7 @@ where
             (Some(rt), _) if rt.source == TenantSource::PlatformHost => {
                 tracing::warn!(
                     user_id = %user_id,
-                    kind = %kind_str,
+                    kind = ?kind,
                     "RequestPrincipal: non-platform principal on platform host"
                 );
                 return Err((
@@ -230,7 +259,7 @@ where
                 // do not need a tenant should use a different extractor.
                 tracing::warn!(
                     user_id = %user_id,
-                    kind = %kind_str,
+                    kind = ?kind,
                     "RequestPrincipal: no ResolvedTenant for non-platform principal"
                 );
                 return Err((StatusCode::FORBIDDEN, "tenant not resolved"));
@@ -341,74 +370,17 @@ where
     type Rejection = (StatusCode, &'static str);
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        // ----- (1) Decode JWT — sub is the only trustworthy claim. -----
-        let auth_header = parts
-            .headers
-            .get(axum::http::header::AUTHORIZATION)
-            .and_then(|v| v.to_str().ok())
-            .ok_or((StatusCode::UNAUTHORIZED, "Missing Authorization header"))?;
-
-        let token = auth_header.strip_prefix("Bearer ").ok_or((
-            StatusCode::UNAUTHORIZED,
-            "Invalid Authorization header format",
-        ))?;
-
-        let secret = std::env::var("JWT_SECRET").map_err(|_| {
-            tracing::error!("JWT_SECRET environment variable not set");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Server configuration error",
-            )
-        })?;
-
-        let token_data = decode::<PrincipalClaims>(
-            token,
-            &DecodingKey::from_secret(secret.as_bytes()),
-            &Validation::default(),
-        )
-        .map_err(|_| (StatusCode::UNAUTHORIZED, "Invalid or expired token"))?;
-
-        // Reject refresh (and any non-access) tokens before touching the DB —
-        // mirrors `RequestPrincipal`.
-        if let Some(token_type) = token_data.claims.token_type.as_deref() {
-            if token_type != "access" {
-                tracing::warn!(
-                    token_type = %token_type,
-                    "PortalPrincipal: rejected non-access token on access-only route"
-                );
-                return Err((
-                    StatusCode::UNAUTHORIZED,
-                    "Invalid token type for this endpoint",
-                ));
-            }
-        }
-
-        let user_id = token_data.claims.sub;
-
-        // ----- (2) Re-derive principal_kind from the trusted users table. -----
+        // (1) Decode JWT (sub only) and (2) re-derive principal_kind from the
+        // trusted users table — both via the shared helpers so this
+        // security-critical path is byte-for-byte identical to
+        // `RequestPrincipal` (GH #1584 finding 4). `PortalPrincipal`
+        // deliberately stops here: it requires NO `ResolvedTenant` and NO
+        // membership, because per-resource authorization is enforced at the
+        // repo layer by `user_id` keying (see the type docs above).
+        let user_id = decode_bearer_subject(parts)?;
         let pool = state.db_pool();
-        let kind_str: Option<String> = sqlx::query_scalar(
-            r#"SELECT principal_kind FROM users WHERE id = $1 AND status != 'deleted'"#,
-        )
-        .bind(user_id)
-        .fetch_optional(pool)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, user_id = %user_id, "PortalPrincipal: principal_kind lookup failed");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Failed to resolve principal",
-            )
-        })?;
+        let kind = resolve_principal_kind(pool, user_id).await?;
 
-        let Some(kind_str) = kind_str else {
-            tracing::warn!(user_id = %user_id, "PortalPrincipal: user not found / deleted");
-            return Err((StatusCode::UNAUTHORIZED, "Unknown principal"));
-        };
-
-        Ok(PortalPrincipal {
-            user_id,
-            kind: PrincipalKind::parse(&kind_str),
-        })
+        Ok(PortalPrincipal { user_id, kind })
     }
 }

--- a/backend/crates/db/src/models/reality_portal.rs
+++ b/backend/crates/db/src/models/reality_portal.rs
@@ -693,6 +693,11 @@ pub type RealityFeedSubscription = FeedSubscription;
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize, ToSchema)]
 pub struct FeedSubscription {
     pub id: Uuid,
+    /// Owner key. Legacy-named `agency_id` (and still FK'd to `reality_agencies`
+    /// in the schema), but the reality-portal import surface is per-user, so
+    /// this physically stores the owning portal user's `user_id`. The
+    /// column/FK rename is tracked as the BIT-130 schema-migration follow-up
+    /// (GH #1584 finding 2).
     pub agency_id: Uuid,
     pub name: String,
     pub feed_url: String,

--- a/backend/crates/db/src/repositories/reality_portal.rs
+++ b/backend/crates/db/src/repositories/reality_portal.rs
@@ -1342,35 +1342,48 @@ impl RealityPortalRepository {
 
     // ========================================================================
     // Feed Subscriptions (Story 34.2)
+    //
+    // OWNERSHIP NOTE (GH #1584 finding 1/2): these feeds are owned **per portal
+    // user**, not per agency — the reality-portal import surface
+    // (`reality-server/src/routes/imports.rs`) is intentionally per-user (see
+    // its module docs). The owner key is therefore the caller's `user_id`. The
+    // physical `feed_subscriptions` column is still legacy-named `agency_id`
+    // (and FK'd to `reality_agencies`) even though it stores a `user_id`; the
+    // column/FK rename is the schema-migration follow-up tracked on the BIT-130
+    // child issue. Until then the SQL below references the real column name
+    // `agency_id` while the Rust parameter is named `user_id` to make the
+    // owner-keyed intent unambiguous at every call site.
     // ========================================================================
 
-    /// List feed subscriptions for an agency.
+    /// List feed subscriptions owned by `user_id`.
     pub async fn list_feed_subscriptions(
         &self,
-        agency_id: Uuid,
+        user_id: Uuid,
     ) -> Result<Vec<RealityFeedSubscription>, SqlxError> {
         sqlx::query_as::<_, RealityFeedSubscription>(
+            // `agency_id` column physically stores the owner `user_id` (see note).
             "SELECT * FROM feed_subscriptions WHERE agency_id = $1 ORDER BY created_at DESC",
         )
-        .bind(agency_id)
+        .bind(user_id)
         .fetch_all(&self.pool)
         .await
     }
 
-    /// Create feed subscription.
+    /// Create a feed subscription owned by `user_id`.
     pub async fn create_feed_subscription(
         &self,
-        agency_id: Uuid,
+        user_id: Uuid,
         data: CreateFeedSubscription,
     ) -> Result<RealityFeedSubscription, SqlxError> {
         sqlx::query_as::<_, RealityFeedSubscription>(
+            // `agency_id` column physically stores the owner `user_id` (see note).
             r#"
             INSERT INTO feed_subscriptions (agency_id, name, feed_url, feed_type, sync_interval)
             VALUES ($1, $2, $3, COALESCE($4, 'xml'), COALESCE($5, 'daily'))
             RETURNING *
             "#,
         )
-        .bind(agency_id)
+        .bind(user_id)
         .bind(&data.name)
         .bind(&data.feed_url)
         .bind(&data.feed_type)
@@ -1379,30 +1392,32 @@ impl RealityPortalRepository {
         .await
     }
 
-    /// Get feed subscription by ID. Scoped to the owning `agency_id` so an
-    /// agency cannot read another agency's feed by id (IDOR, PAP-142).
+    /// Get feed subscription by ID. Scoped to the owning `user_id` so a portal
+    /// user cannot read another user's feed by id (IDOR, PAP-142).
     pub async fn get_feed_subscription(
         &self,
         id: Uuid,
-        agency_id: Uuid,
+        user_id: Uuid,
     ) -> Result<Option<RealityFeedSubscription>, SqlxError> {
         sqlx::query_as::<_, RealityFeedSubscription>(
+            // `agency_id` column physically stores the owner `user_id` (see note).
             "SELECT * FROM feed_subscriptions WHERE id = $1 AND agency_id = $2",
         )
         .bind(id)
-        .bind(agency_id)
+        .bind(user_id)
         .fetch_optional(&self.pool)
         .await
     }
 
-    /// Update feed subscription. Scoped to the owning `agency_id` (IDOR, PAP-142).
+    /// Update feed subscription. Scoped to the owning `user_id` (IDOR, PAP-142).
     pub async fn update_feed_subscription(
         &self,
         id: Uuid,
-        agency_id: Uuid,
+        user_id: Uuid,
         data: UpdateFeedSubscription,
     ) -> Result<RealityFeedSubscription, SqlxError> {
         sqlx::query_as::<_, RealityFeedSubscription>(
+            // `agency_id` column physically stores the owner `user_id` (see note).
             r#"
             UPDATE feed_subscriptions SET
                 name = COALESCE($3, name),
@@ -1416,7 +1431,7 @@ impl RealityPortalRepository {
             "#,
         )
         .bind(id)
-        .bind(agency_id)
+        .bind(user_id)
         .bind(&data.name)
         .bind(&data.feed_url)
         .bind(&data.feed_type)
@@ -1426,14 +1441,15 @@ impl RealityPortalRepository {
         .await
     }
 
-    /// Trigger immediate feed sync. Scoped to the owning `agency_id` (IDOR, PAP-142).
+    /// Trigger immediate feed sync. Scoped to the owning `user_id` (IDOR, PAP-142).
     pub async fn trigger_feed_sync(
         &self,
         id: Uuid,
-        agency_id: Uuid,
+        user_id: Uuid,
     ) -> Result<RealityFeedSubscription, SqlxError> {
-        // Mark as syncing and update last sync time
+        // Mark as syncing and update last sync time.
         sqlx::query_as::<_, RealityFeedSubscription>(
+            // `agency_id` column physically stores the owner `user_id` (see note).
             r#"
             UPDATE feed_subscriptions SET
                 last_sync_at = NOW()
@@ -1442,7 +1458,7 @@ impl RealityPortalRepository {
             "#,
         )
         .bind(id)
-        .bind(agency_id)
+        .bind(user_id)
         .fetch_one(&self.pool)
         .await
     }

--- a/backend/servers/reality-server/src/routes/imports.rs
+++ b/backend/servers/reality-server/src/routes/imports.rs
@@ -5,6 +5,34 @@
 //! and reach the portal on a `PlatformHost`, so `RequestPrincipal` 403s them.
 //! `PortalPrincipal` authenticates the JWT + re-derives kind without requiring
 //! a tenant/membership; IDOR stays closed via `user_id` repo keying (PR #1297).
+//!
+//! # Authorization model — intentionally **per-user** (GH #1584 finding 1)
+//!
+//! This portal surface and its sibling [`super::agency_imports`] deliberately
+//! use *different* authorization models; they are NOT an accidental divergence
+//! to collapse onto one helper:
+//!
+//! * **`imports.rs` (this file) — per-user, owner-keyed.** Every job/feed is
+//!   owned by the authenticating portal user (`portal_import_jobs.user_id`;
+//!   `feed_subscriptions` owner column — see the repo note below). There is no
+//!   `agency_id` in any route path here, and a portal user need not belong to
+//!   any `reality_agency`. Authorization is the repo-layer `user_id`/owner
+//!   keying: a caller can only ever see or mutate rows they own (cross-user →
+//!   404). Routing this through `assert_agency_member` was considered and
+//!   **rejected**: it would break the individual-portal-user case (those users
+//!   have no `reality_agency_members` row) and force a tenant that does not
+//!   exist on a `PlatformHost`.
+//! * **`agency_imports.rs` — agency-membership, mounted under
+//!   `/api/v1/agencies/{id}/imports`.** It gates every handler on
+//!   `reality_agency_members` membership via `check_agency_membership`, because
+//!   that surface IS agency-scoped (the agency id is in the path and rows are
+//!   shared across an agency's members).
+//!
+//! One residual wart from this split is tracked separately: the
+//! `feed_subscriptions` owner column is still physically named `agency_id`
+//! while it stores the owner `user_id`. The column/FK rename (and a non-owning
+//! same-agency-member guard test) is the schema-migration follow-up to this
+//! issue — see the child issue linked on GH #1584 / BIT-130.
 
 use crate::state::AppState;
 use api_core::extractors::PortalPrincipal;


### PR DESCRIPTION
Follow-up to merged PR #1561. Closes the two non-schema constructive items from GH #1584; the IDOR itself was already fixed (PR #1297) and finding 3's regression tests already merged (#1603, #1620).

## Finding 1 — divergent authz models (medium-high)
`imports.rs` authorizes by `user_id`; sibling `agency_imports.rs` gates on `reality_agency_members`. **Decision: keep them distinct — `imports.rs` is intentionally per-user.** The reality-portal import surface has no `agency_id` in any route path and serves individual `principal_kind='public'` portal users who need not belong to any `reality_agency`; routing it through `assert_agency_member` would break those users (no membership row) and force a tenant that doesn't exist on a `PlatformHost`. Reconciliation here = making that intent explicit:
- `imports.rs` module docs now state the per-user model and contrast it with the agency-membership surface.
- Feed repo parameters renamed `agency_id` → `user_id` so every call site reads the owner-keyed intent. The physical `feed_subscriptions.agency_id` column (FK → `reality_agencies`) still carries its legacy name while storing a `user_id`; SQL keeps the real column name with a clarifying comment.

## Finding 4 — extractor duplication (low)
Factored the shared, security-critical JWT path into `decode_bearer_subject()` (header → token → HS256 decode → reject non-`access` `token_type` → trusted `sub`) and `resolve_principal_kind()` (re-derive kind from `users`). `RequestPrincipal` and `PortalPrincipal` now call the same helpers, so a future change to the auth path can't be applied to one and missed on the other.

## Split out — finding 2 (medium, schema migration)
Renaming `feed_subscriptions.agency_id` → `user_id` + swapping the FK to `users(id)` + the model/repo/test updates + a non-owning same-agency-member guard test is a production-data-affecting migration; split into a tracked child issue per the issue's approach note.

## Verification
Backend has no local toolchain on this host — relying on CI (`cargo fmt --all`, clippy, `#[sqlx::test]` integration suite incl. `imports_idor_tests.rs`). Behavior is unchanged: pure refactor + docs/parameter-rename; all repo calls remain positional so existing IDOR tests bind unchanged.

Refs GH #1584 (findings 1, 4). Part of BIT-130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)