### PR TITLE
chore(scripts): first-class service-role allowlist in RLS gate (BIT-229)

### DIFF
--- a/backend/scripts/check-rls-enforcement.sh
+++ b/backend/scripts/check-rls-enforcement.sh
@@ -303,9 +303,18 @@ echo "🔍 Checking repository structs holding a raw pool field (FORCE-RLS guard
 
 MIGRATIONS_DIR="$BACKEND_DIR/crates/db/migrations"
 BASELINE_FILE="$SCRIPT_DIR/rls-pool-field-baseline.txt"
+# First-class allowlist of service-role-by-design repos. These are NOT
+# conversion-pending debt: their table RLS policy is a service-role *allowance*
+# (permits the unset-GUC service pool), so the executor pattern is inapplicable
+# and converting them would flip the policy to deny. Kept distinct from the
+# baseline so they are reported as ALLOWED, never "conversion pending", and a
+# PAP-80-style sweep can't mis-classify them. See the file header for the
+# access-model invariant.
+SERVICE_ROLE_ALLOWLIST_FILE="$SCRIPT_DIR/rls-service-role-allowlist.txt"
 
 POOL_FIELD_VIOLATIONS=0
 POOL_FIELD_BASELINED=0
+POOL_FIELD_SERVICE_ROLE=0
 
 if [[ -d "$REPO_DIR" && -d "$MIGRATIONS_DIR" ]]; then
     # FORCE-RLS table set, derived from migrations (source of truth). Tables
@@ -328,7 +337,15 @@ if [[ -d "$REPO_DIR" && -d "$MIGRATIONS_DIR" ]]; then
     if [[ -f "$BASELINE_FILE" ]]; then
         { grep -vE '^[[:space:]]*(#|$)' "$BASELINE_FILE" || true; } | awk '{print $1}' | sort -u > "$TMP_PREFIX/baseline"
     fi
+
+    # Service-role-by-design allowlist (permanent, distinct semantics from the
+    # baseline — see SERVICE_ROLE_ALLOWLIST_FILE comment above).
+    : > "$TMP_PREFIX/service_role"
+    if [[ -f "$SERVICE_ROLE_ALLOWLIST_FILE" ]]; then
+        { grep -vE '^[[:space:]]*(#|$)' "$SERVICE_ROLE_ALLOWLIST_FILE" || true; } | awk '{print $1}' | sort -u > "$TMP_PREFIX/service_role"
+    fi
     : > "$TMP_PREFIX/hit_names"
+    : > "$TMP_PREFIX/service_role_hits"
 
     POOL_FIELD_RE='^[[:space:]]*(pub([[:space:]]*\([^)]*\))?[[:space:]]+)?(pool|db):[[:space:]]*(sqlx::|crate::)?(PgPool|DbPool)'
 
@@ -355,7 +372,18 @@ if [[ -d "$REPO_DIR" && -d "$MIGRATIONS_DIR" ]]; then
         total_tables=$(wc -l < "$TMP_PREFIX/hit_tables")
         field_line=$(grep -nE "$POOL_FIELD_RE" "$repo_file" | head -1 | cut -d: -f1)
 
-        if grep -qxF "$base" "$TMP_PREFIX/baseline"; then
+        if grep -qxF "$base" "$TMP_PREFIX/service_role"; then
+            # Service-role-by-design: the table RLS policy permits the unset-GUC
+            # service pool. Correct as written; the executor pattern does NOT
+            # apply (a request-scoped user GUC would flip the policy to deny).
+            # Reported as ALLOWED, never "conversion pending".
+            ((POOL_FIELD_SERVICE_ROLE+=1))
+            echo "$base" >> "$TMP_PREFIX/service_role_hits"
+            echo -e "${GREEN}ALLOWED${NC} [$repo_file:${field_line:-?}] (service-role-by-design)"
+            echo "  raw pool field on the off-request service path; table policy permits the"
+            echo "  unset-GUC service pool by design — FORCE-RLS tables ($total_tables): $tables_short"
+            echo ""
+        elif grep -qxF "$base" "$TMP_PREFIX/baseline"; then
             ((POOL_FIELD_BASELINED+=1))
             echo -e "${YELLOW}KNOWN OFFENDER${NC} [$repo_file:${field_line:-?}] (baselined, conversion pending)"
             echo "  raw pool field + 0 set_request_context; FORCE-RLS tables ($total_tables): $tables_short"
