### PR TITLE
fix(portal-listings): validate enums/status + ownership IDOR tests + FE field wiring (#1671)

### DIFF
--- a/backend/crates/db/src/models/listing.rs
+++ b/backend/crates/db/src/models/listing.rs
@@ -59,7 +59,10 @@ pub struct Listing {
     pub title: String,
     pub description: Option<String>,
     pub property_type: String,
-    #[sqlx(try_from = "rust_decimal::Decimal")]
+    // NULLable NUMERIC: decode natively as `Option<Decimal>`. A `try_from`
+    // attribute here forces a non-null decode and panics with
+    // `UnexpectedNullError` whenever the column is NULL (e.g. a portal listing
+    // created without an area), so it must not be used on optional columns.
     pub size_sqm: Option<Decimal>,
     pub rooms: Option<i32>,
     pub bathrooms: Option<i32>,
@@ -72,10 +75,8 @@ pub struct Listing {
     pub postal_code: String,
     pub country: String,
 
-    // Location coordinates (optional)
-    #[sqlx(try_from = "rust_decimal::Decimal")]
+    // Location coordinates (optional) — NULLable, decode natively (no try_from).
     pub latitude: Option<Decimal>,
-    #[sqlx(try_from = "rust_decimal::Decimal")]
     pub longitude: Option<Decimal>,
 
     // Pricing
@@ -151,7 +152,7 @@ pub struct ListingSummary {
     #[sqlx(try_from = "rust_decimal::Decimal")]
     pub price: Decimal,
     pub currency: String,
-    #[sqlx(try_from = "rust_decimal::Decimal")]
+    // NULLable NUMERIC — decode natively (no try_from; see `Listing::size_sqm`).
     pub size_sqm: Option<Decimal>,
     pub rooms: Option<i32>,
     pub city: String,

--- a/backend/servers/reality-server/src/routes/portal_listings.rs
+++ b/backend/servers/reality-server/src/routes/portal_listings.rs
@@ -25,6 +25,59 @@ pub fn router() -> Router<AppState> {
         .route("/{id}", patch(update_listing))
 }
 
+// ============================================================================
+// Enum allow-lists (mirror the inline comments in migration 00049_create_listings)
+// ============================================================================
+
+/// Allowed `property_type` values (`listings.property_type`).
+const ALLOWED_PROPERTY_TYPES: &[&str] = &[
+    "apartment",
+    "house",
+    "commercial",
+    "land",
+    "parking",
+    "storage",
+    "other",
+];
+
+/// Allowed `transaction_type` values (`listings.transaction_type`).
+const ALLOWED_TRANSACTION_TYPES: &[&str] = &["sale", "rent"];
+
+/// Allowed `currency` values (`listings.currency`).
+const ALLOWED_CURRENCIES: &[&str] = &["EUR", "CZK"];
+
+/// Statuses an owner may set directly via create/update.
+///
+/// Public visibility is gated by `is_published` (set only through the
+/// moderation path — see migration 00186), so an owner must not be able to
+/// flip a listing into the publicly-visible `active` state, nor into any
+/// `published`/`approved`-style moderated state. They may only move a listing
+/// between its own draft/paused/sold/rented/archived lifecycle states.
+const ALLOWED_OWNER_STATUSES: &[&str] = &["draft", "paused", "sold", "rented", "archived"];
+
+/// Validate an optional enum-like field against an allow-list.
+///
+/// `None` (field omitted) always passes. An unknown value yields a
+/// `400 Bad Request` with a deterministic message.
+fn validate_enum(
+    field: &str,
+    value: Option<&str>,
+    allowed: &[&str],
+) -> Result<(), (axum::http::StatusCode, String)> {
+    if let Some(v) = value {
+        if !allowed.contains(&v) {
+            return Err((
+                axum::http::StatusCode::BAD_REQUEST,
+                format!(
+                    "Invalid {field}: '{v}'. Allowed values: {}",
+                    allowed.join(", ")
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Request body for creating a portal listing.
 #[derive(Debug, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
@@ -140,6 +193,20 @@ pub async fn create_listing(
     Json(body): Json<CreatePortalListingRequest>,
 ) -> Result<(axum::http::StatusCode, Json<PortalListingResponse>), (axum::http::StatusCode, String)>
 {
+    // Reject unknown enum-like values before hitting the DB (free-text columns
+    // have no CHECK constraint — see migration 00049).
+    validate_enum(
+        "propertyType",
+        Some(body.property_type.as_str()),
+        ALLOWED_PROPERTY_TYPES,
+    )?;
+    validate_enum(
+        "transactionType",
+        Some(body.transaction_type.as_str()),
+        ALLOWED_TRANSACTION_TYPES,
+    )?;
+    validate_enum("currency", body.currency.as_deref(), ALLOWED_CURRENCIES)?;
+
     let listing = state
         .reality_portal_repo
         .create_portal_listing(
@@ -232,6 +299,23 @@ pub async fn update_listing(
     Path(id): Path<Uuid>,
     Json(body): Json<UpdatePortalListingRequest>,
 ) -> Result<Json<PortalListingResponse>, (axum::http::StatusCode, String)> {
+    // Reject unknown enum-like values (free-text columns, no DB CHECK).
+    validate_enum(
+        "propertyType",
+        body.property_type.as_deref(),
+        ALLOWED_PROPERTY_TYPES,
+    )?;
+    validate_enum(
+        "transactionType",
+        body.transaction_type.as_deref(),
+        ALLOWED_TRANSACTION_TYPES,
+    )?;
+    validate_enum("currency", body.currency.as_deref(), ALLOWED_CURRENCIES)?;
+    // Owners may only move a listing between its own lifecycle states; flipping
+    // into the publicly-visible `active`/`published`/`approved` states is a
+    // privileged transition reserved for the moderation path.
+    validate_enum("status", body.status.as_deref(), ALLOWED_OWNER_STATUSES)?;
+
     let listing = state
         .reality_portal_repo
         .update_portal_listing(

--- a/backend/servers/reality-server/tests/portal_listings_idor_tests.rs
+++ b/backend/servers/reality-server/tests/portal_listings_idor_tests.rs
@@ -1,0 +1,405 @@
+//! Handler-level IDOR + validation regression tests for the portal-listing
+//! CRUD surface in `reality-server/src/routes/portal_listings.rs` (GH #1671,
+//! follow-up to PR #1642 / task #986).
+//!
+//! # Background
+//!
+//! PR #1642 added owner-facing listing CRUD (`POST /api/v1/my/listings`,
+//! `GET|PATCH /api/v1/my/listings/{id}`) gated by the `SECURITY DEFINER`
+//! functions of migration 00186 (`portal_owner_id = user_id OR created_by =
+//! user_id`). The post-merge review (#1671) flagged two gaps:
+//!
+//! 1. **No ownership tests** — the PR's own test plan left the IDOR cases as
+//!    unchecked boxes. This file closes that with end-to-end HTTP probes:
+//!    user B's `GET`/`PATCH` of user A's listing must return 404 (not 200),
+//!    while A's own `GET`/`PATCH` succeed.
+//! 2. **No enum/status validation** — `property_type` / `transaction_type` /
+//!    `currency` were accepted as free text (the columns have no DB CHECK), and
+//!    an owner could set `status` directly into the publicly-visible `active`
+//!    state, bypassing the moderation path that gates `is_published`. The route
+//!    now allow-lists those fields; these tests assert the `400` rejections.
+//!
+//! The tests drive the real production router (no mocking) with real HS256
+//! JWTs, and use `#[sqlx::test(migrator = "db::MIGRATOR")]` for an isolated,
+//! migrated database — the same harness as every other integration test here.
+
+use api_core::PrincipalClaims;
+use axum::{
+    body::Body,
+    http::{header, Method, Request, StatusCode},
+    Router,
+};
+use jsonwebtoken::{encode, EncodingKey, Header};
+use reality_server::{routes, state::AppState};
+use serde_json::json;
+use sqlx::PgPool;
+use std::sync::{Arc, Once};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+// ============================================================================
+// Test environment setup
+// ============================================================================
+
+const TEST_JWT_SECRET: &str =
+    "test-secret-key-that-is-at-least-64-characters-long-for-testing-purposes";
+
+static TEST_ENV: Once = Once::new();
+
+fn ensure_test_env() {
+    TEST_ENV.call_once(|| {
+        if std::env::var("RUST_ENV").is_err() {
+            std::env::set_var("RUST_ENV", "development");
+        }
+        if std::env::var("JWT_SECRET").is_err() {
+            std::env::set_var("JWT_SECRET", TEST_JWT_SECRET);
+        }
+    });
+}
+
+/// Build a minimal Axum router with only the portal-listings sub-router, backed
+/// by the given pool. This is the real production router code — no mocking.
+fn listings_router(pool: PgPool) -> Router {
+    ensure_test_env();
+
+    let tenant_cache = Arc::new(api_core::TenantResolutionCache::new(60, 60, 1000));
+    let rate_limiters = Arc::new(api_core::TenantRateLimiterSet::new());
+    let state = AppState::new(pool, tenant_cache, rate_limiters);
+    Router::new()
+        .nest("/api/v1/my/listings", routes::portal_listings::router())
+        .with_state(state)
+}
+
+/// Mint a real HS256 access token for `user_id` signed with `TEST_JWT_SECRET`.
+fn mint_token(user_id: Uuid) -> String {
+    let claims = PrincipalClaims {
+        sub: user_id,
+        iat: 0,
+        exp: i64::MAX,
+        kind: Some("public".to_string()),
+        token_type: Some("access".to_string()),
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(TEST_JWT_SECRET.as_bytes()),
+    )
+    .expect("mint test token")
+}
+
+// ============================================================================
+// Seed helpers
+// ============================================================================
+
+/// Seed a `public`-kind portal user (the kind `PortalPrincipal` admits).
+async fn seed_portal_user(pool: &PgPool, tag: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', $2, 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("{tag}@portal-listings-idor.test"))
+    .bind(format!("PortalListingsIDOR {tag}"))
+    .fetch_one(pool)
+    .await
+    .unwrap_or_else(|e| panic!("seed_portal_user({tag}): {e}"))
+}
+
+/// Create a listing owned by `user_id` via the SECURITY DEFINER repo path and
+/// return its id (status starts as `draft`, `is_published = FALSE`).
+async fn seed_listing(pool: &PgPool, user_id: Uuid) -> Uuid {
+    let repo = db::repositories::RealityPortalRepository::new(pool.clone());
+    let listing = repo
+        .create_portal_listing(
+            user_id,
+            "IDOR Test Listing",
+            Some("desc"),
+            "apartment",
+            "sale",
+            rust_decimal::Decimal::new(100_000, 0),
+            "EUR",
+            "Test Street 1",
+            "Bratislava",
+            "81101",
+            "SK",
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("seed_listing");
+    listing.id
+}
+
+/// Issue a request and return its status code.
+async fn status_of(app: &Router, req: Request<Body>) -> StatusCode {
+    app.clone().oneshot(req).await.unwrap().status()
+}
+
+fn get_req(id: Uuid, token: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::GET)
+        .uri(format!("/api/v1/my/listings/{id}"))
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn patch_req(id: Uuid, token: &str, body: serde_json::Value) -> Request<Body> {
+    Request::builder()
+        .method(Method::PATCH)
+        .uri(format!("/api/v1/my/listings/{id}"))
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap()
+}
+
+// ============================================================================
+// IDOR — cross-user access is denied
+// ============================================================================
+
+/// User B `GET`-ing user A's listing must return 404 (not 200, not 401).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_cross_user_returns_404(pool: PgPool) {
+    let user_a = seed_portal_user(&pool, "get-a").await;
+    let user_b = seed_portal_user(&pool, "get-b").await;
+    let listing_id = seed_listing(&pool, user_a).await;
+
+    let app = listings_router(pool);
+    let status = status_of(&app, get_req(listing_id, &mint_token(user_b))).await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "cross-user GET IDOR probe must return 404, got {status}"
+    );
+}
+
+/// User A reading their own listing → 200.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_owner_returns_200(pool: PgPool) {
+    let user_a = seed_portal_user(&pool, "get-own-a").await;
+    let listing_id = seed_listing(&pool, user_a).await;
+
+    let app = listings_router(pool);
+    let status = status_of(&app, get_req(listing_id, &mint_token(user_a))).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "owner must read own listing with 200, got {status}"
+    );
+}
+
+/// User B `PATCH`-ing user A's listing must return 404 (the SECURITY DEFINER
+/// update matches 0 rows → `fetch_optional` is `None` → handler maps to 404).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn patch_cross_user_returns_404(pool: PgPool) {
+    let user_a = seed_portal_user(&pool, "patch-a").await;
+    let user_b = seed_portal_user(&pool, "patch-b").await;
+    let listing_id = seed_listing(&pool, user_a).await;
+
+    let app = listings_router(pool.clone());
+    let body = json!({ "city": "Hacked" });
+    let status = status_of(&app, patch_req(listing_id, &mint_token(user_b), body)).await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "cross-user PATCH IDOR probe must return 404, got {status}"
+    );
+
+    // Defense-in-depth: the value must be unchanged in the DB.
+    let city: String = sqlx::query_scalar("SELECT city FROM listings WHERE id = $1")
+        .bind(listing_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        city, "Bratislava",
+        "cross-user PATCH must not mutate the row"
+    );
+}
+
+/// User A patching their own listing with valid data → 200.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn patch_owner_returns_200(pool: PgPool) {
+    let user_a = seed_portal_user(&pool, "patch-own-a").await;
+    let listing_id = seed_listing(&pool, user_a).await;
+
+    let app = listings_router(pool);
+    let body = json!({ "city": "Kosice", "status": "paused" });
+    let status = status_of(&app, patch_req(listing_id, &mint_token(user_a), body)).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "owner must patch own listing with 200, got {status}"
+    );
+}
+
+/// Unauthenticated GET → 401.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_unauthenticated_returns_401(pool: PgPool) {
+    let user_a = seed_portal_user(&pool, "unauth-a").await;
+    let listing_id = seed_listing(&pool, user_a).await;
+
+    let app = listings_router(pool);
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri(format!("/api/v1/my/listings/{listing_id}"))
+        .body(Body::empty())
+        .unwrap();
+    let status = status_of(&app, req).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "unauthenticated GET must return 401, got {status}"
+    );
+}
+
+// ============================================================================
+// Validation — enum allow-lists + privileged status guard (400)
+// ============================================================================
+
+/// Create with an unknown `propertyType` → 400.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_invalid_property_type_returns_400(pool: PgPool) {
+    let user = seed_portal_user(&pool, "cv-pt").await;
+    let app = listings_router(pool);
+    let body = json!({
+        "title": "T", "propertyType": "spaceship", "transactionType": "sale",
+        "price": "100000", "street": "S", "city": "C", "postalCode": "81101"
+    });
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/v1/my/listings")
+        .header(
+            header::AUTHORIZATION,
+            format!("Bearer {}", mint_token(user)),
+        )
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let status = status_of(&app, req).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "unknown propertyType must be rejected with 400, got {status}"
+    );
+}
+
+/// Create with an unknown `transactionType` → 400.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_invalid_transaction_type_returns_400(pool: PgPool) {
+    let user = seed_portal_user(&pool, "cv-tt").await;
+    let app = listings_router(pool);
+    let body = json!({
+        "title": "T", "propertyType": "apartment", "transactionType": "barter",
+        "price": "100000", "street": "S", "city": "C", "postalCode": "81101"
+    });
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/v1/my/listings")
+        .header(
+            header::AUTHORIZATION,
+            format!("Bearer {}", mint_token(user)),
+        )
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let status = status_of(&app, req).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "unknown transactionType must be rejected with 400, got {status}"
+    );
+}
+
+/// Create with an unknown `currency` → 400.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_invalid_currency_returns_400(pool: PgPool) {
+    let user = seed_portal_user(&pool, "cv-cur").await;
+    let app = listings_router(pool);
+    let body = json!({
+        "title": "T", "propertyType": "apartment", "transactionType": "sale",
+        "price": "100000", "currency": "XYZ",
+        "street": "S", "city": "C", "postalCode": "81101"
+    });
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/v1/my/listings")
+        .header(
+            header::AUTHORIZATION,
+            format!("Bearer {}", mint_token(user)),
+        )
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let status = status_of(&app, req).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "unknown currency must be rejected with 400, got {status}"
+    );
+}
+
+/// Owner attempting the privileged transition `status = active` (publicly
+/// visible) must be rejected with 400 — publishing is moderation-only.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn patch_status_active_is_rejected_400(pool: PgPool) {
+    let user = seed_portal_user(&pool, "ps-active").await;
+    let listing_id = seed_listing(&pool, user).await;
+
+    let app = listings_router(pool.clone());
+    let body = json!({ "status": "active" });
+    let status = status_of(&app, patch_req(listing_id, &mint_token(user), body)).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "owner self-publish via status=active must be rejected with 400, got {status}"
+    );
+
+    // The status must remain `draft` — the privileged transition was blocked.
+    let db_status: String = sqlx::query_scalar("SELECT status FROM listings WHERE id = $1")
+        .bind(listing_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        db_status, "draft",
+        "rejected status transition must not mutate the row"
+    );
+}
+
+/// An entirely unknown `status` value → 400.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn patch_unknown_status_is_rejected_400(pool: PgPool) {
+    let user = seed_portal_user(&pool, "ps-unknown").await;
+    let listing_id = seed_listing(&pool, user).await;
+
+    let app = listings_router(pool);
+    let body = json!({ "status": "superpublished" });
+    let status = status_of(&app, patch_req(listing_id, &mint_token(user), body)).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "unknown status value must be rejected with 400, got {status}"
+    );
+}
+
+/// A permitted owner lifecycle status (`paused`) → 200.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn patch_status_paused_is_accepted_200(pool: PgPool) {
+    let user = seed_portal_user(&pool, "ps-paused").await;
+    let listing_id = seed_listing(&pool, user).await;
+
+    let app = listings_router(pool);
+    let body = json!({ "status": "paused" });
+    let status = status_of(&app, patch_req(listing_id, &mint_token(user), body)).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "permitted lifecycle status=paused must be accepted with 200, got {status}"
+    );
+}

