### PR TITLE
feat(financial): financial statement reports screen (Story 11.7)

### DIFF
--- a/docs/screens/ppt/financial-reports.md
+++ b/docs/screens/ppt/financial-reports.md
@@ -1,0 +1,47 @@
+---
+id: ppt/financial-reports
+name: Financial Reports
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/financial/reports"
+    component: FinancialReportsPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: wired
+endpoints:
+  - "GET /api/v1/financial/reports/income-statement"
+  - "GET /api/v1/financial/reports/balance-sheet"
+  - "GET /api/v1/financial/reports/cash-flow"
+  - "GET /api/v1/financial/reports/{report}/export"
+relatedScreens:
+  - id: ppt/financial
+    rel: parent
+sharedComponents: []
+diagrams: []
+useCases: []
+epics:
+  - "Epic 11 / Story 11.7 — Financial statement reports"
+designSources: []
+owner: pm-frontend
+---
+
+# Financial Reports
+
+Tabbed financial statement viewer: Income Statement, Balance Sheet, and Cash Flow.
+Income statement and cash flow use a from/to date range (default year-to-date);
+the balance sheet uses an as-of date (default today). Each report renders as a
+card/table and offers PDF + Excel (xlsx) export, which streams the backend blob
+to a browser download.
+
+## Notes
+
+### Specific (recent)
+- 2026-06-22 — BIT-222: page + IncomeStatementView / BalanceSheetView / CashFlowView
+  components created; route `/financial/reports` wired in `routes/groups/financial.tsx`
+  via TanStack Query (one query per active tab) against the Story 11.7 endpoints.
+
+## Agent Log
+- 2026-06-22 — FrontendEngineer: created screen + screen-map for Story 11.7 FE
+  follow-up (BIT-222). Backend endpoints live on dev (PRs #1717 + #1723).

--- a/docs/screens/ppt/financial-reports.md
+++ b/docs/screens/ppt/financial-reports.md
@@ -9,12 +9,8 @@ implementations:
     component: FinancialReportsPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: wired
-endpoints:
-  - "GET /api/v1/financial/reports/income-statement"
-  - "GET /api/v1/financial/reports/balance-sheet"
-  - "GET /api/v1/financial/reports/cash-flow"
-  - "GET /api/v1/financial/reports/{report}/export"
+    apiStatus: complete
+endpoints: []
 relatedScreens:
   - id: ppt/financial
     rel: parent

--- a/docs/screens/ppt/financial.md
+++ b/docs/screens/ppt/financial.md
@@ -11,7 +11,9 @@ implementations:
     redesignStatus: not-started
     apiStatus: partial
 endpoints: []
-relatedScreens: []
+relatedScreens:
+  - id: ppt/financial-reports
+    rel: child
 sharedComponents: []
 diagrams: []
 useCases: []

--- a/frontend/apps/ppt-web/src/features/financial/components/BalanceSheetView.tsx
+++ b/frontend/apps/ppt-web/src/features/financial/components/BalanceSheetView.tsx
@@ -1,0 +1,132 @@
+/**
+ * BalanceSheetView component (Story 11.7).
+ *
+ * Renders a balance sheet: accounts grouped by type with their balances, plus
+ * the total assets / liabilities / net equity summary.
+ */
+
+import type { BalanceSheetReport } from '@ppt/api-client';
+import { Fragment } from 'react';
+import { formatCurrency, formatDate } from '../utils/formatting';
+
+interface BalanceSheetViewProps {
+  data?: BalanceSheetReport;
+  isLoading?: boolean;
+  currency?: string;
+}
+
+/** Humanise an account_type slug (e.g. `current_asset` → `Current Asset`). */
+function formatAccountType(type: string): string {
+  return type
+    .split(/[_\s]+/)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+export function BalanceSheetView({ data, isLoading, currency = 'EUR' }: BalanceSheetViewProps) {
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-lg shadow p-6 animate-pulse space-y-3">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="h-8 bg-gray-200 rounded" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="bg-white rounded-lg shadow p-6">
+        <p className="text-gray-500 text-center py-8">
+          Select an as-of date to view the balance sheet.
+        </p>
+      </div>
+    );
+  }
+
+  // Group accounts by their type so the sheet reads section-by-section.
+  const groups = data.accounts.reduce<Record<string, BalanceSheetReport['accounts']>>(
+    (acc, line) => {
+      const bucket = acc[line.account_type] ?? [];
+      bucket.push(line);
+      acc[line.account_type] = bucket;
+      return acc;
+    },
+    {}
+  );
+  const groupKeys = Object.keys(groups).sort();
+
+  return (
+    <div className="bg-white rounded-lg shadow overflow-hidden">
+      <div className="px-6 py-4 border-b border-gray-200">
+        <h3 className="text-lg font-medium text-gray-900">Balance Sheet</h3>
+        <p className="mt-1 text-sm text-gray-500">As of {formatDate(data.as_of_date)}</p>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <tbody className="divide-y divide-gray-200">
+            {data.accounts.length === 0 ? (
+              <tr>
+                <td colSpan={2} className="px-6 py-8 text-sm text-gray-400 text-center">
+                  No accounts
+                </td>
+              </tr>
+            ) : (
+              groupKeys.map((type) => (
+                <Fragment key={type}>
+                  <tr className="bg-gray-50">
+                    <th
+                      scope="col"
+                      className="px-6 py-2 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider"
+                    >
+                      {formatAccountType(type)}
+                    </th>
+                    <th
+                      scope="col"
+                      className="px-6 py-2 text-right text-xs font-semibold text-gray-600 uppercase tracking-wider"
+                    >
+                      Balance
+                    </th>
+                  </tr>
+                  {groups[type].map((line) => (
+                    <tr key={line.account_id}>
+                      <td className="px-6 py-3 text-sm text-gray-700">{line.account_name}</td>
+                      <td className="px-6 py-3 text-sm text-right text-gray-700 tabular-nums">
+                        {formatCurrency(line.balance, currency)}
+                      </td>
+                    </tr>
+                  ))}
+                </Fragment>
+              ))
+            )}
+          </tbody>
+          <tfoot className="bg-gray-100">
+            <tr>
+              <td className="px-6 py-3 text-sm font-medium text-gray-900">Total Assets</td>
+              <td className="px-6 py-3 text-sm text-right font-medium text-gray-900 tabular-nums">
+                {formatCurrency(data.total_assets, currency)}
+              </td>
+            </tr>
+            <tr>
+              <td className="px-6 py-3 text-sm font-medium text-gray-900">Total Liabilities</td>
+              <td className="px-6 py-3 text-sm text-right font-medium text-gray-900 tabular-nums">
+                {formatCurrency(data.total_liabilities, currency)}
+              </td>
+            </tr>
+            <tr>
+              <td className="px-6 py-4 text-sm font-bold text-gray-900">Net Equity</td>
+              <td
+                className={`px-6 py-4 text-sm text-right font-bold tabular-nums ${
+                  data.net_equity < 0 ? 'text-red-600' : 'text-gray-900'
+                }`}
+              >
+                {formatCurrency(data.net_equity, currency)}
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/financial/components/CashFlowView.tsx
+++ b/frontend/apps/ppt-web/src/features/financial/components/CashFlowView.tsx
@@ -1,0 +1,134 @@
+/**
+ * CashFlowView component (Story 11.7).
+ *
+ * Renders a cash-flow statement: inflow lines, outflow lines, and the derived
+ * totals / net cash flow.
+ */
+
+import type { CashFlowReport } from '@ppt/api-client';
+import { formatCurrency, formatDate } from '../utils/formatting';
+
+interface CashFlowViewProps {
+  data?: CashFlowReport;
+  isLoading?: boolean;
+  currency?: string;
+}
+
+function SectionRows({ lines, currency }: { lines: CashFlowReport['inflows']; currency: string }) {
+  if (lines.length === 0) {
+    return (
+      <tr>
+        <td colSpan={2} className="px-6 py-4 text-sm text-gray-400 text-center">
+          No entries
+        </td>
+      </tr>
+    );
+  }
+  return (
+    <>
+      {lines.map((line) => (
+        <tr key={line.category}>
+          <td className="px-6 py-3 text-sm text-gray-700">{line.category}</td>
+          <td className="px-6 py-3 text-sm text-right text-gray-700 tabular-nums">
+            {formatCurrency(line.amount, currency)}
+          </td>
+        </tr>
+      ))}
+    </>
+  );
+}
+
+export function CashFlowView({ data, isLoading, currency = 'EUR' }: CashFlowViewProps) {
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-lg shadow p-6 animate-pulse space-y-3">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="h-8 bg-gray-200 rounded" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="bg-white rounded-lg shadow p-6">
+        <p className="text-gray-500 text-center py-8">
+          Select a date range to view the cash-flow statement.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow overflow-hidden">
+      <div className="px-6 py-4 border-b border-gray-200">
+        <h3 className="text-lg font-medium text-gray-900">Cash Flow</h3>
+        <p className="mt-1 text-sm text-gray-500">
+          {formatDate(data.from_date)} – {formatDate(data.to_date)}
+        </p>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <tbody className="divide-y divide-gray-200">
+            <tr className="bg-gray-50">
+              <th
+                scope="col"
+                className="px-6 py-2 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider"
+              >
+                Inflows
+              </th>
+              <th
+                scope="col"
+                className="px-6 py-2 text-right text-xs font-semibold text-gray-600 uppercase tracking-wider"
+              >
+                Amount
+              </th>
+            </tr>
+            <SectionRows lines={data.inflows} currency={currency} />
+            <tr className="bg-gray-50/60">
+              <td className="px-6 py-3 text-sm font-medium text-gray-900">Total Inflows</td>
+              <td className="px-6 py-3 text-sm text-right font-medium text-gray-900 tabular-nums">
+                {formatCurrency(data.total_inflows, currency)}
+              </td>
+            </tr>
+
+            <tr className="bg-gray-50">
+              <th
+                scope="col"
+                className="px-6 py-2 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider"
+              >
+                Outflows
+              </th>
+              <th
+                scope="col"
+                className="px-6 py-2 text-right text-xs font-semibold text-gray-600 uppercase tracking-wider"
+              >
+                Amount
+              </th>
+            </tr>
+            <SectionRows lines={data.outflows} currency={currency} />
+            <tr className="bg-gray-50/60">
+              <td className="px-6 py-3 text-sm font-medium text-gray-900">Total Outflows</td>
+              <td className="px-6 py-3 text-sm text-right font-medium text-gray-900 tabular-nums">
+                {formatCurrency(data.total_outflows, currency)}
+              </td>
+            </tr>
+          </tbody>
+          <tfoot className="bg-gray-100">
+            <tr>
+              <td className="px-6 py-4 text-sm font-bold text-gray-900">Net Cash Flow</td>
+              <td
+                className={`px-6 py-4 text-sm text-right font-bold tabular-nums ${
+                  data.net_cash_flow < 0 ? 'text-red-600' : 'text-green-700'
+                }`}
+              >
+                {formatCurrency(data.net_cash_flow, currency)}
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/financial/components/IncomeStatementView.tsx
+++ b/frontend/apps/ppt-web/src/features/financial/components/IncomeStatementView.tsx
@@ -1,0 +1,138 @@
+/**
+ * IncomeStatementView component (Story 11.7).
+ *
+ * Renders an income statement: revenue lines, expense lines, and the derived
+ * totals / net income.
+ */
+
+import type { IncomeStatement } from '@ppt/api-client';
+import { formatCurrency, formatDate } from '../utils/formatting';
+
+interface IncomeStatementViewProps {
+  data?: IncomeStatement;
+  isLoading?: boolean;
+  currency?: string;
+}
+
+function SectionRows({ lines, currency }: { lines: IncomeStatement['revenue']; currency: string }) {
+  if (lines.length === 0) {
+    return (
+      <tr>
+        <td colSpan={2} className="px-6 py-4 text-sm text-gray-400 text-center">
+          No entries
+        </td>
+      </tr>
+    );
+  }
+  return (
+    <>
+      {lines.map((line) => (
+        <tr key={line.category}>
+          <td className="px-6 py-3 text-sm text-gray-700">{line.category}</td>
+          <td className="px-6 py-3 text-sm text-right text-gray-700 tabular-nums">
+            {formatCurrency(line.amount, currency)}
+          </td>
+        </tr>
+      ))}
+    </>
+  );
+}
+
+export function IncomeStatementView({
+  data,
+  isLoading,
+  currency = 'EUR',
+}: IncomeStatementViewProps) {
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-lg shadow p-6 animate-pulse space-y-3">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="h-8 bg-gray-200 rounded" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="bg-white rounded-lg shadow p-6">
+        <p className="text-gray-500 text-center py-8">
+          Select a date range to view the income statement.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow overflow-hidden">
+      <div className="px-6 py-4 border-b border-gray-200">
+        <h3 className="text-lg font-medium text-gray-900">Income Statement</h3>
+        <p className="mt-1 text-sm text-gray-500">
+          {formatDate(data.from_date)} – {formatDate(data.to_date)}
+        </p>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <tbody className="divide-y divide-gray-200">
+            <tr className="bg-gray-50">
+              <th
+                scope="col"
+                className="px-6 py-2 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider"
+              >
+                Revenue
+              </th>
+              <th
+                scope="col"
+                className="px-6 py-2 text-right text-xs font-semibold text-gray-600 uppercase tracking-wider"
+              >
+                Amount
+              </th>
+            </tr>
+            <SectionRows lines={data.revenue} currency={currency} />
+            <tr className="bg-gray-50/60">
+              <td className="px-6 py-3 text-sm font-medium text-gray-900">Total Revenue</td>
+              <td className="px-6 py-3 text-sm text-right font-medium text-gray-900 tabular-nums">
+                {formatCurrency(data.total_revenue, currency)}
+              </td>
+            </tr>
+
+            <tr className="bg-gray-50">
+              <th
+                scope="col"
+                className="px-6 py-2 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider"
+              >
+                Expenses
+              </th>
+              <th
+                scope="col"
+                className="px-6 py-2 text-right text-xs font-semibold text-gray-600 uppercase tracking-wider"
+              >
+                Amount
+              </th>
+            </tr>
+            <SectionRows lines={data.expenses} currency={currency} />
+            <tr className="bg-gray-50/60">
+              <td className="px-6 py-3 text-sm font-medium text-gray-900">Total Expenses</td>
+              <td className="px-6 py-3 text-sm text-right font-medium text-gray-900 tabular-nums">
+                {formatCurrency(data.total_expenses, currency)}
+              </td>
+            </tr>
+          </tbody>
+          <tfoot className="bg-gray-100">
+            <tr>
+              <td className="px-6 py-4 text-sm font-bold text-gray-900">Net Income</td>
+              <td
+                className={`px-6 py-4 text-sm text-right font-bold tabular-nums ${
+                  data.net_income < 0 ? 'text-red-600' : 'text-green-700'
+                }`}
+              >
+                {formatCurrency(data.net_income, currency)}
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/financial/components/index.ts
+++ b/frontend/apps/ppt-web/src/features/financial/components/index.ts
@@ -3,11 +3,14 @@
  */
 
 export { ARAgingTable } from './ARAgingTable';
+export { BalanceSheetView } from './BalanceSheetView';
 export { BudgetCard } from './BudgetCard';
 export { BudgetForm } from './BudgetForm';
 export { BudgetOverview } from './BudgetOverview';
 export { BuildingFilter } from './BuildingFilter';
+export { CashFlowView } from './CashFlowView';
 export { DateRangeFilter } from './DateRangeFilter';
+export { IncomeStatementView } from './IncomeStatementView';
 export { InvoiceDetail } from './InvoiceDetail';
 export { InvoiceForm } from './InvoiceForm';
 export { InvoiceList } from './InvoiceList';

--- a/frontend/apps/ppt-web/src/features/financial/index.ts
+++ b/frontend/apps/ppt-web/src/features/financial/index.ts
@@ -6,10 +6,12 @@
  * - Story 52.2: Invoice Management
  * - Story 52.3: Payment Reconciliation
  * - Story 52.4: Budget Tracking
+ * - Story 11.7: Financial Statement Reports
  */
 
 export * from './components';
 export { BudgetManagementPage } from './pages/BudgetManagementPage';
 export { FinancialDashboardPage } from './pages/FinancialDashboardPage';
+export { FinancialReportsPage } from './pages/FinancialReportsPage';
 export { InvoiceManagementPage } from './pages/InvoiceManagementPage';
 export { PaymentManagementPage } from './pages/PaymentManagementPage';

--- a/frontend/apps/ppt-web/src/features/financial/pages/FinancialReportsPage.tsx
+++ b/frontend/apps/ppt-web/src/features/financial/pages/FinancialReportsPage.tsx
@@ -1,0 +1,202 @@
+/**
+ * FinancialReportsPage - Story 11.7
+ *
+ * Financial statement reports: Income Statement, Balance Sheet, and Cash Flow.
+ * Each tab has its own date control (from/to range for the statements, as-of for
+ * the balance sheet) plus PDF / xlsx export buttons.
+ *
+ * Presentational only — data fetching, date state, and the export download live
+ * in the route wrapper (routes/groups/financial.tsx).
+ */
+
+import type {
+  BalanceSheetReport,
+  CashFlowReport,
+  IncomeStatement,
+  ReportExportFormat,
+  ReportType,
+} from '@ppt/api-client';
+import { BalanceSheetView, CashFlowView, IncomeStatementView } from '../components';
+
+const TABS: { key: ReportType; label: string }[] = [
+  { key: 'income-statement', label: 'Income Statement' },
+  { key: 'balance-sheet', label: 'Balance Sheet' },
+  { key: 'cash-flow', label: 'Cash Flow' },
+];
+
+export interface FinancialReportsPageProps {
+  activeTab: ReportType;
+  onTabChange: (tab: ReportType) => void;
+
+  /** From/to range — used by income statement and cash flow. */
+  fromDate: string;
+  toDate: string;
+  onFromDateChange: (date: string) => void;
+  onToDateChange: (date: string) => void;
+
+  /** As-of date — used by the balance sheet. */
+  asOfDate: string;
+  onAsOfDateChange: (date: string) => void;
+
+  incomeStatement?: IncomeStatement;
+  balanceSheet?: BalanceSheetReport;
+  cashFlow?: CashFlowReport;
+
+  isLoading?: boolean;
+  error?: string | null;
+  currency?: string;
+
+  onExport: (format: ReportExportFormat) => void;
+  /** Non-null while an export is downloading, so its button can show progress. */
+  exportingFormat?: ReportExportFormat | null;
+}
+
+export function FinancialReportsPage({
+  activeTab,
+  onTabChange,
+  fromDate,
+  toDate,
+  onFromDateChange,
+  onToDateChange,
+  asOfDate,
+  onAsOfDateChange,
+  incomeStatement,
+  balanceSheet,
+  cashFlow,
+  isLoading,
+  error,
+  currency = 'EUR',
+  onExport,
+  exportingFormat,
+}: FinancialReportsPageProps) {
+  const isRange = activeTab !== 'balance-sheet';
+
+  return (
+    <div className="min-h-screen bg-gray-100">
+      {/* Header */}
+      <div className="bg-white shadow">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+          <h1 className="text-2xl font-bold text-gray-900">Financial Reports</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Income statement, balance sheet, and cash-flow reports.
+          </p>
+
+          {/* Tabs */}
+          <div className="mt-4 border-b border-gray-200">
+            <nav className="-mb-px flex gap-6" aria-label="Report tabs">
+              {TABS.map((tab) => (
+                <button
+                  key={tab.key}
+                  type="button"
+                  onClick={() => onTabChange(tab.key)}
+                  className={`whitespace-nowrap border-b-2 py-3 px-1 text-sm font-medium ${
+                    activeTab === tab.key
+                      ? 'border-blue-600 text-blue-600'
+                      : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
+                  }`}
+                  aria-current={activeTab === tab.key ? 'page' : undefined}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </nav>
+          </div>
+
+          {/* Date controls + export */}
+          <div className="mt-4 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+            <div className="flex flex-wrap items-end gap-3">
+              {isRange ? (
+                <>
+                  <div className="flex flex-col">
+                    <label htmlFor="report-from" className="text-xs font-medium text-gray-600">
+                      From
+                    </label>
+                    <input
+                      id="report-from"
+                      type="date"
+                      value={fromDate}
+                      max={toDate || undefined}
+                      onChange={(e) => onFromDateChange(e.target.value)}
+                      className="mt-1 px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                    />
+                  </div>
+                  <div className="flex flex-col">
+                    <label htmlFor="report-to" className="text-xs font-medium text-gray-600">
+                      To
+                    </label>
+                    <input
+                      id="report-to"
+                      type="date"
+                      value={toDate}
+                      min={fromDate || undefined}
+                      onChange={(e) => onToDateChange(e.target.value)}
+                      className="mt-1 px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                    />
+                  </div>
+                </>
+              ) : (
+                <div className="flex flex-col">
+                  <label htmlFor="report-as-of" className="text-xs font-medium text-gray-600">
+                    As of
+                  </label>
+                  <input
+                    id="report-as-of"
+                    type="date"
+                    value={asOfDate}
+                    onChange={(e) => onAsOfDateChange(e.target.value)}
+                    className="mt-1 px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                  />
+                </div>
+              )}
+            </div>
+
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-gray-500">Export:</span>
+              <button
+                type="button"
+                onClick={() => onExport('pdf')}
+                disabled={!!exportingFormat}
+                className="px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {exportingFormat === 'pdf' ? 'Exporting…' : 'PDF'}
+              </button>
+              <button
+                type="button"
+                onClick={() => onExport('xlsx')}
+                disabled={!!exportingFormat}
+                className="px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {exportingFormat === 'xlsx' ? 'Exporting…' : 'Excel'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Main content */}
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {error ? (
+          <div className="bg-red-50 border border-red-200 rounded-lg p-6">
+            <p className="text-sm text-red-700">{error}</p>
+          </div>
+        ) : (
+          <>
+            {activeTab === 'income-statement' && (
+              <IncomeStatementView
+                data={incomeStatement}
+                isLoading={isLoading}
+                currency={currency}
+              />
+            )}
+            {activeTab === 'balance-sheet' && (
+              <BalanceSheetView data={balanceSheet} isLoading={isLoading} currency={currency} />
+            )}
+            {activeTab === 'cash-flow' && (
+              <CashFlowView data={cashFlow} isLoading={isLoading} currency={currency} />
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/financial/pages/index.ts
+++ b/frontend/apps/ppt-web/src/features/financial/pages/index.ts
@@ -6,6 +6,8 @@
 export type { BudgetManagementPageProps } from './BudgetManagementPage';
 export { BudgetManagementPage } from './BudgetManagementPage';
 export { FinancialDashboardPage } from './FinancialDashboardPage';
+export type { FinancialReportsPageProps } from './FinancialReportsPage';
+export { FinancialReportsPage } from './FinancialReportsPage';
 export type { InvoiceManagementPageProps } from './InvoiceManagementPage';
 export { InvoiceManagementPage } from './InvoiceManagementPage';
 export type { PaymentManagementPageProps } from './PaymentManagementPage';

--- a/frontend/apps/ppt-web/src/routes/groups/financial.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/financial.tsx
@@ -4,12 +4,16 @@
  * Owns the financial route-wrapper components and the `<Route>` table fragment.
  * Extracted from App.tsx to isolate financial work.
  */
-import type { InvoiceStatus } from '@ppt/api-client';
+import type { InvoiceStatus, ReportExportFormat, ReportType } from '@ppt/api-client';
 import {
   allocatePayment,
   autoMatchPayments,
   downloadInvoicePdf,
+  exportReport,
   getARAgingReport,
+  getBalanceSheet,
+  getCashFlowReport,
+  getIncomeStatement,
   getOverdueInvoices,
   listInvoices,
   listPayments,
@@ -25,9 +29,27 @@ import { useAuth } from '../../contexts';
 import {
   BudgetManagementPage,
   FinancialDashboardPage,
+  FinancialReportsPage,
   InvoiceManagementPage,
   PaymentManagementPage,
 } from '../lazyRoutes';
+
+/** Trigger a browser download for a fetched report blob. */
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}
+
+/** YYYY-MM-DD for a Date (local-safe via the same slice the date filters use). */
+function isoDate(d: Date): string {
+  return d.toISOString().split('T')[0];
+}
 
 /**
  * Route wrapper for financial dashboard (Epic 52, #975.1).
@@ -313,6 +335,101 @@ function BudgetManagementPageRoute() {
   );
 }
 
+/**
+ * Route wrapper for financial statement reports (Epic 11, Story 11.7).
+ *
+ * Wires the three statement endpoints via TanStack Query, fetching only the
+ * report for the active tab:
+ *   getIncomeStatement({ organization_id, from, to })
+ *   getBalanceSheet({ organization_id, as_of })
+ *   getCashFlowReport({ organization_id, from, to })
+ *
+ * Export buttons call exportReport(report, { format, ... }) and stream the
+ * returned PDF / xlsx blob to a browser download. Date defaults are year-to-date
+ * for the range reports and today for the balance sheet's as-of.
+ */
+function FinancialReportsPageRoute() {
+  const { user } = useAuth();
+  const { t } = useTranslation();
+  const { showToast } = useToast();
+  const orgId = user?.organizationId ?? '';
+
+  const now = new Date();
+  const todayStr = isoDate(now);
+  const yearStartStr = isoDate(new Date(now.getFullYear(), 0, 1));
+
+  const [activeTab, setActiveTab] = useState<ReportType>('income-statement');
+  const [fromDate, setFromDate] = useState(yearStartStr);
+  const [toDate, setToDate] = useState(todayStr);
+  const [asOfDate, setAsOfDate] = useState(todayStr);
+  const [exportingFormat, setExportingFormat] = useState<ReportExportFormat | null>(null);
+
+  const rangeReady = !!orgId && !!fromDate && !!toDate;
+
+  const incomeQuery = useQuery({
+    queryKey: ['financial', 'income-statement', orgId, fromDate, toDate],
+    queryFn: () => getIncomeStatement({ organization_id: orgId, from: fromDate, to: toDate }),
+    enabled: rangeReady && activeTab === 'income-statement',
+  });
+  const balanceQuery = useQuery({
+    queryKey: ['financial', 'balance-sheet', orgId, asOfDate],
+    queryFn: () => getBalanceSheet({ organization_id: orgId, as_of: asOfDate }),
+    enabled: !!orgId && !!asOfDate && activeTab === 'balance-sheet',
+  });
+  const cashFlowQuery = useQuery({
+    queryKey: ['financial', 'cash-flow', orgId, fromDate, toDate],
+    queryFn: () => getCashFlowReport({ organization_id: orgId, from: fromDate, to: toDate }),
+    enabled: rangeReady && activeTab === 'cash-flow',
+  });
+
+  const activeQuery =
+    activeTab === 'income-statement'
+      ? incomeQuery
+      : activeTab === 'balance-sheet'
+        ? balanceQuery
+        : cashFlowQuery;
+
+  const handleExport = (format: ReportExportFormat) => {
+    if (!orgId) return;
+    setExportingFormat(format);
+    const params =
+      activeTab === 'balance-sheet'
+        ? { organization_id: orgId, format, as_of: asOfDate }
+        : { organization_id: orgId, format, from: fromDate, to: toDate };
+    const ext = format === 'pdf' ? 'pdf' : 'xlsx';
+    exportReport(activeTab, params)
+      .then((blob) => downloadBlob(blob, `${activeTab}.${ext}`))
+      .catch((err) => {
+        showToast({
+          type: 'error',
+          title: t('financial.reports.exportFailed', { defaultValue: 'Export failed' }),
+          message: err instanceof Error ? err.message : '',
+        });
+      })
+      .finally(() => setExportingFormat(null));
+  };
+
+  return (
+    <FinancialReportsPage
+      activeTab={activeTab}
+      onTabChange={setActiveTab}
+      fromDate={fromDate}
+      toDate={toDate}
+      onFromDateChange={setFromDate}
+      onToDateChange={setToDate}
+      asOfDate={asOfDate}
+      onAsOfDateChange={setAsOfDate}
+      incomeStatement={incomeQuery.data}
+      balanceSheet={balanceQuery.data}
+      cashFlow={cashFlowQuery.data}
+      isLoading={activeQuery.isLoading && activeQuery.fetchStatus !== 'idle'}
+      error={activeQuery.error instanceof Error ? activeQuery.error.message : null}
+      onExport={handleExport}
+      exportingFormat={exportingFormat}
+    />
+  );
+}
+
 /** Financial routes (Epic 52). */
 export function financialRoutes() {
   return (
@@ -321,6 +438,7 @@ export function financialRoutes() {
       <Route path="/financial/invoices" element={<InvoiceManagementPageRoute />} />
       <Route path="/financial/payments" element={<PaymentManagementPageRoute />} />
       <Route path="/financial/budgets" element={<BudgetManagementPageRoute />} />
+      <Route path="/financial/reports" element={<FinancialReportsPageRoute />} />
     </>
   );
 }

--- a/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
+++ b/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
@@ -250,6 +250,10 @@ export const PaymentManagementPage = lazy(() =>
 export const BudgetManagementPage = lazy(() =>
   import('../features/financial').then((m) => ({ default: m.BudgetManagementPage }))
 );
+// Story 11.7 - Financial statement reports (income statement / balance sheet / cash flow)
+export const FinancialReportsPage = lazy(() =>
+  import('../features/financial').then((m) => ({ default: m.FinancialReportsPage }))
+);
 
 // --- Accounting ---
 

--- a/frontend/packages/api-client/src/index.ts
+++ b/frontend/packages/api-client/src/index.ts
@@ -24,6 +24,14 @@ export * from './esignature';
 export * from './facilities';
 export * from './faults';
 export * from './financial';
+// Resolve the name collision between the analytics reports module (Epic 81) and
+// the financial statement reports module (Story 11.7), which both export
+// `ReportType` and `exportReport`. The financial Story 11.7 symbols are the
+// canonical barrel names (actively consumed by the financial Reports screen);
+// an explicit re-export takes precedence over the two ambiguous `export *`s.
+// The Epic 81 analytics counterparts are preserved here under distinct names so
+// nothing is silently dropped from the public surface.
+export { exportReport, type ReportType } from './financial';
 export * from './forms';
 // Export generated types and client
 // These will be populated after running `pnpm generate`
@@ -48,6 +56,10 @@ export * from './packages';
 export * from './person-months';
 export * from './registry';
 export * from './reports';
+export {
+  exportReport as exportAnalyticsReport,
+  type ReportType as AnalyticsReportType,
+} from './reports';
 export * from './templates';
 export * from './voting';
 export * from './workflow-automation';


### PR DESCRIPTION
## Financial Reports screen — ppt-web UI wiring (Story 11.7)

Frontend follow-up for Story 11.7 (PM **#975.3** / BIT-222). Wires the financial
statement report endpoints (live on `dev` via #1717 + #1723) into a new Reports
screen.

### What's here
- **`/financial/reports`** route — tabbed screen for **Income Statement**,
  **Balance Sheet**, and **Cash Flow**.
- Date controls: from/to range (income statement + cash flow, default
  year-to-date), as-of date (balance sheet, default today).
- Readable table/card layout per report via `IncomeStatementView`,
  `BalanceSheetView` (accounts grouped by type), and `CashFlowView`.
- **PDF / Excel (xlsx) export** buttons → `exportReport()` streams the blob to a
  browser download.
- Route wrapper fetches the active tab's report through TanStack Query
  (`getIncomeStatement` / `getBalanceSheet` / `getCashFlowReport`) with
  loading / error states.
- Screen-map: `docs/screens/ppt/financial-reports.md`.

### Incidental fix
`@ppt/api-client` had a pre-existing barrel ambiguity (TS2308) — both
`./financial` (Story 11.7) and `./reports` (Epic 81) export `ReportType` and
`exportReport`. Resolved by making the financial symbols canonical and
re-exporting the analytics ones as `exportAnalyticsReport` /
`AnalyticsReportType` (no current consumers of the Epic 81 names by those
identifiers).

### Verification
- `tsc --noEmit` clean for `@ppt/web` and `@ppt/api-client`.
- `biome check` clean on all changed files.
- Browser/visual validation to be handled by QA.

Part of epic #975 (does not close it; other gaps remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)