### PR TITLE
code-review-reality-web-listing-page-ssr-crash: defend listing detail JSON-LD against partial SSR bodies

### DIFF
--- a/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/jsonLd.test.ts
+++ b/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/jsonLd.test.ts
@@ -1,0 +1,121 @@
+/**
+ * buildListingJsonLd Tests
+ *
+ * Regression guard for the SSR crash where a malformed/partial 200 body
+ * (truthy but not a real ListingDetail) made the listing page throw while
+ * dereferencing nested fields (listing.photos.map, listing.address.street).
+ * buildListingJsonLd must return null instead of throwing.
+ */
+
+import type { ListingDetail } from '@ppt/reality-api-client';
+import { describe, expect, it } from 'vitest';
+import { buildListingJsonLd } from './jsonLd';
+
+const validListing: ListingDetail = {
+  id: 'listing-1',
+  slug: 'beautiful-apartment',
+  title: 'Beautiful Apartment',
+  propertyType: 'apartment',
+  transactionType: 'sale',
+  status: 'active',
+  price: 150000,
+  currency: 'EUR',
+  area: 75,
+  rooms: 3,
+  address: {
+    street: 'Main St 1',
+    city: 'Bratislava',
+    district: 'Old Town',
+    postalCode: '81101',
+    country: 'SK',
+  },
+  isFeatured: false,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  description: 'A lovely place to live with plenty of light.',
+  features: {},
+  photos: [
+    {
+      id: 'p1',
+      url: 'https://cdn.example.com/p1.jpg',
+      thumbnailUrl: 'https://cdn.example.com/p1-thumb.jpg',
+      isPrimary: true,
+      order: 0,
+    },
+  ],
+  agent: { id: 'a1', name: 'Agent', email: 'a@example.com' },
+  viewCount: 0,
+  favoriteCount: 0,
+  primaryPhoto: {
+    id: 'p1',
+    url: 'https://cdn.example.com/p1.jpg',
+    thumbnailUrl: 'https://cdn.example.com/p1-thumb.jpg',
+    isPrimary: true,
+    order: 0,
+  },
+};
+
+describe('buildListingJsonLd', () => {
+  it('builds full JSON-LD from a valid listing', () => {
+    const jsonLd = buildListingJsonLd(validListing) as Record<string, unknown>;
+    expect(jsonLd).not.toBeNull();
+    expect(jsonLd['@type']).toBe('RealEstateListing');
+    expect(jsonLd.name).toBe('Beautiful Apartment');
+    expect(jsonLd.description).toBe('A lovely place to live with plenty of light.');
+    expect(jsonLd.image).toEqual(['https://cdn.example.com/p1.jpg']);
+    expect(jsonLd.numberOfRooms).toBe(3);
+    expect((jsonLd.address as Record<string, unknown>).addressLocality).toBe('Bratislava');
+    expect((jsonLd.offers as Record<string, unknown>).price).toBe(150000);
+    expect((jsonLd.floorSize as Record<string, unknown>).value).toBe(75);
+  });
+
+  it('returns null when the body is null/undefined (not-found / network failure)', () => {
+    expect(buildListingJsonLd(null)).toBeNull();
+    expect(buildListingJsonLd(undefined)).toBeNull();
+  });
+
+  // The core regression: malformed but truthy 200 bodies must NOT throw.
+  it('returns null on an empty object body without throwing', () => {
+    expect(() => buildListingJsonLd({})).not.toThrow();
+    expect(buildListingJsonLd({})).toBeNull();
+  });
+
+  it('returns null when address is missing (would have thrown on .street)', () => {
+    const malformed = { title: 'Has title but no address', slug: 'x' };
+    expect(() => buildListingJsonLd(malformed)).not.toThrow();
+    expect(buildListingJsonLd(malformed)).toBeNull();
+  });
+
+  it('returns null when title is missing', () => {
+    const malformed = { slug: 'x', address: { city: 'Bratislava', country: 'SK' } };
+    expect(buildListingJsonLd(malformed)).toBeNull();
+  });
+
+  it('returns null on non-object bodies (string / number / array)', () => {
+    expect(buildListingJsonLd('oops')).toBeNull();
+    expect(buildListingJsonLd(42)).toBeNull();
+    expect(buildListingJsonLd([])).toBeNull();
+  });
+
+  it('builds JSON-LD without an image field when photos are missing (would have thrown on .map)', () => {
+    const noPhotos = { ...validListing, photos: undefined as unknown as ListingDetail['photos'] };
+    expect(() => buildListingJsonLd(noPhotos)).not.toThrow();
+    const jsonLd = buildListingJsonLd(noPhotos) as Record<string, unknown>;
+    expect(jsonLd).not.toBeNull();
+    expect(jsonLd.name).toBe('Beautiful Apartment');
+    expect('image' in jsonLd).toBe(false);
+  });
+
+  it('omits optional price/rooms/area blocks when missing', () => {
+    const minimal = {
+      title: 'Minimal',
+      slug: 'minimal',
+      address: { city: 'Bratislava', country: 'SK' },
+    };
+    const jsonLd = buildListingJsonLd(minimal) as Record<string, unknown>;
+    expect(jsonLd).not.toBeNull();
+    expect('offers' in jsonLd).toBe(false);
+    expect('numberOfRooms' in jsonLd).toBe(false);
+    expect('floorSize' in jsonLd).toBe(false);
+  });
+});

