### PR TITLE
fix(dispatcher): archive-terminal reconciler pass + unique branch names/collision guard (#1747, #1739)

### DIFF
--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -706,8 +706,10 @@ was a hidden contributor to the GC3 overshoot too). The cascade is the
 idempotent `gc1-reconcile.sh` and drains the two ACTIONABLE GC1 violations:
 
 ```bash
-# (1) archive-terminal leak → auto-close (open gap item whose exact task_id is
-#     already merged/done in the archive; same leak as reclaim-of-already-merged-task-id).
+# (1) archive-terminal leak → auto-close any OPEN action-list item (ANY id shape,
+#     not just gap-*: code-review-*, test-gap-*, screen-map-*, churn-hotspot-*, …)
+#     whose exact task_id is terminal in the archive — merged/done → done,
+#     failed → dropped (issue #1747, #1739; same leak as reclaim-of-already-merged-task-id).
 # (2) stem orphan → emit to gc1-orphan-triage.md for a coverage author (NOT closed:
 #     these are real stories missing from coverage.json — relink, never prune).
 # Legitimate open follow-ups under a done story (exact task not merged) are left alone.
@@ -717,10 +719,11 @@ bash .research/gc1-reconcile.sh --apply
 This is bounded and self-describing: every closed row gets a `gc1_closed`
 stamp (merged PR + date), every orphan lands in the triage doc — **never a
 silent prune of live work**. Include `action-list.json` (and the triage doc)
-in the Phase 6 commit when the cascade closed any row. Matching is by the
-`<epic>-<story>` stem, identical to `goal-check.sh` GC1 — the stem, not the
-descriptive slug, is the stable join key (the slug mismatch is what made GC1
-false-flag ~95 live items as orphans before this fix). Going forward GC1 stays
+in the Phase 6 commit when the cascade closed any row. The leak pass (1)
+matches on the **exact task_id** against the archive (any id shape); the orphan
+pass (2) matches by the `<epic>-<story>` stem, identical to `goal-check.sh` GC1
+— the stem, not the descriptive slug, is the stable join key (the slug mismatch
+is what made GC1 false-flag ~95 live items as orphans before this fix). Going forward GC1 stays
 green run-to-run because the leak is drained here every cycle; once the orphan
 triage backlog reaches 0 (coverage authored for the missing stems), flip GC1 to
 a hard Phase 6 gate (`hard=true`) the same way GC2 is enforced today.
@@ -1047,6 +1050,22 @@ TERMINAL_IDS=$(jq -r '.assignments[]
   .research/management/assignments-archive.json \
   | sort -u)
 
+# ARCHIVED_IDS = ALL archived/terminal ids, INCLUDING failed (issue #1739 #3).
+# The claim self-exclusion below must reject ANY id already in the archive,
+# not just merged/done — a previously-FAILED task_id otherwise passes the
+# filter, gets claimed, then trips the cross-file duplicate self-test (T4) at
+# the Phase 6 gate (the row exists in the archive as `failed`). Distinct from
+# TERMINAL_IDS, which feeds dependency satisfaction (`claimable`): a failed dep
+# must NOT count as satisfied, so failed ids stay OUT of TERMINAL_IDS and only
+# join the self-exclusion set here. A failed task that should be retried must
+# use a suffixed id (e.g. `<id>-retry`), per the stem/suffix convention.
+ARCHIVED_IDS=$(jq -r '.assignments[]
+                     | select(.status=="merged" or .status=="done" or .status=="failed")
+                     | .task_id' \
+  .research/management/assignments.json \
+  .research/management/assignments-archive.json \
+  | sort -u)
+
 # PR 5/5 — stem-aware active check, parallel to the terminal check.
 # active_stems and quarantined_stems both block re-claim under a
 # suffix-variant slug; quarantined deserves explicit attention because
@@ -1058,10 +1077,10 @@ active_stems = {stem(r.task_id) for r in assignments
 candidates = [c for c in action-list
               if c.status == "open"
               and c.id not in active_ids
-              and c.id not in TERMINAL_IDS                  # exact-id terminal check
-              and stem(c.id) not in {stem(t) for t in TERMINAL_IDS}   # stem-aware terminal check
+              and c.id not in ARCHIVED_IDS                  # exact-id archive check (incl. failed — issue #1739 #3)
+              and stem(c.id) not in {stem(t) for t in ARCHIVED_IDS}   # stem-aware archive check (incl. failed)
               and stem(c.id) not in active_stems            # stem-aware active+quarantined check (PR 5/5)
-              and claimable(c, TERMINAL_IDS)]
+              and claimable(c, TERMINAL_IDS)]               # dep satisfaction: merged/done only (failed deps unsatisfied)
 candidates.sort(key=lambda c: (priority_rank(c.priority), source_rank(c.source)))
 ```
 
