### PR TITLE
i18n(ppt-web): IoT sensor strings across 6 locales (fast-follow to #1646)

### DIFF
--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -39,7 +39,10 @@
     "copied": "Zkopírováno",
     "copyErrorMessage": "Kopírovat chybovou zprávu",
     "dismissNotification": "Zavřít oznámení",
-    "notifications": "Oznámení"
+    "notifications": "Oznámení",
+    "actions": "Actions",
+    "deleting": "Deleting...",
+    "saveChanges": "Save changes"
   },
   "nav": {
     "home": "Domů",
@@ -1153,5 +1156,36 @@
     "title": "Konkurenční funkce",
     "percentComplete": "Dokončeno {{percent}} %",
     "viewAnalysis": "Zobrazit analýzu"
+  },
+  "iot": {
+    "sensorsTitle": "Sensors & Devices",
+    "sensorsSubtitle": "Register and manage the IoT devices across your buildings.",
+    "openDashboard": "Dashboard",
+    "registerSensor": "Register sensor",
+    "noDevices": "No devices registered yet.",
+    "colName": "Name",
+    "colType": "Type",
+    "colLocation": "Location",
+    "colStatus": "Status",
+    "colLastReading": "Last reading",
+    "registerSensorTitle": "Register sensor",
+    "registerSensorSubtitle": "Add a new IoT device to a building.",
+    "editSensorTitle": "Edit sensor",
+    "editSensorSubtitle": "Update device configuration.",
+    "fieldBuilding": "Building",
+    "selectBuilding": "Select a building",
+    "buildingImmutable": "Building cannot be changed after registration.",
+    "fieldName": "Name",
+    "fieldType": "Sensor type",
+    "fieldStatus": "Status",
+    "fieldLocation": "Location",
+    "fieldLocationDescription": "Location description",
+    "fieldConnectionType": "Connection type",
+    "fieldUnit": "Unit of measurement",
+    "fieldInterval": "Reporting interval (s)",
+    "fieldManufacturer": "Manufacturer",
+    "fieldModel": "Model",
+    "fieldFirmware": "Firmware version",
+    "fieldSerial": "Serial number"
   }
 }

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -39,7 +39,10 @@
     "copied": "Kopiert",
     "copyErrorMessage": "Fehlermeldung kopieren",
     "dismissNotification": "Benachrichtigung schließen",
-    "notifications": "Benachrichtigungen"
+    "notifications": "Benachrichtigungen",
+    "actions": "Actions",
+    "deleting": "Deleting...",
+    "saveChanges": "Save changes"
   },
   "nav": {
     "home": "Startseite",
@@ -1148,5 +1151,36 @@
     "title": "Wettbewerbsfunktionen",
     "percentComplete": "{{percent}} % abgeschlossen",
     "viewAnalysis": "Analyse anzeigen"
+  },
+  "iot": {
+    "sensorsTitle": "Sensors & Devices",
+    "sensorsSubtitle": "Register and manage the IoT devices across your buildings.",
+    "openDashboard": "Dashboard",
+    "registerSensor": "Register sensor",
+    "noDevices": "No devices registered yet.",
+    "colName": "Name",
+    "colType": "Type",
+    "colLocation": "Location",
+    "colStatus": "Status",
+    "colLastReading": "Last reading",
+    "registerSensorTitle": "Register sensor",
+    "registerSensorSubtitle": "Add a new IoT device to a building.",
+    "editSensorTitle": "Edit sensor",
+    "editSensorSubtitle": "Update device configuration.",
+    "fieldBuilding": "Building",
+    "selectBuilding": "Select a building",
+    "buildingImmutable": "Building cannot be changed after registration.",
+    "fieldName": "Name",
+    "fieldType": "Sensor type",
+    "fieldStatus": "Status",
+    "fieldLocation": "Location",
+    "fieldLocationDescription": "Location description",
+    "fieldConnectionType": "Connection type",
+    "fieldUnit": "Unit of measurement",
+    "fieldInterval": "Reporting interval (s)",
+    "fieldManufacturer": "Manufacturer",
+    "fieldModel": "Model",
+    "fieldFirmware": "Firmware version",
+    "fieldSerial": "Serial number"
   }
 }

--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -53,7 +53,10 @@
     "unknown": "Unknown",
     "expand": "Expand",
     "collapse": "Collapse",
