### PR TITLE
feat(epic-15): portal-user listing CRUD — owner/realtor edit (#986)

### DIFF
--- a/backend/crates/db/migrations/00186_portal_listing_ownership.sql
+++ b/backend/crates/db/migrations/00186_portal_listing_ownership.sql
@@ -1,0 +1,258 @@
+-- Epic 15.1/15.2: Portal-user listing ownership (owner/realtor edit flow).
+--
+-- The `listings` table was originally org-scoped only (organization_id NOT NULL).
+-- This migration adds first-class portal-user ownership so authenticated portal
+-- users can create and edit their own listings without belonging to a PPT org.
+--
+-- Changes:
+--   1. `organization_id` becomes nullable (NULL = portal-direct listing).
+--   2. `portal_owner_id UUID REFERENCES users(id)` added as the portal owner FK.
+--   3. An ownership CHECK ensures every row is owned by exactly one of the two paths.
+--   4. SECURITY DEFINER functions let portal routes write without an RLS org context:
+--        portal_create_listing(...)  — INSERT with portal_owner_id
+--        portal_update_listing(...)  — ownership-gated UPDATE
+--        portal_get_listing(...)     — ownership-gated SELECT
+--   5. The existing `listings_four_context` RLS policy is extended to cover portal-
+--      owner reads/writes.
+
+-- ===========================================================================
+-- 1. Make organization_id nullable for portal-direct listings.
+-- ===========================================================================
+ALTER TABLE listings ALTER COLUMN organization_id DROP NOT NULL;
+
+-- ===========================================================================
+-- 2. Add portal_owner_id.
+-- ===========================================================================
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS portal_owner_id UUID
+    REFERENCES users(id) ON DELETE CASCADE;
+
+CREATE INDEX IF NOT EXISTS idx_listings_portal_owner
+    ON listings(portal_owner_id)
+    WHERE portal_owner_id IS NOT NULL;
+
+-- ===========================================================================
+-- 3. Ownership invariant.
+-- ===========================================================================
+ALTER TABLE listings ADD CONSTRAINT listings_owner_invariant
+    CHECK (organization_id IS NOT NULL OR portal_owner_id IS NOT NULL);
+
+-- ===========================================================================
+-- 4a. Helper: get_current_portal_user_id()
+--     Reads app.current_user_id set by portal routes.
+-- ===========================================================================
+CREATE OR REPLACE FUNCTION get_current_portal_user_id()
+RETURNS UUID
+LANGUAGE plpgsql
+STABLE
+AS $$
+BEGIN
+    RETURN NULLIF(current_setting('app.current_user_id', TRUE), '')::UUID;
+EXCEPTION
+    WHEN OTHERS THEN
+        RETURN NULL;
+END;
+$$;
+
+-- ===========================================================================
+-- 4b. Update listings RLS to cover portal-owner reads and writes.
+--
+-- Policy becomes 5 contexts:
+--   1. Super-admin            — is_super_admin()
+--   2. Org-staff write        — organization_id = get_current_org_id()
+--   3. Agency-subdomain       — same predicate (app-layer differentiates)
+--   4. Global-read (portal)   — is_published AND is_global_read_context()
+--   5. Portal-owner (new)     — portal_owner_id = get_current_portal_user_id()
+-- ===========================================================================
+DROP POLICY IF EXISTS listings_four_context ON listings;
+DROP POLICY IF EXISTS listings_five_context ON listings;
+
+CREATE POLICY listings_five_context ON listings
+    FOR ALL
+    USING (
+        is_super_admin()
+        OR organization_id = get_current_org_id()
+        OR (is_published AND is_global_read_context())
+        OR portal_owner_id = get_current_portal_user_id()
+    )
+    WITH CHECK (
+        is_super_admin()
+        OR organization_id = get_current_org_id()
+        OR portal_owner_id = get_current_portal_user_id()
+    );
+
+COMMENT ON POLICY listings_five_context ON listings IS
+    'Five-context RLS: (1) super-admin, (2/3) org-staff and agency subdomain '
+    'gated by get_current_org_id(), (4) PlatformHost global read-only of '
+    'is_published rows, (5) portal-owner CRUD gated by portal_owner_id = '
+    'get_current_portal_user_id(). WITH CHECK omits global-read (read-only by '
+    'design) and adds portal-owner for direct portal-user writes.';
+
+-- listing_photos follows listings via FK; portal users need to manage photos.
+-- Replaces the tenant-isolation policy (00110 / 00140) with one that also
+-- covers the portal-owner arm and the global-read arm.
+DROP POLICY IF EXISTS listing_photos_tenant_isolation ON listing_photos;
+CREATE POLICY listing_photos_five_context ON listing_photos
+    FOR ALL
+    USING (
+        is_super_admin()
+        OR (
+            EXISTS (
+                SELECT 1 FROM listings p
+                WHERE p.id = listing_photos.listing_id
+                  AND p.organization_id = get_current_org_id()
+            ) AND get_current_org_not_deleted()
+        )
+        OR EXISTS (
+            SELECT 1 FROM listings p
+            WHERE p.id = listing_photos.listing_id
+              AND p.is_published AND is_global_read_context()
+        )
+        OR EXISTS (
+            SELECT 1 FROM listings p
+            WHERE p.id = listing_photos.listing_id
+              AND p.portal_owner_id = get_current_portal_user_id()
+        )
+    )
+    WITH CHECK (
+        is_super_admin()
+        OR (
+            EXISTS (
+                SELECT 1 FROM listings p
+                WHERE p.id = listing_photos.listing_id
+                  AND p.organization_id = get_current_org_id()
+            ) AND get_current_org_not_deleted()
+        )
+        OR EXISTS (
+            SELECT 1 FROM listings p
+            WHERE p.id = listing_photos.listing_id
+              AND p.portal_owner_id = get_current_portal_user_id()
+        )
+    );
+
+-- ===========================================================================
+-- 5a. SECURITY DEFINER: create portal-user listing (bypasses org-scoped RLS).
+-- ===========================================================================
+CREATE OR REPLACE FUNCTION portal_create_listing(
+    p_user_id        UUID,
+    p_title          TEXT,
+    p_description    TEXT,
+    p_property_type  TEXT,
+    p_transaction_type TEXT,
+    p_price          NUMERIC,
+    p_currency       TEXT,
+    p_street         TEXT,
+    p_city           TEXT,
+    p_postal_code    TEXT,
+    p_country        TEXT    DEFAULT 'SK',
+    p_size_sqm       NUMERIC DEFAULT NULL,
+    p_rooms          INTEGER DEFAULT NULL,
+    p_floor          INTEGER DEFAULT NULL,
+    p_total_floors   INTEGER DEFAULT NULL
+)
+RETURNS SETOF listings
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    RETURN QUERY
+    INSERT INTO listings (
+        portal_owner_id, created_by,
+        status, is_published, title, description, property_type, transaction_type,
+        price, currency, street, city, postal_code, country,
+        size_sqm, rooms, floor, total_floors, features
+    )
+    VALUES (
+        p_user_id, p_user_id,
+        'draft', FALSE, p_title, p_description, p_property_type, p_transaction_type,
+        p_price, p_currency, p_street, p_city, p_postal_code, p_country,
+        p_size_sqm, p_rooms, p_floor, p_total_floors, '[]'::jsonb
+    )
+    RETURNING *;
+END;
+$$;
+
+COMMENT ON FUNCTION portal_create_listing IS
+    'Create a portal-user-owned listing (no PPT org required). Ownership is '
+    'enforced via portal_owner_id = p_user_id; status starts as draft.';
+
+-- ===========================================================================
+-- 5b. SECURITY DEFINER: get portal-user owned listing for editing.
+-- ===========================================================================
+CREATE OR REPLACE FUNCTION portal_get_listing(
+    p_listing_id UUID,
+    p_user_id    UUID
+)
+RETURNS SETOF listings
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT * FROM listings
+    WHERE id = p_listing_id
+      AND (portal_owner_id = p_user_id OR created_by = p_user_id);
+END;
+$$;
+
+COMMENT ON FUNCTION portal_get_listing IS
+    'Return a listing owned by p_user_id for editing. Checks both portal_owner_id '
+    'and created_by to cover listings migrated before this schema change.';
+
+-- ===========================================================================
+-- 5c. SECURITY DEFINER: update portal-user owned listing.
+-- ===========================================================================
+CREATE OR REPLACE FUNCTION portal_update_listing(
+    p_listing_id       UUID,
+    p_user_id          UUID,
+    p_title            TEXT    DEFAULT NULL,
+    p_description      TEXT    DEFAULT NULL,
+    p_property_type    TEXT    DEFAULT NULL,
+    p_transaction_type TEXT    DEFAULT NULL,
+    p_price            NUMERIC DEFAULT NULL,
+    p_currency         TEXT    DEFAULT NULL,
+    p_street           TEXT    DEFAULT NULL,
+    p_city             TEXT    DEFAULT NULL,
+    p_postal_code      TEXT    DEFAULT NULL,
+    p_country          TEXT    DEFAULT NULL,
+    p_size_sqm         NUMERIC DEFAULT NULL,
+    p_rooms            INTEGER DEFAULT NULL,
+    p_floor            INTEGER DEFAULT NULL,
+    p_total_floors     INTEGER DEFAULT NULL,
+    p_status           TEXT    DEFAULT NULL,
+    p_is_negotiable    BOOLEAN DEFAULT NULL
+)
+RETURNS SETOF listings
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    RETURN QUERY
+    UPDATE listings SET
+        title            = COALESCE(p_title, title),
+        description      = COALESCE(p_description, description),
+        property_type    = COALESCE(p_property_type, property_type),
+        transaction_type = COALESCE(p_transaction_type, transaction_type),
+        price            = COALESCE(p_price, price),
+        currency         = COALESCE(p_currency, currency),
+        street           = COALESCE(p_street, street),
+        city             = COALESCE(p_city, city),
+        postal_code      = COALESCE(p_postal_code, postal_code),
+        country          = COALESCE(p_country, country),
+        size_sqm         = COALESCE(p_size_sqm, size_sqm),
+        rooms            = COALESCE(p_rooms, rooms),
+        floor            = COALESCE(p_floor, floor),
+        total_floors     = COALESCE(p_total_floors, total_floors),
+        status           = COALESCE(p_status, status),
+        is_negotiable    = COALESCE(p_is_negotiable, is_negotiable)
+    WHERE id = p_listing_id
+      AND (portal_owner_id = p_user_id OR created_by = p_user_id)
+    RETURNING *;
+END;
+$$;
+
+COMMENT ON FUNCTION portal_update_listing IS
+    'Patch a portal-user-owned listing. NULL arguments are skipped (COALESCE). '
+    'Ownership enforced via portal_owner_id = p_user_id OR created_by = p_user_id.';

--- a/backend/crates/db/src/models/listing.rs
+++ b/backend/crates/db/src/models/listing.rs
@@ -44,9 +44,12 @@ pub mod currency {
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize, ToSchema)]
 pub struct Listing {
     pub id: Uuid,
-    pub organization_id: Uuid,
+    /// NULL for portal-direct listings (no PPT org). See migration 00186.
+    pub organization_id: Option<Uuid>,
     pub unit_id: Option<Uuid>,
     pub created_by: Uuid,
+    /// Set for portal-user-created listings; NULL for org-owned listings.
+    pub portal_owner_id: Option<Uuid>,
 
     // Listing status
     pub status: String,
@@ -141,7 +144,7 @@ impl Listing {
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize, ToSchema)]
 pub struct ListingSummary {
     pub id: Uuid,
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     pub title: String,
     pub property_type: String,
     pub transaction_type: String,
@@ -410,8 +413,8 @@ pub struct SyndicationJobPayload {
     pub previous_status: Option<String>,
     /// New status (for status change operations)
     pub new_status: Option<String>,
-    /// Organization ID for context
-    pub organization_id: Uuid,
+    /// Organization ID for context (None for portal-direct listings).
+    pub organization_id: Option<Uuid>,
 }
 
 /// Syndication status dashboard response.

--- a/backend/crates/db/src/repositories/listing.rs
+++ b/backend/crates/db/src/repositories/listing.rs
@@ -18,7 +18,7 @@ use uuid::Uuid;
 #[derive(Debug, FromRow)]
 struct ListingSummaryRow {
     pub id: Uuid,
-    pub organization_id: Uuid,
+    pub organization_id: Option<Uuid>,
     pub title: String,
     pub property_type: String,
     pub transaction_type: String,

--- a/backend/crates/db/src/repositories/reality_portal.rs
+++ b/backend/crates/db/src/repositories/reality_portal.rs
@@ -3,6 +3,7 @@
 //! Repository for agencies, realtors, inquiries, and property import.
 
 use crate::models::reality_portal::*;
+use crate::models::Listing;
 use crate::models::PublicListingQuery;
 use crate::DbPool;
 use chrono::{DateTime, NaiveDate, Utc};
@@ -1129,6 +1130,123 @@ impl RealityPortalRepository {
 
         tx.commit().await?;
         Ok(Some(msg))
+    }
+
+    // ========================================================================
+    // Portal Listing CRUD (Epic 15.1/15.2 — owner/realtor edit flow)
+    // ========================================================================
+
+    /// Create a portal-user-owned listing (no PPT org required).
+    ///
+    /// Uses the SECURITY DEFINER `portal_create_listing` function (migration 00186)
+    /// so the operation bypasses the org-scoped RLS on the `listings` table.
+    pub async fn create_portal_listing(
+        &self,
+        user_id: Uuid,
+        title: &str,
+        description: Option<&str>,
+        property_type: &str,
+        transaction_type: &str,
+        price: rust_decimal::Decimal,
+        currency: &str,
+        street: &str,
+        city: &str,
+        postal_code: &str,
+        country: &str,
+        size_sqm: Option<rust_decimal::Decimal>,
+        rooms: Option<i32>,
+        floor: Option<i32>,
+        total_floors: Option<i32>,
+    ) -> Result<Listing, SqlxError> {
+        sqlx::query_as::<_, Listing>(
+            r#"SELECT * FROM portal_create_listing($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)"#,
+        )
+        .bind(user_id)
+        .bind(title)
+        .bind(description)
+        .bind(property_type)
+        .bind(transaction_type)
+        .bind(price)
+        .bind(currency)
+        .bind(street)
+        .bind(city)
+        .bind(postal_code)
+        .bind(country)
+        .bind(size_sqm)
+        .bind(rooms)
+        .bind(floor)
+        .bind(total_floors)
+        .fetch_one(&self.pool)
+        .await
+    }
+
+    /// Get a portal-user-owned listing for editing.
+    ///
+    /// Uses SECURITY DEFINER `portal_get_listing` (migration 00186); ownership
+    /// checked via `portal_owner_id = user_id OR created_by = user_id`.
+    pub async fn get_portal_listing(
+        &self,
+        listing_id: Uuid,
+        user_id: Uuid,
+    ) -> Result<Option<Listing>, SqlxError> {
+        sqlx::query_as::<_, Listing>(
+            r#"SELECT * FROM portal_get_listing($1, $2)"#,
+        )
+        .bind(listing_id)
+        .bind(user_id)
+        .fetch_optional(&self.pool)
+        .await
+    }
+
+    /// Patch a portal-user-owned listing. None fields are left unchanged.
+    ///
+    /// Uses SECURITY DEFINER `portal_update_listing` (migration 00186); ownership
+    /// is enforced inside the function. Returns None when not found / not owned.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn update_portal_listing(
+        &self,
+        listing_id: Uuid,
+        user_id: Uuid,
+        title: Option<&str>,
+        description: Option<&str>,
+        property_type: Option<&str>,
+        transaction_type: Option<&str>,
+        price: Option<rust_decimal::Decimal>,
+        currency: Option<&str>,
+        street: Option<&str>,
+        city: Option<&str>,
+        postal_code: Option<&str>,
+        country: Option<&str>,
+        size_sqm: Option<rust_decimal::Decimal>,
+        rooms: Option<i32>,
+        floor: Option<i32>,
+        total_floors: Option<i32>,
+        status: Option<&str>,
+        is_negotiable: Option<bool>,
+    ) -> Result<Option<Listing>, SqlxError> {
+        sqlx::query_as::<_, Listing>(
+            r#"SELECT * FROM portal_update_listing($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18)"#,
+        )
+        .bind(listing_id)
+        .bind(user_id)
+        .bind(title)
+        .bind(description)
+        .bind(property_type)
+        .bind(transaction_type)
+        .bind(price)
+        .bind(currency)
+        .bind(street)
+        .bind(city)
+        .bind(postal_code)
+        .bind(country)
+        .bind(size_sqm)
+        .bind(rooms)
+        .bind(floor)
+        .bind(total_floors)
+        .bind(status)
+        .bind(is_negotiable)
+        .fetch_optional(&self.pool)
+        .await
     }
 
     // ========================================================================

--- a/backend/crates/db/src/repositories/reality_portal.rs
+++ b/backend/crates/db/src/repositories/reality_portal.rs
@@ -1189,13 +1189,11 @@ impl RealityPortalRepository {
         listing_id: Uuid,
         user_id: Uuid,
     ) -> Result<Option<Listing>, SqlxError> {
-        sqlx::query_as::<_, Listing>(
-            r#"SELECT * FROM portal_get_listing($1, $2)"#,
-        )
-        .bind(listing_id)
-        .bind(user_id)
-        .fetch_optional(&self.pool)
-        .await
+        sqlx::query_as::<_, Listing>(r#"SELECT * FROM portal_get_listing($1, $2)"#)
+            .bind(listing_id)
+            .bind(user_id)
+            .fetch_optional(&self.pool)
+            .await
     }
 
     /// Patch a portal-user-owned listing. None fields are left unchanged.

--- a/backend/crates/db/src/repositories/reality_portal.rs
+++ b/backend/crates/db/src/repositories/reality_portal.rs
@@ -1140,6 +1140,7 @@ impl RealityPortalRepository {
     ///
     /// Uses the SECURITY DEFINER `portal_create_listing` function (migration 00186)
     /// so the operation bypasses the org-scoped RLS on the `listings` table.
+    #[allow(clippy::too_many_arguments)]
     pub async fn create_portal_listing(
         &self,
         user_id: Uuid,

--- a/backend/servers/api-server/src/services/syndication.rs
+++ b/backend/servers/api-server/src/services/syndication.rs
@@ -130,7 +130,7 @@ impl SyndicationService {
                 scheduled_at: None, // Run immediately
                 queue: Some(SYNDICATION_QUEUE.to_string()),
                 max_attempts: Some(3),
-                org_id: Some(listing.organization_id),
+                org_id: listing.organization_id,
             };
 
             let job = self
@@ -206,7 +206,7 @@ impl SyndicationService {
                 scheduled_at: None,
                 queue: Some(SYNDICATION_QUEUE.to_string()),
                 max_attempts: Some(3),
-                org_id: Some(listing.organization_id),
+                org_id: listing.organization_id,
             };
 
             let job = self
@@ -258,7 +258,7 @@ impl SyndicationService {
             scheduled_at: None,
             queue: Some(SYNDICATION_QUEUE.to_string()),
             max_attempts: Some(3),
-            org_id: Some(listing.organization_id),
+            org_id: listing.organization_id,
         };
 
         let job = self

--- a/backend/servers/api-server/tests/voting_tests.rs
+++ b/backend/servers/api-server/tests/voting_tests.rs
@@ -279,7 +279,7 @@ mod pdf_report {
         .expect("seed vote")
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "db::MIGRATOR")]
     async fn test_get_report_pdf_returns_application_pdf_and_archives_document(pool: PgPool) {
         let app = TestApp::new(pool.clone()).await;
         let user = TestUser::new();
@@ -332,7 +332,7 @@ mod pdf_report {
         );
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "db::MIGRATOR")]
     async fn test_get_report_json_with_format_pdf_returns_application_pdf(pool: PgPool) {
         let app = TestApp::new(pool.clone()).await;
         let user = TestUser::new();

--- a/backend/servers/reality-server/Cargo.toml
+++ b/backend/servers/reality-server/Cargo.toml
@@ -43,6 +43,7 @@ urlencoding = { workspace = true }
 url = { workspace = true }
 argon2 = { workspace = true }
 sqlx = { workspace = true }
+rust_decimal = { workspace = true }
 
 # Observability (Epic 95)
 opentelemetry = { workspace = true }

--- a/backend/servers/reality-server/src/main.rs
+++ b/backend/servers/reality-server/src/main.rs
@@ -199,6 +199,10 @@ fn parse_default_origins() -> Vec<HeaderValue> {
         routes::imports::get_feed,
         routes::imports::update_feed,
         routes::imports::sync_feed,
+        // Portal listing CRUD (Epic 15.1/15.2)
+        routes::portal_listings::create_listing,
+        routes::portal_listings::get_my_listing,
+        routes::portal_listings::update_listing,
         // Compare (UC-48)
         routes::compare::get_compare_list,
         routes::compare::add_to_compare,
@@ -293,6 +297,10 @@ fn parse_default_origins() -> Vec<HeaderValue> {
         CreateFeedSubscription,
         UpdateFeedSubscription,
         RealityFeedSubscription,
+        // Portal listing CRUD (Epic 15.1/15.2)
+        routes::portal_listings::PortalListingResponse,
+        routes::portal_listings::CreatePortalListingRequest,
+        routes::portal_listings::UpdatePortalListingRequest,
         // Compare (UC-48)
         routes::compare::CompareEntry,
         routes::compare::CompareListResponse,
@@ -347,6 +355,7 @@ fn parse_default_origins() -> Vec<HeaderValue> {
         (name = "Agencies", description = "Real estate agency management (Epic 32)"),
         (name = "Realtors", description = "Realtor profiles and tools (Epic 33)"),
         (name = "Imports", description = "Property import and feed management (Epic 34)"),
+        (name = "PortalListings", description = "Owner/realtor listing CRUD (Epic 15.1/15.2)"),
         (name = "Compare", description = "Compare up to 4 listings side-by-side (UC-48)"),
         (name = "Reports", description = "Report problematic listings (UC-23)"),
         (name = "AgentReviews", description = "Realtor reviews and ratings (UC-49, UC-51)"),
@@ -454,6 +463,8 @@ async fn main() -> anyhow::Result<()> {
         .nest("/api/v1/realtors", routes::realtors::router())
         // Import routes (Epic 34)
         .nest("/api/v1/imports", routes::imports::router())
+        // Portal listing CRUD (Epic 15.1/15.2 — owner/realtor edit)
+        .nest("/api/v1/my/listings", routes::portal_listings::router())
         // Compare routes (UC-48)
         .nest("/api/v1/compare", routes::compare::router())
         // Reports routes (UC-23)

--- a/backend/servers/reality-server/src/routes/mod.rs
+++ b/backend/servers/reality-server/src/routes/mod.rs
@@ -13,6 +13,7 @@ pub mod health;
 pub mod imports;
 pub mod inquiries;
 pub mod listings;
+pub mod portal_listings;
 pub mod price_map;
 pub mod realtors;
 pub mod reports;

--- a/backend/servers/reality-server/src/routes/portal_listings.rs
+++ b/backend/servers/reality-server/src/routes/portal_listings.rs
@@ -1,0 +1,273 @@
+//! Owner/realtor listing CRUD routes (Epic 15.1/15.2).
+//!
+//! Uses `PortalPrincipal` — portal users have `principal_kind = 'public'` and
+//! no `organization_members` row, so `RequestPrincipal` would 403 them.
+//! IDOR is closed by the SECURITY DEFINER DB functions (migration 00186) which
+//! gate all writes on `portal_owner_id = user_id OR created_by = user_id`.
+
+use crate::state::AppState;
+use api_core::extractors::PortalPrincipal;
+use axum::{
+    extract::{Path, State},
+    routing::{get, patch, post},
+    Json, Router,
+};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+/// Create portal listings router.
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/", post(create_listing))
+        .route("/{id}", get(get_my_listing))
+        .route("/{id}", patch(update_listing))
+}
+
+/// Request body for creating a portal listing.
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreatePortalListingRequest {
+    pub title: String,
+    pub description: Option<String>,
+    pub property_type: String,
+    pub transaction_type: String,
+    pub price: Decimal,
+    pub currency: Option<String>,
+    pub street: String,
+    pub city: String,
+    pub postal_code: String,
+    pub country: Option<String>,
+    pub size_sqm: Option<Decimal>,
+    pub rooms: Option<i32>,
+    pub floor: Option<i32>,
+    pub total_floors: Option<i32>,
+}
+
+/// Request body for patching a portal listing. All fields are optional.
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdatePortalListingRequest {
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub property_type: Option<String>,
+    pub transaction_type: Option<String>,
+    pub price: Option<Decimal>,
+    pub currency: Option<String>,
+    pub street: Option<String>,
+    pub city: Option<String>,
+    pub postal_code: Option<String>,
+    pub country: Option<String>,
+    pub size_sqm: Option<Decimal>,
+    pub rooms: Option<i32>,
+    pub floor: Option<i32>,
+    pub total_floors: Option<i32>,
+    pub status: Option<String>,
+    pub is_negotiable: Option<bool>,
+}
+
+/// Listing response for portal owner/editor.
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PortalListingResponse {
+    pub id: Uuid,
+    pub title: String,
+    pub description: Option<String>,
+    pub property_type: String,
+    pub transaction_type: String,
+    pub price: Decimal,
+    pub currency: String,
+    pub street: String,
+    pub city: String,
+    pub postal_code: String,
+    pub country: String,
+    pub size_sqm: Option<Decimal>,
+    pub rooms: Option<i32>,
+    pub floor: Option<i32>,
+    pub total_floors: Option<i32>,
+    pub status: String,
+    pub is_negotiable: bool,
+    pub is_published: bool,
+    pub slug: Option<String>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+fn map_listing(l: db::models::Listing) -> PortalListingResponse {
+    PortalListingResponse {
+        id: l.id,
+        title: l.title,
+        description: l.description,
+        property_type: l.property_type,
+        transaction_type: l.transaction_type,
+        price: l.price,
+        currency: l.currency,
+        street: l.street,
+        city: l.city,
+        postal_code: l.postal_code,
+        country: l.country,
+        size_sqm: l.size_sqm,
+        rooms: l.rooms,
+        floor: l.floor,
+        total_floors: l.total_floors,
+        status: l.status,
+        is_negotiable: l.is_negotiable,
+        is_published: l.is_published,
+        slug: None,
+        created_at: l.created_at,
+        updated_at: l.updated_at,
+    }
+}
+
+/// Create a new portal listing owned by the authenticated user.
+///
+/// POST /api/v1/my/listings
+#[utoipa::path(
+    post,
+    path = "/api/v1/my/listings",
+    tag = "PortalListings",
+    request_body = CreatePortalListingRequest,
+    responses(
+        (status = 201, description = "Listing created", body = PortalListingResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 400, description = "Validation error")
+    )
+)]
+pub async fn create_listing(
+    State(state): State<AppState>,
+    principal: PortalPrincipal,
+    Json(body): Json<CreatePortalListingRequest>,
+) -> Result<(axum::http::StatusCode, Json<PortalListingResponse>), (axum::http::StatusCode, String)>
+{
+    let listing = state
+        .reality_portal_repo
+        .create_portal_listing(
+            principal.user_id,
+            &body.title,
+            body.description.as_deref(),
+            &body.property_type,
+            &body.transaction_type,
+            body.price,
+            body.currency.as_deref().unwrap_or("EUR"),
+            &body.street,
+            &body.city,
+            &body.postal_code,
+            body.country.as_deref().unwrap_or("SK"),
+            body.size_sqm,
+            body.rooms,
+            body.floor,
+            body.total_floors,
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, user_id = %principal.user_id, "Failed to create portal listing");
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to create listing".to_string(),
+            )
+        })?;
+
+    Ok((axum::http::StatusCode::CREATED, Json(map_listing(listing))))
+}
+
+/// Get a portal listing owned by the authenticated user (for editing).
+///
+/// GET /api/v1/my/listings/{id}
+#[utoipa::path(
+    get,
+    path = "/api/v1/my/listings/{id}",
+    tag = "PortalListings",
+    params(("id" = Uuid, Path, description = "Listing ID")),
+    responses(
+        (status = 200, description = "Listing detail", body = PortalListingResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Not found or not owned")
+    )
+)]
+pub async fn get_my_listing(
+    State(state): State<AppState>,
+    principal: PortalPrincipal,
+    Path(id): Path<Uuid>,
+) -> Result<Json<PortalListingResponse>, (axum::http::StatusCode, String)> {
+    let listing = state
+        .reality_portal_repo
+        .get_portal_listing(id, principal.user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, listing_id = %id, user_id = %principal.user_id, "Failed to get portal listing");
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to get listing".to_string(),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                axum::http::StatusCode::NOT_FOUND,
+                "Listing not found".to_string(),
+            )
+        })?;
+
+    Ok(Json(map_listing(listing)))
+}
+
+/// Update a portal listing owned by the authenticated user.
+///
+/// PATCH /api/v1/my/listings/{id}
+#[utoipa::path(
+    patch,
+    path = "/api/v1/my/listings/{id}",
+    tag = "PortalListings",
+    params(("id" = Uuid, Path, description = "Listing ID")),
+    request_body = UpdatePortalListingRequest,
+    responses(
+        (status = 200, description = "Updated listing", body = PortalListingResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Not found or not owned")
+    )
+)]
+pub async fn update_listing(
+    State(state): State<AppState>,
+    principal: PortalPrincipal,
+    Path(id): Path<Uuid>,
+    Json(body): Json<UpdatePortalListingRequest>,
+) -> Result<Json<PortalListingResponse>, (axum::http::StatusCode, String)> {
+    let listing = state
+        .reality_portal_repo
+        .update_portal_listing(
+            id,
+            principal.user_id,
+            body.title.as_deref(),
+            body.description.as_deref(),
+            body.property_type.as_deref(),
+            body.transaction_type.as_deref(),
+            body.price,
+            body.currency.as_deref(),
+            body.street.as_deref(),
+            body.city.as_deref(),
+            body.postal_code.as_deref(),
+            body.country.as_deref(),
+            body.size_sqm,
+            body.rooms,
+            body.floor,
+            body.total_floors,
+            body.status.as_deref(),
+            body.is_negotiable,
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, listing_id = %id, user_id = %principal.user_id, "Failed to update portal listing");
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to update listing".to_string(),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                axum::http::StatusCode::NOT_FOUND,
+                "Listing not found or not owned".to_string(),
+            )
+        })?;
+
+    Ok(Json(map_listing(listing)))
+}

