### PR TITLE
feat(ppt-web): fault reports/analytics page (Story 4.7, BIT-186)

### DIFF
--- a/docs/screens/ppt/fault-reports.md
+++ b/docs/screens/ppt/fault-reports.md
@@ -1,0 +1,95 @@
+---
+id: ppt/fault-reports
+name: Fault Reports
+product: ppt
+implementations:
+  ppt-web:
+    route: /faults/reports
+    component: FaultReportsPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: complete
+  mobile:
+    buildStatus: n/a
+    redesignStatus: n/a
+    apiStatus: n/a
+endpoints: []
+relatedScreens:
+  - id: ppt/faults-list
+    rel: parent
+useCases:
+  - UC-03
+sharedComponents:
+  - kpi-card
+  - bar-chart
+  - date-range-filter
+  - building-selector
+epics: []
+diagrams: []
+owner: pm-frontend
+---
+
+## Functionality Checklist
+
+<!-- tag with [w] / [m] / [w,m] / [-] -->
+
+### Filters (web)
+- [x] [w] Building selector (all buildings or a single building) → drives `useFaultStatistics`
+- [x] [w] Date range (from / to) with min/max cross-bounding → `date_from` / `date_to`
+- [x] [w] Manager-only gating — non-managers see an access notice (mirrors `isManagerRole`)
+
+### KPIs (web)
+- [x] [w] Total / Open / Closed counts
+- [x] [w] Average resolution time (hours), `—` when null
+- [x] [w] Average resident rating (1–5), `—` when null
+
+### Charts (web)
+- [x] [w] By-status breakdown bar chart (accessible labelled bars, share %)
+- [x] [w] By-category breakdown bar chart
+- [x] [w] By-priority breakdown bar chart
+- [x] [w] Drill-down: clicking a bar navigates to the faults list pre-filtered (`/faults?status=…`)
+
+### Export (web)
+- [x] [w] Export CSV (client-side Blob, BOM-prefixed for Excel)
+- [x] [w] Export PDF (browser print pipeline; print stylesheet hides controls)
+
+## States
+
+- **Empty**: when the filtered statistics return `total_count === 0`, a blunt single-line "No faults match the selected filters." is shown (filters retained).
+- **Loading**: centered spinner with `aria-busy` while `useFaultStatistics` is fetching.
+- **Error**: inline `role="alert"` danger tile ("Failed to load fault statistics") + `common.retry` button wired to `refetch()`.
+- **Forbidden**: non-managers see an amber `role="alert"` access notice and no data/charts.
+
+## Notes
+
+### Broader context
+
+UC-03 fault analytics (Story 4.7, BIT-186 / PM #970 gap 5). Consumes the
+already-implemented `GET /faults/statistics` endpoint (`FaultStatistics`:
+total/open/closed, by_status, by_category, by_priority,
+average_resolution_time_hours, average_rating). Previously the endpoint was only
+read by the faults-list summary bar (total/open/closed); this page is the
+dedicated manager reporting surface.
+
+### Specific (recent)
+
+- **Endpoint catalogue drift**: the statistics endpoint has no `operationId` in
+  `@ppt/sitemap` yet (only `faults_list` / `faults_get` / `faults_create` are
+  catalogued), so `endpoints: []` here to keep `/screens validate` green. Add a
+  `faults_statistics` operationId to the sitemap and reference it when the
+  catalogue is extended.
+- **Route not in sitemap**: like `ppt/faults-list`, `/faults/reports` is not in
+  `@ppt/sitemap` `pptWebRoutes`, so `sitemapRefs` is omitted. Reachable from the
+  faults list via a manager-only "View reports →" link.
+- Status enum is the backend's (`new` / `waiting_parts` / …), not
+  `reported` / `on_hold`; bucket keys are humanised for display
+  (`waiting_parts` → "Waiting parts").
+- Charts are dependency-free (Tailwind div-bars), matching the existing
+  `features/reports` convention of avoiding a charting library. CSV/PDF export
+  is client-side (no server export endpoint for statistics).
+
+## Agent Log
+
+<!-- newest entries on top -->
+
+- 2026-06-22 — agent: BIT-186 (FrontendEngineer) — created from scratch for Story 4.7. New `/faults/reports` route + `FaultReportsPage` + `FaultBreakdownChart` + CSV/PDF export; extended `useFaultStatistics` to accept building + date-range filters; manager-only gating mirrors `isManagerRole`; drill-down into the pre-filtered faults list. ppt-web buildStatus shipped / apiStatus complete; mobile n/a. Tests added for page + chart; typecheck + biome green.

--- a/frontend/apps/ppt-web/src/features/faults/components/FaultBreakdownChart.test.tsx
+++ b/frontend/apps/ppt-web/src/features/faults/components/FaultBreakdownChart.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * FaultBreakdownChart tests (Story 4.7, BIT-186).
+ * Covers accessible labels, empty state, and drill-down clicks.
+ */
+
+/// <reference types="vitest/globals" />
+import { fireEvent, render, screen } from '@testing-library/react';
+import { FaultBreakdownChart } from './FaultBreakdownChart';
+
+const data = [
+  { key: 'new', label: 'New', count: 3 },
+  { key: 'closed', label: 'Closed', count: 1 },
+];
+
+describe('FaultBreakdownChart', () => {
+  it('renders an empty message when there is no data', () => {
+    render(<FaultBreakdownChart title="By status" data={[]} emptyLabel="No data" />);
+    expect(screen.getByText('No data')).toBeInTheDocument();
+  });
+
+  it('renders accessible buttons with share percentages when onSelect is set', () => {
+    const onSelect = vi.fn();
+    render(<FaultBreakdownChart title="By status" data={data} onSelect={onSelect} />);
+    const btn = screen.getByRole('button', { name: /New: 3 \(75%\).*View these faults/ });
+    fireEvent.click(btn);
+    expect(onSelect).toHaveBeenCalledWith('new');
+  });
+
+  it('renders non-interactive rows (no buttons) when onSelect is omitted', () => {
+    render(<FaultBreakdownChart title="By status" data={data} />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('New: 3 (75%)')).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/ppt-web/src/features/faults/components/FaultBreakdownChart.tsx
+++ b/frontend/apps/ppt-web/src/features/faults/components/FaultBreakdownChart.tsx
@@ -1,0 +1,92 @@
+/**
+ * FaultBreakdownChart — accessible horizontal bar chart for fault statistic
+ * breakdowns (by status / category / priority).
+ *
+ * Story 4.7 (BIT-186). Each bucket is rendered as a labelled, proportional bar.
+ * When `onSelect` is provided the bars become buttons that drill down into the
+ * faults list filtered by that bucket. Dependency-free (Tailwind + SVG-less
+ * div bars) to match the existing reports charts which avoid a charting lib.
+ */
+
+export interface FaultBreakdownDatum {
+  /** Machine value forwarded to `onSelect` (e.g. the raw status/category key). */
+  key: string;
+  /** Human-readable label shown next to the bar. */
+  label: string;
+  count: number;
+}
+
+interface FaultBreakdownChartProps {
+  title: string;
+  data: FaultBreakdownDatum[];
+  /** Tailwind background class for the bars (e.g. `bg-blue-500`). */
+  barClassName?: string;
+  /** Drill-down handler; when set, bars are keyboard-focusable buttons. */
+  onSelect?: (key: string) => void;
+  /** Localised "no data" message. */
+  emptyLabel?: string;
+}
+
+export function FaultBreakdownChart({
+  title,
+  data,
+  barClassName = 'bg-blue-500',
+  onSelect,
+  emptyLabel = 'No data available',
+}: FaultBreakdownChartProps) {
+  const total = data.reduce((sum, d) => sum + d.count, 0);
+  const max = data.reduce((m, d) => (d.count > m ? d.count : m), 0);
+
+  return (
+    <section className="bg-white rounded-lg shadow p-6" aria-label={title}>
+      <h3 className="text-lg font-medium text-gray-900 mb-4">{title}</h3>
+
+      {data.length === 0 || total === 0 ? (
+        <p className="text-sm text-gray-500 py-4">{emptyLabel}</p>
+      ) : (
+        <ul className="space-y-3">
+          {data.map((d) => {
+            const widthPct = max > 0 ? Math.max((d.count / max) * 100, 2) : 0;
+            const sharePct = total > 0 ? (d.count / total) * 100 : 0;
+            const rowLabel = `${d.label}: ${d.count} (${sharePct.toFixed(0)}%)`;
+
+            const bar = (
+              <div className="flex items-center gap-3">
+                <span className="w-32 shrink-0 text-sm text-gray-700 truncate" title={d.label}>
+                  {d.label}
+                </span>
+                <span className="flex-1 h-5 bg-gray-100 rounded overflow-hidden">
+                  <span
+                    className={`block h-full ${barClassName} transition-all duration-300`}
+                    style={{ width: `${widthPct}%` }}
+                  />
+                </span>
+                <span className="w-20 shrink-0 text-right text-sm tabular-nums text-gray-900">
+                  {d.count}
+                  <span className="text-gray-400"> ({sharePct.toFixed(0)}%)</span>
+                </span>
+              </div>
+            );
+
+            return (
+              <li key={d.key}>
+                {onSelect ? (
+                  <button
+                    type="button"
+                    onClick={() => onSelect(d.key)}
+                    aria-label={`${rowLabel}. View these faults`}
+                    className="w-full text-left rounded px-1 py-0.5 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  >
+                    {bar}
+                  </button>
+                ) : (
+                  <div aria-label={rowLabel}>{bar}</div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/faults/components/index.ts
+++ b/frontend/apps/ppt-web/src/features/faults/components/index.ts
@@ -3,6 +3,7 @@
  * Epic 4: Fault Reporting & Resolution
  */
 
+export * from './FaultBreakdownChart';
 export * from './FaultCard';
 export * from './FaultForm';
 export * from './FaultList';

--- a/frontend/apps/ppt-web/src/features/faults/pages/FaultReportsPage.test.tsx
+++ b/frontend/apps/ppt-web/src/features/faults/pages/FaultReportsPage.test.tsx
@@ -4,9 +4,9 @@
  * rendering, drill-down, and CSV export wiring.
  */
 
+import type { FaultStatistics } from '@ppt/api-client';
 /// <reference types="vitest/globals" />
 import { fireEvent, render, screen } from '@testing-library/react';
-import type { FaultStatistics } from '@ppt/api-client';
 import { FaultReportsPage } from './FaultReportsPage';
 
 const noop = () => {};
@@ -82,9 +82,7 @@ describe('FaultReportsPage', () => {
     const revokeObjectURL = vi.fn();
     // jsdom lacks these — stub them.
     vi.stubGlobal('URL', { ...URL, createObjectURL, revokeObjectURL });
-    const clickSpy = vi
-      .spyOn(HTMLAnchorElement.prototype, 'click')
-      .mockImplementation(() => {});
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
 
     render(<FaultReportsPage {...baseProps} stats={stats} />);
     fireEvent.click(screen.getByRole('button', { name: 'Export CSV' }));

--- a/frontend/apps/ppt-web/src/features/faults/pages/FaultReportsPage.test.tsx
+++ b/frontend/apps/ppt-web/src/features/faults/pages/FaultReportsPage.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * FaultReportsPage tests (Story 4.7, BIT-186).
+ * Covers manager-only gating, loading / empty / error states, KPI + chart
+ * rendering, drill-down, and CSV export wiring.
+ */
+
+/// <reference types="vitest/globals" />
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { FaultStatistics } from '@ppt/api-client';
+import { FaultReportsPage } from './FaultReportsPage';
+
+const noop = () => {};
+
+const baseProps = {
+  isManager: true,
+  buildings: [{ id: 'b-1', name: 'Maple Court' }],
+  filters: {},
+  onFiltersChange: noop,
+  onDrillDown: noop,
+};
+
+const stats: FaultStatistics = {
+  total_count: 12,
+  open_count: 5,
+  closed_count: 7,
+  by_status: [
+    { status: 'new', count: 3 },
+    { status: 'waiting_parts', count: 2 },
+  ],
+  by_category: [{ category: 'plumbing', count: 8 }],
+  by_priority: [{ priority: 'high', count: 4 }],
+  average_resolution_time_hours: 36.5,
+  average_rating: 4.25,
+};
+
+describe('FaultReportsPage', () => {
+  it('shows an access notice for non-managers and no charts', () => {
+    render(<FaultReportsPage {...baseProps} isManager={false} stats={stats} />);
+    expect(screen.getByRole('alert')).toHaveTextContent('do not have permission');
+    expect(screen.queryByText('By status')).not.toBeInTheDocument();
+  });
+
+  it('renders a loading spinner when isLoading', () => {
+    const { container } = render(<FaultReportsPage {...baseProps} isLoading />);
+    expect(container.querySelector('[aria-busy="true"]')).toBeInTheDocument();
+  });
+
+  it('renders an error state with a retry button', () => {
+    const onRetry = vi.fn();
+    render(<FaultReportsPage {...baseProps} isError onRetry={onRetry} />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Failed to load fault statistics');
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it('renders the empty state when there are no faults', () => {
+    render(<FaultReportsPage {...baseProps} stats={{ ...stats, total_count: 0 }} />);
+    expect(screen.getByText('No faults match the selected filters.')).toBeInTheDocument();
+  });
+
+  it('renders KPIs and breakdown charts when stats are present', () => {
+    render(<FaultReportsPage {...baseProps} stats={stats} />);
+    expect(screen.getByText('Total faults')).toBeInTheDocument();
+    expect(screen.getByText('36.5')).toBeInTheDocument(); // avg resolution hours
+    expect(screen.getByText('4.25 ★')).toBeInTheDocument(); // avg rating
+    expect(screen.getByLabelText('By status')).toBeInTheDocument();
+    expect(screen.getByLabelText('By category')).toBeInTheDocument();
+    expect(screen.getByLabelText('By priority')).toBeInTheDocument();
+    // snake_case status humanised
+    expect(screen.getByText('Waiting parts')).toBeInTheDocument();
+  });
+
+  it('calls onDrillDown with the raw bucket key when a bar is clicked', () => {
+    const onDrillDown = vi.fn();
+    render(<FaultReportsPage {...baseProps} stats={stats} onDrillDown={onDrillDown} />);
+    fireEvent.click(screen.getByRole('button', { name: /New: 3.*View these faults/ }));
+    expect(onDrillDown).toHaveBeenCalledWith({ status: 'new' });
+  });
+
+  it('exports a CSV blob when Export CSV is clicked', () => {
+    const createObjectURL = vi.fn(() => 'blob:fake');
+    const revokeObjectURL = vi.fn();
+    // jsdom lacks these — stub them.
+    vi.stubGlobal('URL', { ...URL, createObjectURL, revokeObjectURL });
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {});
+
+    render(<FaultReportsPage {...baseProps} stats={stats} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Export CSV' }));
+    expect(createObjectURL).toHaveBeenCalledOnce();
+    expect(clickSpy).toHaveBeenCalledOnce();
+
+    clickSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+});

--- a/frontend/apps/ppt-web/src/features/faults/pages/FaultReportsPage.tsx
+++ b/frontend/apps/ppt-web/src/features/faults/pages/FaultReportsPage.tsx
@@ -1,0 +1,304 @@
+/**
+ * FaultReportsPage — fault analytics / reports surface (Story 4.7, BIT-186).
+ *
+ * Manager-only. Lets a manager pick a building + date range, then renders the
+ * top-line KPIs (count, avg resolution time, avg rating) and status/category/
+ * priority breakdown charts with drill-down into the faults list. Supports CSV
+ * and PDF (print) export.
+ *
+ * Presentational: the building/date filters are controlled by the route
+ * wrapper (FaultReportsPageRoute), which drives `useFaultStatistics`.
+ */
+
+import type { FaultStatistics } from '@ppt/api-client';
+import { useTranslation } from 'react-i18next';
+import { FaultBreakdownChart, type FaultBreakdownDatum } from '../components/FaultBreakdownChart';
+import { buildStatisticsCsv, downloadCsv, type FaultReportMeta } from '../utils/faultReportExport';
+
+export interface FaultReportFilters {
+  buildingId?: string;
+  dateFrom?: string;
+  dateTo?: string;
+}
+
+interface FaultReportsPageProps {
+  /** Manager-equivalent access (mirrors isManagerRole). */
+  isManager: boolean;
+  stats?: FaultStatistics;
+  isLoading?: boolean;
+  isError?: boolean;
+  onRetry?: () => void;
+  buildings: Array<{ id: string; name: string }>;
+  filters: FaultReportFilters;
+  onFiltersChange: (filters: FaultReportFilters) => void;
+  /** Drill down into the faults list filtered by a status/category/priority. */
+  onDrillDown: (params: { status?: string; category?: string; priority?: string }) => void;
+}
+
+/** Humanise a snake_case enum value for display (`waiting_parts` → `Waiting parts`). */
+function humanise(value: string): string {
+  const s = value.replace(/_/g, ' ');
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function toData(buckets: Array<{ key: string; count: number }>): FaultBreakdownDatum[] {
+  return buckets.map((b) => ({ key: b.key, label: humanise(b.key), count: b.count }));
+}
+
+export function FaultReportsPage({
+  isManager,
+  stats,
+  isLoading,
+  isError,
+  onRetry,
+  buildings,
+  filters,
+  onFiltersChange,
+  onDrillDown,
+}: FaultReportsPageProps) {
+  const { t } = useTranslation();
+
+  if (!isManager) {
+    return (
+      <div className="max-w-5xl mx-auto px-4 py-8">
+        <div
+          role="alert"
+          className="border border-amber-200 bg-amber-50 text-amber-800 rounded-lg p-6 text-center"
+        >
+          <p className="font-medium">
+            {t('faults.reports.forbidden', {
+              defaultValue: 'You do not have permission to view fault reports.',
+            })}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const buildingLabel =
+    buildings.find((b) => b.id === filters.buildingId)?.name ??
+    t('faults.reports.allBuildings', { defaultValue: 'All buildings' });
+
+  const handleExportCsv = () => {
+    if (!stats) return;
+    const meta: FaultReportMeta = {
+      buildingLabel,
+      dateFrom: filters.dateFrom,
+      dateTo: filters.dateTo,
+    };
+    downloadCsv('fault-report.csv', buildStatisticsCsv(stats, meta));
+  };
+
+  const handleExportPdf = () => {
+    // Browser print pipeline — the print stylesheet below hides chrome so the
+    // user can "Save as PDF" from the dialog. Dependency-free.
+    window.print();
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-8 fault-reports">
+      {/* Print stylesheet: hide interactive controls so the PDF shows data only. */}
+      <style>{`@media print {
+        .fault-reports__no-print { display: none !important; }
+        .fault-reports { max-width: none; padding: 0; }
+      }`}</style>
+
+      <header className="mb-6 flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">
+            {t('faults.reports.title', { defaultValue: 'Fault Reports' })}
+          </h1>
+          <p className="text-sm text-gray-500">
+            {t('faults.reports.subtitle', {
+              defaultValue: 'Fault analytics across buildings and time.',
+            })}
+          </p>
+        </div>
+        <div className="fault-reports__no-print flex gap-2">
+          <button
+            type="button"
+            onClick={handleExportCsv}
+            disabled={!stats}
+            className="px-3 py-2 text-sm font-medium border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          >
+            {t('faults.reports.exportCsv', { defaultValue: 'Export CSV' })}
+          </button>
+          <button
+            type="button"
+            onClick={handleExportPdf}
+            disabled={!stats}
+            className="px-3 py-2 text-sm font-medium border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          >
+            {t('faults.reports.exportPdf', { defaultValue: 'Export PDF' })}
+          </button>
+        </div>
+      </header>
+
+      {/* Filters */}
+      <div className="fault-reports__no-print mb-6 grid grid-cols-1 sm:grid-cols-3 gap-4 p-4 bg-gray-50 border border-gray-200 rounded-lg">
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-medium text-gray-700">
+            {t('faults.reports.building', { defaultValue: 'Building' })}
+          </span>
+          <select
+            value={filters.buildingId ?? ''}
+            onChange={(e) =>
+              onFiltersChange({ ...filters, buildingId: e.target.value || undefined })
+            }
+            className="border border-gray-300 rounded-lg px-3 py-2"
+          >
+            <option value="">
+              {t('faults.reports.allBuildings', { defaultValue: 'All buildings' })}
+            </option>
+            {buildings.map((b) => (
+              <option key={b.id} value={b.id}>
+                {b.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-medium text-gray-700">
+            {t('faults.reports.dateFrom', { defaultValue: 'From' })}
+          </span>
+          <input
+            type="date"
+            value={filters.dateFrom ?? ''}
+            max={filters.dateTo || undefined}
+            onChange={(e) => onFiltersChange({ ...filters, dateFrom: e.target.value || undefined })}
+            className="border border-gray-300 rounded-lg px-3 py-2"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-medium text-gray-700">
+            {t('faults.reports.dateTo', { defaultValue: 'To' })}
+          </span>
+          <input
+            type="date"
+            value={filters.dateTo ?? ''}
+            min={filters.dateFrom || undefined}
+            onChange={(e) => onFiltersChange({ ...filters, dateTo: e.target.value || undefined })}
+            className="border border-gray-300 rounded-lg px-3 py-2"
+          />
+        </label>
+      </div>
+
+      {/* Loading */}
+      {isLoading && (
+        <div className="flex justify-center py-16" aria-live="polite" aria-busy="true">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+        </div>
+      )}
+
+      {/* Error */}
+      {!isLoading && isError && (
+        <div
+          role="alert"
+          className="text-center py-8 border border-red-200 bg-red-50 rounded-lg text-red-700"
+        >
+          <p className="font-medium">
+            {t('faults.reports.failedToLoad', {
+              defaultValue: 'Failed to load fault statistics',
+            })}
+          </p>
+          {onRetry && (
+            <button
+              type="button"
+              onClick={onRetry}
+              className="mt-3 px-3 py-1 border border-red-300 rounded hover:bg-red-100"
+            >
+              {t('common.retry', { defaultValue: 'Retry' })}
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Empty */}
+      {!isLoading && !isError && stats && stats.total_count === 0 && (
+        <div className="text-center py-12 text-gray-500">
+          {t('faults.reports.empty', {
+            defaultValue: 'No faults match the selected filters.',
+          })}
+        </div>
+      )}
+
+      {/* Content */}
+      {!isLoading && !isError && stats && stats.total_count > 0 && (
+        <>
+          {/* KPIs */}
+          <div className="grid grid-cols-2 lg:grid-cols-5 gap-4 mb-8">
+            <Kpi
+              label={t('faults.reports.kpiTotal', { defaultValue: 'Total faults' })}
+              value={stats.total_count}
+            />
+            <Kpi
+              label={t('faults.reports.kpiOpen', { defaultValue: 'Open' })}
+              value={stats.open_count}
+              valueClassName="text-blue-600"
+            />
+            <Kpi
+              label={t('faults.reports.kpiClosed', { defaultValue: 'Closed' })}
+              value={stats.closed_count}
+              valueClassName="text-gray-400"
+            />
+            <Kpi
+              label={t('faults.reports.kpiResolution', { defaultValue: 'Avg resolution (h)' })}
+              value={
+                stats.average_resolution_time_hours == null
+                  ? '—'
+                  : stats.average_resolution_time_hours.toFixed(1)
+              }
+            />
+            <Kpi
+              label={t('faults.reports.kpiRating', { defaultValue: 'Avg rating' })}
+              value={stats.average_rating == null ? '—' : `${stats.average_rating.toFixed(2)} ★`}
+              valueClassName="text-amber-500"
+            />
+          </div>
+
+          {/* Breakdown charts */}
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            <FaultBreakdownChart
+              title={t('faults.reports.byStatus', { defaultValue: 'By status' })}
+              data={toData(stats.by_status.map((s) => ({ key: s.status, count: s.count })))}
+              barClassName="bg-blue-500"
+              onSelect={(status) => onDrillDown({ status })}
+              emptyLabel={t('faults.reports.noData', { defaultValue: 'No data available' })}
+            />
+            <FaultBreakdownChart
+              title={t('faults.reports.byCategory', { defaultValue: 'By category' })}
+              data={toData(stats.by_category.map((c) => ({ key: c.category, count: c.count })))}
+              barClassName="bg-emerald-500"
+              onSelect={(category) => onDrillDown({ category })}
+              emptyLabel={t('faults.reports.noData', { defaultValue: 'No data available' })}
+            />
+            <FaultBreakdownChart
+              title={t('faults.reports.byPriority', { defaultValue: 'By priority' })}
+              data={toData(stats.by_priority.map((p) => ({ key: p.priority, count: p.count })))}
+              barClassName="bg-amber-500"
+              onSelect={(priority) => onDrillDown({ priority })}
+              emptyLabel={t('faults.reports.noData', { defaultValue: 'No data available' })}
+            />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Kpi({
+  label,
+  value,
+  valueClassName = 'text-gray-900',
+}: {
+  label: string;
+  value: string | number;
+  valueClassName?: string;
+}) {
+  return (
+    <div className="bg-white rounded-lg shadow p-4">
+      <p className="text-sm font-medium text-gray-500">{label}</p>
+      <p className={`mt-2 text-2xl font-bold ${valueClassName}`}>{value}</p>
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/faults/pages/FaultsPage.tsx
+++ b/frontend/apps/ppt-web/src/features/faults/pages/FaultsPage.tsx
@@ -45,6 +45,8 @@ interface FaultsPageProps {
   onDelete?: (id: string) => void;
   /** Optional statistics summary from useFaultStatistics for the summary bar. */
   stats?: FaultStatsSummary;
+  /** Navigate to the fault reports/analytics page (managers only; omitted otherwise). */
+  onNavigateToReports?: () => void;
   onNavigateToCreate: () => void;
   onNavigateToView: (id: string) => void;
   onNavigateToEdit: (id: string) => void;
@@ -60,6 +62,7 @@ export function FaultsPage({
   onRetry,
   onDelete,
   stats,
+  onNavigateToReports,
   onNavigateToCreate,
   onNavigateToView,
   onNavigateToEdit,
@@ -105,6 +108,18 @@ export function FaultsPage({
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-8">
+      {onNavigateToReports && (
+        <div className="mb-4 flex justify-end">
+          <button
+            type="button"
+            onClick={onNavigateToReports}
+            className="text-sm font-medium text-blue-600 hover:text-blue-700 underline"
+          >
+            View reports →
+          </button>
+        </div>
+      )}
+
       {/* Statistics summary bar — populated by useFaultStatistics in route wrapper */}
       {stats && (
         <div

--- a/frontend/apps/ppt-web/src/features/faults/pages/index.ts
+++ b/frontend/apps/ppt-web/src/features/faults/pages/index.ts
@@ -6,4 +6,5 @@
 export * from './CreateFaultPage';
 export * from './EditFaultPage';
 export * from './FaultDetailPage';
+export * from './FaultReportsPage';
 export * from './FaultsPage';

--- a/frontend/apps/ppt-web/src/features/faults/utils/faultReportExport.ts
+++ b/frontend/apps/ppt-web/src/features/faults/utils/faultReportExport.ts
@@ -1,0 +1,82 @@
+/**
+ * Client-side export helpers for the Fault Reports page (Story 4.7 / BIT-186).
+ *
+ * The fault statistics endpoint has no server-side export, so CSV is assembled
+ * in the browser and offered as a Blob download. PDF export reuses the browser
+ * print pipeline (`window.print()`) with a print stylesheet on the page, which
+ * keeps the bundle dependency-free (no jsPDF/pdfmake) and lets the user "Save
+ * as PDF" from the print dialog.
+ */
+
+import type { FaultStatistics } from '@ppt/api-client';
+
+/** Escape a single CSV field per RFC 4180 (quote when it contains , " or newline). */
+function csvField(value: string | number | null | undefined): string {
+  const s = value == null ? '' : String(value);
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+export interface FaultReportMeta {
+  buildingLabel: string;
+  dateFrom?: string;
+  dateTo?: string;
+}
+
+/**
+ * Build a CSV document summarising the fault statistics. Sections are separated
+ * by blank lines: a header/meta block, top-line KPIs, then each breakdown.
+ */
+export function buildStatisticsCsv(stats: FaultStatistics, meta: FaultReportMeta): string {
+  const rows: string[] = [];
+  const push = (...cells: Array<string | number | null | undefined>) =>
+    rows.push(cells.map(csvField).join(','));
+
+  push('Fault Report');
+  push('Building', meta.buildingLabel);
+  push('Date from', meta.dateFrom || 'All time');
+  push('Date to', meta.dateTo || 'All time');
+  push();
+
+  push('Metric', 'Value');
+  push('Total faults', stats.total_count);
+  push('Open faults', stats.open_count);
+  push('Closed faults', stats.closed_count);
+  push(
+    'Average resolution time (hours)',
+    stats.average_resolution_time_hours == null
+      ? 'N/A'
+      : stats.average_resolution_time_hours.toFixed(1)
+  );
+  push(
+    'Average rating (1-5)',
+    stats.average_rating == null ? 'N/A' : stats.average_rating.toFixed(2)
+  );
+  push();
+
+  push('Status', 'Count');
+  for (const s of stats.by_status) push(s.status, s.count);
+  push();
+
+  push('Category', 'Count');
+  for (const c of stats.by_category) push(c.category, c.count);
+  push();
+
+  push('Priority', 'Count');
+  for (const p of stats.by_priority) push(p.priority, p.count);
+
+  return rows.join('\n');
+}
+
+/** Trigger a browser download of `content` as a UTF-8 CSV file. */
+export function downloadCsv(filename: string, content: string): void {
+  // Prepend a BOM so Excel opens UTF-8 correctly.
+  const blob = new Blob([`﻿${content}`], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/frontend/apps/ppt-web/src/routes/groups/faults.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/faults.tsx
@@ -29,16 +29,26 @@ import {
 } from '@ppt/api-client';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Route, useNavigate, useParams } from 'react-router-dom';
+import { Route, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useToast } from '../../components';
 import { useAuth } from '../../contexts';
-import type { FaultDetail, FaultAttachment as UiFaultAttachment } from '../../features/faults';
+import type {
+  FaultDetail,
+  FaultReportFilters,
+  FaultAttachment as UiFaultAttachment,
+} from '../../features/faults';
 import type {
   FaultStatus,
   FaultSummary as UiFaultSummary,
 } from '../../features/faults/components/FaultCard';
 import type { TimelineAction, TimelineEntry } from '../../features/faults/components/FaultTimeline';
-import { CreateFaultPage, EditFaultPage, FaultDetailPage, FaultsPage } from '../lazyRoutes';
+import {
+  CreateFaultPage,
+  EditFaultPage,
+  FaultDetailPage,
+  FaultReportsPage,
+  FaultsPage,
+} from '../lazyRoutes';
 import { isManagerRole } from '../shared';
 
 /**
@@ -211,7 +221,19 @@ function FaultsPageRoute() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { showToast } = useToast();
-  const [faultQuery, setFaultQuery] = useState<FaultListQuery>({ page: 1, limit: 10 });
+  const { user } = useAuth();
+  const isManager = isManagerRole(user?.role);
+  const [searchParams] = useSearchParams();
+  // Seed the initial query from URL params so reports-page drill-down
+  // (`/faults?status=new`) lands on a pre-filtered list. Status/category/
+  // priority use the API enums directly (FaultListQuery is the API shape).
+  const [faultQuery, setFaultQuery] = useState<FaultListQuery>(() => ({
+    page: 1,
+    limit: 10,
+    status: (searchParams.get('status') as FaultListQuery['status']) ?? undefined,
+    category: (searchParams.get('category') as FaultListQuery['category']) ?? undefined,
+    priority: (searchParams.get('priority') as FaultListQuery['priority']) ?? undefined,
+  }));
 
   const { data, isLoading, error, refetch } = useFaults(faultQuery);
   const deleteFault = useDeleteFault();
@@ -310,6 +332,7 @@ function FaultsPageRoute() {
       onNavigateToView={(id) => navigate(`/faults/${id}`)}
       onNavigateToEdit={(id) => navigate(`/faults/${id}/edit`)}
       onNavigateToTriage={(id) => navigate(`/faults/${id}`)}
+      onNavigateToReports={isManager ? () => navigate('/faults/reports') : undefined}
       onFilterChange={handleFaultsFilterChange}
     />
   );
@@ -493,12 +516,56 @@ function EditFaultPageRoute() {
   );
 }
 
+/**
+ * Fault reports / analytics page (Story 4.7, BIT-186).
+ *
+ * Manager-only — gating mirrors isManagerRole (the page renders an access
+ * notice for non-managers). Owns the building + date-range filter state that
+ * drives useFaultStatistics, and drills down into the faults list.
+ */
+function FaultReportsPageRoute() {
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const isManager = isManagerRole(user?.role);
+
+  const [filters, setFilters] = useState<FaultReportFilters>({});
+  const { data: buildingsData } = useBuildings();
+  const buildings = (buildingsData?.items ?? []).map((b) => ({ id: b.id, name: b.name }));
+
+  const { data, isLoading, error, refetch } = useFaultStatistics(filters);
+
+  const handleDrillDown = (params: { status?: string; category?: string; priority?: string }) => {
+    const search = new URLSearchParams();
+    if (params.status) search.set('status', params.status);
+    if (params.category) search.set('category', params.category);
+    if (params.priority) search.set('priority', params.priority);
+    navigate(`/faults?${search.toString()}`);
+  };
+
+  return (
+    <FaultReportsPage
+      isManager={isManager}
+      stats={isManager ? data : undefined}
+      isLoading={isManager && isLoading}
+      isError={!!error}
+      onRetry={() => {
+        void refetch();
+      }}
+      buildings={buildings}
+      filters={filters}
+      onFiltersChange={setFilters}
+      onDrillDown={handleDrillDown}
+    />
+  );
+}
+
 /** Faults routes (UC-03). */
 export function faultRoutes() {
   return (
     <>
       <Route path="/faults" element={<FaultsPageRoute />} />
       <Route path="/faults/new" element={<CreateFaultPageRoute />} />
+      <Route path="/faults/reports" element={<FaultReportsPageRoute />} />
       <Route path="/faults/:faultId" element={<FaultDetailPageRoute />} />
       <Route path="/faults/:faultId/edit" element={<EditFaultPageRoute />} />
     </>

--- a/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
+++ b/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
@@ -208,6 +208,9 @@ export const CreateFaultPage = lazy(() =>
 export const EditFaultPage = lazy(() =>
   import('../features/faults').then((m) => ({ default: m.EditFaultPage }))
 );
+export const FaultReportsPage = lazy(() =>
+  import('../features/faults').then((m) => ({ default: m.FaultReportsPage }))
+);
 
 // Community feature (Epic 42)
 export const FeedPage = lazy(() =>

--- a/frontend/packages/api-client/src/faults/hooks.ts
+++ b/frontend/packages/api-client/src/faults/hooks.ts
@@ -33,8 +33,18 @@ export const faultKeys = {
   attachments: (id: string) => [...faultKeys.all, 'attachments', id] as const,
   comments: (id: string) => [...faultKeys.all, 'comments', id] as const,
   suggestion: (id: string) => [...faultKeys.all, 'suggestion', id] as const,
-  statistics: (buildingId?: string) => [...faultKeys.all, 'statistics', buildingId] as const,
+  statistics: (filters?: FaultStatisticsFilters) =>
+    [...faultKeys.all, 'statistics', filters ?? {}] as const,
 };
+
+/** Optional filters for the fault statistics query (building + date range). */
+export interface FaultStatisticsFilters {
+  buildingId?: string;
+  /** ISO date (inclusive lower bound) passed to the backend as `date_from`. */
+  dateFrom?: string;
+  /** ISO date (inclusive upper bound) passed to the backend as `date_to`. */
+  dateTo?: string;
+}
 
 // ============================================================================
 // Query Hooks
@@ -66,11 +76,21 @@ export function useFaultComments(faultId: string) {
   });
 }
 
-/** Get fault statistics */
-export function useFaultStatistics(buildingId?: string) {
+/**
+ * Get fault statistics, optionally scoped by building and/or date range.
+ *
+ * Accepts either no argument (building-wide, all-time — used by the faults
+ * list summary bar) or a {@link FaultStatisticsFilters} object (used by the
+ * `/faults/reports` analytics page). A bare `buildingId` string is also
+ * accepted for backward compatibility.
+ */
+export function useFaultStatistics(filters?: FaultStatisticsFilters | string) {
+  const normalized: FaultStatisticsFilters =
+    typeof filters === 'string' ? { buildingId: filters } : (filters ?? {});
   return useQuery<FaultStatistics>({
-    queryKey: faultKeys.statistics(buildingId),
-    queryFn: () => api.getFaultStatistics(buildingId),
+    queryKey: faultKeys.statistics(normalized),
+    queryFn: () =>
+      api.getFaultStatistics(normalized.buildingId, normalized.dateFrom, normalized.dateTo),
   });
 }
 

--- a/frontend/packages/api-client/src/faults/index.ts
+++ b/frontend/packages/api-client/src/faults/index.ts
@@ -26,6 +26,7 @@ export {
   updateFault,
 } from './api';
 // React Query hooks
+export type { FaultStatisticsFilters } from './hooks';
 export {
   faultKeys,
   useAcceptAiSuggestion,


### PR DESCRIPTION
## What

Adds a manager-only **`/faults/reports`** analytics page (Story 4.7 / PM #970 gap 5, BIT-186) that consumes the already-implemented `GET /faults/statistics` endpoint as a dedicated reporting surface. Previously the statistics endpoint was only read for the faults-list summary bar.

## Changes
- **`useFaultStatistics`** extended to accept `{ buildingId, dateFrom, dateTo }` (the API already supported `date_from`/`date_to`; the hook only passed `buildingId`). Backward-compatible — bare call and bare `buildingId` string still work.
- **`FaultReportsPage`** — building + date-range filters; KPIs (total/open/closed, avg resolution time, avg rating); by-status/category/priority breakdown charts with drill-down; CSV + PDF export; loading/empty/error/forbidden states.
- **`FaultBreakdownChart`** — accessible, dependency-free Tailwind bar chart (labelled bars + share %), optional drill-down buttons.
- **`faultReportExport`** — client-side CSV (Blob, Excel BOM) builder; PDF via the browser print pipeline (print stylesheet hides controls).
- Route wired in `routes/groups/faults.tsx` (+ lazy route); drill-down navigates to the faults list pre-filtered via URL params (`/faults?status=…`), which the list route now seeds from `useSearchParams`.
- Manager-only gating mirrors `isManagerRole`; a "View reports →" link is surfaced on the faults list for managers.

## Bar
- Manager-only gating (mirrors `isManagerRole`), loading/empty/error states, accessible charts ✅
- Status enum is the backend's (`new`/`waiting_parts`/…) — bucket keys humanised for display ✅
- `pnpm --filter @ppt/web typecheck` ✅ · `pnpm check` (biome) ✅
- New tests for page + chart (10) green; existing faults route/page tests (15) green
- `docs/screens/ppt/fault-reports.md` added; `/screens validate` green (144 maps, 0 errors)

## Notes
- Charts are dependency-free (no charting lib), matching `features/reports` conventions; export is client-side as there is no server export endpoint for statistics.
- The statistics endpoint has no `operationId` in `@ppt/sitemap` yet, so the screen-map uses `endpoints: []` with a documented drift note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)