### PR TITLE
feat(api-server): Stripe Checkout payment integration (Story 11.5, BIT-181)

### DIFF
--- a/backend/crates/db/src/repositories/financial.rs
+++ b/backend/crates/db/src/repositories/financial.rs
@@ -1165,13 +1165,43 @@ impl FinancialRepository {
     /// The `update_invoice_on_allocation` trigger recomputes the invoice's
     /// `amount_paid`/`balance_due`/`status`, so a fully-covered invoice
     /// transitions to `paid` automatically.
+    ///
+    /// **Idempotency is enforced atomically**: the first statement in the tx
+    /// is a conditional `UPDATE … WHERE status <> 'completed'` that claims the
+    /// session row. Stripe is at-least-once and does not serialize deliveries,
+    /// so two concurrent duplicates can both pass a pre-tx status read; the
+    /// conditional UPDATE row-locks the session, so the loser observes
+    /// `rows_affected() == 0` and returns `Ok(None)` (a safe no-op) instead of
+    /// inserting a second payment + allocation. Returns `Ok(Some(payment))`
+    /// for the delivery that actually settles.
     pub async fn settle_invoice_from_gateway(
         &self,
         session: &OnlinePaymentSession,
         invoice: &Invoice,
         gateway_reference: &str,
-    ) -> Result<Payment, SqlxError> {
+    ) -> Result<Option<Payment>, SqlxError> {
         let mut tx = self.pool.begin().await?;
+
+        // Atomic idempotency claim. Only the first concurrent delivery flips
+        // the row from a non-`completed` state; the conditional predicate
+        // row-locks the session so duplicates serialize behind this tx and
+        // then no-op. Bail before touching `payments` if we lost the race.
+        let claim = sqlx::query(
+            r#"
+            UPDATE online_payment_sessions
+            SET status = 'completed', updated_at = NOW()
+            WHERE id = $1 AND status <> 'completed'
+            "#,
+        )
+        .bind(session.id)
+        .execute(&mut *tx)
+        .await?;
+
+        if claim.rows_affected() == 0 {
+            // Another delivery already settled this session — safe no-op.
+            tx.rollback().await?;
+            return Ok(None);
+        }
 
         let payment = sqlx::query_as::<_, Payment>(
             r#"
@@ -1205,10 +1235,12 @@ impl FinancialRepository {
         .execute(&mut *tx)
         .await?;
 
+        // Status was already set to 'completed' by the atomic claim above; here
+        // we only link the freshly-recorded payment back to the session.
         sqlx::query(
             r#"
             UPDATE online_payment_sessions
-            SET status = 'completed', payment_id = $2, updated_at = NOW()
+            SET payment_id = $2, updated_at = NOW()
             WHERE id = $1
             "#,
         )
@@ -1218,7 +1250,7 @@ impl FinancialRepository {
         .await?;
 
         tx.commit().await?;
-        Ok(payment)
+        Ok(Some(payment))
     }
 
     // ========================================================================

--- a/backend/crates/db/src/repositories/financial.rs
+++ b/backend/crates/db/src/repositories/financial.rs
@@ -1151,6 +1151,76 @@ impl FinancialRepository {
         .await
     }
 
+    /// Settle an invoice from a confirmed online-gateway payment (Story 11.5).
+    ///
+    /// Runs in one transaction so a webhook delivery either fully settles or
+    /// not at all:
+    ///   1. inserts a `payments` row (`payment_method = 'online'`,
+    ///      `recorded_by = NULL` — the payer is the gateway, not an internal
+    ///      user; `external_reference` = the gateway transaction id),
+    ///   2. allocates it to `invoice` (capped at the invoice's `balance_due`),
+    ///   3. links the payment back to the originating `online_payment_sessions`
+    ///      row and marks the session `completed`.
+    ///
+    /// The `update_invoice_on_allocation` trigger recomputes the invoice's
+    /// `amount_paid`/`balance_due`/`status`, so a fully-covered invoice
+    /// transitions to `paid` automatically.
+    pub async fn settle_invoice_from_gateway(
+        &self,
+        session: &OnlinePaymentSession,
+        invoice: &Invoice,
+        gateway_reference: &str,
+    ) -> Result<Payment, SqlxError> {
+        let mut tx = self.pool.begin().await?;
+
+        let payment = sqlx::query_as::<_, Payment>(
+            r#"
+            INSERT INTO payments (
+                organization_id, unit_id, amount, currency, payment_method,
+                status, reference, external_reference, recorded_by
+            )
+            VALUES ($1, $2, $3, $4, 'online', 'completed', $5, $6, NULL)
+            RETURNING *
+            "#,
+        )
+        .bind(session.organization_id)
+        .bind(invoice.unit_id)
+        .bind(session.amount)
+        .bind(&session.currency)
+        .bind(&session.session_id)
+        .bind(gateway_reference)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        let allocation_amount = session.amount.min(invoice.balance_due);
+        sqlx::query(
+            r#"
+            INSERT INTO payment_allocations (payment_id, invoice_id, amount)
+            VALUES ($1, $2, $3)
+            "#,
+        )
+        .bind(payment.id)
+        .bind(invoice.id)
+        .bind(allocation_amount)
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            r#"
+            UPDATE online_payment_sessions
+            SET status = 'completed', payment_id = $2, updated_at = NOW()
+            WHERE id = $1
+            "#,
+        )
+        .bind(session.id)
+        .bind(payment.id)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(payment)
+    }
+
     // ========================================================================
     // REMINDERS (Story 11.6)
     // ========================================================================

--- a/backend/servers/api-server/src/routes/financial.rs
+++ b/backend/servers/api-server/src/routes/financial.rs
@@ -1091,7 +1091,9 @@ async fn initiate_invoice_checkout(
     let cfg = &state.stripe_config;
     // Fail closed: never attempt a checkout without server-side credentials.
     if cfg.secret_key.is_empty() || cfg.success_url.is_empty() || cfg.cancel_url.is_empty() {
-        tracing::error!("Stripe Checkout is not fully configured (secret_key/success_url/cancel_url)");
+        tracing::error!(
+            "Stripe Checkout is not fully configured (secret_key/success_url/cancel_url)"
+        );
         return Err((
             StatusCode::SERVICE_UNAVAILABLE,
             Json(ErrorResponse::new(

--- a/backend/servers/api-server/src/routes/financial.rs
+++ b/backend/servers/api-server/src/routes/financial.rs
@@ -13,8 +13,8 @@ use axum::{
 use chrono::NaiveDate;
 use common::errors::ErrorResponse;
 use db::models::{
-    CreateFeeSchedule, CreateFinancialAccount, CreateInvoice, CreateTransaction, InvoiceStatus,
-    Payment, PaymentAllocation, RecordPayment,
+    CreateFeeSchedule, CreateFinancialAccount, CreateInvoice, CreateTransaction,
+    InitiatePaymentResponse, InvoiceStatus, Payment, PaymentAllocation, RecordPayment,
 };
 use rust_decimal::Decimal;
 use serde::Deserialize;
@@ -148,6 +148,8 @@ pub fn router() -> Router<AppState> {
         .route("/invoices/{id}", get(get_invoice))
         .route("/invoices/{id}/send", post(send_invoice))
         .route("/invoices/{id}/pdf", get(get_invoice_pdf))
+        // Online payment / gateway checkout (Story 11.5, BIT-181)
+        .route("/invoices/{id}/checkout", post(initiate_invoice_checkout))
         .route("/units/{unit_id}/invoices", get(list_unit_invoices))
         // Payments (Story 11.4)
         .route("/payments", post(record_payment))
@@ -1071,6 +1073,120 @@ async fn record_payment(
                 Json(ErrorResponse::new("DB_ERROR", "Failed to record payment")),
             )
         })
+}
+
+/// Initiate a hosted Stripe Checkout for an invoice (Story 11.5, BIT-181).
+///
+/// Tenant isolation: the invoice is loaded by id, then the caller's membership
+/// of the invoice's organization is verified — a foreign invoice id returns
+/// `404` (so cross-tenant probing cannot distinguish missing from forbidden).
+/// Returns the hosted `checkout_url` the client redirects the payer to; the
+/// invoice is only marked paid once the signed `checkout.session.completed`
+/// webhook is received.
+async fn initiate_invoice_checkout(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path(invoice_id): Path<Uuid>,
+) -> Result<Json<InitiatePaymentResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let cfg = &state.stripe_config;
+    // Fail closed: never attempt a checkout without server-side credentials.
+    if cfg.secret_key.is_empty() || cfg.success_url.is_empty() || cfg.cancel_url.is_empty() {
+        tracing::error!("Stripe Checkout is not fully configured (secret_key/success_url/cancel_url)");
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse::new(
+                "NOT_CONFIGURED",
+                "Online payments are not configured",
+            )),
+        ));
+    }
+
+    let invoice = state
+        .financial_repo
+        .get_invoice(invoice_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to load invoice: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", "Failed to load invoice")),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new("NOT_FOUND", "Invoice not found")),
+            )
+        })?;
+
+    if !is_member_or_not_found(&state, auth.user_id, invoice.organization_id).await? {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("NOT_FOUND", "Invoice not found")),
+        ));
+    }
+
+    // Nothing to collect — don't open a gateway session for a settled invoice.
+    if invoice.balance_due <= Decimal::ZERO {
+        return Err((
+            StatusCode::CONFLICT,
+            Json(ErrorResponse::new(
+                "ALREADY_SETTLED",
+                "Invoice has no outstanding balance",
+            )),
+        ));
+    }
+
+    let created = crate::services::stripe::create_checkout_session(
+        &cfg.secret_key,
+        &cfg.success_url,
+        &cfg.cancel_url,
+        &invoice.id.to_string(),
+        &invoice.organization_id.to_string(),
+        &invoice.invoice_number,
+        invoice.balance_due,
+        &invoice.currency,
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!(error = %e, "Stripe checkout session creation failed");
+        (
+            StatusCode::BAD_GATEWAY,
+            Json(ErrorResponse::new(
+                "GATEWAY_ERROR",
+                "Failed to create payment session",
+            )),
+        )
+    })?;
+
+    let session = state
+        .financial_repo
+        .create_payment_session(
+            invoice.organization_id,
+            invoice.id,
+            "stripe",
+            &created.id,
+            &created.url,
+            invoice.balance_due,
+            &invoice.currency,
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to persist payment session: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(
+                    "DB_ERROR",
+                    "Failed to record payment session",
+                )),
+            )
+        })?;
+
+    Ok(Json(InitiatePaymentResponse {
+        session_id: session.id,
+        checkout_url: created.url,
+        expires_at: session.expires_at.unwrap_or(session.created_at),
+    }))
 }
 
 async fn get_payment(

--- a/backend/servers/api-server/src/routes/integrations/webhook.rs
+++ b/backend/servers/api-server/src/routes/integrations/webhook.rs
@@ -1536,7 +1536,7 @@ pub async fn handle_payment_webhook(
         .clone()
         .unwrap_or_else(|| session.session_id.clone());
 
-    state
+    let settled = state
         .financial_repo
         .settle_invoice_from_gateway(&session, &invoice, &gateway_ref)
         .await
@@ -1548,11 +1548,19 @@ pub async fn handle_payment_webhook(
             )
         })?;
 
