### PR TITLE
fix(api-server): repair voting PDF test setup regression (#1645)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -164,6 +164,18 @@ jobs:
         with:
           workspaces: backend
 
+      # The voting PDF-report path (routes/voting.rs::render_pdf_report, added
+      # in #1625) loads the LiberationSans TTFs from
+      # `/usr/share/fonts/truetype/liberation` via `genpdf::fonts::from_files`.
+      # GitHub's `ubuntu-latest` image does NOT ship `fonts-liberation`, so the
+      # `voting_report_tests` PDF E2E tests 500 on the render step and the whole
+      # `test` job goes red. Install the package the production code depends on
+      # so the tests exercise the same path they do in prod (issue #1645).
+      - name: Install PDF report fonts
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends fonts-liberation
+
       # The GitHub-hosted runner's root disk fills during the link step of
       # `cargo test --workspace` (the large workspace + test binaries), failing
       # with "No space left on device". Reclaim the preinstalled toolchains we


### PR DESCRIPTION
## Root cause

`dev`'s backend `test` job has been red since #1625 (voting PDF generation, commit 3c63a6d). Because the `test` job runs the full workspace suite, every backend PR inherits the failure.

Two issues stacked up:

1. **Setup-time 500 — already fixed by #1656.** The original `pdf_report` tests in `voting_tests.rs` mixed schema-less `#[sqlx::test]` auth-rejection tests with schema-full `#[sqlx::test(migrator = "db::MIGRATOR")]` tests in one binary, leaving the migrator tests on an un-migrated DB → `POST /auth/register` 500'd with `relation "users" does not exist` (the 201≠500 panic at `common/mod.rs`). #1656 isolated them into `voting_report_tests.rs` and applies the schema explicitly via `db::run_migrations`. Confirmed locally that setup now reaches 201.

2. **Runtime font dependency — this PR.** `routes/voting.rs::render_pdf_report` (and `routes/financial.rs`) load LiberationSans from `/usr/share/fonts/truetype/liberation` via `genpdf::fonts::from_files`. GitHub's `ubuntu-latest` runner does **not** ship `fonts-liberation`, so the PDF-render step errors → 500 at the report assertion → the `test` job stays red.

## Fix

Install `fonts-liberation` in the backend `test` job before `cargo test --workspace`, so the PDF-render tests exercise the same font path they use in production. No production code changes.

## Verification

Reproduced and verified against a real Postgres (`postgres://postgres:postgres@localhost:5432/test`) with `fonts-liberation` present:

```
cargo test -p api-server --test voting_report_tests
cargo test: 2 passed (1 suite, 150.39s)
```

Both `test_get_report_pdf_returns_application_pdf_and_archives_document` and `test_get_report_json_with_format_pdf_returns_application_pdf` pass: setup reaches 201, the PDF renders, and the archived `documents WHERE category = 'reports'::document_category` row is asserted. Without the fonts, `render_pdf_report` returns `Err` → 500, which is exactly the CI failure mode.

Closes #1645