### PR TITLE
feat(financial): income statement, balance sheet, cash flow + PDF/xlsx export (Story 11.7)

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -107,6 +107,7 @@ redis = { version = "1.2", features = ["tokio-comp", "connection-manager"] }
 clap = { version = "4.4", features = ["derive", "env"] }
 dialoguer = "0.12"
 genpdf = "0.2.0"
+rust_xlsxwriter = "0.80"
 
 # i18n (Epic 111)
 fluent = "0.16"

--- a/backend/crates/db/src/models/financial.rs
+++ b/backend/crates/db/src/models/financial.rs
@@ -578,3 +578,64 @@ pub struct ARReportTotals {
     pub days_90_plus: Decimal,
     pub total: Decimal,
 }
+
+// ============================================================================
+// Story 11.7 — Financial statement reports
+// ============================================================================
+
+/// Single line item in an income statement (revenue or expense).
+#[derive(Debug, Clone, FromRow, Serialize, ToSchema)]
+pub struct IncomeStatementLine {
+    pub category: String,
+    pub amount: Decimal,
+}
+
+/// Income statement for a date range.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct IncomeStatement {
+    pub from_date: NaiveDate,
+    pub to_date: NaiveDate,
+    pub revenue: Vec<IncomeStatementLine>,
+    pub expenses: Vec<IncomeStatementLine>,
+    pub total_revenue: Decimal,
+    pub total_expenses: Decimal,
+    pub net_income: Decimal,
+}
+
+/// One account row in the balance sheet.
+#[derive(Debug, Clone, FromRow, Serialize, ToSchema)]
+pub struct BalanceSheetLine {
+    pub account_id: Uuid,
+    pub account_name: String,
+    pub account_type: String,
+    pub balance: Decimal,
+}
+
+/// Balance sheet snapshot as of a date.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct BalanceSheetReport {
+    pub as_of_date: NaiveDate,
+    pub accounts: Vec<BalanceSheetLine>,
+    pub total_assets: Decimal,
+    pub total_liabilities: Decimal,
+    pub net_equity: Decimal,
+}
+
+/// Single line item in a cash flow report.
+#[derive(Debug, Clone, FromRow, Serialize, ToSchema)]
+pub struct CashFlowLine {
+    pub category: String,
+    pub amount: Decimal,
+}
+
+/// Cash flow report for a date range.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct CashFlowReport {
+    pub from_date: NaiveDate,
+    pub to_date: NaiveDate,
+    pub inflows: Vec<CashFlowLine>,
+    pub outflows: Vec<CashFlowLine>,
+    pub total_inflows: Decimal,
+    pub total_outflows: Decimal,
+    pub net_cash_flow: Decimal,
+}

--- a/backend/crates/db/src/models/mod.rs
+++ b/backend/crates/db/src/models/mod.rs
@@ -175,13 +175,14 @@ pub use fault::{
     ReopenFault, ResolveFault, StatusCount, TriageFault, UpdateFault, UpdateFaultStatus,
 };
 pub use financial::{
-    ARReportEntry, ARReportTotals, AccountTransaction, AccountsReceivableReport, CreateFeeSchedule,
-    CreateFinancialAccount, CreateInvoice, CreateInvoiceItem, CreateTransaction, FeeFrequency,
-    FeeSchedule, FinancialAccount, FinancialAccountResponse, FinancialAccountType,
-    InitiatePaymentResponse, Invoice, InvoiceItem, InvoiceResponse, InvoiceStatus, LateFeeConfig,
-    ListInvoicesResponse, OnlinePaymentSession, Payment, PaymentAllocation, PaymentMethod,
-    PaymentResponse, PaymentStatus, RecordPayment, ReminderSchedule, TransactionCategory,
-    TransactionType, UnitCreditBalance, UnitFee,
+    ARReportEntry, ARReportTotals, AccountTransaction, AccountsReceivableReport, BalanceSheetLine,
+    BalanceSheetReport, CashFlowLine, CashFlowReport, CreateFeeSchedule, CreateFinancialAccount,
+    CreateInvoice, CreateInvoiceItem, CreateTransaction, FeeFrequency, FeeSchedule,
+    FinancialAccount, FinancialAccountResponse, FinancialAccountType, IncomeStatement,
+    IncomeStatementLine, InitiatePaymentResponse, Invoice, InvoiceItem, InvoiceResponse,
+    InvoiceStatus, LateFeeConfig, ListInvoicesResponse, OnlinePaymentSession, Payment,
+    PaymentAllocation, PaymentMethod, PaymentResponse, PaymentStatus, RecordPayment,
+    ReminderSchedule, TransactionCategory, TransactionType, UnitCreditBalance, UnitFee,
 };
 pub use granular_notification::{
     AddToGroupRequest, CategorySummary, CreateHeldNotification, DigestNotification,

--- a/backend/crates/db/src/repositories/financial.rs
+++ b/backend/crates/db/src/repositories/financial.rs
@@ -1264,4 +1264,184 @@ impl FinancialRepository {
             totals,
         })
     }