--- a/frontend/apps/reality-web/src/app/[locale]/account/listings/[id]/edit/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/account/listings/[id]/edit/page.tsx
@@ -9,13 +9,13 @@
  */
 
 import { useParams } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ProtectedRoute } from '@/components/auth';
 import { Footer, Header } from '@/components/ui';
+import { getMyListing, updateListing, RealtorApiError } from '@/lib/realtor-api';
 import {
   EDIT_STEPS,
   type ListingEditFormData,
-  MOCK_LISTING_DATA,
   PROPERTY_TYPE_OPTIONS,
 } from './_mock';
 
@@ -88,19 +88,112 @@ function StepIndicator({ current }: { current: number }) {
   );
 }
 
+const EMPTY_FORM: ListingEditFormData = {
+  transactionType: 'sale',
+  propertyType: 'apartment',
+  address: '',
+  city: '',
+  area: '',
+  rooms: '',
+  floor: '',
+  totalFloors: '',
+  yearBuilt: '',
+  description: '',
+  existingPhotoUrls: [],
+  newPhotos: [],
+  price: '',
+  currency: 'EUR',
+  priceNegotiable: false,
+  status: 'draft',
+};
+
 function EditWizardContent() {
   const params = useParams<{ id: string }>();
   const listingId = params?.id ?? '';
 
   const [step, setStep] = useState(1);
-  // Pre-populate with mock listing data (would be fetched from API in production)
-  const [form, setForm] = useState<ListingEditFormData>(MOCK_LISTING_DATA);
+  const [form, setForm] = useState<ListingEditFormData>(EMPTY_FORM);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const [removedPhotos, setRemovedPhotos] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!listingId) return;
+    setLoading(true);
+    getMyListing(listingId)
+      .then((listing) => {
+        setForm({
+          transactionType: (listing.transactionType as 'sale' | 'rent') ?? 'sale',
+          propertyType: (listing.propertyType as ListingEditFormData['propertyType']) ?? 'apartment',
+          address: listing.street ?? '',
+          city: listing.city ?? '',
+          area: listing.area ?? '',
+          rooms: listing.rooms ?? '',
+          floor: listing.floor ?? '',
+          totalFloors: listing.totalFloors ?? '',
+          yearBuilt: '',
+          description: listing.description ?? '',
+          existingPhotoUrls: [],
+          newPhotos: [],
+          price: listing.price ?? '',
+          currency: listing.currency ?? 'EUR',
+          priceNegotiable: listing.isNegotiable ?? false,
+          status: (listing.status as ListingEditFormData['status']) ?? 'draft',
+        });
+      })
+      .catch((err) => {
+        setLoadError(err instanceof RealtorApiError ? err.message : 'Načítanie inzerátu zlyhalo.');
+      })
+      .finally(() => setLoading(false));
+  }, [listingId]);
 
   const update = (patch: Partial<ListingEditFormData>) => setForm((f) => ({ ...f, ...patch }));
 
