### PR TITLE
feat(ppt-web): person-month tracking wiring + routes (Story 3.5)

### DIFF
--- a/docs/screens/ppt/person-months.md
+++ b/docs/screens/ppt/person-months.md
@@ -1,0 +1,75 @@
+---
+id: ppt/person-months
+name: Person-months
+product: ppt
+implementations:
+  ppt-web:
+    route: "/buildings/:buildingId/person-months"
+    component: PersonMonthsPage
+    buildStatus: complete
+    redesignStatus: not-started
+    apiStatus: complete
+endpoints:
+  - "GET /api/v1/buildings/{building_id}/person-months"
+  - "POST /api/v1/buildings/{building_id}/person-months/bulk"
+  - "GET /api/v1/buildings/{building_id}/person-months/summary"
+  - "GET /api/v1/buildings/{building_id}/units/{unit_id}/person-months"
+  - "POST /api/v1/buildings/{building_id}/units/{unit_id}/person-months"
+  - "PUT /api/v1/buildings/{building_id}/units/{unit_id}/person-months/{id}"
+  - "DELETE /api/v1/buildings/{building_id}/units/{unit_id}/person-months/{id}"
+  - "GET /api/v1/buildings/{building_id}/units/{unit_id}/person-months/yearly"
+  - "POST /api/v1/buildings/{building_id}/units/{unit_id}/person-months/calculate"
+relatedScreens:
+  - ppt/building-detail
+sharedComponents: []
+diagrams: []
+useCases: []
+epics:
+  - "Epic 3 / Story 3.5"
+designSources: []
+owner: pm-frontend
+---
+
+# Person-months
+
+Person-month tracking (resident counts per unit/month, used for shared-utility
+billing). Wired into ppt-web `AppRoutes.tsx` by BIT-190 (Epic 3, Story 3.5). The
+`features/person-months/` pages were already built but unrouted and had no
+api-client; this work authored the `@ppt/api-client` person-months module
+(unit + building endpoints incl. `calculate`) and the route group that wires the
+pages to it.
+
+## Routes
+
+- `/buildings/:buildingId/person-months` — `PersonMonthsPage`: building-level
+  summary, one card per unit for the selected year/month.
+- `/buildings/:buildingId/person-months/bulk` — `BulkEntryPage`: enter counts for
+  every unit in one period, submitted via the `/person-months/bulk` endpoint.
+- `/buildings/:buildingId/units/:unitId/person-months` — `UnitPersonMonthsPage`:
+  per-unit history + yearly summary chart, with per-entry delete.
+- `/buildings/:buildingId/units/:unitId/person-months/edit/:year/:month` —
+  `EditPersonMonthPage`: add/edit a single entry (upsert). When no entry exists
+  for the period, the count is pre-populated from the unit's resident history via
+  the `calculate` endpoint (Story 3.5 auto-suggest).
+
+Reachable from the building detail page via a "Person-months" quick link.
+
+## States
+
+- **Loading**: spinners while building/units/entries queries are in flight.
+- **Empty**: units with no entry render a card with count 0; unit history shows
+  an empty-state when a year has no entries.
+- **Error**: mutations surface failures via toast; the bulk results panel lists
+  per-unit failures returned by the backend.
+
+## Notes
+
+### Specific (recent)
+- 2026-06-22 — BIT-190: authored `@ppt/api-client/person-months` (api + hooks +
+  types), added the `person-months` route group, mounted it in `AppRoutes.tsx`,
+  and added a building-detail entry point. Building-level views also list units
+  via `/api/v1/units?buildingId=` because the person-months endpoints only return
+  units that already have an entry.
+
+## Agent Log
+- 2026-06-22 — FrontendEngineer: created on route+api-client wiring (BIT-190).

