### PR TITLE
feat(api-server): notification delivery tracking & analytics (#969 gap 4 / Story 2B-C.3)

### DIFF
--- a/backend/crates/db/migrations/00187_create_notification_events.sql
+++ b/backend/crates/db/migrations/00187_create_notification_events.sql
@@ -1,0 +1,76 @@
+-- Migration: 00187_create_notification_events
+-- Epic 2B, Story 2B-C.3 (gap-sweep #969 gap 4): notification delivery tracking
+-- & analytics.
+--
+-- Background
+-- ----------
+-- The notification pipeline (`NotificationPipeline::dispatch`, Epic 2B) produces
+-- `DeliveryRecord`s in memory only — they were logged and discarded, so there
+-- was no way to compute delivery/failure rates or drive a >5% failure-rate
+-- alert. This table is the append-only event log those records are persisted to
+-- (asynchronously, off the dispatch hot path).
+--
+-- Access model
+-- ------------
+-- Rows are written by the pipeline through the service-role pool (no per-request
+-- user GUC is set), and read by operators through the capability-gated admin
+-- analytics endpoint (also the service-role pool). There is no per-tenant read
+-- here: this is platform-operator observability, mirroring `audit_logs`. RLS is
+-- therefore a service-role-or-super-admin allowance, matching the
+-- `device_push_tokens` / `critical_notifications` service-role convention
+-- (00157, 00177): the GUC is unset on the service pool, so the policy permits;
+-- an authenticated end-user RLS connection (user GUC set) is denied.
+--
+-- No foreign keys: this is a best-effort analytics log written after dispatch
+-- completes, so a notification or user that disappears between dispatch and the
+-- async write must never make the insert fail (and the `notification_id` for
+-- email/push has no stored row to reference).
+
+CREATE TABLE notification_events (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- The notification this event belongs to (not an FK — see header).
+    notification_id UUID        NOT NULL,
+    -- Target user (not an FK — append-only analytics, see header).
+    user_id         UUID        NOT NULL,
+    -- Delivery channel. Matches `NotificationChannel::as_str()`.
+    channel         TEXT        NOT NULL CHECK (channel IN ('push', 'email', 'in_app')),
+    -- Delivery event. `sent`/`failed`/`skipped` are emitted by the pipeline at
+    -- dispatch time (mirroring `DeliveryStatus`); `delivered`/`opened`/`clicked`
+    -- are reserved for downstream receipt/engagement tracking (email pixel,
+    -- click webhooks) added in a follow-up — the table is ready for them now.
+    event           TEXT        NOT NULL CHECK (
+                                    event IN ('pending', 'sent', 'delivered',
+                                              'failed', 'skipped', 'opened',
+                                              'clicked')
+                                ),
+    -- Human-readable error (set when event = 'failed').
+    error_message   TEXT,
+    -- When the underlying delivery attempt / event occurred.
+    occurred_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Time-window aggregation is the primary query shape (rates over a window),
+-- usually further filtered by channel.
+CREATE INDEX notification_events_occurred_at_idx
+    ON notification_events (occurred_at);
+CREATE INDEX notification_events_channel_event_idx
+    ON notification_events (channel, event);
+-- Per-notification lookup (timeline for one notification across channels).
+CREATE INDEX notification_events_notification_id_idx
+    ON notification_events (notification_id);
+
+-- RLS: service-role (no user GUC) and super-admins only. See header.
+ALTER TABLE notification_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE notification_events FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY notification_events_service_policy ON notification_events
+    FOR ALL
+    USING (
+        NULLIF(current_setting('app.current_user_id', TRUE), '') IS NULL
+        OR is_super_admin()
+    )
+    WITH CHECK (
+        NULLIF(current_setting('app.current_user_id', TRUE), '') IS NULL
+        OR is_super_admin()
+    );

--- a/backend/crates/db/src/models/mod.rs
+++ b/backend/crates/db/src/models/mod.rs
@@ -211,6 +211,8 @@ pub use notification_preference::{
     NotificationPreferenceResponse, NotificationPreferencesResponse,
     UpdateNotificationPreferenceRequest,
 };
+pub mod notification_event;
+pub use notification_event::{ChannelEventCounts, NewNotificationEvent, NotificationEvent};
 pub use oauth::{
     AuthorizeRequest, ConsentPageData, CreateAccessToken, CreateAuthorizationCode,
     CreateOAuthClient, CreateRefreshToken as CreateOAuthRefreshToken, CreateUserOAuthGrant,

--- a/backend/crates/db/src/models/notification_event.rs
+++ b/backend/crates/db/src/models/notification_event.rs
@@ -1,0 +1,73 @@
+//! Notification delivery-event models (Epic 2B, Story 2B-C.3 / gap #969-4).
+//!
+//! `notification_events` is an append-only log the notification pipeline writes
+//! `DeliveryRecord`s to (asynchronously). The admin analytics endpoint reads
+//! aggregates from it to compute per-channel delivery/failure rates and drive
+//! the >5% failure-rate alert.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+/// A single persisted delivery event (one row of `notification_events`).
+#[derive(Debug, Clone, sqlx::FromRow, Serialize, Deserialize, ToSchema)]
+pub struct NotificationEvent {
+    pub id: Uuid,
+    pub notification_id: Uuid,
+    pub user_id: Uuid,
+    /// `push` | `email` | `in_app`.
+    pub channel: String,
+    /// `pending` | `sent` | `delivered` | `failed` | `skipped` | `opened` | `clicked`.
+    pub event: String,
+    pub error_message: Option<String>,
+    pub occurred_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// An event to append. Built from a `DeliveryRecord` by the pipeline; `id` /
+/// `created_at` are assigned by the database.
+#[derive(Debug, Clone)]
+pub struct NewNotificationEvent {
+    pub notification_id: Uuid,
+    pub user_id: Uuid,
+    pub channel: String,
+    pub event: String,
+    pub error_message: Option<String>,
+    pub occurred_at: DateTime<Utc>,
+}
+
+/// Per-channel aggregate counts over a time window. Raw `BIGINT` counts come
+/// straight from the `COUNT(*) FILTER (...)` query; the rate is derived in the
+/// handler so the SQL stays a pure GROUP BY.
+#[derive(Debug, Clone, sqlx::FromRow, Serialize, Deserialize, ToSchema)]
+pub struct ChannelEventCounts {
+    /// Channel (`push` | `email` | `in_app`), or `all` for the synthesized total row.
+    pub channel: String,
+    pub sent: i64,
+    pub delivered: i64,
+    pub failed: i64,
+    pub skipped: i64,
+    pub opened: i64,
+    pub clicked: i64,
+}
+
+impl ChannelEventCounts {
+    /// Delivery attempts that resolved to success or failure. Skipped channels
+    /// are intentional non-attempts (preference/quiet-hours) and are excluded
+    /// from the failure-rate denominator.
+    pub fn attempted(&self) -> i64 {
+        self.sent + self.failed
+    }
+
+    /// Failure rate over attempts in `[0.0, 1.0]`; `0.0` when there were no
+    /// attempts (empty window → no false alert).
+    pub fn failure_rate(&self) -> f64 {
+        let attempted = self.attempted();
+        if attempted <= 0 {
+            0.0
+        } else {
+            self.failed as f64 / attempted as f64
+        }
+    }
+}

--- a/backend/crates/db/src/repositories/mod.rs
+++ b/backend/crates/db/src/repositories/mod.rs
@@ -26,6 +26,7 @@ pub mod help;
 pub mod membership;
 pub mod messaging;
 pub mod meter;
+pub mod notification_event;
 pub mod notification_preference;
 pub mod oauth;
 pub mod onboarding;
@@ -108,6 +109,7 @@ pub use help::{FaqEntry, HelpArticle, HelpCategory, HelpRepository, Tooltip};
 pub use membership::MembershipRepository;
 pub use messaging::MessagingRepository;
 pub use meter::MeterRepository;
+pub use notification_event::{total_counts, NotificationEventRepository};
 pub use notification_preference::NotificationPreferenceRepository;
 pub use oauth::OAuthRepository;
 pub use onboarding::{

--- a/backend/crates/db/src/repositories/notification_event.rs
+++ b/backend/crates/db/src/repositories/notification_event.rs
@@ -1,0 +1,131 @@
+//! Notification delivery-event repository (Epic 2B, Story 2B-C.3 / gap #969-4).
+//!
+//! Append-only writes from the notification pipeline plus the time-windowed
+//! aggregation the admin analytics endpoint consumes. Both run on the
+//! service-role pool (no per-request user GUC), which the table's RLS policy
+//! permits — see migration `00187_create_notification_events.sql`.
+
+use chrono::{DateTime, Utc};
+use sqlx::Error as SqlxError;
+use uuid::Uuid;
+
+use crate::models::notification_event::{ChannelEventCounts, NewNotificationEvent};
+use crate::DbPool;
+
+#[derive(Clone)]
+pub struct NotificationEventRepository {
+    pool: DbPool,
+}
+
+impl NotificationEventRepository {
+    pub fn new(pool: DbPool) -> Self {
+        Self { pool }
+    }
+
+    /// Append a batch of delivery events in a single multi-row insert.
+    ///
+    /// Best-effort analytics: callers spawn this off the dispatch hot path and
+    /// log (never propagate) errors so persistence can never affect delivery.
+    /// Returns the number of rows written. An empty batch is a no-op.
+    pub async fn insert_events(
+        &self,
+        events: &[NewNotificationEvent],
+    ) -> Result<u64, SqlxError> {
+        if events.is_empty() {
+            return Ok(0);
+        }
+
+        // Decompose into column arrays for a single UNNEST insert — one round
+        // trip regardless of batch size.
+        let notification_ids: Vec<Uuid> = events.iter().map(|e| e.notification_id).collect();
+        let user_ids: Vec<Uuid> = events.iter().map(|e| e.user_id).collect();
+        let channels: Vec<String> = events.iter().map(|e| e.channel.clone()).collect();
+        let event_kinds: Vec<String> = events.iter().map(|e| e.event.clone()).collect();
+        let error_messages: Vec<Option<String>> =
+            events.iter().map(|e| e.error_message.clone()).collect();
+        let occurred_ats: Vec<DateTime<Utc>> = events.iter().map(|e| e.occurred_at).collect();
+
+        let result = sqlx::query(
+            r#"
+            INSERT INTO notification_events
+                (notification_id, user_id, channel, event, error_message, occurred_at)
+            SELECT * FROM UNNEST(
+                $1::uuid[], $2::uuid[], $3::text[], $4::text[], $5::text[], $6::timestamptz[]
+            )
+            "#,
+        )
+        .bind(&notification_ids)
+        .bind(&user_ids)
+        .bind(&channels)
+        .bind(&event_kinds)
+        .bind(&error_messages)
+        .bind(&occurred_ats)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected())
+    }
+
+    /// Aggregate event counts per channel over `[from, to]`, optionally
+    /// restricted to a single channel. Channels with no events in the window
+    /// are simply absent from the result (callers synthesize zeroed rows if a
+    /// fixed channel set is required).
+    pub async fn aggregate_by_channel(
+        &self,
+        from: DateTime<Utc>,
+        to: DateTime<Utc>,
+        channel: Option<&str>,
+    ) -> Result<Vec<ChannelEventCounts>, SqlxError> {
+        let rows = sqlx::query_as::<_, ChannelEventCounts>(
+            r#"
+            SELECT
+                channel,
+                COUNT(*) FILTER (WHERE event = 'sent')      AS sent,
+                COUNT(*) FILTER (WHERE event = 'delivered') AS delivered,
+                COUNT(*) FILTER (WHERE event = 'failed')    AS failed,
+                COUNT(*) FILTER (WHERE event = 'skipped')   AS skipped,
+                COUNT(*) FILTER (WHERE event = 'opened')    AS opened,
+                COUNT(*) FILTER (WHERE event = 'clicked')   AS clicked
+            FROM notification_events
+            WHERE occurred_at >= $1
+              AND occurred_at <= $2
+              AND ($3::text IS NULL OR channel = $3)
+            GROUP BY channel
+            ORDER BY channel
+            "#,
+        )
+        .bind(from)
+        .bind(to)
+        .bind(channel)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+}
+
+/// Roll a per-channel breakdown up into a single `all`-channel total. Kept as a
+/// free function (not SQL) so the window query stays a pure GROUP BY and the
+/// total is always consistent with the rows returned.
+pub fn total_counts(rows: &[ChannelEventCounts]) -> ChannelEventCounts {
+    rows.iter().fold(
+        ChannelEventCounts {
+            channel: "all".to_string(),
+            sent: 0,
+            delivered: 0,
+            failed: 0,
+            skipped: 0,
+            opened: 0,
+            clicked: 0,
+        },
+        |mut acc, r| {
+            acc.sent += r.sent;
+            acc.delivered += r.delivered;
+            acc.failed += r.failed;
+            acc.skipped += r.skipped;
+            acc.opened += r.opened;
+            acc.clicked += r.clicked;
+            acc
+        },
+    )
+}

--- a/backend/crates/db/src/repositories/notification_event.rs
+++ b/backend/crates/db/src/repositories/notification_event.rs
@@ -27,10 +27,7 @@ impl NotificationEventRepository {
     /// Best-effort analytics: callers spawn this off the dispatch hot path and
     /// log (never propagate) errors so persistence can never affect delivery.
     /// Returns the number of rows written. An empty batch is a no-op.
-    pub async fn insert_events(
-        &self,
-        events: &[NewNotificationEvent],
-    ) -> Result<u64, SqlxError> {
+    pub async fn insert_events(&self, events: &[NewNotificationEvent]) -> Result<u64, SqlxError> {
         if events.is_empty() {
             return Ok(0);
         }

--- a/backend/crates/db/tests/notification_events_repo_tests.rs
+++ b/backend/crates/db/tests/notification_events_repo_tests.rs
@@ -1,0 +1,228 @@
+//! Repository + RLS tests for `notification_events` (Epic 2B, Story 2B-C.3 /
+//! gap #969-4).
+//!
+//! Covers:
+//!   1. Append-batch insert + per-channel aggregation + totals roll-up.
+//!   2. Failure-rate math and the >5% alert threshold (firing, below-threshold,
+//!      and the min-attempts noise guard).
+//!   3. Channel filter and empty-window behavior (no false alert).
+//!   4. The service-role RLS policy: a `FORCE`-bound non-super role with NO user
+//!      GUC (the pipeline / admin service pool) may write and read, while the
+//!      same role WITH a user GUC set (an end-user RLS connection) is denied.
+//!
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS — so
+//! the RLS test (4) creates a `NOSUPERUSER NOBYPASSRLS` role and `SET ROLE`s to
+//! it, mirroring `vendor_rls_repo_tests.rs`, so `FORCE` actually binds.
+
+use chrono::{DateTime, Duration, Utc};
+use db::models::NewNotificationEvent;
+use db::repositories::{total_counts, NotificationEventRepository};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+fn ev(channel: &str, event: &str, at: DateTime<Utc>) -> NewNotificationEvent {
+    NewNotificationEvent {
+        notification_id: Uuid::new_v4(),
+        user_id: Uuid::new_v4(),
+        channel: channel.to_string(),
+        event: event.to_string(),
+        error_message: (event == "failed").then(|| "transport error".to_string()),
+        occurred_at: at,
+    }
+}
+
+/// Build `n` events of one (channel, event) kind at time `at`.
+fn many(channel: &str, event: &str, n: usize, at: DateTime<Utc>) -> Vec<NewNotificationEvent> {
+    (0..n).map(|_| ev(channel, event, at)).collect()
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn insert_aggregate_and_alert_fires(pool: PgPool) {
+    let repo = NotificationEventRepository::new(pool.clone());
+    let now = Utc::now();
+
+    // email: 18 sent + 2 failed (attempted 20, 10% failure).
+    // push:  5 sent + 3 skipped (skipped excluded from failure denominator).
+    let mut batch = Vec::new();
+    batch.extend(many("email", "sent", 18, now));
+    batch.extend(many("email", "failed", 2, now));
+    batch.extend(many("push", "sent", 5, now));
+    batch.extend(many("push", "skipped", 3, now));
+
+    let written = repo.insert_events(&batch).await.expect("insert");
+    assert_eq!(written, 28, "all rows written in one batch");
+
+    let from = now - Duration::hours(1);
+    let to = now + Duration::hours(1);
+    let rows = repo
+        .aggregate_by_channel(from, to, None)
+        .await
+        .expect("aggregate");
+
+    // Two channels present, ordered by channel name (email, push).
+    assert_eq!(rows.len(), 2);
+    let email = rows.iter().find(|r| r.channel == "email").expect("email row");
+    let push = rows.iter().find(|r| r.channel == "push").expect("push row");
+
+    assert_eq!(email.sent, 18);
+    assert_eq!(email.failed, 2);
+    assert_eq!(email.attempted(), 20);
+    assert!((email.failure_rate() - 0.10).abs() < 1e-9);
+
+    assert_eq!(push.sent, 5);
+    assert_eq!(push.skipped, 3);
+    assert_eq!(push.failed, 0);
+    assert_eq!(push.attempted(), 5);
+    assert_eq!(push.failure_rate(), 0.0);
+
+    // Totals roll-up: 23 sent, 2 failed, 3 skipped → attempted 25, rate 8%.
+    let totals = total_counts(&rows);
+    assert_eq!(totals.channel, "all");
+    assert_eq!(totals.sent, 23);
+    assert_eq!(totals.failed, 2);
+    assert_eq!(totals.skipped, 3);
+    assert_eq!(totals.attempted(), 25);
+    assert!((totals.failure_rate() - 0.08).abs() < 1e-9);
+
+    // Alert: 8% > 5% threshold with 25 >= 20 attempts → fires.
+    assert!(totals.failure_rate() > 0.05);
+    assert!(totals.attempted() >= 20);
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn min_attempts_guard_suppresses_noisy_alert(pool: PgPool) {
+    let repo = NotificationEventRepository::new(pool.clone());
+    let now = Utc::now();
+
+    // 1 failed of 1 attempt = 100% failure, but only 1 attempt: the alert's
+    // min-attempts guard (>= 20) must keep it from firing on a near-idle window.
+    repo.insert_events(&[ev("email", "failed", now)])
+        .await
+        .expect("insert");
+
+    let rows = repo
+        .aggregate_by_channel(now - Duration::hours(1), now + Duration::hours(1), None)
+        .await
+        .expect("aggregate");
+    let totals = total_counts(&rows);
+
+    assert_eq!(totals.attempted(), 1);
+    assert!((totals.failure_rate() - 1.0).abs() < 1e-9);
+    // Rate is over threshold, but attempts are below the guard → no fire.
+    assert!(totals.attempted() < 20);
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn channel_filter_and_empty_window(pool: PgPool) {
+    let repo = NotificationEventRepository::new(pool.clone());
+    let now = Utc::now();
+
+    let mut batch = Vec::new();
+    batch.extend(many("email", "sent", 4, now));
+    batch.extend(many("push", "sent", 7, now));
+    repo.insert_events(&batch).await.expect("insert");
+
+    // Channel filter: only the push row comes back.
+    let push_only = repo
+        .aggregate_by_channel(now - Duration::hours(1), now + Duration::hours(1), Some("push"))
+        .await
+        .expect("aggregate push");
+    assert_eq!(push_only.len(), 1);
+    assert_eq!(push_only[0].channel, "push");
+    assert_eq!(push_only[0].sent, 7);
+
+    // Empty window (entirely in the past) → no rows, zeroed totals, no alert.
+    let empty = repo
+        .aggregate_by_channel(now - Duration::hours(48), now - Duration::hours(24), None)
+        .await
+        .expect("aggregate empty");
+    assert!(empty.is_empty());
+    let totals = total_counts(&empty);
+    assert_eq!(totals.attempted(), 0);
+    assert_eq!(totals.failure_rate(), 0.0, "empty window must not divide-by-zero");
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn service_role_rls_allows_unset_guc_denies_user(pool: PgPool) {
+    let now = Utc::now();
+
+    // NOSUPERUSER NOBYPASSRLS role so FORCE ROW LEVEL SECURITY actually binds
+    // (the production owner role is also bound by FORCE).
+    let role = format!("ppt_rls_notif_evt_{}", Uuid::new_v4().simple());
+    for stmt in [
+        format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
+        format!("GRANT SELECT, INSERT ON notification_events TO \"{role}\""),
+        // The policy evaluates is_super_admin(); the bound role must EXECUTE it.
+        format!("GRANT EXECUTE ON FUNCTION is_super_admin() TO \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .expect("role setup");
+    }
+
+    // (a) SERVICE PATH: no user GUC set → policy permits insert + read. This is
+    //     exactly what the pipeline write / admin analytics read pool does.
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_config('app.current_user_id', '', false)")
+            .execute(&mut *conn)
+            .await
+            .expect("clear user guc");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        sqlx::query(
+            r#"INSERT INTO notification_events (notification_id, user_id, channel, event, occurred_at)
+               VALUES ($1, $2, 'email', 'sent', $3)"#,
+        )
+        .bind(Uuid::new_v4())
+        .bind(Uuid::new_v4())
+        .bind(now)
+        .execute(&mut *conn)
+        .await
+        .expect("service-role insert (unset GUC) must be permitted");
+
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM notification_events")
+            .fetch_one(&mut *conn)
+            .await
+            .expect("service-role read");
+        assert_eq!(count, 1, "service role (unset GUC) sees the row it wrote");
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+
+    // (b) END-USER PATH: a user GUC is set (an authenticated RLS connection).
+    //     The policy denies — this analytics log is operator-only.
+    {
+        let mut conn = pool.acquire().await.expect("acquire");
+        sqlx::query("SELECT set_config('app.current_user_id', $1, false)")
+            .bind(Uuid::new_v4().to_string())
+            .execute(&mut *conn)
+            .await
+            .expect("set user guc");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM notification_events")
+            .fetch_one(&mut *conn)
+            .await
+            .expect("user-context read");
+        assert_eq!(
+            count, 0,
+            "an end-user RLS connection (user GUC set) must NOT read the operator analytics log"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+}

--- a/backend/crates/db/tests/notification_events_repo_tests.rs
+++ b/backend/crates/db/tests/notification_events_repo_tests.rs
@@ -61,7 +61,10 @@ async fn insert_aggregate_and_alert_fires(pool: PgPool) {
 
     // Two channels present, ordered by channel name (email, push).
     assert_eq!(rows.len(), 2);
-    let email = rows.iter().find(|r| r.channel == "email").expect("email row");
+    let email = rows
+        .iter()
+        .find(|r| r.channel == "email")
+        .expect("email row");
     let push = rows.iter().find(|r| r.channel == "push").expect("push row");
 
     assert_eq!(email.sent, 18);
@@ -124,7 +127,11 @@ async fn channel_filter_and_empty_window(pool: PgPool) {
 
     // Channel filter: only the push row comes back.
     let push_only = repo
-        .aggregate_by_channel(now - Duration::hours(1), now + Duration::hours(1), Some("push"))
+        .aggregate_by_channel(
+            now - Duration::hours(1),
+            now + Duration::hours(1),
+            Some("push"),
+        )
         .await
         .expect("aggregate push");
     assert_eq!(push_only.len(), 1);
@@ -139,7 +146,11 @@ async fn channel_filter_and_empty_window(pool: PgPool) {
     assert!(empty.is_empty());
     let totals = total_counts(&empty);
     assert_eq!(totals.attempted(), 0);
-    assert_eq!(totals.failure_rate(), 0.0, "empty window must not divide-by-zero");
+    assert_eq!(
+        totals.failure_rate(),
+        0.0,
+        "empty window must not divide-by-zero"
+    );
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]

--- a/backend/servers/api-server/src/routes/admin/mod.rs
+++ b/backend/servers/api-server/src/routes/admin/mod.rs
@@ -20,6 +20,7 @@ pub mod impersonation;
 pub mod memberships;
 pub mod metrics;
 pub mod mfa;
+pub mod notifications;
 pub mod users;
 pub mod users_lifecycle;
 
@@ -92,6 +93,7 @@ pub fn router() -> Router<AppState> {
         .nest("/impersonation", impersonation::router())
         .nest("/mfa", mfa::router())
         .nest("/metrics", metrics::router())
+        .nest("/notifications", notifications::router())
 }
 
 #[cfg(test)]

--- a/backend/servers/api-server/src/routes/admin/notifications.rs
+++ b/backend/servers/api-server/src/routes/admin/notifications.rs
@@ -1,0 +1,223 @@
+//! Admin notification delivery analytics (Epic 2B, Story 2B-C.3 / gap #969-4).
+//!
+//! Reads aggregates from `notification_events` (written asynchronously by the
+//! notification pipeline) and exposes per-channel delivery/failure rates plus a
+//! **>5% failure-rate alert** for operators.
+//!
+//! Mounted under `/api/v1/admin/notifications`. Capability-gated with
+//! [`Capability::AuditRead`] — this is platform-operator observability of the
+//! delivery infrastructure, the same audience and risk class as the audit-log
+//! viewer (no per-tenant data is returned, only aggregate counts).
+//!
+//! ## Query parameters (`GET /analytics`)
+//!
+//! * `from=<iso8601>` / `to=<iso8601>` — absolute window bounds.
+//! * `after=<24h|7d|15m>` — relative lower bound; ignored when `from` is set.
+//! * `channel=push|email|in_app` — restrict to one channel.
+//!
+//! Defaults: `to = now`, `from = now − 24h`.
+
+use admin_core::{require_capability, Capability, RequireCapability};
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    routing::get,
+    Json, Router,
+};
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use db::models::ChannelEventCounts;
+use db::repositories::{total_counts, NotificationEventRepository};
+
+use crate::state::AppState;
+
+/// Failure-rate threshold above which the alert fires (Story 2B-C.3: >5%).
+const FAILURE_RATE_THRESHOLD: f64 = 0.05;
+
+/// Minimum attempts in the window before the alert can fire. Guards against a
+/// noisy 1-failed-of-1 (100%) alert on a near-idle window; the alert is about a
+/// sustained delivery problem, not a single failure.
+const ALERT_MIN_ATTEMPTS: i64 = 20;
+
+/// Default lookback when no `from`/`after` is supplied.
+const DEFAULT_WINDOW_HOURS: i64 = 24;
+
+/// Valid channel filter values (mirror `NotificationChannel::as_str()`).
+const VALID_CHANNELS: [&str; 3] = ["push", "email", "in_app"];
+
+pub fn router() -> Router<AppState> {
+    Router::new().route(
+        "/analytics",
+        get(get_analytics).layer(require_capability(Capability::AuditRead)),
+    )
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AnalyticsQuery {
+    /// Absolute lower bound on `occurred_at`. Wins over `after`.
+    #[serde(default)]
+    pub from: Option<DateTime<Utc>>,
+    /// Absolute upper bound on `occurred_at`. Defaults to now.
+    #[serde(default)]
+    pub to: Option<DateTime<Utc>>,
+    /// Relative lower-bound alias (`24h`, `7d`, `15m`). Ignored when `from` set.
+    #[serde(default)]
+    pub after: Option<String>,
+    /// Restrict to a single channel (`push` | `email` | `in_app`).
+    #[serde(default)]
+    pub channel: Option<String>,
+}
+
+/// Per-channel (or total) analytics row returned to the operator.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct ChannelAnalytics {
+    pub channel: String,
+    pub sent: i64,
+    pub delivered: i64,
+    pub failed: i64,
+    pub skipped: i64,
+    pub opened: i64,
+    pub clicked: i64,
+    /// `sent + failed` — deliveries that resolved to success or failure.
+    pub attempted: i64,
+    /// `failed / attempted` in `[0,1]`; `0` for an empty window.
+    pub failure_rate: f64,
+}
+
+impl From<&ChannelEventCounts> for ChannelAnalytics {
+    fn from(c: &ChannelEventCounts) -> Self {
+        Self {
+            channel: c.channel.clone(),
+            sent: c.sent,
+            delivered: c.delivered,
+            failed: c.failed,
+            skipped: c.skipped,
+            opened: c.opened,
+            clicked: c.clicked,
+            attempted: c.attempted(),
+            failure_rate: c.failure_rate(),
+        }
+    }
+}
+
+/// The >5% failure-rate alert state for the window. Computed once per query (per
+/// window) rather than emitted per event.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct FailureRateAlert {
+    /// `true` when `attempted >= min_attempts` and `failure_rate > threshold`.
+    pub firing: bool,
+    pub threshold: f64,
+    pub failure_rate: f64,
+    pub attempted: i64,
+    pub min_attempts: i64,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct NotificationAnalyticsResponse {
+    pub from: DateTime<Utc>,
+    pub to: DateTime<Utc>,
+    /// Echoes the `channel` filter, if any.
+    pub channel_filter: Option<String>,
+    /// Aggregate across all channels in the window.
+    pub totals: ChannelAnalytics,
+    /// One row per channel that had events in the window.
+    pub by_channel: Vec<ChannelAnalytics>,
+    pub alert: FailureRateAlert,
+}
+
+/// Parse a relative duration suffixed with `h`/`d`/`m`. Bounded so an
+/// attacker-controlled value cannot panic or wrap (`try_*` constructors + a
+/// generous upper bound). Returns `None` on any malformed input.
+fn parse_relative_duration(s: &str) -> Option<Duration> {
+    const MAX_DAYS: i64 = 36_500; // ~100y
+    const MAX_HOURS: i64 = MAX_DAYS * 24;
+    const MAX_MINUTES: i64 = MAX_HOURS * 60;
+
+    let s = s.trim();
+    if let Some(val) = s.strip_suffix('h') {
+        let n = val.parse::<i64>().ok()?;
+        if !(0..=MAX_HOURS).contains(&n) {
+            return None;
+        }
+        Duration::try_hours(n)
+    } else if let Some(val) = s.strip_suffix('d') {
+        let n = val.parse::<i64>().ok()?;
+        if !(0..=MAX_DAYS).contains(&n) {
+            return None;
+        }
+        Duration::try_days(n)
+    } else if let Some(val) = s.strip_suffix('m') {
+        let n = val.parse::<i64>().ok()?;
+        if !(0..=MAX_MINUTES).contains(&n) {
+            return None;
+        }
+        Duration::try_minutes(n)
+    } else {
+        None
+    }
+}
+
+/// GET /api/v1/admin/notifications/analytics
+async fn get_analytics(
+    _cap: RequireCapability,
+    State(state): State<AppState>,
+    Query(q): Query<AnalyticsQuery>,
+) -> Result<Json<NotificationAnalyticsResponse>, (StatusCode, String)> {
+    if let Some(ch) = q.channel.as_deref() {
+        if !VALID_CHANNELS.contains(&ch) {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!("invalid channel `{ch}` (expected one of {VALID_CHANNELS:?})"),
+            ));
+        }
+    }
+
+    let now = Utc::now();
+    let to = q.to.unwrap_or(now);
+    let from = q
+        .from
+        .or_else(|| {
+            q.after
+                .as_deref()
+                .and_then(parse_relative_duration)
+                .map(|d| now - d)
+        })
+        .unwrap_or_else(|| now - Duration::hours(DEFAULT_WINDOW_HOURS));
+
+    if from > to {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "`from` must be earlier than or equal to `to`".to_string(),
+        ));
+    }
+
+    let repo = NotificationEventRepository::new(state.db.clone());
+    let rows = repo
+        .aggregate_by_channel(from, to, q.channel.as_deref())
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let totals = ChannelAnalytics::from(&total_counts(&rows));
+    let by_channel: Vec<ChannelAnalytics> = rows.iter().map(ChannelAnalytics::from).collect();
+
+    let firing =
+        totals.attempted >= ALERT_MIN_ATTEMPTS && totals.failure_rate > FAILURE_RATE_THRESHOLD;
+    let alert = FailureRateAlert {
+        firing,
+        threshold: FAILURE_RATE_THRESHOLD,
+        failure_rate: totals.failure_rate,
+        attempted: totals.attempted,
+        min_attempts: ALERT_MIN_ATTEMPTS,
+    };
+
+    Ok(Json(NotificationAnalyticsResponse {
+        from,
+        to,
+        channel_filter: q.channel,
+        totals,
+        by_channel,
+        alert,
+    }))
+}

--- a/backend/servers/api-server/src/services/notification_pipeline.rs
+++ b/backend/servers/api-server/src/services/notification_pipeline.rs
@@ -33,9 +33,10 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use db::{
-    models::{CreateHeldNotification, HeldNotification, Locale, User},
+    models::{CreateHeldNotification, HeldNotification, Locale, NewNotificationEvent, User},
     repositories::{
-        GranularNotificationRepository, NotificationPreferenceRepository, UserRepository,
+        GranularNotificationRepository, NotificationEventRepository,
+        NotificationPreferenceRepository, UserRepository,
     },
     DbPool,
 };
@@ -342,6 +343,25 @@ impl Default for PipelineConfig {
 ///
 /// Wires together preference routing (2b-2), transport adapters (2b-4), and
 /// delivery tracking (2b-3) into a single `dispatch` entry point (2b-5).
+/// Map the pipeline's in-memory `DeliveryRecord`s into persistable analytics
+/// events (Story 2B-C.3 / #969-4). The `DeliveryStatus` display form
+/// (`sent`/`failed`/`skipped`/`pending`) is exactly the `event` value the
+/// `notification_events` table accepts. `occurred_at` prefers the confirmed
+/// `delivered_at` and falls back to the attempt time.
+fn records_to_events(records: &[DeliveryRecord]) -> Vec<NewNotificationEvent> {
+    records
+        .iter()
+        .map(|r| NewNotificationEvent {
+            notification_id: r.notification_id,
+            user_id: r.user_id,
+            channel: r.channel.as_str().to_string(),
+            event: r.status.to_string(),
+            error_message: r.error_message.clone(),
+            occurred_at: r.delivered_at.unwrap_or(r.attempted_at),
+        })
+        .collect()
+}
+
 #[derive(Clone)]
 pub struct NotificationPipeline {
     config: PipelineConfig,
@@ -352,6 +372,9 @@ pub struct NotificationPipeline {
     in_app_adapter: Arc<dyn InAppTransport>,
     /// Story 8B.3 / #980: read quiet-hours schedules and persist held pushes.
     granular_repo: GranularNotificationRepository,
+    /// Story 2B-C.3 / #969-4: append delivery records for analytics,
+    /// asynchronously off the dispatch path.
+    events_repo: NotificationEventRepository,
 }
 
 impl NotificationPipeline {
@@ -365,6 +388,7 @@ impl NotificationPipeline {
         let user_repo = UserRepository::new(pool.clone());
         let notification_pref_repo = NotificationPreferenceRepository::new(pool.clone());
         let granular_repo = GranularNotificationRepository::new(pool.clone());
+        let events_repo = NotificationEventRepository::new(pool.clone());
 
         let preference_router =
             PreferenceRouter::new(notification_pref_repo, granular_repo.clone());
@@ -387,6 +411,7 @@ impl NotificationPipeline {
             push_adapter,
             in_app_adapter,
             granular_repo,
+            events_repo,
         }
     }
 
@@ -575,6 +600,24 @@ impl NotificationPipeline {
             failed = result.failed,
             "[Epic 2B] Notification dispatch complete"
         );
+
+        // Story 2B-C.3 (#969-4): persist delivery records for analytics. This is
+        // strictly off the dispatch path — we spawn a detached task so a slow or
+        // failing write can never delay or fail delivery, and we log (never
+        // propagate) any error. Records are cloned out before the result is
+        // returned to the caller so nothing is dropped on the success path.
+        let events = records_to_events(&result.records);
+        if !events.is_empty() {
+            let repo = self.events_repo.clone();
+            tokio::spawn(async move {
+                if let Err(e) = repo.insert_events(&events).await {
+                    tracing::warn!(
+                        error = %e,
+                        "[Epic 2B] Failed to persist notification delivery events"
+                    );
+                }
+            });
+        }
 
         Ok(result)
     }


### PR DESCRIPTION
## What & why

Story 2B-C.3 (gap-sweep epic #969, gap 4 / BIT-180). The notification pipeline produced `DeliveryRecord`s **in memory only** — logged then discarded — so there was no delivery/failure-rate analytics and no **>5% failure-rate alert**. This adds the persistence + aggregation backend.

Frontend operator dashboard is a **follow-up child** assigned to FrontendEngineer (this PR is backend persistence + endpoints, which I own).

## Changes

**Schema** — `00187_create_notification_events.sql`
- Append-only `notification_events` (`notification_id, user_id, channel, event, error_message, occurred_at`). `event` domain: `sent`/`failed`/`skipped` (emitted now) + `delivered`/`opened`/`clicked` (reserved for receipt/engagement tracking, table-ready).
- Indexed for time-window + per-channel aggregation and per-notification timeline.
- **RLS**: service-role + super-admin only (GUC-unset service pool writes/reads; an end-user RLS connection is denied), mirroring `device_push_tokens` (00157) / `critical_notifications` (00177). No FKs — best-effort analytics written after dispatch must never fail the write.

**db crate**
- `NotificationEvent` / `NewNotificationEvent` / `ChannelEventCounts` models.
- `NotificationEventRepository`: batch `UNNEST` insert + per-channel windowed aggregation; `total_counts` roll-up. `failure_rate` excludes intentional `skipped` and is 0 on an empty window.

**Pipeline** — `NotificationPipeline::dispatch`
- Persists records **asynchronously** via a detached `tokio::spawn`: strictly off the dispatch path, errors logged not propagated, records cloned before the result returns so nothing is dropped on the success path. Covers single / multi-user / broadcast (all funnel through `dispatch`).

**Endpoint** — `GET /api/v1/admin/notifications/analytics`
- Per-channel + total delivery/failure rates over a window (`from`/`to`/`after`, optional `channel`).
- **>5% failure-rate alert** computed **once per window** (not per event), with a min-attempts guard to suppress noise on near-idle windows.
- Capability-gated with `AuditRead` — platform-operator observability, same audience/risk class as the audit-log viewer; returns aggregate counts only, no per-tenant data.

## Tests (`db` crate, `sqlx::test`)
- Batch insert + per-channel aggregation + totals roll-up.
- Alert fires at >5%; min-attempts guard suppresses a 1-of-1 noisy alert.
- Channel filter; empty-window (no divide-by-zero, no false alert).
- Service-role RLS policy on a `FORCE`-bound `NOSUPERUSER` role: unset GUC permitted (pipeline/admin pool), user GUC denied (end-user connection).

## Reviewed bar
- Async persistence cannot drop records on the success path or block dispatch ✔
- Aggregation handles empty windows ✔
- Alert fires once per window, not per event ✔

## Notes
- No local Rust toolchain (mercury offline) — relying on CI for fmt/clippy/test.
- Analytics endpoint follows the `admin/audit` precedent (not registered in the OpenAPI doc); the follow-up frontend page calls the REST path directly.

Refs #969. Resolves BIT-180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)