### PR TITLE
feat(epic-3): story 3.1 AC3 - building geocoding/coordinates (BIT-191)

### DIFF
--- a/backend/crates/db/migrations/00187_buildings_add_coordinates.sql
+++ b/backend/crates/db/migrations/00187_buildings_add_coordinates.sql
@@ -1,0 +1,14 @@
+-- Story 3.1 AC3 (BIT-200): Building geocoding / coordinates
+-- Adds latitude/longitude so buildings can be geocoded on write and shown on a map.
+-- Mirrors the precision used by listings/emergency (DECIMAL(10,8) / DECIMAL(11,8)).
+
+ALTER TABLE buildings
+    ADD COLUMN IF NOT EXISTS latitude DECIMAL(10, 8),
+    ADD COLUMN IF NOT EXISTS longitude DECIMAL(11, 8);
+
+COMMENT ON COLUMN buildings.latitude IS 'Geocoded latitude (WGS84); NULL when geocoding is unconfigured or unresolved';
+COMMENT ON COLUMN buildings.longitude IS 'Geocoded longitude (WGS84); NULL when geocoding is unconfigured or unresolved';
+
+-- Supports map/proximity queries that filter on a populated coordinate pair.
+CREATE INDEX IF NOT EXISTS idx_buildings_coordinates ON buildings (latitude, longitude)
+    WHERE latitude IS NOT NULL AND longitude IS NOT NULL;

--- a/backend/crates/db/src/models/building.rs
+++ b/backend/crates/db/src/models/building.rs
@@ -1,6 +1,7 @@
 //! Building model (Epic 2B, UC-15).
 
 use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use utoipa::ToSchema;
