### PR TITLE
fix(api-server): require manager role to list Airbnb reservations — guest PII (#1667)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -318,7 +318,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -329,7 +329,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -410,6 +410,7 @@ dependencies = [
  "reqwest",
  "rust_decimal",
  "rust_decimal_macros",
+ "rust_xlsxwriter",
  "sentry",
  "serde",
  "serde_json",
@@ -2270,7 +2271,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2538,7 +2539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3458,7 +3459,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4298,7 +4299,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5341,7 +5342,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5379,7 +5380,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5906,6 +5907,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_xlsxwriter"
+version = "0.80.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442eafa04d985ae671e027481e07a5b70fdb1b2cb5e46d9e074b67ca98e01a0a"
+dependencies = [
+ "zip 2.4.2",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5945,7 +5955,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6014,7 +6024,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6666,7 +6676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7111,7 +7121,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7928,7 +7938,7 @@ dependencies = [
  "serde_json",
  "url",
  "utoipa",
- "zip",
+ "zip 3.0.0",
 ]
 
 [[package]]
@@ -8221,7 +8231,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8752,6 +8762,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
 ]
 
 [[package]]

--- a/backend/servers/api-server/src/routes/integrations/oauth.rs
+++ b/backend/servers/api-server/src/routes/integrations/oauth.rs
@@ -565,7 +565,7 @@ pub struct AirbnbReservationsResponse {
     params(OrgIdPath, AirbnbReservationsQuery),
     responses(
         (status = 200, description = "Airbnb reservations — `{reservations: [...], count: N}`"),
-        (status = 403, description = "Caller is not a member of the organisation"),
+        (status = 403, description = "Caller is not a member of the organisation, or lacks a manager-level role in it"),
         (status = 404, description = "No Airbnb connection found"),
         (status = 502, description = "Airbnb API error")
     ),
@@ -586,6 +586,13 @@ pub async fn list_airbnb_reservations(
     );
 
     verify_org_access(&state, auth.user_id, path.org_id).await?;
+    // Manager-level gate (issue #1667, follow-up to #1626/#1635): live Airbnb
+    // reservation data carries guest PII (names, check-in/check-out dates,
+    // booking/listing IDs) — a plain `resident` member must not be able to
+    // enumerate it via this live proxy, for parity with `/airbnb/listings`
+    // (#1635) and `/airbnb/connections` (#1639). Role is read from the caller's
+    // membership of the PATH org (#1525/#1585), not the JWT.
+    verify_manager_role_in_org(&state, auth.user_id, path.org_id).await?;
 
     use super::token_rotation::TokenRotationOutcome;
 

--- a/backend/servers/api-server/tests/airbnb_oauth_routes_tests.rs
+++ b/backend/servers/api-server/tests/airbnb_oauth_routes_tests.rs
@@ -506,6 +506,33 @@ async fn reservations_idor_guard_rejects_non_member(pool: PgPool) {
     );
 }
 
+/// Manager gate (#1667, follow-up to #1626/#1635): a member whose org role is
+/// `resident` must be rejected with 403 even though they pass the membership
+/// IDOR check — live Airbnb reservation data carries guest PII (names,
+/// check-in/check-out dates, booking/listing IDs) and is manager-level
+/// operational data, for parity with `/airbnb/listings`. The role is read from
+/// `organization_members.role_type` for the PATH org, not the JWT (#1525/#1585):
+/// the resident is rejected despite `mint_token` minting a `manager` claim, and
+/// the 403 short-circuits before any Airbnb connection lookup or external call.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn reservations_manager_gate_rejects_resident(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org_id = seed_org(&pool, "res-resident").await;
+    let user_id = seed_user(&pool, "res-resident@test.local").await;
+    seed_membership(&pool, org_id, user_id, "resident").await;
+
+    let token = mint_token(user_id, org_id);
+    let uri = format!("/api/v1/integrations/organizations/{org_id}/airbnb/reservations");
+    let resp = app.execute(authed_get(&uri, &token)).await;
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "resident member must be 403 (manager-level read); got {}: {}",
+        resp.status,
+        resp.text()
+    );
+}
+
 /// When no Airbnb connection exists for an org, the reservations endpoint
 /// returns 404.
 #[sqlx::test(migrator = "db::MIGRATOR")]


### PR DESCRIPTION
## Problem (PII exposure)

`GET /api/v1/integrations/organizations/{org_id}/airbnb/reservations` (`list_airbnb_reservations`, `oauth.rs`) only ran `verify_org_access`, so **any active org member — including a `resident` — could enumerate the org's live Airbnb reservation data** through the proxy: guest names, check-in/check-out dates, and booking/listing IDs.

This is the same resident-IDOR class as #1626 / #1639, and arguably more sensitive than the already-gated listings data, because reservations carry **guest PII**. The sibling live-proxy reads `/airbnb/listings` (#1635) and `/airbnb/connections` (#1639) were already manager-gated; the reservations twin was simply out of #1635's scope and slipped through. Surfaced by the post-merge review of #1635 (issue #1667).

## Fix (manager-gate)

Add `verify_manager_role_in_org(&state, auth.user_id, path.org_id).await?` right after the membership check in `list_airbnb_reservations`, exactly matching the sibling handlers' arg convention (`oauth.rs` lines 140, 310, 469 and `airbnb_connections.rs:99`). Properties:

- Role is read from the caller's **PATH-org `organization_members.role_type`** (#1525/#1585), **not** the JWT, and **fails closed** (decision derived from canonical `TenantRole::is_manager`).
- The 403 **short-circuits before** any Airbnb connection lookup or external API call.
- The `#[utoipa::path]` 403 description is updated to match the listings wording ("…or lacks a manager-level role in it").

## Test

Adds `reservations_manager_gate_rejects_resident` (mirrors `listings_manager_gate_rejects_resident`): seeds a `resident` membership, mints a token, and asserts the reservations endpoint returns **403** — even though the resident passes the membership IDOR check and `mint_token` mints a `manager` claim (proving the role is read from the DB, not the JWT).

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — no issues
- `cargo test -p api-server --test airbnb_oauth_routes_tests` — **17 passed, 0 failed** (incl. the new test), pinned toolchain 1.94.1, against a local Postgres test DB

Closes #1667