### PR TITLE
feat(ppt-web): Sentiment & Predictive Maintenance dashboards (Epic 13, Story 13.2/13.3)

### DIFF
--- a/frontend/apps/ppt-web/src/features/predictive-maintenance/components/EquipmentList.tsx
+++ b/frontend/apps/ppt-web/src/features/predictive-maintenance/components/EquipmentList.tsx
@@ -1,0 +1,64 @@
+import type { JSX } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { Equipment } from '../types';
+
+const STATUS_CLASSES: Record<string, string> = {
+  operational: 'bg-green-100 text-green-700',
+  needs_maintenance: 'bg-yellow-100 text-yellow-700',
+  under_repair: 'bg-orange-100 text-orange-700',
+  decommissioned: 'bg-gray-100 text-gray-600',
+};
+
+interface EquipmentListProps {
+  equipment: Equipment[];
+  isLoading: boolean;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}
+
+export function EquipmentList({ equipment, isLoading, selectedId, onSelect }: EquipmentListProps): JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <div className="rounded-lg border bg-white shadow-sm">
+      <div className="border-b px-4 py-3">
+        <h2 className="text-base font-semibold text-gray-900">
+          {t('predictive.equipmentTitle', { defaultValue: 'Equipment' })}
+        </h2>
+      </div>
+      {isLoading ? (
+        <div className="space-y-2 p-3">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="h-10 animate-pulse rounded bg-gray-100" />
+          ))}
+        </div>
+      ) : equipment.length === 0 ? (
+        <p className="p-4 text-center text-sm text-gray-500">
+          {t('predictive.noEquipment', { defaultValue: 'No equipment found.' })}
+        </p>
+      ) : (
+        <ul className="divide-y divide-gray-100">
+          {equipment.map((e) => (
+            <li key={e.id}>
+              <button
+                type="button"
+                onClick={() => onSelect(e.id)}
+                className={`w-full px-4 py-3 text-left hover:bg-gray-50 ${selectedId === e.id ? 'bg-indigo-50' : ''}`}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="truncate text-sm font-medium text-gray-900">{e.name}</span>
+                  <span
+                    className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_CLASSES[e.status] ?? 'bg-gray-100 text-gray-600'}`}
+                  >
+                    {e.status.replace(/_/g, ' ')}
+                  </span>
+                </div>
+                <p className="mt-0.5 text-xs text-gray-500">{e.category}</p>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/predictive-maintenance/components/EquipmentList.tsx
+++ b/frontend/apps/ppt-web/src/features/predictive-maintenance/components/EquipmentList.tsx
@@ -16,7 +16,12 @@ interface EquipmentListProps {
   onSelect: (id: string) => void;
 }
 
-export function EquipmentList({ equipment, isLoading, selectedId, onSelect }: EquipmentListProps): JSX.Element {
+export function EquipmentList({
+  equipment,
+  isLoading,
+  selectedId,
+  onSelect,
+}: EquipmentListProps): JSX.Element {
   const { t } = useTranslation();
 
   return (

--- a/frontend/apps/ppt-web/src/features/predictive-maintenance/components/PredictionsList.tsx
+++ b/frontend/apps/ppt-web/src/features/predictive-maintenance/components/PredictionsList.tsx
@@ -1,0 +1,90 @@
+import type { JSX } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { MaintenancePrediction } from '../types';
+
+function RiskBadge({ score }: { score: number }): JSX.Element {
+  const pct = Math.round(score * 100);
+  const cls =
+    pct >= 75
+      ? 'bg-red-100 text-red-700'
+      : pct >= 50
+        ? 'bg-orange-100 text-orange-700'
+        : 'bg-yellow-100 text-yellow-700';
+  return (
+    <span className={`rounded-full px-2 py-0.5 text-xs font-semibold ${cls}`}>{pct}% risk</span>
+  );
+}
+
+interface PredictionsListProps {
+  predictions: MaintenancePrediction[];
+  isLoading: boolean;
+  pendingAcknowledgeId: string | null;
+  onAcknowledge: (id: string) => void;
+}
+
+export function PredictionsList({
+  predictions,
+  isLoading,
+  pendingAcknowledgeId,
+  onAcknowledge,
+}: PredictionsListProps): JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <div className="rounded-lg border bg-white p-4 shadow-sm">
+      <h2 className="mb-3 text-base font-semibold text-gray-900">
+        {t('predictive.predictionsTitle', { defaultValue: 'Maintenance Predictions' })}
+      </h2>
+
+      {isLoading ? (
+        <div className="space-y-2">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-14 animate-pulse rounded bg-gray-100" />
+          ))}
+        </div>
+      ) : predictions.length === 0 ? (
+        <p className="py-4 text-center text-sm text-gray-500">
+          {t('predictive.noPredictions', { defaultValue: 'No high-risk predictions.' })}
+        </p>
+      ) : (
+        <ul className="divide-y divide-gray-100">
+          {predictions.map((p) => (
+            <li key={p.id} className="flex items-start justify-between gap-4 py-3">
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <RiskBadge score={p.riskScore} />
+                  {p.predictedFailureDate && (
+                    <span className="text-xs text-gray-500">
+                      Failure ~{new Date(p.predictedFailureDate).toLocaleDateString()}
+                    </span>
+                  )}
+                </div>
+                <p className="mt-1 text-sm text-gray-700">{p.recommendation}</p>
+                <p className="text-xs text-gray-400">
+                  Confidence {Math.round(p.confidence * 100)}% ·{' '}
+                  {new Date(p.createdAt).toLocaleDateString()}
+                </p>
+              </div>
+              {!p.acknowledged ? (
+                <button
+                  type="button"
+                  disabled={pendingAcknowledgeId === p.id}
+                  onClick={() => onAcknowledge(p.id)}
+                  className="shrink-0 rounded-md bg-indigo-600 px-3 py-1 text-xs font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+                >
+                  {pendingAcknowledgeId === p.id
+                    ? t('common.saving', { defaultValue: 'Saving…' })
+                    : t('predictive.acknowledge', { defaultValue: 'Acknowledge' })}
+                </button>
+              ) : (
+                <span className="shrink-0 rounded-full bg-green-100 px-2 py-0.5 text-xs text-green-700">
+                  {t('predictive.acknowledged', { defaultValue: 'Acknowledged' })}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/predictive-maintenance/components/index.ts
+++ b/frontend/apps/ppt-web/src/features/predictive-maintenance/components/index.ts
@@ -1,0 +1,2 @@
+export * from './EquipmentList';
+export * from './PredictionsList';

--- a/frontend/apps/ppt-web/src/features/predictive-maintenance/hooks/index.ts
+++ b/frontend/apps/ppt-web/src/features/predictive-maintenance/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './usePredictiveMaintenance';

--- a/frontend/apps/ppt-web/src/features/predictive-maintenance/hooks/usePredictiveMaintenance.ts
+++ b/frontend/apps/ppt-web/src/features/predictive-maintenance/hooks/usePredictiveMaintenance.ts
@@ -36,8 +36,7 @@ export function useEquipmentList(query?: EquipmentQuery) {
 
   return useQuery({
     queryKey: predictiveKeys.equipment(query),
-    queryFn: () =>
-      apiFetch<{ equipment: Equipment[] }>(`${EQUIPMENT_API}${qs ? `?${qs}` : ''}`),
+    queryFn: () => apiFetch<{ equipment: Equipment[] }>(`${EQUIPMENT_API}${qs ? `?${qs}` : ''}`),
     staleTime: 60 * 1000,
   });
 }
@@ -72,10 +71,10 @@ export function useAcknowledgeMaintenancePrediction() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (predictionId: string) =>
-      apiFetch<MaintenancePrediction>(
-        `${EQUIPMENT_API}/predictions/${predictionId}/acknowledge`,
-        { method: 'POST', body: JSON.stringify({}) }
-      ),
+      apiFetch<MaintenancePrediction>(`${EQUIPMENT_API}/predictions/${predictionId}/acknowledge`, {
+        method: 'POST',
+        body: JSON.stringify({}),
+      }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: predictiveKeys.all });
     },

--- a/frontend/apps/ppt-web/src/features/predictive-maintenance/hooks/usePredictiveMaintenance.ts
+++ b/frontend/apps/ppt-web/src/features/predictive-maintenance/hooks/usePredictiveMaintenance.ts
@@ -1,0 +1,83 @@
+/**
+ * Predictive Maintenance Hooks (Epic 13, Story 13.3)
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { Equipment, EquipmentQuery, MaintenancePrediction, PredictionsQuery } from '../types';
+
+const EQUIPMENT_API = '/api/v1/ai/equipment';
+
+async function apiFetch<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    ...options,
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ message: 'Request failed' }));
+    throw new Error(err.message || `HTTP ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+export const predictiveKeys = {
+  all: ['predictive-maintenance'] as const,
+  equipment: (q?: EquipmentQuery) => [...predictiveKeys.all, 'equipment', q] as const,
+  predictions: (q?: PredictionsQuery) => [...predictiveKeys.all, 'predictions', q] as const,
+  needingMaintenance: () => [...predictiveKeys.all, 'needing-maintenance'] as const,
+};
+
+export function useEquipmentList(query?: EquipmentQuery) {
+  const params = new URLSearchParams();
+  if (query?.buildingId) params.set('building_id', query.buildingId);
+  if (query?.category) params.set('category', query.category);
+  if (query?.status) params.set('status', query.status);
+  if (query?.limit) params.set('limit', String(query.limit));
+  if (query?.offset) params.set('offset', String(query.offset));
+  const qs = params.toString();
+
+  return useQuery({
+    queryKey: predictiveKeys.equipment(query),
+    queryFn: () =>
+      apiFetch<{ equipment: Equipment[] }>(`${EQUIPMENT_API}${qs ? `?${qs}` : ''}`),
+    staleTime: 60 * 1000,
+  });
+}
+
+export function useMaintenancePredictions(query?: PredictionsQuery) {
+  const params = new URLSearchParams();
+  if (query?.limit) params.set('limit', String(query.limit));
+  const qs = params.toString();
+
+  return useQuery({
+    queryKey: predictiveKeys.predictions(query),
+    queryFn: () =>
+      apiFetch<{ predictions: MaintenancePrediction[] }>(
+        `${EQUIPMENT_API}/predictions${qs ? `?${qs}` : ''}`
+      ),
+    staleTime: 60 * 1000,
+  });
+}
+
+export function useNeedingMaintenance(daysAhead = 30) {
+  return useQuery({
+    queryKey: predictiveKeys.needingMaintenance(),
+    queryFn: () =>
+      apiFetch<{ equipment: Equipment[] }>(
+        `${EQUIPMENT_API}/needing-maintenance?days_ahead=${daysAhead}`
+      ),
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useAcknowledgeMaintenancePrediction() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (predictionId: string) =>
+      apiFetch<MaintenancePrediction>(
+        `${EQUIPMENT_API}/predictions/${predictionId}/acknowledge`,
+        { method: 'POST', body: JSON.stringify({}) }
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: predictiveKeys.all });
+    },
+  });
+}

--- a/frontend/apps/ppt-web/src/features/predictive-maintenance/index.ts
+++ b/frontend/apps/ppt-web/src/features/predictive-maintenance/index.ts
@@ -1,0 +1,4 @@
+export * from './components';
+export * from './hooks';
+export * from './pages';
+export * from './types';

--- a/frontend/apps/ppt-web/src/features/predictive-maintenance/pages/PredictiveMaintenancePage.tsx
+++ b/frontend/apps/ppt-web/src/features/predictive-maintenance/pages/PredictiveMaintenancePage.tsx
@@ -1,0 +1,111 @@
+/**
+ * Predictive Maintenance Dashboard (Epic 13, Story 13.3)
+ *
+ * Presentational component — the route wrapper in routes/groups/ai-dashboards.tsx
+ * wires API hooks and passes data + handlers in.
+ */
+import type { JSX } from 'react';
+import { useTranslation } from 'react-i18next';
+import { EquipmentList, PredictionsList } from '../components';
+import type { Equipment, MaintenancePrediction } from '../types';
+
+export interface PredictiveMaintenancePageProps {
+  equipment: Equipment[];
+  equipmentLoading: boolean;
+  selectedEquipmentId: string | null;
+  onSelectEquipment: (id: string) => void;
+  predictions: MaintenancePrediction[];
+  predictionsLoading: boolean;
+  pendingAcknowledgeId: string | null;
+  onAcknowledgePrediction: (id: string) => void;
+}
+
+export function PredictiveMaintenancePage({
+  equipment,
+  equipmentLoading,
+  selectedEquipmentId,
+  onSelectEquipment,
+  predictions,
+  predictionsLoading,
+  pendingAcknowledgeId,
+  onAcknowledgePrediction,
+}: PredictiveMaintenancePageProps): JSX.Element {
+  const { t } = useTranslation();
+
+  const needsMaintenance = equipment.filter((e) => e.status === 'needs_maintenance').length;
+  const highRisk = predictions.filter((p) => p.riskScore >= 0.75 && !p.acknowledged).length;
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-6">
+      <header className="mb-6">
+        <h1 className="text-2xl font-semibold text-gray-900">
+          {t('predictive.pageTitle', { defaultValue: 'Predictive Maintenance' })}
+        </h1>
+        <p className="mt-1 text-sm text-gray-500">
+          {t('predictive.pageSubtitle', {
+            defaultValue: 'AI-powered equipment health monitoring and failure predictions.',
+          })}
+        </p>
+      </header>
+
+      {/* KPI row */}
+      <div className="mb-6 grid grid-cols-2 gap-4 md:grid-cols-4">
+        <div className="rounded-lg border bg-white p-4 shadow-sm">
+          <p className="text-sm font-medium text-gray-500">
+            {t('predictive.totalEquipment', { defaultValue: 'Total equipment' })}
+          </p>
+          <p className="mt-1 text-2xl font-semibold text-gray-900">
+            {equipmentLoading ? '—' : equipment.length}
+          </p>
+        </div>
+        <div className="rounded-lg border bg-white p-4 shadow-sm">
+          <p className="text-sm font-medium text-gray-500">
+            {t('predictive.needsMaintenance', { defaultValue: 'Needs maintenance' })}
+          </p>
+          <p
+            className={`mt-1 text-2xl font-semibold ${needsMaintenance > 0 ? 'text-yellow-600' : 'text-gray-900'}`}
+          >
+            {equipmentLoading ? '—' : needsMaintenance}
+          </p>
+        </div>
+        <div className="rounded-lg border bg-white p-4 shadow-sm">
+          <p className="text-sm font-medium text-gray-500">
+            {t('predictive.highRisk', { defaultValue: 'High-risk open' })}
+          </p>
+          <p
+            className={`mt-1 text-2xl font-semibold ${highRisk > 0 ? 'text-red-600' : 'text-gray-900'}`}
+          >
+            {predictionsLoading ? '—' : highRisk}
+          </p>
+        </div>
+        <div className="rounded-lg border bg-white p-4 shadow-sm">
+          <p className="text-sm font-medium text-gray-500">
+            {t('predictive.totalPredictions', { defaultValue: 'Total predictions' })}
+          </p>
+          <p className="mt-1 text-2xl font-semibold text-gray-900">
+            {predictionsLoading ? '—' : predictions.length}
+          </p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <div className="lg:col-span-1">
+          <EquipmentList
+            equipment={equipment}
+            isLoading={equipmentLoading}
+            selectedId={selectedEquipmentId}
+            onSelect={onSelectEquipment}
+          />
+        </div>
+        <div className="lg:col-span-2">
+          <PredictionsList
+            predictions={predictions}
+            isLoading={predictionsLoading}
+            pendingAcknowledgeId={pendingAcknowledgeId}
+            onAcknowledge={onAcknowledgePrediction}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/predictive-maintenance/pages/index.ts
+++ b/frontend/apps/ppt-web/src/features/predictive-maintenance/pages/index.ts
@@ -1,0 +1,1 @@
+export * from './PredictiveMaintenancePage';

--- a/frontend/apps/ppt-web/src/features/predictive-maintenance/types.ts
+++ b/frontend/apps/ppt-web/src/features/predictive-maintenance/types.ts
@@ -1,0 +1,55 @@
+/**
+ * Predictive Maintenance & Equipment Types (Epic 13, Story 13.3)
+ */
+
+export interface Equipment {
+  id: string;
+  organizationId: string;
+  buildingId: string;
+  facilityId: string | null;
+  name: string;
+  category: string;
+  manufacturer: string | null;
+  model: string | null;
+  serialNumber: string | null;
+  installationDate: string | null;
+  warrantyExpires: string | null;
+  expectedLifespanYears: number | null;
+  maintenanceIntervalDays: number | null;
+  lastMaintenanceDate: string | null;
+  nextMaintenanceDue: string | null;
+  status: string;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MaintenancePrediction {
+  id: string;
+  equipmentId: string;
+  riskScore: number;
+  predictedFailureDate: string | null;
+  confidence: number;
+  recommendation: string;
+  factors: Record<string, unknown>;
+  acknowledged: boolean;
+  acknowledgedBy: string | null;
+  actionTaken: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface EquipmentQuery {
+  buildingId?: string;
+  facilityId?: string;
+  category?: string;
+  status?: string;
+  needsMaintenance?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+export interface PredictionsQuery {
+  equipmentId?: string;
+  limit?: number;
+}

--- a/frontend/apps/ppt-web/src/features/sentiment/components/SentimentAlertsPanel.tsx
+++ b/frontend/apps/ppt-web/src/features/sentiment/components/SentimentAlertsPanel.tsx
@@ -1,0 +1,79 @@
+import type { JSX } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { SentimentAlert } from '../types';
+
+const ALERT_TYPE_LABELS: Record<string, string> = {
+  spike_negative: 'Negative spike',
+  sustained_decline: 'Sustained decline',
+  anomaly: 'Anomaly',
+};
+
+interface SentimentAlertsPanelProps {
+  alerts: SentimentAlert[];
+  isLoading: boolean;
+  pendingAcknowledgeId: string | null;
+  onAcknowledge: (alertId: string) => void;
+}
+
+export function SentimentAlertsPanel({
+  alerts,
+  isLoading,
+  pendingAcknowledgeId,
+  onAcknowledge,
+}: SentimentAlertsPanelProps): JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <div className="rounded-lg border bg-white p-4 shadow-sm">
+      <h2 className="mb-3 text-base font-semibold text-gray-900">
+        {t('sentiment.alertsTitle', { defaultValue: 'Sentiment Alerts' })}
+      </h2>
+
+      {isLoading ? (
+        <div className="space-y-2">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-12 animate-pulse rounded bg-gray-100" />
+          ))}
+        </div>
+      ) : alerts.length === 0 ? (
+        <p className="py-4 text-center text-sm text-gray-500">
+          {t('sentiment.noAlerts', { defaultValue: 'No active alerts.' })}
+        </p>
+      ) : (
+        <ul className="divide-y divide-gray-100">
+          {alerts.map((alert) => (
+            <li key={alert.id} className="flex items-center justify-between gap-4 py-3">
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium text-gray-900">
+                  {ALERT_TYPE_LABELS[alert.alertType] ?? alert.alertType}
+                </p>
+                <p className="text-xs text-gray-500">
+                  Score {alert.currentSentiment.toFixed(2)} · threshold{' '}
+                  {alert.thresholdBreached.toFixed(2)} ·{' '}
+                  {new Date(alert.createdAt).toLocaleDateString()}
+                </p>
+              </div>
+              {!alert.acknowledged && (
+                <button
+                  type="button"
+                  disabled={pendingAcknowledgeId === alert.id}
+                  onClick={() => onAcknowledge(alert.id)}
+                  className="shrink-0 rounded-md bg-indigo-600 px-3 py-1 text-xs font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+                >
+                  {pendingAcknowledgeId === alert.id
+                    ? t('common.saving', { defaultValue: 'Saving…' })
+                    : t('sentiment.acknowledge', { defaultValue: 'Acknowledge' })}
+                </button>
+              )}
+              {alert.acknowledged && (
+                <span className="shrink-0 rounded-full bg-green-100 px-2 py-0.5 text-xs text-green-700">
+                  {t('sentiment.acknowledged', { defaultValue: 'Acknowledged' })}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/sentiment/components/SentimentStatCard.tsx
+++ b/frontend/apps/ppt-web/src/features/sentiment/components/SentimentStatCard.tsx
@@ -15,7 +15,11 @@ interface SentimentStatCardProps {
   tone?: Tone;
 }
 
-export function SentimentStatCard({ label, value, tone = 'default' }: SentimentStatCardProps): JSX.Element {
+export function SentimentStatCard({
+  label,
+  value,
+  tone = 'default',
+}: SentimentStatCardProps): JSX.Element {
   return (
     <div className={`rounded-lg border p-4 shadow-sm ${toneClasses[tone]}`}>
       <p className="text-sm font-medium opacity-70">{label}</p>

--- a/frontend/apps/ppt-web/src/features/sentiment/components/SentimentStatCard.tsx
+++ b/frontend/apps/ppt-web/src/features/sentiment/components/SentimentStatCard.tsx
@@ -1,0 +1,25 @@
+import type { JSX } from 'react';
+
+type Tone = 'default' | 'success' | 'warning' | 'danger';
+
+const toneClasses: Record<Tone, string> = {
+  default: 'bg-white text-gray-900',
+  success: 'bg-green-50 text-green-800',
+  warning: 'bg-yellow-50 text-yellow-800',
+  danger: 'bg-red-50 text-red-800',
+};
+
+interface SentimentStatCardProps {
+  label: string;
+  value: string | number;
+  tone?: Tone;
+}
+
+export function SentimentStatCard({ label, value, tone = 'default' }: SentimentStatCardProps): JSX.Element {
+  return (
+    <div className={`rounded-lg border p-4 shadow-sm ${toneClasses[tone]}`}>
+      <p className="text-sm font-medium opacity-70">{label}</p>
+      <p className="mt-1 text-2xl font-semibold">{value}</p>
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/sentiment/components/SentimentTrendChart.tsx
+++ b/frontend/apps/ppt-web/src/features/sentiment/components/SentimentTrendChart.tsx
@@ -13,9 +13,7 @@ interface SentimentTrendChartProps {
 
 function SentimentLine({ trends }: { trends: SentimentTrend[] }): JSX.Element {
   if (trends.length < 2) {
-    return (
-      <p className="py-8 text-center text-sm text-gray-400">Not enough data to draw trend.</p>
-    );
+    return <p className="py-8 text-center text-sm text-gray-400">Not enough data to draw trend.</p>;
   }
 
   const W = 600;

--- a/frontend/apps/ppt-web/src/features/sentiment/components/SentimentTrendChart.tsx
+++ b/frontend/apps/ppt-web/src/features/sentiment/components/SentimentTrendChart.tsx
@@ -1,0 +1,100 @@
+/**
+ * Trend line chart for daily average sentiment scores.
+ * Uses a simple SVG sparkline — no chart library dependency.
+ */
+import type { JSX } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { SentimentTrend } from '../types';
+
+interface SentimentTrendChartProps {
+  trends: SentimentTrend[];
+  isLoading: boolean;
+}
+
+function SentimentLine({ trends }: { trends: SentimentTrend[] }): JSX.Element {
+  if (trends.length < 2) {
+    return (
+      <p className="py-8 text-center text-sm text-gray-400">Not enough data to draw trend.</p>
+    );
+  }
+
+  const W = 600;
+  const H = 120;
+  const PAD = 8;
+
+  const sorted = [...trends].sort((a, b) => a.date.localeCompare(b.date));
+  const scores = sorted.map((t) => t.avgSentiment);
+  const minScore = Math.min(...scores);
+  const maxScore = Math.max(...scores);
+  const range = maxScore - minScore || 1;
+
+  const xStep = (W - PAD * 2) / (sorted.length - 1);
+  const toX = (i: number) => PAD + i * xStep;
+  const toY = (v: number) => H - PAD - ((v - minScore) / range) * (H - PAD * 2);
+
+  const d = sorted
+    .map((t, i) => `${i === 0 ? 'M' : 'L'}${toX(i).toFixed(1)},${toY(t.avgSentiment).toFixed(1)}`)
+    .join(' ');
+
+  // Highlight spikes (drops > 0.2)
+  const spikes = sorted
+    .slice(1)
+    .map((t, i) => ({ t, i: i + 1, delta: t.avgSentiment - sorted[i].avgSentiment }))
+    .filter((s) => s.delta < -0.2);
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="w-full" aria-label="Sentiment trend">
+      {/* Zero line at 0.5 */}
+      <line
+        x1={PAD}
+        y1={toY(0.5).toFixed(1)}
+        x2={W - PAD}
+        y2={toY(0.5).toFixed(1)}
+        stroke="#e5e7eb"
+        strokeDasharray="4"
+      />
+      <path d={d} fill="none" stroke="#6366f1" strokeWidth="2" strokeLinejoin="round" />
+      {/* Spike markers */}
+      {spikes.map((s) => (
+        <circle
+          key={s.i}
+          cx={toX(s.i).toFixed(1)}
+          cy={toY(s.t.avgSentiment).toFixed(1)}
+          r="4"
+          fill="#ef4444"
+          aria-label={`Spike on ${s.t.date}`}
+        />
+      ))}
+      {/* Labels */}
+      {[sorted[0], sorted[sorted.length - 1]].map((t, idx) => (
+        <text
+          key={idx}
+          x={idx === 0 ? PAD : W - PAD}
+          y={H}
+          fontSize="10"
+          textAnchor={idx === 0 ? 'start' : 'end'}
+          fill="#9ca3af"
+        >
+          {t.date}
+        </text>
+      ))}
+    </svg>
+  );
+}
+
+export function SentimentTrendChart({ trends, isLoading }: SentimentTrendChartProps): JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <div className="rounded-lg border bg-white p-4 shadow-sm">
+      <h2 className="mb-3 text-base font-semibold text-gray-900">
+        {t('sentiment.trendTitle', { defaultValue: 'Sentiment Trend (30 days)' })}
+      </h2>
+      {isLoading ? (
+        <div className="h-32 animate-pulse rounded bg-gray-100" />
+      ) : (
+        <SentimentLine trends={trends} />
+      )}
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/sentiment/components/index.ts
+++ b/frontend/apps/ppt-web/src/features/sentiment/components/index.ts
@@ -1,0 +1,3 @@
+export * from './SentimentAlertsPanel';
+export * from './SentimentStatCard';
+export * from './SentimentTrendChart';

--- a/frontend/apps/ppt-web/src/features/sentiment/hooks/index.ts
+++ b/frontend/apps/ppt-web/src/features/sentiment/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useSentiment';

--- a/frontend/apps/ppt-web/src/features/sentiment/hooks/useSentiment.ts
+++ b/frontend/apps/ppt-web/src/features/sentiment/hooks/useSentiment.ts
@@ -1,0 +1,109 @@
+/**
+ * Sentiment Analysis Hooks (Epic 13, Story 13.2)
+ *
+ * TanStack Query hooks for the sentiment API.
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type {
+  SentimentAlert,
+  SentimentDashboard,
+  SentimentThresholds,
+  SentimentTrend,
+  SentimentTrendQuery,
+  UpdateSentimentThresholdsRequest,
+} from '../types';
+
+const API_BASE = '/api/v1/ai/sentiment';
+
+async function apiFetch<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    ...options,
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ message: 'Request failed' }));
+    throw new Error(err.message || `HTTP ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+export const sentimentKeys = {
+  all: ['sentiment'] as const,
+  dashboard: () => [...sentimentKeys.all, 'dashboard'] as const,
+  trends: (query?: SentimentTrendQuery) => [...sentimentKeys.all, 'trends', query] as const,
+  alerts: (acknowledged?: boolean) => [...sentimentKeys.all, 'alerts', acknowledged] as const,
+  thresholds: () => [...sentimentKeys.all, 'thresholds'] as const,
+};
+
+export function useSentimentDashboard() {
+  return useQuery({
+    queryKey: sentimentKeys.dashboard(),
+    queryFn: () => apiFetch<SentimentDashboard>(`${API_BASE}/dashboard`),
+    staleTime: 60 * 1000,
+  });
+}
+
+export function useSentimentTrends(query?: SentimentTrendQuery) {
+  const params = new URLSearchParams();
+  if (query?.buildingId) params.set('building_id', query.buildingId);
+  if (query?.fromDate) params.set('from_date', query.fromDate);
+  if (query?.toDate) params.set('to_date', query.toDate);
+  if (query?.limit) params.set('limit', String(query.limit));
+  const qs = params.toString();
+
+  return useQuery({
+    queryKey: sentimentKeys.trends(query),
+    queryFn: () =>
+      apiFetch<{ trends: SentimentTrend[] }>(`${API_BASE}/trends${qs ? `?${qs}` : ''}`).then(
+        (r) => r.trends
+      ),
+    staleTime: 60 * 1000,
+  });
+}
+
+export function useSentimentAlerts(acknowledged?: boolean) {
+  const params = new URLSearchParams();
+  if (acknowledged !== undefined) params.set('acknowledged', String(acknowledged));
+
+  return useQuery({
+    queryKey: sentimentKeys.alerts(acknowledged),
+    queryFn: () =>
+      apiFetch<{ alerts: SentimentAlert[] }>(
+        `${API_BASE}/alerts${params.toString() ? `?${params}` : ''}`
+      ).then((r) => r.alerts),
+    staleTime: 30 * 1000,
+  });
+}
+
+export function useSentimentThresholds() {
+  return useQuery({
+    queryKey: sentimentKeys.thresholds(),
+    queryFn: () => apiFetch<SentimentThresholds>(`${API_BASE}/thresholds`),
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useAcknowledgeSentimentAlert() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (alertId: string) =>
+      apiFetch<SentimentAlert>(`${API_BASE}/alerts/${alertId}/acknowledge`, { method: 'POST' }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: sentimentKeys.all });
+    },
+  });
+}
+
+export function useUpdateSentimentThresholds() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (req: UpdateSentimentThresholdsRequest) =>
+      apiFetch<SentimentThresholds>(`${API_BASE}/thresholds`, {
+        method: 'PUT',
+        body: JSON.stringify(req),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: sentimentKeys.thresholds() });
+    },
+  });
+}

--- a/frontend/apps/ppt-web/src/features/sentiment/index.ts
+++ b/frontend/apps/ppt-web/src/features/sentiment/index.ts
@@ -1,0 +1,4 @@
+export * from './components';
+export * from './hooks';
+export * from './pages';
+export * from './types';

--- a/frontend/apps/ppt-web/src/features/sentiment/pages/SentimentDashboardPage.tsx
+++ b/frontend/apps/ppt-web/src/features/sentiment/pages/SentimentDashboardPage.tsx
@@ -1,0 +1,87 @@
+/**
+ * Sentiment Dashboard (Epic 13, Story 13.2)
+ *
+ * Presentational component — the route wrapper in routes/groups/core.tsx
+ * wires API hooks and passes data + handlers in.
+ */
+import type { JSX } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SentimentAlertsPanel, SentimentStatCard, SentimentTrendChart } from '../components';
+import type { SentimentAlert, SentimentDashboard, SentimentTrend } from '../types';
+
+export interface SentimentDashboardPageProps {
+  dashboard: SentimentDashboard | undefined;
+  dashboardLoading: boolean;
+  trends: SentimentTrend[];
+  trendsLoading: boolean;
+  alerts: SentimentAlert[];
+  alertsLoading: boolean;
+  pendingAcknowledgeId: string | null;
+  onAcknowledge: (alertId: string) => void;
+}
+
+export function SentimentDashboardPage({
+  dashboard,
+  dashboardLoading,
+  trends,
+  trendsLoading,
+  alerts,
+  alertsLoading,
+  pendingAcknowledgeId,
+  onAcknowledge,
+}: SentimentDashboardPageProps): JSX.Element {
+  const { t } = useTranslation();
+
+  const avgScore = dashboard?.organization_avg ?? null;
+  const unacknowledged = alerts.filter((a) => !a.acknowledged).length;
+
+  const scoreTone =
+    avgScore === null ? 'default' : avgScore >= 0.6 ? 'success' : avgScore >= 0.4 ? 'warning' : 'danger';
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-6">
+      <header className="mb-6">
+        <h1 className="text-2xl font-semibold text-gray-900">
+          {t('sentiment.pageTitle', { defaultValue: 'Tenant Sentiment' })}
+        </h1>
+        <p className="mt-1 text-sm text-gray-500">
+          {t('sentiment.pageSubtitle', {
+            defaultValue: 'AI-derived sentiment trends and alerts from tenant communications.',
+          })}
+        </p>
+      </header>
+
+      {/* KPI row */}
+      <div className="mb-6 grid grid-cols-2 gap-4 md:grid-cols-4">
+        <SentimentStatCard
+          label={t('sentiment.orgAvg', { defaultValue: 'Org avg (30d)' })}
+          value={dashboardLoading ? '—' : avgScore !== null ? avgScore.toFixed(2) : 'N/A'}
+          tone={scoreTone}
+        />
+        <SentimentStatCard
+          label={t('sentiment.totalTrends', { defaultValue: 'Data points' })}
+          value={dashboardLoading ? '—' : (dashboard?.trends.length ?? 0)}
+        />
+        <SentimentStatCard
+          label={t('sentiment.openAlerts', { defaultValue: 'Open alerts' })}
+          value={alertsLoading ? '—' : unacknowledged}
+          tone={unacknowledged > 0 ? 'danger' : 'default'}
+        />
+        <SentimentStatCard
+          label={t('sentiment.totalAlerts', { defaultValue: 'Total alerts' })}
+          value={alertsLoading ? '—' : alerts.length}
+        />
+      </div>
+
+      <div className="space-y-6">
+        <SentimentTrendChart trends={trends} isLoading={trendsLoading} />
+        <SentimentAlertsPanel
+          alerts={alerts}
+          isLoading={alertsLoading}
+          pendingAcknowledgeId={pendingAcknowledgeId}
+          onAcknowledge={onAcknowledge}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/sentiment/pages/SentimentDashboardPage.tsx
+++ b/frontend/apps/ppt-web/src/features/sentiment/pages/SentimentDashboardPage.tsx
@@ -36,7 +36,13 @@ export function SentimentDashboardPage({
   const unacknowledged = alerts.filter((a) => !a.acknowledged).length;
 
   const scoreTone =
-    avgScore === null ? 'default' : avgScore >= 0.6 ? 'success' : avgScore >= 0.4 ? 'warning' : 'danger';
+    avgScore === null
+      ? 'default'
+      : avgScore >= 0.6
+        ? 'success'
+        : avgScore >= 0.4
+          ? 'warning'
+          : 'danger';
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-6">

--- a/frontend/apps/ppt-web/src/features/sentiment/pages/index.ts
+++ b/frontend/apps/ppt-web/src/features/sentiment/pages/index.ts
@@ -1,0 +1,1 @@
+export * from './SentimentDashboardPage';

--- a/frontend/apps/ppt-web/src/features/sentiment/types.ts
+++ b/frontend/apps/ppt-web/src/features/sentiment/types.ts
@@ -1,0 +1,65 @@
+/**
+ * Sentiment Analysis Feature Types (Epic 13, Story 13.2)
+ */
+
+export interface SentimentTrend {
+  id: string;
+  organizationId: string;
+  buildingId: string | null;
+  date: string;
+  avgSentiment: number;
+  messageCount: number;
+  negativeCount: number;
+  neutralCount: number;
+  positiveCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SentimentAlert {
+  id: string;
+  organizationId: string;
+  buildingId: string | null;
+  alertType: string;
+  thresholdBreached: number;
+  currentSentiment: number;
+  previousSentiment: number | null;
+  sampleMessageIds: string[];
+  acknowledged: boolean;
+  acknowledgedBy: string | null;
+  acknowledgedAt: string | null;
+  createdAt: string;
+}
+
+export interface SentimentThresholds {
+  id: string;
+  organizationId: string;
+  negativeThreshold: number;
+  alertOnSpike: boolean;
+  spikeThresholdChange: number;
+  minMessagesForAlert: number;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SentimentDashboard {
+  organization_avg: number;
+  trends: SentimentTrend[];
+  recent_alerts: SentimentAlert[];
+}
+
+export interface UpdateSentimentThresholdsRequest {
+  negativeThreshold?: number;
+  alertOnSpike?: boolean;
+  spikeThresholdChange?: number;
+  minMessagesForAlert?: number;
+  enabled?: boolean;
+}
+
+export interface SentimentTrendQuery {
+  buildingId?: string;
+  fromDate?: string;
+  toDate?: string;
+  limit?: number;
+}

--- a/frontend/apps/ppt-web/src/routes/AppRoutes.tsx
+++ b/frontend/apps/ppt-web/src/routes/AppRoutes.tsx
@@ -13,6 +13,7 @@
  */
 import { Route, Routes } from 'react-router-dom';
 import { accountingRoutes } from './groups/accounting';
+import { aiDashboardRoutes } from './groups/ai-dashboards';
 import { announcementRoutes } from './groups/announcements';
 import { buildingRoutes } from './groups/buildings';
 import { communityRoutes } from './groups/community';
@@ -52,6 +53,7 @@ export function AppRoutes() {
       {meterRoutes()}
       {leaseRoutes()}
       {votingRoutes()}
+      {aiDashboardRoutes()}
       {iotRoutes()}
       {reportRoutes()}
       {buildingRoutes()}

--- a/frontend/apps/ppt-web/src/routes/groups/ai-dashboards.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/ai-dashboards.tsx
@@ -7,16 +7,16 @@
 import { useState } from 'react';
 import { Route } from 'react-router-dom';
 import {
+  useAcknowledgeMaintenancePrediction,
+  useEquipmentList,
+  useMaintenancePredictions,
+} from '../../features/predictive-maintenance/hooks';
+import {
   useAcknowledgeSentimentAlert,
   useSentimentAlerts,
   useSentimentDashboard,
   useSentimentTrends,
 } from '../../features/sentiment/hooks';
-import {
-  useAcknowledgeMaintenancePrediction,
-  useEquipmentList,
-  useMaintenancePredictions,
-} from '../../features/predictive-maintenance/hooks';
 import { PredictiveMaintenancePage, SentimentDashboardPage } from '../lazyRoutes';
 
 // ── Sentiment ──────────────────────────────────────────────────────────────

--- a/frontend/apps/ppt-web/src/routes/groups/ai-dashboards.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/ai-dashboards.tsx
@@ -1,0 +1,83 @@
+/**
+ * AI Dashboard route group — Sentiment (13.2) & Predictive Maintenance (13.3).
+ *
+ * Each route wrapper wires API hooks to the presentational page component,
+ * following the same convention as routes/groups/iot.tsx.
+ */
+import { useState } from 'react';
+import { Route } from 'react-router-dom';
+import {
+  useAcknowledgeSentimentAlert,
+  useSentimentAlerts,
+  useSentimentDashboard,
+  useSentimentTrends,
+} from '../../features/sentiment/hooks';
+import {
+  useAcknowledgeMaintenancePrediction,
+  useEquipmentList,
+  useMaintenancePredictions,
+} from '../../features/predictive-maintenance/hooks';
+import { PredictiveMaintenancePage, SentimentDashboardPage } from '../lazyRoutes';
+
+// ── Sentiment ──────────────────────────────────────────────────────────────
+
+function SentimentDashboardRoute() {
+  const { data: dashboard, isLoading: dashboardLoading } = useSentimentDashboard();
+  const { data: trends, isLoading: trendsLoading } = useSentimentTrends({ limit: 60 });
+  const { data: alerts, isLoading: alertsLoading } = useSentimentAlerts(false);
+  const acknowledge = useAcknowledgeSentimentAlert();
+
+  const pendingAcknowledgeId = acknowledge.isPending ? (acknowledge.variables ?? null) : null;
+
+  return (
+    <SentimentDashboardPage
+      dashboard={dashboard}
+      dashboardLoading={dashboardLoading}
+      trends={trends ?? []}
+      trendsLoading={trendsLoading}
+      alerts={alerts ?? []}
+      alertsLoading={alertsLoading}
+      pendingAcknowledgeId={pendingAcknowledgeId}
+      onAcknowledge={(id) => acknowledge.mutate(id)}
+    />
+  );
+}
+
+// ── Predictive Maintenance ─────────────────────────────────────────────────
+
+function PredictiveMaintenanceRoute() {
+  const [selectedEquipmentId, setSelectedEquipmentId] = useState<string | null>(null);
+
+  const { data: equipmentData, isLoading: equipmentLoading } = useEquipmentList();
+  const { data: predictions, isLoading: predictionsLoading } = useMaintenancePredictions({
+    equipmentId: selectedEquipmentId ?? undefined,
+    limit: 50,
+  });
+  const acknowledge = useAcknowledgeMaintenancePrediction();
+
+  const pendingAcknowledgeId = acknowledge.isPending ? (acknowledge.variables ?? null) : null;
+
+  return (
+    <PredictiveMaintenancePage
+      equipment={equipmentData?.equipment ?? []}
+      equipmentLoading={equipmentLoading}
+      selectedEquipmentId={selectedEquipmentId}
+      onSelectEquipment={setSelectedEquipmentId}
+      predictions={predictions?.predictions ?? []}
+      predictionsLoading={predictionsLoading}
+      pendingAcknowledgeId={pendingAcknowledgeId}
+      onAcknowledgePrediction={(id) => acknowledge.mutate(id)}
+    />
+  );
+}
+
+// ── Route table ────────────────────────────────────────────────────────────
+
+export function aiDashboardRoutes() {
+  return (
+    <>
+      <Route path="/ai/sentiment" element={<SentimentDashboardRoute />} />
+      <Route path="/ai/predictive-maintenance" element={<PredictiveMaintenanceRoute />} />
+    </>
+  );
+}

--- a/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
+++ b/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
@@ -283,6 +283,18 @@ export const AiChatPage = lazy(() =>
   import('../features/ai-chat').then((m) => ({ default: m.AiChatPage }))
 );
 
+// Sentiment Dashboard (Epic 13, Story 13.2) — gap-sweep
+export const SentimentDashboardPage = lazy(() =>
+  import('../features/sentiment').then((m) => ({ default: m.SentimentDashboardPage }))
+);
+
+// Predictive Maintenance Dashboard (Epic 13, Story 13.3) — gap-sweep
+export const PredictiveMaintenancePage = lazy(() =>
+  import('../features/predictive-maintenance').then((m) => ({
+    default: m.PredictiveMaintenancePage,
+  }))
+);
+
 // Workflow Automation (Epic 13) — built + API-wired, now routed (gap-sweep)
 export const AutomationRulesPage = lazy(() =>
   import('../features/workflow-automation').then((m) => ({ default: m.AutomationRulesPage }))


### PR DESCRIPTION
## Summary

- **Sentiment Dashboard** (`/ai/sentiment`, Story 13.2): trend sparkline (30-day, with negative-spike highlighting), alert list with one-click acknowledge, KPI row (org avg, open alerts).
- **Predictive Maintenance Dashboard** (`/ai/predictive-maintenance`, Story 13.3): equipment list with status badges, high-risk predictions list with risk % and acknowledge action, KPI row.
- New route group `routes/groups/ai-dashboards.tsx` wires API hooks to presentational pages (same pattern as `iot.tsx`).
- Self-contained TanStack Query hooks in each feature (pattern: ai-chat) — no api-client package changes.
- Two lazy entries added to `lazyRoutes.tsx`; `aiDashboardRoutes()` added to `AppRoutes.tsx`.

## Endpoints consumed

| Route | Endpoint |
|-------|----------|
| Sentiment | `GET /api/v1/ai/sentiment/dashboard`, `/trends`, `/alerts`, `POST .../alerts/{id}/acknowledge` |
| Equipment | `GET /api/v1/ai/equipment`, `/predictions`, `POST .../predictions/{id}/acknowledge` |

## Test plan

- [ ] `GET /ai/sentiment` renders KPI cards, SVG trend line, alert list
- [ ] Acknowledge button calls `POST /api/v1/ai/sentiment/alerts/{id}/acknowledge` and refreshes
- [ ] `GET /ai/predictive-maintenance` renders equipment list and predictions
- [ ] Acknowledge button calls `POST /api/v1/ai/equipment/predictions/{id}/acknowledge` and refreshes
- [ ] No TS errors in CI typecheck

Closes #984

🤖 Generated with [Claude Code](https://claude.com/claude-code)