### PR TITLE
feat(buildings): show building location on a map (Story 3.1 AC3, BIT-191)

### DIFF
--- a/docs/screens/ppt/buildings-detail.md
+++ b/docs/screens/ppt/buildings-detail.md
@@ -1,0 +1,75 @@
+---
+id: ppt/buildings-detail
+name: Building Detail
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    component: BuildingDetailPage
+    buildStatus: shipped
+    redesignStatus: n/a
+    apiStatus: partial
+  mobile:
+    buildStatus: n/a
+    redesignStatus: n/a
+    apiStatus: n/a
+endpoints: []
+epics:
+  - Epic-3
+  - Epic-81
+sharedComponents:
+  - status-pill
+  - stat-card
+  - location-map
+useCases:
+  - UC-15
+diagrams: []
+owner: pm-frontend
+---
+
+## Overview
+
+Detail view for a single building in the PPT admin portal. Route
+`/buildings/:buildingId`, rendered by `BuildingDetailPage`
+(`frontend/apps/ppt-web/src/features/buildings/pages/BuildingDetailPage.tsx`).
+Loads the building, its floors, units, and common areas from the buildings API.
+
+## Functionality Checklist
+
+<!-- tag with [w] / [m] / [w,m] / [-] -->
+
+### Header card
+- [x] [w] Hero image (falls back to placeholder when `photoUrl` is unsafe/absent)
+- [x] [w] Name + composed address line + status pill
+- [x] [w] Optional description
+- [x] [w] Stat grid: Type / Units / Floors / Year Built / Total Area
+
+### Location map (Story 3.1 AC3)
+- [x] [w] Renders `BuildingLocationMap` immediately under the header card
+- [x] [w] Shows a keyless OpenStreetMap embed centred on the building with a marker
+- [x] [w] "Open in OpenStreetMap" link opens the point in a new tab
+- [x] [w] Coordinate readout (lat, lng to 6 dp) under the map
+- [x] [w] Renders nothing when the building has no resolved coordinates (graceful
+  degradation while geocoding is unconfigured/pending)
+
+### Floors / Units / Common Areas
+- [x] [w] Floors list with per-floor unit counts (loading + empty states)
+- [x] [w] Units section (`UnitsSection`)
+- [x] [w] Common areas grid with type + description + area (loading + empty states)
+
+## Data Flow / API Notes
+
+Endpoints (not yet registered in `@ppt/sitemap`, so listed here in prose):
+`GET /api/v1/buildings/:id`, `GET /api/v1/buildings/:id/floors`,
+`GET /api/v1/buildings/:id/common-areas`.
+
+- Coordinates are geocoded and stored server-side (Story 3.1 AC3, backend
+  [BIT-200](/BIT/issues/BIT-200) / PR #1691). The API serializes them as
+  top-level `latitude` / `longitude` fields.
+- The client `Building` model exposes coordinates as nested
+  `location: GeoLocation`. The buildings API client normalizes the flat
+  backend shape into `location` (`packages/api-client/src/buildings/api.ts:
+  normalizeBuilding`), tolerating numeric strings and out-of-range/missing
+  values, so the page can rely on `building.location` regardless of transport.
+- The map uses the OpenStreetMap keyless embed (`/export/embed.html`) — no API
+  key and no extra dependency, so it works in CI and offline dev.

--- a/frontend/apps/ppt-web/src/features/buildings/components/BuildingLocationMap.tsx
+++ b/frontend/apps/ppt-web/src/features/buildings/components/BuildingLocationMap.tsx
@@ -1,0 +1,78 @@
+/**
+ * BuildingLocationMap - renders a building's geocoded location on a map.
+ *
+ * Story 3.1 AC3: the system geocodes the building address and displays the
+ * building on a map. Coordinates are resolved server-side (see BIT-200) and
+ * surfaced via `Building.location`; this component renders them.
+ *
+ * Uses the keyless OpenStreetMap embed (no API key, no extra dependency) so it
+ * works in CI and offline dev without configuration. Renders nothing when the
+ * building has no resolved coordinates, so it degrades gracefully while
+ * geocoding is unconfigured or pending.
+ */
+
+import type { GeoLocation } from '@ppt/api-client';
+
+interface BuildingLocationMapProps {
+  location?: GeoLocation;
+  /** Building name, used for the marker's accessible label. */
+  name?: string;
+}
+
+/** Clamp + round a coordinate for stable, URL-safe embed parameters. */
+function fmt(value: number): string {
+  return value.toFixed(6);
+}
+
+export function BuildingLocationMap({ location, name }: BuildingLocationMapProps) {
+  if (!location || !Number.isFinite(location.latitude) || !Number.isFinite(location.longitude)) {
+    return null;
+  }
+
+  const { latitude, longitude } = location;
+
+  // A small bounding box around the point keeps the marker centred at a
+  // street-level zoom in the keyless embed.
+  const delta = 0.0045;
+  const bbox = [
+    fmt(longitude - delta),
+    fmt(latitude - delta),
+    fmt(longitude + delta),
+    fmt(latitude + delta),
+  ].join('%2C');
+
+  const embedUrl =
+    `https://www.openstreetmap.org/export/embed.html?bbox=${bbox}` +
+    `&layer=mapnik&marker=${fmt(latitude)}%2C${fmt(longitude)}`;
+  const viewUrl = `https://www.openstreetmap.org/?mlat=${fmt(latitude)}&mlon=${fmt(longitude)}#map=16/${fmt(latitude)}/${fmt(longitude)}`;
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+      <div className="flex items-start justify-between mb-4">
+        <h2 className="text-lg font-semibold text-gray-900">Location</h2>
+        <a
+          href={viewUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm text-blue-600 hover:text-blue-800"
+        >
+          Open in OpenStreetMap
+        </a>
+      </div>
+      <div className="overflow-hidden rounded-lg border border-gray-200">
+        <iframe
+          title={name ? `Map showing ${name}` : 'Building location map'}
+          src={embedUrl}
+          className="w-full h-72 border-0"
+          loading="lazy"
+          referrerPolicy="no-referrer"
+        />
+      </div>
+      <p className="mt-3 text-sm text-gray-500">
+        {fmt(latitude)}, {fmt(longitude)}
+      </p>
+    </div>
+  );
+}
+
+BuildingLocationMap.displayName = 'BuildingLocationMap';

--- a/frontend/apps/ppt-web/src/features/buildings/components/index.ts
+++ b/frontend/apps/ppt-web/src/features/buildings/components/index.ts
@@ -4,5 +4,6 @@
 
 export { BuildingCard } from './BuildingCard';
 export { BuildingList } from './BuildingList';
+export { BuildingLocationMap } from './BuildingLocationMap';
 export { OCCUPANCY_OPTIONS, UNIT_TYPE_OPTIONS, UnitForm, type UnitFormValues } from './UnitForm';
 export { UnitsSection } from './UnitsSection';

--- a/frontend/apps/ppt-web/src/features/buildings/pages/BuildingDetailPage.tsx
+++ b/frontend/apps/ppt-web/src/features/buildings/pages/BuildingDetailPage.tsx
@@ -9,7 +9,7 @@
 import type { BuildingStatus, BuildingType } from '@ppt/api-client';
 import { isSafeImageUrl } from '@ppt/shared';
 import { Link } from 'react-router-dom';
-import { UnitsSection } from '../components';
+import { BuildingLocationMap, UnitsSection } from '../components';
 import { useBuilding, useBuildingCommonAreas, useBuildingFloors } from '../hooks';
 
 interface BuildingDetailPageProps {
@@ -174,6 +174,9 @@ export function BuildingDetailPage({ buildingId }: BuildingDetailPageProps) {
           </div>
         </div>
       </div>
+
+      {/* Location Map (Story 3.1 AC3) — only shown when coordinates are resolved */}
+      <BuildingLocationMap location={building.location} name={building.name} />
 
       {/* Floors Section */}
       <div className="bg-white rounded-lg shadow-md p-6 mb-6">

--- a/frontend/packages/api-client/src/buildings/api.ts
+++ b/frontend/packages/api-client/src/buildings/api.ts
@@ -73,6 +73,52 @@ function buildQueryString(params: object): string {
 }
 
 /**
+ * Coerce an unknown coordinate value to a finite number, or null.
+ *
+ * Tolerates numeric strings because `rust_decimal::Decimal` serializes as a
+ * JSON string by default.
+ */
+function toCoordinate(value: unknown): number | null {
+  if (value == null || value === '') return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Normalize a raw building payload so `location` is populated whenever the
+ * backend has resolved coordinates.
+ *
+ * The buildings API serializes geocoded coordinates as top-level `latitude`/
+ * `longitude` fields (Story 3.1 AC3), while the client `Building` model exposes
+ * them as a nested `location: GeoLocation`. This bridges the two shapes so
+ * consumers can rely on `building.location` regardless of transport, and stays
+ * a no-op when coordinates are absent/unresolved.
+ */
+function normalizeBuilding<T extends Partial<Building>>(building: T): T {
+  if (!building || typeof building !== 'object' || building.location) return building;
+  const raw = building as Record<string, unknown>;
+  const latitude = toCoordinate(raw.latitude);
+  const longitude = toCoordinate(raw.longitude);
+  if (
+    latitude !== null &&
+    longitude !== null &&
+    Math.abs(latitude) <= 90 &&
+    Math.abs(longitude) <= 180
+  ) {
+    return { ...building, location: { latitude, longitude } };
+  }
+  return building;
+}
+
+/** Normalize every building in a paginated list response. */
+function normalizeBuildingList(
+  response: BuildingsPaginatedResponse<Building>
+): BuildingsPaginatedResponse<Building> {
+  if (!response || !Array.isArray(response.items)) return response;
+  return { ...response, items: response.items.map(normalizeBuilding) };
+}
+
+/**
  * List buildings with optional filters.
  */
 export async function listBuildings(
@@ -80,14 +126,18 @@ export async function listBuildings(
   signal?: AbortSignal
 ): Promise<BuildingsPaginatedResponse<Building>> {
   const qs = buildQueryString(params || {});
-  return apiRequest<BuildingsPaginatedResponse<Building>>(`${API_BASE}${qs}`, { signal });
+  const response = await apiRequest<BuildingsPaginatedResponse<Building>>(`${API_BASE}${qs}`, {
+    signal,
+  });
+  return normalizeBuildingList(response);
 }
 
 /**
  * Get building by ID.
  */
 export async function getBuilding(id: string, signal?: AbortSignal): Promise<Building> {
-  return apiRequest<Building>(`${API_BASE}/${id}`, { signal });
+  const building = await apiRequest<Building>(`${API_BASE}/${id}`, { signal });
+  return normalizeBuilding(building);
 }
 
 // ============================================
@@ -131,7 +181,9 @@ export const createBuildingsApi = (config: ApiConfig) => {
 
       const url = searchParams.toString() ? `${baseUrl}?${searchParams}` : baseUrl;
       const response = await fetch(url, { headers });
-      return handleResponse(response);
+      return normalizeBuildingList(
+        await handleResponse<BuildingsPaginatedResponse<Building>>(response)
+      );
     },
 
     /**
@@ -143,7 +195,7 @@ export const createBuildingsApi = (config: ApiConfig) => {
         headers,
         body: JSON.stringify(data),
       });
-      return handleResponse(response);
+      return normalizeBuilding(await handleResponse<Building>(response));
     },
 
     /**
@@ -151,7 +203,7 @@ export const createBuildingsApi = (config: ApiConfig) => {
      */
     get: async (id: string): Promise<Building> => {
       const response = await fetch(`${baseUrl}/${id}`, { headers });
-      return handleResponse(response);
+      return normalizeBuilding(await handleResponse<Building>(response));
     },
 
     /**
@@ -163,7 +215,7 @@ export const createBuildingsApi = (config: ApiConfig) => {
         headers,
         body: JSON.stringify(data),
       });
-      return handleResponse(response);
+      return normalizeBuilding(await handleResponse<Building>(response));
     },
 
     /**


### PR DESCRIPTION
## Summary

Frontend half of **Story 3.1 AC3** — _"the system geocodes the address and displays the building on a map."_ The backend geocoding/coordinates work (migration, model, geocode-on-write) lands separately in **BIT-200 / #1691**; this PR delivers the map UI that consumes the resulting coordinates.

Part of PM gap-sweep Epic 3 (#981, gap #4).

## Changes

- **api-client** (`packages/api-client/src/buildings/api.ts`): normalize the backend's flat top-level `latitude`/`longitude` into the client's nested `Building.location` (`GeoLocation`) across read/write paths (`getBuilding`, `listBuildings`, class `get`/`list`/`create`/`update`). Tolerates numeric strings (`rust_decimal` serializes `Decimal` as a string), rejects `null`/empty/out-of-range values, and is a no-op when coordinates are unresolved.
- **ppt-web**: new `BuildingLocationMap` component — keyless **OpenStreetMap** embed + "Open in OpenStreetMap" link + coordinate readout. Renders nothing when the building has no coordinates, so it degrades gracefully while geocoding is unconfigured/pending. Wired into `BuildingDetailPage` under the header card.
- **docs**: `docs/screens/ppt/buildings-detail.md` screen-map.

No new dependency and no API key required → works in CI and offline dev.

## Verification

- `tsc --noEmit` clean for `@ppt/api-client` and `@ppt/web`
- `biome check` clean on touched files
- screen-map validate `--strict`: 0 errors, 0 warnings

## Notes

- Backend coordinate shape is defined by **#1691** (flat `latitude`/`longitude`). This PR's normalizer also accepts a pre-nested `location`, so it is forward-compatible either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)