### PR TITLE
chore(research): dispatcher archive sweep 2026-06-21 — move merged #1615 to archive

### DIFF
--- a/.research/management/assignments-archive.json
+++ b/.research/management/assignments-archive.json
@@ -1,5 +1,5 @@
 {
-  "archived_at": "2026-06-18T16:30:38Z",
+  "archived_at": "2026-06-21T16:20:32Z",
   "assignments": [
     {
       "task_id": "bug-announcer-stale-message",
@@ -697,6 +697,28 @@
       "reclaim_attempts": 0,
       "fix_rounds": 0,
       "merge_attempted_at": null
+    },
+    {
+      "task_id": "feat-airbnb-integration-list-api-routes-backend",
+      "branch": "auto-impl/feat-airbnb-integration-list-api-routes-",
+      "status": "merged",
+      "claimed_at": "2026-06-19T22:08:12Z",
+      "last_updated": "2026-06-20T20:11:14Z",
+      "status_changed_at": "2026-06-20T20:11:14Z",
+      "pr_number": 1615,
+      "pr_url": "https://github.com/martin-janci/property-management/pull/1615",
+      "merged_at": "2026-06-20T00:14:08Z",
+      "specialist": "rust-backend",
+      "implementer_summary": "pr=1615 status=done specialist=rust-backend scope_drift=false code_reuse_warn=none note=premise partly stale (status/listings/reservations already exist); added DB-backed GET /airbnb/connections + RentalRepository::list_airbnb_connections w/ IDOR/tenant scoping + 3 unit tests; check/clippy green",
+      "reviewer_summary": "verdict=approve note=clean-rls-scoped-list-route-tokenfree-tests-pass-ci-green-posted-as-comment-author-self-approve-blocked",
+      "last_reviewed_oid": "38d5ab3b183e01022fcfee7ea6c81b7bd4af7062",
+      "scope_drift": false,
+      "code_reuse_warn": null,
+      "empty_branch": null,
+      "rebase_attempts": 0,
+      "reclaim_attempts": 0,
+      "fix_rounds": 0,
+      "merge_attempted_at": "2026-06-20T00:13:24Z"
     },
     {
       "task_id": "feat-airbnb-oauth-and-sync-no-integrations-airbnb-backend",

--- a/.research/management/assignments.json
+++ b/.research/management/assignments.json
@@ -24,28 +24,6 @@
       "merge_attempted_at": null
     },
     {
-      "task_id": "feat-airbnb-integration-list-api-routes-backend",
-      "branch": "auto-impl/feat-airbnb-integration-list-api-routes-",
-      "status": "merged",
-      "claimed_at": "2026-06-19T22:08:12Z",
-      "last_updated": "2026-06-20T20:11:14Z",
-      "status_changed_at": "2026-06-20T20:11:14Z",
-      "pr_number": 1615,
-      "pr_url": "https://github.com/martin-janci/property-management/pull/1615",
-      "merged_at": "2026-06-20T00:14:08Z",
-      "specialist": "rust-backend",
-      "implementer_summary": "pr=1615 status=done specialist=rust-backend scope_drift=false code_reuse_warn=none note=premise partly stale (status/listings/reservations already exist); added DB-backed GET /airbnb/connections + RentalRepository::list_airbnb_connections w/ IDOR/tenant scoping + 3 unit tests; check/clippy green",
-      "reviewer_summary": "verdict=approve note=clean-rls-scoped-list-route-tokenfree-tests-pass-ci-green-posted-as-comment-author-self-approve-blocked",
-      "last_reviewed_oid": "38d5ab3b183e01022fcfee7ea6c81b7bd4af7062",
-      "scope_drift": false,
-      "code_reuse_warn": null,
-      "empty_branch": null,
-      "rebase_attempts": 0,
-      "reclaim_attempts": 0,
-      "fix_rounds": 0,
-      "merge_attempted_at": "2026-06-20T00:13:24Z"
-    },
-    {
       "task_id": "feat-booking-com-ota-xml-rate-availability-backend",
       "branch": "auto-impl/feat-booking-com-ota-xml-rate-availabili",
       "status": "review",


### PR DESCRIPTION
Phase 6 archive sweep, landed via the proven large-archive workaround (finding `mcp-push-cannot-inline-large-archive`): the merged PR #1615 row leaked into active `assignments.json` (T19) and `assignments-archive.json` (438 KB) exceeds the 64 KB MCP inline-push ceiling while direct push to `dev` is proxy-403'd. New-branch push + API squash-merge carries the full-size archive server-side.

- Moves `feat-airbnb-integration-list-api-routes-backend` (merged PR #1615) from active → archive.
- active 4 → 3, archive 401 → 402 (combined 405, unchanged — move not copy).
- `dispatcher-self-test.sh` PASS (T19 clean).

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4ZLgtPRnN6N7goWtAXrUe)_