-    tracing::info!(
-        invoice_id = %invoice.id,
-        session_id = %session.session_id,
-        "Invoice settled from Stripe Checkout webhook"
-    );
+    match settled {
+        Some(_) => tracing::info!(
+            invoice_id = %invoice.id,
+            session_id = %session.session_id,
+            "Invoice settled from Stripe Checkout webhook"
+        ),
+        // The atomic idempotency claim found the session already settled by a
+        // concurrent delivery. Ack so Stripe stops retrying; no double-credit.
+        None => tracing::info!(
+            session_id = %session.session_id,
+            "Stripe webhook duplicate: session already settled, no-op"
+        ),
+    }
 
     Ok(StatusCode::OK)
 }

--- a/backend/servers/api-server/src/routes/integrations/webhook.rs
+++ b/backend/servers/api-server/src/routes/integrations/webhook.rs
@@ -99,6 +99,8 @@ pub fn router() -> Router<AppState> {
         )
         // Gap 83-1: Airbnb inbound webhook
         .route("/airbnb/webhook", post(handle_airbnb_webhook))
+        // Story 11.5 (BIT-181): payment-gateway confirmation webhook
+        .route("/webhooks/payments/{provider}", post(handle_payment_webhook))
 }
 
 // ==================== Outbound Webhook Subscriptions (Story 61.5) ====================
@@ -1381,6 +1383,170 @@ pub async fn handle_airbnb_webhook(
             tracing::info!(listing_id = ?event.listing_id, "Airbnb webhook: ReviewReceived (not yet handled)");
         }
     }