+
+    /// Income statement: revenue vs expenses from account_transactions over a date range.
+    pub async fn get_income_statement(
+        &self,
+        org_id: Uuid,
+        from: NaiveDate,
+        to: NaiveDate,
+    ) -> Result<crate::models::financial::IncomeStatement, SqlxError> {
+        use crate::models::financial::{IncomeStatement, IncomeStatementLine};
+
+        let revenue_rows = sqlx::query_as::<_, IncomeStatementLine>(
+            r#"
+            SELECT category::text AS category,
+                   COALESCE(SUM(amount), 0) AS amount
+            FROM account_transactions at_
+            JOIN financial_accounts fa ON fa.id = at_.account_id
+            WHERE fa.organization_id = $1
+              AND at_.transaction_type = 'credit'
+              AND at_.transaction_date >= $2
+              AND at_.transaction_date <= $3
+            GROUP BY category
+            ORDER BY amount DESC
+            "#,
+        )
+        .bind(org_id)
+        .bind(from)
+        .bind(to)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let expense_rows = sqlx::query_as::<_, IncomeStatementLine>(
+            r#"
+            SELECT category::text AS category,
+                   COALESCE(SUM(amount), 0) AS amount
+            FROM account_transactions at_
+            JOIN financial_accounts fa ON fa.id = at_.account_id
+            WHERE fa.organization_id = $1
+              AND at_.transaction_type = 'debit'
+              AND at_.transaction_date >= $2
+              AND at_.transaction_date <= $3
+            GROUP BY category
+            ORDER BY amount DESC
+            "#,
+        )
+        .bind(org_id)
+        .bind(from)
+        .bind(to)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let total_revenue = revenue_rows.iter().map(|r| r.amount).sum();
+        let total_expenses = expense_rows.iter().map(|r| r.amount).sum();
+        let net_income = total_revenue - total_expenses;
+
+        Ok(IncomeStatement {
+            from_date: from,
+            to_date: to,
+            revenue: revenue_rows,
+            expenses: expense_rows,
+            total_revenue,
+            total_expenses,
+            net_income,
+        })
+    }
+
+    /// Balance sheet snapshot: all account balances as of a date.
+    pub async fn get_balance_sheet(
+        &self,
+        org_id: Uuid,
+        as_of: NaiveDate,
+    ) -> Result<crate::models::financial::BalanceSheetReport, SqlxError> {
+        use crate::models::financial::{BalanceSheetLine, BalanceSheetReport};
+
+        let accounts = sqlx::query_as::<_, BalanceSheetLine>(
+            r#"
+            SELECT fa.id AS account_id,
+                   fa.name AS account_name,
+                   fa.account_type::text AS account_type,
+                   fa.opening_balance
+                   + COALESCE(SUM(CASE WHEN at_.transaction_type = 'credit' THEN at_.amount ELSE 0 END), 0)
+                   - COALESCE(SUM(CASE WHEN at_.transaction_type = 'debit'  THEN at_.amount ELSE 0 END), 0)
+                   AS balance
+            FROM financial_accounts fa
+            LEFT JOIN account_transactions at_
+                   ON at_.account_id = fa.id AND at_.transaction_date <= $2
+            WHERE fa.organization_id = $1
+              AND fa.is_active = true
+            GROUP BY fa.id, fa.name, fa.account_type, fa.opening_balance
+            ORDER BY fa.account_type, fa.name
+            "#,
+        )
+        .bind(org_id)
+        .bind(as_of)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let total_assets: Decimal = accounts
+            .iter()
+            .filter(|a| a.balance > Decimal::ZERO)
+            .map(|a| a.balance)
+            .sum();
+        let total_liabilities: Decimal = accounts
+            .iter()
+            .filter(|a| a.balance < Decimal::ZERO)
+            .map(|a| a.balance.abs())
+            .sum();
+        let net_equity = total_assets - total_liabilities;
+
+        Ok(BalanceSheetReport {
+            as_of_date: as_of,
+            accounts,
+            total_assets,
+            total_liabilities,
+            net_equity,
+        })
+    }
+
+    /// Cash flow report: inflows vs outflows for a date range.
+    pub async fn get_cash_flow(
+        &self,
+        org_id: Uuid,
+        from: NaiveDate,
+        to: NaiveDate,
+    ) -> Result<crate::models::financial::CashFlowReport, SqlxError> {
+        use crate::models::financial::{CashFlowLine, CashFlowReport};
+
+        let inflow_rows = sqlx::query_as::<_, CashFlowLine>(
+            r#"
+            SELECT category::text AS category,
+                   COALESCE(SUM(amount), 0) AS amount
+            FROM account_transactions at_
+            JOIN financial_accounts fa ON fa.id = at_.account_id
+            WHERE fa.organization_id = $1
+              AND at_.transaction_type = 'credit'
+              AND at_.transaction_date >= $2
+              AND at_.transaction_date <= $3
+            GROUP BY category
+            ORDER BY amount DESC
+            "#,
+        )
+        .bind(org_id)
+        .bind(from)
+        .bind(to)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let outflow_rows = sqlx::query_as::<_, CashFlowLine>(
+            r#"
+            SELECT category::text AS category,
+                   COALESCE(SUM(amount), 0) AS amount
+            FROM account_transactions at_
+            JOIN financial_accounts fa ON fa.id = at_.account_id
+            WHERE fa.organization_id = $1
+              AND at_.transaction_type = 'debit'
+              AND at_.transaction_date >= $2
+              AND at_.transaction_date <= $3
+            GROUP BY category
+            ORDER BY amount DESC
+            "#,
+        )
+        .bind(org_id)
+        .bind(from)
+        .bind(to)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let total_inflows = inflow_rows.iter().map(|r| r.amount).sum();
+        let total_outflows = outflow_rows.iter().map(|r| r.amount).sum();
+        let net_cash_flow = total_inflows - total_outflows;
+
+        Ok(CashFlowReport {
+            from_date: from,
+            to_date: to,
+            inflows: inflow_rows,
+            outflows: outflow_rows,
+            total_inflows,
+            total_outflows,
+            net_cash_flow,
+        })
+    }
 }

--- a/backend/servers/api-server/Cargo.toml
+++ b/backend/servers/api-server/Cargo.toml
@@ -28,6 +28,7 @@ api-core = { workspace = true }
 admin-core = { workspace = true }
 db = { workspace = true }
 genpdf = { workspace = true }
+rust_xlsxwriter = { workspace = true }
 integrations = { workspace = true }
 tenant-ops = { workspace = true }
 sqlx = { workspace = true }

