### PR TITLE
feat(ppt-web): real-time IoT dashboard via BIT-145 WebSocket channel (Epic 14, FR72)

### DIFF
--- a/frontend/apps/ppt-web/src/features/iot/hooks/index.ts
+++ b/frontend/apps/ppt-web/src/features/iot/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useIotWebSocket } from './useIotWebSocket';

--- a/frontend/apps/ppt-web/src/features/iot/hooks/useIotWebSocket.ts
+++ b/frontend/apps/ppt-web/src/features/iot/hooks/useIotWebSocket.ts
@@ -1,0 +1,102 @@
+/**
+ * Real-time IoT sensor reading WebSocket hook (Epic 14, FR72 — BIT-145 backend channel).
+ *
+ * Connects to `GET /api/v1/iot/ws?token=<jwt>`, subscribes to the
+ * `sensors:{org_id}` Redis pub/sub channel, and streams
+ * `{ event: "sensor.reading", payload: SensorReading }` frames.
+ *
+ * The REST polling hook (`useSensorReadings`) remains the primary data source.
+ * This hook prepends fresh readings so the telemetry chart updates in real-time
+ * without waiting for the next poll interval.
+ *
+ * Falls back gracefully when the WS server is unreachable or Redis is not
+ * configured (the backend returns heartbeat-only frames in that case).
+ */
+
+import type { SensorReading } from '@ppt/api-client';
+import { getToken } from '@ppt/api-client';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+const WS_MAX_BUFFER = 200;
+const WS_RECONNECT_MS = 5_000;
+
+function buildWsUrl(token: string): string {
+  const win = typeof window !== 'undefined' ? (window as unknown as Record<string, unknown>) : {};
+  const httpBase = win.__API_BASE_URL__ ? String(win.__API_BASE_URL__) : '';
+  const wsBase = httpBase.replace(/^https/, 'wss').replace(/^http/, 'ws');
+  return `${wsBase}/api/v1/iot/ws?token=${encodeURIComponent(token)}`;
+}
+
+export function useIotWebSocket(sensorId: string | null): {
+  liveReadings: SensorReading[];
+  isConnected: boolean;
+} {
+  const [allReadings, setAllReadings] = useState<SensorReading[]>([]);
+  const [isConnected, setIsConnected] = useState(false);
+  const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const cancelled = useRef(false);
+
+  useEffect(() => {
+    cancelled.current = false;
+
+    function connect() {
+      const token = getToken();
+      if (!token || cancelled.current) return;
+
+      const ws = new WebSocket(buildWsUrl(token));
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        if (!cancelled.current) setIsConnected(true);
+      };
+
+      ws.onmessage = (event) => {
+        if (cancelled.current) return;
+        try {
+          const msg = JSON.parse(String(event.data)) as {
+            event: string;
+            payload: SensorReading;
+          };
+          if (msg.event === 'sensor.reading') {
+            setAllReadings((prev: SensorReading[]) => {
+              const next = [msg.payload, ...prev];
+              return next.length > WS_MAX_BUFFER ? next.slice(0, WS_MAX_BUFFER) : next;
+            });
+          }
+        } catch {
+          // ignore malformed frames
+        }
+      };
+
+      ws.onerror = () => {
+        ws.close();
+      };
+
+      ws.onclose = () => {
+        if (!cancelled.current) {
+          setIsConnected(false);
+          reconnectTimer.current = setTimeout(() => {
+            if (!cancelled.current) connect();
+          }, WS_RECONNECT_MS);
+        }
+      };
+    }
+
+    connect();
+
+    return () => {
+      cancelled.current = true;
+      if (reconnectTimer.current) clearTimeout(reconnectTimer.current);
+      wsRef.current?.close();
+      wsRef.current = null;
+    };
+  }, []);
+
+  const liveReadings = useMemo(
+    () => (sensorId ? allReadings.filter((r: SensorReading) => r.sensor_id === sensorId) : []),
+    [allReadings, sensorId]
+  );
+
+  return { liveReadings, isConnected };
+}

--- a/frontend/apps/ppt-web/src/features/iot/index.ts
+++ b/frontend/apps/ppt-web/src/features/iot/index.ts
@@ -4,6 +4,7 @@
  * Manager-web front door for the IoT sensor backend.
  */
 export * from './components';
