### PR TITLE
fix(messaging): N-party delivery/block/unhide for all recipients + unread honors soft-delete/archive (#1773, #1771)

### DIFF
--- a/backend/crates/db/src/repositories/messaging.rs
+++ b/backend/crates/db/src/repositories/messaging.rs
@@ -555,11 +555,19 @@ impl MessagingRepository {
             SELECT COUNT(*)
             FROM messages m
             JOIN message_threads t ON t.id = m.thread_id
+            -- Per-participant view state (BIT-182, #1771): exclude threads this
+            -- user soft-deleted or archived, matching the default inbox in
+            -- list_threads_rls. A missing row means default (neither), so the
+            -- LEFT JOIN + IS NULL checks keep those threads counted.
+            LEFT JOIN thread_participant_state tps
+                ON tps.thread_id = t.id AND tps.user_id = $1
             WHERE $1 = ANY(t.participant_ids)
               AND t.organization_id = $2
               AND m.sender_id != $1
               AND m.read_at IS NULL
               AND m.deleted_at IS NULL
+              AND tps.deleted_at IS NULL
+              AND tps.archived_at IS NULL
             "#,
         )
         .bind(user_id)

--- a/backend/servers/api-server/src/routes/messaging.rs
+++ b/backend/servers/api-server/src/routes/messaging.rs
@@ -933,41 +933,51 @@ async fn send_message(
         ));
     }
 
-    // Check if blocked
-    let other_user_id = thread
+    // Recipients = every participant except the sender. For a 2-party direct
+    // thread this is a single user; for an N-party group thread (UC-05.8) it is
+    // all the others. The previous code only ever looked at the FIRST other
+    // participant, so in a group thread the rest were never block-checked, never
+    // un-hidden, and never notified in realtime (#1773).
+    let recipients: Vec<Uuid> = thread
         .participant_ids
         .iter()
-        .find(|&&uid| uid != user_id)
         .copied()
-        .ok_or_else(|| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(
-                    "INVALID_THREAD",
-                    "Thread has invalid participants",
-                )),
-            )
-        })?;
-
-    let is_blocked = repo
-        .is_blocked_rls(&mut **rls.conn(), user_id, other_user_id)
-        .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-            )
-        })?;
-
-    if is_blocked {
+        .filter(|&uid| uid != user_id)
+        .collect();
+    if recipients.is_empty() {
         rls.release().await;
         return Err((
-            StatusCode::FORBIDDEN,
+            StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse::new(
-                "USER_BLOCKED",
-                "Cannot message this user",
+                "INVALID_THREAD",
+                "Thread has invalid participants",
             )),
         ));
+    }
+
+    // Block gate: reject the send if the sender is blocked with ANY recipient,
+    // mirroring start_thread. For a 2-party thread this is exactly the previous
+    // single-user check; for a group it now also covers the other members.
+    for &rid in &recipients {
+        let is_blocked = repo
+            .is_blocked_rls(&mut **rls.conn(), user_id, rid)
+            .await
+            .map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("DB_ERROR", e.to_string())),
+                )
+            })?;
+        if is_blocked {
+            rls.release().await;
+            return Err((
+                StatusCode::FORBIDDEN,
+                Json(ErrorResponse::new(
+                    "USER_BLOCKED",
+                    "Cannot message this conversation",
+                )),
+            ));
+        }
     }
 
     // Send message
@@ -989,23 +999,22 @@ async fn send_message(
             )
         })?;
 
-    // A new inbound message un-hides the thread for the recipient if they had
+    // A new inbound message un-hides the thread for every recipient who had
     // previously soft-deleted it (BIT-182). Best-effort: a failure here must not
     // fail an otherwise-successful send.
-    let _ = repo
-        .unhide_thread_for_user(&mut **rls.conn(), id, other_user_id)
-        .await;
+    for &rid in &recipients {
+        let _ = repo
+            .unhide_thread_for_user(&mut **rls.conn(), id, rid)
+            .await;
+    }
 
     rls.release().await;
 
-    // Realtime fanout: notify the recipient's WebSocket channel (Epic 2B / 8A.3).
-    dispatch_new_message_event(
-        state.pubsub_service.as_ref(),
-        other_user_id,
-        &message,
-        user_id,
-    )
-    .await;
+    // Realtime fanout: notify EVERY recipient's WebSocket channel
+    // (Epic 2B / 8A.3), not just the first other participant.
+    for &rid in &recipients {
+        dispatch_new_message_event(state.pubsub_service.as_ref(), rid, &message, user_id).await;
+    }
 
     Ok(Json(SendMessageResponse {
         message: "Message sent successfully".to_string(),


### PR DESCRIPTION
Closes #1773, #1771.

## #1773 — N-party group threads only served the first other participant (high)
`send_message` computed `other_user_id = participant_ids.find(|uid| uid != sender)` and used that single user for the block check, the un-hide, and the realtime dispatch. In a 3+-party thread the remaining members were never block-checked, never had their soft-deleted view restored, and received **no** WebSocket delivery.

Now: `recipients = participant_ids − sender`; block-gate against **any** recipient (mirrors `start_thread`; for a 2-party thread this is byte-for-byte the previous behavior), then un-hide + `dispatch_new_message_event` for **every** recipient.

> Per-participant *read* state is intentionally out of scope: `messages.read_at` is a single per-message column, so true per-recipient unread requires a schema change (separate ticket).

## #1771 — unread count ignored per-user soft-delete/archive (high)
`count_unread_rls` didn't join `thread_participant_state`, so a thread the user soft-deleted or archived still inflated their unread badge (inconsistent with `list_threads_rls`). Added the `LEFT JOIN` + `tps.deleted_at IS NULL AND tps.archived_at IS NULL`, matching the default-inbox semantics.

## Verification
- `cargo clippy -p db -p api-server -- -D warnings` — no issues.
- `rustup run 1.94.1 cargo fmt --all` — clean.
- DB-backed `#[sqlx::test]` integration tests run in CI (draft until green).