### PR TITLE
chore(api-server): document sqlx test-schema idiom + reconcile migrator no-op gotcha (#1665)

### DIFF
--- a/backend/crates/db/src/lib.rs
+++ b/backend/crates/db/src/lib.rs
@@ -80,6 +80,46 @@ pub async fn run_migrations(pool: &DbPool) -> Result<(), sqlx::migrate::MigrateE
 /// Embedded migrator. Use as `#[sqlx::test(migrator = "db::MIGRATOR")]` from
 /// integration tests in other crates so they get the same migration set as
 /// the production binary.
+///
+/// # Getting the full schema into a `#[sqlx::test]` (test-author guide)
+///
+/// `#[sqlx::test]` creates a **fresh, empty, uniquely-named database per test
+/// function** and only applies migrations when a migrator is supplied. There
+/// are two supported idioms, and they apply the *same* migration set — pick by
+/// what the test needs:
+///
+/// 1. **Schema-full tests** (touch any table — register a user, seed an org,
+///    etc.) — attach the migrator. Either form works and is equivalent:
+///    - `#[sqlx::test(migrator = "db::MIGRATOR")]` — the macro emits
+///      `args.migrator(&db::MIGRATOR)`, and sqlx runs `MIGRATOR.run_direct(..)`
+///      during per-test DB setup. This is the default idiom (~100 api-server
+///      test binaries use it).
+///    - bare `#[sqlx::test]` + `db::run_migrations(&pool).await` as the first
+///      line of the test body — runs `MIGRATOR.run(pool)` (the *production*
+///      path: idempotent + advisory-locked). Equivalent schema, and turns any
+///      migration failure into a loud, attributable panic *inside* the test.
+///      Use this when you want the production migration entrypoint exercised,
+///      or to keep a binary uniform with schema-less tests (see below).
+///
+/// 2. **Schema-less tests** (auth-rejection / smoke tests that assert
+///    401/400/404 *before* any DB query) — bare `#[sqlx::test]` with **no**
+///    migrator. The macro's `InferredPath` looks for a `./migrations` dir
+///    relative to the *test crate* (`servers/api-server/migrations`), which
+///    does not exist, so no migrator is attached and the test runs against an
+///    empty database. This is correct and intended for these tests.
+///
+/// ## Gotcha: don't mix the two idioms ad-hoc in one body
+///
+/// A bare `#[sqlx::test]` whose body *does* hit a table without first calling
+/// `db::run_migrations(&pool)` will fail with `relation "..." does not exist`
+/// (the DB is empty). This bit the voting PDF-report tests (#1656/#1665): they
+/// were authored bare alongside schema-less auth tests in `voting_tests.rs`.
+/// The macro expands each test fn independently, so a `migrator = ` test is
+/// never silently disabled by a sibling schema-less test — but a bare
+/// schema-full test *will* see an empty DB. The fix was to call
+/// `db::run_migrations(&pool)` explicitly (idiom 1, second form). If you ever
+/// see an unexplained missing-relation 500 in a `#[sqlx::test]`, check that the
+/// failing test actually attaches a migrator by one of the two idioms above.
 pub static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
 
 /// Create database connection pool.

--- a/backend/servers/api-server/tests/voting_report_tests.rs
+++ b/backend/servers/api-server/tests/voting_report_tests.rs
@@ -3,23 +3,25 @@
 //! These exercise the full PDF-report flow (register → seed building/vote →
 //! `GET /report.pdf`), so every test needs the complete schema.
 //!
-//! As originally written (in #1625) inside `voting_tests.rs`, these used
-//! `#[sqlx::test(migrator = "db::MIGRATOR")]`, but on `dev` they failed
-//! deterministically: register 500'd with `relation "users" does not exist`,
-//! i.e. the macro-supplied migrator never applied the schema for this binary
-//! (the failing binary returned in ~3s, far too fast for the 185-file
-//! migrator to have run). The identical attribute applies the schema in 600+
-//! other usages, so the trigger is binary-specific and could not be pinned
-//! without a local Rust run (none available — mercury offload).
+//! As originally written (in #1625) inside `voting_tests.rs`, these failed
+//! deterministically on `dev`: register 500'd with `relation "users" does not
+//! exist`. Root cause (pinned in #1665): the report tests were authored as a
+//! **bare `#[sqlx::test]`** (no `migrator = ...`), so sqlx 0.9 created an empty
+//! per-test database and attached no migrator — the schema was never applied.
+//! (`#[sqlx::test]`'s inferred-path discovery looks for a `migrations/` dir in
+//! *this* crate, which doesn't exist.) The earlier "mysterious binary-specific
+//! macro no-op" theory was wrong: the macro expands each test fn independently,
+//! so a `migrator = "db::MIGRATOR"` test is never disabled by a schema-less
+//! sibling. See the test-author guide on `db::MIGRATOR` for the full mechanism.
 //!
-//! Rather than depend on the macro doing the right thing here, we run the
-//! migrations **explicitly** on the per-test pool via `db::run_migrations`
-//! (the exact production path; idempotent + advisory-locked). This guarantees
-//! the schema regardless of the macro behaviour, and turns any migration
-//! failure into a loud, attributable panic instead of a downstream
-//! `users does not exist`. Kept in a dedicated binary to isolate the heavy
-//! schema-full E2E flow from `voting_tests.rs`'s schema-less auth tests.
-//! (BIT-158)
+//! We keep the bare `#[sqlx::test]` and run the migrations **explicitly** on
+//! the per-test pool via `db::run_migrations` (the exact production path;
+//! idempotent + advisory-locked). This is one of the two canonical schema-full
+//! idioms (the other being `#[sqlx::test(migrator = "db::MIGRATOR")]`); both
+//! apply the same migration set. The explicit form turns any migration failure
+//! into a loud, attributable panic instead of a downstream `users does not
+//! exist`. Kept in a dedicated binary to isolate the heavy schema-full E2E flow
+//! from `voting_tests.rs`'s schema-less auth tests. (BIT-158, #1665)
 
 #[allow(dead_code)]
 mod common;


### PR DESCRIPTION
## Summary

Low-priority test-infra debt follow-up from PR #1656. Pins the root cause of the voting PDF-report test failure and documents the canonical `#[sqlx::test]` schema-setup idioms so future authors aren't bitten. **Doc-only — no logic changes**, the working `voting_report_tests.rs` behaviour is untouched.

## Root cause (verified, not speculated)

PR #1656 worked around a failure where `voting_report_tests` register 500'd with `relation "users" does not exist`, but left the underlying cause unpinned — its two commit messages offered two *different* and (it turns out) *both incorrect* theories:

- `f02086982`: "mixing schema-less `#[sqlx::test]` with `#[sqlx::test(migrator = "db::MIGRATOR")]` in one binary leaves the migrator tests un-migrated."
- `d24d5a7e7`: "the `#[sqlx::test(migrator = "db::MIGRATOR")]` macro silently no-op'd for this binary (returned in ~3s)."

Checking the actual pre-fix source (PR #1625 at `3c63a6d31`), the report tests were authored as **bare `#[sqlx::test]`** (no `migrator =`) inside a `mod pdf_report` block. So:

- There was never a `migrator =` attribute to "silently no-op."
- "Mixing" can't disable a migrator test — the macro (`sqlx-macros-core` 0.9 `test_attr.rs`) expands **each test fn independently**, and sqlx allocates a **fresh empty per-test database**; `setup_test_db` runs the migrator **iff** `args.migrator` is `Some`.

A bare `#[sqlx::test]` falls into `MigrationsOpt::InferredPath`, which looks for a `migrations/` dir relative to the **test crate** (`servers/api-server/migrations`). That dir does not exist, so **no migrator is attached and the schema is never applied.** The first table hit (`users`) → `relation "users" does not exist`. This is deterministic, not mysterious.

## Canonical idiom (documented)

For a `#[sqlx::test]` that needs the full schema, two equivalent forms apply the same migration set:

1. `#[sqlx::test(migrator = "db::MIGRATOR")]` — macro emits `args.migrator(&db::MIGRATOR)`; sqlx runs `MIGRATOR.run_direct(..)` during per-test setup. (~100 api-server binaries use this.)
2. bare `#[sqlx::test]` + `db::run_migrations(&pool).await` as the first body line — runs `MIGRATOR.run(pool)` (production path; idempotent + advisory-locked), and turns a migration failure into a loud panic inside the test. (`voting_report_tests.rs` uses this.)

Schema-less auth/smoke tests (assert 401/400/404 before any DB query) correctly stay bare `#[sqlx::test]` with no migrator.

## Changes

- `backend/crates/db/src/lib.rs` — test-author guide on `MIGRATOR` documenting both idioms, when to use schema-less bare tests, and the empty-DB gotcha.
- `backend/servers/api-server/tests/voting_report_tests.rs` — corrected module-header narrative + cross-reference to the guide.

## Verification

- `cargo fmt --all` clean
- `cargo clippy -p db --all-targets -- -D warnings` → exit 0
- workspace clippy + `voting_report_tests` run reported in PR thread

Closes #1665