+
+    Ok(StatusCode::OK)
+}
+
+// ==================== Payment-gateway webhook (Story 11.5, BIT-181) ====================
+
+/// Inbound payment-gateway confirmation webhook.
+///
+/// `POST /api/v1/integrations/webhooks/payments/{provider}` (currently only
+/// `stripe`). Mirrors the other inbound receivers: load the signing secret
+/// from `AppState` (never the request), **fail closed** when it is unset,
+/// verify the signature over the raw body before parsing, and acknowledge
+/// idempotently.
+///
+/// On a verified `checkout.session.completed` with `payment_status == "paid"`,
+/// the originating `online_payment_sessions` row is looked up by its Stripe
+/// session id, the invoice is settled via the gateway-settlement path (records
+/// a `payments` row + allocation; the DB trigger marks the invoice `paid`), and
+/// the session is marked `completed`. Already-completed sessions are a no-op so
+/// Stripe's at-least-once retries cannot double-settle.
+///
+/// Tenant isolation: the session id is the only attacker-influenced input and
+/// it is resolved server-side to its owning organization/invoice — no org id is
+/// trusted from the payload, and a forged session id that matches nothing is
+/// acknowledged without side effects.
+pub async fn handle_payment_webhook(
+    State(state): State<AppState>,
+    Path(provider): Path<String>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    use crate::services::stripe;
+
+    // Only Stripe is wired today; reject unknown providers explicitly.
+    if provider != "stripe" {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new(
+                "UNKNOWN_PROVIDER",
+                "Unsupported payment provider",
+            )),
+        ));
+    }
+
+    // Fail closed when the signing secret is not configured.
+    let secret = state.stripe_config.webhook_secret.as_str();
+    if secret.is_empty() {
+        tracing::error!("STRIPE_WEBHOOK_SECRET is not configured — refusing webhook");
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse::new(
+                "NOT_CONFIGURED",
+                "Payment webhook secret is not configured",
+            )),
+        ));
+    }
+
+    let signature = headers
+        .get("Stripe-Signature")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+
+    let now_unix = chrono::Utc::now().timestamp();
+    if let Err(e) = stripe::verify_signature(
+        &body,
+        signature,
+        secret,
+        now_unix,
+        stripe::DEFAULT_SIGNATURE_TOLERANCE_SECS,
+    ) {
+        tracing::warn!(?e, "Stripe webhook signature verification failed");
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            Json(ErrorResponse::new(
+                "INVALID_SIGNATURE",
+                "Webhook signature verification failed",
+            )),
+        ));
+    }
+
+    let event = stripe::parse_event(&body).map_err(|e| {
+        tracing::warn!(error = %e, "Failed to parse Stripe webhook event");
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new("PARSE_ERROR", "Invalid webhook payload")),
+        )
+    })?;
+
+    // Only settlement events are actionable; acknowledge everything else so
+    // Stripe does not retry events we deliberately ignore.
+    if event.event_type != "checkout.session.completed" {
+        return Ok(StatusCode::OK);
+    }
+    if event.data.object.payment_status.as_deref() != Some("paid") {
+        return Ok(StatusCode::OK);
+    }
+
+    let provider_session_id = &event.data.object.id;
+    let session = match state
+        .financial_repo
+        .get_payment_session_by_provider_id(provider_session_id)
+        .await
+    {
+        Ok(Some(s)) => s,
+        Ok(None) => {
+            // Unknown session — ack so Stripe stops retrying; nothing to do.
+            tracing::warn!(session_id = %provider_session_id, "Stripe webhook for unknown session");
+            return Ok(StatusCode::OK);
+        }
+        Err(e) => {
+            tracing::error!("Failed to load payment session: {:?}", e);
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", "Failed to load payment session")),
+            ));
+        }
+    };
+
+    // Idempotency: a session already settled is a no-op (Stripe retries).
+    if session.status == "completed" {
+        return Ok(StatusCode::OK);
+    }
+
+    let invoice = match state.financial_repo.get_invoice(session.invoice_id).await {
+        Ok(Some(inv)) => inv,
+        Ok(None) => {
+            tracing::error!(invoice_id = %session.invoice_id, "Webhook session references a missing invoice");
+            return Ok(StatusCode::OK);
+        }
+        Err(e) => {
+            tracing::error!("Failed to load invoice for webhook: {:?}", e);
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", "Failed to load invoice")),
+            ));
+        }
+    };
+
+    // Prefer the PaymentIntent id as the gateway reference; fall back to the
+    // Checkout Session id.
+    let gateway_ref = event
+        .data
+        .object
+        .payment_intent
+        .clone()
+        .unwrap_or_else(|| session.session_id.clone());
+
+    state
+        .financial_repo
+        .settle_invoice_from_gateway(&session, &invoice, &gateway_ref)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to settle invoice from gateway webhook: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", "Failed to settle invoice")),
+            )
+        })?;
+
+    tracing::info!(
+        invoice_id = %invoice.id,
+        session_id = %session.session_id,
+        "Invoice settled from Stripe Checkout webhook"
+    );
 
     Ok(StatusCode::OK)
 }

--- a/backend/servers/api-server/src/routes/integrations/webhook.rs
+++ b/backend/servers/api-server/src/routes/integrations/webhook.rs
@@ -100,7 +100,10 @@ pub fn router() -> Router<AppState> {
         // Gap 83-1: Airbnb inbound webhook
         .route("/airbnb/webhook", post(handle_airbnb_webhook))
         // Story 11.5 (BIT-181): payment-gateway confirmation webhook
-        .route("/webhooks/payments/{provider}", post(handle_payment_webhook))
+        .route(
+            "/webhooks/payments/{provider}",
+            post(handle_payment_webhook),
+        )
 }
 
 // ==================== Outbound Webhook Subscriptions (Story 61.5) ====================
@@ -1496,7 +1499,10 @@ pub async fn handle_payment_webhook(
             tracing::error!("Failed to load payment session: {:?}", e);
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to load payment session")),
+                Json(ErrorResponse::new(
+                    "DB_ERROR",
+                    "Failed to load payment session",
+                )),
             ));
         }
     };

