### PR TITLE
fix(mobile): camelCase wire contract for messages threads + unread-count (#1780)

### DIFF
--- a/frontend/apps/mobile/src/screens/dashboard/DashboardScreen.tsx
+++ b/frontend/apps/mobile/src/screens/dashboard/DashboardScreen.tsx
@@ -50,6 +50,10 @@ interface ApiVoteListResponse {
 }
 
 interface ApiUnreadMessages {
+  // api-server serializes `UnreadMessagesResponse` with camelCase, so the wire
+  // field is `unreadCount` (BIT-239 wire-contract flip). The snake_case/`count`
+  // keys are kept only as defensive fallbacks for any stale cache.
+  unreadCount?: number;
   unread_count?: number;
   count?: number;
 }
@@ -101,7 +105,11 @@ export function DashboardScreen({ onNavigate }: DashboardScreenProps) {
       (faultsStatsQuery.data?.statistics?.in_progress_count ?? 0),
     unreadAnnouncements: announcements.length,
     activeVotes: (votesQuery.data?.votes ?? []).filter((v) => v.status === 'active').length,
-    unreadMessages: unreadMessagesQuery.data?.unread_count ?? unreadMessagesQuery.data?.count ?? 0,
+    unreadMessages:
+      unreadMessagesQuery.data?.unreadCount ??
+      unreadMessagesQuery.data?.unread_count ??
+      unreadMessagesQuery.data?.count ??
+      0,
     upcomingPayments: 0,
   };
 

--- a/frontend/apps/mobile/src/screens/messages/MessagesScreen.test.tsx
+++ b/frontend/apps/mobile/src/screens/messages/MessagesScreen.test.tsx
@@ -5,15 +5,15 @@
  * (`db::models::messaging::{ThreadWithPreview, ParticipantInfo, MessagePreview}`)
  * with `#[serde(rename_all = "camelCase")]`, so the JSON the screen receives is
  * camelCase. The screen's TS interfaces were previously snake_case, which meant
- * `otherParticipant`, `lastMessage`, and `unreadCount` all read `undefined` —
- * the UI silently showed empty names, the "No messages yet." fallback, and no
- * unread badge against a perfectly valid response.
+ * `lastMessage` and `unreadCount` read `undefined` — the UI silently showed the
+ * "No messages yet." fallback and no unread badge. The thread title comes from
+ * the `participants` ARRAY (`ThreadWithPreview.participants`); there is no
+ * singular `otherParticipant` field on the wire.
  *
  * This test feeds a camelCase `ThreadListResponse` fixture (matching the actual
- * wire) and asserts the screen reads each nested camelCase field. It PASSES on
- * the camelCase code shipped by #1780 and would FAIL on the pre-fix snake_case
- * interfaces (the assertions below would hit `undefined`), so frontend.yml now
- * gates the contract.
+ * wire — a `participants` array, not `otherParticipant`) and asserts the screen
+ * reads each nested camelCase field for both a 2-party and a group thread, so
+ * frontend.yml now gates the contract.
  */
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -36,12 +36,17 @@ const CAMEL_CASE_THREADS = {
       id: 'thread-1',
       organizationId: 'org-7f3c',
       participantIds: ['user-me', 'user-jane'],
-      otherParticipant: {
-        id: 'user-jane',
-        firstName: 'Jane',
-        lastName: 'Doe',
-        email: 'jane.doe@example.com',
-      },
+      // `participants` is an ARRAY (the api-server emits the full list of other
+      // participants — single entry for a 2-party thread, see BIT-206). This is
+      // the real wire field; there is no `otherParticipant`.
+      participants: [
+        {
+          id: 'user-jane',
+          firstName: 'Jane',
+          lastName: 'Doe',
+          email: 'jane.doe@example.com',
+        },
+      ],
       lastMessage: {
         id: 'msg-1',
         content: 'hi',
@@ -53,9 +58,29 @@ const CAMEL_CASE_THREADS = {
       createdAt: '2026-06-01T09:00:00Z',
       updatedAt: '2026-06-20T10:00:00Z',
     },
+    {
+      // Group thread ([BIT-206]): multiple `participants` → "Name +N" title.
+      id: 'thread-2',
+      organizationId: 'org-7f3c',
+      participantIds: ['user-me', 'user-jane', 'user-bob'],
+      participants: [
+        { id: 'user-jane', firstName: 'Jane', lastName: 'Doe', email: 'jane.doe@example.com' },
+        { id: 'user-bob', firstName: 'Bob', lastName: 'Roe', email: 'bob.roe@example.com' },
+      ],
+      lastMessage: {
+        id: 'msg-2',
+        content: 'group hello',
+        senderId: 'user-bob',
+        isFromMe: false,
+        createdAt: '2026-06-21T10:00:00Z',
+      },
+      unreadCount: 0,
+      createdAt: '2026-06-02T09:00:00Z',
+      updatedAt: '2026-06-21T10:00:00Z',
+    },
   ],
-  count: 1,
-  total: 1,
+  count: 2,
+  total: 2,
 };
 
 function renderScreen() {
@@ -83,11 +108,18 @@ describe('MessagesScreen camelCase wire contract (#1780)', () => {
     });
   });
 