--- a/frontend/apps/ppt-web/src/features/buildings/pages/BuildingDetailPage.tsx
+++ b/frontend/apps/ppt-web/src/features/buildings/pages/BuildingDetailPage.tsx
@@ -143,6 +143,16 @@ export function BuildingDetailPage({ buildingId }: BuildingDetailPageProps) {
 
           {building.description && <p className="mt-4 text-gray-600">{building.description}</p>}
 
+          {/* Quick links to building-scoped features */}
+          <div className="mt-4 flex flex-wrap gap-3">
+            <Link
+              to={`/buildings/${buildingId}/person-months`}
+              className="inline-flex items-center px-4 py-2 text-sm font-medium text-blue-700 bg-blue-50 rounded-md hover:bg-blue-100"
+            >
+              Person-months
+            </Link>
+          </div>
+
           {/* Stats */}
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-6">
             <div className="bg-gray-50 rounded-lg p-4">

--- a/frontend/apps/ppt-web/src/routes/AppRoutes.tsx
+++ b/frontend/apps/ppt-web/src/routes/AppRoutes.tsx
@@ -29,6 +29,7 @@ import { messagingRoutes } from './groups/messaging';
 import { meterRoutes } from './groups/meters';
 import { neighborRoutes } from './groups/neighbors';
 import { outageRoutes } from './groups/outages';
+import { personMonthRoutes } from './groups/person-months';
 import { rentalRoutes } from './groups/rentals';
 import { reportRoutes } from './groups/reports';
 import { votingRoutes } from './groups/voting';
@@ -53,6 +54,7 @@ export function AppRoutes() {
       {accountingRoutes()}
       {rentalRoutes()}
       {meterRoutes()}
+      {personMonthRoutes()}
       {leaseRoutes()}
       {votingRoutes()}
       {aiDashboardRoutes()}

--- a/frontend/apps/ppt-web/src/routes/groups/person-months.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/person-months.tsx
@@ -1,0 +1,425 @@
+/**
+ * Person-months route group (Epic 3, Story 3.5 — person-month tracking).
+ *
+ * Mounts the already-built `features/person-months/` pages into ppt-web, wired
+ * to the `@ppt/api-client` person-months module (BIT-190). This group owns the
+ * API↔UI mappers (backend wire shapes are snake_case) and the thin route-wrapper
+ * components.
+ *
+ * Person-months hang off a building (and, for the unit views, a unit), so every
+ * route is nested under `/buildings/:buildingId`. The building- and unit-level
+ * endpoints only return units that already have an entry, so the building-level
+ * wrappers also list the building's units (`/api/v1/units?buildingId=`) and
+ * left-join the counts onto them — units with no data show a count of 0.
+ */
+import type {
+  PersonMonth as ApiPersonMonth,
+  BulkPersonMonthUpsertResult,
+  PersonMonthWithUnit,
+  YearlyPersonMonthSummary,
+} from '@ppt/api-client';
+import {
+  calculateFromResidents,
+  personMonthKeys,
+  useBuilding,
+  useBuildingPersonMonths,
+  useBulkUpsertPersonMonths,
+  useDeletePersonMonth,
+  useUnitPersonMonths,
+  useUnitYearlySummary,
+  useUpsertPersonMonth,
+} from '@ppt/api-client';
+import { useQuery } from '@tanstack/react-query';
+import { lazy, useState } from 'react';
+import { Route, useNavigate, useParams } from 'react-router-dom';
+import { ProtectedRoute, useToast } from '../../components';
+import type { PersonMonth as UiPersonMonth } from '../../features/person-months/components/PersonMonthCard';
+import type { YearlySummary as UiYearlySummary } from '../../features/person-months/components/YearlySummaryChart';
+import type {
+  BuildingPersonMonthSummary,
+  UnitPersonMonthSummary,
+} from '../../features/person-months/pages/PersonMonthsPage';
+import type {
+  BulkEntryFormData,
+  BulkEntrySummary,
+  BulkEntryUnit,
+} from '../../features/person-months/types';
+
+// Person-months feature pages (Epic 3) — lazy-loaded for code splitting.
+const PersonMonthsPage = lazy(() =>
+  import('../../features/person-months').then((m) => ({ default: m.PersonMonthsPage }))
+);
+const BulkEntryPage = lazy(() =>
+  import('../../features/person-months').then((m) => ({ default: m.BulkEntryPage }))
+);
+const UnitPersonMonthsPage = lazy(() =>
+  import('../../features/person-months').then((m) => ({ default: m.UnitPersonMonthsPage }))
+);
+const EditPersonMonthPage = lazy(() =>
+  import('../../features/person-months').then((m) => ({ default: m.EditPersonMonthPage }))
+);
+
+const currentYear = new Date().getFullYear();
+const currentMonth = new Date().getMonth() + 1;
+
+// ============================================================================
+// Building units (no person-months endpoint lists all units, so fetch them)
+// ============================================================================
+
+interface BuildingUnit {
+  id: string;
+  designation: string;
+}
+
+/** Fetch every unit for a building, mapped to `{ id, designation }`. */
+function useBuildingUnits(buildingId: string | undefined) {
+  const { data, isLoading } = useQuery({
+    queryKey: ['person-months', 'building-units', buildingId ?? ''],
+    enabled: !!buildingId,
+    queryFn: async (): Promise<BuildingUnit[]> => {
+      const res = await fetch(`/api/v1/units?buildingId=${buildingId}&limit=500`, {
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const body = (await res.json()) as { data: Array<{ id: string; unitNumber: string }> };
+      return (body.data ?? []).map((u) => ({ id: u.id, designation: u.unitNumber }));
+    },
+  });
+  return { units: data ?? [], isLoading };
+}
+
+// ============================================================================
+// API → UI mappers
+// ============================================================================
+
+/** Map a wire person-month entry → the UI `PersonMonth` card shape. */
+function mapApiPersonMonthToUi(pm: ApiPersonMonth, unitDesignation: string): UiPersonMonth {
+  return {
+    id: pm.id,
+    unitId: pm.unit_id,
+    unitDesignation,
+    year: pm.year,
+    month: pm.month,
+    personCount: pm.count,
+    updatedAt: pm.updated_at,
+  };
+}
+
+/** Map a wire yearly summary → the UI `YearlySummary` chart shape. */
+function mapYearlySummaryToUi(summary: YearlyPersonMonthSummary): UiYearlySummary {
+  const monthsWithData = summary.months.filter((m) => m.count > 0);
+  return {
+    year: summary.year,
+    totalPersonMonths: summary.total,
+    averagePersons: monthsWithData.length > 0 ? summary.total / monthsWithData.length : 0,
+    monthlyData: summary.months.map((m) => ({ month: m.month, personCount: m.count })),
+  };
+}
+
+/** Build the building-level summary the `PersonMonthsPage` expects. */
+function buildBuildingSummary(
+  buildingId: string,
+  buildingName: string,
+  year: number,
+  month: number,
+  units: BuildingUnit[],
+  entries: PersonMonthWithUnit[]
+): BuildingPersonMonthSummary {
+  const countByUnit = new Map(entries.map((e) => [e.unit_id, e.count]));
+  const unitSummaries: UnitPersonMonthSummary[] = units.map((u) => ({
+    unitId: u.id,
+    unitDesignation: u.designation,
+    personCount: countByUnit.get(u.id) ?? 0,
+  }));
+  const totalPersons = unitSummaries.reduce((sum, u) => sum + u.personCount, 0);
+  return { buildingId, buildingName, year, month, totalPersons, units: unitSummaries };
+}
+
+// ============================================================================
+// Route wrappers
+// ============================================================================
+
+/** Building-level person-months summary (`/buildings/:buildingId/person-months`). */
+function PersonMonthsPageRoute() {
+  const navigate = useNavigate();
+  const { buildingId = '' } = useParams<{ buildingId: string }>();
+  const [year, setYear] = useState(currentYear);
+  const [month, setMonth] = useState(currentMonth);
+
+  const buildingQuery = useBuilding(buildingId);
+  const { units, isLoading: unitsLoading } = useBuildingUnits(buildingId);
+  const entriesQuery = useBuildingPersonMonths(buildingId, { year, month });
+
+  const buildingName = buildingQuery.data?.name ?? '';
+  const summary = buildBuildingSummary(
+    buildingId,
+    buildingName,
+    year,
+    month,
+    units,
+    entriesQuery.data ?? []
+  );
+
+  return (
+    <PersonMonthsPage
+      buildingName={buildingName}
+      summary={summary}
+      isLoading={unitsLoading || entriesQuery.isLoading}
+      onYearChange={setYear}
+      onMonthChange={setMonth}
+      onNavigateToUnit={(unitId) =>
+        navigate(`/buildings/${buildingId}/units/${unitId}/person-months`)
+      }
+      onNavigateToEdit={(unitId, y, m) =>
+        navigate(`/buildings/${buildingId}/units/${unitId}/person-months/edit/${y}/${m}`)
+      }
+      onNavigateToBulkEntry={() => navigate(`/buildings/${buildingId}/person-months/bulk`)}
+      onBack={() => navigate(`/buildings/${buildingId}`)}
+    />
+  );
+}
+
+/** Bulk entry for every unit (`/buildings/:buildingId/person-months/bulk`). */
+function BulkEntryPageRoute() {
+  const navigate = useNavigate();
+  const { showToast } = useToast();
+  const { buildingId = '' } = useParams<{ buildingId: string }>();
+
+  const buildingQuery = useBuilding(buildingId);
+  const { units } = useBuildingUnits(buildingId);
+  const entriesQuery = useBuildingPersonMonths(buildingId, {
+    year: currentYear,
+    month: currentMonth,
+  });
+  const bulkUpsert = useBulkUpsertPersonMonths(buildingId);
+  const [results, setResults] = useState<BulkEntrySummary | undefined>();
+
+  const countByUnit = new Map((entriesQuery.data ?? []).map((e) => [e.unit_id, e.count]));
+  const bulkUnits: BulkEntryUnit[] = units.map((u) => ({
+    unitId: u.id,
+    unitDesignation: u.designation,
+    personCount: countByUnit.get(u.id) ?? 0,
+    currentPersonCount: countByUnit.get(u.id),
+  }));
+
+  const mapResult = (
+    res: BulkPersonMonthUpsertResult,
+    submitted: BulkEntryFormData
+  ): BulkEntrySummary => {
+    const designationByUnit = new Map(units.map((u) => [u.id, u.designation]));
+    return {
+      total: submitted.entries.length,
+      successful: res.successful,
+      failed: res.failed,
+      results: res.results.map((r) => ({
+        unitId: r.unit_id,
+        unitDesignation: designationByUnit.get(r.unit_id) ?? r.unit_id,
+        success: r.success,
+        error: r.error ?? undefined,
+      })),
+    };
+  };
+
+  return (
+    <BulkEntryPage
+      buildingName={buildingQuery.data?.name ?? ''}
+      units={bulkUnits}
+      initialYear={currentYear}
+      initialMonth={currentMonth}
+      isSubmitting={bulkUpsert.isPending}
+      submitResults={results}
+      onDismissResults={() => setResults(undefined)}
+      onBack={() => navigate(`/buildings/${buildingId}/person-months`)}
+      onSubmit={async (data: BulkEntryFormData) => {
+        try {
+          const res = await bulkUpsert.mutateAsync({
+            year: data.year,
+            month: data.month,
+            entries: data.entries.map((e) => ({ unit_id: e.unitId, count: e.personCount })),
+          });
+          setResults(mapResult(res, data));
+          showToast({
+            type: res.failed > 0 ? 'warning' : 'success',
+            title: 'Saved',
+            message: `${res.successful} unit(s) updated`,
+          });
+        } catch (err) {
+          showToast({
+            type: 'error',
+            title: 'Bulk entry failed',
+            message: err instanceof Error ? err.message : 'Could not save person-months',
+          });
+        }
+      }}
+    />
+  );
+}
+
+/** Unit history + yearly summary (`/buildings/:buildingId/units/:unitId/person-months`). */
+function UnitPersonMonthsPageRoute() {
+  const navigate = useNavigate();
+  const { showToast } = useToast();
+  const { buildingId = '', unitId = '' } = useParams<{ buildingId: string; unitId: string }>();
+  const [year, setYear] = useState(currentYear);
+
+  const buildingQuery = useBuilding(buildingId);
+  const { units } = useBuildingUnits(buildingId);
+  const entriesQuery = useUnitPersonMonths(buildingId, unitId, { year });
+  const summaryQuery = useUnitYearlySummary(buildingId, unitId, year);
+  const deleteEntry = useDeletePersonMonth(buildingId, unitId);
+
+  const unitDesignation = units.find((u) => u.id === unitId)?.designation ?? '';
+  const personMonths = (entriesQuery.data ?? []).map((pm) =>
+    mapApiPersonMonthToUi(pm, unitDesignation)
+  );
+  const yearlySummary: UiYearlySummary = summaryQuery.data
+    ? mapYearlySummaryToUi(summaryQuery.data)
+    : { year, totalPersonMonths: 0, averagePersons: 0, monthlyData: [] };
+
+  return (
+    <UnitPersonMonthsPage
+      buildingName={buildingQuery.data?.name ?? ''}
+      unitDesignation={unitDesignation}
+      personMonths={personMonths}
+      yearlySummary={yearlySummary}
+      isLoading={entriesQuery.isLoading || summaryQuery.isLoading}
+      isDeleting={deleteEntry.isPending}
+      selectedYear={year}
+      onYearChange={setYear}
+      onNavigateToEdit={(y, m) =>
+        navigate(`/buildings/${buildingId}/units/${unitId}/person-months/edit/${y}/${m}`)
+      }
+      onDelete={async (pm) => {
+        try {
+          await deleteEntry.mutateAsync(pm.id);
+          showToast({ type: 'success', title: 'Deleted', message: 'Entry removed' });
+        } catch (err) {
+          showToast({
+            type: 'error',
+            title: 'Delete failed',
+            message: err instanceof Error ? err.message : 'Could not delete entry',
+          });
+        }
+      }}
+      onBack={() => navigate(`/buildings/${buildingId}/person-months`)}
+    />
+  );
+}
+
+/**
+ * Add / edit a single entry
+ * (`/buildings/:buildingId/units/:unitId/person-months/edit/:year/:month`).
+ *
+ * When no entry exists for the period yet, the count is pre-populated from the
+ * unit's resident history via the `calculate` endpoint (Story 3.5 auto-suggest).
+ */
+function EditPersonMonthPageRoute() {
+  const navigate = useNavigate();
+  const { showToast } = useToast();
+  const {
+    buildingId = '',
+    unitId = '',
+    year: yearParam,
+    month: monthParam,
+  } = useParams<{ buildingId: string; unitId: string; year: string; month: string }>();
+  const year = Number.parseInt(yearParam ?? '', 10) || currentYear;
+  const month = Number.parseInt(monthParam ?? '', 10) || currentMonth;
+
+  const buildingQuery = useBuilding(buildingId);
+  const { units } = useBuildingUnits(buildingId);
+  const existingQuery = useUnitPersonMonths(buildingId, unitId, { year, month });
+  const upsert = useUpsertPersonMonth(buildingId, unitId);
+
+  const existing = existingQuery.data?.[0];
+  // Auto-suggest a count from residents only when there is no entry yet.
+  const suggestionQuery = useQuery({
+    queryKey: [...personMonthKeys.unit(buildingId, unitId), 'calculate', year, month],
+    enabled: !!buildingId && !!unitId && existingQuery.isSuccess && !existing,
+    queryFn: () => calculateFromResidents(buildingId, unitId, { year, month }),
+  });
+
+  const unitDesignation = units.find((u) => u.id === unitId)?.designation ?? '';
+  const isLoading =
+    existingQuery.isLoading || (existingQuery.isSuccess && !existing && suggestionQuery.isLoading);
+
+  const personCount = existing?.count ?? suggestionQuery.data;
+  const backToUnit = () => navigate(`/buildings/${buildingId}/units/${unitId}/person-months`);
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto max-w-md py-16 text-center">
+        <span className="animate-spin inline-block rounded-full h-8 w-8 border-b-2 border-blue-600" />
+      </div>
+    );
+  }
+
+  return (
+    <EditPersonMonthPage
+      buildingName={buildingQuery.data?.name ?? ''}
+      unitDesignation={unitDesignation}
+      initialData={{ year, month, personCount }}
+      isSubmitting={upsert.isPending}
+      onCancel={backToUnit}
+      onSubmit={async (data) => {
+        try {
+          await upsert.mutateAsync({
+            year: data.year,
+            month: data.month,
+            count: data.personCount,
+            source: 'manual',
+          });
+          showToast({ type: 'success', title: 'Saved', message: 'Person-month saved' });
+          backToUnit();
+        } catch (err) {
+          showToast({
+            type: 'error',
+            title: 'Save failed',
+            message: err instanceof Error ? err.message : 'Could not save person-month',
+          });
+        }
+      }}
+    />
+  );
+}
+
+/** Person-months routes (Epic 3, Story 3.5). */
+export function personMonthRoutes() {
+  return (
+    <>
+      <Route
+        path="/buildings/:buildingId/person-months"
+        element={
+          <ProtectedRoute>
+            <PersonMonthsPageRoute />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/buildings/:buildingId/person-months/bulk"
+        element={
+          <ProtectedRoute>
+            <BulkEntryPageRoute />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/buildings/:buildingId/units/:unitId/person-months"
+        element={
+          <ProtectedRoute>
+            <UnitPersonMonthsPageRoute />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/buildings/:buildingId/units/:unitId/person-months/edit/:year/:month"
+        element={
+          <ProtectedRoute>
+            <EditPersonMonthPageRoute />
+          </ProtectedRoute>
+        }
+      />
+    </>
+  );
+}

--- a/frontend/packages/api-client/src/index.ts
+++ b/frontend/packages/api-client/src/index.ts
@@ -46,6 +46,7 @@ export * from './oauth-grants';
 export * from './onboarding';
 export * from './outages';
 export * from './packages';
+export * from './person-months';
 export * from './registry';
 export * from './reports';
 export * from './voting';

--- a/frontend/packages/api-client/src/person-months/api.ts
+++ b/frontend/packages/api-client/src/person-months/api.ts
@@ -1,0 +1,195 @@
+/**
+ * Person-months API client functions (Epic 3, Story 3.5).
+ *
+ * Thin typed `fetch` wrappers over the building-nested person-months endpoints
+ * (`/api/v1/buildings/{building_id}/...`). Mirrors the structure of the meters
+ * module (its own `fetchApi`/`buildQueryString` helpers) so the two stay
+ * consistent.
+ */
+
+import type {
+  BuildingPersonMonthsQuery,
+  BulkPersonMonthUpsertResult,
+  BulkUpsertPersonMonthsRequest,
+  CalculatePersonMonthRequest,
+  GetUnitPersonMonthsQuery,
+  PersonMonth,
+  PersonMonthBuildingSummary,
+  PersonMonthWithUnit,
+  UpdatePersonMonthRequest,
+  UpsertPersonMonthRequest,
+  YearlyPersonMonthSummary,
+} from './types';
+
+const API_BASE = '/api/v1/buildings';
+
+/** Build a query string from params, skipping empty values. */
+function buildQueryString(
+  params: Record<string, string | number | boolean | undefined | null>
+): string {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null && value !== '') {
+      searchParams.append(key, String(value));
+    }
+  }
+  const query = searchParams.toString();
+  return query ? `?${query}` : '';
+}
+
+/** Generic fetch wrapper with error handling. */
+async function fetchApi<T>(url: string, options?: RequestInit): Promise<T> {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...options?.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ message: 'Request failed' }));
+    throw new Error(error.message || `HTTP ${response.status}`);
+  }
+
+  return response.json();
+}
+
+/** Fetch wrapper for endpoints that return no body (e.g. delete → 200 OK). */
+async function fetchVoid(url: string, options?: RequestInit): Promise<void> {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...options?.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ message: 'Request failed' }));
+    throw new Error(error.message || `HTTP ${response.status}`);
+  }
+}
+
+function unitBase(buildingId: string, unitId: string): string {
+  return `${API_BASE}/${buildingId}/units/${unitId}/person-months`;
+}
+
+function buildingBase(buildingId: string): string {
+  return `${API_BASE}/${buildingId}/person-months`;
+}
+
+// ============================================================================
+// Unit-level
+// ============================================================================
+
+/** Get person-months for a unit (a whole year, or a single month). */
+export async function getUnitPersonMonths(
+  buildingId: string,
+  unitId: string,
+  query: GetUnitPersonMonthsQuery
+): Promise<PersonMonth[]> {
+  const qs = buildQueryString({ year: query.year, month: query.month });
+  return fetchApi<PersonMonth[]>(`${unitBase(buildingId, unitId)}${qs}`);
+}
+
+/** Get a single person-month entry by id. */
+export async function getPersonMonth(
+  buildingId: string,
+  unitId: string,
+  id: string
+): Promise<PersonMonth> {
+  return fetchApi<PersonMonth>(`${unitBase(buildingId, unitId)}/${id}`);
+}
+
+/** Create or update a unit's person-month entry for a period. */
+export async function upsertPersonMonth(
+  buildingId: string,
+  unitId: string,
+  body: UpsertPersonMonthRequest
+): Promise<PersonMonth> {
+  return fetchApi<PersonMonth>(unitBase(buildingId, unitId), {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+/** Update an existing person-month entry. */
+export async function updatePersonMonth(
+  buildingId: string,
+  unitId: string,
+  id: string,
+  body: UpdatePersonMonthRequest
+): Promise<PersonMonth> {
+  return fetchApi<PersonMonth>(`${unitBase(buildingId, unitId)}/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(body),
+  });
+}
+
+/** Delete a person-month entry. */
+export async function deletePersonMonth(
+  buildingId: string,
+  unitId: string,
+  id: string
+): Promise<void> {
+  return fetchVoid(`${unitBase(buildingId, unitId)}/${id}`, { method: 'DELETE' });
+}
+
+/** Get the yearly summary (per-month counts + total) for a unit. */
+export async function getYearlySummary(
+  buildingId: string,
+  unitId: string,
+  year: number
+): Promise<YearlyPersonMonthSummary> {
+  const qs = buildQueryString({ year });
+  return fetchApi<YearlyPersonMonthSummary>(`${unitBase(buildingId, unitId)}/yearly${qs}`);
+}
+
+/**
+ * Calculate a suggested person-month count from the unit's resident history for
+ * the period (used to pre-populate the entry form). Returns the count.
+ */
+export async function calculateFromResidents(
+  buildingId: string,
+  unitId: string,
+  body: CalculatePersonMonthRequest
+): Promise<number> {
+  return fetchApi<number>(`${unitBase(buildingId, unitId)}/calculate`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+// ============================================================================
+// Building-level
+// ============================================================================
+
+/** List per-unit person-months for a building for a given period. */
+export async function listBuildingPersonMonths(
+  buildingId: string,
+  query: BuildingPersonMonthsQuery
+): Promise<PersonMonthWithUnit[]> {
+  const qs = buildQueryString({ year: query.year, month: query.month });
+  return fetchApi<PersonMonthWithUnit[]>(`${buildingBase(buildingId)}${qs}`);
+}
+
+/** Bulk create-or-update person-months for many units in one period. */
+export async function bulkUpsertPersonMonths(
+  buildingId: string,
+  body: BulkUpsertPersonMonthsRequest
+): Promise<BulkPersonMonthUpsertResult> {
+  return fetchApi<BulkPersonMonthUpsertResult>(`${buildingBase(buildingId)}/bulk`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+/** Building-level aggregate summary for a period (total persons + unit count). */
+export async function getBuildingSummary(
+  buildingId: string,
+  query: BuildingPersonMonthsQuery
+): Promise<PersonMonthBuildingSummary> {
+  const qs = buildQueryString({ year: query.year, month: query.month });
+  return fetchApi<PersonMonthBuildingSummary>(`${buildingBase(buildingId)}/summary${qs}`);
+}

--- a/frontend/packages/api-client/src/person-months/hooks.ts
+++ b/frontend/packages/api-client/src/person-months/hooks.ts
@@ -1,0 +1,163 @@
+/**
+ * TanStack Query hooks for the person-months API (Epic 3, Story 3.5).
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import * as api from './api';
+import type {
+  BuildingPersonMonthsQuery,
+  BulkUpsertPersonMonthsRequest,
+  CalculatePersonMonthRequest,
+  GetUnitPersonMonthsQuery,
+  UpdatePersonMonthRequest,
+  UpsertPersonMonthRequest,
+} from './types';
+
+// ============================================================================
+// Query keys
+// ============================================================================
+
+export const personMonthKeys = {
+  all: ['person-months'] as const,
+  unit: (buildingId: string, unitId: string) =>
+    [...personMonthKeys.all, 'unit', buildingId, unitId] as const,
+  unitList: (buildingId: string, unitId: string, query: GetUnitPersonMonthsQuery) =>
+    [...personMonthKeys.unit(buildingId, unitId), 'list', query] as const,
+  unitYearly: (buildingId: string, unitId: string, year: number) =>
+    [...personMonthKeys.unit(buildingId, unitId), 'yearly', year] as const,
+  entry: (buildingId: string, unitId: string, id: string) =>
+    [...personMonthKeys.unit(buildingId, unitId), 'entry', id] as const,
+  building: (buildingId: string) => [...personMonthKeys.all, 'building', buildingId] as const,
+  buildingList: (buildingId: string, query: BuildingPersonMonthsQuery) =>
+    [...personMonthKeys.building(buildingId), 'list', query] as const,
+  buildingSummary: (buildingId: string, query: BuildingPersonMonthsQuery) =>
+    [...personMonthKeys.building(buildingId), 'summary', query] as const,
+};
+
+// ============================================================================
+// Queries
+// ============================================================================
+
+/** Person-months for a unit (whole year or a single month). */
+export function useUnitPersonMonths(
+  buildingId: string | undefined,
+  unitId: string | undefined,
+  query: GetUnitPersonMonthsQuery
+) {
+  return useQuery({
+    queryKey: personMonthKeys.unitList(buildingId ?? '', unitId ?? '', query),
+    queryFn: () => api.getUnitPersonMonths(buildingId as string, unitId as string, query),
+    enabled: !!buildingId && !!unitId,
+  });
+}
+
+/** Yearly summary (per-month counts + total) for a unit. */
+export function useUnitYearlySummary(
+  buildingId: string | undefined,
+  unitId: string | undefined,
+  year: number
+) {
+  return useQuery({
+    queryKey: personMonthKeys.unitYearly(buildingId ?? '', unitId ?? '', year),
+    queryFn: () => api.getYearlySummary(buildingId as string, unitId as string, year),
+    enabled: !!buildingId && !!unitId,
+  });
+}
+
+/** A single person-month entry by id. */
+export function usePersonMonth(
+  buildingId: string | undefined,
+  unitId: string | undefined,
+  id: string | undefined
+) {
+  return useQuery({
+    queryKey: personMonthKeys.entry(buildingId ?? '', unitId ?? '', id ?? ''),
+    queryFn: () => api.getPersonMonth(buildingId as string, unitId as string, id as string),
+    enabled: !!buildingId && !!unitId && !!id,
+  });
+}
+
+/** Per-unit person-months for a building for a given period. */
+export function useBuildingPersonMonths(
+  buildingId: string | undefined,
+  query: BuildingPersonMonthsQuery
+) {
+  return useQuery({
+    queryKey: personMonthKeys.buildingList(buildingId ?? '', query),
+    queryFn: () => api.listBuildingPersonMonths(buildingId as string, query),
+    enabled: !!buildingId,
+  });
+}
+
+/** Building-level aggregate summary for a period. */
+export function useBuildingPersonMonthSummary(
+  buildingId: string | undefined,
+  query: BuildingPersonMonthsQuery
+) {
+  return useQuery({
+    queryKey: personMonthKeys.buildingSummary(buildingId ?? '', query),
+    queryFn: () => api.getBuildingSummary(buildingId as string, query),
+    enabled: !!buildingId,
+  });
+}
+
+// ============================================================================
+// Mutations
+// ============================================================================
+
+/** Upsert a unit's person-month; invalidates that unit's and building caches. */
+export function useUpsertPersonMonth(buildingId: string, unitId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: UpsertPersonMonthRequest) => api.upsertPersonMonth(buildingId, unitId, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: personMonthKeys.unit(buildingId, unitId) });
+      queryClient.invalidateQueries({ queryKey: personMonthKeys.building(buildingId) });
+    },
+  });
+}
+
+/** Update an existing person-month entry. */
+export function useUpdatePersonMonth(buildingId: string, unitId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, body }: { id: string; body: UpdatePersonMonthRequest }) =>
+      api.updatePersonMonth(buildingId, unitId, id, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: personMonthKeys.unit(buildingId, unitId) });
+      queryClient.invalidateQueries({ queryKey: personMonthKeys.building(buildingId) });
+    },
+  });
+}
+
+/** Delete a person-month entry. */
+export function useDeletePersonMonth(buildingId: string, unitId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.deletePersonMonth(buildingId, unitId, id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: personMonthKeys.unit(buildingId, unitId) });
+      queryClient.invalidateQueries({ queryKey: personMonthKeys.building(buildingId) });
+    },
+  });
+}
+
+/** Bulk upsert person-months for a building; invalidates the building caches. */
+export function useBulkUpsertPersonMonths(buildingId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: BulkUpsertPersonMonthsRequest) =>
+      api.bulkUpsertPersonMonths(buildingId, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: personMonthKeys.all });
+    },
+  });
+}
+
+/** Calculate a suggested count from residents (for pre-populating the form). */
+export function useCalculateFromResidents(buildingId: string, unitId: string) {
+  return useMutation({
+    mutationFn: (body: CalculatePersonMonthRequest) =>
+      api.calculateFromResidents(buildingId, unitId, body),
+  });
+}

--- a/frontend/packages/api-client/src/person-months/index.ts
+++ b/frontend/packages/api-client/src/person-months/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Person-months API Client (Epic 3, Story 3.5 — person-month tracking).
+ *
+ * API client, hooks and types for unit- and building-level person-months,
+ * yearly summaries, bulk entry and resident-based calculation.
+ */
+
+export * from './api';
+export * from './hooks';
+export * from './types';

--- a/frontend/packages/api-client/src/person-months/types.ts
+++ b/frontend/packages/api-client/src/person-months/types.ts
@@ -1,0 +1,129 @@
+/**
+ * Person-months API types (Epic 3, Story 3.5).
+ *
+ * Wire shapes for `/api/v1/buildings/{building_id}/.../person-months`. These
+ * mirror the backend `routes/person_months.rs` response/request structs and are
+ * therefore snake_case. Domain-prefixed names (`PersonMonthMonthlyCount`,
+ * `PersonMonthBuildingSummary`, …) avoid collisions with the `reports` and
+ * `buildings` modules that already export `MonthlyCount` / `BuildingSummary`.
+ */
+
+/** Source of a person-month entry. */
+export type PersonMonthSource = 'manual' | 'calculated' | 'imported';
+
+/** A single person-month entry for a unit (unit-level response). */
+export interface PersonMonth {
+  id: string;
+  unit_id: string;
+  year: number;
+  month: number;
+  count: number;
+  source: string;
+  source_display: string;
+  period: string;
+  notes?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Person-month entry enriched with its unit designation (building-level list). */
+export interface PersonMonthWithUnit {
+  id: string;
+  unit_id: string;
+  unit_designation: string;
+  year: number;
+  month: number;
+  count: number;
+  source: string;
+}
+
+/** Count for one month within a yearly summary. */
+export interface PersonMonthMonthlyCount {
+  month: number;
+  count: number;
+  source: string;
+}
+
+/** Yearly summary of person-months for a single unit. */
+export interface YearlyPersonMonthSummary {
+  unit_id: string;
+  year: number;
+  months: PersonMonthMonthlyCount[];
+  total: number;
+}
+
+/** Building-level aggregate summary for a month. */
+export interface PersonMonthBuildingSummary {
+  building_id: string;
+  year: number;
+  month: number;
+  total_count: number;
+  unit_count: number;
+}
+
+/** Result for a single entry in a bulk upsert. */
+export interface BulkPersonMonthUpsertEntryResult {
+  unit_id: string;
+  success: boolean;
+  person_month_id?: string | null;
+  error?: string | null;
+}
+
+/** Outcome of a bulk upsert. */
+export interface BulkPersonMonthUpsertResult {
+  successful: number;
+  failed: number;
+  results: BulkPersonMonthUpsertEntryResult[];
+}
+
+// ============================================================================
+// Requests / queries
+// ============================================================================
+
+/** Query for unit person-months: a year, optionally narrowed to one month. */
+export interface GetUnitPersonMonthsQuery {
+  year: number;
+  month?: number;
+}
+
+/** Create-or-update a unit's person-month entry. */
+export interface UpsertPersonMonthRequest {
+  year: number;
+  month: number;
+  count: number;
+  /** Defaults to `manual` server-side when omitted. */
+  source?: PersonMonthSource;
+  notes?: string | null;
+}
+
+/** Partial update of an existing person-month entry. */
+export interface UpdatePersonMonthRequest {
+  count?: number;
+  source?: PersonMonthSource;
+  notes?: string | null;
+}
+
+/** A single unit's count within a bulk upsert request. */
+export interface BulkPersonMonthEntry {
+  unit_id: string;
+  count: number;
+}
+
+/** Bulk upsert of person-months for every unit in a building for one period. */
+export interface BulkUpsertPersonMonthsRequest {
+  year: number;
+  month: number;
+  entries: BulkPersonMonthEntry[];
+}
+
+/** Query for building-level person-month operations (a specific period). */
+export interface BuildingPersonMonthsQuery {
+  year: number;
+  month: number;
+}
+
+/** Request to derive a person-month count from a unit's resident history. */
+export interface CalculatePersonMonthRequest {
+  year: number;
+  month?: number;
+}


### PR DESCRIPTION
## What

Wires the built-but-unreachable **person-months** feature (Epic 3, Story 3.5) into ppt-web and gives it an api-client. Addresses #981 (gap 3 — person-month tracking). Paperclip: BIT-190.

Before this, `features/person-months/` had full pages but no `@ppt/api-client` module and no route — Story 3.5 entry/history/bulk/auto-suggest were unreachable.

## Changes

**api-client (`packages/api-client/src/person-months/`)** — new module mirroring the meters module:
- `api.ts` — typed `fetch` wrappers for all unit- and building-level endpoints under `/api/v1/buildings/{id}/.../person-months`, including `calculate`-from-residents.
- `hooks.ts` — TanStack Query hooks + query keys (queries + upsert/update/delete/bulk/calculate mutations).
- `types.ts` — wire shapes (snake_case). Domain-prefixed names avoid the existing `MonthlyCount` / `BuildingSummary` exports in the reports/buildings modules.
- Registered in the api-client barrel.

**ppt-web (`routes/groups/person-months.tsx`)** — new route group: API↔UI mappers + thin route wrappers mounting the existing pages, mounted in `AppRoutes.tsx`. Reachable from the building detail page via a quick link.

Routes:
- `/buildings/:buildingId/person-months` — building summary (one card per unit)
- `/buildings/:buildingId/person-months/bulk` — bulk entry
- `/buildings/:buildingId/units/:unitId/person-months` — unit history + yearly chart
- `/buildings/:buildingId/units/:unitId/person-months/edit/:year/:month` — add/edit (upsert); new entries pre-populate the count from residents via `calculate`

Building-level views also list units via `/api/v1/units?buildingId=` because the person-months endpoints only return units that already have an entry, so units with no data still render (count 0).

Adds the screen-map under `docs/screens/ppt/person-months.md`.

## Verification

- `pnpm --filter @ppt/api-client typecheck` ✅
- `pnpm --filter @ppt/web typecheck` (+ e2e tsconfig) ✅
- `pnpm --filter @ppt/web build` ✅ (only pre-existing unrelated chunk-size/dynamic-import warnings)
- `biome check` ✅ on all changed files

Loading/error/validation states are handled (query spinners, toast on mutation failure, bulk per-unit failure list, the form's existing client-side validation). Browser/visual validation hand-off to QA recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)