### PR TITLE
test(authz): pin unit-content access revocation on move-out (BIT-202, Story 3.3 AC3)

### DIFF
--- a/backend/servers/api-server/tests/announcement_residency_revocation_tests.rs
+++ b/backend/servers/api-server/tests/announcement_residency_revocation_tests.rs
@@ -1,0 +1,182 @@
+//! Announcement read-path residency revocation tests
+//! (PM #981 gap 6 / Story 3.3 AC3).
+//!
+//! Background
+//! ----------
+//! `AnnouncementRepository::list_published_rls` / `count_published_rls` gate the
+//! visibility of published announcements with `announcement_targeting_predicate!`
+//! (`announcement.rs`). For `building`- and `units`-targeted announcements the
+//! predicate requires an ACTIVE residency:
+//!
+//! ```sql
+//! EXISTS (SELECT 1 FROM unit_residents ur ...
+//!         WHERE ur.user_id = current_setting('app.current_user_id') ...
+//!           AND ur.end_date IS NULL ...)
+//! ```
+//!
+//! AC3 requires that when a manager ends a resident's association the resident
+//! "loses access to unit content" while "historical records are preserved".
+//! This test pins that the predicate enforces revocation on move-out:
+//!   - a current resident (`end_date IS NULL`) sees the building/unit-targeted
+//!     announcement,
+//!   - a moved-out resident (past `end_date`) does NOT, and
+//!   - an `all`-targeted (org-wide) announcement stays visible to both, because
+//!     org membership is separate from unit residency.
+//!
+//! The targeting predicate reads `app.current_user_id`, set on the connection via
+//! `db::set_request_context` — the same call `RlsConnection` makes in production.
+//! The CI/test database role bypasses RLS, so these assertions pin the
+//! application-level predicate inside the query.
+
+#[allow(dead_code)]
+mod common;
+
+use db::repositories::AnnouncementRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::seed_org;
+
+async fn seed_user(pool: &PgPool, label: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO users (email, password_hash, name)
+           VALUES ($1, 'x', $2) RETURNING id"#,
+    )
+    .bind(format!("{label}-{}@ann-res.test", Uuid::new_v4()))
+    .bind(format!("Ann Res {label}"))
+    .fetch_one(pool)
+    .await
+    .expect("seed_user")
+}
+
+async fn seed_building(pool: &PgPool, org_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO buildings (organization_id, name, street, city, postal_code, country)
+           VALUES ($1, 'Bldg', 'Addr', 'City', '00000', 'Country') RETURNING id"#,
+    )
+    .bind(org_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed_building")
+}
+
+async fn seed_unit(pool: &PgPool, building_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO units (building_id, designation) VALUES ($1, 'U-1') RETURNING id"#,
+    )
+    .bind(building_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed_unit")
+}
+
+/// Insert a `unit_residents` row; `ended` makes it inactive (moved out 30d ago).
+async fn seed_resident(pool: &PgPool, unit_id: Uuid, user_id: Uuid, ended: bool) {
+    let sql = if ended {
+        // `start_date` precedes `end_date` to satisfy the `valid_date_range`
+        // check constraint (end_date >= start_date).
+        r#"INSERT INTO unit_residents (unit_id, user_id, resident_type, start_date, end_date)
+           VALUES ($1, $2, 'tenant', CURRENT_DATE - 60, CURRENT_DATE - 30)"#
+    } else {
+        r#"INSERT INTO unit_residents (unit_id, user_id, resident_type)
+           VALUES ($1, $2, 'tenant')"#
+    };
+    sqlx::query(sql)
+        .bind(unit_id)
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .expect("seed_resident");
+}
+
+/// Insert a published announcement and return its id. `target_ids` is the JSONB
+/// array of building/unit uuids (empty for `all`).
+async fn seed_published_announcement(
+    pool: &PgPool,
+    org_id: Uuid,
+    author_id: Uuid,
+    title: &str,
+    target_type: &str,
+    target_ids: &[Uuid],
+) -> Uuid {
+    let target_json =
+        serde_json::json!(target_ids.iter().map(Uuid::to_string).collect::<Vec<_>>());
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO announcements
+               (organization_id, author_id, title, content, target_type, target_ids,
+                status, published_at)
+           VALUES ($1, $2, $3, 'body', $4::announcement_target_type, $5::jsonb,
+                   'published', NOW())
+           RETURNING id"#,
+    )
+    .bind(org_id)
+    .bind(author_id)
+    .bind(title)
+    .bind(target_type)
+    .bind(target_json)
+    .fetch_one(pool)
+    .await
+    .expect("seed_published_announcement")
+}
+
+/// Story 3.3 AC3: building/unit-targeted announcements are revoked on move-out.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn published_announcements_revoke_on_move_out(pool: PgPool) {
+    let repo = AnnouncementRepository::new(pool.clone());
+
+    let manager = seed_user(&pool, "manager").await;
+    let org = seed_org(&pool, "ann-moveout").await;
+    let building = seed_building(&pool, org).await;
+    let unit = seed_unit(&pool, building).await;
+
+    let current = seed_user(&pool, "current").await;
+    let ended = seed_user(&pool, "ended").await;
+    seed_resident(&pool, unit, current, false).await;
+    seed_resident(&pool, unit, ended, true).await;
+
+    seed_published_announcement(&pool, org, manager, "Org Wide", "all", &[]).await;
+    seed_published_announcement(&pool, org, manager, "Building Notice", "building", &[building])
+        .await;
+    seed_published_announcement(&pool, org, manager, "Unit Notice", "units", &[unit]).await;
+
+    let mut conn = pool.acquire().await.expect("acquire");
+
+    // ---- Current resident sees org-wide + building + unit announcements ----
+    db::set_request_context(&mut *conn, Some(org), Some(current), false)
+        .await
+        .expect("set context (current)");
+    let current_titles: Vec<String> = repo
+        .list_published_rls(&mut *conn, org, None, None)
+        .await
+        .expect("list (current)")
+        .into_iter()
+        .map(|a| a.title)
+        .collect();
+    assert!(
+        current_titles.iter().any(|t| t == "Org Wide")
+            && current_titles.iter().any(|t| t == "Building Notice")
+            && current_titles.iter().any(|t| t == "Unit Notice"),
+        "current resident must see org-wide + building + unit announcements: {current_titles:?}"
+    );
+
+    // ---- Moved-out resident sees ONLY the org-wide announcement ----
+    db::set_request_context(&mut *conn, Some(org), Some(ended), false)
+        .await
+        .expect("set context (ended)");
+    let ended_titles: Vec<String> = repo
+        .list_published_rls(&mut *conn, org, None, None)
+        .await
+        .expect("list (ended)")
+        .into_iter()
+        .map(|a| a.title)
+        .collect();
+    assert!(
+        ended_titles.iter().any(|t| t == "Org Wide"),
+        "moved-out resident keeps org-wide announcements: {ended_titles:?}"
+    );
+    assert!(
+        !ended_titles.iter().any(|t| t == "Building Notice")
+            && !ended_titles.iter().any(|t| t == "Unit Notice"),
+        "moved-out resident must NOT see building/unit announcements: {ended_titles:?}"
+    );
+}