--- a/backend/servers/api-server/src/routes/organizations/mod.rs
+++ b/backend/servers/api-server/src/routes/organizations/mod.rs
@@ -15,6 +15,12 @@ pub mod settings;
 // Re-export all public types so `main.rs` (OpenApi derive) can reference them
 // via `routes::organizations::*` without change.
 pub use core::{
+    // types
+    CreateOrganizationRequest,
+    DeleteOrganizationResponse,
+    ListOrganizationsResponse,
+    OrganizationResponse,
+    UpdateOrganizationRequest,
     // handler fns (needed for utoipa __path_* re-export below)
     __path_create_organization,
     __path_delete_organization,
@@ -22,31 +28,25 @@ pub use core::{
     __path_list_my_organizations,
     __path_list_organizations,
     __path_update_organization,
-    // types
-    CreateOrganizationRequest,
-    DeleteOrganizationResponse,
-    ListOrganizationsResponse,
-    OrganizationResponse,
-    UpdateOrganizationRequest,
 };
 pub use members::{
-    __path_add_organization_member, __path_list_organization_members,
-    __path_remove_organization_member, __path_update_organization_member, AddMemberRequest,
-    AddMemberResponse, ListMembersResponse, MemberResponse, RemoveMemberResponse,
-    UpdateMemberRequest, UpdateMemberResponse,
+    AddMemberRequest, AddMemberResponse, ListMembersResponse, MemberResponse, RemoveMemberResponse,
+    UpdateMemberRequest, UpdateMemberResponse, __path_add_organization_member,
+    __path_list_organization_members, __path_remove_organization_member,
+    __path_update_organization_member,
 };
 pub use roles::{
-    __path_create_organization_role, __path_delete_organization_role, __path_get_organization_role,
-    __path_list_organization_roles, __path_update_organization_role, CreateRoleRequest,
-    CreateRoleResponse, DeleteRoleResponse, GetRoleResponse, ListRolesResponse, RoleResponse,
-    UpdateRoleRequest, UpdateRoleResponse,
+    CreateRoleRequest, CreateRoleResponse, DeleteRoleResponse, GetRoleResponse, ListRolesResponse,
+    RoleResponse, UpdateRoleRequest, UpdateRoleResponse, __path_create_organization_role,
+    __path_delete_organization_role, __path_get_organization_role, __path_list_organization_roles,
+    __path_update_organization_role,
 };
 pub use settings::{
-    __path_export_organization_data, __path_get_organization_branding,
-    __path_get_organization_settings, __path_update_organization_branding,
-    __path_update_organization_settings, ExportMember, ExportQuery, ExportRole,
-    OrganizationBrandingResponse, OrganizationExportResponse, OrganizationSettingsResponse,
-    UpdateOrganizationBrandingRequest, UpdateOrganizationSettingsRequest,
+    ExportMember, ExportQuery, ExportRole, OrganizationBrandingResponse,
+    OrganizationExportResponse, OrganizationSettingsResponse, UpdateOrganizationBrandingRequest,
+    UpdateOrganizationSettingsRequest, __path_export_organization_data,
+    __path_get_organization_branding, __path_get_organization_settings,
+    __path_update_organization_branding, __path_update_organization_settings,
 };
 
 use axum::Router;

--- a/backend/servers/api-server/src/services/mod.rs
+++ b/backend/servers/api-server/src/services/mod.rs
@@ -16,6 +16,7 @@ pub mod push_fanout;
 pub mod quiet_hours;
 pub mod quiet_hours_drain;
 pub mod scheduler;
+pub mod stripe;
 pub mod syndication;
 pub mod totp;
 pub mod voice_commands;

--- a/backend/servers/api-server/src/services/stripe.rs
+++ b/backend/servers/api-server/src/services/stripe.rs
@@ -1,0 +1,347 @@
+//! Stripe Checkout integration (Story 11.5, [BIT-181]).
+//!
+//! We use Stripe **hosted Checkout** so raw card data never touches our
+//! servers (PCI SAQ-A). The flow is:
+//!
+//! 1. The server creates a Checkout Session via the Stripe API
+//!    ([`create_checkout_session`]) and returns the hosted `checkout_url`.
+//! 2. The payer completes payment on Stripe's hosted page and is redirected
+//!    back to `success_url`/`cancel_url`.
+//! 3. Stripe POSTs a `checkout.session.completed` webhook, whose signature we
+//!    verify ([`verify_signature`]) before settling the invoice.
+//!
+//! Secrets live on [`crate::state::StripeAppConfig`] (loaded from env at boot),
+//! never in request bodies, and never logged.
+
+use hmac::{Hmac, KeyInit, Mac};
+use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
+use serde::Deserialize;
+use sha2::Sha256;
+use subtle::ConstantTimeEq;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Stripe's API base. Overridable in tests via `STRIPE_API_BASE` so the
+/// outbound call can be pointed at a local mock; defaults to the live API.
+fn api_base() -> String {
+    std::env::var("STRIPE_API_BASE").unwrap_or_else(|_| "https://api.stripe.com".to_string())
+}
+
+/// Default tolerance (seconds) for the webhook timestamp, matching Stripe's
+/// recommended replay-protection window of 5 minutes.
+pub const DEFAULT_SIGNATURE_TOLERANCE_SECS: i64 = 300;
+
+/// Error creating a Checkout Session against the Stripe API.
+#[derive(Debug)]
+pub enum CheckoutError {
+    /// The configured secret key is empty — the integration is not configured.
+    NotConfigured,
+    /// Transport-level failure talking to Stripe.
+    Transport(String),
+    /// Stripe returned a non-2xx response (status + body excerpt).
+    Api { status: u16, body: String },
+    /// The Stripe response could not be parsed.
+    Decode(String),
+}
+
+impl std::fmt::Display for CheckoutError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CheckoutError::NotConfigured => write!(f, "Stripe secret key is not configured"),
+            CheckoutError::Transport(e) => write!(f, "Stripe transport error: {e}"),
+            CheckoutError::Api { status, .. } => write!(f, "Stripe API error (status {status})"),
+            CheckoutError::Decode(e) => write!(f, "Stripe response decode error: {e}"),
+        }
+    }
+}
+
+/// The fields we need from a created Checkout Session.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CreatedCheckoutSession {
+    /// Stripe Checkout Session id (`cs_...`). Stored as `session_id`.
+    pub id: String,
+    /// Hosted checkout page the payer is redirected to.
+    pub url: String,
+}
+
+/// Create a Stripe Checkout Session for `amount` (in `currency`) tied to an
+/// invoice. `amount` is the invoice currency amount (e.g. 12.34 EUR); Stripe
+/// expects the smallest currency unit (cents), so we multiply by 100.
+///
+/// `client_reference_id`/`metadata.invoice_id` carry our invoice id so the
+/// webhook (and any manual reconciliation) can correlate the session back to
+/// the invoice without trusting client input.
+#[allow(clippy::too_many_arguments)]
+pub async fn create_checkout_session(
+    secret_key: &str,
+    success_url: &str,
+    cancel_url: &str,
+    invoice_id: &str,
+    organization_id: &str,
+    invoice_number: &str,
+    amount: Decimal,
+    currency: &str,
+) -> Result<CreatedCheckoutSession, CheckoutError> {
+    if secret_key.is_empty() {
+        return Err(CheckoutError::NotConfigured);
+    }
+
+    // Smallest currency unit (cents). Round to avoid sub-cent fractions.
+    let unit_amount = (amount * Decimal::from(100))
+        .round()
+        .to_i64()
+        .ok_or_else(|| CheckoutError::Decode("amount out of range".to_string()))?;
+
+    let product_name = format!("Invoice {invoice_number}");
+    let form: Vec<(&str, String)> = vec![
+        ("mode", "payment".to_string()),
+        ("success_url", success_url.to_string()),
+        ("cancel_url", cancel_url.to_string()),
+        ("client_reference_id", invoice_id.to_string()),
+        ("metadata[invoice_id]", invoice_id.to_string()),
+        ("metadata[organization_id]", organization_id.to_string()),
+        ("line_items[0][quantity]", "1".to_string()),
+        (
+            "line_items[0][price_data][currency]",
+            currency.to_lowercase(),
+        ),
+        (
+            "line_items[0][price_data][unit_amount]",
+            unit_amount.to_string(),
+        ),
+        (
+            "line_items[0][price_data][product_data][name]",
+            product_name,
+        ),
+    ];
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/v1/checkout/sessions", api_base()))
+        .bearer_auth(secret_key)
+        .form(&form)
+        .send()
+        .await
+        .map_err(|e| CheckoutError::Transport(e.to_string()))?;
+
+    let status = resp.status();
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| CheckoutError::Transport(e.to_string()))?;
+
+    if !status.is_success() {
+        // Truncate so a verbose Stripe error never floods logs / responses.
+        let excerpt: String = body.chars().take(500).collect();
+        return Err(CheckoutError::Api {
+            status: status.as_u16(),
+            body: excerpt,
+        });
+    }
+
+    serde_json::from_str::<CreatedCheckoutSession>(&body)
+        .map_err(|e| CheckoutError::Decode(e.to_string()))
+}
+
+/// Why a webhook signature was rejected. All variants fail the request closed.
+#[derive(Debug, PartialEq, Eq)]
+pub enum SignatureError {
+    /// The `Stripe-Signature` header was missing a `t=` or `v1=` component.
+    Malformed,
+    /// The `t=` timestamp was outside the tolerance window (replay defense).
+    TimestampOutOfTolerance,
+    /// No `v1=` signature matched the computed HMAC.
+    NoMatch,
+}
+
+/// Verify a Stripe webhook signature over the **raw** request body.
+///
+/// Implements Stripe's scheme: the `Stripe-Signature` header is a list of
+/// `key=value` pairs (e.g. `t=1690000000,v1=abc...,v1=def...`). The signed
+/// payload is `"{t}.{raw_body}"`; the expected value is its HMAC-SHA256 keyed
+/// by the webhook signing secret, hex-encoded. The header is valid if **any**
+/// `v1` matches (constant-time compare) and `t` is within `tolerance_secs` of
+/// `now_unix`.
+///
+/// `now_unix`/`tolerance_secs` are injected so the timestamp window is unit
+/// testable without wall-clock dependence.
+pub fn verify_signature(
+    payload: &[u8],
+    signature_header: &str,
+    secret: &str,
+    now_unix: i64,
+    tolerance_secs: i64,
+) -> Result<(), SignatureError> {
+    let mut timestamp: Option<i64> = None;
+    let mut v1_sigs: Vec<&str> = Vec::new();
+
+    for part in signature_header.split(',') {
+        let mut kv = part.splitn(2, '=');
+        match (kv.next(), kv.next()) {
+            (Some("t"), Some(t)) => timestamp = t.trim().parse::<i64>().ok(),
+            (Some("v1"), Some(v)) => v1_sigs.push(v.trim()),
+            _ => {}
+        }
+    }
+
+    let timestamp = timestamp.ok_or(SignatureError::Malformed)?;
+    if v1_sigs.is_empty() {
+        return Err(SignatureError::Malformed);
+    }
+
+    // Replay defense: reject deliveries whose timestamp is too far from now.
+    if (now_unix - timestamp).abs() > tolerance_secs {
+        return Err(SignatureError::TimestampOutOfTolerance);
+    }
+
+    // signed_payload = "{timestamp}.{raw_body}"
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
+        .map_err(|_| SignatureError::Malformed)?;
+    mac.update(timestamp.to_string().as_bytes());
+    mac.update(b".");
+    mac.update(payload);
+    let expected = mac.finalize().into_bytes();
+    let expected_hex = hex::encode(expected);
+    let expected_bytes = expected_hex.as_bytes();
+
+    let matched = v1_sigs.iter().any(|candidate| {
+        let candidate = candidate.as_bytes();
+        candidate.len() == expected_bytes.len()
+            && candidate.ct_eq(expected_bytes).unwrap_u8() == 1
+    });
+
+    if matched {
+        Ok(())
+    } else {
+        Err(SignatureError::NoMatch)
+    }
+}
+
+/// The subset of a Stripe event we act on. Stripe sends a large envelope; we
+/// only deserialize the fields we use so unknown fields are ignored.
+#[derive(Debug, Clone, Deserialize)]
+pub struct StripeEvent {
+    /// e.g. `"checkout.session.completed"`.
+    #[serde(rename = "type")]
+    pub event_type: String,
+    pub data: StripeEventData,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StripeEventData {
+    pub object: StripeCheckoutObject,
+}
+
+/// The Checkout Session object carried by `checkout.session.*` events.
+#[derive(Debug, Clone, Deserialize)]
+pub struct StripeCheckoutObject {
+    /// Checkout Session id (`cs_...`) — matches our stored `session_id`.
+    pub id: String,
+    /// `"paid"`, `"unpaid"`, or `"no_payment_required"`.
+    #[serde(default)]
+    pub payment_status: Option<String>,
+    /// The PaymentIntent id (`pi_...`), used as the gateway reference.
+    #[serde(default)]
+    pub payment_intent: Option<String>,
+}
+
+/// Parse a Stripe event from a raw (already signature-verified) body.
+pub fn parse_event(payload: &[u8]) -> Result<StripeEvent, String> {
+    serde_json::from_slice::<StripeEvent>(payload).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a valid `Stripe-Signature` header for `payload` at `ts`.
+    fn sign(payload: &[u8], secret: &str, ts: i64) -> String {
+        let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(ts.to_string().as_bytes());
+        mac.update(b".");
+        mac.update(payload);
+        let sig = hex::encode(mac.finalize().into_bytes());
+        format!("t={ts},v1={sig}")
+    }
+
+    #[test]
+    fn valid_signature_passes() {
+        let body = br#"{"type":"checkout.session.completed"}"#;
+        let header = sign(body, "whsec_test", 1_000_000);
+        assert_eq!(
+            verify_signature(body, &header, "whsec_test", 1_000_000, 300),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn tampered_body_fails() {
+        let body = br#"{"type":"checkout.session.completed"}"#;
+        let header = sign(body, "whsec_test", 1_000_000);
+        let tampered = br#"{"type":"checkout.session.completed","x":1}"#;
+        assert_eq!(
+            verify_signature(tampered, &header, "whsec_test", 1_000_000, 300),
+            Err(SignatureError::NoMatch)
+        );
+    }
+
+    #[test]
+    fn wrong_secret_fails() {
+        let body = br#"{"a":1}"#;
+        let header = sign(body, "whsec_real", 1_000_000);
+        assert_eq!(
+            verify_signature(body, &header, "whsec_attacker", 1_000_000, 300),
+            Err(SignatureError::NoMatch)
+        );
+    }
+
+    #[test]
+    fn stale_timestamp_fails() {
+        let body = br#"{"a":1}"#;
+        let header = sign(body, "whsec_test", 1_000_000);
+        // now is 10 minutes after the signed timestamp, tolerance 5 minutes.
+        assert_eq!(
+            verify_signature(body, &header, "whsec_test", 1_000_600, 300),
+            Err(SignatureError::TimestampOutOfTolerance)
+        );
+    }
+
+    #[test]
+    fn malformed_header_fails() {
+        let body = br#"{"a":1}"#;
+        assert_eq!(
+            verify_signature(body, "garbage", "whsec_test", 1_000_000, 300),
+            Err(SignatureError::Malformed)
+        );
+        assert_eq!(
+            verify_signature(body, "t=1000000", "whsec_test", 1_000_000, 300),
+            Err(SignatureError::Malformed)
+        );
+    }
+
+    #[test]
+    fn multiple_v1_one_matching_passes() {
+        let body = br#"{"a":1}"#;
+        let good = sign(body, "whsec_test", 1_000_000);
+        // Prepend a bogus v1; Stripe sends several during secret rotation.
+        let header = format!("{good},v1=deadbeef");
+        assert_eq!(
+            verify_signature(body, &header, "whsec_test", 1_000_000, 300),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn parse_checkout_completed_event() {
+        let body = br#"{
+            "type":"checkout.session.completed",
+            "data":{"object":{"id":"cs_test_123","payment_status":"paid","payment_intent":"pi_abc"}}
+        }"#;
+        let ev = parse_event(body).unwrap();
+        assert_eq!(ev.event_type, "checkout.session.completed");
+        assert_eq!(ev.data.object.id, "cs_test_123");
+        assert_eq!(ev.data.object.payment_status.as_deref(), Some("paid"));
+        assert_eq!(ev.data.object.payment_intent.as_deref(), Some("pi_abc"));
+    }
+}

--- a/backend/servers/api-server/src/services/stripe.rs
+++ b/backend/servers/api-server/src/services/stripe.rs
@@ -196,8 +196,8 @@ pub fn verify_signature(
     }
 
     // signed_payload = "{timestamp}.{raw_body}"
-    let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
-        .map_err(|_| SignatureError::Malformed)?;
+    let mut mac =
+        HmacSha256::new_from_slice(secret.as_bytes()).map_err(|_| SignatureError::Malformed)?;
     mac.update(timestamp.to_string().as_bytes());
     mac.update(b".");
     mac.update(payload);
@@ -207,8 +207,7 @@ pub fn verify_signature(
 
     let matched = v1_sigs.iter().any(|candidate| {
         let candidate = candidate.as_bytes();
-        candidate.len() == expected_bytes.len()
-            && candidate.ct_eq(expected_bytes).unwrap_u8() == 1
+        candidate.len() == expected_bytes.len() && candidate.ct_eq(expected_bytes).unwrap_u8() == 1
     });
 
     if matched {

--- a/backend/servers/api-server/src/state.rs
+++ b/backend/servers/api-server/src/state.rs
@@ -107,6 +107,45 @@ impl BookingOAuthAppConfig {
     }
 }
 
+/// Stripe Checkout integration configuration loaded once at startup
+/// (Story 11.5, [BIT-181]). Mirrors [`AirbnbAppConfig`]: secrets are read from
+/// the environment at boot, never accepted from a request body, and an empty
+/// `secret_key`/`webhook_secret` fails closed at the handler.
+///
+/// We use Stripe **hosted Checkout** (SAQ-A): raw card data never touches our
+/// servers — the server only creates a Checkout Session and confirms the
+/// webhook. So we hold the API secret key (server→Stripe) and the webhook
+/// signing secret (Stripe→server), plus the redirect URLs the payer returns to.
+#[derive(Debug, Clone, Default)]
+pub struct StripeAppConfig {
+    /// `STRIPE_SECRET_KEY` — server-side API key used to create Checkout
+    /// Sessions. Required to initiate a checkout; empty ⇒ `503 NOT_CONFIGURED`.
+    pub secret_key: String,
+    /// `STRIPE_WEBHOOK_SECRET` — signing secret for inbound webhook signature
+    /// verification (`Stripe-Signature` header). Required to accept a webhook;
+    /// empty ⇒ the receiver fails closed with `503 NOT_CONFIGURED`.
+    pub webhook_secret: String,
+    /// `STRIPE_SUCCESS_URL` — where Stripe redirects the payer on success.
+    /// `{CHECKOUT_SESSION_ID}` is substituted by Stripe.
+    pub success_url: String,
+    /// `STRIPE_CANCEL_URL` — where Stripe redirects the payer on cancel.
+    pub cancel_url: String,
+}
+
+impl StripeAppConfig {
+    /// Load from the standard env vars. Empty strings are preserved so the
+    /// handlers can emit `NOT_CONFIGURED` for missing values — matching the
+    /// fail-closed contract of the other integration configs.
+    pub fn from_env() -> Self {
+        Self {
+            secret_key: std::env::var("STRIPE_SECRET_KEY").unwrap_or_default(),
+            webhook_secret: std::env::var("STRIPE_WEBHOOK_SECRET").unwrap_or_default(),
+            success_url: std::env::var("STRIPE_SUCCESS_URL").unwrap_or_default(),
+            cancel_url: std::env::var("STRIPE_CANCEL_URL").unwrap_or_default(),
+        }
+    }
+}
+
 /// A single realtime preference-sync event captured by a
 /// [`PreferenceEventRecorder`] (issue #1376).
 ///
@@ -356,6 +395,10 @@ pub struct AppState {
     /// Booking.com OAuth integration configuration loaded once at startup
     /// (Coverage 83-2). Handlers fail closed when `client_id.is_empty()`.
     pub booking_config: BookingOAuthAppConfig,
+    /// Stripe Checkout configuration loaded once at startup (Story 11.5,
+    /// [BIT-181]). Handlers fail closed when `secret_key`/`webhook_secret`
+    /// are empty.
+    pub stripe_config: StripeAppConfig,
 }
 
 impl AppState {
@@ -643,6 +686,8 @@ impl AppState {
             airbnb_config: AirbnbAppConfig::from_env(),
             // Coverage 83-2: Booking.com OAuth env vars cached at startup.
             booking_config: BookingOAuthAppConfig::from_env(),
+            // Story 11.5 (BIT-181): Stripe Checkout env vars cached at startup.
+            stripe_config: StripeAppConfig::from_env(),
         }
     }
 

--- a/backend/servers/api-server/tests/payment_webhook_settlement_tests.rs
+++ b/backend/servers/api-server/tests/payment_webhook_settlement_tests.rs
@@ -1,0 +1,259 @@
+//! End-to-end tests for the Stripe Checkout settlement webhook
+//! (Story 11.5, BIT-181), driven through the wired Axum router via `TestApp`.
+//!
+//! These pin the security-critical contract of
+//! `POST /api/v1/integrations/webhooks/payments/{provider}`:
+//!
+//! - **Fail closed** when `STRIPE_WEBHOOK_SECRET` is unset (`503`, never accept).
+//! - **Reject forged signatures** with `401` before any DB mutation.
+//! - **Settle on a valid signature**: a correctly-signed
+//!   `checkout.session.completed` (`payment_status = "paid"`) records a payment,
+//!   allocates it to the invoice (the DB trigger flips the invoice to `paid`),
+//!   and marks the session `completed`.
+//! - **Idempotent**: a second delivery of the same event does not double-settle.
+//!
+//! They need a `PgPool` because `TestApp` builds the full `AppState`; CI runs
+//! them against an ephemeral migrated database.
+
+#[allow(dead_code)]
+mod common;
+
+use axum::http::StatusCode;
+use common::{seed_org, TestApp};
+use hmac::{Hmac, Mac};
+use rust_decimal::Decimal;
+use sha2::Sha256;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+type HmacSha256 = Hmac<Sha256>;
+
+const SECRET_ENV: &str = "STRIPE_WEBHOOK_SECRET";
+const SIG_HEADER: &str = "Stripe-Signature";
+const WEBHOOK_URI: &str = "/api/v1/integrations/webhooks/payments/stripe";
+
+/// `std::env::{set_var, remove_var}` are not safe to interleave with `getenv`
+/// on glibc, and integration tests in this binary may run concurrently. Every
+/// test that mutates the webhook-secret env serializes behind this mutex, held
+/// across the whole test body so the env stays stable while `TestApp` boots.
+static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Build the `t=<ts>,v1=<hex>` Stripe-Signature header for `body`.
+fn sign(secret: &str, ts: i64, body: &[u8]) -> String {
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).expect("hmac key");
+    mac.update(ts.to_string().as_bytes());
+    mac.update(b".");
+    mac.update(body);
+    format!("t={ts},v1={}", hex::encode(mac.finalize().into_bytes()))
+}
+
+/// Seed an org → building → unit → invoice (balance_due = `total`) → pending
+/// `online_payment_sessions` row, and return `(invoice_id, session_id_str)`.
+async fn seed_invoice_with_session(
+    pool: &PgPool,
+    slug: &str,
+    provider_session_id: &str,
+    total: Decimal,
+) -> (Uuid, Uuid) {
+    let org_id = seed_org(pool, slug).await;
+
+    let building_id = sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO buildings (organization_id, street, city, postal_code, country)
+           VALUES ($1, $2, 'Bratislava', '81101', 'Slovakia') RETURNING id"#,
+    )
+    .bind(org_id)
+    .bind(format!("{slug} Street 1"))
+    .fetch_one(pool)
+    .await
+    .expect("seed building");
+
+    let unit_id = sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO units (building_id, designation) VALUES ($1, $2) RETURNING id"#,
+    )
+    .bind(building_id)
+    .bind(format!("U-{slug}"))
+    .fetch_one(pool)
+    .await
+    .expect("seed unit");
+
+    let invoice_id = sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO invoices
+               (organization_id, unit_id, invoice_number, status, due_date,
+                subtotal, total, balance_due, currency)
+           VALUES ($1, $2, $3, 'sent', CURRENT_DATE,
+                   $4, $4, $4, 'EUR')
+           RETURNING id"#,
+    )
+    .bind(org_id)
+    .bind(unit_id)
+    .bind(format!("INV-{slug}"))
+    .bind(total)
+    .fetch_one(pool)
+    .await
+    .expect("seed invoice");
+
+    let session_id = sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO online_payment_sessions
+               (organization_id, invoice_id, provider, session_id, checkout_url,
+                amount, currency, status)
+           VALUES ($1, $2, 'stripe', $3, 'https://checkout.stripe.test/x',
+                   $4, 'EUR', 'pending')
+           RETURNING id"#,
+    )
+    .bind(org_id)
+    .bind(invoice_id)
+    .bind(provider_session_id)
+    .bind(total)
+    .fetch_one(pool)
+    .await
+    .expect("seed session");
+
+    (invoice_id, session_id)
+}
+
+/// Fail-closed: with NO secret configured the route rejects any webhook with
+/// `503` — it never silently accepts an unverified payload.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn unconfigured_secret_fails_closed(pool: PgPool) {
+    let _guard = ENV_LOCK.lock().await;
+    std::env::remove_var(SECRET_ENV);
+
+    let app = TestApp::new(pool).await;
+    let body = serde_json::json!({ "type": "checkout.session.completed" });
+    let req = app
+        .post(WEBHOOK_URI)
+        .header(SIG_HEADER, "t=1,v1=deadbeef")
+        .json(body)
+        .build();
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no secret must fail closed; body: {}",
+        resp.text()
+    );
+}
+
+/// A forged signature is rejected with `401`.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn invalid_signature_rejected(pool: PgPool) {
+    let _guard = ENV_LOCK.lock().await;
+    std::env::set_var(SECRET_ENV, "whsec_test");
+
+    let app = TestApp::new(pool).await;
+    let body = serde_json::json!({ "type": "checkout.session.completed" });
+    let req = app
+        .post(WEBHOOK_URI)
+        .header(SIG_HEADER, "t=1700000000,v1=deadbeef")
+        .json(body)
+        .build();
+    let resp = app.execute(req).await;
+
+    std::env::remove_var(SECRET_ENV);
+    assert_eq!(
+        resp.status,
+        StatusCode::UNAUTHORIZED,
+        "forged signature must be rejected; body: {}",
+        resp.text()
+    );
+}
+
+/// Happy path: a valid `checkout.session.completed` settles the invoice and the
+/// session, and a duplicate delivery is idempotent (no double-settlement).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn valid_webhook_settles_invoice_and_is_idempotent(pool: PgPool) {
+    let _guard = ENV_LOCK.lock().await;
+    let secret = "whsec_settle";
+    std::env::set_var(SECRET_ENV, secret);
+
+    let provider_session_id = "cs_test_settle_1";
+    let (invoice_id, session_pk) =
+        seed_invoice_with_session(&pool, "settle", provider_session_id, Decimal::new(10000, 2))
+            .await;
+
+    let app = TestApp::new(pool.clone()).await;
+
+    let body = serde_json::json!({
+        "type": "checkout.session.completed",
+        "data": { "object": {
+            "id": provider_session_id,
+            "payment_status": "paid",
+            "payment_intent": "pi_test_settle_1"
+        }}
+    });
+    // Sign the exact bytes the test client will send (`Value::to_string`).
+    let raw = body.to_string();
+    let ts = chrono::Utc::now().timestamp();
+    let header = sign(secret, ts, raw.as_bytes());
+
+    let resp = app
+        .execute(
+            app.post(WEBHOOK_URI)
+                .header(SIG_HEADER, &header)
+                .json(body.clone())
+                .build(),
+        )
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "valid webhook should be accepted; body: {}",
+        resp.text()
+    );
+
+    // Invoice is now paid with zero balance.
+    let (status, balance): (String, Decimal) =
+        sqlx::query_as("SELECT status::text, balance_due FROM invoices WHERE id = $1")
+            .bind(invoice_id)
+            .fetch_one(&pool)
+            .await
+            .expect("load invoice");
+    assert_eq!(status, "paid", "invoice should be marked paid");
+    assert_eq!(balance, Decimal::ZERO, "balance should be cleared");
+
+    // A payment was recorded with the gateway reference and no internal user.
+    let (pay_count, ext_ref, recorded_by): (i64, Option<String>, Option<Uuid>) = sqlx::query_as(
+        "SELECT count(*)::int8, max(external_reference), max(recorded_by) \
+         FROM payments WHERE unit_id = (SELECT unit_id FROM invoices WHERE id = $1)",
+    )
+    .bind(invoice_id)
+    .fetch_one(&pool)
+    .await
+    .expect("load payments");
+    assert_eq!(pay_count, 1, "exactly one payment recorded");
+    assert_eq!(ext_ref.as_deref(), Some("pi_test_settle_1"));
+    assert!(recorded_by.is_none(), "gateway payment has no internal user");
+
+    // The session is marked completed and linked to the payment.
+    let sess_status: String =
+        sqlx::query_scalar("SELECT status FROM online_payment_sessions WHERE id = $1")
+            .bind(session_pk)
+            .fetch_one(&pool)
+            .await
+            .expect("load session");
+    assert_eq!(sess_status, "completed");
+
+    // Idempotency: replaying the same delivery must not record a second payment.
+    let resp2 = app
+        .execute(
+            app.post(WEBHOOK_URI)
+                .header(SIG_HEADER, &header)
+                .json(body)
+                .build(),
+        )
+        .await;
+    assert_eq!(resp2.status, StatusCode::OK, "replay should be acked");
+
+    let pay_count2: i64 = sqlx::query_scalar(
+        "SELECT count(*)::int8 FROM payments \
+         WHERE unit_id = (SELECT unit_id FROM invoices WHERE id = $1)",
+    )
+    .bind(invoice_id)
+    .fetch_one(&pool)
+    .await
+    .expect("recount payments");
+
+    std::env::remove_var(SECRET_ENV);
+    assert_eq!(pay_count2, 1, "replay must not double-settle");
+}