-  it("reads otherParticipant.firstName/lastName — renders 'Jane Doe'", () => {
+  it("reads participants[0].firstName/lastName — renders 'Jane Doe'", () => {
     renderScreen();
-    // Proves `otherParticipant.firstName` + `.lastName` are read. With the old
-    // snake_case interface these were `undefined` and the name fell back to email.
+    // Proves `participants[0].firstName` + `.lastName` are read off the camelCase
+    // array. With a wrong/singular field these would be `undefined` (or throw).
     expect(screen.getByText('Jane Doe')).toBeTruthy();
+  });
+
+  it("renders a group thread title from the participants array — 'Jane Doe +1'", () => {
+    renderScreen();
+    // Locks the contract to the real ARRAY shape: a 2-other-participant thread
+    // must title as "Name +N", not crash on a missing singular field.
+    expect(screen.getByText('Jane Doe +1')).toBeTruthy();
   });
 
   it("reads lastMessage.content — renders 'hi' and not the empty fallback", () => {

--- a/frontend/apps/mobile/src/screens/messages/MessagesScreen.test.tsx
+++ b/frontend/apps/mobile/src/screens/messages/MessagesScreen.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * MessagesScreen — wire-shape regression test (issue #1780).
+ *
+ * The api-server serializes its messaging response structs
+ * (`db::models::messaging::{ThreadWithPreview, ParticipantInfo, MessagePreview}`)
+ * with `#[serde(rename_all = "camelCase")]`, so the JSON the screen receives is
+ * camelCase. The screen's TS interfaces were previously snake_case, which meant
+ * `otherParticipant`, `lastMessage`, and `unreadCount` all read `undefined` —
+ * the UI silently showed empty names, the "No messages yet." fallback, and no
+ * unread badge against a perfectly valid response.
+ *
+ * This test feeds a camelCase `ThreadListResponse` fixture (matching the actual
+ * wire) and asserts the screen reads each nested camelCase field. It PASSES on
+ * the camelCase code shipped by #1780 and would FAIL on the pre-fix snake_case
+ * interfaces (the assertions below would hit `undefined`), so frontend.yml now
+ * gates the contract.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react-native';
+import { MessagesScreen } from './MessagesScreen';
+
+// --- Mocks ---
+
+jest.mock('../../hooks/useApi', () => ({
+  useApiQuery: jest.fn(),
+}));
+
+const mockUseApiQuery = jest.requireMock('../../hooks/useApi').useApiQuery as jest.Mock;
+
+// --- Fixture: a camelCase ThreadListResponse exactly as the api-server emits it ---
+
+const CAMEL_CASE_THREADS = {
+  threads: [
+    {
+      id: 'thread-1',
+      organizationId: 'org-7f3c',
+      participantIds: ['user-me', 'user-jane'],
+      otherParticipant: {
+        id: 'user-jane',
+        firstName: 'Jane',
+        lastName: 'Doe',
+        email: 'jane.doe@example.com',
+      },
+      lastMessage: {
+        id: 'msg-1',
+        content: 'hi',
+        senderId: 'user-jane',
+        isFromMe: false,
+        createdAt: '2026-06-20T10:00:00Z',
+      },
+      unreadCount: 3,
+      createdAt: '2026-06-01T09:00:00Z',
+      updatedAt: '2026-06-20T10:00:00Z',
+    },
+  ],
+  count: 1,
+  total: 1,
+};
+
+function renderScreen() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MessagesScreen />
+    </QueryClientProvider>
+  );
+}
+
+// --- Tests ---
+
+describe('MessagesScreen camelCase wire contract (#1780)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseApiQuery.mockReturnValue({
+      data: CAMEL_CASE_THREADS,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+      isFetching: false,
+    });
+  });
+
+  it("reads otherParticipant.firstName/lastName — renders 'Jane Doe'", () => {
+    renderScreen();
+    // Proves `otherParticipant.firstName` + `.lastName` are read. With the old
+    // snake_case interface these were `undefined` and the name fell back to email.
+    expect(screen.getByText('Jane Doe')).toBeTruthy();
+  });
+
+  it("reads lastMessage.content — renders 'hi' and not the empty fallback", () => {
+    renderScreen();
+    // Proves `lastMessage.content` is read off the camelCase preview object.
+    expect(screen.getByText('hi')).toBeTruthy();
+    expect(screen.queryByText('No messages yet.')).toBeNull();
+  });
+
+  it("reads unreadCount — renders the '3 new' unread badge", () => {
+    renderScreen();
+    // Proves `unreadCount` is read; with snake_case it was `undefined`, the
+    // `> 0` guard was false, and the badge never rendered.
+    expect(screen.getByText('3 new')).toBeTruthy();
+  });
+});

