### PR TITLE
fix(api-server): manager-gate Airbnb linked-listing config reads (closes #1626)

### DIFF
--- a/backend/servers/api-server/src/routes/integrations/airbnb_connections.rs
+++ b/backend/servers/api-server/src/routes/integrations/airbnb_connections.rs
@@ -34,7 +34,7 @@ use db::models::rental::PlatformConnectionDetail;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-use super::sync::{verify_org_access, OrgIdPath};
+use super::sync::{verify_manager_role_in_org, verify_org_access, OrgIdPath};
 use crate::state::AppState;
 use common::errors::ErrorResponse;
 
@@ -92,6 +92,11 @@ pub async fn list_airbnb_connections(
 
     // IDOR guard (issue #765): caller must belong to this org.
     verify_org_access(&state, auth.user_id, path.org_id).await?;
+    // Authz (#1626): OTA linked-listing configuration is landlord/manager-level
+    // operational data, so reads are manager-gated (matching the write paths and
+    // the sibling /airbnb/listings read) — a plain member/resident must not be
+    // able to enumerate the org's integration config.
+    verify_manager_role_in_org(&state, auth.user_id, path.org_id).await?;
 
     let connections = state
         .rental_repo


### PR DESCRIPTION
Post-merge review of PR #1615: `GET .../airbnb/connections` gated only on `verify_org_access`, so any active org member — incl. a **resident** — could enumerate the org's Airbnb integration config (`external_property_id`, `external_listing_url`, `is_active`, `last_sync_at`, `sync_error`). Tokens are already stripped (`PlatformConnectionDetail`), so not a secret leak, but this is landlord/manager-level operational data.

Add `verify_manager_role_in_org` after the membership check in `list_airbnb_connections`, matching the module's write paths and the already-gated sibling `/airbnb/listings` read. Plain members/residents now get **403**.

Verified on the remote builder: clippy `-D warnings` clean, `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)