--- a/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/jsonLd.ts
+++ b/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/jsonLd.ts
@@ -1,0 +1,89 @@
+/**
+ * Listing detail JSON-LD helpers.
+ *
+ * Kept in a standalone module (no component / next-intl imports) so the
+ * defensive structured-data logic can be unit-tested in isolation, mirroring
+ * the sibling `metadata.ts`.
+ */
+
+import type { ListingDetail } from '@ppt/reality-api-client';
+
+/**
+ * Build the RealEstateListing JSON-LD object defensively.
+ *
+ * `getListing` returns the raw JSON body of any 200 response, so a malformed
+ * or partial 200 (e.g. `{}`, or a body missing `address` / `photos`) is truthy
+ * but does not match `ListingDetail`. Dereferencing nested fields off such a
+ * body (`listing.photos.map`, `listing.address.street`) would throw during SSR
+ * and crash the request. Treat the body as `unknown`, require the minimum set
+ * of fields, and return `null` whenever a required field is missing or has the
+ * wrong shape. Optional fields (`photos`, `price`, `rooms`, `area`, …) are
+ * emitted only when present.
+ */
+export function buildListingJsonLd(listing: unknown): object | null {
+  if (!listing || typeof listing !== 'object') {
+    return null;
+  }
+
+  const l = listing as Partial<ListingDetail>;
+  const address = l.address;
+
+  if (
+    typeof l.title !== 'string' ||
+    typeof l.slug !== 'string' ||
+    !address ||
+    typeof address !== 'object' ||
+    typeof address.city !== 'string' ||
+    typeof address.country !== 'string'
+  ) {
+    return null;
+  }
+
+  const jsonLd: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'RealEstateListing',
+    name: l.title,
+    url: `${process.env.NEXT_PUBLIC_SITE_URL || ''}/listings/${l.slug}`,
+    address: {
+      '@type': 'PostalAddress',
+      streetAddress: address.street,
+      addressLocality: address.city,
+      addressRegion: address.district,
+      postalCode: address.postalCode,
+      addressCountry: address.country,
+    },
+  };
+
+  if (typeof l.description === 'string') {
+    jsonLd.description = l.description;
+  }
+
+  if (Array.isArray(l.photos)) {
+    jsonLd.image = l.photos
+      .map((p) => (p && typeof p.url === 'string' ? p.url : undefined))
+      .filter((url): url is string => typeof url === 'string');
+  }
+
+  if (typeof l.price === 'number') {
+    jsonLd.offers = {
+      '@type': 'Offer',
+      price: l.price,
+      priceCurrency: typeof l.currency === 'string' ? l.currency : undefined,
+      availability: l.status === 'active' ? 'InStock' : 'OutOfStock',
+    };
+  }
+
+  if (typeof l.rooms === 'number') {
+    jsonLd.numberOfRooms = l.rooms;
+  }
+
+  if (typeof l.area === 'number') {
+    jsonLd.floorSize = {
+      '@type': 'QuantitativeValue',
+      value: l.area,
+      unitCode: 'MTK',
+    };
+  }
+
+  return jsonLd;
+}

--- a/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/page.tsx
@@ -12,6 +12,7 @@ import type { ListingDetail } from '@ppt/reality-api-client';
 import type { Metadata } from 'next';
 import { headers } from 'next/headers';
 import { ListingDetailContent, ListingNotFound } from '@/components/listings';
