### PR TITLE
feat(mobile): offline fault queue + image compression (Story 4.1, #970.6)

### DIFF
--- a/frontend/apps/mobile/package.json
+++ b/frontend/apps/mobile/package.json
@@ -36,6 +36,7 @@
     "expo-device": "~56.0.4",
     "expo-document-picker": "~13.1.6",
     "expo-file-system": "~55.0.19",
+    "expo-image-manipulator": "~56.0.19",
     "expo-image-picker": "~56.0.18",
     "expo-local-authentication": "~55.0.13",
     "expo-localization": "^56.0.6",

--- a/frontend/apps/mobile/src/locales/cs.json
+++ b/frontend/apps/mobile/src/locales/cs.json
@@ -127,7 +127,15 @@
     "selectBuilding": "Vyberte budovu",
     "loadingBuildings": "Načítají se budovy…",
     "noBuildings": "Žádné dostupné budovy",
-    "buildingsLoadError": "Nepodařilo se načíst vaše budovy"
+    "buildingsLoadError": "Nepodařilo se načíst vaše budovy",
+    "photosCompressedTitle": "Fotky komprimovány",
+    "photosCompressedWarning": "Vybrané fotky přesáhly 10 MB ({{original}} MB) a byly komprimovány na {{final}} MB, aby se nahrály rychleji. Kvalita obrázků může být snížena.",
+    "compressingPhotos": "Optimalizuji fotky…",
+    "queuedTitle": "Uloženo offline",
+    "queuedMessage": "Jste offline. Hlášení bylo uloženo a automaticky se synchronizuje po obnovení připojení.",
+    "queuedOnErrorMessage": "Nepodařilo se spojit se serverem. Hlášení bylo uloženo a automaticky se synchronizuje po obnovení připojení.",
+    "offlineSubmitHint": "Jste offline — hlášení se uloží a synchronizuje po obnovení připojení.",
+    "submitButtonOffline": "Uložit a synchronizovat později"
   },
   "news": {
     "title": "Zpravy",

--- a/frontend/apps/mobile/src/locales/de.json
+++ b/frontend/apps/mobile/src/locales/de.json
@@ -127,7 +127,15 @@
     "selectBuilding": "Bitte ein Gebäude auswählen",
     "loadingBuildings": "Gebäude werden geladen…",
     "noBuildings": "Keine Gebäude verfügbar",
-    "buildingsLoadError": "Ihre Gebäude konnten nicht geladen werden"
+    "buildingsLoadError": "Ihre Gebäude konnten nicht geladen werden",
+    "photosCompressedTitle": "Fotos komprimiert",
+    "photosCompressedWarning": "Die ausgewählten Fotos überschritten 10 MB ({{original}} MB) und wurden auf {{final}} MB komprimiert, damit sie schneller hochgeladen werden. Die Bildqualität kann reduziert sein.",
+    "compressingPhotos": "Fotos werden optimiert…",
+    "queuedTitle": "Offline gespeichert",
+    "queuedMessage": "Sie sind offline. Ihre Meldung wurde gespeichert und wird automatisch synchronisiert, sobald Sie wieder online sind.",
+    "queuedOnErrorMessage": "Der Server war nicht erreichbar. Ihre Meldung wurde gespeichert und wird automatisch synchronisiert, sobald die Verbindung wiederhergestellt ist.",
+    "offlineSubmitHint": "Sie sind offline — diese Meldung wird gespeichert und synchronisiert, sobald Sie wieder online sind.",
+    "submitButtonOffline": "Speichern und später synchronisieren"
   },
   "news": {
     "title": "Nachrichten",

--- a/frontend/apps/mobile/src/locales/en.json
+++ b/frontend/apps/mobile/src/locales/en.json
@@ -127,7 +127,15 @@
     "selectBuilding": "Please select a building",
     "loadingBuildings": "Loading buildings…",
     "noBuildings": "No buildings available",
-    "buildingsLoadError": "Couldn't load your buildings"
+    "buildingsLoadError": "Couldn't load your buildings",
+    "photosCompressedTitle": "Photos compressed",
+    "photosCompressedWarning": "Selected photos exceeded 10 MB ({{original}} MB) and were compressed to {{final}} MB so they upload faster. Image quality may be reduced.",
+    "compressingPhotos": "Optimizing photos…",
+    "queuedTitle": "Saved offline",
+    "queuedMessage": "You're offline. Your report was saved and will sync automatically when you reconnect.",
+    "queuedOnErrorMessage": "We couldn't reach the server. Your report was saved and will sync automatically when the connection is restored.",
+    "offlineSubmitHint": "You're offline — this report will be saved and synced when you reconnect.",
+    "submitButtonOffline": "Save & sync later"
   },
   "news": {
     "title": "News",

--- a/frontend/apps/mobile/src/locales/hu.json
+++ b/frontend/apps/mobile/src/locales/hu.json
@@ -127,7 +127,15 @@
     "selectBuilding": "Válasszon épületet",
     "loadingBuildings": "Épületek betöltése…",
     "noBuildings": "Nincs elérhető épület",
-    "buildingsLoadError": "Nem sikerült betölteni az épületeit"
+    "buildingsLoadError": "Nem sikerült betölteni az épületeit",
+    "photosCompressedTitle": "Fényképek tömörítve",
+    "photosCompressedWarning": "A kiválasztott fényképek meghaladták a 10 MB-ot ({{original}} MB), ezért {{final}} MB-ra tömörítettük őket a gyorsabb feltöltés érdekében. A képminőség csökkenhet.",
+    "compressingPhotos": "Fényképek optimalizálása…",
+    "queuedTitle": "Offline mentve",
+    "queuedMessage": "Jelenleg offline van. A bejelentést elmentettük, és automatikusan szinkronizálódik, amint újra online lesz.",
+    "queuedOnErrorMessage": "Nem sikerült elérni a kiszolgálót. A bejelentést elmentettük, és automatikusan szinkronizálódik, amint helyreáll a kapcsolat.",
+    "offlineSubmitHint": "Jelenleg offline van — ezt a bejelentést elmentjük, és szinkronizáljuk, amint újra online lesz.",
+    "submitButtonOffline": "Mentés és szinkronizálás később"
   },
   "news": {
     "title": "Hirek",

--- a/frontend/apps/mobile/src/locales/pl.json
+++ b/frontend/apps/mobile/src/locales/pl.json
@@ -127,7 +127,15 @@
     "selectBuilding": "Wybierz budynek",
     "loadingBuildings": "Ładowanie budynków…",
     "noBuildings": "Brak dostępnych budynków",
-    "buildingsLoadError": "Nie udało się wczytać Twoich budynków"
+    "buildingsLoadError": "Nie udało się wczytać Twoich budynków",
+    "photosCompressedTitle": "Zdjęcia skompresowane",
+    "photosCompressedWarning": "Wybrane zdjęcia przekroczyły 10 MB ({{original}} MB) i zostały skompresowane do {{final}} MB, aby szybciej się przesłały. Jakość obrazu może być niższa.",
+    "compressingPhotos": "Optymalizowanie zdjęć…",
+    "queuedTitle": "Zapisano offline",
+    "queuedMessage": "Jesteś offline. Zgłoszenie zostało zapisane i zsynchronizuje się automatycznie po ponownym połączeniu.",
+    "queuedOnErrorMessage": "Nie udało się połączyć z serwerem. Zgłoszenie zostało zapisane i zsynchronizuje się automatycznie po przywróceniu połączenia.",
+    "offlineSubmitHint": "Jesteś offline — to zgłoszenie zostanie zapisane i zsynchronizowane po ponownym połączeniu.",
+    "submitButtonOffline": "Zapisz i zsynchronizuj później"
   },
   "news": {
     "title": "Aktualnosci",

--- a/frontend/apps/mobile/src/locales/sk.json
+++ b/frontend/apps/mobile/src/locales/sk.json
@@ -127,7 +127,15 @@
     "selectBuilding": "Vyberte budovu",
     "loadingBuildings": "Načítavajú sa budovy…",
     "noBuildings": "Žiadne dostupné budovy",
-    "buildingsLoadError": "Nepodarilo sa načítať vaše budovy"
+    "buildingsLoadError": "Nepodarilo sa načítať vaše budovy",
+    "photosCompressedTitle": "Fotky komprimované",
+    "photosCompressedWarning": "Vybrané fotky presiahli 10 MB ({{original}} MB) a boli komprimované na {{final}} MB, aby sa nahrali rýchlejšie. Kvalita obrázkov môže byť znížená.",
+    "compressingPhotos": "Optimalizujem fotky…",
+    "queuedTitle": "Uložené offline",
+    "queuedMessage": "Ste offline. Hlásenie bolo uložené a automaticky sa zosynchronizuje po obnovení pripojenia.",
+    "queuedOnErrorMessage": "Nepodarilo sa spojiť so serverom. Hlásenie bolo uložené a automaticky sa zosynchronizuje po obnovení pripojenia.",
+    "offlineSubmitHint": "Ste offline — hlásenie sa uloží a zosynchronizuje po obnovení pripojenia.",
+    "submitButtonOffline": "Uložiť a zosynchronizovať neskôr"
   },
   "news": {
     "title": "Spravy",

--- a/frontend/apps/mobile/src/screens/faults/ReportFaultScreen.test.tsx
+++ b/frontend/apps/mobile/src/screens/faults/ReportFaultScreen.test.tsx
@@ -1,25 +1,27 @@
 /**
- * ReportFaultScreen — unit tests
- * (code-review-mobile-rn-report-fault-fake-submit).
+ * ReportFaultScreen — unit tests.
  *
- * Regression guard for the bug where `handleSubmit` faked the network call
- * with `setTimeout(1500)` and showed a success Alert without ever reaching the
- * backend. These tests assert that submitting actually fires the
- * `POST /api/v1/faults` mutation with the form payload, and that the success
- * Alert only follows a 2xx (mutation `onSuccess`).
+ * Originally a regression guard for the bug where `handleSubmit` faked the
+ * network call (code-review-mobile-rn-report-fault-fake-submit). Extended for
+ * Story 4.1 (gap #970.6): offline fault queue + image-compression. The screen
+ * now creates the fault via `apiRequest` directly so it can fall back to the
+ * persisted offline queue, carrying a Story 2B.7 idempotency key so retries /
+ * replays never duplicate.
  *
  * Covers:
  *   - Renders the building picker from the buildings query.
  *   - The buildings query carries the required `organization_id` and is gated
- *     on the tenant id (the reviewer's blocking finding).
- *   - Submitting a valid form calls the create-fault mutation with the
- *     expected `{ building_id, title, description, category, priority }`.
- *   - Validation blocks submit (no building selected) — mutation NOT called.
- *   - mutation onSuccess fires the success Alert; onError fires the error Alert.
+ *     on the tenant id.
+ *   - Online submit fires `POST /api/v1/faults` with the form payload + an
+ *     idempotency key; success Alert follows a 2xx.
+ *   - Validation blocks submit (no building selected) — no request, no enqueue.
+ *   - Offline submit enqueues the create instead of firing a request.
+ *   - A failed request falls back to the queue, reusing the SAME idempotency
+ *     key it attempted with (no duplicate across the retry).
  */
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen } from '@testing-library/react-native';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import { Alert } from 'react-native';
 import { ReportFaultScreen } from './ReportFaultScreen';
 