-    "unknownError": "An error occurred. Please try again."
+    "unknownError": "An error occurred. Please try again.",
+    "actions": "Actions",
+    "deleting": "Deleting...",
+    "saveChanges": "Save changes"
   },
   "nav": {
     "home": "Home",
@@ -3438,5 +3441,36 @@
     "title": "Competitive Features",
     "percentComplete": "{{percent}}% Complete",
     "viewAnalysis": "View Analysis"
+  },
+  "iot": {
+    "sensorsTitle": "Sensors & Devices",
+    "sensorsSubtitle": "Register and manage the IoT devices across your buildings.",
+    "openDashboard": "Dashboard",
+    "registerSensor": "Register sensor",
+    "noDevices": "No devices registered yet.",
+    "colName": "Name",
+    "colType": "Type",
+    "colLocation": "Location",
+    "colStatus": "Status",
+    "colLastReading": "Last reading",
+    "registerSensorTitle": "Register sensor",
+    "registerSensorSubtitle": "Add a new IoT device to a building.",
+    "editSensorTitle": "Edit sensor",
+    "editSensorSubtitle": "Update device configuration.",
+    "fieldBuilding": "Building",
+    "selectBuilding": "Select a building",
+    "buildingImmutable": "Building cannot be changed after registration.",
+    "fieldName": "Name",
+    "fieldType": "Sensor type",
+    "fieldStatus": "Status",
+    "fieldLocation": "Location",
+    "fieldLocationDescription": "Location description",
+    "fieldConnectionType": "Connection type",
+    "fieldUnit": "Unit of measurement",
+    "fieldInterval": "Reporting interval (s)",
+    "fieldManufacturer": "Manufacturer",
+    "fieldModel": "Model",
+    "fieldFirmware": "Firmware version",
+    "fieldSerial": "Serial number"
   }
 }

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -39,7 +39,10 @@
     "copied": "Másolva",
     "copyErrorMessage": "Hibaüzenet másolása",
     "dismissNotification": "Értesítés bezárása",
-    "notifications": "Értesítések"
+    "notifications": "Értesítések",
+    "actions": "Actions",
+    "deleting": "Deleting...",
+    "saveChanges": "Save changes"
   },
   "nav": {
     "home": "Főoldal",
@@ -1121,5 +1124,36 @@
     "title": "Versenyképességi funkciók",
     "percentComplete": "{{percent}}% kész",
     "viewAnalysis": "Elemzés megtekintése"
+  },
+  "iot": {
+    "sensorsTitle": "Sensors & Devices",
+    "sensorsSubtitle": "Register and manage the IoT devices across your buildings.",
+    "openDashboard": "Dashboard",
+    "registerSensor": "Register sensor",
+    "noDevices": "No devices registered yet.",
+    "colName": "Name",
+    "colType": "Type",
+    "colLocation": "Location",
+    "colStatus": "Status",
+    "colLastReading": "Last reading",
+    "registerSensorTitle": "Register sensor",
+    "registerSensorSubtitle": "Add a new IoT device to a building.",
+    "editSensorTitle": "Edit sensor",
+    "editSensorSubtitle": "Update device configuration.",
+    "fieldBuilding": "Building",
+    "selectBuilding": "Select a building",
+    "buildingImmutable": "Building cannot be changed after registration.",
+    "fieldName": "Name",
+    "fieldType": "Sensor type",
+    "fieldStatus": "Status",
+    "fieldLocation": "Location",
+    "fieldLocationDescription": "Location description",
+    "fieldConnectionType": "Connection type",
+    "fieldUnit": "Unit of measurement",
+    "fieldInterval": "Reporting interval (s)",
+    "fieldManufacturer": "Manufacturer",
+    "fieldModel": "Model",
+    "fieldFirmware": "Firmware version",
+    "fieldSerial": "Serial number"
   }
 }

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -39,7 +39,10 @@
     "copied": "Skopiowano",
     "copyErrorMessage": "Kopiuj komunikat błędu",
     "dismissNotification": "Zamknij powiadomienie",
