### PR TITLE
feat(delegations): wire delegation feature into ppt-web (BIT-189, Story 3.4)

### DIFF
--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -120,6 +120,7 @@ function AppNavigation() {
       <Link to="/emergency">{t('nav.emergency')}</Link>
       <Link to="/disputes">{t('nav.disputes')}</Link>
       <Link to="/leases">{t('nav.leases', { defaultValue: 'Leases' })}</Link>
+      <Link to="/delegations">{t('nav.delegations', { defaultValue: 'Delegations' })}</Link>
       <Link to="/outages">{t('nav.outages')}</Link>
       <Link to="/iot">{t('nav.iot', { defaultValue: 'Smart Building' })}</Link>
       <Link to="/iot/alerts">{t('nav.iotAlerts', { defaultValue: 'Sensor Alerts' })}</Link>

--- a/frontend/apps/ppt-web/src/features/delegations/index.ts
+++ b/frontend/apps/ppt-web/src/features/delegations/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Delegations feature (Epic 3, Story 3.4).
+ *
+ * Exposes the page component for the lazy-loaded route at `/delegations`.
+ */
+
+export { DelegationsPage } from './pages';

--- a/frontend/apps/ppt-web/src/features/delegations/pages/DelegationsPage.tsx
+++ b/frontend/apps/ppt-web/src/features/delegations/pages/DelegationsPage.tsx
@@ -1,0 +1,443 @@
+/**
+ * Delegations management page (Epic 3, Story 3.4).
+ *
+ * Lets a unit owner delegate voting / document / fault / financial rights to
+ * another user, and lets a delegate accept or decline delegations they
+ * received. Wires the full backend surface
+ * (`backend/servers/api-server/src/routes/delegations.rs`) into ppt-web:
+ *
+ *   POST   /api/v1/delegations            — create        (useCreateDelegation)
+ *   GET    /api/v1/delegations            — list mine      (useMyDelegations)
+ *   GET    /api/v1/delegations/received   — list received  (useReceivedDelegations)
+ *   POST   /api/v1/delegations/{id}/accept   — accept      (useAcceptDelegation)
+ *   POST   /api/v1/delegations/{id}/decline  — decline     (useDeclineDelegation)
+ *   DELETE /api/v1/delegations/{id}/revoke   — revoke      (useRevokeDelegation)
+ */
+
+import {
+  DELEGATION_SCOPES,
+  type DelegationScope,
+  type DelegationSummary,
+  useAcceptDelegation,
+  useCreateDelegation,
+  useDeclineDelegation,
+  useMyDelegations,
+  useReceivedDelegations,
+  useRevokeDelegation,
+} from '@ppt/api-client';
+import type React from 'react';
+import { useState } from 'react';
+import { useToast } from '../../../components';
+
+/** Map a delegation status to a small badge style. */
+function statusBadgeClass(status: string): string {
+  switch (status) {
+    case 'active':
+      return 'bg-green-100 text-green-800';
+    case 'pending':
+      return 'bg-yellow-100 text-yellow-800';
+    case 'declined':
+    case 'revoked':
+    case 'expired':
+      return 'bg-gray-100 text-gray-600';
+    default:
+      return 'bg-gray-100 text-gray-600';
+  }
+}
+
+function ScopeBadges({ scopes }: { scopes: string[] }) {
+  if (scopes.length === 0) return null;
+  return (
+    <span className="flex flex-wrap gap-1" aria-label={`Scopes: ${scopes.join(', ')}`}>
+      {scopes.map((scope) => (
+        <span
+          key={scope}
+          className="rounded bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700"
+        >
+          {scope}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+/** Shared visual shell for one delegation row. */
+function DelegationRow({
+  delegation,
+  subjectLabel,
+  subjectId,
+  actions,
+}: {
+  delegation: DelegationSummary;
+  subjectLabel: string;
+  subjectId: string;
+  actions?: React.ReactNode;
+}) {
+  return (
+    <li className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-gray-200 p-4">
+      <div className="min-w-0 space-y-1">
+        <div className="flex items-center gap-2">
+          <span
+            className={`rounded-full px-2 py-0.5 text-xs font-medium ${statusBadgeClass(
+              delegation.status
+            )}`}
+          >
+            {delegation.status}
+          </span>
+          <span className="text-sm text-gray-700">
+            {subjectLabel}: <span className="font-mono text-xs">{subjectId}</span>
+          </span>
+        </div>
+        <div className="text-sm text-gray-600">
+          Unit:{' '}
+          {delegation.unit_id ? (
+            <span className="font-mono text-xs">{delegation.unit_id}</span>
+          ) : (
+            <span className="italic">all units</span>
+          )}
+        </div>
+        <ScopeBadges scopes={delegation.scopes} />
+      </div>
+      {actions && <div className="flex shrink-0 gap-2">{actions}</div>}
+    </li>
+  );
+}
+
+/** Create-delegation form. */
+function CreateDelegationForm() {
+  const { showToast } = useToast();
+  const createDelegation = useCreateDelegation();
+  const [delegateUserId, setDelegateUserId] = useState('');
+  const [unitId, setUnitId] = useState('');
+  const [scopes, setScopes] = useState<DelegationScope[]>(['all']);
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+
+  const toggleScope = (scope: DelegationScope) => {
+    setScopes((prev) =>
+      prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope]
+    );
+  };
+
+  const reset = () => {
+    setDelegateUserId('');
+    setUnitId('');
+    setScopes(['all']);
+    setStartDate('');
+    setEndDate('');
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!delegateUserId.trim()) {
+      showToast({
+        type: 'error',
+        title: 'Delegate required',
+        message: 'Enter a delegate user ID.',
+      });
+      return;
+    }
+    if (scopes.length === 0) {
+      showToast({ type: 'error', title: 'Scope required', message: 'Select at least one scope.' });
+      return;
+    }
+    try {
+      await createDelegation.mutateAsync({
+        delegate_user_id: delegateUserId.trim(),
+        unit_id: unitId.trim() || null,
+        scopes,
+        start_date: startDate || null,
+        end_date: endDate || null,
+      });
+      showToast({
+        type: 'success',
+        title: 'Delegation created',
+        message: 'Invitation sent to the delegate.',
+      });
+      reset();
+    } catch (err) {
+      showToast({
+        type: 'error',
+        title: 'Failed to create delegation',
+        message: err instanceof Error ? err.message : 'An unexpected error occurred.',
+      });
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border border-gray-200 p-4">
+      <h2 className="text-lg font-semibold">Delegate your rights</h2>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-medium">Delegate user ID *</span>
+          <input
+            type="text"
+            value={delegateUserId}
+            onChange={(e) => setDelegateUserId(e.target.value)}
+            required
+            placeholder="user UUID"
+            className="rounded-lg border border-gray-300 px-3 py-2"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-medium">Unit ID (optional)</span>
+          <input
+            type="text"
+            value={unitId}
+            onChange={(e) => setUnitId(e.target.value)}
+            placeholder="leave blank for all owned units"
+            className="rounded-lg border border-gray-300 px-3 py-2"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-medium">Start date (optional)</span>
+          <input
+            type="date"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+            className="rounded-lg border border-gray-300 px-3 py-2"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-medium">End date (optional)</span>
+          <input
+            type="date"
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+            className="rounded-lg border border-gray-300 px-3 py-2"
+          />
+        </label>
+      </div>
+      <fieldset>
+        <legend className="text-sm font-medium">Scopes</legend>
+        <div className="mt-2 flex flex-wrap gap-3">
+          {DELEGATION_SCOPES.map((scope) => (
+            <label key={scope} className="flex items-center gap-1.5 text-sm">
+              <input
+                type="checkbox"
+                checked={scopes.includes(scope)}
+                onChange={() => toggleScope(scope)}
+              />
+              {scope}
+            </label>
+          ))}
+        </div>
+      </fieldset>
+      <button
+        type="submit"
+        disabled={createDelegation.isPending}
+        className="btn-primary-token rounded-lg px-4 py-2 text-sm font-medium"
+      >
+        {createDelegation.isPending ? 'Creating…' : 'Create delegation'}
+      </button>
+    </form>
+  );
+}
+
+/** Section that lists delegations the current user received (as delegate). */
+function ReceivedDelegationsSection() {
+  const { showToast } = useToast();
+  const { data, isLoading, isError, error, refetch } = useReceivedDelegations();
+  const accept = useAcceptDelegation();
+  const decline = useDeclineDelegation();
+
+  const run = async (mutate: (id: string) => Promise<unknown>, id: string, verb: string) => {
+    try {
+      await mutate(id);
+      showToast({
+        type: 'success',
+        title: `Delegation ${verb}`,
+        message: `You ${verb} the delegation.`,
+      });
+    } catch (err) {
+      showToast({
+        type: 'error',
+        title: `Failed to ${verb.replace(/ed$/, '')} delegation`,
+        message: err instanceof Error ? err.message : 'An unexpected error occurred.',
+      });
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <p role="status" aria-busy="true" className="text-sm text-gray-600">
+        Loading received delegations…
+      </p>
+    );
+  }
+  if (isError) {
+    return (
+      <div role="alert" className="space-y-2 text-sm">
+        <p className="text-red-700">
+          {error instanceof Error ? error.message : 'Failed to load received delegations.'}
+        </p>
+        <button
+          type="button"
+          onClick={() => refetch()}
+          className="btn-outline-token rounded-lg px-3 py-1.5"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  const list = data ?? [];
+  if (list.length === 0) {
+    return (
+      <p role="status" className="text-sm text-gray-600">
+        No one has delegated rights to you yet.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="space-y-3" aria-label="Delegations received">
+      {list.map((d) => (
+        <DelegationRow
+          key={d.id}
+          delegation={d}
+          subjectLabel="From owner"
+          subjectId={d.owner_user_id}
+          actions={
+            d.status === 'pending' ? (
+              <>
+                <button
+                  type="button"
+                  onClick={() => run(accept.mutateAsync, d.id, 'accepted')}
+                  disabled={accept.isPending || decline.isPending}
+                  className="btn-primary-token rounded-lg px-3 py-1.5 text-sm font-medium"
+                >
+                  Accept
+                </button>
+                <button
+                  type="button"
+                  onClick={() => run(decline.mutateAsync, d.id, 'declined')}
+                  disabled={accept.isPending || decline.isPending}
+                  className="btn-outline-token rounded-lg px-3 py-1.5 text-sm font-medium"
+                >
+                  Decline
+                </button>
+              </>
+            ) : undefined
+          }
+        />
+      ))}
+    </ul>
+  );
+}
+
+/** Section that lists delegations the current user created (as owner). */
+function MyDelegationsSection() {
+  const { showToast } = useToast();
+  const { data, isLoading, isError, error, refetch } = useMyDelegations();
+  const revoke = useRevokeDelegation();
+
+  const handleRevoke = async (id: string) => {
+    try {
+      await revoke.mutateAsync(id);
+      showToast({
+        type: 'success',
+        title: 'Delegation revoked',
+        message: 'The delegate no longer has access.',
+      });
+    } catch (err) {
+      showToast({
+        type: 'error',
+        title: 'Failed to revoke delegation',
+        message: err instanceof Error ? err.message : 'An unexpected error occurred.',
+      });
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <p role="status" aria-busy="true" className="text-sm text-gray-600">
+        Loading your delegations…
+      </p>
+    );
+  }
+  if (isError) {
+    return (
+      <div role="alert" className="space-y-2 text-sm">
+        <p className="text-red-700">
+          {error instanceof Error ? error.message : 'Failed to load your delegations.'}
+        </p>
+        <button
+          type="button"
+          onClick={() => refetch()}
+          className="btn-outline-token rounded-lg px-3 py-1.5"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  const list = data ?? [];
+  if (list.length === 0) {
+    return (
+      <p role="status" className="text-sm text-gray-600">
+        You haven&apos;t delegated any rights yet.
+      </p>
+    );
+  }
+
+  const revocable = new Set(['pending', 'active']);
+
+  return (
+    <ul className="space-y-3" aria-label="Delegations created">
+      {list.map((d) => (
+        <DelegationRow
+          key={d.id}
+          delegation={d}
+          subjectLabel="To delegate"
+          subjectId={d.delegate_user_id}
+          actions={
+            revocable.has(d.status) ? (
+              <button
+                type="button"
+                onClick={() => handleRevoke(d.id)}
+                disabled={revoke.isPending}
+                className="btn-outline-token rounded-lg px-3 py-1.5 text-sm font-medium"
+                aria-label={`Revoke delegation to ${d.delegate_user_id}`}
+              >
+                Revoke
+              </button>
+            ) : undefined
+          }
+        />
+      ))}
+    </ul>
+  );
+}
+
+export const DelegationsPage: React.FC = () => {
+  return (
+    <div className="mx-auto max-w-3xl space-y-8 p-4">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-bold">Delegations</h1>
+        <p className="text-sm text-gray-600">
+          Delegate your ownership rights (voting, documents, faults, financial) to another user, or
+          manage delegations others have shared with you.
+        </p>
+      </header>
+
+      <CreateDelegationForm />
+
+      <section className="space-y-3" aria-labelledby="received-heading">
+        <h2 id="received-heading" className="text-lg font-semibold">
+          Received delegations
+        </h2>
+        <ReceivedDelegationsSection />
+      </section>
+
+      <section className="space-y-3" aria-labelledby="mine-heading">
+        <h2 id="mine-heading" className="text-lg font-semibold">
+          Delegations you created
+        </h2>
+        <MyDelegationsSection />
+      </section>
+    </div>
+  );
+};

--- a/frontend/apps/ppt-web/src/features/delegations/pages/index.ts
+++ b/frontend/apps/ppt-web/src/features/delegations/pages/index.ts
@@ -1,0 +1,1 @@
+export { DelegationsPage } from './DelegationsPage';

--- a/frontend/apps/ppt-web/src/routes/AppRoutes.tsx
+++ b/frontend/apps/ppt-web/src/routes/AppRoutes.tsx
@@ -18,6 +18,7 @@ import { announcementRoutes } from './groups/announcements';
 import { buildingRoutes } from './groups/buildings';
 import { communityRoutes } from './groups/community';
 import { authRoutes, dashboardRoutes, errorRoutes, Home, settingsRoutes } from './groups/core';
+import { delegationRoutes } from './groups/delegations';
 import { disputeRoutes } from './groups/disputes';
 import { documentRoutes, newsRoutes } from './groups/documents';
 import { faultRoutes } from './groups/faults';
@@ -41,6 +42,7 @@ export function AppRoutes() {
       {documentRoutes()}
       {newsRoutes()}
       {disputeRoutes()}
+      {delegationRoutes()}
       {outageRoutes()}
       {announcementRoutes()}
       {messagingRoutes()}

--- a/frontend/apps/ppt-web/src/routes/groups/delegations.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/delegations.tsx
@@ -1,0 +1,26 @@
+/**
+ * Delegations route group (Epic 3, Story 3.4).
+ *
+ * Mounts `features/delegations/` into ppt-web. The `@ppt/api-client` delegation
+ * module ships its own hooks, so the page consumes them directly and this
+ * wrapper only guards the route behind authentication.
+ */
+import { Route } from 'react-router-dom';
+import { ProtectedRoute } from '../../components';
+import { DelegationsPage } from '../lazyRoutes';
+
+/** Delegation routes (Epic 3, Story 3.4). */
+export function delegationRoutes() {
+  return (
+    <>
+      <Route
+        path="/delegations"
+        element={
+          <ProtectedRoute>
+            <DelegationsPage />
+          </ProtectedRoute>
+        }
+      />
+    </>
+  );
+}

--- a/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
+++ b/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
@@ -63,6 +63,11 @@ export const IotThresholdConfigPage = lazy(() =>
   import('../features/iot').then((m) => ({ default: m.IotThresholdConfigPage }))
 );
 
+// Delegations feature (Epic 3, Story 3.4)
+export const DelegationsPage = lazy(() =>
+  import('../features/delegations').then((m) => ({ default: m.DelegationsPage }))
+);
+
 // Disputes feature (Epic 77)
 export const DisputesPage = lazy(() =>
   import('../features/disputes').then((m) => ({ default: m.DisputesPage }))

--- a/frontend/packages/api-client/src/delegation/api.test.ts
+++ b/frontend/packages/api-client/src/delegation/api.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Contract tests for the hand-rolled delegation API client (Epic 3, Story 3.4).
+ *
+ * `delegation/api.ts` is a hand-written transport layer the ppt-web delegations
+ * feature calls directly. These tests pin the request wiring (URL template +
+ * HTTP method + body) of every endpoint against
+ * `backend/servers/api-server/src/routes/delegations.rs`, so the client can't
+ * silently drift onto the wrong path/verb and 404 at runtime with no
+ * compile-time signal.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  acceptDelegation,
+  checkDelegation,
+  createDelegation,
+  declineDelegation,
+  getDelegation,
+  listMyDelegations,
+  listReceivedDelegations,
+  revokeDelegation,
+} from './api';
+
+const ID = '11111111-1111-1111-1111-111111111111';
+const UNIT_ID = '22222222-2222-2222-2222-222222222222';
+const DELEGATE_ID = '33333333-3333-3333-3333-333333333333';
+
+/** Minimal ok JSON response stub. */
+function okJson(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as Response;
+}
+
+/** Read the (url, method, body) the client passed to the last fetch call. */
+function lastCall(): { url: string; method: string; body: string | undefined } {
+  const calls = vi.mocked(fetch).mock.calls;
+  const call = calls[calls.length - 1];
+  if (!call) throw new Error('fetch was not called');
+  const url = String(call[0]);
+  const init = call[1] as RequestInit | undefined;
+  const method = (init?.method ?? 'GET').toUpperCase();
+  const body = init?.body == null ? undefined : String(init.body);
+  return { url, method, body };
+}
+
+describe('delegation api client — request wiring contract', () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(okJson({}));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('createDelegation → POST /api/v1/delegations with JSON body', async () => {
+    await createDelegation({ delegate_user_id: DELEGATE_ID, scopes: ['voting'] });
+    const { url, method, body } = lastCall();
+    expect(method).toBe('POST');
+    expect(url).toBe('/api/v1/delegations');
+    expect(JSON.parse(body ?? '{}')).toEqual({
+      delegate_user_id: DELEGATE_ID,
+      scopes: ['voting'],
+    });
+  });
+
+  it('listMyDelegations → GET /api/v1/delegations (bare path, no filters)', async () => {
+    await listMyDelegations();
+    const { url, method } = lastCall();
+    expect(method).toBe('GET');
+    expect(url).toBe('/api/v1/delegations');
+  });
+
+  it('listMyDelegations serializes filters as snake_case query params', async () => {
+    await listMyDelegations({ unit_id: UNIT_ID, status: 'active' });
+    const { url } = lastCall();
+    const qs = new URLSearchParams(url.split('?')[1] ?? '');
+    expect(qs.get('unit_id')).toBe(UNIT_ID);
+    expect(qs.get('status')).toBe('active');
+  });
+
+  it('listReceivedDelegations → GET /api/v1/delegations/received', async () => {
+    await listReceivedDelegations();
+    const { url, method } = lastCall();
+    expect(method).toBe('GET');
+    expect(url).toBe('/api/v1/delegations/received');
+  });
+
+  it('getDelegation → GET /api/v1/delegations/{id}', async () => {
+    await getDelegation(ID);
+    const { url, method } = lastCall();
+    expect(method).toBe('GET');
+    expect(url).toBe(`/api/v1/delegations/${ID}`);
+  });
+
+  it('acceptDelegation → POST /api/v1/delegations/{id}/accept', async () => {
+    await acceptDelegation(ID);
+    const { url, method } = lastCall();
+    expect(method).toBe('POST');
+    expect(url).toBe(`/api/v1/delegations/${ID}/accept`);
+  });
+
+  it('declineDelegation → POST /api/v1/delegations/{id}/decline', async () => {
+    await declineDelegation(ID);
+    const { url, method } = lastCall();
+    expect(method).toBe('POST');
+    expect(url).toBe(`/api/v1/delegations/${ID}/decline`);
+  });
+
+  it('revokeDelegation → DELETE /api/v1/delegations/{id}/revoke', async () => {
+    await revokeDelegation(ID);
+    const { url, method } = lastCall();
+    expect(method).toBe('DELETE');
+    expect(url).toBe(`/api/v1/delegations/${ID}/revoke`);
+  });
+
+  it('checkDelegation → GET /api/v1/delegations/check/{unit_id}/{scope}', async () => {
+    await checkDelegation(UNIT_ID, 'voting');
+    const { url, method } = lastCall();
+    expect(method).toBe('GET');
+    expect(url).toBe(`/api/v1/delegations/check/${UNIT_ID}/voting`);
+  });
+});

--- a/frontend/packages/api-client/src/delegation/api.ts
+++ b/frontend/packages/api-client/src/delegation/api.ts
@@ -1,0 +1,120 @@
+/**
+ * Delegation API client (Epic 3, Story 3.4).
+ *
+ * Thin transport over `/api/v1/delegations` (see
+ * `backend/servers/api-server/src/routes/delegations.rs`). Uses the centralised
+ * authenticated fetch helper so token + MFA + error handling stay consistent
+ * with the rest of the api-client (lib/fetch.ts, #486).
+ */
+
+import { authenticatedFetchJson } from '../lib/fetch';
+import type {
+  CheckDelegationResult,
+  CreateDelegationRequest,
+  Delegation,
+  DelegationSummary,
+  ListDelegationsQuery,
+} from './types';
+
+const API_BASE = '/api/v1/delegations';
+
+/** Build a `?a=b&c=d` query string, skipping empty/undefined values. */
+function buildQueryString(params: Record<string, string | undefined | null>): string {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null && value !== '') {
+      searchParams.append(key, value);
+    }
+  }
+  const query = searchParams.toString();
+  return query ? `?${query}` : '';
+}
+
+/**
+ * Create a new delegation.
+ *
+ * `POST /api/v1/delegations` → 201 {@link Delegation}.
+ */
+export async function createDelegation(request: CreateDelegationRequest): Promise<Delegation> {
+  return authenticatedFetchJson<Delegation>(API_BASE, {
+    method: 'POST',
+    body: JSON.stringify(request),
+  });
+}
+
+/**
+ * List delegations the current user created (as owner).
+ *
+ * `GET /api/v1/delegations` → {@link DelegationSummary}[].
+ */
+export async function listMyDelegations(
+  query: ListDelegationsQuery = {}
+): Promise<DelegationSummary[]> {
+  const qs = buildQueryString({ unit_id: query.unit_id, status: query.status });
+  return authenticatedFetchJson<DelegationSummary[]>(`${API_BASE}${qs}`);
+}
+
+/**
+ * List delegations the current user received (as delegate).
+ *
+ * `GET /api/v1/delegations/received` → {@link DelegationSummary}[].
+ */
+export async function listReceivedDelegations(): Promise<DelegationSummary[]> {
+  return authenticatedFetchJson<DelegationSummary[]>(`${API_BASE}/received`);
+}
+
+/**
+ * Fetch a single delegation by id (owner or delegate only).
+ *
+ * `GET /api/v1/delegations/{id}` → {@link Delegation}.
+ */
+export async function getDelegation(id: string): Promise<Delegation> {
+  return authenticatedFetchJson<Delegation>(`${API_BASE}/${encodeURIComponent(id)}`);
+}
+
+/**
+ * Accept a delegation invitation (delegate only).
+ *
+ * `POST /api/v1/delegations/{id}/accept` → {@link Delegation}.
+ */
+export async function acceptDelegation(id: string): Promise<Delegation> {
+  return authenticatedFetchJson<Delegation>(`${API_BASE}/${encodeURIComponent(id)}/accept`, {
+    method: 'POST',
+  });
+}
+
+/**
+ * Decline a delegation invitation (delegate only).
+ *
+ * `POST /api/v1/delegations/{id}/decline` → {@link Delegation}.
+ */
+export async function declineDelegation(id: string): Promise<Delegation> {
+  return authenticatedFetchJson<Delegation>(`${API_BASE}/${encodeURIComponent(id)}/decline`, {
+    method: 'POST',
+  });
+}
+
+/**
+ * Revoke an active delegation (owner only).
+ *
+ * `DELETE /api/v1/delegations/{id}/revoke` → {@link Delegation}.
+ */
+export async function revokeDelegation(id: string): Promise<Delegation> {
+  return authenticatedFetchJson<Delegation>(`${API_BASE}/${encodeURIComponent(id)}/revoke`, {
+    method: 'DELETE',
+  });
+}
+
+/**
+ * Check whether the current user holds a delegation for a unit + scope.
+ *
+ * `GET /api/v1/delegations/check/{unit_id}/{scope}` → {@link CheckDelegationResult}.
+ */
+export async function checkDelegation(
+  unitId: string,
+  scope: string
+): Promise<CheckDelegationResult> {
+  return authenticatedFetchJson<CheckDelegationResult>(
+    `${API_BASE}/check/${encodeURIComponent(unitId)}/${encodeURIComponent(scope)}`
+  );
+}

--- a/frontend/packages/api-client/src/delegation/hooks.ts
+++ b/frontend/packages/api-client/src/delegation/hooks.ts
@@ -1,0 +1,107 @@
+/**
+ * Delegation TanStack Query hooks (Epic 3, Story 3.4).
+ *
+ * React hooks over the delegation API. List queries are cached under
+ * `delegationKeys`; every mutation invalidates the affected lists so the UI
+ * reflects accept/decline/revoke/create without a manual reload.
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  acceptDelegation,
+  createDelegation,
+  declineDelegation,
+  getDelegation,
+  listMyDelegations,
+  listReceivedDelegations,
+  revokeDelegation,
+} from './api';
+import type { CreateDelegationRequest, ListDelegationsQuery } from './types';
+
+// ============================================
+// Query Key Factory
+// ============================================
+
+export const delegationKeys = {
+  all: ['delegations'] as const,
+  mine: (query?: ListDelegationsQuery) => [...delegationKeys.all, 'mine', query ?? {}] as const,
+  received: () => [...delegationKeys.all, 'received'] as const,
+  detail: (id: string) => [...delegationKeys.all, 'detail', id] as const,
+};
+
+// ============================================
+// Queries
+// ============================================
+
+/** Delegations the current user created (as owner). */
+export function useMyDelegations(query: ListDelegationsQuery = {}) {
+  return useQuery({
+    queryKey: delegationKeys.mine(query),
+    queryFn: () => listMyDelegations(query),
+    staleTime: 30_000,
+  });
+}
+
+/** Delegations the current user received (as delegate). */
+export function useReceivedDelegations() {
+  return useQuery({
+    queryKey: delegationKeys.received(),
+    queryFn: () => listReceivedDelegations(),
+    staleTime: 30_000,
+  });
+}
+
+/** A single delegation by id. */
+export function useDelegation(id: string | undefined) {
+  return useQuery({
+    queryKey: delegationKeys.detail(id ?? ''),
+    queryFn: () => getDelegation(id as string),
+    enabled: Boolean(id),
+  });
+}
+
+// ============================================
+// Mutations
+// ============================================
+
+/** Invalidate every delegation list + detail after a mutation. */
+function useInvalidateDelegations() {
+  const queryClient = useQueryClient();
+  return () => queryClient.invalidateQueries({ queryKey: delegationKeys.all });
+}
+
+/** Create a delegation (owner action). Invalidates the "mine" list. */
+export function useCreateDelegation() {
+  const invalidate = useInvalidateDelegations();
+  return useMutation({
+    mutationFn: (request: CreateDelegationRequest) => createDelegation(request),
+    onSuccess: invalidate,
+  });
+}
+
+/** Accept a received delegation (delegate action). */
+export function useAcceptDelegation() {
+  const invalidate = useInvalidateDelegations();
+  return useMutation({
+    mutationFn: (id: string) => acceptDelegation(id),
+    onSuccess: invalidate,
+  });
+}
+
+/** Decline a received delegation (delegate action). */
+export function useDeclineDelegation() {
+  const invalidate = useInvalidateDelegations();
+  return useMutation({
+    mutationFn: (id: string) => declineDelegation(id),
+    onSuccess: invalidate,
+  });
+}
+
+/** Revoke a delegation you created (owner action). */
+export function useRevokeDelegation() {
+  const invalidate = useInvalidateDelegations();
+  return useMutation({
+    mutationFn: (id: string) => revokeDelegation(id),
+    onSuccess: invalidate,
+  });
+}

--- a/frontend/packages/api-client/src/delegation/index.ts
+++ b/frontend/packages/api-client/src/delegation/index.ts
@@ -1,0 +1,38 @@
+/**
+ * Delegation module (Epic 3, Story 3.4).
+ *
+ * Ownership delegation: a unit owner delegates voting / document / fault /
+ * financial rights to another user. Wires to `/api/v1/delegations` on
+ * api-server (`routes/delegations.rs`).
+ */
+
+export {
+  acceptDelegation,
+  checkDelegation,
+  createDelegation,
+  declineDelegation,
+  getDelegation,
+  listMyDelegations,
+  listReceivedDelegations,
+  revokeDelegation,
+} from './api';
+export {
+  delegationKeys,
+  useAcceptDelegation,
+  useCreateDelegation,
+  useDeclineDelegation,
+  useDelegation,
+  useMyDelegations,
+  useReceivedDelegations,
+  useRevokeDelegation,
+} from './hooks';
+export {
+  type CheckDelegationResult,
+  type CreateDelegationRequest,
+  DELEGATION_SCOPES,
+  type Delegation,
+  type DelegationScope,
+  type DelegationStatus,
+  type DelegationSummary,
+  type ListDelegationsQuery,
+} from './types';

--- a/frontend/packages/api-client/src/delegation/types.ts
+++ b/frontend/packages/api-client/src/delegation/types.ts
@@ -1,0 +1,90 @@
+/**
+ * Delegation types (Epic 3, Story 3.4).
+ *
+ * Mirrors the wire format of `backend/servers/api-server/src/routes/delegations.rs`.
+ * The Rust response structs use plain `serde` (no rename), so every field is
+ * serialised in `snake_case` — these types match that exactly to avoid runtime
+ * key drift.
+ */
+
+/** A delegation scope. Mirrors the backend's `valid_scopes` allow-list. */
+export type DelegationScope = 'all' | 'voting' | 'documents' | 'faults' | 'financial';
+
+/** All valid delegation scopes, in display order. */
+export const DELEGATION_SCOPES: readonly DelegationScope[] = [
+  'all',
+  'voting',
+  'documents',
+  'faults',
+  'financial',
+] as const;
+
+/** Lifecycle status of a delegation (as stored/returned by the backend). */
+export type DelegationStatus = 'pending' | 'active' | 'declined' | 'revoked' | 'expired' | string;
+
+/**
+ * Compact delegation record returned by the list endpoints.
+ *
+ * Corresponds to `DelegationSummaryResponse` in `routes/delegations.rs`.
+ */
+export interface DelegationSummary {
+  id: string;
+  owner_user_id: string;
+  delegate_user_id: string;
+  unit_id: string | null;
+  scopes: string[];
+  status: DelegationStatus;
+}
+
+/**
+ * Full delegation record returned by create/get/accept/decline/revoke.
+ *
+ * Corresponds to `DelegationResponse` in `routes/delegations.rs`.
+ */
+export interface Delegation {
+  id: string;
+  owner_user_id: string;
+  delegate_user_id: string;
+  unit_id: string | null;
+  scopes: string[];
+  status: DelegationStatus;
+  /** ISO date (YYYY-MM-DD). */
+  start_date: string;
+  /** ISO date (YYYY-MM-DD) or null. */
+  end_date: string | null;
+  /** RFC3339 timestamp or null. */
+  accepted_at: string | null;
+  /** RFC3339 timestamp or null. */
+  revoked_at: string | null;
+  revoked_reason: string | null;
+  /** RFC3339 timestamp. */
+  created_at: string;
+}
+
+/**
+ * Body for `POST /api/v1/delegations`.
+ *
+ * Corresponds to `CreateDelegationRequest` in `routes/delegations.rs`.
+ */
+export interface CreateDelegationRequest {
+  delegate_user_id: string;
+  /** Optional — applies to all owned units when omitted. */
+  unit_id?: string | null;
+  /** Defaults to `["all"]` server-side when omitted. */
+  scopes?: string[];
+  /** ISO date (YYYY-MM-DD). Defaults to today server-side. */
+  start_date?: string | null;
+  /** ISO date (YYYY-MM-DD). */
+  end_date?: string | null;
+}
+
+/** Filters for `GET /api/v1/delegations`. */
+export interface ListDelegationsQuery {
+  unit_id?: string;
+  status?: string;
+}
+
+/** Result of `GET /api/v1/delegations/check/{unit_id}/{scope}`. */
+export interface CheckDelegationResult {
+  has_delegation: boolean;
+}

--- a/frontend/packages/api-client/src/index.ts
+++ b/frontend/packages/api-client/src/index.ts
@@ -16,6 +16,7 @@ export * from './buildings';
 export * from './community';
 export * from './compliance';
 export * from './critical-notifications';
+export * from './delegation';
 export * from './disputes';
 export * from './documents';
 export * from './ecosystem';


### PR DESCRIPTION
## [PM #981 — gap 2] Delegation feature frontend wiring + route (Story 3.4)

Canonical issue: **BIT-194** (supersedes cancelled sibling BIT-189). Parent BIT-169 · GH epic #981.

Wires the complete delegation feature into `ppt-web`. Backend (`/api/v1/delegations`, Epic 3 Story 3.4) was already complete; the frontend scaffold had been retired (PAP-33), so this rebuilds it **wired** rather than re-adding dead scaffolds.

### Included
- **api-client** `packages/api-client/src/delegation/`: api.ts (all 8 endpoints), types.ts (snake_case wire types mirroring delegations.rs), hooks.ts (React Query + invalidation), api.test.ts (9 tests), index.ts; exported from package index.
- **DelegationsPage** `features/delegations/`: given/received tabs, create form, accept/decline/revoke mutations, loading/error/empty states.
- **Route + nav**: `/delegations` lazy route + nav link in App.tsx.

### Done criteria
- [x] create/list/received/accept/decline/revoke reachable + working
- [x] loading/error/empty states; invalidating mutations
- [x] rebased onto dev, CI green → merge --admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)