+import { buildListingJsonLd } from './jsonLd';
 import { buildListingMetadata } from './metadata';
 
 function inferApiBaseFromHost(host: string): string | null {
@@ -96,35 +97,11 @@ export default async function ListingDetailPage({ params }: PageProps) {
     return <ListingNotFound />;
   }
 
-  // JSON-LD structured data
-  const jsonLd = {
-    '@context': 'https://schema.org',
-    '@type': 'RealEstateListing',
-    name: listing.title,
-    description: listing.description,
-    url: `${process.env.NEXT_PUBLIC_SITE_URL || ''}/listings/${listing.slug}`,
-    image: listing.photos.map((p) => p.url),
-    address: {
-      '@type': 'PostalAddress',
-      streetAddress: listing.address.street,
-      addressLocality: listing.address.city,
-      addressRegion: listing.address.district,
-      postalCode: listing.address.postalCode,
-      addressCountry: listing.address.country,
-    },
-    offers: {
-      '@type': 'Offer',
-      price: listing.price,
-      priceCurrency: listing.currency,
-      availability: listing.status === 'active' ? 'InStock' : 'OutOfStock',
-    },
-    numberOfRooms: listing.rooms,
-    floorSize: {
-      '@type': 'QuantitativeValue',
-      value: listing.area,
-      unitCode: 'MTK',
-    },
-  };
+  // JSON-LD structured data, built defensively: a partial/malformed 200 body
+  // is truthy but may be missing nested fields (address/photos), which would
+  // crash SSR if dereferenced directly. buildListingJsonLd returns null in
+  // that case and ListingDetailContent skips the <script> tag.
+  const jsonLd = buildListingJsonLd(listing) ?? undefined;
 
   return <ListingDetailContent listing={listing} jsonLd={jsonLd} />;
 }


### PR DESCRIPTION
## Task

Reality-web listing detail SSR (`app/[locale]/listings/[slug]/page.tsx`) built JSON-LD by dereferencing listing fields (photos/address/price/rooms/area) with no runtime validation; a partial 200 body crashed SSR. Replicate the defensive shape-check pattern already used in the sibling `metadata.ts:17-36` before constructing `jsonLd`.

## Owner

pm-frontend

## Root cause

`getListing` returns the raw `response.json()` body cast `as ListingDetail | null` — TypeScript types are not enforced at runtime. The only guard is `!response.ok`, which doesn't catch a 200 whose body doesn't match the schema. The inline `jsonLd` literal then dereferenced `listing.photos.map`, `listing.address.street`, etc., so a partial body (`{}`, missing `address`/`photos`) threw `TypeError: Cannot read properties of undefined (reading 'map')` and the Next.js error boundary served a 500 on the core conversion route. `generateMetadata` was already defended (`metadata.ts`); the page body was not.

## Fix

- New `jsonLd.ts` module exporting `buildListingJsonLd(listing: unknown): object | null`, mirroring `metadata.ts`'s shape-check style. It narrows `listing` to an object, requires `title`/`slug` strings and a non-null `address` with `city`/`country` strings, and returns `null` otherwise. Optional fields (`photos`, `description`, `price`, `rooms`, `area`) are emitted only when present and well-typed; `image` is built by filtering photo URLs.
- `page.tsx` now calls `const jsonLd = buildListingJsonLd(listing) ?? undefined;` instead of the inline literal. `ListingDetailContent` already types `jsonLd?: object` and conditionally renders the `<script type="application/ld+json">` tag, so no component change was needed (kept in scope per the plan's option (b)).
- New `jsonLd.test.ts` mirrors the metadata test: valid body builds full object; `null`/`undefined`/`{}`/non-object → null; missing `address` or `title` → null; missing `photos` → object without `image`; missing optional price/rooms/area blocks omitted.

## Tested (Band A — fast check)

- `pnpm -F @ppt/reality-web typecheck` → exit 0
- `npx @biomejs/biome check` on the 3 changed files → exit 0 ("Checked 3 files, No fixes applied")
- `pnpm -F @ppt/reality-web test -- jsonLd metadata` → 2 files, 16 tests passed (9 new)

Note: the package's `lint` script is `next lint`, which is broken repo-wide under Next.js 16 (the `lint` subcommand was removed, so it treats `lint` as a directory and errors). This pre-exists this change and is unrelated to it; the repo's real lint gate is Biome, which passes.

## Built (Band B — full build)

- `pnpm -F @ppt/reality-web build` → exit 0 (production build succeeded, including the `/[locale]/listings/[slug]` route)

## CI parity (Band C — hot-path only)

skipped: not a security/auth/billing/data-integrity change. Public SSR route, no data mutation.

## Remote-tested

skipped

## Notes

- Scope-drift check (`scope-check.sh --owner pm-frontend`) → exit 0; all changes under `frontend/apps/reality-web/`.
- Out-of-scope items respected: no zod/runtime-schema refactor, no `ListingDetailContent.tsx` change, no reality-server contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtbUM7UTpax6fcwZH3ji3V

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtbUM7UTpax6fcwZH3ji3V)_