### PR TITLE
feat(ppt-web): document-template generation UI (Story 7B.2)

### DIFF
--- a/docs/screens/ppt/document-templates.md
+++ b/docs/screens/ppt/document-templates.md
@@ -1,0 +1,124 @@
+---
+id: ppt/document-templates
+name: Document Templates — List & Generate
+product: ppt
+implementations:
+  ppt-web:
+    route: "/documents/templates"
+    component: DocumentTemplatesPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: complete
+endpoints: []
+relatedScreens:
+  - id: ppt/documents
+    rel: parent
+  - id: ppt/document-detail
+    rel: child
+sharedComponents:
+  - GenerateDocumentDialog
+diagrams: []
+useCases: []
+epics:
+  - 7B
+designSources: []
+owner: pm-frontend
+---
+
+# Document Templates — List & Generate
+
+The template-driven document generation surface for Epic 7B (Story 7B.2). It
+lets a manager browse reusable document templates and run the
+select → context → prefill → preview → save flow that produces a real document
+in the org's library.
+
+Mounted by `routes/groups/documents.tsx` on the hand-written `@ppt/api-client`
+`templates` module (`useTemplates`, `useTemplate`, `useGenerateDocument`). These
+endpoints are **not** `@ppt/sitemap`-registered and **not** TypeSpec-generated,
+so `endpoints: []` above and the contract is documented in prose below.
+
+## Routes
+
+- `/documents/templates` — `DocumentTemplatesPage`: searchable, type-filterable
+  list of the organization's document templates. Each row opens the generate
+  dialog. Reachable from the Documents page header ("Šablóny" link).
+
+## Endpoints (prose — not sitemap-registered)
+
+All under `/api/v1` and tenant-scoped server-side (manager role required for
+mutations; generation is allowed for the caller's organization templates):
+
+- `GET /templates` — list (`template_type`, `search`, `limit`, `offset` query
+  params) → `{ templates: TemplateSummary[], count, total }`.
+- `GET /templates/{id}` — single template with placeholders + content
+  (`TemplateWithDetails`).
+- `POST /templates/{id}/generate` — body
+  `{ values: Record<string,string>, title, description?, category, folder_id? }`
+  → `{ document_id, message }`. Server validates required placeholders
+  (400 `MISSING_PLACEHOLDERS`) and the category (400) before creating the doc.
+- CRUD (`POST /templates`, `PUT /templates/{id}`, `DELETE /templates/{id}`) is
+  also exposed in the api-client module; no authoring UI ships in this story.
+
+## Functionality Checklist
+
+### List page (`/documents/templates`)
+- [x] [w] H1 "Šablóny dokumentov" + subtitle, back-link to `/documents`
+- [x] [w] Search input (debounced via React Query key) + template-type filter select
+- [x] [w] Template cards: name + type badge + description + placeholder/usage counts + "Generovať" CTA
+- [x] [w] Loading skeleton rows
+- [x] [w] Error state with retry
+- [x] [w] Empty state (distinguishes "no templates" vs "no matches for filters")
+
+### Generate dialog (`GenerateDocumentDialog`)
+- [x] [w] Loads the template (`useTemplate`); loading + load-error (retry) states
+- [x] [w] Context selector: building → unit; pre-fills placeholders whose name
+  matches building/unit fields (building name/address, unit designation/floor)
+- [x] [w] Typed placeholder inputs (text/date/number/currency) seeded with defaults
+- [x] [w] Document metadata: title (required), category (backend `document_category`), description
+- [x] [w] Live preview mirroring the server's `{{name}}` substitution
+- [x] [w] Required-placeholder validation blocks submit + lists missing names
+- [x] [w] Generate failure surfaces the server message inline
+- [x] [w] On success → navigate to `/documents/{document_id}`
+- [x] [w] Focus trap + Escape close (WCAG 2.1.2), overlay click closes
+
+## States
+
+- **List · loading**: 4 shimmer skeleton cards.
+- **List · error**: danger tile + retry.
+- **List · empty**: "no templates yet" or "no matches" depending on active filters.
+- **List · loaded**: template cards with type badge + counts.
+- **Dialog · loading/error**: spinner copy / retry on the template fetch.
+- **Dialog · ready**: context + placeholders + metadata + live preview.
+- **Dialog · invalid**: required placeholders highlighted, alert lists names.
+- **Dialog · submitting**: primary button shows "Generuje sa…", disabled.
+
+## Notes
+
+### Broader context
+
+Story 7B.2 closes the last genuinely-new frontend gap from GH epic #974
+(document templates). The backend (`routes/templates.rs`,
+`services/document_generation.rs`, migration `00036_add_document_templates.sql`)
+shipped CRUD + generate; this surface is the first UI to consume it.
+
+### Specific
+
+- The building/unit **context** is a frontend convenience only — the backend
+  `generate` endpoint takes a flat `values` map, so context selection just
+  pre-fills matching placeholder inputs (by case-insensitive name match,
+  EN + SK aliases) and never overwrites a value the user already typed.
+- Only **non-empty** values are sent; the server applies each placeholder's
+  `default_value` for omitted keys, matching `DocumentTemplate::generate_content`.
+- i18n keys live under the `documentTemplates` namespace (en/sk/cs; de/pl/hu
+  fall back to en).
+- The generated document is created as `text/markdown` server-side; this UI
+  hands off to `ppt/document-detail` after generation.
+
+## Agent Log
+
+<!-- newest entries on top -->
+
+- 2026-06-22 — agent (FrontendEngineer): BIT-207 — shipped `@ppt/api-client`
+  `templates` module (hand-written, mirrors `esignature`) + `DocumentTemplatesPage`
+  and `GenerateDocumentDialog` on `/documents/templates`; wired into App router +
+  Documents header; en/sk/cs i18n; vitest coverage for preview/validation/submit.

--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -1289,5 +1289,61 @@
     "descriptions": {
       "goToIotAlerts": "IoT threshold alerts: acknowledge and resolve"
     }
+  },
+  "documentTemplates": {
+    "title": "Šablony dokumentů",
+    "subtitle": "Generujte dokumenty z opakovaně použitelných šablon.",
+    "searchPlaceholder": "Hledat šablony…",
+    "typeFilter": "Filtrovat podle typu",
+    "allTypes": "Všechny typy",
+    "loadError": "Šablony se nepodařilo načíst.",
+    "types": {
+      "lease": "Nájemní smlouva",
+      "notice": "Oznámení",
+      "invoice": "Faktura",
+      "report": "Zpráva",
+      "minutes": "Zápis",
+      "contract": "Smlouva",
+      "custom": "Vlastní"
+    },
+    "categories": {
+      "contracts": "Smlouvy",
+      "invoices": "Faktury",
+      "reports": "Zprávy",
+      "manuals": "Příručky",
+      "certificates": "Certifikáty",
+      "other": "Ostatní"
+    },
+    "empty": {
+      "title": "Zatím žádné šablony",
+      "body": "Pro tuto organizaci nebyly vytvořeny žádné šablony dokumentů.",
+      "noMatches": "Vašim filtrům neodpovídají žádné šablony."
+    },
+    "card": {
+      "placeholders": "{{count}} zástupných symbolů",
+      "usage": "použito {{count}}×",
+      "generate": "Generovat"
+    },
+    "generate": {
+      "title": "Generovat ze šablony „{{name}}“",
+      "contextLegend": "Kontext",
+      "building": "Budova",
+      "unit": "Jednotka",
+      "noContext": "— Žádná budova —",
+      "noUnit": "— Žádná jednotka —",
+      "contextHint": "Vyberte budovu nebo jednotku pro předvyplnění odpovídajících zástupných symbolů. Každou hodnotu můžete upravit.",
+      "placeholdersLegend": "Zástupné symboly",
+      "noPlaceholders": "Tato šablona nemá žádné zástupné symboly.",
+      "documentLegend": "Dokument",
+      "docTitle": "Název",
+      "category": "Kategorie",
+      "description": "Popis",
+      "previewLegend": "Náhled",
+      "missingPlaceholders": "Vyplňte povinné zástupné symboly: {{names}}",
+      "generateError": "Dokument se nepodařilo vygenerovat. {{message}}",
+      "loadError": "Šablonu se nepodařilo načíst.",
+      "generating": "Generuje se…",
+      "submit": "Generovat dokument"
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -3575,5 +3575,61 @@
     "descriptions": {
       "goToIotAlerts": "IoT threshold alerts: acknowledge and resolve"
     }
+  },
+  "documentTemplates": {
+    "title": "Document Templates",
+    "subtitle": "Generate documents from reusable templates.",
+    "searchPlaceholder": "Search templates…",
+    "typeFilter": "Filter by type",
+    "allTypes": "All types",
+    "loadError": "Failed to load templates.",
+    "types": {
+      "lease": "Lease",
+      "notice": "Notice",
+      "invoice": "Invoice",
+      "report": "Report",
+      "minutes": "Minutes",
+      "contract": "Contract",
+      "custom": "Custom"
+    },
+    "categories": {
+      "contracts": "Contracts",
+      "invoices": "Invoices",
+      "reports": "Reports",
+      "manuals": "Manuals",
+      "certificates": "Certificates",
+      "other": "Other"
+    },
+    "empty": {
+      "title": "No templates yet",
+      "body": "No document templates have been created for this organization.",
+      "noMatches": "No templates match your filters."
+    },
+    "card": {
+      "placeholders": "{{count}} placeholders",
+      "usage": "used {{count}}×",
+      "generate": "Generate"
+    },
+    "generate": {
+      "title": "Generate from “{{name}}”",
+      "contextLegend": "Context",
+      "building": "Building",
+      "unit": "Unit",
+      "noContext": "— No building —",
+      "noUnit": "— No unit —",
+      "contextHint": "Pick a building or unit to pre-fill matching placeholders. You can still edit every value.",
+      "placeholdersLegend": "Placeholders",
+      "noPlaceholders": "This template has no placeholders.",
+      "documentLegend": "Document",
+      "docTitle": "Title",
+      "category": "Category",
+      "description": "Description",
+      "previewLegend": "Preview",
+      "missingPlaceholders": "Please fill in the required placeholders: {{names}}",
+      "generateError": "Failed to generate document. {{message}}",
+      "loadError": "Failed to load the template.",
+      "generating": "Generating…",
+      "submit": "Generate document"
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -1291,5 +1291,61 @@
     "descriptions": {
       "goToIotAlerts": "IoT threshold alerts: acknowledge and resolve"
     }
+  },
+  "documentTemplates": {
+    "title": "Šablóny dokumentov",
+    "subtitle": "Generujte dokumenty z opakovane použiteľných šablón.",
+    "searchPlaceholder": "Hľadať šablóny…",
+    "typeFilter": "Filtrovať podľa typu",
+    "allTypes": "Všetky typy",
+    "loadError": "Šablóny sa nepodarilo načítať.",
+    "types": {
+      "lease": "Nájomná zmluva",
+      "notice": "Oznámenie",
+      "invoice": "Faktúra",
+      "report": "Správa",
+      "minutes": "Zápisnica",
+      "contract": "Zmluva",
+      "custom": "Vlastná"
+    },
+    "categories": {
+      "contracts": "Zmluvy",
+      "invoices": "Faktúry",
+      "reports": "Správy",
+      "manuals": "Príručky",
+      "certificates": "Certifikáty",
+      "other": "Ostatné"
+    },
+    "empty": {
+      "title": "Zatiaľ žiadne šablóny",
+      "body": "Pre túto organizáciu neboli vytvorené žiadne šablóny dokumentov.",
+      "noMatches": "Vašim filtrom nezodpovedajú žiadne šablóny."
+    },
+    "card": {
+      "placeholders": "{{count}} zástupných symbolov",
+      "usage": "použité {{count}}×",
+      "generate": "Generovať"
+    },
+    "generate": {
+      "title": "Generovať zo šablóny „{{name}}“",
+      "contextLegend": "Kontext",
+      "building": "Budova",
+      "unit": "Jednotka",
+      "noContext": "— Žiadna budova —",
+      "noUnit": "— Žiadna jednotka —",
+      "contextHint": "Vyberte budovu alebo jednotku na predvyplnenie zodpovedajúcich zástupných symbolov. Každú hodnotu môžete upraviť.",
+      "placeholdersLegend": "Zástupné symboly",
+      "noPlaceholders": "Táto šablóna nemá žiadne zástupné symboly.",
+      "documentLegend": "Dokument",
+      "docTitle": "Názov",
+      "category": "Kategória",
+      "description": "Popis",
+      "previewLegend": "Náhľad",
+      "missingPlaceholders": "Vyplňte povinné zástupné symboly: {{names}}",
+      "generateError": "Dokument sa nepodarilo vygenerovať. {{message}}",
+      "loadError": "Šablónu sa nepodarilo načítať.",
+      "generating": "Generuje sa…",
+      "submit": "Generovať dokument"
+    }
   }
 }

--- a/frontend/apps/ppt-web/src/features/document-templates/components/GenerateDocumentDialog.test.tsx
+++ b/frontend/apps/ppt-web/src/features/document-templates/components/GenerateDocumentDialog.test.tsx
@@ -1,0 +1,118 @@
+/// <reference types="vitest/globals" />
+/**
+ * Tests for the Story 7B.2 document-template generate dialog.
+ *
+ * Pins the contractual behavior of the generate flow:
+ *   1. live preview substitutes `{{name}}` placeholders with current values;
+ *   2. required-placeholder validation blocks submit and surfaces the names;
+ *   3. a valid submit POSTs only non-empty values (server applies defaults)
+ *      plus the title + category, and navigates to the generated document.
+ *
+ * Only the network boundary (`@ppt/api-client`) and context hooks
+ * (`../../buildings/hooks`) are mocked; the dialog logic runs for real.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GenerateDocumentDialog } from './GenerateDocumentDialog';
+
+// ─── network boundary: @ppt/api-client ──────────────────────────────────────
+const useTemplateMock = vi.fn();
+const mutateMock = vi.fn();
+
+vi.mock('@ppt/api-client', () => ({
+  useTemplate: (id: string) => useTemplateMock(id),
+  useGenerateDocument: () => ({
+    mutate: mutateMock,
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
+}));
+
+// ─── context hooks ──────────────────────────────────────────────────────────
+vi.mock('../../buildings/hooks', () => ({
+  useBuildings: () => ({ data: { items: [] } }),
+  useUnits: () => ({ data: { units: [] } }),
+}));
+
+// ─── leaf helpers ───────────────────────────────────────────────────────────
+vi.mock('../../../hooks/useFocusTrap', () => ({ useFocusTrap: () => {} }));
+
+const navigateMock = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateMock,
+}));
+
+const TEMPLATE = {
+  id: 'tpl-1',
+  organization_id: 'org-1',
+  name: 'Notice',
+  template_type: 'notice',
+  content: 'Dear {{tenant}}, your rent is {{amount}}.',
+  placeholders: [
+    { name: 'tenant', type: 'text', required: true, default_value: null, description: null },
+    { name: 'amount', type: 'currency', required: false, default_value: '500', description: null },
+  ],
+  usage_count: 0,
+  created_by: 'u-1',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  created_by_name: 'Manager',
+};
+
+function renderDialog() {
+  return render(
+    <GenerateDocumentDialog templateId="tpl-1" templateName="Notice" onClose={vi.fn()} />
+  );
+}
+
+describe('GenerateDocumentDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useTemplateMock.mockReturnValue({
+      data: { template: TEMPLATE },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+  });
+
+  it('renders a live preview, seeding defaults and substituting placeholders', () => {
+    renderDialog();
+    // `amount` default (500) is seeded; `tenant` is still empty.
+    expect(screen.getByText(/Dear , your rent is 500\./)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole('textbox', { name: /tenant/i }), {
+      target: { value: 'Jane' },
+    });
+    expect(screen.getByText(/Dear Jane, your rent is 500\./)).toBeInTheDocument();
+  });
+
+  it('blocks submit and lists missing required placeholders', () => {
+    renderDialog();
+    fireEvent.click(screen.getByRole('button', { name: 'Generate document' }));
+    expect(mutateMock).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent('tenant');
+  });
+
+  it('submits non-empty values + metadata and navigates on success', () => {
+    renderDialog();
+    fireEvent.change(screen.getByRole('textbox', { name: /tenant/i }), {
+      target: { value: 'Jane' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Generate document' }));
+
+    expect(mutateMock).toHaveBeenCalledTimes(1);
+    const [body, opts] = mutateMock.mock.calls[0];
+    expect(body).toMatchObject({
+      values: { tenant: 'Jane', amount: '500' },
+      title: 'Notice',
+      category: 'other',
+    });
+
+    // Drive the success callback and assert navigation to the new document.
+    opts.onSuccess({ document_id: 'doc-9' });
+    expect(navigateMock).toHaveBeenCalledWith('/documents/doc-9');
+  });
+});

--- a/frontend/apps/ppt-web/src/features/document-templates/components/GenerateDocumentDialog.tsx
+++ b/frontend/apps/ppt-web/src/features/document-templates/components/GenerateDocumentDialog.tsx
@@ -1,0 +1,428 @@
+/**
+ * GenerateDocumentDialog (Epic 7B, Story 7B.2).
+ *
+ * Modal that drives the template → document generation flow:
+ *   1. loads the template (placeholders + content) via `useTemplate`
+ *   2. lets the manager pick a building / unit *context* whose fields pre-fill
+ *      matching placeholders (e.g. `{{building_name}}`, `{{unit_number}}`)
+ *   3. collects the remaining placeholder values (typed inputs)
+ *   4. shows a live preview of the rendered content (client mirror of the
+ *      server's `generate_content` substitution)
+ *   5. POSTs to `/api/v1/templates/{id}/generate` and navigates to the new doc
+ *
+ * Endpoints are wired through the hand-written `@ppt/api-client` templates
+ * module (`useTemplate`, `useGenerateDocument`).
+ */
+
+import { type TemplatePlaceholder, useGenerateDocument, useTemplate } from '@ppt/api-client';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { useFocusTrap } from '../../../hooks/useFocusTrap';
+import { useBuildings, useUnits } from '../../buildings/hooks';
+
+/** Document categories accepted by the backend (`document_category::ALL`). */
+const DOCUMENT_CATEGORIES = [
+  'contracts',
+  'invoices',
+  'reports',
+  'manuals',
+  'certificates',
+  'other',
+] as const;
+
+interface GenerateDocumentDialogProps {
+  templateId: string;
+  templateName: string;
+  onClose: () => void;
+}
+
+/** Map a placeholder data-type to a sensible HTML input type. */
+function inputTypeFor(type: TemplatePlaceholder['type']): string {
+  switch (type) {
+    case 'date':
+      return 'date';
+    case 'number':
+    case 'currency':
+      return 'number';
+    default:
+      return 'text';
+  }
+}
+
+/**
+ * Decide whether a building/unit context field should pre-fill a placeholder.
+ * Matching is by case-insensitive substring on the placeholder name so a
+ * template authored with `{{building_name}}`, `{{buildingName}}` or
+ * `{{nazov_budovy}}`-style names still benefits where the alias matches.
+ */
+function contextValueFor(
+  placeholderName: string,
+  ctx: {
+    buildingName?: string;
+    buildingAddress?: string;
+    unitDesignation?: string;
+    unitFloor?: string;
+  }
+): string | undefined {
+  const n = placeholderName.toLowerCase();
+  const has = (...keys: string[]) => keys.some((k) => n.includes(k));
+
+  if (
+    ctx.unitDesignation &&
+    has('unit_number', 'unit_designation', 'unit', 'apartment', 'byt', 'jednotka')
+  ) {
+    return ctx.unitDesignation;
+  }
+  if (ctx.unitFloor && has('floor', 'poschodie')) {
+    return ctx.unitFloor;
+  }
+  if (ctx.buildingAddress && has('address', 'adresa')) {
+    return ctx.buildingAddress;
+  }
+  if (ctx.buildingName && has('building', 'budova', 'dom')) {
+    return ctx.buildingName;
+  }
+  return undefined;
+}
+
+/** Render template content by substituting `{{name}}` with values / defaults. */
+function renderPreview(
+  content: string,
+  placeholders: TemplatePlaceholder[],
+  values: Record<string, string>
+): string {
+  let out = content;
+  for (const p of placeholders) {
+    const value = values[p.name] ?? p.default_value ?? '';
+    out = out.split(`{{${p.name}}}`).join(value);
+  }
+  return out;
+}
+
+export function GenerateDocumentDialog({
+  templateId,
+  templateName,
+  onClose,
+}: GenerateDocumentDialogProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  useFocusTrap(dialogRef, onClose);
+
+  const { data, isLoading, isError, refetch } = useTemplate(templateId);
+  const generate = useGenerateDocument(templateId);
+
+  const template = data?.template;
+  const placeholders = useMemo(() => template?.placeholders ?? [], [template]);
+
+  // Form state
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [category, setCategory] = useState<string>('other');
+  const [buildingId, setBuildingId] = useState('');
+  const [unitId, setUnitId] = useState('');
+  const [submitAttempted, setSubmitAttempted] = useState(false);
+
+  // Context data
+  const { data: buildingsData } = useBuildings();
+  const buildings = buildingsData?.items ?? [];
+  const { data: unitsData } = useUnits(buildingId, undefined, !!buildingId);
+  const units = unitsData?.units ?? [];
+
+  // Seed default values once the template loads.
+  useEffect(() => {
+    if (!template) return;
+    setValues((prev) => {
+      const next = { ...prev };
+      for (const p of placeholders) {
+        if (next[p.name] === undefined && p.default_value) {
+          next[p.name] = p.default_value;
+        }
+      }
+      return next;
+    });
+    if (!title) setTitle(template.name);
+  }, [template, placeholders, title]);
+
+  // Pre-fill placeholders from the chosen building / unit context.
+  useEffect(() => {
+    const building = buildings.find((b) => b.id === buildingId);
+    const unit = units.find((u) => u.id === unitId);
+    if (!building && !unit) return;
+
+    const ctx = {
+      buildingName: building?.name,
+      buildingAddress: building
+        ? [building.address?.street, building.address?.city].filter(Boolean).join(', ')
+        : undefined,
+      unitDesignation: unit?.designation,
+      unitFloor: unit ? String(unit.floor) : undefined,
+    };
+
+    setValues((prev) => {
+      const next = { ...prev };
+      let changed = false;
+      for (const p of placeholders) {
+        const ctxValue = contextValueFor(p.name, ctx);
+        if (ctxValue && !next[p.name]) {
+          next[p.name] = ctxValue;
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [buildingId, unitId, buildings, units, placeholders]);
+
+  const missingRequired = useMemo(
+    () =>
+      placeholders.filter((p) => p.required && !(values[p.name] ?? '').trim()).map((p) => p.name),
+    [placeholders, values]
+  );
+
+  const canSubmit = title.trim().length > 0 && missingRequired.length === 0;
+
+  const handleGenerate = () => {
+    setSubmitAttempted(true);
+    if (!canSubmit) return;
+
+    // Only send non-empty values; the server applies placeholder defaults.
+    const payloadValues: Record<string, string> = {};
+    for (const [k, v] of Object.entries(values)) {
+      if (v.trim()) payloadValues[k] = v;
+    }
+
+    generate.mutate(
+      {
+        values: payloadValues,
+        title: title.trim(),
+        description: description.trim() || undefined,
+        category,
+      },
+      {
+        onSuccess: (res) => {
+          onClose();
+          navigate(`/documents/${res.document_id}`);
+        },
+      }
+    );
+  };
+
+  return (
+    <div className="gdt-overlay" role="presentation" onClick={onClose}>
+      <div
+        ref={dialogRef}
+        className="gdt-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="gdt-title"
+        tabIndex={-1}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="gdt-header">
+          <h2 id="gdt-title" className="gdt-title">
+            {t('documentTemplates.generate.title', { name: templateName })}
+          </h2>
+          <button
+            type="button"
+            className="gdt-close"
+            onClick={onClose}
+            aria-label={t('common.close')}
+          >
+            ×
+          </button>
+        </header>
+
+        {isLoading && <div className="gdt-state">{t('common.loading')}</div>}
+
+        {isError && (
+          <div className="gdt-state gdt-state--error">
+            <p>{t('documentTemplates.generate.loadError')}</p>
+            <button type="button" className="gdt-btn" onClick={() => refetch()}>
+              {t('common.retry')}
+            </button>
+          </div>
+        )}
+
+        {template && (
+          <div className="gdt-body">
+            {/* Context selector */}
+            <fieldset className="gdt-section">
+              <legend className="gdt-legend">
+                {t('documentTemplates.generate.contextLegend')}
+              </legend>
+              <div className="gdt-grid">
+                <label className="gdt-field">
+                  <span className="gdt-label">{t('documentTemplates.generate.building')}</span>
+                  <select
+                    className="gdt-input"
+                    value={buildingId}
+                    onChange={(e) => {
+                      setBuildingId(e.target.value);
+                      setUnitId('');
+                    }}
+                  >
+                    <option value="">{t('documentTemplates.generate.noContext')}</option>
+                    {buildings.map((b) => (
+                      <option key={b.id} value={b.id}>
+                        {b.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="gdt-field">
+                  <span className="gdt-label">{t('documentTemplates.generate.unit')}</span>
+                  <select
+                    className="gdt-input"
+                    value={unitId}
+                    onChange={(e) => setUnitId(e.target.value)}
+                    disabled={!buildingId}
+                  >
+                    <option value="">{t('documentTemplates.generate.noUnit')}</option>
+                    {units.map((u) => (
+                      <option key={u.id} value={u.id}>
+                        {u.designation}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+              <p className="gdt-hint">{t('documentTemplates.generate.contextHint')}</p>
+            </fieldset>
+
+            {/* Placeholder inputs */}
+            <fieldset className="gdt-section">
+              <legend className="gdt-legend">
+                {t('documentTemplates.generate.placeholdersLegend')}
+              </legend>
+              {placeholders.length === 0 ? (
+                <p className="gdt-hint">{t('documentTemplates.generate.noPlaceholders')}</p>
+              ) : (
+                <div className="gdt-grid">
+                  {placeholders.map((p) => {
+                    const isMissing =
+                      submitAttempted && p.required && !(values[p.name] ?? '').trim();
+                    return (
+                      <label className="gdt-field" key={p.name}>
+                        <span className="gdt-label">
+                          {p.name}
+                          {p.required && (
+                            <span className="gdt-req" aria-hidden="true">
+                              {' '}
+                              *
+                            </span>
+                          )}
+                        </span>
+                        <input
+                          className={`gdt-input${isMissing ? ' gdt-input--error' : ''}`}
+                          type={inputTypeFor(p.type)}
+                          step={p.type === 'currency' ? '0.01' : undefined}
+                          value={values[p.name] ?? ''}
+                          placeholder={p.description ?? undefined}
+                          aria-invalid={isMissing || undefined}
+                          onChange={(e) =>
+                            setValues((prev) => ({ ...prev, [p.name]: e.target.value }))
+                          }
+                        />
+                        {p.description && <span className="gdt-desc">{p.description}</span>}
+                      </label>
+                    );
+                  })}
+                </div>
+              )}
+            </fieldset>
+
+            {/* Document metadata */}
+            <fieldset className="gdt-section">
+              <legend className="gdt-legend">
+                {t('documentTemplates.generate.documentLegend')}
+              </legend>
+              <div className="gdt-grid">
+                <label className="gdt-field">
+                  <span className="gdt-label">
+                    {t('documentTemplates.generate.docTitle')}
+                    <span className="gdt-req" aria-hidden="true">
+                      {' '}
+                      *
+                    </span>
+                  </span>
+                  <input
+                    className={`gdt-input${submitAttempted && !title.trim() ? ' gdt-input--error' : ''}`}
+                    type="text"
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                  />
+                </label>
+                <label className="gdt-field">
+                  <span className="gdt-label">{t('documentTemplates.generate.category')}</span>
+                  <select
+                    className="gdt-input"
+                    value={category}
+                    onChange={(e) => setCategory(e.target.value)}
+                  >
+                    {DOCUMENT_CATEGORIES.map((c) => (
+                      <option key={c} value={c}>
+                        {t(`documentTemplates.categories.${c}`)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="gdt-field gdt-field--full">
+                  <span className="gdt-label">{t('documentTemplates.generate.description')}</span>
+                  <input
+                    className="gdt-input"
+                    type="text"
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                  />
+                </label>
+              </div>
+            </fieldset>
+
+            {/* Live preview */}
+            <fieldset className="gdt-section">
+              <legend className="gdt-legend">
+                {t('documentTemplates.generate.previewLegend')}
+              </legend>
+              <pre className="gdt-preview" aria-live="polite">
+                {renderPreview(template.content, placeholders, values)}
+              </pre>
+            </fieldset>
+
+            {submitAttempted && missingRequired.length > 0 && (
+              <p className="gdt-error" role="alert">
+                {t('documentTemplates.generate.missingPlaceholders', {
+                  names: missingRequired.join(', '),
+                })}
+              </p>
+            )}
+            {generate.isError && (
+              <p className="gdt-error" role="alert">
+                {t('documentTemplates.generate.generateError', {
+                  message: (generate.error as Error)?.message ?? '',
+                })}
+              </p>
+            )}
+          </div>
+        )}
+
+        <footer className="gdt-footer">
+          <button type="button" className="gdt-btn" onClick={onClose}>
+            {t('common.cancel')}
+          </button>
+          <button
+            type="button"
+            className="gdt-btn gdt-btn--primary"
+            onClick={handleGenerate}
+            disabled={!template || generate.isPending}
+          >
+            {generate.isPending
+              ? t('documentTemplates.generate.generating')
+              : t('documentTemplates.generate.submit')}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/document-templates/document-templates.css
+++ b/frontend/apps/ppt-web/src/features/document-templates/document-templates.css
@@ -1,0 +1,359 @@
+/* Document templates (Epic 7B, Story 7B.2). */
+
+.dt-page {
+  padding: 1.5rem;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.dt-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.dt-subtitle {
+  margin: 0.25rem 0 0;
+  color: var(--text-secondary, #64748b);
+  font-size: 0.875rem;
+}
+
+.dt-back-link {
+  font-size: 0.875rem;
+  color: var(--brand-600, #4f46e5);
+  text-decoration: none;
+  white-space: nowrap;
+}
+.dt-back-link:hover {
+  text-decoration: underline;
+}
+
+.dt-toolbar {
+  display: flex;
+  gap: 0.75rem;
+  margin: 1rem 0 1.25rem;
+  flex-wrap: wrap;
+}
+
+.dt-search {
+  flex: 1 1 16rem;
+  min-width: 0;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border, #d1d5db);
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.dt-type-filter {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border, #d1d5db);
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  background: #fff;
+}
+
+/* List */
+.dt-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.dt-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 0.75rem;
+  background: #fff;
+}
+
+.dt-card--skeleton {
+  height: 5.5rem;
+  background: linear-gradient(90deg, #f1f5f9 25%, #e2e8f0 50%, #f1f5f9 75%);
+  background-size: 200% 100%;
+  animation: dt-shimmer 1.2s ease-in-out infinite;
+  border-color: transparent;
+}
+
+@keyframes dt-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dt-card--skeleton {
+    animation: none;
+  }
+}
+
+.dt-card__main {
+  min-width: 0;
+}
+
+.dt-card__heading {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.dt-card__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.dt-badge {
+  font-size: 0.75rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  background: var(--brand-soft, #eef2ff);
+  color: var(--brand-700, #4338ca);
+  text-transform: capitalize;
+}
+
+.dt-card__desc {
+  margin: 0.375rem 0 0;
+  color: var(--text-secondary, #475569);
+  font-size: 0.875rem;
+}
+
+.dt-card__meta {
+  margin: 0.375rem 0 0;
+  color: var(--text-muted, #94a3b8);
+  font-size: 0.75rem;
+}
+
+/* States */
+.dt-state {
+  text-align: center;
+  padding: 2.5rem 1rem;
+  border: 1px dashed var(--border, #d1d5db);
+  border-radius: 0.75rem;
+  color: var(--text-secondary, #64748b);
+}
+.dt-state--error {
+  border-color: var(--danger, #ef4444);
+  color: var(--danger, #b91c1c);
+}
+.dt-state h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.125rem;
+}
+
+.dt-fetching {
+  margin-top: 0.75rem;
+  font-size: 0.75rem;
+  color: var(--text-muted, #94a3b8);
+}
+
+/* Buttons */
+.dt-btn {
+  padding: 0.5rem 0.875rem;
+  border: 1px solid var(--border, #d1d5db);
+  border-radius: 0.5rem;
+  background: #fff;
+  font-size: 0.875rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.dt-btn:hover {
+  background: #f8fafc;
+}
+.dt-btn--primary {
+  background: var(--brand-600, #4f46e5);
+  border-color: var(--brand-600, #4f46e5);
+  color: #fff;
+}
+.dt-btn--primary:hover {
+  background: var(--brand-700, #4338ca);
+}
+.dt-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* ── Generate dialog ───────────────────────────────────────────────── */
+.gdt-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 2rem 1rem;
+  overflow-y: auto;
+  z-index: 1000;
+}
+
+.gdt-dialog {
+  background: #fff;
+  border-radius: 0.75rem;
+  width: min(640px, 100%);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.25);
+}
+
+.gdt-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--border, #e5e7eb);
+}
+.gdt-title {
+  margin: 0;
+  font-size: 1.0625rem;
+  font-weight: 600;
+}
+.gdt-close {
+  border: none;
+  background: none;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--text-muted, #94a3b8);
+}
+
+.gdt-body {
+  padding: 1rem 1.25rem;
+  overflow-y: auto;
+}
+
+.gdt-state {
+  padding: 2rem;
+  text-align: center;
+  color: var(--text-secondary, #64748b);
+}
+.gdt-state--error {
+  color: var(--danger, #b91c1c);
+}
+
+.gdt-section {
+  border: none;
+  padding: 0;
+  margin: 0 0 1.25rem;
+}
+.gdt-legend {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-muted, #94a3b8);
+  margin-bottom: 0.5rem;
+  padding: 0;
+}
+
+.gdt-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.gdt-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+.gdt-field--full {
+  grid-column: 1 / -1;
+}
+
+.gdt-label {
+  font-size: 0.8125rem;
+  font-weight: 500;
+}
+.gdt-req {
+  color: var(--danger, #ef4444);
+}
+
+.gdt-input {
+  padding: 0.5rem 0.625rem;
+  border: 1px solid var(--border, #d1d5db);
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  width: 100%;
+}
+.gdt-input--error {
+  border-color: var(--danger, #ef4444);
+}
+
+.gdt-desc {
+  font-size: 0.6875rem;
+  color: var(--text-muted, #94a3b8);
+}
+
+.gdt-hint {
+  margin: 0.5rem 0 0;
+  font-size: 0.75rem;
+  color: var(--text-muted, #94a3b8);
+}
+
+.gdt-preview {
+  margin: 0;
+  padding: 0.75rem;
+  background: #f8fafc;
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 0.5rem;
+  font-size: 0.8125rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 14rem;
+  overflow-y: auto;
+}
+
+.gdt-error {
+  margin: 0 0 0.75rem;
+  color: var(--danger, #b91c1c);
+  font-size: 0.8125rem;
+}
+
+.gdt-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  padding: 0.875rem 1.25rem;
+  border-top: 1px solid var(--border, #e5e7eb);
+}
+.gdt-btn {
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--border, #d1d5db);
+  border-radius: 0.5rem;
+  background: #fff;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+.gdt-btn:hover {
+  background: #f8fafc;
+}
+.gdt-btn--primary {
+  background: var(--brand-600, #4f46e5);
+  border-color: var(--brand-600, #4f46e5);
+  color: #fff;
+}
+.gdt-btn--primary:hover {
+  background: var(--brand-700, #4338ca);
+}
+.gdt-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+@media (max-width: 560px) {
+  .gdt-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/apps/ppt-web/src/features/document-templates/index.ts
+++ b/frontend/apps/ppt-web/src/features/document-templates/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Document templates feature (Epic 7B, Story 7B.2).
+ */
+
+export { GenerateDocumentDialog } from './components/GenerateDocumentDialog';
+export { DocumentTemplatesPage } from './pages/DocumentTemplatesPage';

--- a/frontend/apps/ppt-web/src/features/document-templates/pages/DocumentTemplatesPage.tsx
+++ b/frontend/apps/ppt-web/src/features/document-templates/pages/DocumentTemplatesPage.tsx
@@ -1,0 +1,142 @@
+/**
+ * DocumentTemplatesPage (Epic 7B, Story 7B.2 — Document Templates & Generation).
+ *
+ * Lists the organization's document templates and launches the
+ * {@link GenerateDocumentDialog} for the template → document flow. Wired to the
+ * hand-written `@ppt/api-client` templates module (`useTemplates`).
+ *
+ * Route: `/documents/templates` (mounted by `routes/groups/documents.tsx`).
+ */
+
+import { type DocumentTemplateSummary, useTemplates } from '@ppt/api-client';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { GenerateDocumentDialog } from '../components/GenerateDocumentDialog';
+import '../document-templates.css';
+
+const TEMPLATE_TYPES = ['lease', 'notice', 'invoice', 'report', 'minutes', 'contract', 'custom'];
+
+export function DocumentTemplatesPage() {
+  const { t } = useTranslation();
+  const [search, setSearch] = useState('');
+  const [typeFilter, setTypeFilter] = useState('');
+  const [active, setActive] = useState<DocumentTemplateSummary | null>(null);
+
+  const params = useMemo(
+    () => ({
+      search: search.trim() || undefined,
+      template_type: typeFilter || undefined,
+    }),
+    [search, typeFilter]
+  );
+
+  const { data, isLoading, isError, refetch, isFetching } = useTemplates(params);
+  const templates = data?.templates ?? [];
+
+  return (
+    <div className="dt-page">
+      <header className="page-header dt-header">
+        <div>
+          <h1 className="page-title">{t('documentTemplates.title')}</h1>
+          <p className="dt-subtitle">{t('documentTemplates.subtitle')}</p>
+        </div>
+        <Link to="/documents" className="dt-back-link">
+          {t('common.backToDocuments')}
+        </Link>
+      </header>
+
+      <div className="dt-toolbar">
+        <input
+          className="dt-search"
+          type="search"
+          value={search}
+          placeholder={t('documentTemplates.searchPlaceholder')}
+          onChange={(e) => setSearch(e.target.value)}
+          aria-label={t('documentTemplates.searchPlaceholder')}
+        />
+        <select
+          className="dt-type-filter"
+          value={typeFilter}
+          onChange={(e) => setTypeFilter(e.target.value)}
+          aria-label={t('documentTemplates.typeFilter')}
+        >
+          <option value="">{t('documentTemplates.allTypes')}</option>
+          {TEMPLATE_TYPES.map((type) => (
+            <option key={type} value={type}>
+              {t(`documentTemplates.types.${type}`)}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {isLoading && (
+        <ul className="dt-list" aria-hidden="true">
+          {[0, 1, 2, 3].map((i) => (
+            <li key={i} className="dt-card dt-card--skeleton" />
+          ))}
+        </ul>
+      )}
+
+      {isError && (
+        <div className="dt-state dt-state--error" role="alert">
+          <p>{t('documentTemplates.loadError')}</p>
+          <button type="button" className="dt-btn" onClick={() => refetch()}>
+            {t('common.retry')}
+          </button>
+        </div>
+      )}
+
+      {!isLoading && !isError && templates.length === 0 && (
+        <div className="dt-state dt-state--empty">
+          <h2>{t('documentTemplates.empty.title')}</h2>
+          <p>
+            {search || typeFilter
+              ? t('documentTemplates.empty.noMatches')
+              : t('documentTemplates.empty.body')}
+          </p>
+        </div>
+      )}
+
+      {!isLoading && !isError && templates.length > 0 && (
+        <ul className="dt-list">
+          {templates.map((tpl) => (
+            <li key={tpl.id} className="dt-card">
+              <div className="dt-card__main">
+                <div className="dt-card__heading">
+                  <h2 className="dt-card__title">{tpl.name}</h2>
+                  <span className="dt-badge">
+                    {t(`documentTemplates.types.${tpl.template_type}`)}
+                  </span>
+                </div>
+                {tpl.description && <p className="dt-card__desc">{tpl.description}</p>}
+                <p className="dt-card__meta">
+                  {t('documentTemplates.card.placeholders', { count: tpl.placeholder_count })}
+                  {' · '}
+                  {t('documentTemplates.card.usage', { count: tpl.usage_count })}
+                </p>
+              </div>
+              <button
+                type="button"
+                className="dt-btn dt-btn--primary"
+                onClick={() => setActive(tpl)}
+              >
+                {t('documentTemplates.card.generate')}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {isFetching && !isLoading && <div className="dt-fetching">{t('common.loading')}</div>}
+
+      {active && (
+        <GenerateDocumentDialog
+          templateId={active.id}
+          templateName={active.name}
+          onClose={() => setActive(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/documents/pages/DocumentsPage.tsx
+++ b/frontend/apps/ppt-web/src/features/documents/pages/DocumentsPage.tsx
@@ -57,6 +57,21 @@ export function DocumentsPage({ organizationId, buildingId }: DocumentsPageProps
             </svg>
             Upload
           </Link>
+          <Link to="/documents/templates" className="folders-link">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              aria-hidden="true"
+            >
+              <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+              <polyline points="14 2 14 8 20 8" />
+            </svg>
+            Šablóny
+          </Link>
           <div className="view-toggle">
             <button
               type="button"

--- a/frontend/apps/ppt-web/src/routes/groups/documents.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/documents.tsx
@@ -12,6 +12,7 @@ import {
   ArticleDetailPage,
   DocumentDetailPage,
   DocumentsPage,
+  DocumentTemplatesPage,
   DocumentUploadPage,
   FolderTreePage,
   NewsListPage,
@@ -80,6 +81,14 @@ export function documentRoutes() {
         element={
           <ProtectedRoute>
             <DocumentUploadPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/documents/templates"
+        element={
+          <ProtectedRoute>
+            <DocumentTemplatesPage />
           </ProtectedRoute>
         }
       />

--- a/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
+++ b/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
@@ -22,6 +22,11 @@ export const FolderTreePage = lazy(() =>
   import('../features/documents').then((m) => ({ default: m.FolderTreePage }))
 );
 
+// Document templates feature (Epic 7B, Story 7B.2)
+export const DocumentTemplatesPage = lazy(() =>
+  import('../features/document-templates').then((m) => ({ default: m.DocumentTemplatesPage }))
+);
+
 // News feature (Epic 59)
 export const NewsListPage = lazy(() =>
   import('../features/news').then((m) => ({ default: m.NewsListPage }))

--- a/frontend/packages/api-client/src/index.ts
+++ b/frontend/packages/api-client/src/index.ts
@@ -48,6 +48,7 @@ export * from './outages';
 export * from './packages';
 export * from './registry';
 export * from './reports';
+export * from './templates';
 export * from './voting';
 export * from './workflow-automation';
 

--- a/frontend/packages/api-client/src/templates/api.ts
+++ b/frontend/packages/api-client/src/templates/api.ts
@@ -1,0 +1,130 @@
+/**
+ * Document template API client (Epic 7B, Story 7B.2).
+ *
+ * Endpoints (hand-written — NOT TypeSpec-generated):
+ *   GET    /api/v1/templates
+ *   GET    /api/v1/templates/{id}
+ *   POST   /api/v1/templates
+ *   PUT    /api/v1/templates/{id}
+ *   DELETE /api/v1/templates/{id}
+ *   POST   /api/v1/templates/{id}/generate
+ */
+
+import { getToken } from '../auth';
+import type {
+  CreateTemplateRequest,
+  CreateTemplateResponse,
+  GenerateDocumentRequest,
+  GenerateDocumentResponse,
+  ListDocumentTemplatesParams,
+  TemplateActionResponse,
+  TemplateDetailResponse,
+  TemplateListResponse,
+  UpdateTemplateRequest,
+} from './types';
+
+const TEMPLATES_BASE = '/api/v1/templates';
+
+function getAuthHeaders(): HeadersInit {
+  const token = getToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+async function apiRequest<T>(url: string, options: RequestInit = {}): Promise<T> {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...getAuthHeaders(),
+      ...options.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.message || `HTTP ${response.status}`);
+  }
+
+  // 204 No Content (e.g. DELETE) has no JSON body.
+  if (response.status === 204 || response.headers.get('content-length') === '0') {
+    return undefined as T;
+  }
+
+  return response.json();
+}
+
+function buildQuery(params?: ListDocumentTemplatesParams): string {
+  if (!params) return '';
+  const search = new URLSearchParams();
+  if (params.template_type) search.set('template_type', params.template_type);
+  if (params.search) search.set('search', params.search);
+  if (params.limit != null) search.set('limit', String(params.limit));
+  if (params.offset != null) search.set('offset', String(params.offset));
+  const qs = search.toString();
+  return qs ? `?${qs}` : '';
+}
+
+/**
+ * List document templates.
+ * GET /api/v1/templates
+ */
+export async function listDocumentTemplates(
+  params?: ListDocumentTemplatesParams
+): Promise<TemplateListResponse> {
+  return apiRequest<TemplateListResponse>(`${TEMPLATES_BASE}${buildQuery(params)}`);
+}
+
+/**
+ * Get a single template (with placeholders + content) by ID.
+ * GET /api/v1/templates/{id}
+ */
+export async function getDocumentTemplate(id: string): Promise<TemplateDetailResponse> {
+  return apiRequest<TemplateDetailResponse>(`${TEMPLATES_BASE}/${id}`);
+}
+
+/**
+ * Generate a document from a template.
+ * POST /api/v1/templates/{id}/generate
+ */
+export async function generateDocument(
+  id: string,
+  body: GenerateDocumentRequest
+): Promise<GenerateDocumentResponse> {
+  return apiRequest<GenerateDocumentResponse>(`${TEMPLATES_BASE}/${id}/generate`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Create a new template (manager-only on the server).
+ * POST /api/v1/templates
+ */
+export async function createTemplate(body: CreateTemplateRequest): Promise<CreateTemplateResponse> {
+  return apiRequest<CreateTemplateResponse>(TEMPLATES_BASE, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Update an existing template.
+ * PUT /api/v1/templates/{id}
+ */
+export async function updateTemplate(
+  id: string,
+  body: UpdateTemplateRequest
+): Promise<TemplateActionResponse> {
+  return apiRequest<TemplateActionResponse>(`${TEMPLATES_BASE}/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Delete (soft-delete) a template.
+ * DELETE /api/v1/templates/{id}
+ */
+export async function deleteTemplate(id: string): Promise<void> {
+  await apiRequest<unknown>(`${TEMPLATES_BASE}/${id}`, { method: 'DELETE' });
+}

--- a/frontend/packages/api-client/src/templates/hooks.ts
+++ b/frontend/packages/api-client/src/templates/hooks.ts
@@ -1,0 +1,104 @@
+/**
+ * Document template React Query hooks (Epic 7B, Story 7B.2).
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import * as api from './api';
+import type {
+  CreateTemplateRequest,
+  GenerateDocumentRequest,
+  ListDocumentTemplatesParams,
+  UpdateTemplateRequest,
+} from './types';
+
+// Query keys
+export const templateKeys = {
+  all: ['templates'] as const,
+  lists: () => [...templateKeys.all, 'list'] as const,
+  list: (params?: ListDocumentTemplatesParams) => [...templateKeys.lists(), params ?? {}] as const,
+  details: () => [...templateKeys.all, 'detail'] as const,
+  detail: (id: string) => [...templateKeys.details(), id] as const,
+};
+
+/**
+ * List document templates (optionally filtered by type / search).
+ */
+export function useTemplates(params?: ListDocumentTemplatesParams) {
+  return useQuery({
+    queryKey: templateKeys.list(params),
+    queryFn: () => api.listDocumentTemplates(params),
+    staleTime: 30_000,
+  });
+}
+
+/**
+ * Get a single template by ID (placeholders + content for the generate flow).
+ */
+export function useTemplate(id: string | undefined) {
+  return useQuery({
+    queryKey: templateKeys.detail(id ?? ''),
+    queryFn: () => api.getDocumentTemplate(id!),
+    enabled: !!id,
+    staleTime: 30_000,
+  });
+}
+
+/**
+ * Generate a document from a template.
+ * Invalidates the template lists on success (server bumps `usage_count`).
+ */
+export function useGenerateDocument(templateId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: GenerateDocumentRequest) => api.generateDocument(templateId, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: templateKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: templateKeys.detail(templateId) });
+    },
+  });
+}
+
+/**
+ * Create a template. Invalidates template lists on success.
+ */
+export function useCreateTemplate() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: CreateTemplateRequest) => api.createTemplate(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: templateKeys.lists() });
+    },
+  });
+}
+
+/**
+ * Update a template. Invalidates the affected detail + lists on success.
+ */
+export function useUpdateTemplate() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, body }: { id: string; body: UpdateTemplateRequest }) =>
+      api.updateTemplate(id, body),
+    onSuccess: (_data, { id }) => {
+      queryClient.invalidateQueries({ queryKey: templateKeys.detail(id) });
+      queryClient.invalidateQueries({ queryKey: templateKeys.lists() });
+    },
+  });
+}
+
+/**
+ * Delete a template. Invalidates template lists on success.
+ */
+export function useDeleteTemplate() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => api.deleteTemplate(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: templateKeys.lists() });
+    },
+  });
+}

--- a/frontend/packages/api-client/src/templates/index.ts
+++ b/frontend/packages/api-client/src/templates/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Document templates API module (Epic 7B, Story 7B.2).
+ */
+
+export * from './api';
+export * from './hooks';
+export * from './types';

--- a/frontend/packages/api-client/src/templates/types.ts
+++ b/frontend/packages/api-client/src/templates/types.ts
@@ -1,0 +1,137 @@
+/**
+ * Document template types (Epic 7B, Story 7B.2 — Document Templates & Generation).
+ *
+ * Mirrors backend `db::models::document_template` and the route request/response
+ * shapes in `api-server/src/routes/templates.rs`. These endpoints are NOT
+ * TypeSpec-generated, so this module is hand-written (mirrors the `esignature`
+ * module pattern).
+ */
+
+/** Template type — matches backend `template_type::ALL`. */
+export type TemplateType =
+  | 'lease'
+  | 'notice'
+  | 'invoice'
+  | 'report'
+  | 'minutes'
+  | 'contract'
+  | 'custom';
+
+/** Placeholder data type — matches backend `placeholder_type::ALL`. */
+export type PlaceholderType = 'text' | 'date' | 'number' | 'currency';
+
+/** A single `{{name}}` placeholder definition on a template. */
+export interface TemplatePlaceholder {
+  /** Placeholder name, used in `{{name}}` syntax inside the template content. */
+  name: string;
+  /** Data type: text, date, number, currency. Serialized as `type` on the wire. */
+  type: PlaceholderType;
+  /** Whether a value is required to generate. */
+  required: boolean;
+  /** Default value substituted when no value is provided. */
+  default_value?: string | null;
+  /** Human-readable description shown next to the input. */
+  description?: string | null;
+}
+
+/** Full document template entity (`DocumentTemplate`). */
+export interface DocumentTemplate {
+  id: string;
+  organization_id: string;
+  name: string;
+  description?: string | null;
+  template_type: string;
+  content: string;
+  placeholders: TemplatePlaceholder[];
+  usage_count: number;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+  deleted_at?: string | null;
+}
+
+/** Template summary row for list views (`DocumentTemplateSummary`). */
+export interface DocumentTemplateSummary {
+  id: string;
+  name: string;
+  description?: string | null;
+  template_type: string;
+  usage_count: number;
+  placeholder_count: number;
+  created_at: string;
+}
+
+/** Template with creator details (`TemplateWithDetails` — flattens the entity). */
+export interface TemplateWithDetails extends DocumentTemplate {
+  created_by_name: string;
+}
+
+/** GET /api/v1/templates response. */
+export interface TemplateListResponse {
+  templates: DocumentTemplateSummary[];
+  count: number;
+  total: number;
+}
+
+/** GET /api/v1/templates/{id} response. */
+export interface TemplateDetailResponse {
+  template: TemplateWithDetails;
+}
+
+/** Query parameters for listing templates. */
+export interface ListDocumentTemplatesParams {
+  template_type?: string;
+  search?: string;
+  limit?: number;
+  offset?: number;
+}
+
+/** POST /api/v1/templates/{id}/generate request body. */
+export interface GenerateDocumentRequest {
+  /** Placeholder name → value map. */
+  values: Record<string, string>;
+  /** Title for the generated document. */
+  title: string;
+  /** Optional description for the generated document. */
+  description?: string;
+  /** Document category (see backend `document_category::ALL`). */
+  category: string;
+  /** Optional folder to place the generated document in. */
+  folder_id?: string;
+}
+
+/** POST /api/v1/templates/{id}/generate response. */
+export interface GenerateDocumentResponse {
+  document_id: string;
+  message: string;
+}
+
+/** POST /api/v1/templates request body. */
+export interface CreateTemplateRequest {
+  name: string;
+  description?: string;
+  template_type: string;
+  content: string;
+  placeholders: TemplatePlaceholder[];
+}
+
+/** POST /api/v1/templates response. */
+export interface CreateTemplateResponse {
+  id: string;
+  message: string;
+}
+
+/** PUT /api/v1/templates/{id} request body. */
+export interface UpdateTemplateRequest {
+  name?: string;
+  description?: string;
+  template_type?: string;
+  content?: string;
+  placeholders?: TemplatePlaceholder[];
+}
+
+/** PUT /api/v1/templates/{id} response. */
+export interface TemplateActionResponse {
+  message: string;
+  template: DocumentTemplate;
+}


### PR DESCRIPTION
## Summary

Implements **Story 7B.2 — Document-template generation UI** (BIT-207), the last genuinely-new frontend gap from GH epic #974. The backend (`routes/templates.rs`, `services/document_generation.rs`, migration `00036_add_document_templates.sql`) already ships full CRUD + `POST /templates/{id}/generate`; this PR builds the consuming UI.

### `@ppt/api-client` — new hand-written `templates` module
Mirrors the `esignature` module pattern (these endpoints are **not** TypeSpec-generated). Exposes `listDocumentTemplates` / `getDocumentTemplate` / `generateDocument` (+ CRUD) and React Query hooks (`useTemplates`, `useTemplate`, `useGenerateDocument`, …). Wire-facing exports are renamed domain-specific (`DocumentTemplateSummary`, `ListDocumentTemplatesParams`) to avoid root-barrel collisions with the existing `government-portal` and `migration` modules.

### `ppt-web`
- **`DocumentTemplatesPage`** (`/documents/templates`) — searchable, type-filterable template list with loading/error/empty states (empty distinguishes "no templates" vs "no filter matches").
- **`GenerateDocumentDialog`** — the select → context → prefill → preview → save flow: building/unit context selector that pre-fills matching placeholders (EN+SK name aliases, never clobbers typed values), typed placeholder inputs (text/date/number/currency) seeded with defaults, live `{{name}}` preview mirroring the server substitution, required-placeholder validation, generate-failure handling, and navigate-to-document on success. Focus trap + Escape close (WCAG 2.1.2).
- Routed via `lazyRoutes` + `routes/groups/documents.tsx`; discoverable from the Documents page header.

### Docs + i18n + tests
- `docs/screens/ppt/document-templates.md` (`endpoints: []`, contract documented in prose).
- `documentTemplates` i18n namespace (en/sk/cs; de/pl/hu fall back to en).
- vitest: preview substitution, required-placeholder validation, submit payload shape + navigation.

## Verification
- `cd frontend && pnpm typecheck` ✅
- `cd frontend && pnpm check` (biome) ✅
- `NODE_ENV=test vitest run …GenerateDocumentDialog.test.tsx` ✅ (3/3)

## Notes
The building/unit context is a frontend convenience only — the backend `generate` endpoint takes a flat `values` map; context selection just pre-fills inputs. Only non-empty values are sent (server applies placeholder defaults). After merge, GH epic #974 gap 2 (Story 7B.2) is complete; closing the epic + marking BIT-167 done is a follow-up per the BIT-207 ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)