@@ -27,6 +28,11 @@ pub struct Building {
     pub total_floors: i32,
     pub total_entrances: i32,
 
+    // Geocoded coordinates (Story 3.1 AC3). NULL when geocoding is
+    // unconfigured or the address could not be resolved.
+    pub latitude: Option<Decimal>,
+    pub longitude: Option<Decimal>,
+
     // Flexible JSONB fields
     pub amenities: serde_json::Value,
     pub contacts: serde_json::Value,
@@ -44,6 +50,11 @@ impl Building {
     /// Check if building is active.
     pub fn is_active(&self) -> bool {
         self.status == "active"
+    }
+
+    /// Whether the building has resolved map coordinates.
+    pub fn has_coordinates(&self) -> bool {
+        self.latitude.is_some() && self.longitude.is_some()
     }
 
     /// Get full address as a single string.
@@ -77,6 +88,12 @@ pub struct BuildingSummary {
     pub postal_code: String,
     pub total_floors: i32,
     pub status: String,
+    /// Geocoded latitude (Story 3.1 AC3); null when unresolved.
+    #[sqlx(default)]
+    pub latitude: Option<Decimal>,
+    /// Geocoded longitude (Story 3.1 AC3); null when unresolved.
+    #[sqlx(default)]
+    pub longitude: Option<Decimal>,
     #[sqlx(default)]
     pub unit_count: Option<i64>,
 }
@@ -99,6 +116,12 @@ pub struct CreateBuilding {
     pub total_entrances: i32,
     #[serde(default)]
     pub amenities: Vec<String>,
+    /// Latitude (e.g. from geocoding). Optional; defaults to NULL.
+    #[serde(default)]
+    pub latitude: Option<Decimal>,
+    /// Longitude (e.g. from geocoding). Optional; defaults to NULL.
+    #[serde(default)]
+    pub longitude: Option<Decimal>,
 }
 
 fn default_country() -> String {
@@ -124,6 +147,10 @@ pub struct UpdateBuilding {
     pub amenities: Option<Vec<String>>,
     pub contacts: Option<serde_json::Value>,
     pub settings: Option<serde_json::Value>,
+    /// New latitude (e.g. re-geocoded after an address change).
+    pub latitude: Option<Decimal>,
+    /// New longitude (e.g. re-geocoded after an address change).
+    pub longitude: Option<Decimal>,
 }
 
 /// Building contact information.

--- a/backend/crates/db/src/repositories/building.rs
+++ b/backend/crates/db/src/repositories/building.rs
@@ -64,9 +64,10 @@ impl BuildingRepository {
             r#"
             INSERT INTO buildings (
                 organization_id, street, city, postal_code, country,
-                name, description, year_built, total_floors, total_entrances, amenities
+                name, description, year_built, total_floors, total_entrances, amenities,
+                latitude, longitude
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
             RETURNING *
             "#,
         )
@@ -81,6 +82,8 @@ impl BuildingRepository {
         .bind(data.total_floors)
         .bind(data.total_entrances)
         .bind(&amenities)
+        .bind(data.latitude)
+        .bind(data.longitude)
         .fetch_one(executor)
         .await?;
 
@@ -170,6 +173,14 @@ impl BuildingRepository {
             param_idx += 1;
             updates.push(format!("settings = ${}", param_idx));
         }
+        if data.latitude.is_some() {
+            param_idx += 1;
+            updates.push(format!("latitude = ${}", param_idx));
+        }
+        if data.longitude.is_some() {
+            param_idx += 1;
+            updates.push(format!("longitude = ${}", param_idx));
+        }
 
         let query = format!(
             "UPDATE buildings SET {} WHERE id = $1 AND status != 'archived' RETURNING *",
@@ -214,6 +225,12 @@ impl BuildingRepository {
         }
         if let Some(settings) = &data.settings {
             q = q.bind(settings);
+        }
+        if let Some(latitude) = &data.latitude {
+            q = q.bind(latitude);
+        }
+        if let Some(longitude) = &data.longitude {
+            q = q.bind(longitude);
         }
 
         let building = q.fetch_optional(executor).await?;
@@ -277,6 +294,7 @@ impl BuildingRepository {
         let data_query = format!(
             r#"
             SELECT b.id, b.name, b.street, b.city, b.postal_code, b.total_floors, b.status,
+                   b.latitude, b.longitude,
                    (SELECT COUNT(*) FROM units u WHERE u.building_id = b.id AND u.status = 'active') as unit_count
             FROM buildings b
             WHERE {}
@@ -346,6 +364,7 @@ impl BuildingRepository {
         let data_query = format!(
             r#"
             SELECT b.id, b.name, b.street, b.city, b.postal_code, b.total_floors, b.status,
+                   b.latitude, b.longitude,
                    (SELECT COUNT(*) FROM units u WHERE u.building_id = b.id AND u.status = 'active') as unit_count
             FROM buildings b
             WHERE {}
@@ -579,6 +598,7 @@ impl BuildingRepository {
         let data_query = format!(
             r#"
             SELECT b.id, b.name, b.street, b.city, b.postal_code, b.total_floors, b.status,
+                   b.latitude, b.longitude,
                    (SELECT COUNT(*) FROM units u WHERE u.building_id = b.id AND u.status = 'active') as unit_count
             FROM buildings b
             WHERE {}

--- a/backend/crates/integrations/src/geocoding.rs
+++ b/backend/crates/integrations/src/geocoding.rs
@@ -1,0 +1,429 @@
+//! Geocoding integration (Story 3.1 AC3, BIT-200).
+//!
+//! Converts a building's street address into latitude/longitude coordinates so
+//! the building can be displayed on a map.
+//!
+//! # Graceful degradation (feature-flagged)
+//!
+//! The service is **disabled by default**. It only makes external HTTP calls
+//! when a provider *and* the credentials it needs are configured via
+//! environment variables. When unconfigured, [`GeocodingService::geocode`]
+//! returns `Ok(None)` without touching the network, so:
+//!
+//! - CI and offline development never make external calls, and
+//! - building create/update keep working, storing `NULL` coordinates.
+//!
+//! This keeps API keys out of the repository: an operator opts in per
+//! deployment by setting the env vars below.
+//!
+//! ## Configuration
+//!
+//! - `GEOCODING_PROVIDER` — `google`, `mapbox`, or `nominatim` (alias `osm`).
+//!   Anything else (or unset) disables geocoding.
+//! - `GEOCODING_API_KEY` — required for `google`/`mapbox`. Optional for
+//!   `nominatim` (most OSM endpoints are keyless).
+//! - `GEOCODING_BASE_URL` — optional endpoint override. Required for
+//!   `nominatim` (no default is hard-coded so we never hammer the public OSM
+//!   service unintentionally).
+
+use rust_decimal::Decimal;
+use serde::Deserialize;
+use std::time::Duration;
+
+/// Resolved geographic coordinates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Coordinates {
+    pub latitude: Decimal,
+    pub longitude: Decimal,
+}
+
+/// Errors that can occur while geocoding.
+///
+/// Note: callers on the building create/update path treat these as
+/// non-fatal — a building is still persisted with `NULL` coordinates when
+/// geocoding fails, so a flaky provider never blocks a write.
+#[derive(Debug, thiserror::Error)]
+pub enum GeocodingError {
+    #[error("geocoding request failed: {0}")]
+    Request(String),
+    #[error("geocoding response could not be parsed: {0}")]
+    Parse(String),
+}
+
+/// Supported geocoding providers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GeocodingProvider {
+    Google,
+    Mapbox,
+    /// Nominatim / OSM-compatible endpoint (keyless; requires a base URL).
+    Nominatim,
+}
+
+impl GeocodingProvider {
+    fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "google" => Some(Self::Google),
+            "mapbox" => Some(Self::Mapbox),
+            "nominatim" | "osm" => Some(Self::Nominatim),
+            _ => None,
+        }
+    }
+}
+
+/// Resolved, validated configuration for an *enabled* geocoder.
+#[derive(Debug, Clone)]
+struct GeocodingConfig {
+    provider: GeocodingProvider,
+    api_key: String,
+    base_url: Option<String>,
+}
+
+/// Address-to-coordinates service.
+///
+/// Cheap to clone (wraps a `reqwest::Client`, which is internally `Arc`'d).
+#[derive(Clone)]
+pub struct GeocodingService {
+    /// `None` when geocoding is disabled (the default).
+    config: Option<GeocodingConfig>,
+    client: reqwest::Client,
+}
+
+impl std::fmt::Debug for GeocodingService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never print the API key.
+        f.debug_struct("GeocodingService")
+            .field("enabled", &self.config.is_some())
+            .field("provider", &self.config.as_ref().map(|c| c.provider))
+            .finish()
+    }
+}
+
+impl GeocodingService {
+    /// Build a service from environment variables. Returns a disabled service
+    /// (no-op) when the configuration is absent or incomplete — this never
+    /// panics, so it is safe to call unconditionally at startup.
+    pub fn from_env() -> Self {
+        let config = Self::config_from_env();
+        if let Some(cfg) = &config {
+            tracing::info!(provider = ?cfg.provider, "Geocoding enabled");
+        } else {
+            tracing::info!("Geocoding disabled (no provider configured); buildings stored without coordinates");
+        }
+        Self::with_config(config)
+    }
+
+    fn with_config(config: Option<GeocodingConfig>) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(8))
+            // Nominatim's usage policy requires a descriptive User-Agent.
+            .user_agent("property-management/geocoding")
+            .build()
+            .unwrap_or_default();
+        Self { config, client }
+    }
+
+    fn config_from_env() -> Option<GeocodingConfig> {
+        let provider = GeocodingProvider::parse(&std::env::var("GEOCODING_PROVIDER").ok()?)?;
+        let api_key = std::env::var("GEOCODING_API_KEY").unwrap_or_default();
+        let base_url = std::env::var("GEOCODING_BASE_URL")
+            .ok()
+            .filter(|s| !s.trim().is_empty());
+
+        match provider {
+            GeocodingProvider::Google | GeocodingProvider::Mapbox => {
+                if api_key.trim().is_empty() {
+                    tracing::warn!(
+                        provider = ?provider,
+                        "GEOCODING_PROVIDER set but GEOCODING_API_KEY is empty; geocoding disabled"
+                    );
+                    return None;
+                }
+            }
+            GeocodingProvider::Nominatim => {
+                if base_url.is_none() {
+                    tracing::warn!(
+                        "GEOCODING_PROVIDER=nominatim requires GEOCODING_BASE_URL; geocoding disabled"
+                    );
+                    return None;
+                }
+            }
+        }
+
+        Some(GeocodingConfig {
+            provider,
+            api_key,
+            base_url,
+        })
+    }
+
+    /// Whether geocoding is actually configured. When `false`, [`Self::geocode`]
+    /// always returns `Ok(None)`.
+    pub fn is_enabled(&self) -> bool {
+        self.config.is_some()
+    }
+
+    /// Geocode a free-form address into coordinates.
+    ///
+    /// Returns `Ok(None)` when geocoding is disabled, when the address is blank,
+    /// or when the provider finds no match. Returns `Err` only on a transport or
+    /// parse failure (which callers on the write path should log and ignore).
+    pub async fn geocode(&self, address: &str) -> Result<Option<Coordinates>, GeocodingError> {
+        let Some(cfg) = &self.config else {
+            return Ok(None);
+        };
+        if address.trim().is_empty() {
+            return Ok(None);
+        }
+
+        let url = build_request_url(cfg, address);
+        let resp = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| GeocodingError::Request(e.to_string()))?;
+
+        if !resp.status().is_success() {
+            return Err(GeocodingError::Request(format!(
+                "provider returned HTTP {}",
+                resp.status()
+            )));
+        }
+
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| GeocodingError::Request(e.to_string()))?;
+
+        match cfg.provider {
+            GeocodingProvider::Google => parse_google(&body),
+            GeocodingProvider::Mapbox => parse_mapbox(&body),
+            GeocodingProvider::Nominatim => parse_nominatim(&body),
+        }
+    }
+}
+
+impl Default for GeocodingService {
+    /// A disabled (no-op) service. Useful in tests.
+    fn default() -> Self {
+        Self::with_config(None)
+    }
+}
+
+/// Build the provider request URL for an address.
+fn build_request_url(cfg: &GeocodingConfig, address: &str) -> String {
+    let encoded = urlencoding::encode(address);
+    match cfg.provider {
+        GeocodingProvider::Google => {
+            let base = cfg
+                .base_url
+                .as_deref()
+                .unwrap_or("https://maps.googleapis.com/maps/api/geocode/json");
+            format!("{base}?address={encoded}&key={}", cfg.api_key)
+        }
+        GeocodingProvider::Mapbox => {
+            let base = cfg
+                .base_url
+                .as_deref()
+                .unwrap_or("https://api.mapbox.com/geocoding/v5/mapbox.places");
+            format!("{base}/{encoded}.json?limit=1&access_token={}", cfg.api_key)
+        }
+        GeocodingProvider::Nominatim => {
+            // base_url is guaranteed present for Nominatim (see config_from_env).
+            let base = cfg.base_url.as_deref().unwrap_or_default();
+            let key_param = if cfg.api_key.trim().is_empty() {
+                String::new()
+            } else {
+                format!("&key={}", cfg.api_key)
+            };
+            format!("{base}/search?q={encoded}&format=json&limit=1{key_param}")
+        }
+    }
+}
+
+fn coords_from_f64(lat: f64, lng: f64) -> Result<Coordinates, GeocodingError> {
+    let latitude = Decimal::from_f64_retain(lat)
+        .ok_or_else(|| GeocodingError::Parse(format!("invalid latitude: {lat}")))?;
+    let longitude = Decimal::from_f64_retain(lng)
+        .ok_or_else(|| GeocodingError::Parse(format!("invalid longitude: {lng}")))?;
+    Ok(Coordinates {
+        latitude,
+        longitude,
+    })
+}
+
+// ---- Provider response parsers (pure; unit-tested) ----
+
+#[derive(Deserialize)]
+struct GoogleResponse {
+    results: Vec<GoogleResult>,
+}
+#[derive(Deserialize)]
+struct GoogleResult {
+    geometry: GoogleGeometry,
+}
+#[derive(Deserialize)]
+struct GoogleGeometry {
+    location: GoogleLocation,
+}
+#[derive(Deserialize)]
+struct GoogleLocation {
+    lat: f64,
+    lng: f64,
+}
+
+fn parse_google(body: &str) -> Result<Option<Coordinates>, GeocodingError> {
+    let parsed: GoogleResponse =
+        serde_json::from_str(body).map_err(|e| GeocodingError::Parse(e.to_string()))?;
+    match parsed.results.into_iter().next() {
+        Some(r) => Ok(Some(coords_from_f64(
+            r.geometry.location.lat,
+            r.geometry.location.lng,
+        )?)),
+        None => Ok(None),
+    }
+}
+
+#[derive(Deserialize)]
+struct MapboxResponse {
+    features: Vec<MapboxFeature>,
+}
+#[derive(Deserialize)]
+struct MapboxFeature {
+    /// Mapbox returns `[longitude, latitude]`.
+    center: Vec<f64>,
+}
+
+fn parse_mapbox(body: &str) -> Result<Option<Coordinates>, GeocodingError> {
+    let parsed: MapboxResponse =
+        serde_json::from_str(body).map_err(|e| GeocodingError::Parse(e.to_string()))?;
+    match parsed.features.into_iter().next() {
+        Some(f) => {
+            if f.center.len() < 2 {
+                return Err(GeocodingError::Parse(
+                    "mapbox feature missing center coordinates".to_string(),
+                ));
+            }
+            // center = [lng, lat]
+            Ok(Some(coords_from_f64(f.center[1], f.center[0])?))
+        }
+        None => Ok(None),
+    }
+}
+
+#[derive(Deserialize)]
+struct NominatimResult {
+    lat: String,
+    lon: String,
+}
+
+fn parse_nominatim(body: &str) -> Result<Option<Coordinates>, GeocodingError> {
+    let parsed: Vec<NominatimResult> =
+        serde_json::from_str(body).map_err(|e| GeocodingError::Parse(e.to_string()))?;
+    match parsed.into_iter().next() {
+        Some(r) => {
+            let lat: f64 = r
+                .lat
+                .parse()
+                .map_err(|_| GeocodingError::Parse(format!("invalid latitude: {}", r.lat)))?;
+            let lng: f64 = r
+                .lon
+                .parse()
+                .map_err(|_| GeocodingError::Parse(format!("invalid longitude: {}", r.lon)))?;
+            Ok(Some(coords_from_f64(lat, lng)?))
+        }
+        None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_decimal::prelude::ToPrimitive;
+
+    fn approx(d: Decimal, expected: f64) {
+        let v = d.to_f64().unwrap();
+        assert!((v - expected).abs() < 1e-6, "expected ~{expected}, got {v}");
+    }
+
+    #[test]
+    fn disabled_when_provider_unset() {
+        let svc = GeocodingService::default();
+        assert!(!svc.is_enabled());
+    }
+
+    #[tokio::test]
+    async fn disabled_service_returns_none_without_network() {
+        let svc = GeocodingService::default();
+        let out = svc.geocode("Hlavna 1, Bratislava").await.unwrap();
+        assert_eq!(out, None);
+    }
+
+    #[test]
+    fn provider_parse_aliases() {
+        assert_eq!(GeocodingProvider::parse("Google"), Some(GeocodingProvider::Google));
+        assert_eq!(GeocodingProvider::parse("MAPBOX"), Some(GeocodingProvider::Mapbox));
+        assert_eq!(GeocodingProvider::parse("osm"), Some(GeocodingProvider::Nominatim));
+        assert_eq!(GeocodingProvider::parse("nominatim"), Some(GeocodingProvider::Nominatim));
+        assert_eq!(GeocodingProvider::parse("bogus"), None);
+    }
+
+    #[test]
+    fn parse_google_ok() {
+        let body = r#"{
+            "results": [
+                {"geometry": {"location": {"lat": 48.1485965, "lng": 17.1077477}}}
+            ],
+            "status": "OK"
+        }"#;
+        let c = parse_google(body).unwrap().unwrap();
+        approx(c.latitude, 48.1485965);
+        approx(c.longitude, 17.1077477);
+    }
+
+    #[test]
+    fn parse_google_empty_is_none() {
+        let body = r#"{"results": [], "status": "ZERO_RESULTS"}"#;
+        assert_eq!(parse_google(body).unwrap(), None);
+    }
+
+    #[test]
+    fn parse_mapbox_ok() {
+        // Mapbox center is [lng, lat].
+        let body = r#"{"features": [{"center": [17.1077477, 48.1485965]}]}"#;
+        let c = parse_mapbox(body).unwrap().unwrap();
+        approx(c.latitude, 48.1485965);
+        approx(c.longitude, 17.1077477);
+    }
+
+    #[test]
+    fn parse_mapbox_empty_is_none() {
+        let body = r#"{"features": []}"#;
+        assert_eq!(parse_mapbox(body).unwrap(), None);
+    }
+
+    #[test]
+    fn parse_nominatim_ok() {
+        let body = r#"[{"lat": "48.1485965", "lon": "17.1077477"}]"#;
+        let c = parse_nominatim(body).unwrap().unwrap();
+        approx(c.latitude, 48.1485965);
+        approx(c.longitude, 17.1077477);
+    }
+
+    #[test]
+    fn parse_nominatim_empty_is_none() {
+        assert_eq!(parse_nominatim("[]").unwrap(), None);
+    }
+
+    #[test]
+    fn build_url_encodes_address() {
+        let cfg = GeocodingConfig {
+            provider: GeocodingProvider::Google,
+            api_key: "secret".to_string(),
+            base_url: None,
+        };
+        let url = build_request_url(&cfg, "Hlavná 1, Bratislava");
+        assert!(url.contains("address=Hlavn%C3%A1%201"));
+        assert!(url.contains("key=secret"));
+    }
+}

--- a/backend/crates/integrations/src/geocoding.rs
+++ b/backend/crates/integrations/src/geocoding.rs
@@ -107,7 +107,9 @@ impl GeocodingService {
         if let Some(cfg) = &config {
             tracing::info!(provider = ?cfg.provider, "Geocoding enabled");
         } else {
-            tracing::info!("Geocoding disabled (no provider configured); buildings stored without coordinates");
+            tracing::info!(
+                "Geocoding disabled (no provider configured); buildings stored without coordinates"
+            );
         }
         Self::with_config(config)
     }
@@ -361,10 +363,22 @@ mod tests {
 
     #[test]
     fn provider_parse_aliases() {
-        assert_eq!(GeocodingProvider::parse("Google"), Some(GeocodingProvider::Google));
-        assert_eq!(GeocodingProvider::parse("MAPBOX"), Some(GeocodingProvider::Mapbox));
-        assert_eq!(GeocodingProvider::parse("osm"), Some(GeocodingProvider::Nominatim));
-        assert_eq!(GeocodingProvider::parse("nominatim"), Some(GeocodingProvider::Nominatim));
+        assert_eq!(
+            GeocodingProvider::parse("Google"),
+            Some(GeocodingProvider::Google)
+        );
+        assert_eq!(
+            GeocodingProvider::parse("MAPBOX"),
+            Some(GeocodingProvider::Mapbox)
+        );
+        assert_eq!(
+            GeocodingProvider::parse("osm"),
+            Some(GeocodingProvider::Nominatim)
+        );
+        assert_eq!(
+            GeocodingProvider::parse("nominatim"),
+            Some(GeocodingProvider::Nominatim)
+        );
         assert_eq!(GeocodingProvider::parse("bogus"), None);
     }
 

--- a/backend/crates/integrations/src/lib.rs
+++ b/backend/crates/integrations/src/lib.rs
@@ -33,6 +33,9 @@ pub mod redis;
 // Epic 64: Advanced AI & LLM Capabilities
 pub mod llm;
 
+// Story 3.1 AC3 (BIT-200): Building geocoding
+pub mod geocoding;
+
 // Epic 97: Workflow Execution Engine
 pub mod workflow_executor;
 
@@ -102,6 +105,9 @@ pub use voice_oauth::{
     VoiceOAuthClient, VoiceOAuthConfig, VoiceOAuthError, VoiceOAuthManager, VoiceOAuthTokens,
     VoicePlatform,
 };
+
+// Story 3.1 AC3 (BIT-200): Building geocoding
+pub use geocoding::{Coordinates, GeocodingError, GeocodingProvider, GeocodingService};
 
 // Story 64.1-64.4: LLM Integration
 // Story 97.1-97.4: Enhanced LLM Capabilities

--- a/backend/servers/api-server/src/routes/buildings.rs
+++ b/backend/servers/api-server/src/routes/buildings.rs
@@ -144,6 +144,10 @@ pub struct BuildingResponse {
     pub total_floors: i32,
     pub total_entrances: i32,
     pub amenities: Vec<String>,
+    /// Geocoded latitude (Story 3.1 AC3); null when unresolved.
+    pub latitude: Option<Decimal>,
+    /// Geocoded longitude (Story 3.1 AC3); null when unresolved.
+    pub longitude: Option<Decimal>,
     pub status: String,
     pub created_at: String,
     pub updated_at: String,
@@ -165,6 +169,8 @@ impl From<Building> for BuildingResponse {
             total_floors: b.total_floors,
             total_entrances: b.total_entrances,
             amenities,
+            latitude: b.latitude,
+            longitude: b.longitude,
             status: b.status,
             created_at: b.created_at.to_rfc3339(),
             updated_at: b.updated_at.to_rfc3339(),
@@ -439,6 +445,21 @@ pub struct BulkImportBuildingsResponse {
     pub results: Vec<BulkImportResult>,
 }
 
+/// Geocode an address on a building write path, never failing the request.
+///
+/// Returns `(None, None)` when geocoding is disabled, finds no match, or errors,
+/// so a missing/flaky provider degrades gracefully (Story 3.1 AC3).
+async fn geocode_address(state: &AppState, address: &str) -> (Option<Decimal>, Option<Decimal>) {
+    match state.geocoding.geocode(address).await {
+        Ok(Some(c)) => (Some(c.latitude), Some(c.longitude)),
+        Ok(None) => (None, None),
+        Err(e) => {
+            tracing::warn!(error = %e, "Geocoding failed; storing building without coordinates");
+            (None, None)
+        }
+    }
+}
+
 // ==================== Building Handlers ====================
 
 /// Create a new building (UC-15.1).
@@ -505,6 +526,14 @@ pub async fn create_building(
         ));
     }
 
+    // Story 3.1 AC3: geocode on write. Degrades gracefully — an unconfigured
+    // provider or a failed lookup simply leaves coordinates NULL.
+    let address = format!(
+        "{}, {} {}, {}",
+        req.street, req.postal_code, req.city, req.country
+    );
+    let (latitude, longitude) = geocode_address(&state, &address).await;
+
     // Create building using RLS-enabled connection
     let create_data = CreateBuilding {
         organization_id: req.organization_id,
@@ -518,6 +547,8 @@ pub async fn create_building(
         total_floors: req.total_floors,
         total_entrances: req.total_entrances,
         amenities: req.amenities,
+        latitude,
+        longitude,
     };
 
     let building = state
@@ -716,6 +747,10 @@ pub async fn bulk_import_buildings(
             total_floors: entry.total_floors,
             total_entrances: entry.total_entrances,
             amenities: entry.amenities,
+            // Bulk import skips live geocoding to avoid N sequential external
+            // calls; coordinates are filled on a later edit/update.
+            latitude: None,
+            longitude: None,
         };
 
         match state
@@ -831,6 +866,33 @@ pub async fn update_building(
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateBuildingRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    // Story 3.1 AC3: re-geocode when any address component changes. We load the
+    // current row to fill in unchanged components so the lookup uses the full
+    // effective address. Failure leaves coordinates untouched (graceful).
+    let address_changed = req.street.is_some()
+        || req.city.is_some()
+        || req.postal_code.is_some()
+        || req.country.is_some();
+    let (latitude, longitude) = if address_changed {
+        match state
+            .building_repo
+            .find_by_id_rls(&mut **rls.conn(), id)
+            .await
+        {
+            Ok(Some(current)) => {
+                let street = req.street.clone().unwrap_or(current.street);
+                let city = req.city.clone().unwrap_or(current.city);
+                let postal_code = req.postal_code.clone().unwrap_or(current.postal_code);
+                let country = req.country.clone().unwrap_or(current.country);
+                let address = format!("{}, {} {}, {}", street, postal_code, city, country);
+                geocode_address(&state, &address).await
+            }
+            _ => (None, None),
+        }
+    } else {
+        (None, None)
+    };
+
     let update_data = UpdateBuilding {
         street: req.street,
         city: req.city,
@@ -844,6 +906,8 @@ pub async fn update_building(
         amenities: req.amenities,
         contacts: None,
         settings: None,
+        latitude,
+        longitude,
     };
 
     // RLS policies automatically enforce tenant isolation and access control

--- a/backend/servers/api-server/src/state.rs
+++ b/backend/servers/api-server/src/state.rs
@@ -37,7 +37,9 @@ use db::{
     },
     DbPool,
 };
-use integrations::{LlmClient, PubSubService, RedisClient, SessionStore, StorageService};
+use integrations::{
+    GeocodingService, LlmClient, PubSubService, RedisClient, SessionStore, StorageService,
+};
 
 /// Airbnb integration configuration loaded once at startup (issue #711).
 ///
@@ -182,6 +184,9 @@ pub struct AppState {
     pub org_member_repo: OrganizationMemberRepository,
     pub role_repo: RoleRepository,
     pub building_repo: BuildingRepository,
+    /// Story 3.1 AC3 (BIT-200): geocodes building addresses on write. Disabled
+    /// (no-op) unless `GEOCODING_PROVIDER` + credentials are configured.
+    pub geocoding: GeocodingService,
     pub unit_repo: UnitRepository,
     pub unit_resident_repo: UnitResidentRepository,
     pub delegation_repo: DelegationRepository,
@@ -369,6 +374,7 @@ impl AppState {
         let org_member_repo = OrganizationMemberRepository::new(db.clone());
         let role_repo = RoleRepository::new(db.clone());
         let building_repo = BuildingRepository::new(db.clone());
+        let geocoding = GeocodingService::from_env();
         let unit_repo = UnitRepository::new(db.clone());
         let unit_resident_repo = UnitResidentRepository::new(db.clone());
         let delegation_repo = DelegationRepository::new(db.clone());
@@ -529,6 +535,7 @@ impl AppState {
             org_member_repo,
             role_repo,
             building_repo,
+            geocoding,
             unit_repo,
             unit_resident_repo,
             delegation_repo,


### PR DESCRIPTION
## Building geocoding / coordinates (Story 3.1 AC3) — gap 4

> **Tracking note (BIT-212 reconciliation):** This PR was originally opened under BIT-200, which was later cancelled as a gap-4 duplicate during the PM #981 dedup. The retained canonical gap-4 issue is **BIT-191**. Re-pointed here so the PR is not orphaned; closes BIT-191. No code change — tracking only.

Adds latitude/longitude to buildings and geocodes addresses on write.

### Changes
- **Migration `00187`**: `latitude DECIMAL(10,8)` / `longitude DECIMAL(11,8)` on `buildings` + partial index (mirrors listings/emergency precision).
- **Model**: coords on `Building`, `CreateBuilding`, `UpdateBuilding`, `BuildingSummary`; `has_coordinates()` helper.
- **Repository**: persists coordinates on `create_rls`/`update_rls`; selects them in summary list queries.
- **`integrations::geocoding`**: feature-flagged `GeocodingService` (Google / Mapbox / Nominatim) configured via `GEOCODING_PROVIDER` + credentials. **Disabled by default** → `geocode()` returns `Ok(None)` with no network call, so CI/offline dev work and **no API keys are committed**.
- **Routes**: geocode-on-create and re-geocode-on-address-change; failures degrade gracefully (NULL coordinates). Coordinates exposed in `BuildingResponse`/`BuildingSummary` for map display.
- Unit tests for provider response parsing + disabled-service no-op.

### Config (opt-in per deployment)
- `GEOCODING_PROVIDER` = `google` | `mapbox` | `nominatim` (unset = disabled)
- `GEOCODING_API_KEY` (required for google/mapbox)
- `GEOCODING_BASE_URL` (required for nominatim; optional override otherwise)

### Verification
- Local Rust toolchain is offloaded to a remote builder that is currently unreachable, so the **GitHub Actions `backend.yml` gate (fmt → clippy → test) is the authoritative check** here. Code reviewed for self-consistency; deps confirmed present.

Closes BIT-191. (supersedes cancelled BIT-200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