--- a/backend/servers/api-server/src/routes/financial.rs
+++ b/backend/servers/api-server/src/routes/financial.rs
@@ -164,6 +164,10 @@ pub fn router() -> Router<AppState> {
         .route("/overdue-invoices", get(get_overdue_invoices))
         // Reports (Story 11.7)
         .route("/reports/ar-aging", get(get_ar_aging_report))
+        .route("/reports/income-statement", get(get_income_statement))
+        .route("/reports/balance-sheet", get(get_balance_sheet))
+        .route("/reports/cash-flow", get(get_cash_flow))
+        .route("/reports/{report}/export", get(export_report))
 }
 
 // ==================== Request/Response Types ====================
@@ -328,6 +332,34 @@ pub struct ARReportQuery {
     pub organization_id: Uuid,
     /// Filter by building
     pub building_id: Option<Uuid>,
+}
+
+/// Income statement / cash flow date-range query.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct DateRangeReportQuery {
+    pub organization_id: Uuid,
+    pub from: NaiveDate,
+    pub to: NaiveDate,
+}
+
+/// Balance sheet as-of query.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct BalanceSheetQuery {
+    pub organization_id: Uuid,
+    pub as_of: Option<NaiveDate>,
+}
+
+/// Export query — wraps either a date range or as_of, plus format.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ExportQuery {
+    pub organization_id: Uuid,
+    /// "pdf" or "xlsx"
+    pub format: String,
+    /// Required for income-statement and cash-flow exports
+    pub from: Option<NaiveDate>,
+    pub to: Option<NaiveDate>,
+    /// Required for balance-sheet export
+    pub as_of: Option<NaiveDate>,
 }
 
 /// Create account with org.
@@ -1315,6 +1347,434 @@ async fn get_ar_aging_report(
         })
 }
 