@@ -369,7 +397,9 @@ if [[ -d "$REPO_DIR" && -d "$MIGRATIONS_DIR" ]]; then
             echo "  FORCE-RLS tables touched ($total_tables): $tables_short"
             echo "  → Convert to the executor pattern (take impl Executor / &mut PgConnection"
             echo "    from the RlsConnection extractor) like document.rs / board_meetings.rs,"
-            echo "    or add a baseline entry with a tracking issue."
+            echo "    or add a baseline entry with a tracking issue. If the table policy is a"
+            echo "    service-role allowance (unset-GUC permitted, off-request path), add it to"
+            echo "    $(basename "$SERVICE_ROLE_ALLOWLIST_FILE") instead — see that file's invariant."
             echo ""
         fi
     done
@@ -383,6 +413,23 @@ if [[ -d "$REPO_DIR" && -d "$MIGRATIONS_DIR" ]]; then
         echo -e "${YELLOW}WARNING${NC} stale baseline entry '$stale' — repo no longer flagged; remove it from $(basename "$BASELINE_FILE")"
         echo ""
     done < <(comm -23 "$TMP_PREFIX/baseline" "$TMP_PREFIX/hit_names_sorted")
+
+    # Stale service-role allowlist entries: listed but no longer flagged by the
+    # detector (e.g. the repo was refactored away from a raw pool field). These
+    # are by-design permanent allowances, not a ratchet, so this is purely
+    # informational — it NEVER fails --strict.
+    sort -u "$TMP_PREFIX/service_role_hits" > "$TMP_PREFIX/service_role_hits_sorted"
+    while IFS= read -r stale; do
+        [[ -n "$stale" ]] || continue
+        ((WARNINGS+=1))
+        echo -e "${YELLOW}INFO${NC} service-role allowlist entry '$stale' is no longer flagged by the detector; it can be removed from $(basename "$SERVICE_ROLE_ALLOWLIST_FILE") (informational — does not fail CI)"
+        echo ""
+    done < <(comm -23 "$TMP_PREFIX/service_role" "$TMP_PREFIX/service_role_hits_sorted")
+
+    if [[ $POOL_FIELD_SERVICE_ROLE -gt 0 ]]; then
+        echo -e "${GREEN}✓ $POOL_FIELD_SERVICE_ROLE service-role-by-design repo(s) allowed (policy permits the unset-GUC service pool; not conversion debt)${NC}"
+        echo ""
+    fi
 
     if [[ $POOL_FIELD_VIOLATIONS -eq 0 ]]; then
         if [[ $POOL_FIELD_BASELINED -gt 0 ]]; then

--- a/backend/scripts/rls-pool-field-baseline.txt
+++ b/backend/scripts/rls-pool-field-baseline.txt
@@ -9,6 +9,13 @@
 # to the pattern fails CI. When a repo is converted, REMOVE its line (the
 # script warns on stale entries).
 #
+# This file is conversion-pending debt ONLY. Repos whose table RLS policy is a
+# service-role *allowance* (permits the unset-GUC service pool by design, so the
+# executor pattern is inapplicable and converting them would break access) live
+# in the separate first-class allowlist rls-service-role-allowlist.txt and are
+# reported by the gate as ALLOWED, never "conversion pending". Do NOT add such
+# repos here.
+#
 # One basename per line. Comments after '#'.
 
 # --- PAP-80 sweep: conversion PRs in flight ---
@@ -21,9 +28,7 @@ automation.rs
 building.rs
 community.rs
 compliance.rs
-critical_notification.rs
 data_export.rs
-device_push_token.rs
 dispute.rs
 edd.rs
 energy.rs
@@ -33,7 +38,6 @@ listing.rs
 marketplace.rs
 membership.rs
 messaging.rs
-notification_event.rs
 notification_preference.rs
 onboarding.rs
 organization.rs