-  const handleSave = () => setSaved(true);
+  const handleSave = async () => {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await updateListing(listingId, {
+        title: form.description?.slice(0, 80) || `${form.propertyType} ${form.city}`,
+        description: form.description,
+        propertyType: form.propertyType,
+        transactionType: form.transactionType,
+        price: typeof form.price === 'number' ? form.price : Number(form.price) || 0,
+        currency: form.currency,
+        street: form.address,
+        city: form.city,
+        area: typeof form.area === 'number' ? form.area : Number(form.area) || undefined,
+        rooms: typeof form.rooms === 'number' ? form.rooms : Number(form.rooms) || undefined,
+      });
+      setSaved(true);
+    } catch (err) {
+      setSaveError(err instanceof RealtorApiError ? err.message : 'Uloženie zlyhalo, skúste znova.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div style={{ maxWidth: 600, margin: '80px auto', textAlign: 'center', padding: '0 24px' }}>
+        <p style={{ color: 'var(--ppt-fg-secondary)' }}>Načítavam inzerát…</p>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div style={{ maxWidth: 600, margin: '80px auto', textAlign: 'center', padding: '0 24px' }}>
+        <p style={{ color: 'var(--ppt-color-danger, #ef4444)' }}>{loadError}</p>
+        <a href="/account" style={{ color: 'var(--ppt-color-primary, #2563eb)' }}>
+          ← Späť na účet
+        </a>
+      </div>
+    );
+  }
 
   if (saved) {
     return (
@@ -660,21 +753,29 @@ function EditWizardContent() {
                 Ďalej →
               </button>
             ) : (
-              <button
-                type="button"
-                onClick={handleSave}
-                style={{
-                  padding: '11px 28px',
-                  background: 'var(--ppt-color-success, #10b981)',
-                  color: '#fff',
-                  border: 'none',
-                  borderRadius: 8,
-                  fontWeight: 700,
-                  cursor: 'pointer',
-                }}
-              >
-                Uložiť zmeny
-              </button>
+              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 8 }}>
+                {saveError && (
+                  <p style={{ color: 'var(--ppt-color-danger, #ef4444)', fontSize: '0.875rem', margin: 0 }}>
+                    {saveError}
+                  </p>
+                )}
+                <button
+                  type="button"
+                  onClick={handleSave}
+                  disabled={saving}
+                  style={{
+                    padding: '11px 28px',
+                    background: saving ? 'var(--ppt-border-default, #e5e7eb)' : 'var(--ppt-color-success, #10b981)',
+                    color: saving ? 'var(--ppt-fg-muted, #9ca3af)' : '#fff',
+                    border: 'none',
+                    borderRadius: 8,
+                    fontWeight: 700,
+                    cursor: saving ? 'not-allowed' : 'pointer',
+                  }}
+                >
+                  {saving ? 'Ukladám…' : 'Uložiť zmeny'}
+                </button>
+              </div>
             )}
           </div>
         </div>

