### PR TITLE
docs(screens): financial-payments apiStatus -> partial (#975.5)

### DIFF
--- a/docs/screens/ppt/financial-payments.md
+++ b/docs/screens/ppt/financial-payments.md
@@ -9,7 +9,7 @@ implementations:
     component: PaymentManagementPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: stub
+    apiStatus: partial
 endpoints: []
 relatedScreens:
   - id: ppt/financial
@@ -33,3 +33,4 @@ Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, e
 
 ## Agent Log
 - 2026-05-18 — agent: created stub for unmapped route.
+- 2026-06-22 — agent: confirmed PaymentManagementPageRoute wired (#975.5) to listPayments + listUnallocatedPayments + listInvoices via TanStack Query, with allocatePayment (onMatch) and autoMatchPayments (onAutoMatch) mutations; apiStatus stub -> partial (no building_id filter param; buildings stays []).


### PR DESCRIPTION
Part of gap-sweep Epic 11 (BIT-166 / GH #975).

PaymentManagementPageRoute (frontend/apps/ppt-web/src/routes/groups/financial.tsx:220) is fully wired to the org-wide payment endpoints (listPayments, listUnallocatedPayments, listInvoices, allocatePayment, autoMatchPayments) — gap #975.5 — but the screen-map still read `apiStatus: stub`. This flips it to `partial` (no building filter param yet) to match financial.md / financial-invoices.md.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)