### PR TITLE
feat(api-server): fail-fast preflight for required production env vars (#951)

### DIFF
--- a/backend/servers/api-server/src/main.rs
+++ b/backend/servers/api-server/src/main.rs
@@ -41,6 +41,11 @@ use state::AppState;
 // dependency chain via these helpers so they cannot drift.
 use api_server::{attach_admin_extensions, build_admin_extensions, route_table};
 
+// Boot-time preflight for required production env vars (issue #951 recurrence
+// guard). Binary-local — it gates on `RUST_ENV` and fails fast before heavy
+// init, so it lives next to `main` rather than in the shared library crate.
+mod preflight;
+
 /// Default CORS allowed origins for api-server.
 /// Includes development origins and production domains.
 const DEFAULT_CORS_ORIGINS: &[&str] = &[
@@ -417,6 +422,16 @@ struct ApiDoc;
 async fn main() -> anyhow::Result<()> {
     // Load .env file if present
     dotenvy::dotenv().ok();
+
+    // Recurrence guard for #951: fail fast if a required production secret is
+    // missing, listing ALL of them at once, BEFORE any heavy init (DB pool,
+    // migrations, server bind). In development this is a no-op — the per-var
+    // dev fallbacks below apply. Outside development a missing var returns an
+    // Err that propagates out of `main`, exiting non-zero before the server can
+    // boot half-broken.
+    if let Err(message) = preflight::run() {
+        return Err(anyhow::anyhow!("{message}"));
+    }
 
     // Initialize observability (Epic 95)
     // This sets up OpenTelemetry tracing, Sentry error tracking, and Prometheus metrics

--- a/backend/servers/api-server/src/preflight.rs
+++ b/backend/servers/api-server/src/preflight.rs
@@ -1,0 +1,155 @@
+//! Boot-time preflight for required production environment variables.
+//!
+//! Recurrence guard for issue #951: the deploy that shipped the e-signature
+//! feature didn't inject `ESIGN_TOKEN_SECRET` / `ESIGN_WEBHOOK_SECRET`, so
+//! `api-server` panicked deep inside startup (`LightweightProvider::from_env()`)
+//! and the blue/green deploy aborted with a half-broken container. PR #949
+//! fixed the missing injection in the deploy-server; this preflight is the
+//! belt-and-braces guard so that *any* future missing required secret is caught
+//! up front with ONE clear error listing exactly what's missing — before the
+//! server does any heavy init or starts accepting connections.
+//!
+//! The check is gated to non-development environments (matching how `main.rs`
+//! derives `is_development` from `RUST_ENV == "development"`) so it never breaks
+//! local `cargo run`.
+
+/// Environment variables that are hard-required in production / staging and
+/// have **no safe fallback** outside development. Keep this list conservative:
+/// only vars that genuinely make the server boot half-broken (or panic later)
+/// when absent belong here.
+///
+/// - `DATABASE_URL` — no prod default; `main.rs` panics without it outside dev.
+/// - `JWT_SECRET` — no prod default; auth tokens cannot be issued/verified.
+/// - `ESIGN_TOKEN_SECRET` — required by `LightweightProvider::from_env()`
+///   (issue #951).
+/// - `ESIGN_WEBHOOK_SECRET` — required for the e-signature webhook receiver
+///   (issue #951); empty/missing makes it reject all events.
+pub const REQUIRED_PROD_ENV_VARS: &[&str] = &[
+    "DATABASE_URL",
+    "JWT_SECRET",
+    "ESIGN_TOKEN_SECRET",
+    "ESIGN_WEBHOOK_SECRET",
+];
+
+/// Pure core of the preflight check, kept free of process-global state so it is
+/// trivially testable.
+///
+/// `is_development` mirrors `main.rs`'s `RUST_ENV == "development"` gate. `lookup`
+/// resolves a variable name to its value (returning `None` when unset); a value
+/// that is present but empty/whitespace-only is treated as missing, because an
+/// empty secret is as broken as an absent one.
+///
+/// Returns `Ok(())` when development is true (the per-var dev fallbacks in
+/// `main.rs` handle those cases) or when every required var is present and
+/// non-empty. Otherwise returns `Err` with a single human-readable message
+/// listing **all** missing vars.
+pub fn check_required_env<F>(is_development: bool, lookup: F) -> Result<(), String>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    if is_development {
+        return Ok(());
+    }
+
+    let missing: Vec<&str> = REQUIRED_PROD_ENV_VARS
+        .iter()
+        .copied()
+        .filter(|name| match lookup(name) {
+            Some(value) => value.trim().is_empty(),
+            None => true,
+        })
+        .collect();
+
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "Missing required environment variables: {}. \
+             Set RUST_ENV=development to use dev defaults.",
+            missing.join(", ")
+        ))
+    }
+}
+
+/// Run the preflight against the real process environment.
+///
+/// Call this early in `main()` — after `dotenvy::dotenv()` so `.env` files are
+/// honoured, but before any heavy init (DB pool, migrations, server bind). In
+/// development it is a no-op (the per-var fallbacks in `main.rs` apply); outside
+/// development a missing required var produces an `Err` that `main` propagates,
+/// so the process exits non-zero before partial initialization.
+pub fn run() -> Result<(), String> {
+    let is_development = std::env::var("RUST_ENV").unwrap_or_default() == "development";
+    check_required_env(is_development, |name| std::env::var(name).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// Build a lookup closure backed by a fixed map, so tests never touch the
+    /// real process environment.
+    fn map_lookup(map: HashMap<&'static str, &'static str>) -> impl Fn(&str) -> Option<String> {
+        move |name: &str| map.get(name).map(|v| v.to_string())
+    }
+
+    fn all_present() -> HashMap<&'static str, &'static str> {
+        REQUIRED_PROD_ENV_VARS
+            .iter()
+            .map(|name| (*name, "set-value"))
+            .collect()
+    }
+
+    #[test]
+    fn all_present_in_prod_is_ok() {
+        let result = check_required_env(false, map_lookup(all_present()));
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+    }
+
+    #[test]
+    fn missing_esign_secrets_in_prod_lists_them() {
+        let mut map = all_present();
+        map.remove("ESIGN_TOKEN_SECRET");
+        map.remove("ESIGN_WEBHOOK_SECRET");
+
+        let err = check_required_env(false, map_lookup(map))
+            .expect_err("expected Err when ESIGN secrets are missing");
+
+        assert!(err.contains("ESIGN_TOKEN_SECRET"), "msg: {err}");
+        assert!(err.contains("ESIGN_WEBHOOK_SECRET"), "msg: {err}");
+        // Vars that ARE present must not be reported as missing.
+        assert!(!err.contains("DATABASE_URL"), "msg: {err}");
+        assert!(!err.contains("JWT_SECRET"), "msg: {err}");
+    }
+
+    #[test]
+    fn empty_value_counts_as_missing() {
+        let mut map = all_present();
+        map.insert("ESIGN_WEBHOOK_SECRET", "   "); // whitespace-only
+
+        let err = check_required_env(false, map_lookup(map))
+            .expect_err("expected Err when a required var is empty");
+        assert!(err.contains("ESIGN_WEBHOOK_SECRET"), "msg: {err}");
+    }
+
+    #[test]
+    fn development_skips_check_even_when_all_missing() {
+        let empty: HashMap<&'static str, &'static str> = HashMap::new();
+        let result = check_required_env(true, map_lookup(empty));
+        assert!(
+            result.is_ok(),
+            "development must never fail preflight, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn missing_all_lists_every_required_var() {
+        let empty: HashMap<&'static str, &'static str> = HashMap::new();
+        let err = check_required_env(false, map_lookup(empty))
+            .expect_err("expected Err when everything is missing");
+        for name in REQUIRED_PROD_ENV_VARS {
+            assert!(err.contains(name), "missing {name} in: {err}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Recurrence guard for #951. When the e-signature feature shipped, a deploy didn't inject `ESIGN_TOKEN_SECRET` / `ESIGN_WEBHOOK_SECRET`, so `api-server` panicked **deep inside startup** (`LightweightProvider::from_env()`) and the blue/green deploy aborted with a half-broken container. The missing injection was fixed in deploy-server by **PR #949**.

This PR adds a belt-and-braces **boot-time preflight** so that any future missing required secret is caught **up front with ONE clear error listing exactly what's missing**, before any heavy init (DB pool, migrations, server bind) — instead of a half-broken boot or a panic 100 lines later.

Example failure:
```
Missing required environment variables: ESIGN_TOKEN_SECRET, ESIGN_WEBHOOK_SECRET. Set RUST_ENV=development to use dev defaults.
```

## What changed

- New binary-local `preflight` module (`servers/api-server/src/preflight.rs`) with:
  - `REQUIRED_PROD_ENV_VARS` — the conservative required set.
  - `check_required_env(is_development, lookup)` — pure, testable core (takes a lookup closure so tests never mutate process env). Treats present-but-empty/whitespace values as missing.
  - `run()` — wires the real process env in.
- `main()` calls `preflight::run()` right after `dotenvy::dotenv()` and **before** observability/DB init; an `Err` propagates out of `main`, so the process exits non-zero before partial init.

## Required env var set (and why)

These are the vars with **no safe production fallback** — `main.rs` already panics (or boots broken) without them outside development:

| Var | Why required |
|-----|--------------|
| `DATABASE_URL` | No prod default; `main.rs` panics without it outside dev. |
| `JWT_SECRET` | No prod default; auth tokens can't be issued/verified. |
| `ESIGN_TOKEN_SECRET` | Required by `LightweightProvider::from_env()` — the #951 panic. |
| `ESIGN_WEBHOOK_SECRET` | Required for the webhook receiver — empty/missing rejects all events (#951). |

Deliberately **excluded** (legitimate prod defaults or feature-flagged, so not hard-required): `CORS_ALLOWED_ORIGINS` (baked-in defaults), `APP_BASE_URL`, `EMAIL_ENABLED`, scheduler/reminder knobs, S3/storage (`StorageService::from_env_async` has its own handling). Candidate vars that *may* warrant promotion later — e.g. `TOTP_ENCRYPTION_KEY`, `INTEGRATION_ENCRYPTION_KEY` (injected by deploy-server but read elsewhere) — were left out to keep the guard conservative; they can be added if confirmed hard-required.

## Dev-safe

The check is a **no-op in development** (`RUST_ENV == "development"`, matching `main.rs`'s existing `is_development` gate), so local `cargo run` is unaffected and the per-var dev fallbacks in `main.rs` still apply.

## Tests

Table-driven unit tests next to the function (5, all passing): all-present → Ok; missing ESIGN secrets → Err listing them (and not the present ones); empty/whitespace value → treated as missing; development-mode → Ok even with everything missing; missing-all → lists every required var.

Closes #951