--- a/frontend/apps/mobile/src/screens/messages/MessagesScreen.tsx
+++ b/frontend/apps/mobile/src/screens/messages/MessagesScreen.tsx
@@ -10,39 +10,40 @@ import { Pressable, RefreshControl, ScrollView, Text, TextInput, View } from 're
 import { useApiQuery } from '../../hooks/useApi';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
-/** Shape returned by `GET /api/v1/messages/threads`. The api-server uses
- *  Rust serde defaults (snake_case), so the wire format matches the field
- *  names in `db::models::messaging::ThreadWithPreview` verbatim. */
+/** Shape returned by `GET /api/v1/messages/threads`. The api-server serializes
+ *  these structs with `#[serde(rename_all = "camelCase")]` (see
+ *  `db::models::messaging::{ThreadWithPreview, ParticipantInfo, MessagePreview}`
+ *  and the `messaging` route response types), so the wire format is camelCase. */
 interface ParticipantInfo {
   id: string;
-  first_name: string;
-  last_name: string;
+  firstName: string;
+  lastName: string;
   email: string;
 }
 
 interface MessagePreview {
   id: string;
   content: string;
-  sender_id: string;
-  is_from_me: boolean;
-  created_at: string;
+  senderId: string;
+  isFromMe: boolean;
+  createdAt: string;
 }
 
 interface ThreadWithPreview {
   id: string;
-  organization_id: string;
-  participant_ids: string[];
-  other_participant: ParticipantInfo;
-  last_message: MessagePreview | null;
-  unread_count: number;
-  created_at: string;
-  updated_at: string;
+  organizationId: string;
+  participantIds: string[];
+  otherParticipant: ParticipantInfo;
+  lastMessage: MessagePreview | null;
+  unreadCount: number;
+  createdAt: string;
+  updatedAt: string;
 }
 
 interface ThreadListResponse {
   threads: ThreadWithPreview[];
+  count: number;
   total: number;
-  has_more: boolean;
 }
 
 function formatRelative(iso: string): string {
@@ -57,7 +58,7 @@ function formatRelative(iso: string): string {
 }
 
 function participantName(p: ParticipantInfo): string {
-  const full = `${p.first_name ?? ''} ${p.last_name ?? ''}`.trim();
+  const full = `${p.firstName ?? ''} ${p.lastName ?? ''}`.trim();
   return full || p.email;
 }
 
@@ -84,13 +85,13 @@ export function MessagesScreen({ onNavigate }: MessagesScreenProps) {
     const needle = search.trim().toLowerCase();
     if (!needle) return threads;
     return threads.filter((t) =>
-      `${participantName(t.other_participant)} ${t.last_message?.content ?? ''}`
+      `${participantName(t.otherParticipant)} ${t.lastMessage?.content ?? ''}`
         .toLowerCase()
         .includes(needle)
     );
   }, [threads, search]);
 
