### PR TITLE
fix(ci): unblock backend gate — organizations fmt + notification_event RLS baseline

### DIFF
--- a/backend/scripts/rls-pool-field-baseline.txt
+++ b/backend/scripts/rls-pool-field-baseline.txt
@@ -33,6 +33,12 @@ listing.rs
 marketplace.rs
 membership.rs
 messaging.rs
+# --- #1710 / Story 2B-C.3 (gap #969-4): notification delivery-event analytics.
+# service-role-or-super-admin RLS by design (migration 00188), same convention
+# as device_push_token.rs / critical_notification.rs above — end-user GUC
+# connections are denied at the DB. Baselined, not converted (no per-request
+# user context on the spawned analytics path). ---
+notification_event.rs
 notification_preference.rs
 onboarding.rs
 organization.rs

--- a/backend/servers/api-server/src/routes/organizations/mod.rs
+++ b/backend/servers/api-server/src/routes/organizations/mod.rs
@@ -15,6 +15,12 @@ pub mod settings;
 // Re-export all public types so `main.rs` (OpenApi derive) can reference them
 // via `routes::organizations::*` without change.
 pub use core::{
+    // types
+    CreateOrganizationRequest,
+    DeleteOrganizationResponse,
+    ListOrganizationsResponse,
+    OrganizationResponse,
+    UpdateOrganizationRequest,
     // handler fns (needed for utoipa __path_* re-export below)
     __path_create_organization,
     __path_delete_organization,
@@ -22,31 +28,25 @@ pub use core::{
     __path_list_my_organizations,
     __path_list_organizations,
     __path_update_organization,
-    // types
-    CreateOrganizationRequest,
-    DeleteOrganizationResponse,
-    ListOrganizationsResponse,
-    OrganizationResponse,
-    UpdateOrganizationRequest,
 };
 pub use members::{
-    __path_add_organization_member, __path_list_organization_members,
-    __path_remove_organization_member, __path_update_organization_member, AddMemberRequest,
-    AddMemberResponse, ListMembersResponse, MemberResponse, RemoveMemberResponse,
-    UpdateMemberRequest, UpdateMemberResponse,
+    AddMemberRequest, AddMemberResponse, ListMembersResponse, MemberResponse, RemoveMemberResponse,
+    UpdateMemberRequest, UpdateMemberResponse, __path_add_organization_member,
+    __path_list_organization_members, __path_remove_organization_member,
+    __path_update_organization_member,
 };
 pub use roles::{
-    __path_create_organization_role, __path_delete_organization_role, __path_get_organization_role,
-    __path_list_organization_roles, __path_update_organization_role, CreateRoleRequest,
-    CreateRoleResponse, DeleteRoleResponse, GetRoleResponse, ListRolesResponse, RoleResponse,
-    UpdateRoleRequest, UpdateRoleResponse,
+    CreateRoleRequest, CreateRoleResponse, DeleteRoleResponse, GetRoleResponse, ListRolesResponse,
+    RoleResponse, UpdateRoleRequest, UpdateRoleResponse, __path_create_organization_role,
+    __path_delete_organization_role, __path_get_organization_role, __path_list_organization_roles,
+    __path_update_organization_role,
 };
 pub use settings::{
-    __path_export_organization_data, __path_get_organization_branding,
-    __path_get_organization_settings, __path_update_organization_branding,
-    __path_update_organization_settings, ExportMember, ExportQuery, ExportRole,
-    OrganizationBrandingResponse, OrganizationExportResponse, OrganizationSettingsResponse,
-    UpdateOrganizationBrandingRequest, UpdateOrganizationSettingsRequest,
+    ExportMember, ExportQuery, ExportRole, OrganizationBrandingResponse,
+    OrganizationExportResponse, OrganizationSettingsResponse, UpdateOrganizationBrandingRequest,
+    UpdateOrganizationSettingsRequest, __path_export_organization_data,
+    __path_get_organization_branding, __path_get_organization_settings,
+    __path_update_organization_branding, __path_update_organization_settings,
 };
 
 use axum::Router;


### PR DESCRIPTION
## Summary

`dev`'s **Backend** workflow is red, blocking every backend PR (incl. [#1716](https://github.com/martin-janci/property-management/pull/1716) / BIT-178). Two independent, pre-existing breaks — neither introduced here:

1. **rustfmt** — `servers/api-server/src/routes/organizations/mod.rs` `pub use` blocks order `__path_*` before the capitalized types. rustfmt 1.96 (CI toolchain) sorts uppercase before `_`, so `cargo fmt --all --check` fails. Pure re-ordering, no logic change. (#1721 fixed `financial.rs` but missed this file.)

2. **RLS strict gate** — `db/src/repositories/notification_event.rs` (added by #1710, Story 2B-C.3) holds a raw pool field and reads/writes the FORCE-RLS table `notification_events` with no `set_request_context`, so `check-rls-enforcement.sh --strict` fails. This is **service-role-or-super-admin by design**: migration `00188` policy denies end-user GUC connections at the DB, matching the already-baselined `device_push_token.rs` / `critical_notification.rs` convention. Added to `rls-pool-field-baseline.txt` with rationale — **no behavior change, not masking a vuln**.

## Why baseline (not convert) #2
The analytics write/read path runs off the dispatch hot path on the service-role pool with no per-request user context — there is no RlsConnection to thread. The DB-level policy already enforces the security boundary. This is the established pattern for `device_push_token` / `critical_notification`.

## Scope / out of scope
- ✅ Unblocks the Backend **fmt** + **check** gates for `dev` and all backend PRs.
- ⛔ Frontend gate has a **separate** unrelated break (`person-months` PAP-55 unwired-feature test) — not touched here; needs its own owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)