--- a/backend/servers/api-server/tests/announcement_residency_revocation_tests.rs
+++ b/backend/servers/api-server/tests/announcement_residency_revocation_tests.rs
@@ -99,8 +99,7 @@ async fn seed_published_announcement(
     target_type: &str,
     target_ids: &[Uuid],
 ) -> Uuid {
-    let target_json =
-        serde_json::json!(target_ids.iter().map(Uuid::to_string).collect::<Vec<_>>());
+    let target_json = serde_json::json!(target_ids.iter().map(Uuid::to_string).collect::<Vec<_>>());
     sqlx::query_scalar::<_, Uuid>(
         r#"INSERT INTO announcements
                (organization_id, author_id, title, content, target_type, target_ids,
@@ -135,8 +134,15 @@ async fn published_announcements_revoke_on_move_out(pool: PgPool) {
     seed_resident(&pool, unit, ended, true).await;
 
     seed_published_announcement(&pool, org, manager, "Org Wide", "all", &[]).await;
-    seed_published_announcement(&pool, org, manager, "Building Notice", "building", &[building])
-        .await;
+    seed_published_announcement(
+        &pool,
+        org,
+        manager,
+        "Building Notice",
+        "building",
+        &[building],
+    )
+    .await;
     seed_published_announcement(&pool, org, manager, "Unit Notice", "units", &[unit]).await;
 
     let mut conn = pool.acquire().await.expect("acquire");

--- a/backend/servers/api-server/tests/document_access_rls_tests.rs
+++ b/backend/servers/api-server/tests/document_access_rls_tests.rs
@@ -254,3 +254,177 @@ async fn list_accessible_rls_enforces_building_scope(pool: PgPool) {
         "reader not in building B2 must fail the single-doc gate"
     );
 }
+
+/// Insert a building and return its id.
+async fn seed_building(pool: &PgPool, org_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO buildings (organization_id, name, street, city, postal_code, country)
+           VALUES ($1, 'Bldg', 'Addr', 'City', '00000', 'Country') RETURNING id"#,
+    )
+    .bind(org_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed_building")
+}
+
+/// Insert a unit in a building and return its id.
+async fn seed_unit(pool: &PgPool, building_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO units (building_id, designation) VALUES ($1, 'U-1') RETURNING id"#,
+    )
+    .bind(building_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed_unit")
+}
+
+/// Insert a `unit_residents` row. `ended` controls whether the residency is
+/// still active (`end_date IS NULL`) or moved out 30 days ago.
+async fn seed_resident(pool: &PgPool, unit_id: Uuid, user_id: Uuid, ended: bool) {
+    let sql = if ended {
+        // Moved out: a past `end_date` makes the residency inactive. `start_date`
+        // precedes it to satisfy the `valid_date_range` check (end >= start).
+        r#"INSERT INTO unit_residents (unit_id, user_id, resident_type, start_date, end_date)
+           VALUES ($1, $2, 'tenant', CURRENT_DATE - 60, CURRENT_DATE - 30)"#
+    } else {
+        // Current resident: open-ended residency.
+        r#"INSERT INTO unit_residents (unit_id, user_id, resident_type)
+           VALUES ($1, $2, 'tenant')"#
+    };
+    sqlx::query(sql)
+        .bind(unit_id)
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .expect("seed_resident");
+}
+
+/// Story 3.3 AC3 (PM #981 gap 6): when a manager ends a resident's association,
+/// the resident must lose access to unit/building-scoped content while a current
+/// resident keeps it and historical records stay readable by the manager.
+///
+/// `DocumentRepository::user_scope_memberships_rls` is the single chokepoint that
+/// resolves a user into their `(building_ids, unit_ids)` for the document read
+/// path (both `list_accessible_rls` and the download/preview gate). It excludes
+/// ended residencies with `unit_residents.end_date IS NULL`. This test pins:
+///   - the chokepoint returns the unit/building for a current resident,
+///   - it returns NOTHING for an ended (moved-out) resident, and
+///   - the end-to-end effect: the ended resident no longer sees the unit/building
+///     document, the current resident does, and the manager/creator still does.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn user_scope_memberships_rls_revokes_on_move_out(pool: PgPool) {
+    let repo = DocumentRepository::new(pool.clone());
+
+    let manager = seed_user(&pool, "manager").await;
+    let org = seed_org(&pool, "moveout").await;
+    let building = seed_building(&pool, org).await;
+    let unit = seed_unit(&pool, building).await;
+
+    // Two residents of the same unit: one current, one moved out.
+    let current = seed_user(&pool, "current").await;
+    let ended = seed_user(&pool, "ended").await;
+    seed_resident(&pool, unit, current, false).await;
+    seed_resident(&pool, unit, ended, true).await;
+
+    // Manager-authored unit- and building-scoped documents (the "unit content").
+    seed_doc(&pool, org, manager, "Org Wide", "organization", &[], &[]).await;
+    seed_doc(&pool, org, manager, "Building Doc", "building", &[building], &[]).await;
+    seed_doc(&pool, org, manager, "Unit Doc", "unit", &[unit], &[]).await;
+
+    let mut conn = pool.acquire().await.expect("acquire");
+    db::set_request_context(&mut *conn, Some(org), Some(manager), false)
+        .await
+        .expect("set context");
+
+    // ---- Chokepoint: current resident resolves to the unit + building ----
+    let (current_buildings, current_units) = repo
+        .user_scope_memberships_rls(&mut *conn, current)
+        .await
+        .expect("user_scope_memberships_rls (current)");
+    assert!(
+        current_buildings.contains(&building) && current_units.contains(&unit),
+        "current resident must resolve to their unit/building: \
+         buildings={current_buildings:?} units={current_units:?}"
+    );
+
+    // ---- Chokepoint: ended resident resolves to NOTHING ----
+    let (ended_buildings, ended_units) = repo
+        .user_scope_memberships_rls(&mut *conn, ended)
+        .await
+        .expect("user_scope_memberships_rls (ended)");
+    assert!(
+        ended_buildings.is_empty() && ended_units.is_empty(),
+        "moved-out resident must resolve to no unit/building (access revoked): \
+         buildings={ended_buildings:?} units={ended_units:?}"
+    );
+
+    // ---- End-to-end: current resident sees unit/building docs ----
+    let current_titles: Vec<String> = repo
+        .list_accessible_rls(
+            &mut *conn,
+            org,
+            current,
+            &current_buildings,
+            &current_units,
+            &[],
+            DocumentListQuery::default(),
+        )
+        .await
+        .expect("list (current)")
+        .into_iter()
+        .map(|d| d.title)
+        .collect();
+    assert!(
+        current_titles.iter().any(|t| t == "Building Doc")
+            && current_titles.iter().any(|t| t == "Unit Doc"),
+        "current resident must see unit/building documents: {current_titles:?}"
+    );
+
+    // ---- End-to-end: ended resident sees ONLY org-wide content ----
+    let ended_titles: Vec<String> = repo
+        .list_accessible_rls(
+            &mut *conn,
+            org,
+            ended,
+            &ended_buildings,
+            &ended_units,
+            &[],
+            DocumentListQuery::default(),
+        )
+        .await
+        .expect("list (ended)")
+        .into_iter()
+        .map(|d| d.title)
+        .collect();
+    assert!(
+        ended_titles.iter().any(|t| t == "Org Wide"),
+        "ended resident keeps org-wide content (org membership is separate): {ended_titles:?}"
+    );
+    assert!(
+        !ended_titles.iter().any(|t| t == "Building Doc")
+            && !ended_titles.iter().any(|t| t == "Unit Doc"),
+        "moved-out resident must NOT see unit/building documents: {ended_titles:?}"
+    );
+
+    // ---- Historical records still readable by the manager (creator branch) ----
+    let manager_titles: Vec<String> = repo
+        .list_accessible_rls(
+            &mut *conn,
+            org,
+            manager,
+            &[],
+            &[],
+            &[],
+            DocumentListQuery::default(),
+        )
+        .await
+        .expect("list (manager)")
+        .into_iter()
+        .map(|d| d.title)
+        .collect();
+    assert!(
+        manager_titles.iter().any(|t| t == "Building Doc")
+            && manager_titles.iter().any(|t| t == "Unit Doc"),
+        "manager (creator) must still read the historical unit/building docs: {manager_titles:?}"
+    );
+}

--- a/backend/servers/api-server/tests/document_access_rls_tests.rs
+++ b/backend/servers/api-server/tests/document_access_rls_tests.rs
@@ -328,7 +328,16 @@ async fn user_scope_memberships_rls_revokes_on_move_out(pool: PgPool) {
 
     // Manager-authored unit- and building-scoped documents (the "unit content").
     seed_doc(&pool, org, manager, "Org Wide", "organization", &[], &[]).await;
-    seed_doc(&pool, org, manager, "Building Doc", "building", &[building], &[]).await;
+    seed_doc(
+        &pool,
+        org,
+        manager,
+        "Building Doc",
+        "building",
+        &[building],
+        &[],
+    )
+    .await;
     seed_doc(&pool, org, manager, "Unit Doc", "unit", &[unit], &[]).await;
 
     let mut conn = pool.acquire().await.expect("acquire");


### PR DESCRIPTION
## BIT-202 · PM #981 gap 6 · Story 3.3 AC3 — unit-content access revocation on move-out

**Investigate-first outcome:** the read paths already revoke unit/building content for moved-out (ended) residents; the residency chokepoints were just **untested**. This PR records the determination and adds the missing regression tests. **No production code change.**

### Determination — read-path gating on active residency (`unit_residents.end_date IS NULL`)
| Surface | Verdict | Where |
|---|---|---|
| Documents | ✅ Enforced (was untested) | `DocumentRepository::user_scope_memberships_rls` → feeds `list_accessible_rls` + download/preview gate |
| Announcements | ✅ Enforced | `announcement_targeting_predicate!` macro → `list_published_rls` / `count_published_rls` |
| Votes | ✅ No leak | Reads are **org-scoped governance** (host-resolved tenant, visible to all org members — never residency-granted, so move-out revokes nothing). The privileged action (cast/eligibility) **is** residency-gated in `vote.rs::check_eligibility`. |

Org/tenant context is resolved from the request **host**, not from membership — so an ended resident retains only org-wide content (org membership is independent of unit residency), exactly matching AC3's "loses **unit** content / historical records preserved".

### Tests
- `document_access_rls_tests::user_scope_memberships_rls_revokes_on_move_out` — current resident → unit/building; ended resident → none; end-to-end: ended loses unit/building docs, keeps org-wide, **manager still reads historical docs**.
- `announcement_residency_revocation_tests::published_announcements_revoke_on_move_out` — current sees org+building+unit; ended sees only org-wide.

Covers AC3's three clauses: ended denied · current allowed · manager retains.

### Verification
Predicate logic + seed SQL validated against the **full 183-migration schema** on a local Postgres (all assertions green). The `cargo fmt/clippy/test` gate runs here in CI — the local remote build host was unavailable this run.

### Out of AC3 scope (observation, not a blocker)
Vote **reads** are org-wide for every org member (managers, staff, residents). If the product wants building-scoped vote-read visibility, that's a separate, manager-aware access-control change — not a move-out revocation gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)