### PR TITLE
fix(ppt-web): add loading state + double-click guard to invoice PDF download (#1673)

### DIFF
--- a/frontend/apps/ppt-web/src/features/financial/components/InvoiceList.test.tsx
+++ b/frontend/apps/ppt-web/src/features/financial/components/InvoiceList.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * InvoiceList — PDF-download loading state + double-click guard (#1673).
+ *
+ * PR #1654 wired the per-row "PDF" download button but rendered it as a bare
+ * always-enabled action. These tests pin the follow-up behaviour: while a
+ * download is in flight (the route container reports the in-flight invoice id
+ * via `downloadingPdfId`), that invoice's PDF button must render disabled +
+ * busy so a second click cannot fire a concurrent download.
+ */
+
+/// <reference types="vitest/globals" />
+import type { Invoice } from '@ppt/api-client';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { InvoiceList } from './InvoiceList';
+
+function makeInvoice(overrides: Partial<Invoice> = {}): Invoice {
+  return {
+    id: 'inv-1',
+    organization_id: 'org-1',
+    unit_id: 'unit-1',
+    invoice_number: 'INV-0001',
+    status: 'sent',
+    issue_date: '2026-06-01',
+    due_date: '2026-06-15',
+    subtotal: 100,
+    tax_amount: 20,
+    total: 120,
+    amount_paid: 0,
+    balance_due: 120,
+    currency: 'EUR',
+    created_at: '2026-06-01T00:00:00Z',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+const baseProps = {
+  total: 1,
+  page: 1,
+  pageSize: 10,
+  onPageChange: vi.fn(),
+  onViewInvoice: vi.fn(),
+};
+
+describe('InvoiceList — PDF download loading state (#1673)', () => {
+  it('renders an enabled PDF button when no download is in flight', () => {
+    render(<InvoiceList {...baseProps} invoices={[makeInvoice()]} onDownloadPdf={vi.fn()} />);
+
+    const pdfBtn = screen.getByRole('button', { name: 'PDF' });
+    expect(pdfBtn).toBeEnabled();
+    expect(pdfBtn).toHaveAttribute('aria-busy', 'false');
+  });
+
+  it('disables + marks busy the PDF button of the invoice currently downloading', () => {
+    render(
+      <InvoiceList
+        {...baseProps}
+        invoices={[makeInvoice()]}
+        onDownloadPdf={vi.fn()}
+        downloadingPdfId="inv-1"
+      />
+    );
+
+    const pdfBtn = screen.getByRole('button', { name: 'PDF…' });
+    expect(pdfBtn).toBeDisabled();
+    expect(pdfBtn).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('does not invoke onDownloadPdf when the in-flight button is clicked (double-click guard)', async () => {
+    const onDownloadPdf = vi.fn();
+    render(
+      <InvoiceList
+        {...baseProps}
+        invoices={[makeInvoice()]}
+        onDownloadPdf={onDownloadPdf}
+        downloadingPdfId="inv-1"
+      />
+    );
+
+    // userEvent respects the `disabled` attribute and won't dispatch the click.
+    await userEvent.click(screen.getByRole('button', { name: 'PDF…' }));
+    expect(onDownloadPdf).not.toHaveBeenCalled();
+  });
+
+  it('only disables the downloading invoice, leaving sibling PDF buttons active', () => {
+    render(
+      <InvoiceList
+        {...baseProps}
+        total={2}
+        invoices={[
+          makeInvoice({ id: 'inv-1', invoice_number: 'INV-0001' }),
+          makeInvoice({ id: 'inv-2', invoice_number: 'INV-0002' }),
+        ]}
+        onDownloadPdf={vi.fn()}
+        downloadingPdfId="inv-1"
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'PDF…' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'PDF' })).toBeEnabled();
+  });
+});

--- a/frontend/apps/ppt-web/src/features/financial/components/InvoiceList.tsx
+++ b/frontend/apps/ppt-web/src/features/financial/components/InvoiceList.tsx
@@ -17,6 +17,8 @@ interface InvoiceListProps {
   onViewInvoice: (invoiceId: string) => void;
   onSendInvoice?: (invoiceId: string) => void;
   onDownloadPdf?: (invoiceId: string) => void;
+  /** Id of the invoice whose PDF is currently downloading; disables its PDF button. */
+  downloadingPdfId?: string | null;
   onStatusFilter?: (status?: InvoiceStatus) => void;
   onSearch?: (query: string) => void;
 }
@@ -31,6 +33,7 @@ export function InvoiceList({
   onViewInvoice,
   onSendInvoice,
   onDownloadPdf,
+  downloadingPdfId,
   onStatusFilter,
   onSearch,
 }: InvoiceListProps) {
@@ -205,18 +208,24 @@ export function InvoiceList({
                           Send
                         </button>
                       )}
-                      {onDownloadPdf && (
-                        <button
-                          type="button"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onDownloadPdf(invoice.id);
-                          }}
-                          className="text-gray-600 hover:text-gray-800"
-                        >
-                          PDF
-                        </button>
-                      )}
+                      {onDownloadPdf &&
+                        (() => {
+                          const isDownloading = downloadingPdfId === invoice.id;
+                          return (
+                            <button
+                              type="button"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onDownloadPdf(invoice.id);
+                              }}
+                              disabled={isDownloading}
+                              aria-busy={isDownloading}
+                              className="text-gray-600 hover:text-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                              {isDownloading ? 'PDF…' : 'PDF'}
+                            </button>
+                          );
+                        })()}
                       <button
                         type="button"
                         onClick={(e) => {

--- a/frontend/apps/ppt-web/src/features/financial/pages/InvoiceManagementPage.tsx
+++ b/frontend/apps/ppt-web/src/features/financial/pages/InvoiceManagementPage.tsx
@@ -23,6 +23,8 @@ export interface InvoiceManagementPageProps {
   onNavigateToDetail: (invoiceId: string) => void;
   onSendInvoice: (invoiceId: string) => void;
   onDownloadPdf?: (invoiceId: string) => void;
+  /** Id of the invoice whose PDF is currently downloading (drives the busy/disabled state). */
+  downloadingPdfId?: string | null;
   onFilterChange: (params: {
     page: number;
     pageSize: number;
@@ -41,6 +43,7 @@ export function InvoiceManagementPage({
   onNavigateToDetail,
   onSendInvoice,
   onDownloadPdf,
+  downloadingPdfId,
   onFilterChange,
 }: InvoiceManagementPageProps) {
   const { t } = useTranslation();
@@ -138,6 +141,7 @@ export function InvoiceManagementPage({
           onViewInvoice={onNavigateToDetail}
           onSendInvoice={onSendInvoice}
           onDownloadPdf={onDownloadPdf}
+          downloadingPdfId={downloadingPdfId}
           onStatusFilter={handleStatusFilter}
           onSearch={handleSearch}
         />

--- a/frontend/apps/ppt-web/src/routes/groups/financial.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/financial.tsx
@@ -163,26 +163,35 @@ function InvoiceManagementPageRoute() {
     },
   });
 
-  const handleDownloadPdf = (id: string) => {
-    const number = data?.invoices.find((inv) => inv.id === id)?.invoice_number ?? id;
-    downloadInvoicePdf(id)
-      .then((blob) => {
-        const url = URL.createObjectURL(blob);
-        const anchor = document.createElement('a');
-        anchor.href = url;
-        anchor.download = `invoice-${number}.pdf`;
-        document.body.appendChild(anchor);
-        anchor.click();
-        document.body.removeChild(anchor);
-        URL.revokeObjectURL(url);
-      })
-      .catch((err) => {
-        showToast({
-          type: 'error',
-          title: t('financial.invoices.pdfFailed', { defaultValue: 'Failed to download PDF' }),
-          message: err instanceof Error ? err.message : '',
-        });
+  // Route the PDF download through a TanStack mutation (mirrors sendInvoiceMutation)
+  // so we get an in-flight `isPending` + `variables` (the invoice id) for free.
+  // This drives the per-row loading affordance and the double-click guard below.
+  const downloadPdfMutation = useMutation({
+    mutationFn: (id: string) => downloadInvoicePdf(id),
+    onSuccess: (blob, id) => {
+      const number = data?.invoices.find((inv) => inv.id === id)?.invoice_number ?? id;
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = `invoice-${number}.pdf`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+      URL.revokeObjectURL(url);
+    },
+    onError: (err) => {
+      showToast({
+        type: 'error',
+        title: t('financial.invoices.pdfFailed', { defaultValue: 'Failed to download PDF' }),
+        message: err instanceof Error ? err.message : '',
       });
+    },
+  });
+
+  const handleDownloadPdf = (id: string) => {
+    // Double-click guard: ignore new clicks while any download is in flight.
+    if (downloadPdfMutation.isPending) return;
+    downloadPdfMutation.mutate(id);
   };
 
   return (
@@ -195,6 +204,9 @@ function InvoiceManagementPageRoute() {
       onNavigateToDetail={(id: string) => navigate(`/financial/invoices/${id}`)}
       onSendInvoice={(id: string) => sendInvoiceMutation.mutate(id)}
       onDownloadPdf={handleDownloadPdf}
+      downloadingPdfId={
+        downloadPdfMutation.isPending ? (downloadPdfMutation.variables ?? null) : null
+      }
       onFilterChange={(params) => {
         setStatusFilter(params.status);
         setPage(params.page);


### PR DESCRIPTION
Closes #1673.

## Problem
The invoice "PDF" download button (added in #1654, route `frontend/apps/ppt-web/src/routes/groups/financial.tsx`) fired a bare promise with no in-flight state:
- **No loading feedback** — server-side PDF rendering can be slow; the user saw nothing between click and download.
- **No double-click guard** — rapid clicks fired N concurrent fetches and N browser downloads.

## Fix
- Routed the PDF download through a TanStack `useMutation` (`downloadPdfMutation`), mirroring the sibling `sendInvoiceMutation` already in this file. The blob/anchor logic moved into `onSuccess`, the toast into `onError`.
- `handleDownloadPdf` now early-returns while `downloadPdfMutation.isPending` (double-click guard).
- Threaded a new `downloadingPdfId` prop (`mutation.variables` while pending) through `InvoiceManagementPage` → `InvoiceList`. The in-flight invoice's PDF button renders `disabled` + `aria-busy` with a `PDF…` label; sibling rows stay active.

## Tests
Added `InvoiceList.test.tsx` (4 cases): enabled-by-default, disabled+busy for the downloading row, click is a no-op while pending (guard), and only the in-flight row is disabled. All pass.

## Verification
- `pnpm --filter @ppt/web exec biome check <touched files>` — clean
- `pnpm --filter @ppt/web exec vitest run InvoiceList.test.tsx` — 4/4 pass
- `pnpm --filter @ppt/web typecheck` — only a **pre-existing** ambiguity in the generated `@ppt/api-client/src/index.ts` (`ReportType`/`exportReport` re-export), present unchanged on `origin/dev` and not in any file this PR touches.