### PR TITLE
feat(ppt-web): IoT sensor registry, register & edit pages (Epic 14, FR71)

### DIFF
--- a/docs/screens/ppt/iot-sensors.md
+++ b/docs/screens/ppt/iot-sensors.md
@@ -9,14 +9,10 @@ implementations:
     buildStatus: shipped
     redesignStatus: not-started
     apiStatus: partial
-endpoints:
-  - "GET /api/v1/iot/sensors"
-  - "POST /api/v1/iot/sensors"
-  - "GET /api/v1/iot/sensors/{id}"
-  - "PUT /api/v1/iot/sensors/{id}"
-  - "DELETE /api/v1/iot/sensors/{id}"
+endpoints: []
 relatedScreens:
-  - ppt/iot-dashboard
+  - id: ppt/iot-dashboard
+    rel: sibling
 sharedComponents:
   - SensorStatusBadge
 diagrams: []

--- a/docs/screens/ppt/iot-sensors.md
+++ b/docs/screens/ppt/iot-sensors.md
@@ -1,0 +1,73 @@
+---
+id: ppt/iot-sensors
+name: IoT Sensors — Registry, Register & Edit
+product: ppt
+implementations:
+  ppt-web:
+    route: "/iot/sensors"
+    component: SensorListPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: partial
+endpoints:
+  - "GET /api/v1/iot/sensors"
+  - "POST /api/v1/iot/sensors"
+  - "GET /api/v1/iot/sensors/{id}"
+  - "PUT /api/v1/iot/sensors/{id}"
+  - "DELETE /api/v1/iot/sensors/{id}"
+relatedScreens:
+  - ppt/iot-dashboard
+sharedComponents:
+  - SensorStatusBadge
+diagrams: []
+useCases: []
+epics:
+  - "14"
+designSources: []
+owner: pm-frontend
+---
+
+# IoT Sensors — Registry, Register & Edit
+
+The device-management surface for the Epic 14 IoT backend (FR71). Complements
+the read-only [IoT dashboard](./iot-dashboard.md) with full sensor CRUD entry
+points, mounted by `routes/groups/iot.tsx` on the `@ppt/api-client` IoT module
+(`useSensors`, `useSensor`, `useCreateSensor`, `useUpdateSensor`,
+`useDeleteSensor`, `useBuildings`).
+
+## Routes
+
+- `/iot/sensors` — `SensorListPage`: a table of every registered device with
+  status, location and last-reading columns, plus register / edit / delete
+  actions.
+- `/iot/sensors/new` — `SensorFormPage` (`mode="create"`): register a new device
+  against a building. `organization_id` is pinned to the caller's tenant
+  server-side; `created_by` comes from the authenticated user.
+- `/iot/sensors/:sensorId/edit` — `SensorFormPage` (`mode="edit"`): update an
+  existing device. Identity fields (building, type, serial number) are
+  read-only because the api-server `UpdateSensor` shape does not accept them;
+  `status` becomes editable instead.
+
+## States
+
+- **Empty**: list shows empty copy + a register CTA when the org has no sensors.
+- **Loading**: per-query loading flags drive spinners (list, form prefill,
+  building options).
+- **Saving**: submit/delete buttons disable and show progress while the
+  mutation is in flight.
+- **Error**: create/update/delete failures surface as toasts; `apiStatus:
+  partial` until verified end-to-end against the live IoT backend.
+
+## Notes
+
+### Specific (recent)
+- 2026-06-21 — [BIT-146](/BIT/issues/BIT-146): added the sensor registry +
+  register/edit pages and the `@ppt/api-client` create/update/delete layer
+  (`createSensor`/`updateSensor`/`deleteSensor` + hooks). Nav link + command
+  palette entries added. Thresholds UI ([BIT-148](/BIT/issues/BIT-148)) and a
+  dedicated alerts page ([BIT-149](/BIT/issues/BIT-149)) follow as later
+  increments.
+
+## Agent Log
+- 2026-06-21 — FrontendEngineer: created with the sensor-CRUD increment
+  (BIT-146, Epic 14 / FR71).