--- a/backend/servers/api-server/tests/payment_webhook_settlement_tests.rs
+++ b/backend/servers/api-server/tests/payment_webhook_settlement_tests.rs
@@ -213,8 +213,11 @@ async fn valid_webhook_settles_invoice_and_is_idempotent(pool: PgPool) {
     assert_eq!(balance, Decimal::ZERO, "balance should be cleared");
 
     // A payment was recorded with the gateway reference and no internal user.
-    let (pay_count, ext_ref, recorded_by): (i64, Option<String>, Option<Uuid>) = sqlx::query_as(
-        "SELECT count(*)::int8, max(external_reference), max(recorded_by) \
+    // `count(recorded_by)` counts only non-null values (Postgres has no
+    // `max(uuid)` aggregate), so 0 confirms the single payment has a NULL
+    // `recorded_by` — the payer is the gateway, not an internal user.
+    let (pay_count, ext_ref, recorded_by_count): (i64, Option<String>, i64) = sqlx::query_as(
+        "SELECT count(*)::int8, max(external_reference), count(recorded_by)::int8 \
          FROM payments WHERE unit_id = (SELECT unit_id FROM invoices WHERE id = $1)",
     )
     .bind(invoice_id)
@@ -223,9 +226,9 @@ async fn valid_webhook_settles_invoice_and_is_idempotent(pool: PgPool) {
     .expect("load payments");
     assert_eq!(pay_count, 1, "exactly one payment recorded");
     assert_eq!(ext_ref.as_deref(), Some("pi_test_settle_1"));
-    assert!(
-        recorded_by.is_none(),
-        "gateway payment has no internal user"
+    assert_eq!(
+        recorded_by_count, 0,
+        "gateway payment has no internal user (recorded_by NULL)"
     );
 
     // The session is marked completed and linked to the payment.

--- a/backend/servers/api-server/tests/payment_webhook_settlement_tests.rs
+++ b/backend/servers/api-server/tests/payment_webhook_settlement_tests.rs
@@ -260,3 +260,99 @@ async fn valid_webhook_settles_invoice_and_is_idempotent(pool: PgPool) {
     std::env::remove_var(SECRET_ENV);
     assert_eq!(pay_count2, 1, "replay must not double-settle");
 }
+
+/// Concurrent-replay (the race the sequential test above cannot catch):
+/// Stripe is at-least-once and does not serialize deliveries, so two duplicate
+/// `checkout.session.completed` events can BOTH read the session as not-yet
+/// `completed` before either commits. The pre-tx status read in the handler is
+/// a TOCTOU window; the security property is enforced at the DB level by the
+/// atomic claim inside `settle_invoice_from_gateway`. We exercise that claim
+/// directly — two settlements racing on the same pending session snapshot must
+/// produce exactly ONE payment + allocation (no double-credit), and the loser
+/// must return `Ok(None)`.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn concurrent_settlement_does_not_double_credit(pool: PgPool) {
+    use db::repositories::FinancialRepository;
+
+    let provider_session_id = "cs_test_concurrent_1";
+    let (invoice_id, _session_pk) = seed_invoice_with_session(
+        &pool,
+        "concurrent",
+        provider_session_id,
+        Decimal::new(10000, 2),
+    )
+    .await;
+
+    let repo = FinancialRepository::new(pool.clone());
+
+    // Both "deliveries" load the SAME pending snapshot — emulating two
+    // duplicates that each passed the handler's pre-tx status read.
+    let session = repo
+        .get_payment_session_by_provider_id(provider_session_id)
+        .await
+        .expect("load session")
+        .expect("session exists");
+    let invoice = repo
+        .get_invoice(invoice_id)
+        .await
+        .expect("load invoice")
+        .expect("invoice exists");
+    assert_eq!(session.status, "pending", "precondition: not yet settled");
+
+    let task1 = {
+        let (repo, session, invoice) = (repo.clone(), session.clone(), invoice.clone());
+        tokio::spawn(async move {
+            repo.settle_invoice_from_gateway(&session, &invoice, "pi_concurrent_1")
+                .await
+        })
+    };
+    let task2 = {
+        let (repo, session, invoice) = (repo.clone(), session.clone(), invoice.clone());
+        tokio::spawn(async move {
+            repo.settle_invoice_from_gateway(&session, &invoice, "pi_concurrent_1")
+                .await
+        })
+    };
+
+    let r1 = task1.await.expect("join task1").expect("settle task1 ok");
+    let r2 = task2.await.expect("join task2").expect("settle task2 ok");
+
+    // Exactly one delivery settles (Some), the other no-ops (None).
+    assert!(
+        r1.is_some() ^ r2.is_some(),
+        "exactly one of the two concurrent deliveries must settle; got {:?} / {:?}",
+        r1.is_some(),
+        r2.is_some(),
+    );
+
+    // The DB-level invariant: one payment, one allocation, invoice paid once.
+    let pay_count: i64 = sqlx::query_scalar(
+        "SELECT count(*)::int8 FROM payments \
+         WHERE unit_id = (SELECT unit_id FROM invoices WHERE id = $1)",
+    )
+    .bind(invoice_id)
+    .fetch_one(&pool)
+    .await
+    .expect("count payments");
+    assert_eq!(
+        pay_count, 1,
+        "concurrent duplicate deliveries must record exactly one payment"
+    );
+
+    let alloc_count: i64 =
+        sqlx::query_scalar("SELECT count(*)::int8 FROM payment_allocations WHERE invoice_id = $1")
+            .bind(invoice_id)
+            .fetch_one(&pool)
+            .await
+            .expect("count allocations");
+    assert_eq!(alloc_count, 1, "exactly one allocation");
+
+    let (status, balance): (String, Decimal) =
+        sqlx::query_as("SELECT status::text, balance_due FROM invoices WHERE id = $1")
+            .bind(invoice_id)
+            .fetch_one(&pool)
+            .await
+            .expect("load invoice");
+    assert_eq!(status, "paid", "invoice settled exactly once");
+    assert_eq!(balance, Decimal::ZERO, "balance cleared, not over-credited");
+}

--- a/backend/servers/api-server/tests/payment_webhook_settlement_tests.rs
+++ b/backend/servers/api-server/tests/payment_webhook_settlement_tests.rs
@@ -223,7 +223,10 @@ async fn valid_webhook_settles_invoice_and_is_idempotent(pool: PgPool) {
     .expect("load payments");
     assert_eq!(pay_count, 1, "exactly one payment recorded");
     assert_eq!(ext_ref.as_deref(), Some("pi_test_settle_1"));
-    assert!(recorded_by.is_none(), "gateway payment has no internal user");
+    assert!(
+        recorded_by.is_none(),
+        "gateway payment has no internal user"
+    );
 
     // The session is marked completed and linked to the payment.
     let sess_status: String =

--- a/backend/servers/api-server/tests/payment_webhook_settlement_tests.rs
+++ b/backend/servers/api-server/tests/payment_webhook_settlement_tests.rs
@@ -20,7 +20,7 @@ mod common;
 
 use axum::http::StatusCode;
 use common::{seed_org, TestApp};
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use rust_decimal::Decimal;
 use sha2::Sha256;
 use sqlx::PgPool;


### PR DESCRIPTION
## Summary

Implements online payment for invoices via **Stripe hosted Checkout** (PCI **SAQ-A** — raw card data never touches our servers), per the CTO architecture decision on BIT-181.

- `POST /api/v1/financial/invoices/{id}/checkout` — creates a Stripe Checkout Session, returns the hosted `checkout_url`.
- `POST /api/v1/integrations/webhooks/payments/{provider}` (`stripe`) — verifies the `Stripe-Signature` HMAC over the **raw** body, then settles the invoice and marks the session `completed`.
- `StripeAppConfig` loaded from env at boot (`STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_SUCCESS_URL`, `STRIPE_CANCEL_URL`). **No secrets committed.**
- Reuses the pre-existing `online_payment_sessions` table (migration `00040`) and `create_payment_session` / `get_payment_session_by_provider_id` repo methods — **no new migration**.
- Receipt = the existing paid-invoice PDF at `GET /invoices/{id}/pdf` (the DB trigger flips the invoice to `paid`, which the PDF reflects).

## Security properties (for SecurityEngineer sign-off)

- **Tenant isolation**: checkout loads the invoice by id then verifies the caller's org membership (foreign id → `404`, indistinguishable from missing). The webhook trusts **no** org id from the payload — the Stripe session id is resolved server-side to its owning org/invoice.
- **Fail closed**: missing signing secret → `503 NOT_CONFIGURED` (never accept an unverified webhook); bad/forged signature → `401`.
- **Replay defense**: timestamp tolerance (300s) on the `Stripe-Signature` `t=`; constant-time HMAC compare (`subtle`); supports multiple `v1=` during secret rotation.
- **Idempotency**: settlement runs in one transaction; an already-`completed` session is a no-op, so Stripe's at-least-once retries cannot double-settle.
- Gateway payments record `recorded_by = NULL` (no internal user) with the PaymentIntent id as `external_reference`.

## Tests

- Unit (`services/stripe.rs`): signature verification — valid / tampered body / wrong secret / stale timestamp / malformed header / key-rotation multi-`v1`; event parsing.
- E2E (`tests/payment_webhook_settlement_tests.rs`): unconfigured → `503`, forged signature → `401`, valid webhook settles invoice to `paid` (balance 0, payment recorded, session completed), duplicate delivery idempotent.

## Build note

The remote Rust builder (mercury) was unreachable during authoring, so this relies on CI to compile/clippy/fmt and run the focused tests. Code was hand-formatted to rustfmt conventions.

Closes part of [BIT-166]. Story 11.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)