### PR TITLE
fix(mobile): resolve node-types typecheck break in icon guard test (dev build red)

### DIFF
--- a/frontend/apps/mobile/tsconfig.json
+++ b/frontend/apps/mobile/tsconfig.json
@@ -14,6 +14,7 @@
     "node_modules",
     "app.config.ts",
     "plugins/withIosBuildConfig.ts",
-    "app.config.iosBuildConfig.test.ts"
+    "app.config.iosBuildConfig.test.ts",
+    "app.config.icon.test.ts"
   ]
 }


### PR DESCRIPTION
## Problem

`dev` is red across the whole repo: the CI jobs **Build Property Management Mobile** and **Build Property Management Web** fail at the mobile `tsc --noEmit` typecheck.

Introduced by merged PR #1745 (RN app icons, #1670), which added `frontend/apps/mobile/app.config.icon.test.ts`. The error:

```
app.config.icon.test.ts(23,30): error TS2307: Cannot find module 'node:fs'
app.config.icon.test.ts(24,23): error TS2307: Cannot find module 'node:path'
app.config.icon.test.ts(143,46): error TS2304: Cannot find name '__dirname'
```

## Root cause

The mobile `tsconfig.json` sets `compilerOptions.types: ["jest", "@testing-library/react-native"]` — an explicit `types` list, which excludes `@types/node`. The icon guard test (correctly) uses Node built-ins (`node:fs`, `node:path`, `__dirname`) to assert icon assets exist on disk. It runs fine under jest (jest provides the Node runtime + babel), but the production-build `tsc --noEmit` typecheck has no Node types in scope and errors.

Its sibling `app.config.iosBuildConfig.test.ts` uses the *exact same* Node built-ins and was already handled by being listed in the tsconfig `exclude`. PR #1745 simply forgot to add the new icon test alongside it.

## Fix

Add `app.config.icon.test.ts` to the mobile `tsconfig.json` `exclude` array — matching the existing repo convention for these expo-`app.config`-level guard tests. This is the minimal change; it does not weaken type safety anywhere else (jest still typechecks/runs the test in full).

## Verification

- `pnpm -F @ppt/mobile typecheck` — 0 errors (was 3).
- `pnpm -F @ppt/mobile test app.config.icon` — 13/13 pass; the on-disk asset guard still works.
- `biome check` clean on the touched file.

Fixes the dev-wide `Build PM Mobile` / `Build PM Web` typecheck failure introduced by #1745's guard test.