### PR TITLE
gap-81-2-report-execution-history-download-verify: harden report presigned-download path

### DIFF
--- a/frontend/apps/ppt-web/src/features/reports/pages/ScheduleDetailPage.download-retry.test.tsx
+++ b/frontend/apps/ppt-web/src/features/reports/pages/ScheduleDetailPage.download-retry.test.tsx
@@ -184,6 +184,62 @@ describe('ScheduleDetailPage — presigned download + retry path (81.2)', () => 
     expect(document.querySelector(`a[download="${completedExecution.fileName}"]`)).toBeNull();
   });
 
+  it('does not trigger an anchor click (and leaves no leaked node) when the presigned URL is empty', async () => {
+    // Backend hands back a 200 with a blank `url` (e.g. storage key not yet
+    // materialised). The hook must treat this as a failure rather than clicking
+    // an anchor with href="" — which would navigate to the current page.
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      okJson({
+        url: '',
+        fileName: completedExecution.fileName,
+        expiresAt: '2026-06-01T09:00:00Z',
+        contentType: 'application/pdf',
+      })
+    );
+
+    render(
+      <Wrapper client={newClient()}>
+        <Harness executions={[completedExecution]} />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /download report/i }));
+
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    expect(clickSpy).not.toHaveBeenCalled();
+    // No detached anchor leaked into the DOM.
+    expect(document.querySelector(`a[download="${completedExecution.fileName}"]`)).toBeNull();
+  });
+
+  it('cleans up the temporary anchor even when the click() throws', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      okJson({
+        url: PRESIGNED_URL,
+        fileName: completedExecution.fileName,
+        expiresAt: '2026-06-01T09:00:00Z',
+        contentType: 'application/pdf',
+      })
+    );
+    // Simulate a browser/jsdom click that throws — the hook's try/finally must
+    // still remove the appended anchor from <body>.
+    clickSpy.mockImplementation(() => {
+      throw new Error('click boom');
+    });
+
+    render(
+      <Wrapper client={newClient()}>
+        <Harness executions={[completedExecution]} />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /download report/i }));
+
+    await waitFor(() => expect(clickSpy).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(document.querySelector(`a[download="${completedExecution.fileName}"]`)).toBeNull()
+    );
+  });
+
   it('does not trigger an anchor click when the presigned-URL request fails', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(errJson(403, { message: 'Forbidden' }));
 

--- a/frontend/packages/api-client/src/reports/hooks.ts
+++ b/frontend/packages/api-client/src/reports/hooks.ts
@@ -144,13 +144,25 @@ export function useDownloadReport() {
     mutationFn: async (executionId: string) => {
       const { url, fileName } = await getReportExecutionDownloadUrl(executionId);
 
-      // Trigger browser download
+      // Guard against a malformed/empty presigned URL: an empty href would
+      // navigate the anchor to the current page instead of downloading the
+      // report, so treat it as a failure the caller's onError can surface.
+      if (!url) {
+        throw new Error('Download URL is missing from the server response');
+      }
+
+      // Trigger browser download. Use try/finally so the temporary anchor is
+      // always removed from the DOM, even if click() throws (otherwise a thrown
+      // click leaks a detached <a> node into <body>).
       const link = document.createElement('a');
       link.href = url;
       link.download = fileName;
       document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
+      try {
+        link.click();
+      } finally {
+        document.body.removeChild(link);
+      }
 
       return { url, fileName };
     },


### PR DESCRIPTION
## Task

Report execution-history: verify+harden presigned-download + retry end-to-end (coverage 81-2). Owner: pm-frontend.

## Outcome

Verify+harden pass on the report execution-history presigned-download + retry flow. The download hook (`useDownloadReport`) had two robustness gaps:

- An empty/missing presigned `url` was still wired to an anchor whose empty href navigates the page instead of downloading. Now throws so the caller's `onError` can surface a toast.
- The temporary `<a>` was removed only on the success path; if `click()` throws, the detached node leaks into `<body>`. Wrapped in try/finally.

Adds two regression tests to the existing end-to-end download/retry suite (both fail against the prior hook). Retry path verified unchanged.

## Files

- `frontend/packages/api-client/src/reports/hooks.ts` (+18/-3)
- `frontend/apps/ppt-web/src/features/reports/pages/ScheduleDetailPage.download-retry.test.tsx` (+56)

Auto-generated draft PR by the research dispatcher (Phase 2 reconciliation of branch pushed by the implementer).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGuQWzSmfBC8wREE6XoKE8)_