+// ==================== Financial Statement Handlers (Story 11.7) ====================
+
+async fn get_income_statement(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Query(query): Query<DateRangeReportQuery>,
+) -> Result<Json<db::models::IncomeStatement>, (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, auth.user_id, query.organization_id).await?;
+    state
+        .financial_repo
+        .get_income_statement(query.organization_id, query.from, query.to)
+        .await
+        .map(Json)
+        .map_err(|e| {
+            tracing::error!("Failed to generate income statement: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", "Failed to generate income statement")),
+            )
+        })
+}
+
+async fn get_balance_sheet(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Query(query): Query<BalanceSheetQuery>,
+) -> Result<Json<db::models::BalanceSheetReport>, (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, auth.user_id, query.organization_id).await?;
+    let as_of = query.as_of.unwrap_or_else(|| chrono::Utc::now().date_naive());
+    state
+        .financial_repo
+        .get_balance_sheet(query.organization_id, as_of)
+        .await
+        .map(Json)
+        .map_err(|e| {
+            tracing::error!("Failed to generate balance sheet: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", "Failed to generate balance sheet")),
+            )
+        })
+}
+
+async fn get_cash_flow(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Query(query): Query<DateRangeReportQuery>,
+) -> Result<Json<db::models::CashFlowReport>, (StatusCode, Json<ErrorResponse>)> {
+    verify_org_access(&state, auth.user_id, query.organization_id).await?;
+    state
+        .financial_repo
+        .get_cash_flow(query.organization_id, query.from, query.to)
+        .await
+        .map(Json)
+        .map_err(|e| {
+            tracing::error!("Failed to generate cash flow report: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", "Failed to generate cash flow report")),
+            )
+        })
+}
+
+/// Render an income statement to PDF bytes using genpdf.
+fn render_income_statement_pdf(report: &db::models::IncomeStatement) -> Result<Vec<u8>, String> {
+    use genpdf::{elements, style::Style, Element};
+
+    let font_family = genpdf::fonts::from_files(
+        "/usr/share/fonts/truetype/liberation",
+        "LiberationSans",
+        None,
+    )
+    .map_err(|e| format!("font load error: {}", e))?;
+    let mut doc = genpdf::Document::new(font_family);
+    doc.set_title("Income Statement");
+    let mut decorator = genpdf::SimplePageDecorator::new();
+    decorator.set_margins(15);
+    doc.set_page_decorator(decorator);
+
+    doc.push(
+        elements::Paragraph::new("Income Statement")
+            .styled(Style::new().bold().with_font_size(18)),
+    );
+    doc.push(elements::Paragraph::new(format!(
+        "Period: {} – {}",
+        report.from_date, report.to_date
+    )));
+    doc.push(elements::Break::new(1));
+
+    doc.push(elements::Paragraph::new("Revenue").styled(Style::new().bold().with_font_size(13)));
+    for line in &report.revenue {
+        doc.push(elements::Paragraph::new(format!(
+            "  {}: {}",
+            line.category, line.amount
+        )));
+    }
+    doc.push(elements::Paragraph::new(format!(
+        "Total Revenue: {}",
+        report.total_revenue
+    )).styled(Style::new().bold()));
+    doc.push(elements::Break::new(1));
+
+    doc.push(elements::Paragraph::new("Expenses").styled(Style::new().bold().with_font_size(13)));
+    for line in &report.expenses {
+        doc.push(elements::Paragraph::new(format!(
+            "  {}: {}",
+            line.category, line.amount
+        )));
+    }
+    doc.push(elements::Paragraph::new(format!(
+        "Total Expenses: {}",
+        report.total_expenses
+    )).styled(Style::new().bold()));
+    doc.push(elements::Break::new(1));
+
+    doc.push(elements::Paragraph::new(format!(
+        "Net Income: {}",
+        report.net_income
+    )).styled(Style::new().bold().with_font_size(14)));
+
+    let mut bytes = Vec::new();
+    doc.render(&mut bytes)
+        .map_err(|e| format!("PDF render error: {}", e))?;
+    Ok(bytes)
+}
+
+/// Render a balance sheet to PDF bytes.
+fn render_balance_sheet_pdf(report: &db::models::BalanceSheetReport) -> Result<Vec<u8>, String> {
+    use genpdf::{elements, style::Style, Element};
+
+    let font_family = genpdf::fonts::from_files(
+        "/usr/share/fonts/truetype/liberation",
+        "LiberationSans",
+        None,
+    )
+    .map_err(|e| format!("font load error: {}", e))?;
+    let mut doc = genpdf::Document::new(font_family);
+    doc.set_title("Balance Sheet");
+    let mut decorator = genpdf::SimplePageDecorator::new();
+    decorator.set_margins(15);
+    doc.set_page_decorator(decorator);
+
+    doc.push(
+        elements::Paragraph::new("Balance Sheet")
+            .styled(Style::new().bold().with_font_size(18)),
+    );
+    doc.push(elements::Paragraph::new(format!("As of: {}", report.as_of_date)));
+    doc.push(elements::Break::new(1));
+
+    let mut table = elements::TableLayout::new(vec![6, 3, 3]);
+    table.set_cell_decorator(elements::FrameCellDecorator::new(true, true, false));
+    table
+        .row()
+        .element(elements::Paragraph::new("Account").styled(Style::new().bold()))
+        .element(elements::Paragraph::new("Type").styled(Style::new().bold()))
+        .element(elements::Paragraph::new("Balance").styled(Style::new().bold()))
+        .push()
+        .map_err(|e| format!("table header: {}", e))?;
+    for line in &report.accounts {
+        table
+            .row()
+            .element(elements::Paragraph::new(line.account_name.clone()))
+            .element(elements::Paragraph::new(line.account_type.clone()))
+            .element(elements::Paragraph::new(line.balance.to_string()))
+            .push()
+            .map_err(|e| format!("table row: {}", e))?;
+    }
+    doc.push(table);
+    doc.push(elements::Break::new(1));
+
+    doc.push(elements::Paragraph::new(format!("Total Assets: {}", report.total_assets)).styled(Style::new().bold()));
+    doc.push(elements::Paragraph::new(format!("Total Liabilities: {}", report.total_liabilities)).styled(Style::new().bold()));
+    doc.push(elements::Paragraph::new(format!("Net Equity: {}", report.net_equity)).styled(Style::new().bold()));
+
+    let mut bytes = Vec::new();
+    doc.render(&mut bytes)
+        .map_err(|e| format!("PDF render error: {}", e))?;
+    Ok(bytes)
+}
+
+/// Render a cash flow report to PDF bytes.
+fn render_cash_flow_pdf(report: &db::models::CashFlowReport) -> Result<Vec<u8>, String> {
+    use genpdf::{elements, style::Style, Element};
+
+    let font_family = genpdf::fonts::from_files(
+        "/usr/share/fonts/truetype/liberation",
+        "LiberationSans",
+        None,
+    )
+    .map_err(|e| format!("font load error: {}", e))?;
+    let mut doc = genpdf::Document::new(font_family);
+    doc.set_title("Cash Flow Statement");
+    let mut decorator = genpdf::SimplePageDecorator::new();
+    decorator.set_margins(15);
+    doc.set_page_decorator(decorator);
+
+    doc.push(
+        elements::Paragraph::new("Cash Flow Statement")
+            .styled(Style::new().bold().with_font_size(18)),
+    );
+    doc.push(elements::Paragraph::new(format!(
+        "Period: {} – {}",
+        report.from_date, report.to_date
+    )));
+    doc.push(elements::Break::new(1));
+
+    doc.push(elements::Paragraph::new("Inflows").styled(Style::new().bold().with_font_size(13)));
+    for line in &report.inflows {
+        doc.push(elements::Paragraph::new(format!(
+            "  {}: {}",
+            line.category, line.amount
+        )));
+    }
+    doc.push(elements::Paragraph::new(format!("Total Inflows: {}", report.total_inflows)).styled(Style::new().bold()));
+    doc.push(elements::Break::new(1));
+
+    doc.push(elements::Paragraph::new("Outflows").styled(Style::new().bold().with_font_size(13)));
+    for line in &report.outflows {
+        doc.push(elements::Paragraph::new(format!(
+            "  {}: {}",
+            line.category, line.amount
+        )));
+    }
+    doc.push(elements::Paragraph::new(format!("Total Outflows: {}", report.total_outflows)).styled(Style::new().bold()));
+    doc.push(elements::Break::new(1));
+
+    doc.push(elements::Paragraph::new(format!("Net Cash Flow: {}", report.net_cash_flow)).styled(Style::new().bold().with_font_size(14)));
+
+    let mut bytes = Vec::new();
+    doc.render(&mut bytes)
+        .map_err(|e| format!("PDF render error: {}", e))?;
+    Ok(bytes)
+}
+
+/// Render an income statement to xlsx bytes.
+fn render_income_statement_xlsx(report: &db::models::IncomeStatement) -> Result<Vec<u8>, String> {
+    use rust_xlsxwriter::Workbook;
+
+    let mut workbook = Workbook::new();
+    let sheet = workbook.add_worksheet();
+    sheet.set_name("Income Statement").map_err(|e| e.to_string())?;
+
+    sheet.write(0, 0, "Income Statement").map_err(|e| e.to_string())?;
+    sheet.write(1, 0, format!("Period: {} to {}", report.from_date, report.to_date)).map_err(|e| e.to_string())?;
+
+    let mut row: u32 = 3;
+    sheet.write(row, 0, "Revenue").map_err(|e| e.to_string())?;
+    sheet.write(row, 1, "Amount").map_err(|e| e.to_string())?;
+    row += 1;
+    for line in &report.revenue {
+        sheet.write(row, 0, line.category.as_str()).map_err(|e| e.to_string())?;
+        sheet.write(row, 1, line.amount.to_string().parse::<f64>().unwrap_or(0.0)).map_err(|e| e.to_string())?;
+        row += 1;
+    }
+    sheet.write(row, 0, "Total Revenue").map_err(|e| e.to_string())?;
+    sheet.write(row, 1, report.total_revenue.to_string().parse::<f64>().unwrap_or(0.0)).map_err(|e| e.to_string())?;
+
+    row += 2;
+    sheet.write(row, 0, "Expenses").map_err(|e| e.to_string())?;
+    sheet.write(row, 1, "Amount").map_err(|e| e.to_string())?;
+    row += 1;
+    for line in &report.expenses {
+        sheet.write(row, 0, line.category.as_str()).map_err(|e| e.to_string())?;
+        sheet.write(row, 1, line.amount.to_string().parse::<f64>().unwrap_or(0.0)).map_err(|e| e.to_string())?;
+        row += 1;
+    }
+    sheet.write(row, 0, "Total Expenses").map_err(|e| e.to_string())?;
+    sheet.write(row, 1, report.total_expenses.to_string().parse::<f64>().unwrap_or(0.0)).map_err(|e| e.to_string())?;
+
+    row += 2;
+    sheet.write(row, 0, "Net Income").map_err(|e| e.to_string())?;
+    sheet.write(row, 1, report.net_income.to_string().parse::<f64>().unwrap_or(0.0)).map_err(|e| e.to_string())?;
+
+    workbook.save_to_buffer().map_err(|e| e.to_string())
+}
+
+/// Render a balance sheet to xlsx bytes.
+fn render_balance_sheet_xlsx(report: &db::models::BalanceSheetReport) -> Result<Vec<u8>, String> {
+    use rust_xlsxwriter::Workbook;
+
+    let mut workbook = Workbook::new();
+    let sheet = workbook.add_worksheet();
+    sheet.set_name("Balance Sheet").map_err(|e| e.to_string())?;
+
+    sheet.write(0, 0, "Balance Sheet").map_err(|e| e.to_string())?;
+    sheet.write(1, 0, format!("As of: {}", report.as_of_date)).map_err(|e| e.to_string())?;
+
+    let mut row: u32 = 3;
+    sheet.write(row, 0, "Account").map_err(|e| e.to_string())?;
+    sheet.write(row, 1, "Type").map_err(|e| e.to_string())?;
+    sheet.write(row, 2, "Balance").map_err(|e| e.to_string())?;
+    row += 1;
+    for line in &report.accounts {
+        sheet.write(row, 0, line.account_name.as_str()).map_err(|e| e.to_string())?;
+        sheet.write(row, 1, line.account_type.as_str()).map_err(|e| e.to_string())?;
+        sheet.write(row, 2, line.balance.to_string().parse::<f64>().unwrap_or(0.0)).map_err(|e| e.to_string())?;
+        row += 1;
+    }
+    row += 1;
+    sheet.write(row, 0, "Total Assets").map_err(|e| e.to_string())?;
+    sheet.write(row, 2, report.total_assets.to_string().parse::<f64>().unwrap_or(0.0)).map_err(|e| e.to_string())?;
+    row += 1;
+    sheet.write(row, 0, "Total Liabilities").map_err(|e| e.to_string())?;
+    sheet.write(row, 2, report.total_liabilities.to_string().parse::<f64>().unwrap_or(0.0)).map_err(|e| e.to_string())?;
+    row += 1;
+    sheet.write(row, 0, "Net Equity").map_err(|e| e.to_string())?;
+    sheet.write(row, 2, report.net_equity.to_string().parse::<f64>().unwrap_or(0.0)).map_err(|e| e.to_string())?;
+
+    workbook.save_to_buffer().map_err(|e| e.to_string())
+}
+
+/// Render a cash flow report to xlsx bytes.
+fn render_cash_flow_xlsx(report: &db::models::CashFlowReport) -> Result<Vec<u8>, String> {
+    use rust_xlsxwriter::Workbook;
+
+    let mut workbook = Workbook::new();
+    let sheet = workbook.add_worksheet();
+    sheet.set_name("Cash Flow").map_err(|e| e.to_string())?;
+
+    sheet.write(0, 0, "Cash Flow Statement").map_err(|e| e.to_string())?;
+    sheet.write(1, 0, format!("Period: {} to {}", report.from_date, report.to_date)).map_err(|e| e.to_string())?;
+
+    let mut row: u32 = 3;
+    sheet.write(row, 0, "Inflows").map_err(|e| e.to_string())?;
+    sheet.write(row, 1, "Amount").map_err(|e| e.to_string())?;
+    row += 1;
+    for line in &report.inflows {
+        sheet.write(row, 0, line.category.as_str()).map_err(|e| e.to_string())?;
+        sheet.write(row, 1, line.amount.to_string().parse::<f64>().unwrap_or(0.0)).map_err(|e| e.to_string())?;
+        row += 1;
+    }
+    sheet.write(row, 0, "Total Inflows").map_err(|e| e.to_string())?;
+    sheet.write(row, 1, report.total_inflows.to_string().parse::<f64>().unwrap_or(0.0)).map_err(|e| e.to_string())?;
+
+    row += 2;
+    sheet.write(row, 0, "Outflows").map_err(|e| e.to_string())?;
+    sheet.write(row, 1, "Amount").map_err(|e| e.to_string())?;
+    row += 1;
+    for line in &report.outflows {
+        sheet.write(row, 0, line.category.as_str()).map_err(|e| e.to_string())?;
+        sheet.write(row, 1, line.amount.to_string().parse::<f64>().unwrap_or(0.0)).map_err(|e| e.to_string())?;
+        row += 1;
+    }
+    sheet.write(row, 0, "Total Outflows").map_err(|e| e.to_string())?;
+    sheet.write(row, 1, report.total_outflows.to_string().parse::<f64>().unwrap_or(0.0)).map_err(|e| e.to_string())?;
+
+    row += 2;
+    sheet.write(row, 0, "Net Cash Flow").map_err(|e| e.to_string())?;
+    sheet.write(row, 1, report.net_cash_flow.to_string().parse::<f64>().unwrap_or(0.0)).map_err(|e| e.to_string())?;
+
+    workbook.save_to_buffer().map_err(|e| e.to_string())
+}
+
+/// Export a financial report as PDF or xlsx.
+/// Path: GET /financial/reports/{report}/export
+/// `report` is one of: income-statement, balance-sheet, cash-flow
+async fn export_report(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path(report): Path<String>,
+    Query(query): Query<ExportQuery>,
+) -> Result<axum::response::Response, (StatusCode, Json<ErrorResponse>)> {
+    use axum::response::IntoResponse;
+
+    verify_org_access(&state, auth.user_id, query.organization_id).await?;
+
+    let format = query.format.to_lowercase();
+    if format != "pdf" && format != "xlsx" {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new("BAD_REQUEST", "format must be pdf or xlsx")),
+        ));
+    }
+
+    let today = chrono::Utc::now().date_naive();
+
+    match report.as_str() {
+        "income-statement" => {
+            let from = query.from.ok_or_else(|| (StatusCode::BAD_REQUEST, Json(ErrorResponse::new("BAD_REQUEST", "from date required for income-statement"))))?;
+            let to = query.to.unwrap_or(today);
+            let data = state.financial_repo.get_income_statement(query.organization_id, from, to).await
+                .map_err(|e| { tracing::error!("income statement export: {:?}", e); (StatusCode::INTERNAL_SERVER_ERROR, Json(ErrorResponse::new("DB_ERROR", "Failed to load income statement"))) })?;
+            if format == "pdf" {
+                let bytes = render_income_statement_pdf(&data).map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(ErrorResponse::new("PDF_ERROR", &e))))?;
+                let headers = [(axum::http::header::CONTENT_TYPE, "application/pdf"), (axum::http::header::CONTENT_DISPOSITION, "attachment; filename=\"income-statement.pdf\"")];
+                Ok((StatusCode::OK, headers, bytes).into_response())
+            } else {
+                let bytes = render_income_statement_xlsx(&data).map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(ErrorResponse::new("XLSX_ERROR", &e))))?;
+                let headers = [(axum::http::header::CONTENT_TYPE, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"), (axum::http::header::CONTENT_DISPOSITION, "attachment; filename=\"income-statement.xlsx\"")];
+                Ok((StatusCode::OK, headers, bytes).into_response())
+            }
+        }
+        "balance-sheet" => {
+            let as_of = query.as_of.unwrap_or(today);
+            let data = state.financial_repo.get_balance_sheet(query.organization_id, as_of).await
+                .map_err(|e| { tracing::error!("balance sheet export: {:?}", e); (StatusCode::INTERNAL_SERVER_ERROR, Json(ErrorResponse::new("DB_ERROR", "Failed to load balance sheet"))) })?;
+            if format == "pdf" {
+                let bytes = render_balance_sheet_pdf(&data).map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(ErrorResponse::new("PDF_ERROR", &e))))?;
+                let headers = [(axum::http::header::CONTENT_TYPE, "application/pdf"), (axum::http::header::CONTENT_DISPOSITION, "attachment; filename=\"balance-sheet.pdf\"")];
+                Ok((StatusCode::OK, headers, bytes).into_response())
+            } else {
+                let bytes = render_balance_sheet_xlsx(&data).map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(ErrorResponse::new("XLSX_ERROR", &e))))?;
+                let headers = [(axum::http::header::CONTENT_TYPE, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"), (axum::http::header::CONTENT_DISPOSITION, "attachment; filename=\"balance-sheet.xlsx\"")];
+                Ok((StatusCode::OK, headers, bytes).into_response())
+            }
+        }
+        "cash-flow" => {
+            let from = query.from.ok_or_else(|| (StatusCode::BAD_REQUEST, Json(ErrorResponse::new("BAD_REQUEST", "from date required for cash-flow"))))?;
+            let to = query.to.unwrap_or(today);
+            let data = state.financial_repo.get_cash_flow(query.organization_id, from, to).await
+                .map_err(|e| { tracing::error!("cash flow export: {:?}", e); (StatusCode::INTERNAL_SERVER_ERROR, Json(ErrorResponse::new("DB_ERROR", "Failed to load cash flow"))) })?;
+            if format == "pdf" {
+                let bytes = render_cash_flow_pdf(&data).map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(ErrorResponse::new("PDF_ERROR", &e))))?;
+                let headers = [(axum::http::header::CONTENT_TYPE, "application/pdf"), (axum::http::header::CONTENT_DISPOSITION, "attachment; filename=\"cash-flow.pdf\"")];
+                Ok((StatusCode::OK, headers, bytes).into_response())
+            } else {
+                let bytes = render_cash_flow_xlsx(&data).map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(ErrorResponse::new("XLSX_ERROR", &e))))?;
+                let headers = [(axum::http::header::CONTENT_TYPE, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"), (axum::http::header::CONTENT_DISPOSITION, "attachment; filename=\"cash-flow.xlsx\"")];
+                Ok((StatusCode::OK, headers, bytes).into_response())
+            }
+        }
+        _ => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("NOT_FOUND", "Unknown report type")),
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1366,6 +1826,82 @@ mod tests {
             }],
             payments: vec![],
         }
