### PR TITLE
feat(faults): fire notifications on every fault lifecycle event (BIT-185)

### DIFF
--- a/backend/crates/db/src/repositories/membership.rs
+++ b/backend/crates/db/src/repositories/membership.rs
@@ -222,4 +222,30 @@ impl MembershipRepository {
         .await?;
         Ok(exists.unwrap_or(false))
     }
+
+    /// Return the user IDs of all active manager-tier members in `org_id`.
+    ///
+    /// Manager-tier roles are the same set as [`is_manager_in_org`].
+    pub async fn list_manager_ids(&self, org_id: Uuid) -> Result<Vec<Uuid>, SqlxError> {
+        let rows: Vec<(Uuid,)> = sqlx::query_as(
+            r#"
+            SELECT DISTINCT user_id FROM user_memberships
+            WHERE organization_id = $1
+              AND revoked_at IS NULL
+              AND (expires_at IS NULL OR expires_at > NOW())
+              AND role IN (
+                  'SuperAdmin',
+                  'PlatformAdmin',
+                  'OrgAdmin',
+                  'Manager',
+                  'TechnicalManager',
+                  'PropertyManager'
+              )
+            "#,
+        )
+        .bind(org_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
 }

--- a/backend/servers/api-server/src/routes/faults.rs
+++ b/backend/servers/api-server/src/routes/faults.rs
@@ -977,7 +977,10 @@ async fn update_status(
             Uuid::nil(),
             NotificationCategory::Faults,
             format!("Fault status updated: {}", fault.title),
-            format!("Your fault report status has been updated to '{}'.", fault.status),
+            format!(
+                "Your fault report status has been updated to '{}'.",
+                fault.status
+            ),
         )
         .with_action_url(format!("/faults/{}", fault.id))
         .with_data(serde_json::json!({
@@ -1054,7 +1057,8 @@ async fn resolve_fault(
             Uuid::nil(),
             NotificationCategory::Faults,
             format!("Fault resolved: {}", fault.title),
-            "Your fault report has been resolved. Please confirm if the issue was fixed.".to_string(),
+            "Your fault report has been resolved. Please confirm if the issue was fixed."
+                .to_string(),
         )
         .with_action_url(format!("/faults/{}", fault.id))
         .with_data(serde_json::json!({

--- a/backend/servers/api-server/src/routes/faults.rs
+++ b/backend/servers/api-server/src/routes/faults.rs
@@ -10,6 +10,7 @@ use axum::{
     Json, Router,
 };
 use common::errors::ErrorResponse;
+use common::notifications::{Notification, NotificationCategory};
 use db::models::{
     AddFaultComment, AddWorkNote, AiSuggestion, AssignFault, ConfirmFault, CreateFault,
     CreateFaultAttachment, Fault, FaultAttachment, FaultListQuery, FaultStatistics, FaultSummary,
@@ -410,6 +411,49 @@ async fn create_fault(
                 )),
             )
         })?;
+
+    // Story 4.1: notify all org managers about the new fault. Best-effort —
+    // notification failures must not fail the mutation.
+    match MembershipRepository::new(state.db.clone())
+        .list_manager_ids(tenant_id)
+        .await
+    {
+        Ok(manager_ids) => {
+            let recipients: Vec<Uuid> = manager_ids
+                .into_iter()
+                .filter(|id| *id != principal.user_id)
+                .collect();
+            if !recipients.is_empty() {
+                let notification = Notification::new(
+                    Uuid::nil(),
+                    NotificationCategory::Faults,
+                    format!("New fault reported: {}", fault.title),
+                    "A new fault has been reported and requires triage.".to_string(),
+                )
+                .with_action_url(format!("/faults/{}", fault.id))
+                .with_data(serde_json::json!({
+                    "fault_id": fault.id,
+                    "organization_id": fault.organization_id,
+                }));
+                let results = state
+                    .notification_pipeline
+                    .dispatch_to_users(&recipients, &notification, Some(fault.id), None)
+                    .await;
+                tracing::info!(
+                    fault_id = %fault.id,
+                    recipients = results.len(),
+                    "FaultCreated notifications dispatched to managers"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::error!(
+                fault_id = %fault.id,
+                error = %e,
+                "Failed to load manager ids for FaultCreated notification"
+            );
+        }
+    }
 
     rls.release().await;
     Ok((
@@ -813,6 +857,41 @@ async fn assign_fault(
             )
         })?;
 
+    // Story 4.3: notify assignee + reporter (relevant parties). Best-effort.
+    {
+        let mut recipients: Vec<Uuid> = Vec::new();
+        if fault.assigned_to != Some(principal.user_id) {
+            if let Some(assignee) = fault.assigned_to {
+                recipients.push(assignee);
+            }
+        }
+        if fault.reporter_id != principal.user_id && Some(fault.reporter_id) != fault.assigned_to {
+            recipients.push(fault.reporter_id);
+        }
+        if !recipients.is_empty() {
+            let notification = Notification::new(
+                Uuid::nil(),
+                NotificationCategory::Faults,
+                format!("Fault assigned: {}", fault.title),
+                "The fault has been assigned and is now in progress.".to_string(),
+            )
+            .with_action_url(format!("/faults/{}", fault.id))
+            .with_data(serde_json::json!({
+                "fault_id": fault.id,
+                "organization_id": fault.organization_id,
+            }));
+            let results = state
+                .notification_pipeline
+                .dispatch_to_users(&recipients, &notification, Some(fault.id), None)
+                .await;
+            tracing::info!(
+                fault_id = %fault.id,
+                recipients = results.len(),
+                "FaultAssigned notifications dispatched"
+            );
+        }
+    }
+
     Ok(Json(FaultActionResponse {
         message: "Fault assigned successfully".to_string(),
         fault,
@@ -892,6 +971,33 @@ async fn update_status(
             )
         })?;
 
+    // Story 4.4: notify reporter on status change (push). Best-effort.
+    if fault.reporter_id != principal.user_id {
+        let notification = Notification::new(
+            Uuid::nil(),
+            NotificationCategory::Faults,
+            format!("Fault status updated: {}", fault.title),
+            format!("Your fault report status has been updated to '{}'.", fault.status),
+        )
+        .with_action_url(format!("/faults/{}", fault.id))
+        .with_data(serde_json::json!({
+            "fault_id": fault.id,
+            "organization_id": fault.organization_id,
+            "status": fault.status,
+        }));
+        if let Err(e) = state
+            .notification_pipeline
+            .dispatch(fault.reporter_id, &notification, Some(fault.id), None)
+            .await
+        {
+            tracing::error!(
+                fault_id = %fault.id,
+                error = %e,
+                "Failed to dispatch FaultStatusChanged notification"
+            );
+        }
+    }
+
     rls.release().await;
     Ok(Json(FaultActionResponse {
         message: "Status updated successfully".to_string(),
@@ -941,6 +1047,32 @@ async fn resolve_fault(
                 )),
             )
         })?;
+
+    // Story 4.5: notify reporter that their fault has been resolved. Best-effort.
+    if fault.reporter_id != principal.user_id {
+        let notification = Notification::new(
+            Uuid::nil(),
+            NotificationCategory::Faults,
+            format!("Fault resolved: {}", fault.title),
+            "Your fault report has been resolved. Please confirm if the issue was fixed.".to_string(),
+        )
+        .with_action_url(format!("/faults/{}", fault.id))
+        .with_data(serde_json::json!({
+            "fault_id": fault.id,
+            "organization_id": fault.organization_id,
+        }));
+        if let Err(e) = state
+            .notification_pipeline
+            .dispatch(fault.reporter_id, &notification, Some(fault.id), None)
+            .await
+        {
+            tracing::error!(
+                fault_id = %fault.id,
+                error = %e,
+                "Failed to dispatch FaultResolved notification"
+            );
+        }
+    }
 
     Ok(Json(FaultActionResponse {
         message: "Fault resolved successfully".to_string(),
@@ -1037,6 +1169,48 @@ async fn reopen_fault(
                 )),
             )
         })?;
+
+    // Story 4.6: notify managers when a fault is reopened. Best-effort.
+    match MembershipRepository::new(state.db.clone())
+        .list_manager_ids(tenant_id)
+        .await
+    {
+        Ok(manager_ids) => {
+            let recipients: Vec<Uuid> = manager_ids
+                .into_iter()
+                .filter(|id| *id != principal.user_id)
+                .collect();
+            if !recipients.is_empty() {
+                let notification = Notification::new(
+                    Uuid::nil(),
+                    NotificationCategory::Faults,
+                    format!("Fault reopened: {}", fault.title),
+                    "A resolved fault has been reopened and requires attention.".to_string(),
+                )
+                .with_action_url(format!("/faults/{}", fault.id))
+                .with_data(serde_json::json!({
+                    "fault_id": fault.id,
+                    "organization_id": fault.organization_id,
+                }));
+                let results = state
+                    .notification_pipeline
+                    .dispatch_to_users(&recipients, &notification, Some(fault.id), None)
+                    .await;
+                tracing::info!(
+                    fault_id = %fault.id,
+                    recipients = results.len(),
+                    "FaultReopened notifications dispatched to managers"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::error!(
+                fault_id = %fault.id,
+                error = %e,
+                "Failed to load manager ids for FaultReopened notification"
+            );
+        }
+    }
 
     Ok(Json(FaultActionResponse {
         message: "Fault reopened successfully".to_string(),

--- a/backend/servers/api-server/tests/fault_notification_recipient_tests.rs
+++ b/backend/servers/api-server/tests/fault_notification_recipient_tests.rs
@@ -29,7 +29,10 @@ async fn seed_user(pool: &PgPool, tag: &str) -> Uuid {
         r#"INSERT INTO users (email, password_hash, name, status, email_verified_at)
            VALUES ($1, 'test_hash', $2, 'active', NOW()) RETURNING id"#,
     )
-    .bind(format!("fault-notif-{tag}-{}@test.internal", Uuid::new_v4()))
+    .bind(format!(
+        "fault-notif-{tag}-{}@test.internal",
+        Uuid::new_v4()
+    ))
     .bind(format!("FaultNotif-{tag}"))
     .fetch_one(pool)
     .await

--- a/backend/servers/api-server/tests/fault_notification_recipient_tests.rs
+++ b/backend/servers/api-server/tests/fault_notification_recipient_tests.rs
@@ -1,0 +1,373 @@
+//! BIT-185 — Fault lifecycle notification recipient tests.
+//!
+//! Verifies that the correct recipients are resolved for each fault lifecycle
+//! event.  Because `TestApp` mounts routes without `host_tenant_middleware`
+//! (so `require_tenant_id` always short-circuits at 403 TENANT_REQUIRED),
+//! these tests operate at the repository + pipeline layer — the same boundary
+//! as `faults_authz_gap_tests.rs` and `notification_pipeline_dispatch_tests.rs`.
+//!
+//! | Event | Expected recipients |
+//! |-------|---------------------|
+//! | create | org managers (not the reporter) |
+//! | assign | assignee + reporter (not the assigning manager) |
+//! | status change | reporter only (not the manager) |
+//! | resolve | reporter only (not the resolving manager) |
+//! | reopen | org managers (not the reopener) |
+
+use api_server::services::{EmailService, NotificationPipeline, PipelineConfig};
+use common::notifications::{Notification, NotificationCategory};
+use db::repositories::MembershipRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async fn seed_user(pool: &PgPool, tag: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO users (email, password_hash, name, status, email_verified_at)
+           VALUES ($1, 'test_hash', $2, 'active', NOW()) RETURNING id"#,
+    )
+    .bind(format!("fault-notif-{tag}-{}@test.internal", Uuid::new_v4()))
+    .bind(format!("FaultNotif-{tag}"))
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_org(pool: &PgPool) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO organizations (name, slug, contact_email, status)
+           VALUES ('FaultNotif Org', $1, $2, 'active') RETURNING id"#,
+    )
+    .bind(format!("fault-notif-org-{}", Uuid::new_v4()))
+    .bind(format!("fault-notif-{}@test.internal", Uuid::new_v4()))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+/// Seed into `user_memberships` — the table queried by `MembershipRepository`.
+/// Note: `common::seed_membership` writes to `organization_members` (legacy),
+/// which is NOT the table `list_manager_ids` / `is_manager_in_org` queries.
+async fn seed_user_membership(pool: &PgPool, org_id: Uuid, user_id: Uuid, role: &str) {
+    sqlx::query(
+        r#"INSERT INTO user_memberships (user_id, organization_id, role)
+           VALUES ($1, $2, $3)
+           ON CONFLICT DO NOTHING"#,
+    )
+    .bind(user_id)
+    .bind(org_id)
+    .bind(role)
+    .execute(pool)
+    .await
+    .expect("seed user_membership");
+}
+
+fn build_pipeline(pool: &PgPool) -> NotificationPipeline {
+    NotificationPipeline::new(
+        pool.clone(),
+        EmailService::development(),
+        None,
+        PipelineConfig::default(),
+    )
+}
+
+/// Count `notification_groups` rows for `user_id` where entity_type = "faults".
+async fn count_fault_notif_groups(pool: &PgPool, user_id: Uuid) -> i64 {
+    sqlx::query_scalar::<_, i64>(
+        r#"SELECT COUNT(*) FROM notification_groups
+           WHERE user_id = $1 AND entity_type = 'faults'"#,
+    )
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .expect("count notification_groups")
+}
+
+// ---------------------------------------------------------------------------
+// R1: list_manager_ids returns manager-tier members only
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_manager_ids_returns_only_managers(pool: PgPool) {
+    let org = seed_org(&pool).await;
+    let manager = seed_user(&pool, "mgr").await;
+    let resident = seed_user(&pool, "res").await;
+
+    seed_user_membership(&pool, org, manager, "Manager").await;
+    seed_user_membership(&pool, org, resident, "Resident").await;
+
+    let ids = MembershipRepository::new(pool.clone())
+        .list_manager_ids(org)
+        .await
+        .expect("list_manager_ids");
+
+    assert!(
+        ids.contains(&manager),
+        "list_manager_ids must include the Manager-role member"
+    );
+    assert!(
+        !ids.contains(&resident),
+        "list_manager_ids must NOT include a Resident-role member"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// R2: create — managers notified; reporter excluded (self-notify guard)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_fault_notifies_managers_not_reporter(pool: PgPool) {
+    let org = seed_org(&pool).await;
+    let reporter = seed_user(&pool, "reporter-create").await;
+    let manager = seed_user(&pool, "manager-create").await;
+
+    seed_user_membership(&pool, org, manager, "Manager").await;
+
+    let fault_id = Uuid::new_v4();
+    let pipeline = build_pipeline(&pool);
+
+    let manager_ids = MembershipRepository::new(pool.clone())
+        .list_manager_ids(org)
+        .await
+        .expect("list_manager_ids");
+
+    let recipients: Vec<Uuid> = manager_ids
+        .into_iter()
+        .filter(|id| *id != reporter)
+        .collect();
+
+    assert!(
+        recipients.contains(&manager),
+        "create: manager must be in recipient list"
+    );
+    assert!(
+        !recipients.contains(&reporter),
+        "create: reporter must be excluded (self-notify guard)"
+    );
+
+    let notification = Notification::new(
+        Uuid::nil(),
+        NotificationCategory::Faults,
+        "New fault reported: Leaking pipe",
+        "A new fault has been reported and requires triage.",
+    )
+    .with_action_url(format!("/faults/{fault_id}"))
+    .with_data(serde_json::json!({"fault_id": fault_id, "organization_id": org}));
+
+    pipeline
+        .dispatch_to_users(&recipients, &notification, Some(fault_id), None)
+        .await;
+
+    assert_eq!(
+        count_fault_notif_groups(&pool, manager).await,
+        1,
+        "create: manager must receive exactly one in-app fault notification"
+    );
+    assert_eq!(
+        count_fault_notif_groups(&pool, reporter).await,
+        0,
+        "create: reporter must receive no notification (self-notify guard)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// R3: assign — assignee + reporter notified; assigning manager excluded
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn assign_fault_notifies_assignee_and_reporter_not_assigner(pool: PgPool) {
+    let _org = seed_org(&pool).await;
+    let reporter = seed_user(&pool, "reporter-assign").await;
+    let assignee = seed_user(&pool, "assignee-assign").await;
+    let assigner = seed_user(&pool, "assigner-assign").await;
+
+    let fault_id = Uuid::new_v4();
+    let pipeline = build_pipeline(&pool);
+
+    // Mirror assign_fault recipient logic (assigner = principal.user_id)
+    let assigned_to: Option<Uuid> = Some(assignee);
+    let mut recipients: Vec<Uuid> = Vec::new();
+    if assigned_to != Some(assigner) {
+        if let Some(a) = assigned_to {
+            recipients.push(a);
+        }
+    }
+    if reporter != assigner && Some(reporter) != assigned_to {
+        recipients.push(reporter);
+    }
+
+    let notification = Notification::new(
+        Uuid::nil(),
+        NotificationCategory::Faults,
+        "Fault assigned: Leaking pipe",
+        "The fault has been assigned and is now in progress.",
+    )
+    .with_action_url(format!("/faults/{fault_id}"))
+    .with_data(serde_json::json!({"fault_id": fault_id}));
+
+    pipeline
+        .dispatch_to_users(&recipients, &notification, Some(fault_id), None)
+        .await;
+
+    assert_eq!(
+        count_fault_notif_groups(&pool, assignee).await,
+        1,
+        "assign: assignee must receive notification"
+    );
+    assert_eq!(
+        count_fault_notif_groups(&pool, reporter).await,
+        1,
+        "assign: reporter must receive notification"
+    );
+    assert_eq!(
+        count_fault_notif_groups(&pool, assigner).await,
+        0,
+        "assign: assigning manager must not receive self-notification"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// R4: status change — reporter notified; updating manager excluded
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn status_change_notifies_reporter_not_manager(pool: PgPool) {
+    let _org = seed_org(&pool).await;
+    let reporter = seed_user(&pool, "reporter-status").await;
+    let manager = seed_user(&pool, "manager-status").await;
+
+    let fault_id = Uuid::new_v4();
+    let pipeline = build_pipeline(&pool);
+
+    // Guard: reporter != manager (same check the handler applies)
+    assert_ne!(reporter, manager, "test precondition: distinct users");
+
+    let notification = Notification::new(
+        Uuid::nil(),
+        NotificationCategory::Faults,
+        "Fault status updated: Leaking pipe",
+        "Your fault report status has been updated to 'in_progress'.",
+    )
+    .with_action_url(format!("/faults/{fault_id}"))
+    .with_data(serde_json::json!({"fault_id": fault_id, "status": "in_progress"}));
+
+    // reporter != manager → dispatch to reporter only
+    pipeline
+        .dispatch(reporter, &notification, Some(fault_id), None)
+        .await
+        .expect("dispatch");
+
+    assert_eq!(
+        count_fault_notif_groups(&pool, reporter).await,
+        1,
+        "status change: reporter must receive notification"
+    );
+    assert_eq!(
+        count_fault_notif_groups(&pool, manager).await,
+        0,
+        "status change: manager must not receive notification"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// R5: resolve — reporter notified; resolving manager excluded
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn resolve_fault_notifies_reporter_not_manager(pool: PgPool) {
+    let _org = seed_org(&pool).await;
+    let reporter = seed_user(&pool, "reporter-resolve").await;
+    let manager = seed_user(&pool, "manager-resolve").await;
+
+    let fault_id = Uuid::new_v4();
+    let pipeline = build_pipeline(&pool);
+
+    assert_ne!(reporter, manager, "test precondition: distinct users");
+
+    let notification = Notification::new(
+        Uuid::nil(),
+        NotificationCategory::Faults,
+        "Fault resolved: Leaking pipe",
+        "Your fault report has been resolved. Please confirm if the issue was fixed.",
+    )
+    .with_action_url(format!("/faults/{fault_id}"))
+    .with_data(serde_json::json!({"fault_id": fault_id}));
+
+    pipeline
+        .dispatch(reporter, &notification, Some(fault_id), None)
+        .await
+        .expect("dispatch");
+
+    assert_eq!(
+        count_fault_notif_groups(&pool, reporter).await,
+        1,
+        "resolve: reporter must receive notification"
+    );
+    assert_eq!(
+        count_fault_notif_groups(&pool, manager).await,
+        0,
+        "resolve: resolving manager must not receive notification"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// R6: reopen — org managers notified; reopener excluded
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn reopen_fault_notifies_managers_not_reopener(pool: PgPool) {
+    let org = seed_org(&pool).await;
+    let reopener = seed_user(&pool, "reopener").await;
+    let manager = seed_user(&pool, "manager-reopen").await;
+
+    seed_user_membership(&pool, org, manager, "Manager").await;
+
+    let fault_id = Uuid::new_v4();
+    let pipeline = build_pipeline(&pool);
+
+    let manager_ids = MembershipRepository::new(pool.clone())
+        .list_manager_ids(org)
+        .await
+        .expect("list_manager_ids");
+
+    let recipients: Vec<Uuid> = manager_ids
+        .into_iter()
+        .filter(|id| *id != reopener)
+        .collect();
+
+    assert!(
+        recipients.contains(&manager),
+        "reopen: manager must be in recipient list"
+    );
+    assert!(
+        !recipients.contains(&reopener),
+        "reopen: reopener must be excluded (self-notify guard)"
+    );
+
+    let notification = Notification::new(
+        Uuid::nil(),
+        NotificationCategory::Faults,
+        "Fault reopened: Leaking pipe",
+        "A resolved fault has been reopened and requires attention.",
+    )
+    .with_action_url(format!("/faults/{fault_id}"))
+    .with_data(serde_json::json!({"fault_id": fault_id, "organization_id": org}));
+
+    pipeline
+        .dispatch_to_users(&recipients, &notification, Some(fault_id), None)
+        .await;
+
+    assert_eq!(
+        count_fault_notif_groups(&pool, manager).await,
+        1,
+        "reopen: manager must receive in-app notification"
+    );
+    assert_eq!(
+        count_fault_notif_groups(&pool, reopener).await,
+        0,
+        "reopen: reopener must not receive self-notification"
+    );
+}


### PR DESCRIPTION
## Summary

Closes [BIT-185](/BIT/issues/BIT-185) — Gap 3 of epic #970.

Wires the existing notification pipeline into each fault mutation handler. None of the six fault lifecycle endpoints emitted server-side notifications before this PR.

- **create (4.1)**: org managers notified; reporter excluded (self-notify guard)
- **assign (4.3)**: assignee + reporter notified; assigning manager excluded
- **update_status (4.4)**: reporter notified on push/status change
- **resolve (4.5)**: reporter notified
- **reopen (4.6)**: org managers notified; reopener excluded

All notification calls are best-effort: failures are logged but never fail the mutation, matching `routes/voting.rs`, `routes/documents/shares.rs`, and `routes/critical_notifications.rs`.

## Changes

- `db/repositories/membership.rs`: add `MembershipRepository::list_manager_ids(org_id)` — returns manager-tier user IDs using the same role set as `is_manager_in_org`
- `routes/faults.rs`: import `common::notifications::{Notification, NotificationCategory}`, add notification dispatch blocks to `create_fault`, `assign_fault`, `update_status`, `resolve_fault`, `reopen_fault`
- `tests/fault_notification_recipient_tests.rs`: 6 new `#[sqlx::test]` tests asserting correct recipients per event (R1: list_manager_ids correctness, R2–R6: per-event recipients)

## Test plan

- [ ] CI `cargo test -p api-server` green
- [ ] CI `cargo clippy -p api-server` green
- [ ] `fault_notification_recipient_tests` — 6 tests: R1 list_manager_ids, R2 create, R3 assign, R4 status change, R5 resolve, R6 reopen

🤖 Generated with [Claude Code](https://claude.ai/claude-code)