@@ -27,8 +29,24 @@ import { ReportFaultScreen } from './ReportFaultScreen';
 
 jest.mock('../../hooks/useApi', () => ({
   useApiQuery: jest.fn(),
-  useApiMutation: jest.fn(),
   useTenantId: jest.fn(),
+  apiRequest: jest.fn(),
+}));
+
+jest.mock('../../hooks', () => ({
+  useOfflineSupport: jest.fn(),
+}));
+
+const FIXED_KEY = 'idem-test-key';
+jest.mock('../../utils', () => ({
+  generateIdempotencyKey: () => FIXED_KEY,
+  compressImagesIfNeeded: jest.fn(async (uris: string[]) => ({
+    uris,
+    originalBytes: 0,
+    finalBytes: 0,
+    compressed: false,
+  })),
+  bytesToMb: (bytes: number) => String(bytes),
 }));
 
 // Expo native modules touched by the screen — stub so the import graph resolves.
@@ -44,9 +62,11 @@ jest.mock('expo-location', () => ({
   reverseGeocodeAsync: jest.fn(),
 }));
 
-const mockUseApiQuery = jest.requireMock('../../hooks/useApi').useApiQuery as jest.Mock;
-const mockUseApiMutation = jest.requireMock('../../hooks/useApi').useApiMutation as jest.Mock;
-const mockUseTenantId = jest.requireMock('../../hooks/useApi').useTenantId as jest.Mock;
+const useApiMock = jest.requireMock('../../hooks/useApi');
+const mockUseApiQuery = useApiMock.useApiQuery as jest.Mock;
+const mockUseTenantId = useApiMock.useTenantId as jest.Mock;
+const mockApiRequest = useApiMock.apiRequest as jest.Mock;
+const mockUseOfflineSupport = jest.requireMock('../../hooks').useOfflineSupport as jest.Mock;
 
 // --- Helpers ---
 
