### PR TITLE
fix(mobile): exclude app.config.icon.test.ts from tsc typecheck (unblock dev frontend CI)

### DIFF
--- a/frontend/apps/mobile/tsconfig.json
+++ b/frontend/apps/mobile/tsconfig.json
@@ -14,6 +14,7 @@
     "node_modules",
     "app.config.ts",
     "plugins/withIosBuildConfig.ts",
-    "app.config.iosBuildConfig.test.ts"
+    "app.config.iosBuildConfig.test.ts",
+    "app.config.icon.test.ts"
   ]
 }


### PR DESCRIPTION
## Problem — dev frontend CI is red, blocking the merge pipeline

The `Build Property Management Web` job currently **fails on `dev`** (and therefore on every open PR's CI), because `apps/mobile` typecheck is broken:

```
apps/mobile typecheck: app.config.icon.test.ts(23,30): error TS2307: Cannot find module 'node:fs'
apps/mobile typecheck: app.config.icon.test.ts(24,23): error TS2307: Cannot find module 'node:path'
apps/mobile typecheck: app.config.icon.test.ts(154,46): error TS2304: Cannot find name '__dirname'
ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @ppt/mobile@0.3.218 typecheck: `tsc --noEmit`  Exit status 2
```

### Root cause

The icon-asset regression test `app.config.icon.test.ts` (added in #1745 / commit `76d3a70`) uses node builtins — `import * as path from 'node:path'`, `jest.requireActual('node:fs')`, and `__dirname`. But `apps/mobile/tsconfig.json` declares `"types": ["jest", "@testing-library/react-native"]` (no `node`) and apps/mobile has no `@types/node` dependency, so `tsc --noEmit` can't resolve those symbols.

### Why this is the right fix

The sibling test `app.config.iosBuildConfig.test.ts` — which uses the **same** node builtins — is **already** in the tsconfig `exclude` list. That's the established project convention for these node-builtin config tests. `app.config.icon.test.ts` was simply omitted from the exclude list when #1745 landed. This PR adds it, matching the precedent.

Jest still runs the test (it transpiles via babel, not `tsc`), so test coverage is unaffected — only the `tsc --noEmit` lint pass skips it.

## Change

One line: add `"app.config.icon.test.ts"` to `exclude` in `frontend/apps/mobile/tsconfig.json`.

## Impact

Unblocks `Build Property Management Web` on `dev`, which is currently stalling the entire merge pipeline (observed blocking approved PRs #1683 and #1718, whose CI fails only on this unrelated apps/mobile typecheck error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ki5x4W88himPJpEzSrSf5w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ki5x4W88himPJpEzSrSf5w)_