### PR TITLE
fix(booking_channel): DB-backed manager gate instead of JWT role claim (#1787)

### DIFF
--- a/backend/servers/api-server/src/routes/integrations/booking_channel.rs
+++ b/backend/servers/api-server/src/routes/integrations/booking_channel.rs
@@ -24,10 +24,9 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-use super::sync::OrgIdPath;
+use super::sync::{verify_manager_role_in_org, verify_org_access, OrgIdPath};
 use crate::state::AppState;
 use common::errors::ErrorResponse;
-use common::TenantRole;
 
 /// Maximum number of availability/rate updates accepted in a single
 /// `listing-push` request.
@@ -252,35 +251,13 @@ pub async fn push_booking_listing(
         "Pushing listing to Booking.com"
     );
 
-    // BLOCKING-1: Ensure caller belongs to this org (defense-in-depth alongside RLS).
-    if auth.tenant_id != Some(path.org_id) && !auth.is_platform_admin() {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse::new(
-                "FORBIDDEN",
-                "You do not have access to this organization",
-            )),
-        ));
-    }
-
-    // BLOCKING-2: Require an administrative role to manage integrations.
-    let role = auth.role.unwrap_or(TenantRole::Guest);
-    let allowed = matches!(
-        role,
-        TenantRole::SuperAdmin
-            | TenantRole::PlatformAdmin
-            | TenantRole::OrgAdmin
-            | TenantRole::Manager
-    );
-    if !allowed {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse::new(
-                "FORBIDDEN",
-                "Insufficient permissions to manage integrations",
-            )),
-        ));
-    }
+    // SECURITY (#1787, mirrors #1525): authorize against the caller's DB
+    // membership + role for the PATH org — not the JWT `role`/`tenant_id` claim,
+    // which is tied to X-Tenant-ID and can diverge from the caller's actual role
+    // in path.org_id (a manager in org A could otherwise mutate org B's OTA
+    // integration). Matches the canonical airbnb_connections / oauth pattern.
+    verify_org_access(&state, auth.user_id, path.org_id).await?;
+    verify_manager_role_in_org(&state, auth.user_id, path.org_id).await?;
 
     // Validate the payload before any DB lookup or OTA XML generation so a
     // malformed batch fails fast with a 400 instead of producing invalid XML.
@@ -562,35 +539,13 @@ pub async fn get_booking_conflicts(
         "Checking Booking.com reservation conflicts"
     );
 
-    // BLOCKING-1: Ensure caller belongs to this org (defense-in-depth alongside RLS).
-    if auth.tenant_id != Some(path.org_id) && !auth.is_platform_admin() {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse::new(
-                "FORBIDDEN",
-                "You do not have access to this organization",
-            )),
-        ));
-    }
-
-    // BLOCKING-2: Require an administrative role to manage integrations.
-    let role = auth.role.unwrap_or(TenantRole::Guest);
-    let allowed = matches!(
-        role,
-        TenantRole::SuperAdmin
-            | TenantRole::PlatformAdmin
-            | TenantRole::OrgAdmin
-            | TenantRole::Manager
-    );
-    if !allowed {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse::new(
-                "FORBIDDEN",
-                "Insufficient permissions to manage integrations",
-            )),
-        ));
-    }
+    // SECURITY (#1787, mirrors #1525): authorize against the caller's DB
+    // membership + role for the PATH org — not the JWT `role`/`tenant_id` claim,
+    // which is tied to X-Tenant-ID and can diverge from the caller's actual role
+    // in path.org_id (a manager in org A could otherwise mutate org B's OTA
+    // integration). Matches the canonical airbnb_connections / oauth pattern.
+    verify_org_access(&state, auth.user_id, path.org_id).await?;
+    verify_manager_role_in_org(&state, auth.user_id, path.org_id).await?;
 
     let rental_repo = &state.rental_repo;
 

--- a/backend/servers/api-server/tests/integrations_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/integrations_cross_org_idor_tests.rs
@@ -43,10 +43,68 @@ use axum::{
     body::Body,
     http::{header, Method, Request, StatusCode},
 };
+use chrono::{Duration, Utc};
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::Serialize;
 use sqlx::PgPool;
 use uuid::Uuid;
 
 use common::{create_authenticated_user, seed_membership, TestApp, TestUser};
