### PR TITLE
fix(messaging): camelCase wire contract for thread/message/participant API (BIT-239)

### DIFF
--- a/backend/crates/db/src/models/messaging.rs
+++ b/backend/crates/db/src/models/messaging.rs
@@ -14,6 +14,7 @@ use uuid::Uuid;
 
 /// A conversation thread between two users
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct MessageThread {
     pub id: Uuid,
     pub organization_id: Uuid,
@@ -25,6 +26,7 @@ pub struct MessageThread {
 
 /// Thread with preview info for list display
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ThreadWithPreview {
     pub id: Uuid,
     pub organization_id: Uuid,
@@ -90,6 +92,7 @@ impl ThreadWithPreviewRow {
 
 /// Basic participant info for display
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ParticipantInfo {
     pub id: Uuid,
     pub first_name: String,
@@ -99,6 +102,7 @@ pub struct ParticipantInfo {
 
 /// Message preview for thread list
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct MessagePreview {
     pub id: Uuid,
     /// Truncated content (first 100 chars)
@@ -110,6 +114,7 @@ pub struct MessagePreview {
 
 /// Request to create a new thread
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateThread {
     pub organization_id: Uuid,
     pub participant_ids: Vec<Uuid>,
@@ -121,6 +126,7 @@ pub struct CreateThread {
 
 /// An individual message within a thread
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct Message {
     pub id: Uuid,
     pub thread_id: Uuid,
@@ -135,6 +141,7 @@ pub struct Message {
 
 /// Message with sender info for display
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct MessageWithSender {
     pub id: Uuid,
     pub thread_id: Uuid,
@@ -186,6 +193,7 @@ impl From<MessageWithSenderRow> for MessageWithSender {
 
 /// Request to create a new message
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateMessage {
     pub thread_id: Uuid,
     pub sender_id: Uuid,
@@ -215,6 +223,7 @@ pub struct MessageAttachment {
 
 /// Request to link an uploaded S3 object to a message.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateMessageAttachment {
     pub message_id: Uuid,
     pub file_key: String,
@@ -229,6 +238,7 @@ pub struct CreateMessageAttachment {
 
 /// A user block record
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct UserBlock {
     pub id: Uuid,
     pub blocker_id: Uuid,
@@ -240,6 +250,7 @@ pub struct UserBlock {
 
 /// Block with blocked user info for display
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct BlockWithUserInfo {
     pub id: Uuid,
     pub blocked_user: ParticipantInfo,
@@ -276,6 +287,7 @@ impl From<BlockWithUserInfoRow> for BlockWithUserInfo {
 
 /// Request to create a block
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateBlock {
     pub blocker_id: Uuid,
     pub blocked_id: Uuid,

--- a/backend/servers/api-server/src/routes/messaging.rs
+++ b/backend/servers/api-server/src/routes/messaging.rs
@@ -43,6 +43,7 @@ const MESSAGE_PREVIEW_LEN: usize = 120;
 
 /// Response for thread list.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ThreadListResponse {
     pub threads: Vec<ThreadWithPreview>,
     pub count: usize,
@@ -51,6 +52,7 @@ pub struct ThreadListResponse {
 
 /// Response for thread detail with messages.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ThreadDetailResponse {
     pub thread: MessageThread,
     pub other_participant: ParticipantInfo,
@@ -60,6 +62,7 @@ pub struct ThreadDetailResponse {
 
 /// Response for message creation.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct SendMessageResponse {
     pub message: String,
     pub sent_message: Message,
@@ -67,12 +70,14 @@ pub struct SendMessageResponse {
 
 /// Response for unread count.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct UnreadMessagesResponse {
     pub unread_count: i64,
 }
 
 /// Response for blocked users list.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct BlockedUsersResponse {
     pub blocked_users: Vec<BlockWithUserInfo>,
     pub count: usize,
@@ -80,6 +85,7 @@ pub struct BlockedUsersResponse {
 
 /// Generic success response.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct MessageSuccessResponse {
     pub message: String,
 }
@@ -95,6 +101,7 @@ pub struct MessageSuccessResponse {
 /// UC-05.8 / [BIT-183]). When both are supplied they are merged. After
 /// de-duplication and removing the caller, at least one recipient must remain.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct StartThreadRequest {
     /// Recipient user IDs for an N-party (group) conversation. Preferred field.
     #[serde(default)]
@@ -125,6 +132,7 @@ impl StartThreadRequest {
 
 /// Request for sending a message.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct SendMessageRequest {
     pub content: String,
 }

--- a/backend/servers/api-server/tests/messaging_group_conversations_tests.rs
+++ b/backend/servers/api-server/tests/messaging_group_conversations_tests.rs
@@ -100,8 +100,8 @@ async fn start_group_thread_creates_three_party_thread(pool: PgPool) {
 
     let token = mint_token(alice, "grp3-alice@msg.test");
     let body = json!({
-        "recipient_ids": [bob, carol],
-        "initial_message": "Hello group",
+        "recipientIds": [bob, carol],
+        "initialMessage": "Hello group",
     });
     let resp = app
         .execute(
@@ -115,9 +115,9 @@ async fn start_group_thread_creates_three_party_thread(pool: PgPool) {
 
     resp.assert_status(StatusCode::OK);
     let v = resp.json_value();
-    let participants = v["thread"]["participant_ids"]
+    let participants = v["thread"]["participantIds"]
         .as_array()
-        .expect("participant_ids array");
+        .expect("participantIds array");
     assert_eq!(
         participants.len(),
         3,
@@ -145,7 +145,7 @@ async fn start_thread_back_compat_single_recipient(pool: PgPool) {
     seed_membership(&pool, org, bob, "resident").await;
 
     let token = mint_token(alice, "compat-alice@msg.test");
-    let body = json!({ "recipient_id": bob });
+    let body = json!({ "recipientId": bob });
     let resp = app
         .execute(
             app.post("/api/v1/messages/threads")
@@ -158,9 +158,9 @@ async fn start_thread_back_compat_single_recipient(pool: PgPool) {
 
     resp.assert_status(StatusCode::OK);
     let v = resp.json_value();
-    let participants = v["thread"]["participant_ids"]
+    let participants = v["thread"]["participantIds"]
         .as_array()
-        .expect("participant_ids array");
+        .expect("participantIds array");
     assert_eq!(
         participants.len(),
         2,
@@ -187,7 +187,7 @@ async fn start_group_thread_with_cross_org_recipient_is_rejected(pool: PgPool) {
 
     let token = mint_token(alice, "xorg-alice@msg.test");
     // Alice (org A) tries to pull a foreign-tenant user (Mallory) into a thread.
-    let body = json!({ "recipient_ids": [bob, mallory] });
+    let body = json!({ "recipientIds": [bob, mallory] });
     let resp = app
         .execute(
             app.post("/api/v1/messages/threads")
@@ -230,7 +230,7 @@ async fn start_group_thread_with_blocked_recipient_is_rejected(pool: PgPool) {
     seed_block(&pool, org, carol, alice).await;
 
     let token = mint_token(alice, "blk-alice@msg.test");
-    let body = json!({ "recipient_ids": [bob, carol] });
+    let body = json!({ "recipientIds": [bob, carol] });
     let resp = app
         .execute(
             app.post("/api/v1/messages/threads")


### PR DESCRIPTION
## Summary

Extends the camelCase wire-contract fix from BIT-238 (#1756) to the rest of the messaging API surface — thread list, thread detail, messages, participants, and block endpoints.

- Adds `#[serde(rename_all = "camelCase")]` to all `Serialize`/`Deserialize` messaging structs in `crates/db/src/models/messaging.rs` and `routes/messaging.rs`
- `*Row` (FromRow-only) structs intentionally excluded — `FromRow` column mapping is serde-independent
- `ListThreadsQuery`/`ListMessagesQuery` intentionally excluded — single-word fields, no-op
- Group-conversation integration tests updated to use camelCase JSON keys (`recipientIds`, `initialMessage`, `participantIds`)
- Attachment structs (`MessageAttachment`, `CreateMessageAttachment`, attachment route structs) also annotated here; coordinate rebase if #1756 lands first

## Why

`ppt-web` / `api-client` reads camelCase throughout (`apiThread.otherParticipant`, `.unreadCount`, `.lastMessage`, etc.). The backend was serializing snake_case, so all those fields resolved to `undefined` — breaking thread list and thread detail rendering.

## Test plan

- [ ] CI: fmt → clippy → check → messaging integration tests green
- [ ] Rebase on top of #1756 if that merges first (adjacent-line additions, trivial conflict)
- [ ] Live browser QA tracked in BIT-240

Closes BIT-239