### PR TITLE
fix(ppt-web): surface IoT alert mutation errors + add alerts error state (#1669)

### DIFF
--- a/docs/screens/ppt/iot.md
+++ b/docs/screens/ppt/iot.md
@@ -78,8 +78,13 @@ alongside the dashboard's inline `AlertsPanel`.
 - **Loading**: per-query spinners (dashboard rollup, sensor list, alert list).
 - **Saving**: ack/resolve and sensor CRUD buttons disable while their mutation
   is pending.
-- **Error**: mutation failures surface as toasts. `apiStatus: partial` until the
-  IoT backend is verified end-to-end.
+- **Error**: ack/resolve and sensor CRUD mutation failures surface as error
+  toasts (`iot.acknowledgeFailed` / `iot.resolveFailed` / the CRUD failure keys)
+  from the `routes/groups/iot.tsx` wrappers. The alerts page additionally renders
+  a distinct error panel with a Retry affordance when its source query
+  (`useIotDashboard`) fails (`iot.alerts.loadError` + `common.retry`), so a hard
+  load failure is not misreported as the "All clear" empty state. `apiStatus:
+  partial` until the IoT backend is verified end-to-end.
 
 ## Notes
 
@@ -94,3 +99,7 @@ alongside the dashboard's inline `AlertsPanel`.
 ## Agent Log
 - 2026-06-21 — FrontendEngineer: created the IoT module map with the standalone
   alerts page increment (BIT-149, Epic 14 / FR74).
+- 2026-06-23 — agent: surfaced ack/resolve mutation failures as toasts on the
+  alerts + dashboard wrappers and added a distinct `isError` panel with Retry to
+  `IotAlertsPage` (issue #1669); reconciled the States > Error section. Deferred:
+  the dedicated cross-sensor alerts list endpoint + `recent_alerts` source limit.

--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -1253,6 +1253,8 @@
     "acknowledge": "Potvrdit",
     "resolve": "Vyřešit",
     "resolved": "vyřešeno",
+    "acknowledgeFailed": "Potvrzení upozornění selhalo",
+    "resolveFailed": "Vyřešení upozornění selhalo",
     "triggered": "Spuštěno",
     "thresholdBreach": "Překročení prahu",
     "thresholds": "Prahy",
@@ -1308,6 +1310,7 @@
       "subtitle": "Překročení prahů napříč vašimi budovami.",
       "backToDashboard": "Zpět na přehled",
       "empty": "Žádná upozornění neodpovídají těmto filtrům. Vše v pořádku.",
+      "loadError": "Nepodařilo se načíst upozornění. Zkuste to znovu.",
       "filter": {
         "allStates": "Všechny stavy",
         "allSeverities": "Všechny závažnosti"

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -1202,6 +1202,8 @@
     "acknowledge": "Bestätigen",
     "resolve": "Lösen",
     "resolved": "gelöst",
+    "acknowledgeFailed": "Bestätigen der Warnung fehlgeschlagen",
+    "resolveFailed": "Lösen der Warnung fehlgeschlagen",
     "triggered": "Ausgelöst",
     "thresholdBreach": "Schwellenwertüberschreitung",
     "thresholds": "Schwellenwerte",
@@ -1257,6 +1259,7 @@
       "subtitle": "Schwellenwertüberschreitungen in Ihren Gebäuden.",
       "backToDashboard": "Zurück zur Übersicht",
       "empty": "Keine Warnungen entsprechen diesen Filtern. Alles in Ordnung.",
+      "loadError": "Warnungen konnten nicht geladen werden. Bitte erneut versuchen.",
       "filter": {
         "allStates": "Alle Status",
         "allSeverities": "Alle Schweregrade"

--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -3543,6 +3543,8 @@
     "acknowledge": "Acknowledge",
     "resolve": "Resolve",
     "resolved": "resolved",
+    "acknowledgeFailed": "Failed to acknowledge alert",
+    "resolveFailed": "Failed to resolve alert",
     "triggered": "Triggered",
     "thresholdBreach": "Threshold breach",
     "thresholds": "Thresholds",
@@ -3598,6 +3600,7 @@
       "subtitle": "Threshold breaches across your buildings.",
       "backToDashboard": "Back to dashboard",
       "empty": "No alerts match these filters. All clear.",
+      "loadError": "Failed to load alerts. Please try again.",
       "filter": {
         "allStates": "All states",
         "allSeverities": "All severities"

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -1175,6 +1175,8 @@
     "acknowledge": "Nyugtázás",
     "resolve": "Megoldás",
     "resolved": "megoldva",
+    "acknowledgeFailed": "A riasztás nyugtázása sikertelen",
+    "resolveFailed": "A riasztás megoldása sikertelen",
     "triggered": "Kiváltva",
     "thresholdBreach": "Küszöbérték túllépése",
     "thresholds": "Küszöbértékek",
@@ -1230,6 +1232,7 @@
       "subtitle": "Küszöbérték-túllépések az épületeiben.",
       "backToDashboard": "Vissza az áttekintéshez",
       "empty": "Egyetlen riasztás sem felel meg ezeknek a szűrőknek. Minden rendben.",
+      "loadError": "A riasztások betöltése sikertelen. Kérjük, próbálja újra.",
       "filter": {
         "allStates": "Minden állapot",
         "allSeverities": "Minden súlyosság"

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -1181,6 +1181,8 @@
     "acknowledge": "Potwierdź",
     "resolve": "Rozwiąż",
     "resolved": "rozwiązano",
+    "acknowledgeFailed": "Nie udało się potwierdzić alertu",
+    "resolveFailed": "Nie udało się rozwiązać alertu",
     "triggered": "Wyzwolono",
     "thresholdBreach": "Przekroczenie progu",
     "thresholds": "Progi",
@@ -1236,6 +1238,7 @@
       "subtitle": "Przekroczenia progów w Twoich budynkach.",
       "backToDashboard": "Powrót do pulpitu",
       "empty": "Żadne alerty nie pasują do tych filtrów. Wszystko w porządku.",
+      "loadError": "Nie udało się załadować alertów. Spróbuj ponownie.",
       "filter": {
         "allStates": "Wszystkie stany",
         "allSeverities": "Wszystkie poziomy ważności"

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -1255,6 +1255,8 @@
     "acknowledge": "Potvrdiť",
     "resolve": "Vyriešiť",
     "resolved": "vyriešené",
+    "acknowledgeFailed": "Potvrdenie upozornenia zlyhalo",
+    "resolveFailed": "Vyriešenie upozornenia zlyhalo",
     "triggered": "Spustené",
     "thresholdBreach": "Prekročenie prahu",
     "thresholds": "Prahy",
@@ -1310,6 +1312,7 @@
       "subtitle": "Prekročenia prahov naprieč vašimi budovami.",
       "backToDashboard": "Späť na prehľad",
       "empty": "Žiadne upozornenia nezodpovedajú týmto filtrom. Všetko v poriadku.",
+      "loadError": "Nepodarilo sa načítať upozornenia. Skúste to znova.",
       "filter": {
         "allStates": "Všetky stavy",
         "allSeverities": "Všetky závažnosti"

--- a/frontend/apps/ppt-web/src/features/iot/pages/IotAlertsPage.test.tsx
+++ b/frontend/apps/ppt-web/src/features/iot/pages/IotAlertsPage.test.tsx
@@ -1,0 +1,63 @@
+/// <reference types="vitest/globals" />
+/**
+ * Tests for the standalone IoT alerts page (Epic 14 — FR74, issue #1669).
+ *
+ * Pins the distinct render states:
+ *   1. `isError` renders an error panel (role="alert") with a Retry affordance,
+ *      NOT the "All clear" empty copy — a hard load failure must not be
+ *      misreported as "no alerts";
+ *   2. Retry invokes `onRetry`;
+ *   3. the empty state (no error, no alerts) still shows the "All clear" copy.
+ *
+ * Presentational component — no network/context mocks needed; i18n is the real
+ * English bundle from the shared test setup.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { IotAlertsPage, type IotAlertsPageProps } from './IotAlertsPage';
+
+function renderPage(overrides: Partial<IotAlertsPageProps> = {}) {
+  const props: IotAlertsPageProps = {
+    alerts: [],
+    sensorNames: {},
+    isLoading: false,
+    pendingAlertId: null,
+    filterSeverity: '',
+    filterState: '',
+    onFilterSeverityChange: vi.fn(),
+    onFilterStateChange: vi.fn(),
+    onAcknowledge: vi.fn(),
+    onResolve: vi.fn(),
+    onBackToDashboard: vi.fn(),
+    ...overrides,
+  };
+  return { props, ...render(<IotAlertsPage {...props} />) };
+}
+
+describe('IotAlertsPage', () => {
+  it('renders a distinct error panel (not the empty state) when isError', () => {
+    renderPage({ isError: true, onRetry: vi.fn() });
+
+    // Error panel present...
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent(/failed to load alerts/i);
+    // ...and the "All clear" empty copy is NOT shown.
+    expect(screen.queryByText(/all clear/i)).toBeNull();
+  });
+
+  it('invokes onRetry when the retry button is clicked', () => {
+    const onRetry = vi.fn();
+    renderPage({ isError: true, onRetry });
+
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the empty "All clear" copy when there is no error and no alerts', () => {
+    renderPage({ isError: false, alerts: [] });
+
+    expect(screen.getByText(/all clear/i)).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+});

--- a/frontend/apps/ppt-web/src/features/iot/pages/IotAlertsPage.tsx
+++ b/frontend/apps/ppt-web/src/features/iot/pages/IotAlertsPage.tsx
@@ -24,6 +24,10 @@ export interface IotAlertsPageProps {
   /** sensor_id → display name, for resolving the sensor column. */
   sensorNames: Record<string, string>;
   isLoading: boolean;
+  /** True when the alerts source query failed; renders an error panel. */
+  isError?: boolean;
+  /** Retry handler for the error panel (re-runs the alerts source query). */
+  onRetry?: () => void;
   pendingAlertId: string | null;
   filterSeverity: string;
   filterState: AlertStateFilter;
@@ -56,6 +60,8 @@ export function IotAlertsPage({
   alerts,
   sensorNames,
   isLoading,
+  isError = false,
+  onRetry,
   pendingAlertId,
   filterSeverity,
   filterState,
@@ -141,6 +147,23 @@ export function IotAlertsPage({
         {isLoading ? (
           <div className="flex items-center justify-center py-16">
             <div className="h-6 w-6 animate-spin rounded-full border-b-2 border-blue-600" />
+          </div>
+        ) : isError ? (
+          <div className="px-4 py-16 text-center" role="alert">
+            <p className="text-sm font-medium text-red-600">
+              {t('iot.alerts.loadError', {
+                defaultValue: 'Failed to load alerts. Please try again.',
+              })}
+            </p>
+            {onRetry && (
+              <button
+                type="button"
+                onClick={onRetry}
+                className="mt-3 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              >
+                {t('common.retry', { defaultValue: 'Retry' })}
+              </button>
+            )}
           </div>
         ) : visibleAlerts.length === 0 ? (
           <div className="px-4 py-16 text-center">

--- a/frontend/apps/ppt-web/src/routes/groups/iot.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/iot.tsx
@@ -70,7 +70,9 @@ function orNull(value: string): string | null {
  * REST-polled snapshot so the telemetry chart updates as readings arrive.
  */
 function IotDashboardPageRoute() {
+  const { t } = useTranslation();
   const { user } = useAuth();
+  const { showToast } = useToast();
   const [selectedSensorId, setSelectedSensorId] = useState<string | null>(null);
 
   const { data: dashboard, isLoading: dashboardLoading } = useIotDashboard();
@@ -109,6 +111,30 @@ function IotDashboardPageRoute() {
       ? (resolveAlert.variables?.alertId ?? null)
       : null;
 
+  const handleAcknowledgeAlert = async (alertId: string) => {
+    try {
+      await acknowledgeAlert.mutateAsync(alertId);
+    } catch (error) {
+      showToast({
+        type: 'error',
+        title: t('iot.acknowledgeFailed', { defaultValue: 'Failed to acknowledge alert' }),
+        message: error instanceof Error ? error.message : t('auth.unexpectedError'),
+      });
+    }
+  };
+
+  const handleResolveAlert = async (alertId: string) => {
+    try {
+      await resolveAlert.mutateAsync({ alertId });
+    } catch (error) {
+      showToast({
+        type: 'error',
+        title: t('iot.resolveFailed', { defaultValue: 'Failed to resolve alert' }),
+        message: error instanceof Error ? error.message : t('auth.unexpectedError'),
+      });
+    }
+  };
+
   return (
     <IotDashboardPage
       dashboard={dashboard}
@@ -123,8 +149,8 @@ function IotDashboardPageRoute() {
       pendingAlertId={pendingAlertId}
       isLive={isConnected}
       onSelectSensor={setSelectedSensorId}
-      onAcknowledgeAlert={(alertId) => acknowledgeAlert.mutate(alertId)}
-      onResolveAlert={(alertId) => resolveAlert.mutate({ alertId })}
+      onAcknowledgeAlert={handleAcknowledgeAlert}
+      onResolveAlert={handleResolveAlert}
     />
   );
 }
@@ -329,12 +355,19 @@ function EditSensorPageRoute() {
  * come from `useSensors()` so the table can label each alert's sensor.
  */
 function IotAlertsPageRoute() {
+  const { t } = useTranslation();
   const { user } = useAuth();
   const navigate = useNavigate();
+  const { showToast } = useToast();
   const [filterSeverity, setFilterSeverity] = useState('');
   const [filterState, setFilterState] = useState<AlertStateFilter>('');
 
-  const { data: dashboard, isLoading: dashboardLoading } = useIotDashboard();
+  const {
+    data: dashboard,
+    isLoading: dashboardLoading,
+    isError: dashboardError,
+    refetch: refetchDashboard,
+  } = useIotDashboard();
   const { data: sensorsData } = useSensors();
 
   const acknowledgeAlert = useAcknowledgeSensorAlert();
@@ -358,18 +391,44 @@ function IotAlertsPageRoute() {
       ? (resolveAlert.variables?.alertId ?? null)
       : null;
 
+  const handleAcknowledge = async (alertId: string) => {
+    try {
+      await acknowledgeAlert.mutateAsync(alertId);
+    } catch (error) {
+      showToast({
+        type: 'error',
+        title: t('iot.acknowledgeFailed', { defaultValue: 'Failed to acknowledge alert' }),
+        message: error instanceof Error ? error.message : t('auth.unexpectedError'),
+      });
+    }
+  };
+
+  const handleResolve = async (alertId: string) => {
+    try {
+      await resolveAlert.mutateAsync({ alertId });
+    } catch (error) {
+      showToast({
+        type: 'error',
+        title: t('iot.resolveFailed', { defaultValue: 'Failed to resolve alert' }),
+        message: error instanceof Error ? error.message : t('auth.unexpectedError'),
+      });
+    }
+  };
+
   return (
     <IotAlertsPage
       alerts={dashboard?.recent_alerts ?? []}
       sensorNames={sensorNames}
       isLoading={dashboardLoading}
+      isError={dashboardError}
+      onRetry={() => refetchDashboard()}
       pendingAlertId={pendingAlertId}
       filterSeverity={filterSeverity}
       filterState={filterState}
       onFilterSeverityChange={setFilterSeverity}
       onFilterStateChange={setFilterState}
-      onAcknowledge={(alertId) => acknowledgeAlert.mutate(alertId)}
-      onResolve={(alertId) => resolveAlert.mutate({ alertId })}
+      onAcknowledge={handleAcknowledge}
+      onResolve={handleResolve}
       onBackToDashboard={() => navigate('/iot')}
     />
   );


### PR DESCRIPTION
Closes #1669 (both frontend parts).

Post-merge review of PR #1652 flagged that the IoT alerts page swallows mutation failures and has no error state distinct from "empty". This addresses both FE findings.

## What changed

### 1. Silent mutation failures → error toasts
`IotAlertsPageRoute` and (for parity) `IotDashboardPageRoute` in `routes/groups/iot.tsx` now wrap the acknowledge / resolve mutations in `mutateAsync` + try/catch and surface an error toast via `useToast().showToast({ type: 'error', ... })` — mirroring the existing sensor-CRUD wrappers in the same file (`handleDelete`, `handleCreate`, etc.). New i18n keys `iot.acknowledgeFailed` / `iot.resolveFailed` added across all 6 languages (en, sk, cs, de, pl, hu); message body falls back to `auth.unexpectedError`.

Note: the `@ppt/api-client` IoT mutation hooks don't accept option args, and the established codebase pattern for IoT error feedback is route-wrapper try/catch (not hook `onError`), so I mirrored that rather than widening the hook signatures.

### 2. Distinct error state on the alerts page
`IotAlertsPage` gains optional `isError` + `onRetry` props and renders an error panel (`role="alert"`, `iot.alerts.loadError` + `common.retry` Retry button) **before** the empty branch — so a failed `useIotDashboard()` query no longer renders the false-negative "All clear" copy. The route wraps `useIotDashboard()`'s `isError` / `refetch` through. Mirrors the `DocumentTemplatesPage` error/retry pattern.

### 3. Screen-map reconciled
`docs/screens/ppt/iot.md` States > Error section updated to match the implemented toasts + alerts error panel, plus an Agent Log entry.

### Tests
Added `IotAlertsPage.test.tsx` (3 cases): error panel renders distinct from empty, Retry invokes `onRetry`, empty "All clear" still renders with no error. All pass.

Consistent with current dev including #1737 (branch based on fresh `origin/dev`) — no changes to `useIotWebSocket` / the WS route.

## Deferred (out of scope — backend)
The larger finding 2 item — a dedicated cross-sensor alerts list endpoint (`GET /api/v1/iot/alerts` with state/severity/pagination) + `useIotAlerts` hook, to replace the capped `dashboard.recent_alerts` source — is **deferred** to a backend/typespec increment. The page still sources from `recent_alerts` for now. (Finding 3, the stray `# ci-trigger` in `backend/Cargo.toml`, is also out of scope here.)

## Verify
- `pnpm --filter @ppt/web exec biome check <touched>` — clean
- `pnpm --filter @ppt/web typecheck` — clean
- `vitest run src/features/iot/pages/IotAlertsPage.test.tsx` — 3 passed