### PR TITLE
feat(ppt-web): invoice "PDF" download button (#975.6)

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -146,3 +146,5 @@ codegen-units = 1
 # traces still carry function names; only line-level debug info is omitted.
 [profile.test]
 debug = false
+
+# ci-trigger

--- a/frontend/apps/ppt-web/src/features/financial/components/InvoiceList.tsx
+++ b/frontend/apps/ppt-web/src/features/financial/components/InvoiceList.tsx
@@ -16,6 +16,7 @@ interface InvoiceListProps {
   onPageChange: (page: number) => void;
   onViewInvoice: (invoiceId: string) => void;
   onSendInvoice?: (invoiceId: string) => void;
+  onDownloadPdf?: (invoiceId: string) => void;
   onStatusFilter?: (status?: InvoiceStatus) => void;
   onSearch?: (query: string) => void;
 }
@@ -29,6 +30,7 @@ export function InvoiceList({
   onPageChange,
   onViewInvoice,
   onSendInvoice,
+  onDownloadPdf,
   onStatusFilter,
   onSearch,
 }: InvoiceListProps) {
@@ -201,6 +203,18 @@ export function InvoiceList({
                           className="text-blue-600 hover:text-blue-800"
                         >
                           Send
+                        </button>
+                      )}
+                      {onDownloadPdf && (
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onDownloadPdf(invoice.id);
+                          }}
+                          className="text-gray-600 hover:text-gray-800"
+                        >
+                          PDF
                         </button>
                       )}
                       <button