--- a/backend/scripts/rls-service-role-allowlist.txt
+++ b/backend/scripts/rls-service-role-allowlist.txt
@@ -1,0 +1,36 @@
+# Service-role-by-design repositories (first-class allowlist).
+#
+# These repositories hold a raw pool field and query FORCE-RLS tables, so the
+# PAP-68 pool-field detector in check-rls-enforcement.sh flags them. Unlike the
+# entries in rls-pool-field-baseline.txt, they are NOT conversion-pending debt:
+# they are correct as written and must NOT be moved to the executor pattern.
+#
+# ── Access-model invariant ─────────────────────────────────────────────────
+# Each table below carries a *service-role-allowance* RLS policy of the form
+#
+#     USING ( NULLIF(current_setting('app.current_user_id', TRUE), '') IS NULL
+#             OR is_super_admin()
+#             [OR <tenant predicate for the request path>] )
+#
+# i.e. the policy PERMITS the unset-GUC service pool by design. These rows are
+# written/read entirely off the request path (detached spawns, webhook/service
+# workers, admin-analytics reads), where there is no RlsConnection and therefore
+# no executor to take. Converting such a repo to the executor pattern would set
+# a request-scoped user GUC, which flips the very same policy to DENY and breaks
+# the feature. The table's RLS policy — not the detector — is the source of
+# truth; these entries are PERMANENT, not a ratchet to tighten.
+#
+# Adding an entry here is an explicit security assertion. Only add a repo after
+# confirming, in the owning migration, that the table's policy grants the
+# unset-GUC service pool (and that the writes/reads genuinely run off the
+# request path). Cite the migration in the trailing comment.
+#
+# This file is distinct from rls-pool-field-baseline.txt on purpose: the gate
+# reports these as ALLOWED (service-role-by-design), never as "conversion
+# pending", so a future PAP-80-style executor sweep cannot mis-classify them.
+#
+# One basename per line. Comments after '#'.
+
+notification_event.rs       # migration 00188: detached-spawn analytics writes + admin-analytics reads; policy permits unset-GUC service pool, denies user GUC
+device_push_token.rs        # migrations 00157/00159/00161: per-user tokens with device_push_tokens_service_policy (SELECT/DELETE) permitting unset-GUC service pool
+critical_notification.rs    # migration 00177 (Epic 8A GUC fix): critical_notifications / *_acknowledgments keep a service-role allowance (GUC unset => permitted), mirroring device_push_tokens_service_policy


### PR DESCRIPTION
## Summary

Promotes the **service-role-by-design** distinction from a file-level comment (the BIT-227 / #1728 split) into `scripts/check-rls-enforcement.sh`, so the two RLS-baseline classes stop sharing "conversion-pending" semantics entirely. Closes BIT-229.

## What changed
- **New `backend/scripts/rls-service-role-allowlist.txt`** — first-class allowlist, documenting the access-model invariant: each table's RLS policy is a *service-role allowance* (`current_user_id IS NULL OR is_super_admin()`) that permits the unset-GUC service pool by design. These repos read/write off the request path, so there is no `RlsConnection`/executor to take; converting them would set a request-scoped user GUC and flip the policy to **deny**, breaking the feature.
- **`check-rls-enforcement.sh`** — the pool-field detector now reports allowlisted, flagged repos as `ALLOWED (service-role-by-design)` rather than `KNOWN OFFENDER (conversion pending)`, with a dedicated counter. A stale allowlist entry (no longer flagged) is **informational only** and never fails `--strict`. The `VIOLATION` hint now points new service-role cases at the allowlist.
- **`rls-pool-field-baseline.txt`** — moved `notification_event.rs`, `device_push_token.rs`, `critical_notification.rs` out of conversion-pending debt into the allowlist; header clarified that the file is conversion debt **only**.

## Why these three
Each cites its owning migration, verified against the policy body:
- `notification_event.rs` — `00188`: `current_user_id IS NULL OR is_super_admin()`
- `device_push_token.rs` — `00157`/`00159`/`00161`: `device_push_tokens_service_policy` (SELECT + DELETE) permits unset GUC
- `critical_notification.rs` — `00177` (Epic 8A GUC fix): keeps a service-role allowance "mirroring `device_push_tokens_service_policy`"

`audit_log.rs` is a service-role table too but is **not** flagged by the detector, so it needs no entry.

## Verification
- `bash -n` clean; `./scripts/check-rls-enforcement.sh --strict` → **exit 0**
- Output: `✓ 3 service-role-by-design repo(s) allowed`, `⚠ 30 known pool-field offender(s) pending conversion` (was 33), `✓ No RLS violations found`
- Stale-allowlist INFO path tested: emits INFO, still exit 0 under `--strict`
- No Rust changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
