### PR TITLE
feat(api-server): IoT real-time sensor readings WS channel (Epic 14, Story 14.3)

### DIFF
--- a/backend/crates/api-core/src/extractors/auth.rs
+++ b/backend/crates/api-core/src/extractors/auth.rs
@@ -213,3 +213,19 @@ where
         }
     }
 }
+
+/// Like [`validate_access_token_with_exp`] but also returns the `tenant_id`
+/// claim so WebSocket handlers can derive the org-scoped pub/sub channel
+/// without a DB round-trip.
+pub fn validate_access_token_full(
+    token: &str,
+) -> Result<(Uuid, i64, Option<Uuid>), &'static str> {
+    let verifier = jwt_verifier()?;
+    let token_data = decode::<Claims>(token, &verifier.key, &verifier.validation)
+        .map_err(|_| "Invalid or expired token")?;
+    let claims = token_data.claims;
+    if claims.token_type != "access" {
+        return Err("Invalid token type for this endpoint");
+    }
+    Ok((claims.sub, claims.exp, claims.tenant_id))
+}

--- a/backend/crates/api-core/src/extractors/auth.rs
+++ b/backend/crates/api-core/src/extractors/auth.rs
@@ -217,9 +217,7 @@ where
 /// Like [`validate_access_token_with_exp`] but also returns the `tenant_id`
 /// claim so WebSocket handlers can derive the org-scoped pub/sub channel
 /// without a DB round-trip.
-pub fn validate_access_token_full(
-    token: &str,
-) -> Result<(Uuid, i64, Option<Uuid>), &'static str> {
+pub fn validate_access_token_full(token: &str) -> Result<(Uuid, i64, Option<Uuid>), &'static str> {
     let verifier = jwt_verifier()?;
     let token_data = decode::<Claims>(token, &verifier.key, &verifier.validation)
         .map_err(|_| "Invalid or expired token")?;