--- a/frontend/apps/ppt-web/src/features/financial/pages/InvoiceManagementPage.tsx
+++ b/frontend/apps/ppt-web/src/features/financial/pages/InvoiceManagementPage.tsx
@@ -22,6 +22,7 @@ export interface InvoiceManagementPageProps {
   onNavigateToCreate: () => void;
   onNavigateToDetail: (invoiceId: string) => void;
   onSendInvoice: (invoiceId: string) => void;
+  onDownloadPdf?: (invoiceId: string) => void;
   onFilterChange: (params: {
     page: number;
     pageSize: number;
@@ -39,6 +40,7 @@ export function InvoiceManagementPage({
   onNavigateToCreate,
   onNavigateToDetail,
   onSendInvoice,
+  onDownloadPdf,
   onFilterChange,
 }: InvoiceManagementPageProps) {
   const { t } = useTranslation();
@@ -135,6 +137,7 @@ export function InvoiceManagementPage({
           onPageChange={handlePageChange}
           onViewInvoice={onNavigateToDetail}
           onSendInvoice={onSendInvoice}
+          onDownloadPdf={onDownloadPdf}
           onStatusFilter={handleStatusFilter}
           onSearch={handleSearch}
         />

--- a/frontend/apps/ppt-web/src/routes/groups/financial.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/financial.tsx
@@ -8,6 +8,7 @@ import type { InvoiceStatus } from '@ppt/api-client';
 import {
   allocatePayment,
   autoMatchPayments,
+  downloadInvoicePdf,
   getARAgingReport,
   getOverdueInvoices,
   listInvoices,
@@ -162,6 +163,28 @@ function InvoiceManagementPageRoute() {
     },
   });
 
+  const handleDownloadPdf = (id: string) => {
+    const number = data?.invoices.find((inv) => inv.id === id)?.invoice_number ?? id;
+    downloadInvoicePdf(id)
+      .then((blob) => {
+        const url = URL.createObjectURL(blob);
+        const anchor = document.createElement('a');
+        anchor.href = url;
+        anchor.download = `invoice-${number}.pdf`;
+        document.body.appendChild(anchor);
+        anchor.click();
+        document.body.removeChild(anchor);
+        URL.revokeObjectURL(url);
+      })
+      .catch((err) => {
+        showToast({
+          type: 'error',
+          title: t('financial.invoices.pdfFailed', { defaultValue: 'Failed to download PDF' }),
+          message: err instanceof Error ? err.message : '',
+        });
+      });
+  };
+
   return (
     <InvoiceManagementPage
       invoices={data?.invoices ?? []}
@@ -171,6 +194,7 @@ function InvoiceManagementPageRoute() {
       onNavigateToCreate={() => navigate('/financial/invoices/new')}
       onNavigateToDetail={(id: string) => navigate(`/financial/invoices/${id}`)}
       onSendInvoice={(id: string) => sendInvoiceMutation.mutate(id)}
+      onDownloadPdf={handleDownloadPdf}
       onFilterChange={(params) => {
         setStatusFilter(params.status);
         setPage(params.page);

--- a/frontend/packages/api-client/src/financial/api.test.ts
+++ b/frontend/packages/api-client/src/financial/api.test.ts
@@ -19,7 +19,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock('../auth', () => ({ getToken: mocks.getToken, getOrg: mocks.getOrg }));
 vi.mock('../generated/client.gen', () => ({ client: { getConfig: mocks.getConfig } }));
 
-import { getOverdueInvoices, listAccounts } from './api';
+import { downloadInvoicePdf, getOverdueInvoices, listAccounts } from './api';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -99,6 +99,36 @@ describe('financial decimal coercion', () => {
     const invoices = await getOverdueInvoices('o');
     const outstanding = invoices.reduce((sum, inv) => sum + inv.balance_due, 0);
     expect(outstanding).toBe(100); // 60 + 40, not "060.0040.00"
+
+    vi.unstubAllGlobals();
+  });
+});
+
+describe('downloadInvoicePdf', () => {
+  it('fetches the invoice PDF endpoint with auth and returns the blob', async () => {
+    mocks.getToken.mockReturnValue('tok');
+    mocks.getOrg.mockReturnValue('org-1');
+    const blob = new Blob(['%PDF-1.7'], { type: 'application/pdf' });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, blob: async () => blob });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await downloadInvoicePdf('inv-9');
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe('https://api.example.test/api/v1/financial/invoices/inv-9/pdf');
+    expect(init.headers.Authorization).toBe('Bearer tok');
+    expect(init.headers['X-Tenant-ID']).toBe('org-1');
+    expect(result).toBe(blob);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('throws when the PDF response is not ok', async () => {
+    mocks.getToken.mockReturnValue('tok');
+    mocks.getOrg.mockReturnValue('org-1');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+
+    await expect(downloadInvoicePdf('missing')).rejects.toThrow('HTTP 404');
 
     vi.unstubAllGlobals();
   });

--- a/frontend/packages/api-client/src/financial/api.ts
+++ b/frontend/packages/api-client/src/financial/api.ts
@@ -308,6 +308,26 @@ export async function sendInvoice(id: string): Promise<Invoice> {
   );
 }
 
+/**
+ * Fetch an invoice rendered as a PDF (#975.6). Returns the raw `Blob` so the
+ * caller can trigger a browser download — `fetchApi` can't be used because it
+ * parses JSON. Auth + base URL come from the same providers as every other call.
+ */
+export async function downloadInvoicePdf(invoiceId: string): Promise<Blob> {
+  const token = getToken();
+  const org = getOrg();
+  const baseUrl = client.getConfig().baseUrl ?? '';
+  const headers: Record<string, string> = {};
+  if (token) headers.Authorization = `Bearer ${token}`;
+  if (org) headers['X-Tenant-ID'] = org;
+
+  const response = await fetch(`${baseUrl}${API_BASE}/invoices/${invoiceId}/pdf`, { headers });
+  if (!response.ok) {
+    throw new Error(`Failed to download invoice PDF (HTTP ${response.status})`);
+  }
+  return response.blob();
+}
+
 export async function listUnitInvoices(
   unitId: string,
   params?: Omit<ListInvoicesParams, 'organization_id' | 'unit_id'>


### PR DESCRIPTION
Makes the invoice PDF endpoint (#1648) user-reachable. The endpoint is auth-gated, so a plain link won't carry the headers — fetch the PDF as an auth'd blob and trigger a browser download.

- **api-client:** `downloadInvoicePdf(invoiceId) -> Blob` (auth'd binary fetch; `fetchApi` parses JSON so can't be reused).
- **ppt-web:** a "PDF" action per invoice row (`InvoiceList` → `InvoiceManagementPage` → route wrapper) that saves `invoice-<number>.pdf` (toast on failure).

Tests: `downloadInvoicePdf` (auth'd fetch → blob; non-ok → throws). Verified on the remote builder: api-client + ppt-web typecheck clean, financial vitest **6/6**, biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)