### PR TITLE
ci: emit required check/test contexts on pure-frontend PRs (BIT-157)

### DIFF
--- a/.github/workflows/backend-skip.yml
+++ b/.github/workflows/backend-skip.yml
@@ -1,0 +1,71 @@
+# Pure-frontend required-check gate (BIT-157).
+#
+# WHY this exists:
+#   `dev` branch protection makes the `check` and `test` contexts REQUIRED on
+#   every PR (confirmed via
+#   `gh api repos/martin-janci/property-management/branches/dev/protection`
+#   -> required_status_checks.checks = [check, test]). Both contexts are
+#   produced only by `backend.yml`, which is path-filtered to `backend/**` (and
+#   its own workflow file). On a PURE-FRONTEND PR (no backend/** paths) that
+#   workflow never runs, so the two required contexts stay "expected" forever
+#   and `mergeStateStatus` is stuck at BLOCKED — auto-merge can never complete
+#   and the PR has to be force-landed with `gh pr merge --admin`. PR #1641
+#   (frontend-only, all 23 real checks green) hit exactly this and only merged
+#   via --admin (BIT-156). The #984 / BIT-136 "marked done but never shipped"
+#   gap was the same root cause.
+#
+# WHAT it does:
+#   This workflow is the path-complement of backend.yml: it runs ONLY when a PR
+#   touches NO backend paths, and emits trivially-green jobs named exactly
+#   `check` and `test`. That satisfies branch protection for pure-frontend PRs
+#   without weakening it for backend PRs (where the real backend.yml jobs run
+#   and report the same context names).
+#
+# WHY paths-ignore is the safe complement (and the mixed-PR case):
+#   backend.yml triggers on `paths: [backend/**, .github/workflows/backend.yml]`.
+#   This workflow triggers on `paths-ignore:` of the SAME set, so:
+#     - pure-frontend PR  -> only THIS runs        -> check/test reported green here.
+#     - pure-backend PR   -> only backend.yml runs -> real check/test there.
+#     - mixed PR (backend + frontend files) -> BOTH run. GitHub evaluates a
+#       required context by its most-recently-completed run, and the real jobs
+#       (cargo check / the full test job) always finish far later than these
+#       ~1s no-ops, so the REAL result is the one that decides the merge. The
+#       no-op never masks a failing backend check.
+#   This is GitHub's documented "handling skipped but required checks" pattern.
+#
+# Job names below MUST stay exactly `check` and `test` — branch protection
+# matches required status checks by context (= job) name. If backend.yml ever
+# renames those jobs or the required set changes, update both in lockstep.
+name: Backend (frontend-only skip gate)
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'backend/**'
+      - '.github/workflows/backend.yml'
+  # Lets maintainers re-emit the gate on demand if a PR's status gets wedged.
+  workflow_dispatch:
+
+# Minimal permissions — these jobs only report their own status.
+permissions:
+  contents: read
+
+# A newer push to the PR branch makes an in-flight run obsolete.
+concurrency:
+  group: backend-skip-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Context name must match the required check `check` from backend.yml.
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No backend paths changed — required `check` satisfied
+        run: echo "Pure-frontend PR: no backend/** changes, backend 'check' not required to run."
+
+  # Context name must match the required check `test` from backend.yml.
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No backend paths changed — required `test` satisfied
+        run: echo "Pure-frontend PR: no backend/** changes, backend 'test' not required to run."

--- a/.github/workflows/backend-skip.yml
+++ b/.github/workflows/backend-skip.yml
@@ -60,12 +60,14 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - name: No backend paths changed — required `check` satisfied
-        run: echo "Pure-frontend PR: no backend/** changes, backend 'check' not required to run."
+      - name: Required check satisfied (no backend paths changed)
+        run: |
+          echo "Pure-frontend PR - no backend/** changes; backend 'check' job not required to run."
 
   # Context name must match the required check `test` from backend.yml.
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: No backend paths changed — required `test` satisfied
-        run: echo "Pure-frontend PR: no backend/** changes, backend 'test' not required to run."
+      - name: Required check satisfied (no backend paths changed)
+        run: |
+          echo "Pure-frontend PR - no backend/** changes; backend 'test' job not required to run."


### PR DESCRIPTION
## What

Adds `.github/workflows/backend-skip.yml` — the exact path-complement of `backend.yml`. It runs only when a PR touches **no** backend paths and emits trivially-green jobs named exactly `check` and `test`.

## Why

`dev` branch protection requires the `check` and `test` contexts on **every** PR (`required_status_checks.checks = [check, test]`). Both are produced only by `backend.yml`, which is path-filtered to `backend/**`. On a **pure-frontend PR** that workflow never runs, so the two required contexts stay `expected` forever → `mergeStateStatus: BLOCKED` → auto-merge can't complete and the PR has to be force-landed with `gh pr merge --admin`.

- Hit by PR #1641 (frontend-only, all 23 real checks green) — BIT-156.
- Same root cause as #984 / BIT-136 ("marked done but never shipped").

## How it's safe

- pure-frontend PR → only this runs → `check`/`test` reported green here.
- pure-backend PR → only `backend.yml` runs → real `check`/`test` there.
- mixed PR → both run; GitHub decides a required context by its most-recently-completed run, and the real jobs always finish far later than these ~1s no-ops, so the real result decides the merge. The no-op never masks a failing backend check.

This is GitHub's documented "handling skipped but required checks" pattern; it satisfies branch protection without weakening it for backend PRs.

## Verification

This PR touches only the workflow file (no backend paths), so it is itself a pure-frontend-class PR: `backend.yml` will not run and `backend-skip.yml` will emit `check`+`test` green. If it reaches `CLEAN` and auto-merges without `--admin`, the acceptance criterion is met.

Closes BIT-157.

Co-Authored-By: Paperclip <noreply@paperclip.ing>