### PR TITLE
test(mobile): guard API_BASE_URL against placeholder/process.env regression + scrub stale doc (#1663)

### DIFF
--- a/.claude/skills/ppt-implement/agents/react-native.md
+++ b/.claude/skills/ppt-implement/agents/react-native.md
@@ -17,7 +17,7 @@ frontend/apps/mobile/
     navigation/          — React Navigation stacks
     components/          — reusable
     hooks/               — feature hooks
-    config/api.ts        — env-driven API URL (Expo Constants + process.env)
+    config/api.ts        — env-driven API URL (reads Constants.expoConfig.extra)
     services/            — push notifications, secure storage
   .env.{dev,staging,prod}
   app.json / app.config.ts
@@ -28,7 +28,7 @@ frontend/apps/mobile/
 - Navigation: React Navigation v6 (stacks + tabs).
 - Forms: `react-hook-form` + `zod` (same as web).
 - Secure storage: `expo-secure-store` for tokens (NOT AsyncStorage for sensitive data).
-- Env loading: Expo Constants → `process.env` fallback (see existing `src/config/api.ts`).
+- Env loading: single source of truth is `Constants.expoConfig.extra`, populated by `app.config.ts` from `.env.<APP_ENV>`. All env-driven config flows through `src/config/api.ts` (`getApiBaseUrl()` etc.); `src/config/constants.ts` re-exports those resolved values. NEVER read `process.env.EXPO_PUBLIC_*` at module scope and never fall back to a placeholder host like `api.ppt.example.com` — that path bypasses the single source of truth, can't reach the iOS `Info.plist`, and ships the placeholder in release builds. The `EXPO_PUBLIC_*` fallback was removed in #523 and must not be reintroduced (regression guard: `src/config/constants.test.ts`).
 - Push: `expo-notifications`.
 
 ## Step-by-step
@@ -40,13 +40,16 @@ frontend/apps/mobile/
 ## Verify (MANDATORY)
 ```bash
 pnpm -F mobile typecheck
-pnpm -F mobile lint
+pnpm -F mobile test            # jest-expo
+# The mobile package has no per-package `lint` script — use the workspace
+# Biome gate instead (run from frontend/):
+pnpm exec biome check apps/mobile/<changed-paths>
 ```
 Quote both exit codes. Do NOT attempt `expo run:android` or `:ios` in the
 sandbox — those need devices/emulators not available to the routine.
 
 ## Common pitfalls
-- Reading from `process.env` directly at module scope before Expo Constants are loaded → wrong env in production. Always go through `src/config/api.ts`.
+- Reading from `process.env` (e.g. `EXPO_PUBLIC_*`) directly at module scope → wrong env in production and a placeholder host baked into release builds. Always go through `src/config/api.ts`, which reads `Constants.expoConfig.extra` (the single source of truth). Do NOT reintroduce a `process.env` / `api.ppt.example.com` fallback (#523, #1658).
 - Storing tokens in AsyncStorage → use SecureStore.
 - Forgetting `.env.production` when adding a new env var → app crashes on prod build.
 - Bundling web-only modules (e.g., `axios` interceptors that touch `document`) → use the abstraction in `@ppt/api-client`.

--- a/frontend/apps/mobile/src/config/constants.test.ts
+++ b/frontend/apps/mobile/src/config/constants.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Regression guard for issue #1663 (follow-up to #1658 / Epic 85 story 85.1).
+ *
+ * `src/config/constants.ts` must derive `API_BASE_URL` from the single source
+ * of truth — `Constants.expoConfig.extra.API_BASE_URL` (populated by
+ * `app.config.ts` from `.env.<APP_ENV>`), via `getApiBaseUrl()` in
+ * `src/config/api.ts`. It must NEVER:
+ *   - fall back to a hardcoded placeholder host (`api.ppt.example.com`), nor
+ *   - read `process.env.EXPO_PUBLIC_API_BASE_URL` (or any `EXPO_PUBLIC_*`) at
+ *     module scope.
+ *
+ * This exact regression has shipped more than once (#523 removed it, #535/#620
+ * reintroduced it in app.config.ts, #1658 removed it again from constants.ts).
+ * This test locks the contract so it cannot silently come back.
+ */
+
+const PLACEHOLDER_HOST = 'api.ppt.example.com';
+
+/**
+ * Load `./constants` fresh against a given `expoConfig.extra` payload.
+ *
+ * `jest.isolateModules` + `jest.doMock` give each scenario its own module
+ * registry so the module-scope `API_BASE_URL = getApiBaseUrl()` evaluates
+ * against the mock we set for that scenario.
+ */
+function loadConstantsWithExtra(extra: Record<string, unknown> | undefined): {
+  API_BASE_URL: string;
+  CONSTANTS: { API_BASE_URL: string };
+} {
+  let mod!: typeof import('./constants');
+  jest.isolateModules(() => {
+    jest.doMock('expo-constants', () => ({
+      expoConfig: extra === undefined ? {} : { extra },
+    }));
+    // Keep the platform branch in getApiBaseUrl() deterministic.
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }), { virtual: true });
+    mod = require('./constants');
+  });
+  return mod;
+}
+
+describe('constants — API_BASE_URL single source of truth (#1663)', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+    jest.dontMock('expo-constants');
+    jest.dontMock('react-native');
+  });
+
+  it('resolves API_BASE_URL from Constants.expoConfig.extra.API_BASE_URL', () => {
+    const { API_BASE_URL, CONSTANTS } = loadConstantsWithExtra({
+      API_BASE_URL: 'https://configured.example',
+    });
+
+    expect(API_BASE_URL).toBe('https://configured.example');
+    expect(CONSTANTS.API_BASE_URL).toBe('https://configured.example');
+  });
+
+  it('never falls back to the api.ppt.example.com placeholder host', () => {
+    // No extra configured at all — must NOT yield the legacy placeholder.
+    const { API_BASE_URL } = loadConstantsWithExtra(undefined);
+
+    expect(API_BASE_URL).not.toContain(PLACEHOLDER_HOST);
+  });
+
+  it('ignores process.env.EXPO_PUBLIC_API_BASE_URL — extra wins', () => {
+    process.env.EXPO_PUBLIC_API_BASE_URL = 'https://leaked.example';
+
+    const { API_BASE_URL } = loadConstantsWithExtra({
+      API_BASE_URL: 'https://configured.example',
+    });
+
+    expect(API_BASE_URL).toBe('https://configured.example');
+    expect(API_BASE_URL).not.toBe('https://leaked.example');
+  });
+
+  it('does not read EXPO_PUBLIC_API_BASE_URL even when extra is absent', () => {
+    // The forbidden regression: a process.env fallback at module scope. With no
+    // extra configured the value must come from the dev/platform default in
+    // getApiBaseUrl(), never from EXPO_PUBLIC_*.
+    process.env.EXPO_PUBLIC_API_BASE_URL = 'https://leaked.example';
+
+    const { API_BASE_URL } = loadConstantsWithExtra(undefined);
+
+    expect(API_BASE_URL).not.toBe('https://leaked.example');
+    expect(API_BASE_URL).not.toContain(PLACEHOLDER_HOST);
+  });
+});


