### PR TITLE
code-review-reality-web-share-comparison-404: route shared comparison fetch to canonical /api/v1/listings

### DIFF
--- a/frontend/apps/reality-web/src/components/comparison/ComparisonUrlHandler.test.tsx
+++ b/frontend/apps/reality-web/src/components/comparison/ComparisonUrlHandler.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * ComparisonUrlHandler Tests
+ *
+ * Regression guard for the shared-comparison 404 bug (Epic 51 Story 51.3):
+ * the handler used to fetch a non-existent Next.js route `/api/listings/${id}`,
+ * so every shared comparison URL 404'd and silently rendered the error state.
+ * The fix routes the fetch through reality-server's canonical endpoint
+ * `${getApiBase()}/api/v1/listings/${id}`.
+ */
+
+import type { ListingSummary } from '@ppt/reality-api-client';
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const addToComparison = vi.fn();
+
+// Mock the comparison context: empty comparison so the loader runs.
+vi.mock('../../lib/comparison-context', () => ({
+  useComparison: () => ({ listings: [], addToComparison }),
+}));
+
+// Pin getApiBase so the asserted URL is deterministic in jsdom.
+vi.mock('../../lib/env', () => ({
+  getApiBase: () => 'https://api.test',
+}));
+
+import { ComparisonUrlHandler } from './ComparisonUrlHandler';
+
+const mockListing: ListingSummary = {
+  id: 'abc',
+  slug: 'abc-listing',
+  title: 'Listing abc',
+  price: 100000,
+  currency: 'EUR',
+  transactionType: 'sale',
+  propertyType: 'apartment',
+  status: 'active',
+  area: 60,
+  rooms: 2,
+  floor: 1,
+  address: { city: 'Bratislava', district: 'Old Town', country: 'Slovakia' },
+  isFavorite: false,
+  isFeatured: false,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+} as ListingSummary;
+
+describe('ComparisonUrlHandler', () => {
+  beforeEach(() => {
+    addToComparison.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches each shared listing via the canonical /api/v1/listings path', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => mockListing,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<ComparisonUrlHandler sharedIds={['abc']} />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    // Regression bar: the wrong URL (/api/listings/abc) silently 404'd.
+    expect(calledUrl).toBe('https://api.test/api/v1/listings/abc');
+    expect(calledUrl).toMatch(/\/api\/v1\/listings\/abc$/);
+
+    await waitFor(() => expect(addToComparison).toHaveBeenCalledWith(mockListing));
+  });
+
+  it('renders the error state when the upstream listing 404s', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({}),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<ComparisonUrlHandler sharedIds={['missing']} />);
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(addToComparison).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/apps/reality-web/src/components/comparison/ComparisonUrlHandler.test.tsx
+++ b/frontend/apps/reality-web/src/components/comparison/ComparisonUrlHandler.test.tsx
@@ -24,6 +24,13 @@ vi.mock('../../lib/env', () => ({
   getApiBase: () => 'https://api.test',
 }));
 
+// Stub next-intl so the component's localized strings resolve in jsdom
+// without a NextIntlClientProvider. The handler renders t('loading') /
+// t('loadError'); returning the key keeps the i18n wiring under test.
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => `comparison.${key}`,
+}));
+
 import { ComparisonUrlHandler } from './ComparisonUrlHandler';
 
 const mockListing: ListingSummary = {

--- a/frontend/apps/reality-web/src/components/comparison/ComparisonUrlHandler.tsx
+++ b/frontend/apps/reality-web/src/components/comparison/ComparisonUrlHandler.tsx
@@ -7,6 +7,7 @@
 'use client';
 
 import type { ListingSummary } from '@ppt/reality-api-client';
+import { useTranslations } from 'next-intl';
 import { useEffect, useState } from 'react';
 
 import { useComparison } from '../../lib/comparison-context';
@@ -17,6 +18,7 @@ interface ComparisonUrlHandlerProps {
 }
 
 export function ComparisonUrlHandler({ sharedIds }: ComparisonUrlHandlerProps) {
+  const t = useTranslations('comparison');
   const { listings, addToComparison } = useComparison();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -54,7 +56,7 @@ export function ComparisonUrlHandler({ sharedIds }: ComparisonUrlHandlerProps) {
           }
         }
       } catch (err) {
-        setError('Failed to load shared comparison. Some properties may no longer be available.');
+        setError(t('loadError'));
         console.error('Error loading shared listings:', err);
       } finally {
         setLoading(false);
@@ -62,13 +64,13 @@ export function ComparisonUrlHandler({ sharedIds }: ComparisonUrlHandlerProps) {
     };
 
     loadSharedListings();
-  }, [sharedIds, listings.length, addToComparison]);
+  }, [sharedIds, listings.length, addToComparison, t]);
 
   if (loading) {
     return (
       <div className="loading-shared">
         <div className="spinner" />
-        <p>Loading shared comparison...</p>
+        <p>{t('loading')}</p>
         <style jsx>{`
           .loading-shared {
             display: flex;

--- a/frontend/apps/reality-web/src/components/comparison/ComparisonUrlHandler.tsx
+++ b/frontend/apps/reality-web/src/components/comparison/ComparisonUrlHandler.tsx
@@ -7,17 +7,16 @@
 'use client';
 
 import type { ListingSummary } from '@ppt/reality-api-client';
-import { useTranslations } from 'next-intl';
 import { useEffect, useState } from 'react';
 
 import { useComparison } from '../../lib/comparison-context';
+import { getApiBase } from '../../lib/env';
 
 interface ComparisonUrlHandlerProps {
   sharedIds: string[];
 }
 
 export function ComparisonUrlHandler({ sharedIds }: ComparisonUrlHandlerProps) {
-  const t = useTranslations('comparison');
   const { listings, addToComparison } = useComparison();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -35,9 +34,13 @@ export function ComparisonUrlHandler({ sharedIds }: ComparisonUrlHandlerProps) {
       try {
         // Fetch each listing by ID
         const fetchPromises = sharedIds.slice(0, 4).map(async (id) => {
-          const response = await fetch(`/api/listings/${id}`);
+          // Hit reality-server's canonical listing endpoint via getApiBase()
+          // (the same pattern every other reality-web client fetcher uses).
+          // The previous bare `/api/listings/${id}` targeted a Next.js API
+          // route that does not exist, so every shared comparison URL 404'd.
+          const response = await fetch(`${getApiBase()}/api/v1/listings/${id}`);
           if (!response.ok) {
-            throw new Error(`Failed to load listing ${id}`);
+            throw new Error(`Failed to load listing ${id} (HTTP ${response.status})`);
           }
           return response.json() as Promise<ListingSummary>;
         });
@@ -51,7 +54,7 @@ export function ComparisonUrlHandler({ sharedIds }: ComparisonUrlHandlerProps) {
           }
         }
       } catch (err) {
-        setError(t('loadError'));
+        setError('Failed to load shared comparison. Some properties may no longer be available.');
         console.error('Error loading shared listings:', err);
       } finally {
         setLoading(false);
@@ -59,13 +62,13 @@ export function ComparisonUrlHandler({ sharedIds }: ComparisonUrlHandlerProps) {
     };
 
     loadSharedListings();
-  }, [sharedIds, listings.length, addToComparison, t]);
+  }, [sharedIds, listings.length, addToComparison]);
 
   if (loading) {
     return (
       <div className="loading-shared">
         <div className="spinner" />
-        <p>{t('loading')}</p>
+        <p>Loading shared comparison...</p>
         <style jsx>{`
           .loading-shared {
             display: flex;


### PR DESCRIPTION
## Task

Reality-web `ComparisonUrlHandler` hits non-existent `/api/listings/${id}` — every shared comparison URL 404s. Fix: route the fetch through the canonical reality-server path `${getApiBase()}/api/v1/listings/${id}` like every other reality-web caller.

## Root cause

`ComparisonUrlHandler` (Epic 51 Story 51.3, "Share Comparison") fetched `/api/listings/${id}`, a Next.js API route that does not exist in reality-web — `src/app/api/` only ships `health/route.ts`. Every shared comparison URL therefore 404'd; the `catch` swallowed it into the error state and the user saw an empty comparison page. The canonical pattern (`auth-api.ts` and every other client fetcher) is `${getApiBase()}/api/v1/...`.

## Fix

- Import `getApiBase` from `../../lib/env` and fetch `${getApiBase()}/api/v1/listings/${id}`.
- Include the HTTP status in the thrown `Error` so future upstream-shape regressions surface in observability instead of silently rendering the generic error copy.
- Add `ComparisonUrlHandler.test.tsx` regression guard: asserts the fetch URL is `…/api/v1/listings/abc` (would have failed on the old `/api/listings/abc`), asserts the 200 path calls `addToComparison`, and asserts the 404 path renders the error state.

## Owner

pm-frontend

## Tested (Band A — fast check)

- `pnpm -F @ppt/reality-web typecheck` → exit 0
- `pnpm exec vitest run src/components/comparison/ComparisonUrlHandler.test.tsx` → 2 passed
- Full reality-web suite: `vitest run` → 82 passed (10 files)
- `pnpm exec biome check` on both changed files → clean (no fixes applied)

Note: `pnpm -F @ppt/reality-web lint` maps to `next lint` and mis-parses the package-filter passthrough in this sandbox; the repo's actual lint gate is Biome (`pnpm check`), which is clean on the changed files.

## Built (Band B — full build)

Skipped: change is ~15 LOC + a test, no public API / config / build-output change.

## CI parity (Band C — hot-path only)

Skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Notes

- Out of scope (per plan): migrating to the generated `@ppt/reality-api-client` SDK (only exposes `ListingDetail`, not `ListingSummary`), and i18n copy changes. The existing error string is preserved as-is — the file does not use `t('loadError')` despite the plan's wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtbUM7UTpax6fcwZH3ji3V

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtbUM7UTpax6fcwZH3ji3V)_