### PR TITLE
feat-mobile-env-config-info-plist-keys-mobile: finish mobile env-var setup (Constants single source + Info.plist docs)

### DIFF
--- a/frontend/apps/mobile/README.md
+++ b/frontend/apps/mobile/README.md
@@ -28,7 +28,32 @@ environment.
   `Constants.expoConfig.extra`.
 - `EXPO_PUBLIC_*` variables are **not** used here (removed in issue #523).
   They cannot reach the iOS `Info.plist` and would require hand-syncing two
-  copies of every value. Do not reintroduce them.
+  copies of every value. Do not reintroduce them. The `Constants` re-export in
+  [`src/config/constants.ts`](./src/config/constants.ts) (`API_BASE_URL`) reads
+  through `getApiBaseUrl()` for the same reason — it never touches
+  `process.env`.
+
+### Reading config in JS vs. native iOS
+
+There are two consumers of the resolved env values, both fed by `app.config.ts`:
+
+| Consumer | Reads from | API |
+| -------- | ---------- | --- |
+| JavaScript / TypeScript | `Constants.expoConfig.extra` | `getApiBaseUrl()`, `getEnvironment()`, `getWsBaseUrl()`, `isDebugMode()` in [`src/config/api.ts`](./src/config/api.ts) (via `expo-constants`). Never read `process.env` at module scope. |
+| Native iOS (Swift / Obj-C) | `Info.plist` | `Bundle.main.object(forInfoDictionaryKey: "API_BASE_URL")` / `"ENVIRONMENT"`. |
+
+`app.config.ts` injects the following keys into `ios.infoPlist` so native code
+can read the same per-environment values without a second config path:
+
+| `Info.plist` key | Source env var | Notes |
+| ---------------- | -------------- | ----- |
+| `API_BASE_URL`   | `API_BASE_URL` | REST base URL — identical to `extra.API_BASE_URL`. |
+| `ENVIRONMENT`    | `ENVIRONMENT`  | Logical environment label (`development` / `staging` / `production`). |
+
+These keys are written into the generated `ios/` project at `expo prebuild`
+time; the committed `ios/xcconfig/*.xcconfig` files carry only native
+build-layer markers (`PPT_APP_ENV`, bundle id) and deliberately do **not**
+duplicate the runtime values above, to avoid drift (see GH #1410).
 
 ### How `APP_ENV` selects the config file
 

--- a/frontend/apps/mobile/src/config/constants.ts
+++ b/frontend/apps/mobile/src/config/constants.ts
@@ -3,7 +3,18 @@
  *
  * This file provides a centralized location for app-wide constants including
  * version info and API endpoints.
+ *
+ * Epic 85 - Story 85.1: Environment Variable Setup.
+ * Env-driven values (API base URL, environment, …) are NOT read from
+ * `process.env` here — that bypasses the single source of truth and cannot
+ * reach the iOS `Info.plist`. The `EXPO_PUBLIC_*` fallback was removed in
+ * issue #523; do not reintroduce it. Instead this module re-exports the
+ * resolved value from `./api`, which reads `Constants.expoConfig.extra`
+ * (injected by `app.config.ts` from `.env.<APP_ENV>`). See README.md
+ * ("Environment variable setup") and `src/config/api.ts`.
  */
+
+import { getApiBaseUrl } from './api';
 
 /**
  * App version from package.json
@@ -18,10 +29,14 @@ export const APP_VERSION = '0.2.96';
 export const BUILD_NUMBER = process.env.BUILD_NUMBER ?? '1';
 
 /**
- * API base URL from environment variable or default
- * Set EXPO_PUBLIC_API_BASE_URL in .env file for custom endpoints
+ * API base URL — resolved from the single source of truth
+ * (`Constants.expoConfig.extra.API_BASE_URL`, populated by `app.config.ts`
+ * from `.env.<APP_ENV>`), with the same dev / platform fallbacks as the rest
+ * of the app. Previously this read `process.env.EXPO_PUBLIC_API_BASE_URL`
+ * directly, which silently shipped the `api.ppt.example.com` placeholder in
+ * release builds and diverged from the iOS `Info.plist` value (issue #523).
  */
-export const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL ?? 'https://api.ppt.example.com';
+export const API_BASE_URL = getApiBaseUrl();
 
 /**
  * Default constants

--- a/frontend/apps/mobile/src/config/index.ts
+++ b/frontend/apps/mobile/src/config/index.ts
@@ -3,7 +3,8 @@
  *
  * Prefer importing from this file rather than individual config modules.
  * All env-driven config flows through src/config/api.ts (reads from
- * Constants.expoConfig.extra set by app.config.ts, with EXPO_PUBLIC_* fallback).
+ * Constants.expoConfig.extra, set by app.config.ts from .env.<APP_ENV>).
+ * The EXPO_PUBLIC_* fallback was removed in issue #523 — do not reintroduce it.
  */
 
 export {


### PR DESCRIPTION
## Task
Coverage 85-1 (gap): finish mobile environment-variable setup — document the Expo Constants env workflow and add API_BASE_URL/ENVIRONMENT keys to the iOS Info.plist (xcconfig-driven) for the React Native Property Management app. Frontend mobile; config + docs, no binary assets.

## Owner
pm-frontend (note: the mobile app path `frontend/apps/mobile/**` is mapped to `pm-mobile` in `scripts/owner-areas.json` — see Scope drift below)

## What was already in `dev` (not duplicated)
Most of story 85-1/85-2 is already shipped on `dev`:
- `app.config.ts` already loads `.env.<APP_ENV>` via dotenv and **already injects `API_BASE_URL` + `ENVIRONMENT` into `ios.infoPlist`** (lines ~286-289), with a placeholder-URL build guard (#523/#620).
- The xcconfig-driven prebuild plugin (`plugins/withIosBuildConfig.ts` + `ios/xcconfig/{Development,Staging,Production}.xcconfig`) exists with passing tests (`app.config.iosBuildConfig.test.ts`).
- `README.md` already had an "Environment variable setup" section and `src/config/api.ts` reads `Constants.expoConfig.extra`.

So the Info.plist keys requested by the task **already exist**. This PR closes only the genuine remaining seam.

## The genuine gap closed here
`src/config/constants.ts` still re-introduced the forbidden pattern: it read `process.env.EXPO_PUBLIC_API_BASE_URL` at module scope and fell back to the `api.ppt.example.com` placeholder. This:
- contradicts the documented single source of truth (`EXPO_PUBLIC_*` was removed in #523),
- diverges from the value `app.config.ts` injects into the iOS `Info.plist`,
- and is consumed by `FeedbackManager` (`feedbackManager = new FeedbackManager(API_BASE_URL, …)`), so release-build feedback/bug-report submissions targeted the placeholder host instead of the configured API.

Changes:
- `src/config/constants.ts` — `API_BASE_URL` now re-exports `getApiBaseUrl()` (the documented `Constants.expoConfig.extra` reader), removing the `process.env.EXPO_PUBLIC_*` read.
- `src/config/index.ts` — comment corrected to stop referencing the removed `EXPO_PUBLIC_*` fallback.
- `README.md` — documented the Expo Constants env workflow explicitly: the JS-vs-native-iOS read paths and the `API_BASE_URL` / `ENVIRONMENT` `Info.plist` keys (xcconfig-driven prebuild), without duplicating runtime values into xcconfig.

## Tested (Band A — fast check)
- `pnpm -F mobile typecheck` → `tsc --noEmit`, exit 0
- `pnpm exec biome check apps/mobile/src/config/constants.ts apps/mobile/src/config/index.ts` → "No fixes applied", exit 0 (mobile package has no per-package `lint` script; Biome is the workspace lint gate)
- `pnpm -F mobile jest` → 258/258 tests pass; all three `app.config.*` suites green. 5 suites error on a pre-existing sandbox lockfile mismatch (`react-test-renderer` 19.2.6 vs expected 19.2.0) in `@testing-library/react-native` rendering tests (LanguageSwitcher / App.authgate / LeaseSignatureScreen / integration) — none of which this PR touches.

## Built (Band B — full build)
skipped: change <50 LOC of substantive code (2 small TS edits + docs), no public API/config-output change. `app.config.ts` (build output) is unchanged.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped

## Scope drift
`scope-check.sh --owner pm-frontend` exits 2: the changed paths live under `frontend/apps/mobile/**`, which `scripts/owner-areas.json` maps to `pm-mobile`, not `pm-frontend`. The dispatcher hint was `pm-frontend`; the work is legitimately mobile-frontend and the drift is purely an owner-hint/area-map mismatch. Drifting paths:
- `frontend/apps/mobile/README.md`
- `frontend/apps/mobile/src/config/constants.ts`
- `frontend/apps/mobile/src/config/index.ts`

## Code-reuse review
`reuse-grep.sh --specialist react-native` → no warnings. The change in fact *removes* a duplicated config path by reusing the existing `getApiBaseUrl()` single source of truth.

## Notes
No binary assets. Pure config + docs. The requested Info.plist `API_BASE_URL`/`ENVIRONMENT` keys were already present in `dev`'s `app.config.ts`; this PR documents them and removes the contradicting `EXPO_PUBLIC_*` reintroduction that was the real 85-1 gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4ZLgtPRnN6N7goWtAXrUe

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4ZLgtPRnN6N7goWtAXrUe)_