+    }
+
+    #[test]
+    fn render_income_statement_pdf_produces_valid_pdf() {
+        use db::models::{IncomeStatement, IncomeStatementLine};
+        use rust_decimal::Decimal;
+        let report = IncomeStatement {
+            from_date: chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+            to_date: chrono::NaiveDate::from_ymd_opt(2026, 3, 31).unwrap(),
+            revenue: vec![IncomeStatementLine { category: "payment_received".into(), amount: Decimal::new(50000, 2) }],
+            expenses: vec![IncomeStatementLine { category: "maintenance_fee".into(), amount: Decimal::new(10000, 2) }],
+            total_revenue: Decimal::new(50000, 2),
+            total_expenses: Decimal::new(10000, 2),
+            net_income: Decimal::new(40000, 2),
+        };
+        let bytes = render_income_statement_pdf(&report).expect("render income statement PDF");
+        assert!(bytes.len() > 100);
+        assert_eq!(&bytes[..5], b"%PDF-");
+    }
+
+    #[test]
+    fn render_balance_sheet_pdf_produces_valid_pdf() {
+        use db::models::{BalanceSheetLine, BalanceSheetReport};
+        use rust_decimal::Decimal;
+        let report = BalanceSheetReport {
+            as_of_date: chrono::NaiveDate::from_ymd_opt(2026, 3, 31).unwrap(),
+            accounts: vec![BalanceSheetLine {
+                account_id: uuid::Uuid::new_v4(),
+                account_name: "Operating Account".into(),
+                account_type: "operating".into(),
+                balance: Decimal::new(100000, 2),
+            }],
+            total_assets: Decimal::new(100000, 2),
+            total_liabilities: Decimal::ZERO,
+            net_equity: Decimal::new(100000, 2),
+        };
+        let bytes = render_balance_sheet_pdf(&report).expect("render balance sheet PDF");
+        assert!(bytes.len() > 100);
+        assert_eq!(&bytes[..5], b"%PDF-");
+    }
+
+    #[test]
+    fn render_cash_flow_pdf_produces_valid_pdf() {
+        use db::models::{CashFlowLine, CashFlowReport};
+        use rust_decimal::Decimal;
+        let report = CashFlowReport {
+            from_date: chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+            to_date: chrono::NaiveDate::from_ymd_opt(2026, 3, 31).unwrap(),
+            inflows: vec![CashFlowLine { category: "payment_received".into(), amount: Decimal::new(50000, 2) }],
+            outflows: vec![CashFlowLine { category: "maintenance_fee".into(), amount: Decimal::new(10000, 2) }],
+            total_inflows: Decimal::new(50000, 2),
+            total_outflows: Decimal::new(10000, 2),
+            net_cash_flow: Decimal::new(40000, 2),
+        };
+        let bytes = render_cash_flow_pdf(&report).expect("render cash flow PDF");
+        assert!(bytes.len() > 100);
+        assert_eq!(&bytes[..5], b"%PDF-");
+    }
+
+    #[test]
+    fn render_income_statement_xlsx_produces_valid_xlsx() {
+        use db::models::{IncomeStatement, IncomeStatementLine};
+        use rust_decimal::Decimal;
+        let report = IncomeStatement {
+            from_date: chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+            to_date: chrono::NaiveDate::from_ymd_opt(2026, 3, 31).unwrap(),
+            revenue: vec![IncomeStatementLine { category: "payment_received".into(), amount: Decimal::new(50000, 2) }],
+            expenses: vec![],
+            total_revenue: Decimal::new(50000, 2),
+            total_expenses: Decimal::ZERO,
+            net_income: Decimal::new(50000, 2),
+        };
+        let bytes = render_income_statement_xlsx(&report).expect("render xlsx");
+        // xlsx files start with PK (zip)
+        assert!(bytes.len() > 100);
+        assert_eq!(&bytes[..2], b"PK");
     }
 
     #[test]