@@ -56,6 +76,26 @@ const BUILDINGS = [
   { id: 'b-1', name: 'Lipová Residence', street: 'Lipová 5', city: 'Bratislava' },
   { id: 'b-2', name: 'Cottage 12', street: 'Záhradná 12', city: 'Pezinok' },
 ];
+
+const EXPECTED_PAYLOAD = {
+  building_id: 'b-1',
+  title: 'Leaking pipe',
+  description: 'Water is leaking from the ceiling in the hallway near unit 3.',
+  category: 'plumbing',
+  priority: 'medium',
+  location_description: '3rd floor',
+  idempotency_key: FIXED_KEY,
+};
+
+let addToQueue: jest.Mock;
+
+function setConnectivity(isConnected: boolean) {
+  mockUseOfflineSupport.mockReturnValue({
+    isConnected,
+    isInternetReachable: isConnected,
+    addToQueue,
+  });
+}
 
 function renderScreen(props: React.ComponentProps<typeof ReportFaultScreen> = {}) {
   const queryClient = new QueryClient({
@@ -84,19 +124,19 @@ function fillValidForm() {
 // --- Tests ---
 
 describe('ReportFaultScreen', () => {
-  let mutate: jest.Mock;
   let alertSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mutate = jest.fn();
-    mockUseApiMutation.mockReturnValue({ mutate, isPending: false });
+    addToQueue = jest.fn().mockResolvedValue(undefined);
+    mockApiRequest.mockResolvedValue({ id: 'fault-1', message: 'ok' });
     mockUseTenantId.mockReturnValue({ tenantId: TENANT_ID, isLoading: false });
     mockUseApiQuery.mockReturnValue({
       data: { buildings: BUILDINGS },
       isLoading: false,
       error: null,
     });
+    setConnectivity(true);
     alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
   });
 
@@ -110,34 +150,36 @@ describe('ReportFaultScreen', () => {
     expect(screen.getByText('Cottage 12')).toBeTruthy();
   });
 
-  it('fires POST /api/v1/faults with the form payload on submit', () => {
+  it('fires POST /api/v1/faults with the form payload (incl. idempotency key) when online', async () => {
     renderScreen();
     fillValidForm();
     fireEvent.press(screen.getByText('faults.submitButton'));
 
-    expect(mutate).toHaveBeenCalledTimes(1);
-    expect(mutate).toHaveBeenCalledWith(
-      {
-        building_id: 'b-1',
-        title: 'Leaking pipe',
-        description: 'Water is leaking from the ceiling in the hallway near unit 3.',
-        category: 'plumbing',
-        priority: 'medium',
-        location_description: '3rd floor',
-      },
-      expect.any(Object)
-    );
+    await waitFor(() => expect(mockApiRequest).toHaveBeenCalledTimes(1));
+    expect(mockApiRequest).toHaveBeenCalledWith('/api/v1/faults', {
+      method: 'POST',
+      body: EXPECTED_PAYLOAD,
+    });
+    expect(addToQueue).not.toHaveBeenCalled();
   });
 
-  it('targets the /api/v1/faults endpoint with POST', () => {
-    renderScreen();
-    expect(mockUseApiMutation).toHaveBeenCalledWith('/api/v1/faults', 'POST');
+  it('shows the success Alert after a 2xx and does not enqueue', async () => {
+    const onSuccess = jest.fn();
+    renderScreen({ onSuccess });
+    fillValidForm();
+    fireEvent.press(screen.getByText('faults.submitButton'));
+
+    await waitFor(() =>
+      expect(alertSpy).toHaveBeenCalledWith(
+        'common.done',
+        'faults.successSubmit',
+        expect.any(Array)
+      )
+    );
+    expect(addToQueue).not.toHaveBeenCalled();
   });
 
   it('queries buildings with the required organization_id and keys the cache on it', () => {
-    // Regression guard for the reviewer finding: `GET /api/v1/buildings`
-    // 400s/403s without `organization_id`, so the picker silently breaks.
-    // The org id is the JWT tenant id surfaced via `useTenantId`.
     renderScreen();
 
     const buildingsCall = mockUseApiQuery.mock.calls.find(
@@ -147,7 +189,6 @@ describe('ReportFaultScreen', () => {
 
     const [queryKey, path] = buildingsCall as [readonly unknown[], string];
     expect(path).toBe(`/api/v1/buildings?organization_id=${TENANT_ID}`);
-    // Cache is keyed on the tenant so switching org refetches.
     expect(queryKey).toContain(TENANT_ID);
   });
 
@@ -161,11 +202,10 @@ describe('ReportFaultScreen', () => {
     expect(buildingsCall).toBeDefined();
     const [, , options] = buildingsCall as [readonly unknown[], string, { enabled?: boolean }];
     expect(options.enabled).toBe(false);
-    // Loading copy is shown while the tenant id is still resolving.
     expect(screen.getByText('faults.loadingBuildings')).toBeTruthy();
   });
 
-  it('does not call the mutation when no building is selected', () => {
+  it('does not submit or enqueue when no building is selected', () => {
     renderScreen();
     fireEvent.changeText(screen.getByPlaceholderText('faults.titlePlaceholder'), 'Leaking pipe');
     fireEvent.changeText(
@@ -176,30 +216,50 @@ describe('ReportFaultScreen', () => {
     fireEvent.press(screen.getByText('Plumbing'));
 
     fireEvent.press(screen.getByText('faults.submitButton'));
-    expect(mutate).not.toHaveBeenCalled();
+    expect(mockApiRequest).not.toHaveBeenCalled();
+    expect(addToQueue).not.toHaveBeenCalled();
     expect(screen.getByText('faults.selectBuilding')).toBeTruthy();
   });
 
-  it('shows the success Alert via the mutation onSuccess callback', () => {
-    const onSuccess = jest.fn();
-    renderScreen({ onSuccess });
+  it('enqueues the create instead of firing a request when offline', async () => {
+    setConnectivity(false);
+    renderScreen();
     fillValidForm();
-    fireEvent.press(screen.getByText('faults.submitButton'));
+    // Offline the button label switches to the "save & sync later" copy.
+    fireEvent.press(screen.getByText('faults.submitButtonOffline'));
 
-    const [, options] = mutate.mock.calls[0];
-    options.onSuccess({ id: 'fault-1', message: 'ok' });
-
-    expect(alertSpy).toHaveBeenCalledWith('common.done', 'faults.successSubmit', expect.any(Array));
+    await waitFor(() => expect(addToQueue).toHaveBeenCalledTimes(1));
+    expect(addToQueue).toHaveBeenCalledWith({
+      type: 'CREATE',
+      endpoint: '/api/v1/faults',
+      method: 'POST',
+      body: EXPECTED_PAYLOAD,
+    });
+    expect(mockApiRequest).not.toHaveBeenCalled();
+    expect(alertSpy).toHaveBeenCalledWith(
+      'faults.queuedTitle',
+      'faults.queuedMessage',
+      expect.any(Array)
+    );
   });
 
-  it('shows an error Alert via the mutation onError callback', () => {
+  it('falls back to the queue on request failure, reusing the attempted idempotency key', async () => {
+    mockApiRequest.mockRejectedValueOnce(new Error('network down'));
     renderScreen();
     fillValidForm();
     fireEvent.press(screen.getByText('faults.submitButton'));
 
-    const [, options] = mutate.mock.calls[0];
-    options.onError(new Error('Server exploded'));
+    await waitFor(() => expect(addToQueue).toHaveBeenCalledTimes(1));
 
-    expect(alertSpy).toHaveBeenCalledWith('common.error', 'Server exploded');
+    const attemptedKey = mockApiRequest.mock.calls[0][1].body.idempotency_key;
+    const queuedKey = addToQueue.mock.calls[0][0].body.idempotency_key;
+    // Same key on the attempt and the queued replay → the idempotent backend
+    // returns the existing fault rather than inserting a duplicate.
+    expect(queuedKey).toBe(attemptedKey);
+    expect(alertSpy).toHaveBeenCalledWith(
+      'faults.queuedTitle',
+      'faults.queuedOnErrorMessage',
+      expect.any(Array)
+    );
   });
 });

--- a/frontend/apps/mobile/src/screens/faults/ReportFaultScreen.tsx
+++ b/frontend/apps/mobile/src/screens/faults/ReportFaultScreen.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import * as ImagePicker from 'expo-image-picker';
 import * as Location from 'expo-location';
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   ActivityIndicator,
@@ -16,7 +16,10 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import { useApiMutation, useApiQuery, useTenantId } from '../../hooks/useApi';
+import { PendingSyncIndicator } from '../../components/sync';
+import { useOfflineSupport } from '../../hooks';
+import { apiRequest, useApiQuery, useTenantId } from '../../hooks/useApi';
+import { bytesToMb, compressImagesIfNeeded, generateIdempotencyKey } from '../../utils';
 import { colors } from '../shared/screenStyles';
 import type { FaultCategory, FaultPriority } from './FaultsListScreen';
 
@@ -45,6 +48,10 @@ interface CreateFaultVariables {
   category: string;
   priority: string;
   location_description?: string;
+  // Story 2B.7 idempotency key: the backend create dedupes on this, so a
+  // create that is queued offline and replayed (possibly more than once) never
+  // produces a duplicate fault.
+  idempotency_key: string;
 }
 
 /** Response from `POST /api/v1/faults` (mirrors `CreateFaultResponse`). */
@@ -88,7 +95,23 @@ export function ReportFaultScreen({ onSuccess, onCancel }: ReportFaultScreenProp
   const [location, setLocation] = useState('');
   const [photos, setPhotos] = useState<string[]>([]);
   const [isDetectingLocation, setIsDetectingLocation] = useState(false);
+  const [isCompressing, setIsCompressing] = useState(false);
+  const [compressionNotice, setCompressionNotice] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [queuedOffline, setQueuedOffline] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
+
+  // Connectivity + the persisted offline action queue (AC 4.1). When the
+  // device is offline the create is enqueued and the global sync machinery
+  // (badge in the tab bar + `processQueue` on reconnect) replays it.
+  const { isConnected, isInternetReachable, addToQueue } = useOfflineSupport();
+  const isOffline = !isConnected || isInternetReachable === false;
+
+  // One idempotency key per report attempt, generated lazily and reused across
+  // every retry/replay so the backend returns the existing fault instead of
+  // inserting a duplicate. Kept in a ref (not state) so it survives re-renders
+  // without triggering them.
+  const idempotencyKeyRef = useRef<string | null>(null);
 
   // The api-server requires a `building_id` on every fault. Load the
   // buildings the user belongs to so they can pick which one the fault is for.
@@ -108,14 +131,6 @@ export function ReportFaultScreen({ onSuccess, onCancel }: ReportFaultScreenProp
   // Show the loading state while we resolve the tenant id too, otherwise the
   // gated-off query would flash the empty/"no buildings" state first.
   const isBuildingsLoading = isTenantLoading || buildingsQuery.isLoading;
-
-  // POST the fault to the api-server. `isPending` drives the submit button's
-  // spinner/disabled state (replacing the old local `isSubmitting` flag).
-  const createMutation = useApiMutation<CreateFaultResult, CreateFaultVariables>(
-    '/api/v1/faults',
-    'POST'
-  );
-  const isSubmitting = createMutation.isPending;
 
   const validateForm = (): boolean => {
     const newErrors: Record<string, string> = {};
@@ -179,15 +194,45 @@ export function ReportFaultScreen({ onSuccess, onCancel }: ReportFaultScreenProp
 
       if (!result.canceled) {
         const newPhotos = result.assets.map((asset: { uri: string }) => asset.uri);
-        setPhotos((prev) => [...prev, ...newPhotos].slice(0, 5));
+        const combined = [...photos, ...newPhotos].slice(0, 5);
+        await applyPhotos(combined);
       }
     } catch (_error) {
       Alert.alert(t('common.error'), t('faults.failedToPickImage'));
     }
   };
 
+  // Set the photo list, compressing first when the selection exceeds 10 MB
+  // total (AC 4.1). Compression is lossy, so the user is warned once a pass
+  // runs; under the limit the originals are kept untouched.
+  const applyPhotos = async (next: string[]) => {
+    setIsCompressing(true);
+    try {
+      const result = await compressImagesIfNeeded(next);
+      setPhotos(result.uris);
+      if (result.compressed) {
+        const notice = t('faults.photosCompressedWarning', {
+          original: bytesToMb(result.originalBytes),
+          final: bytesToMb(result.finalBytes),
+        });
+        setCompressionNotice(notice);
+        Alert.alert(t('faults.photosCompressedTitle'), notice);
+      } else {
+        setCompressionNotice(null);
+      }
+    } finally {
+      setIsCompressing(false);
+    }
+  };
+
   const removePhoto = (index: number) => {
-    setPhotos((prev) => prev.filter((_, i) => i !== index));
+    setPhotos((prev) => {
+      const next = prev.filter((_, i) => i !== index);
+      if (next.length === 0) {
+        setCompressionNotice(null);
+      }
+      return next;
+    });
   };
 
   const detectLocation = useCallback(async () => {
@@ -216,37 +261,71 @@ export function ReportFaultScreen({ onSuccess, onCancel }: ReportFaultScreenProp
     }
   }, [t]);
 
-  const handleSubmit = () => {
+  // Persist the create to the offline queue for replay on reconnect.
+  const queueForLater = async (payload: CreateFaultVariables, message: string) => {
+    await addToQueue({
+      type: 'CREATE',
+      endpoint: '/api/v1/faults',
+      method: 'POST',
+      body: payload,
+    });
+    setQueuedOffline(true);
+    Alert.alert(t('faults.queuedTitle'), message, [{ text: t('common.ok'), onPress: onSuccess }]);
+  };
+
+  const handleSubmit = async () => {
     if (!validateForm() || !buildingId) {
       return;
     }
 
-    // NOTE: `photos` holds local device URIs. Uploading attachments needs the
-    // presigned-URL pipeline (POST /faults/{id}/attachments), which has no
-    // shared mobile helper yet — tracked as a follow-up. The fault itself is
-    // created here so reports stop silently disappearing.
-    createMutation.mutate(
-      {
-        building_id: buildingId,
-        title: title.trim(),
-        description: description.trim(),
-        category: category ?? 'other',
-        priority,
-        location_description: location.trim() || undefined,
-      },
-      {
-        onSuccess: () => {
-          // Refresh the faults list so the new report shows on return.
-          queryClient.invalidateQueries({ queryKey: ['faults', 'list'] });
-          Alert.alert(t('common.done'), t('faults.successSubmit'), [
-            { text: t('common.ok'), onPress: onSuccess },
-          ]);
-        },
-        onError: (error) => {
-          Alert.alert(t('common.error'), error.message || t('faults.failedSubmit'));
-        },
+    // Reuse the same key across every retry/replay so the idempotent backend
+    // create never produces a duplicate, even if the request below half-fails
+    // and is later replayed from the queue.
+    if (!idempotencyKeyRef.current) {
+      idempotencyKeyRef.current = generateIdempotencyKey();
+    }
+
+    // NOTE: `photos` holds local device URIs (compressed in-place when over
+    // 10 MB). Uploading attachments needs the presigned-URL pipeline
+    // (POST /faults/{id}/attachments), which has no shared mobile helper yet —
+    // tracked as a follow-up. The fault itself is created/queued here.
+    const payload: CreateFaultVariables = {
+      building_id: buildingId,
+      title: title.trim(),
+      description: description.trim(),
+      category: category ?? 'other',
+      priority,
+      location_description: location.trim() || undefined,
+      idempotency_key: idempotencyKeyRef.current,
+    };
+
+    setIsSubmitting(true);
+    try {
+      // Offline: queue immediately rather than firing a request that will fail.
+      if (isOffline) {
+        await queueForLater(payload, t('faults.queuedMessage'));
+        return;
       }
-    );
+
+      await apiRequest<CreateFaultResult>('/api/v1/faults', { method: 'POST', body: payload });
+      // Refresh the faults list so the new report shows on return.
+      queryClient.invalidateQueries({ queryKey: ['faults', 'list'] });
+      // The key has been consumed; a subsequent report gets a fresh one.
+      idempotencyKeyRef.current = null;
+      Alert.alert(t('common.done'), t('faults.successSubmit'), [
+        { text: t('common.ok'), onPress: onSuccess },
+      ]);
+    } catch (error) {
+      // The request failed mid-flight. We can't tell a dropped connection from
+      // a server error here, so queue for replay: a transient/5xx error retries
+      // on reconnect, and a genuine 4xx is dropped by the queue (it marks 4xx
+      // permanent) instead of looping. The idempotency key guarantees that if
+      // the fault was in fact created, the replay won't duplicate it.
+      await queueForLater(payload, t('faults.queuedOnErrorMessage'));
+      void error;
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   // Category label mapping (these would ideally come from translations)
@@ -454,18 +533,45 @@ export function ReportFaultScreen({ onSuccess, onCancel }: ReportFaultScreenProp
             )}
           </View>
           <Text style={styles.photoHint}>{t('faults.photosHint', { current: photos.length })}</Text>
+          {isCompressing && (
+            <View style={styles.compressingRow}>
+              <ActivityIndicator size="small" color={colors.accent} />
+              <Text style={styles.compressingText}>{t('faults.compressingPhotos')}</Text>
+            </View>
+          )}
+          {compressionNotice && (
+            <View style={styles.compressionNotice}>
+              <Text style={styles.compressionNoticeIcon}>🗜️</Text>
+              <Text style={styles.compressionNoticeText}>{compressionNotice}</Text>
+            </View>
+          )}
         </View>
+
+        {/* Offline / pending-sync status (AC 4.1) */}
+        {queuedOffline ? (
+          <PendingSyncIndicator status="pending" />
+        ) : isOffline ? (
+          <View style={styles.offlineHint}>
+            <Text style={styles.offlineHintIcon}>📡</Text>
+            <Text style={styles.offlineHintText}>{t('faults.offlineSubmitHint')}</Text>
+          </View>
+        ) : null}
 
         {/* Submit Button */}
         <Pressable
-          style={[styles.submitButton, isSubmitting && styles.submitButtonDisabled]}
+          style={[
+            styles.submitButton,
+            (isSubmitting || isCompressing) && styles.submitButtonDisabled,
+          ]}
           onPress={handleSubmit}
-          disabled={isSubmitting}
+          disabled={isSubmitting || isCompressing}
         >
           {isSubmitting ? (
             <ActivityIndicator color={colors.surface} />
           ) : (
-            <Text style={styles.submitButtonText}>{t('faults.submitButton')}</Text>
+            <Text style={styles.submitButtonText}>
+              {isOffline ? t('faults.submitButtonOffline') : t('faults.submitButton')}
+            </Text>
           )}
         </Pressable>
 
@@ -668,6 +774,52 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: colors.textSubtle,
     marginTop: 6,
+  },
+  compressingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginTop: 8,
+  },
+  compressingText: {
+    fontSize: 13,
+    color: colors.textMuted,
+  },
+  compressionNotice: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 8,
+    marginTop: 8,
+    padding: 10,
+    borderRadius: 8,
+    backgroundColor: colors.warningBg,
+  },
+  compressionNoticeIcon: {
+    fontSize: 16,
+  },
+  compressionNoticeText: {
+    flex: 1,
+    fontSize: 13,
+    color: colors.warningDark,
+    lineHeight: 18,
+  },
+  offlineHint: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    padding: 10,
+    borderRadius: 8,
+    backgroundColor: colors.warningBg,
+    marginBottom: 8,
+  },
+  offlineHintIcon: {
+    fontSize: 16,
+  },
+  offlineHintText: {
+    flex: 1,
+    fontSize: 13,
+    color: colors.warningDark,
+    lineHeight: 18,
   },
   submitButton: {
     backgroundColor: colors.accent,

--- a/frontend/apps/mobile/src/utils/idempotencyKey.test.ts
+++ b/frontend/apps/mobile/src/utils/idempotencyKey.test.ts
@@ -1,0 +1,13 @@
+import { generateIdempotencyKey } from './idempotencyKey';
+
+describe('generateIdempotencyKey', () => {
+  it('produces an RFC-4122 v4-shaped string', () => {
+    const key = generateIdempotencyKey();
+    expect(key).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+
+  it('is unique across calls (so each report dedupes independently)', () => {
+    const keys = new Set(Array.from({ length: 1000 }, () => generateIdempotencyKey()));
+    expect(keys.size).toBe(1000);
+  });
+});

--- a/frontend/apps/mobile/src/utils/idempotencyKey.ts
+++ b/frontend/apps/mobile/src/utils/idempotencyKey.ts
@@ -1,0 +1,26 @@
+/**
+ * Client-generated idempotency keys for offline-safe fault creation
+ * (Story 4.1 / 2B.7, gap #970.6).
+ *
+ * The api-server `POST /api/v1/faults` create is idempotent on a body
+ * `idempotency_key`: replaying the same key returns the existing fault instead
+ * of inserting a duplicate (backend gap #970 / PR #989). The offline queue can
+ * retry a create several times across reconnects, so each report must carry a
+ * stable key generated once, at submit time, and reused on every replay.
+ */
+
+/**
+ * Generate an RFC-4122-ish v4 UUID string.
+ *
+ * `Math.random` is sufficient here: the key only needs to be unique per device
+ * per report so the server can dedupe replays — it is not a security token.
+ * React Native does not ship `crypto.randomUUID` on all engines, so we avoid
+ * relying on it.
+ */
+export function generateIdempotencyKey(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (char) => {
+    const rand = (Math.random() * 16) | 0;
+    const value = char === 'x' ? rand : (rand & 0x3) | 0x8;
+    return value.toString(16);
+  });
+}

--- a/frontend/apps/mobile/src/utils/imageCompression.test.ts
+++ b/frontend/apps/mobile/src/utils/imageCompression.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for the offline-fault image-compression helper (Story 4.1, gap #970.6).
+ *
+ * expo-image-manipulator and expo-file-system/legacy are mocked so the
+ * 10 MB-threshold branching is exercised without a native runtime.
+ */
+
+const mockGetInfoAsync = jest.fn();
+const mockManipulateAsync = jest.fn();
+
+jest.mock('expo-file-system/legacy', () => ({
+  getInfoAsync: (...args: unknown[]) => mockGetInfoAsync(...args),
+}));
+
+jest.mock('expo-image-manipulator', () => ({
+  manipulateAsync: (...args: unknown[]) => mockManipulateAsync(...args),
+  SaveFormat: { JPEG: 'jpeg', PNG: 'png', WEBP: 'webp' },
+}));
+
+import { bytesToMb, compressImagesIfNeeded, MAX_TOTAL_BYTES } from './imageCompression';
+
+const MB = 1024 * 1024;
+
+beforeEach(() => {
+  mockGetInfoAsync.mockReset();
+  mockManipulateAsync.mockReset();
+});
+
+/** Make getInfoAsync return a fixed size for every uri. */
+function sizeEachFile(bytes: number) {
+  mockGetInfoAsync.mockResolvedValue({ exists: true, size: bytes });
+}
+
+describe('compressImagesIfNeeded', () => {
+  it('returns originals untouched when total is at or under 10 MB', async () => {
+    sizeEachFile(3 * MB); // 2 photos = 6 MB, under the limit
+    const result = await compressImagesIfNeeded(['a.jpg', 'b.jpg']);
+
+    expect(result.compressed).toBe(false);
+    expect(result.uris).toEqual(['a.jpg', 'b.jpg']);
+    expect(result.originalBytes).toBe(6 * MB);
+    expect(mockManipulateAsync).not.toHaveBeenCalled();
+  });
+
+  it('compresses every photo when the total exceeds 10 MB', async () => {
+    // 3 photos × 5 MB = 15 MB > limit, then each compresses to 1 MB.
+    mockGetInfoAsync
+      .mockResolvedValueOnce({ exists: true, size: 5 * MB })
+      .mockResolvedValueOnce({ exists: true, size: 5 * MB })
+      .mockResolvedValueOnce({ exists: true, size: 5 * MB })
+      .mockResolvedValue({ exists: true, size: 1 * MB });
+    mockManipulateAsync.mockImplementation(async (uri: string) => ({
+      uri: `${uri}.compressed`,
+      width: 1920,
+      height: 1080,
+    }));
+
+    const result = await compressImagesIfNeeded(['a.jpg', 'b.jpg', 'c.jpg']);
+
+    expect(result.compressed).toBe(true);
+    expect(result.uris).toEqual(['a.jpg.compressed', 'b.jpg.compressed', 'c.jpg.compressed']);
+    expect(mockManipulateAsync).toHaveBeenCalledTimes(3);
+    expect(result.originalBytes).toBe(15 * MB);
+    expect(result.finalBytes).toBe(3 * MB);
+  });
+
+  it('keeps the original uri when a single image fails to compress', async () => {
+    mockGetInfoAsync.mockResolvedValue({ exists: true, size: 6 * MB }); // 2 × 6 = 12 MB
+    mockManipulateAsync
+      .mockResolvedValueOnce({ uri: 'a.jpg.compressed', width: 1, height: 1 })
+      .mockRejectedValueOnce(new Error('decode failed'));
+
+    const result = await compressImagesIfNeeded(['a.jpg', 'b.jpg']);
+
+    expect(result.compressed).toBe(true);
+    expect(result.uris).toEqual(['a.jpg.compressed', 'b.jpg']);
+  });
+
+  it('treats an empty selection as nothing to compress', async () => {
+    const result = await compressImagesIfNeeded([]);
+    expect(result).toEqual({ uris: [], originalBytes: 0, finalBytes: 0, compressed: false });
+    expect(mockGetInfoAsync).not.toHaveBeenCalled();
+  });
+
+  it('honours an overridden threshold', async () => {
+    sizeEachFile(1 * MB); // 1 MB total
+    mockManipulateAsync.mockResolvedValue({ uri: 'a.jpg.c', width: 1, height: 1 });
+
+    const result = await compressImagesIfNeeded(['a.jpg'], { maxTotalBytes: 0.5 * MB });
+    expect(result.compressed).toBe(true);
+  });
+});
+
+describe('bytesToMb', () => {
+  it('formats bytes as one-decimal megabytes', () => {
+    expect(bytesToMb(MAX_TOTAL_BYTES)).toBe('10.0');
+    expect(bytesToMb(15 * MB)).toBe('15.0');
+    expect(bytesToMb(1.55 * MB)).toBe('1.6');
+  });
+});

--- a/frontend/apps/mobile/src/utils/imageCompression.ts
+++ b/frontend/apps/mobile/src/utils/imageCompression.ts
@@ -1,0 +1,114 @@
+/**
+ * Image compression for offline fault reporting (Story 4.1, gap #970.6).
+ *
+ * AC 4.1 requires that when selected photos exceed 10 MB in total they are
+ * compressed before they are attached to a fault report, and the user is shown
+ * a quality-loss warning. Phone cameras routinely produce 4–8 MB images, so a
+ * handful of photos blow past the limit and would make uploads (especially on
+ * a flaky/offline connection that later replays from the queue) slow and
+ * failure-prone.
+ *
+ * The strategy is a single down-scale + re-encode pass per image: cap the
+ * longest edge at {@link MAX_DIMENSION}px and re-encode as JPEG at
+ * {@link DEFAULT_QUALITY}. This is the standard expo-image-manipulator recipe
+ * and shrinks multi-megapixel camera shots by an order of magnitude while
+ * leaving the photos legible for a maintenance technician.
+ */
+import * as FileSystem from 'expo-file-system/legacy';
+import { manipulateAsync, SaveFormat } from 'expo-image-manipulator';
+
+/** The 10 MB total-size threshold from AC 4.1. */
+export const MAX_TOTAL_BYTES = 10 * 1024 * 1024;
+
+/** Longest-edge cap applied when compressing. */
+const MAX_DIMENSION = 1920;
+
+/** JPEG quality (0–1) applied when compressing. */
+const DEFAULT_QUALITY = 0.6;
+
+export interface CompressionResult {
+  /** Photo URIs — compressed copies when {@link compressed} is true, otherwise the originals. */
+  uris: string[];
+  /** Combined size of the original photos, in bytes. */
+  originalBytes: number;
+  /** Combined size after the (possible) compression pass, in bytes. */
+  finalBytes: number;
+  /** True when the photos exceeded the limit and a compression pass ran. */
+  compressed: boolean;
+}
+
+export interface CompressionOptions {
+  /** Override the total-size threshold (defaults to {@link MAX_TOTAL_BYTES}). */
+  maxTotalBytes?: number;
+  /** Override the longest-edge cap (defaults to {@link MAX_DIMENSION}). */
+  maxDimension?: number;
+  /** Override the JPEG quality (defaults to {@link DEFAULT_QUALITY}). */
+  quality?: number;
+}
+
+/** Best-effort size of a single local file in bytes; 0 if it can't be read. */
+async function fileSize(uri: string): Promise<number> {
+  try {
+    // Legacy `getInfoAsync` returns `size` on the `exists: true` branch of the
+    // FileInfo union; no option is needed to opt into it.
+    const info = await FileSystem.getInfoAsync(uri);
+    return info.exists ? info.size : 0;
+  } catch {
+    // A missing/unreadable file contributes 0 to the total rather than
+    // aborting the whole size check.
+    return 0;
+  }
+}
+
+/** Combined byte size of a set of local image URIs. */
+export async function totalImageBytes(uris: string[]): Promise<number> {
+  if (uris.length === 0) return 0;
+  const sizes = await Promise.all(uris.map(fileSize));
+  return sizes.reduce((sum, size) => sum + size, 0);
+}
+
+/** Bytes → megabytes, rounded to one decimal, for user-facing copy. */
+export function bytesToMb(bytes: number): string {
+  return (bytes / (1024 * 1024)).toFixed(1);
+}
+
+/**
+ * Compress `uris` only when their combined size exceeds the limit.
+ *
+ * When under the limit the originals are returned untouched (`compressed:
+ * false`) so we never degrade quality needlessly. When over, every image is
+ * down-scaled + re-encoded; a single image that fails to process falls back to
+ * its original URI rather than dropping the photo.
+ */
+export async function compressImagesIfNeeded(
+  uris: string[],
+  options: CompressionOptions = {}
+): Promise<CompressionResult> {
+  const maxTotalBytes = options.maxTotalBytes ?? MAX_TOTAL_BYTES;
+  const originalBytes = await totalImageBytes(uris);
+
+  if (uris.length === 0 || originalBytes <= maxTotalBytes) {
+    return { uris, originalBytes, finalBytes: originalBytes, compressed: false };
+  }
+
+  const maxDimension = options.maxDimension ?? MAX_DIMENSION;
+  const quality = options.quality ?? DEFAULT_QUALITY;
+
+  const compressedUris = await Promise.all(
+    uris.map(async (uri) => {
+      try {
+        const result = await manipulateAsync(uri, [{ resize: { width: maxDimension } }], {
+          compress: quality,
+          format: SaveFormat.JPEG,
+        });
+        return result.uri;
+      } catch {
+        // Keep the original on a per-image failure so the report still has the photo.
+        return uri;
+      }
+    })
+  );
+
+  const finalBytes = await totalImageBytes(compressedUris);
+  return { uris: compressedUris, originalBytes, finalBytes, compressed: true };
+}

--- a/frontend/apps/mobile/src/utils/index.ts
+++ b/frontend/apps/mobile/src/utils/index.ts
@@ -1,0 +1,9 @@
+export { generateIdempotencyKey } from './idempotencyKey';
+export {
+  bytesToMb,
+  type CompressionOptions,
+  type CompressionResult,
+  compressImagesIfNeeded,
+  MAX_TOTAL_BYTES,
+  totalImageBytes,
+} from './imageCompression';

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       expo-file-system:
         specifier: ~55.0.19
         version: 55.0.19(expo@56.0.12)(react-native@0.86.0)
+      expo-image-manipulator:
+        specifier: ~56.0.19
+        version: 56.0.19(expo@56.0.12)
       expo-image-picker:
         specifier: ~56.0.18
         version: 56.0.18(expo@56.0.12)
@@ -6530,6 +6533,15 @@ packages:
       expo: '*'
     dependencies:
       expo: 56.0.12(@babel/core@8.0.1)(@expo/dom-webview@56.0.5)(react-native@0.86.0)(react@19.2.0)(typescript@5.9.3)
+    dev: false
+
+  /expo-image-manipulator@56.0.19(expo@56.0.12):
+    resolution: {integrity: sha512-FzMFgrIljDdHfNX6kXONU/y1WF2Eu8Mkqiq7jeortcOakQTsfzWj+1dMIv3AjIvFK2sf0d4L7Dqk7lqK8q+SZA==}
+    peerDependencies:
+      expo: '*'
+    dependencies:
+      expo: 56.0.12(@babel/core@8.0.1)(@expo/dom-webview@56.0.5)(react-native@0.86.0)(react@19.2.0)(typescript@5.9.3)
+      expo-image-loader: 56.0.3(expo@56.0.12)
     dev: false
 
   /expo-image-picker@56.0.18(expo@56.0.12):


### PR DESCRIPTION
## [PM #970 — Gap 6] Mobile offline fault queue + image compression (Story 4.1)

Implements **AC 4.1** for the resident mobile app's fault reporting (BIT-187, parent BIT-168). The online create + building picker already existed on `dev`; this PR adds the two missing capabilities.

### 1. Offline queue + idempotency
- When the device is **offline** (or the create request fails mid-flight), the fault create is persisted to the existing AsyncStorage-backed offline action queue (`useOfflineSupport`) and **replayed on reconnect** by the global sync machinery.
- Each report carries a **Story 2B.7 `idempotency_key`**, generated **once** and reused across every retry/replay, so the idempotent backend (gap 2 / PR #989) returns the existing fault instead of inserting a **duplicate**.
- A **"Pending sync"** indicator shows on the screen once queued; the tab-bar badge already reflects queue depth and clears on successful sync.
- Error path: a failed request falls back to the queue with the **same key it attempted with** (4xx are dropped by the queue as permanent; 5xx/network retry).

### 2. Image compression
- When selected photos exceed **10 MB total**, they are down-scaled + re-encoded as JPEG via **`expo-image-manipulator` (`manipulateAsync`)**, and the user is shown a **localized quality-loss warning**. Under the limit, originals are kept untouched. Per-image failures fall back to the original URI.

### Other
- New copy localized across **en/sk/cs/de/pl/hu**.
- Added `expo-image-manipulator` (~56.0.19) to the mobile app.

### Tests / verification
- `tsc --noEmit` green; biome clean on changed files.
- Unit tests: compression helper (threshold/branching/fallback), idempotency-key generator (shape + uniqueness), and the screen's **online / offline / error** submit paths incl. same-key-on-retry. 16 tests pass.

> Note: the repo's `react` / `react-test-renderer` versions are skewed in some environments (pre-existing on `dev`); RNTL's own `RNTL_SKIP_DEPS_CHECK` was used locally only to execute the component test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)