### PR TITLE
chore(admin-web): remove stale 404/501 fallbacks for endpoints that now exist

### DIFF
--- a/frontend/apps/admin-web/src/pages/Dashboard.test.tsx
+++ b/frontend/apps/admin-web/src/pages/Dashboard.test.tsx
@@ -70,12 +70,13 @@ describe('Dashboard', () => {
     vi.restoreAllMocks();
   });
 
-  // 1. Metrics endpoint 404 → tiles render with hardcoded zeros + console.warn fires
-  it('renders tiles with zero values and warns when metrics endpoint returns 404', async () => {
+  // 1. Metrics endpoint error → query errors, tiles fall back to zero via the
+  //    consumer's `?? 0` defaults (the dead "stub fallback" path was removed).
+  it('renders tiles with zero values when the metrics endpoint errors', async () => {
     vi.mocked(fetch).mockImplementation(async (input) => {
       const url = input.toString();
       if (url.includes('metrics/summary')) {
-        return { ok: false, status: 404 } as Response;
+        return { ok: false, status: 500 } as Response;
       }
       return { ok: false, status: 404 } as Response;
     });
@@ -85,15 +86,9 @@ describe('Dashboard', () => {
     // Wait for tiles to render (not skeleton anymore)
     await waitFor(() => expect(screen.getByText('Tenants active')).toBeDefined());
 
-    // All values should be 0 (stub fallback)
+    // No metrics data → tiles fall back to 0 via `metrics?.field ?? 0`.
     const values = screen.getAllByText('0');
     expect(values.length).toBeGreaterThanOrEqual(3);
-    // console.warn should have been called with a [Dashboard] message at some point
-    const warnCalls: unknown[][] = (console.warn as ReturnType<typeof vi.fn>).mock.calls;
-    const dashboardWarn = warnCalls.find(
-      (args) => typeof args[0] === 'string' && args[0].includes('[Dashboard]')
-    );
-    expect(dashboardWarn).toBeDefined();
   });
 
   // 2. Metrics endpoint 200 → tiles render with values

--- a/frontend/apps/admin-web/src/pages/Dashboard.tsx
+++ b/frontend/apps/admin-web/src/pages/Dashboard.tsx
@@ -276,48 +276,23 @@ interface MergeCollision {
 // ---------------------------------------------------------------------------
 
 async function fetchMetricsSummary(token: string | null): Promise<MetricsSummary> {
-  // TODO(backend): GET /api/v1/admin/metrics/summary — endpoint not yet implemented.
-  // Stub fallback with zeros until backend provides this endpoint.
-  const STUB: MetricsSummary = {
-    tenantsActive: 0,
-    operatorsOnline: 1,
-    pendingMerges: 0,
-    highRisk24h: 0,
-  };
-
-  if (!token) return STUB;
-
-  try {
-    const resp = await fetch('/api/v1/admin/metrics/summary', {
-      headers: { Authorization: `Bearer ${token}` },
-      credentials: 'include',
-    });
-    if (!resp.ok) {
-      console.warn(
-        '[Dashboard] GET /api/v1/admin/metrics/summary returned',
-        resp.status,
-        '— falling back to stub metrics. TODO: implement this endpoint in api-server.'
-      );
-      return STUB;
-    }
-    // Backend now serializes camelCase (MetricsSummary has
-    // `#[serde(rename_all = "camelCase")]`). Coerce each field through
-    // `Number()` so missing / null values fall back to 0 instead of NaN.
-    const raw = (await resp.json()) as Partial<MetricsSummary>;
-    return {
-      tenantsActive: Number(raw.tenantsActive ?? 0),
-      operatorsOnline: Number(raw.operatorsOnline ?? 0),
-      pendingMerges: Number(raw.pendingMerges ?? 0),
-      highRisk24h: Number(raw.highRisk24h ?? 0),
-    };
-  } catch (err) {
-    console.warn(
-      '[Dashboard] GET /api/v1/admin/metrics/summary failed:',
-      err,
-      '— falling back to stub metrics. TODO: implement this endpoint in api-server.'
-    );
-    return STUB;
+  const resp = await fetch('/api/v1/admin/metrics/summary', {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    credentials: 'include',
+  });
+  if (!resp.ok) {
+    throw new Error(`HTTP ${resp.status}`);
   }
+  // Backend serializes camelCase (MetricsSummary has
+  // `#[serde(rename_all = "camelCase")]`). Coerce each field through
+  // `Number()` so missing / null values fall back to 0 instead of NaN.
+  const raw = (await resp.json()) as Partial<MetricsSummary>;
+  return {
+    tenantsActive: Number(raw.tenantsActive ?? 0),
+    operatorsOnline: Number(raw.operatorsOnline ?? 0),
+    pendingMerges: Number(raw.pendingMerges ?? 0),
+    highRisk24h: Number(raw.highRisk24h ?? 0),
+  };
 }
 
 async function fetchHighRiskEvents(token: string | null): Promise<AuditEvent[]> {

--- a/frontend/apps/admin-web/src/pages/ImpersonationListPage.test.tsx
+++ b/frontend/apps/admin-web/src/pages/ImpersonationListPage.test.tsx
@@ -166,18 +166,17 @@ describe('ImpersonationListPage', () => {
   });
 
   // ------------------------------------------------------------------
-  // 3. 404 from active endpoint → page renders empty list (backend contract)
+  // 3. 404 from active endpoint → error alert. The endpoint now exists in
+  //    api-server, so a 404 is a genuine failure (the old "not implemented
+  //    yet → empty list" fallback was removed).
   // ------------------------------------------------------------------
-  it('treats 404 from /impersonation/active as an empty list', async () => {
+  it('renders an error alert when the active endpoint returns 404', async () => {
     vi.mocked(fetch).mockResolvedValue({ ok: false, status: 404 } as Response);
 
     renderPage();
 
-    await waitFor(() =>
-      expect(screen.getByText(/No active impersonation sessions/i)).toBeDefined()
-    );
-    // The 404 path also logs a console.warn
-    expect(console.warn).toHaveBeenCalled();
+    await waitFor(() => expect(screen.getByRole('alert')).toBeDefined());
+    expect(screen.getByText(/404/)).toBeDefined();
   });
 
   // ------------------------------------------------------------------

--- a/frontend/apps/admin-web/src/pages/ImpersonationListPage.tsx
+++ b/frontend/apps/admin-web/src/pages/ImpersonationListPage.tsx
@@ -54,13 +54,6 @@ export default function ImpersonationListPage() {
         credentials: 'include',
       });
       if (!res.ok) {
-        if (res.status === 404) {
-          // Endpoint not yet implemented on backend — fall back to empty list
-          console.warn(
-            'GET /api/v1/admin/impersonation/active returned 404 — endpoint may not be implemented yet'
-          );
-          return { items: [] };
-        }
         throw new Error(`Failed to load impersonation sessions: ${res.status}`);
       }
       return res.json() as Promise<ActiveSessionsResponse>;

--- a/frontend/apps/admin-web/src/pages/agencies.tsx
+++ b/frontend/apps/admin-web/src/pages/agencies.tsx
@@ -95,8 +95,6 @@ const AgenciesPage: React.FC = () => {
   );
 
   // N9+: Add Domain action — wired to POST /api/v1/admin/agencies/{id}/domains.
-  // The backend stub currently returns 501 NOT_IMPLEMENTED. The call is made
-  // so future delivery of the provisioning service auto-wires without a FE change.
   const handleAddDomain = useCallback(
     async (agency: Agency) => {
       const host = window.prompt(`Enter domain to add to ${agency.name}:`);
@@ -110,13 +108,7 @@ const AgenciesPage: React.FC = () => {
           credentials: 'include',
           body: JSON.stringify({ host }),
         });
-        if (res.status === 501) {
-          showToast({
-            type: 'warning',
-            title: t('admin.agencies.toast.notWiredTitle'),
-            message: t('admin.agencies.toast.notWiredMessage', { id: agency.id }),
-          });
-        } else if (res.ok) {
+        if (res.ok) {
           showToast({
             type: 'success',
             title: t('admin.agencies.toast.domainAddedTitle', { defaultValue: 'Domain added' }),

--- a/frontend/apps/admin-web/src/pages/audit.tsx
+++ b/frontend/apps/admin-web/src/pages/audit.tsx
@@ -855,13 +855,6 @@ const AuditPage: FC = () => {
         credentials: 'include',
         headers: token ? { Authorization: `Bearer ${token}` } : {},
       });
-      if (res.status === 404) {
-        // TODO: endpoint not yet implemented
-        console.warn(
-          '[AuditPage] GET /api/v1/admin/audit returned 404 — endpoint not yet implemented'
-        );
-        return { items: [], next_cursor: undefined };
-      }
       if (!res.ok) {
         throw new Error(`HTTP ${res.status}`);
       }


### PR DESCRIPTION
## Summary

Removes four STALE dead-code branches in `admin-web` that handled a
404/501/"not implemented" response for backend endpoints that **now exist** and
return real data. Each removal was gated on verifying the corresponding
api-server route.

## Backend verification

All four endpoints are implemented under
`backend/servers/api-server/src/routes/admin/` and mounted in `admin/mod.rs`:

| Frontend call | Backend route | Status |
|---|---|---|
| `GET /api/v1/admin/metrics/summary` | `metrics.rs::metrics_summary` (real SQL, camelCase JSON, `AuditRead`) | exists |
| `GET /api/v1/admin/audit` | `audit.rs::list_audit_events` (`AuditRead`) | exists |
| `POST /api/v1/admin/agencies/{id}/domains` | `agencies.rs::add_domain` returns `201 CREATED` + real `AgencyDomain` (no 501) | exists |
| `GET /api/v1/admin/impersonation/active` | `impersonation.rs::list_active` (`UsersImpersonate`) | exists |

## Fallbacks REMOVED (all 4 confirmed)

- **`pages/Dashboard.tsx`** — dropped the zero-stub fallback + `TODO(backend)` in
  `fetchMetricsSummary`; non-OK responses now surface via React Query. Tiles still
  default to `0` through the existing `metrics?.field ?? 0` consumers.
- **`pages/audit.tsx`** — dropped the dead `if (res.status === 404) → { items: [] }` branch + TODO.
- **`pages/agencies.tsx`** — dropped the dead `if (res.status === 501)` NOT_IMPLEMENTED branch in `handleAddDomain` and its stale comment.
- **`pages/ImpersonationListPage.tsx`** — dropped the dead `404 → { items: [] }` fallback.

## Fallbacks LEFT

None — all four flagged items had their backend endpoints confirmed, so all four were removed.

## Notes

- Two unit tests asserted the removed behavior and were updated to the corrected behavior:
  - `Dashboard.test.tsx`: metrics-error case now checks tiles fall back to `0` (no stub/console.warn assertion).
  - `ImpersonationListPage.test.tsx`: a `404` from `/impersonation/active` now asserts an error alert (the endpoint exists, so a 404 is a genuine failure).
- Orphaned i18n keys `admin.agencies.toast.notWired{Title,Message}` left in `messages/{en,cs,sk}.json` to keep the diff scoped to the dead branches (harmless, and avoids locale-parity churn).

## Verification

- `pnpm --filter @ppt/admin-web typecheck` — clean.
- `biome check` on all changed files — no issues.
- `pnpm --filter @ppt/admin-web test:run` — the 3 affected page tests pass.
  Remaining red is pre-existing and unrelated: `CapabilitiesAdminPage.test.tsx`
  (`renders all 17 capability cards`) fails identically with this PR's changes
  stashed, and the `e2e/specs/*` specs require a live server. This PR does not
  touch either.