--- a/frontend/packages/api-client/src/financial/api.ts
+++ b/frontend/packages/api-client/src/financial/api.ts
@@ -13,13 +13,19 @@ import type {
   ARReportParams,
   ARReportTotals,
   AutoMatchResult,
+  BalanceSheetParams,
+  BalanceSheetReport,
+  CashFlowReport,
   CreateFeeSchedule,
   CreateFinancialAccount,
   CreateInvoice,
   CreateTransaction,
+  DateRangeReportParams,
+  ExportReportParams,
   FeeSchedule,
   FinancialAccount,
   FinancialAccountResponse,
+  IncomeStatement,
   Invoice,
   InvoiceItem,
   InvoiceResponse,
@@ -36,6 +42,7 @@ import type {
   PaymentResponse,
   RecordPayment,
   ReminderSchedule,
+  ReportType,
   UnitFee,
 } from './types';
 
@@ -450,4 +457,90 @@ export async function getARAgingReport(params: ARReportParams): Promise<Accounts
       totals: coerceArBuckets(r.totals),
     })
   );
+}
+
+// ============================================================================
+// FINANCIAL STATEMENT REPORTS (Story 11.7)
+// ============================================================================
+
+function coerceIncomeStatementLine(l: IncomeStatement['revenue'][0]) {
+  return { ...l, amount: toNum(l.amount) };
+}
+function coerceBalanceSheetLine(l: BalanceSheetReport['accounts'][0]) {
+  return { ...l, balance: toNum(l.balance) };
+}
+function coerceCashFlowLine(l: CashFlowReport['inflows'][0]) {
+  return { ...l, amount: toNum(l.amount) };
+}
+
+export async function getIncomeStatement(params: DateRangeReportParams): Promise<IncomeStatement> {
+  const q = new URLSearchParams({
+    organization_id: params.organization_id,
+    from: params.from,
+    to: params.to,
+  });
+  return fetchApi<IncomeStatement>(`${API_BASE}/reports/income-statement?${q}`).then((r) => ({
+    ...r,
+    revenue: r.revenue.map(coerceIncomeStatementLine),
+    expenses: r.expenses.map(coerceIncomeStatementLine),
+    total_revenue: toNum(r.total_revenue),
+    total_expenses: toNum(r.total_expenses),
+    net_income: toNum(r.net_income),
+  }));
+}
+
+export async function getBalanceSheet(params: BalanceSheetParams): Promise<BalanceSheetReport> {
+  const q = new URLSearchParams({ organization_id: params.organization_id });
+  if (params.as_of) q.set('as_of', params.as_of);
+  return fetchApi<BalanceSheetReport>(`${API_BASE}/reports/balance-sheet?${q}`).then((r) => ({
+    ...r,
+    accounts: r.accounts.map(coerceBalanceSheetLine),
+    total_assets: toNum(r.total_assets),
+    total_liabilities: toNum(r.total_liabilities),
+    net_equity: toNum(r.net_equity),
+  }));
+}
+
+export async function getCashFlowReport(params: DateRangeReportParams): Promise<CashFlowReport> {
+  const q = new URLSearchParams({
+    organization_id: params.organization_id,
+    from: params.from,
+    to: params.to,
+  });
+  return fetchApi<CashFlowReport>(`${API_BASE}/reports/cash-flow?${q}`).then((r) => ({
+    ...r,
+    inflows: r.inflows.map(coerceCashFlowLine),
+    outflows: r.outflows.map(coerceCashFlowLine),
+    total_inflows: toNum(r.total_inflows),
+    total_outflows: toNum(r.total_outflows),
+    net_cash_flow: toNum(r.net_cash_flow),
+  }));
+}
+
+async function fetchBlob(url: string): Promise<Blob> {
+  const token = getToken();
+  const org = getOrg();
+  const baseUrl = client.getConfig().baseUrl ?? '';
+  const response = await fetch(`${baseUrl}${url}`, {
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(org ? { 'X-Tenant-ID': org } : {}),
+    },
+  });
+  if (!response.ok) throw new Error(`Export failed: HTTP ${response.status}`);
+  return response.blob();
+}
+
+export async function exportReport(
+  report: ReportType,
+  params: ExportReportParams
+): Promise<Blob> {
+  const q = new URLSearchParams({
+    organization_id: params.organization_id,
+    format: params.format,
+  });
+  if (params.from) q.set('from', params.from);
+  if (params.to) q.set('to', params.to);
+  if (params.as_of) q.set('as_of', params.as_of);
+  return fetchBlob(`${API_BASE}/reports/${report}/export?${q}`);
 }

