### PR TITLE
churn-hotspot-backend-crates-db-tests-form-rls-repo-tests-rs: dedupe inline RLS role setup

### DIFF
--- a/backend/crates/db/tests/form_rls_repo_tests.rs
+++ b/backend/crates/db/tests/form_rls_repo_tests.rs
@@ -167,32 +167,21 @@ async fn form_repo_force_rls_deny_all_and_fix(pool: PgPool) {
         seed_form_with_status(&pool, org_a, user_a, "Published Form A", "published").await;
 
     // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds ---
-    let role = format!("ppt_rls_form_{}", Uuid::new_v4().simple());
-    for stmt in [
-        format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
-        format!(
-            "GRANT SELECT, INSERT, UPDATE, DELETE ON \
-             forms, form_fields, form_submissions, form_downloads TO \"{role}\""
-        ),
-        format!(
-            "GRANT EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
-             get_current_org_not_deleted() TO \"{role}\""
-        ),
-        format!("GRANT SELECT ON organizations TO \"{role}\""),
-        // `FormRepository::list` LEFT JOINs `users` to surface `created_by_name`,
-        // so the NOSUPERUSER RLS role needs SELECT on `users` or the join trips
-        // Postgres 42501 (permission denied on `users`).
-        format!("GRANT SELECT ON users TO \"{role}\""),
-        // `get_submission` LEFT JOINs `units` (un.designation) and `buildings`
-        // (b.name) for the submission detail view, so the role likewise needs
-        // SELECT on both or the join trips 42501 (permission denied on `units`).
-        format!("GRANT SELECT ON units, buildings TO \"{role}\""),
-    ] {
-        sqlx::query(sqlx::AssertSqlSafe(stmt))
-            .execute(&pool)
-            .await
-            .expect("grant setup");
-    }
+    // Reuses the shared `create_rls_role` helper for the common CREATE + grant
+    // set (forms/form_fields/form_submissions/form_downloads + the RLS
+    // functions + organizations + users), then adds the extra grants this test
+    // alone needs:
+    //
+    //   `get_submission` LEFT JOINs `units` (un.designation) and `buildings`
+    //   (b.name) for the submission detail view, so the role likewise needs
+    //   SELECT on both or the join trips 42501 (permission denied on `units`).
+    let role = create_rls_role(&pool).await;
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT SELECT ON units, buildings TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant setup");
 
     // ====================================================================
     // (1) DENY-ALL: role bound, NO context set.


### PR DESCRIPTION
## Task

Churn hotspot: `backend/crates/db/tests/form_rls_repo_tests.rs` touched 2x since 2026-06-12. Assess whether a SAFE behavior-preserving structural improvement is warranted to reduce churn surface. This is a TEST file. (Cloud sandbox has NO Postgres — DB-backed `cargo test -p db` cannot run; verification via `cargo check`/`clippy`, DB tests deferred to CI.)

## Owner

pm-backend

## What changed (pure behavior-preserving move)

`form_repo_force_rls_deny_all_and_fix` re-inlined a CREATE ROLE + grant block that is **byte-identical** to the existing `create_rls_role` helper (already used by the sibling test `form_repo_force_rls_write_paths_and_cross_tenant`), plus one extra `GRANT SELECT ON units, buildings` statement.

This PR replaces the ~22-line inline block with a `create_rls_role(&pool)` call followed by the single test-specific `units, buildings` grant. That is the actual churn surface: the duplicated role-setup SQL had to be kept in sync with the helper by hand.

Equivalence preserved:
- Same SQL statements issued, in the same order (CREATE → forms/fields/submissions/downloads grant → RLS-function grants → organizations → users → units, buildings).
- Identical role-name generation (`ppt_rls_form_{uuid}` — done inside `create_rls_role`).
- The test's teardown (REVOKE/DROP ROLE block) is left **untouched** — no change to the role lifecycle the DB tests exercise.

No new helpers added (this removes duplication), so no code-reuse concern.

## Tested (Band A — fast check)

`cargo check -p db --tests` / `cargo clippy` — **could not run in this sandbox**: crates.io is unreachable (private-IP DNS block) and the local registry cache is incomplete (`adler2` and other transitive deps cannot be fetched). Exit: network 403 / `--offline` download failure.

Verified what was runnable without the dependency graph:
- `cargo fmt -p db -- --check` → exit 0
- `rustfmt --edition 2021 --check crates/db/tests/form_rls_repo_tests.rs` → exit 0
- Manual symbol-resolution check: `create_rls_role` is an existing `async fn(&PgPool) -> String` called identically by the sibling test; all imports (incl. `Uuid`) remain used post-edit — no unused-import/variable risk.

Compile + clippy + the two `#[sqlx::test]` DB tests are **deferred to CI** (backend.yml), which has Postgres and full deps. Kept as a draft PR until CI is green.

## Built (Band B — full build)

Skipped: change is a <30 LOC test-only mechanical move, no public API/config/migration touch.

## CI parity (Band C — hot-path only)

Skipped: not a hot-path PR (test refactor, no security/auth/billing/data-integrity behavior change).

## Notes

Conservative scope: I did NOT swap the first test's cleanup to `drop_rls_role` (its revoke set/order differs from the inline teardown and changing it would be an unverifiable behavior change without the DB). I also did NOT migrate this file onto `tests/common/mod.rs` helpers — the local-helper pattern is the dominant convention in this RLS-repo-test family (e.g. `budget_rls_repo_tests.rs`, which this file mirrors, also keeps local `set_ctx`/`seed_org`). scope_drift=false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvLFEdGSoGsQKnQP5thYuM

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvLFEdGSoGsQKnQP5thYuM)_