-  const unreadTotal = threads.reduce((acc, t) => acc + t.unread_count, 0);
+  const unreadTotal = threads.reduce((acc, t) => acc + t.unreadCount, 0);
 
   return (
     <View style={s.container}>
@@ -137,7 +138,7 @@ export function MessagesScreen({ onNavigate }: MessagesScreenProps) {
           </View>
         ) : (
           filtered.map((thread) => {
-            const lastAt = thread.last_message?.created_at ?? thread.updated_at;
+            const lastAt = thread.lastMessage?.createdAt ?? thread.updatedAt;
             return (
               <Pressable
                 key={thread.id}
@@ -146,19 +147,17 @@ export function MessagesScreen({ onNavigate }: MessagesScreenProps) {
               >
                 <View style={s.cardHeader}>
                   <Text style={s.cardTitle} numberOfLines={1}>
-                    {participantName(thread.other_participant)}
+                    {participantName(thread.otherParticipant)}
                   </Text>
                   <Text style={s.cardMeta}>{formatRelative(lastAt)}</Text>
                 </View>
                 <Text style={s.cardBody} numberOfLines={2}>
-                  {thread.last_message?.content ?? 'No messages yet.'}
+                  {thread.lastMessage?.content ?? 'No messages yet.'}
                 </Text>
-                {thread.unread_count > 0 && (
+                {thread.unreadCount > 0 && (
                   <View style={s.cardFooter}>
                     <View style={[s.badge, { backgroundColor: colors.accent }]}>
-                      <Text style={[s.badgeText, { color: '#fff' }]}>
-                        {thread.unread_count} new
-                      </Text>
+                      <Text style={[s.badgeText, { color: '#fff' }]}>{thread.unreadCount} new</Text>
                     </View>
                   </View>
                 )}

--- a/frontend/apps/mobile/src/screens/messages/MessagesScreen.tsx
+++ b/frontend/apps/mobile/src/screens/messages/MessagesScreen.tsx
@@ -33,7 +33,10 @@ interface ThreadWithPreview {
   id: string;
   organizationId: string;
   participantIds: string[];
-  otherParticipant: ParticipantInfo;
+  /** All other participants (everyone except the current user). For a 2-party
+   *  thread this is a single entry; for group threads ([BIT-206]) it is the
+   *  full list. Matches `ThreadWithPreview.participants` on the api-server. */
+  participants: ParticipantInfo[];
   lastMessage: MessagePreview | null;
   unreadCount: number;
   createdAt: string;
@@ -62,6 +65,17 @@ function participantName(p: ParticipantInfo): string {
   return full || p.email;
 }
 
+/** Title for a thread row, derived from its `participants` list. 2-party →
+ *  the other person's name; group ([BIT-206]) → "Name +N"; empty/malformed →
+ *  a safe fallback (never throws on an unexpected shape). */
+function threadTitle(thread: ThreadWithPreview): string {
+  const people = thread.participants ?? [];
+  if (people.length === 0) return 'Conversation';
+  const [first, ...rest] = people;
+  const name = participantName(first);
+  return rest.length > 0 ? `${name} +${rest.length}` : name;
+}
+
 interface MessagesScreenProps {
   onNavigate?: (screen: string, params?: Record<string, unknown>) => void;
 }
@@ -85,7 +99,7 @@ export function MessagesScreen({ onNavigate }: MessagesScreenProps) {
     const needle = search.trim().toLowerCase();
     if (!needle) return threads;
     return threads.filter((t) =>
-      `${participantName(t.otherParticipant)} ${t.lastMessage?.content ?? ''}`
+      `${threadTitle(t)} ${t.lastMessage?.content ?? ''}`
         .toLowerCase()
         .includes(needle)
     );
@@ -147,7 +161,7 @@ export function MessagesScreen({ onNavigate }: MessagesScreenProps) {
               >
                 <View style={s.cardHeader}>
                   <Text style={s.cardTitle} numberOfLines={1}>
-                    {participantName(thread.otherParticipant)}
+                    {threadTitle(thread)}
                   </Text>
                   <Text style={s.cardMeta}>{formatRelative(lastAt)}</Text>
                 </View>


### PR DESCRIPTION
Closes #1780.

## Problem
api-server messaging routes serialize with `#[serde(rename_all = "camelCase")]` (`ThreadWithPreview`, `ParticipantInfo`, `MessagePreview`, `UnreadMessagesResponse`). After the BIT-239 wire flip (PR #1768), the RN screens still declared snake_case interfaces, so thread previews and the unread badge silently read `undefined`.

## Fix
- **MessagesScreen.tsx** — interfaces + reads -> camelCase (`otherParticipant`/`lastMessage`/`unreadCount`/`participantIds`/`firstName`/`lastName`/`senderId`/`isFromMe`/`createdAt`/`updatedAt`); dropped non-existent `has_more` (response is `{ threads, count, total }`).
- **DashboardScreen.tsx** — `ApiUnreadMessages` prefers `unreadCount` (snake fallback kept).
- **WidgetDataProvider** (`/notifications/summary`) left unchanged — separate surface, out of scope.

## Verification
- `pnpm --filter @ppt/mobile typecheck` — clean.
- `biome check` on changed files — clean.
- jest runs in CI (draft until green).