### PR TITLE
fix(ppt-web): reconcile person-months route with UNWIRED_FEATURES (dev test regression)

### DIFF
--- a/frontend/apps/ppt-web/src/features/unwired-features.ts
+++ b/frontend/apps/ppt-web/src/features/unwired-features.ts
@@ -1,7 +1,7 @@
 /**
  * Unwired feature registry — Stable Beta (PAP-55 / WS-C, decision on PAP-28).
  *
- * These 11 ppt-web feature directories are **fully built** (1.0k–5.7k LOC each)
+ * These 10 ppt-web feature directories are **fully built** (1.0k–5.7k LOC each)
  * with live, mounted api-server backends, but are intentionally **not wired**
  * into the router or navigation. Board decision (PAP-51 confirmation, accepted):
  *
@@ -31,7 +31,10 @@
  *   migration, integrations, multi-currency, api-ecosystem, delegation,
  *   data-residency, packages. Those dirs no longer exist on `dev`, so the guard
  *   no longer tracks them (a deleted feature cannot be re-exposed). This list
- *   was reconciled from 18 → 11 when PAP-55 landed on top of PAP-33.
+ *   was reconciled from 18 → 11 when PAP-55 landed on top of PAP-33, then
+ *   11 → 10 when `person-months` was deliberately wired (Story 3.5, #1714):
+ *   its route group (`routes/groups/person-months.tsx`) is mounted in
+ *   `AppRoutes.tsx`, so it is no longer hidden and is removed from the guard.
  */
 export const UNWIRED_FEATURES = [
   'insurance',
@@ -44,7 +47,6 @@ export const UNWIRED_FEATURES = [
   'compliance',
   'registry',
   'portfolio-performance',
-  'person-months',
 ] as const;
 
 export type UnwiredFeature = (typeof UNWIRED_FEATURES)[number];

--- a/frontend/apps/ppt-web/src/test/unwired-features.test.ts
+++ b/frontend/apps/ppt-web/src/test/unwired-features.test.ts
@@ -47,8 +47,8 @@ function routingSurfaceSources(): { file: string; content: string }[] {
 }
 
 describe('Unwired feature registry (PAP-55)', () => {
-  it('lists 11 features', () => {
-    expect(UNWIRED_FEATURES.length).toBe(11);
+  it('lists 10 features', () => {
+    expect(UNWIRED_FEATURES.length).toBe(10);
   });
 
   it('retains the code for every unwired feature (dir exists)', () => {


### PR DESCRIPTION
## Problem

The **Test Property Management Web** CI job is **RED on `dev` itself** — a dev-wide frontend regression that blocks/penalizes multiple frontend PRs (e.g. #1725).

Root cause: PR #1714 (`feat(ppt-web): person-month tracking wiring + routes (Story 3.5)`) wired the `person-months` feature into the router — `routes/groups/person-months.tsx` is imported and rendered via `personMonthRoutes()` in `routes/AppRoutes.tsx`, and it `import('../../features/person-months')`. But `person-months` was **left in** the `UNWIRED_FEATURES` array.

The PAP-55 guard test (`src/test/unwired-features.test.ts`) asserts that no routing-surface file references any unwired feature dir. Since `person-months` is now wired, the guard fails:

```
AssertionError: Unwired feature "person-months" is referenced by routing surface file(s): routes/groups/person-months.tsx.
expected [ 'routes/groups/person-months.tsx' ] to deeply equal []
```

## Fix

`person-months` is a genuinely wired, shipping feature (route group mounted in `AppRoutes.tsx`, lazy-loaded pages, full `@ppt/api-client` person-months integration). Per the registry's own contract — *"To wire one of these features in a future phase: build its route group + nav entry, then DELETE its slug from this array"* — the correct fix is to **remove `person-months` from `UNWIRED_FEATURES`**, not to hide a shipped feature.

Changes (minimal):
- Remove `'person-months'` from `UNWIRED_FEATURES` (11 → 10) in `features/unwired-features.ts`, and update the doc comment to record the 11 → 10 reconciliation.
- Update the count assertion in `test/unwired-features.test.ts` (`lists 11 features` → `lists 10 features`).

No feature code is deleted; the guard now reflects true app state.

## Verification

`pnpm --filter @ppt/web exec vitest run src/test/unwired-features.test.ts` → **12 passed (0 failed)** (was 1 failed | 12 passed).
`pnpm --filter @ppt/web exec biome check` on both touched files → clean.

## Notes

- This is a **dev-wide `Test PM Web` regression introduced by #1714**; merging this should turn the job green on `dev` and **unblock frontend PRs like #1725** that inherit the red base.
- No tracking issue appears to exist for this regression; filing one is optional given the fix is contained here.