### PR TITLE
feat(iot): sensor register + edit + standalone list [BIT-147]

### DIFF
--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -1153,5 +1153,82 @@
     "title": "Konkurenční funkce",
     "percentComplete": "Dokončeno {{percent}} %",
     "viewAnalysis": "Zobrazit analýzu"
+  },
+  "iot": {
+    "title": "IoT Sensors",
+    "sensors": "Sensors",
+    "registerSensor": "Register Sensor",
+    "editSensor": "Edit Sensor",
+    "backToSensors": "Back to Sensors",
+    "backToDashboard": "Back to Dashboard",
+    "noSensors": "No sensors found.",
+    "registeredSuccessfully": "Sensor registered",
+    "sensorRegisteredMsg": "The sensor has been registered successfully.",
+    "updatedSuccessfully": "Sensor updated",
+    "sensorUpdatedMsg": "The sensor has been updated successfully.",
+    "failedToRegister": "Failed to register sensor",
+    "failedToUpdate": "Failed to update sensor",
+    "form": {
+      "name": "Name",
+      "namePlaceholder": "e.g. Living room temperature",
+      "sensorType": "Sensor Type",
+      "buildingId": "Building ID",
+      "buildingIdPlaceholder": "Enter building ID",
+      "location": "Location",
+      "locationPlaceholder": "e.g. Room 101",
+      "unitOfMeasurement": "Unit of Measurement",
+      "unitPlaceholder": "e.g. °C, %, ppm",
+      "connectionType": "Connection Type",
+      "manufacturer": "Manufacturer",
+      "manufacturerPlaceholder": "e.g. Bosch",
+      "model": "Model",
+      "modelPlaceholder": "e.g. BME280",
+      "serialNumber": "Serial Number",
+      "serialNumberPlaceholder": "e.g. SN-123456",
+      "dataIntervalSeconds": "Data Interval (seconds)",
+      "dataIntervalPlaceholder": "e.g. 60"
+    },
+    "sensorType": {
+      "temperature": "Temperature",
+      "humidity": "Humidity",
+      "motion": "Motion",
+      "co2": "CO2",
+      "pressure": "Pressure",
+      "energy": "Energy",
+      "water": "Water",
+      "smoke": "Smoke",
+      "door_window": "Door/Window",
+      "other": "Other"
+    },
+    "connectionType": {
+      "mqtt": "MQTT",
+      "http": "HTTP",
+      "modbus": "Modbus",
+      "zigbee": "Zigbee",
+      "zwave": "Z-Wave",
+      "other": "Other"
+    },
+    "errors": {
+      "nameRequired": "Name is required",
+      "sensorTypeRequired": "Sensor type is required",
+      "buildingIdRequired": "Building ID is required"
+    },
+    "filter": {
+      "allTypes": "All Types",
+      "allStatuses": "All Statuses",
+      "searchPlaceholder": "Search sensors..."
+    },
+    "columns": {
+      "name": "Name",
+      "type": "Type",
+      "status": "Status",
+      "location": "Location",
+      "building": "Building",
+      "actions": "Actions"
+    },
+    "actions": {
+      "edit": "Edit",
+      "delete": "Delete"
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -1148,5 +1148,82 @@
     "title": "Wettbewerbsfunktionen",
     "percentComplete": "{{percent}} % abgeschlossen",
     "viewAnalysis": "Analyse anzeigen"
+  },
+  "iot": {
+    "title": "IoT Sensors",
+    "sensors": "Sensors",
+    "registerSensor": "Register Sensor",
+    "editSensor": "Edit Sensor",
+    "backToSensors": "Back to Sensors",
+    "backToDashboard": "Back to Dashboard",
+    "noSensors": "No sensors found.",
+    "registeredSuccessfully": "Sensor registered",
+    "sensorRegisteredMsg": "The sensor has been registered successfully.",
+    "updatedSuccessfully": "Sensor updated",
+    "sensorUpdatedMsg": "The sensor has been updated successfully.",
+    "failedToRegister": "Failed to register sensor",
+    "failedToUpdate": "Failed to update sensor",
+    "form": {
+      "name": "Name",
+      "namePlaceholder": "e.g. Living room temperature",
+      "sensorType": "Sensor Type",
+      "buildingId": "Building ID",
+      "buildingIdPlaceholder": "Enter building ID",
+      "location": "Location",
+      "locationPlaceholder": "e.g. Room 101",
+      "unitOfMeasurement": "Unit of Measurement",
+      "unitPlaceholder": "e.g. °C, %, ppm",
+      "connectionType": "Connection Type",
+      "manufacturer": "Manufacturer",
+      "manufacturerPlaceholder": "e.g. Bosch",
+      "model": "Model",
+      "modelPlaceholder": "e.g. BME280",
+      "serialNumber": "Serial Number",
+      "serialNumberPlaceholder": "e.g. SN-123456",
+      "dataIntervalSeconds": "Data Interval (seconds)",
+      "dataIntervalPlaceholder": "e.g. 60"
+    },
+    "sensorType": {
+      "temperature": "Temperature",
+      "humidity": "Humidity",
+      "motion": "Motion",
+      "co2": "CO2",
+      "pressure": "Pressure",
+      "energy": "Energy",
+      "water": "Water",
+      "smoke": "Smoke",
+      "door_window": "Door/Window",
+      "other": "Other"
+    },
+    "connectionType": {
+      "mqtt": "MQTT",
+      "http": "HTTP",
+      "modbus": "Modbus",
+      "zigbee": "Zigbee",
+      "zwave": "Z-Wave",
+      "other": "Other"
+    },
+    "errors": {
+      "nameRequired": "Name is required",
+      "sensorTypeRequired": "Sensor type is required",
+      "buildingIdRequired": "Building ID is required"
+    },
+    "filter": {
+      "allTypes": "All Types",
+      "allStatuses": "All Statuses",
+      "searchPlaceholder": "Search sensors..."
+    },
+    "columns": {
+      "name": "Name",
+      "type": "Type",
+      "status": "Status",
+      "location": "Location",
+      "building": "Building",
+      "actions": "Actions"
+    },
+    "actions": {
+      "edit": "Edit",
+      "delete": "Delete"
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -3438,5 +3438,82 @@
     "title": "Competitive Features",
     "percentComplete": "{{percent}}% Complete",
     "viewAnalysis": "View Analysis"
+  },
+  "iot": {
+    "title": "IoT Sensors",
+    "sensors": "Sensors",
+    "registerSensor": "Register Sensor",
+    "editSensor": "Edit Sensor",
+    "backToSensors": "Back to Sensors",
+    "backToDashboard": "Back to Dashboard",
+    "noSensors": "No sensors found.",
+    "registeredSuccessfully": "Sensor registered",
+    "sensorRegisteredMsg": "The sensor has been registered successfully.",
+    "updatedSuccessfully": "Sensor updated",
+    "sensorUpdatedMsg": "The sensor has been updated successfully.",
+    "failedToRegister": "Failed to register sensor",
+    "failedToUpdate": "Failed to update sensor",
+    "form": {
+      "name": "Name",
+      "namePlaceholder": "e.g. Living room temperature",
+      "sensorType": "Sensor Type",
+      "buildingId": "Building ID",
+      "buildingIdPlaceholder": "Enter building ID",
+      "location": "Location",
+      "locationPlaceholder": "e.g. Room 101",
+      "unitOfMeasurement": "Unit of Measurement",
+      "unitPlaceholder": "e.g. °C, %, ppm",
+      "connectionType": "Connection Type",
+      "manufacturer": "Manufacturer",
+      "manufacturerPlaceholder": "e.g. Bosch",
+      "model": "Model",
+      "modelPlaceholder": "e.g. BME280",
+      "serialNumber": "Serial Number",
+      "serialNumberPlaceholder": "e.g. SN-123456",
+      "dataIntervalSeconds": "Data Interval (seconds)",
+      "dataIntervalPlaceholder": "e.g. 60"
+    },
+    "sensorType": {
+      "temperature": "Temperature",
+      "humidity": "Humidity",
+      "motion": "Motion",
+      "co2": "CO2",
+      "pressure": "Pressure",
+      "energy": "Energy",
+      "water": "Water",
+      "smoke": "Smoke",
+      "door_window": "Door/Window",
+      "other": "Other"
+    },
+    "connectionType": {
+      "mqtt": "MQTT",
+      "http": "HTTP",
+      "modbus": "Modbus",
+      "zigbee": "Zigbee",
+      "zwave": "Z-Wave",
+      "other": "Other"
+    },
+    "errors": {
+      "nameRequired": "Name is required",
+      "sensorTypeRequired": "Sensor type is required",
+      "buildingIdRequired": "Building ID is required"
+    },
+    "filter": {
+      "allTypes": "All Types",
+      "allStatuses": "All Statuses",
+      "searchPlaceholder": "Search sensors..."
+    },
+    "columns": {
+      "name": "Name",
+      "type": "Type",
+      "status": "Status",
+      "location": "Location",
+      "building": "Building",
+      "actions": "Actions"
+    },
+    "actions": {
+      "edit": "Edit",
+      "delete": "Delete"
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -1121,5 +1121,82 @@
     "title": "Versenyképességi funkciók",
     "percentComplete": "{{percent}}% kész",
     "viewAnalysis": "Elemzés megtekintése"
+  },
+  "iot": {
+    "title": "IoT Sensors",
+    "sensors": "Sensors",
+    "registerSensor": "Register Sensor",
+    "editSensor": "Edit Sensor",
+    "backToSensors": "Back to Sensors",
+    "backToDashboard": "Back to Dashboard",
+    "noSensors": "No sensors found.",
+    "registeredSuccessfully": "Sensor registered",
+    "sensorRegisteredMsg": "The sensor has been registered successfully.",
+    "updatedSuccessfully": "Sensor updated",
+    "sensorUpdatedMsg": "The sensor has been updated successfully.",
+    "failedToRegister": "Failed to register sensor",
+    "failedToUpdate": "Failed to update sensor",
+    "form": {
+      "name": "Name",
+      "namePlaceholder": "e.g. Living room temperature",
+      "sensorType": "Sensor Type",
+      "buildingId": "Building ID",
+      "buildingIdPlaceholder": "Enter building ID",
+      "location": "Location",
+      "locationPlaceholder": "e.g. Room 101",
+      "unitOfMeasurement": "Unit of Measurement",
+      "unitPlaceholder": "e.g. °C, %, ppm",
+      "connectionType": "Connection Type",
+      "manufacturer": "Manufacturer",
+      "manufacturerPlaceholder": "e.g. Bosch",
+      "model": "Model",
+      "modelPlaceholder": "e.g. BME280",
+      "serialNumber": "Serial Number",
+      "serialNumberPlaceholder": "e.g. SN-123456",
+      "dataIntervalSeconds": "Data Interval (seconds)",
+      "dataIntervalPlaceholder": "e.g. 60"
+    },
+    "sensorType": {
+      "temperature": "Temperature",
+      "humidity": "Humidity",
+      "motion": "Motion",
+      "co2": "CO2",
+      "pressure": "Pressure",
+      "energy": "Energy",
+      "water": "Water",
+      "smoke": "Smoke",
+      "door_window": "Door/Window",
+      "other": "Other"
+    },
+    "connectionType": {
+      "mqtt": "MQTT",
+      "http": "HTTP",
+      "modbus": "Modbus",
+      "zigbee": "Zigbee",
+      "zwave": "Z-Wave",
+      "other": "Other"
+    },
+    "errors": {
+      "nameRequired": "Name is required",
+      "sensorTypeRequired": "Sensor type is required",
+      "buildingIdRequired": "Building ID is required"
+    },
+    "filter": {
+      "allTypes": "All Types",
+      "allStatuses": "All Statuses",
+      "searchPlaceholder": "Search sensors..."
+    },
+    "columns": {
+      "name": "Name",
+      "type": "Type",
+      "status": "Status",
+      "location": "Location",
+      "building": "Building",
+      "actions": "Actions"
+    },
+    "actions": {
+      "edit": "Edit",
+      "delete": "Delete"
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -1127,5 +1127,82 @@
     "title": "Funkcje konkurencyjne",
     "percentComplete": "Ukończono {{percent}}%",
     "viewAnalysis": "Wyświetl analizę"
+  },
+  "iot": {
+    "title": "IoT Sensors",
+    "sensors": "Sensors",
+    "registerSensor": "Register Sensor",
+    "editSensor": "Edit Sensor",
+    "backToSensors": "Back to Sensors",
+    "backToDashboard": "Back to Dashboard",
+    "noSensors": "No sensors found.",
+    "registeredSuccessfully": "Sensor registered",
+    "sensorRegisteredMsg": "The sensor has been registered successfully.",
+    "updatedSuccessfully": "Sensor updated",
+    "sensorUpdatedMsg": "The sensor has been updated successfully.",
+    "failedToRegister": "Failed to register sensor",
+    "failedToUpdate": "Failed to update sensor",
+    "form": {
+      "name": "Name",
+      "namePlaceholder": "e.g. Living room temperature",
+      "sensorType": "Sensor Type",
+      "buildingId": "Building ID",
+      "buildingIdPlaceholder": "Enter building ID",
+      "location": "Location",
+      "locationPlaceholder": "e.g. Room 101",
+      "unitOfMeasurement": "Unit of Measurement",
+      "unitPlaceholder": "e.g. °C, %, ppm",
+      "connectionType": "Connection Type",
+      "manufacturer": "Manufacturer",
+      "manufacturerPlaceholder": "e.g. Bosch",
+      "model": "Model",
+      "modelPlaceholder": "e.g. BME280",
+      "serialNumber": "Serial Number",
+      "serialNumberPlaceholder": "e.g. SN-123456",
+      "dataIntervalSeconds": "Data Interval (seconds)",
+      "dataIntervalPlaceholder": "e.g. 60"
+    },
+    "sensorType": {
+      "temperature": "Temperature",
+      "humidity": "Humidity",
+      "motion": "Motion",
+      "co2": "CO2",
+      "pressure": "Pressure",
+      "energy": "Energy",
+      "water": "Water",
+      "smoke": "Smoke",
+      "door_window": "Door/Window",
+      "other": "Other"
+    },
+    "connectionType": {
+      "mqtt": "MQTT",
+      "http": "HTTP",
+      "modbus": "Modbus",
+      "zigbee": "Zigbee",
+      "zwave": "Z-Wave",
+      "other": "Other"
+    },
+    "errors": {
+      "nameRequired": "Name is required",
+      "sensorTypeRequired": "Sensor type is required",
+      "buildingIdRequired": "Building ID is required"
+    },
+    "filter": {
+      "allTypes": "All Types",
+      "allStatuses": "All Statuses",
+      "searchPlaceholder": "Search sensors..."
+    },
+    "columns": {
+      "name": "Name",
+      "type": "Type",
+      "status": "Status",
+      "location": "Location",
+      "building": "Building",
+      "actions": "Actions"
+    },
+    "actions": {
+      "edit": "Edit",
+      "delete": "Delete"
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -1154,5 +1154,82 @@
     "title": "Konkurenčné funkcie",
     "percentComplete": "Dokončené {{percent}} %",
     "viewAnalysis": "Zobraziť analýzu"
+  },
+  "iot": {
+    "title": "IoT Sensors",
+    "sensors": "Sensors",
+    "registerSensor": "Register Sensor",
+    "editSensor": "Edit Sensor",
+    "backToSensors": "Back to Sensors",
+    "backToDashboard": "Back to Dashboard",
+    "noSensors": "No sensors found.",
+    "registeredSuccessfully": "Sensor registered",
+    "sensorRegisteredMsg": "The sensor has been registered successfully.",
+    "updatedSuccessfully": "Sensor updated",
+    "sensorUpdatedMsg": "The sensor has been updated successfully.",
+    "failedToRegister": "Failed to register sensor",
+    "failedToUpdate": "Failed to update sensor",
+    "form": {
+      "name": "Name",
+      "namePlaceholder": "e.g. Living room temperature",
+      "sensorType": "Sensor Type",
+      "buildingId": "Building ID",
+      "buildingIdPlaceholder": "Enter building ID",
+      "location": "Location",
+      "locationPlaceholder": "e.g. Room 101",
+      "unitOfMeasurement": "Unit of Measurement",
+      "unitPlaceholder": "e.g. °C, %, ppm",
+      "connectionType": "Connection Type",
+      "manufacturer": "Manufacturer",
+      "manufacturerPlaceholder": "e.g. Bosch",
+      "model": "Model",
+      "modelPlaceholder": "e.g. BME280",
+      "serialNumber": "Serial Number",
+      "serialNumberPlaceholder": "e.g. SN-123456",
+      "dataIntervalSeconds": "Data Interval (seconds)",
+      "dataIntervalPlaceholder": "e.g. 60"
+    },
+    "sensorType": {
+      "temperature": "Temperature",
+      "humidity": "Humidity",
+      "motion": "Motion",
+      "co2": "CO2",
+      "pressure": "Pressure",
+      "energy": "Energy",
+      "water": "Water",
+      "smoke": "Smoke",
+      "door_window": "Door/Window",
+      "other": "Other"
+    },
+    "connectionType": {
+      "mqtt": "MQTT",
+      "http": "HTTP",
+      "modbus": "Modbus",
+      "zigbee": "Zigbee",
+      "zwave": "Z-Wave",
+      "other": "Other"
+    },
+    "errors": {
+      "nameRequired": "Name is required",
+      "sensorTypeRequired": "Sensor type is required",
+      "buildingIdRequired": "Building ID is required"
+    },
+    "filter": {
+      "allTypes": "All Types",
+      "allStatuses": "All Statuses",
+      "searchPlaceholder": "Search sensors..."
+    },
+    "columns": {
+      "name": "Name",
+      "type": "Type",
+      "status": "Status",
+      "location": "Location",
+      "building": "Building",
+      "actions": "Actions"
+    },
+    "actions": {
+      "edit": "Edit",
+      "delete": "Delete"
+    }
   }
 }

--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -120,6 +120,7 @@ function AppNavigation() {
       <Link to="/emergency">{t('nav.emergency')}</Link>
       <Link to="/disputes">{t('nav.disputes')}</Link>
       <Link to="/outages">{t('nav.outages')}</Link>
+      <Link to="/iot">{t('nav.iot', { defaultValue: 'Smart Building' })}</Link>
       <Link to="/rentals">{t('nav.rentals', { defaultValue: 'Rentals' })}</Link>
       <Link to="/settings/accessibility">{t('nav.accessibility')}</Link>
       <Link to="/settings/privacy">{t('nav.privacy')}</Link>

--- a/frontend/apps/ppt-web/src/features/command-palette/hooks/useNavigationCommands.tsx
+++ b/frontend/apps/ppt-web/src/features/command-palette/hooks/useNavigationCommands.tsx
@@ -76,6 +76,28 @@ export function useNavigationCommands() {
         icon: '⚡',
         action: () => navigate('/outages'),
       },
+      {
+        id: 'nav-iot',
+        label: t('commandPalette.commands.goToIot', { defaultValue: 'Go to Smart Building' }),
+        description: t('commandPalette.descriptions.goToIot', {
+          defaultValue: 'IoT sensors, telemetry and alerts',
+        }),
+        category: 'navigation',
+        keywords: ['iot', 'smart building', 'sensors', 'devices', 'telemetry', 'alerts'],
+        icon: '📡',
+        action: () => navigate('/iot'),
+      },
+      {
+        id: 'nav-iot-sensors',
+        label: t('commandPalette.commands.goToSensors', { defaultValue: 'Go to Sensors' }),
+        description: t('commandPalette.descriptions.goToSensors', {
+          defaultValue: 'Manage registered IoT devices',
+        }),
+        category: 'navigation',
+        keywords: ['sensors', 'devices', 'iot', 'registry'],
+        icon: '📡',
+        action: () => navigate('/iot/sensors'),
+      },
       // Create commands
       {
         id: 'create-dispute',

--- a/frontend/apps/ppt-web/src/features/iot/components/SensorForm.tsx
+++ b/frontend/apps/ppt-web/src/features/iot/components/SensorForm.tsx
@@ -1,0 +1,288 @@
+/**
+ * SensorForm — shared create/edit form for IoT sensors (Epic 14 — FR71).
+ *
+ * Presentational only; validation is manual (useState). The route wrapper
+ * converts SensorFormData to the @ppt/api-client request shape.
+ */
+import { type FormEvent, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export interface SensorFormData {
+  name: string;
+  sensor_type: string;
+  building_id: string;
+  location: string;
+  unit_of_measurement: string;
+  connection_type: string;
+  manufacturer: string;
+  model: string;
+  serial_number: string;
+  data_interval_seconds: string; // string for input, convert to number|null on submit
+}
+
+interface SensorFormProps {
+  initialData?: Partial<SensorFormData>;
+  isLoading?: boolean;
+  onSubmit: (data: SensorFormData) => void;
+  onCancel: () => void;
+}
+
+const SENSOR_TYPES = [
+  'temperature',
+  'humidity',
+  'motion',
+  'co2',
+  'pressure',
+  'energy',
+  'water',
+  'smoke',
+  'door_window',
+  'other',
+] as const;
+
+const CONNECTION_TYPES = ['mqtt', 'http', 'modbus', 'zigbee', 'zwave', 'other'] as const;
+
+const EMPTY: SensorFormData = {
+  name: '',
+  sensor_type: '',
+  building_id: '',
+  location: '',
+  unit_of_measurement: '',
+  connection_type: '',
+  manufacturer: '',
+  model: '',
+  serial_number: '',
+  data_interval_seconds: '',
+};
+
+const fieldClass =
+  'mt-1 block w-full px-3 py-2 border rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 text-sm';
+
+export function SensorForm({ initialData, isLoading, onSubmit, onCancel }: SensorFormProps) {
+  const { t } = useTranslation();
+  const [formData, setFormData] = useState<SensorFormData>({ ...EMPTY, ...initialData });
+  const [errors, setErrors] = useState<Partial<Record<keyof SensorFormData, string>>>({});
+
+  const validate = (): boolean => {
+    const next: Partial<Record<keyof SensorFormData, string>> = {};
+    if (!formData.name.trim()) {
+      next.name = t('iot.errors.nameRequired', { defaultValue: 'Name is required' });
+    }
+    if (!formData.sensor_type) {
+      next.sensor_type = t('iot.errors.sensorTypeRequired', {
+        defaultValue: 'Sensor type is required',
+      });
+    }
+    if (!formData.building_id.trim()) {
+      next.building_id = t('iot.errors.buildingIdRequired', {
+        defaultValue: 'Building ID is required',
+      });
+    }
+    setErrors(next);
+    return Object.keys(next).length === 0;
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (validate()) {
+      onSubmit(formData);
+    }
+  };
+
+  const set = (key: keyof SensorFormData, value: string) =>
+    setFormData((prev: SensorFormData) => ({ ...prev, [key]: value }));
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      {/* Name */}
+      <div>
+        <label htmlFor="sf-name" className="block text-sm font-medium text-gray-700">
+          {t('iot.form.name', { defaultValue: 'Name' })} *
+        </label>
+        <input
+          type="text"
+          id="sf-name"
+          value={formData.name}
+          onChange={(e) => set('name', e.target.value)}
+          placeholder={t('iot.form.namePlaceholder', {
+            defaultValue: 'e.g. Living room temperature',
+          })}
+          className={`${fieldClass} ${errors.name ? 'border-red-300' : 'border-gray-300'}`}
+        />
+        {errors.name && <p className="mt-1 text-sm text-red-600">{errors.name}</p>}
+      </div>
+
+      {/* Sensor Type */}
+      <div>
+        <label htmlFor="sf-sensor-type" className="block text-sm font-medium text-gray-700">
+          {t('iot.form.sensorType', { defaultValue: 'Sensor Type' })} *
+        </label>
+        <select
+          id="sf-sensor-type"
+          value={formData.sensor_type}
+          onChange={(e) => set('sensor_type', e.target.value)}
+          className={`${fieldClass} ${errors.sensor_type ? 'border-red-300' : 'border-gray-300'}`}
+        >
+          <option value="">—</option>
+          {SENSOR_TYPES.map((type) => (
+            <option key={type} value={type}>
+              {t(`iot.sensorType.${type}`, { defaultValue: type })}
+            </option>
+          ))}
+        </select>
+        {errors.sensor_type && <p className="mt-1 text-sm text-red-600">{errors.sensor_type}</p>}
+      </div>
+
+      {/* Building ID */}
+      <div>
+        <label htmlFor="sf-building-id" className="block text-sm font-medium text-gray-700">
+          {t('iot.form.buildingId', { defaultValue: 'Building ID' })} *
+        </label>
+        <input
+          type="text"
+          id="sf-building-id"
+          value={formData.building_id}
+          onChange={(e) => set('building_id', e.target.value)}
+          placeholder={t('iot.form.buildingIdPlaceholder', { defaultValue: 'Enter building ID' })}
+          className={`${fieldClass} ${errors.building_id ? 'border-red-300' : 'border-gray-300'}`}
+        />
+        {errors.building_id && <p className="mt-1 text-sm text-red-600">{errors.building_id}</p>}
+      </div>
+
+      {/* Location */}
+      <div>
+        <label htmlFor="sf-location" className="block text-sm font-medium text-gray-700">
+          {t('iot.form.location', { defaultValue: 'Location' })}
+        </label>
+        <input
+          type="text"
+          id="sf-location"
+          value={formData.location}
+          onChange={(e) => set('location', e.target.value)}
+          placeholder={t('iot.form.locationPlaceholder', { defaultValue: 'e.g. Room 101' })}
+          className={`${fieldClass} border-gray-300`}
+        />
+      </div>
+
+      {/* Unit of Measurement + Connection Type */}
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label htmlFor="sf-unit" className="block text-sm font-medium text-gray-700">
+            {t('iot.form.unitOfMeasurement', { defaultValue: 'Unit of Measurement' })}
+          </label>
+          <input
+            type="text"
+            id="sf-unit"
+            value={formData.unit_of_measurement}
+            onChange={(e) => set('unit_of_measurement', e.target.value)}
+            placeholder={t('iot.form.unitPlaceholder', { defaultValue: 'e.g. °C, %, ppm' })}
+            className={`${fieldClass} border-gray-300`}
+          />
+        </div>
+        <div>
+          <label htmlFor="sf-connection" className="block text-sm font-medium text-gray-700">
+            {t('iot.form.connectionType', { defaultValue: 'Connection Type' })}
+          </label>
+          <select
+            id="sf-connection"
+            value={formData.connection_type}
+            onChange={(e) => set('connection_type', e.target.value)}
+            className={`${fieldClass} border-gray-300`}
+          >
+            <option value="">—</option>
+            {CONNECTION_TYPES.map((ct) => (
+              <option key={ct} value={ct}>
+                {t(`iot.connectionType.${ct}`, { defaultValue: ct })}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Manufacturer + Model */}
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label htmlFor="sf-manufacturer" className="block text-sm font-medium text-gray-700">
+            {t('iot.form.manufacturer', { defaultValue: 'Manufacturer' })}
+          </label>
+          <input
+            type="text"
+            id="sf-manufacturer"
+            value={formData.manufacturer}
+            onChange={(e) => set('manufacturer', e.target.value)}
+            placeholder={t('iot.form.manufacturerPlaceholder', { defaultValue: 'e.g. Bosch' })}
+            className={`${fieldClass} border-gray-300`}
+          />
+        </div>
+        <div>
+          <label htmlFor="sf-model" className="block text-sm font-medium text-gray-700">
+            {t('iot.form.model', { defaultValue: 'Model' })}
+          </label>
+          <input
+            type="text"
+            id="sf-model"
+            value={formData.model}
+            onChange={(e) => set('model', e.target.value)}
+            placeholder={t('iot.form.modelPlaceholder', { defaultValue: 'e.g. BME280' })}
+            className={`${fieldClass} border-gray-300`}
+          />
+        </div>
+      </div>
+
+      {/* Serial Number + Data Interval */}
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label htmlFor="sf-serial" className="block text-sm font-medium text-gray-700">
+            {t('iot.form.serialNumber', { defaultValue: 'Serial Number' })}
+          </label>
+          <input
+            type="text"
+            id="sf-serial"
+            value={formData.serial_number}
+            onChange={(e) => set('serial_number', e.target.value)}
+            placeholder={t('iot.form.serialNumberPlaceholder', {
+              defaultValue: 'e.g. SN-123456',
+            })}
+            className={`${fieldClass} border-gray-300`}
+          />
+        </div>
+        <div>
+          <label htmlFor="sf-interval" className="block text-sm font-medium text-gray-700">
+            {t('iot.form.dataIntervalSeconds', { defaultValue: 'Data Interval (seconds)' })}
+          </label>
+          <input
+            type="number"
+            id="sf-interval"
+            min="0"
+            value={formData.data_interval_seconds}
+            onChange={(e) => set('data_interval_seconds', e.target.value)}
+            placeholder={t('iot.form.dataIntervalPlaceholder', { defaultValue: 'e.g. 60' })}
+            className={`${fieldClass} border-gray-300`}
+          />
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center justify-end gap-3 pt-4 border-t">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isLoading}
+          className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50"
+        >
+          {t('common.cancel', { defaultValue: 'Cancel' })}
+        </button>
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2"
+        >
+          {isLoading && (
+            <span className="animate-spin rounded-full h-4 w-4 border-b-2 border-white" />
+          )}
+          {t('common.save', { defaultValue: 'Save' })}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/iot/components/index.ts
+++ b/frontend/apps/ppt-web/src/features/iot/components/index.ts
@@ -1,5 +1,6 @@
 export { AlertsPanel, type AlertsPanelProps } from './AlertsPanel';
 export { IotStatCard, type IotStatCardProps } from './IotStatCard';
+export { SensorForm, type SensorFormData } from './SensorForm';
 export { SensorListPanel, type SensorListPanelProps } from './SensorListPanel';
 export { SensorStatusBadge } from './SensorStatusBadge';
 export { TelemetryPanel, type TelemetryPanelProps } from './TelemetryPanel';

--- a/frontend/apps/ppt-web/src/features/iot/index.ts
+++ b/frontend/apps/ppt-web/src/features/iot/index.ts
@@ -4,4 +4,19 @@
  * Manager-web front door for the IoT sensor backend.
  */
 export * from './components';
-export { IotDashboardPage, type IotDashboardPageProps } from './pages';
+export {
+  IotDashboardPage,
+  type IotDashboardPageProps,
+  IotSensorEditPage,
+  type IotSensorEditPageProps,
+  IotSensorListPage,
+  type IotSensorListPageProps,
+  IotSensorRegisterPage,
+  type IotSensorRegisterPageProps,
+  SensorFormPage,
+  type SensorFormBuildingOption,
+  type SensorFormPageProps,
+  type SensorFormValues,
+  SensorListPage,
+  type SensorListPageProps,
+} from './pages';

--- a/frontend/apps/ppt-web/src/features/iot/pages/IotSensorEditPage.tsx
+++ b/frontend/apps/ppt-web/src/features/iot/pages/IotSensorEditPage.tsx
@@ -1,0 +1,78 @@
+/**
+ * IotSensorEditPage — edit-sensor form wrapper (Epic 14 — FR71).
+ * Presentational; route wrapper wires the useUpdateSensor mutation.
+ */
+import type { Sensor } from '@ppt/api-client';
+import type { JSX } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SensorForm, type SensorFormData } from '../components';
+
+export interface IotSensorEditPageProps {
+  sensor?: Sensor;
+  isLoading?: boolean;
+  onSubmit: (data: SensorFormData) => void;
+  onCancel: () => void;
+}
+
+export function IotSensorEditPage({
+  sensor,
+  isLoading,
+  onSubmit,
+  onCancel,
+}: IotSensorEditPageProps): JSX.Element {
+  const { t } = useTranslation();
+
+  const initialData: Partial<SensorFormData> | undefined = sensor
+    ? {
+        name: sensor.name,
+        sensor_type: sensor.sensor_type,
+        building_id: sensor.building_id,
+        location: sensor.location ?? '',
+        unit_of_measurement: sensor.unit_of_measurement ?? '',
+        connection_type: sensor.connection_type ?? '',
+        manufacturer: sensor.manufacturer ?? '',
+        model: sensor.model ?? '',
+        serial_number: sensor.serial_number ?? '',
+        data_interval_seconds: sensor.data_interval_seconds != null
+          ? String(sensor.data_interval_seconds)
+          : '',
+      }
+    : undefined;
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-8">
+      <button
+        type="button"
+        onClick={onCancel}
+        className="mb-4 text-blue-600 hover:text-blue-800 flex items-center gap-1"
+      >
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+        </svg>
+        {t('iot.backToSensors', { defaultValue: 'Back to Sensors' })}
+      </button>
+
+      <div className="bg-white rounded-lg shadow">
+        <div className="p-6 border-b">
+          <h1 className="text-2xl font-bold text-gray-900">
+            {t('iot.editSensor', { defaultValue: 'Edit Sensor' })}
+          </h1>
+        </div>
+        <div className="p-6">
+          {!sensor && isLoading ? (
+            <div className="flex items-center justify-center py-16">
+              <div className="h-6 w-6 animate-spin rounded-full border-b-2 border-blue-600" />
+            </div>
+          ) : (
+            <SensorForm
+              initialData={initialData}
+              isLoading={isLoading}
+              onSubmit={onSubmit}
+              onCancel={onCancel}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/iot/pages/IotSensorListPage.tsx
+++ b/frontend/apps/ppt-web/src/features/iot/pages/IotSensorListPage.tsx
@@ -1,0 +1,196 @@
+/**
+ * IotSensorListPage — device registry list with filter bar and CRUD actions.
+ * Epic 14 — FR71. Presentational only; route wrapper wires hooks.
+ */
+import type { Sensor } from '@ppt/api-client';
+import type { JSX } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SensorStatusBadge } from '../components';
+
+export interface IotSensorListPageProps {
+  sensors: Sensor[];
+  isLoading: boolean;
+  total: number;
+  page: number;
+  pageSize: number;
+  filterType: string;
+  filterStatus: string;
+  filterSearch: string;
+  onPageChange: (page: number) => void;
+  onFilterTypeChange: (type: string) => void;
+  onFilterStatusChange: (status: string) => void;
+  onFilterSearchChange: (search: string) => void;
+  onRegister: () => void;
+  onEdit: (id: string) => void;
+}
+
+const SENSOR_TYPES = [
+  'temperature',
+  'humidity',
+  'motion',
+  'co2',
+  'pressure',
+  'energy',
+  'water',
+  'smoke',
+  'door_window',
+  'other',
+];
+
+const SENSOR_STATUSES = ['active', 'offline', 'error', 'maintenance'];
+
+export function IotSensorListPage({
+  sensors,
+  isLoading,
+  total,
+  page,
+  pageSize,
+  filterType,
+  filterStatus,
+  filterSearch,
+  onPageChange,
+  onFilterTypeChange,
+  onFilterStatusChange,
+  onFilterSearchChange,
+  onRegister,
+  onEdit,
+}: IotSensorListPageProps): JSX.Element {
+  const { t } = useTranslation();
+  const totalPages = Math.ceil(total / pageSize) || 1;
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-6">
+      <header className="mb-6 flex flex-wrap items-start justify-between gap-3">
+        <h1 className="text-2xl font-semibold text-gray-900">
+          {t('iot.title', { defaultValue: 'IoT Sensors' })}
+        </h1>
+        <button
+          type="button"
+          onClick={onRegister}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          {t('iot.registerSensor', { defaultValue: 'Register Sensor' })}
+        </button>
+      </header>
+
+      {/* Filter bar */}
+      <div className="mb-4 flex flex-wrap gap-3">
+        <input
+          type="text"
+          value={filterSearch}
+          onChange={(e) => onFilterSearchChange(e.target.value)}
+          placeholder={t('iot.filter.searchPlaceholder', { defaultValue: 'Search sensors...' })}
+          className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        />
+        <select
+          value={filterType}
+          onChange={(e) => onFilterTypeChange(e.target.value)}
+          className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        >
+          <option value="">{t('iot.filter.allTypes', { defaultValue: 'All Types' })}</option>
+          {SENSOR_TYPES.map((type) => (
+            <option key={type} value={type}>
+              {t(`iot.sensorType.${type}`, { defaultValue: type })}
+            </option>
+          ))}
+        </select>
+        <select
+          value={filterStatus}
+          onChange={(e) => onFilterStatusChange(e.target.value)}
+          className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        >
+          <option value="">{t('iot.filter.allStatuses', { defaultValue: 'All Statuses' })}</option>
+          {SENSOR_STATUSES.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <section className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+        {isLoading ? (
+          <div className="flex items-center justify-center py-16">
+            <div className="h-6 w-6 animate-spin rounded-full border-b-2 border-blue-600" />
+          </div>
+        ) : sensors.length === 0 ? (
+          <div className="px-4 py-16 text-center">
+            <p className="text-sm text-gray-400">
+              {t('iot.noSensors', { defaultValue: 'No sensors found.' })}
+            </p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-100 text-sm">
+              <thead className="bg-gray-50 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <tr>
+                  <th className="px-4 py-3">{t('iot.columns.name', { defaultValue: 'Name' })}</th>
+                  <th className="px-4 py-3">{t('iot.columns.type', { defaultValue: 'Type' })}</th>
+                  <th className="px-4 py-3">
+                    {t('iot.columns.status', { defaultValue: 'Status' })}
+                  </th>
+                  <th className="px-4 py-3">
+                    {t('iot.columns.location', { defaultValue: 'Location' })}
+                  </th>
+                  <th className="px-4 py-3">
+                    {t('iot.columns.building', { defaultValue: 'Building' })}
+                  </th>
+                  <th className="px-4 py-3 text-right">
+                    {t('iot.columns.actions', { defaultValue: 'Actions' })}
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {sensors.map((sensor) => (
+                  <tr key={sensor.id} className="hover:bg-gray-50">
+                    <td className="px-4 py-3 font-medium text-gray-900">{sensor.name}</td>
+                    <td className="px-4 py-3 text-gray-600">{sensor.sensor_type}</td>
+                    <td className="px-4 py-3">
+                      <SensorStatusBadge value={sensor.status} />
+                    </td>
+                    <td className="px-4 py-3 text-gray-600">{sensor.location ?? '—'}</td>
+                    <td className="px-4 py-3 text-gray-600">{sensor.building_id}</td>
+                    <td className="px-4 py-3 text-right">
+                      <button
+                        type="button"
+                        onClick={() => onEdit(sensor.id)}
+                        className="rounded px-2 py-1 text-xs font-medium text-blue-600 hover:bg-blue-50"
+                      >
+                        {t('iot.actions.edit', { defaultValue: 'Edit' })}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="mt-4 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => onPageChange(page - 1)}
+            disabled={page <= 1}
+            className="rounded px-3 py-1 text-sm text-gray-700 border border-gray-300 disabled:opacity-40 hover:bg-gray-50"
+          >
+            &lt;
+          </button>
+          <span className="text-sm text-gray-600">
+            {page} / {totalPages}
+          </span>
+          <button
+            type="button"
+            onClick={() => onPageChange(page + 1)}
+            disabled={page >= totalPages}
+            className="rounded px-3 py-1 text-sm text-gray-700 border border-gray-300 disabled:opacity-40 hover:bg-gray-50"
+          >
+            &gt;
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/iot/pages/IotSensorRegisterPage.tsx
+++ b/frontend/apps/ppt-web/src/features/iot/pages/IotSensorRegisterPage.tsx
@@ -1,0 +1,47 @@
+/**
+ * IotSensorRegisterPage — create-sensor form wrapper (Epic 14 — FR71).
+ * Presentational; route wrapper wires the useCreateSensor mutation.
+ */
+import type { JSX } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SensorForm, type SensorFormData } from '../components';
+
+export interface IotSensorRegisterPageProps {
+  isLoading?: boolean;
+  onSubmit: (data: SensorFormData) => void;
+  onCancel: () => void;
+}
+
+export function IotSensorRegisterPage({
+  isLoading,
+  onSubmit,
+  onCancel,
+}: IotSensorRegisterPageProps): JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-8">
+      <button
+        type="button"
+        onClick={onCancel}
+        className="mb-4 text-blue-600 hover:text-blue-800 flex items-center gap-1"
+      >
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+        </svg>
+        {t('iot.backToSensors', { defaultValue: 'Back to Sensors' })}
+      </button>
+
+      <div className="bg-white rounded-lg shadow">
+        <div className="p-6 border-b">
+          <h1 className="text-2xl font-bold text-gray-900">
+            {t('iot.registerSensor', { defaultValue: 'Register Sensor' })}
+          </h1>
+        </div>
+        <div className="p-6">
+          <SensorForm isLoading={isLoading} onSubmit={onSubmit} onCancel={onCancel} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/iot/pages/index.ts
+++ b/frontend/apps/ppt-web/src/features/iot/pages/index.ts
@@ -1,1 +1,11 @@
 export { IotDashboardPage, type IotDashboardPageProps } from './IotDashboardPage';
+export { IotSensorEditPage, type IotSensorEditPageProps } from './IotSensorEditPage';
+export { IotSensorListPage, type IotSensorListPageProps } from './IotSensorListPage';
+export { IotSensorRegisterPage, type IotSensorRegisterPageProps } from './IotSensorRegisterPage';
+export {
+  SensorFormPage,
+  type SensorFormBuildingOption,
+  type SensorFormPageProps,
+  type SensorFormValues,
+} from './SensorFormPage';
+export { SensorListPage, type SensorListPageProps } from './SensorListPage';

--- a/frontend/apps/ppt-web/src/routes/groups/iot.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/iot.tsx
@@ -5,18 +5,28 @@
  * Wires `@ppt/api-client` IoT hooks to the presentational dashboard page,
  * mirroring the outages/faults route-group convention.
  */
+import type { UpdateSensorRequest } from '@ppt/api-client';
 import {
   useAcknowledgeSensorAlert,
+  useCreateSensor,
   useIotDashboard,
   useResolveSensorAlert,
+  useSensor,
   useSensorReadings,
   useSensors,
+  useUpdateSensor,
 } from '@ppt/api-client';
 import { useMemo, useState } from 'react';
-import { Route } from 'react-router-dom';
-import { AuthRequiredGate } from '../../components';
+import { Route, useNavigate, useParams } from 'react-router-dom';
+import { AuthRequiredGate, useToast } from '../../components';
 import { useAuth } from '../../contexts';
-import { IotDashboardPage } from '../lazyRoutes';
+import type { SensorFormData } from '../../features/iot';
+import {
+  IotDashboardPage,
+  IotSensorEditPage,
+  IotSensorListPage,
+  IotSensorRegisterPage,
+} from '../lazyRoutes';
 
 /**
  * Route wrapper for the IoT dashboard (Epic 14 / FR71-75).
@@ -71,11 +81,166 @@ function IotDashboardPageRoute() {
   );
 }
 
+/** Route wrapper for IoT sensor list using the new IotSensorListPage (BIT-147). */
+function IotSensorListPageRoute() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [page, setPage] = useState(1);
+  const [filterType, setFilterType] = useState('');
+  const [filterStatus, setFilterStatus] = useState('');
+  const [filterSearch, setFilterSearch] = useState('');
+  const pageSize = 20;
+
+  const params = {
+    sensor_type: filterType || undefined,
+    status: filterStatus || undefined,
+    search: filterSearch || undefined,
+    limit: pageSize,
+    offset: (page - 1) * pageSize,
+  };
+
+  const { data: sensorsData, isLoading } = useSensors(params);
+  const sensors = useMemo(() => sensorsData?.sensors ?? [], [sensorsData]);
+
+  if (!user?.organizationId) {
+    return <AuthRequiredGate />;
+  }
+
+  return (
+    <IotSensorListPage
+      sensors={sensors}
+      isLoading={isLoading}
+      total={sensors.length + (page - 1) * pageSize}
+      page={page}
+      pageSize={pageSize}
+      filterType={filterType}
+      filterStatus={filterStatus}
+      filterSearch={filterSearch}
+      onPageChange={setPage}
+      onFilterTypeChange={(t: string) => { setFilterType(t); setPage(1); }}
+      onFilterStatusChange={(s: string) => { setFilterStatus(s); setPage(1); }}
+      onFilterSearchChange={(s: string) => { setFilterSearch(s); setPage(1); }}
+      onRegister={() => navigate('/iot/sensors/new')}
+      onEdit={(id: string) => navigate(`/iot/sensors/${id}/edit`)}
+    />
+  );
+}
+
+/** Route wrapper for sensor register flow using the new IotSensorRegisterPage (BIT-147). */
+function IotSensorRegisterPageRoute() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const { showToast } = useToast();
+  const createSensor = useCreateSensor();
+
+  if (!user?.organizationId || !user.id) {
+    return <AuthRequiredGate />;
+  }
+
+  const handleSubmit = async (data: SensorFormData) => {
+    const payload = {
+      organization_id: user.organizationId!,
+      building_id: data.building_id,
+      name: data.name.trim(),
+      sensor_type: data.sensor_type,
+      location: data.location.trim() || null,
+      connection_type: data.connection_type || null,
+      unit_of_measurement: data.unit_of_measurement.trim() || null,
+      data_interval_seconds: data.data_interval_seconds
+        ? (parseInt(data.data_interval_seconds, 10) || null)
+        : null,
+      manufacturer: data.manufacturer.trim() || null,
+      model: data.model.trim() || null,
+      serial_number: data.serial_number.trim() || null,
+      created_by: user.id!,
+    };
+    try {
+      await createSensor.mutateAsync(payload);
+      showToast({
+        type: 'success',
+        title: 'Sensor registered',
+        message: 'The sensor has been registered successfully.',
+      });
+      navigate('/iot/sensors');
+    } catch (error) {
+      showToast({
+        type: 'error',
+        title: 'Failed to register sensor',
+        message: error instanceof Error ? error.message : 'Unexpected error',
+      });
+    }
+  };
+
+  return (
+    <IotSensorRegisterPage
+      isLoading={createSensor.isPending}
+      onSubmit={handleSubmit}
+      onCancel={() => navigate('/iot/sensors')}
+    />
+  );
+}
+
+/** Route wrapper for sensor edit flow using the new IotSensorEditPage (BIT-147). */
+function IotSensorEditPageRoute() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const { showToast } = useToast();
+  const { sensorId } = useParams<{ sensorId: string }>();
+  const { data: sensor, isLoading: sensorLoading } = useSensor(sensorId ?? '');
+  const updateSensor = useUpdateSensor();
+
+  if (!user?.organizationId) {
+    return <AuthRequiredGate />;
+  }
+
+  const handleSubmit = async (data: SensorFormData) => {
+    if (!sensorId) return;
+    const payload: UpdateSensorRequest = {
+      name: data.name.trim(),
+      location: data.location.trim() || null,
+      connection_type: data.connection_type || null,
+      unit_of_measurement: data.unit_of_measurement.trim() || null,
+      data_interval_seconds: data.data_interval_seconds
+        ? (parseInt(data.data_interval_seconds, 10) || null)
+        : null,
+      manufacturer: data.manufacturer.trim() || null,
+      model: data.model.trim() || null,
+    };
+    try {
+      await updateSensor.mutateAsync({ id: sensorId, data: payload });
+      showToast({
+        type: 'success',
+        title: 'Sensor updated',
+        message: 'The sensor has been updated successfully.',
+      });
+      navigate('/iot/sensors');
+    } catch (error) {
+      showToast({
+        type: 'error',
+        title: 'Failed to update sensor',
+        message: error instanceof Error ? error.message : 'Unexpected error',
+      });
+    }
+  };
+
+  return (
+    <IotSensorEditPage
+      sensor={sensor}
+      isLoading={sensorLoading || updateSensor.isPending}
+      onSubmit={handleSubmit}
+      onCancel={() => navigate('/iot/sensors')}
+    />
+  );
+}
+
 /** IoT / Smart-Building routes (Epic 14 / FR71-75). */
 export function iotRoutes() {
   return (
     <>
       <Route path="/iot" element={<IotDashboardPageRoute />} />
+      <Route path="/iot/sensors" element={<IotSensorListPageRoute />} />
+      <Route path="/iot/sensors/new" element={<IotSensorRegisterPageRoute />} />
+      <Route path="/iot/sensors/:sensorId/edit" element={<IotSensorEditPageRoute />} />
     </>
   );
 }

--- a/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
+++ b/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
@@ -50,6 +50,18 @@ export const VoteDetailPage = lazy(() =>
 export const IotDashboardPage = lazy(() =>
   import('../features/iot').then((m) => ({ default: m.IotDashboardPage }))
 );
+export const IotSensorListPage = lazy(() =>
+  import('../features/iot').then((m) => ({ default: m.IotSensorListPage }))
+);
+export const IotSensorFormPage = lazy(() =>
+  import('../features/iot').then((m) => ({ default: m.SensorFormPage }))
+);
+export const IotSensorRegisterPage = lazy(() =>
+  import('../features/iot').then((m) => ({ default: m.IotSensorRegisterPage }))
+);
+export const IotSensorEditPage = lazy(() =>
+  import('../features/iot').then((m) => ({ default: m.IotSensorEditPage }))
+);
 
 // Disputes feature (Epic 77)
 export const DisputesPage = lazy(() =>

--- a/frontend/packages/api-client/src/iot/api.ts
+++ b/frontend/packages/api-client/src/iot/api.ts
@@ -8,6 +8,7 @@
 
 import { getToken } from '../auth';
 import type {
+  CreateSensorRequest,
   ListAlertsParams,
   ListAlertsResponse,
   ListReadingsParams,
@@ -17,6 +18,7 @@ import type {
   Sensor,
   SensorAlert,
   SensorDashboard,
+  UpdateSensorRequest,
 } from './types';
 
 const _win = typeof window !== 'undefined' ? (window as unknown as Record<string, unknown>) : {};
@@ -81,6 +83,27 @@ export async function listSensors(
 /** Get a single sensor by id (FR71). */
 export async function getSensor(id: string, signal?: AbortSignal): Promise<Sensor> {
   return apiRequest<Sensor>(`${API_BASE}/${id}`, { signal });
+}
+
+/** Register a new sensor / device (FR71). */
+export async function createSensor(req: CreateSensorRequest): Promise<Sensor> {
+  return apiRequest<Sensor>(`${API_BASE}`, {
+    method: 'POST',
+    body: JSON.stringify(req),
+  });
+}
+
+/** Update an existing sensor (FR71). */
+export async function updateSensor(id: string, req: UpdateSensorRequest): Promise<Sensor> {
+  return apiRequest<Sensor>(`${API_BASE}/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(req),
+  });
+}
+
+/** Delete (decommission) a sensor (FR71). */
+export async function deleteSensor(id: string): Promise<void> {
+  return apiRequest<void>(`${API_BASE}/${id}`, { method: 'DELETE' });
 }
 
 /** List telemetry readings for a sensor (FR72). */

--- a/frontend/packages/api-client/src/iot/hooks.ts
+++ b/frontend/packages/api-client/src/iot/hooks.ts
@@ -8,14 +8,23 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   acknowledgeSensorAlert,
+  createSensor,
+  deleteSensor,
   getIotDashboard,
   getSensor,
   listSensorAlerts,
   listSensorReadings,
   listSensors,
   resolveSensorAlert,
+  updateSensor,
 } from './api';
-import type { ListAlertsParams, ListReadingsParams, ListSensorsParams } from './types';
+import type {
+  CreateSensorRequest,
+  ListAlertsParams,
+  ListReadingsParams,
+  ListSensorsParams,
+  UpdateSensorRequest,
+} from './types';
 
 // ============================================
 // Query Key Factory
@@ -106,6 +115,41 @@ export function useResolveSensorAlert() {
   return useMutation({
     mutationFn: ({ alertId, resolvedValue }: { alertId: string; resolvedValue?: number | null }) =>
       resolveSensorAlert(alertId, resolvedValue),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: iotKeys.all });
+    },
+  });
+}
+
+/** Register a new sensor (FR71). Refreshes sensor lists + dashboard on success. */
+export function useCreateSensor() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (req: CreateSensorRequest) => createSensor(req),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: iotKeys.all });
+    },
+  });
+}
+
+/** Update a sensor (FR71). Refreshes the affected sensor + lists on success. */
+export function useUpdateSensor() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateSensorRequest }) => updateSensor(id, data),
+    onSuccess: (_result, { id }) => {
+      queryClient.invalidateQueries({ queryKey: iotKeys.sensor(id) });
+      queryClient.invalidateQueries({ queryKey: iotKeys.sensors() });
+      queryClient.invalidateQueries({ queryKey: iotKeys.dashboard() });
+    },
+  });
+}
+
+/** Delete a sensor (FR71). Refreshes sensor lists + dashboard on success. */
+export function useDeleteSensor() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => deleteSensor(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: iotKeys.all });
     },

--- a/frontend/packages/api-client/src/iot/index.ts
+++ b/frontend/packages/api-client/src/iot/index.ts
@@ -6,25 +6,32 @@
 
 export {
   acknowledgeSensorAlert,
+  createSensor,
+  deleteSensor,
   getIotDashboard,
   getSensor,
   listSensorAlerts,
   listSensorReadings,
   listSensors,
   resolveSensorAlert,
+  updateSensor,
 } from './api';
 export {
   iotKeys,
   useAcknowledgeSensorAlert,
+  useCreateSensor,
+  useDeleteSensor,
   useIotDashboard,
   useResolveSensorAlert,
   useSensor,
   useSensorAlerts,
   useSensorReadings,
   useSensors,
+  useUpdateSensor,
 } from './hooks';
 export type {
   AggregatedReading,
+  CreateSensorRequest,
   ListAlertsParams,
   ListAlertsResponse,
   ListReadingsParams,
@@ -37,4 +44,5 @@ export type {
   SensorDashboard,
   SensorReading,
   SensorTypeCount,
+  UpdateSensorRequest,
 } from './types';

--- a/frontend/packages/api-client/src/iot/types.ts
+++ b/frontend/packages/api-client/src/iot/types.ts
@@ -131,3 +131,45 @@ export interface ListAlertsResponse {
 export interface ResolveSensorAlertRequest {
   resolved_value?: number | null;
 }
+
+/**
+ * Register-sensor request (FR71). Mirrors `CreateSensor` in the api-server.
+ * `organization_id` is pinned to the caller's tenant server-side, but the
+ * field is still required on the wire — send the authenticated org id.
+ */
+export interface CreateSensorRequest {
+  organization_id: string;
+  building_id: string;
+  unit_id?: string | null;
+  name: string;
+  sensor_type: string;
+  location?: string | null;
+  location_description?: string | null;
+  connection_type?: string | null;
+  connection_config?: unknown;
+  unit_of_measurement?: string | null;
+  data_interval_seconds?: number | null;
+  manufacturer?: string | null;
+  model?: string | null;
+  firmware_version?: string | null;
+  serial_number?: string | null;
+  installed_at?: string | null;
+  metadata?: unknown;
+  created_by: string;
+}
+
+/** Edit-sensor request (FR71). Mirrors `UpdateSensor`; all fields optional. */
+export interface UpdateSensorRequest {
+  name?: string | null;
+  location?: string | null;
+  location_description?: string | null;
+  connection_type?: string | null;
+  connection_config?: unknown;
+  unit_of_measurement?: string | null;
+  data_interval_seconds?: number | null;
+  status?: string | null;
+  manufacturer?: string | null;
+  model?: string | null;
+  firmware_version?: string | null;
+  metadata?: unknown;
+}


### PR DESCRIPTION
## Summary

- **api-client**: `CreateSensorRequest`, `UpdateSensorRequest` types; `createSensor`/`updateSensor`/`deleteSensor` API fns; `useCreateSensor`/`useUpdateSensor`/`useDeleteSensor` mutations with `iotKeys.all` cache invalidation
- **SensorForm.tsx**: shared create/edit form (name/sensor_type/building_id required; location/unit/connection/manufacturer/model/serial/interval optional) — mirrors `OutageForm.tsx` pattern with manual useState validation
- **3 new pages**: `IotSensorListPage` (table + filter bar + pagination), `IotSensorRegisterPage`, `IotSensorEditPage` — all presentational, wired by route wrappers
- **routes/groups/iot.tsx**: list/register/edit route wrappers with hooks, toast, navigate; `/iot/sensors`, `/iot/sensors/new`, `/iot/sensors/:sensorId/edit`
- **lazyRoutes.tsx**: lazy imports for 3 new pages
- **App.tsx**: Smart Building nav link; command-palette: iot + sensors nav entries
- **i18n**: `iot.*` keys added to all 6 locale files (en/sk/cs/de/pl/hu)

## Test plan

- [ ] `/iot/sensors` lists sensors with type/status/search filter and Register button
- [ ] `/iot/sensors/new` submits POST to `/api/v1/iot/sensors` with correct payload
- [ ] `/iot/sensors/:id/edit` pre-populates form from sensor data, submits PUT
- [ ] Typecheck: no new errors beyond pre-existing env issues

Closes BIT-147 scope 1/3