--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -120,6 +120,7 @@ function AppNavigation() {
       <Link to="/emergency">{t('nav.emergency')}</Link>
       <Link to="/disputes">{t('nav.disputes')}</Link>
       <Link to="/outages">{t('nav.outages')}</Link>
+      <Link to="/iot">{t('nav.iot', { defaultValue: 'Smart Building' })}</Link>
       <Link to="/rentals">{t('nav.rentals', { defaultValue: 'Rentals' })}</Link>
       <Link to="/settings/accessibility">{t('nav.accessibility')}</Link>
       <Link to="/settings/privacy">{t('nav.privacy')}</Link>

--- a/frontend/apps/ppt-web/src/features/command-palette/hooks/useNavigationCommands.tsx
+++ b/frontend/apps/ppt-web/src/features/command-palette/hooks/useNavigationCommands.tsx
@@ -76,6 +76,28 @@ export function useNavigationCommands() {
         icon: '⚡',
         action: () => navigate('/outages'),
       },
+      {
+        id: 'nav-iot',
+        label: t('commandPalette.commands.goToIot', { defaultValue: 'Go to Smart Building' }),
+        description: t('commandPalette.descriptions.goToIot', {
+          defaultValue: 'IoT sensors, telemetry and alerts',
+        }),
+        category: 'navigation',
+        keywords: ['iot', 'smart building', 'sensors', 'devices', 'telemetry', 'alerts'],
+        icon: '📡',
+        action: () => navigate('/iot'),
+      },
+      {
+        id: 'nav-iot-sensors',
+        label: t('commandPalette.commands.goToSensors', { defaultValue: 'Go to Sensors' }),
+        description: t('commandPalette.descriptions.goToSensors', {
+          defaultValue: 'Manage registered IoT devices',
+        }),
+        category: 'navigation',
+        keywords: ['sensors', 'devices', 'iot', 'registry'],
+        icon: '📡',
+        action: () => navigate('/iot/sensors'),
+      },
       // Create commands
       {
         id: 'create-dispute',

--- a/frontend/apps/ppt-web/src/features/iot/index.ts
+++ b/frontend/apps/ppt-web/src/features/iot/index.ts
@@ -4,4 +4,13 @@
  * Manager-web front door for the IoT sensor backend.
  */
 export * from './components';
-export { IotDashboardPage, type IotDashboardPageProps } from './pages';
+export {
+  IotDashboardPage,
+  type IotDashboardPageProps,
+  type SensorFormBuildingOption,
+  SensorFormPage,
+  type SensorFormPageProps,
+  type SensorFormValues,
+  SensorListPage,
+  type SensorListPageProps,
+} from './pages';

--- a/frontend/apps/ppt-web/src/features/iot/pages/SensorFormPage.tsx
+++ b/frontend/apps/ppt-web/src/features/iot/pages/SensorFormPage.tsx
@@ -1,0 +1,391 @@
+/**
+ * Sensor register / edit form (Epic 14 — FR71).
+ *
+ * One presentational form drives both the register (`mode="create"`) and edit
+ * (`mode="edit"`) flows. The route wrapper in `routes/groups/iot.tsx` maps the
+ * emitted {@link SensorFormValues} onto the `@ppt/api-client` create/update
+ * request shapes.
+ *
+ * In edit mode the immutable identity fields (building, type, serial number)
+ * are rendered read-only because the api-server `UpdateSensor` shape does not
+ * accept them; `status` becomes editable instead.
+ */
+import type { JSX } from 'react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export interface SensorFormBuildingOption {
+  id: string;
+  name: string;
+}
+
+export interface SensorFormValues {
+  buildingId: string;
+  name: string;
+  sensorType: string;
+  location: string;
+  locationDescription: string;
+  connectionType: string;
+  unitOfMeasurement: string;
+  dataIntervalSeconds: string;
+  manufacturer: string;
+  model: string;
+  firmwareVersion: string;
+  serialNumber: string;
+  status: string;
+}
+
+export interface SensorFormPageProps {
+  mode: 'create' | 'edit';
+  buildings: SensorFormBuildingOption[];
+  buildingsLoading?: boolean;
+  initialValues?: Partial<SensorFormValues>;
+  isSaving: boolean;
+  isLoading?: boolean;
+  onSubmit: (values: SensorFormValues) => void;
+  onCancel: () => void;
+}
+
+const EMPTY_VALUES: SensorFormValues = {
+  buildingId: '',
+  name: '',
+  sensorType: '',
+  location: '',
+  locationDescription: '',
+  connectionType: '',
+  unitOfMeasurement: '',
+  dataIntervalSeconds: '',
+  manufacturer: '',
+  model: '',
+  firmwareVersion: '',
+  serialNumber: '',
+  status: 'active',
+};
+
+/** Common sensor types — offered as suggestions, free text still allowed. */
+const SENSOR_TYPE_OPTIONS = [
+  'temperature',
+  'humidity',
+  'co2',
+  'water_leak',
+  'electricity',
+  'gas',
+  'motion',
+  'door',
+  'smoke',
+  'pressure',
+];
+
+const STATUS_OPTIONS = ['active', 'offline', 'error', 'maintenance'];
+
+const fieldClass =
+  'mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:bg-gray-100 disabled:text-gray-500';
+const labelClass = 'block text-sm font-medium text-gray-700';
+
+export function SensorFormPage({
+  mode,
+  buildings,
+  buildingsLoading = false,
+  initialValues,
+  isSaving,
+  isLoading = false,
+  onSubmit,
+  onCancel,
+}: SensorFormPageProps): JSX.Element {
+  const { t } = useTranslation();
+  const [values, setValues] = useState<SensorFormValues>({
+    ...EMPTY_VALUES,
+    ...initialValues,
+  });
+
+  const isEdit = mode === 'edit';
+
+  const setField = (key: keyof SensorFormValues, value: string) => {
+    setValues((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const canSubmit =
+    values.name.trim().length > 0 &&
+    values.sensorType.trim().length > 0 &&
+    (isEdit || values.buildingId.trim().length > 0);
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!canSubmit || isSaving) {
+      return;
+    }
+    onSubmit(values);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-6">
+        <div className="flex items-center justify-center py-16">
+          <div className="h-6 w-6 animate-spin rounded-full border-b-2 border-blue-600" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-6">
+      <header className="mb-6">
+        <h1 className="text-2xl font-semibold text-gray-900">
+          {isEdit
+            ? t('iot.editSensorTitle', { defaultValue: 'Edit sensor' })
+            : t('iot.registerSensorTitle', { defaultValue: 'Register sensor' })}
+        </h1>
+        <p className="mt-1 text-sm text-gray-500">
+          {isEdit
+            ? t('iot.editSensorSubtitle', { defaultValue: 'Update device configuration.' })
+            : t('iot.registerSensorSubtitle', {
+                defaultValue: 'Add a new IoT device to a building.',
+              })}
+        </p>
+      </header>
+
+      <form
+        onSubmit={handleSubmit}
+        className="space-y-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm"
+      >
+        {/* Identity */}
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div>
+            <label htmlFor="sensor-building" className={labelClass}>
+              {t('iot.fieldBuilding', { defaultValue: 'Building' })}
+              {!isEdit && <span className="text-red-500"> *</span>}
+            </label>
+            <select
+              id="sensor-building"
+              className={fieldClass}
+              value={values.buildingId}
+              disabled={isEdit || buildingsLoading}
+              onChange={(e) => setField('buildingId', e.target.value)}
+              required={!isEdit}
+            >
+              <option value="">
+                {buildingsLoading
+                  ? t('common.loading', { defaultValue: 'Loading…' })
+                  : t('iot.selectBuilding', { defaultValue: 'Select a building' })}
+              </option>
+              {buildings.map((b) => (
+                <option key={b.id} value={b.id}>
+                  {b.name}
+                </option>
+              ))}
+            </select>
+            {isEdit && (
+              <p className="mt-1 text-xs text-gray-400">
+                {t('iot.buildingImmutable', {
+                  defaultValue: 'Building cannot be changed after registration.',
+                })}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label htmlFor="sensor-name" className={labelClass}>
+              {t('iot.fieldName', { defaultValue: 'Name' })}
+              <span className="text-red-500"> *</span>
+            </label>
+            <input
+              id="sensor-name"
+              type="text"
+              className={fieldClass}
+              value={values.name}
+              onChange={(e) => setField('name', e.target.value)}
+              required
+            />
+          </div>
+
+          <div>
+            <label htmlFor="sensor-type" className={labelClass}>
+              {t('iot.fieldType', { defaultValue: 'Sensor type' })}
+              <span className="text-red-500"> *</span>
+            </label>
+            <input
+              id="sensor-type"
+              type="text"
+              list="sensor-type-options"
+              className={fieldClass}
+              value={values.sensorType}
+              disabled={isEdit}
+              onChange={(e) => setField('sensorType', e.target.value)}
+              required
+            />
+            <datalist id="sensor-type-options">
+              {SENSOR_TYPE_OPTIONS.map((opt) => (
+                <option key={opt} value={opt} />
+              ))}
+            </datalist>
+          </div>
+
+          {isEdit && (
+            <div>
+              <label htmlFor="sensor-status" className={labelClass}>
+                {t('iot.fieldStatus', { defaultValue: 'Status' })}
+              </label>
+              <select
+                id="sensor-status"
+                className={fieldClass}
+                value={values.status}
+                onChange={(e) => setField('status', e.target.value)}
+              >
+                {STATUS_OPTIONS.map((opt) => (
+                  <option key={opt} value={opt}>
+                    {opt}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+        </div>
+
+        {/* Placement */}
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div>
+            <label htmlFor="sensor-location" className={labelClass}>
+              {t('iot.fieldLocation', { defaultValue: 'Location' })}
+            </label>
+            <input
+              id="sensor-location"
+              type="text"
+              className={fieldClass}
+              value={values.location}
+              onChange={(e) => setField('location', e.target.value)}
+            />
+          </div>
+          <div>
+            <label htmlFor="sensor-location-desc" className={labelClass}>
+              {t('iot.fieldLocationDescription', { defaultValue: 'Location description' })}
+            </label>
+            <input
+              id="sensor-location-desc"
+              type="text"
+              className={fieldClass}
+              value={values.locationDescription}
+              onChange={(e) => setField('locationDescription', e.target.value)}
+            />
+          </div>
+        </div>
+
+        {/* Connectivity */}
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div>
+            <label htmlFor="sensor-connection" className={labelClass}>
+              {t('iot.fieldConnectionType', { defaultValue: 'Connection type' })}
+            </label>
+            <input
+              id="sensor-connection"
+              type="text"
+              className={fieldClass}
+              placeholder="mqtt, http, modbus…"
+              value={values.connectionType}
+              onChange={(e) => setField('connectionType', e.target.value)}
+            />
+          </div>
+          <div>
+            <label htmlFor="sensor-unit" className={labelClass}>
+              {t('iot.fieldUnit', { defaultValue: 'Unit of measurement' })}
+            </label>
+            <input
+              id="sensor-unit"
+              type="text"
+              className={fieldClass}
+              placeholder="°C, %, ppm…"
+              value={values.unitOfMeasurement}
+              onChange={(e) => setField('unitOfMeasurement', e.target.value)}
+            />
+          </div>
+          <div>
+            <label htmlFor="sensor-interval" className={labelClass}>
+              {t('iot.fieldInterval', { defaultValue: 'Reporting interval (s)' })}
+            </label>
+            <input
+              id="sensor-interval"
+              type="number"
+              min="0"
+              className={fieldClass}
+              value={values.dataIntervalSeconds}
+              onChange={(e) => setField('dataIntervalSeconds', e.target.value)}
+            />
+          </div>
+        </div>
+
+        {/* Hardware */}
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div>
+            <label htmlFor="sensor-manufacturer" className={labelClass}>
+              {t('iot.fieldManufacturer', { defaultValue: 'Manufacturer' })}
+            </label>
+            <input
+              id="sensor-manufacturer"
+              type="text"
+              className={fieldClass}
+              value={values.manufacturer}
+              onChange={(e) => setField('manufacturer', e.target.value)}
+            />
+          </div>
+          <div>
+            <label htmlFor="sensor-model" className={labelClass}>
+              {t('iot.fieldModel', { defaultValue: 'Model' })}
+            </label>
+            <input
+              id="sensor-model"
+              type="text"
+              className={fieldClass}
+              value={values.model}
+              onChange={(e) => setField('model', e.target.value)}
+            />
+          </div>
+          <div>
+            <label htmlFor="sensor-firmware" className={labelClass}>
+              {t('iot.fieldFirmware', { defaultValue: 'Firmware version' })}
+            </label>
+            <input
+              id="sensor-firmware"
+              type="text"
+              className={fieldClass}
+              value={values.firmwareVersion}
+              onChange={(e) => setField('firmwareVersion', e.target.value)}
+            />
+          </div>
+          <div>
+            <label htmlFor="sensor-serial" className={labelClass}>
+              {t('iot.fieldSerial', { defaultValue: 'Serial number' })}
+            </label>
+            <input
+              id="sensor-serial"
+              type="text"
+              className={fieldClass}
+              value={values.serialNumber}
+              disabled={isEdit}
+              onChange={(e) => setField('serialNumber', e.target.value)}
+            />
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-3 border-t border-gray-100 pt-4">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="btn-outline-token rounded-lg px-4 py-2 text-sm font-medium"
+          >
+            {t('common.cancel', { defaultValue: 'Cancel' })}
+          </button>
+          <button
+            type="submit"
+            disabled={!canSubmit || isSaving}
+            className="btn-primary-token rounded-lg px-4 py-2 text-sm font-medium disabled:opacity-50"
+          >
+            {isSaving
+              ? t('common.saving', { defaultValue: 'Saving…' })
+              : isEdit
+                ? t('common.saveChanges', { defaultValue: 'Save changes' })
+                : t('iot.registerSensor', { defaultValue: 'Register sensor' })}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/iot/pages/SensorListPage.tsx
+++ b/frontend/apps/ppt-web/src/features/iot/pages/SensorListPage.tsx
@@ -1,0 +1,160 @@
+/**
+ * Sensor list / management page (Epic 14 — FR71).
+ *
+ * Standalone device registry: a sortable table of all sensors with register,
+ * edit and decommission actions. Complements the read-only dashboard list
+ * (`SensorListPanel`) with full CRUD entry points.
+ *
+ * Presentational only — the route wrapper in `routes/groups/iot.tsx` wires the
+ * `@ppt/api-client` hooks and passes data + handlers in.
+ */
+import type { Sensor } from '@ppt/api-client';
+import type { JSX } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SensorStatusBadge } from '../components';
+
+export interface SensorListPageProps {
+  sensors: Sensor[];
+  isLoading: boolean;
+  deletingSensorId: string | null;
+  onNavigateToDashboard: () => void;
+  onNavigateToRegister: () => void;
+  onNavigateToEdit: (id: string) => void;
+  onDelete: (sensor: Sensor) => void;
+}
+
+function formatTimestamp(value: string | null): string {
+  if (!value) {
+    return '—';
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? '—' : date.toLocaleString();
+}
+
+export function SensorListPage({
+  sensors,
+  isLoading,
+  deletingSensorId,
+  onNavigateToDashboard,
+  onNavigateToRegister,
+  onNavigateToEdit,
+  onDelete,
+}: SensorListPageProps): JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-6">
+      <header className="mb-6 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">
+            {t('iot.sensorsTitle', { defaultValue: 'Sensors & Devices' })}
+          </h1>
+          <p className="mt-1 text-sm text-gray-500">
+            {t('iot.sensorsSubtitle', {
+              defaultValue: 'Register and manage the IoT devices across your buildings.',
+            })}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onNavigateToDashboard}
+            className="btn-outline-token rounded-lg px-3 py-1.5 text-sm font-medium"
+          >
+            {t('iot.openDashboard', { defaultValue: 'Dashboard' })}
+          </button>
+          <button
+            type="button"
+            onClick={onNavigateToRegister}
+            className="btn-primary-token rounded-lg px-3 py-1.5 text-sm font-medium"
+          >
+            {t('iot.registerSensor', { defaultValue: 'Register sensor' })}
+          </button>
+        </div>
+      </header>
+
+      <section className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+        {isLoading ? (
+          <div className="flex items-center justify-center py-16">
+            <div className="h-6 w-6 animate-spin rounded-full border-b-2 border-blue-600" />
+          </div>
+        ) : sensors.length === 0 ? (
+          <div className="px-4 py-16 text-center">
+            <p className="text-sm text-gray-400">
+              {t('iot.noDevices', { defaultValue: 'No devices registered yet.' })}
+            </p>
+            <button
+              type="button"
+              onClick={onNavigateToRegister}
+              className="btn-primary-token mt-4 rounded-lg px-3 py-1.5 text-sm font-medium"
+            >
+              {t('iot.registerSensor', { defaultValue: 'Register sensor' })}
+            </button>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-100 text-sm">
+              <thead className="bg-gray-50 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <tr>
+                  <th className="px-4 py-3">{t('iot.colName', { defaultValue: 'Name' })}</th>
+                  <th className="px-4 py-3">{t('iot.colType', { defaultValue: 'Type' })}</th>
+                  <th className="px-4 py-3">
+                    {t('iot.colLocation', { defaultValue: 'Location' })}
+                  </th>
+                  <th className="px-4 py-3">{t('iot.colStatus', { defaultValue: 'Status' })}</th>
+                  <th className="px-4 py-3">
+                    {t('iot.colLastReading', { defaultValue: 'Last reading' })}
+                  </th>
+                  <th className="px-4 py-3 text-right">
+                    {t('common.actions', { defaultValue: 'Actions' })}
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {sensors.map((sensor) => {
+                  const deleting = sensor.id === deletingSensorId;
+                  return (
+                    <tr key={sensor.id} className="hover:bg-gray-50">
+                      <td className="px-4 py-3 font-medium text-gray-900">{sensor.name}</td>
+                      <td className="px-4 py-3 text-gray-600">{sensor.sensor_type}</td>
+                      <td className="px-4 py-3 text-gray-600">
+                        {sensor.location || sensor.location_description || '—'}
+                      </td>
+                      <td className="px-4 py-3">
+                        <SensorStatusBadge value={sensor.status} />
+                      </td>
+                      <td className="px-4 py-3 text-gray-500">
+                        {formatTimestamp(sensor.last_reading_at)}
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center justify-end gap-2">
+                          <button
+                            type="button"
+                            onClick={() => onNavigateToEdit(sensor.id)}
+                            className="rounded px-2 py-1 text-xs font-medium text-blue-600 hover:bg-blue-50"
+                          >
+                            {t('common.edit', { defaultValue: 'Edit' })}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => onDelete(sensor)}
+                            disabled={deleting}
+                            className="rounded px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-50 disabled:opacity-50"
+                          >
+                            {deleting
+                              ? t('common.deleting', { defaultValue: 'Deleting…' })
+                              : t('common.delete', { defaultValue: 'Delete' })}
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/iot/pages/index.ts
+++ b/frontend/apps/ppt-web/src/features/iot/pages/index.ts
@@ -1,1 +1,8 @@
 export { IotDashboardPage, type IotDashboardPageProps } from './IotDashboardPage';
+export {
+  type SensorFormBuildingOption,
+  SensorFormPage,
+  type SensorFormPageProps,
+  type SensorFormValues,
+} from './SensorFormPage';
+export { SensorListPage, type SensorListPageProps } from './SensorListPage';

--- a/frontend/apps/ppt-web/src/routes/groups/iot.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/iot.tsx
@@ -5,18 +5,42 @@
  * Wires `@ppt/api-client` IoT hooks to the presentational dashboard page,
  * mirroring the outages/faults route-group convention.
  */
+import type { CreateSensorRequest, Sensor, UpdateSensorRequest } from '@ppt/api-client';
 import {
   useAcknowledgeSensorAlert,
+  useBuildings,
+  useCreateSensor,
+  useDeleteSensor,
   useIotDashboard,
   useResolveSensorAlert,
+  useSensor,
   useSensorReadings,
   useSensors,
+  useUpdateSensor,
 } from '@ppt/api-client';
 import { useMemo, useState } from 'react';
-import { Route } from 'react-router-dom';
-import { AuthRequiredGate } from '../../components';
+import { Route, useNavigate, useParams } from 'react-router-dom';
+import { AuthRequiredGate, useToast } from '../../components';
 import { useAuth } from '../../contexts';
-import { IotDashboardPage } from '../lazyRoutes';
+import type { SensorFormValues } from '../../features/iot';
+import { IotDashboardPage, IotSensorFormPage, IotSensorListPage } from '../lazyRoutes';
+import { transformBuildingForUI } from '../shared';
+
+/** Map a numeric-string form field to a number, or null when blank. */
+function toIntOrNull(value: string): number | null {
+  const trimmed = value.trim();
+  if (trimmed === '') {
+    return null;
+  }
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/** Empty-string → null helper for optional text fields. */
+function orNull(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed === '' ? null : trimmed;
+}
 
 /**
  * Route wrapper for the IoT dashboard (Epic 14 / FR71-75).
@@ -71,11 +95,205 @@ function IotDashboardPageRoute() {
   );
 }
 
+/**
+ * Route wrapper for the standalone sensor registry / management list (FR71).
+ * Wires list + delete and navigation to register/edit.
+ */
+function SensorListPageRoute() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const { showToast } = useToast();
+
+  const { data: sensorsData, isLoading } = useSensors();
+  const deleteSensor = useDeleteSensor();
+
+  const sensors = useMemo(() => sensorsData?.sensors ?? [], [sensorsData]);
+
+  if (!user?.organizationId) {
+    return <AuthRequiredGate />;
+  }
+
+  const handleDelete = async (sensor: Sensor) => {
+    if (
+      !window.confirm(
+        `Delete sensor "${sensor.name}"? This removes its readings and alerts and cannot be undone.`
+      )
+    ) {
+      return;
+    }
+    try {
+      await deleteSensor.mutateAsync(sensor.id);
+      showToast({ type: 'success', title: 'Sensor deleted', message: sensor.name });
+    } catch (error) {
+      showToast({
+        type: 'error',
+        title: 'Failed to delete sensor',
+        message: error instanceof Error ? error.message : 'Unexpected error',
+      });
+    }
+  };
+
+  return (
+    <IotSensorListPage
+      sensors={sensors}
+      isLoading={isLoading}
+      deletingSensorId={deleteSensor.isPending ? (deleteSensor.variables ?? null) : null}
+      onNavigateToDashboard={() => navigate('/iot')}
+      onNavigateToRegister={() => navigate('/iot/sensors/new')}
+      onNavigateToEdit={(id) => navigate(`/iot/sensors/${id}/edit`)}
+      onDelete={handleDelete}
+    />
+  );
+}
+
+/** Route wrapper for registering a new sensor (FR71). */
+function RegisterSensorPageRoute() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const { showToast } = useToast();
+
+  const { data: buildingsData, isLoading: buildingsLoading } = useBuildings();
+  const createSensor = useCreateSensor();
+
+  if (!user?.organizationId || !user.id) {
+    return <AuthRequiredGate />;
+  }
+
+  const organizationId = user.organizationId;
+  const createdBy = user.id;
+
+  const buildings = (buildingsData?.items ?? []).map(transformBuildingForUI);
+
+  const handleSubmit = async (values: SensorFormValues) => {
+    const payload: CreateSensorRequest = {
+      organization_id: organizationId,
+      building_id: values.buildingId,
+      name: values.name.trim(),
+      sensor_type: values.sensorType.trim(),
+      location: orNull(values.location),
+      location_description: orNull(values.locationDescription),
+      connection_type: orNull(values.connectionType),
+      unit_of_measurement: orNull(values.unitOfMeasurement),
+      data_interval_seconds: toIntOrNull(values.dataIntervalSeconds),
+      manufacturer: orNull(values.manufacturer),
+      model: orNull(values.model),
+      firmware_version: orNull(values.firmwareVersion),
+      serial_number: orNull(values.serialNumber),
+      created_by: createdBy,
+    };
+    try {
+      await createSensor.mutateAsync(payload);
+      showToast({ type: 'success', title: 'Sensor registered', message: payload.name });
+      navigate('/iot/sensors');
+    } catch (error) {
+      showToast({
+        type: 'error',
+        title: 'Failed to register sensor',
+        message: error instanceof Error ? error.message : 'Unexpected error',
+      });
+    }
+  };
+
+  return (
+    <IotSensorFormPage
+      mode="create"
+      buildings={buildings}
+      buildingsLoading={buildingsLoading}
+      isSaving={createSensor.isPending}
+      onSubmit={handleSubmit}
+      onCancel={() => navigate('/iot/sensors')}
+    />
+  );
+}
+
+/** Map a loaded sensor onto the editable form value shape. */
+function sensorToFormValues(sensor: Sensor): Partial<SensorFormValues> {
+  return {
+    buildingId: sensor.building_id,
+    name: sensor.name,
+    sensorType: sensor.sensor_type,
+    location: sensor.location ?? '',
+    locationDescription: sensor.location_description ?? '',
+    connectionType: sensor.connection_type ?? '',
+    unitOfMeasurement: sensor.unit_of_measurement ?? '',
+    dataIntervalSeconds:
+      sensor.data_interval_seconds != null ? String(sensor.data_interval_seconds) : '',
+    manufacturer: sensor.manufacturer ?? '',
+    model: sensor.model ?? '',
+    firmwareVersion: sensor.firmware_version ?? '',
+    serialNumber: sensor.serial_number ?? '',
+    status: sensor.status,
+  };
+}
+
+/** Route wrapper for editing an existing sensor (FR71). */
+function EditSensorPageRoute() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const { showToast } = useToast();
+  const { sensorId } = useParams<{ sensorId: string }>();
+
+  const { data: sensor, isLoading } = useSensor(sensorId ?? '');
+  const { data: buildingsData, isLoading: buildingsLoading } = useBuildings();
+  const updateSensor = useUpdateSensor();
+
+  if (!user?.organizationId) {
+    return <AuthRequiredGate />;
+  }
+
+  const buildings = (buildingsData?.items ?? []).map(transformBuildingForUI);
+
+  const handleSubmit = async (values: SensorFormValues) => {
+    if (!sensorId) {
+      return;
+    }
+    const payload: UpdateSensorRequest = {
+      name: values.name.trim(),
+      location: orNull(values.location),
+      location_description: orNull(values.locationDescription),
+      connection_type: orNull(values.connectionType),
+      unit_of_measurement: orNull(values.unitOfMeasurement),
+      data_interval_seconds: toIntOrNull(values.dataIntervalSeconds),
+      status: values.status,
+      manufacturer: orNull(values.manufacturer),
+      model: orNull(values.model),
+      firmware_version: orNull(values.firmwareVersion),
+    };
+    try {
+      await updateSensor.mutateAsync({ id: sensorId, data: payload });
+      showToast({ type: 'success', title: 'Sensor updated', message: payload.name ?? '' });
+      navigate('/iot/sensors');
+    } catch (error) {
+      showToast({
+        type: 'error',
+        title: 'Failed to update sensor',
+        message: error instanceof Error ? error.message : 'Unexpected error',
+      });
+    }
+  };
+
+  return (
+    <IotSensorFormPage
+      mode="edit"
+      buildings={buildings}
+      buildingsLoading={buildingsLoading}
+      isLoading={isLoading}
+      initialValues={sensor ? sensorToFormValues(sensor) : undefined}
+      isSaving={updateSensor.isPending}
+      onSubmit={handleSubmit}
+      onCancel={() => navigate('/iot/sensors')}
+    />
+  );
+}
+
 /** IoT / Smart-Building routes (Epic 14 / FR71-75). */
 export function iotRoutes() {
   return (
     <>
       <Route path="/iot" element={<IotDashboardPageRoute />} />
+      <Route path="/iot/sensors" element={<SensorListPageRoute />} />
+      <Route path="/iot/sensors/new" element={<RegisterSensorPageRoute />} />
+      <Route path="/iot/sensors/:sensorId/edit" element={<EditSensorPageRoute />} />
     </>
   );
 }

--- a/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
+++ b/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
@@ -50,6 +50,12 @@ export const VoteDetailPage = lazy(() =>
 export const IotDashboardPage = lazy(() =>
   import('../features/iot').then((m) => ({ default: m.IotDashboardPage }))
 );
+export const IotSensorListPage = lazy(() =>
+  import('../features/iot').then((m) => ({ default: m.SensorListPage }))
+);
+export const IotSensorFormPage = lazy(() =>
+  import('../features/iot').then((m) => ({ default: m.SensorFormPage }))
+);
 
 // Disputes feature (Epic 77)
 export const DisputesPage = lazy(() =>

--- a/frontend/packages/api-client/src/iot/api.ts
+++ b/frontend/packages/api-client/src/iot/api.ts
@@ -8,6 +8,7 @@
 
 import { getToken } from '../auth';
 import type {
+  CreateSensorRequest,
   ListAlertsParams,
   ListAlertsResponse,
   ListReadingsParams,
@@ -17,6 +18,7 @@ import type {
   Sensor,
   SensorAlert,
   SensorDashboard,
+  UpdateSensorRequest,
 } from './types';
 
 const _win = typeof window !== 'undefined' ? (window as unknown as Record<string, unknown>) : {};
@@ -81,6 +83,27 @@ export async function listSensors(
 /** Get a single sensor by id (FR71). */
 export async function getSensor(id: string, signal?: AbortSignal): Promise<Sensor> {
   return apiRequest<Sensor>(`${API_BASE}/${id}`, { signal });
+}
+
+/** Register a new sensor / device (FR71). */
+export async function createSensor(req: CreateSensorRequest): Promise<Sensor> {
+  return apiRequest<Sensor>(`${API_BASE}`, {
+    method: 'POST',
+    body: JSON.stringify(req),
+  });
+}
+
+/** Update an existing sensor (FR71). */
+export async function updateSensor(id: string, req: UpdateSensorRequest): Promise<Sensor> {
+  return apiRequest<Sensor>(`${API_BASE}/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(req),
+  });
+}
+
+/** Delete (decommission) a sensor (FR71). */
+export async function deleteSensor(id: string): Promise<void> {
+  return apiRequest<void>(`${API_BASE}/${id}`, { method: 'DELETE' });
 }
 
 /** List telemetry readings for a sensor (FR72). */

--- a/frontend/packages/api-client/src/iot/hooks.ts
+++ b/frontend/packages/api-client/src/iot/hooks.ts
@@ -8,14 +8,23 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   acknowledgeSensorAlert,
+  createSensor,
+  deleteSensor,
   getIotDashboard,
   getSensor,
   listSensorAlerts,
   listSensorReadings,
   listSensors,
   resolveSensorAlert,
+  updateSensor,
 } from './api';
-import type { ListAlertsParams, ListReadingsParams, ListSensorsParams } from './types';
+import type {
+  CreateSensorRequest,
+  ListAlertsParams,
+  ListReadingsParams,
+  ListSensorsParams,
+  UpdateSensorRequest,
+} from './types';
 
 // ============================================
 // Query Key Factory
@@ -106,6 +115,41 @@ export function useResolveSensorAlert() {
   return useMutation({
     mutationFn: ({ alertId, resolvedValue }: { alertId: string; resolvedValue?: number | null }) =>
       resolveSensorAlert(alertId, resolvedValue),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: iotKeys.all });
+    },
+  });
+}
+
+/** Register a new sensor (FR71). Refreshes sensor lists + dashboard on success. */
+export function useCreateSensor() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (req: CreateSensorRequest) => createSensor(req),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: iotKeys.all });
+    },
+  });
+}
+
+/** Update a sensor (FR71). Refreshes the affected sensor + lists on success. */
+export function useUpdateSensor() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateSensorRequest }) => updateSensor(id, data),
+    onSuccess: (_result, { id }) => {
+      queryClient.invalidateQueries({ queryKey: iotKeys.sensor(id) });
+      queryClient.invalidateQueries({ queryKey: iotKeys.sensors() });
+      queryClient.invalidateQueries({ queryKey: iotKeys.dashboard() });
+    },
+  });
+}
+
+/** Delete a sensor (FR71). Refreshes sensor lists + dashboard on success. */
+export function useDeleteSensor() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => deleteSensor(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: iotKeys.all });
     },

--- a/frontend/packages/api-client/src/iot/index.ts
+++ b/frontend/packages/api-client/src/iot/index.ts
@@ -6,25 +6,32 @@
 
 export {
   acknowledgeSensorAlert,
+  createSensor,
+  deleteSensor,
   getIotDashboard,
   getSensor,
   listSensorAlerts,
   listSensorReadings,
   listSensors,
   resolveSensorAlert,
+  updateSensor,
 } from './api';
 export {
   iotKeys,
   useAcknowledgeSensorAlert,
+  useCreateSensor,
+  useDeleteSensor,
   useIotDashboard,
   useResolveSensorAlert,
   useSensor,
   useSensorAlerts,
   useSensorReadings,
   useSensors,
+  useUpdateSensor,
 } from './hooks';
 export type {
   AggregatedReading,
+  CreateSensorRequest,
   ListAlertsParams,
   ListAlertsResponse,
   ListReadingsParams,
@@ -37,4 +44,5 @@ export type {
   SensorDashboard,
   SensorReading,
   SensorTypeCount,
+  UpdateSensorRequest,
 } from './types';

--- a/frontend/packages/api-client/src/iot/types.ts
+++ b/frontend/packages/api-client/src/iot/types.ts
@@ -131,3 +131,45 @@ export interface ListAlertsResponse {
 export interface ResolveSensorAlertRequest {
   resolved_value?: number | null;
 }
+
+/**
+ * Register-sensor request (FR71). Mirrors `CreateSensor` in the api-server.
+ * `organization_id` is pinned to the caller's tenant server-side, but the
+ * field is still required on the wire — send the authenticated org id.
+ */
+export interface CreateSensorRequest {
+  organization_id: string;
+  building_id: string;
+  unit_id?: string | null;
+  name: string;
+  sensor_type: string;
+  location?: string | null;
+  location_description?: string | null;
+  connection_type?: string | null;
+  connection_config?: unknown;
+  unit_of_measurement?: string | null;
+  data_interval_seconds?: number | null;
+  manufacturer?: string | null;
+  model?: string | null;
+  firmware_version?: string | null;
+  serial_number?: string | null;
+  installed_at?: string | null;
+  metadata?: unknown;
+  created_by: string;
+}
+
+/** Edit-sensor request (FR71). Mirrors `UpdateSensor`; all fields optional. */
+export interface UpdateSensorRequest {
+  name?: string | null;
+  location?: string | null;
+  location_description?: string | null;
+  connection_type?: string | null;
+  connection_config?: unknown;
+  unit_of_measurement?: string | null;
+  data_interval_seconds?: number | null;
+  status?: string | null;
+  manufacturer?: string | null;
+  model?: string | null;
+  firmware_version?: string | null;
+  metadata?: unknown;
+}


### PR DESCRIPTION
## Summary

First increment of the **ppt-web IoT & Smart Building** module (Epic 14, BIT-146 / PM #985 gap 1): **sensor registry + register/edit pages**, wired to the existing `/api/v1/iot/sensors` backend. Complements the already-shipped read-only IoT dashboard with full sensor CRUD.

The IoT module previously had a dashboard but **no nav entry and no way to register/edit/remove devices** — this adds both.

## What's included

**api-client (`@ppt/api-client`)**
- `createSensor` / `updateSensor` / `deleteSensor` (POST/PUT/DELETE `/api/v1/iot/sensors`).
- `useCreateSensor` / `useUpdateSensor` / `useDeleteSensor` mutation hooks with cache invalidation.
- `CreateSensorRequest` / `UpdateSensorRequest` types mirroring the api-server `CreateSensor`/`UpdateSensor` shapes.

**ppt-web**
- `SensorListPage` — device registry table (status, location, last-reading) with register / edit / delete actions.
- `SensorFormPage` — one shared form driving both register (`/iot/sensors/new`) and edit (`/iot/sensors/:id/edit`), with a `useBuildings` building selector.
- Route wrappers in `routes/groups/iot.tsx`; nav link (`/iot` → "Smart Building") + command-palette entries.
- Screen-map: `docs/screens/ppt/iot-sensors.md`.

## Notes
- `organization_id` is pinned to the caller's tenant server-side; `created_by` comes from the authenticated user.
- In **edit** mode the immutable identity fields (building, type, serial number) are read-only to match the api-server `UpdateSensor` shape; `status` becomes editable.

## Verification
- `pnpm --filter @ppt/api-client typecheck` ✅
- `pnpm --filter @ppt/web exec tsc --noEmit` ✅ (0 errors)
- `biome check` ✅

## Scope / follow-ups
Part of **BIT-146** (does **not** close PM #985 — gap 2 sensor WebSocket lands separately, and thresholds/alerts pages follow):
- Thresholds configuration UI — BIT-148
- Dedicated alerts page + further screen-map — BIT-149
- Real-time dashboard via the BIT-145 WS channel once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)