### PR TITLE
feat(notifications): 24h-inactivity email digest worker (Story 2B.3, #969)

### DIFF
--- a/backend/crates/db/src/repositories/granular_notification.rs
+++ b/backend/crates/db/src/repositories/granular_notification.rs
@@ -3,7 +3,7 @@
 //! Provides database operations for per-event and per-channel notification preferences.
 
 use chrono::{NaiveTime, Utc};
-use sqlx::{Error as SqlxError, PgPool, Row};
+use sqlx::{Error as SqlxError, FromRow, PgPool, Row};
 use uuid::Uuid;
 
 use crate::models::{
@@ -16,6 +16,38 @@ use crate::models::{
 #[derive(Clone)]
 pub struct GranularNotificationRepository {
     pool: PgPool,
+}
+
+/// A user eligible for a 24h-inactivity email digest (Story 2B.3, PM #969 gap 1).
+/// Produced by [`GranularNotificationRepository::find_inactive_digest_candidates`].
+#[derive(Debug, Clone, FromRow)]
+pub struct InactiveDigestCandidate {
+    pub user_id: Uuid,
+    pub email: String,
+    pub locale: String,
+    /// Total unread notifications across all categories.
+    pub notification_count: i64,
+    /// Unread counts keyed by `entity_type`, e.g. `{ "fault": 5, "vote": 2 }`.
+    pub category_counts: serde_json::Value,
+    /// Earliest unread notification group creation time.
+    pub period_start: chrono::DateTime<Utc>,
+    /// Most recent unread activity time.
+    pub period_end: chrono::DateTime<Utc>,
+}
+
+/// A persisted digest row whose email has not yet been delivered, joined with
+/// the recipient address so it can be (re)sent. Produced by
+/// [`GranularNotificationRepository::get_unsent_digests`].
+#[derive(Debug, Clone, FromRow)]
+pub struct PendingDigestEmail {
+    pub digest_id: Uuid,
+    pub user_id: Uuid,
+    pub email: String,
+    pub locale: String,
+    pub notification_count: i32,
+    pub category_counts: serde_json::Value,
+    pub period_start: chrono::DateTime<Utc>,
+    pub period_end: chrono::DateTime<Utc>,
 }
 
 impl GranularNotificationRepository {
@@ -785,6 +817,115 @@ impl GranularNotificationRepository {
             .execute(&self.pool)
             .await?;
         Ok(())
+    }
+
+    /// Find users eligible for a 24h-inactivity email digest (Story 2B.3,
+    /// PM #969 gap 1). A user qualifies when they:
+    ///   * have opted in via `notification_schedule.digest_enabled = true`,
+    ///   * have been inactive since `inactivity_cutoff` (no refresh-token use —
+    ///     the closest proxy for "last seen", since `users` has no `last_seen`),
+    ///   * are an active, non-deleted account,
+    ///   * have at least one unread notification group, and
+    ///   * have not had any digest row created since `resend_cutoff` (this
+    ///     dedup also prevents re-creating a row for a digest whose email send
+    ///     failed — those are retried in place via [`Self::get_unsent_digests`]).
+    ///
+    /// `category_counts` aggregates unread per `entity_type` (fault, vote, …)
+    /// and `notification_count` is the total across all categories.
+    pub async fn find_inactive_digest_candidates(
+        &self,
+        inactivity_cutoff: chrono::DateTime<Utc>,
+        resend_cutoff: chrono::DateTime<Utc>,
+        limit: i64,
+    ) -> Result<Vec<InactiveDigestCandidate>, SqlxError> {
+        sqlx::query_as::<_, InactiveDigestCandidate>(
+            r#"
+            WITH last_activity AS (
+                SELECT user_id, MAX(last_used_at) AS last_active
+                FROM refresh_tokens
+                GROUP BY user_id
+            ),
+            unread AS (
+                SELECT user_id,
+                       SUM(cat_count)::bigint AS notification_count,
+                       jsonb_object_agg(entity_type, cat_count) AS category_counts,
+                       MIN(first_at) AS period_start,
+                       MAX(last_at) AS period_end
+                FROM (
+                    SELECT user_id,
+                           entity_type,
+                           SUM(notification_count)::bigint AS cat_count,
+                           MIN(created_at) AS first_at,
+                           MAX(latest_notification_at) AS last_at
+                    FROM notification_groups
+                    WHERE is_read = false
+                    GROUP BY user_id, entity_type
+                ) per_cat
+                GROUP BY user_id
+            )
+            SELECT u.id AS user_id,
+                   u.email,
+                   u.locale,
+                   un.notification_count,
+                   un.category_counts,
+                   un.period_start,
+                   un.period_end
+            FROM users u
+            JOIN notification_schedule s ON s.user_id = u.id AND s.digest_enabled = true
+            JOIN unread un ON un.user_id = u.id
+            JOIN last_activity la ON la.user_id = u.id
+            WHERE u.status = 'active'
+              AND u.deleted_at IS NULL
+              AND la.last_active < $1
+              AND NOT EXISTS (
+                  SELECT 1 FROM notification_digests d
+                  WHERE d.user_id = u.id
+                    AND d.created_at > $2
+              )
+            ORDER BY un.period_end ASC
+            LIMIT $3
+            "#,
+        )
+        .bind(inactivity_cutoff)
+        .bind(resend_cutoff)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    /// Fetch digest rows whose email has not yet been sent and that were
+    /// created since `created_after`, joined with the recipient's address.
+    /// Used to retry transient `EmailService` failures without losing the
+    /// already-persisted digest row or creating duplicates. Story 2B.3.
+    pub async fn get_unsent_digests(
+        &self,
+        created_after: chrono::DateTime<Utc>,
+        limit: i64,
+    ) -> Result<Vec<PendingDigestEmail>, SqlxError> {
+        sqlx::query_as::<_, PendingDigestEmail>(
+            r#"
+            SELECT d.id AS digest_id,
+                   d.user_id,
+                   u.email,
+                   u.locale,
+                   d.notification_count,
+                   d.category_counts,
+                   d.period_start,
+                   d.period_end
+            FROM notification_digests d
+            JOIN users u ON u.id = d.user_id
+            WHERE d.email_sent_at IS NULL
+              AND d.created_at > $1
+              AND u.status = 'active'
+              AND u.deleted_at IS NULL
+            ORDER BY d.created_at ASC
+            LIMIT $2
+            "#,
+        )
+        .bind(created_after)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await
     }
 
     /// Add notification to digest.

--- a/backend/crates/db/src/repositories/granular_notification_test.rs
+++ b/backend/crates/db/src/repositories/granular_notification_test.rs
@@ -39,14 +39,12 @@ mod tests {
 
     /// Enable (or disable) the digest preference for a user.
     async fn set_digest_enabled(pool: &sqlx::PgPool, user_id: Uuid, enabled: bool) {
-        sqlx::query(
-            "INSERT INTO notification_schedule (user_id, digest_enabled) VALUES ($1, $2)",
-        )
-        .bind(user_id)
-        .bind(enabled)
-        .execute(pool)
-        .await
-        .unwrap();
+        sqlx::query("INSERT INTO notification_schedule (user_id, digest_enabled) VALUES ($1, $2)")
+            .bind(user_id)
+            .bind(enabled)
+            .execute(pool)
+            .await
+            .unwrap();
     }
 
     /// Insert one notification group for the user.

--- a/backend/crates/db/src/repositories/granular_notification_test.rs
+++ b/backend/crates/db/src/repositories/granular_notification_test.rs
@@ -1,0 +1,207 @@
+//! Tests for the inactivity email-digest query path (Story 2B.3, PM #969 gap 1).
+
+#[cfg(test)]
+mod tests {
+    use crate::repositories::granular_notification::GranularNotificationRepository;
+    use chrono::{Duration, Utc};
+    use sqlx::Row;
+    use uuid::Uuid;
+
+    /// Insert a minimal active user and return its id.
+    async fn make_user(pool: &sqlx::PgPool, email: &str) -> Uuid {
+        sqlx::query(
+            "INSERT INTO users (email, password_hash, name, status) \
+             VALUES ($1, 'x', 'Test User', 'active') RETURNING id",
+        )
+        .bind(email)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+        .get("id")
+    }
+
+    /// Record the user's last activity by inserting a refresh token whose
+    /// `last_used_at` is `hours_ago` in the past.
+    async fn set_last_active(pool: &sqlx::PgPool, user_id: Uuid, hours_ago: i64) {
+        let when = Utc::now() - Duration::hours(hours_ago);
+        sqlx::query(
+            "INSERT INTO refresh_tokens (user_id, token_hash, expires_at, last_used_at) \
+             VALUES ($1, $2, $3, $4)",
+        )
+        .bind(user_id)
+        .bind(format!("hash-{user_id}-{hours_ago}"))
+        .bind(Utc::now() + Duration::days(30))
+        .bind(when)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    /// Enable (or disable) the digest preference for a user.
+    async fn set_digest_enabled(pool: &sqlx::PgPool, user_id: Uuid, enabled: bool) {
+        sqlx::query(
+            "INSERT INTO notification_schedule (user_id, digest_enabled) VALUES ($1, $2)",
+        )
+        .bind(user_id)
+        .bind(enabled)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    /// Insert one notification group for the user.
+    async fn add_group(
+        pool: &sqlx::PgPool,
+        user_id: Uuid,
+        entity_type: &str,
+        count: i32,
+        is_read: bool,
+    ) {
+        let entity_id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO notification_groups \
+             (user_id, group_key, entity_type, entity_id, title, notification_count, is_read) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7)",
+        )
+        .bind(user_id)
+        .bind(format!("{entity_type}-{entity_id}"))
+        .bind(entity_type)
+        .bind(entity_id)
+        .bind(format!("{entity_type} group"))
+        .bind(count)
+        .bind(is_read)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[sqlx::test(migrator = "crate::MIGRATOR")]
+    async fn inactive_opted_in_user_with_unread_is_a_candidate(pool: sqlx::PgPool) {
+        let repo = GranularNotificationRepository::new(pool.clone());
+        let user = make_user(&pool, "digest-hit@example.com").await;
+        set_last_active(&pool, user, 48).await; // inactive > 24h
+        set_digest_enabled(&pool, user, true).await;
+        // 2 fault notifications (2 + 1) and 2 vote notifications.
+        add_group(&pool, user, "fault", 2, false).await;
+        add_group(&pool, user, "fault", 1, false).await;
+        add_group(&pool, user, "vote", 2, false).await;
+        // A read group must NOT be counted.
+        add_group(&pool, user, "announcement", 9, true).await;
+
+        let now = Utc::now();
+        let candidates = repo
+            .find_inactive_digest_candidates(
+                now - Duration::hours(24),
+                now - Duration::hours(20),
+                100,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(candidates.len(), 1, "exactly one candidate expected");
+        let c = &candidates[0];
+        assert_eq!(c.user_id, user);
+        assert_eq!(c.email, "digest-hit@example.com");
+        assert_eq!(c.notification_count, 5, "2+1 fault + 2 vote = 5 unread");
+        assert_eq!(c.category_counts["fault"].as_i64(), Some(3));
+        assert_eq!(c.category_counts["vote"].as_i64(), Some(2));
+        assert!(
+            c.category_counts.get("announcement").is_none(),
+            "read groups must be excluded from the breakdown"
+        );
+    }
+
+    #[sqlx::test(migrator = "crate::MIGRATOR")]
+    async fn excludes_recently_active_optout_and_no_unread_users(pool: sqlx::PgPool) {
+        let repo = GranularNotificationRepository::new(pool.clone());
+
+        // Recently active (12h) — excluded despite unread + opt-in.
+        let active = make_user(&pool, "active@example.com").await;
+        set_last_active(&pool, active, 12).await;
+        set_digest_enabled(&pool, active, true).await;
+        add_group(&pool, active, "fault", 3, false).await;
+
+        // Inactive but opted OUT — excluded.
+        let optout = make_user(&pool, "optout@example.com").await;
+        set_last_active(&pool, optout, 48).await;
+        set_digest_enabled(&pool, optout, false).await;
+        add_group(&pool, optout, "fault", 3, false).await;
+
+        // Inactive, opted in, but no unread — excluded.
+        let empty = make_user(&pool, "empty@example.com").await;
+        set_last_active(&pool, empty, 48).await;
+        set_digest_enabled(&pool, empty, true).await;
+        add_group(&pool, empty, "fault", 3, true).await; // all read
+
+        let now = Utc::now();
+        let candidates = repo
+            .find_inactive_digest_candidates(
+                now - Duration::hours(24),
+                now - Duration::hours(20),
+                100,
+            )
+            .await
+            .unwrap();
+
+        assert!(candidates.is_empty(), "no user should qualify");
+    }
+
+    #[sqlx::test(migrator = "crate::MIGRATOR")]
+    async fn recent_digest_suppresses_then_unsent_is_retried(pool: sqlx::PgPool) {
+        let repo = GranularNotificationRepository::new(pool.clone());
+        let user = make_user(&pool, "dedup@example.com").await;
+        set_last_active(&pool, user, 48).await;
+        set_digest_enabled(&pool, user, true).await;
+        add_group(&pool, user, "fault", 4, false).await;
+
+        let now = Utc::now();
+
+        // Persist a digest row (email not yet sent).
+        let digest = repo
+            .create_digest(
+                user,
+                "daily",
+                now - Duration::hours(1),
+                now,
+                4,
+                serde_json::json!({ "fault": 4 }),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // The fresh row is within the resend window, so the user must NOT be a
+        // new candidate (no duplicate digest).
+        let candidates = repo
+            .find_inactive_digest_candidates(
+                now - Duration::hours(24),
+                now - Duration::hours(20),
+                100,
+            )
+            .await
+            .unwrap();
+        assert!(
+            candidates.is_empty(),
+            "a recent digest row must suppress new candidacy"
+        );
+
+        // But the unsent row is surfaced for retry.
+        let unsent = repo
+            .get_unsent_digests(now - Duration::hours(20), 100)
+            .await
+            .unwrap();
+        assert_eq!(unsent.len(), 1);
+        assert_eq!(unsent[0].digest_id, digest.id);
+        assert_eq!(unsent[0].email, "dedup@example.com");
+        assert_eq!(unsent[0].notification_count, 4);
+
+        // Once marked sent, it is no longer retried.
+        repo.mark_digest_email_sent(digest.id).await.unwrap();
+        let unsent_after = repo
+            .get_unsent_digests(now - Duration::hours(20), 100)
+            .await
+            .unwrap();
+        assert!(unsent_after.is_empty(), "sent digests are not retried");
+    }
+}

--- a/backend/crates/db/src/repositories/mod.rs
+++ b/backend/crates/db/src/repositories/mod.rs
@@ -21,6 +21,7 @@ pub mod fault;
 pub mod feature_flag;
 pub mod financial;
 pub mod granular_notification;
+pub mod granular_notification_test;
 pub mod health_monitoring;
 pub mod help;
 pub mod membership;
@@ -99,7 +100,9 @@ pub use feature_flag::{
     FeatureFlagRepository, FeatureFlagWithCount, FeatureFlagWithOverrides, ResolvedFeatureFlag,
 };
 pub use financial::FinancialRepository;
-pub use granular_notification::GranularNotificationRepository;
+pub use granular_notification::{
+    GranularNotificationRepository, InactiveDigestCandidate, PendingDigestEmail,
+};
 pub use health_monitoring::{
     CurrentMetric, HealthDashboard, HealthMonitoringRepository, MetricDataPoint, MetricHistory,
     MetricStats, MetricStatus,

--- a/backend/servers/api-server/src/main.rs
+++ b/backend/servers/api-server/src/main.rs
@@ -31,8 +31,9 @@ use api_server::{observability, routes, services, state};
 
 use db::repositories::AnnouncementRepository;
 use services::{
-    EmailService, JwtService, PushFanoutConfig, PushFanoutWorker, QuietHoursDrainConfig,
-    QuietHoursDrainWorker, Scheduler, SchedulerConfig,
+    EmailService, JwtService, NotificationDigestConfig, NotificationDigestWorker,
+    PushFanoutConfig, PushFanoutWorker, QuietHoursDrainConfig, QuietHoursDrainWorker, Scheduler,
+    SchedulerConfig,
 };
 use state::AppState;
 
@@ -654,6 +655,18 @@ async fn main() -> anyhow::Result<()> {
         QuietHoursDrainConfig::from_env(),
     );
     let _quiet_hours_drain_handle = quiet_hours_drain_worker.start();
+
+    // Story 2B.3 / PM #969 gap 1: email a notification digest to users who have
+    // been inactive for >24h and have unread (pending) notifications. Drives the
+    // previously-uncalled `create_digest` write path. Polls on an interval and is
+    // disabled-safe (no crash when env vars are unset; gated per-user behind the
+    // `digest_enabled` preference).
+    let notification_digest_worker = NotificationDigestWorker::new(
+        db_pool.clone(),
+        email_service.clone(),
+        NotificationDigestConfig::from_env(),
+    );
+    let _notification_digest_handle = notification_digest_worker.start();
 
     // Phase 5 — admin dependency injection (B7).
     //

--- a/backend/servers/api-server/src/main.rs
+++ b/backend/servers/api-server/src/main.rs
@@ -31,9 +31,8 @@ use api_server::{observability, routes, services, state};
 
 use db::repositories::AnnouncementRepository;
 use services::{
-    EmailService, JwtService, NotificationDigestConfig, NotificationDigestWorker,
-    PushFanoutConfig, PushFanoutWorker, QuietHoursDrainConfig, QuietHoursDrainWorker, Scheduler,
-    SchedulerConfig,
+    EmailService, JwtService, NotificationDigestConfig, NotificationDigestWorker, PushFanoutConfig,
+    PushFanoutWorker, QuietHoursDrainConfig, QuietHoursDrainWorker, Scheduler, SchedulerConfig,
 };
 use state::AppState;
 

--- a/backend/servers/api-server/src/services/email.rs
+++ b/backend/servers/api-server/src/services/email.rs
@@ -1128,6 +1128,123 @@ impl EmailService {
         }
     }
 
+    /// Send the 24h-inactivity notification digest (Story 2B.3, PM #969 gap 1).
+    ///
+    /// Renders a localized summary of unread notifications — a total plus a
+    /// per-category breakdown taken from `category_counts` (keyed by
+    /// `entity_type`, e.g. `{ "fault": 5, "vote": 2 }`) — and always includes a
+    /// link to manage/unsubscribe from digests. Delivery goes through
+    /// [`Self::send_html_email`], so it degrades to logging when SMTP is
+    /// unconfigured and surfaces transport failures to the caller (the worker
+    /// only marks the digest sent on `Ok`).
+    pub async fn send_digest_email(
+        &self,
+        to: &str,
+        locale: &Locale,
+        notification_count: i64,
+        category_counts: &serde_json::Value,
+    ) -> Result<(), EmailError> {
+        // Manage/unsubscribe link — the digest opt-in lives in notification settings.
+        let unsubscribe_url = format!("{}/settings/notifications", self.base_url);
+        let unsubscribe_url_h = Self::html_escape(&unsubscribe_url);
+
+        let (subject, heading, intro, manage_label, footer) = match locale {
+            Locale::Slovak => (
+                format!("Máte {} nových upozornení", notification_count),
+                "Súhrn upozornení",
+                "Kým ste boli preč, nazbierali sa vám nové upozornenia:",
+                "Spravovať upozornenia alebo sa odhlásiť",
+                "Tento súhrn dostávate, pretože máte zapnuté e-mailové súhrny.",
+            ),
+            Locale::Czech => (
+                format!("Máte {} nových upozornění", notification_count),
+                "Souhrn upozornění",
+                "Zatímco jste byli pryč, nasbírala se nová upozornění:",
+                "Spravovat upozornění nebo se odhlásit",
+                "Tento souhrn dostáváte, protože máte zapnuté e-mailové souhrny.",
+            ),
+            Locale::German => (
+                format!("Sie haben {} neue Benachrichtigungen", notification_count),
+                "Benachrichtigungsübersicht",
+                "Während Ihrer Abwesenheit sind neue Benachrichtigungen eingegangen:",
+                "Benachrichtigungen verwalten oder abbestellen",
+                "Sie erhalten diese Übersicht, weil E-Mail-Zusammenfassungen aktiviert sind.",
+            ),
+            Locale::English => (
+                format!("You have {} new notifications", notification_count),
+                "Notification summary",
+                "While you were away, new notifications piled up:",
+                "Manage notifications or unsubscribe",
+                "You receive this summary because email digests are enabled.",
+            ),
+        };
+
+        // Build the per-category rows (HTML) and plain-text lines.
+        let mut rows_html = String::new();
+        let mut rows_text = String::new();
+        if let Some(map) = category_counts.as_object() {
+            let mut entries: Vec<(&String, i64)> = map
+                .iter()
+                .map(|(k, v)| (k, v.as_i64().unwrap_or(0)))
+                .collect();
+            // Stable, deterministic ordering: highest count first, then name.
+            entries.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+            for (category, count) in entries {
+                let label = Self::humanize_category(category);
+                let label_h = Self::html_escape(&label);
+                rows_html.push_str(&format!(
+                    r#"<tr><td style="padding:6px 12px;border-bottom:1px solid #e2e8f0">{label_h}</td><td style="padding:6px 12px;border-bottom:1px solid #e2e8f0;text-align:right;font-weight:bold">{count}</td></tr>"#
+                ));
+                rows_text.push_str(&format!("  - {label}: {count}\n"));
+            }
+        }
+
+        let html_body = format!(
+            r#"<!DOCTYPE html>
+<html lang="{lang}"><head><meta charset="UTF-8"><title>{heading}</title></head>
+<body style="font-family:Arial,sans-serif;color:#333;max-width:600px;margin:0 auto;padding:20px">
+  <h2 style="color:#2c5282">{heading}</h2>
+  <p>{intro}</p>
+  <table style="border-collapse:collapse;width:100%;margin:16px 0">{rows_html}</table>
+  <p style="margin:24px 0">
+    <a href="{unsubscribe_url_h}" style="color:#2c5282">{manage_label}</a>
+  </p>
+  <hr style="border:none;border-top:1px solid #e2e8f0;margin:24px 0">
+  <p style="font-size:12px;color:#718096">{footer}</p>
+</body></html>"#,
+            lang = locale.as_str(),
+        );
+
+        let text_body = format!(
+            "{heading}\n\n{intro}\n\n{rows_text}\n{manage_label}: {unsubscribe_url}\n\n{footer}\n",
+        );
+
+        self.send_html_email(to, &subject, &html_body, &text_body)
+            .await
+    }
+
+    /// Turn a raw `entity_type` (e.g. `fault`, `vote`, `announcement`) into a
+    /// human-friendly, Title-Cased label for the digest breakdown.
+    fn humanize_category(category: &str) -> String {
+        let cleaned = category.replace(['_', '-'], " ");
+        let mut out = String::with_capacity(cleaned.len());
+        for (i, word) in cleaned.split_whitespace().enumerate() {
+            if i > 0 {
+                out.push(' ');
+            }
+            let mut chars = word.chars();
+            if let Some(first) = chars.next() {
+                out.extend(first.to_uppercase());
+                out.push_str(chars.as_str());
+            }
+        }
+        if out.is_empty() {
+            category.to_string()
+        } else {
+            out
+        }
+    }
+
     /// Check if SMTP is properly configured.
     pub fn is_smtp_configured(&self) -> bool {
         matches!(self.transport.as_ref(), EmailTransport::Smtp(_))

--- a/backend/servers/api-server/src/services/mod.rs
+++ b/backend/servers/api-server/src/services/mod.rs
@@ -9,6 +9,7 @@ pub mod email;
 pub mod feature_service;
 pub mod jwt;
 pub mod notification;
+pub mod notification_digest;
 pub mod notification_pipeline;
 pub mod oauth;
 pub mod push_fanout;
@@ -30,6 +31,7 @@ pub use feature_service::FeatureService;
 pub use jwt::JwtService;
 #[allow(unused_imports)]
 pub use notification::{NotificationService, NotificationServiceConfig};
+pub use notification_digest::{NotificationDigestConfig, NotificationDigestWorker};
 #[allow(unused_imports)]
 pub use notification_pipeline::{
     NotificationPipeline, PipelineConfig, PreferenceRouter, SmtpEmailAdapter,

--- a/backend/servers/api-server/src/services/notification_digest.rs
+++ b/backend/servers/api-server/src/services/notification_digest.rs
@@ -113,7 +113,11 @@ pub struct NotificationDigestWorker {
 
 impl NotificationDigestWorker {
     /// Construct the worker from shared resources.
-    pub fn new(pool: DbPool, email_service: EmailService, config: NotificationDigestConfig) -> Self {
+    pub fn new(
+        pool: DbPool,
+        email_service: EmailService,
+        config: NotificationDigestConfig,
+    ) -> Self {
         let granular_repo = GranularNotificationRepository::new(pool);
         Self {
             granular_repo,
@@ -156,9 +160,7 @@ impl NotificationDigestWorker {
         let inactivity_cutoff = now - chrono::Duration::hours(self.config.inactivity_hours);
 
         let retried = self.retry_unsent(resend_cutoff, now).await;
-        let sent = self
-            .send_new(inactivity_cutoff, resend_cutoff, now)
-            .await;
+        let sent = self.send_new(inactivity_cutoff, resend_cutoff, now).await;
 
         if retried > 0 || sent > 0 {
             tracing::info!(
@@ -278,12 +280,7 @@ impl NotificationDigestWorker {
             let locale = Locale::parse(&c.locale);
             match self
                 .email_service
-                .send_digest_email(
-                    &c.email,
-                    &locale,
-                    c.notification_count,
-                    &c.category_counts,
-                )
+                .send_digest_email(&c.email, &locale, c.notification_count, &c.category_counts)
                 .await
             {
                 Ok(()) => {

--- a/backend/servers/api-server/src/services/notification_digest.rs
+++ b/backend/servers/api-server/src/services/notification_digest.rs
@@ -1,0 +1,319 @@
+//! 24h-inactivity email digest worker — Story 2B.3 (PM #969 gap 1).
+//!
+//! Story 2B.3 AC1: *"users who haven't been active for 24 hours and have
+//! pending notifications -> email digest is sent with a summary."* The DB write
+//! path (`create_digest`) and the read API (`GET /digests`) already existed, but
+//! nothing ever drove them — `notification_digests` was write-dead-code. This
+//! background worker closes that gap. It mirrors the [`PushFanoutWorker`] /
+//! [`QuietHoursDrainWorker`] lifecycle so the server always starts cleanly
+//! (disabled → no-op) and never panics.
+//!
+//! Each tick the worker:
+//!   1. Retries any digest rows whose email send previously failed (transient
+//!      `EmailService` errors) — the row is preserved and only marked sent on
+//!      success, so a digest is never lost or silently duplicated.
+//!   2. Finds opted-in users (`digest_enabled`) who have been inactive past the
+//!      cutoff (no refresh-token use — the closest proxy for "last seen") and
+//!      have unread notification groups, aggregates per-category unread counts,
+//!      persists a digest row, and emails a localized summary with an
+//!      unsubscribe link.
+//!
+//! Quiet hours are respected: a user inside their quiet-hours window is skipped
+//! this tick (no row created, no email) and naturally picked up on a later tick
+//! once the window has passed.
+
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use db::models::Locale;
+use db::{repositories::GranularNotificationRepository, DbPool};
+use tokio::time::interval;
+use tracing::Instrument;
+
+use super::email::EmailService;
+use super::quiet_hours;
+
+/// Digest period type recorded on every row. The 24h-inactivity sweep is a
+/// `daily` digest (the schema CHECK allows `hourly`/`daily`/`weekly`).
+const DIGEST_TYPE: &str = "daily";
+
+/// Configuration for the inactivity digest worker.
+#[derive(Debug, Clone)]
+pub struct NotificationDigestConfig {
+    /// When false, the worker starts but does nothing (no-op heartbeat).
+    pub enabled: bool,
+    /// How often to sweep for inactive users with pending notifications.
+    pub poll_interval_secs: u64,
+    /// A user must have been inactive for at least this long to be digested.
+    pub inactivity_hours: i64,
+    /// Minimum gap between digests for the same user. Also bounds how far back
+    /// unsent digest rows are retried, so a failed send retries within the
+    /// window but the user is never sent two digests in one window.
+    pub resend_window_hours: i64,
+    /// Safety cap on users processed per tick.
+    pub batch_limit: i64,
+}
+
+impl Default for NotificationDigestConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            poll_interval_secs: 3600,
+            inactivity_hours: 24,
+            resend_window_hours: 20,
+            batch_limit: 200,
+        }
+    }
+}
+
+impl NotificationDigestConfig {
+    /// Build from environment:
+    /// - `NOTIFICATION_DIGEST_ENABLED` (default `true`)
+    /// - `NOTIFICATION_DIGEST_INTERVAL_SECS` (default `3600`)
+    /// - `NOTIFICATION_DIGEST_INACTIVITY_HOURS` (default `24`)
+    /// - `NOTIFICATION_DIGEST_RESEND_WINDOW_HOURS` (default `20`)
+    /// - `NOTIFICATION_DIGEST_BATCH_LIMIT` (default `200`)
+    pub fn from_env() -> Self {
+        let default = Self::default();
+        let enabled = std::env::var("NOTIFICATION_DIGEST_ENABLED")
+            .map(|v| v != "false" && v != "0")
+            .unwrap_or(default.enabled);
+        let poll_interval_secs = std::env::var("NOTIFICATION_DIGEST_INTERVAL_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(default.poll_interval_secs);
+        let inactivity_hours = std::env::var("NOTIFICATION_DIGEST_INACTIVITY_HOURS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(default.inactivity_hours);
+        let resend_window_hours = std::env::var("NOTIFICATION_DIGEST_RESEND_WINDOW_HOURS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(default.resend_window_hours);
+        let batch_limit = std::env::var("NOTIFICATION_DIGEST_BATCH_LIMIT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(default.batch_limit);
+        Self {
+            enabled,
+            poll_interval_secs,
+            inactivity_hours,
+            resend_window_hours,
+            batch_limit,
+        }
+    }
+}
+
+/// Background worker that emails notification digests to inactive users.
+pub struct NotificationDigestWorker {
+    granular_repo: GranularNotificationRepository,
+    email_service: EmailService,
+    config: NotificationDigestConfig,
+}
+
+impl NotificationDigestWorker {
+    /// Construct the worker from shared resources.
+    pub fn new(pool: DbPool, email_service: EmailService, config: NotificationDigestConfig) -> Self {
+        let granular_repo = GranularNotificationRepository::new(pool);
+        Self {
+            granular_repo,
+            email_service,
+            config,
+        }
+    }
+
+    /// Spawn the background task and return its `JoinHandle`.
+    pub fn start(self) -> tokio::task::JoinHandle<()> {
+        let poll_secs = self.config.poll_interval_secs;
+        tokio::spawn(
+            async move {
+                if !self.config.enabled {
+                    tracing::info!("[2B.3] NotificationDigestWorker disabled — not starting");
+                    return;
+                }
+                tracing::info!(
+                    poll_interval_secs = self.config.poll_interval_secs,
+                    inactivity_hours = self.config.inactivity_hours,
+                    "[2B.3] NotificationDigestWorker started"
+                );
+                let mut ticker = interval(Duration::from_secs(self.config.poll_interval_secs));
+                loop {
+                    ticker.tick().await;
+                    self.process_due(Utc::now()).await;
+                }
+            }
+            .instrument(tracing::info_span!(
+                "bg.notification_digest",
+                poll_secs = poll_secs
+            )),
+        )
+    }
+
+    /// One sweep: retry unsent digests, then build+send new ones. Best-effort;
+    /// never panics so a single bad row can't take down the worker.
+    async fn process_due(&self, now: DateTime<Utc>) {
+        let resend_cutoff = now - chrono::Duration::hours(self.config.resend_window_hours);
+        let inactivity_cutoff = now - chrono::Duration::hours(self.config.inactivity_hours);
+
+        let retried = self.retry_unsent(resend_cutoff, now).await;
+        let sent = self
+            .send_new(inactivity_cutoff, resend_cutoff, now)
+            .await;
+
+        if retried > 0 || sent > 0 {
+            tracing::info!(
+                retried = retried,
+                sent = sent,
+                "[2B.3] NotificationDigestWorker tick complete"
+            );
+        }
+    }
+
+    /// Re-attempt digest rows whose email send previously failed. Returns the
+    /// number successfully sent this tick.
+    async fn retry_unsent(&self, resend_cutoff: DateTime<Utc>, now: DateTime<Utc>) -> usize {
+        let pending = match self
+            .granular_repo
+            .get_unsent_digests(resend_cutoff, self.config.batch_limit)
+            .await
+        {
+            Ok(rows) => rows,
+            Err(e) => {
+                tracing::error!(error = %e, "[2B.3] Failed to fetch unsent digests for retry");
+                return 0;
+            }
+        };
+
+        let mut sent = 0usize;
+        for d in pending {
+            if self.is_in_quiet_hours(d.user_id, now).await {
+                continue;
+            }
+            let locale = Locale::parse(&d.locale);
+            match self
+                .email_service
+                .send_digest_email(
+                    &d.email,
+                    &locale,
+                    d.notification_count as i64,
+                    &d.category_counts,
+                )
+                .await
+            {
+                Ok(()) => {
+                    if let Err(e) = self.granular_repo.mark_digest_email_sent(d.digest_id).await {
+                        tracing::warn!(digest_id = %d.digest_id, error = %e, "[2B.3] Re-sent digest email but failed to mark sent; may resend");
+                        continue;
+                    }
+                    sent += 1;
+                }
+                Err(e) => {
+                    tracing::warn!(digest_id = %d.digest_id, error = %e, "[2B.3] Retry of digest email failed; will retry next tick");
+                }
+            }
+        }
+        sent
+    }
+
+    /// Find inactive opted-in users with pending notifications, persist a digest
+    /// row, and email it. Returns the number of digests emailed this tick.
+    async fn send_new(
+        &self,
+        inactivity_cutoff: DateTime<Utc>,
+        resend_cutoff: DateTime<Utc>,
+        now: DateTime<Utc>,
+    ) -> usize {
+        let candidates = match self
+            .granular_repo
+            .find_inactive_digest_candidates(
+                inactivity_cutoff,
+                resend_cutoff,
+                self.config.batch_limit,
+            )
+            .await
+        {
+            Ok(rows) => rows,
+            Err(e) => {
+                tracing::error!(error = %e, "[2B.3] Failed to fetch inactivity digest candidates");
+                return 0;
+            }
+        };
+
+        if candidates.is_empty() {
+            return 0;
+        }
+
+        let mut sent = 0usize;
+        for c in candidates {
+            // Respect quiet hours: defer the whole digest (no row, no email)
+            // until the user is outside their quiet-hours window.
+            if self.is_in_quiet_hours(c.user_id, now).await {
+                continue;
+            }
+
+            // Persist the digest row first so the work is never lost; the email
+            // is marked sent only on a successful send (a failure is retried in
+            // place next tick by `retry_unsent`).
+            let digest = match self
+                .granular_repo
+                .create_digest(
+                    c.user_id,
+                    DIGEST_TYPE,
+                    c.period_start,
+                    c.period_end,
+                    c.notification_count.try_into().unwrap_or(i32::MAX),
+                    c.category_counts.clone(),
+                    None,
+                    None,
+                )
+                .await
+            {
+                Ok(d) => d,
+                Err(e) => {
+                    tracing::error!(user_id = %c.user_id, error = %e, "[2B.3] Failed to persist digest row");
+                    continue;
+                }
+            };
+
+            let locale = Locale::parse(&c.locale);
+            match self
+                .email_service
+                .send_digest_email(
+                    &c.email,
+                    &locale,
+                    c.notification_count,
+                    &c.category_counts,
+                )
+                .await
+            {
+                Ok(()) => {
+                    if let Err(e) = self.granular_repo.mark_digest_email_sent(digest.id).await {
+                        tracing::warn!(digest_id = %digest.id, error = %e, "[2B.3] Sent digest email but failed to mark sent; may resend");
+                        continue;
+                    }
+                    sent += 1;
+                    tracing::debug!(user_id = %c.user_id, digest_id = %digest.id, count = c.notification_count, "[2B.3] Sent inactivity digest");
+                }
+                Err(e) => {
+                    tracing::warn!(user_id = %c.user_id, digest_id = %digest.id, error = %e, "[2B.3] Digest email send failed; row preserved for retry");
+                }
+            }
+        }
+        sent
+    }
+
+    /// True when the user is currently inside their quiet-hours window. A user
+    /// with no schedule row (cannot happen for fresh candidates, possible for
+    /// retried rows after a preference change) is treated as not quiet.
+    async fn is_in_quiet_hours(&self, user_id: uuid::Uuid, now: DateTime<Utc>) -> bool {
+        match self.granular_repo.get_user_schedule(user_id).await {
+            Ok(Some(schedule)) => quiet_hours::evaluate(&schedule, now).active,
+            Ok(None) => false,
+            Err(e) => {
+                // On a transient read error, don't block the digest.
+                tracing::warn!(user_id = %user_id, error = %e, "[2B.3] Failed to read schedule for quiet-hours check; proceeding");
+                false
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Closes gap 1 of #969 / BIT-177. Story 2B.3 AC1 requires an automatic 24h-inactivity email digest: *"users who haven't been active for 24 hours and have pending notifications → email digest is sent with a summary."* The DB write path (`create_digest`) and read API (`GET /digests`) already existed, but nothing ever invoked them — `notification_digests` was write-dead-code.

## What this adds
- **`NotificationDigestWorker`** (`services/notification_digest.rs`), modeled on `PushFanoutWorker` / `QuietHoursDrainWorker` and wired into `main.rs` alongside the other workers. Disabled-safe (no-op when disabled; never panics). Configurable via `NOTIFICATION_DIGEST_*` env vars (enabled, interval, inactivity hours, resend window, batch limit).
- Each tick:
  1. **Retries** digest rows whose email send previously failed — the row is preserved and marked sent **only on success**, so a digest is never lost or duplicated.
  2. **Builds new digests**: finds opted-in (`digest_enabled`) users inactive >24h with unread notification groups, aggregates per-category unread counts, persists a row via `create_digest`, and emails a localized summary with an **unsubscribe/manage link**.
- **Quiet hours respected**: reuses the existing tested `quiet_hours::evaluate`; users inside their window are deferred to a later tick (no row, no email).
- New repo queries `find_inactive_digest_candidates` / `get_unsent_digests`, and `EmailService::send_digest_email` (SK/CS/DE/EN).

## Design notes
- **Activity signal**: `users` has **no `last_seen`/`last_active` column** (the issue's plan assumed one). The closest existing proxy is `refresh_tokens.last_used_at` (updated on every token refresh during active use), so a user is "inactive >24h" when their most recent `last_used_at` is older than the cutoff.
- **No duplicates / no lost rows**: the candidate query excludes any user with a digest row created within the resend window; failed sends are retried in place via `get_unsent_digests`.

## Tests
`granular_notification_test.rs` (uses `#[sqlx::test(migrator = "crate::MIGRATOR")]`):
- candidate query with per-category aggregation (read groups excluded);
- exclusions: recently-active, opted-out, and all-read users;
- resend dedup + unsent-row retry + mark-sent stops retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)