-    "notifications": "Powiadomienia"
+    "notifications": "Powiadomienia",
+    "actions": "Actions",
+    "deleting": "Deleting...",
+    "saveChanges": "Save changes"
   },
   "nav": {
     "home": "Strona główna",
@@ -1127,5 +1130,36 @@
     "title": "Funkcje konkurencyjne",
     "percentComplete": "Ukończono {{percent}}%",
     "viewAnalysis": "Wyświetl analizę"
+  },
+  "iot": {
+    "sensorsTitle": "Sensors & Devices",
+    "sensorsSubtitle": "Register and manage the IoT devices across your buildings.",
+    "openDashboard": "Dashboard",
+    "registerSensor": "Register sensor",
+    "noDevices": "No devices registered yet.",
+    "colName": "Name",
+    "colType": "Type",
+    "colLocation": "Location",
+    "colStatus": "Status",
+    "colLastReading": "Last reading",
+    "registerSensorTitle": "Register sensor",
+    "registerSensorSubtitle": "Add a new IoT device to a building.",
+    "editSensorTitle": "Edit sensor",
+    "editSensorSubtitle": "Update device configuration.",
+    "fieldBuilding": "Building",
+    "selectBuilding": "Select a building",
+    "buildingImmutable": "Building cannot be changed after registration.",
+    "fieldName": "Name",
+    "fieldType": "Sensor type",
+    "fieldStatus": "Status",
+    "fieldLocation": "Location",
+    "fieldLocationDescription": "Location description",
+    "fieldConnectionType": "Connection type",
+    "fieldUnit": "Unit of measurement",
+    "fieldInterval": "Reporting interval (s)",
+    "fieldManufacturer": "Manufacturer",
+    "fieldModel": "Model",
+    "fieldFirmware": "Firmware version",
+    "fieldSerial": "Serial number"
   }
 }

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -40,7 +40,10 @@
     "copyErrorMessage": "Kopírovať chybovú správu",
     "dismissNotification": "Zavrieť oznámenie",
     "notifications": "Oznámenia",
-    "unknownError": "Nastala chyba. Prosím skúste znova."
+    "unknownError": "Nastala chyba. Prosím skúste znova.",
+    "actions": "Actions",
+    "deleting": "Deleting...",
+    "saveChanges": "Save changes"
   },
   "nav": {
     "home": "Domov",
@@ -1154,5 +1157,36 @@
     "title": "Konkurenčné funkcie",
     "percentComplete": "Dokončené {{percent}} %",
     "viewAnalysis": "Zobraziť analýzu"
+  },
+  "iot": {
+    "sensorsTitle": "Sensors & Devices",
+    "sensorsSubtitle": "Register and manage the IoT devices across your buildings.",
+    "openDashboard": "Dashboard",
+    "registerSensor": "Register sensor",
+    "noDevices": "No devices registered yet.",
+    "colName": "Name",
+    "colType": "Type",
+    "colLocation": "Location",
+    "colStatus": "Status",
+    "colLastReading": "Last reading",
+    "registerSensorTitle": "Register sensor",
+    "registerSensorSubtitle": "Add a new IoT device to a building.",
+    "editSensorTitle": "Edit sensor",
+    "editSensorSubtitle": "Update device configuration.",
+    "fieldBuilding": "Building",
+    "selectBuilding": "Select a building",
+    "buildingImmutable": "Building cannot be changed after registration.",
+    "fieldName": "Name",
+    "fieldType": "Sensor type",
+    "fieldStatus": "Status",
+    "fieldLocation": "Location",
+    "fieldLocationDescription": "Location description",
+    "fieldConnectionType": "Connection type",
+    "fieldUnit": "Unit of measurement",
+    "fieldInterval": "Reporting interval (s)",
+    "fieldManufacturer": "Manufacturer",
+    "fieldModel": "Model",
+    "fieldFirmware": "Firmware version",
+    "fieldSerial": "Serial number"
   }
 }


### PR DESCRIPTION
## What

Registers the `iot.*` translation keys used by the ppt-web IoT sensor pages (`SensorListPage`, `SensorFormPage`) in **all six** locale files — `cs`, `de`, `en`, `hu`, `pl`, `sk` — plus the three shared `common.*` keys those pages reference (`actions`, `deleting`, `saveChanges`).

## Why

Per the **BIT-153** (CEO) cross-team conflict-resolution decision, the duplicate PR #1647 was retired in favor of the canonical #1646. #1647's one unique contribution was 6-locale i18n for the sensor surface. This PR preserves that contribution, re-expressed against #1646's key scheme (flat `iot.*` keys consumed via `react-i18next` with `defaultValue` fallbacks) rather than #1647's divergent nested scheme.

## Behavior

The IoT pages already render via `t('iot.x', { defaultValue: '…' })`, so they worked without these keys. This change makes the locale files the source of truth and the strings extractable for translation. English values match the existing `defaultValue`s, so rendered output is unchanged. Non-English values are English placeholders pending translation (same baseline #1647 shipped).

## Verification

- `biome check apps/ppt-web/messages/` → clean (6 files, no fixes)
- JSON-only, additive change; no code paths touched.

Refs BIT-147, BIT-153. Fast-follow to #1646.