### PR TITLE
bug(mobile): fix duplicate nav + unhandled rejection in useDeepLinkRouting

### DIFF
--- a/frontend/apps/mobile/src/hooks/useDeepLinkRouting.test.tsx
+++ b/frontend/apps/mobile/src/hooks/useDeepLinkRouting.test.tsx
@@ -35,16 +35,72 @@ jest.mock('../qrcode', () => ({
   },
 }));
 
-// Run every `useEffect` synchronously and collect cleanups so the test can
-// simulate unmount. Effects run in declaration order, matching React.
+// Minimal React hook emulation so the test can drive the hook's wiring without
+// mounting the RN tree.
+//
+//  - `useEffect` runs synchronously, but only re-runs when its dependency array
+//    changes — emulated with a per-call-site dep cache keyed by declaration
+//    order so the "stable, runs once" wiring effect ([]) is exercised
+//    faithfully across re-renders, and cleanups are collected for unmount.
+//  - `useRef` returns a persistent box per call site (also keyed by declaration
+//    order), so the latest-callback ref survives re-renders.
+//
+// All shared state lives on a single `mock`-prefixed object so the
+// `jest.mock('react', …)` factory may legally reference it.
 type EffectCleanup = () => void;
-const mockCleanups: EffectCleanup[] = [];
-jest.mock('react', () => ({
-  useEffect: (effect: () => undefined | EffectCleanup) => {
-    const cleanup = effect();
-    if (typeof cleanup === 'function') {
-      mockCleanups.push(cleanup);
+const mockReactState = {
+  cleanups: [] as EffectCleanup[],
+  effectIndex: 0,
+  effectDeps: [] as (readonly unknown[] | undefined)[],
+  effectCleanupByIndex: [] as (EffectCleanup | undefined)[],
+  refIndex: 0,
+  refBoxes: [] as { current: unknown }[],
+  depsChanged(prev: readonly unknown[] | undefined, next: readonly unknown[] | undefined): boolean {
+    if (prev === undefined || next === undefined) {
+      return true;
     }
+    if (prev.length !== next.length) {
+      return true;
+    }
+    return prev.some((value, i) => !Object.is(value, next[i]));
+  },
+  // Reset per-render call-site cursors. Call between simulated renders.
+  startRender(): void {
+    this.effectIndex = 0;
+    this.refIndex = 0;
+  },
+  reset(): void {
+    this.cleanups.length = 0;
+    this.effectDeps.length = 0;
+    this.effectCleanupByIndex.length = 0;
+    this.refBoxes.length = 0;
+    this.startRender();
+  },
+};
+// Back-compat alias used by the unmount test.
+const mockCleanups = mockReactState.cleanups;
+const startRender = () => mockReactState.startRender();
+
+jest.mock('react', () => ({
+  useEffect: (effect: () => undefined | EffectCleanup, deps?: readonly unknown[]) => {
+    const index = mockReactState.effectIndex++;
+    if (mockReactState.depsChanged(mockReactState.effectDeps[index], deps)) {
+      mockReactState.effectCleanupByIndex[index]?.();
+      mockReactState.effectDeps[index] = deps;
+      const cleanup = effect();
+      mockReactState.effectCleanupByIndex[index] =
+        typeof cleanup === 'function' ? cleanup : undefined;
+      if (typeof cleanup === 'function') {
+        mockReactState.cleanups.push(cleanup);
+      }
+    }
+  },
+  useRef: (initial: unknown) => {
+    const index = mockReactState.refIndex++;
+    if (mockReactState.refBoxes[index] === undefined) {
+      mockReactState.refBoxes[index] = { current: initial };
+    }
+    return mockReactState.refBoxes[index];
   },
 }));
 
@@ -57,7 +113,7 @@ const manager = deepLinkManager as unknown as {
 beforeEach(() => {
   jest.clearAllMocks();
   mockDeepLink.registeredHandler = null;
-  mockCleanups.length = 0;
+  mockReactState.reset();
 });
 
 describe('useDeepLinkRouting', () => {
@@ -98,8 +154,46 @@ describe('useDeepLinkRouting', () => {
     useDeepLinkRouting(onNavigate, false);
     expect(manager.setAuthenticated).toHaveBeenLastCalledWith(false);
 
+    startRender();
     useDeepLinkRouting(onNavigate, true);
     expect(manager.setAuthenticated).toHaveBeenLastCalledWith(true);
+  });
+
+  it('does not re-register or re-initialize when onNavigate identity changes', () => {
+    // App passes a memoised callback, but a new identity on re-render must not
+    // re-run the wiring effect (regression: duplicate handlers / re-init).
+    const firstOnNavigate = jest.fn();
+    useDeepLinkRouting(firstOnNavigate, false);
+
+    startRender();
+    const secondOnNavigate = jest.fn();
+    useDeepLinkRouting(secondOnNavigate, false);
+
+    expect(manager.addHandler).toHaveBeenCalledTimes(1);
+    expect(manager.initialize).toHaveBeenCalledTimes(1);
+
+    // A link dispatched after the re-render routes through the LATEST callback.
+    mockDeepLink.registeredHandler?.({
+      success: true,
+      screen: 'Documents',
+      params: { id: 'doc-9' },
+    } as ParsedDeepLink);
+
+    expect(firstOnNavigate).not.toHaveBeenCalled();
+    expect(secondOnNavigate).toHaveBeenCalledWith('DocumentDetail', { documentId: 'doc-9' });
+  });
+
+  it('swallows a rejected initialize() so it is not an unhandled rejection', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    manager.initialize.mockRejectedValueOnce(new Error('cold-start boom'));
+
+    const onNavigate = jest.fn();
+    expect(() => useDeepLinkRouting(onNavigate, false)).not.toThrow();
+
+    // Let the rejected promise's `.catch` settle.
+    await Promise.resolve();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 
   it('unsubscribes the handler on cleanup', () => {

--- a/frontend/apps/mobile/src/hooks/useDeepLinkRouting.ts
+++ b/frontend/apps/mobile/src/hooks/useDeepLinkRouting.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { deepLinkManager } from '../qrcode';
 import { resolveDeepLinkTarget } from '../services/deepLinkRouting';
 
@@ -24,16 +24,28 @@ export function useDeepLinkRouting(
   onNavigate: (screen: string, params?: Record<string, unknown>) => void,
   isAuthenticated: boolean
 ): void {
+  // Hold the latest `onNavigate` in a ref so the wiring effect can read the
+  // current callback without listing it as a dependency. This keeps the effect
+  // stable: the handler is registered and `initialize()` runs exactly once for
+  // the hook's lifetime, even when the parent passes a fresh `onNavigate`
+  // identity on re-render (avoids duplicate handlers / re-initialisation).
+  const onNavigateRef = useRef(onNavigate);
+  onNavigateRef.current = onNavigate;
+
   useEffect(() => {
     const unsubscribe = deepLinkManager.addHandler((link) => {
       const target = resolveDeepLinkTarget(link);
       if (target) {
-        onNavigate(target.screen, target.params);
+        onNavigateRef.current(target.screen, target.params);
       }
     });
-    void deepLinkManager.initialize();
+    // `initialize()` rejecting must not surface as an unhandled promise
+    // rejection; deep-link cold-start failures are non-fatal for the app.
+    deepLinkManager.initialize().catch((error) => {
+      console.warn('[useDeepLinkRouting] deepLinkManager.initialize() failed', error);
+    });
     return unsubscribe;
-  }, [onNavigate]);
+  }, []);
 
   // Keep the manager's auth gate in sync so auth-required links queued while
   // logged out are dispatched the moment the user authenticates.


### PR DESCRIPTION
## Problem

`frontend/apps/mobile/src/hooks/useDeepLinkRouting.ts` (the deep-link wiring effect, originally around lines 27-36) had two coupled defects:

1. **Re-runs on every `onNavigate` identity change.** The wiring effect listed `onNavigate` in its dependency array. Whenever the parent passed a fresh callback identity on re-render, the effect tore down and re-ran — **re-registering the deep-link handler and re-running `deepLinkManager.initialize()`**, which can cause duplicate navigation.
2. **Unhandled promise rejection.** `void deepLinkManager.initialize()` discarded the promise with no `.catch`. A cold-start failure surfaced as an unhandled promise rejection.

## Fix (minimal, scoped to the bug)

- Hold the latest `onNavigate` in a `useRef` and read `onNavigateRef.current` inside the handler, so the wiring effect can run **once** (`[]` deps). Handler registration + `initialize()` now happen exactly once per hook lifetime, regardless of `onNavigate` identity churn.
- Attach a `.catch` to `initialize()` that logs via `console.warn` and swallows the (non-fatal) cold-start error.

The auth-gate effect is unchanged.

## Tests

Added two focused cases to the sibling `useDeepLinkRouting.test.tsx` and extended the lightweight React-hook emulation (`useEffect` now respects its dependency array across simulated re-renders; a `useRef` mock was added):

- `does not re-register or re-initialize when onNavigate identity changes` — asserts `addHandler`/`initialize` are each called once across a re-render and that dispatched links route through the **latest** callback.
- `swallows a rejected initialize() so it is not an unhandled rejection` — asserts the hook does not throw and the rejection is caught.

## Verification transcript

```
$ pnpm install                       # frontend/ (fresh checkout)
Done in 17.9s

$ pnpm jest src/hooks/useDeepLinkRouting.test.tsx   # apps/mobile
PASS src/hooks/useDeepLinkRouting.test.tsx
  useDeepLinkRouting
    ✓ registers a handler and initializes the manager
    ✓ routes a dispatched link through resolveDeepLinkTarget to onNavigate
    ✓ ignores links that resolve to no target
    ✓ keeps the auth gate in sync with isAuthenticated
    ✓ does not re-register or re-initialize when onNavigate identity changes
    ✓ swallows a rejected initialize() so it is not an unhandled rejection
    ✓ unsubscribes the handler on cleanup
Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total

$ pnpm typecheck                     # apps/mobile (tsc --noEmit)
(no errors)

$ pnpm biome check --write apps/mobile/src/hooks/useDeepLinkRouting.ts apps/mobile/src/hooks/useDeepLinkRouting.test.tsx
Checked 2 files. Fixed 1 file.   # formatting only
```

Addresses code-review finding `code-review-mobile-rn-deeplink-init-unhandled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Be8T1mar1ken3UYFmJud84

---
_Generated by [Claude Code](https://claude.ai/code/session_01Be8T1mar1ken3UYFmJud84)_