--- a/frontend/apps/reality-web/src/app/[locale]/account/listings/[id]/edit/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/account/listings/[id]/edit/page.tsx
@@ -12,12 +12,8 @@ import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { ProtectedRoute } from '@/components/auth';
 import { Footer, Header } from '@/components/ui';
-import { getMyListing, updateListing, RealtorApiError } from '@/lib/realtor-api';
-import {
-  EDIT_STEPS,
-  type ListingEditFormData,
-  PROPERTY_TYPE_OPTIONS,
-} from './_mock';
+import { getMyListing, RealtorApiError, updateListing } from '@/lib/realtor-api';
+import { EDIT_STEPS, type ListingEditFormData, PROPERTY_TYPE_OPTIONS } from './_mock';
 
 // TODO: replace stepper with @ppt/ui-kit/Stepper once available
 // TODO: replace file upload with @ppt/ui-kit/FileUpload once available
@@ -127,7 +123,8 @@ function EditWizardContent() {
       .then((listing) => {
         setForm({
           transactionType: (listing.transactionType as 'sale' | 'rent') ?? 'sale',
-          propertyType: (listing.propertyType as ListingEditFormData['propertyType']) ?? 'apartment',
+          propertyType:
+            (listing.propertyType as ListingEditFormData['propertyType']) ?? 'apartment',
           address: listing.street ?? '',
           city: listing.city ?? '',
           area: listing.area ?? '',
@@ -170,7 +167,9 @@ function EditWizardContent() {
       });
       setSaved(true);
     } catch (err) {
-      setSaveError(err instanceof RealtorApiError ? err.message : 'Uloženie zlyhalo, skúste znova.');
+      setSaveError(
+        err instanceof RealtorApiError ? err.message : 'Uloženie zlyhalo, skúste znova.'
+      );
     } finally {
       setSaving(false);
     }
@@ -753,9 +752,17 @@ function EditWizardContent() {
                 Ďalej →
               </button>
             ) : (
-              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 8 }}>
+              <div
+                style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 8 }}
+              >
                 {saveError && (
-                  <p style={{ color: 'var(--ppt-color-danger, #ef4444)', fontSize: '0.875rem', margin: 0 }}>
+                  <p
+                    style={{
+                      color: 'var(--ppt-color-danger, #ef4444)',
+                      fontSize: '0.875rem',
+                      margin: 0,
+                    }}
+                  >
                     {saveError}
                   </p>
                 )}
