### PR TITLE
chore(scripts): reclassify notification_event.rs as service-role-by-design in RLS baseline (BIT-227)

### DIFF
--- a/backend/scripts/rls-pool-field-baseline.txt
+++ b/backend/scripts/rls-pool-field-baseline.txt
@@ -3,13 +3,31 @@
 # RLS-bypass on BYPASSRLS/superuser pools). Detected by
 # check-rls-enforcement.sh (PAP-68 pool-field detector).
 #
-# Every entry here is PRE-EXISTING debt pending conversion to the executor
-# pattern (see document.rs / board_meetings.rs precedent). Baselined entries
-# WARN instead of failing --strict; any repo NOT listed here that regresses
-# to the pattern fails CI. When a repo is converted, REMOVE its line (the
-# script warns on stale entries).
+# Entries fall into TWO classes (both WARN instead of failing --strict; any
+# repo NOT listed here that regresses to the pattern fails CI):
+#
+#   1. Conversion-pending debt — repos that SHOULD move to the executor
+#      pattern (see document.rs / board_meetings.rs precedent). When such a
+#      repo is converted, REMOVE its line (the script warns on stale entries).
+#
+#   2. Service-role-by-design tables — repos whose table RLS policy is a
+#      service-role *allowance* (USING: user GUC unset OR is_super_admin),
+#      written/read entirely off the request path. The executor pattern does
+#      NOT apply and converting them would BREAK access (a request-scoped user
+#      GUC flips the policy to deny). Their baseline entry is PERMANENT. See
+#      the dedicated section directly below.
 #
 # One basename per line. Comments after '#'.
+
+# === Class 2: service-role-by-design (PERMANENT — do NOT attempt conversion) ===
+# These tables use a service-role-allowance RLS policy (permits the unset-GUC
+# service pool, denies a regular user GUC) and are written/read off the request
+# path, mirroring the audit_logs convention. There is no RlsConnection to take
+# an executor from, so the executor pattern is inapplicable by construction.
+notification_event.rs   # BIT-227 / migration 00188: detached-spawn analytics writes + admin-analytics read; policy permits unset-GUC service pool, denies user GUC
+# Note: device_push_token.rs and critical_notification.rs (migrations 00157/00177,
+# the convention 00188 mirrors) are the same class; they sit under PAP-80 tracking
+# below and can be reclassified here when that sweep is reconciled.
 
 # --- PAP-80 sweep: conversion PRs in flight ---
 
@@ -33,7 +51,6 @@ listing.rs
 marketplace.rs
 membership.rs
 messaging.rs
-notification_event.rs
 notification_preference.rs
 onboarding.rs
 organization.rs


### PR DESCRIPTION
## BIT-227 — dev `check` gate / notification_event.rs RLS violation

### TL;DR
The red `check` gate is **already resolved on `dev`** by `616df24` (baseline entry for `notification_event.rs`). This PR is the *honest end-state* follow-up: it documents **why** that entry is correct and **permanent**, so a future sweep does not "convert" the repo and break it.

### Why the executor conversion (the originally-directed "proper fix") is the wrong fix here
`notification_events` (migration `00188`) is a **service-role table**, not conversion-pending debt. Its RLS policy is a service-role *allowance*:

```sql
USING (NULLIF(current_setting('app.current_user_id', TRUE), '') IS NULL OR is_super_admin())
```

- **Permits** the unset-GUC service pool; **denies** a regular user GUC.
- **Writes** run from a detached `tokio::spawn` off the dispatch hot path (`notification_pipeline.rs:612`) — no request, no `RlsConnection`.
- **Read** is the admin-analytics endpoint (`routes/admin/notifications.rs`), which the RLS gate already exempts (`routes/admin/` is cross-tenant by design).

So there is no request-scoped connection to take an `impl Executor` from, and setting a user GUC would flip the policy to **deny**. Converting to the executor pattern would *break* notification analytics, not harden it. This mirrors the documented `audit_logs` / `device_push_tokens` / `critical_notifications` convention.

### Change
Comment-only edit to `scripts/rls-pool-field-baseline.txt`:
- Splits the baseline into two documented classes (conversion-pending vs. service-role-by-design).
- Moves `notification_event.rs` into a permanent **service-role** section with a rationale pointer.

### Verification
- `./scripts/check-rls-enforcement.sh --strict` → `✓ No RLS violations found` (exit 0), no stale-baseline warning.
- No Rust touched; no behavior change.

### Note for reviewer
`device_push_token.rs` / `critical_notification.rs` are the same class but stay under PAP-80 tracking for now (left untouched to avoid disturbing that sweep). They can be reclassified when PAP-80 is reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)