--- a/frontend/packages/api-client/src/financial/types.ts
+++ b/frontend/packages/api-client/src/financial/types.ts
@@ -366,6 +366,77 @@ export interface AccountsReceivableReport {
 }
 
 // ============================================================================
+// FINANCIAL STATEMENT REPORTS (Story 11.7)
+// ============================================================================
+
+export interface IncomeStatementLine {
+  category: string;
+  amount: number;
+}
+
+export interface IncomeStatement {
+  from_date: string;
+  to_date: string;
+  revenue: IncomeStatementLine[];
+  expenses: IncomeStatementLine[];
+  total_revenue: number;
+  total_expenses: number;
+  net_income: number;
+}
+
+export interface BalanceSheetLine {
+  account_id: string;
+  account_name: string;
+  account_type: string;
+  balance: number;
+}
+
+export interface BalanceSheetReport {
+  as_of_date: string;
+  accounts: BalanceSheetLine[];
+  total_assets: number;
+  total_liabilities: number;
+  net_equity: number;
+}
+
+export interface CashFlowLine {
+  category: string;
+  amount: number;
+}
+
+export interface CashFlowReport {
+  from_date: string;
+  to_date: string;
+  inflows: CashFlowLine[];
+  outflows: CashFlowLine[];
+  total_inflows: number;
+  total_outflows: number;
+  net_cash_flow: number;
+}
+
+export interface DateRangeReportParams {
+  organization_id: string;
+  from: string;
+  to: string;
+}
+
+export interface BalanceSheetParams {
+  organization_id: string;
+  as_of?: string;
+}
+
+export type ReportExportFormat = 'pdf' | 'xlsx';
+export type ReportType = 'income-statement' | 'balance-sheet' | 'cash-flow';
+
+export interface ExportReportParams {
+  organization_id: string;
+  format: ReportExportFormat;
+  from?: string;
+  to?: string;
+  as_of?: string;
+}
+
+// ============================================================================
 // QUERY PARAMS
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Implements Story 11.7 financial reports — closes backend gap from gap-sweep #975 item 3 ([BIT-175](/BIT/issues/BIT-175)).