@@ -765,7 +772,9 @@ function EditWizardContent() {
                   disabled={saving}
                   style={{
                     padding: '11px 28px',
-                    background: saving ? 'var(--ppt-border-default, #e5e7eb)' : 'var(--ppt-color-success, #10b981)',
+                    background: saving
+                      ? 'var(--ppt-border-default, #e5e7eb)'
+                      : 'var(--ppt-color-success, #10b981)',
                     color: saving ? 'var(--ppt-fg-muted, #9ca3af)' : '#fff',
                     border: 'none',
                     borderRadius: 8,

--- a/frontend/apps/reality-web/src/app/[locale]/realtor/listings/[id]/edit/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/realtor/listings/[id]/edit/page.tsx
@@ -10,7 +10,7 @@ import { ProtectedRoute } from '@/components/auth';
 import { ListingForm } from '@/components/realtor/ListingForm';
 import { Footer, Header } from '@/components/ui';
 import {
-  getListing,
+  getMyListing,
   type ListingDraft,
   type ListingResponse,
   RealtorApiError,
@@ -33,7 +33,7 @@ function EditListingContent() {
     if (!id) return;
     let cancelled = false;
     setIsLoading(true);
-    getListing(id)
+    getMyListing(id)
       .then((value) => {
         if (!cancelled) setListing(value);
       })

--- a/frontend/apps/reality-web/src/lib/realtor-api.ts
+++ b/frontend/apps/reality-web/src/lib/realtor-api.ts
@@ -91,8 +91,14 @@ export interface ListingDraft {
 
 export interface ListingResponse extends ListingDraft {
   id: string;
-  slug: string;
+  slug?: string | null;
   status: string;
+  isNegotiable?: boolean;
+  isPublished?: boolean;
+  postalCode?: string;
+  country?: string;
+  floor?: number;
+  totalFloors?: number;
   createdAt: string;
   updatedAt: string;
 }
@@ -108,8 +114,13 @@ export function getListing(id: string): Promise<ListingResponse> {
   return request<ListingResponse>(`/api/v1/listings/${id}`);
 }
 
+/** Get an owned listing for editing (includes drafts). Requires auth. */
+export function getMyListing(id: string): Promise<ListingResponse> {
+  return request<ListingResponse>(`/api/v1/my/listings/${id}`);
+}
+
 export function updateListing(id: string, data: Partial<ListingDraft>): Promise<ListingResponse> {
-  return request<ListingResponse>(`/api/v1/listings/${id}`, {
+  return request<ListingResponse>(`/api/v1/my/listings/${id}`, {
     method: 'PATCH',
     body: JSON.stringify(data),
   });


### PR DESCRIPTION
## Summary

- **Migration 00186**: `listings.organization_id` → nullable; add `portal_owner_id UUID → users(id)` column; ownership CHECK; 5-context RLS policy; three `SECURITY DEFINER` SQL functions (`portal_create_listing`, `portal_get_listing`, `portal_update_listing`) gating writes on `portal_owner_id = user_id OR created_by = user_id`
- **Backend**: new `portal_listings.rs` route module (`POST/GET/PATCH /api/v1/my/listings[/{id}]`) using `PortalPrincipal` auth; repo methods in `RealityPortalRepository`; registered in `mod.rs` and `main.rs` (router + OpenAPI)
- **Frontend**: `account/listings/[id]/edit/page.tsx` wired to real API — `getMyListing` on mount, `updateListing` on save with loading/saving/error states; `realtor/listings/[id]/edit/page.tsx` also switched to `getMyListing`; `realtor-api.ts` updated with `getMyListing` helper and `/api/v1/my/listings/{id}` paths

## Test plan

- [ ] Migration runs cleanly on a fresh DB (CI)
- [ ] `portal_create_listing(user_id, ...)` creates a draft listing with `portal_owner_id = user_id`, `organization_id IS NULL`
- [ ] `portal_update_listing(listing_id, wrong_user_id, ...)` returns 0 rows (IDOR gate)
- [ ] `GET /api/v1/my/listings/{id}` returns 404 for listings not owned by the auth user
- [ ] `PATCH /api/v1/my/listings/{id}` updates only non-null fields (COALESCE semantics)
- [ ] Owner edit page loads from API, save calls backend, shows confirmation
- [ ] Existing org-scoped listing routes unaffected (CI compilation pass)

Closes #986

🤖 Generated with [Claude Code](https://claude.com/claude-code)