### PR TITLE
feat(ppt-web): add Leases sidebar nav link (BIT-204 / #977 gap 2)

### DIFF
--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -71,6 +71,7 @@
     "financial": "Financial",
     "community": "Community",
     "disputes": "Disputes",
+    "leases": "Leases",
     "outages": "Outages",
     "emergency": "Emergency Contacts",
     "messages": "Messages",

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -57,6 +57,7 @@
     "financial": "Financie",
     "community": "Komunita",
     "disputes": "Spory",
+    "leases": "Nájmy",
     "emergency": "Núdzové kontakty",
     "settings": "Nastavenia",
     "profile": "Profil",

--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -119,6 +119,7 @@ function AppNavigation() {
       <Link to="/news">{t('nav.news')}</Link>
       <Link to="/emergency">{t('nav.emergency')}</Link>
       <Link to="/disputes">{t('nav.disputes')}</Link>
+      <Link to="/leases">{t('nav.leases', { defaultValue: 'Leases' })}</Link>
       <Link to="/outages">{t('nav.outages')}</Link>
       <Link to="/iot">{t('nav.iot', { defaultValue: 'Smart Building' })}</Link>
       <Link to="/iot/alerts">{t('nav.iotAlerts', { defaultValue: 'Sensor Alerts' })}</Link>


### PR DESCRIPTION
## BIT-204 — Wire PPT-web lease management pages into app router (PM #977 Gap 2)

### Finding
On investigating this gap, almost all of the planned work was **already merged to \`dev\`**:
- `routes/groups/leases.tsx` — full `leaseRoutes()` group with all route-wrapper components, API→UI mappers, and TanStack Query hooks (`useLeases`, `useApplications`, `useLease`, `useViolations`, …).
- `leaseRoutes()` is wired into `routes/AppRoutes.tsx`.
- The `@ppt/api-client` leases module (`api.ts`, `hooks.ts`, `types.ts`) exists and is consumed.

So routes `/leases`, `/leases/list`, `/leases/new`, `/leases/templates`, `/leases/applications`, `/leases/applications/:id`, `/leases/violations`, `/leases/violations/new`, `/leases/violations/:id`, and `/leases/:leaseId` already render live backend data.

### Remaining gap (this PR)
The only outstanding item from the fix plan was **item 5 — the sidebar nav entry**. The lease pages had no entry point in `AppNavigation`, so they were only reachable by typing the URL.

This PR adds:
- A `Leases` link in `AppNavigation` (App.tsx), alongside Disputes.
- `nav.leases` translations in `en.json` ("Leases") and `sk.json` ("Nájmy"). Other locales fall back via `defaultValue`, matching the existing pattern used for `nav.iot` / `nav.rentals`.

### Gate
`cd frontend && pnpm typecheck && pnpm check` — relying on CI (no local frontend toolchain on this host; deps not installed). Change is additive and follows existing nav/i18n patterns.

Co-Authored-By: Paperclip <noreply@paperclip.ing>