### PR TITLE
fix(docker): copy @ppt/e2e package.json into frontend deps stage

### DIFF
--- a/docker/frontend/admin-web.Dockerfile
+++ b/docker/frontend/admin-web.Dockerfile
@@ -19,6 +19,7 @@ COPY frontend/packages/sitemap/package.json ./packages/sitemap/
 COPY frontend/packages/dev-panel/package.json ./packages/dev-panel/
 COPY frontend/packages/vite-plugin-ppt-worktree/package.json ./packages/vite-plugin-ppt-worktree/
 COPY frontend/packages/admin-ui/package.json ./packages/admin-ui/
+COPY frontend/packages/e2e/package.json ./packages/e2e/
 COPY frontend/apps/admin-web/package.json ./apps/admin-web/
 
 RUN pnpm install

--- a/docker/frontend/ppt-web.Dockerfile
+++ b/docker/frontend/ppt-web.Dockerfile
@@ -23,6 +23,7 @@ COPY frontend/packages/sitemap/package.json ./packages/sitemap/
 COPY frontend/packages/dev-panel/package.json ./packages/dev-panel/
 COPY frontend/packages/vite-plugin-ppt-worktree/package.json ./packages/vite-plugin-ppt-worktree/
 COPY frontend/packages/admin-ui/package.json ./packages/admin-ui/
+COPY frontend/packages/e2e/package.json ./packages/e2e/
 COPY frontend/apps/ppt-web/package.json ./apps/ppt-web/
 
 RUN pnpm install

--- a/docker/frontend/reality-web.Dockerfile
+++ b/docker/frontend/reality-web.Dockerfile
@@ -23,6 +23,7 @@ COPY frontend/packages/sitemap/package.json ./packages/sitemap/
 COPY frontend/packages/dev-panel/package.json ./packages/dev-panel/
 COPY frontend/packages/vite-plugin-ppt-worktree/package.json ./packages/vite-plugin-ppt-worktree/
 COPY frontend/packages/admin-ui/package.json ./packages/admin-ui/
+COPY frontend/packages/e2e/package.json ./packages/e2e/
 COPY frontend/apps/reality-web/package.json ./apps/reality-web/
 
 RUN pnpm install


### PR DESCRIPTION
## Problem

`docker-frontend.yml` ("Build Property Management Web") is **failing on `dev`** and on every PR — confirmed red on the last 8 consecutive `dev` commits, including current `dev` HEAD. The failure aborts `pnpm install` in the deps stage:

```
ERR_PNPM_WORKSPACE_PKG_NOT_FOUND  In apps/admin-web: "@ppt/e2e@workspace:*" is in the
dependencies but no package named "@ppt/e2e" is present in the workspace
```

`admin-web` fails first; `reality-web` and `ppt-web` are then **cancelled by the fail-fast matrix**, so the entire frontend image build is down. This blocks the merge pipeline for all frontend (and, since the workflow runs broadly, effectively all) PRs.

## Root cause

All three frontend apps declare a workspace dependency on the test package:

- `frontend/apps/admin-web/package.json` → `"@ppt/e2e": "workspace:*"`
- `frontend/apps/ppt-web/package.json` → `"@ppt/e2e": "workspace:*"`
- `frontend/apps/reality-web/package.json` → `"@ppt/e2e": "workspace:*"`

`@ppt/e2e` is a real private workspace package at `frontend/packages/e2e` (v0.3.11). It resolves fine in local installs (the `pnpm-workspace.yaml` glob covers `packages/*`), but the three frontend Dockerfiles hand-list each `packages/<name>/package.json` they COPY into the deps stage — and **none of them copied `packages/e2e/package.json`**. Inside the Docker build context the workspace graph is therefore missing `@ppt/e2e`, so `pnpm install` aborts.

The `@ppt/e2e` dependency was added to the apps in commit `e5c2e84` (PR #1694), which is when the build started failing.

## Fix

Add the missing line to each of the three deps stages:

```dockerfile
COPY frontend/packages/e2e/package.json ./packages/e2e/
```

Mechanical, behavior-preserving, restores the Docker build context to match the actual workspace. `@ppt/e2e` is test-only and is not imported by any app build, so only its manifest needs to be present for `pnpm install` to resolve the graph — no builder-stage `node_modules` copy is required.

## Verification

CI (`docker-frontend.yml`) on this branch is the verification — it should go green where `dev` is currently red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfQdZmyyN8GYKt5aEhPH3K

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfQdZmyyN8GYKt5aEhPH3K)_