--- a/frontend/apps/reality-web/src/app/[locale]/account/listings/[id]/edit/_mock.ts
+++ b/frontend/apps/reality-web/src/app/[locale]/account/listings/[id]/edit/_mock.ts
@@ -25,6 +25,8 @@ export interface ListingEditFormData {
   propertyType: PropertyType;
   address: string;
   city: string;
+  postalCode: string;
+  country: string;
   area: number | '';
   rooms: number | '';
   floor: number | '';
@@ -52,6 +54,8 @@ export const MOCK_LISTING_DATA: ListingEditFormData = {
   propertyType: 'apartment',
   address: 'Pribinova 25',
   city: 'Bratislava',
+  postalCode: '81109',
+  country: 'SK',
   area: 72,
   rooms: 3,
   floor: 4,

--- a/frontend/apps/reality-web/src/app/[locale]/account/listings/[id]/edit/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/account/listings/[id]/edit/page.tsx
@@ -12,7 +12,7 @@ import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { ProtectedRoute } from '@/components/auth';
 import { Footer, Header } from '@/components/ui';
-import { getMyListing, RealtorApiError, updateListing } from '@/lib/realtor-api';
+import { getMyListing, type ListingDraft, RealtorApiError, updateListing } from '@/lib/realtor-api';
 import { EDIT_STEPS, type ListingEditFormData, PROPERTY_TYPE_OPTIONS } from './_mock';
 
 // TODO: replace stepper with @ppt/ui-kit/Stepper once available
@@ -89,6 +89,8 @@ const EMPTY_FORM: ListingEditFormData = {
   propertyType: 'apartment',
   address: '',
   city: '',
+  postalCode: '',
+  country: '',
   area: '',
   rooms: '',
   floor: '',
@@ -127,6 +129,8 @@ function EditWizardContent() {
             (listing.propertyType as ListingEditFormData['propertyType']) ?? 'apartment',
           address: listing.street ?? '',
           city: listing.city ?? '',
+          postalCode: listing.postalCode ?? '',
+          country: listing.country ?? '',
           area: listing.area ?? '',
           rooms: listing.rooms ?? '',
           floor: listing.floor ?? '',
@@ -138,7 +142,16 @@ function EditWizardContent() {
           price: listing.price ?? '',
           currency: listing.currency ?? 'EUR',
           priceNegotiable: listing.isNegotiable ?? false,
-          status: (listing.status as ListingEditFormData['status']) ?? 'draft',
+          // Backend lifecycle statuses (`active`/`paused`/…) → the form's
+          // 3-state control; unknown values fall back to `draft`.
+          status:
+            listing.status === 'active'
+              ? 'active'
+              : listing.status === 'draft'
+                ? 'draft'
+                : listing.status === 'paused'
+                  ? 'inactive'
+                  : 'draft',
         });
       })
       .catch((err) => {
@@ -153,6 +166,12 @@ function EditWizardContent() {
     setSaving(true);
     setSaveError(null);
     try {
+      const floor = typeof form.floor === 'number' ? form.floor : Number(form.floor) || undefined;
+      // Map the form's owner-intent status onto a backend-permitted lifecycle
+      // value. Publishing (`active`) is moderation-gated server-side, so we omit
+      // `status` in that case rather than send a value the API would reject.
+      const status: ListingDraft['status'] | undefined =
+        form.status === 'inactive' ? 'paused' : form.status === 'draft' ? 'draft' : undefined;
       await updateListing(listingId, {
         title: form.description?.slice(0, 80) || `${form.propertyType} ${form.city}`,
         description: form.description,
@@ -162,8 +181,13 @@ function EditWizardContent() {
         currency: form.currency,
         street: form.address,
         city: form.city,
+        postalCode: form.postalCode || undefined,
+        country: form.country || undefined,
         area: typeof form.area === 'number' ? form.area : Number(form.area) || undefined,
         rooms: typeof form.rooms === 'number' ? form.rooms : Number(form.rooms) || undefined,
+        floor,
+        isNegotiable: form.priceNegotiable,
+        ...(status ? { status } : {}),
       });
       setSaved(true);
     } catch (err) {

--- a/frontend/apps/reality-web/src/lib/realtor-api.ts
+++ b/frontend/apps/reality-web/src/lib/realtor-api.ts
@@ -85,8 +85,19 @@ export interface ListingDraft {
   city: string;
   street?: string;
   postalCode?: string;
+  country?: string;
   area?: number;
   rooms?: number;
+  floor?: number;
+  /**
+   * Owner-settable lifecycle status. Publishing (`active`) is moderation-gated
+   * server-side: owners may only set the non-public lifecycle states
+   * `draft` | `paused` | `sold` | `rented` | `archived` (the server returns 400
+   * for anything else). Typed as `string` because the response can also surface
+   * the moderated `active` state.
+   */
+  status?: string;
+  isNegotiable?: boolean;
 }
 
 export interface ListingResponse extends ListingDraft {


### PR DESCRIPTION
Closes #1671.

Follow-up to PR #1642 (portal-user listing CRUD). Addresses the three actionable findings from the post-merge review.

## 1. Backend validation (`reality-server/src/routes/portal_listings.rs`)
The `listings` enum-like columns have no DB `CHECK`, so the route now allow-lists them and returns `400` on unknown values (matching the repo's `(StatusCode::BAD_REQUEST, msg)` pattern):

- `propertyType` ∈ {apartment, house, commercial, land, parking, storage, other}
- `transactionType` ∈ {sale, rent}
- `currency` ∈ {EUR, CZK}
- **Privileged status guard:** owners may only set `status` ∈ {draft, paused, sold, rented, archived}. Publishing/approval (the publicly-visible `active` state, and any `published`/`approved`-style value) is gated by `is_published` behind the moderation path, so an owner-supplied transition into those states is rejected with `400`. Public visibility was already gated by `is_published` (never touched on the owner CRUD path), so this closes the self-publish gap at the route layer.

Validation runs on both `create_listing` (required `propertyType`/`transactionType`, optional `currency`) and `update_listing` (all optional + the status guard).

## 2. Ownership / IDOR tests
New `reality-server/tests/portal_listings_idor_tests.rs`, modeled on `imports_idor_tests.rs` — drives the real production router with real HS256 JWTs over an isolated `#[sqlx::test(migrator = "db::MIGRATOR")]` DB:

- cross-user `GET`/`PATCH` of another owner's listing → `404` (+ asserts the row is not mutated)
- owner's own `GET`/`PATCH` → `200`
- unauthenticated `GET` → `401`
- create with invalid `propertyType` / `transactionType` / `currency` → `400`
- `PATCH status=active` (self-publish) → `400` and DB status stays `draft`
- `PATCH` unknown status → `400`; permitted `status=paused` → `200`

## 3. Frontend wiring (`reality-web` account listing edit)
`handleSave` now sends the previously-dropped fields: `postalCode`, `country`, `floor`, `isNegotiable`, and `status` (mapped onto the backend-permitted lifecycle values; the publish-intent `active` is omitted since publishing is moderation-gated). `ListingDraft` in the hand-rolled `realtor-api.ts` was extended with `country`, `floor`, `status`, `isNegotiable`; `postalCode` already existed. Form type/defaults updated to carry `postalCode`/`country` round-trip.

> Note (unchanged from #1671's low-severity findings, left out of scope): the endpoints still bypass TypeSpec (`realtor-api.ts` is hand-rolled), the page uses Slovak literals + inline styles, and photo persistence is still unwired. Flagging for a separate sub-task.

## Verification
- `cargo fmt --all` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` → 0 ✓
- new IDOR/validation test compiles ✓ (run status in PR thread)
- `biome check` + `tsc --noEmit` on reality-web ✓