+
+// Must match `TestConfig::default().jwt_secret` (see
+// `airbnb_connections_routes_tests.rs`, which uses the same constant). Lets the
+// manager-gate tests mint a JWT whose `role` claim deliberately *disagrees* with
+// the caller's DB `role_type`, proving the gate reads the DB, not the token.
+const JWT_SECRET: &str = "test-secret-key-that-is-at-least-64-characters-long-for-testing-purposes";
+
+/// Mirror of `api_core::extractors::auth::Claims`.
+#[derive(Serialize)]
+struct AccessClaims {
+    sub: Uuid,
+    exp: i64,
+    iat: i64,
+    token_type: String,
+    tenant_id: Option<Uuid>,
+    role: Option<String>,
+    email: String,
+    name: String,
+}
+
+/// Mint an access token whose `role` claim is `manager` (the JWT-claim role the
+/// pre-#1787 handlers trusted), regardless of the caller's real DB membership.
+fn mint_manager_claim_token(user_id: Uuid, tenant_id: Uuid) -> String {
+    let now = Utc::now();
+    let claims = AccessClaims {
+        sub: user_id,
+        iat: now.timestamp(),
+        exp: (now + Duration::hours(1)).timestamp(),
+        token_type: "access".to_string(),
+        tenant_id: Some(tenant_id),
+        role: Some("manager".to_string()),
+        email: "booking-gate-test@test.local".to_string(),
+        name: "Booking Gate Test".to_string(),
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(JWT_SECRET.as_bytes()),
+    )
+    .expect("mint access token")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'hash', 'Booking Gate User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -199,5 +257,106 @@ async fn member_passes_org_access_guard(pool: PgPool) {
     assert_eq!(
         json["connected"], false,
         "expected connected=false for an org with no Airbnb connection"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3 — Booking.com manager gate reads the DB role, not the JWT claim
+// ---------------------------------------------------------------------------
+//
+// #1787: `get_booking_conflicts` and `push_booking_listing`
+// (`routes/integrations/booking_channel.rs`) previously authorized off the JWT
+// `role`/`tenant_id` claim with a hand-rolled `matches!(role, …)`. A user who is
+// only a `resident` in the path org — but carries a `manager` role claim in
+// their token — would have been admitted. After the fix both handlers run
+// `verify_org_access` + `verify_manager_role_in_org`, which read
+// `organization_members.role_type` for the PATH org, so the resident is rejected
+// with `403` despite the `manager` JWT claim.
+//
+// These tests mint a token whose `role` claim is `manager` while the DB
+// membership is `resident`: on the pre-#1787 (JWT-claim) code they would PASS the
+// gate (200 / 404), so the assertion FAILS; on the DB-backed code they return
+// `403`, so the assertion PASSES — the IG3 failing-on-old-code property.
+
+/// `GET /booking/conflicts`: a `resident` member is rejected with `403` even
+/// though the JWT carries a `manager` role claim (gate reads the DB role).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn booking_conflicts_manager_gate_rejects_resident(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org_x = seed_org(&pool, "booking-resident").await;
+    let user_id = seed_user(&pool, "booking-conflicts-resident@test.local").await;
+    seed_membership(&pool, org_x, user_id, "resident").await;
+
+    let token = mint_manager_claim_token(user_id, org_x);
+    let uri = format!("/api/v1/integrations/organizations/{org_x}/booking/conflicts");
+    let response = app
+        .execute(authed_req(Method::GET, &uri, &token, None))
+        .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::FORBIDDEN,
+        "#1787: a resident member must be 403 on booking/conflicts despite a manager JWT claim; got {}: {}",
+        response.status,
+        response.text()
+    );
+}
+
+/// `POST /booking/listing-push` (the byte-identical write gate): a `resident`
+/// member is rejected with `403` despite a `manager` JWT claim. The gate fires
+/// before payload validation, so a minimal body still 403s.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn booking_listing_push_manager_gate_rejects_resident(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org_x = seed_org(&pool, "booking-push-resident").await;
+    let user_id = seed_user(&pool, "booking-push-resident@test.local").await;
+    seed_membership(&pool, org_x, user_id, "resident").await;
+
+    let token = mint_manager_claim_token(user_id, org_x);
+    let uri = format!("/api/v1/integrations/organizations/{org_x}/booking/listing-push");
+    let body = serde_json::json!({
+        "unit_id": Uuid::new_v4(),
+        "room_type_id": "RT-1",
+        "availability": [],
+        "rates": [],
+    });
+    let response = app
+        .execute(authed_req(Method::POST, &uri, &token, Some(body)))
+        .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::FORBIDDEN,
+        "#1787: a resident member must be 403 on booking/listing-push despite a manager JWT claim; got {}: {}",
+        response.status,
+        response.text()
+    );
+}
+
+/// No-lockout sanity: a `manager` DB member passes the gate on
+/// `GET /booking/conflicts` (NOT `403`). With no Booking.com connection the
+/// handler returns `404`, so we assert only that the manager gate does not block.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn booking_conflicts_manager_member_passes_gate(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org_x = seed_org(&pool, "booking-manager").await;
+    let user_id = seed_user(&pool, "booking-conflicts-manager@test.local").await;
+    seed_membership(&pool, org_x, user_id, "manager").await;
+
+    let token = mint_manager_claim_token(user_id, org_x);
+    let uri = format!("/api/v1/integrations/organizations/{org_x}/booking/conflicts");
+    let response = app
+        .execute(authed_req(Method::GET, &uri, &token, None))
+        .await;
+
+    assert_ne!(
+        response.status,
+        StatusCode::FORBIDDEN,
+        "#1787: a legitimate manager member must NOT be blocked by the manager gate; got {}: {}",
+        response.status,
+        response.text()
     );
 }


### PR DESCRIPTION
Closes #1787.

## Problem (medium — authz drift)
`get_booking_conflicts` **and** `push_listing_to_booking` authorized off the JWT `role`/`tenant_id` claim (tied to `X-Tenant-ID`) with a hand-rolled `matches!(role, …)`, never cross-checked against the **path** org. A user who is a manager in org A (per JWT) but only a plain member of org B could mutate org B's Booking.com OTA integration — the JWT-vs-DB anti-pattern PR #1741 flagged and #1525 fixed for the Airbnb endpoints.

## Fix
Both handlers now use the canonical DB-backed helpers (as in `airbnb_connections.rs` / `oauth.rs`): `verify_org_access` + `verify_manager_role_in_org` against `path.org_id` (role derived from `TenantRole::is_manager`). Now-unused `TenantRole` import dropped.

> #1787 named `get_booking_conflicts`; `push_listing_to_booking` carried the byte-identical block, so it's fixed in the same change (the more sensitive write path).

## Verification
- `cargo clippy -p api-server -- -D warnings` — no issues.
- `rustup run 1.94.1 cargo fmt --all` — clean.