**New endpoints (all org-scoped, same auth/tenant guard as `/reports/ar-aging`):**
- `GET /financial/reports/income-statement?organization_id=&from=&to=`
- `GET /financial/reports/balance-sheet?organization_id=&as_of=`
- `GET /financial/reports/cash-flow?organization_id=&from=&to=`
- `GET /financial/reports/{report}/export?organization_id=&format=pdf|xlsx[&from=&to=|&as_of=]`

**What changed:**
- `backend/crates/db/src/models/financial.rs` — 6 new structs: `IncomeStatement`, `IncomeStatementLine`, `BalanceSheetReport`, `BalanceSheetLine`, `CashFlowReport`, `CashFlowLine`
- `backend/crates/db/src/repositories/financial.rs` — 3 new repo methods aggregating `account_transactions` by credit/debit and date range
- `backend/servers/api-server/src/routes/financial.rs` — 4 new route handlers + 6 render functions (genpdf PDF + rust_xlsxwriter xlsx) + 4 unit tests
- `backend/Cargo.toml` / `backend/servers/api-server/Cargo.toml` — add `rust_xlsxwriter = "0.80"`
- `frontend/packages/api-client/src/financial/` — types and API functions for all new endpoints

**Frontend wiring** (Reports screen) is a follow-up child of [BIT-166](/BIT/issues/BIT-166) — API is ready.

## Test plan
- [ ] CI fmt → clippy → unit tests pass (PDF/xlsx render tests included)
- [ ] `GET /financial/reports/income-statement` returns correct revenue/expense aggregates
- [ ] `GET /financial/reports/balance-sheet` returns account balances as of date
- [ ] `GET /financial/reports/cash-flow` returns inflow/outflow aggregates
- [ ] `GET /financial/reports/income-statement/export?format=pdf` streams valid PDF
- [ ] `GET /financial/reports/income-statement/export?format=xlsx` streams valid xlsx (PK header)
- [ ] 403 returned for non-member org access

🤖 Generated with [Claude Code](https://claude.com/claude-code)