@@ -1084,7 +1103,8 @@ predicate. Only `depends_on` is.
 claim any task_id that appears in either `assignments.json` (active) OR
 `assignments-archive.json` (terminal). Reusing a task_id from the archive
 would resurrect a merged/failed task with a fresh `claimed_at` — a bug.
-The `c.id not in terminal_ids` check above enforces this.
+The `c.id not in ARCHIVED_IDS` check above enforces this (ARCHIVED_IDS
+includes `failed`, so previously-failed ids are also refused — issue #1739 #3).
 
 **Same-epic burst-claim guard (NEW — item #2):**
 
@@ -1192,18 +1212,73 @@ improvements.
 
    Log: `Dup-skip: <candidate.id> reason=file-overlap with=<other_id> shared=<count>:<first-3-paths>`.
 
-The three guards form a defense-in-depth ladder: (1) catches collisions
+4. **Computed-branch collision (reason code: `branch-collision`; issue
+   #1747, #1739).** Even with the hash-suffixed branch name above, never
+   claim a candidate whose **computed branch** equals a branch that is
+   already active or recently merged — that would force-push over a live or
+   just-landed PR. This is the guard the old stem-only ladder lacked: it
+   compares the *exact computed branch string*, not a stem, so it catches
+   the truncation-collision class directly. Build the blocked-branch set
+   once per run from (a) every `in-progress`/`review` row's `branch` in
+   `assignments.json`, (b) open `auto-impl/*` PR head refs, and (c)
+   recently-merged `auto-impl/*` PR head refs (last 14 days):
+
+   ```bash
+   # (a) active rows + (b) open auto-impl/ PR heads + (c) recently-merged heads
+   jq -r '.assignments[] | select(.status=="in-progress" or .status=="review")
+            | .branch // empty' .research/management/assignments.json > /tmp/blocked-branches.txt
+   gh pr list --state open --limit 100 --search 'head:auto-impl/' \
+     --json headRefName -q '.[].headRefName' >> /tmp/blocked-branches.txt
+   gh pr list --state merged --limit 100 --search 'head:auto-impl/ merged:>='"$(date -u -d '14 days ago' +%F)" \
+     --json headRefName -q '.[].headRefName' >> /tmp/blocked-branches.txt
+   sort -u /tmp/blocked-branches.txt -o /tmp/blocked-branches.txt
+   ```
+
+   Hit predicate: `compute_branch(candidate.id)` (the exact string from the
+   branch-computation block below) appears in `/tmp/blocked-branches.txt`.
+
+   Log: `Dup-skip: <candidate.id> reason=branch-collision branch=<branch> conflicts_with=<active-row|PR>`.
+
+The four guards form a defense-in-depth ladder: (1) catches collisions
 across runs, (2) catches collisions within the same run, (3) catches
 semantically-equivalent slugs whose stems differ but whose plans land on
-the same files. Every skip writes a structured row that Phase 8 aggregates
-to detect systemic drift (e.g. repeated `open-assignment` skips on the
-same epic signal a planner bug, not a claim-time issue).
+the same files, (4) catches the exact-computed-branch collision class
+(truncated-prefix families) before it can force-push over a live or
+recently-merged branch. Every skip writes a structured row that Phase 8
+aggregates to detect systemic drift (e.g. repeated `open-assignment` skips
+on the same epic signal a planner bug, not a claim-time issue).
 
-Implementation note: all three guards rely on `stem(...)`. Define it once
-at the top of Phase 3 and reuse. The `gh pr list` calls are bounded by
+Implementation note: guards 1–3 rely on `stem(...)`; guard 4 relies on
+`compute_branch(...)` (defined in the branch-computation block below).
+Define each once at the top of Phase 3 and reuse. The `gh pr list` calls are bounded by
 `free_slots` (≤ `DISPATCHER_CLAIM_CAP` per run × 2 calls) — at most `2 × DISPATCHER_CLAIM_CAP` (default 12) extra `gh` invocations.
 
-For each picked task: `branch = "auto-impl/" + first_40_chars_kebab(task_id)`.
+**Branch computation (collision-safe — issue #1747, #1739).**
+For each picked task, compute the branch as the 40-char kebab prefix **plus a
+short hash of the FULL `task_id`**, so distinct ids that share a 40-char prefix
+get distinct branches:
+
+```bash
+# Stable, collision-safe branch name for a task_id.
+# The 40-char kebab prefix keeps the branch human-readable; the 8-char sha1 of
+# the FULL id disambiguates whole task families that share that prefix (e.g.
+# churn-hotspot-backend-servers-api-server-* — 10+ ids that all truncate to
+# auto-impl/churn-hotspot-backend-servers-api-server and used to collapse to ONE
+# branch, capping the family to one in-flight item at a time).
+compute_branch() {
+  local id="$1"
+  local kebab; kebab=$(printf '%s' "$id" \
+    | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | sed 's/^-//; s/-$//')
+  local slug="${kebab:0:40}"; slug="${slug%-}"   # trim a dangling hyphen
+  local h; h=$(printf '%s' "$id" | sha1sum | cut -c1-8)
+  printf 'auto-impl/%s-%s' "$slug" "$h"
+}
+branch="$(compute_branch "$task_id")"
+```
+
+The hash suffix only affects **new** claims — in-flight branches keep their
+existing names (no orphaning of live PRs #1683/#1718 etc.). Two distinct ids
+can no longer share a branch unless they sha1-collide on the full id.
 
 **Branch-prefix guard (ingestion contract — issue #573):**
 Before appending any row to `assignments.json`, assert that `branch` starts

--- a/.research/dispatcher-self-test.sh
+++ b/.research/dispatcher-self-test.sh
@@ -672,6 +672,31 @@ for spec in "${T27_SPECS[@]}"; do
 done
 echo
 
+# --- T28: no OPEN action-list item is already terminal in the archive -------
+# (issue #1747, #1739) The gc1-reconcile.sh archive-terminal pass closes any
+# OPEN action-list item whose exact id is terminal (merged/done/failed) in
+# assignments-archive.json. If any survive, they inflate the claimable pool
+# and the claim predicate can near-re-claim already-merged work (only T4 caught
+# it before). Advisory (warn, not fail) because gc1-reconcile.sh --apply is
+# self-healing on the next Phase 2.6 — but it surfaces the leak every run.
+echo "T28 no OPEN action-list item is terminal in the archive (issue #1747/#1739; advisory)"
+if [ -f "$ACTION_LIST" ] && [ -f "$ASSIGN_ARCHIVE" ]; then
+  LEAK28=$(jq -n --slurpfile al "$ACTION_LIST" --slurpfile arc "$ASSIGN_ARCHIVE" '
+    ($arc[0].assignments
+      | map(select(.status=="merged" or .status=="done" or .status=="failed"))
+      | map(.task_id) | unique) as $term
+    | [ $al[0].items[] | select(.status=="open") | select(.id as $i | $term | index($i)) | .id ]')
+  N28=$(jq 'length' <<<"$LEAK28")
+  if [ "$N28" = "0" ]; then note "no open action-list item is terminal in the archive"
+  else
+    warn "$N28 open action-list item(s) already terminal in archive — run: bash .research/gc1-reconcile.sh --apply"
+    jq -r '.[] | "    \(.)"' <<<"$LEAK28" >&2
+  fi
+else
+  printf '  skip  %s or %s not found\n' "$ACTION_LIST" "$ASSIGN_ARCHIVE"
+fi
+echo
+
 # --- Summary ---------------------------------------------------------------
 if [ "$FAIL" = "0" ]; then
   echo "==> dispatcher-self-test: PASS"

--- a/.research/gc1-reconcile.sh
+++ b/.research/gc1-reconcile.sh
@@ -3,11 +3,16 @@
 #
 # Drains the two ACTIONABLE classes of GC1 violation (see goal-check.sh GC1):
 #
-#   (1) archive-terminal LEAK — an OPEN gap-* action-list item whose exact
-#       task_id is already merged/done in assignments-archive.json. The work
-#       shipped; the action-list row was never closed. SAFE to auto-close:
-#       set status=done and stamp the merge evidence. This is the same leak as
-#       finding reclaim-of-already-merged-task-id, drained at the coverage layer.
+#   (1) archive-terminal LEAK — an OPEN action-list item of ANY id shape whose
+#       exact task_id is already terminal in assignments-archive.json. The work
+#       is settled; the action-list row was never closed. SAFE to auto-close:
+#       merged/done → status=done; failed → status=dropped, stamping the
+#       archive evidence. This is the same leak as finding
+#       reclaim-of-already-merged-task-id, drained at the coverage layer.
+#       (issue #1747, #1739: the old pass only matched gap-* ids, so
+#       code-review-*, test-gap-*, screen-map-*, churn-hotspot-*, triage-* etc.
+#       leaked — terminal in the archive yet still status=open, inflating the
+#       claimable pool and near-re-claiming merged work.)
 #
 #   (2) stem ORPHAN — a coverage-keyed gap item (id ~ gap-<epic>-<story>-…)
 #       whose <epic>-<story> stem maps to NO coverage story. These are real
@@ -39,15 +44,36 @@ APPLY=0
 # Same <epic>-<story> stem extractor as goal-check.sh GC1 — keep in lockstep.
 STEM='capture("^(?<s>[0-9]+[a-z]?-[0-9]+)").s'
 
-# --- (1) archive-terminal leak: open gap items whose exact id is merged/done ---
+# --- (1) archive-terminal leak: open action-list items whose EXACT id is
+#         terminal in the archive — ANY id shape, not just gap-* (issue #1747,
+#         #1739). The archive is the source of truth for shipped/abandoned
+#         work: merged/done → close as done; failed → close as dropped. The
+#         old pass only matched gap-* ids, so code-review-*, test-gap-*,
+#         screen-map-*, churn-hotspot-*, triage-* items whose work was already
+#         terminal stayed status=open, inflating open_claimable_count and
+#         near-re-claiming merged work. We map the close target per terminal
+#         status: a failed archive row means the task was abandoned, so the
+#         open action-list item is dropped (not re-presented as claimable),
+#         while merged/done means the work shipped (done).
+#
+# Each LEAK row carries `to` = the status we close the open item to, so the
+# apply pass needs no second lookup. PR/date evidence is best-effort (failed
+# rows usually have neither).
 LEAK_ROWS=$(jq -c --slurpfile arc "$ARCHIVE" '
   ($arc[0].assignments
-    | map(select(.status=="merged" or .status=="done"))
-    | map({key:.task_id, value:{pr:.pr_number, at:.merged_at, st:.status}}) | from_entries) as $term
+    | map(select(.status=="merged" or .status=="done" or .status=="failed"))
+    # Dedup by task_id keeping the freshest (last) archive row, mirroring the
+    # group_by/last semantics archive-reconcile.sh uses, so a task that failed
+    # then later merged closes as done, not dropped.
+    | group_by(.task_id) | map(last)
+    | map({key:.task_id,
+           value:{pr:.pr_number, at:.merged_at, st:.status,
+                  to:(if .status=="failed" then "dropped" else "done" end)}})
+    | from_entries) as $term
   | [ .items[]
-      | select(.status=="open" and (.id|startswith("gap-")))
+      | select(.status=="open")
       | select($term[.id] != null)
-      | {id, pr:$term[.id].pr, at:$term[.id].at} ]' "$ACTION_LIST")
+      | {id, pr:$term[.id].pr, at:$term[.id].at, st:$term[.id].st, to:$term[.id].to} ]' "$ACTION_LIST")
 LEAK_N=$(jq 'length' <<<"$LEAK_ROWS")
 
 # --- (2) stem orphans: coverage-keyed gaps whose stem has no coverage story ---
@@ -61,8 +87,8 @@ ORPHAN_ROWS=$(jq -c --slurpfile cov "$COVERAGE" "
 ORPHAN_N=$(jq 'length' <<<"$ORPHAN_ROWS")
 
 echo "==> gc1-reconcile (apply=$APPLY)  leak=$LEAK_N  orphans=$ORPHAN_N" >&2
-echo "--- archive-terminal leak (open → done) ---" >&2
-jq -r '.[] | "  \(.id)  (merged PR#\(.pr // "?") at \(.at // "?"))"' <<<"$LEAK_ROWS" >&2
+echo "--- archive-terminal leak (open → done|dropped, any id shape) ---" >&2
+jq -r '.[] | "  \(.id)  archive=\(.st) → \(.to)  (PR#\(.pr // "?") at \(.at // "?"))"' <<<"$LEAK_ROWS" >&2
 echo "--- stem orphans (coverage missing — triage, NOT auto-closed) ---" >&2
 jq -r '.[] | "  \(.id)  stem=\(.stem) status=\(.status)"' <<<"$ORPHAN_ROWS" >&2
 
@@ -71,18 +97,21 @@ if [ "$APPLY" != "1" ]; then
   exit 0
 fi
 
-# --- apply (1): close the leak rows in place, stamping merge evidence ---
+# --- apply (1): close the leak rows in place, stamping archive evidence ---
+# Close ANY open item whose exact id is terminal in the archive (issue #1747,
+# #1739): merged/done → done, failed → dropped. Idempotent — only `open` rows
+# are touched, and the per-row close target comes from `$l.to` computed above.
 if [ "$LEAK_N" -gt 0 ]; then
   jq --argjson leak "$LEAK_ROWS" --arg now "$NOW" '
     (reduce $leak[] as $l ({}; .[$l.id] = $l)) as $by
     | .items |= map(
-        if ($by[.id] != null and .status=="open" and (.id|startswith("gap-")))
-        then .status = "done"
+        if ($by[.id] != null and .status=="open")
+        then .status = $by[.id].to
            | .source = ((.source // "") | if .=="" then "gc1-reconcile \($now)" else . + " | gc1-reconcile \($now)" end)
-           | .gc1_closed = {reason:"archive-terminal", merged_pr:$by[.id].pr, merged_at:$by[.id].at, at:$now}
+           | .gc1_closed = {reason:"archive-terminal", archive_status:$by[.id].st, merged_pr:$by[.id].pr, merged_at:$by[.id].at, at:$now}
         else . end)
   ' "$ACTION_LIST" > "$ACTION_LIST.tmp" && mv "$ACTION_LIST.tmp" "$ACTION_LIST"
-  echo "==> closed $LEAK_N leak row(s) in $ACTION_LIST (status open→done + gc1_closed evidence)." >&2
+  echo "==> closed $LEAK_N leak row(s) in $ACTION_LIST (status open→done|dropped + gc1_closed evidence)." >&2
 fi
 
 # --- apply (2): (re)write the orphan triage doc (overwrite — current snapshot) ---


### PR DESCRIPTION
Closes #1747
Closes #1739

Fixes two concrete, well-specified defects in the research dispatcher's shell scripts / routine spec (the `.research/` dispatcher). Conservative + surgical — no redesign. The two issues overlap heavily and are treated as one body of work.

## Defect 1 — phantom backlog: reconciler doesn't close action-list items already terminal in the archive

**Symptom (from #1747/#1739).** `open` action-list items whose exact `task_id` was already terminal (merged/done/failed) in `assignments-archive.json` stayed `status:open`, inflating `open_claimable_count` and near-re-claiming merged work (only `dispatcher-self-test` T4 caught the re-claim). The old `gc1-reconcile.sh` leak pass only matched `gap-*` ids, so `code-review-*`, `test-gap-*`, `screen-map-*`, `churn-hotspot-*`, `triage-*` etc. never closed.

**Fix.** Broadened the `gc1-reconcile.sh` archive-terminal leak pass (`.research/gc1-reconcile.sh`) to close **any** OPEN action-list item whose **exact `task_id`** is terminal in the archive, independent of id shape / stem / subject:
- `merged`/`done` → `status=done`
- `failed` → `status=dropped`

Each closed row gets a `gc1_closed` stamp (`archive_status`, PR, date). Dedup-by-`task_id` keeps the freshest archive row (a task that failed-then-merged closes as `done`, not `dropped`), mirroring `archive-reconcile.sh` semantics. Idempotent — only `open` rows are touched; re-apply closes 0. The stem-orphan pass (2) is unchanged. The routine already invokes `gc1-reconcile.sh --apply` first thing in Phase 2.6, so the new behavior recurs every run. Phase 2.6 prose updated to match.

## Defect 2 — 40-char branch truncation collides across task families (silent throughput cap)

**Symptom (from #1747/#1739).** `branch = "auto-impl/" + first_40_chars_kebab(task_id)` collapsed whole families (e.g. all `churn-hotspot-backend-servers-api-server-*`, 10+ ids) to ONE branch, so only one item per family could be in-flight; the rest were silently branch-blocked. The Phase 3 dedup guards compared stems, not the computed branch, so a collision could also corrupt an in-flight PR's branch.

**Fix (`.research/dispatcher-prompt.md`).**
1. **Collision-safe branch name.** Branch is now the 40-char kebab prefix **plus an 8-char sha1 of the FULL `task_id`** (`compute_branch()` helper). Distinct ids that share a 40-char prefix now get distinct branches; verified 6 colliding family ids → 6 unique branches, deterministic, all still `auto-impl/`-prefixed (T7/T16 ingestion guard intact). Backward-compatible: only **new** claims get the suffix; in-flight branches (PR #1683/#1718) keep their names — no orphaning.
2. **Phase 3 dedup guard #4 (`branch-collision`).** New 4th guard in the cross-PR dedup ladder rejects any candidate whose **exact computed branch** equals an active row branch, an open `auto-impl/*` PR head, or a recently-merged (14d) `auto-impl/*` head — preventing a force-push over a live or just-landed PR. Compares the exact branch string, not a stem (the gap the old ladder had).
3. **Claim predicate excludes `failed` archived ids (#1739 item 3).** Added `ARCHIVED_IDS` (merged/done/**failed**) for the claim self-exclusion check, kept `TERMINAL_IDS` (merged/done only) for dependency satisfaction. A previously-failed `task_id` no longer passes the filter only to trip T4 at the Phase 6 self-test gate; retries must use a suffixed id (`-retry`).

## Self-test
Added **T28** to `dispatcher-self-test.sh`: advisory check that no OPEN action-list item is terminal in the archive (the invariant the reconciler enforces; self-heals via `gc1-reconcile.sh --apply`). Passes `ok` on current state. Existing tests unaffected.

## Validation
- `bash -n` clean on both touched scripts.
- jq filters tested against synthetic fixtures: leak pass closes merged→done / failed→dropped, leaves live & already-closed rows untouched, idempotent on re-apply; T28 detection catches merged+failed leaks, excludes live items.
- `compute_branch` tested: 6 colliding family ids → 6 distinct branches, deterministic, `auto-impl/`-prefixed.
- Full self-test run: my changes pass; the **T19** FAIL is pre-existing on `origin/dev` (the unpushable-archive environmental issue below), not a regression.
- `shellcheck` not available in this env (noted).

## Out of scope — operator/environmental (NOT fixed here)
Per the issues, these are environmental, not in-repo-codeable:
- **`assignments-archive.json` unpushable** (464 KB > 64 KB MCP inline-push ceiling; `git push` HTTP-403 in the cloud runner). This is why **T19** fails every run — terminal rows can't be swept off active because the archive-move can't be persisted. Needs an operator path (server-side push, or archive sharding/blob-trimming). Left untouched to keep this PR low-risk; flagged for operator action.
- **Stale `coverage.json` (2026-06-16)** — needs a coverage refresh; operator action.