--- a/backend/servers/api-server/src/lib.rs
+++ b/backend/servers/api-server/src/lib.rs
@@ -253,6 +253,8 @@ pub fn route_table() -> Router<AppState> {
         .nest("/api/v1/ai/llm", routes::ai::llm_router())
         // IoT routes
         .nest("/api/v1/iot/sensors", routes::iot::sensor_router())
+        // IoT WebSocket real-time sensor readings (Epic 14, Story 14.3)
+        .nest("/api/v1/iot", routes::ws_sensor::router())
         // Agency routes
         .nest("/api/v1/agencies", routes::agencies::router())
         // Lease routes

--- a/backend/servers/api-server/src/routes/iot.rs
+++ b/backend/servers/api-server/src/routes/iot.rs
@@ -276,14 +276,30 @@ async fn add_reading(
     Json(mut req): Json<CreateSensorReading>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
     req.sensor_id = id;
-    let out = state
+    let org_id = rls.tenant_id();
+    let result = state
         .sensor_repo
         .create_reading(rls.conn(), req)
         .await
-        .map(|reading| (StatusCode::CREATED, Json(serde_json::json!(reading))))
         .map_err(|e| insert_child_error("Failed to add reading", "Sensor not found", e));
     rls.release().await;
-    out
+    let reading = result?;
+    // Publish real-time fanout (Epic 14, Story 14.3) — non-fatal.
+    if let Some(ref pubsub) = state.pubsub_service {
+        let channel = format!("sensors:{org_id}");
+        if let Err(e) = pubsub
+            .publish_event(&channel, "sensor.reading", serde_json::json!(reading))
+            .await
+        {
+            tracing::warn!(
+                sensor_id = %id,
+                channel = %channel,
+                error = %e,
+                "[IoT 14.3] Failed to publish sensor.reading to WebSocket channel (non-fatal)"
+            );
+        }
+    }
+    Ok((StatusCode::CREATED, Json(serde_json::json!(reading))))
 }
 
 async fn add_batch_readings(
@@ -292,19 +308,37 @@ async fn add_batch_readings(
     Path(id): Path<Uuid>,
     Json(req): Json<BatchSensorReadings>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
-    let out = state
+    let org_id = rls.tenant_id();
+    let result = state
         .sensor_repo
         .create_batch_readings(rls.conn(), id, req.readings)
         .await
-        .map(|count| {
-            (
-                StatusCode::CREATED,
-                Json(serde_json::json!({ "inserted": count })),
-            )
-        })
         .map_err(|e| insert_child_error("Failed to add batch readings", "Sensor not found", e));
     rls.release().await;
-    out
+    let count = result?;
+    // Publish real-time fanout (Epic 14, Story 14.3) — non-fatal.
+    if let Some(ref pubsub) = state.pubsub_service {
+        let channel = format!("sensors:{org_id}");
+        if let Err(e) = pubsub
+            .publish_event(
+                &channel,
+                "sensor.batch_readings",
+                serde_json::json!({ "sensor_id": id, "inserted": count }),
+            )
+            .await
+        {
+            tracing::warn!(
+                sensor_id = %id,
+                channel = %channel,
+                error = %e,
+                "[IoT 14.3] Failed to publish sensor.batch_readings to WebSocket channel (non-fatal)"
+            );
+        }
+    }
+    Ok((
+        StatusCode::CREATED,
+        Json(serde_json::json!({ "inserted": count })),
+    ))
 }
 
 async fn get_aggregated_readings(

--- a/backend/servers/api-server/src/routes/mod.rs
+++ b/backend/servers/api-server/src/routes/mod.rs
@@ -54,6 +54,8 @@ pub mod vendors;
 pub mod voting;
 pub mod work_orders;
 pub mod ws_notifications;
+// Epic 14, Story 14.3 — WebSocket real-time sensor reading channel
+pub mod ws_sensor;
 
 // Epic 23: Emergency Management
 pub mod emergency;

--- a/backend/servers/api-server/src/routes/ws_sensor.rs
+++ b/backend/servers/api-server/src/routes/ws_sensor.rs
@@ -1,0 +1,245 @@
+//! WebSocket real-time sensor reading channel (Epic 14, Story 14.3).
+//!
+//! # Purpose
+//!
+//! Opens a persistent WebSocket connection for an authenticated user and
+//! streams sensor reading events from the Redis pub/sub channel
+//! `sensors:{org_id}`.  Events are published by `routes/iot.rs` whenever a
+//! reading is ingested via `POST /api/v1/iot/sensors/{id}/readings` or the
+//! batch variant.
+//!
+//! # Authentication
+//!
+//! Same token-in-query-param pattern as `ws_notifications.rs`: the caller
+//! supplies a standard JWT as the `token` query parameter.  The resolved
+//! `org_id` comes from the token's `organization_id` claim via
+//! `api_core::extractors::validate_access_token_with_exp`.
+//!
+//! # Wire format
+//!
+//! Server → client JSON text frames:
+//! ```json
+//! { "event": "sensor.reading", "payload": { <SensorReading fields> } }
+//! ```
+//!
+//! Client → server: any frame is treated as a heartbeat.  The connection is
+//! closed server-side after `WS_IDLE_TIMEOUT_SECS` of inactivity.
+
+use std::time::Duration;
+
+use api_core::extractors::validate_access_token_full;
+use axum::{
+    extract::{
+        ws::{Message, WebSocket, WebSocketUpgrade},
+        Query, State,
+    },
+    http::StatusCode,
+    response::IntoResponse,
+    routing::get,
+    Router,
+};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::state::AppState;
+
+const WS_IDLE_TIMEOUT_SECS: u64 = 60;
+const WS_MAX_SESSION_SECS: u64 = 4 * 60 * 60;
+
+// ============================================================================
+// Router
+// ============================================================================
+
+pub fn router() -> Router<AppState> {
+    Router::new().route("/ws", get(ws_handler))
+}
+
+// ============================================================================
+// Query parameters
+// ============================================================================
+
+#[derive(Debug, Deserialize)]
+pub struct WsQuery {
+    pub token: String,
+}
+
+// ============================================================================
+// Outbound message shape
+// ============================================================================
+
+#[derive(Debug, Serialize)]
+pub struct WsEvent {
+    pub event: String,
+    pub payload: serde_json::Value,
+}
+
+// ============================================================================
+// Handler
+// ============================================================================
+
+pub async fn ws_handler(
+    ws: WebSocketUpgrade,
+    Query(params): Query<WsQuery>,
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    // Validate JWT; extract user_id, exp, and tenant_id (org_id) from claims.
+    let (user_id, exp, org_id) = match validate_ws_token_with_exp(&params.token) {
+        Ok(t) => t,
+        Err(msg) => {
+            tracing::warn!(msg = %msg, "Sensor WS connection rejected: invalid token");
+            return (StatusCode::UNAUTHORIZED, msg).into_response();
+        }
+    };
+
+    let pubsub_service = state.pubsub_service.clone();
+
+    ws.protocols(["ppt.v1"])
+        .on_upgrade(move |socket| handle_ws_session(socket, user_id, org_id, exp, pubsub_service))
+        .into_response()
+}
+
+// ============================================================================
+// Session driver
+// ============================================================================
+
+async fn handle_ws_session(
+    mut socket: WebSocket,
+    user_id: Uuid,
+    org_id: Option<Uuid>,
+    jwt_exp_unix: i64,
+    pubsub_service: Option<integrations::PubSubService>,
+) {
+    tracing::info!(
+        user_id = %user_id,
+        org_id = ?org_id,
+        "Sensor WS session opened"
+    );
+
+    let channel = org_id.map(|oid| format!("sensors:{oid}"));
+
+    let mut pubsub_rx = match (pubsub_service.as_ref(), channel.as_deref()) {
+        (Some(svc), Some(ch)) => match svc.subscribe(ch).await {
+            Ok(rx) => {
+                tracing::debug!(channel = %ch, "Subscribed to Redis sensor channel");
+                Some(rx)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    channel = %ch,
+                    error = %e,
+                    "Failed to subscribe to Redis sensor channel; heartbeat-only mode"
+                );
+                None
+            }
+        },
+        _ => {
+            tracing::debug!(
+                user_id = %user_id,
+                "Redis not configured or org_id unknown; sensor WS in heartbeat-only mode"
+            );
+            None
+        }
+    };
+
+    let idle_timeout = Duration::from_secs(WS_IDLE_TIMEOUT_SECS);
+    let max_session = Duration::from_secs(WS_MAX_SESSION_SECS);
+    let session_deadline = tokio::time::Instant::now() + max_session;
+
+    loop {
+        if tokio::time::Instant::now() >= session_deadline {
+            tracing::info!(user_id = %user_id, "Sensor WS session max-lifetime reached; closing");
+            break;
+        }
+
+        if chrono::Utc::now().timestamp() >= jwt_exp_unix {
+            tracing::info!(user_id = %user_id, "Sensor WS session JWT expired; closing");
+            break;
+        }
+
+        tokio::select! {
+            pubsub_msg = async {
+                match pubsub_rx.as_mut() {
+                    Some(rx) => rx.recv().await.ok(),
+                    None => {
+                        tokio::time::sleep(Duration::from_secs(30)).await;
+                        None
+                    }
+                }
+            } => {
+                if let Some(msg) = pubsub_msg {
+                    let envelope = WsEvent {
+                        event: msg.event_type.clone(),
+                        payload: msg.payload.clone(),
+                    };
+                    let text = match serde_json::to_string(&envelope) {
+                        Ok(t) => t,
+                        Err(e) => {
+                            tracing::warn!(error = %e, "Failed to serialise sensor WsEvent; skipping");
+                            continue;
+                        }
+                    };
+                    if socket.send(Message::Text(text.into())).await.is_err() {
+                        tracing::debug!(user_id = %user_id, "Sensor WS send failed; closing");
+                        break;
+                    }
+                }
+            }
+
+            inbound = tokio::time::timeout(idle_timeout, socket.recv()) => {
+                match inbound {
+                    Err(_elapsed) => {
+                        if socket.send(Message::Ping(vec![].into())).await.is_err() {
+                            tracing::debug!(user_id = %user_id, "Sensor WS ping failed; closing");
+                            break;
+                        }
+                    }
+                    Ok(Some(Ok(Message::Close(_)))) | Ok(None) => {
+                        tracing::debug!(user_id = %user_id, "Sensor WS closed by client");
+                        break;
+                    }
+                    Ok(Some(Err(e))) => {
+                        tracing::debug!(user_id = %user_id, error = %e, "Sensor WS receive error; closing");
+                        break;
+                    }
+                    Ok(Some(Ok(_other))) => {
+                        tracing::trace!(user_id = %user_id, "Sensor WS heartbeat received");
+                    }
+                }
+            }
+        }
+    }
+
+    tracing::info!(user_id = %user_id, "Sensor WS session closed");
+}
+
+// ============================================================================
+// JWT validation
+// ============================================================================
+
+fn validate_ws_token_with_exp(token: &str) -> Result<(Uuid, i64, Option<Uuid>), &'static str> {
+    validate_access_token_full(token)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ws_event_serialises_correctly() {
+        let evt = WsEvent {
+            event: "sensor.reading".to_string(),
+            payload: serde_json::json!({
+                "sensor_id": "00000000-0000-0000-0000-000000000001",
+                "value": 23.5,
+                "unit": "°C"
+            }),
+        };
+        let text = serde_json::to_string(&evt).unwrap();
+        assert!(text.contains("\"event\":\"sensor.reading\""));
+        assert!(text.contains("\"payload\""));
+    }
+}

--- a/backend/servers/api-server/tests/voting_tests.rs
+++ b/backend/servers/api-server/tests/voting_tests.rs
@@ -279,7 +279,7 @@ mod pdf_report {
         .expect("seed vote")
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "db::MIGRATOR")]
     async fn test_get_report_pdf_returns_application_pdf_and_archives_document(pool: PgPool) {
         let app = TestApp::new(pool.clone()).await;
         let user = TestUser::new();
@@ -332,7 +332,7 @@ mod pdf_report {
         );
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "db::MIGRATOR")]
     async fn test_get_report_json_with_format_pdf_returns_application_pdf(pool: PgPool) {
         let app = TestApp::new(pool.clone()).await;
         let user = TestUser::new();


### PR DESCRIPTION
## IoT real-time sensor readings WS channel (Epic 14, Story 14.3)

Closes part of #985 (Story 14.3 — real-time channel).

### What
- `routes/iot.rs`: `add_reading` / `add_batch_readings` publish `sensor.reading` / `sensor.batch_readings` to Redis channel `sensors:{org_id}` (non-fatal).
- `routes/ws_sensor.rs` (new): `GET /api/v1/iot/ws` — authenticated WS streaming reading events; mirrors `ws_notifications.rs` (token-in-query auth, idle + max-session timeouts, mid-session JWT-expiry enforcement).
- `api-core/extractors/auth.rs`: `validate_access_token_full` returns `(user_id, exp, tenant_id)` for org-scoped channel derivation without a DB round-trip.

### Security
Org-scoped channel (`sensors:{org_id}`) — no cross-tenant leakage; WS closes on JWT expiry + max lifetime.

### Scope note
Backend-only. Epic 13 (Sentiment/Predictive Maintenance) frontend that was accidentally bundled has been split to branch `feat/epic13-ai-dashboards`.

Co-Authored-By: Paperclip <noreply@paperclip.ing>