### PR TITLE
code-review-api-core-osrng-expect: propagate CSPRNG failure in crypto encrypt instead of panicking

### DIFF
--- a/backend/crates/integrations/src/crypto.rs
+++ b/backend/crates/integrations/src/crypto.rs
@@ -48,6 +48,9 @@ pub enum CryptoError {
     #[error("Encryption failed: {0}")]
     EncryptionFailed(String),
 
+    #[error("Secure random number generation failed: {0}")]
+    RngFailed(String),
+
     #[error("Decryption failed: {0}")]
     DecryptionFailed(String),
 
@@ -122,9 +125,12 @@ impl IntegrationCrypto {
         // or predictable source at process start.
         use rand::TryRng;
         let mut nonce_bytes = [0u8; NONCE_LENGTH];
+        // SECURITY: do NOT panic on a CSPRNG failure — a transient OS entropy
+        // error must surface as a handled error so the caller can refuse to
+        // persist the secret, never crash the process mid-encrypt.
         rand::rngs::SysRng
             .try_fill_bytes(&mut nonce_bytes)
-            .expect("OS rng failed");
+            .map_err(|e| CryptoError::RngFailed(e.to_string()))?;
         let nonce = Nonce::from_slice(&nonce_bytes);
 
         // Encrypt
@@ -425,6 +431,17 @@ mod tests {
             .unwrap();
         assert!(encrypted.starts_with(ENCRYPTED_PREFIX));
         assert_eq!(decrypt_if_available(Some(&crypto), &encrypted), "refresh");
+    }
+
+    #[test]
+    fn test_rng_failed_error_renders() {
+        // Regression: a CSPRNG failure during nonce generation must propagate as
+        // a handled CryptoError::RngFailed rather than panicking the process.
+        let err = CryptoError::RngFailed("entropy source unavailable".to_string());
+        assert!(matches!(err, CryptoError::RngFailed(_)));
+        let msg = err.to_string();
+        assert!(msg.contains("Secure random number generation failed"));
+        assert!(msg.contains("entropy source unavailable"));
     }
 
     #[test]


### PR DESCRIPTION
## Task
crypto.rs:127 `SysRng.try_fill_bytes(...).expect()` panics if the OS CSPRNG errors during integration-credential encrypt. Replace the panic with proper error propagation (return a Result/error instead of `.expect()`), so a CSPRNG failure surfaces as a handled error rather than crashing the process. Add a unit test if feasible.

## Owner
pm-backend

## Change
The `.expect("OS rng failed")` site was in `backend/crates/integrations/src/crypto.rs` (the `:127`/`api-core` reference in the task had drifted — the actual integration-credential encrypt path lives in the `integrations` crate). `IntegrationCrypto::encrypt` already returns `Result<String, CryptoError>`, so the fix is minimal:

- Added `CryptoError::RngFailed(String)` variant.
- Replaced `.expect("OS rng failed")` on `SysRng::try_fill_bytes` with `.map_err(|e| CryptoError::RngFailed(e.to_string()))?`, so a transient OS-entropy failure surfaces as a handled error (the caller — e.g. `encrypt_required` — then refuses to persist the secret) instead of crashing the process.
- Added `test_rng_failed_error_renders` unit test. A real CSPRNG failure can't be forced deterministically, so the test asserts the new variant matches and its `Display` renders correctly; the propagation path itself is now `?` rather than a panic.

## Tested (Band A — fast check)
- `cargo fmt -p integrations` → exit 0
- `cargo check -p integrations` → exit 0
- `cargo test -p integrations crypto` → exit 0 (13 passed, incl. new `test_rng_failed_error_renders`)
- `cargo clippy -p integrations -- -D warnings` → exit 0

## Built (Band B — full build)
skipped: change <50 LOC, no public-API-shape change beyond one additive error variant, no migration/config touch.

## CI parity (Band C — hot-path only)
Crypto path is security-adjacent, but the change is a panic→Result swap confined to one crate; Band A clippy+test already mirror what `backend.yml` runs (`cargo fmt`, `clippy -D warnings`, `cargo test`). No further CI-parity divergence expected.

## Remote-tested
skipped

## Scope drift
none — `scope-check.sh --owner pm-backend` exit 0. Only `backend/crates/integrations/src/crypto.rs` changed (incidental `Cargo.lock` churn from the build was reverted to keep the diff minimal).

## Code-reuse review
none — `reuse-grep.sh --specialist rust-backend` exit 0. The fix reuses the existing `CryptoError` enum / `thiserror` machinery; no new helper introduced.

## Notes
The new `RngFailed` error message is generic and leaks no key/entropy-source internals. `encrypt_if_available` (the dev-mode fallback) already logs and degrades on `Err`, and `encrypt_required` (the secret-persistence path) already fails closed on `Err`, so both callers handle the new variant correctly without further changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjG55JvVdRZEANW3rys84y

---
_Generated by [Claude Code](https://claude.ai/code/session_01TjG55JvVdRZEANW3rys84y)_