### PR DESCRIPTION
Closes #1663

Follow-up to #1658 (Epic 85 / story 85.1). Two non-blocking constructive items from the post-merge review.

## 1. Regression guard test — `frontend/apps/mobile/src/config/constants.test.ts`

`constants.ts` re-exports `API_BASE_URL = getApiBaseUrl()` (from `src/config/api.ts`), the documented single source of truth that reads `Constants.expoConfig.extra.API_BASE_URL` (populated by `app.config.ts` from `.env.<APP_ENV>`). The `EXPO_PUBLIC_*` / `api.ppt.example.com` placeholder read at module scope was removed in #523 and again in #1658, but had no test locking it.

This regression has shipped 3+ times. The new jest test (mocks `expo-constants` via `jest.isolateModules` + `jest.doMock`, matching the existing mobile mock idiom) asserts:
- `API_BASE_URL` resolves from `Constants.expoConfig.extra.API_BASE_URL`,
- it never falls back to the `api.ppt.example.com` placeholder host,
- it ignores `process.env.EXPO_PUBLIC_API_BASE_URL` (extra wins, and even with no extra it never reads the leaked env value).

Verified the 4 tests **pass** on current `constants.ts` and **all fail** when the old `process.env.EXPO_PUBLIC_API_BASE_URL ?? 'https://api.ppt.example.com'` version is reinstated (failing-on-regression guard). `pnpm exec biome check` clean.

## 2. Doc scrub — `.claude/skills/ppt-implement/agents/react-native.md`

Removed the stale "Expo Constants → `process.env` fallback" guidance that contradicted the #523/#1658 single-source-of-truth rule:
- layout cheatsheet: `config/api.ts` now described as "reads `Constants.expoConfig.extra`",
- Conventions: env loading flows through `Constants.expoConfig.extra` / `src/config/api.ts`; never read `process.env.EXPO_PUBLIC_*` at module scope; never a placeholder host,
- Pitfalls: reframed to forbid reintroducing the `process.env` / placeholder fallback,
- Verify block: `pnpm -F mobile lint` (no such script) replaced with the workspace Biome gate `pnpm exec biome check apps/mobile/...` + added `pnpm -F mobile test`.

## Verification
- `pnpm --filter @ppt/mobile test -- config` → 20 passed (4 new + existing app.config tests).
- `pnpm exec biome check apps/mobile/src/config/constants.test.ts` → no issues.