### PR TITLE
fix(reality-server): paginate the saved-search alerts list (closes #1627)

### DIFF
--- a/backend/crates/db/src/repositories/reality_portal.rs
+++ b/backend/crates/db/src/repositories/reality_portal.rs
@@ -172,6 +172,7 @@ impl RealityPortalRepository {
         &self,
         user_id: Uuid,
         limit: i64,
+        offset: i64,
     ) -> Result<Vec<SavedSearchAlert>, SqlxError> {
         sqlx::query_as::<_, SavedSearchAlert>(
             r#"
@@ -188,11 +189,12 @@ impl RealityPortalRepository {
             JOIN portal_saved_searches s ON s.id = q.saved_search_id
             WHERE q.user_id = $1
             ORDER BY q.created_at DESC
-            LIMIT $2
+            LIMIT $2 OFFSET $3
             "#,
         )
         .bind(user_id)
         .bind(limit)
+        .bind(offset)
         .fetch_all(&self.pool)
         .await
     }

--- a/backend/crates/db/tests/search_alert_delivery_tests.rs
+++ b/backend/crates/db/tests/search_alert_delivery_tests.rs
@@ -60,7 +60,7 @@ async fn search_alert_delivery_lifecycle(pool: PgPool) {
 
     // List: one pending alert, joined to its search name, carrying the matches.
     let alerts = repo
-        .get_search_alerts(user, 100)
+        .get_search_alerts(user, 100, 0)
         .await
         .expect("list alerts");
     assert_eq!(alerts.len(), 1, "expected exactly one alert");
@@ -86,7 +86,7 @@ async fn search_alert_delivery_lifecycle(pool: PgPool) {
         0,
         "no unread alerts after ack"
     );
-    let after = repo.get_search_alerts(user, 100).await.unwrap();
+    let after = repo.get_search_alerts(user, 100, 0).await.unwrap();
     assert_eq!(after[0].status, "sent");
     assert!(after[0].processed_at.is_some());
 
@@ -106,7 +106,7 @@ async fn search_alert_read_is_owner_scoped(pool: PgPool) {
     repo.enqueue_search_alert(&pool, search_id, owner, &[Uuid::new_v4()], "new_listing")
         .await
         .expect("enqueue alert");
-    let alert_id = repo.get_search_alerts(owner, 100).await.unwrap()[0].id;
+    let alert_id = repo.get_search_alerts(owner, 100, 0).await.unwrap()[0].id;
 
     // The attacker cannot ack the owner's alert (no IDOR) and sees none of it.
     assert!(
@@ -117,7 +117,7 @@ async fn search_alert_read_is_owner_scoped(pool: PgPool) {
         "a non-owner must not be able to mark another user's alert read"
     );
     assert!(
-        repo.get_search_alerts(attacker, 100)
+        repo.get_search_alerts(attacker, 100, 0)
             .await
             .unwrap()
             .is_empty(),
@@ -141,4 +141,40 @@ async fn search_alert_read_is_owner_scoped(pool: PgPool) {
         "mark-all clears the owner's pending alert"
     );
     assert_eq!(repo.count_pending_search_alerts(owner).await.unwrap(), 0);
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn search_alerts_paginate_with_limit_and_offset(pool: PgPool) {
+    let repo = RealityPortalRepository::new(pool.clone());
+    let user = seed_portal_user(&pool, "alerts-pagination@test.sk").await;
+    let search_id = seed_saved_search(&repo, user, "Paged search").await;
+
+    // Three alerts for the same user.
+    for _ in 0..3 {
+        repo.enqueue_search_alert(&pool, search_id, user, &[Uuid::new_v4()], "new_listing")
+            .await
+            .expect("enqueue alert");
+    }
+
+    // Without paging, all three are visible.
+    assert_eq!(repo.get_search_alerts(user, 100, 0).await.unwrap().len(), 3);
+
+    // limit/offset page the list (sizes are deterministic regardless of tie order).
+    assert_eq!(
+        repo.get_search_alerts(user, 2, 0).await.unwrap().len(),
+        2,
+        "first page returns the page-size rows"
+    );
+    assert_eq!(
+        repo.get_search_alerts(user, 2, 2).await.unwrap().len(),
+        1,
+        "second page returns the remainder"
+    );
+    assert!(
+        repo.get_search_alerts(user, 2, 10)
+            .await
+            .unwrap()
+            .is_empty(),
+        "an offset past the end yields no rows"
+    );
 }

--- a/backend/servers/reality-server/src/routes/saved_searches.rs
+++ b/backend/servers/reality-server/src/routes/saved_searches.rs
@@ -5,7 +5,7 @@
 use crate::state::AppState;
 use api_core::extractors::RequestPrincipal;
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     routing::{delete, get, post, put},
     Json, Router,
 };
@@ -264,12 +264,33 @@ pub async fn run_saved_search(
 // them. (reality-server has no email transport; in-app is the delivery channel.)
 // ============================================================================
 
+/// Default and maximum page size for the alerts list (#1627).
+const ALERTS_DEFAULT_LIMIT: i64 = 100;
+const ALERTS_MAX_LIMIT: i64 = 200;
+
+/// Pagination query for the saved-search alerts list.
+#[derive(Debug, Deserialize)]
+pub struct SearchAlertsQuery {
+    /// Page size (default 100, capped at 200).
+    #[serde(default)]
+    pub limit: Option<i64>,
+    /// Number of newest alerts to skip (default 0).
+    #[serde(default)]
+    pub offset: Option<i64>,
+}
+
 /// Saved-search alerts list response.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct SearchAlertsResponse {
     pub alerts: Vec<SavedSearchAlert>,
     /// Number of still-undelivered (`pending`) alerts — drives an unread badge.
+    /// This is the total across all pages, so it can legitimately exceed the
+    /// number of `alerts` rows returned for the current page.
     pub unread_count: i64,
+    /// Page size applied (after clamping).
+    pub limit: i64,
+    /// Offset applied.
+    pub offset: i64,
 }
 
 /// Mark-all-read response.
@@ -291,11 +312,18 @@ pub struct MarkAllAlertsReadResponse {
 pub async fn list_search_alerts(
     State(state): State<AppState>,
     principal: RequestPrincipal,
+    Query(query): Query<SearchAlertsQuery>,
 ) -> Result<Json<SearchAlertsResponse>, (axum::http::StatusCode, String)> {
+    let limit = query
+        .limit
+        .unwrap_or(ALERTS_DEFAULT_LIMIT)
+        .clamp(1, ALERTS_MAX_LIMIT);
+    let offset = query.offset.unwrap_or(0).max(0);
+
     let (alerts, unread_count) = tokio::try_join!(
         state
             .reality_portal_repo
-            .get_search_alerts(principal.user_id, 100),
+            .get_search_alerts(principal.user_id, limit, offset),
         state
             .reality_portal_repo
             .count_pending_search_alerts(principal.user_id),
@@ -305,6 +333,8 @@ pub async fn list_search_alerts(
     Ok(Json(SearchAlertsResponse {
         alerts,
         unread_count,
+        limit,
+        offset,
     }))
 }
 


### PR DESCRIPTION
Post-merge review of PR #1622: `GET /api/v1/saved-searches/alerts` fetched a hardcoded `LIMIT 100` with no offset — a user with >100 alerts could never page to the oldest, and the unread badge (counted separately) could exceed the returnable rows.

- `get_search_alerts` gains an `offset` (`OFFSET $3`).
- `list_search_alerts` accepts `limit` (default 100, cap 200) + `offset` (default 0) query params, clamps them, and echoes them in the response. `unread_count` stays the all-pages total (documented).
- Tests: existing delivery tests updated for the new signature + new `search_alerts_paginate_with_limit_and_offset` (3 alerts paged 2+1; offset-past-end → empty).

Verified on the remote builder: clippy `-D warnings` clean, `cargo fmt` clean, `search_alert_delivery_tests` **3/3** vs live Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)