+export { useIotWebSocket } from './hooks';
 export {
   type AlertStateFilter,
   IotAlertsPage,

--- a/frontend/apps/ppt-web/src/features/iot/pages/IotDashboardPage.tsx
+++ b/frontend/apps/ppt-web/src/features/iot/pages/IotDashboardPage.tsx
@@ -24,6 +24,7 @@ export interface IotDashboardPageProps {
   readingsLoading: boolean;
   alerts: SensorAlert[];
   pendingAlertId: string | null;
+  isLive?: boolean;
   onSelectSensor: (id: string) => void;
   onAcknowledgeAlert: (alertId: string) => void;
   onResolveAlert: (alertId: string) => void;
@@ -40,6 +41,7 @@ export function IotDashboardPage({
   readingsLoading,
   alerts,
   pendingAlertId,
+  isLive = false,
   onSelectSensor,
   onAcknowledgeAlert,
   onResolveAlert,
@@ -48,15 +50,23 @@ export function IotDashboardPage({
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-6">
-      <header className="mb-6">
-        <h1 className="text-2xl font-semibold text-gray-900">
-          {t('iot.dashboardTitle', { defaultValue: 'Smart Building' })}
-        </h1>
-        <p className="mt-1 text-sm text-gray-500">
-          {t('iot.dashboardSubtitle', {
-            defaultValue: 'Sensors, telemetry and alerts across your buildings.',
-          })}
-        </p>
+      <header className="mb-6 flex items-start justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">
+            {t('iot.dashboardTitle', { defaultValue: 'Smart Building' })}
+          </h1>
+          <p className="mt-1 text-sm text-gray-500">
+            {t('iot.dashboardSubtitle', {
+              defaultValue: 'Sensors, telemetry and alerts across your buildings.',
+            })}
+          </p>
+        </div>
+        {isLive && (
+          <span className="mt-1 inline-flex items-center gap-1.5 rounded-full bg-green-100 px-2.5 py-1 text-xs font-medium text-green-700">
+            <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-green-500" />
+            {t('iot.live', { defaultValue: 'Live' })}
+          </span>
+        )}
       </header>
 
       {/* KPI rollup (FR75) */}

--- a/frontend/apps/ppt-web/src/routes/groups/iot.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/iot.tsx
@@ -37,6 +37,7 @@ import { Route, useNavigate, useParams } from 'react-router-dom';
 import { AuthRequiredGate, useToast } from '../../components';
 import { useAuth } from '../../contexts';
 import type { AlertStateFilter, SensorFormValues, ThresholdFormValues } from '../../features/iot';
+import { useIotWebSocket } from '../../features/iot';
 import {
   IotAlertsPage,
   IotDashboardPage,
@@ -65,6 +66,8 @@ function orNull(value: string): string | null {
 /**
  * Route wrapper for the IoT dashboard (Epic 14 / FR71-75).
  * Manages sensor selection and wires the IoT API hooks.
+ * Real-time readings from the BIT-145 WS channel are merged with the
+ * REST-polled snapshot so the telemetry chart updates as readings arrive.
  */
 function IotDashboardPageRoute() {
   const { user } = useAuth();
@@ -77,6 +80,8 @@ function IotDashboardPageRoute() {
     { limit: 50 }
   );
 
+  const { liveReadings, isConnected } = useIotWebSocket(selectedSensorId);
+
   const acknowledgeAlert = useAcknowledgeSensorAlert();
   const resolveAlert = useResolveSensorAlert();
 
@@ -85,6 +90,14 @@ function IotDashboardPageRoute() {
     () => sensors.find((s) => s.id === selectedSensorId) ?? null,
     [sensors, selectedSensorId]
   );
+
+  const mergedReadings = useMemo(() => {
+    const polled = readingsData?.readings ?? [];
+    if (liveReadings.length === 0) return polled;
+    const seen = new Set(polled.map((r) => r.id));
+    const fresh = liveReadings.filter((r) => !seen.has(r.id));
+    return [...fresh, ...polled].slice(0, 100);
+  }, [liveReadings, readingsData]);
 
   if (!user?.organizationId) {
     return <AuthRequiredGate />;
@@ -104,10 +117,11 @@ function IotDashboardPageRoute() {
       sensorsLoading={sensorsLoading}
       selectedSensorId={selectedSensorId}
       selectedSensor={selectedSensor}
-      readings={readingsData?.readings ?? []}
+      readings={mergedReadings}
       readingsLoading={readingsLoading && !!selectedSensorId}
       alerts={dashboard?.recent_alerts ?? []}
       pendingAlertId={pendingAlertId}
+      isLive={isConnected}
       onSelectSensor={setSelectedSensorId}
       onAcknowledgeAlert={(alertId) => acknowledgeAlert.mutate(alertId)}
       onResolveAlert={(alertId) => resolveAlert.mutate({ alertId })}


### PR DESCRIPTION
## Summary

Completes the final BIT-146 scope item: real-time telemetry in the dashboard, gated on [BIT-145](/BIT/issues/BIT-145) (backend WS channel, merged `16c4bd7`).

- **`useIotWebSocket(sensorId)`** — new hook in `features/iot/hooks/`. Connects to `GET /api/v1/iot/ws?token=<jwt>`, parses `{ event: "sensor.reading", payload }` frames, auto-reconnects after 5s on close. Buffer capped at 200 readings; filtered by `sensorId`.
- **`IotDashboardPageRoute`** — calls `useIotWebSocket(selectedSensorId)`, deduplicates live + polled readings by `id`, passes merged array (newest-first, sliced at 100) to `TelemetryPanel`. Passes `isLive={isConnected}` down.
- **`IotDashboardPage`** — new optional `isLive` prop; renders an animated green **Live** badge in the header when WS is connected. REST polling (`useSensorReadings`, 15s staleTime) remains the primary data source — WS supplements it without replacing it.

**Typecheck:** 0 errors on both `@ppt/api-client` and `@ppt/web`. Biome: clean.

## Test plan

- [ ] Open `/iot`, select a sensor — Live badge appears in header within ~1s
- [ ] POST a reading to `POST /api/v1/iot/sensors/:id/readings` → chart updates without waiting for poll
- [ ] Kill/disconnect WS (e.g. revoke token or stop Redis) → Live badge disappears, polling continues
- [ ] WS reconnects after ~5s when connection restores → Live badge reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)